### PR TITLE
MR for quick fix for graceful exit

### DIFF
--- a/include/cudnn_frontend_Errata.h
+++ b/include/cudnn_frontend_Errata.h
@@ -35,15 +35,15 @@ namespace cudnn_frontend {
 // json file is defined by environment variable
 // CUDNN_ERRATA_JSON_FILE. If the environment variable
 // is not set the value set in the API is considered.
-static void
+static bool
 load_from_config(json &json_handle, const std::string & errata_json) {
     const char * err_json = std::getenv("CUDNN_ERRATA_JSON_FILE");
-    if (err_json == NULL && errata_json == "") {return;}
+    if (err_json == NULL && errata_json == "") {return false;}
     if (err_json == NULL) { err_json = errata_json.c_str();}
     std::ifstream ifs(err_json, std::ifstream::in);
-    if (!ifs.is_open() || !ifs.good()) {return;}
+    if (!ifs.is_open() || !ifs.good()) {return false;}
     ifs >> json_handle;
-    return;
+    return true;
 }
 
 template <typename T>

--- a/include/cudnn_frontend_find_plan.h
+++ b/include/cudnn_frontend_find_plan.h
@@ -55,7 +55,9 @@ time_sorted_plan(cudnnHandle_t handle, executionPlans_t plans, VariantPack &vari
         float min_time_ms   = std::numeric_limits<float>::max();
 
         // Warm-up run
-        ::cudnnBackendExecute(handle, plan.get_raw_desc(), variantPack.get_raw_desc());
+        auto warmup_status = ::cudnnBackendExecute(handle, plan.get_raw_desc(), variantPack.get_raw_desc());
+        if (warmup_status != CUDNN_STATUS_SUCCESS) {continue;}
+
         cudaDeviceSynchronize();
 
         for (int i = 0; i < maxIterCount; i++) {


### PR DESCRIPTION
- Adding status check on the cudnnBackendExecute during warm up. 
- Adding status check on json_handle when loading from a file