### PR TITLE
Patch 0.4.1

### DIFF
--- a/include/cudnn_frontend.h
+++ b/include/cudnn_frontend.h
@@ -111,6 +111,7 @@
 #include "cudnn_frontend_VariantPack.h"
 #include "cudnn_frontend_PointWiseDesc.h"
 #include "cudnn_frontend_MatMulDesc.h"
+#include "cudnn_frontend_Reorder_Tensor.h"
 
 namespace cudnn_frontend {
 using Tensor                    = Tensor_v8;

--- a/include/cudnn_frontend_ConvDesc.h
+++ b/include/cudnn_frontend_ConvDesc.h
@@ -85,22 +85,20 @@ class ConvDesc_v8 : public BackendDescriptor {
         return ss.str();
     }
 
-    ConvDesc_v8(ConvDesc_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          compute_precision(from.compute_precision),
-          mode(from.mode),
-          nDims(from.nDims) {
-        std::copy(std::begin(from.padLower), std::end(from.padLower), padLower);
-        std::copy(std::begin(from.padUpper), std::end(from.padUpper), padUpper);
-        std::copy(std::begin(from.dilation), std::end(from.dilation), dilation);
-        std::copy(std::begin(from.stride), std::end(from.stride), stride);
-    }
+    ConvDesc_v8(ConvDesc_v8 &&from) = default;
+    ConvDesc_v8 &
+    operator=(ConvDesc_v8 &&) = default;
 
     ~ConvDesc_v8() = default;
 
     cudnnDataType_t
     getComputePrecision() const {
         return compute_precision;
+    }
+
+    int64_t
+    getDimensionCount() const {
+        return nDims;
     }
 
    private:

--- a/include/cudnn_frontend_ConvDesc.h
+++ b/include/cudnn_frontend_ConvDesc.h
@@ -97,7 +97,7 @@ class ConvDesc_v8 : public BackendDescriptor {
     }
 
     int64_t
-    getDimensionCount() const {
+    getSpatialDimensionCount() const {
         return nDims;
     }
 

--- a/include/cudnn_frontend_Engine.h
+++ b/include/cudnn_frontend_Engine.h
@@ -205,6 +205,8 @@ class Engine_v8 : public BackendDescriptor {
         }
         buildKnobs();
     }
+    Engine_v8 &
+    operator=(Engine_v8 &&) = default;
     ~Engine_v8() = default;
 
     std::string const &

--- a/include/cudnn_frontend_EngineConfig.h
+++ b/include/cudnn_frontend_EngineConfig.h
@@ -58,13 +58,11 @@ class EngineConfig_v8 : public BackendDescriptor {
         ss << " Number of knobs: " << numKnobs;
         return ss.str();
     }
-    EngineConfig_v8(EngineConfig_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          engine(from.engine),
-          numKnobs(from.numKnobs),
-          opGraphTag(from.opGraphTag) {
-        bChoices = from.bChoices;
-    }
+    EngineConfig_v8 &
+    operator=(EngineConfig_v8 &&from) = default;
+
+    EngineConfig_v8(EngineConfig_v8 &&from) = default;
+
     ~EngineConfig_v8() = default;
 
     std::string const &

--- a/include/cudnn_frontend_Heuristics.h
+++ b/include/cudnn_frontend_Heuristics.h
@@ -54,11 +54,9 @@ class EngineHeuristics_v8 : public BackendDescriptor {
         return ss.str();
     }
 
-    EngineHeuristics_v8(EngineHeuristics_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          mode(from.mode),
-          opGraph(from.opGraph),
-          opGraphTag(from.opGraphTag) {}
+    EngineHeuristics_v8(EngineHeuristics_v8 &&from) = default;
+    EngineHeuristics_v8 &
+    operator= (EngineHeuristics_v8 &&from) = default;
 
     ~EngineHeuristics_v8() = default;
 

--- a/include/cudnn_frontend_MatMulDesc.h
+++ b/include/cudnn_frontend_MatMulDesc.h
@@ -55,9 +55,9 @@ class MatMulDesc_v8 : public BackendDescriptor {
         return ss.str();
     }
 
-    MatMulDesc_v8(MatMulDesc_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          math_precision(from.math_precision) {}
+    MatMulDesc_v8(MatMulDesc_v8 &&from) = default;
+    MatMulDesc_v8 &
+    operator= (MatMulDesc_v8 &&from) = default;
 
     ~MatMulDesc_v8() = default;
 

--- a/include/cudnn_frontend_Operation.h
+++ b/include/cudnn_frontend_Operation.h
@@ -92,33 +92,10 @@ class Operation_v8 : public BackendDescriptor {
         ss << " Beta: " << beta_s << " " << beta_d;
         return ss.str();
     }
-    Operation_v8(Operation_v8 &&from)
-        : BackendDescriptor(from.pointer, from.get_status(), from.get_error()),
-          op_mode(from.op_mode),
-          xdesc(from.xdesc),
-          ydesc(from.ydesc),
-          wdesc(from.wdesc),
-          bdesc(from.bdesc),
-          dydesc(from.dydesc),
-          dxdesc(from.dxdesc),
-          dwdesc(from.dwdesc),
-          cdesc(from.cdesc),
-          amatdesc(from.amatdesc),
-          bmatdesc(from.bmatdesc),
-          cmatdesc(from.cmatdesc),
-          pwdesc(from.pwdesc),
-          matmuldesc(from.matmuldesc),
-          reductiondesc(from.reductiondesc),
-          alphabetaType(from.alphabetaType),
-          alpha_s(from.alpha_s),
-          beta_s(from.beta_s),
-          alpha2_s(from.alpha2_s),
-          alpha_d(from.alpha_d),
-          beta_d(from.beta_d),
-          alpha2_d(from.alpha2_d),
-          pointwise_port_count(from.pointwise_port_count),
-          pointwise_mode(from.pointwise_mode),
-          operationTag(from.operationTag) {}
+
+    Operation_v8(Operation_v8 &&from) = default;
+    Operation_v8 &
+    operator= (Operation_v8 &&from) = default;
 
     ManagedOpaqueDescriptor
     getOutputTensor() {

--- a/include/cudnn_frontend_OperationGraph.h
+++ b/include/cudnn_frontend_OperationGraph.h
@@ -58,12 +58,9 @@ class OperationGraph_v8 : public BackendDescriptor {
         return ss.str();
     }
 
-    OperationGraph_v8(OperationGraph_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          handle(from.handle),
-          ops(from.ops),
-          numOps(from.numOps),
-          opGraphTag(from.opGraphTag) {}
+    OperationGraph_v8(OperationGraph_v8 &&from) = default;
+    OperationGraph_v8 &
+    operator= (OperationGraph_v8 &&from) = default;
 
     ~OperationGraph_v8() = default;
 

--- a/include/cudnn_frontend_PointWiseDesc.h
+++ b/include/cudnn_frontend_PointWiseDesc.h
@@ -97,17 +97,9 @@ class PointWiseDesc_v8 : public BackendDescriptor {
         return mode;
     }
 
-    PointWiseDesc_v8(PointWiseDesc_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          math_precision(from.math_precision),
-          mode(from.mode),
-          nan_propagation(from.nan_propagation),
-          upper_clip(from.upper_clip),
-          lower_clip(from.lower_clip),
-          lower_clip_slope(from.lower_clip_slope),
-          elu_alpha(from.elu_alpha),
-          softplus_beta(from.softplus_beta),
-          swish_beta(from.swish_beta) {}
+    PointWiseDesc_v8(PointWiseDesc_v8 &&from) = default;
+    PointWiseDesc_v8 &
+    operator= (PointWiseDesc_v8 &&from) = default; 
 
     ~PointWiseDesc_v8() = default;
 

--- a/include/cudnn_frontend_ReductionDesc.h
+++ b/include/cudnn_frontend_ReductionDesc.h
@@ -56,10 +56,9 @@ class ReductionDesc_v8 : public BackendDescriptor {
         return ss.str();
     }
 
-    ReductionDesc_v8(ReductionDesc_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          math_precision(from.math_precision),
-          reduction_op(from.reduction_op) {}
+    ReductionDesc_v8(ReductionDesc_v8 &&from) = default;
+    ReductionDesc_v8 &
+    operator= (ReductionDesc_v8 &&from) = default; 
 
     ~ReductionDesc_v8() = default;
 

--- a/include/cudnn_frontend_Reorder_Tensor.h
+++ b/include/cudnn_frontend_Reorder_Tensor.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <iostream>
+#include <utility>
+
+#include "cudnn_frontend_Tensor.h" 
+#include "cudnn_frontend_ConvDesc.h" 
+
+namespace cudnn_frontend {
+
+static cudnnStatus_t 
+cudnnReorderFilterAndBiasInt8x32(cudnnHandle_t handle, 
+        const Tensor_v8 &tensor, 
+        const ConvDesc_v8 &conv_desc,
+        void *dev_filter_ptr, void *reordered_filter_ptr,
+        void *dev_bias_ptr,   void *reordered_bias_ptr) {
+
+    auto cudnn_status = CUDNN_STATUS_SUCCESS;
+
+    if (dev_filter_ptr && reordered_filter_ptr == nullptr) {
+        return CUDNN_STATUS_BAD_PARAM;
+    }
+    if (dev_bias_ptr && reordered_bias_ptr == nullptr) {
+        return CUDNN_STATUS_BAD_PARAM;
+    }
+
+    cudnnFilterDescriptor_t filterDesc = nullptr;
+
+    cudnn_status = cudnnCreateFilterDescriptor(&filterDesc);
+    if (cudnn_status != CUDNN_STATUS_SUCCESS) {return cudnn_status;}
+
+    auto conv_dims       = conv_desc.getDimensionCount();
+    auto tensor_dims     = tensor.getDimensionCount();
+    auto non_shape_dims  = tensor_dims - conv_dims;
+    
+    if (non_shape_dims != 2 && non_shape_dims != 3) {
+        return CUDNN_STATUS_BAD_PARAM;
+    }
+
+    if (conv_dims != 2 && conv_dims != 3) {
+        return CUDNN_STATUS_BAD_PARAM;
+    }
+
+    int filter_dims_[5] = {1,1,1,1,1};
+    int64_t const * filter_dims = tensor.getDimArray();
+    filter_dims_[0] = static_cast<int> (filter_dims[0]); // n
+    filter_dims_[1] = static_cast<int> ((non_shape_dims == 2) ? filter_dims[1] : filter_dims[2]) * 32; // c
+    filter_dims_[2] = static_cast<int> ((non_shape_dims == 2) ? filter_dims[2] : filter_dims[3]); // d/h
+    filter_dims_[3] = static_cast<int> ((non_shape_dims == 2) ? filter_dims[3] : filter_dims[4]); // h/w
+    if (conv_dims == 3) {
+        filter_dims_[4] = static_cast<int> ((non_shape_dims == 2) ? filter_dims[4] : filter_dims[5]); // w
+    }
+
+    cudnn_status = cudnnSetFilterNdDescriptor(filterDesc, CUDNN_DATA_INT8x32, CUDNN_TENSOR_NCHW_VECT_C, conv_dims + 2, filter_dims_);
+
+    if (cudnn_status != CUDNN_STATUS_SUCCESS) {return cudnn_status;}
+
+    int reorderBias = (dev_bias_ptr != nullptr);
+
+    cudnn_status = cudnnReorderFilterAndBias(handle,
+        filterDesc, CUDNN_DEFAULT_REORDER, dev_filter_ptr, reordered_filter_ptr, reorderBias, dev_bias_ptr, reordered_bias_ptr);
+
+    cudnnDestroyFilterDescriptor(filterDesc);
+    return cudnn_status;
+}
+}

--- a/include/cudnn_frontend_Reorder_Tensor.h
+++ b/include/cudnn_frontend_Reorder_Tensor.h
@@ -56,7 +56,7 @@ cudnnReorderFilterAndBiasInt8x32(cudnnHandle_t handle,
     cudnn_status = cudnnCreateFilterDescriptor(&filterDesc);
     if (cudnn_status != CUDNN_STATUS_SUCCESS) {return cudnn_status;}
 
-    auto conv_dims       = conv_desc.getDimensionCount();
+    auto conv_dims       = conv_desc.getSpatialDimensionCount();
     auto tensor_dims     = tensor.getDimensionCount();
     auto non_shape_dims  = tensor_dims - conv_dims;
     

--- a/include/cudnn_frontend_Tensor.h
+++ b/include/cudnn_frontend_Tensor.h
@@ -73,16 +73,28 @@ class Tensor_v8 : public BackendDescriptor {
         return ss.str();
     }
 
-    Tensor_v8(Tensor_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          data_type(from.data_type),
-          id(from.id),
-          alignment(from.alignment),
-          nDims(from.nDims),
-          isVirtual(from.isVirtual) {
-        std::copy(std::begin(from.btensor_dimA), std::end(from.btensor_dimA), btensor_dimA);
-        std::copy(std::begin(from.btensor_strA), std::end(from.btensor_strA), btensor_strA);
+    int64_t
+    getPackedElementCount() const {
+        int64_t count = vectorCount;
+        for (auto i = 0; i < nDims; i++) {
+            count = count * btensor_dimA[i];
+        }
+        return count;
+    };
+
+    int64_t
+    getDimensionCount() const {
+        return nDims;
     }
+
+    int64_t const *
+    getDimArray() const {
+        return btensor_dimA;
+    }
+
+    Tensor_v8(Tensor_v8 &&from) = default;
+    Tensor_v8 &
+    operator=(Tensor_v8 &&) = default;
 
     ~Tensor_v8() = default;
 
@@ -320,4 +332,5 @@ class TensorBuilder_v8 {
    private:
     Tensor_v8 m_tensor;  //! Tensor built by the TensorBuilder class.
 };
+
 }

--- a/include/cudnn_frontend_VariantPack.h
+++ b/include/cudnn_frontend_VariantPack.h
@@ -59,13 +59,11 @@ class VariantPack_v8 : public BackendDescriptor {
            << " has " << num_ptrs << " data pointers";
         return ss.str();
     }
-    VariantPack_v8(VariantPack_v8 &&from)
-        : BackendDescriptor(from.get_desc(), from.get_status(), from.get_error()),
-          workspace(from.workspace),
-          num_ptrs(from.num_ptrs) {
-        std::copy(std::begin(from.data_pointers), std::end(from.data_pointers), data_pointers);
-        std::copy(std::begin(from.uid), std::end(from.uid), uid);
-    }
+
+    VariantPack_v8(VariantPack_v8 &&from) = default;
+    VariantPack_v8 &
+    operator=(VariantPack_v8 &&from) = default;
+
     ~VariantPack_v8() = default;
 
    private:

--- a/samples/conv_sample.h
+++ b/samples/conv_sample.h
@@ -166,3 +166,16 @@ void run_dp4a(
     int64_t vectorCount,
     int64_t vectorDimension);
 
+void run_imma(
+    int64_t* dimA_padded,
+    int64_t* padA,
+    int64_t* convstrideA,
+    int64_t* dilationA,
+    int64_t* filterdimA_padded,
+    int64_t* outdimA_padded,
+    cudnnConvolutionMode_t mode,
+    void * devPtrI,
+    void * devPtrF,
+    void * devPtrO,
+    int64_t vectorCount,
+    int64_t vectorDimension);


### PR DESCRIPTION
[Bug Fix] : Fixed an issue where the vector count was not copied over during move construction phase of Tensor.
[Samples]: New sample added for Int8x32 data type. 
[Errata]: Added an errata filter which blocks engine from running when data type is int8x32, since they may produce numerically wrong results.
[CleanUp]: Change all move constructors to default and fixed move assignment operator.