### PR TITLE
cudnnFrontend v0.6 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ else()
 link_directories(/usr/local/cuda/lib64)
 endif()
 
+if(DEFINED ENV{CUDNN_PATH})
+link_directories($ENV{CUDNN_PATH}/lib64)
+endif()
+
 add_executable(Samples samples/conv_sample.cpp 
                        samples/test_list.cpp 
                        samples/fp16_emu.cpp 
@@ -24,12 +28,18 @@ add_executable(Samples samples/conv_sample.cpp
                        samples/fusion_sample.cpp 
                        samples/mha_sample.cpp)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
 if(DEFINED ENV{CUDA_PATH})
     target_include_directories(Samples PUBLIC $ENV{CUDA_PATH}/include/)
     target_include_directories(Samples PUBLIC $ENV{CUDA_PATH}/targets/ppc64le-linux/include)
 else()
     target_include_directories(Samples PUBLIC /usr/local/cuda/include/)
     target_include_directories(Samples PUBLIC /usr/local/cuda/targets/ppc64le-linux/include)
+endif()
+
+if(DEFINED ENV{CUDNN_PATH})
+    target_include_directories(Samples PUBLIC $ENV{CUDNN_PATH}/include/)
 endif()
 
 if(DEFINED ENV{CUDNN_FRONTEND_PATH})

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "CUDNN Frontend API"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 8.3.0
+PROJECT_NUMBER         = 8.4.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Sample tests are written using the [Catch2](https://github.com/catchorg/Catch2) 
 
      mkdir build; cd build
      cmake ..
+     make
      ./Samples
     
 ## cudnnFindPlan and cudnnGetPlan:
@@ -94,6 +95,13 @@ cuDNN through heuristics provides a way to query a list of good engine configs. 
 
 PS: ExecutionPlanCaching today supports only single operation operation_graphs.
 
+## Execution Plan Serialization and Deserialization (Experimental)
+cuDNN v8.4 and above provides exeuction plan serialization and deserialization to save the execution plan as a string in JSON format. The execution plan can be then restored from that string at a later point, and this also saves compilation time compared to rebuilding the plan from scratch. Currently, this is an experimental feature that only supports the runtime fusion engine. No forward/backward or cross-device compatibility guarantee is offered at this time.
+
+### API:
+    - std::string cudnn_frontend::ExecutionPlan_v8::getJsonRepresentation() : Serialize the execution plan into a string in JSON format.
+    - cudnn_frontend::ExecutionPlan_v8&& cudnn_frontend::ExecutionPlanBuilder_v8::loadFromJson(const std::string &json_plan) : Deserialize from a string containing the JSON representation of the execution plan.
+
 ## Logging
 cuDNN Frontend API logging records execution flow through cuDNN frontend API. This functionality is disabled by default, and can be enabled through methods described in this section.
 
@@ -107,7 +115,6 @@ cuDNN Frontend API logging records execution flow through cuDNN frontend API. Th
 ### Method 2: Using API calls:
 Calling `cudnn_frontend::isLoggingEnabled() = true|false` has same effect of setting the environment variable.
 Calling `cudnn_frontend::getStream() = stream_name` can be used to assign the output stream directly. 
-
 
 ## Documentation
 Documentation can be found at https://nvidia.github.io/cudnn-frontend/

--- a/include/cudnn_frontend_EngineConfigGenerator.h
+++ b/include/cudnn_frontend_EngineConfigGenerator.h
@@ -111,7 +111,9 @@ filter(Predicate pred, executionPlans_t &plans) -> executionPlans_t {
             getLogger() << "and Added ";
             filtered_plans.emplace_back(std::move(plan));
         }
-        getLogger() << filtered_plans.back().getTag() << std::endl;
+        if (filtered_plans.size()) {
+            getLogger() << filtered_plans.back().getTag() << std::endl;
+        }
     }
     getLogger() << "[cudnn_frontend] Filtered plans count " << filtered_plans.size() << std::endl;
     return filtered_plans;

--- a/include/cudnn_frontend_ExecutionPlanCache.h
+++ b/include/cudnn_frontend_ExecutionPlanCache.h
@@ -86,7 +86,7 @@ class ExecutionPlanCache_v1 {
                     return true;
                 }
             }
-	    return false;
+            return false;
         }
     };
 

--- a/include/cudnn_frontend_Reorder_Tensor.h
+++ b/include/cudnn_frontend_Reorder_Tensor.h
@@ -56,8 +56,8 @@ cudnnReorderFilterAndBiasInt8x32(cudnnHandle_t handle,
     cudnn_status = cudnnCreateFilterDescriptor(&filterDesc);
     if (cudnn_status != CUDNN_STATUS_SUCCESS) {return cudnn_status;}
 
-    auto conv_dims       = conv_desc.getDimensionCount();
-    auto tensor_dims     = tensor.getDimensionCount();
+    int conv_dims        = conv_desc.getDimensionCount();
+    int tensor_dims      = tensor.getDimensionCount();
     auto non_shape_dims  = tensor_dims - conv_dims;
     
     if (non_shape_dims != 2 && non_shape_dims != 3) {

--- a/include/cudnn_frontend_get_plan.h
+++ b/include/cudnn_frontend_get_plan.h
@@ -39,6 +39,7 @@ EngineConfigGenerator::cudnnGetPlan(cudnnHandle_t handle, OperationGraph & opGra
             getLogger() << "[cudnn_frontend] Added plan " << plans.back().getTag() << " " << to_string(plans.back().get_status()) << std::endl;
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
         } catch (cudnnException &e) {
+            (void)e;
             continue;
         }
 #endif

--- a/samples/fusion_sample.cpp
+++ b/samples/fusion_sample.cpp
@@ -24,6 +24,12 @@
 #include <cudnn_frontend.h>
 #include "error_util.h"
 
+bool
+allowAll(cudnnBackendDescriptor_t engine_config) {
+    (void)engine_config;
+    return false;
+}
+
 #if (CUDNN_VERSION >= 8200)
 bool
 isRuntimeCompilation(cudnnBackendDescriptor_t engine_config) {
@@ -59,16 +65,20 @@ get_execplan_from_heuristics_else_fall_back(cudnn_frontend::OperationGraph&& opG
 #endif
 
     {
-        auto total_engines = opGraph.getEngineCount();
-        std::cout << opGraph.describe() << " has " << total_engines << " engines." << std::endl;
-        auto engine = cudnn_frontend::EngineBuilder().setGlobalEngineIdx(0).setOperationGraph(opGraph).build();
-        std::cout << engine.describe() << std::endl;
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = 
+            cudnn_frontend::get_heuristics_list<1>({
+            "heuristics_fallback"
+            }, opGraph,::allowAll, filtered_configs, true);
+        
+        std::cout << "get_heuristics_list Statuses: ";
+        for (auto i = 0 ; i < statuses.size(); i++) {
+            std::cout << cudnn_frontend::to_string(statuses[i]) << " ";
+        }
+        std::cout << std::endl;
+        std::cout << "Filter config list has " << filtered_configs.size() << " configurations " << std::endl;
 
-        auto engine_config = cudnn_frontend::EngineConfigBuilder().setEngine(engine).build();
-
-        std::cout << engine_config.describe() << std::endl;
-
-        return cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(engine_config).build();
+        return cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
     }
 }
 
@@ -326,7 +336,9 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
             std::cout << "Fusion with float inputs is only supported on Ampere or later" << std::endl;
         } else {
             std::cout << "[ERROR] Exception " << e.what() << std::endl;
+#if (CUDNN_VERSION >= 8300)
             CHECK(false);
+#endif
         }
     }
 }
@@ -548,8 +560,621 @@ run_conv_bias_scale_relu(int64_t* x_dim,
             std::cout << "Example is only supported for Ampere GPUs" << std::endl;
         } else {
             std::cout << "[ERROR] Exception " << e.what() << std::endl;
+#if (CUDNN_VERSION >= 8300)
             CHECK(false);
+#endif
         }
+    }
+}
+
+void
+run_serialization_conv_bias_scale_relu(int64_t* x_dim,
+                         int64_t* w_dim,
+                         int64_t* y_dim,
+                         int64_t* b_dim,
+                         int64_t* s_dim,
+                         cudnnDataType_t dataType,
+                         int convDim,
+                         int64_t* conv_padA,
+                         int64_t* conv_dilationA,
+                         int64_t* conv_strideA,
+                         void* devPtrX,
+                         void* devPtrW,
+                         void* devPtrY,
+                         void* devPtrB,
+                         void* devPtrS) {
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // Creates the necessary tensor descriptors
+        int64_t stride[4];
+        generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto xTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, x_dim)
+                           .setStrides(4, stride)
+                           .setId('x')
+                           .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                           .setDataType(dataType)
+                           .build();
+        generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto wTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, w_dim)
+                           .setStrides(4, stride)
+                           .setId('w')
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+
+        generateStrides(b_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto bTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, b_dim)
+                           .setStrides(4, stride)
+                           .setId('b')
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+        generateStrides(s_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto sTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, s_dim)
+                           .setStrides(4, stride)
+                           .setId('s')
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+
+        generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto afterConvTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStrides(4, stride)
+                                   .setId('A')  // after conv
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(dataType)
+                                   .build();
+        auto afterBiasTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStrides(4, stride)
+                                   .setId('B')  // after bias
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(dataType)
+                                   .build();
+        auto afterScaleTensor = cudnn_frontend::TensorBuilder()
+                                    .setDim(4, y_dim)
+                                    .setStrides(4, stride)
+                                    .setId('C')  // after scale
+                                    .setAlignment(16)
+                                    .setVirtual()
+                                    .setDataType(dataType)
+                                    .build();
+        auto yTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, y_dim)
+                           .setStrides(4, stride)
+                           .setId('y')  // output
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+
+        std::cout << xTensor.describe() << std::endl;
+        std::cout << wTensor.describe() << std::endl;
+        std::cout << bTensor.describe() << std::endl;
+        std::cout << sTensor.describe() << std::endl;
+        std::cout << afterConvTensor.describe() << std::endl;
+        std::cout << afterBiasTensor.describe() << std::endl;
+        std::cout << afterScaleTensor.describe() << std::endl;
+        std::cout << yTensor.describe() << std::endl;
+
+        // Define the bias descriptor
+        auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .build();
+        std::cout << biasDesc.describe() << std::endl;
+
+        // Define the scale descriptor
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_MUL)
+                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << scaleDesc.describe() << std::endl;
+
+        // Define the activation descriptor
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_RELU_FWD)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        std::cout << actDesc.describe() << std::endl;
+
+        // Define the convolution problem
+        auto convDesc = cudnn_frontend::ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, conv_strideA)
+                            .setPrePadding(convDim, conv_padA)
+                            .setPostPadding(convDim, conv_padA)
+                            .setDilation(convDim, conv_dilationA)
+                            .build();
+        std::cout << convDesc.describe() << std::endl;
+
+        float alpha = 1.0f;
+        float beta  = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                           .setxDesc(xTensor)
+                           .setwDesc(wTensor)
+                           .setyDesc(afterConvTensor)
+                           .setcDesc(convDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        std::cout << conv_op.describe() << std::endl;
+
+        // Create a Bias Node.
+        auto bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(conv_op.getOutputTensor())
+                           .setbDesc(bTensor)
+                           .setyDesc(afterBiasTensor)
+                           .setpwDesc(biasDesc)
+                           .build();
+        std::cout << bias_op.describe() << std::endl;
+
+        // Create a Multiplication Node with scaling parameters.
+        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(bias_op.getOutputTensor())
+                            .setbDesc(sTensor)
+                            .setyDesc(afterScaleTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << scale_op.describe() << std::endl;
+
+        // Create an Activation Node.
+        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(scale_op.getOutputTensor())
+                          .setyDesc(yTensor)
+                          .setpwDesc(actDesc)
+                          .build();
+        std::cout << act_op.describe() << std::endl;
+
+        // Create an Operation Graph. In this case it is convolution bias scale activation
+        std::array<cudnn_frontend::Operation const*, 4> ops = {&conv_op, &bias_op, &scale_op, &act_op};
+
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(ops.size(), ops.data())
+                           .build();
+
+
+        std::string plan_json;
+        {
+            // Suppose this is how execution plans are normally created
+            auto plan_tmp = get_execplan_from_heuristics_else_fall_back(std::move(opGraph), handle_);
+            // Generate a JSON serialization of the execution plan
+            plan_json = plan_tmp.getJsonRepresentation();
+            // Optionally save to a file, etc...
+            // std::ofstream output_file("execution_plan.json");
+            // output_file << plan_json;
+            // The temporary execution plan can now be discarded.
+        }
+        // Load the plan from a JSON string.
+        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).loadFromJson(plan_json);
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+        void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrB, devPtrS};
+        int64_t uids[]    = {'x', 'y', 'w', 'b', 's'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(5, data_ptrs)
+                               .setUids(5, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+        // this example is only for Ampere cards
+        if (prop.major < 8 &&
+            (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+            std::cout << "Example is only supported for Ampere GPUs" << std::endl;
+        } else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+#if (CUDNN_VERSION >= 8400)
+            CHECK(false);
+#endif
+        }
+    }
+}
+
+void
+run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
+                              int64_t* w_dim,
+                              int64_t* y_dim,
+                              int64_t* s_dim,
+                              int64_t* b_dim,
+                              int64_t* threshold_dim,
+                              cudnnDataType_t dataType,
+                              int convDim,
+                              int64_t* conv_padA,
+                              int64_t* conv_dilationA,
+                              int64_t* conv_strideA,
+                              int axis,
+                              void* devPtrX,
+                              void* devPtrW,
+                              void* devPtrY,
+                              void* devPtrS,
+                              void* devPtrB,
+                              void* devPtrTopThreshold,
+                              void* devPtrBottomThreshold) {
+    cudnnHandle_t handle_;
+    try {
+#if (CUDNN_VERSION >= 8400)
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // Creates the necessary tensor descriptors
+        int64_t stride[4];
+        generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto xTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, x_dim)
+                           .setStrides(4, stride)
+                           .setId('x')
+                           .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                           .setDataType(dataType)
+                           .build();
+        generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto wTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, w_dim)
+                           .setStrides(4, stride)
+                           .setId('w')
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+        generateStrides(s_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto sTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, s_dim)
+                           .setStrides(4, stride)
+                           .setId('s')
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+
+        generateStrides(b_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto bTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, b_dim)
+                           .setStrides(4, stride)
+                           .setId('b')
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+
+        generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto afterConvTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStrides(4, stride)
+                                   .setId('A')  // after conv
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+        auto afterScaleTensor = cudnn_frontend::TensorBuilder()
+                                    .setDim(4, y_dim)
+                                    .setStrides(4, stride)
+                                    .setId('B')  // after scale
+                                    .setAlignment(16)
+                                    .setVirtual()
+                                    .setDataType(CUDNN_DATA_FLOAT)
+                                    .build();
+        auto afterBiasTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStrides(4, stride)
+                                   .setId('C')  // after bias
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+
+        auto afterActivationTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStrides(4, stride)
+                                   .setId('D')  // after activation
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+
+        auto genIndexTensor = cudnn_frontend::TensorBuilder()
+                                .setDim(4, y_dim)
+                                .setStrides(4, stride)
+                                .setId('I')  // output of the gen index operation
+                                .setAlignment(16)
+                                .setVirtual()
+                                .setDataType(CUDNN_DATA_INT32)
+                                .build();
+
+        auto maskTopTensor = cudnn_frontend::TensorBuilder()
+                                .setDim(4, y_dim)
+                                .setStrides(4, stride)
+                                .setId('m')  // top half of the mask created after the less than
+                                .setAlignment(16)
+                                .setVirtual()
+                                .setDataType(CUDNN_DATA_BOOLEAN)
+                                .build();
+
+        auto maskBottomTensor = cudnn_frontend::TensorBuilder()
+                                .setDim(4, y_dim)
+                                .setStrides(4, stride)
+                                .setId('n')  // bottom half of the mask
+                                .setAlignment(16)
+                                .setVirtual()
+                                .setDataType(CUDNN_DATA_BOOLEAN)
+                                .build();
+
+        auto maskTensor = cudnn_frontend::TensorBuilder()
+                                .setDim(4, y_dim)
+                                .setStrides(4, stride)
+                                .setId('M')  // OR of the top and bottom masks
+                                .setAlignment(16)
+                                .setVirtual()
+                                .setDataType(CUDNN_DATA_BOOLEAN)
+                                .build();
+
+        auto yTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, y_dim)
+                           .setStrides(4, stride)
+                           .setId('y')  // output
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+
+        generateStrides(threshold_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto thresholdTopTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, threshold_dim)
+                           .setStrides(4, stride)
+                           .setId('t')  // threshold for creating the top mask
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_INT32)
+                           .build();
+
+        auto thresholdBottomTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, threshold_dim)
+                           .setStrides(4, stride)
+                           .setId('u')  // threshold for creating the bottom mask
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_INT32)
+                           .build();
+
+
+        std::cout << xTensor.describe() << std::endl;
+        std::cout << wTensor.describe() << std::endl;
+        std::cout << bTensor.describe() << std::endl;
+        std::cout << sTensor.describe() << std::endl;
+        std::cout << afterConvTensor.describe() << std::endl;
+        std::cout << afterBiasTensor.describe() << std::endl;
+        std::cout << afterScaleTensor.describe() << std::endl;
+        std::cout << afterActivationTensor.describe() << std::endl;
+        std::cout << genIndexTensor.describe() << std::endl;
+        std::cout << maskTopTensor.describe() << std::endl;
+        std::cout << maskBottomTensor.describe() << std::endl;
+        std::cout << maskTensor.describe() << std::endl;
+        std::cout << yTensor.describe() << std::endl;
+        std::cout << thresholdTopTensor.describe() << std::endl;
+        std::cout << thresholdBottomTensor.describe() << std::endl;
+
+        // Define the convolution problem
+        auto convDesc = cudnn_frontend::ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, conv_strideA)
+                            .setPrePadding(convDim, conv_padA)
+                            .setPostPadding(convDim, conv_padA)
+                            .setDilation(convDim, conv_dilationA)
+                            .build();
+        std::cout << convDesc.describe() << std::endl;
+
+        // Define the scale descriptor
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_MUL)
+                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << scaleDesc.describe() << std::endl;
+
+        // Define the bias descriptor
+        auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .build();
+        std::cout << biasDesc.describe() << std::endl;
+
+        // Define the activation descriptor
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_RELU_FWD)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        std::cout << actDesc.describe() << std::endl;
+
+        // Define the genIndex descriptor
+        auto genIndexDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_GEN_INDEX)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setAxis(axis)
+                           .build();
+        std::cout << genIndexDesc.describe() << std::endl;
+
+        // Define the lessThan descriptor
+        auto lessThanDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_CMP_LT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        std::cout << lessThanDesc.describe() << std::endl;
+
+        // Define the greaterThan descriptor
+        auto greaterThanDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_CMP_GT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        std::cout << greaterThanDesc.describe() << std::endl;
+
+        // Define the logical_or descriptor
+        auto logicalOrDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_LOGICAL_OR)
+                           .setMathPrecision(CUDNN_DATA_BOOLEAN)
+                           .build();
+        std::cout << logicalOrDesc.describe() << std::endl;
+
+        // Define the binary_selection descriptor
+        auto selectionDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_BINARY_SELECT)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .build();
+        std::cout << selectionDesc.describe() << std::endl;
+
+        float alpha = 1.0f;
+        float beta  = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                           .setxDesc(xTensor)
+                           .setwDesc(wTensor)
+                           .setyDesc(afterConvTensor)
+                           .setcDesc(convDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        std::cout << conv_op.describe() << std::endl;
+
+        // Create a Multiplication Node with scaling parameters.
+        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(afterConvTensor)
+                            .setbDesc(sTensor)
+                            .setyDesc(afterScaleTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << scale_op.describe() << std::endl;
+
+        // Create a Bias Node.
+        auto bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(afterScaleTensor)
+                           .setbDesc(bTensor)
+                           .setyDesc(afterBiasTensor)
+                           .setpwDesc(biasDesc)
+                           .build();
+        std::cout << bias_op.describe() << std::endl;
+        
+
+        // Create an Activation Node.
+        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(afterBiasTensor)
+                          .setyDesc(afterActivationTensor)
+                          .setpwDesc(actDesc)
+                          .build();
+        std::cout << act_op.describe() << std::endl;
+
+        // Create a Gen_Index Node.
+        auto genIndex_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(afterActivationTensor)
+                          .setyDesc(genIndexTensor)
+                          .setpwDesc(genIndexDesc)
+                          .build();
+        std::cout << genIndex_op.describe() << std::endl;
+
+        // Create a LessThan Node.
+        auto lessThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(genIndexTensor)
+                          .setbDesc(thresholdTopTensor)
+                          .setyDesc(maskTopTensor)
+                          .setpwDesc(lessThanDesc)
+                          .build();
+        std::cout << lessThan_op.describe() << std::endl;
+
+        // Create a GreaterThan Node.
+        auto greaterThan_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(genIndexTensor)
+                          .setbDesc(thresholdBottomTensor)
+                          .setyDesc(maskBottomTensor)
+                          .setpwDesc(greaterThanDesc)
+                          .build();
+        std::cout << greaterThan_op.describe() << std::endl;
+
+        // Create a LogicalOr Node.
+        auto logicalOr_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(maskTopTensor)
+                          .setbDesc(maskBottomTensor)
+                          .setyDesc(maskTensor)
+                          .setpwDesc(logicalOrDesc)
+                          .build();
+        std::cout << logicalOr_op.describe() << std::endl;
+
+        // Create a Binary_Selection Node.
+        auto selection_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(afterConvTensor)
+                          .setbDesc(afterActivationTensor)
+                          .settDesc(maskTensor)
+                          .setyDesc(yTensor)
+                          .setpwDesc(selectionDesc)
+                          .build();
+        std::cout << selection_op.describe() << std::endl;
+
+        // Create an Operation Graph. In this case it is convolution bias scale activation
+        std::array<cudnn_frontend::Operation const*, 9> ops = {&conv_op, &scale_op, &bias_op, &act_op, &genIndex_op, &lessThan_op, &greaterThan_op, &logicalOr_op, &selection_op};
+
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(ops.size(), ops.data())
+                           .build();
+
+        // How many engines support this operation graph ?
+        auto plan = get_execplan_from_heuristics_else_fall_back(std::move(opGraph), handle_);
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+        void* data_ptrs[] = {devPtrX, devPtrY, devPtrW, devPtrS, devPtrB, devPtrTopThreshold, devPtrBottomThreshold};
+        int64_t uids[]    = {'x', 'y', 'w', 's', 'b', 't', 'u'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(7, data_ptrs)
+                               .setUids(7, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+        
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+#endif
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        std::cout << "[ERROR] Exception " << e.what() << std::endl;
+        CHECK(false);
     }
 }
 
@@ -770,7 +1395,9 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
             std::cout << "Example is only supported for Ampere GPUs" << std::endl; 
         }  else {
             std::cout << "[ERROR] Exception " << e.what() << std::endl;
+#if (CUDNN_VERSION >= 8300)
             CHECK(false);
+#endif
         }
     }
 }
@@ -941,7 +1568,9 @@ run_matmul_bias_gelu(int64_t* a_dim,
             std::cout << "Fusion with float inputs is only supported on Ampere or later" << std::endl;
         } else {
             std::cout << "[ERROR] Exception " << e.what() << std::endl;
+#if (CUDNN_VERSION >= 8300)
             CHECK(false);
+#endif
         }
     }
 }
@@ -1406,5 +2035,411 @@ run_conv_reduction(int64_t* x_dim,
     } catch (cudnn_frontend::cudnnException& e) {
         std::cout << "[ERROR] Exception " << e.what() << std::endl;
         CHECK(false);
+    }
+}
+
+void
+run_bn_conv_gen_stat(int64_t* xTensorDim, 
+                    int64_t* wTensorDim, 
+                    int64_t* yTensorDim,
+                    int64_t* scaleTensorDim,  
+                    int convDim, 
+                    int64_t *conv_padA, 
+                    int64_t* conv_dilationA, 
+                    int64_t* conv_strideA, 
+                    void *XdevPtr, 
+                    void *WdevPtr, 
+                    void *YdevPtr,
+                    void *scaledevPtr, 
+                    void *biasdevPtr, 
+                    void *sumdevPtr, 
+                    void *sqSumdevPtr) {
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // Creates the necessary tensor descriptors
+        int64_t stride[4];
+        generateStrides(xTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto xTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, xTensorDim)
+                           .setStrides(4, stride)
+                           .setId('x')
+                           .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                           .setDataType(CUDNN_DATA_HALF)
+                           .build();
+        
+        auto afterScaleTensor = cudnn_frontend::TensorBuilder()
+                                .setDim(4, xTensorDim)
+                                .setStrides(4, stride)
+                                .setId('d')
+                                .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                                .setDataType(CUDNN_DATA_FLOAT)
+                                .setVirtual()
+                                .build();
+
+        auto afterBiasTensor = cudnn_frontend::TensorBuilder()
+                                .setDim(4, xTensorDim)
+                                .setStrides(4, stride)
+                                .setId('e')
+                                .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                                .setDataType(CUDNN_DATA_FLOAT)
+                                .setVirtual()
+                                .build();
+
+        auto afterReluTensor = cudnn_frontend::TensorBuilder()
+                                .setDim(4, xTensorDim)
+                                .setStrides(4, stride)
+                                .setId('f')
+                                .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                                .setDataType(CUDNN_DATA_FLOAT)
+                                .setVirtual()
+                                .build();
+
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto scaleTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, scaleTensorDim)
+                           .setStrides(4, stride)
+                           .setId('s')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_HALF)
+                           .build();
+
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto biasTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, scaleTensorDim)
+                           .setStrides(4, stride)
+                           .setId('b')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_HALF)
+                           .build();
+        generateStrides(wTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto wTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, wTensorDim)
+                           .setStrides(4, stride)
+                           .setId('w')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_HALF)
+                           .build();
+
+        generateStrides(yTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto yTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, yTensorDim)
+                                   .setStrides(4, stride)
+                                   .setId('y')  // after conv
+                                   .setAlignment(16)
+                                   .setDataType(CUDNN_DATA_HALF)
+                                   .build();
+
+        std::cout << xTensor.describe() << std::endl;
+        std::cout << wTensor.describe() << std::endl;
+        std::cout << yTensor.describe() << std::endl;
+
+        // Define the convolution problem
+        auto convDesc = cudnn_frontend::ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, conv_strideA)
+                            .setPrePadding(convDim, conv_padA)
+                            .setPostPadding(convDim, conv_padA)
+                            .setDilation(convDim, conv_dilationA)
+                            .build();
+        std::cout << convDesc.describe() << std::endl;
+
+                // Define the scale descriptor
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_MUL)
+                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << scaleDesc.describe() << std::endl;
+
+        // Define the bias descriptor
+        auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .build();
+        std::cout << biasDesc.describe() << std::endl;
+
+        // Define the activation descriptor
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_RELU_FWD)
+                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setReluLowerClipSlope(0.01)  // leaky relu
+                           .build();
+        std::cout << actDesc.describe() << std::endl;
+        std::cout << "Creating OPs " << std::endl;
+        // Create a Multiplication Node with scaling parameters.
+        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(xTensor)
+                            .setbDesc(scaleTensor)
+                            .setyDesc(afterScaleTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << scale_op.describe() << std::endl;
+
+        // Create a Bias Node.
+        auto bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(afterScaleTensor)
+                           .setbDesc(biasTensor)
+                           .setyDesc(afterBiasTensor)
+                           .setpwDesc(biasDesc)
+                           .build();
+        std::cout << bias_op.describe() << std::endl;
+
+        // Create an Activation Node.
+        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(afterBiasTensor)
+                          .setyDesc(afterReluTensor)
+                          .setpwDesc(actDesc)
+                          .build();
+        std::cout << act_op.describe() << std::endl;
+        float alpha = 1.0f;
+        float beta  = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                           .setxDesc(afterReluTensor)
+                           .setwDesc(wTensor)
+                           .setyDesc(yTensor)
+                           .setcDesc(convDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        std::cout << conv_op.describe() << std::endl;
+
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto sumTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, scaleTensorDim)
+                           .setStrides(4, stride)
+                           .setId('u')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_FLOAT)
+                           .build();
+
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto sqsumTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, scaleTensorDim)
+                           .setStrides(4, stride)
+                           .setId('v')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_FLOAT)
+                           .build();
+
+        //Create a genstats node
+        auto genstat_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_GEN_STATS_DESCRIPTOR)
+                    .setxDesc(yTensor)
+                    .setMathPrecision(CUDNN_DATA_FLOAT)
+                    .setGenStatsMode(CUDNN_GENSTATS_SUM_SQSUM)
+                    .setSumDesc(sumTensor)
+                    .setSqSumDesc(sqsumTensor)
+                    .build();
+        std::cout << genstat_op.describe() << std::endl;
+
+        // Create an Operation Graph. In this case it is scale bias Relu conv gen_stats
+        std::array<cudnn_frontend::Operation const*, 5> ops = {&scale_op, &bias_op, &conv_op, &act_op, &genstat_op};
+        auto opGraph = cudnn_frontend::OperationGraphBuilder().setHandle(handle_).setOperationGraph(ops.size(), ops.data()).build();
+        std::cout << opGraph.describe() << std::endl;
+
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = 
+            cudnn_frontend::get_heuristics_list<2>({"heuristics_instant" 
+            , "heuristics_fallback"
+            }, opGraph,::allowAll, filtered_configs, true);
+        
+        std::cout << "get_heuristics_list Statuses: ";
+        for (auto i = 0 ; i < statuses.size(); i++) {
+            std::cout << cudnn_frontend::to_string(statuses[i]) << " ";
+        }
+        std::cout << std::endl;
+        std::cout << "Filter config list has " << filtered_configs.size() << " configurations " << std::endl;
+
+        auto plan =
+            cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        void* data_ptrs[] = {XdevPtr, WdevPtr, YdevPtr, scaledevPtr, biasdevPtr, sumdevPtr, sqSumdevPtr};
+        int64_t uids[]    = {'x', 'w', 'y', 's', 'b', 'u', 'v'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(7, data_ptrs)
+                               .setUids(7, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+
+        // this example is only for Ampere cards
+        if (prop.major < 8 && e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED) {
+            std::cout << "Fusion with float inputs is only supported on Ampere or later" << std::endl;
+        } else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+#if (CUDNN_VERSION >= 8300)
+            CHECK(false);
+#endif
+        }
+    }
+}
+
+void
+run_bn_finalize( 
+    int64_t *perChannelSum, 
+    int64_t *epsilon,
+
+    void *YSumdevPtr, 
+    void *YSqSumdevPtr, 
+    void *scaledevPtr, 
+    void *biasdevPtr, 
+    void *in_meandevPtr, 
+    void *in_vardevPtr, 
+    void *out_meandevPtr, 
+    void *out_vardevPtr,
+    void *saved_meandevPtr, 
+    void *saved_inv_vardevPtr, 
+    void *eq_scaledevPtr, 
+    void *eq_biasdevPtr,
+
+    double epsilon_val,
+    double exponential_decay_factor,
+    int64_t accumCnt_val
+) {
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // Creates the necessary tensor descriptors
+        int64_t stride[4];
+        generateStrides(perChannelSum, stride, 4, CUDNN_TENSOR_NHWC);
+
+        auto tensor_create = [&stride, &perChannelSum](cudnnDataType_t type,
+                                int64_t id) {
+            return cudnn_frontend::TensorBuilder()
+                   .setDim(4, perChannelSum)
+                   .setStrides(4, stride)
+                   .setId(id)
+                   .setAlignment(16)
+                   .setDataType(type)
+                   .build();
+        };
+
+        auto sumTensor           = tensor_create(CUDNN_DATA_FLOAT, 100);
+        auto sqSumTensor         = tensor_create(CUDNN_DATA_FLOAT, 101);
+        auto scaleTensor         = tensor_create(CUDNN_DATA_FLOAT, 102);
+        auto biasTensor          = tensor_create(CUDNN_DATA_FLOAT, 103);
+        auto inMeanTensor        = tensor_create(CUDNN_DATA_FLOAT, 104);
+        auto inVarTensor         = tensor_create(CUDNN_DATA_FLOAT, 105);
+        auto outMeanTensor       = tensor_create(CUDNN_DATA_FLOAT, 106);
+        auto outVarTensor        = tensor_create(CUDNN_DATA_FLOAT, 107);
+        auto savedMeanTensor     = tensor_create(CUDNN_DATA_FLOAT, 108);
+        auto savedInvVarTensor   = tensor_create(CUDNN_DATA_FLOAT, 109);
+        auto outEqScaleTensor    = tensor_create(CUDNN_DATA_FLOAT, 200);
+        auto outEqBiasTensor     = tensor_create(CUDNN_DATA_FLOAT, 201);
+
+        int64_t epsilon_stride[4];
+        generateStrides(epsilon, epsilon_stride, 4, CUDNN_TENSOR_NHWC);
+        auto scalar_tensor_create = [&epsilon_stride, &epsilon](cudnnDataType_t type,
+                                int64_t id) {
+            return cudnn_frontend::TensorBuilder()
+                   .setDim(4, epsilon)
+                   .setStrides(4, epsilon_stride)
+                   .setId(id)
+                   .setAlignment(16)
+                   .setDataType(type)
+                   .setByValue(true)
+                   .build();
+        };
+
+        auto epsilonTensor       = scalar_tensor_create(CUDNN_DATA_DOUBLE, 300);
+        auto expDecayTensor      = scalar_tensor_create(CUDNN_DATA_DOUBLE, 301);
+        auto accumCountTensor    = scalar_tensor_create(CUDNN_DATA_INT64,  302);
+
+        //Create a Finalize node
+        auto finalize_stat_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_BN_FINALIZE_STATISTICS_DESCRIPTOR)
+                    .setMathPrecision(CUDNN_DATA_FLOAT)
+                    .setBNFinalizeMode(CUDNN_BN_FINALIZE_STATISTICS_TRAINING)
+                    .setSumDesc(sumTensor)
+                    .setSqSumDesc(sqSumTensor)
+                    .setScaleAndBias(scaleTensor, biasTensor)
+                    .setEqScaleAndBias(outEqScaleTensor, outEqBiasTensor)
+                    .setPrevRunningMeanAndVar(inMeanTensor, inVarTensor)
+                    .setNextRunningMeanAndVar(outMeanTensor, outVarTensor)
+                    .setSavedMeanAndInvVar(savedMeanTensor, savedInvVarTensor)
+                    .setEpsilonTensor(epsilonTensor)
+                    .setAccumCountTensor(accumCountTensor)
+                    .setExpDecayFactorTensor(expDecayTensor)
+                    .build();
+
+        std::array<cudnn_frontend::Operation const*, 1> ops = {&finalize_stat_op};
+        auto opGraph = cudnn_frontend::OperationGraphBuilder().setHandle(handle_).setOperationGraph(ops.size(), ops.data()).build();
+        std::cout << opGraph.describe() << std::endl;
+
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = 
+            cudnn_frontend::get_heuristics_list<2>({"heuristics_instant" 
+            , "heuristics_fallback"
+            }, opGraph,::allowAll, filtered_configs, true);
+        
+        std::cout << "get_heuristics_list Statuses: ";
+        for (auto i = 0 ; i < statuses.size(); i++) {
+            std::cout << cudnn_frontend::to_string(statuses[i]) << " ";
+        }
+        std::cout << std::endl;
+        std::cout << "Filter config list has " << filtered_configs.size() << " configurations " << std::endl;
+
+        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        void* data_ptrs[15] = {YSumdevPtr, YSqSumdevPtr, scaledevPtr, biasdevPtr, 
+                               in_meandevPtr, in_vardevPtr, out_meandevPtr, out_vardevPtr,
+                               saved_meandevPtr, saved_inv_vardevPtr, eq_scaledevPtr, eq_biasdevPtr,
+                               &epsilon_val, &exponential_decay_factor, &accumCountTensor};
+        int64_t uids[15]    = {100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 200, 201, 300, 301, 302};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(15, data_ptrs)
+                               .setUids(15, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+        
+    } catch (cudnn_frontend::cudnnException &e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+#if (CUDNN_VERSION >= 8303)
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+            CHECK(false);
+#endif   
     }
 }

--- a/samples/fusion_sample.h
+++ b/samples/fusion_sample.h
@@ -74,6 +74,44 @@ run_conv_bias_scale_relu(int64_t* x_dim,
                          void* devPtrS);
 
 void
+run_serialization_conv_bias_scale_relu(int64_t* x_dim,
+                         int64_t* w_dim,
+                         int64_t* y_dim,
+                         int64_t* b_dim,
+                         int64_t* s_dim,
+                         cudnnDataType_t dataType,
+                         int convDim,
+                         int64_t* conv_padA,
+                         int64_t* conv_dilationA,
+                         int64_t* conv_strideA,
+                         void* devPtrX,
+                         void* devPtrW,
+                         void* devPtrY,
+                         void* devPtrB,
+                         void* devPtrS);
+
+void
+run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
+                              int64_t* w_dim,
+                              int64_t* y_dim,
+                              int64_t* s_dim,
+                              int64_t* b_dim,
+                              int64_t* threshold_dim,
+                              cudnnDataType_t dataType,
+                              int convDim,
+                              int64_t* conv_padA,
+                              int64_t* conv_dilationA,
+                              int64_t* conv_strideA,
+                              int axis,
+                              void* devPtrX,
+                              void* devPtrW,
+                              void* devPtrY,
+                              void* devPtrS,
+                              void* devPtrB,
+                              void* devPtrTopThreshold,
+                              void* devPtrBottomThreshold);
+
+void
 run_conv_scale_bias_relu_int8(int64_t* x_dim,
                               int64_t* w_dim,
                               int64_t* y_dim,
@@ -139,3 +177,43 @@ run_conv_reduction(int64_t* x_dim,
                    void* devPtrX,
                    void* devPtrW,
                    void* devPtrR);
+
+void
+run_bn_conv_gen_stat(int64_t* xTensorDim, 
+                    int64_t* wTensorDim, 
+                    int64_t* yTensorDim,  
+                    int64_t* scaleTensorDim,
+                    int convdim, 
+                    int64_t *conv_padA, 
+                    int64_t* conv_dilationA, 
+                    int64_t* conv_strideA, 
+                    void *XdevPtr, 
+                    void *WdevPtr, 
+                    void *YdevPtr,
+                    void *scaledevPtr, 
+                    void *biasdevPtr, 
+                    void *sumdevPtr, 
+                    void *sqSumdevPtr);
+
+void
+run_bn_finalize( 
+    int64_t *perChannelSum, 
+    int64_t *epsilon, 
+
+    void *YSumdevPtr, 
+    void *YSqSumdevPtr, 
+    void *scaledevPtr, 
+    void *biasdevPtr, 
+    void *in_meandevPtr, 
+    void *in_vardevPtr, 
+    void *out_meandevPtr, 
+    void *out_vardevPtr,
+    void *saved_meandevPtr, 
+    void *saved_inv_vardevPtr, 
+    void *eq_scaledevPtr, 
+    void *eq_biasdevPtr,
+
+    double epsilon_val,
+    double exponential_decay_factor,
+    int64_t accumCnt_val
+);

--- a/samples/helpers.cpp
+++ b/samples/helpers.cpp
@@ -49,6 +49,39 @@ void initImage(int8_t* image, int imageSize) {
     }
 }
 
+// Currently set to generate uniform integers [0,1]
+void initImage(int32_t* image, int imageSize) {
+    static unsigned seed = 123456789;
+    for (int64_t index = 0; index < imageSize; index++) {
+        seed = (1103515245 * seed + 12345) & 0xffffffff;
+        // Takes floats from [0, 1), scales and casts to ints from [0, 4], then divides by 4
+        image[index] = ((int32_t)(5 * float(seed) * 2.3283064e-10))/4;  // 2^-32
+    }
+}
+
+// Currently set to generate uniform integers [0,1]
+void initImage(int64_t* image, int imageSize) {
+    static unsigned seed = 123456789;
+    for (int64_t index = 0; index < imageSize; index++) {
+        seed = (1103515245 * seed + 12345) & 0xffffffff;
+        // Takes floats from [0, 1), scales and casts to ints from [0, 4], then divides by 4
+        image[index] = ((int64_t)(5 * float(seed) * 2.3283064e-10))/4;  // 2^-32
+    }
+}
+
+// Currently set to generate booleans
+void initImage(bool* image, int imageSize) {
+    static unsigned seed = 123456789;
+    for (int64_t index = 0; index < imageSize; index++) {
+        seed = (1103515245 * seed + 12345) & 0xffffffff;
+        // Takes floats from [0, 1), scales and casts to ints from [0, 4], then divides by 4
+        int val = ((int32_t)(5 * float(seed) * 2.3283064e-10))/4;  // 2^-32
+
+        // val is 0 or 1
+        image[index] = (val == 1);
+    }
+}
+
 void initImagePadded(int8_t* image, int64_t dimA[], int64_t dimPadded[], int64_t stridePadded[], cudnnDataType_t dataType) {
     static unsigned seed = 123456789;
     int resizeFactor     = (dataType == CUDNN_DATA_INT8x4) ? 4 : 32;

--- a/samples/helpers.h
+++ b/samples/helpers.h
@@ -54,6 +54,9 @@ int dim2lin(const int64_t* ids, const int64_t* strides, int length);
 void initImage(float* image, int64_t imageSize);
 void initImage(half1* image, int64_t imageSize);
 void initImage(int8_t* image, int imageSize);
+void initImage(int32_t* image, int imageSize);
+void initImage(int64_t* image, int imageSize);
+void initImage(bool* image, int imageSize);
 void initImagePadded(int8_t* image, int64_t dimA[], int64_t dimPadded[], int64_t stridePadded[], cudnnDataType_t dataType);
 
 void doEpilog(float* out, int idx, float alphaAcc, float beta);


### PR DESCRIPTION
- [New Feature] 
    ## Execution Plan Serialization and Deserialization (Experimental)
    cuDNN v8.4 and above provides exeuction plan serialization and deserialization to save the execution plan as a string in JSON format. The execution plan can be then restored from that string at a later point, and this also saves compilation time compared to rebuilding the plan from scratch. Currently, this is an experimental feature that only supports the runtime fusion engine. No forward/backward or cross-device compatibility guarantee is offered at this time.

    ### API:
        - std::string cudnn_frontend::ExecutionPlan_v8::getJsonRepresentation() : Serialize the execution plan into a string in JSON format.
        - cudnn_frontend::ExecutionPlan_v8&& cudnn_frontend::ExecutionPlanBuilder_v8::loadFromJson(const std::string &json_plan) : Deserialize from a string containing the JSON representation of the execution plan.

- [New API] Added a new API
  ```
  get_heuristics_list(std::array<std::string, SIZE> modes,
    OperationGraph_v8 &opGraph,
    std::function<bool(cudnnBackendDescriptor_t)> filter_fn,
    EngineConfigList &filtered_configs,
    bool evaluate_all = false)
  ```
  This function takes a paramter list of heuristics mode. "heuristics_instant", "heuristic_fallback", "heuristic_mode_b" and computes a list of engine config which do not satisfy the blocking condition in filter_fn. The function can be optionally set to keep going even if one of the mode fails.

- [New Features] Added support for BN Finalize i.e. converts previously collected statistics and learned scale and bias into a set of equivalent normalization scale and bias to be applied in a later normalization
- [New Features] Added support for BN Stats fusion pattern. This pattern covers Scale, Bias, Relu, Conv and generation of SUM and SQSUM for batch normalization.
- [New Features] Added support for CUDNN_POINTWISE_GEN_INDEX and CUDNN_POINTWISE_BINARY_SELECT pointwise operations added in cuDNN 8.4.0.
- [Cleanup] Fixed a bug when used CUDNN_HEUR_MODE_B is used in multiple threads leads to crash in certain conditions. This will be fixed in upcoming cuDNN versions
- [Cleanup] Added the CUDNN_PATH in CMakeLists.txt allowing user to build with different cuDNN installation path.
- [Cleanup] Made Engine_v8 constructor as default which prevents overwriting of the status during knob creation.
- [Cleanup] Take UIDs of variant pack as a const pointer.
- [Cleanup] When logging was enabled and if no plan returned by heuristics is finalizable, it lead to a crash. This is now fixed.
- [Samples] Added a new sample to showcase CUDNN_POINTWISE_GEN_INDEX and CUDNN_POINTWISE_BINARY_SELECT pointwise operations.
- [Samples] Modified MHA sample to show improved numerical stability. Investigation is still going on to further improve the MHA sample
- [Samples] Added samples for fused operation graph for BN Stats generation and stats finalization.