### PR TITLE
Merge v0.6.3 to main

### DIFF
--- a/include/cudnn_frontend_Filters.h
+++ b/include/cudnn_frontend_Filters.h
@@ -52,6 +52,7 @@ hasNumericalNote(cudnnBackendDescriptor_t engine_config) {
         engine_config, CUDNN_ATTR_ENGINECFG_ENGINE, CUDNN_TYPE_BACKEND_DESCRIPTOR, 1, &engine_count, &engine_);
     if (status == CUDNN_STATUS_SUCCESS) {
         cudnnBackendNumericalNote_t notes[CUDNN_NUMERICAL_NOTE_TYPE_COUNT];
+        std::fill_n(notes, CUDNN_NUMERICAL_NOTE_TYPE_COUNT, CUDNN_NUMERICAL_NOTE_TYPE_COUNT);
         int64_t elem_count = 0;
         cudnnBackendGetAttribute(engine->get_backend_descriptor(),
                                  CUDNN_ATTR_ENGINE_NUMERICAL_NOTE,
@@ -80,6 +81,7 @@ hasBehaviorNote(cudnnBackendDescriptor_t engine_config) {
         engine_config, CUDNN_ATTR_ENGINECFG_ENGINE, CUDNN_TYPE_BACKEND_DESCRIPTOR, 1, &engine_count, &engine_);
     if (status == CUDNN_STATUS_SUCCESS) {
         cudnnBackendBehaviorNote_t notes[CUDNN_BEHAVIOR_NOTE_TYPE_COUNT];
+        std::fill_n(notes, CUDNN_BEHAVIOR_NOTE_TYPE_COUNT, CUDNN_BEHAVIOR_NOTE_TYPE_COUNT);
         int64_t elem_count = 0;
         cudnnBackendGetAttribute(engine->get_backend_descriptor(),
                                  CUDNN_ATTR_ENGINE_BEHAVIOR_NOTE,

--- a/include/cudnn_frontend_Heuristics.h
+++ b/include/cudnn_frontend_Heuristics.h
@@ -289,6 +289,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                     .setHeurMode(CUDNN_HEUR_MODE_INSTANT)
                     .build();
                 if (heuristics.get_status() != CUDNN_STATUS_SUCCESS) {
+                    goto heuristics_mode_a;
                     statuses.push_back(heuristics.get_status());
                     if (evaluate_all) 
                         continue;
@@ -316,6 +317,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                 statuses.push_back(heuristics.get_status());
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             } catch (cudnn_frontend::cudnnException &e) {
+                goto heuristics_mode_a;
                 statuses.push_back(e.getCudnnStatus());
                 if (evaluate_all) 
                     continue;
@@ -442,7 +444,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                     .setHeurMode(CUDNN_HEUR_MODE_B)
                     .build();
                 if (heuristics.get_status() != CUDNN_STATUS_SUCCESS) {
-		            goto heuristics_mode_a;
+                    goto heuristics_mode_a;
                     statuses.push_back(heuristics.get_status());
                     if (evaluate_all) 
                         continue;
@@ -470,7 +472,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                 statuses.push_back(heuristics.get_status());
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             } catch (cudnn_frontend::cudnnException &e) {
-		        goto heuristics_mode_a;
+                goto heuristics_mode_a;
                 statuses.push_back(e.getCudnnStatus());
                 if (evaluate_all) 
                     continue;

--- a/include/cudnn_frontend_Heuristics.h
+++ b/include/cudnn_frontend_Heuristics.h
@@ -442,6 +442,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                     .setHeurMode(CUDNN_HEUR_MODE_B)
                     .build();
                 if (heuristics.get_status() != CUDNN_STATUS_SUCCESS) {
+		            goto heuristics_mode_a;
                     statuses.push_back(heuristics.get_status());
                     if (evaluate_all) 
                         continue;
@@ -469,6 +470,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                 statuses.push_back(heuristics.get_status());
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             } catch (cudnn_frontend::cudnnException &e) {
+		        goto heuristics_mode_a;
                 statuses.push_back(e.getCudnnStatus());
                 if (evaluate_all) 
                     continue;
@@ -478,6 +480,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
 #endif
 #if (CUDNN_VERSION >= 8300)
         } else if (mode.find("heuristics_mode_a") != std::string::npos) {
+heuristics_mode_a:
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             try {
 #endif

--- a/include/cudnn_frontend_Heuristics.h
+++ b/include/cudnn_frontend_Heuristics.h
@@ -281,6 +281,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
 
     for (auto &mode : modes) {
         if (mode.find("heuristics_instant") != std::string::npos) {
+heuristics_instant:
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             try {
 #endif
@@ -289,7 +290,6 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                     .setHeurMode(CUDNN_HEUR_MODE_INSTANT)
                     .build();
                 if (heuristics.get_status() != CUDNN_STATUS_SUCCESS) {
-                    goto heuristics_mode_a;
                     statuses.push_back(heuristics.get_status());
                     if (evaluate_all) 
                         continue;
@@ -317,7 +317,6 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                 statuses.push_back(heuristics.get_status());
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             } catch (cudnn_frontend::cudnnException &e) {
-                goto heuristics_mode_a;
                 statuses.push_back(e.getCudnnStatus());
                 if (evaluate_all) 
                     continue;
@@ -444,7 +443,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                     .setHeurMode(CUDNN_HEUR_MODE_B)
                     .build();
                 if (heuristics.get_status() != CUDNN_STATUS_SUCCESS) {
-                    goto heuristics_mode_a;
+                    goto heuristics_instant;
                     statuses.push_back(heuristics.get_status());
                     if (evaluate_all) 
                         continue;
@@ -472,7 +471,7 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
                 statuses.push_back(heuristics.get_status());
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             } catch (cudnn_frontend::cudnnException &e) {
-                goto heuristics_mode_a;
+                goto heuristics_instant;
                 statuses.push_back(e.getCudnnStatus());
                 if (evaluate_all) 
                     continue;
@@ -482,7 +481,6 @@ get_heuristics_list(std::array<std::string, SIZE> modes,
 #endif
 #if (CUDNN_VERSION >= 8300)
         } else if (mode.find("heuristics_mode_a") != std::string::npos) {
-heuristics_mode_a:
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             try {
 #endif


### PR DESCRIPTION
The 0.6.3 release addresses the following issues:
- During the heuristics query if the heur_mode_b fails it fallbacks to heur_mode_a(heur_mode_instant)
- Addressed a bug to initiate the numerical notes and behavior notes to max values instead of 0.