### PR TITLE
cudnn Frontend changes for v0.7 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,7 @@ if (MSVC)
     add_compile_options(/W4 /WX)
 else()
     # lots of warnings and all warnings as errors
-    add_compile_options(-Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter
-	                -Wno-pessimizing-move -Wno-unused-variable -Wno-sign-compare)
+    add_compile_options(-Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter -Wno-pessimizing-move -Wno-unused-variable -Wno-sign-compare -Werror=strict-aliasing -Wnon-virtual-dtor)
 endif()
 
 
@@ -27,6 +26,7 @@ endif()
 
 if(DEFINED ENV{CUDNN_PATH})
 link_directories($ENV{CUDNN_PATH}/lib64)
+link_directories($ENV{CUDNN_PATH}/lib)
 endif()
 
 add_executable(Samples samples/conv_sample.cpp 
@@ -38,6 +38,11 @@ add_executable(Samples samples/conv_sample.cpp
                        samples/mha_sample.cpp)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
+if(DEFINED ENV{NO_DEFAULT_IN_SWITCH})
+    message("Default case in the switch is disabled")
+    add_compile_definitions(NO_DEFAULT_IN_SWITCH)
+endif()
 
 if(DEFINED ENV{CUDA_PATH})
     target_include_directories(Samples PUBLIC $ENV{CUDA_PATH}/include/)

--- a/Doxyfile
+++ b/Doxyfile
@@ -32,13 +32,13 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "CUDNN Frontend API"
+PROJECT_NAME           = "CUDNN API"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 8.4.0
+PROJECT_NUMBER         = 8.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../include/
+INPUT                  = .
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1130,7 +1130,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = .
+HTML_OUTPUT            = html
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ Sample tests are written using the [Catch2](https://github.com/catchorg/Catch2) 
      - CUDA_PATH has the cuda installation. 
         - Include files are in CUDA_PATH/include
         - Link files are in CUDA_PATH/lib64
-        - CUDNN_FRONTEND_PATH has the cudnn frontend header files.
+     - CUDNN_FRONTEND_PATH has the cudnn frontend header files.
+     - CUDNN_PATH has the cudnn installation.
+        - Include files are in CUDNN_PATH/include
+        - Link files are in CUDNN_PATH/lib or CUDNN_PATH/lib64
 
      mkdir build; cd build
      cmake ..

--- a/include/cudnn_frontend.h
+++ b/include/cudnn_frontend.h
@@ -114,6 +114,7 @@
 #include "cudnn_frontend_Logging.h"
 #include "cudnn_frontend_Reorder_Tensor.h"
 #include "cudnn_frontend_ExecutionPlanCache.h"
+#include "cudnn_frontend_Resample.h"
 
 namespace cudnn_frontend {
 using Tensor                    = Tensor_v8;
@@ -138,4 +139,6 @@ using VariantPack               = VariantPack_v8;
 using VariantPackBuilder        = VariantPackBuilder_v8;
 using EngineFallbackList        = EngineFallbackList_v8;
 using EngineFallbackListBuilder = EngineFallbackListBuilder_v8;
+using ResampleDesc              = ResampleDesc_v8;
+using ResampleDescBuilder       = ResampleDescBuilder_v8;
 }

--- a/include/cudnn_frontend_ExecutionPlanCache.h
+++ b/include/cudnn_frontend_ExecutionPlanCache.h
@@ -139,6 +139,9 @@ class ExecutionPlanCache_v1 {
         getLogger() << "[cudnn_frontend] Cached Plan Found in " << name << std::endl;
         return true;
     }
+
+    virtual ~ExecutionPlanCache_v1() = default;
+
 };
 
 class ExecutionPlanCache_v2 : public ExecutionPlanCache_v1 {
@@ -176,6 +179,8 @@ class ExecutionPlanCache_v2 : public ExecutionPlanCache_v1 {
     ExecutionPlanCache_v2(const char * name_) : ExecutionPlanCache_v1(name_) {
     }
 
+    virtual ~ExecutionPlanCache_v2() = default;
+    
 };
 
 using ExecutionPlanCache = ExecutionPlanCache_v2;

--- a/include/cudnn_frontend_MatMulDesc.h
+++ b/include/cudnn_frontend_MatMulDesc.h
@@ -39,7 +39,7 @@ namespace cudnn_frontend {
 /// MatMulDesc  Descriptor Class
 /// This class tells the properties of the MatMul operation
 /// Properties:
-///    - math_precision
+///    - compute_type
 ///
 /// Use MatMulDesc_v8 to build this class.
 /// Describe returns a string describing the MatMul operation
@@ -51,7 +51,7 @@ class MatMulDesc_v8 : public BackendDescriptor {
     describe() const override {
         std::stringstream ss;
         ss << "CUDNN_BACKEND_MATMUL_DESCRIPTOR :"
-           << " Math precision " << (math_precision);
+           << " Math precision " << (compute_type);
         return ss.str();
     }
 
@@ -67,7 +67,7 @@ class MatMulDesc_v8 : public BackendDescriptor {
     MatMulDesc_v8 &
     operator=(MatMulDesc_v8 const &) = delete;
 
-    cudnnDataType_t math_precision = CUDNN_DATA_FLOAT;
+    cudnnDataType_t compute_type = CUDNN_DATA_FLOAT;
 };
 
 ////
@@ -81,11 +81,17 @@ class MatMulDescBuilder_v8 {
      */
     //! Set Math Precision Data Type for the Matmul Operation
     auto
-    setMathPrecision(cudnnDataType_t data_type_) -> MatMulDescBuilder_v8 & {
-        m_matMulDesc.math_precision = data_type_;
+    setComputeType(cudnnDataType_t data_type_) -> MatMulDescBuilder_v8 & {
+        m_matMulDesc.compute_type = data_type_;
         return *this;
     }
     /** @} */
+
+    // TODO Deprecate in v1.0
+    auto
+    setMathPrecision(cudnnDataType_t data_type_) -> MatMulDescBuilder_v8 & {
+        return setComputeType(data_type_);
+    }
 
     //! constructs the MatMulDesc_v8 by calling the cudnn API
     //! Throws the appropriate error message
@@ -103,7 +109,7 @@ class MatMulDescBuilder_v8 {
                                           CUDNN_ATTR_MATMUL_COMP_TYPE,
                                           CUDNN_TYPE_DATA_TYPE,
                                           1,
-                                          &m_matMulDesc.math_precision);
+                                          &m_matMulDesc.compute_type);
         if (status != CUDNN_STATUS_SUCCESS) {
             set_error_and_throw_exception(
                 &m_matMulDesc,

--- a/include/cudnn_frontend_OperationGraph.h
+++ b/include/cudnn_frontend_OperationGraph.h
@@ -55,7 +55,8 @@ class OperationGraph_v8 : public BackendDescriptor {
     std::string
     describe() const override {
         std::stringstream ss;
-        ss << "CUDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR :";
+        ss << "CUDNN_BACKEND_OPERATIONGRAPH_DESCRIPTOR has " << numOps << "operations." << std::endl;
+        ss << "Tag: " << opGraphTag << std::endl;
         return ss.str();
     }
 

--- a/include/cudnn_frontend_ReductionDesc.h
+++ b/include/cudnn_frontend_ReductionDesc.h
@@ -39,7 +39,7 @@ namespace cudnn_frontend {
 /// ReductionDesc  Descriptor Class
 /// This class tells the properties of the Reduction operation
 /// Properties:
-///    - math_precision
+///    - compute_type
 ///    - reduction_op
 ///
 /// Use ReductionDesc_v8 to build this class.
@@ -52,7 +52,7 @@ class ReductionDesc_v8 : public BackendDescriptor {
     describe() const override {
         std::stringstream ss;
         ss << "CUDNN_BACKEND_REDUCTION_DESCRIPTOR :"
-           << " Math precision " << (math_precision) << "Reduction operator " << (reduction_op);
+           << " Math precision " << (compute_type) << "Reduction operator " << (reduction_op);
         return ss.str();
     }
 
@@ -68,7 +68,7 @@ class ReductionDesc_v8 : public BackendDescriptor {
     ReductionDesc_v8 &
     operator=(ReductionDesc_v8 const &) = delete;
 
-    cudnnDataType_t math_precision     = CUDNN_DATA_FLOAT;
+    cudnnDataType_t compute_type     = CUDNN_DATA_FLOAT;
     cudnnReduceTensorOp_t reduction_op = CUDNN_REDUCE_TENSOR_ADD;
 };
 
@@ -83,8 +83,8 @@ class ReductionDescBuilder_v8 {
      */
     //! Set Math Precision Data Type for the Reduction Operation
     auto
-    setMathPrecision(cudnnDataType_t data_type_) -> ReductionDescBuilder_v8 & {
-        m_reductionDesc.math_precision = data_type_;
+    setComputeType(cudnnDataType_t data_type_) -> ReductionDescBuilder_v8 & {
+        m_reductionDesc.compute_type = data_type_;
         return *this;
     }
     //! Set redution operator for the Reduction Operation
@@ -94,6 +94,12 @@ class ReductionDescBuilder_v8 {
         return *this;
     }
     /** @} */
+
+    // TODO Deprecate in v1.0
+    auto
+    setMathPrecision(cudnnDataType_t data_type_) -> ReductionDescBuilder_v8 & {
+        return setComputeType(data_type_);
+    }
 
     //! constructs the ReductionDesc_v8 by calling the cudnn API
     //! Throws the appropriate error message
@@ -112,7 +118,7 @@ class ReductionDescBuilder_v8 {
                                           CUDNN_ATTR_REDUCTION_COMP_TYPE,
                                           CUDNN_TYPE_DATA_TYPE,
                                           1,
-                                          &m_reductionDesc.math_precision);
+                                          &m_reductionDesc.compute_type);
         if (status != CUDNN_STATUS_SUCCESS) {
             set_error_and_throw_exception(
                 &m_reductionDesc,

--- a/include/cudnn_frontend_Resample.h
+++ b/include/cudnn_frontend_Resample.h
@@ -1,0 +1,459 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <utility>
+
+#include <cudnn.h>
+#include <cudnn_backend.h>
+
+#include "cudnn_frontend_utils.h"
+
+namespace cudnn_frontend {
+
+///
+/// Resample Descriptor Class
+/// This class tells the properties of the Resample operation
+/// Properties:
+///
+/// Use ResampleDescBuilder_v8 to build this class.
+/// Describe returns a string describing the Resample operation
+///
+class ResampleDesc_v8 : public BackendDescriptor {
+   public:
+    friend class ResampleDescBuilder_v8;
+    std::string
+    describe() const override {
+        std::stringstream ss;
+#if (CUDNN_VERSION >= 8500)
+        char sep = ',';
+        ss << "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: "
+           << "Compute Type: " << to_string(computeType)
+           << ", Mode: " << to_string(mode)
+           << ", Spatial Dimensions: " << spatialDim 
+           << ", Nan Propagation: " << std::to_string(nanOpt)
+           << ", Padding Mode: " << to_string(paddingMode);
+        ss << ", WindowDim: [";
+        for (auto i = 0; i < spatialDim; i++) {
+            ss << '(' << windowDim[i].numerator << sep << windowDim[i].denominator << ')' << sep;
+        }
+        ss << "]";
+        ss << ", prePadding: [";
+        for (auto i = 0; i < spatialDim; i++) {
+            ss << '(' << prePadding[i].numerator << sep << prePadding[i].denominator << ')' << sep;
+        }
+        ss << "]";
+        ss << ", postPadding: [";
+        for (auto i = 0; i < spatialDim; i++) {
+            ss << '(' << postPadding[i].numerator << sep << postPadding[i].denominator << ')' << sep;
+        }
+        ss << "]";
+        ss << ", stride: [ ";
+        for (auto i = 0; i < spatialDim; i++) {
+            ss << '(' << stride[i].numerator << sep << stride[i].denominator << ')' << sep;
+        }
+        ss << "]";
+#endif
+        return ss.str();
+    }
+
+    ResampleDesc_v8(ResampleDesc_v8 &&from) = default;
+    ResampleDesc_v8 &
+    operator=(ResampleDesc_v8 &&) = default;
+
+    ~ResampleDesc_v8() = default;
+
+    /** @defgroup ResampleDescBuilder_v8
+     *  Get individual property of ResampleDesc_v8 class
+     *  @{
+     */
+    
+    cudnnDataType_t
+    getComputeType() const {
+        return computeType;
+    }
+    
+    int64_t
+    getSpatialDimCount() const {
+        return spatialDim;
+    }
+
+#if (CUDNN_VERSION >= 8500)
+
+    cudnnResampleMode_t
+    getMode() const {
+        return mode;
+    }
+
+    cudnnNanPropagation_t
+    getNanOpt() const {
+        return nanOpt;
+    }
+
+    cudnnPaddingMode_t
+    getPaddingMode() const {
+        return paddingMode;
+    }
+
+    cudnnFraction_t const *
+    getSpatialStride() const {
+        return stride;
+    }
+
+    cudnnFraction_t const *
+    getPrePadding() const {
+        return prePadding;
+    }
+
+    cudnnFraction_t const *
+    getPostPadding() const {
+        return postPadding;
+    }
+
+    cudnnFraction_t const *
+    getWindowDim() const {
+        return windowDim;
+    }
+#endif
+    /** @} */
+
+   private:
+
+    ResampleDesc_v8()                    = default;
+    ResampleDesc_v8(ResampleDesc_v8 const &) = delete;
+    ResampleDesc_v8 &
+    operator=(ResampleDesc_v8 const &) = delete;
+
+    // default values for attributes 
+    cudnnDataType_t computeType = CUDNN_DATA_FLOAT;   
+    cudnnNanPropagation_t nanOpt = CUDNN_NOT_PROPAGATE_NAN;
+    
+    int64_t spatialDim = 0;
+
+#if (CUDNN_VERSION >= 8500)
+    cudnnResampleMode_t mode = CUDNN_RESAMPLE_AVGPOOL;
+    cudnnPaddingMode_t paddingMode = CUDNN_ZERO_PAD;
+    // Shape attributes
+    cudnnFraction_t windowDim[CUDNN_DIM_MAX] = {{0,1},{0,1}};
+    cudnnFraction_t prePadding[CUDNN_DIM_MAX] = {{0,1},{0,1}};
+    cudnnFraction_t postPadding[CUDNN_DIM_MAX] = {{0,1},{0,1}};
+    cudnnFraction_t stride[CUDNN_DIM_MAX] = {{0,1},{0,1}};
+#endif
+    };
+
+///
+/// ResampleDescBuilder_v8 Class
+/// Helper class used to build ResampleDesc_v8 class
+class ResampleDescBuilder_v8 {
+   public:
+    /** @defgroup ResampleDescBuilder_v8
+     *  Set individual property of ResampleDesc_v8 class
+     *  @{
+     */
+    //! Set compute type for the Resample Descriptor
+    auto
+    setComputeType(cudnnDataType_t data_type_) ->  ResampleDescBuilder_v8 & {
+        m_resampleDesc.computeType = data_type_;
+        return *this;
+    }
+
+#if (CUDNN_VERSION >= 8500)
+    //! (Overloaded) Set post padding for the Resample Operation with cudnnFraction_t
+    auto
+    setPostPadding(int64_t count, cudnnFraction_t const * arr) -> ResampleDescBuilder_v8 & {
+        // TODO: check the provided array count against the stored spatial dimension count.
+        std::copy(arr, arr + count, m_resampleDesc.postPadding);
+        return *this;
+    }
+ 
+    //! (Overloaded) Set post padding for the Resample Operation with int64_t
+    auto
+    setPostPadding(int64_t count, int64_t const * arr) -> ResampleDescBuilder_v8 & {
+        // TODO: check the provided array count against the stored spatial dimension count.
+        for (int i = 0; i < count; i++) {
+            m_resampleDesc.postPadding[i].numerator = arr[i];
+            m_resampleDesc.postPadding[i].denominator = 1;
+        }
+        return *this;
+    }
+
+    //! (Overloaded) Set pre padding for the Resample Operation with cudnnFraction_t
+    auto
+    setPrePadding(int64_t count, cudnnFraction_t const * arr) -> ResampleDescBuilder_v8 & {
+        // TODO: check the provided array count against the stored spatial dimension count.
+        std::copy(arr, arr + count, m_resampleDesc.prePadding);
+        return *this;
+    }
+    
+    //! (Overloaded) Set pre padding for the Resample Operation with int64_t
+    auto
+    setPrePadding(int64_t count, int64_t const * arr) -> ResampleDescBuilder_v8 & {
+        // TODO: check the provided array count against the stored spatial dimension count.
+        for (int i = 0; i < count; i++) {
+            m_resampleDesc.prePadding[i].numerator = arr[i];
+            m_resampleDesc.prePadding[i].denominator = 1;
+        }
+        return *this;
+    }
+
+    //! (Overloaded) Set stride for the Resample Operation with cudnnFraction_t
+    auto
+    setSpatialStride(int64_t count, cudnnFraction_t const * arr) -> ResampleDescBuilder_v8 & {
+        // TODO: check the provided array count against the stored spatial dimension count.
+        std::copy(arr, arr + count, m_resampleDesc.stride);
+        return *this;
+    }
+    
+    //! (Overloaded) Set stride for the Resample Operation with int64_t
+    auto
+    setSpatialStride(int64_t count, int64_t const * arr) -> ResampleDescBuilder_v8 & {
+        // TODO: check the provided array count against the stored spatial dimension count.
+        for (int i = 0; i < count; i++) {
+            m_resampleDesc.stride[i].numerator = arr[i];
+            m_resampleDesc.stride[i].denominator = 1;
+        }
+        return *this;
+    }
+
+    //! (Overloaded) Set window dim for the Resample Operation with cudnnFraction_t
+    auto
+    setSpatialDim(int64_t count, cudnnFraction_t const * arr) -> ResampleDescBuilder_v8 & {
+        // TODO: check the provided array count against the stored spatial dimension count.
+        std::copy(arr, arr + count, m_resampleDesc.windowDim);
+        return *this;
+    }
+
+    //! (Overloaded) Set window dim for the Resample Operation with int64_t
+    auto
+    setSpatialDim(int64_t count, int64_t const * arr) -> ResampleDescBuilder_v8 & {
+        // TODO: check the provided array count against the stored spatial dimension count.
+        m_resampleDesc.spatialDim = count;
+        for (int i = 0; i < count; i++) {
+            m_resampleDesc.windowDim[i].numerator = arr[i];
+            m_resampleDesc.windowDim[i].denominator = 1;
+        }
+        return *this;
+    }
+    
+     //! Set padding mode for the Resample Operation
+    auto
+    setPaddingMode(cudnnPaddingMode_t paddingMode_) -> ResampleDescBuilder_v8 & {
+        m_resampleDesc.paddingMode = paddingMode_;
+        return *this;
+    }
+
+    //! Set resample mode for the Resample Operation
+    auto
+    setResampleMode(cudnnResampleMode_t mode_) -> ResampleDescBuilder_v8 & {
+        m_resampleDesc.mode = mode_;
+        return *this;
+    }
+
+#endif
+    
+    //! Set nan propagation mode for the Resample Operation
+    auto
+    setNanPropagation(cudnnNanPropagation_t nanOpt_) -> ResampleDescBuilder_v8 & {
+        m_resampleDesc.nanOpt = nanOpt_;
+        return *this;
+    }
+
+    /** @} */
+
+    //! constructs the ResampleDesc_v8 by calling the cudnn API
+    //! Throws the appropriate error message
+    ResampleDesc_v8 &&
+    build() {
+#if (CUDNN_VERSION >= 8500)
+        // Sanity check if non-default fields have been set correctly.
+        if (m_resampleDesc.spatialDim < 0) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                CUDNN_STATUS_BAD_PARAM,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: Check and Set the spatialDim field");
+            return std::move(m_resampleDesc);
+        };
+
+
+        // Create a descriptor. Memory allocation happens here.
+        auto status = m_resampleDesc.initialize_managed_backend_pointer(CUDNN_BACKEND_RESAMPLE_DESCRIPTOR);
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc, status, "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: cudnnCreate Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        // Once Created lets set the descriptor parameters.
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(), 
+                                          CUDNN_ATTR_RESAMPLE_MODE, 
+                                          CUDNN_TYPE_RESAMPLE_MODE, 
+                                          1,
+                                          &(m_resampleDesc.mode));
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_MODE Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(),
+                                          CUDNN_ATTR_RESAMPLE_COMP_TYPE, 
+                                          CUDNN_TYPE_DATA_TYPE,    
+                                          1, 
+                                          &(m_resampleDesc.computeType));
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_COMP_TYPE Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(),
+                                            CUDNN_ATTR_RESAMPLE_NAN_PROPAGATION,
+                                            CUDNN_TYPE_NAN_PROPOGATION,
+                                            1,
+                                            &(m_resampleDesc.nanOpt));
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_NAN_PROPAGATION Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(),
+                                           CUDNN_ATTR_RESAMPLE_PADDING_MODE, 
+                                           CUDNN_TYPE_PADDING_MODE, 
+                                           1, 
+                                           &(m_resampleDesc.paddingMode));
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_PADDING_MODE Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(),
+                                          CUDNN_ATTR_RESAMPLE_SPATIAL_DIMS, 
+                                          CUDNN_TYPE_INT64, 
+                                          1, 
+                                          &(m_resampleDesc.spatialDim));
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_SPATIAL_DIMS Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(),
+                                            CUDNN_ATTR_RESAMPLE_WINDOW_DIMS,
+                                            CUDNN_TYPE_FRACTION,
+                                            m_resampleDesc.spatialDim,
+                                            m_resampleDesc.windowDim);
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_WINDOW_DIMS Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(),
+                                            CUDNN_ATTR_RESAMPLE_PRE_PADDINGS,
+                                            CUDNN_TYPE_FRACTION,
+                                            m_resampleDesc.spatialDim,
+                                            m_resampleDesc.prePadding);
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_PRE_PADDINGS Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(),
+                                            CUDNN_ATTR_RESAMPLE_POST_PADDINGS,
+                                            CUDNN_TYPE_FRACTION,
+                                            m_resampleDesc.spatialDim,
+                                            m_resampleDesc.postPadding);
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_POST_PADDINGS Failed");
+            return std::move(m_resampleDesc);
+        }
+
+        
+        status = cudnnBackendSetAttribute(m_resampleDesc.pointer->get_backend_descriptor(),
+                                            CUDNN_ATTR_RESAMPLE_STRIDES,
+                                            CUDNN_TYPE_FRACTION,
+                                            m_resampleDesc.spatialDim,
+                                            m_resampleDesc.stride);
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc,
+                status,
+                "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: SetAttribute CUDNN_ATTR_RESAMPLE_STRIDES Failed");
+            return std::move(m_resampleDesc);
+        }
+
+
+        // Finalizing the descriptor
+        status = cudnnBackendFinalize(m_resampleDesc.pointer->get_backend_descriptor());
+        if (status != CUDNN_STATUS_SUCCESS) {
+            set_error_and_throw_exception(
+                &m_resampleDesc, status, "CUDNN_BACKEND_RESAMPLE_DESCRIPTOR: cudnnFinalize Failed");
+            return std::move(m_resampleDesc);
+        }
+        getLogger() << "[cudnn_frontend] " << m_resampleDesc << std::endl;
+        return std::move(m_resampleDesc);
+#else 
+    set_error_and_throw_exception(&m_resampleDesc,
+                                    CUDNN_STATUS_NOT_SUPPORTED,
+                                    "CUDNN_RESAMPLE_DESCRIPTOR: Not supported in this version");
+    return std::move(m_resampleDesc);
+#endif
+    }
+
+    explicit ResampleDescBuilder_v8()                  = default;
+    ~ResampleDescBuilder_v8()                          = default;
+    ResampleDescBuilder_v8(ResampleDescBuilder_v8 &&)      = delete;
+    ResampleDescBuilder_v8(ResampleDescBuilder_v8 const &) = delete;
+    ResampleDescBuilder_v8 &
+    operator=(ResampleDescBuilder_v8 const &) = delete;
+
+   private:
+    ResampleDesc_v8 m_resampleDesc;
+};
+}

--- a/include/cudnn_frontend_Tensor.h
+++ b/include/cudnn_frontend_Tensor.h
@@ -87,23 +87,57 @@ class Tensor_v8 : public BackendDescriptor {
     };
 
     int64_t
-    getDimensionCount() const {
+    getDimCount() const {
         return nDims;
     }
 
     int64_t const *
-    getDimArray() const {
+    getDim() const {
         return btensor_dimA;
     }
 
     int64_t const *
-    getStrideArray() const {
+    getStride() const {
         return btensor_strA;
+    }
+
+
+    // TODO: Deprecate in v1.0
+    int64_t const *
+    getDimArray() const {
+        return getDim();
+    }
+
+    // TODO: Deprecate in v1.0
+    int64_t const *
+    getStrideArray() const {
+        return getStride();
     }
 
     int64_t
     getDataType() const {
         return static_cast<int64_t>(data_type);
+    }
+
+    int64_t
+    getId() const {
+        return id;
+    }
+
+    int64_t
+    getAlignment() const {
+        return alignment;
+    }
+
+    bool
+    isVirtualTensor() const {
+        return isVirtual;
+    }
+
+    // TODO: Deprecate in v1.0
+    int64_t
+    getDimensionCount() const {
+        return getDimCount();
     }
 
     Tensor_v8(Tensor_v8 &&from) = default;
@@ -158,7 +192,7 @@ class TensorBuilder_v8 {
     }
     //! Set Strides of the tensor
     auto
-    setStrides(int64_t ndim, int64_t const *strides) -> TensorBuilder_v8 & {
+    setStride(int64_t ndim, int64_t const *strides) -> TensorBuilder_v8 & {
         std::copy(strides, strides + ndim, m_tensor.btensor_strA);
         return *this;
     }
@@ -200,6 +234,31 @@ class TensorBuilder_v8 {
     }
 #endif
     /** @} */
+
+    // TODO: Deprecate in v1.0
+    auto
+    setStrides(int64_t ndim, int64_t const *strides) -> TensorBuilder_v8 & {
+        return setStride(ndim, strides);
+    }
+
+    // Clone parameters of another tensor. Make sure to still set the UID since UID of two tensors shouldn't be the same.
+    auto cloneFrom(Tensor_v8 const &from, int64_t newID) -> TensorBuilder_v8 & {
+        m_tensor.data_type = from.data_type;
+        m_tensor.nDims      = from.nDims;
+        m_tensor.id         = newID;
+        std::copy(from.getDimArray(), from.getDimArray() + m_tensor.nDims, m_tensor.btensor_dimA);
+        std::copy(from.getStrideArray(), from.getStrideArray() + m_tensor.nDims, m_tensor.btensor_strA);
+        m_tensor.alignment = from.alignment;
+        m_tensor.isVirtual = from.isVirtual;
+        m_tensor.isByValue = from.isByValue;
+        m_tensor.vectorCount = from.vectorCount;
+        m_tensor.vectorDimension = from.vectorDimension;
+
+#if (CUDNN_VERSION >= 8300)
+        m_tensor.reorder_type = from.reorder_type;
+#endif
+        return *this;
+    }
 
     //! constructs the Tensor_v8 by calling the cudnn API
     //! Throws the appropriate error message

--- a/include/cudnn_frontend_utils.h
+++ b/include/cudnn_frontend_utils.h
@@ -98,8 +98,68 @@ to_string(cudnnDataType_t type) {
         case CUDNN_DATA_BOOLEAN:
             return std::string("CUDNN_DATA_BOOLEAN");
 #endif
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            return std::string("UNKNOWN DATA_TYPE");
+#endif
     }
     return std::string("");
+}
+
+#if (CUDNN_VERSION >= 8200)  
+static inline std::string
+to_string(cudnnBackendBehaviorNote_t note) {
+    switch(note) {
+        case CUDNN_BEHAVIOR_NOTE_RUNTIME_COMPILATION:
+            return std::string("CUDNN_BEHAVIOR_NOTE_RUNTIME_COMPILATION");
+#if (CUDNN_VERSION >= 8300)
+        case CUDNN_BEHAVIOR_NOTE_REQUIRES_FILTER_INT8x32_REORDER:
+            return std::string("CUDNN_BEHAVIOR_NOTE_REQUIRES_FILTER_INT8x32_REORDER");
+        case CUDNN_BEHAVIOR_NOTE_REQUIRES_BIAS_INT8x32_REORDER:
+            return std::string("CUDNN_BEHAVIOR_NOTE_REQUIRES_BIAS_INT8x32_REORDER");
+#endif
+        case CUDNN_BEHAVIOR_NOTE_TYPE_COUNT:
+            return std::string("CUDNN_BEHAVIOR_NOTE_TYPE_COUNT");
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            return std::string("UNKNOWN_BEHAVIOR_NOTE");
+#endif
+    }
+    return std::string("INVALID_BEHAVIOR_NOTE");
+}
+#endif
+
+static inline std::string
+to_string(cudnnBackendNumericalNote_t note) {
+    switch(note) {
+        case CUDNN_NUMERICAL_NOTE_TENSOR_CORE:
+            return std::string("CUDNN_NUMERICAL_NOTE_TENSOR_CORE");
+        case CUDNN_NUMERICAL_NOTE_DOWN_CONVERT_INPUTS:
+            return std::string("CUDNN_NUMERICAL_NOTE_DOWN_CONVERT_INPUTS");
+        case CUDNN_NUMERICAL_NOTE_REDUCED_PRECISION_REDUCTION:
+            return std::string("CUDNN_NUMERICAL_NOTE_REDUCED_PRECISION_REDUCTION");
+        case CUDNN_NUMERICAL_NOTE_FFT:
+            return std::string("CUDNN_NUMERICAL_NOTE_FFT");
+        case CUDNN_NUMERICAL_NOTE_NONDETERMINISTIC:
+            return std::string("CUDNN_NUMERICAL_NOTE_NONDETERMINISTIC");
+        case CUDNN_NUMERICAL_NOTE_WINOGRAD:
+            return std::string("CUDNN_NUMERICAL_NOTE_WINOGRAD");
+#if (CUDNN_VERSION >= 8300)
+        case CUDNN_NUMERICAL_NOTE_WINOGRAD_TILE_4x4:
+            return std::string("CUDNN_NUMERICAL_NOTE_WINOGRAD_TILE_4x4");
+        case CUDNN_NUMERICAL_NOTE_WINOGRAD_TILE_6x6:
+            return std::string("CUDNN_NUMERICAL_NOTE_WINOGRAD_TILE_6x6");
+        case CUDNN_NUMERICAL_NOTE_WINOGRAD_TILE_13x13:
+            return std::string("CUDNN_NUMERICAL_NOTE_WINOGRAD_TILE_13x13");
+#endif
+        case CUDNN_NUMERICAL_NOTE_TYPE_COUNT:
+            return std::string("CUDNN_NUMERICAL_NOTE_TYPE_COUNT");
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            return std::string("UNKNOWN_NUMERICAL_NOTE");
+#endif
+    }
+    return std::string("INVALID_NUMERICAL_NOTE");
 }
 
 static inline std::string
@@ -135,6 +195,167 @@ to_string(cudnnStatus_t status) {
             return std::string("CUDNN_STATUS_RUNTIME_FP_OVERFLOW");
         case CUDNN_STATUS_VERSION_MISMATCH:
             return std::string("CUDNN_STATUS_VERSION_MISMATCH");
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            return std::string("UNKNOWN_CUDNN_STATUS");
+#endif
+    }
+    return std::string("");
+}
+
+#if (CUDNN_VERSION >= 8500)
+static inline std::string
+to_string(cudnnResampleMode_t mode) {
+    switch(mode) {
+        case CUDNN_RESAMPLE_NEAREST:
+            return std::string("CUDNN_RESAMPLE_NEAREST");
+        case CUDNN_RESAMPLE_BILINEAR:
+            return std::string("CUDNN_RESAMPLE_BILINEAR");
+        case CUDNN_RESAMPLE_AVGPOOL:
+            return std::string("CUDNN_RESAMPLE_AVGPOOL");
+        case CUDNN_RESAMPLE_MAXPOOL:
+            return std::string("CUDNN_RESAMPLE_MAXPOOL");
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            return std::string("UNKNOWN_CUDNN_RESAMPLE_MODE");
+#endif
+    }
+    return std::string("");
+}
+
+static inline std::string
+to_string(cudnnPaddingMode_t mode) {
+    switch(mode) {
+        case CUDNN_ZERO_PAD:
+            return std::string("CUDNN_ZERO_PAD");
+        case CUDNN_NEG_INF_PAD:
+            return std::string("CUDNN_NEG_INF_PAD");
+        case CUDNN_EDGE_VAL_PAD:
+            return std::string("CUDNN_EDGE_VAL_PAD");
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            return std::string("UNKNOWN_CUDNN_PAD_MODE");
+#endif
+    }
+    return std::string("");
+}
+#endif
+
+static inline std::string
+to_string(cudnnPointwiseMode_t mode) {
+    switch(mode) {
+        case CUDNN_POINTWISE_ADD:
+            return std::string("CUDNN_POINTWISE_ADD");
+        case CUDNN_POINTWISE_MUL:
+            return std::string("CUDNN_POINTWISE_MUL");
+#if (CUDNN_VERSION >= 8300)
+        case CUDNN_POINTWISE_DIV:
+            return std::string("CUDNN_POINTWISE_DIV");
+        case CUDNN_POINTWISE_ADD_SQUARE:
+            return std::string("CUDNN_POINTWISE_ADD_SQUARE");
+        case CUDNN_POINTWISE_SUB:
+            return std::string("CUDNN_POINTWISE_SUB");
+        case CUDNN_POINTWISE_CMP_EQ:
+            return std::string("CUDNN_POINTWISE_CMP_EQ");
+        case CUDNN_POINTWISE_CMP_NEQ:
+            return std::string("CUDNN_POINTWISE_CMP_NEQ");
+        case CUDNN_POINTWISE_CMP_GT:
+            return std::string("CUDNN_POINTWISE_CMP_GT");
+        case CUDNN_POINTWISE_CMP_GE:
+            return std::string("CUDNN_POINTWISE_CMP_GE");
+        case CUDNN_POINTWISE_CMP_LT:
+            return std::string("CUDNN_POINTWISE_CMP_LT");
+        case CUDNN_POINTWISE_CMP_LE:
+            return std::string("CUDNN_POINTWISE_CMP_LE");
+        case CUDNN_POINTWISE_LOGICAL_AND:
+            return std::string("CUDNN_POINTWISE_LOGICAL_AND");
+        case CUDNN_POINTWISE_LOGICAL_OR:
+            return std::string("CUDNN_POINTWISE_LOGICAL_OR");
+#endif
+        case CUDNN_POINTWISE_MIN:
+            return std::string("CUDNN_POINTWISE_MIN");
+        case CUDNN_POINTWISE_MAX:
+            return std::string("CUDNN_POINTWISE_MAX");
+        case CUDNN_POINTWISE_RELU_BWD:
+            return std::string("CUDNN_POINTWISE_RELU_BWD");
+        case CUDNN_POINTWISE_TANH_BWD:
+            return std::string("CUDNN_POINTWISE_TANH_BWD");
+        case CUDNN_POINTWISE_SIGMOID_BWD:
+            return std::string("CUDNN_POINTWISE_SIGMOID_BWD");
+        case CUDNN_POINTWISE_ELU_BWD:
+            return std::string("CUDNN_POINTWISE_ELU_BWD");
+        case CUDNN_POINTWISE_GELU_BWD:
+            return std::string("CUDNN_POINTWISE_GELU_BWD");
+        case CUDNN_POINTWISE_SOFTPLUS_BWD:
+            return std::string("CUDNN_POINTWISE_SOFTPLUS_BWD");
+        case CUDNN_POINTWISE_SWISH_BWD:
+            return std::string("CUDNN_POINTWISE_SWISH_BWD");
+#if (CUDNN_VERSION >= 8500)
+        case CUDNN_POINTWISE_GELU_APPROX_TANH_BWD:
+            return std::string("CUDNN_POINTWISE_GELU_APPROX_TANH_BWD");
+#endif
+        case CUDNN_POINTWISE_SQRT:
+            return std::string("CUDNN_POINTWISE_SQRT");
+        case CUDNN_POINTWISE_RELU_FWD:
+            return std::string("CUDNN_POINTWISE_RELU_FWD");
+        case CUDNN_POINTWISE_TANH_FWD:
+            return std::string("CUDNN_POINTWISE_TANH_FWD");
+        case CUDNN_POINTWISE_SIGMOID_FWD:
+            return std::string("CUDNN_POINTWISE_SIGMOID_FWD");
+        case CUDNN_POINTWISE_ELU_FWD:
+            return std::string("CUDNN_POINTWISE_ELU_FWD");
+        case CUDNN_POINTWISE_GELU_FWD:
+            return std::string("CUDNN_POINTWISE_GELU_FWD");
+        case CUDNN_POINTWISE_SOFTPLUS_FWD:
+            return std::string("CUDNN_POINTWISE_SOFTPLUS_FWD");
+        case CUDNN_POINTWISE_SWISH_FWD:
+            return std::string("CUDNN_POINTWISE_SWISH_FWD");
+#if (CUDNN_VERSION >= 8300)
+        case CUDNN_POINTWISE_EXP:
+            return std::string("CUDNN_POINTWISE_EXP");
+        case CUDNN_POINTWISE_LOG:
+            return std::string("CUDNN_POINTWISE_LOG");
+        case CUDNN_POINTWISE_NEG:
+            return std::string("CUDNN_POINTWISE_NEG");
+        case CUDNN_POINTWISE_MOD:
+            return std::string("CUDNN_POINTWISE_MOD");
+        case CUDNN_POINTWISE_POW:
+            return std::string("CUDNN_POINTWISE_POW");
+        case CUDNN_POINTWISE_ABS:
+            return std::string("CUDNN_POINTWISE_ABS");
+        case CUDNN_POINTWISE_CEIL:
+            return std::string("CUDNN_POINTWISE_CEIL");
+        case CUDNN_POINTWISE_FLOOR:
+            return std::string("CUDNN_POINTWISE_FLOOR");
+        case CUDNN_POINTWISE_COS:
+            return std::string("CUDNN_POINTWISE_COS");
+        case CUDNN_POINTWISE_TAN:
+            return std::string("CUDNN_POINTWISE_TAN");
+        case CUDNN_POINTWISE_SIN:
+            return std::string("CUDNN_POINTWISE_SIN");
+        case CUDNN_POINTWISE_RSQRT:
+            return std::string("CUDNN_POINTWISE_RSQRT");
+        case CUDNN_POINTWISE_LOGICAL_NOT:
+            return std::string("CUDNN_POINTWISE_LOGICAL_NOT");
+#endif
+#if (CUDNN_VERSION >= 8400)
+        case CUDNN_POINTWISE_GEN_INDEX:
+            return std::string("CUDNN_POINTWISE_GEN_INDEX");
+        case CUDNN_POINTWISE_BINARY_SELECT:
+            return std::string("CUDNN_POINTWISE_BINARY_SELECT");
+#endif
+#if (CUDNN_VERSION >= 8500)
+        case CUDNN_POINTWISE_ERF:
+            return std::string("CUDNN_POINTWISE_ERF");
+        case CUDNN_POINTWISE_GELU_APPROX_TANH_FWD:
+            return std::string("CUDNN_POINTWISE_GELU_APPROX_TANH_FWD");
+        case CUDNN_POINTWISE_IDENTITY:
+            return std::string("CUDNN_POINTWISE_IDENTITY");
+#endif
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            return std::string("UNKNOWN_CUDNN_POINTWISE_MODE");
+#endif
     }
     return std::string("");
 }

--- a/samples/conv_sample.h
+++ b/samples/conv_sample.h
@@ -71,7 +71,8 @@ void run_from_heuristics(
     cudnnBackendHeurMode_t heur_mode,
     bool expect_in_cache = false);
 
-void run_with_external_config(
+cudnnStatus_t 
+run_with_external_config(
     int64_t* dimA_padded,
     int64_t* padA,
     int64_t* convstrideA,

--- a/samples/fp16_emu.h
+++ b/samples/fp16_emu.h
@@ -50,36 +50,54 @@ float cpu_half2float(half1 h);
 
 static __inline__ __device__ __host__ half1 habs(half1 h)
 {
-    __half_raw hr = reinterpret_cast<__half_raw&>(h);
+    // Add an indirection to get around type aliasing check
+    void* h_ptr = &h;
+    __half_raw hr = *reinterpret_cast<__half_raw*>(h_ptr);
     hr.x &= 0x7fffU;
-    return reinterpret_cast<half1&>(hr);
+    // Add an indirection to get around type aliasing check
+    void* hr_ptr = &hr;
+    return *reinterpret_cast<half1*>(hr_ptr);
 }
 
 static __inline__ __device__ __host__ half1 hneg(half1 h)
 {
-    __half_raw hr = reinterpret_cast<__half_raw&>(h);
+    // Add an indirection to get around type aliasing check
+    void* h_ptr = &h;
+    __half_raw hr = *reinterpret_cast<__half_raw*>(h_ptr);
     hr.x ^= 0x8000U;
-    return reinterpret_cast<half1&>(hr);
+    // Add an indirection to get around type aliasing check
+    void* hr_ptr = &hr;
+    return *reinterpret_cast<half1*>(hr_ptr);
 }
 
 static __inline__ __device__ __host__ int ishnan(half1 h)
 {
+    // Add an indirection to get around type aliasing check
+    void* h_ptr = &h;
+    __half_raw hr = *reinterpret_cast<__half_raw*>(h_ptr);
     // When input is NaN, exponent is all ones and mantissa is non-zero.
-    __half_raw hr = reinterpret_cast<__half_raw&>(h);
     return (hr.x & 0x7c00U) == 0x7c00U && (hr.x & 0x03ffU) != 0;
 }
 
 static __inline__ __device__ __host__ int ishinf(half1 h)
 {
+    // Add an indirection to get around type aliasing check
+    void* h_ptr = &h;
+    __half_raw hr = *reinterpret_cast<__half_raw*>(h_ptr);
     // When input is +/- inf, exponent is all ones and mantissa is zero.
-    __half_raw hr = reinterpret_cast<__half_raw&>(h);
     return (hr.x & 0x7c00U) == 0x7c00U && (hr.x & 0x03ffU) == 0;
 }
 
 static __inline__ __device__ __host__ int ishequ(half1 x, half1 y)
 {
-    __half_raw xr = reinterpret_cast<__half_raw&>(x);
-    __half_raw yr = reinterpret_cast<__half_raw&>(y);
+    // Add an indirection to get around type aliasing check
+    void* x_ptr = &x;
+    __half_raw xr = *reinterpret_cast<__half_raw*>(x_ptr);
+    
+    // Add an indirection to get around type aliasing check
+    void* y_ptr = &y;
+    __half_raw yr = *reinterpret_cast<__half_raw*>(y_ptr);
+
     return ishnan(x) == 0 && ishnan(y) == 0 && xr.x == yr.x;
 }
 
@@ -88,7 +106,9 @@ static __inline__ __device__ __host__ half1 hzero()
 {
     __half_raw hr;
     hr.x = 0x0000U;
-    return reinterpret_cast<half1&>(hr);
+    // Add an indirection to get around type aliasing check
+    void* hr_ptr = &hr;
+    return *reinterpret_cast<half1*>(hr_ptr);
 }
 
 // Returns 1.0000 in FP16 binary form
@@ -96,7 +116,9 @@ static __inline__ __device__ __host__ half1 hone()
 {
     __half_raw hr;
     hr.x = 0x3c00U;
-    return reinterpret_cast<half1&>(hr);
+    // Add an indirection to get around type aliasing check
+    void* hr_ptr = &hr;
+    return *reinterpret_cast<half1*>(hr_ptr);
 }
 
 // Returns quiet NaN, the most significant fraction bit #9 is set
@@ -104,7 +126,9 @@ static __inline__ __device__ __host__ half1 hnan()
 {
     __half_raw hr;
     hr.x = 0x7e00U;
-    return reinterpret_cast<half1&>(hr);
+    // Add an indirection to get around type aliasing check
+    void* hr_ptr = &hr;
+    return *reinterpret_cast<half1*>(hr_ptr);
 }
 
 // Largest positive FP16 value, corresponds to 6.5504e+04
@@ -113,7 +137,9 @@ static __inline__ __device__ __host__ half1 hmax()
     // Exponent all ones except LSB (0x1e), mantissa is all ones (0x3ff)
     __half_raw hr;
     hr.x = 0x7bffU;
-    return reinterpret_cast<half1&>(hr);
+    // Add an indirection to get around type aliasing check
+    void* hr_ptr = &hr;
+    return *reinterpret_cast<half1*>(hr_ptr);
 }
 
 // Smallest positive (normalized) FP16 value, corresponds to 6.1035e-05
@@ -122,7 +148,9 @@ static __inline__ __device__ __host__ half1 hmin()
     // Exponent is 0x01 (5 bits), mantissa is all zeros (10 bits)
     __half_raw hr;
     hr.x = 0x0400U;
-    return reinterpret_cast<half1&>(hr);
+    // Add an indirection to get around type aliasing check
+    void* hr_ptr = &hr;
+    return *reinterpret_cast<half1*>(hr_ptr);
 }
 
 #endif  // _FP16_EMU_H_

--- a/samples/fusion_sample.cpp
+++ b/samples/fusion_sample.cpp
@@ -110,7 +110,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
         generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto xTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, x_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('x')
                            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                            .setDataType(dataType)
@@ -118,7 +118,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
         generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto wTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, w_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('w')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -127,7 +127,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
         generateStrides(s_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto sTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, s_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('s')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -135,7 +135,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
         generateStrides(b_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto bTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, b_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('b')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -143,7 +143,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
         generateStrides(a_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto aTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, a_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('a')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -152,7 +152,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
         generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto afterConvTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('A')  // after conv
                                    .setAlignment(16)
                                    .setVirtual()
@@ -160,7 +160,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
                                    .build();
         auto afterScaleTensor = cudnn_frontend::TensorBuilder()
                                     .setDim(4, y_dim)
-                                    .setStrides(4, stride)
+                                    .setStride(4, stride)
                                     .setId('B')  // after scale
                                     .setAlignment(16)
                                     .setVirtual()
@@ -168,7 +168,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
                                     .build();
         auto afterBiasTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('C')  // after bias
                                    .setAlignment(16)
                                    .setVirtual()
@@ -176,7 +176,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
                                    .build();
         auto afterAddTensor = cudnn_frontend::TensorBuilder()
                                   .setDim(4, y_dim)
-                                  .setStrides(4, stride)
+                                  .setStride(4, stride)
                                   .setId('D')  // after add
                                   .setAlignment(16)
                                   .setVirtual()
@@ -184,7 +184,7 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
                                   .build();
         auto yTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, y_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('y')  // output
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -204,38 +204,38 @@ run_conv_scale_bias_add_leaky_relu(int64_t* x_dim,
         // Define the scale descriptor
         auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
                              .setMode(CUDNN_POINTWISE_MUL)
-                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .setComputeType(CUDNN_DATA_FLOAT)
                              .build();
         std::cout << scaleDesc.describe() << std::endl;
 
         // Define the bias descriptor
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         std::cout << biasDesc.describe() << std::endl;
 
         // Define the add descriptor
         auto addDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_ADD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << addDesc.describe() << std::endl;
 
         // Define the activation descriptor
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_RELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .setReluLowerClipSlope(0.01)  // leaky relu
                            .build();
         std::cout << actDesc.describe() << std::endl;
 
         // Define the convolution problem
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, conv_strideA)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, conv_strideA)
                             .setPrePadding(convDim, conv_padA)
                             .setPostPadding(convDim, conv_padA)
                             .setDilation(convDim, conv_dilationA)
@@ -369,7 +369,7 @@ run_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto xTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, x_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('x')
                            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                            .setDataType(dataType)
@@ -377,7 +377,7 @@ run_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto wTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, w_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('w')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -386,7 +386,7 @@ run_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(b_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto bTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, b_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('b')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -394,7 +394,7 @@ run_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(s_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto sTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, s_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('s')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -403,7 +403,7 @@ run_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto afterConvTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('A')  // after conv
                                    .setAlignment(16)
                                    .setVirtual()
@@ -411,7 +411,7 @@ run_conv_bias_scale_relu(int64_t* x_dim,
                                    .build();
         auto afterBiasTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('B')  // after bias
                                    .setAlignment(16)
                                    .setVirtual()
@@ -419,7 +419,7 @@ run_conv_bias_scale_relu(int64_t* x_dim,
                                    .build();
         auto afterScaleTensor = cudnn_frontend::TensorBuilder()
                                     .setDim(4, y_dim)
-                                    .setStrides(4, stride)
+                                    .setStride(4, stride)
                                     .setId('C')  // after scale
                                     .setAlignment(16)
                                     .setVirtual()
@@ -427,7 +427,7 @@ run_conv_bias_scale_relu(int64_t* x_dim,
                                     .build();
         auto yTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, y_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('y')  // output
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -445,30 +445,30 @@ run_conv_bias_scale_relu(int64_t* x_dim,
         // Define the bias descriptor
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         std::cout << biasDesc.describe() << std::endl;
 
         // Define the scale descriptor
         auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
                              .setMode(CUDNN_POINTWISE_MUL)
-                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .setComputeType(CUDNN_DATA_FLOAT)
                              .build();
         std::cout << scaleDesc.describe() << std::endl;
 
         // Define the activation descriptor
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_RELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << actDesc.describe() << std::endl;
 
         // Define the convolution problem
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, conv_strideA)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, conv_strideA)
                             .setPrePadding(convDim, conv_padA)
                             .setPostPadding(convDim, conv_padA)
                             .setDilation(convDim, conv_dilationA)
@@ -593,7 +593,7 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto xTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, x_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('x')
                            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                            .setDataType(dataType)
@@ -601,7 +601,7 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto wTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, w_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('w')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -610,7 +610,7 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(b_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto bTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, b_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('b')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -618,7 +618,7 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(s_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto sTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, s_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('s')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -627,7 +627,7 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
         generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto afterConvTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('A')  // after conv
                                    .setAlignment(16)
                                    .setVirtual()
@@ -635,7 +635,7 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
                                    .build();
         auto afterBiasTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('B')  // after bias
                                    .setAlignment(16)
                                    .setVirtual()
@@ -643,7 +643,7 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
                                    .build();
         auto afterScaleTensor = cudnn_frontend::TensorBuilder()
                                     .setDim(4, y_dim)
-                                    .setStrides(4, stride)
+                                    .setStride(4, stride)
                                     .setId('C')  // after scale
                                     .setAlignment(16)
                                     .setVirtual()
@@ -651,7 +651,7 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
                                     .build();
         auto yTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, y_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('y')  // output
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -669,30 +669,30 @@ run_serialization_conv_bias_scale_relu(int64_t* x_dim,
         // Define the bias descriptor
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         std::cout << biasDesc.describe() << std::endl;
 
         // Define the scale descriptor
         auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
                              .setMode(CUDNN_POINTWISE_MUL)
-                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .setComputeType(CUDNN_DATA_FLOAT)
                              .build();
         std::cout << scaleDesc.describe() << std::endl;
 
         // Define the activation descriptor
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_RELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << actDesc.describe() << std::endl;
 
         // Define the convolution problem
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, conv_strideA)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, conv_strideA)
                             .setPrePadding(convDim, conv_padA)
                             .setPostPadding(convDim, conv_padA)
                             .setDilation(convDim, conv_dilationA)
@@ -835,7 +835,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
         generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto xTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, x_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('x')
                            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                            .setDataType(dataType)
@@ -843,7 +843,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
         generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto wTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, w_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('w')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -851,7 +851,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
         generateStrides(s_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto sTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, s_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('s')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -860,7 +860,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
         generateStrides(b_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto bTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, b_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('b')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -869,7 +869,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
         generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto afterConvTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('A')  // after conv
                                    .setAlignment(16)
                                    .setVirtual()
@@ -877,7 +877,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
                                    .build();
         auto afterScaleTensor = cudnn_frontend::TensorBuilder()
                                     .setDim(4, y_dim)
-                                    .setStrides(4, stride)
+                                    .setStride(4, stride)
                                     .setId('B')  // after scale
                                     .setAlignment(16)
                                     .setVirtual()
@@ -885,7 +885,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
                                     .build();
         auto afterBiasTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('C')  // after bias
                                    .setAlignment(16)
                                    .setVirtual()
@@ -894,7 +894,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
 
         auto afterActivationTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('D')  // after activation
                                    .setAlignment(16)
                                    .setVirtual()
@@ -903,7 +903,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
 
         auto genIndexTensor = cudnn_frontend::TensorBuilder()
                                 .setDim(4, y_dim)
-                                .setStrides(4, stride)
+                                .setStride(4, stride)
                                 .setId('I')  // output of the gen index operation
                                 .setAlignment(16)
                                 .setVirtual()
@@ -912,7 +912,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
 
         auto maskTopTensor = cudnn_frontend::TensorBuilder()
                                 .setDim(4, y_dim)
-                                .setStrides(4, stride)
+                                .setStride(4, stride)
                                 .setId('m')  // top half of the mask created after the less than
                                 .setAlignment(16)
                                 .setVirtual()
@@ -921,7 +921,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
 
         auto maskBottomTensor = cudnn_frontend::TensorBuilder()
                                 .setDim(4, y_dim)
-                                .setStrides(4, stride)
+                                .setStride(4, stride)
                                 .setId('n')  // bottom half of the mask
                                 .setAlignment(16)
                                 .setVirtual()
@@ -930,7 +930,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
 
         auto maskTensor = cudnn_frontend::TensorBuilder()
                                 .setDim(4, y_dim)
-                                .setStrides(4, stride)
+                                .setStride(4, stride)
                                 .setId('M')  // OR of the top and bottom masks
                                 .setAlignment(16)
                                 .setVirtual()
@@ -939,7 +939,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
 
         auto yTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, y_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('y')  // output
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -948,7 +948,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
         generateStrides(threshold_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto thresholdTopTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, threshold_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('t')  // threshold for creating the top mask
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_INT32)
@@ -956,7 +956,7 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
 
         auto thresholdBottomTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, threshold_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('u')  // threshold for creating the bottom mask
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_INT32)
@@ -981,10 +981,10 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
 
         // Define the convolution problem
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, conv_strideA)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, conv_strideA)
                             .setPrePadding(convDim, conv_padA)
                             .setPostPadding(convDim, conv_padA)
                             .setDilation(convDim, conv_dilationA)
@@ -994,28 +994,28 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
         // Define the scale descriptor
         auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
                              .setMode(CUDNN_POINTWISE_MUL)
-                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .setComputeType(CUDNN_DATA_FLOAT)
                              .build();
         std::cout << scaleDesc.describe() << std::endl;
 
         // Define the bias descriptor
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         std::cout << biasDesc.describe() << std::endl;
 
         // Define the activation descriptor
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_RELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << actDesc.describe() << std::endl;
 
         // Define the genIndex descriptor
         auto genIndexDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_GEN_INDEX)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .setAxis(axis)
                            .build();
         std::cout << genIndexDesc.describe() << std::endl;
@@ -1023,28 +1023,28 @@ run_conv_scale_bias_relu_gen_index_selection(int64_t* x_dim,
         // Define the lessThan descriptor
         auto lessThanDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_CMP_LT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << lessThanDesc.describe() << std::endl;
 
         // Define the greaterThan descriptor
         auto greaterThanDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_CMP_GT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << greaterThanDesc.describe() << std::endl;
 
         // Define the logical_or descriptor
         auto logicalOrDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_LOGICAL_OR)
-                           .setMathPrecision(CUDNN_DATA_BOOLEAN)
+                           .setComputeType(CUDNN_DATA_BOOLEAN)
                            .build();
         std::cout << logicalOrDesc.describe() << std::endl;
 
         // Define the binary_selection descriptor
         auto selectionDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_BINARY_SELECT)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << selectionDesc.describe() << std::endl;
 
@@ -1203,7 +1203,7 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
         generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto xTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, x_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('x')
                            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                            .setDataType(CUDNN_DATA_INT8)
@@ -1211,7 +1211,7 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
         generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto wTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, w_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('w')
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_INT8)
@@ -1219,7 +1219,7 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
         generateStrides(s_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto sTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, s_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('s')
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_FLOAT)
@@ -1228,7 +1228,7 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
         generateStrides(b_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto bTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, b_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('b')
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_FLOAT)
@@ -1237,7 +1237,7 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
         generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto afterConvTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('A')  // after conv
                                    .setAlignment(16)
                                    .setVirtual()
@@ -1245,7 +1245,7 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
                                    .build();
         auto afterScaleTensor = cudnn_frontend::TensorBuilder()
                                     .setDim(4, y_dim)
-                                    .setStrides(4, stride)
+                                    .setStride(4, stride)
                                     .setId('B')  // after scale
                                     .setAlignment(16)
                                     .setVirtual()
@@ -1253,7 +1253,7 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
                                     .build();
         auto afterBiasTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('C')  // after bias
                                    .setAlignment(16)
                                    .setVirtual()
@@ -1261,7 +1261,7 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
                                    .build();
         auto yTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, y_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('y')  // output
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_INT8)
@@ -1278,10 +1278,10 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
 
         // Define the convolution problem
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_INT32)
+                            .setComputeType(CUDNN_DATA_INT32)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, conv_strideA)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, conv_strideA)
                             .setPrePadding(convDim, conv_padA)
                             .setPostPadding(convDim, conv_padA)
                             .setDilation(convDim, conv_dilationA)
@@ -1291,21 +1291,21 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
         // Define the scale descriptor
         auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
                              .setMode(CUDNN_POINTWISE_MUL)
-                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .setComputeType(CUDNN_DATA_FLOAT)
                              .build();
         std::cout << scaleDesc.describe() << std::endl;
 
         // Define the bias descriptor
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         std::cout << biasDesc.describe() << std::endl;
 
         // Define the activation descriptor
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_RELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << actDesc.describe() << std::endl;
 
@@ -1403,6 +1403,243 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
 }
 
 void
+run_pool_scale_bias_relu_int8(int64_t* x_dim,
+                              int64_t* y_dim,
+                              int64_t* s_dim,
+                              int64_t* b_dim,
+                              void* devPtrX,
+                              void* devPtrY,
+                              void* devPtrS,
+                              void* devPtrB, 
+                              cudnnDataType_t compType,
+#if (CUDNN_VERSION >= 8500)
+                              cudnnResampleMode_t mode,
+                              cudnnNanPropagation_t nanOpt, 
+                              cudnnPaddingMode_t paddingMode,
+#endif       
+                              int64_t nbSpatialDims,                         
+                              double alpha,                           
+                              double beta,
+                              int64_t* windowDimA,
+                              int64_t* prePaddingA,
+                              int64_t* postPaddingA,
+                              int64_t* strideA ) {
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // Creates the necessary tensor descriptors
+        int64_t strideTensor[4];
+        generateStrides(x_dim, strideTensor, 4, CUDNN_TENSOR_NHWC);
+        auto xTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, x_dim)
+                           .setStride(4, strideTensor)
+                           .setId('x')
+                           .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                           .setDataType(CUDNN_DATA_FLOAT)
+                           .build();
+        generateStrides(s_dim, strideTensor, 4, CUDNN_TENSOR_NHWC);
+        auto sTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, s_dim)
+                           .setStride(4, strideTensor)
+                           .setId('s')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_FLOAT)
+                           .build();
+
+        generateStrides(b_dim, strideTensor, 4, CUDNN_TENSOR_NHWC);
+        auto bTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, b_dim)
+                           .setStride(4, strideTensor)
+                           .setId('b')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_FLOAT)
+                           .build();
+
+        generateStrides(y_dim, strideTensor, 4, CUDNN_TENSOR_NHWC);
+        auto afterPoolTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStride(4, strideTensor)
+                                   .setId('A')  // after conv
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+        auto afterScaleTensor = cudnn_frontend::TensorBuilder()
+                                    .setDim(4, y_dim)
+                                    .setStride(4, strideTensor)
+                                    .setId('B')  // after scale
+                                    .setAlignment(16)
+                                    .setVirtual()
+                                    .setDataType(CUDNN_DATA_FLOAT)
+                                    .build();
+        auto afterBiasTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStride(4, strideTensor)
+                                   .setId('C')  // after bias
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+        auto yTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, y_dim)
+                           .setStride(4, strideTensor)
+                           .setId('y')  // output
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_INT8)
+                           .build();
+
+        std::cout << xTensor.describe() << std::endl;
+        std::cout << bTensor.describe() << std::endl;
+        std::cout << sTensor.describe() << std::endl;
+        std::cout << afterPoolTensor.describe() << std::endl;
+        std::cout << afterBiasTensor.describe() << std::endl;
+        std::cout << afterScaleTensor.describe() << std::endl;
+        std::cout << yTensor.describe() << std::endl;
+
+         // Define the resample descriptor
+        auto poolDesc = cudnn_frontend::ResampleDescBuilder_v8()
+                            .setComputeType(compType)
+#if (CUDNN_VERSION >= 8500)
+                            .setNanPropagation(nanOpt)
+                            .setResampleMode(mode)
+                            .setPaddingMode(paddingMode)
+                            .setSpatialDim(nbSpatialDims, windowDimA)
+                            .setSpatialStride(nbSpatialDims, strideA)
+                            .setPrePadding(nbSpatialDims, prePaddingA)
+                            .setPostPadding(nbSpatialDims, postPaddingA)
+#endif
+                            .build(); 
+        std::cout << "Initialized Pool Desc" << std::endl;
+        std::cout << poolDesc.describe() << std::endl;
+
+        // Define the scale descriptor
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_MUL)
+                             .setComputeType(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << "Initialized Scale Desc"<< std::endl;
+        std::cout << scaleDesc.describe() << std::endl;
+
+        // Define the bias descriptor
+        auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setComputeType(CUDNN_DATA_FLOAT)
+                            .build();
+        std::cout << "Initialized Bias Desc"<< std::endl;
+        std::cout << biasDesc.describe() << std::endl;
+
+        // Define the activation descriptor
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+                           .setMode(CUDNN_POINTWISE_RELU_FWD)
+                           .setComputeType(CUDNN_DATA_FLOAT)
+                           .build();
+        std::cout << "Initialized Activation Desc"<< std::endl;
+        std::cout << actDesc.describe() << std::endl;
+
+#if (CUDNN_VERSION >= 8500) 
+         // Create a Resample Node
+        auto pool_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RESAMPLE_FWD_DESCRIPTOR)
+                           .setxDesc(xTensor)
+                           .setyDesc(afterPoolTensor)
+                           .setResampleDesc(poolDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        std::cout << pool_op.describe() << std::endl;
+#endif
+        // Create a Multiplication Node with scaling parameters.
+        auto scale_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+#if (CUDNN_VERSION >= 8500) 
+                            .setxDesc(pool_op.getOutputTensor())
+#endif                    
+                            .setbDesc(sTensor)
+                            .setyDesc(afterScaleTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << scale_op.describe() << std::endl;
+
+        // Create a Bias Node.
+        auto bias_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                           .setxDesc(scale_op.getOutputTensor())
+                           .setbDesc(bTensor)
+                           .setyDesc(afterBiasTensor)
+                           .setpwDesc(biasDesc)
+                           .build();
+        std::cout << bias_op.describe() << std::endl;
+        
+        // Create an Activation Node.
+        auto act_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setxDesc(bias_op.getOutputTensor())
+                          .setyDesc(yTensor)
+                          .setpwDesc(actDesc)
+                          .build();
+        std::cout << act_op.describe() << std::endl;
+
+#if (CUDNN_VERSION >= 8500)
+        // Create an Operation Graph. In this case it is convolution bias scale activation
+        std::array<cudnn_frontend::Operation const*, 4> ops = {&pool_op, &scale_op, &bias_op, &act_op};
+#else
+        std::array<cudnn_frontend::Operation const*, 3> ops = {&scale_op, &bias_op, &act_op};
+#endif
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(ops.size(), ops.data())
+                           .build();
+       
+
+        // How many engines support this operation graph ?
+        auto plan = get_execplan_from_heuristics_else_fall_back(std::move(opGraph), handle_);
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        // Create the variant pack and associate with the data pointers 
+        void* data_ptrs[] = {devPtrX, devPtrY, devPtrS, devPtrB};
+        int64_t uids[]    = {'x', 'y', 's', 'b'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(4, data_ptrs)
+                               .setUids(4, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+
+        // Trigger the execute operation 
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+        checkCudnnErr(cudnnDestroy(handle_));
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+        std::cout << "EXECUTE SUCCESS" << std::endl;
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
+        
+        // this example is only for Ampere cards
+        if (prop.major < 8 && (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+            std::cout << "Example is only supported for Ampere GPUs" << std::endl; 
+        }  else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+
+#if (CUDNN_VERSION >= 8500)
+            CHECK(false);
+#endif
+        }
+    }
+}
+
+
+void
 run_matmul_bias_gelu(int64_t* a_dim,
                      int64_t* b_dim,
                      int64_t* c_dim,
@@ -1411,7 +1648,8 @@ run_matmul_bias_gelu(int64_t* a_dim,
                      void* devPtrA,
                      void* devPtrB,
                      void* devPtrC,
-                     void* devPtrZ) {
+                     void* devPtrZ,
+                     void* devPtrAfterZ) {
     cudnnHandle_t handle_;
     try {
         // Create cudnn handle
@@ -1424,7 +1662,7 @@ run_matmul_bias_gelu(int64_t* a_dim,
         generateStrides(a_dim, stride, 3, CUDNN_TENSOR_NCHW);
         auto aMatrixTensor = cudnn_frontend::TensorBuilder()
                                  .setDim(3, a_dim)
-                                 .setStrides(3, stride)
+                                 .setStride(3, stride)
                                  .setId('a')
                                  .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                                  .setDataType(dataType)
@@ -1432,7 +1670,7 @@ run_matmul_bias_gelu(int64_t* a_dim,
         generateStrides(b_dim, stride, 3, CUDNN_TENSOR_NCHW);
         auto bMatrixTensor = cudnn_frontend::TensorBuilder()
                                  .setDim(3, b_dim)
-                                 .setStrides(3, stride)
+                                 .setStride(3, stride)
                                  .setId('b')
                                  .setAlignment(16)
                                  .setDataType(dataType)
@@ -1441,7 +1679,7 @@ run_matmul_bias_gelu(int64_t* a_dim,
         generateStrides(z_dim, stride, 3, CUDNN_TENSOR_NCHW);
         auto biasTensor = cudnn_frontend::TensorBuilder()
                               .setDim(3, z_dim)
-                              .setStrides(3, stride)
+                              .setStride(3, stride)
                               .setId('z')
                               .setAlignment(16)
                               .setDataType(dataType)
@@ -1450,7 +1688,7 @@ run_matmul_bias_gelu(int64_t* a_dim,
         generateStrides(c_dim, stride, 3, CUDNN_TENSOR_NCHW);
         auto afterMatMulTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, c_dim)
-                                     .setStrides(3, stride)
+                                     .setStride(3, stride)
                                      .setId('A')  // after matmul
                                      .setAlignment(16)
                                      .setVirtual()
@@ -1458,15 +1696,14 @@ run_matmul_bias_gelu(int64_t* a_dim,
                                      .build();
         auto afterBiasTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(3, c_dim)
-                                   .setStrides(3, stride)
+                                   .setStride(3, stride)
                                    .setId('B')  // after bias
                                    .setAlignment(16)
-                                   .setVirtual()
                                    .setDataType(dataType)
                                    .build();
         auto outputTensor = cudnn_frontend::TensorBuilder()
                                 .setDim(3, c_dim)
-                                .setStrides(3, stride)
+                                .setStride(3, stride)
                                 .setId('c')  // output after gelu
                                 .setAlignment(16)
                                 .setDataType(dataType)
@@ -1482,19 +1719,23 @@ run_matmul_bias_gelu(int64_t* a_dim,
         // Define the bias descriptor
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         std::cout << biasDesc.describe() << std::endl;
 
         // Define the activation descriptor
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+#if (CUDNN_VERSION >= 8500)
+                           .setMode(CUDNN_POINTWISE_GELU_APPROX_TANH_FWD)
+#else
                            .setMode(CUDNN_POINTWISE_GELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+#endif
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << actDesc.describe() << std::endl;
 
         // Define the matmul desc
-        auto matmulDesc = cudnn_frontend::MatMulDescBuilder().setMathPrecision(CUDNN_DATA_FLOAT).build();
+        auto matmulDesc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
         std::cout << matmulDesc.describe() << std::endl;
 
         // Create a matmul Node
@@ -1542,12 +1783,12 @@ run_matmul_bias_gelu(int64_t* a_dim,
         if (workspace_size > 0) {
             checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
         }
-        void* data_ptrs[] = {devPtrA, devPtrB, devPtrC, devPtrZ};
-        int64_t uids[]    = {'a', 'b', 'c', 'z'};
+        void* data_ptrs[] = {devPtrA, devPtrB, devPtrC, devPtrZ, devPtrAfterZ};
+        int64_t uids[]    = {'a', 'b', 'c', 'z', 'B'};
         auto variantPack  = cudnn_frontend::VariantPackBuilder()
                                .setWorkspacePointer(workspace_ptr)
-                               .setDataPointers(4, data_ptrs)
-                               .setUids(4, uids)
+                               .setDataPointers(5, data_ptrs)
+                               .setUids(5, uids)
                                .build();
         std::cout << "variantPack " << variantPack.describe() << std::endl;
         cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
@@ -1610,7 +1851,7 @@ run_conv_drelu(int64_t* x_dim,
 
         auto x_tensor = cudnn_frontend::TensorBuilder()
                             .setDim(4, x_dim)
-                            .setStrides(4, x_stride_padded)
+                            .setStride(4, x_stride_padded)
                             .setId(x_id)
                             .setAlignment(4)
                             .setDataType(dataType)
@@ -1618,7 +1859,7 @@ run_conv_drelu(int64_t* x_dim,
 
         auto w_tensor = cudnn_frontend::TensorBuilder()
                             .setDim(4, w_dim)
-                            .setStrides(4, w_stride_padded)
+                            .setStride(4, w_stride_padded)
                             .setId(w_id)
                             .setAlignment(4)
                             .setDataType(dataType)
@@ -1626,7 +1867,7 @@ run_conv_drelu(int64_t* x_dim,
 
         auto after_conv_tensor = cudnn_frontend::TensorBuilder()
                                      .setDim(4, y_dim)
-                                     .setStrides(4, y_stride_padded)
+                                     .setStride(4, y_stride_padded)
                                      .setId(after_conv_id)
                                      .setAlignment(4)
                                      .setVirtual()
@@ -1635,7 +1876,7 @@ run_conv_drelu(int64_t* x_dim,
 
         auto bwd_act_x_tensor = cudnn_frontend::TensorBuilder()
                                     .setDim(4, y_dim)
-                                    .setStrides(4, y_stride_padded)
+                                    .setStride(4, y_stride_padded)
                                     .setId(bwd_act_x_id)
                                     .setAlignment(4)
                                     .setDataType(dataType)
@@ -1643,7 +1884,7 @@ run_conv_drelu(int64_t* x_dim,
 
         auto after_activation_tensor = cudnn_frontend::TensorBuilder()
                                            .setDim(4, y_dim)
-                                           .setStrides(4, y_stride_padded)
+                                           .setStride(4, y_stride_padded)
                                            .setId(y_id)
                                            .setAlignment(4)
                                            .setDataType(dataType)
@@ -1656,10 +1897,10 @@ run_conv_drelu(int64_t* x_dim,
         std::cout << after_activation_tensor.describe() << std::endl;
 
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, convstride)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, convstride)
                             .setPrePadding(convDim, pad)
                             .setPostPadding(convDim, pad)
                             .setDilation(convDim, dilation)
@@ -1678,7 +1919,7 @@ run_conv_drelu(int64_t* x_dim,
 
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_RELU_BWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << actDesc.describe() << std::endl;
 
@@ -1768,7 +2009,7 @@ run_dgrad_drelu(int64_t* dx_dim,
 
         auto after_dgrad_dx_tensor = cudnn_frontend::TensorBuilder()
                                          .setDim(4, dx_dim)
-                                         .setStrides(4, dx_stride)
+                                         .setStride(4, dx_stride)
                                          .setId(after_dgrad_id)
                                          .setAlignment(4)
                                          .setVirtual()
@@ -1777,7 +2018,7 @@ run_dgrad_drelu(int64_t* dx_dim,
 
         auto w_tensor = cudnn_frontend::TensorBuilder()
                             .setDim(4, w_dim)
-                            .setStrides(4, w_stride)
+                            .setStride(4, w_stride)
                             .setId(w_id)
                             .setAlignment(4)
                             .setDataType(dataType)
@@ -1785,7 +2026,7 @@ run_dgrad_drelu(int64_t* dx_dim,
 
         auto dy_tensor = cudnn_frontend::TensorBuilder()
                              .setDim(4, dy_dim)
-                             .setStrides(4, dy_stride)
+                             .setStride(4, dy_stride)
                              .setId(dy_id)
                              .setAlignment(4)
                              .setDataType(dataType)
@@ -1793,7 +2034,7 @@ run_dgrad_drelu(int64_t* dx_dim,
 
         auto bwd_act_x_tensor = cudnn_frontend::TensorBuilder()
                                     .setDim(4, dx_dim)
-                                    .setStrides(4, dx_stride)
+                                    .setStride(4, dx_stride)
                                     .setId(bwd_act_x_id)
                                     .setAlignment(4)
                                     .setDataType(dataType)
@@ -1801,7 +2042,7 @@ run_dgrad_drelu(int64_t* dx_dim,
 
         auto after_bwd_activation_dx_tensor = cudnn_frontend::TensorBuilder()
                                                   .setDim(4, dx_dim)
-                                                  .setStrides(4, dx_stride)
+                                                  .setStride(4, dx_stride)
                                                   .setId(dx_id)
                                                   .setAlignment(4)
                                                   .setDataType(dataType)
@@ -1814,10 +2055,10 @@ run_dgrad_drelu(int64_t* dx_dim,
         std::cout << after_bwd_activation_dx_tensor.describe() << std::endl;
 
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, convstride)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, convstride)
                             .setPrePadding(convDim, pad)
                             .setPostPadding(convDim, pad)
                             .setDilation(convDim, dilation)
@@ -1838,7 +2079,7 @@ run_dgrad_drelu(int64_t* dx_dim,
 
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_RELU_BWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .build();
         std::cout << actDesc.describe() << std::endl;
 
@@ -1893,6 +2134,198 @@ run_dgrad_drelu(int64_t* dx_dim,
     }
 }
 
+
+void
+run_matmul_dgelu_dbias(const int64_t* dy_dim,
+                       const int64_t* w_dim,
+                       const int64_t* dx_dim,
+                       const int64_t* dbias_dim,
+                       cudnnDataType_t dataType,
+                       void* dev_ptr_dy,
+                       void* dev_ptr_w,
+                       void* dev_ptr_bwd_act_x,
+                       void* dev_ptr_dx,
+                       void* dev_ptr_dbias) {
+
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // Creates the necessary tensor descriptors
+        int64_t stride[3];
+
+        // Use the following UIDs for tensors
+        int64_t dy_uid        = 101;
+        int64_t w_uid         = 102;
+        int64_t bwd_act_x_uid = 103;
+        int64_t dx_uid        = 104;
+        int64_t dbias_uid     = 105;
+
+        // Create tensor descriptor for DY matrix
+        generateStrides(dy_dim, stride, 3, CUDNN_TENSOR_NCHW);
+        auto dyMatrixTensor = cudnn_frontend::TensorBuilder()
+                                 .setDim(3, dy_dim)
+                                 .setStride(3, stride)
+                                 .setId(dy_uid)
+                                 .setAlignment(16)
+                                 .setDataType(dataType)
+                                 .build();
+        std::cout << dyMatrixTensor.describe() << std::endl;
+
+        // Create tensor descriptor for weight matrix
+        generateStrides(w_dim, stride, 3, CUDNN_TENSOR_NCHW);
+        auto wMatrixTensor = cudnn_frontend::TensorBuilder()
+                                 .setDim(3, w_dim)
+                                 .setStride(3, stride)
+                                 .setId(w_uid)
+                                 .setAlignment(16)
+                                 .setDataType(dataType)
+                                 .build();
+        std::cout << wMatrixTensor.describe() << std::endl;
+
+        // Create tensor descriptor for dx matrix
+        generateStrides(dx_dim, stride, 3, CUDNN_TENSOR_NCHW);
+        auto dataGrad1MatrixTensor = cudnn_frontend::TensorBuilder()
+                                 .setDim(3, dx_dim)
+                                 .setStride(3, stride)
+                                 .setId('X')
+                                 .setAlignment(16)
+                                 .setDataType(dataType)
+                                 .setVirtual(true)
+                                 .build();
+        std::cout << dataGrad1MatrixTensor.describe() << std::endl;
+        
+        // Create tensor descriptor for geluInput matrix
+        generateStrides(dx_dim, stride, 3, CUDNN_TENSOR_NCHW);
+        auto geluInputMatrixTensor = cudnn_frontend::TensorBuilder()
+                                 .setDim(3, dx_dim)
+                                 .setStride(3, stride)
+                                 .setId(bwd_act_x_uid)
+                                 .setAlignment(16)
+                                 .setDataType(dataType)
+                                 .build();
+        std::cout << geluInputMatrixTensor.describe() << std::endl;
+        
+        // Create tensor descriptor for output of backwardGelu matrix
+        generateStrides(dx_dim, stride, 3, CUDNN_TENSOR_NCHW);
+        auto backwardGeluMatrixTensor = cudnn_frontend::TensorBuilder()
+                                 .setDim(3, dx_dim)
+                                 .setStride(3, stride)
+                                 .setId(dx_uid)
+                                 .setAlignment(16)
+                                 .setDataType(dataType)
+                                 .build();
+        std::cout << backwardGeluMatrixTensor.describe() << std::endl;
+
+        // Create tensor descriptor for output of biasGrad(reduction) matrix
+        generateStrides(dbias_dim, stride, 3, CUDNN_TENSOR_NCHW);
+        auto backwardBiasMatrixTensor = cudnn_frontend::TensorBuilder()
+                                 .setDim(3, dbias_dim)
+                                 .setStride(3, stride)
+                                 .setId(dbias_uid)
+                                 .setAlignment(16)
+                                 .setDataType(CUDNN_DATA_FLOAT)
+                                 .build();
+        std::cout << backwardBiasMatrixTensor.describe() << std::endl;
+
+        auto matmulDesc = cudnn_frontend::MatMulDescBuilder()
+                              .setComputeType(CUDNN_DATA_FLOAT)
+                              .build();
+        std::cout << matmulDesc.describe() << std::endl;
+        
+        auto geluDesc = cudnn_frontend::PointWiseDescBuilder()
+#if (CUDNN_VERSION >= 8500)
+                           .setMode(CUDNN_POINTWISE_GELU_APPROX_TANH_BWD)
+#else
+                           .setMode(CUDNN_POINTWISE_GELU_BWD)
+#endif
+                           .setComputeType(CUDNN_DATA_FLOAT)
+                           .build();
+        std::cout << geluDesc.describe() << std::endl;
+
+        // Define the reduction descriptor
+        auto reductionDesc = cudnn_frontend::ReductionDescBuilder()
+                                  .setComputeType(CUDNN_DATA_FLOAT)
+                                  .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                                  .build();
+        std::cout << reductionDesc.describe() << std::endl;
+
+        // Create a matmul Node for Dgrad
+        auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(dyMatrixTensor)
+                            .setbMatDesc(wMatrixTensor)
+                            .setcMatDesc(dataGrad1MatrixTensor)
+                            .setmatmulDesc(matmulDesc)
+                            .build();
+        std::cout << matmulOp.describe() << std::endl;
+
+        // Create a matmul Node for dGeLU
+        auto geluOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                          .setdyDesc(matmulOp.getOutputTensor())
+                          .setxDesc(geluInputMatrixTensor)
+                          .setdxDesc(backwardGeluMatrixTensor)
+                          .setpwDesc(geluDesc)
+                          .build();
+        std::cout << geluOp.describe() << std::endl;
+
+        // Create a reduction add Node.
+        auto reduction_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(backwardGeluMatrixTensor)
+                                .setyDesc(backwardBiasMatrixTensor)
+                                .setreductionDesc(reductionDesc)
+                                .build();
+        std::cout << reduction_op.describe() << std::endl;
+
+        // Create an Operation Graph.
+        std::array<cudnn_frontend::Operation const*, 3> ops = {&matmulOp, &geluOp, &reduction_op};
+
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(ops.size(), ops.data())
+                           .build();
+
+        auto plan = get_execplan_from_heuristics_else_fall_back(std::move(opGraph), handle_);
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+        void* data_ptrs[] = {dev_ptr_dy, dev_ptr_w, dev_ptr_dx, dev_ptr_bwd_act_x, dev_ptr_dbias};
+        int64_t uids[]    = {dy_uid, w_uid, dx_uid, bwd_act_x_uid, dbias_uid};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(5, data_ptrs)
+                               .setUids(5, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+
+        // this example is only for Ampere cards
+        if (prop.major < 8 && e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED) {
+            std::cout << "Fusion with float inputs is only supported on Ampere or later" << std::endl;
+        } else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+        }
+    }
+}
+
 void
 run_conv_reduction(int64_t* x_dim,
                    int64_t* w_dim,
@@ -1916,7 +2349,7 @@ run_conv_reduction(int64_t* x_dim,
         generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto xTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, x_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('x')
                            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                            .setDataType(dataType)
@@ -1924,7 +2357,7 @@ run_conv_reduction(int64_t* x_dim,
         generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto wTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, w_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('w')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -1933,7 +2366,7 @@ run_conv_reduction(int64_t* x_dim,
         generateStrides(r_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto rTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, r_dim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('r')  // output
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_FLOAT)
@@ -1942,7 +2375,7 @@ run_conv_reduction(int64_t* x_dim,
         generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
         auto afterConvTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, y_dim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('y')  // after conv
                                    .setAlignment(16)
                                    .setVirtual()
@@ -1957,17 +2390,17 @@ run_conv_reduction(int64_t* x_dim,
 
         // Define the reduction descriptor
         auto redunctionDesc = cudnn_frontend::ReductionDescBuilder()
-                                  .setMathPrecision(CUDNN_DATA_FLOAT)
+                                  .setComputeType(CUDNN_DATA_FLOAT)
                                   .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
                                   .build();
         std::cout << redunctionDesc.describe() << std::endl;
 
         // Define the convolution problem
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, conv_strideA)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, conv_strideA)
                             .setPrePadding(convDim, conv_padA)
                             .setPostPadding(convDim, conv_padA)
                             .setDilation(convDim, conv_dilationA)
@@ -2038,7 +2471,7 @@ run_conv_reduction(int64_t* x_dim,
     }
 }
 
-void
+cudnnStatus_t
 run_bn_conv_gen_stat(int64_t* xTensorDim, 
                     int64_t* wTensorDim, 
                     int64_t* yTensorDim,
@@ -2054,6 +2487,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
                     void *biasdevPtr, 
                     void *sumdevPtr, 
                     void *sqSumdevPtr) {
+                        
     cudnnHandle_t handle_;
     try {
         // Create cudnn handle
@@ -2064,7 +2498,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         generateStrides(xTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
         auto xTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, xTensorDim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('x')
                            .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                            .setDataType(CUDNN_DATA_HALF)
@@ -2072,7 +2506,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         
         auto afterScaleTensor = cudnn_frontend::TensorBuilder()
                                 .setDim(4, xTensorDim)
-                                .setStrides(4, stride)
+                                .setStride(4, stride)
                                 .setId('d')
                                 .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                                 .setDataType(CUDNN_DATA_FLOAT)
@@ -2081,7 +2515,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
 
         auto afterBiasTensor = cudnn_frontend::TensorBuilder()
                                 .setDim(4, xTensorDim)
-                                .setStrides(4, stride)
+                                .setStride(4, stride)
                                 .setId('e')
                                 .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                                 .setDataType(CUDNN_DATA_FLOAT)
@@ -2090,7 +2524,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
 
         auto afterReluTensor = cudnn_frontend::TensorBuilder()
                                 .setDim(4, xTensorDim)
-                                .setStrides(4, stride)
+                                .setStride(4, stride)
                                 .setId('f')
                                 .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
                                 .setDataType(CUDNN_DATA_FLOAT)
@@ -2100,7 +2534,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
         auto scaleTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, scaleTensorDim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('s')
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_HALF)
@@ -2109,7 +2543,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
         auto biasTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, scaleTensorDim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('b')
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_HALF)
@@ -2117,7 +2551,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         generateStrides(wTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
         auto wTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, wTensorDim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('w')
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_HALF)
@@ -2126,7 +2560,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         generateStrides(yTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
         auto yTensor = cudnn_frontend::TensorBuilder()
                                    .setDim(4, yTensorDim)
-                                   .setStrides(4, stride)
+                                   .setStride(4, stride)
                                    .setId('y')  // after conv
                                    .setAlignment(16)
                                    .setDataType(CUDNN_DATA_HALF)
@@ -2138,10 +2572,10 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
 
         // Define the convolution problem
         auto convDesc = cudnn_frontend::ConvDescBuilder()
-                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .setMathMode(CUDNN_CROSS_CORRELATION)
-                            .setNDims(convDim)
-                            .setStrides(convDim, conv_strideA)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, conv_strideA)
                             .setPrePadding(convDim, conv_padA)
                             .setPostPadding(convDim, conv_padA)
                             .setDilation(convDim, conv_dilationA)
@@ -2151,21 +2585,21 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
                 // Define the scale descriptor
         auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
                              .setMode(CUDNN_POINTWISE_MUL)
-                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .setComputeType(CUDNN_DATA_FLOAT)
                              .build();
         std::cout << scaleDesc.describe() << std::endl;
 
         // Define the bias descriptor
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         std::cout << biasDesc.describe() << std::endl;
 
         // Define the activation descriptor
         auto actDesc = cudnn_frontend::PointWiseDescBuilder()
                            .setMode(CUDNN_POINTWISE_RELU_FWD)
-                           .setMathPrecision(CUDNN_DATA_FLOAT)
+                           .setComputeType(CUDNN_DATA_FLOAT)
                            .setReluLowerClipSlope(0.01)  // leaky relu
                            .build();
         std::cout << actDesc.describe() << std::endl;
@@ -2212,7 +2646,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
         auto sumTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, scaleTensorDim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('u')
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_FLOAT)
@@ -2221,7 +2655,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
         auto sqsumTensor = cudnn_frontend::TensorBuilder()
                            .setDim(4, scaleTensorDim)
-                           .setStrides(4, stride)
+                           .setStride(4, stride)
                            .setId('v')
                            .setAlignment(16)
                            .setDataType(CUDNN_DATA_FLOAT)
@@ -2230,7 +2664,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         //Create a genstats node
         auto genstat_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_GEN_STATS_DESCRIPTOR)
                     .setxDesc(yTensor)
-                    .setMathPrecision(CUDNN_DATA_FLOAT)
+                    .setComputeType(CUDNN_DATA_FLOAT)
                     .setGenStatsMode(CUDNN_GENSTATS_SUM_SQSUM)
                     .setSumDesc(sumTensor)
                     .setSqSumDesc(sqsumTensor)
@@ -2255,12 +2689,27 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
         std::cout << std::endl;
         std::cout << "Filter config list has " << filtered_configs.size() << " configurations " << std::endl;
 
-        auto plan =
-            cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
-        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+        cudnn_frontend::ManagedOpaqueDescriptor plan_desc = nullptr;
+        auto workspace_size = 0;
+        cudnnStatus_t st = CUDNN_STATUS_SUCCESS;
+        for (auto &config: filtered_configs) {
+            try {
+                auto plan =
+                    cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(config, opGraph.getTag()).build();
+                std::cout << "Plan tag: " << plan.getTag() << std::endl;
 
-        auto workspace_size = plan.getWorkspaceSize();
-        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+                workspace_size = plan.getWorkspaceSize();
+                std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+                plan_desc = plan.get_desc();
+            } catch (cudnn_frontend::cudnnException& e)  {
+                st = e.getCudnnStatus();
+                continue;
+            }
+        }
+        if (plan_desc == nullptr ) {
+            std::cout << "No plan found implementing the operation graph" << std::endl;
+            return st;
+        }
 
         void* workspace_ptr = nullptr;
         if (workspace_size > 0) {
@@ -2275,12 +2724,14 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
                                .setUids(7, uids)
                                .build();
         std::cout << "variantPack " << variantPack.describe() << std::endl;
-        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan_desc->get_backend_descriptor(), variantPack.get_raw_desc());
 
         if (workspace_size > 0) {
             checkCudaErr(cudaFree(workspace_ptr));
         }
         cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+        return status;
 
     } catch (cudnn_frontend::cudnnException& e) {
         struct cudaDeviceProp prop;
@@ -2295,6 +2746,7 @@ run_bn_conv_gen_stat(int64_t* xTensorDim,
             CHECK(false);
 #endif
         }
+        return CUDNN_STATUS_SUCCESS;
     }
 }
 
@@ -2333,7 +2785,7 @@ run_bn_finalize(
                                 int64_t id) {
             return cudnn_frontend::TensorBuilder()
                    .setDim(4, perChannelSum)
-                   .setStrides(4, stride)
+                   .setStride(4, stride)
                    .setId(id)
                    .setAlignment(16)
                    .setDataType(type)
@@ -2359,7 +2811,7 @@ run_bn_finalize(
                                 int64_t id) {
             return cudnn_frontend::TensorBuilder()
                    .setDim(4, epsilon)
-                   .setStrides(4, epsilon_stride)
+                   .setStride(4, epsilon_stride)
                    .setId(id)
                    .setAlignment(16)
                    .setDataType(type)
@@ -2373,7 +2825,7 @@ run_bn_finalize(
 
         //Create a Finalize node
         auto finalize_stat_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_BN_FINALIZE_STATISTICS_DESCRIPTOR)
-                    .setMathPrecision(CUDNN_DATA_FLOAT)
+                    .setComputeType(CUDNN_DATA_FLOAT)
                     .setBNFinalizeMode(CUDNN_BN_FINALIZE_STATISTICS_TRAINING)
                     .setSumDesc(sumTensor)
                     .setSqSumDesc(sqSumTensor)
@@ -2404,7 +2856,20 @@ run_bn_finalize(
         std::cout << std::endl;
         std::cout << "Filter config list has " << filtered_configs.size() << " configurations " << std::endl;
 
-        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+        auto plan_builder = [&filtered_configs, &opGraph, &handle_]() {
+            for (auto i = 0; i < filtered_configs.size(); i++) {
+                try {
+                    auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[i], opGraph.getTag()).build();
+		            return plan;
+                } catch (cudnn_frontend::cudnnException &e) {
+                    continue;
+                }
+            }
+            return cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+        };
+
+	    CHECK(filtered_configs.size() > 0);
+        auto plan = plan_builder();
         std::cout << "Plan tag: " << plan.getTag() << std::endl;
 
         auto workspace_size = plan.getWorkspaceSize();
@@ -2418,7 +2883,7 @@ run_bn_finalize(
         void* data_ptrs[15] = {YSumdevPtr, YSqSumdevPtr, scaledevPtr, biasdevPtr, 
                                in_meandevPtr, in_vardevPtr, out_meandevPtr, out_vardevPtr,
                                saved_meandevPtr, saved_inv_vardevPtr, eq_scaledevPtr, eq_biasdevPtr,
-                               &epsilon_val, &exponential_decay_factor, &accumCountTensor};
+                               &epsilon_val, &exponential_decay_factor, &accumCnt_val};
         int64_t uids[15]    = {100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 200, 201, 300, 301, 302};
         auto variantPack  = cudnn_frontend::VariantPackBuilder()
                                .setWorkspacePointer(workspace_ptr)
@@ -2433,6 +2898,8 @@ run_bn_finalize(
         }
 
         cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+        std::cout << "BN Finalize run completed successfully" << std::endl;
         
     } catch (cudnn_frontend::cudnnException &e) {
         struct cudaDeviceProp prop;
@@ -2441,5 +2908,491 @@ run_bn_finalize(
             std::cout << "[ERROR] Exception " << e.what() << std::endl;
             CHECK(false);
 #endif   
+    }
+}
+
+cudnnStatus_t run_dsbar(int64_t *Y_dim,
+               int64_t *scaleTensorDim,
+               int64_t *biasTensorDim,
+               void *RP_YdevPtr,
+               void *RP_scaleDevPtr,
+               void *RP_biasDevPtr,
+               void *DP_YdevPtr,
+               void *DP_scaleDevPtr,
+               void *DP_biasDevPtr,
+               void *YdevPtr)
+{
+    cudnnHandle_t handle_;
+
+    try {
+        // Create a handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // Create tensor descriptors
+        int64_t stride[4];
+
+        // RP_Y tensor
+        generateStrides(Y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto RP_yTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, Y_dim)
+                            .setStride(4, stride)
+                            .setId('y')
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_HALF)
+                            .build();
+
+        // RP_scale tensor
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto RP_scaleTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, scaleTensorDim)
+                            .setStride(4, stride)
+                            .setId('s')
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        // After RP scale tensor (RP_yTensor * RP_scaleTensor)
+        generateStrides(Y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto RP_afterScaleTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, Y_dim)
+                            .setStride(4, stride)
+                            .setId('d')
+                            .setVirtual()
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+
+        // RP_bias tensor
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto RP_biasTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, scaleTensorDim)
+                            .setStride(4, stride)
+                            .setId('b')
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        // After RP bias tensor (RP_afterScaleTensor + RP_biasTensor)
+        generateStrides(Y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto RP_afterBiasTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, Y_dim)
+                            .setStride(4, stride)
+                            .setId('e')
+                            .setVirtual()
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        // DP_Y tensor
+        generateStrides(Y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto DP_yTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, Y_dim)
+                            .setStride(4, stride)
+                            .setId('a')
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_HALF)
+                            .build();
+
+        // DP_scale tensor
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto DP_scaleTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, scaleTensorDim)
+                            .setStride(4, stride)
+                            .setId('h')
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        // After DP scale tensor (DP_yTensor * DP_scaleTensor)
+        generateStrides(Y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto DP_afterScaleTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, Y_dim)
+                            .setStride(4, stride)
+                            .setId('p')
+                            .setVirtual()
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+
+        // DP_bias tensor
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto DP_biasTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, scaleTensorDim)
+                            .setStride(4, stride)
+                            .setId('t')
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        // After DP bias tensor (DP_afterScaleTensor + DP_biasTensor)
+        generateStrides(Y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto DP_afterBiasTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, Y_dim)
+                            .setStride(4, stride)
+                            .setId('n')
+                            .setVirtual()
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        // After add RP_bias and DP_bias tensor (RP_afterBiasTensor + DP_afterBiasTensor)
+        generateStrides(Y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto afterAddTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, Y_dim)
+                            .setStride(4, stride)
+                            .setId('m')
+                            .setVirtual()
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        // Final output tensor after ReLU
+        auto yTensor = cudnn_frontend::TensorBuilder()
+                            .setDim(4, Y_dim)
+                            .setStride(4, stride)
+                            .setId('f')
+                            .setAlignment(16) //16 byte alignment
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        std::cout << RP_yTensor.describe() << std::endl;
+        std::cout << DP_yTensor.describe() << std::endl;
+
+        // Create the scale, add, and relu problems
+        // Scale descriptor
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_MUL)
+                            .setComputeType(CUDNN_DATA_FLOAT)
+                            .build();
+        std::cout << scaleDesc.describe() << std::endl;
+
+        // Bias (add) descriptor
+        auto addDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_ADD)
+                            .setComputeType(CUDNN_DATA_FLOAT)
+                            .build();
+        std::cout << addDesc.describe() << std::endl;
+
+        // ReLU descriptor
+        auto actDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_RELU_FWD)
+                            .setComputeType(CUDNN_DATA_FLOAT)
+                            .build();
+        std::cout << actDesc.describe() << std::endl;
+        std::cout << "Creating Operations now!" << std::endl;
+
+        // Create RP scaling operation
+        auto RP_scaleOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(RP_yTensor)
+                            .setbDesc(RP_scaleTensor)
+                            .setyDesc(RP_afterScaleTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << RP_scaleOp.describe() << std::endl;
+
+        // Create RP bias operation
+        auto RP_biasOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(RP_afterScaleTensor)
+                            .setbDesc(RP_biasTensor)
+                            .setyDesc(RP_afterBiasTensor)
+                            .setpwDesc(addDesc)
+                            .build();
+        std::cout << RP_biasOp.describe() << std::endl;
+
+        // Create DP scaling operation
+        auto DP_scaleOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(DP_yTensor)
+                            .setbDesc(DP_scaleTensor)
+                            .setyDesc(DP_afterScaleTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << DP_scaleOp.describe() << std::endl;
+
+        // Create DP bias operation
+        auto DP_biasOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(DP_afterScaleTensor)
+                            .setbDesc(DP_biasTensor)
+                            .setyDesc(DP_afterBiasTensor)
+                            .setpwDesc(addDesc)
+                            .build();
+        std::cout << DP_biasOp.describe() << std::endl;
+
+        // Create add operation
+        auto addOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(RP_afterBiasTensor)
+                            .setbDesc(DP_afterBiasTensor)
+                            .setyDesc(afterAddTensor)
+                            .setpwDesc(addDesc)
+                            .build();
+        std::cout << addOp.describe() << std::endl;
+
+        // Create ReLU operation
+        auto actOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(afterAddTensor)
+                            .setyDesc(yTensor)
+                            .setpwDesc(actDesc)
+                            .build();
+        std::cout << actOp.describe() << std::endl;
+        std::cout << "Creating operation graph now!" << std::endl;
+
+        // Create an Operation Graph. In this case it is:
+        // RP_scaleOp -> RP_biasOp -> DP_scaleOp -> DP_biasOp -> addOp -> reluOp
+        std::array<cudnn_frontend::Operation const*, 6> ops = {&RP_scaleOp, &RP_biasOp, &DP_scaleOp, &DP_biasOp, &addOp, &actOp};
+        auto opGraph = cudnn_frontend::OperationGraphBuilder().setHandle(handle_).setOperationGraph(ops.size(), ops.data()).build();
+        std::cout << opGraph.describe() << std::endl;
+
+        // Create engine configuration
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = cudnn_frontend::get_heuristics_list<2>({"heuristics_instant", "heuristics_fallback"}, opGraph,::allowAll, filtered_configs, true);
+
+        std::cout << "get_heuristics_list Statuses: ";
+        for (auto i = 0 ; i < statuses.size(); i++) {
+            std::cout << cudnn_frontend::to_string(statuses[i]) << " ";
+        }
+        std::cout << std::endl;
+        std::cout << "Filter config list has " << filtered_configs.size() << " configurations " << std::endl;
+    
+
+        auto plan =
+            cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        void* data_ptrs[] = {RP_YdevPtr, DP_YdevPtr, RP_scaleDevPtr, DP_scaleDevPtr, RP_biasDevPtr, DP_biasDevPtr, YdevPtr};
+        int64_t uids[]    = {'y', 'a', 's', 'h', 'b', 't', 'f'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(7, data_ptrs)
+                               .setUids(7, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+        return status;
+        
+    } catch (cudnn_frontend::cudnnException &e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+#if (CUDNN_VERSION >= 8300)
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+            CHECK(false);
+#endif
+        return CUDNN_STATUS_SUCCESS;
+    }
+}
+
+void
+run_conv_two_global_scales(int64_t* xTensorDim,
+                   int64_t* wTensorDim,
+                   int64_t* yTensorDim,
+                   int64_t* scaleTensorDim,
+                   int convDim,
+                   int64_t* conv_padA,
+                   int64_t* conv_dilationA,
+                   int64_t* conv_strideA,
+                   void* devPtrX,
+                   void* devPtrW,
+                   void* devPtrScale1,
+                   void* devPtrScale2,
+                   void* devPtrOutput,
+                   void* afterConv) {
+                        
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // Creates the necessary tensor descriptors
+        int64_t stride[4];
+        generateStrides(xTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto xTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, xTensorDim)
+                           .setStride(4, stride)
+                           .setId('x')
+                           .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                           .setDataType(CUDNN_DATA_HALF)
+                           .build();
+
+        generateStrides(scaleTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto scale1Tensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, scaleTensorDim)
+                           .setStride(4, stride)
+                           .setId('s')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_FLOAT)
+                           .build();
+        
+        auto scale2Tensor = cudnn_frontend::TensorBuilder()
+                            .cloneFrom(scale1Tensor, 'b')
+                            .build();
+
+        generateStrides(wTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto wTensor = cudnn_frontend::TensorBuilder()
+                           .setDim(4, wTensorDim)
+                           .setStride(4, stride)
+                           .setId('w')
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_HALF)
+                           .build();
+
+        generateStrides(yTensorDim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto afterConvTensor = cudnn_frontend::TensorBuilder()
+                                   .setDim(4, yTensorDim)
+                                   .setStride(4, stride)
+                                   .setId('a')  // after conv
+                                   .setAlignment(16)
+                                   .setDataType(CUDNN_DATA_HALF)
+                                   .build();
+
+        auto afterScale1Tensor = cudnn_frontend::TensorBuilder()
+                                    .cloneFrom(afterConvTensor, 'v')
+                                    .setVirtual()
+                                    .build();
+
+        auto finalOutputTensor = cudnn_frontend::TensorBuilder()
+                                   .cloneFrom(afterConvTensor, 'y')
+                                   .setVirtual(false)
+                                   .build();
+
+        std::cout << xTensor.describe() << std::endl;
+        std::cout << wTensor.describe() << std::endl;
+        std::cout << finalOutputTensor.describe() << std::endl;
+
+        // Define the convolution problem
+        auto convDesc = cudnn_frontend::ConvDescBuilder()
+                            .setComputeType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setSpatialDimCount(convDim)
+                            .setSpatialStride(convDim, conv_strideA)
+                            .setPrePadding(convDim, conv_padA)
+                            .setPostPadding(convDim, conv_padA)
+                            .setDilation(convDim, conv_dilationA)
+                            .build();
+        std::cout << convDesc.describe() << std::endl;
+
+        // Define the scale descriptor
+        auto scaleDesc = cudnn_frontend::PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_MUL)
+                             .setComputeType(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << scaleDesc.describe() << std::endl;
+
+        std::cout << "Creating OPs " << std::endl;
+
+        // Create a Multiplication Node with scaling parameters.
+        auto scale1_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(afterConvTensor)
+                            .setbDesc(scale1Tensor)
+                            .setyDesc(afterScale1Tensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << scale1_op.describe() << std::endl;
+
+        auto scale2_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(afterScale1Tensor)
+                            .setbDesc(scale2Tensor)
+                            .setyDesc(finalOutputTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << scale2_op.describe() << std::endl;
+
+        float alpha = 1.0f;
+        float beta  = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                           .setxDesc(xTensor)
+                           .setwDesc(wTensor)
+                           .setyDesc(afterConvTensor)
+                           .setcDesc(convDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        std::cout << conv_op.describe() << std::endl;
+
+        // Create an Operation Graph. In this case it is scale bias Relu conv gen_stats
+        std::array<cudnn_frontend::Operation const*, 3> ops = {&conv_op, &scale1_op, &scale2_op};
+        auto opGraph = cudnn_frontend::OperationGraphBuilder().setHandle(handle_).setOperationGraph(ops.size(), ops.data()).build();
+        std::cout << opGraph.describe() << std::endl;
+
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = 
+            cudnn_frontend::get_heuristics_list<2>({"heuristics_instant" 
+            , "heuristics_fallback"
+            }, opGraph,::allowAll, filtered_configs, true);
+        
+        std::cout << "get_heuristics_list Statuses: ";
+        for (auto i = 0 ; i < statuses.size(); i++) {
+            std::cout << cudnn_frontend::to_string(statuses[i]) << " ";
+        }
+        std::cout << std::endl;
+        std::cout << "Filter config list has " << filtered_configs.size() << " configurations " << std::endl;
+
+        cudnn_frontend::ManagedOpaqueDescriptor plan_desc = nullptr;
+        auto workspace_size = 0;
+        for (auto &config: filtered_configs) {
+            try {
+                auto plan =
+                    cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(config, opGraph.getTag()).build();
+                std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+                workspace_size = plan.getWorkspaceSize();
+                std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+                plan_desc = plan.get_desc();
+            } catch (cudnn_frontend::cudnnException& e)  {
+                continue;
+            }
+        }
+        if (plan_desc == nullptr ) {
+            std::cout << "No plan found implementing the operation graph" << std::endl;
+        }
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        void* data_ptrs[] = {devPtrX, devPtrW, devPtrScale1, devPtrScale2, devPtrOutput, afterConv};
+        int64_t uids[]    = {'x', 'w', 's', 'b', 'y', 'a'};
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(6, data_ptrs)
+                               .setUids(6, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan_desc->get_backend_descriptor(), variantPack.get_raw_desc());
+
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+
+        // this example is only for Ampere cards
+        if (prop.major < 8 && e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED) {
+            std::cout << "Fusion with float inputs is only supported on Ampere or later" << std::endl;
+        } else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+#if (CUDNN_VERSION >= 8300)
+            CHECK(false);
+#endif
+        }
     }
 }

--- a/samples/fusion_sample.h
+++ b/samples/fusion_sample.h
@@ -128,6 +128,30 @@ run_conv_scale_bias_relu_int8(int64_t* x_dim,
                               void* devPtrB);
 
 void
+run_pool_scale_bias_relu_int8(int64_t* x_dim,
+                              int64_t* y_dim,
+                              int64_t* s_dim,
+                              int64_t* b_dim,
+                              void* devPtrX,
+                              void* devPtrY,
+                              void* devPtrS,
+                              void* devPtrB, 
+                              cudnnDataType_t compType,
+#if (CUDNN_VERSION >= 8500) 
+                              cudnnResampleMode_t mode ,
+                              cudnnNanPropagation_t nanOpt, 
+                              cudnnPaddingMode_t paddingMode, 
+#endif
+                              int64_t nbSpatialDims,                         
+                              double alpha,                           
+                              double beta,
+                              int64_t* windowDimA,
+                              int64_t* prePaddingA,
+                              int64_t* postPaddingA,
+                              int64_t* strideA);
+ 
+
+void
 run_matmul_bias_gelu(int64_t* a_dim,
                      int64_t* b_dim,
                      int64_t* c_dim,
@@ -136,7 +160,21 @@ run_matmul_bias_gelu(int64_t* a_dim,
                      void* devPtrA,
                      void* devPtrB,
                      void* devPtrC,
-                     void* devPtrZ);
+                     void* devPtrZ,
+                     void* devPtrAfterZ);
+
+                     
+void
+run_matmul_dgelu_dbias(const int64_t* a_dim,
+                       const int64_t* b_dim,
+                       const int64_t* c_dim,
+                       const int64_t* bias_dim,
+                       cudnnDataType_t dataType,
+                       void* devPtrDy,
+                       void* devPtrW,
+                       void* devPtrX,
+                       void* devPtrDX,
+                       void* devPtrDBias);
 
 void
 run_conv_drelu(int64_t* x,
@@ -178,7 +216,7 @@ run_conv_reduction(int64_t* x_dim,
                    void* devPtrW,
                    void* devPtrR);
 
-void
+cudnnStatus_t
 run_bn_conv_gen_stat(int64_t* xTensorDim, 
                     int64_t* wTensorDim, 
                     int64_t* yTensorDim,  
@@ -217,3 +255,31 @@ run_bn_finalize(
     double exponential_decay_factor,
     int64_t accumCnt_val
 );
+
+cudnnStatus_t run_dsbar(int64_t *Y_dim,
+               int64_t *scaleTensorDim,
+               int64_t *biasTensorDim,
+               void *RP_YdevPtr,
+               void *RP_scaleDevPtr,
+               void *RP_biasDevPtr,
+               void *DP_YdevPtr,
+               void *DP_scaleDevPtr,
+               void *DP_biasDevPtr,
+               void *YdevPtr);
+
+void
+run_conv_two_global_scales(int64_t* xTensorDim,
+                   int64_t* wTensorDim,
+                   int64_t* yTensorDim,
+                   int64_t* scaleTensorDim,
+                   int convDim,
+                   int64_t* conv_padA,
+                   int64_t* conv_dilationA,
+                   int64_t* conv_strideA,
+                   void* devPtrX,
+                   void* devPtrW,
+                   void* devPtrScale1,
+                   void* devPtrScale2,
+                   void* devPtrOutput,
+                   void* afterConv);
+

--- a/samples/mha_sample.cpp
+++ b/samples/mha_sample.cpp
@@ -224,7 +224,7 @@ class MHA_intputProjLayer {
 
         auto wMatrixTensor = cudnn_frontend::TensorBuilder()
                                  .setDim(3, wDim)
-                                 .setStrides(3, wStride)
+                                 .setStride(3, wStride)
                                  .setId('W')
                                  .setAlignment(16)
                                  .setDataType(dataType)
@@ -236,7 +236,7 @@ class MHA_intputProjLayer {
 
         auto iMatrixTensor = cudnn_frontend::TensorBuilder()
                                  .setDim(3, iDim)
-                                 .setStrides(3, iStride)
+                                 .setStride(3, iStride)
                                  .setId('i')
                                  .setAlignment(16)
                                  .setDataType(dataType)
@@ -248,7 +248,7 @@ class MHA_intputProjLayer {
 
         auto bTensor = cudnn_frontend::TensorBuilder()
                            .setDim(3, bDim)
-                           .setStrides(3, bStride)
+                           .setStride(3, bStride)
                            .setId('b')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -260,7 +260,7 @@ class MHA_intputProjLayer {
 
         auto beforeBiasMatrixTensor = cudnn_frontend::TensorBuilder()
                                           .setDim(3, oDim)
-                                          .setStrides(3, oStride)
+                                          .setStride(3, oStride)
                                           .setId('a')
                                           .setAlignment(16)
                                           .setVirtual()
@@ -269,7 +269,7 @@ class MHA_intputProjLayer {
 
         auto oMatrixTensor = cudnn_frontend::TensorBuilder()
                                  .setDim(3, oDim)
-                                 .setStrides(3, oStride)
+                                 .setStride(3, oStride)
                                  .setId('o')
                                  .setAlignment(16)
                                  .setDataType(dataType)
@@ -277,12 +277,12 @@ class MHA_intputProjLayer {
 
         // Define the matmul descriptor for Q, K, V = W * Input
         auto matmulDesc = cudnn_frontend::MatMulDescBuilder()
-                              .setMathPrecision(CUDNN_DATA_FLOAT)
+                              .setComputeType(CUDNN_DATA_FLOAT)
                               .build();
         // Define the Bias descriptor for Q, K, V = W * Input + Bias
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         // Create a matmul Node for Q, K, V = W * Input
         auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
@@ -366,7 +366,7 @@ class MHA_outputProjLayer {
 
         auto wMatrixTensor = cudnn_frontend::TensorBuilder()
                                  .setDim(3, wDim)
-                                 .setStrides(3, wStride)
+                                 .setStride(3, wStride)
                                  .setId('W')
                                  .setAlignment(16)
                                  .setDataType(dataType)
@@ -378,7 +378,7 @@ class MHA_outputProjLayer {
 
         auto iMatrixTensor = cudnn_frontend::TensorBuilder()
                                  .setDim(3, iDim)
-                                 .setStrides(3, iStride)
+                                 .setStride(3, iStride)
                                  .setId('i')
                                  .setAlignment(16)
                                  .setDataType(dataType)
@@ -390,7 +390,7 @@ class MHA_outputProjLayer {
 
         auto bTensor = cudnn_frontend::TensorBuilder()
                            .setDim(3, bDim)
-                           .setStrides(3, bStride)
+                           .setStride(3, bStride)
                            .setId('b')
                            .setAlignment(16)
                            .setDataType(dataType)
@@ -402,7 +402,7 @@ class MHA_outputProjLayer {
 
         auto beforeBiasMatrixTensor = cudnn_frontend::TensorBuilder()
                                           .setDim(3, oDim)
-                                          .setStrides(3, oStride)
+                                          .setStride(3, oStride)
                                           .setId('a')
                                           .setAlignment(16)
                                           .setVirtual()
@@ -410,7 +410,7 @@ class MHA_outputProjLayer {
                                           .build();
         auto oMatrixTensor = cudnn_frontend::TensorBuilder()
                                  .setDim(3, oDim)
-                                 .setStrides(3, oStride)
+                                 .setStride(3, oStride)
                                  .setId('o')
                                  .setAlignment(16)
                                  .setDataType(dataType)
@@ -418,12 +418,12 @@ class MHA_outputProjLayer {
 
         // Define the matmul descriptor
         auto matmulDesc = cudnn_frontend::MatMulDescBuilder()
-                              .setMathPrecision(CUDNN_DATA_FLOAT)
+                              .setComputeType(CUDNN_DATA_FLOAT)
                               .build();
         // Define the Bias descriptor
         auto biasDesc = cudnn_frontend::PointWiseDescBuilder()
                             .setMode(CUDNN_POINTWISE_ADD)
-                            .setMathPrecision(CUDNN_DATA_FLOAT)
+                            .setComputeType(CUDNN_DATA_FLOAT)
                             .build();
         // Create a matmul Node
         auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
@@ -511,7 +511,7 @@ class MHA_attentionLayer {
 
             auto qMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, qDim)
-                                     .setStrides(3, qStride)
+                                     .setStride(3, qStride)
                                      .setId('q')
                                      .setAlignment(16)
                                      .setDataType(dataType)
@@ -522,7 +522,7 @@ class MHA_attentionLayer {
 
             auto kMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, kDim)
-                                     .setStrides(3, kStride)
+                                     .setStride(3, kStride)
                                      .setId('k')
                                      .setAlignment(16)
                                      .setDataType(dataType)
@@ -534,7 +534,7 @@ class MHA_attentionLayer {
 
             auto sMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, sDim)
-                                     .setStrides(3, sStride)
+                                     .setStride(3, sStride)
                                      .setId('s')
                                      .setAlignment(16)
                                      .setVirtual()
@@ -543,7 +543,7 @@ class MHA_attentionLayer {
             // Create tensor descriptor for Z = softmaxScaler * S
             auto zMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, sDim)
-                                     .setStrides(3, sStride)
+                                     .setStride(3, sStride)
                                      .setId('z')
                                      .setAlignment(16)
                                      .setDataType(dataType)
@@ -551,7 +551,7 @@ class MHA_attentionLayer {
             // Create tensor descriptor for E = exp(Z)
             auto eMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, sDim)
-                                     .setStrides(3, sStride)
+                                     .setStride(3, sStride)
                                      .setId('e')
                                      .setAlignment(16)
                                      .setVirtual()
@@ -563,7 +563,7 @@ class MHA_attentionLayer {
 
             auto softmaxScalerTensor = cudnn_frontend::TensorBuilder()
                                            .setDim(3, scalerDim)
-                                           .setStrides(3, scalerStride)
+                                           .setStride(3, scalerStride)
                                            .setId('m')
                                            .setAlignment(16)
                                            .setDataType(CUDNN_DATA_FLOAT)
@@ -574,26 +574,26 @@ class MHA_attentionLayer {
 
             auto cTensor = cudnn_frontend::TensorBuilder()
                                .setDim(3, cDim)
-                               .setStrides(3, cStride)
+                               .setStride(3, cStride)
                                .setId('c')
                                .setAlignment(16)
                                .setDataType(CUDNN_DATA_FLOAT)
                                .build();
             // Define the matmul descriptor for S = (Q^T * K)
-            auto matmulDesc = cudnn_frontend::MatMulDescBuilder().setMathPrecision(CUDNN_DATA_FLOAT).build();
+            auto matmulDesc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
             // Define the scale descriptor for S' = softmaxScaler * S
             auto softmaxScalerDesc = cudnn_frontend::PointWiseDescBuilder()
                                          .setMode(CUDNN_POINTWISE_MUL)
-                                         .setMathPrecision(CUDNN_DATA_FLOAT)
+                                         .setComputeType(CUDNN_DATA_FLOAT)
                                          .build();
             // Define the activation descriptor for E = exp(S')
             auto expDesc = cudnn_frontend::PointWiseDescBuilder()
                                .setMode(CUDNN_POINTWISE_EXP)
-                               .setMathPrecision(CUDNN_DATA_FLOAT)
+                               .setComputeType(CUDNN_DATA_FLOAT)
                                .build();
             // Define the reduction descriptor
             auto colRedunctionDesc = cudnn_frontend::ReductionDescBuilder()
-                                         .setMathPrecision(CUDNN_DATA_FLOAT)
+                                         .setComputeType(CUDNN_DATA_FLOAT)
                                          .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
                                          .build();
             // Create a matmul Node for S = (Q^T * K)
@@ -642,7 +642,7 @@ class MHA_attentionLayer {
 
             auto vMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, vDim)
-                                     .setStrides(3, vStride)
+                                     .setStride(3, vStride)
                                      .setId('v')
                                      .setAlignment(16)
                                      .setDataType(dataType)
@@ -653,7 +653,7 @@ class MHA_attentionLayer {
 
             auto sMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, eDim)
-                                     .setStrides(3, eStride)
+                                     .setStride(3, eStride)
                                      .setId('s')
                                      .setAlignment(16)
                                      .setDataType(dataType)
@@ -661,7 +661,7 @@ class MHA_attentionLayer {
 
             auto eMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, eDim)
-                                     .setStrides(3, eStride)
+                                     .setStride(3, eStride)
                                      .setId('e')
                                      .setAlignment(16)
                                      .setVirtual()
@@ -671,7 +671,7 @@ class MHA_attentionLayer {
             // Create tensor descriptor for P = Y / R
             auto pMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, eDim)
-                                     .setStrides(3, eStride)
+                                     .setStride(3, eStride)
                                      .setId('p')
                                      .setAlignment(16)
                                      .setVirtual()
@@ -684,7 +684,7 @@ class MHA_attentionLayer {
 
             auto yMatrixTensor = cudnn_frontend::TensorBuilder()
                                      .setDim(3, yDim)
-                                     .setStrides(3, yStride)
+                                     .setStride(3, yStride)
                                      .setId('y')
                                      .setAlignment(16)
                                      .setDataType(dataType)
@@ -696,7 +696,7 @@ class MHA_attentionLayer {
 
             auto rTensor = cudnn_frontend::TensorBuilder()
                                .setDim(3, rDim)
-                               .setStrides(3, rStride)
+                               .setStride(3, rStride)
                                .setId('r')
                                .setAlignment(16)
                                .setDataType(CUDNN_DATA_FLOAT)
@@ -704,15 +704,15 @@ class MHA_attentionLayer {
             // Define the activation descriptor
             auto expDesc = cudnn_frontend::PointWiseDescBuilder()
                                .setMode(CUDNN_POINTWISE_EXP)
-                               .setMathPrecision(CUDNN_DATA_FLOAT)
+                               .setComputeType(CUDNN_DATA_FLOAT)
                                .build();
             // Define the row-broadcast descriptor for P = Y / R
             auto rowBroadcastDesc = cudnn_frontend::PointWiseDescBuilder()
                                         .setMode(CUDNN_POINTWISE_DIV)
-                                        .setMathPrecision(CUDNN_DATA_FLOAT)
+                                        .setComputeType(CUDNN_DATA_FLOAT)
                                         .build();
             // Define the matmul descriptor for Y = E * V^T
-            auto matmulDesc = cudnn_frontend::MatMulDescBuilder().setMathPrecision(CUDNN_DATA_FLOAT).build();
+            auto matmulDesc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
 
             // Create a EXP Node for E = exp(S')
             auto expOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)


### PR DESCRIPTION
Release Notes:

cudnn_frontend v0.7 aims to target the new features introduced in cudnn version v8.5 (https://developer.nvidia.com/cudnn). The following are the changes in the v0.7 release.


[New API] Added support for Resample operation.

[New API] Tensor class has a clone method which allows a user to quickly create a new Tensor object with similar attributes.

[New API] Added support for new pointwise operations CUDNN_POINTWISE_ERF, CUDNN_POINTWISE_GELU_APPROX_TANH_FWD, CUDNN_POINTWISE_GELU_APPROX_TANH_BWD, CUDNN_POINTWISE_IDENTITY.

[New API] Several API names have been unified and made consistent across multiple descriptors for readability.  
- `setComputePrecision`/`setMathPrecision`/`setMathType` have been unified into `setComputeType` in `cudnn_frontend_ConvDesc.h`, `cudnn_frontend_MatMulDesc.h`, `cudnn_frontend_Operation.h`, `cudnn_frontend_PointWiseDesc.h`, `cudnn_frontend_ReductionDesc.h`, `cudnn_frontend_Resample.h`
- Math operations like ConvDesc, ResampleDesc have `getSpatialDimCount` instead of `getDimCount` to avoid confusion with Tensor Dimensions.
- Accessors for arrays will have `[g,s]et[Spatial]<AttributeName>` as the API. `[Spatial]` is only needed when the attribute is common to both Tensor descriptor and Operation descriptor. Currently, its only the Stride and DimCount attributes that have ambiguity.
    - setArray functions will take size and pointer as arguments eg. `setStride(int dim, int64_t* arr)`, `setSpatialStride(int dim, int64_t* arr)`
    - getArray functions will return a pointer to the array whose size is determined by `getDimCount` or `getSpatialDimCount`

[Minor Enhancement] Execution plans and Operation Graph printout more information in their `describe()` method.

[Bug Fixes] Some samples have been updated to go over all fallback configs to ensure that a successful plan is built.

[Bug Fixes] Execution plans had wrongly initialized numerical note CUDNN_NUMERICAL_NOTE_TYPE_TENSOR_CORE. This has been fixed.

[Samples] Added a new sample that does scale and bias of two tensors, adds them followed by a ReLU operation to show how fused operations work.

[Samples] Added a sample to demonstrate how the resample operation works.

[Samples] Added a new sample which shows convolution followed by multiple scales.

[Samples] Added a sample to show Fully Connected Layer fused with GeLU forward.

[Samples] Added a new sample to show fused backward activation, backward bias and backward Data Grad operation.