### PR TITLE
v0.7.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,69 +1,15 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.17)
 
-project(Samples VERSION 0.5)
+project(cudnn_frontend VERSION 0.7)
 
-set(CMAKE_VERBOSE_MAKEFILE on)
+add_library(cudnn_frontend INTERFACE)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+target_include_directories(
+    cudnn_frontend INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
-set (CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE INTERNAL "")
+target_compile_features(cudnn_frontend INTERFACE cxx_std_11)
 
-if (MSVC)
-    # warning level 4 and all warnings as errors
-    add_compile_options(/W4 /WX)
-else()
-    # lots of warnings and all warnings as errors
-    add_compile_options(-Wall -Wextra -Werror -Wno-unused-function -Wno-unused-parameter -Wno-pessimizing-move -Wno-unused-variable -Wno-sign-compare -Werror=strict-aliasing -Wnon-virtual-dtor)
-endif()
-
-
-if(DEFINED ENV{CUDA_PATH})
-link_directories($ENV{CUDA_PATH}/lib64)
-else()
-link_directories(/usr/local/cuda/lib64)
-endif()
-
-if(DEFINED ENV{CUDNN_PATH})
-link_directories($ENV{CUDNN_PATH}/lib64)
-link_directories($ENV{CUDNN_PATH}/lib)
-endif()
-
-add_executable(Samples samples/conv_sample.cpp 
-                       samples/test_list.cpp 
-                       samples/fp16_emu.cpp 
-                       samples/catch.cpp 
-                       samples/helpers.cpp 
-                       samples/fusion_sample.cpp 
-                       samples/mha_sample.cpp)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-
-if(DEFINED ENV{NO_DEFAULT_IN_SWITCH})
-    message("Default case in the switch is disabled")
-    add_compile_definitions(NO_DEFAULT_IN_SWITCH)
-endif()
-
-if(DEFINED ENV{CUDA_PATH})
-    target_include_directories(Samples PUBLIC $ENV{CUDA_PATH}/include/)
-    target_include_directories(Samples PUBLIC $ENV{CUDA_PATH}/targets/ppc64le-linux/include)
-else()
-    target_include_directories(Samples PUBLIC /usr/local/cuda/include/)
-    target_include_directories(Samples PUBLIC /usr/local/cuda/targets/ppc64le-linux/include)
-endif()
-
-if(DEFINED ENV{CUDNN_PATH})
-    target_include_directories(Samples PUBLIC $ENV{CUDNN_PATH}/include/)
-endif()
-
-if(DEFINED ENV{CUDNN_FRONTEND_PATH})
-    target_include_directories(Samples PUBLIC $ENV{CUDNN_FRONTEND_PATH}/include/)
-    target_include_directories(Samples PUBLIC $ENV{CUDNN_FRONTEND_PATH}/contrib/catch2/)
-else()
-    target_include_directories(Samples PUBLIC include/)
-    target_include_directories(Samples PUBLIC contrib/catch2/)
-endif()
-
-target_link_libraries(Samples cudart)
-target_link_libraries(Samples cudnn)
-target_link_libraries(Samples m)
+add_subdirectory(samples)

--- a/README.md
+++ b/README.md
@@ -44,18 +44,15 @@ Samples of runtime fusion are added in `samples/test_list.cpp` and `samples/fusi
 Sample tests are written using the [Catch2](https://github.com/catchorg/Catch2) C++ test framework.
 
 ### How to build samples:
-     - CUDA_PATH has the cuda installation. 
-        - Include files are in CUDA_PATH/include
-        - Link files are in CUDA_PATH/lib64
-     - CUDNN_FRONTEND_PATH has the cudnn frontend header files.
+     - Provide CUDA according to: https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html
      - CUDNN_PATH has the cudnn installation.
-        - Include files are in CUDNN_PATH/include
-        - Link files are in CUDNN_PATH/lib or CUDNN_PATH/lib64
+        - Headers are in CUDNN_PATH/include
+        - Libraries are in CUDNN_PATH/lib or CUDNN_PATH/lib64 or CUDNN_PATH/lib/x64
 
      mkdir build; cd build
-     cmake ..
-     make
-     ./Samples
+     cmake -DCUDNN_PATH=/path/to/cudnn -DCUDAToolkit_ROOT=/path/to/cuda  ../
+     cmake --build . -j16
+     bin/samples
     
 ## cudnnFindPlan and cudnnGetPlan:
 Prior to cuDNN V8, cuDNN provided `cudnnFindConvolution*` and `cudnnGetConvolution*` functions, which provided a way to sample all the algorithms for a given problem and study the run times. This can be further used to cache the best algorithms for a given problem.  In cuDNN V8, this has been replaced with `cudnnFindPlan` and `cudnnGetPlan`.

--- a/include/cudnn_frontend_Engine.h
+++ b/include/cudnn_frontend_Engine.h
@@ -298,7 +298,7 @@ class EngineBuilder_v8 {
         }
 
 
-        for (uint64_t i = 0; i < m_engine.bKnobs.size(); i++) {
+        for (size_t i = 0; i < m_engine.bKnobs.size(); i++) {
             m_engine.bKnobs[i] = make_shared_backend_pointer(CUDNN_BACKEND_KNOB_INFO_DESCRIPTOR);
             if (m_engine.bKnobs[i]->is_good() == false) {
                 status = m_engine.bKnobs[i]->get_status();

--- a/include/cudnn_frontend_EngineConfig.h
+++ b/include/cudnn_frontend_EngineConfig.h
@@ -75,7 +75,7 @@ class EngineConfig_v8 : public BackendDescriptor {
    private:
     EngineConfig_v8() : BackendDescriptor() {
         cudnnStatus_t status;
-        for (uint64_t i = 0; i < bChoices.size(); i++) {
+        for (size_t i = 0; i < bChoices.size(); i++) {
             bChoices[i] = make_shared_backend_pointer(CUDNN_BACKEND_KNOB_CHOICE_DESCRIPTOR);
             if (bChoices[i]->is_good() == false) {
                 status = bChoices[i]->get_status();

--- a/include/cudnn_frontend_Errata.h
+++ b/include/cudnn_frontend_Errata.h
@@ -38,7 +38,7 @@ namespace cudnn_frontend {
 // is not set the value set in the API is considered.
 static bool
 load_from_config(json &json_handle, const std::string & errata_json) {
-    const char * err_json = std::getenv("CUDNN_ERRATA_JSON_FILE");
+    const char * err_json = get_environment("CUDNN_ERRATA_JSON_FILE");
     if (err_json == NULL && errata_json == "") {return false;}
     if (err_json == NULL) { err_json = errata_json.c_str();}
     std::ifstream ifs(err_json, std::ifstream::in);
@@ -54,7 +54,7 @@ check_rule(const json &json_handle, const std::string & executionPlanTag,
     std::string operation = json_handle["operation"];
     int64_t engine        =  json_handle["engine"];
     uint64_t cudnn_start     =  0;
-    uint64_t cudnn_end       =  -1;
+    uint64_t cudnn_end       =  std::numeric_limits<uint64_t>::max();
     if (json_handle.contains("cudnn_version_start")) {
         cudnn_start   =  json_handle["cudnn_version_start"];
     }

--- a/include/cudnn_frontend_ExecutionPlan.h
+++ b/include/cudnn_frontend_ExecutionPlan.h
@@ -142,7 +142,7 @@ class ExecutionPlan_v8 : public BackendDescriptor {
                                           "CUDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR: GetAttribute "
                                           "CUDNN_ATTR_EXECUTION_PLAN_JSON_REPRESENTATION Failed");
         }
-        serialization_buf.resize(serializationSize);
+        serialization_buf.resize(static_cast<size_t>(serializationSize));
         status = cudnnBackendGetAttribute(pointer->get_backend_descriptor(),
                                           CUDNN_ATTR_EXECUTION_PLAN_JSON_REPRESENTATION,
                                           CUDNN_TYPE_CHAR,
@@ -182,18 +182,18 @@ class ExecutionPlan_v8 : public BackendDescriptor {
                                  CUDNN_TYPE_NUMERICAL_NOTE,
                                  CUDNN_NUMERICAL_NOTE_TYPE_COUNT,
                                  &elem_count,
-                                 NULL);
-        numeric_notes_vec.resize(elem_count);
+                                 nullptr);
+        numeric_notes_vec.resize(static_cast<size_t>(elem_count));
         status = cudnnBackendGetAttribute(extractedEngine_,
                                  CUDNN_ATTR_ENGINE_NUMERICAL_NOTE,
                                  CUDNN_TYPE_NUMERICAL_NOTE,
                                  CUDNN_NUMERICAL_NOTE_TYPE_COUNT,
                                  &elem_count,
                                  numeric_notes_vec.data());
-        auto end = std::min(elem_count, static_cast<int64_t>(CUDNN_NUMERICAL_NOTE_TYPE_COUNT));
+        ptrdiff_t end = static_cast<ptrdiff_t>(std::min(elem_count, static_cast<int64_t>(CUDNN_NUMERICAL_NOTE_TYPE_COUNT)));
         std::copy(numeric_notes_vec.begin(), numeric_notes_vec.begin() + end, numeric_notes.begin());
-        if (elem_count < numeric_notes.size())
-            std::fill_n(numeric_notes.begin() + elem_count, numeric_notes.size() - elem_count, CUDNN_NUMERICAL_NOTE_TYPE_COUNT);
+        if (static_cast<size_t>(elem_count) < numeric_notes.size())
+            std::fill_n(numeric_notes.begin() + static_cast<size_t>(elem_count), numeric_notes.size() - static_cast<size_t>(elem_count), CUDNN_NUMERICAL_NOTE_TYPE_COUNT);
         if (status != CUDNN_STATUS_SUCCESS) {
             set_error_and_throw_exception(this,
                                           status,
@@ -206,18 +206,18 @@ class ExecutionPlan_v8 : public BackendDescriptor {
                                  CUDNN_TYPE_BEHAVIOR_NOTE,
                                  CUDNN_BEHAVIOR_NOTE_TYPE_COUNT,
                                  &elem_count,
-                                 NULL);
-        behavior_notes_vec.resize(elem_count);
+                                 nullptr);
+        behavior_notes_vec.resize(static_cast<size_t>(elem_count));
         status = cudnnBackendGetAttribute(extractedEngine_,
                                  CUDNN_ATTR_ENGINE_BEHAVIOR_NOTE,
                                  CUDNN_TYPE_BEHAVIOR_NOTE,
                                  CUDNN_BEHAVIOR_NOTE_TYPE_COUNT,
                                  &elem_count,
                                  behavior_notes_vec.data());
-        end = std::min(elem_count, static_cast<int64_t>(CUDNN_BEHAVIOR_NOTE_TYPE_COUNT));
+        end = static_cast<ptrdiff_t>(std::min(elem_count, static_cast<int64_t>(CUDNN_BEHAVIOR_NOTE_TYPE_COUNT)));
         std::copy(behavior_notes_vec.begin(), behavior_notes_vec.begin() + end, behavior_notes.begin());
-        if (elem_count < behavior_notes.size())
-            std::fill_n(behavior_notes.begin() + elem_count, behavior_notes.size() - elem_count, CUDNN_BEHAVIOR_NOTE_TYPE_COUNT);
+        if (static_cast<size_t>(elem_count) < behavior_notes.size())
+            std::fill_n(behavior_notes.begin() + static_cast<size_t>(elem_count), behavior_notes.size() - static_cast<size_t>(elem_count), CUDNN_BEHAVIOR_NOTE_TYPE_COUNT);
         if (status != CUDNN_STATUS_SUCCESS) {
             set_error_and_throw_exception(this,
                                           status,
@@ -278,7 +278,7 @@ class ExecutionPlan_v8 : public BackendDescriptor {
                                           "CUDNN_BACKEND_EXECUTION_PLAN_DESCRIPTOR: GetAttribute "
                                           "numKnobs exceed the CUDNN_KNOB_TYPE_COUNTS");
         }
-        for (int64_t idx = 0; idx < numKnobs; ++idx) {
+        for (size_t idx = 0; idx < static_cast<size_t>(numKnobs); ++idx) {
             const cudnnBackendDescriptor_t &knob = extractedKnobs_[idx];
             cudnnBackendKnobType_t type          = CUDNN_KNOB_TYPE_COUNTS;
             int64_t choice                       = -2;
@@ -310,7 +310,7 @@ class ExecutionPlan_v8 : public BackendDescriptor {
                 CUDNN_ATTR_EXECUTION_PLAN_WORKSPACE_SIZE,
                 CUDNN_TYPE_INT64,
                 1,
-                NULL,
+                nullptr,
                 &workSpaceSize);
         if (status != CUDNN_STATUS_SUCCESS) {
             set_error_and_throw_exception(this,

--- a/include/cudnn_frontend_ExecutionPlanCache.h
+++ b/include/cudnn_frontend_ExecutionPlanCache.h
@@ -81,12 +81,7 @@ class ExecutionPlanCache_v1 {
    protected:
     struct compare {
         bool operator ()(const feature_vector_t & fv1, const feature_vector_t &fv2) const {
-            for (uint32_t i = 0u; i < fv1.size(); i++) {
-                if (fv1[i] < fv2[i]) {
-                    return true;
-                }
-            }
-            return false;
+            return fv1 < fv2;
         }
     };
 

--- a/include/cudnn_frontend_Logging.h
+++ b/include/cudnn_frontend_Logging.h
@@ -28,20 +28,30 @@
 
 #include "cudnn_backend_base.h"
 namespace  cudnn_frontend {
+
+static const char *
+get_environment(const char *name) {
+#ifdef WIN32
+#pragma warning(disable:4996)
+#define  _CRT_SECURE_NO_WARNINGS
+#endif
+
+    return std::getenv(name);
+}
+
 inline bool &
 isLoggingEnabled() {
-    static bool log_enabled = std::getenv("CUDNN_FRONTEND_LOG_INFO") && std::strncmp(std::getenv("CUDNN_FRONTEND_LOG_INFO"), "0",1);
+    static bool log_enabled = get_environment("CUDNN_FRONTEND_LOG_INFO") && std::strncmp(get_environment("CUDNN_FRONTEND_LOG_INFO"), "0",1);
     return log_enabled;
 }
- 
  
 inline std::ostream &
 getStream() {                                                                                                                                                                                                                      
     static std::ofstream outFile;
-    static std::ostream & stream  = std::getenv("CUDNN_FRONTEND_LOG_FILE")
-         ?  (std::strncmp(std::getenv("CUDNN_FRONTEND_LOG_FILE"), "stdout", 6) == 0 
-             ? std::cout : (std::strncmp(std::getenv("CUDNN_FRONTEND_LOG_FILE"), "stderr", 6) == 0 
-                 ? std::cerr : (outFile.open(std::getenv("CUDNN_FRONTEND_LOG_FILE"), std::ios::out), outFile)))
+    static std::ostream & stream  = get_environment("CUDNN_FRONTEND_LOG_FILE")
+         ?  (std::strncmp(get_environment("CUDNN_FRONTEND_LOG_FILE"), "stdout", 6) == 0 
+             ? std::cout : (std::strncmp(get_environment("CUDNN_FRONTEND_LOG_FILE"), "stderr", 6) == 0 
+                 ? std::cerr : (outFile.open(get_environment("CUDNN_FRONTEND_LOG_FILE"), std::ios::out), outFile)))
          : (isLoggingEnabled() = false, std::cout);
     return stream;
 }

--- a/include/cudnn_frontend_OperationGraph.h
+++ b/include/cudnn_frontend_OperationGraph.h
@@ -78,7 +78,7 @@ class OperationGraph_v8 : public BackendDescriptor {
                                                CUDNN_ATTR_OPERATIONGRAPH_ENGINE_GLOBAL_COUNT,
                                                CUDNN_TYPE_INT64,
                                                1,
-                                               NULL,
+                                               nullptr,
                                                &global_count);
         if (status != CUDNN_STATUS_SUCCESS) {
             set_error_and_throw_exception(this,
@@ -142,7 +142,7 @@ class OperationGraphBuilder_v8 {
     auto
     setOperationGraph(int64_t numOps_, Operation_v8 const **ops_) -> OperationGraphBuilder_v8 & {
         m_operationGraph.numOps = numOps_;
-        m_operationGraph.feature_vectors.resize(numOps_);
+        m_operationGraph.feature_vectors.resize(static_cast<size_t>(numOps_));
         for (auto i = 0u; i < numOps_; i++) {
             m_operationGraph.ops[i] = ops_[i]->get_desc();
             m_operationGraph.opGraphTag += ops_[i]->getTag() + '_';

--- a/include/cudnn_frontend_Reorder_Tensor.h
+++ b/include/cudnn_frontend_Reorder_Tensor.h
@@ -56,8 +56,8 @@ cudnnReorderFilterAndBiasInt8x32(cudnnHandle_t handle,
     cudnn_status = cudnnCreateFilterDescriptor(&filterDesc);
     if (cudnn_status != CUDNN_STATUS_SUCCESS) {return cudnn_status;}
 
-    int conv_dims        = conv_desc.getDimensionCount();
-    int tensor_dims      = tensor.getDimensionCount();
+    auto conv_dims        = int(conv_desc.getDimensionCount());
+    auto tensor_dims      = int(tensor.getDimensionCount());
     auto non_shape_dims  = tensor_dims - conv_dims;
     
     if (non_shape_dims != 2 && non_shape_dims != 3) {

--- a/include/cudnn_frontend_VariantPack.h
+++ b/include/cudnn_frontend_VariantPack.h
@@ -90,7 +90,7 @@ class VariantPackBuilder_v8 {
     //! Set dataPointers for the VariantPack_v8
     auto
     setDataPointers(int64_t num_ptr, void **ptrs) -> VariantPackBuilder_v8 & {
-        m_variant_pack.data_pointers.reserve(num_ptr);
+        m_variant_pack.data_pointers.reserve(static_cast<size_t>(num_ptr));
         std::copy(ptrs, ptrs + num_ptr, std::back_inserter(m_variant_pack.data_pointers));
         m_variant_pack.num_ptrs = num_ptr;
         return *this;
@@ -103,7 +103,7 @@ class VariantPackBuilder_v8 {
 
     auto
     setUids(int64_t num_uids, int64_t *uid) -> VariantPackBuilder_v8 & {
-        m_variant_pack.uid.reserve(num_uids);
+        m_variant_pack.uid.reserve(static_cast<size_t>(num_uids));
         std::copy(uid, uid + num_uids, std::back_inserter(m_variant_pack.uid));
         return *this;
     }
@@ -111,8 +111,8 @@ class VariantPackBuilder_v8 {
     auto
     setDataPointers(std::set<std::pair<uint64_t, void *>> const &data_pointers) -> VariantPackBuilder_v8 & {
         m_variant_pack.num_ptrs = data_pointers.size();
-        m_variant_pack.uid.reserve(m_variant_pack.num_ptrs);
-        m_variant_pack.data_pointers.reserve(m_variant_pack.num_ptrs);
+        m_variant_pack.uid.reserve(static_cast<size_t>(m_variant_pack.num_ptrs));
+        m_variant_pack.data_pointers.reserve(static_cast<size_t>(m_variant_pack.num_ptrs));
         for (auto &data_pointer : data_pointers) {
             m_variant_pack.uid.push_back(data_pointer.first);
             m_variant_pack.data_pointers.push_back(data_pointer.second);

--- a/include/cudnn_frontend_find_plan.h
+++ b/include/cudnn_frontend_find_plan.h
@@ -76,8 +76,14 @@ time_sorted_plan(cudnnHandle_t handle, executionPlans_t plans, VariantPack const
             cudaEventRecord(stop, stream);
             cudaEventSynchronize(stop);
             cudaEventElapsedTime(&time_ms, start, stop);
-
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4127) // this could be ommited with c++17 and contexpr
+#endif
             if (samplingTechnique == CudnnFindSamplingTechnique::CUDNN_FIND_SAMPLE_TILL_STABLE) {
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
                 final_time_ms = std::min(min_time_ms, time_ms);
                 if (time_ms / min_time_ms < threshhold) {
                     min_time_ms = final_time_ms;

--- a/include/cudnn_frontend_utils.h
+++ b/include/cudnn_frontend_utils.h
@@ -28,6 +28,12 @@
 #include "cudnn_backend_base.h"
 #include "cudnn_frontend_Logging.h"
 
+#ifndef NV_CUDNN_DISABLE_EXCEPTION
+#ifdef _MSC_VER
+#pragma warning(disable:4702) // if exceptions are enabled there are unreachable return statements
+#endif
+#endif
+
 #define CUDNN_FRONTEND_UNUSED(X) ((void)X)
 namespace cudnn_frontend {
 
@@ -97,6 +103,12 @@ to_string(cudnnDataType_t type) {
 #if (CUDNN_VERSION >= 8300)
         case CUDNN_DATA_BOOLEAN:
             return std::string("CUDNN_DATA_BOOLEAN");
+#endif
+#if (CUDNN_VERSION >= 8600)
+        case CUDNN_DATA_FP8_E5M2:
+            return std::string("CUDNN_DATA_FP8_E5M2");
+        case CUDNN_DATA_FP8_E4M3:
+            return std::string("CUDNN_DATA_FP8_E4M3");
 #endif
 #ifndef NO_DEFAULT_IN_SWITCH
         default:

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.18)
+
+Include(FetchContent)
+
+# Find the cuda compiler
+find_package(CUDAToolkit)
+
+# Fetch and build catch2
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v3.0.1
+)
+FetchContent_MakeAvailable(Catch2)
+
+# Find cudnn
+include(${CMAKE_SOURCE_DIR}/cmake/cuDNN.cmake)
+
+add_executable(
+    samples
+    conv_sample.cpp 
+    test_list.cpp 
+    fp16_emu.cpp 
+    helpers.cpp 
+    fusion_sample.cpp 
+    fp8_sample.cpp 
+    mha_sample.cpp
+)
+
+if(DEFINED ENV{NO_DEFAULT_IN_SWITCH})
+    message("Default case in the switch is disabled")
+    add_compile_definitions(NO_DEFAULT_IN_SWITCH)
+endif()
+
+if (MSVC)
+    target_compile_options(
+        samples PRIVATE
+        /W4 /WX # warning level 3 and all warnings as errors
+        /wd4100 # allow unused parameters
+        /wd4458 # local hides class member (currently a problem for all inline setters)
+        /wd4505 # unreferenced function with internal linkage has been removed
+        /wd4101 /wd4189 # unreferenced local
+    )
+else()
+    target_compile_options(
+        samples PRIVATE
+        -Wall
+        -Wextra
+        -Werror
+        -Wno-unused-function
+    )
+endif()
+
+target_link_libraries(
+    samples
+    cudnn_frontend
+    Catch2::Catch2WithMain
+
+    CUDA::cudart
+    CUDA::cublas
+    CUDA::nvrtc
+    
+    CUDNN::cudnn_all
+)
+
+# cuDNN dlopen's its libraries
+# Add all libraries in link line as NEEDED
+set_target_properties(
+    samples
+    PROPERTIES
+    LINK_WHAT_YOU_USE TRUE
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)

--- a/samples/cpu_references.h
+++ b/samples/cpu_references.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "helpers.h"
+#include <cmath>
 
 template <typename T_ELEM>
 void weightGrad_cpu_ref(
@@ -60,22 +61,22 @@ void weightGrad_cpu_ref(
     bool isConv = true;  //(CUDNN_CONVOLUTION == mode) ;
 
     // For every filter pixel (k x c x r x s)
-    for (int ci = 0; ci < inDims[1]; ci++) {               // Loop over filter output pixels
-        for (int ri = 0; ri < filDims[2]; ri++) {          //        ^
-            for (int si = 0; si < filDims[3]; si++) {      //    ^
-                for (int ki = 0; ki < filDims[0]; ki++) {  // ^
-                    int filIdx = ki * filterStride[0] + ci * filterStride[1] + ri * filterStride[2] + si * filterStride[3];
+    for (size_t ci = 0; ci < (size_t)inDims[1]; ci++) {               // Loop over filter output pixels
+        for (size_t ri = 0; ri < (size_t)filDims[2]; ri++) {          //        ^
+            for (size_t si = 0; si < (size_t)filDims[3]; si++) {      //    ^
+                for (size_t ki = 0; ki < (size_t)filDims[0]; ki++) {  // ^
+                    int64_t filIdx = ki * filterStride[0] + ci * filterStride[1] + ri * filterStride[2] + si * filterStride[3];
                     float val = 0.f;
                     // For every image (n)
                     for (int ni = 0; ni < inDims[0]; ni++) {  // Sum over the batch
-                        int offset_image = ni * inStride[0] + ci * inStride[1];
-                        int offset_diff  = ni * diffStride[0] + ki * diffStride[1];
+                        int64_t offset_image = ni * inStride[0] + ci * inStride[1];
+                        int64_t offset_diff  = ni * diffStride[0] + ki * diffStride[1];
                         // For every pixel in diff (p x q)
                         for (int pi = 0; pi < diffDims[2]; pi++) {      // Sum over the pixels of diff
                             for (int qi = 0; qi < diffDims[3]; qi++) {  //  ^
                                 // Fetch the value in image and diff, product and accumulate
-                                int y = pi * stride[0] - pad[0];
-                                int x = qi * stride[1] - pad[1];
+                                int64_t y = pi * stride[0] - pad[0];
+                                int64_t x = qi * stride[1] - pad[1];
                                 // Convolution = Correlation with a flipped filter
                                 // So basically, for the convolution, we replace r by dim-1-r 
                                 // and s by dim-1-s to "flip" the filter.
@@ -92,11 +93,11 @@ void weightGrad_cpu_ref(
                                     x += si * dilation[1];
                                 }
                                 // Image value
-                                int inBounds = ((x >= 0) && (x < inDims[3]) && (y >= 0) && (y < inDims[2]));
+                                int64_t inBounds = ((x >= 0) && (x < inDims[3]) && (y >= 0) && (y < inDims[2]));
                                 if (inBounds) {
-                                    int imIdx = offset_image + y * inStride[2] + x * inStride[3];
+                                    int imIdx = static_cast<int>(offset_image + y * inStride[2] + x * inStride[3]);
                                     // Diff value
-                                    int diffIdx = offset_diff + pi * diffStride[2] + qi * diffStride[3];
+                                    int diffIdx = static_cast<int>(offset_diff + pi * diffStride[2] + qi * diffStride[3]);
                                     // Prod and accumulate
                                     T_ELEM imTmp   = image[imIdx];
                                     T_ELEM diffTmp = diffData[diffIdx];
@@ -159,7 +160,7 @@ void gen_stats_cpu(
     const int64_t inputSize,
     const int64_t* inputDims)
 {
-    std::vector<int> totals(inputDims[0], 0);
+    std::vector<int64_t> totals((size_t)inputDims[0], 0);
     for (int i = 0; i < inputSize; i++) {
         int channel_index = i % inputDims[0];
 
@@ -169,7 +170,7 @@ void gen_stats_cpu(
     }
 
     // Calculate the mean for each channel. Assumes NHWC format.
-    for (int i = 0; i < outputData.size(); i++) {
+    for (size_t i = 0; i < outputData.size(); i++) {
         outputData[i].first = outputData[i].first / totals[i];
     }
 
@@ -182,7 +183,7 @@ void gen_stats_cpu(
     }
 
     // Calculate the variance for the channel. Assumes NHWC format.
-    for (int i = 0; i < outputData.size(); i++) {
+    for (size_t i = 0; i < outputData.size(); i++) {
         outputData[i].second = outputData[i].second / totals[i];
     }
 }
@@ -220,7 +221,7 @@ void conv_cpu_ref(
     const int64_t* dilation,
     int64_t nbDims) 
 {
-    int imDims = nbDims - 2;
+    int64_t imDims = nbDims - 2;
     float alpha     = 1.0f;
     float beta      = 0.0;
     // Some sanity checks
@@ -246,13 +247,13 @@ void conv_cpu_ref(
     bool isConv = true;  //(CUDNN_CONVOLUTION == mode) ;
 
     // Number of pixels in output
-    int nPixelsOut = 1;
+    int64_t nPixelsOut = 1;
     for (int i = 2; i < nbDims; i++) {
         nPixelsOut *= diffDims[i];
     }
 
     // Number of pixels in filter
-    int nPixelsFil = 1;
+    int64_t nPixelsFil = 1;
     for (int i = 2; i < nbDims; i++) {
         nPixelsFil *= filDims[i];
     }
@@ -267,7 +268,7 @@ void conv_cpu_ref(
     for (int64_t ni = 0; ni < diffDims[0]; ni++) {
         // For each outer feature layer of the output image
         for (int ki_outer = 0; ki_outer < diffDims[1] / resizeFactor; ki_outer++) {
-            int outputOffset = ni * diffStride[0] / resizeFactor + ki_outer * diffStride[1];
+            int64_t outputOffset = ni * diffStride[0] / resizeFactor + ki_outer * diffStride[1];
             // For every pixel in this output image's feature layer
             for (int outId = 0; outId < nPixelsOut; outId++) {
                 // Get output pixel ids
@@ -283,8 +284,8 @@ void conv_cpu_ref(
                     T_MATH tmp = 0;
                     // For each outer feature layer of the input image and filter
                     for (int ci = 0; ci < inDims[1] / resizeFactor; ci++) {
-                        int inputOffset = ni * inStride[0] / resizeFactor + ci * inStride[1];
-                        int filterOffset = (ki_outer * resizeFactor + ki_inner) * filStride[0] / resizeFactor + ci * filStride[1];
+                        int64_t inputOffset = ni * inStride[0] / resizeFactor + ci * inStride[1];
+                        int64_t filterOffset = (ki_outer * resizeFactor + ki_inner) * filStride[0] / resizeFactor + ci * filStride[1];
                         // Now for every pixel in the filter
                         for (int filId = 0; filId < nPixelsFil; filId++) {
                             // Get the position of the pixel
@@ -304,14 +305,14 @@ void conv_cpu_ref(
                                 inside &= (tmpIds[d] >= 0 && tmpIds[d] < inDims[2 + d]);
                             }
                             if (inside) {
-                                int actualTmpId = inputOffset + dim2lin(tmpIds, (inStride) + 2, imDims);
+                                int64_t actualTmpId = inputOffset + dim2lin(tmpIds, (inStride) + 2, imDims);
                                 // int actualFilId = filterOffset + filId ;
-                                int actualFilId = filterOffset + dim2lin(filIds, (filStride) + 2, imDims);
+                                int64_t actualFilId = filterOffset + dim2lin(filIds, (filStride) + 2, imDims);
 
                                 // For each inner feature layer of the input image and filter
                                 for (int i = 0; i < resizeFactor; i++) {
-                                    T_ELEM fval = filterData[actualFilId * resizeFactor + i];
-                                    T_ELEM ival = inputData[actualTmpId * resizeFactor + i];
+                                    T_ELEM fval = filterData[(size_t)(actualFilId * resizeFactor + i)];
+                                    T_ELEM ival = inputData[(size_t)(actualTmpId * resizeFactor + i)];
                                     tmp         = doFma(fval, ival, tmp);
                                 }
                             }
@@ -319,7 +320,7 @@ void conv_cpu_ref(
                     }
 
                     // Store final result in proper position in output image
-                    int actualOutId = outputOffset + dim2lin(outIds, (diffStride) + 2, imDims);
+                    int64_t actualOutId = outputOffset + dim2lin(outIds, (diffStride) + 2, imDims);
                     doEpilog(outputData, actualOutId * resizeFactor + ki_inner, alpha * tmp, beta);
                 }
             }
@@ -370,16 +371,16 @@ void dataGrad_cpu_ref(
         for (int ci = 0; ci < outDims[1]; ci++) {
             for (int hi = 0; hi < outDims[2]; hi++) {
                 for (int wi = 0; wi < outDims[3]; wi++) {
-                    int outIdx = ni * outStride[0] + ci * outStride[1] + hi * outStride[2] + wi * outStride[3];
+                    int64_t outIdx = ni * outStride[0] + ci * outStride[1] + hi * outStride[2] + wi * outStride[3];
                     float val  = 0.0;
 
                     // For every diff channel (k)
                     for (int ki = 0; ki < inDims[1]; ki++) {  // Sum over k channels
-                        int offset_filter = ki * filStride[0] + ci * filStride[1];
-                        int offset_diff   = ni * inStride[0] + ki * inStride[1];
+                        int64_t offset_filter = ki * filStride[0] + ci * filStride[1];
+                        int64_t offset_diff   = ni * inStride[0] + ki * inStride[1];
                         // For every pixel if filter (r x s)
                         for (int ri = 0; ri < filDims[2]; ri++) {
-                            int p = hi + pad[0];
+                            int64_t p = hi + pad[0];
 
                             if (isConv) {
                                 p -= (filDims[2] - 1 - ri) * dilation[0];
@@ -394,7 +395,7 @@ void dataGrad_cpu_ref(
                             p /= stride[0];
 
                             for (int si = 0; si < filDims[3]; si++) {
-                                int q = wi + pad[1];
+                                int64_t q = wi + pad[1];
 
                                 // Fetch the value in filter and diff, product and accumulate
                                 // So basically, for the convolution, we replace r by dim-1-r 
@@ -415,10 +416,10 @@ void dataGrad_cpu_ref(
 
                                 int inBounds = ((p >= 0) && (p < inDims[2]) && (q >= 0) && (q < inDims[3]));
                                 if (inBounds) {
-                                    int filterIdx = offset_filter + ri * filStride[2] + si * filStride[3];
-                                    int diffIdx   = offset_diff + p * inStride[2] + q * inStride[3];
-                                    T_ELEM imTmp  = top_diff[diffIdx];
-                                    T_ELEM filTmp = weight[filterIdx];
+                                    int64_t filterIdx = offset_filter + ri * filStride[2] + si * filStride[3];
+                                    int64_t diffIdx   = offset_diff + p * inStride[2] + q * inStride[3];
+                                    T_ELEM imTmp  = top_diff[(size_t)diffIdx];
+                                    T_ELEM filTmp = weight[(size_t)filterIdx];
                                     val           = doFma(filTmp, imTmp, val);
                                 }
                             }

--- a/samples/fp16_emu.cpp
+++ b/samples/fp16_emu.cpp
@@ -49,13 +49,13 @@ half1 cpu_float2half_rn(float f)
   
     // Get rid of +Inf/-Inf, +0/-0.
     if (u > 0x477fefff) {
-        hr.x = sign | 0x7c00U;
+        hr.x = static_cast<unsigned short> (sign | 0x7c00U);
         // Add an indirection to get around type aliasing check
         void* hr_ptr = &hr;
         return *reinterpret_cast<half1*>(hr_ptr);
     }
     if (u < 0x33000001) {
-        hr.x = sign | 0x0000U;
+        hr.x = static_cast<unsigned short> (sign | 0x0000U);
         // Add an indirection to get around type aliasing check
         void* hr_ptr = &hr;
         return *reinterpret_cast<half1*>(hr_ptr);
@@ -87,7 +87,7 @@ half1 cpu_float2half_rn(float f)
         }
     }  
 
-    hr.x = (sign | (exponent << 10) | mantissa);  
+    hr.x = static_cast<unsigned short>((sign | (exponent << 10) | mantissa));
 
     // Add an indirection to get around type aliasing check
     void* hr_ptr = &hr;

--- a/samples/fp8_sample.cpp
+++ b/samples/fp8_sample.cpp
@@ -1,0 +1,605 @@
+#include "fp8_sample.h"
+#include <cudnn_frontend.h>
+#include "error_util.h"
+
+using namespace cudnn_frontend;
+
+ExecutionPlan_v8
+get_exec_plan_from_heuristics(OperationGraph_v8 &&opGraph, cudnnHandle_t handle) {
+    auto heuristics = EngineHeuristicsBuilder()
+                          .setOperationGraph(opGraph)
+                          .setHeurMode(CUDNN_HEUR_MODE_INSTANT)
+                          .build();
+
+
+    auto& engine_config = heuristics.getEngineConfig(heuristics.getEngineConfigCount());
+
+    auto plan_builder = [&]() -> ExecutionPlan {
+        for (auto &ecfg : engine_config) {
+            try {
+                auto plan = ExecutionPlanBuilder()
+                                .setHandle(handle)
+                                .setEngineConfig(ecfg, opGraph.getTag())
+                                .build();
+                return plan;
+            } catch (cudnnException &e) {
+                continue;
+            }
+        }
+        return ExecutionPlanBuilder()
+                   .setHandle(handle)
+                   .setEngineConfig(engine_config[0], opGraph.getTag())
+                   .build();
+    };
+
+    return plan_builder();
+}
+
+#if (CUDNN_VERSION >= 8600)
+void
+run_fp8_conv_scale(int64_t* x_dim,
+                   int64_t* w_dim,
+                   int64_t* y_dim,
+                   int64_t* scale_dim,
+                   cudnnDataType_t dataType,
+                   int convDim,
+                   int64_t* conv_padA,
+                   int64_t* conv_dilationA,
+                   int64_t* conv_strideA,
+                   void* devPtrX,
+                   void* devPtrW,
+                   void* devPtrY,
+                   void* devPtrScale) {
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+        if (check_device_arch_newer_than("hopper") == false) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_ARCH_MISMATCH,
+                    "run_fp8_conv_scale: Sample requires Ampere or above GPU");
+        }
+        // Creates the necessary tensor descriptors
+        int64_t stride[4];
+        generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto xTensor = TensorBuilder()
+                           .setDim(4, x_dim)
+                           .setStrides(4, stride)
+                           .setId('x')
+                           .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                           .setDataType(dataType)
+                           .build();
+        generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto wTensor = TensorBuilder()
+                           .setDim(4, w_dim)
+                           .setStrides(4, stride)
+                           .setId('w')
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+
+        generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto afterConvTensor = TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStrides(4, stride)
+                                   .setId('y')  // after conv
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+
+        auto afterScaleTensor = TensorBuilder()
+                                   .cloneFrom(afterConvTensor, 'a')
+                                   .setVirtual(false)
+                                   .setDataType(dataType)
+                                   .build();
+
+        generateStrides(scale_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto scaleTensor = TensorBuilder()
+                                   .setDim(4, scale_dim)
+                                   .setStrides(4, stride)
+                                   .setId('s')  // after conv
+                                   .setAlignment(16)
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+
+        std::cout << xTensor.describe() << std::endl;
+        std::cout << wTensor.describe() << std::endl;
+        std::cout << scaleTensor.describe() << std::endl;
+        std::cout << afterConvTensor.describe() << std::endl;
+
+        // Define the scale descriptor
+        auto scaleDesc = PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_MUL)
+                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << scaleDesc.describe() << std::endl;
+
+        // Define the convolution problem
+        auto convDesc = ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, conv_strideA)
+                            .setPrePadding(convDim, conv_padA)
+                            .setPostPadding(convDim, conv_padA)
+                            .setDilation(convDim, conv_dilationA)
+                            .build();
+        std::cout << convDesc.describe() << std::endl;
+
+        float alpha = 1.0f;
+        float beta  = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                           .setxDesc(xTensor)
+                           .setwDesc(wTensor)
+                           .setyDesc(afterConvTensor)
+                           .setcDesc(convDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        std::cout << conv_op.describe() << std::endl;
+
+        // Create a Multiplication Node with scaling parameters.
+        auto scale_op = OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(conv_op.getOutputTensor())
+                            .setbDesc(scaleTensor)
+                            .setyDesc(afterScaleTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << scale_op.describe() << std::endl;
+
+        // Create an Operation Graph. In this case it is convolution scale
+        std::array<Operation const*, 2> ops = {&conv_op, &scale_op};
+
+        auto opGraph = OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(ops.size(), ops.data())
+                           .build();
+
+        auto plan = get_exec_plan_from_heuristics(std::move(opGraph), handle_);
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, (size_t)workspace_size));
+        }
+        void* data_ptrs[] = {devPtrX, devPtrW, devPtrY, devPtrScale};
+        int64_t uids[]    = {'x', 'w', 'a', 's'};
+        auto variantPack  = VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(4, data_ptrs)
+                               .setUids(4, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnnException& e) {
+
+        // this example is only for Hopper cards
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+        if (prop.major < 9 && (e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED  || e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH)) {
+            std::cout << "Fusion with fp8 inputs is only supported on Hopper or later" << std::endl;
+            return;
+        }
+
+        std::cout << "[ERROR] Exception " << e.what() << std::endl;
+        CHECK(false);
+    }
+}
+
+void
+run_fp8_conv_descale_descale_amax_scale(int64_t* x_dim,
+                   int64_t* w_dim,
+                   int64_t* y_dim,
+                   int64_t* r_dim,
+                   int64_t* scale_dim,
+                   cudnnDataType_t dataType,
+                   int convDim,
+                   int64_t* conv_padA,
+                   int64_t* conv_dilationA,
+                   int64_t* conv_strideA,
+                   void* devPtrX,
+                   void* devPtrW,
+                   void* devPtrR,
+                   void* devPtrOutput,
+                   void* devPtrDescale1,
+                   void* devPtrDescale2,
+                   void* devPtrScale)
+{
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+        if (check_device_arch_newer_than("hopper") == false) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_ARCH_MISMATCH,
+                    "run_fp8_conv_descale_descale_amax_scale: Sample requires Ampere or above GPU");
+        }
+        // Creates the necessary tensor descriptors
+        int64_t stride[4];
+        generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto xTensor = TensorBuilder()
+                           .setDim(4, x_dim)
+                           .setStrides(4, stride)
+                           .setId('x')
+                           .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                           .setDataType(dataType)
+                           .build();
+        generateStrides(w_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto wTensor = TensorBuilder()
+                           .setDim(4, w_dim)
+                           .setStrides(4, stride)
+                           .setId('w')
+                           .setAlignment(16)
+                           .setDataType(dataType)
+                           .build();
+
+        generateStrides(r_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto amaxTensor = TensorBuilder()
+                           .setDim(4, r_dim)
+                           .setStrides(4, stride)
+                           .setId('r')  // output
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_FLOAT)
+                           .build();
+
+        generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto afterConvTensor = TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStrides(4, stride)
+                                   .setId('y')  // after conv
+                                   .setAlignment(16)
+                                   .setVirtual()
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+
+        auto afterDescale1Tensor = TensorBuilder()
+                                   .cloneFrom(afterConvTensor, 'a')
+                                   .build();
+
+        auto afterDescale2Tensor = TensorBuilder()
+                                   .cloneFrom(afterConvTensor, 'b')
+                                   .build();
+
+        auto fp8OutputTensor = TensorBuilder()
+                                   .cloneFrom(afterConvTensor, 'c')
+                                   .setVirtual(false)
+                                   .setDataType(dataType)
+                                   .build();
+
+        generateStrides(scale_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto descaleTensor1 = TensorBuilder()
+                                   .setDim(4, scale_dim)
+                                   .setStrides(4, stride)
+                                   .setId('s') 
+                                   .setAlignment(16)
+                                   .setDataType(CUDNN_DATA_FLOAT)
+                                   .build();
+
+        auto descaleTensor2 = TensorBuilder()
+                                   .cloneFrom(descaleTensor1, 't')
+                                   .build();
+
+        auto scaleTensor = TensorBuilder()
+                                   .cloneFrom(descaleTensor1, 'u')
+                                   .build();
+
+        std::cout << xTensor.describe() << std::endl;
+        std::cout << wTensor.describe() << std::endl;
+        std::cout << scaleTensor.describe() << std::endl;
+        std::cout << afterConvTensor.describe() << std::endl;
+
+        // Define the scale descriptor
+        auto scaleDesc = PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_MUL)
+                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << scaleDesc.describe() << std::endl;
+
+        // Define the reduction descriptor
+        auto redunctionDesc = ReductionDescBuilder()
+                                  .setMathPrecision(CUDNN_DATA_FLOAT)
+                                  .setReductionOp(CUDNN_REDUCE_TENSOR_AMAX)
+                                  .build();
+        std::cout << redunctionDesc.describe() << std::endl;
+
+        // Define the convolution problem
+        auto convDesc = ConvDescBuilder()
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .setMathMode(CUDNN_CROSS_CORRELATION)
+                            .setNDims(convDim)
+                            .setStrides(convDim, conv_strideA)
+                            .setPrePadding(convDim, conv_padA)
+                            .setPostPadding(convDim, conv_padA)
+                            .setDilation(convDim, conv_dilationA)
+                            .build();
+        std::cout << convDesc.describe() << std::endl;
+
+        float alpha = 1.0f;
+        float beta  = 0.0f;
+
+        // Create a convolution Node
+        auto conv_op = OperationBuilder(CUDNN_BACKEND_OPERATION_CONVOLUTION_FORWARD_DESCRIPTOR)
+                           .setxDesc(xTensor)
+                           .setwDesc(wTensor)
+                           .setyDesc(afterConvTensor)
+                           .setcDesc(convDesc)
+                           .setAlpha(alpha)
+                           .setBeta(beta)
+                           .build();
+        std::cout << conv_op.describe() << std::endl;
+
+        // Create a Multiplication Node with scaling parameters.
+        auto descale_op1 = OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(afterConvTensor)
+                            .setbDesc(descaleTensor1)
+                            .setyDesc(afterDescale1Tensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << descale_op1.describe() << std::endl;
+
+        auto descale_op2 = OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(afterDescale1Tensor)
+                            .setbDesc(descaleTensor2)
+                            .setyDesc(afterDescale2Tensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << descale_op2.describe() << std::endl;
+
+
+        auto scale_op = OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(afterDescale2Tensor)
+                            .setbDesc(scaleTensor)
+                            .setyDesc(fp8OutputTensor)
+                            .setpwDesc(scaleDesc)
+                            .build();
+        std::cout << scale_op.describe() << std::endl;
+
+        // Create a reduction add Node.
+        auto reduction_op = OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(afterDescale2Tensor)
+                                .setyDesc(amaxTensor)
+                                .setreductionDesc(redunctionDesc)
+                                .build();
+        std::cout << reduction_op.describe() << std::endl;
+
+        // Create an Operation Graph. In this case it is convolution descale descale amax scale
+        std::array<Operation const*, 5> ops = {&conv_op, &descale_op1, &descale_op2, &scale_op, &reduction_op};
+
+        auto opGraph = OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(ops.size(), ops.data())
+                           .build();
+
+        auto plan = get_exec_plan_from_heuristics(std::move(opGraph), handle_);
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, (size_t)workspace_size));
+        }
+        void* data_ptrs[] = {devPtrX, devPtrW, devPtrR, devPtrDescale1, devPtrDescale2, devPtrScale, devPtrOutput};
+        int64_t uids[]    = {'x', 'w', 'r', 's', 't', 'u', 'c'};
+        auto variantPack  = VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(7, data_ptrs)
+                               .setUids(7, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        checkCudaErr(cudaDeviceSynchronize());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnnException& e) {
+        
+        // this example is only for Hopper cards
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+        if (prop.major < 9 && (e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED  || e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH)) {
+            std::cout << "Fusion with fp8 inputs is only supported on Hopper or later" << std::endl;
+            return;
+        }
+
+        std::cout << "[ERROR] Exception " << e.what() << std::endl;
+        CHECK(false);
+    }
+}
+
+void
+run_tranpose_scale_convert_fp16_fp8_amax(int64_t* x_dim,
+                   int64_t* y_dim,
+                   int64_t* r_dim,
+                   int64_t* scale_dim,
+                   cudnnDataType_t dataType,
+                   void* devPtrX,
+                   void* devPtrR,
+                   void* devPtrOutput,
+                   void* devPtrScale)
+{
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+        if (check_device_arch_newer_than("hopper") == false) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_ARCH_MISMATCH,
+                    "run_tranpose_scale_convert_fp16_fp8_amax: Sample requires Ampere or above GPU");
+        }
+
+        // Creates the necessary tensor descriptors
+        int64_t stride[4];
+        generateStrides(x_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto xTensor = TensorBuilder()
+                           .setDim(4, x_dim)
+                           .setStrides(4, stride)
+                           .setId('x')
+                           .setAlignment(16)  // 16B alignment is needed to run a tensor core engine
+                           .setDataType(CUDNN_DATA_HALF) // Half as input
+                           .build();
+
+        generateStrides(scale_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto scaleTensor = TensorBuilder()
+                            .setDim(4, scale_dim)
+                            .setStrides(4, stride)
+                            .setId('s') 
+                            .setAlignment(16)
+                            .setDataType(CUDNN_DATA_FLOAT)
+                            .build();
+
+        generateStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto afterScaleTensor = TensorBuilder()
+                                .setDim(4, y_dim)
+                                .setStrides(4, stride)
+                                .setId('a')  // after transpose + convert
+                                .setAlignment(16)
+                                .setDataType(CUDNN_DATA_FLOAT) // Transpose + convert to FP8
+                                .setVirtual()
+                                .build();
+
+        
+        // Tranposed from NWHC to CHWN
+        generate4dTransposeStrides(y_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto afterConvertTensor = TensorBuilder()
+                                   .setDim(4, y_dim)
+                                   .setStrides(4, stride)
+                                   .setId('y')  // after transpose + convert
+                                   .setAlignment(16)
+                                   .setDataType(dataType) // Transpose + convert to FP8
+                                   .build();
+
+        generateStrides(r_dim, stride, 4, CUDNN_TENSOR_NHWC);
+        auto amaxTensor = TensorBuilder()
+                           .setDim(4, r_dim)
+                           .setStrides(4, stride)
+                           .setId('r')  // output
+                           .setAlignment(16)
+                           .setDataType(CUDNN_DATA_FLOAT)
+                           .build();
+
+        std::cout << xTensor.describe() << std::endl;
+        std::cout << scaleTensor.describe() << std::endl;
+        std::cout << afterConvertTensor.describe() << std::endl;
+
+        // Define the scale descriptor
+        auto scaleDesc = PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_MUL)
+                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << scaleDesc.describe() << std::endl;
+
+        // Define the convert descriptor
+        auto identityDesc = PointWiseDescBuilder()
+                             .setMode(CUDNN_POINTWISE_IDENTITY)
+                             .setMathPrecision(CUDNN_DATA_FLOAT)
+                             .build();
+        std::cout << identityDesc.describe() << std::endl;
+
+        // Define the reduction descriptor
+        auto redunctionDesc = ReductionDescBuilder()
+                                .setMathPrecision(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_AMAX)
+                                .build();
+        std::cout << redunctionDesc.describe() << std::endl;
+
+        // Create a Multiplication Node with scaling parameters.
+        auto scale_op = OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                        .setxDesc(xTensor)
+                        .setbDesc(scaleTensor)
+                        .setyDesc(afterScaleTensor)
+                        .setpwDesc(scaleDesc)
+                        .build();
+        std::cout << scale_op.describe() << std::endl;
+
+        // Create transpose + convert node
+        auto convert_op = OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                            .setxDesc(afterScaleTensor)
+                            .setyDesc(afterConvertTensor)
+                            .setpwDesc(identityDesc)
+                            .build();
+        std::cout << scale_op.describe() << std::endl;
+
+        // Create a reduction add Node.
+        auto reduction_op = OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(xTensor)
+                                .setyDesc(amaxTensor)
+                                .setreductionDesc(redunctionDesc)
+                                .build();
+        std::cout << reduction_op.describe() << std::endl;
+
+        // Create an Operation Graph. In this case it is scale transpose amax
+        std::array<Operation const*, 3> ops = {&scale_op, &convert_op, &reduction_op};
+
+        auto opGraph = OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(ops.size(), ops.data())
+                           .build();
+
+        auto plan = get_exec_plan_from_heuristics(std::move(opGraph), handle_);
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, (size_t)workspace_size));
+        }
+        void* data_ptrs[] = {devPtrX, devPtrR, devPtrScale, devPtrOutput};
+        int64_t uids[]    = {'x', 'r', 's', 'y'};
+        auto variantPack  = VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(4, data_ptrs)
+                               .setUids(4, uids)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudaErr(cudaDeviceSynchronize());
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnnException& e) {
+        // this example is only for Hopper cards
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties(&prop, 0));
+        if (prop.major < 9 && (e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED  || e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH)) {
+            std::cout << "Fusion with fp8 inputs is only supported on Hopper or later" << std::endl;
+            return;
+        }
+        std::cout << "[ERROR] Exception " << e.what() << std::endl;
+        CHECK(false);
+    }
+}
+
+#endif

--- a/samples/fp8_sample.h
+++ b/samples/fp8_sample.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <cuda_runtime.h>
+#include <assert.h>
+#include <tuple>
+#include <functional>
+
+#include <cudnn.h>
+#include "fp16_dev.h"
+#include "fp16_emu.h"
+#include "helpers.h"
+
+            
+void
+run_fp8_conv_scale(int64_t* x_dim,
+                   int64_t* w_dim,
+                   int64_t* y_dim,
+                   int64_t* scale_dim,
+                   cudnnDataType_t dataType,
+                   int convDim,
+                   int64_t* conv_padA,
+                   int64_t* conv_dilationA,
+                   int64_t* conv_strideA,
+                   void* devPtrX,
+                   void* devPtrW,
+                   void* devPtrY,
+                   void* devPtrScale);
+
+void
+run_fp8_conv_descale_descale_amax_scale(int64_t* x_dim,
+                   int64_t* w_dim,
+                   int64_t* y_dim,
+                   int64_t* r_dim,
+                   int64_t* scale_dim,
+                   cudnnDataType_t dataType,
+                   int convDim,
+                   int64_t* conv_padA,
+                   int64_t* conv_dilationA,
+                   int64_t* conv_strideA,
+                   void* devPtrX,
+                   void* devPtrW,
+                   void* devPtrR,
+                   void* devPtrOutput,
+                   void* devPtrDescale1,
+                   void* devPtrDescale2,
+                   void* devPtrScale);
+
+void
+run_tranpose_scale_convert_fp16_fp8_amax(int64_t* x_dim,
+                   int64_t* y_dim,
+                   int64_t* r_dim,
+                   int64_t* scale_dim,
+                   cudnnDataType_t dataType,
+                   void* devPtrX,
+                   void* devPtrR,
+                   void* devPtrOutput,
+                   void* devPtrScale);

--- a/samples/fusion_sample.h
+++ b/samples/fusion_sample.h
@@ -258,7 +258,6 @@ run_bn_finalize(
 
 cudnnStatus_t run_dsbar(int64_t *Y_dim,
                int64_t *scaleTensorDim,
-               int64_t *biasTensorDim,
                void *RP_YdevPtr,
                void *RP_scaleDevPtr,
                void *RP_biasDevPtr,
@@ -267,7 +266,26 @@ cudnnStatus_t run_dsbar(int64_t *Y_dim,
                void *DP_biasDevPtr,
                void *YdevPtr);
 
+#if (CUDNN_VERSION >= 8600)
 void
+run_maxpool_with_idx(int64_t* x_dim,
+                    int64_t* y_dim,
+                    int64_t* idx_dim,
+                    void* devPtrdX,
+                    void* devPtrdY,
+                    void* devPtrIdx,
+                    cudnnDataType_t tensorType,
+                    cudnnResampleMode_t mode,
+                    cudnnNanPropagation_t nanOpt, 
+                    cudnnPaddingMode_t paddingMode,
+                    int32_t nbSpatialDims,                         
+                    int64_t* windowDimA,
+                    int64_t* prePaddingA,
+                    int64_t* postPaddingA,
+                    int64_t* strideA);
+#endif
+
+cudnnStatus_t
 run_conv_two_global_scales(int64_t* xTensorDim,
                    int64_t* wTensorDim,
                    int64_t* yTensorDim,
@@ -282,4 +300,39 @@ run_conv_two_global_scales(int64_t* xTensorDim,
                    void* devPtrScale2,
                    void* devPtrOutput,
                    void* afterConv);
+
+#if (CUDNN_VERSION >= 8600)
+void
+run_backward_avgpool(int64_t* dx_dim,
+                    int64_t* dy_dim,
+                    void* devPtrdX,
+                    void* devPtrdY,
+                    cudnnDataType_t tensorType,
+                    cudnnResampleMode_t mode,
+                    cudnnNanPropagation_t nanOpt, 
+                    cudnnPaddingMode_t paddingMode,
+                    int32_t nbSpatialDims,                         
+                    int64_t* windowDimA,
+                    int64_t* prePaddingA,
+                    int64_t* postPaddingA,
+                    int64_t* strideA);
+
+void
+run_backward_maxpool(int64_t* dx_dim,
+                    int64_t* dy_dim,
+                    int64_t* idx_dim,
+                    void* devPtrdX,
+                    void* devPtrdY,
+                    void* devPtrIdx,
+                    cudnnDataType_t tensorType,
+                    cudnnResampleMode_t mode,
+                    cudnnNanPropagation_t nanOpt, 
+                    cudnnPaddingMode_t paddingMode,
+                    int32_t nbSpatialDims,                         
+                    int64_t* windowDimA,
+                    int64_t* prePaddingA,
+                    int64_t* postPaddingA,
+                    int64_t* strideA);
+#endif
+
 

--- a/samples/helpers.cpp
+++ b/samples/helpers.cpp
@@ -22,60 +22,82 @@
 
 #include "helpers.h"
 
+
+bool check_device_arch_newer_than(std::string const arch) {
+
+    int arch_major = 6;
+    int arch_minor = 0;
+    if (arch == "hopper") {arch_major = 9;}
+    if (arch == "ampere") {arch_major = 8;}
+    if (arch == "turing")  {arch_major = 7; arch_minor = 5;}
+    if (arch == "volta")  {arch_major = 7;}
+    if (arch == "pascal") {arch_major = 6;}
+
+    struct cudaDeviceProp prop;
+    checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
+
+    auto device_version = prop.major * 10 + prop.minor;
+    auto queried_version = arch_major * 10 + arch_minor;
+     if (device_version >= queried_version) {
+        return true;
+     }
+     return false;
+}
+
 // Generate uniform numbers [0,1)
 void initImage(float* image, int64_t imageSize) {
     static unsigned seed = 123456789;
-    for (int index = 0; index < imageSize; index++) {
+    for (int64_t index = 0; index < imageSize; index++) {
         seed         = (1103515245 * seed + 12345) & 0xffffffff;
-        image[index] = float(seed) * 2.3283064e-10;  // 2^-32
+        image[index] = float(seed) * 2.3283064e-10f;  // 2^-32
     }
 }
 
 void initImage(half1* image, int64_t imageSize) {
     static unsigned seed = 123456789;
-    for (int index = 0; index < imageSize; index++) {
+    for (int64_t index = 0; index < imageSize; index++) {
         seed         = (1103515245 * seed + 12345) & 0xffffffff;
-        image[index] = cpu_float2half_rn(float(seed) * 2.3283064e-10);  // 2^-32
+        image[index] = cpu_float2half_rn(float(seed) * 2.3283064e-10f);  // 2^-32
     }
 }
 
 // Currently set to generate uniform integers [-2, 2] to avoid int8 overflow
-void initImage(int8_t* image, int imageSize) {
+void initImage(int8_t* image, int64_t imageSize) {
     static unsigned seed = 123456789;
     for (int64_t index = 0; index < imageSize; index++) {
         seed = (1103515245 * seed + 12345) & 0xffffffff;
         // Takes floats from [0, 1), scales and casts to ints from [0, 4], then subtracts from 2
-        image[index] = 2 - (int8_t)(5 * float(seed) * 2.3283064e-10);  // 2^-32
+        image[index] = 2 - (int8_t)(5 * float(seed) * 2.3283064e-10f);  // 2^-32
     }
 }
 
 // Currently set to generate uniform integers [0,1]
-void initImage(int32_t* image, int imageSize) {
+void initImage(int32_t* image, int64_t imageSize) {
     static unsigned seed = 123456789;
     for (int64_t index = 0; index < imageSize; index++) {
         seed = (1103515245 * seed + 12345) & 0xffffffff;
         // Takes floats from [0, 1), scales and casts to ints from [0, 4], then divides by 4
-        image[index] = ((int32_t)(5 * float(seed) * 2.3283064e-10))/4;  // 2^-32
+        image[index] = ((int32_t)(5.f * float(seed) * 2.3283064e-10f))/4;  // 2^-32
     }
 }
 
 // Currently set to generate uniform integers [0,1]
-void initImage(int64_t* image, int imageSize) {
+void initImage(int64_t* image, int64_t imageSize) {
     static unsigned seed = 123456789;
     for (int64_t index = 0; index < imageSize; index++) {
         seed = (1103515245 * seed + 12345) & 0xffffffff;
         // Takes floats from [0, 1), scales and casts to ints from [0, 4], then divides by 4
-        image[index] = ((int64_t)(5 * float(seed) * 2.3283064e-10))/4;  // 2^-32
+        image[index] = ((int64_t)(5.f * float(seed) * 2.3283064e-10f))/4;  // 2^-32
     }
 }
 
 // Currently set to generate booleans
-void initImage(bool* image, int imageSize) {
+void initImage(bool* image, int64_t imageSize) {
     static unsigned seed = 123456789;
     for (int64_t index = 0; index < imageSize; index++) {
         seed = (1103515245 * seed + 12345) & 0xffffffff;
         // Takes floats from [0, 1), scales and casts to ints from [0, 4], then divides by 4
-        int val = ((int32_t)(5 * float(seed) * 2.3283064e-10))/4;  // 2^-32
+        int64_t val = ((int32_t)(5.f * float(seed) * 2.3283064e-10f))/4;  // 2^-32
 
         // val is 0 or 1
         image[index] = (val == 1);
@@ -84,15 +106,15 @@ void initImage(bool* image, int imageSize) {
 
 void initImagePadded(int8_t* image, int64_t dimA[], int64_t dimPadded[], int64_t stridePadded[], cudnnDataType_t dataType) {
     static unsigned seed = 123456789;
-    int resizeFactor     = (dataType == CUDNN_DATA_INT8x4) ? 4 : 32;
-    int totalSize        = dimPadded[0] * dimPadded[1] * dimPadded[2] * dimPadded[3];
+    int64_t resizeFactor     = (dataType == CUDNN_DATA_INT8x4) ? 4 : 32;
+    int64_t totalSize        = dimPadded[0] * dimPadded[1] * dimPadded[2] * dimPadded[3];
 
     // #pragma omp parallel for
-    for (int i = 0; i < totalSize; i++) {
-        int n  = (i / stridePadded[0]) % dimPadded[0];
-        int c1 = (i / (stridePadded[1] * resizeFactor)) % (dimPadded[1] / resizeFactor);
-        int c2 = i % resizeFactor;
-        int c  = c1 * resizeFactor + c2;
+    for (int64_t i = 0; i < totalSize; i++) {
+        int64_t n  = (i / stridePadded[0]) % dimPadded[0];
+        int64_t c1 = (i / (stridePadded[1] * resizeFactor)) % (dimPadded[1] / resizeFactor);
+        int64_t c2 = i % resizeFactor;
+        int64_t c  = c1 * resizeFactor + c2;
         if (n < dimA[0] && c < dimA[1]) {
             image[i] = 2 - (int8_t)(5 * float(seed) * 2.3283064e-10);  // 2^-32
         } else {
@@ -101,7 +123,7 @@ void initImagePadded(int8_t* image, int64_t dimA[], int64_t dimPadded[], int64_t
     }
 }
 
-int checkCudaError(cudaError_t code, const char* expr, const char* file, int line) {
+int64_t checkCudaError(cudaError_t code, const char* expr, const char* file, int line) {
     if (code) {
         printf("CUDA error at %s:%d, code=%d (%s) in '%s'", file, line, (int)code, cudaGetErrorString(code), expr);
         return 1;
@@ -109,7 +131,7 @@ int checkCudaError(cudaError_t code, const char* expr, const char* file, int lin
     return 0;
 }
 
-int checkCudnnError(cudnnStatus_t code, const char* expr, const char* file, int line) {
+int64_t checkCudnnError(cudnnStatus_t code, const char* expr, const char* file, int line) {
     if (code) {
         printf("CUDNN error at %s:%d, code=%d (%s) in '%s'\n", file, line, (int)code, cudnnGetErrorString(code), expr);
         return 1;
@@ -117,7 +139,7 @@ int checkCudnnError(cudnnStatus_t code, const char* expr, const char* file, int 
     return 0;
 }
 
-void generateStrides(const int64_t* dimA, int64_t* strideA, int nbDims, cudnnTensorFormat_t filterFormat) {
+void generateStrides(const int64_t* dimA, int64_t* strideA, int64_t nbDims, cudnnTensorFormat_t filterFormat) {
     // For INT8x4 and INT8x32 we still compute standard strides here to input
     // into the cuDNN functions. We will manually scale by resizeFactor in the cpu ref.
     if (filterFormat == CUDNN_TENSOR_NCHW) {
@@ -136,14 +158,35 @@ void generateStrides(const int64_t* dimA, int64_t* strideA, int nbDims, cudnnTen
     }
 }
 
+// Used for CHWN
+void generate4dTransposeStrides(const int64_t* dimA, int64_t* strideA, int64_t nbDims, cudnnTensorFormat_t filterFormat) {
+    // For INT8x4 and INT8x32 we still compute standard strides here to input
+    // into the cuDNN functions. We will manually scale by resizeFactor in the cpu ref.
+    try {
+        if (filterFormat == CUDNN_TENSOR_NCHW) {
+            throw std::runtime_error("[ERROR] NCHW tranpose not supported");
+        } else if (nbDims != 4) {
+            throw std::runtime_error("[ERROR] Only 4 dims supported");
+        } else {
+            // Here we assume that the format is NWHC getting tranposed to CHWN
+            strideA[0] = 1; // N has stride 1
+            strideA[3] = strideA[0] * dimA[0]; // W has stride strideN * dimN
+            strideA[2] = strideA[3] * dimA[3]; // H has stride strideW * dimW
+            strideA[1] = strideA[2] * dimA[2]; // C has stride strideH * dimH
+        }
+    } catch (std::exception &e) {
+        std::cout << "Exception: " << e.what() << std::endl;
+    }
+}
+
 // Convert a linear index
 // i = d_1 s_1 ... s_n + d_2 s_2 ... s_n + d_n-1 s_n + d_n
 // into a multidimensional index
 // (d_1, d_2, ..., d_n)
-void lin2dim(int id, int64_t* ids, const int64_t* dims, int length) {
-    int idrem = id;
-    int prod  = 1;  // accumulates the product of the dimensions
-    for (int i = length - 1; i >= 0; i--) {
+void lin2dim(int64_t id, int64_t* ids, const int64_t* dims, int64_t length) {
+    int64_t idrem = id;
+    int64_t prod  = 1;  // accumulates the product of the dimensions
+    for (int64_t i = length - 1; i >= 0; i--) {
         ids[i] = (idrem / prod) % dims[i];
         idrem  = id - ids[i] * prod;
         prod *= dims[i];
@@ -154,14 +197,14 @@ void lin2dim(int id, int64_t* ids, const int64_t* dims, int length) {
 // (d_1, d_2, ..., d_n)
 // into a linear index
 // i = d_1 s_1 + ... + d_n s_n
-int dim2lin(const int64_t* ids, const int64_t* strides, int length) {
-    int res = 0;
-    for (int i = 0; i < length; i++) {
+int64_t dim2lin(const int64_t* ids, const int64_t* strides, int64_t length) {
+    int64_t res = 0;
+    for (int64_t i = 0; i < length; i++) {
         res += ids[i] * strides[i];
     }
-    return res;
+    return static_cast<int>(res);
 }
-void doEpilog(float* out, int idx, float alphaAcc, float beta) {
+void doEpilog(float* out, int64_t idx, float alphaAcc, float beta) {
     if (beta == 0.f) {
         out[idx] = alphaAcc;
     } else {
@@ -169,7 +212,7 @@ void doEpilog(float* out, int idx, float alphaAcc, float beta) {
     }
 }
 
-void doEpilog(half1* out, int idx, float alphaAcc, float beta) {
+void doEpilog(half1* out, int64_t idx, float alphaAcc, float beta) {
     if (beta == 0.f) {
         out[idx] = cpu_float2half_rn(alphaAcc);
     } else {
@@ -177,12 +220,12 @@ void doEpilog(half1* out, int idx, float alphaAcc, float beta) {
     }
 }
 
-void doEpilog(int8_t* out, int idx, int32_t alphaAcc, float beta) {
+void doEpilog(int8_t* out, int64_t idx, int32_t alphaAcc, float beta) {
     int32_t val;
     if (beta == 0.f) {
         val = alphaAcc;
     } else {
-        val = alphaAcc + out[idx] * beta;
+        val = alphaAcc + int(float(out[idx]) * beta);
     }
     // Properly handle overflow errors in the same way cuDNN does
     if (val > 127) {
@@ -190,7 +233,7 @@ void doEpilog(int8_t* out, int idx, int32_t alphaAcc, float beta) {
     } else if (val < -128) {
         val = -128;
     }
-    out[idx] = val;
+    out[idx] = static_cast<int8_t>(val);
 }
 
 
@@ -212,21 +255,21 @@ int8_t getError(int8_t dev, int8_t ref) {
     return dev - ref;
 }
 
-int getFwdConvDilatedFilterDim(int filterDim, int dilation) {
+int64_t getFwdConvDilatedFilterDim(int64_t filterDim, int64_t dilation) {
     return ((filterDim - 1) * dilation) + 1;
 }
 
-int getFwdConvPaddedImageDim(int tensorDim, int pad) {
+int64_t getFwdConvPaddedImageDim(int64_t tensorDim, int64_t pad) {
     return tensorDim + (2 * pad);
 }
 
-int getFwdConvOutputDim(
-    int tensorDim, 
-    int pad, 
-    int filterDim, 
-    int stride, 
-    int dilation) 
+int64_t getFwdConvOutputDim(
+    int64_t tensorDim, 
+    int64_t pad, 
+    int64_t filterDim, 
+    int64_t stride, 
+    int64_t dilation) 
 {
-    int p = (getFwdConvPaddedImageDim(tensorDim, pad) - getFwdConvDilatedFilterDim(filterDim, dilation)) / stride + 1;
+    int64_t p = (getFwdConvPaddedImageDim(tensorDim, pad) - getFwdConvDilatedFilterDim(filterDim, dilation)) / stride + 1;
     return (p);
 }


### PR DESCRIPTION
[Enhancement] Fixed issues in the code which caused warnings in MSVC and clang compilers.

[Enhancement] Fixed errors in `get_heuristics_list` where for certain heuristics mode in older cuDNN versions, the heuristics list might be incorrect.

[Bug fixes] Fixed several test cases failing on unsupported GPUs to exit gracefully.

[Samples] Added a sample to showcase fp8 convolution forward in Nvidia Hopper GPUs. The sample also showcases post convolution book-keeping operations such as scaling and absolute maximum reduction.

[Samples] Added a sample which converts fp16 tensor to fp8 and performs transpose and absolute maximum reduction.

[Samples] Added a sample to demonstrate Max pooling operation including tensor index dump, necessary to speed up the backward pass.

[Samples] Added a sample to showcase the backward pooling operation.