### PR TITLE
v0.9 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Errata filter gives the cuDNN team an opportunity to block certain faulty kernel
     operation           : ""   - Mandatory. Stringified version of the operation graph.
     engine              : ""   - Mandatory. Stringified version of the engine ID.
     knob                : ""   - Optional.  Stringified version of the knob. If specified only the engineConfig for the engine matching the knobs will be blocked. Else, all possible combination of knobs for the engine will be blocked.
+    input_shape         : []   - Optional. Array of input shape for kernel (ex. [64, 32, 128, 128]) to be filtered out. Use -1 if you don't want to filter that dimension. (ex. [-1, -1, 128, 128] to only filter HxW for NCHW format)
+    filter_shape        : []   - Optional. Array of kernel/filter shape for kernel (ex. [32, 32, 5, 5]) to be filtered out. Use -1 if you don't want to filter that dimension. (ex. [-1, -1, 5, 5] to only filter 5x5 filter sizes)
+    shape_format        : ""   - Mandatory if input_shape and/or kernel_shape is present. Optional otherwise. Shape format of tensors as a string. (Ex. "NCHW", "NHWC").
     cudnn_version_start : 0    - Optional. Denotes the cudnn version after which the engine started having issues.
     cudnn_version_end   : -1   - Optional. Denotes the cudnn_version when the issue was fixed. "-1" denotes its an ongoing issue.
     arch                : ""   - Optional. Architectures where this kernel might be faulty.

--- a/include/cudnn_frontend_Errata.h
+++ b/include/cudnn_frontend_Errata.h
@@ -47,9 +47,81 @@ load_from_config(json &json_handle, const std::string & errata_json) {
     return true;
 }
 
+/**
+ * @brief Checks the shape of an operation to compare against errata filter height and width for kernel blocking
+ * 
+ * @param op The operation's tensors to check
+ * @param shape_format The shape format of the tensor (NCHW vs NHWC)
+ * @param tensor_attr The cudnnBackendAttributeName_t of the tensor's shape we want to check
+ * @param blocked_height The height we want to filter out
+ * @param blocked_width The width we want to filter out
+ * @param blocked_channels The channels we want to filter out. Defaults to -1 (not filter out channels)
+ * @return true The passed in operation shape matches the blocked shape
+ * @return false The passed in operation shape does not match the blocked shape
+ */
+static bool
+check_shape(cudnnBackendDescriptor_t &op,
+            const std::string &shape_format,
+            cudnnBackendAttributeName_t tensor_attr,
+            const std::vector<int64_t> &blocked_shape) {
+
+    // Get backend descriptor to individual tensor to be able to get shape
+    ManagedOpaqueDescriptor tensor = make_shared_backend_pointer(CUDNN_BACKEND_TENSOR_DESCRIPTOR);
+    cudnnBackendDescriptor_t tensor_ = tensor->get_backend_descriptor();
+    int64_t count = 0;
+    cudnnStatus_t status = cudnnBackendGetAttribute(op,
+                                        tensor_attr,
+                                        CUDNN_TYPE_BACKEND_DESCRIPTOR,
+                                        1,
+                                        &count,
+                                        &tensor_);
+    if (status != CUDNN_STATUS_SUCCESS) {
+        #ifndef NV_CUDNN_DISABLE_EXCEPTION
+        throw cudnnException(
+            std::string("Error getting attribute. cudnn_status: " + to_string(status)).c_str(), status);
+        #endif
+    }
+
+    // Get tensor dims
+    std::array<int64_t, 5> tensor_dims;
+    status = cudnnBackendGetAttribute(tensor_,
+                                        CUDNN_ATTR_TENSOR_DIMENSIONS,
+                                        CUDNN_TYPE_INT64,
+                                        5,
+                                        &count,
+                                        tensor_dims.data());
+    if (status != CUDNN_STATUS_SUCCESS) {
+        #ifndef NV_CUDNN_DISABLE_EXCEPTION
+        throw cudnnException(
+            std::string("Error getting attribute. cudnn_status: " + to_string(status)).c_str(), status);
+        #endif
+    }
+    // tensor_dims is 1 indexed
+    int64_t first_dim = tensor_dims[1]; // batch size for input/output tensor, output channels for filter tensor
+    int64_t blocked_first_dim = blocked_shape[0];
+
+    // Defaults to true becuase -1 means we don't filter that out (Wildcard). If something later blocks, then the comparison will be correct
+    bool blocked = (blocked_first_dim != -1) ? (first_dim == blocked_first_dim) : true;
+
+    // Check for shape format to extract the right dimension. Filter shape will always be "NCHW" for convenience.
+    int64_t channels = (shape_format == "NCHW") ? tensor_dims[2] : tensor_dims[4]; // channels
+    int64_t blocked_channels = (shape_format == "NCHW") ? blocked_shape[1] : blocked_shape[3];
+    blocked = (blocked_channels != -1) ? (blocked && channels == blocked_channels) : true;
+
+    int64_t height = (shape_format == "NCHW") ? tensor_dims[3] : tensor_dims[2];
+    int64_t blocked_height = (shape_format == "NCHW") ? blocked_shape[2] : blocked_shape[1];
+    blocked = (blocked_height != -1) ? (blocked && height == blocked_height) : true;
+    
+    int64_t width = (shape_format == "NCHW") ? tensor_dims[4] : tensor_dims[3];
+    int64_t blocked_width = (shape_format == "NCHW") ? blocked_shape[3] : blocked_shape[2];
+    blocked = (blocked_width != -1) ? (blocked && width == blocked_width) : true;
+
+    return blocked;
+}
+
 template <typename T>
 static bool 
-check_rule(const json &json_handle, const std::string & executionPlanTag,
+check_rule(const json &json_handle, const std::string &executionPlanTag,
     cudnnHandle_t handle, T fn) {
     std::string operation = json_handle["operation"];
     int64_t engine        =  json_handle["engine"];
@@ -75,7 +147,98 @@ check_rule(const json &json_handle, const std::string & executionPlanTag,
                 (executionPlanTag.find(kv) != std::string::npos);
         }
     }
+    blocked = blocked && fn(); 
+    return blocked;
 
+    CUDNN_FRONTEND_UNUSED(handle);
+}
+
+// Overload for check_rule to take in an operation graph for shape filtering
+template <typename T>
+static bool 
+check_rule(const json &json_handle, const std::string &executionPlanTag,
+    cudnnHandle_t handle, T fn, const OperationGraph& opGraph) {
+    std::string operation = json_handle["operation"];
+    int64_t engine        =  json_handle["engine"];
+    uint64_t cudnn_start     =  0;
+    uint64_t cudnn_end       =  std::numeric_limits<uint64_t>::max();
+    if (json_handle.contains("cudnn_version_start")) {
+        cudnn_start   =  json_handle["cudnn_version_start"];
+    }
+    if (json_handle.contains("cudnn_version_end")) {
+        cudnn_end     =  json_handle["cudnn_version_end"];
+    }
+    std::string tag_prefix = operation + "_eng" + std::to_string(engine) + "_"; 
+    std::string mod_tag    = executionPlanTag + "_";
+    bool blocked = 
+        tag_prefix.size() <= mod_tag.size() &&
+        std::equal(tag_prefix.begin(), tag_prefix.end(), mod_tag.begin()) &&
+        CUDNN_VERSION >= cudnn_start &&
+        CUDNN_VERSION < cudnn_end;
+
+    if (blocked && json_handle.contains("knob")) { // Short circuit if operation and engine do not match
+        for (auto& kv : json_handle["knob"]) {
+            blocked = blocked &&
+                (executionPlanTag.find(kv) != std::string::npos);
+        }
+    }
+    
+    if (blocked && json_handle.contains("input_shape")) { // Check if user wants to block kernel for specific input shape
+        if (!json_handle.contains("shape_format")) {
+            std::string message = "ERROR: Please set a shape format (e.g. shape_format: \"NCWH\") for errata filters using input/kernel shape";
+            #ifndef NV_CUDNN_DISABLE_EXCEPTION
+            throw cudnnException(message.c_str(), CUDNN_STATUS_BAD_PARAM);
+            #endif
+            getLogger() << message << std::endl;
+            return blocked;
+        }
+
+        std::array<ManagedOpaqueDescriptor, MAX_OPGRAPH_OPS> ops = opGraph.getOps();
+        std::array<cudnnBackendDescriptor_t, MAX_OPGRAPH_OPS> ops_;
+        for (unsigned int i = 0; i < opGraph.getOpCount(); i++) {
+            ops_[i] = ops[i]->get_backend_descriptor();
+        }
+
+        std::string shape_format = json_handle["shape_format"];
+        std::vector<int64_t> blocked_shape = json_handle["input_shape"];
+
+        // Forward conv operation
+        if (operation == "ConvFwd") {
+            blocked = blocked && check_shape(ops_[0], shape_format, CUDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_X, blocked_shape);
+
+        // Operation is conv wgrad
+        } else if (operation == "ConvBwdFilter") {
+            blocked = blocked && check_shape(ops_[0], shape_format, CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_FILTER_X, blocked_shape);
+
+        // Operation is conv dgrad 
+        } else if (operation == "ConvBwdData") {
+            blocked = blocked && check_shape(ops_[0], shape_format, CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_DATA_DX, blocked_shape);
+        }
+    }
+
+    if (blocked && json_handle.contains("filter_shape")) { // Check if user wants to block kernel for specific filter shape
+        std::array<ManagedOpaqueDescriptor, 50> ops = opGraph.getOps();
+        std::array<cudnnBackendDescriptor_t, 50> ops_;
+        for (unsigned int i = 0; i < opGraph.getOpCount(); i++) {
+            ops_[i] = ops[i]->get_backend_descriptor();
+        }
+
+        std::vector<int64_t> blocked_shape = json_handle["filter_shape"];
+
+        // Forward conv operation
+        if (operation == "ConvFwd") {
+            // Filter format is always [output channels, input channels, height, width] so we hardcode "NCHW" to match and not repeat code
+            blocked = blocked && check_shape(ops_[0], "NCHW", CUDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_W, blocked_shape);
+
+        // Operation is conv wgrad
+        } else if (operation == "ConvBwdFilter") {
+            blocked = blocked && check_shape(ops_[0], "NCHW", CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_FILTER_DW, blocked_shape);
+
+        // Operation is conv dgrad 
+        } else if (operation == "ConvBwdData") {
+            blocked = blocked && check_shape(ops_[0], "NCHW", CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_DATA_W, blocked_shape);
+        }
+    }
     blocked = blocked && fn(); 
     return blocked;
 
@@ -93,6 +256,26 @@ check_errata(const json &json_handle, const std::string & executionPlanTag,
     cudnn_frontend::getLogger() << "[cudnn_frontend] " << "Verifying " << executionPlanTag;
     for (auto const &rule : json_handle["rules"]) {
         if (check_rule<T>(rule, executionPlanTag, handle, fn)) {
+            cudnn_frontend::getLogger() << ". Blocking." << std::endl;
+            return true;
+        }
+    }
+
+    cudnn_frontend::getLogger() << ". Passed." << std::endl;
+    return false;
+}
+
+// Overload. Takes in an initialzed json handle, an execution plan tag, and a operation graph and checks if it satisfies the 
+// condition for running it. Returns true if the given executionPlanTag + operation graph
+// is faulty
+template <typename T>
+static bool
+check_errata(const json &json_handle, const std::string & executionPlanTag,
+    cudnnHandle_t handle, const OperationGraph &opGraph, T fn) {
+
+    cudnn_frontend::getLogger() << "[cudnn_frontend] " << "Verifying " << executionPlanTag;
+    for (auto const &rule : json_handle["rules"]) {
+        if (check_rule<T>(rule, executionPlanTag, handle, fn, opGraph)) {
             cudnn_frontend::getLogger() << ". Blocking." << std::endl;
             return true;
         }

--- a/include/cudnn_frontend_Operation.h
+++ b/include/cudnn_frontend_Operation.h
@@ -564,12 +564,18 @@ class OperationBuilder_v8 {
                 m_operation.operationTag = "Identity";
                 break;
 #endif
+#if (CUDNN_VERSION >= 8900)
+            case CUDNN_POINTWISE_RECIPROCAL:
+                m_operation.operationTag = "Reciprocal";
+                break;
+#endif
 #ifndef NO_DEFAULT_IN_SWITCH
-	    default:
+            default:
                 m_operation.operationTag = "UNKNOWN_POINTWISE_OPERATION";
                 break;
 #endif
         }
+        
 
         status = cudnnBackendSetAttribute(m_operation.pointer->get_backend_descriptor(),
                 CUDNN_ATTR_OPERATION_POINTWISE_PW_DESCRIPTOR,
@@ -2018,8 +2024,11 @@ class OperationBuilder_v8 {
             m_operation.feature_vector.push_back(yTensor_strA[i]); // n, c, (g), d, h , w 
         }
 
-        int64_t alpha_as_int = *reinterpret_cast<int64_t *>(&m_operation.alpha_d);
-        int64_t  beta_as_int = *reinterpret_cast<int64_t *>(&m_operation.beta_d);
+        int64_t alpha_as_int;
+        int64_t  beta_as_int;
+        std::memcpy((void *)&alpha_as_int, (void *)(&m_operation.alpha_s), sizeof(int64_t));
+        std::memcpy((void *)&beta_as_int, (void *)(&m_operation.beta_s), sizeof(int64_t));
+
 
         m_operation.feature_vector.push_back(alpha_as_int);
         m_operation.feature_vector.push_back(beta_as_int);
@@ -2730,6 +2739,9 @@ class OperationBuilder_v8 {
 #if (CUDNN_VERSION >= 8500)
                                             (m_operation.pointwise_mode == CUDNN_POINTWISE_ERF) ||
 #endif
+#if (CUDNN_VERSION >= 8900)
+                                            (m_operation.pointwise_mode == CUDNN_POINTWISE_RECIPROCAL) ||
+#endif
                                             (m_operation.pointwise_mode == CUDNN_POINTWISE_MIN) ||
                                             (m_operation.pointwise_mode == CUDNN_POINTWISE_MAX) ||
                                             (m_operation.pointwise_mode == CUDNN_POINTWISE_SQRT));
@@ -2758,7 +2770,7 @@ class OperationBuilder_v8 {
                                                       (m_operation.pointwise_mode == CUDNN_POINTWISE_GELU_BWD) ||
 #if (CUDNN_VERSION >= 8500)
                                                       (m_operation.pointwise_mode == CUDNN_POINTWISE_GELU_APPROX_TANH_BWD) ||
-#endif
+#endif 
                                                       (m_operation.pointwise_mode == CUDNN_POINTWISE_SOFTPLUS_BWD) ||
                                                       (m_operation.pointwise_mode == CUDNN_POINTWISE_SWISH_BWD));
 

--- a/include/cudnn_frontend_OperationGraph.h
+++ b/include/cudnn_frontend_OperationGraph.h
@@ -36,6 +36,9 @@
 #include "cudnn_frontend_Operation.h"
 #include "cudnn_frontend_utils.h"
 
+// Compile time constant for max ops in a op graph
+constexpr int64_t MAX_OPGRAPH_OPS = 50;
+
 namespace cudnn_frontend {
 
 ///
@@ -100,14 +103,24 @@ class OperationGraph_v8 : public BackendDescriptor {
         return opGraphTag;
     }
 
+    bool
+    setFeatureVector(feature_vector_t fv) {
+        feature_vectors.push_back(fv);
+        return true;
+    }
+
     feature_vector_t
     getFeatureVector() const {
-        if (numOps != 1) {
-            return {}; /// We do not support multiop opGraph at this point of time.
-        } else {
+        if(feature_vectors.size() != 0) {
             return feature_vectors[0];
+        } else {
+            return {};
         }
+    }
 
+    const std::array<ManagedOpaqueDescriptor, MAX_OPGRAPH_OPS> &
+    getOps() const {
+        return ops;
     }
 
    private:
@@ -117,7 +130,7 @@ class OperationGraph_v8 : public BackendDescriptor {
     operator=(OperationGraph_v8 const &) = delete;
 
     cudnnHandle_t handle = nullptr;
-    std::array<ManagedOpaqueDescriptor, 50> ops{};
+    std::array<ManagedOpaqueDescriptor, MAX_OPGRAPH_OPS> ops{};
     int64_t numOps         = -1;
     std::string opGraphTag = "";
     std::vector<feature_vector_t> feature_vectors;

--- a/include/cudnn_frontend_PointWiseDesc.h
+++ b/include/cudnn_frontend_PointWiseDesc.h
@@ -131,8 +131,12 @@ class PointWiseDesc_v8 : public BackendDescriptor {
             case CUDNN_POINTWISE_BINARY_SELECT:
                 return 4;
 #endif
+#if (CUDNN_VERSION >= 8900)
+            case CUDNN_POINTWISE_RECIPROCAL:
+                return 2;
+#endif
 #ifndef NO_DEFAULT_IN_SWITCH
-	    default:
+            default:
                 return -1;
 #endif
         }

--- a/include/cudnn_frontend_utils.h
+++ b/include/cudnn_frontend_utils.h
@@ -408,6 +408,10 @@ static inline std::ostream& operator<<(std::ostream& os, const cudnnBackendTenso
         case cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_NONE:
             os << "CUDNN_TENSOR_REORDERING_NONE";
             break;
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            os << "CUDNN_TENSOR_REORDERING_MODE_UNKNOWN";
+#endif
     }
     return os;
 } 
@@ -433,6 +437,10 @@ static inline std::ostream& operator<<(std::ostream& os, const cudnnResampleMode
         case cudnnResampleMode_t::NOT_SET:
             os << "NOT_SET";
             break;
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            os << "CUDNN_TENSOR_RESAMPLE_MODE_UNKNOWN";
+#endif
     }
     return os;
 } 
@@ -452,6 +460,10 @@ static inline std::ostream& operator<<(std::ostream& os, const cudnnPaddingMode_
         case cudnnPaddingMode_t::NOT_SET:
             os << "NOT_SET";
             break;
+#ifndef NO_DEFAULT_IN_SWITCH
+        default:
+            os << "CUDNN_TENSOR_PADDING_MODE_UNKNOWN";
+#endif
     }
     return os;
 } 
@@ -619,4 +631,3 @@ static inline cudnnStatus_t convert_to_cudnn_type(cudnn_frontend::cudnnBackendTe
 } // namespace detail
 
 }
-

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -28,6 +28,8 @@ add_executable(
     fp8_sample.cpp 
     mha_sample.cpp
     fused_mha_sample.cpp
+    f16_flash_mha_sample.cpp
+    fp8_flash_mha_sample.cpp
 )
 
 if(DEFINED ENV{NO_DEFAULT_IN_SWITCH})

--- a/samples/cpu_references.h
+++ b/samples/cpu_references.h
@@ -160,9 +160,10 @@ void gen_stats_cpu(
     const int64_t inputSize,
     const int64_t* inputDims)
 {
-    std::vector<int64_t> totals((size_t)inputDims[0], 0);
+    int64_t channel_dim = inputDims[1];
+    std::vector<int64_t> totals((size_t)channel_dim, 0);
     for (int i = 0; i < inputSize; i++) {
-        int channel_index = i % inputDims[0];
+        int channel_index = i % channel_dim;
 
         // Sum
         outputData[channel_index].first = outputData[channel_index].first + inputData[i];
@@ -175,7 +176,7 @@ void gen_stats_cpu(
     }
 
     for (int i = 0; i < inputSize; i++) {
-        int channel_index = i % inputDims[0];
+        int channel_index = i % channel_dim;
 
         // Sum of squares
         T_ELEM diff = (inputData[i] - outputData[channel_index].first) * (inputData[i] - outputData[channel_index].first);
@@ -196,10 +197,10 @@ void batch_normalize(
     const int64_t inputSize,
     const int64_t* inputDims)
 {   
-
+    int64_t channel_dim = inputDims[1];
     // Loop through each element in the input and normalize it based on what batch it belongs to
     for (int i = 0; i < inputSize; i++) {
-        int batch_index = i % inputDims[0];
+        int batch_index = i % channel_dim;
         outputData[i] = (inputData[i] - stats[batch_index].first) / (T_ELEM) std::sqrt(stats[batch_index].second);
     }
 }

--- a/samples/f16_flash_mha_sample.cpp
+++ b/samples/f16_flash_mha_sample.cpp
@@ -1,0 +1,1224 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "f16_flash_mha_sample.h"
+#include <cudnn_frontend.h>
+#include "error_util.h"
+
+#define Q_ID 1
+#define K_ID 2
+#define V_ID 3
+#define O_ID 4
+#define S_ID 5
+#define B_ID 6
+#define D_CONST_ID 7
+#define S_CONST_ID 8
+#define Q_SEQLEN_ID 9
+#define K_SEQLEN_ID 10
+#define dQ_ID 11
+#define dK_ID 12
+#define dV_ID 13
+#define dO_ID 14
+#define MASK_VAL_ID 15
+#define dS_ID 16
+#define D_SEED_ID 17
+#define D_OFFSET_ID 18
+#define S_STATS_ID 19
+#define S_SUM_ID 20
+#define SCALE_PROB 21
+#define K_TRANSPOSE_ID 22
+#define dQ_ACCUM_ID 23
+
+#define VIRTUAL_ID 30
+
+static bool
+allowAllConfig(cudnnBackendDescriptor_t engine_config) {
+    (void)engine_config;
+    return false;
+}
+
+
+#if (CUDNN_VERSION >= 8900)
+static cudnn_frontend::Tensor tensor_create(cudnnDataType_t type, int64_t id, int64_t const * dim, 
+                                int64_t const * stride, bool is_virtual, bool is_value) {
+    int nbDims = 4;
+    auto tensor_created = cudnn_frontend::TensorBuilder()
+            .setDim(nbDims, dim)
+            .setStride(nbDims, stride)
+            .setId(id) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(type)
+            .setVirtual(is_virtual)
+            .setByValue(is_value)
+            .build();
+    std::cout << tensor_created.describe() << std::endl;
+    return tensor_created;
+};
+
+static cudnn_frontend::PointWiseDesc pw_desc_create(cudnnDataType_t type, cudnnPointwiseMode_t mode) {
+    auto pw_desc_created = cudnn_frontend::PointWiseDescBuilder()
+            .setMode(mode)
+            .setComputeType(type)
+            .build();
+    
+    std::cout << pw_desc_created.describe() << std::endl;
+    return pw_desc_created;
+} 
+
+static cudnn_frontend::Operation unary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &yDesc, 
+                                                    cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                        .setxDesc(xDesc)
+                        .setyDesc(yDesc)
+                        .setpwDesc(pwDesc)
+                        .build();
+    std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+static cudnn_frontend::Operation binary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc, 
+                                                    cudnn_frontend::Tensor const &yDesc, cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                        .setxDesc(xDesc)
+                        .setbDesc(bDesc)
+                        .setyDesc(yDesc)
+                        .setpwDesc(pwDesc)
+                        .build();
+    std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+static cudnn_frontend::Operation ternary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc, cudnn_frontend::Tensor const &tDesc, 
+                                            cudnn_frontend::Tensor const &yDesc, cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                        .setxDesc(xDesc)
+                        .setbDesc(bDesc)
+                        .settDesc(tDesc)
+                        .setyDesc(yDesc)
+                        .setpwDesc(pwDesc)
+                        .build();
+    std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+static cudnn_frontend::Tensor 
+createScale(int64_t b, 
+            int64_t h, 
+            int64_t s_q,
+            int64_t s_kv,
+            int64_t d,
+            MHA_Layout layout, 
+            cudnnDataType_t tensorType,
+            const cudnn_frontend::Tensor& sTensor,
+            std::vector<cudnn_frontend::Operation>& ops) {
+
+    // scale
+    int64_t scale_dim [4] = {1, 1, 1, 1};
+    int64_t scale_stride [4] = {1, 1, 1, 1};
+
+    int64_t s_dim [4] =  {b, h, s_q, s_kv};
+    int64_t s_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, s_stride, layout, MHA_Matrix::S_Matrix);
+
+    auto scaleTensor = tensor_create(tensorType, S_CONST_ID, scale_dim, scale_stride, false, true); // is by value
+    auto sScaleTensor = tensor_create(tensorType, VIRTUAL_ID + 2000, s_dim, s_stride, true, false); // is virtual
+
+    // Define the scale descriptor
+    auto scaleDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a Scale Node.
+    auto scale_op = binary_pw_op_create(sTensor, scaleTensor, sScaleTensor, scaleDesc);
+
+    ops.push_back(std::move(scale_op));
+    return sScaleTensor;
+}
+
+static cudnn_frontend::Tensor
+createQKBMM(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           cudnnDataType_t tensorType,
+           std::vector<cudnn_frontend::Operation>& ops) {
+    // Creates the necessary tensor descriptors
+    int64_t q_dim [4] = {b, h, s_q, d};
+    int64_t q_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, q_stride, layout, MHA_Matrix::Q_Matrix);
+
+    int64_t k_dim [4] =  {b, h, d, s_kv};
+    int64_t k_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::K_Matrix_Transpose);
+
+    int64_t s_dim [4] = {b, h, s_q, s_kv};
+    int64_t s_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, s_stride, layout, MHA_Matrix::S_Matrix);
+
+    auto qTensor = tensor_create(tensorType, Q_ID, q_dim, q_stride, false, false);
+    auto kTransposeTensor = tensor_create(tensorType, K_ID, k_dim, k_stride, false, false); // is virtual
+    // first GEMM output
+    auto sTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 1, s_dim, s_stride, true, false); // is virtual
+
+    // Define the matmul 1 desc
+    auto matmul_1_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
+    std::cout << matmul_1_Desc.describe() << std::endl;
+
+    // Create a matmul 1 Node
+    auto matmul_op1 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(qTensor)
+                            .setbMatDesc(kTransposeTensor)
+                            .setcMatDesc(sTensor)
+                            .setmatmulDesc(matmul_1_Desc)
+                            .build();
+
+    std::cout << matmul_op1.describe() << std::endl;
+
+    ops.push_back(std::move(matmul_op1));
+
+    return sTensor;
+}
+
+static cudnn_frontend::Tensor
+createCausalMask(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           cudnnDataType_t tensorType,
+           std::vector<cudnn_frontend::Operation>& ops,
+           cudnn_frontend::Tensor& prevBlockOutputTensor) {
+
+    CUDNN_FRONTEND_UNUSED(d);
+    CUDNN_FRONTEND_UNUSED(layout);
+    CUDNN_FRONTEND_UNUSED(tensorType);
+
+    cudnn_frontend::throw_if(ops.size() == 0, "Padding Mask constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    // subtraction output
+    int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
+    int64_t afterBMM1_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+    int64_t maskVal_dim [4] =  {1, 1, 1, 1};
+    int64_t maskVal_stride [4] = {1, 1, 1, 1};
+    
+    // mask value to put in the masked pixels
+    auto maskValTensor = tensor_create(CUDNN_DATA_FLOAT, MASK_VAL_ID, maskVal_dim, maskVal_stride, false, true); // is by value
+    // gen index row output
+    auto rowIndexTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 100, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+    // gen index column output
+    auto columnIndexTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 101, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+    // create causal mask (row >= col)
+    auto causalMaskTensor = tensor_create(CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 106, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+    
+    // output after masking
+    auto maskOutputTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 107, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+    // Define the gen index for row descriptor
+    auto genIndexRowDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_GEN_INDEX)
+                            .setAxis(2)
+                            .setComputeType(CUDNN_DATA_FLOAT)
+                            .build();
+    std::cout << genIndexRowDesc.describe() << std::endl;
+
+    // Create a gen index Node.
+    auto genIndexRow_op = unary_pw_op_create(prevBlockOutputTensor, rowIndexTensor, genIndexRowDesc);
+    std::cout << genIndexRow_op.describe() << std::endl;
+
+    // Define the gen index for row descriptor
+    auto genIndexColumnDesc = cudnn_frontend::PointWiseDescBuilder()
+                            .setMode(CUDNN_POINTWISE_GEN_INDEX)
+                            .setAxis(3)
+                            .setComputeType(CUDNN_DATA_FLOAT)
+                            .build();
+    std::cout << genIndexColumnDesc.describe() << std::endl;
+
+    // Create a gen index Node.
+    auto genIndexColumn_op = unary_pw_op_create(prevBlockOutputTensor, columnIndexTensor, genIndexColumnDesc);
+
+    // Define the greater than equal to comparison descriptor
+    auto rowGreaterColDesc = pw_desc_create(CUDNN_DATA_BOOLEAN, CUDNN_POINTWISE_CMP_GE);
+
+    // Create a greater than equal to Node.
+    auto rowGreaterCol_op = binary_pw_op_create(rowIndexTensor, columnIndexTensor, causalMaskTensor, rowGreaterColDesc);
+
+    /////////////////// Apply the mask //////////////////////////
+
+    // Define the binary select to perform masking descriptor
+    auto maskDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_BINARY_SELECT);
+
+    // Create a binary select Node.
+    auto mask_op = ternary_pw_op_create(prevBlockOutputTensor, maskValTensor, causalMaskTensor, maskOutputTensor, maskDesc);
+
+    ops.push_back(std::move(genIndexRow_op));
+    ops.push_back(std::move(genIndexColumn_op));
+    ops.push_back(std::move(rowGreaterCol_op));
+    ops.push_back(std::move(mask_op));
+
+    return maskOutputTensor;
+}
+
+static cudnn_frontend::Tensor
+createSoftmaxForward(int64_t b, 
+                     int64_t h, 
+                     int64_t s_q,
+                     int64_t s_kv,
+                     bool isTraining,
+                     std::vector<cudnn_frontend::Operation>& ops,
+                     cudnn_frontend::Tensor& sAfterMaskTensor) {
+
+    int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
+    int64_t afterBMM1_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+    int64_t afterReduction_dim [4] = {b, h, s_q, 1};
+    int64_t afterReduction_stride [4] = {h * s_q, s_q, 1, 1};
+
+    // max (x)
+    auto afterMaxReductionTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 150, afterReduction_dim, afterReduction_stride, true, false); // is virtual
+
+    // x - max(x)
+    auto afterSubtractionTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 151, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+    // e^(x - max(x))
+    auto afterExponentTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 152, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual;
+
+    // sum (e^(x - max(x)))
+    auto afterAddReductionTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 153, afterReduction_dim, afterReduction_stride, true, false); // is virtual
+
+    // log (sum (e^(x - max(x))))
+    auto afterLogLTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 154, afterReduction_dim, afterReduction_stride, true, false);
+
+    // M + log (sum (e^(x - max(x))))
+    auto softmaxStatsTensor = tensor_create(CUDNN_DATA_FLOAT, S_STATS_ID, afterReduction_dim, afterReduction_stride, !isTraining, false); // not virtual if training is true, virtual if training is false
+
+    // divide (e/ sum(e))
+    auto afterSoftmaxTensor = cudnn_frontend::TensorBuilder()
+            .setDim(4, afterBMM1_dim)
+            .setStride(4, afterBMM1_stride)
+            .setId(VIRTUAL_ID + 156) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(CUDNN_DATA_FLOAT)
+            .setVirtual(true)
+            .setByValue(false)
+            .setReorderType(cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16)
+            .build();
+
+    // Define the reduction descriptor
+    auto reductionMaxDesc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_MAX)
+                                .build();
+    std::cout << reductionMaxDesc.describe() << std::endl;
+
+    // Create a reduction max Node.
+    auto reductionMax_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(sAfterMaskTensor)
+                                .setyDesc(afterMaxReductionTensor)
+                                .setreductionDesc(reductionMaxDesc)
+                                .build();
+    std::cout << reductionMax_op.describe() << std::endl;
+
+    // Define the subtract descriptor
+    auto subtractDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_SUB);
+
+    // Create a subtract Node.
+    auto subtract_op = binary_pw_op_create(sAfterMaskTensor, afterMaxReductionTensor, afterSubtractionTensor, subtractDesc);
+
+    // Define the exponent descriptor
+    auto exponentDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_EXP);
+
+    // Create a exponent Node.
+    auto exponent_op = unary_pw_op_create(afterSubtractionTensor, afterExponentTensor, exponentDesc);
+
+    // Define the reduction descriptor
+    auto reductionAddDesc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                                .build();
+    std::cout << reductionAddDesc.describe() << std::endl;
+
+    // Create a reduction add Node.
+    auto reductionAdd_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(afterExponentTensor)
+                                .setyDesc(afterAddReductionTensor)
+                                .setreductionDesc(reductionAddDesc)
+                                .build();
+
+    std::cout << reductionAdd_op.describe() << std::endl;
+
+    // Create log descriptor
+    auto logDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_LOG);
+
+    // Create log node
+    auto log_op = unary_pw_op_create(afterAddReductionTensor, afterLogLTensor, logDesc);
+
+    // Create add descriptor
+    auto addDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_ADD);
+
+    // Create add node
+    auto add_op = binary_pw_op_create(afterMaxReductionTensor, afterLogLTensor, softmaxStatsTensor, addDesc);
+
+    // Define the division descriptor
+    auto divisionDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_DIV);
+
+    // Create a subtract Node.
+    auto division_op = binary_pw_op_create(afterExponentTensor, afterAddReductionTensor, afterSoftmaxTensor, divisionDesc);
+
+    ops.push_back(std::move(reductionMax_op));
+    ops.push_back(std::move(subtract_op));
+    ops.push_back(std::move(exponent_op));
+    ops.push_back(std::move(reductionAdd_op));
+    ops.push_back(std::move(log_op));
+    ops.push_back(std::move(add_op));
+    ops.push_back(std::move(division_op));
+
+    return afterSoftmaxTensor;
+}
+
+static cudnn_frontend::Tensor
+createDropoutForward(int64_t b, 
+              int64_t h, 
+              int64_t s_q,
+              int64_t s_kv,
+              int64_t d,
+              double probability,
+              cudnnDataType_t tensorType,
+              std::vector<cudnn_frontend::Operation>& ops,
+              cudnn_frontend::Tensor& afterSoftmaxTensor) {
+    
+    CUDNN_FRONTEND_UNUSED(d);
+    
+    cudnn_frontend::throw_if(ops.size() == 0, "Dropout DAG constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
+    int64_t afterBMM1_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+    int64_t scale_dim [4] = {1, 1, 1, 1};
+    int64_t scale_stride [4] = {1, 1, 1, 1};
+
+    auto dropoutSeed = tensor_create(CUDNN_DATA_INT64, D_SEED_ID, scale_dim, scale_stride, false, false); // not virtual
+    auto dropoutOffset = tensor_create(CUDNN_DATA_INT64, D_OFFSET_ID, scale_dim, scale_stride, false, false); // not virtual
+
+    // mask for the dropout
+    auto dropoutMaskTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 200, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+    // after dropout tensor
+    auto afterDropoutTensor = cudnn_frontend::TensorBuilder()
+            .setDim(4, afterBMM1_dim)
+            .setStride(4, afterBMM1_stride)
+            .setId(VIRTUAL_ID + 201) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(tensorType)
+            .setVirtual(true)
+            .setByValue(false)
+            .setReorderType(cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16)
+            .build();
+    // scale after dropout
+    auto scaleDropoutTensor = tensor_create(tensorType, D_CONST_ID, scale_dim, scale_stride, false, true); // is by value
+    // after Scale
+    auto afterScaleTensor = tensor_create(tensorType, VIRTUAL_ID + 202, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+
+    // Define the reduction descriptor
+    auto rngDesc = cudnn_frontend::RngDescBuilder()
+                                .setRngDistribution(CUDNN_RNG_DISTRIBUTION_BERNOULLI)
+                                .setBernoulliDistProbability(1.0 - probability)
+                                .build();
+    std::cout << rngDesc.describe() << std::endl;
+
+    // Create a rng Node.
+    auto rng_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RNG_DESCRIPTOR)
+                                .setyDesc(dropoutMaskTensor)
+                                .setSeedDesc(dropoutSeed)
+                                .setOffsetDesc(dropoutOffset)
+                                .setRngDesc(rngDesc)
+                                .build();
+
+    std::cout << rng_op.describe() << std::endl;
+
+    // Define the multiply mask descriptor
+    auto maskMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply mask Node.
+    auto maskMul_op = binary_pw_op_create(afterSoftmaxTensor, dropoutMaskTensor, afterDropoutTensor, maskMulDesc);
+
+    // Define the multiply scale descriptor
+    auto scaleMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply scale Node.
+    auto scaleMul_op = binary_pw_op_create(afterDropoutTensor, scaleDropoutTensor, afterScaleTensor, scaleMulDesc);
+
+    ops.push_back(std::move(rng_op));
+    ops.push_back(std::move(maskMul_op));
+    ops.push_back(std::move(scaleMul_op));
+
+    return afterScaleTensor;
+}
+
+static cudnn_frontend::Tensor
+createDropoutBackward(int64_t b, 
+              int64_t h, 
+              int64_t s_q,
+              int64_t s_kv,
+              int64_t d,
+              double probability,
+              cudnnDataType_t tensorType,
+              std::vector<cudnn_frontend::Operation>& ops,
+              cudnn_frontend::Tensor& afterSoftmaxTensor,
+              cudnn_frontend::Tensor& dropoutMaskTensor) {
+    
+    CUDNN_FRONTEND_UNUSED(d);
+    
+    cudnn_frontend::throw_if(ops.size() == 0, "Dropout DAG constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
+    int64_t afterBMM1_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+    int64_t scale_dim [4] = {1, 1, 1, 1};
+    int64_t scale_stride [4] = {1, 1, 1, 1};
+
+    auto dropoutSeed = tensor_create(CUDNN_DATA_INT64, D_SEED_ID, scale_dim, scale_stride, false, false); // not virtual
+    auto dropoutOffset = tensor_create(CUDNN_DATA_INT64, D_OFFSET_ID, scale_dim, scale_stride, false, false); // not virtual
+
+    // after dropout tensor
+    auto afterDropoutTensor = cudnn_frontend::TensorBuilder()
+            .setDim(4, afterBMM1_dim)
+            .setStride(4, afterBMM1_stride)
+            .setId(VIRTUAL_ID + 201) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(tensorType)
+            .setVirtual(true)
+            .setByValue(false)
+            .setReorderType(cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16)
+            .build();
+    // scale after dropout
+    auto scaleDropoutTensor = tensor_create(tensorType, D_CONST_ID, scale_dim, scale_stride, false, true); // is by value
+    // after Scale
+    auto afterScaleTensor = tensor_create(tensorType, VIRTUAL_ID + 202, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+
+    // Define the reduction descriptor
+    auto rngDesc = cudnn_frontend::RngDescBuilder()
+                                .setRngDistribution(CUDNN_RNG_DISTRIBUTION_BERNOULLI)
+                                .setBernoulliDistProbability(1.0 - probability)
+                                .build();
+    std::cout << rngDesc.describe() << std::endl;
+
+    // Create a rng Node.
+    auto rng_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RNG_DESCRIPTOR)
+                                .setyDesc(dropoutMaskTensor)
+                                .setSeedDesc(dropoutSeed)
+                                .setOffsetDesc(dropoutOffset)
+                                .setRngDesc(rngDesc)
+                                .build();
+
+    std::cout << rng_op.describe() << std::endl;
+
+    // Define the multiply mask descriptor
+    auto maskMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply mask Node.
+    auto maskMul_op = binary_pw_op_create(afterSoftmaxTensor, dropoutMaskTensor, afterDropoutTensor, maskMulDesc);
+
+    // Define the multiply scale descriptor
+    auto scaleMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply scale Node.
+    auto scaleMul_op = binary_pw_op_create(afterDropoutTensor, scaleDropoutTensor, afterScaleTensor, scaleMulDesc);
+
+    ops.push_back(std::move(rng_op));
+    ops.push_back(std::move(maskMul_op));
+    ops.push_back(std::move(scaleMul_op));
+
+    return afterScaleTensor;
+}
+
+static void
+createSVBMM(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           cudnnDataType_t tensorType,
+           std::vector<cudnn_frontend::Operation>& ops,
+           cudnn_frontend::Tensor const &afterScaleDropoutTensor) {
+
+    cudnn_frontend::throw_if(ops.size() == 0, "BMM2 op constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t v_dim [4] =  {b, h, s_kv, d};
+    int64_t v_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, v_stride, layout, MHA_Matrix::V_Matrix);
+
+    int64_t o_dim [4] =  {b, h, s_q, d};
+    int64_t o_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, o_stride, layout, MHA_Matrix::O_Matrix);
+    
+    auto vTensor = tensor_create(tensorType, V_ID, v_dim, v_stride, false, false);
+    // second GEMM output
+    auto oTensor = tensor_create(tensorType, O_ID, o_dim, o_stride, false, false);
+
+    // Define the matmul 2 desc
+    auto matmul_2_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
+    std::cout << matmul_2_Desc.describe() << std::endl;
+
+    // Create a matmul 2 Node
+    auto matmul_op2 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(afterScaleDropoutTensor)
+                            .setbMatDesc(vTensor)
+                            .setcMatDesc(oTensor)
+                            .setmatmulDesc(matmul_2_Desc)
+                            .build();
+
+    std::cout << matmul_op2.describe() << std::endl;
+
+    ops.push_back(std::move(matmul_op2));
+}
+
+static cudnn_frontend::Tensor
+createSoftmaxBackward(int64_t b, 
+                     int64_t h, 
+                     int64_t s_q,
+                     int64_t s_kv,
+                     int64_t d,
+                     MHA_Layout layout,
+                     cudnnDataType_t tensorType,
+                     std::vector<cudnn_frontend::Operation>& ops,
+                     cudnn_frontend::Tensor& yTensor,
+                     cudnn_frontend::Tensor& dyTensor) {
+
+    CUDNN_FRONTEND_UNUSED(tensorType);
+
+    cudnn_frontend::throw_if(ops.size() == 0, "Softmax backward constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t p_dim [4] = {b, h, s_q, s_kv};
+    int64_t p_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, p_stride, layout, MHA_Matrix::S_Matrix);
+
+    int64_t p_reduction_dim [4] = {b, h, s_q, 1};
+    int64_t p_reduction_stride [4];
+
+    p_reduction_stride[3] = 1;
+    p_reduction_stride[2] = 1;
+    p_reduction_stride[1] = s_q;
+    p_reduction_stride[0] = s_q * h;
+
+    int64_t const_dim [4] =  {1, 1, 1, 1};
+    int64_t const_stride [4] = {1, 1, 1, 1};
+
+    // creating all tensors
+    auto softmaxScaleTensor = tensor_create(CUDNN_DATA_FLOAT, S_CONST_ID, const_dim, const_stride, false, true);
+    auto dyMulYTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 250, p_dim, p_stride, true, false);
+    auto dxAfterReductionTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 251, p_reduction_dim, p_reduction_stride, true, false);
+    auto dxAfterSubtractionTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 252, p_dim, p_stride, true, false);
+    auto dxUnscaleTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 253, p_dim, p_stride, true, false);
+    auto dxTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 254, p_dim, p_stride, true, false);
+
+    // creating all ops
+    // mul (y * dy)
+    auto mul_1_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+    auto mul_1_op = binary_pw_op_create(yTensor, dyTensor, dyMulYTensor, mul_1_desc);
+
+    // reduction add sum (y * dy)
+    auto reductionAddDesc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                                .build();
+    std::cout << reductionAddDesc.describe() << std::endl;
+
+    auto reductionAdd_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(dyMulYTensor)
+                                .setyDesc(dxAfterReductionTensor)
+                                .setreductionDesc(reductionAddDesc)
+                                .build();
+
+    std::cout << reductionAdd_op.describe() << std::endl;
+
+    // subtraction (dy - sum(y * dy))
+    auto sub_0_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_SUB);
+    auto sub_0_op = binary_pw_op_create(dyTensor, dxAfterReductionTensor, dxAfterSubtractionTensor, sub_0_desc);
+
+    // mul (y * (dy - sum(y * dy)))
+    auto mul_2_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+    auto mul_2_op = binary_pw_op_create(yTensor, dxAfterSubtractionTensor, dxUnscaleTensor, mul_2_desc);
+
+    // mul (scale * dx)
+    auto mul_3_desc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+    auto mul_3_op = binary_pw_op_create(dxUnscaleTensor, softmaxScaleTensor, dxTensor, mul_3_desc);
+
+    ops.push_back(std::move(mul_1_op));
+    ops.push_back(std::move(reductionAdd_op));
+    ops.push_back(std::move(sub_0_op));
+    ops.push_back(std::move(mul_2_op));
+    ops.push_back(std::move(mul_3_op));
+
+    return dxTensor;
+}
+
+void 
+run_f16_flash_attention_fprop(int64_t b, 
+              int64_t h, 
+              int64_t s_q,
+              int64_t s_kv,
+              int64_t d,
+              MHA_Layout layout,
+              float scaling_factor,
+              bool isTraining,
+              double dropout_probability,
+              void* devPtrQ, 
+              void* devPtrK,   
+              void* devPtrV,
+              void* devPtrSoftmaxStats,
+              void* devPtrO,
+              void* devPtrDropoutSeed,
+              void* devPtrDropoutOffset,
+              cudnnDataType_t tensorType) {
+                
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        std::vector<cudnn_frontend::Operation const*> all_ops;
+        std::vector<cudnn_frontend::Operation> ops;
+        std::set<std::pair<uint64_t, void*>> data_ptrs;
+
+        // Q * K^T
+        auto sTensor = createQKBMM(b, h, s_q, s_kv, d, layout, tensorType, ops);
+
+        // Q * K^T * bmmScale
+        auto sScaleTensor = createScale(b, h, s_q, s_kv, d, layout, CUDNN_DATA_FLOAT, sTensor, ops);
+
+        // Causual mask
+        float negInfinity = -1.0E+20f; // change this if you have access to float_min
+        auto sAfterMaskTensor = createCausalMask(b, h, s_q, s_kv, d, layout, tensorType, ops, sScaleTensor);
+
+        cudnn_frontend::throw_if(dropout_probability != 0.0f && !isTraining, "Dropout probability should be 0.0f for inference mode", CUDNN_STATUS_BAD_PARAM);
+        cudnn_frontend::throw_if(dropout_probability == 1.0f, "Dropout probability cannot be 1.0", CUDNN_STATUS_BAD_PARAM);
+
+        // needs to be bf16 (Please change)
+        half1 scale_dropout = cpu_float2half_rn(static_cast<float>(1/(1 - dropout_probability)));
+
+        auto softmax_output = createSoftmaxForward(b, h, s_q, s_kv, isTraining, ops, sAfterMaskTensor);
+
+        // Dropout(softmax)
+        auto dropout_output = createDropoutForward(b, h, s_q, s_kv, d, dropout_probability, tensorType, ops, softmax_output);
+        createSVBMM(b, h, s_q, s_kv, d, layout, tensorType, ops, dropout_output);
+        
+        std::cout << "Total ops created: " << ops.size() << std::endl;
+
+        for (unsigned int i = 0; i < ops.size(); i++) {
+            all_ops.push_back(&ops[i]);
+        }
+
+        // Create an Operation Graph
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(all_ops.size(), all_ops.data())
+                           .build();
+
+
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph, ::allowAllConfig, filtered_configs, true);
+
+        if (filtered_configs.size() == 0) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_NOT_SUPPORTED,
+                    "run_mha_fprop: No config returned by the heuristics");
+        }   
+
+        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        // add all the data pointers to be used in the variant pack
+        data_ptrs.insert(std::pair<uint64_t, void*>(Q_ID, devPtrQ));
+        data_ptrs.insert(std::pair<uint64_t, void*>(K_ID, devPtrK));
+        data_ptrs.insert(std::pair<uint64_t, void*>(V_ID, devPtrV));
+        data_ptrs.insert(std::pair<uint64_t, void*>(MASK_VAL_ID, &negInfinity));
+        data_ptrs.insert(std::pair<uint64_t, void*>(S_CONST_ID, &scaling_factor));
+        data_ptrs.insert(std::pair<uint64_t, void*>(O_ID, devPtrO));
+        data_ptrs.insert(std::pair<uint64_t, void*>(D_SEED_ID, devPtrDropoutSeed));
+        data_ptrs.insert(std::pair<uint64_t, void*>(D_OFFSET_ID, devPtrDropoutOffset));
+        data_ptrs.insert(std::pair<uint64_t, void*>(D_CONST_ID, &scale_dropout));
+
+        // If training mode, we write out softmax stats
+        if (isTraining) {
+            data_ptrs.insert(std::pair<uint64_t, void*>(S_STATS_ID, devPtrSoftmaxStats));
+        }
+
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(data_ptrs)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        checkCudaErr(cudaDeviceSynchronize());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
+        
+        // this example is only for GA100 cards and GH100 cards
+        if (!((prop.major == 8 && prop.minor == 0) || (prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8900)) && (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+            std::cout << "Example is only supported for GA100 (cuDNN >= 8900) and GH100 (cuDNN >= 8900) GPUs" << std::endl; 
+        }  else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+            CHECK(false);
+        }
+    }
+}
+
+void 
+run_f16_flash_attention_bprop(int64_t b, 
+              int64_t h, 
+              int64_t s_q,
+              int64_t s_kv,
+              int64_t d,
+              MHA_Layout layout,
+              float scaling_factor,
+              float dropout_probability,
+              void* devPtrQ, 
+              void* devPtrKTranspose,   
+              void* devPtrVTranspose,
+              void* devPtrO,
+              void* devPtrSoftmaxStats,
+              void* devPtrSoftmaxSum,
+              void* devPtrdQAccumulator,
+              void* devPtrdQ, 
+              void* devPtrdK,
+              void* devPtrdV,   
+              void* devPtrdO,
+              void* devPtrDropoutSeed,
+              void* devPtrDropoutOffset,
+              cudnnDataType_t tensorType) {
+                
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        std::vector<cudnn_frontend::Operation const*> all_ops;
+        std::vector<cudnn_frontend::Operation> ops;
+        std::set<std::pair<uint64_t, void*>> data_ptrs;
+
+        // Creates the necessary tensor descriptors
+        int64_t q_dim [4] = {b, h, s_q, d};
+        int64_t q_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, q_stride, layout, MHA_Matrix::Q_Matrix);
+
+        int64_t k_transpose_dim [4] =  {b, h, d, s_kv};
+        int64_t k_transpose_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, k_transpose_stride, layout, MHA_Matrix::K_Matrix_Transpose);
+
+        int64_t v_transpose_dim [4] =  {b, h, d, s_kv};
+        int64_t v_transpose_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, v_transpose_stride, layout, MHA_Matrix::V_Matrix_Transpose); // type is correct as V is transposed
+
+        int64_t p_dim [4] = {b, h, s_q, s_kv};
+        int64_t p_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, p_stride, layout, MHA_Matrix::S_Matrix);
+
+        int64_t p_transpose_dim [4] = {b, h, s_kv, s_q};
+        int64_t p_transpose_stride [4];
+        p_transpose_stride[0] = p_stride[0];
+        p_transpose_stride[1] = p_stride[1];
+        p_transpose_stride[2] = p_stride[3];
+        p_transpose_stride[3] = p_stride[2];
+
+        int64_t o_dim [4] =  {b, h, s_q, d};
+        int64_t o_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, o_stride, layout, MHA_Matrix::O_Matrix);
+
+        int64_t scale_dim [4] = {1, 1, 1, 1};
+        int64_t scale_stride [4] = {1, 1, 1, 1};
+
+        /*******************************************************************************
+         *                          Dot product dO * O
+        *///////////////////////////////////////////////////////////////////////////////
+        // output and gradient of the output
+        auto oTensor = tensor_create(tensorType, O_ID, o_dim, o_stride, false, false);
+        auto dOTensor = tensor_create(tensorType, dO_ID, o_dim, o_stride, false, false);
+        
+        auto dotProductTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID, o_dim, o_stride, true, false); // is virtual
+        // Create pointwise mul
+        auto multiplyDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+        // do * O
+        auto dotProductOp = binary_pw_op_create(dOTensor, oTensor, dotProductTensor, multiplyDesc);
+        ops.push_back(std::move(dotProductOp));
+
+        /*******************************************************************************
+         *                         Reduction(dO * O)
+        *///////////////////////////////////////////////////////////////////////////////
+
+        int64_t reduction_dim [4] = {b, h, s_q, 1};
+        int64_t reduction_stride [4] = {h * s_q, s_q, 1, 1};
+        // reduction(dO * O)
+        auto afterReductionTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 1, reduction_dim, reduction_stride, true, false); // is virtual
+        auto reductionMaxDesc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_MAX)
+                                .build();
+        std::cout << reductionMaxDesc.describe() << std::endl;
+
+        // Create a reduction max Node.
+        auto reductionMax_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                    .setxDesc(dotProductTensor)
+                                    .setyDesc(afterReductionTensor)
+                                    .setreductionDesc(reductionMaxDesc)
+                                    .build();
+        std::cout << reductionMax_op.describe() << std::endl;
+        ops.push_back(std::move(reductionMax_op));
+
+
+        /*******************************************************************************
+         *                        reduction(dO * O) * scale prob -> softmaxSum
+        *///////////////////////////////////////////////////////////////////////////////
+        auto softmaxSumTensor = tensor_create(CUDNN_DATA_FLOAT, S_SUM_ID, reduction_dim, reduction_stride, false, false); // not virtual
+        auto scaleProbTensor = tensor_create(CUDNN_DATA_FLOAT, SCALE_PROB, scale_dim, scale_stride, false, true); // not virtual
+        auto softmaxSumOp = binary_pw_op_create(afterReductionTensor, scaleProbTensor, softmaxSumTensor, multiplyDesc);
+        ops.push_back(std::move(softmaxSumOp));
+
+        /*******************************************************************************
+         *                        Q @ K.T -> P
+        *///////////////////////////////////////////////////////////////////////////////
+        
+        // Inputs from fprop
+        auto qTensor = tensor_create(tensorType, Q_ID, q_dim, q_stride, false, false);
+        auto kTransposeTensor = tensor_create(tensorType, K_ID, k_transpose_dim, k_transpose_stride, false, false);
+        auto pTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 2, p_dim, p_stride, true, false); // is virtual
+
+        // matmul to calculate dvTensor
+        auto matmul_0_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
+        std::cout << matmul_0_Desc.describe() << std::endl;
+
+        auto matmul_op0 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(qTensor)
+                                .setbMatDesc(kTransposeTensor)
+                                .setcMatDesc(pTensor)
+                                .setmatmulDesc(matmul_0_Desc)
+                                .build();
+
+        std::cout << matmul_op0.describe() << std::endl;
+        ops.push_back(std::move(matmul_op0));
+
+        /*******************************************************************************
+         *                        P * bmmScale -> pAfterScale
+        *///////////////////////////////////////////////////////////////////////////////
+        auto bmmScaleTensor = tensor_create(CUDNN_DATA_FLOAT, S_CONST_ID, scale_dim, scale_stride, false, true); // not virtual and by value
+        auto pAfterScaleTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 2000, p_dim, p_stride, true, false); // virtual
+        auto scaleOp = binary_pw_op_create(pTensor, bmmScaleTensor, pAfterScaleTensor, multiplyDesc);
+        ops.push_back(std::move(scaleOp));
+
+        /*******************************************************************************
+         *                          Causal masking -> pAfterMaskTensor
+        *///////////////////////////////////////////////////////////////////////////////
+        float negInfinity = -1.0E+20f; // change this if you have access to float_min
+        auto pAfterMaskTensor = createCausalMask(b, h, s_q, s_kv, d, layout, tensorType, ops, pAfterScaleTensor);
+
+        /*******************************************************************************
+         *                          pAfterMaskTensor - softmaxStats -> pAfterSubtract
+        *///////////////////////////////////////////////////////////////////////////////
+        auto pAfterSubtractTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 3, p_dim, p_stride, true, false); // is virtual
+        auto softmaxStatsTensor = tensor_create(CUDNN_DATA_FLOAT, S_STATS_ID, reduction_dim, reduction_stride, false, false); // not virtual
+        auto subtractDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_SUB);
+        auto subtract_op = binary_pw_op_create(pAfterMaskTensor, softmaxStatsTensor, pAfterSubtractTensor, subtractDesc);
+        ops.push_back(std::move(subtract_op));
+
+        /*******************************************************************************
+         *                          e^(pAfterSubtract) -> pAfterSoftmax
+        *///////////////////////////////////////////////////////////////////////////////
+        auto pAfterSoftmaxTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 4, p_dim, p_stride, true, false); // is virtual
+        auto expDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_EXP);
+        auto exp_op = unary_pw_op_create(pAfterSubtractTensor, pAfterSoftmaxTensor, expDesc);
+        ops.push_back(std::move(exp_op));
+
+        /*******************************************************************************
+         *                          Dropout -> afterScaleDropout
+        *///////////////////////////////////////////////////////////////////////////////
+        // mask for the dropout. used in rng and dS
+        auto dropoutMaskTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 5, p_dim, p_stride, true, false); // is virtual
+        auto afterScaleDropoutTensor = createDropoutBackward(b, h, s_q, s_kv, d, dropout_probability, tensorType, ops, pAfterSoftmaxTensor, dropoutMaskTensor);
+
+        /*******************************************************************************
+         *                          afterScaleDropout -> sTransposeTensor
+        *///////////////////////////////////////////////////////////////////////////////
+        auto sTransposeTensor = tensor_create(tensorType, VIRTUAL_ID + 6, p_transpose_dim, p_transpose_stride, true, false); // is virtual
+        auto reshape_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                                .setxDesc(afterScaleDropoutTensor)
+                                .setyDesc(sTransposeTensor)
+                                .build();
+        ops.push_back(std::move(reshape_op));
+
+        // Outputs of bprop
+        int64_t dqkv_dim[4] = {b, h, s_kv, d};
+        int64_t dqkv_stride[4];
+        generateMHAStrides(b, h, s_q, s_kv, d, dqkv_stride, layout, MHA_Matrix::Q_Matrix);
+        // Outputs of backprop
+        auto dQTensor = tensor_create(tensorType, dQ_ID, dqkv_dim, dqkv_stride, false, false);
+        auto dKTensor = tensor_create(tensorType, dK_ID, dqkv_dim, dqkv_stride, false, false);
+        auto dVTensor = tensor_create(tensorType, dV_ID, dqkv_dim, dqkv_stride, false, false); // not virtual
+
+        /*******************************************************************************
+         *                          sTransposeTensor @ dO -> dV
+        *///////////////////////////////////////////////////////////////////////////////
+        auto matmul_1_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
+        std::cout << matmul_1_Desc.describe() << std::endl;
+
+        auto matmul_op1 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(sTransposeTensor)
+                                .setbMatDesc(dOTensor)
+                                .setcMatDesc(dVTensor)
+                                .setmatmulDesc(matmul_1_Desc)
+                                .build();
+
+        std::cout << matmul_op1.describe() << std::endl;
+        ops.push_back(std::move(matmul_op1));
+
+        /*******************************************************************************
+         *                          dO @ V.T -> dS
+        *///////////////////////////////////////////////////////////////////////////////
+        auto vTransposeTensor = tensor_create(tensorType, V_ID, v_transpose_dim, v_transpose_stride, false, false);
+        auto dSTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 7, p_dim, p_stride, true, false); // is virtual
+        
+        auto matmul_2_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
+        std::cout << matmul_1_Desc.describe() << std::endl;
+
+        auto matmul_op2 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(dOTensor)
+                                .setbMatDesc(vTransposeTensor)
+                                .setcMatDesc(dSTensor)
+                                .setmatmulDesc(matmul_2_Desc)
+                                .build();
+
+        std::cout << matmul_op2.describe() << std::endl;
+        ops.push_back(std::move(matmul_op2));
+
+        /*******************************************************************************
+         *                          dS * dropoutMask -> dSAfterDropout
+        *///////////////////////////////////////////////////////////////////////////////
+        auto dSAfterDropoutTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 8, p_dim, p_stride, true, false); // is virtual
+        auto multiply_op = binary_pw_op_create(dSTensor, dropoutMaskTensor, dSAfterDropoutTensor, multiplyDesc);
+        ops.push_back(std::move(multiply_op));
+
+        /*******************************************************************************
+         *                          dSAfterDropout - softmaxSum -> dsAfterSubtract
+        *///////////////////////////////////////////////////////////////////////////////
+        auto dsAfterSubtractTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 9, p_dim, p_stride, true, false); // is virtual
+        auto subtract_op2 = binary_pw_op_create(dSAfterDropoutTensor, softmaxSumTensor, dsAfterSubtractTensor, subtractDesc);
+        ops.push_back(std::move(subtract_op2));
+
+        /*******************************************************************************
+         *                          dsAfterSubtract * afterSoftmax -> dP
+        *///////////////////////////////////////////////////////////////////////////////
+        auto dPTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 10, p_dim, p_stride, true, false); // is virtual
+        auto multiply_op2 = binary_pw_op_create(dsAfterSubtractTensor, pAfterSoftmaxTensor, dPTensor, multiplyDesc);
+        ops.push_back(std::move(multiply_op2));
+
+        /*******************************************************************************
+         *                          dP * scaleDropout -> dPAfterDropoutScale
+        *///////////////////////////////////////////////////////////////////////////////
+        auto dPAfterDropoutScaleTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 11, p_dim, p_stride, true, false); // is virtual
+        half1 scale_dropout = cpu_float2half_rn(static_cast<float>(1/(1 - dropout_probability)));
+        auto scaleDropoutTensor = tensor_create(CUDNN_DATA_FLOAT, D_CONST_ID, scale_dim, scale_stride, false, true); // is by value
+        auto multiply_op3 = binary_pw_op_create(dPTensor, scaleDropoutTensor, dPAfterDropoutScaleTensor, multiplyDesc);
+        ops.push_back(std::move(multiply_op3));
+
+        /*******************************************************************************
+         *                          dPAfterDropoutScale * bmmScale -> dPScaledTensor
+        *///////////////////////////////////////////////////////////////////////////////
+        auto dPScaledTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 12, p_dim, p_stride, true, false); // is virtual
+        auto multiply_op4 = binary_pw_op_create(dPAfterDropoutScaleTensor, bmmScaleTensor, dPScaledTensor, multiplyDesc);
+        ops.push_back(std::move(multiply_op4));
+
+        /*******************************************************************************
+         *                          K.T -> K
+        *///////////////////////////////////////////////////////////////////////////////
+        int64_t kDim [4] = {b, h, s_kv, d};
+        int64_t kStride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, kStride, layout, MHA_Matrix::K_Matrix);
+        auto kTensor = tensor_create(tensorType, VIRTUAL_ID + 13, kDim, kStride, true, false); // is virtual
+        auto reshape_op2 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                                .setxDesc(kTransposeTensor)
+                                .setyDesc(kTensor)
+                                .build();
+        std::cout << reshape_op2.describe() << std::endl;
+        ops.push_back(std::move(reshape_op2));
+
+        /*******************************************************************************
+         *                          dP @ K -> dqAccumTensor
+        *///////////////////////////////////////////////////////////////////////////////
+        auto dqAccumTensor = cudnn_frontend::TensorBuilder()
+            .setDim(4, dqkv_dim)
+            .setStride(4, dqkv_stride)
+            .setId(dQ_ACCUM_ID) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(CUDNN_DATA_FLOAT)
+            .setVirtual(false)
+            .setByValue(false)
+            .setReorderType(cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16) // dqAccum has reorder type
+            .build();
+        
+        auto matmul_3_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
+        auto matmul_op3 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(dPTensor)
+                                .setbMatDesc(kTensor)
+                                .setcMatDesc(dqAccumTensor)
+                                .setmatmulDesc(matmul_3_Desc)
+                                .build();
+
+        std::cout << matmul_op3.describe() << std::endl;
+        ops.push_back(std::move(matmul_op3));
+
+        /*******************************************************************************
+         *                          dP.T @ Q -> dK
+        *///////////////////////////////////////////////////////////////////////////////
+
+        auto dPTransposeTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 14, p_transpose_dim, p_transpose_stride, true, false); // is virtual
+        auto reshape_op3 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                                .setxDesc(dPTensor)
+                                .setyDesc(dPTransposeTensor)
+                                .build();
+        std::cout << reshape_op3.describe() << std::endl;
+        ops.push_back(std::move(reshape_op3));
+
+        auto matmul_4_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
+        auto matmul_op4 = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                                .setaMatDesc(dPTransposeTensor)
+                                .setbMatDesc(qTensor)
+                                .setcMatDesc(dKTensor)
+                                .setmatmulDesc(matmul_4_Desc)
+                                .build();
+
+        std::cout << matmul_op4.describe() << std::endl;
+        ops.push_back(std::move(matmul_op4));
+
+        /*******************************************************************************
+         *                          dqAccumTensor @ identity -> dqTensor
+        *///////////////////////////////////////////////////////////////////////////////
+        auto identityDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_IDENTITY);
+        auto identity_op = unary_pw_op_create(dqAccumTensor, dQTensor, identityDesc);
+        ops.push_back(std::move(identity_op));
+
+        std::cout << "Total ops created: " << ops.size() << std::endl;
+
+        for (unsigned int i = 0; i < ops.size(); i++) {
+            all_ops.push_back(&ops[i]);
+        }
+
+        // Create an Operation Graph
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(all_ops.size(), all_ops.data())
+                           .build();
+
+
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph, ::allowAllConfig, filtered_configs, true);
+
+        if (filtered_configs.size() == 0) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_NOT_SUPPORTED,
+                    "run_mha_bprop: No config returned by the heuristics");
+        }   
+
+        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        // add all the data pointers to be used in the variant pack
+        data_ptrs.insert(std::pair<uint64_t, void*>(dQ_ID, devPtrdQ));
+        data_ptrs.insert(std::pair<uint64_t, void*>(dQ_ACCUM_ID, devPtrdQAccumulator));
+        data_ptrs.insert(std::pair<uint64_t, void*>(dK_ID, devPtrdK));
+        data_ptrs.insert(std::pair<uint64_t, void*>(dV_ID, devPtrdV));
+
+        data_ptrs.insert(std::pair<uint64_t, void*>(Q_ID, devPtrQ));
+        data_ptrs.insert(std::pair<uint64_t, void*>(K_ID, devPtrKTranspose));
+        data_ptrs.insert(std::pair<uint64_t, void*>(V_ID, devPtrVTranspose));
+        data_ptrs.insert(std::pair<uint64_t, void*>(O_ID, devPtrO));
+        data_ptrs.insert(std::pair<uint64_t, void*>(dO_ID, devPtrdO));
+        data_ptrs.insert(std::pair<uint64_t, void*>(S_STATS_ID, devPtrSoftmaxStats));
+        data_ptrs.insert(std::pair<uint64_t, void*>(S_SUM_ID, devPtrSoftmaxSum));
+        data_ptrs.insert(std::pair<uint64_t, void*>(D_SEED_ID, devPtrDropoutSeed));
+        data_ptrs.insert(std::pair<uint64_t, void*>(D_OFFSET_ID, devPtrDropoutOffset));
+        data_ptrs.insert(std::pair<uint64_t, void*>(MASK_VAL_ID, &negInfinity));
+
+        float scaleProb = 1.0f - dropout_probability;
+        data_ptrs.insert(std::pair<uint64_t, void*>(D_CONST_ID, &scale_dropout));
+        data_ptrs.insert(std::pair<uint64_t, void*>(S_CONST_ID, &scaling_factor));
+        data_ptrs.insert(std::pair<uint64_t, void*>(SCALE_PROB, &scaleProb));
+
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(data_ptrs)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        checkCudaErr(cudaDeviceSynchronize());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
+        
+        // this example is only for GA100 cards and GH100 cards
+        if (!((prop.major == 8 && prop.minor == 0) || (prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8900)) && (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+            std::cout << "Example is only supported for GA100 (cuDNN >= 8900) and GH100 (cuDNN >= 8900) GPUs" << std::endl; 
+        }  else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+            CHECK(false);
+        }
+    }
+}
+#endif

--- a/samples/f16_flash_mha_sample.h
+++ b/samples/f16_flash_mha_sample.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <cuda_runtime.h>
+#include <assert.h>
+#include <tuple>
+#include <functional>
+
+#include <cudnn.h>
+#include "fp16_dev.h"
+#include "fp16_emu.h"
+#include "helpers.h"
+
+#if (CUDNN_VERSION >= 8900)
+
+void 
+run_f16_flash_attention_fprop(int64_t b, 
+              int64_t h, 
+              int64_t s_q,
+              int64_t s_kv,
+              int64_t d,
+              MHA_Layout layout,
+              float scaling_factor,
+              bool isTraining,
+              double dropout_probability,
+              void* devPtrQ, 
+              void* devPtrK,   
+              void* devPtrV,
+              void* devPtrSoftmaxStats,   
+              void* devPtrO,
+              void* devPtrDropoutSeed,
+              void* devPtrDropoutOffset,
+              cudnnDataType_t tensorType);
+
+void 
+run_f16_flash_attention_bprop(int64_t b, 
+              int64_t h, 
+              int64_t s_q,
+              int64_t s_kv,
+              int64_t d,
+              MHA_Layout layout,
+              float scaling_factor,
+              float dropout_probability,
+              void* devPtrQ, 
+              void* devPtrKTranspose,   
+              void* devPtrVTranspose,
+              void* devPtrO,
+              void* devPtrSoftmaxStats,
+              void* devPtrSoftmaxSum,
+              void* devPtrdQAccumulator,
+              void* devPtrdQ, 
+              void* devPtrdK,
+              void* devPtrdV,   
+              void* devPtrdO,
+              void* devPtrDropoutSeed,
+              void* devPtrDropoutOffset,
+              cudnnDataType_t tensorType);
+
+#endif

--- a/samples/fp8_flash_mha_sample.cpp
+++ b/samples/fp8_flash_mha_sample.cpp
@@ -1,0 +1,1727 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "fp8_flash_mha_sample.h"
+#include <cudnn_frontend.h>
+#include "error_util.h"
+
+#if (CUDNN_VERSION >= 8900)
+std::unordered_map<std::string, int> tensor_name_to_uid = {
+    {"Q",                            1},
+    {"K",                            2},
+    {"V",                            3},
+    {"O",                            4},
+    {"S",                            5},
+    {"B",                            6},
+    {"DROPOUT_SCALE",                7},
+    {"S_CONST",                      8},
+    {"MNK_OVERRIDE",                 9},
+    {"dQ",                          11},
+    {"dK",                          12},
+    {"dV",                          13},
+    {"dO",                          14},
+    {"MASK_VAL",                    15},
+    {"dS",                          16},
+    {"O_SEQLEN",                    17},
+    {"M",                           18},
+    {"Z",                           19},
+    {"descaleQ",                    20},
+    {"descaleK",                    21}, 
+    {"descaleV",                    22},
+    {"descaleS",                    23},
+    {"scaleS",                      24},
+    {"amaxS",                       25},
+    {"amaxO",                       26},
+    {"QKV_RAGGED",                  27},
+    {"O_RAGGED",                    28},
+    {"K_TRANSPOSE",                 29},
+    {"AttnScale",                   30},
+    {"scaleO",                      31},
+    {"Z_INV",                       32},
+    {"descaleO",                    33},
+    {"descaledO",                   34},
+    {"descaledS",                   35},
+    {"descaledQ",                   36},
+    {"descaledK",                   37},
+    {"descaledV",                   38},
+    {"scaledS",                     39},
+    {"scaledQ",                     40},
+    {"scaledK",                     41},
+    {"scaledV",                     42},
+    {"amaxdS",                      43},
+    {"amaxdQ",                      44},
+    {"amaxdK",                      45},
+    {"amaxdV",                      46},
+    {"V_TRANSPOSE",                 47},
+    {"AttnScale_dS_K",              48},
+    {"AttnScale_dSTranspose_Q",     49},
+    {"DROPOUT_SCALE_dOVt_OdO",      50},
+    {"DROPOUT_OFFSET",              51},
+    {"DROPOUT_SEED",                52},
+    {"VIRTUAL",                     80}
+};
+
+bool allowAllConfig(cudnnBackendDescriptor_t engine_config) {
+    (void)engine_config;
+    return false;
+}
+
+static cudnn_frontend::Tensor tensor_create(cudnnDataType_t type, int64_t id, int64_t const * dim, 
+                                int64_t const * stride, bool is_virtual, bool is_value) {
+    int nbDims = 4;
+    auto tensor_created = cudnn_frontend::TensorBuilder()
+            .setDim(nbDims, dim)
+            .setStride(nbDims, stride)
+            .setId(id) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(type)
+            .setVirtual(is_virtual)
+            .setByValue(is_value)
+            .build();
+    std::cout << tensor_created.describe() << std::endl;
+    return tensor_created;
+};
+
+static cudnn_frontend::Tensor tensor_create_with_offset(cudnnDataType_t type, int64_t id, int64_t const * dim, 
+                                int64_t const * stride, bool is_virtual, bool is_value, std::shared_ptr<cudnn_frontend::Tensor>& raggedOffset) {
+    int nbDims = 4;
+    auto tensor_created = cudnn_frontend::TensorBuilder()
+            .setDim(nbDims, dim)
+            .setStride(nbDims, stride)
+            .setId(id) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(type)
+            .setVirtual(is_virtual)
+            .setByValue(is_value)
+            .setRaggedOffset(raggedOffset)
+            .build();
+    std::cout << tensor_created.describe() << std::endl;
+    return tensor_created;
+};
+
+static cudnn_frontend::PointWiseDesc pw_desc_create(cudnnDataType_t type, cudnnPointwiseMode_t mode) {
+    auto pw_desc_created = cudnn_frontend::PointWiseDescBuilder()
+            .setMode(mode)
+            .setComputeType(type)
+            .build();
+    
+    std::cout << pw_desc_created.describe() << std::endl;
+    return pw_desc_created;
+} 
+
+static cudnn_frontend::Operation unary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &yDesc, 
+                                                    cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                        .setxDesc(xDesc)
+                        .setyDesc(yDesc)
+                        .setpwDesc(pwDesc)
+                        .build();
+    std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+static cudnn_frontend::Operation binary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc, 
+                                                    cudnn_frontend::Tensor const &yDesc, cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                        .setxDesc(xDesc)
+                        .setbDesc(bDesc)
+                        .setyDesc(yDesc)
+                        .setpwDesc(pwDesc)
+                        .build();
+    std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+static cudnn_frontend::Operation ternary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc, cudnn_frontend::Tensor const &tDesc, 
+                                            cudnn_frontend::Tensor const &yDesc, cudnn_frontend::PointWiseDesc const &pwDesc) {
+    auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
+                        .setxDesc(xDesc)
+                        .setbDesc(bDesc)
+                        .settDesc(tDesc)
+                        .setyDesc(yDesc)
+                        .setpwDesc(pwDesc)
+                        .build();
+    std::cout << pw_op_created.describe() << std::endl;
+    return pw_op_created;
+}
+
+static cudnn_frontend::Tensor
+createAmax(const std::string& amax_tensor_name,
+            cudnn_frontend::Tensor& prevBlockOutputTensor,
+            std::vector<cudnn_frontend::Operation>& ops) {
+
+        // Amax is just a scalar
+        int64_t amax_dim [4] = {1, 1, 1, 1};
+        int64_t amax_stride [4] = {1, 1, 1, 1};
+
+        auto amaxTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid[amax_tensor_name], amax_dim, amax_stride, false, false);
+
+        // Define the amax descriptor
+        auto redunctionDesc = cudnn_frontend::ReductionDescBuilder()
+                                  .setMathPrecision(CUDNN_DATA_FLOAT)
+                                  .setReductionOp(CUDNN_REDUCE_TENSOR_AMAX)
+                                  .build();
+        std::cout << redunctionDesc.describe() << std::endl;
+
+        // Create a reduction amax Node.
+        auto reduction_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(prevBlockOutputTensor)
+                                .setyDesc(amaxTensor)
+                                .setreductionDesc(redunctionDesc)
+                                .build();
+        std::cout << reduction_op.describe() << std::endl;
+        ops.push_back(std::move(reduction_op));
+        return amaxTensor;
+}
+
+static cudnn_frontend::Tensor 
+createScale(cudnn_frontend::Tensor& prevBlockOutputTensor,
+            const std::string& scale_tensor_name,
+            cudnnDataType_t tensorType,
+            bool isOutputVirtual,
+            bool isScaleByValue,
+            std::vector<cudnn_frontend::Operation>& ops,
+            const std::string& output_tensor_name ="") {
+
+    // scale
+    int64_t scale_dim [4] = {1, 1, 1, 1};
+    int64_t scale_stride [4] = {1, 1, 1, 1};
+
+    int64_t output_dim [4];
+    int64_t output_stride [4];
+
+    // output dim and stride should be the same as prev block dim and stride
+    for (int i = 0; i < 4; i++) {
+        output_dim[i] = prevBlockOutputTensor.getDim()[i];
+        output_stride[i] = prevBlockOutputTensor.getStride()[i];
+    }
+
+    auto scaleTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid[scale_tensor_name], scale_dim, scale_stride, false, isScaleByValue); // is by value
+
+    // Hack to get the virtual id to not be same for all the virtual tensors
+    int64_t outputUID = isOutputVirtual ? tensor_name_to_uid["VIRTUAL"] + tensor_name_to_uid[scale_tensor_name] + 5000 : tensor_name_to_uid[output_tensor_name];
+    auto afterScaleKTensor = tensor_create(tensorType, outputUID, output_dim, output_stride, isOutputVirtual, false); // is virtual
+
+    // Define the scale descriptor
+    auto scaleDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a Scale Node.
+    auto scale_op = binary_pw_op_create(prevBlockOutputTensor, scaleTensor, afterScaleKTensor, scaleDesc);
+
+    ops.push_back(std::move(scale_op));
+    return afterScaleKTensor;
+}
+
+static cudnn_frontend::Tensor 
+createScale(cudnn_frontend::Tensor& prevBlockOutputTensor,
+            const cudnn_frontend::Tensor& scaleTensor,
+            cudnnDataType_t tensorType,
+            bool isOutputVirtual,
+            bool isScaleByValue,
+            std::vector<cudnn_frontend::Operation>& ops,
+            int UID_offset,
+            const std::string& output_tensor_name ="") {
+
+    CUDNN_FRONTEND_UNUSED(isScaleByValue);
+    int64_t output_dim [4];
+    int64_t output_stride [4];
+    // output dim and stride should be the same as prev block dim and stride
+    for (int i = 0; i < 4; i++) {
+        output_dim[i] = prevBlockOutputTensor.getDim()[i];
+        output_stride[i] = prevBlockOutputTensor.getStride()[i];
+    }
+
+    // Hack to get the virtual id to not be same for all the virtual tensors
+    int64_t outputUID = isOutputVirtual ? tensor_name_to_uid["VIRTUAL"] + UID_offset : tensor_name_to_uid[output_tensor_name];
+    auto afterScaleTensor = tensor_create(tensorType, outputUID, output_dim, output_stride, isOutputVirtual, false); // is virtual
+
+    // Define the scale descriptor
+    auto scaleDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a Scale Node.
+    auto scale_op = binary_pw_op_create(prevBlockOutputTensor, scaleTensor, afterScaleTensor, scaleDesc);
+
+    ops.push_back(std::move(scale_op));
+    return afterScaleTensor;
+}
+
+static cudnn_frontend::Tensor 
+createScaleWithOffset(cudnn_frontend::Tensor& prevBlockOutputTensor,
+            const std::string& scale_tensor_name,
+            cudnnDataType_t tensorType,
+            bool isOutputVirtual,
+            bool isScaleByValue,
+            std::vector<cudnn_frontend::Operation>& ops,
+            std::shared_ptr<cudnn_frontend::Tensor>& offsetTensor,
+            const std::string& output_tensor_name ="") {
+
+    // scale
+    int64_t scale_dim [4] = {1, 1, 1, 1};
+    int64_t scale_stride [4] = {1, 1, 1, 1};
+
+    int64_t output_dim [4];
+    int64_t output_stride [4];
+    // If output tensor is dQ, dK, or dV, we need to generate QKV interleaved strides
+    if (output_tensor_name == "dQ" || output_tensor_name == "dK" || output_tensor_name == "dV") {
+        // Dims remain the same from previous block
+        for (int i = 0; i < 4; i++) {
+            output_dim[i] = prevBlockOutputTensor.getDim()[i];
+        }
+        // We know that dQ, dK, and dV are dims [batch, head, s_q, embedding_dim]
+        // All dQ, dK, and dV strides will follow Q_Matrix stride layout
+        generateMHAStrides(output_dim[0], output_dim[1], output_dim[2], 0 /*s_kv = 0 for placeholder*/, output_dim[3], output_stride, MHA_Layout::QKV_INTERLEAVED, MHA_Matrix::Q_Matrix);
+    } else {
+        // otherwise output dim and stride should be the same as prev block dim and stride
+        for (int i = 0; i < 4; i++) {
+            output_dim[i] = prevBlockOutputTensor.getDim()[i];
+            output_stride[i] = prevBlockOutputTensor.getStride()[i];
+        }
+    }
+
+    auto scaleTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid[scale_tensor_name], scale_dim, scale_stride, false, isScaleByValue); // is by value
+
+    cudnnDataType_t outputDataType = isOutputVirtual ? CUDNN_DATA_FLOAT : tensorType;
+    // Hack to get the virtual id to not be same for all the virtual tensors
+    int64_t outputUID = isOutputVirtual ? tensor_name_to_uid["VIRTUAL"] + tensor_name_to_uid[scale_tensor_name] + 7000 : tensor_name_to_uid[output_tensor_name];
+    auto afterScaleTensor = tensor_create_with_offset(outputDataType, outputUID, output_dim, output_stride, isOutputVirtual, false, offsetTensor); // is virtual
+
+    // Define the scale descriptor
+    auto scaleDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a Scale Node.
+    auto scale_op = binary_pw_op_create(prevBlockOutputTensor, scaleTensor, afterScaleTensor, scaleDesc);
+
+    ops.push_back(std::move(scale_op));
+    return afterScaleTensor;
+}
+
+static cudnn_frontend::Tensor
+createSoftmaxForward(int64_t b, 
+                     int64_t h, 
+                     int64_t s_q,
+                     int64_t s_kv,
+                     std::vector<cudnn_frontend::Operation>& ops,
+                     cudnn_frontend::Tensor& prevBlockOutputTensor,
+                     bool isTraining) {
+
+    int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
+    int64_t afterBMM1_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+    int64_t afterReduction_dim [4] = {b, h, s_q, 1};
+    int64_t afterReduction_stride [4] = {h * s_q, s_q, 1, 1};
+
+    // max (x) (M tensor)
+    auto afterMaxReductionTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["M"], afterReduction_dim, afterReduction_stride, !isTraining, false); // not virtual if training is true, virtual if training is false
+    // x - max(x)
+    auto afterSubtractionTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 151, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+    // e^(x - max(x))
+    auto afterExponentTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 152, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual;
+    // sum (e^(x - max(x))) (Z tensor)
+    auto zTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["Z"], afterReduction_dim, afterReduction_stride, true, false); // is virtual
+    // 1 / sum (e^(x - max(x))) (Z_INV tensor)
+    auto zInvTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["Z_INV"], afterReduction_dim, afterReduction_stride, !isTraining, false); // not virtual if training is true, virtual if training is false
+    // Final softmax output (After exponent * Z_INV)
+    auto beforeDropoutTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 153, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+    // Define the reduction descriptor
+    auto reductionMaxDesc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_MAX)
+                                .build();
+    std::cout << reductionMaxDesc.describe() << std::endl;
+
+    // Create a reduction max Node.
+    auto reductionMax_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(prevBlockOutputTensor)
+                                .setyDesc(afterMaxReductionTensor)
+                                .setreductionDesc(reductionMaxDesc)
+                                .build();
+    std::cout << reductionMax_op.describe() << std::endl;
+
+    // Define the subtract descriptor
+    auto subtractDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_SUB);
+
+    // Create a subtract Node.
+    auto subtract_op = binary_pw_op_create(prevBlockOutputTensor, afterMaxReductionTensor, afterSubtractionTensor, subtractDesc);
+
+    // Define the exponent descriptor
+    auto exponentDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_EXP);
+
+    // Create a exponent Node.
+    auto exponent_op = unary_pw_op_create(afterSubtractionTensor, afterExponentTensor, exponentDesc);
+
+    // Define the reduction descriptor
+    auto reductionAddDesc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                                .build();
+    std::cout << reductionAddDesc.describe() << std::endl;
+
+    // Create a reduction add Node.
+    auto reductionAdd_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(afterExponentTensor)
+                                .setyDesc(zTensor)
+                                .setreductionDesc(reductionAddDesc)
+                                .build();
+
+    std::cout << reductionAdd_op.describe() << std::endl;
+
+    // Define the reciprocal descriptor
+    auto reciprocalDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_RECIPROCAL);
+
+    // Create a reciprocal Node.
+    auto reciprocal_op = unary_pw_op_create(zTensor, zInvTensor, reciprocalDesc);
+
+    // Define the pw multiply descriptor
+    auto multiplyDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply Node.
+    auto mutliply_op = binary_pw_op_create(afterExponentTensor, zInvTensor, beforeDropoutTensor, multiplyDesc);
+
+    ops.push_back(std::move(reductionMax_op));
+    ops.push_back(std::move(subtract_op));
+    ops.push_back(std::move(exponent_op));
+    ops.push_back(std::move(reductionAdd_op));
+    ops.push_back(std::move(reciprocal_op));
+    ops.push_back(std::move(mutliply_op));
+
+    return beforeDropoutTensor;
+}
+
+static cudnn_frontend::Tensor
+createDropoutForward(int64_t b, 
+              int64_t h, 
+              int64_t s_q,
+              int64_t s_kv,
+              double probability,
+              std::vector<cudnn_frontend::Operation>& ops,
+              cudnn_frontend::Tensor& beforeDropoutTensor) {
+    
+    cudnn_frontend::throw_if(ops.size() == 0, "Dropout DAG constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
+    int64_t afterBMM1_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+    int64_t scale_dim [4] = {1, 1, 1, 1};
+    int64_t scale_stride [4] = {1, 1, 1, 1};
+
+    // mask for the dropout
+    auto dropoutMaskTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 250, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+    auto dropoutSeedTensor = tensor_create(CUDNN_DATA_INT64, tensor_name_to_uid["DROPOUT_SEED"], scale_dim, scale_stride, false, false); // is by value
+    auto dropoutOffsetTensor = tensor_create(CUDNN_DATA_INT64, tensor_name_to_uid["DROPOUT_OFFSET"], scale_dim, scale_stride, false, false); // is by value
+
+    // after dropout tensor befor scale
+    auto beforeDropoutScaleTensor = cudnn_frontend::TensorBuilder()
+            .setDim(4, afterBMM1_dim)
+            .setStride(4, afterBMM1_stride)
+            .setId(tensor_name_to_uid["VIRTUAL"] + 201) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(CUDNN_DATA_FLOAT)
+            .setVirtual(true)
+            .setByValue(false)
+            .setReorderType(cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16)
+            .build();
+    // scale after dropout
+    auto scaleDropoutTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["DROPOUT_SCALE"], scale_dim, scale_stride, false, true); // is by value
+    // after Scale
+    auto afterDropout_before_quan_S = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 202, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+    // Define the reduction descriptor
+    auto rngDesc = cudnn_frontend::RngDescBuilder()
+                                .setRngDistribution(CUDNN_RNG_DISTRIBUTION_BERNOULLI)
+                                .setBernoulliDistProbability(1.0 - probability)
+                                .build();
+    std::cout << rngDesc.describe() << std::endl;
+
+    // Create a rng Node.
+    auto rng_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RNG_DESCRIPTOR)
+                                .setyDesc(dropoutMaskTensor)
+                                .setSeedDesc(dropoutSeedTensor)
+                                .setOffsetDesc(dropoutOffsetTensor)
+                                .setRngDesc(rngDesc)
+                                .build();
+
+    std::cout << rng_op.describe() << std::endl;
+
+    // Define the multiply mask descriptor
+    auto maskMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply mask Node.
+    auto maskMul_op = binary_pw_op_create(beforeDropoutTensor, dropoutMaskTensor, beforeDropoutScaleTensor, maskMulDesc);
+
+    // Define the multiply scale descriptor
+    auto scaleMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply mask Node.
+    auto scaleMul_op = binary_pw_op_create(beforeDropoutScaleTensor, scaleDropoutTensor, afterDropout_before_quan_S, scaleMulDesc);
+
+    ops.push_back(std::move(rng_op));
+    ops.push_back(std::move(maskMul_op));
+    ops.push_back(std::move(scaleMul_op));
+
+    return afterDropout_before_quan_S;
+}
+
+static cudnn_frontend::Tensor
+createDropoutBackward(int64_t b, 
+              int64_t h, 
+              int64_t s_q,
+              int64_t s_kv,
+              double probability,
+              std::vector<cudnn_frontend::Operation>& ops,
+              cudnn_frontend::Tensor& beforeDropoutTensor,
+              cudnn_frontend::Tensor& dropoutMaskTensor) {
+    
+    cudnn_frontend::throw_if(ops.size() == 0, "Dropout DAG constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
+    int64_t afterBMM1_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+    int64_t scale_dim [4] = {1, 1, 1, 1};
+    int64_t scale_stride [4] = {1, 1, 1, 1};
+
+    auto dropoutSeedTensor = tensor_create(CUDNN_DATA_INT64, tensor_name_to_uid["DROPOUT_SEED"], scale_dim, scale_stride, false, false); // is by value
+    auto dropoutOffsetTensor = tensor_create(CUDNN_DATA_INT64, tensor_name_to_uid["DROPOUT_OFFSET"], scale_dim, scale_stride, false, false); // is by value
+
+    // after dropout tensor befor scale
+    auto beforeDropoutScaleTensor = cudnn_frontend::TensorBuilder()
+            .setDim(4, afterBMM1_dim)
+            .setStride(4, afterBMM1_stride)
+            .setId(tensor_name_to_uid["VIRTUAL"] + 201) 
+            .setAlignment(16) // 16B alignment is needed to run a tensor core engine
+            .setDataType(CUDNN_DATA_FLOAT)
+            .setVirtual(true)
+            .setByValue(false)
+            .setReorderType(cudnn_frontend::cudnnBackendTensorReordering_t::CUDNN_TENSOR_REORDERING_F16x16)
+            .build();
+    // scale after dropout (1 / (1 - p))
+    auto scaleDropoutTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["DROPOUT_SCALE"], scale_dim, scale_stride, false, true); // is by value
+    // after Scale
+    auto afterDropout_before_quan_S = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 202, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+    // Define the reduction descriptor
+    auto rngDesc = cudnn_frontend::RngDescBuilder()
+                                .setRngDistribution(CUDNN_RNG_DISTRIBUTION_BERNOULLI)
+                                .setBernoulliDistProbability(1.0 - probability)
+                                .build();
+    std::cout << rngDesc.describe() << std::endl;
+
+    // Create a rng Node.
+    auto rng_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RNG_DESCRIPTOR)
+                                .setyDesc(dropoutMaskTensor)
+                                .setSeedDesc(dropoutSeedTensor)
+                                .setOffsetDesc(dropoutOffsetTensor)
+                                .setRngDesc(rngDesc)
+                                .build();
+
+    std::cout << rng_op.describe() << std::endl;
+
+    // Define the multiply mask descriptor
+    auto maskMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply mask Node.
+    auto maskMul_op = binary_pw_op_create(beforeDropoutTensor, dropoutMaskTensor, beforeDropoutScaleTensor, maskMulDesc);
+
+    // Define the multiply scale descriptor
+    auto scaleMulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply mask Node.
+    auto scaleMul_op = binary_pw_op_create(beforeDropoutScaleTensor, scaleDropoutTensor, afterDropout_before_quan_S, scaleMulDesc);
+
+    ops.push_back(std::move(rng_op));
+    ops.push_back(std::move(maskMul_op));
+    ops.push_back(std::move(scaleMul_op));
+
+    return afterDropout_before_quan_S;
+}
+
+static cudnn_frontend::Tensor
+createSoftmaxBackward(int64_t b, 
+                     int64_t h, 
+                     int64_t s_q,
+                     int64_t s_kv,
+                     std::vector<cudnn_frontend::Operation>& ops,
+                     cudnn_frontend::Tensor& dyTensor) {
+    cudnn_frontend::throw_if(ops.size() == 0, "Softmax backward constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t dx_dim [4] = {b, h, s_q, s_kv};
+    int64_t dx_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+    int64_t M_Z_dim [4] = {b, h, s_q, 1};
+    int64_t M_Z_stride [4] = {h * s_q, s_q, 1, 1};
+
+    // creating all tensors
+    auto MTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["M"], M_Z_dim, M_Z_stride, false, false); // not virtual
+    auto ZInvTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["Z_INV"], M_Z_dim, M_Z_stride, false, false); // not virtual
+    auto dxAfterSubtractionTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 252, dx_dim, dx_stride, true, false); // is virtual
+    auto dxAfterExponentiation = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 253, dx_dim, dx_stride, true, false); // is virtual
+    auto dxBeforeDropout_QKt_Tensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 254, dx_dim, dx_stride, true, false); // is virtual
+
+    // creating all ops
+    // sub (dy - M)
+    auto subtractionDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_SUB);
+    auto subtractionOp = binary_pw_op_create(dyTensor, MTensor, dxAfterSubtractionTensor, subtractionDesc);
+
+    // Define the exponent descriptor
+    auto exponentDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_EXP);
+
+    // Create a exponent Node. (exp(dy - M))
+    auto exponentOp = unary_pw_op_create(dxAfterSubtractionTensor, dxAfterExponentiation, exponentDesc);
+
+    // Define the pw multiply descriptor
+    auto multiplyDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply Node. 
+    auto mutliplyOp = binary_pw_op_create(dxAfterExponentiation, ZInvTensor, dxBeforeDropout_QKt_Tensor, multiplyDesc);
+
+    ops.push_back(std::move(subtractionOp));
+    ops.push_back(std::move(exponentOp));
+    ops.push_back(std::move(mutliplyOp));
+
+    return dxBeforeDropout_QKt_Tensor;
+}
+
+static cudnn_frontend::Tensor
+createQKBMM(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           cudnnDataType_t tensorType,
+           std::vector<cudnn_frontend::Operation>& ops,
+           const cudnn_frontend::Tensor &qTensor,
+           const cudnn_frontend::Tensor &kTensor,
+           const cudnn_frontend::Tensor &mnkOverride,
+           std::shared_ptr<cudnn_frontend::Tensor>& QKVRaggedOffsetTensor) {
+    // Creates the necessary tensor descriptors
+    int64_t k_transpose_dim [4] = {b, h, d, s_kv};
+    int64_t k_transpose_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, k_transpose_stride, layout, MHA_Matrix::K_Matrix_Transpose);
+
+    int64_t s_dim [4] = {b, h, s_q, s_kv};
+    int64_t s_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, s_stride, layout, MHA_Matrix::S_Matrix);
+
+    auto kTransposeTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["K_TRANSPOSE"], k_transpose_dim, k_transpose_stride, false, false, QKVRaggedOffsetTensor); // is virtual
+
+    // first GEMM output
+    auto afterQKTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 1, s_dim, s_stride, true, false); // is virtual
+    
+    // Define the matmul desc
+    auto matmulDesc = cudnn_frontend::MatMulDescBuilder()
+                                    .setComputeType(CUDNN_DATA_FLOAT)
+                                    .setPaddingValue(-2000000)
+                                    .build();
+    std::cout << matmulDesc.describe() << std::endl;
+
+    // Create reshape node for K -> K.T
+    auto reshape_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                            .setxDesc(kTensor)
+                            .setyDesc(kTransposeTensor)
+                            .build();
+
+    std::cout << reshape_op.describe() << std::endl;
+
+    // Create a matmul Node
+    auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(qTensor)
+                            .setbMatDesc(kTransposeTensor)
+                            .setcMatDesc(afterQKTensor)
+                            .setmOverrideDesc(mnkOverride)
+                            .setnOverrideDesc(mnkOverride)
+                            .setmatmulDesc(matmulDesc)
+                            .build();
+
+    std::cout << matmulOp.describe() << std::endl;
+
+    ops.push_back(std::move(reshape_op));
+    ops.push_back(std::move(matmulOp));
+
+    return afterQKTensor;
+}
+
+static cudnn_frontend::Tensor
+createSVBMM(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           cudnnDataType_t tensorType,
+           std::vector<cudnn_frontend::Operation>& ops,
+           const cudnn_frontend::Tensor &softmaxTensor,
+           const cudnn_frontend::Tensor &mnkOverride,
+           std::shared_ptr<cudnn_frontend::Tensor>& QKVRaggedOffsetTensor) {
+
+    cudnn_frontend::throw_if(ops.size() == 0, "BMM2 op constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t v_dim [4] =  {b, h, s_kv, d};
+    int64_t v_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, v_stride, layout, MHA_Matrix::V_Matrix);
+
+    int64_t o_dim [4] =  {b, h, s_q, d};
+    int64_t o_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, o_stride, layout, MHA_Matrix::O_Matrix);
+    
+    auto vTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["V"], v_dim, v_stride, false, false, QKVRaggedOffsetTensor);
+    // second fprop GEMM output
+    auto oTensor = tensor_create(tensorType, tensor_name_to_uid["VIRTUAL"] + 300, o_dim, o_stride, true, false); // is virtual
+
+    // Define the matmul desc
+    auto matmulDesc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
+    std::cout << matmulDesc.describe() << std::endl;
+
+    // Create a matmul Node
+    auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(softmaxTensor)
+                            .setbMatDesc(vTensor)
+                            .setcMatDesc(oTensor)
+                            .setmOverrideDesc(mnkOverride)
+                            .setkOverrideDesc(mnkOverride)
+                            .setmatmulDesc(matmulDesc)
+                            .build();
+
+    std::cout << matmulOp.describe() << std::endl;
+
+    ops.push_back(std::move(matmulOp));
+
+    return oTensor;
+}
+
+static cudnn_frontend::Tensor
+createSdOBMM(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           cudnnDataType_t tensorType,
+           std::vector<cudnn_frontend::Operation>& ops,
+           const cudnn_frontend::Tensor &softmaxTensor,
+           const cudnn_frontend::Tensor &dOTensor,
+           const cudnn_frontend::Tensor &mnkOverride) {
+
+    cudnn_frontend::throw_if(ops.size() == 0, "BMM2 op constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
+
+    int64_t s_dim_transpose [4] =  {b, h, s_kv, s_q};
+    int64_t s_stride_transpose [4] = {h * s_kv * s_q, s_kv * s_q, 1, s_kv};
+    
+    int64_t v_dim [4] =  {b, h, s_kv, d};
+    int64_t v_stride [4] = {h * s_kv * d, d, h * d, 1};
+    
+    auto sTransposeTensor = tensor_create(tensorType, tensor_name_to_uid["VIRTUAL"] + 499, s_dim_transpose, s_stride_transpose, true, false); // is virtual
+    // S.T * dO
+    auto dVTensor_before_dequan_S = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 500, v_dim, v_stride, true, false); // is virtual
+
+    // Create reshape node for softmax -> softmax.T
+    auto reshape_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                            .setxDesc(softmaxTensor)
+                            .setyDesc(sTransposeTensor)
+                            .build();
+
+    // Define the matmul desc
+    auto matmulDesc = cudnn_frontend::MatMulDescBuilder()
+                                    .setComputeType(CUDNN_DATA_FLOAT)
+                                    .setPaddingValue(0)
+                                    .build();
+    std::cout << matmulDesc.describe() << std::endl;
+
+    // Create a matmul Node
+    auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(sTransposeTensor)
+                            .setbMatDesc(dOTensor)
+                            .setcMatDesc(dVTensor_before_dequan_S)
+                            .setmOverrideDesc(mnkOverride)
+                            .setkOverrideDesc(mnkOverride)
+                            .setmatmulDesc(matmulDesc)
+                            .build();
+
+    std::cout << matmulOp.describe() << std::endl;
+
+    ops.push_back(std::move(reshape_op));
+    ops.push_back(std::move(matmulOp));
+
+    return dVTensor_before_dequan_S;
+}
+
+static cudnn_frontend::Tensor
+createdOVBMM(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           cudnnDataType_t tensorType,
+           std::vector<cudnn_frontend::Operation>& ops,
+           const cudnn_frontend::Tensor &dOTensor,
+           const cudnn_frontend::Tensor &mnkOverride,
+           std::shared_ptr<cudnn_frontend::Tensor>& QKVRaggedOffsetTensor) {
+    // Creates the necessary tensor descriptors
+    int64_t v_dim [4] =  {b, h, s_kv, d};
+    int64_t v_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, v_stride, layout, MHA_Matrix::V_Matrix);
+
+    int64_t v_transpose_dim [4] = {b, h, d, s_kv};
+    int64_t v_transpose_stride [4];
+    v_transpose_stride[0] = v_stride[0];
+    v_transpose_stride[1] = v_stride[1];
+    v_transpose_stride[2] = v_stride[3];
+    v_transpose_stride[3] = v_stride[2];
+
+    int64_t s_dim [4] = {b, h, s_q, s_kv};
+    int64_t s_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, s_stride, layout, MHA_Matrix::S_Matrix);
+
+    auto vTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["V"], v_dim, v_stride, false, false, QKVRaggedOffsetTensor);
+    auto vTransposeTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["V_TRANSPOSE"], v_transpose_dim, v_transpose_stride, false, false, QKVRaggedOffsetTensor); // is virtual
+
+    // dO * V.T
+    auto afterdOVTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 600, s_dim, s_stride, true, false); // is virtual
+    
+    // Define the matmul desc
+    auto matmulDesc = cudnn_frontend::MatMulDescBuilder()
+                                            .setComputeType(CUDNN_DATA_FLOAT)
+                                            .setPaddingValue(0)
+                                            .build();
+    std::cout << matmulDesc.describe() << std::endl;
+
+    // Create reshape node for V -> V.T
+    auto reshape_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                            .setxDesc(vTensor)
+                            .setyDesc(vTransposeTensor)
+                            .build();
+
+    std::cout << reshape_op.describe() << std::endl;
+
+    // Create a matmul Node
+    auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(dOTensor)
+                            .setbMatDesc(vTransposeTensor)
+                            .setcMatDesc(afterdOVTensor)
+                            .setmOverrideDesc(mnkOverride)
+                            .setnOverrideDesc(mnkOverride)
+                            .setmatmulDesc(matmulDesc)
+                            .build();
+
+    std::cout << matmulOp.describe() << std::endl;
+
+    ops.push_back(std::move(reshape_op));
+    ops.push_back(std::move(matmulOp));
+
+    return afterdOVTensor;
+}
+
+static cudnn_frontend::Tensor
+createdOAndORowReductionChain(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           std::vector<cudnn_frontend::Operation>& ops,
+           const cudnn_frontend::Tensor &O_after_dequan,
+           const cudnn_frontend::Tensor &dO_after_dequan,
+           const cudnn_frontend::Tensor &dropoutScale_dOVt_OdO_Tensor) {
+
+    int64_t o_dim [4] = {b, h, s_q, d};
+    int64_t o_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, o_stride, layout, MHA_Matrix::O_Matrix);
+    int64_t o_dim_row_sum [4] = {b, h, s_q, 1};
+    int64_t o_dim_row_sum_stride [4] = {s_q * h, s_q, 1, 1};
+
+    auto O_dO_after_pointwise_multiply = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 700, o_dim, o_stride, true, false); // is virtual
+    auto O_dO_after_dropout_scale = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 701, o_dim, o_stride, true, false); // is virtual
+    auto O_dO_after_rowsum = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 702, o_dim_row_sum, o_dim_row_sum_stride, true, false); // is virtual
+    
+    // Define the pw multiply descriptor
+    auto multiplyDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // Create a multiply Node.
+    auto mutliply_op = binary_pw_op_create(O_after_dequan, dO_after_dequan, O_dO_after_pointwise_multiply, multiplyDesc);
+
+    // Create multiply node with dropout scale
+    auto dropout_scale_multiply_op = binary_pw_op_create(O_dO_after_pointwise_multiply, dropoutScale_dOVt_OdO_Tensor, O_dO_after_dropout_scale, multiplyDesc);
+
+    // Define the reduction descriptor
+    auto reductionAddDesc = cudnn_frontend::ReductionDescBuilder()
+                                .setComputeType(CUDNN_DATA_FLOAT)
+                                .setReductionOp(CUDNN_REDUCE_TENSOR_ADD)
+                                .build();
+    std::cout << reductionAddDesc.describe() << std::endl;
+
+    // Create a reduction add Node.
+    auto reductionAdd_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_REDUCTION_DESCRIPTOR)
+                                .setxDesc(O_dO_after_dropout_scale)
+                                .setyDesc(O_dO_after_rowsum)
+                                .setreductionDesc(reductionAddDesc)
+                                .build();
+
+    std::cout << reductionAdd_op.describe() << std::endl;
+
+    ops.push_back(std::move(mutliply_op));
+    ops.push_back(std::move(dropout_scale_multiply_op));
+    ops.push_back(std::move(reductionAdd_op));
+
+    return O_dO_after_rowsum;
+}
+
+static cudnn_frontend::Tensor
+createBiasSubtractionSoftmaxMulChain(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           std::vector<cudnn_frontend::Operation>& ops,
+           const cudnn_frontend::Tensor &dS_after_dropout,
+           const cudnn_frontend::Tensor &AfterDropout_before_quan_S,
+           const cudnn_frontend::Tensor &O_dO_after_rowsum,
+           const cudnn_frontend::Tensor &attnScale) {
+    // TODO: Add dropout
+    int64_t o_dim [4] = {b, h, s_q, s_kv};
+    int64_t o_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, o_stride, layout, MHA_Matrix::S_Matrix);
+    auto dS_minus_O_dO = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 800, o_dim, o_stride, true, false); // is virtual
+    auto AfterAttnScale_before_dS = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 801, o_dim, o_stride, true, false); // is virtual
+    auto S_mul_dS_minus_O_dO = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 802, o_dim, o_stride, true, false); // is virtual
+
+    // Define the pw subtraction descriptor
+    auto subDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_SUB);
+
+    // Create a subtraction Node.
+    auto sub_op = binary_pw_op_create(dS_after_dropout, O_dO_after_rowsum, dS_minus_O_dO, subDesc);
+
+    // Define the pw multiplication descriptor
+    auto multiplyDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+    // dS_minus_O_dO * attnScale
+    auto mutliply_attn_scale_op = binary_pw_op_create(dS_minus_O_dO, attnScale, AfterAttnScale_before_dS, multiplyDesc);
+
+    // AfterDropout_before_quan_S * AfterAttnScale_before_dS
+    auto mutliply_op = binary_pw_op_create(AfterDropout_before_quan_S, AfterAttnScale_before_dS, S_mul_dS_minus_O_dO, multiplyDesc);
+
+    ops.push_back(std::move(sub_op));
+    ops.push_back(std::move(mutliply_attn_scale_op));
+    ops.push_back(std::move(mutliply_op));
+    
+    return S_mul_dS_minus_O_dO;
+}
+
+static cudnn_frontend::Tensor
+createdSKBMM(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           std::vector<cudnn_frontend::Operation>& ops,
+           const cudnn_frontend::Tensor &dSTensor,
+           const cudnn_frontend::Tensor &kTensor,
+           const cudnn_frontend::Tensor &mnkOverride) {
+    CUDNN_FRONTEND_UNUSED(s_q);
+    // Creates the necessary tensor descriptors
+    int64_t after_dSK_dim [4] = {b, h, s_kv, d};
+    int64_t after_dSK_stride [4] = {h * s_kv * d, d, h * d, 1};
+    // dS * K
+    auto After_dS_K = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 875, after_dSK_dim, after_dSK_stride, true, false); // is virtual
+    
+    // Define the matmul desc
+    auto matmulDesc = cudnn_frontend::MatMulDescBuilder()
+                                    .setComputeType(CUDNN_DATA_FLOAT)
+                                    .setPaddingValue(0)
+                                    .build();
+    std::cout << matmulDesc.describe() << std::endl;
+
+    // Create a matmul Node
+    auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(dSTensor)
+                            .setbMatDesc(kTensor)
+                            .setcMatDesc(After_dS_K)
+                            .setmOverrideDesc(mnkOverride)
+                            .setkOverrideDesc(mnkOverride)
+                            .setmatmulDesc(matmulDesc)
+                            .build();
+
+    std::cout << matmulOp.describe() << std::endl;
+
+    ops.push_back(std::move(matmulOp));
+
+    return After_dS_K;
+}
+
+static cudnn_frontend::Tensor
+createdSQBMM(int64_t b, 
+           int64_t h, 
+           int64_t s_q,
+           int64_t s_kv,
+           int64_t d,
+           MHA_Layout layout,
+           std::vector<cudnn_frontend::Operation>& ops,
+           const cudnn_frontend::Tensor &dSTensor,
+           const cudnn_frontend::Tensor &qTensor,
+           const cudnn_frontend::Tensor &mnkOverride) {
+    // Creates the necessary tensor descriptors
+    int64_t dS_stride [4];
+    generateMHAStrides(b, h, s_q, s_kv, d, dS_stride, layout, MHA_Matrix::S_Matrix);
+
+    int64_t dS_transpose_dim [4] = {b, h, s_kv, s_q};
+    int64_t dS_transpose_stride [4];
+    dS_transpose_stride[0] = dS_stride[0];
+    dS_transpose_stride[1] = dS_stride[1];
+    dS_transpose_stride[2] = dS_stride[3];
+    dS_transpose_stride[3] = dS_stride[2];
+
+    int64_t after_dSTranspose_Q_dim [4] = {b, h, s_kv, d};
+    int64_t after_dSTranspose_Q_stride [4] = {h * s_kv * d, d, h * d, 1};
+
+    auto dSTransposeTensor = tensor_create(CUDNN_DATA_FP8_E5M2, tensor_name_to_uid["VIRTUAL"] + 650, dS_transpose_dim, dS_transpose_stride, true, false); // is virtual
+
+    // dS.T * Q
+    auto After_dSTranspose_Q = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 651, after_dSTranspose_Q_dim, after_dSTranspose_Q_stride, true, false); // is virtual
+    
+    // Create reshape node for V -> V.T
+    auto reshape_op = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR)
+                            .setxDesc(dSTensor)
+                            .setyDesc(dSTransposeTensor)
+                            .build();
+
+    std::cout << reshape_op.describe() << std::endl;
+
+    // Define the matmul desc
+    auto matmulDesc = cudnn_frontend::MatMulDescBuilder()
+                                            .setComputeType(CUDNN_DATA_FLOAT)
+                                            .setPaddingValue(0)
+                                            .build();
+    std::cout << matmulDesc.describe() << std::endl;
+
+    // Create a matmul Node
+    auto matmulOp = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_MATMUL_DESCRIPTOR)
+                            .setaMatDesc(dSTransposeTensor)
+                            .setbMatDesc(qTensor)
+                            .setcMatDesc(After_dSTranspose_Q)
+                            .setmOverrideDesc(mnkOverride)
+                            .setkOverrideDesc(mnkOverride)
+                            .setmatmulDesc(matmulDesc)
+                            .build();
+
+    std::cout << matmulOp.describe() << std::endl;
+
+    ops.push_back(std::move(reshape_op));
+    ops.push_back(std::move(matmulOp));
+
+    return After_dSTranspose_Q;
+}
+
+void 
+run_fp8_flash_mha_fprop(int64_t b, 
+                int64_t h, 
+                int64_t s_q,
+                int64_t s_kv,
+                int64_t d,
+                float attnScale,
+                bool isTraining,
+                float dropoutProbability,
+                MHA_Layout layout,
+                void* devPtrQKV, 
+                void* devPtrM,
+                void* devPtrZInv,  
+                void* devPtrO,
+                void* devPtrDropoutSeed,
+                void* devPtrDropoutOffset,
+                void* devPtrDescaleQ,
+                void* devPtrDescaleK,
+                void* devPtrDescaleV,
+                void* devPtrDescaleS,
+                void* devPtrScaleS,
+                void* devPtrScaleO,
+                void* devPtrAmaxO,
+                void* devPtrAmaxS,
+                void* devPtrQKVRaggedOffset,
+                void* devPtrORaggedOffset,
+                void* devPtrMNKOverride,
+                cudnnDataType_t tensorType) {
+      
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // FP8 BERT Flash Attention only runs on cudnn v8.9 and above and only on Hopper
+        if (check_device_arch_newer_than("hopper") == false) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_ARCH_MISMATCH,
+                    "Run FP8 BERT Flash Attention: Sample requires Hopper or above GPU");
+        }
+
+        std::vector<cudnn_frontend::Operation const*> all_ops;
+        std::vector<cudnn_frontend::Operation> ops;
+        std::set<std::pair<uint64_t, void*>> data_ptrs;
+
+        cudnn_frontend::throw_if(dropoutProbability != 0.0f && !isTraining, "Dropout probability should be 0.0f for inference mode", CUDNN_STATUS_BAD_PARAM);
+        cudnn_frontend::throw_if(dropoutProbability == 1.0f, "Dropout probability cannot be 1.0", CUDNN_STATUS_BAD_PARAM);
+
+        // Ragged tensors have b + 1 elements
+        int64_t raggedDim [4] =  {b + 1, 1, 1, 1};
+        int64_t raggedStride [4] = {1, 1, 1, 1};
+        // Create offset tensors
+        auto QKVOffsetTensor = tensor_create(CUDNN_DATA_INT32, tensor_name_to_uid["QKV_RAGGED"], raggedDim, raggedStride, false, false);
+        auto ORaggedOffsetTensor = tensor_create(CUDNN_DATA_INT32, tensor_name_to_uid["O_RAGGED"], raggedDim, raggedStride, false, false);
+
+        int64_t seqlen_dim [4] =  {b, 1, 1, 1};
+        int64_t seqlen_stride [4] = {1, 1, 1, 1};
+        // Create override tensors
+        auto seqlenMNKTensor = tensor_create(CUDNN_DATA_INT32, tensor_name_to_uid["MNK_OVERRIDE"], seqlen_dim, seqlen_stride, false, false);
+
+        // Create shared ptrs to ragged offset tensors for multiple tensors to use ragged offset
+        std::shared_ptr<cudnn_frontend::Tensor> QKVRaggedOffsetTensorPtr = std::make_shared<cudnn_frontend::Tensor>(std::move(QKVOffsetTensor));
+        std::shared_ptr<cudnn_frontend::Tensor> ORaggedOffsetTensorPtr = std::make_shared<cudnn_frontend::Tensor>(std::move(ORaggedOffsetTensor));
+
+        // Create Q and K tensors that are used in different places
+        int64_t q_dim [4] = {b, h, s_q, d};
+        int64_t q_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, q_stride, layout, MHA_Matrix::Q_Matrix);
+
+        int64_t k_dim [4] =  {b, h, s_kv, d};
+        int64_t k_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::K_Matrix);
+
+        auto qTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["Q"], q_dim, q_stride, false, false, QKVRaggedOffsetTensorPtr);
+        auto kTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["K"], k_dim, k_stride, false, false, QKVRaggedOffsetTensorPtr);
+
+        // Q * K.T
+        auto afterQKTensor = createQKBMM(b, h, s_q, s_kv, d, layout, tensorType, ops, qTensor, kTensor, seqlenMNKTensor, QKVRaggedOffsetTensorPtr);
+
+
+        // QK.T * attn scale
+        auto AfterAttnScale_before_dequan_Q_tensor = createScale(afterQKTensor, // input tensor
+                                                                "AttnScale", // scale tensor
+                                                                CUDNN_DATA_FLOAT,  // output tensor type
+                                                                true, // output is virtual
+                                                                true, // scale is by value
+                                                                ops);
+
+        // QK.T * attn scale * dequant_Q
+        auto AfterAttnScale_before_dequan_K_tensor = createScale(AfterAttnScale_before_dequan_Q_tensor, // input tensor
+                                                                "descaleQ", // scale tensor
+                                                                CUDNN_DATA_FLOAT, // output tensor type
+                                                                true, // output is virtual
+                                                                false, // scale is by value
+                                                                ops);
+
+        // QK.T * attn scale * dequant_Q * dequant_K
+        auto AfterAttnScale_tensor = createScale(AfterAttnScale_before_dequan_K_tensor, // input tensor
+                                                "descaleK", // scale tensor
+                                                CUDNN_DATA_FLOAT, // output tensor type
+                                                true, // output is virtual
+                                                false, // scale is by value
+                                                ops);
+
+
+        auto BeforeDropoutTensor = createSoftmaxForward(b, h, s_q, s_kv, ops, AfterAttnScale_tensor, isTraining);
+
+        auto AfterDropout_before_quan_S = createDropoutForward(b, h, s_q, s_kv, dropoutProbability, ops, BeforeDropoutTensor);
+
+        // Amax for S
+        createAmax("amaxS", BeforeDropoutTensor, ops);
+
+        // After softmax * dropout * scale S -> fp8 input to next bmm with V
+        auto AfterMultiplyDropout = createScale(AfterDropout_before_quan_S, // input tensor
+                                                "scaleS", // scale tensor
+                                                tensorType, // output tensor type
+                                                true, // output is virtual
+                                                false, // scale is by value
+                                                ops);
+
+        // After softmax * Dropout * V
+        auto OTensor_before_dequan_S_tensor = createSVBMM(b, h, s_q, s_kv, d, layout, tensorType, ops, AfterMultiplyDropout, seqlenMNKTensor, QKVRaggedOffsetTensorPtr);
+
+        // O * dequant_S
+        auto OTensor_before_dequan_V_tensor = createScale(OTensor_before_dequan_S_tensor, // input tensor
+                                                        "descaleS", // scale tensor
+                                                        CUDNN_DATA_FLOAT, // output tensor type
+                                                        true, // output is virtual
+                                                        false, // scale is by value
+                                                        ops);
+
+        // O * dequant_S * dequant_V
+        auto OTensor_before_quan_O_tensor = createScale(OTensor_before_dequan_V_tensor, // input tensor
+                                                        "descaleV", // scale tensor
+                                                        CUDNN_DATA_FLOAT, // output tensor type
+                                                        true, // output is virtual
+                                                        false, // scale is by value
+                                                        ops);
+
+        // O * dequant_S * dequant_V * scale O
+        auto OTensor = createScaleWithOffset(OTensor_before_quan_O_tensor, // input tensor
+                            "scaleO", // scale tensor
+                            tensorType, // output tensor type
+                            false, // output not virtual
+                            false, // scale is by value
+                            ops,
+                            ORaggedOffsetTensorPtr, // ragged offset
+                            "O");
+
+        // Amax for O
+        createAmax("amaxO", OTensor_before_quan_O_tensor, ops);
+
+        std::cout << "Total ops created: " << ops.size() << std::endl;
+
+        for (unsigned int i = 0; i < ops.size(); i++) {
+            all_ops.push_back(&ops[i]);
+        }
+
+        // Create an Operation Graph
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(all_ops.size(), all_ops.data())
+                           .build();
+
+
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph, ::allowAllConfig, filtered_configs, true);
+
+        if (filtered_configs.size() == 0) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_NOT_SUPPORTED,
+                    "run_mha_fprop: No config returned by the heuristics");
+        }   
+
+        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        void* devPtrQ = (void *) devPtrQKV; // q points to the top of qkv
+        void* devPtrK = (void *)(static_cast<int8_t*>(devPtrQKV) + h * d); // k is at an offset of h * d
+        void* devPtrV = (void *)(static_cast<int8_t*>(devPtrQKV) + 2 * h * d); // v is at an offset of 2 * h * d
+
+        float dropoutScale = 1.0f/(1.0f - dropoutProbability); // 1 / (1 - p) 
+        
+        // add all the data pointers to be used in the variant pack
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["Q"], devPtrQ));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["K"], devPtrK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["K_TRANSPOSE"], devPtrK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["V"], devPtrV));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["AttnScale"], &attnScale));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["DROPOUT_SCALE"], &dropoutScale));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["DROPOUT_SEED"], devPtrDropoutSeed));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["DROPOUT_OFFSET"], devPtrDropoutOffset));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["O"], devPtrO));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleQ"], devPtrDescaleQ));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleK"], devPtrDescaleK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleV"], devPtrDescaleV));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleS"], devPtrDescaleS));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["scaleS"], devPtrScaleS));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["scaleO"], devPtrScaleO));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["amaxO"], devPtrAmaxO));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["amaxS"], devPtrAmaxS));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["QKV_RAGGED"], devPtrQKVRaggedOffset));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["O_RAGGED"], devPtrORaggedOffset));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["MNK_OVERRIDE"], devPtrMNKOverride));
+
+        // If training, then we need to write out M and Z_INV
+        if (isTraining) {
+            data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["M"], devPtrM));
+            data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["Z_INV"], devPtrZInv));
+        }
+
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(data_ptrs)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        checkCudaErr(cudaDeviceSynchronize());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
+        
+        // this example is only for GH100 cards (cudnn Version >= 8900)
+        if (!((prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8900)) && (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+            std::cout << "Example is only supported for GH100 (cuDNN >= 8900) GPUs" << std::endl; 
+        }  else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+            CHECK(false);
+        }
+    }
+}
+
+void 
+run_fp8_flash_mha_bprop(int64_t b, 
+                int64_t h, 
+                int64_t s_q,
+                int64_t s_kv,
+                int64_t d,
+                float attnScale,
+                float dropoutProbability,
+                MHA_Layout layout,
+                void* devPtrQKV,
+                void* devPtrM,
+                void* devPtrZInv,
+                void* devPtrO,
+                void* devPtrdO,
+                void* devPtrdQKV,
+                void* devPtrDropoutSeed,
+                void* devPtrDropoutOffset,
+                void* devPtrDescaleQ,
+                void* devPtrDescaleK,
+                void* devPtrDescaleV,
+                void* devPtrDescaleO,
+                void* devPtrDescaledO,
+                void* devPtrDescaleS,
+                void* devPtrDescaledS,
+                void* devPtrScaleS,
+                void* devPtrScaledS,
+                void* devPtrScaledQ,
+                void* devPtrScaledK,
+                void* devPtrScaledV,
+                void* devPtrAmaxdS,
+                void* devPtrAmaxdQ,
+                void* devPtrAmaxdK,
+                void* devPtrAmaxdV,
+                void* devPtrQKVRaggedOffset,
+                void* devPtrORaggedOffset,
+                void* devPtrMNKOverride,
+                cudnnDataType_t tensorType) {
+
+    cudnnHandle_t handle_;
+    try {
+        // Create cudnn handle
+        checkCudnnErr(cudnnCreate(&handle_));
+
+        // FP8 BERT Flash Attention only runs on cudnn v8.9 and above and only on Hopper
+        if (check_device_arch_newer_than("hopper") == false) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_ARCH_MISMATCH,
+                    "Run FP8 BERT Flash Attention: Sample requires Hopper or above GPU");
+        }
+
+        std::vector<cudnn_frontend::Operation const*> all_ops;
+        std::vector<cudnn_frontend::Operation> ops;
+        std::set<std::pair<uint64_t, void*>> data_ptrs;
+
+        cudnn_frontend::throw_if(dropoutProbability == 1.0f, "Dropout probability cannot be 1.0", CUDNN_STATUS_BAD_PARAM);
+
+        // Ragged tensors have b + 1 elements
+        int64_t raggedDim [4] =  {b + 1, 1, 1, 1};
+        int64_t raggedStride [4] = {1, 1, 1, 1};
+        // Create offset tensors
+        auto QKVOffsetTensor = tensor_create(CUDNN_DATA_INT32, tensor_name_to_uid["QKV_RAGGED"], raggedDim, raggedStride, false, false);
+        auto ORaggedOffsetTensor = tensor_create(CUDNN_DATA_INT32, tensor_name_to_uid["O_RAGGED"], raggedDim, raggedStride, false, false);
+
+        // Create shared ptrs to ragged offset tensors for multiple tensors to use ragged offset
+        std::shared_ptr<cudnn_frontend::Tensor> QKVRaggedOffsetTensorPtr = std::make_shared<cudnn_frontend::Tensor>(std::move(QKVOffsetTensor));
+        std::shared_ptr<cudnn_frontend::Tensor> ORaggedOffsetTensorPtr = std::make_shared<cudnn_frontend::Tensor>(std::move(ORaggedOffsetTensor));
+
+        // Create Q and K tensors that are used in different places
+        int64_t q_dim [4] = {b, h, s_q, d};
+        int64_t q_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, q_stride, layout, MHA_Matrix::Q_Matrix);
+
+        int64_t k_dim [4] =  {b, h, s_kv, d};
+        int64_t k_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::K_Matrix);
+
+        auto qTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["Q"], q_dim, q_stride, false, false, QKVRaggedOffsetTensorPtr);
+        auto kTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["K"], k_dim, k_stride, false, false, QKVRaggedOffsetTensorPtr);
+
+        int64_t scale_dim [4] = {1, 1, 1, 1};
+        int64_t scale_stride [4] = {1, 1, 1, 1};
+
+        // Create attnScale tensor for multiple ops to use
+        auto attnScaleTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["AttnScale"], scale_dim, scale_stride, false, true); // is by value
+
+        // Create descale Q K dO dS global tensors since they are used in multiple places
+        auto descaleQTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["descaleQ"], scale_dim, scale_stride, false, false);
+        auto descaleKTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["descaleK"], scale_dim, scale_stride, false, false);
+        auto descaledOTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["descaledO"], scale_dim, scale_stride, false, false);
+        auto descaledSTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["descaledS"], scale_dim, scale_stride, false, false);
+
+        int64_t seqlen_dim [4] =  {b, 1, 1, 1};
+        int64_t seqlen_stride [4] = {1, 1, 1, 1};
+        // Create MNK override tensor
+        auto seqlenMNKTensor = tensor_create(CUDNN_DATA_INT32, tensor_name_to_uid["MNK_OVERRIDE"], seqlen_dim, seqlen_stride, false, false);
+
+        float dropoutScale = 1.0f/(1.0f - dropoutProbability); // 1 / (1 - p)
+        float dropoutScale_dOVt_OdO = 1.0f - dropoutProbability; // (1 - p)
+
+        int64_t O_dim [4] =  {b, h, s_q, d};
+        int64_t O_stride [4];
+        generateMHAStrides(b, h, s_q, s_kv, d, O_stride, layout, MHA_Matrix::O_Matrix);
+        // Create O and loss tensor
+        auto OTensor = tensor_create_with_offset(tensorType, tensor_name_to_uid["O"], O_dim, O_stride, false, false, ORaggedOffsetTensorPtr);
+        // dO is used in multiple places and E5M2
+        auto dOTensor = tensor_create_with_offset(CUDNN_DATA_FP8_E5M2, tensor_name_to_uid["dO"], O_dim, O_stride, false, false, ORaggedOffsetTensorPtr);
+
+        // Q * K.T
+        auto afterQKTensor = createQKBMM(b, h, s_q, s_kv, d, layout, tensorType, ops, qTensor, kTensor, seqlenMNKTensor, QKVRaggedOffsetTensorPtr);
+
+        // QK.T * attn scale
+        auto AfterAttnScale_before_dequan_Q_tensor = createScale(afterQKTensor, // input tensor
+                                                                attnScaleTensor, // scale tensor
+                                                                CUDNN_DATA_FLOAT,  // output tensor type
+                                                                true, // output is virtual
+                                                                true, // scale is by value
+                                                                ops,
+                                                                1999 /*UID offset*/);
+
+        // QK.T * attn scale * dequant_Q
+        auto AfterAttnScale_before_dequan_K_tensor = createScale(AfterAttnScale_before_dequan_Q_tensor, // input tensor
+                                                                descaleQTensor, // scale tensor
+                                                                CUDNN_DATA_FLOAT, // output tensor type
+                                                                true, // output is virtual
+                                                                false, // scale is by value
+                                                                ops,
+                                                                2000 /*UID offset*/);
+
+        // QK.T * attn scale * dequant_Q * dequant_K
+        auto AfterAttnScale_tensor = createScale(AfterAttnScale_before_dequan_K_tensor, // input tensor
+                                                descaleKTensor, // scale tensor
+                                                CUDNN_DATA_FLOAT, // output tensor type
+                                                true, // output is virtual
+                                                false, // scale is by value
+                                                ops,
+                                                2001 /*UID offset*/);
+
+        auto beforeDropout_QKt_Tensor = createSoftmaxBackward(b, h, s_q, s_kv, ops, AfterAttnScale_tensor);
+
+        int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
+        int64_t afterBMM1_stride [4] = {h * s_q * s_kv, s_q * s_kv, s_kv, 1};
+
+        // mask for the dropout. Used in different places
+        auto dropoutMaskTensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 200, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+        auto AfterDropout_before_quan_S = createDropoutBackward(b, h, s_q, s_kv, dropoutProbability, ops, beforeDropout_QKt_Tensor, dropoutMaskTensor);
+
+        // After softmax * scale S -> fp8 input to next bmm with V
+        auto AfterMultiply = createScale(AfterDropout_before_quan_S, // input tensor
+                                                "scaleS", // scale tensor
+                                                tensorType, // output tensor type
+                                                true, // output is virtual
+                                                false, // scale is by value
+                                                ops);
+
+        // After softmax * dO
+        auto dVTensor_before_dequan_S = createSdOBMM(b, h, s_q, s_kv, d, tensorType, ops, AfterMultiply, dOTensor, seqlenMNKTensor);
+
+        // O * dequant_S
+        auto dVTensor_before_dequan_dO = createScale(dVTensor_before_dequan_S, // input tensor
+                                                        "descaleS", // scale tensor
+                                                        CUDNN_DATA_FLOAT, // output tensor type
+                                                        true, // output is virtual
+                                                        false, // scale is by value
+                                                        ops);
+
+        // O * dequant_S * dequant_dO
+        auto dVTensor_before_quan_dV = createScale(dVTensor_before_dequan_dO, // input tensor
+                                                        descaledOTensor, // scale tensor
+                                                        CUDNN_DATA_FLOAT, // output tensor type
+                                                        true, // output is virtual
+                                                        false, // scale is by value
+                                                        ops,
+                                                        2002 /*UID offset*/);
+
+        // O * dequant_S * dequant_dO * scale dV
+        auto dVTensor = createScaleWithOffset(dVTensor_before_quan_dV, // input tensor
+                            "scaledV", // scale tensor
+                            CUDNN_DATA_FP8_E5M2, // output tensor type
+                            false, // output not virtual
+                            false, // scale is by value
+                            ops,
+                            QKVRaggedOffsetTensorPtr, // ragged offset
+                            "dV" /*Output tensor name*/);
+
+        // Amax for dV
+        createAmax("amaxdV", dVTensor_before_quan_dV, ops);
+
+        auto dS_before_dequan_dO_Tensor = createdOVBMM(b, h, s_q, s_kv, d, layout, tensorType, ops, dOTensor, seqlenMNKTensor, QKVRaggedOffsetTensorPtr);
+
+    
+        // dS * dequant_dO
+        auto dS_before_dequan_V = createScale(dS_before_dequan_dO_Tensor, // input tensor
+                                                        descaledOTensor, // scale tensor
+                                                        CUDNN_DATA_FLOAT, // output tensor type
+                                                        true, // output is virtual
+                                                        false, // scale is by value
+                                                        ops,
+                                                        2003 /*UID offset*/);
+
+        // O * dequant_S * dequant_dV
+        auto dS_after_dequan = createScale(dS_before_dequan_V, // input tensor
+                                                        "descaleV", // scale tensor
+                                                        CUDNN_DATA_FLOAT, // output tensor type
+                                                        true, // output is virtual
+                                                        false, // scale is by value
+                                                        ops);
+
+        // RNG Multiply
+        auto beforeDropoutScale_dOVt_Tensor = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 350, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+        // After dropout mask and scale
+        auto dS_after_dropout = tensor_create(CUDNN_DATA_FLOAT, tensor_name_to_uid["VIRTUAL"] + 351, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
+
+        // Define the multiply mask descriptor
+        auto mulDesc = pw_desc_create(CUDNN_DATA_FLOAT, CUDNN_POINTWISE_MUL);
+
+        // Create a multiply mask Node.
+        auto maskMul_op = binary_pw_op_create(dS_after_dequan, dropoutMaskTensor, beforeDropoutScale_dOVt_Tensor, mulDesc);
+
+        ops.push_back(std::move(maskMul_op));
+
+        // scale after dropout for dO and O chain
+        auto dropoutScale_dOVt_OdO_Tensor = tensor_create(tensorType, tensor_name_to_uid["DROPOUT_SCALE_dOVt_OdO"], scale_dim, scale_stride, false, true); // is by value
+
+        // Create a multiply dropout scale Node.
+        auto mul_dropout_scale_op = binary_pw_op_create(beforeDropoutScale_dOVt_Tensor, dropoutScale_dOVt_OdO_Tensor, dS_after_dropout, mulDesc);
+
+        ops.push_back(std::move(mul_dropout_scale_op));
+
+        // O * dequant_O
+        auto O_after_dequan_Tensor = createScale(OTensor, // input tensor
+                                        "descaleO", // scale tensor
+                                        CUDNN_DATA_FLOAT, // output tensor type
+                                        true, // output is virtual
+                                        false, // scale is by value
+                                        ops);
+
+        // dO * dequant_dO
+        auto dO_after_dequan_Tensor = createScale(dOTensor, // input tensor
+                                        descaledOTensor, // scale tensor
+                                        CUDNN_DATA_FLOAT, // output tensor type
+                                        true, // output is virtual
+                                        false, // scale is by value
+                                        ops,
+                                        2004 /*UID offset*/);
+
+        
+        // row reduction sum[(dO * dequant_dO) * (O * dequant_O) * (1 - p)]
+        auto O_dO_after_rowsum = createdOAndORowReductionChain(b, h, s_q, s_kv, d, layout, ops, O_after_dequan_Tensor, dO_after_dequan_Tensor, dropoutScale_dOVt_OdO_Tensor);
+
+        // (dS_after_dropout - O_dO_after_rowsum) * AfterDropout_before_quan_S * attnScale
+        auto S_mul_dS_minus_O_dO = createBiasSubtractionSoftmaxMulChain(b, h, s_q, s_kv, d, layout, ops, dS_after_dropout, AfterDropout_before_quan_S, O_dO_after_rowsum, attnScaleTensor);
+
+        // S_mul_dS_minus_O_dO * scaledS
+        auto S_mul_dS_minus_O_dO_after_quan_dS = createScale(S_mul_dS_minus_O_dO, // input tensor
+                                                            "scaledS", // scale tensor
+                                                            CUDNN_DATA_FP8_E5M2, // output tensor type
+                                                            true, // output is virtual
+                                                            false, // scale is by value
+                                                            ops);
+
+        // Amax for dS
+        createAmax("amaxdS", S_mul_dS_minus_O_dO, ops);
+
+        // dS @ K
+        auto After_dS_K = createdSKBMM(b, h, s_q, s_kv, d, ops, S_mul_dS_minus_O_dO_after_quan_dS, kTensor, seqlenMNKTensor);
+
+        // (dS * K) * descale dS
+        auto After_dS_K_before_dequan_K = createScale(After_dS_K, // input tensor
+                                        descaledSTensor, // scale tensor
+                                        CUDNN_DATA_FLOAT, // output tensor type
+                                        true, // output is virtual
+                                        false, // scale is by value
+                                        ops,
+                                        2006 /*UID offset*/);
+
+        // (dS * K) * descale dS * descale K
+        auto After_dS_K_before_quan_dQ = createScale(After_dS_K_before_dequan_K, // input tensor
+                                        descaleKTensor, // scale tensor
+                                        CUDNN_DATA_FLOAT, // output tensor type
+                                        true, // output is virtual
+                                        false, // scale is by value
+                                        ops,
+                                        2007 /*UID offset*/);
+
+        // (dS * K) * descale dS * descale K * scale dQ
+        auto dQ = createScaleWithOffset(After_dS_K_before_quan_dQ, // input tensor
+                            "scaledQ", // scale tensor
+                            CUDNN_DATA_FP8_E5M2, // output tensor type
+                            false, // output not virtual
+                            false, // scale is by value
+                            ops,
+                            QKVRaggedOffsetTensorPtr, // ragged offset
+                            "dQ");
+
+        // Amax for dq. IMPORTANT: amaxdQ actually contains the amax for dQKV.
+        createAmax("amaxdQ", After_dS_K_before_quan_dQ, ops);
+
+        // dS.T @ Q
+        auto After_dSTranspose_Q = createdSQBMM(b, h, s_q, s_kv, d, layout, ops, S_mul_dS_minus_O_dO_after_quan_dS, qTensor, seqlenMNKTensor);
+
+        // (dS.T * Q) * descale dS
+        auto After_dSTranspose_Q_before_dequan_Q = createScale(After_dSTranspose_Q, // input tensor
+                                        descaledSTensor, // scale tensor
+                                        CUDNN_DATA_FLOAT, // output tensor type
+                                        true, // output is virtual
+                                        false, // scale is by value
+                                        ops,
+                                        2009 /*UID offset*/);
+
+        // (dS.T * Q) * descale dS * descale Q
+        auto After_dSTranspose_Q_before_quan_dK = createScale(After_dSTranspose_Q_before_dequan_Q, // input tensor
+                                        descaleQTensor, // scale tensor
+                                        CUDNN_DATA_FLOAT, // output tensor type
+                                        true, // output is virtual
+                                        false, // scale is by value
+                                        ops,
+                                        2010 /*UID offset*/);
+
+        // (dS.T * Q) * descale dS * descale Q * scale dK
+        auto dK = createScaleWithOffset(After_dSTranspose_Q_before_quan_dK, // input tensor
+                            "scaledK", // scale tensor
+                            CUDNN_DATA_FP8_E5M2, // output tensor type
+                            false, // output not virtual
+                            false, // scale is by value
+                            ops,
+                            QKVRaggedOffsetTensorPtr, // ragged offset
+                            "dK");
+
+        // Amax for dK
+        createAmax("amaxdK", After_dSTranspose_Q_before_quan_dK, ops);
+
+        std::cout << "Total ops created: " << ops.size() << std::endl;
+
+        for (unsigned int i = 0; i < ops.size(); i++) {
+            all_ops.push_back(&ops[i]);
+        }
+
+        // Create an Operation Graph
+        auto opGraph = cudnn_frontend::OperationGraphBuilder()
+                           .setHandle(handle_)
+                           .setOperationGraph(all_ops.size(), all_ops.data())
+                           .build();
+
+
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph, ::allowAllConfig, filtered_configs, true);
+
+        if (filtered_configs.size() == 0) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_NOT_SUPPORTED,
+                    "run_mha_bprop: No config returned by the heuristics");
+        }   
+
+        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+
+        std::cout << "Plan tag: " << plan.getTag() << std::endl;
+
+        auto workspace_size = plan.getWorkspaceSize();
+        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
+
+        void* workspace_ptr = nullptr;
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+        }
+
+        void* devPtrQ = (void *) devPtrQKV; // q points to the top of qkv
+        void* devPtrK = (void *)(static_cast<int8_t*>(devPtrQKV) + h * d); // k is at an offset of h * d
+        void* devPtrV = (void *)(static_cast<int8_t*>(devPtrQKV) + 2 * h * d); // v is at an offset of 2 * h * d
+
+        void* devPtrdQ = (void *) devPtrdQKV; // dQ points to the top of dQKV
+        void* devPtrdK = (void *)(static_cast<int8_t*>(devPtrdQKV) + h * d); // dK is at an offset of h * d
+        void* devPtrdV = (void *)(static_cast<int8_t*>(devPtrdQKV) + 2 * h * d); // dV is at an offset of 2 * h * d
+
+        // add all the data pointers to be used in the variant pack
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["Q"], devPtrQ));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["K"], devPtrK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["K_TRANSPOSE"], devPtrK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["V"], devPtrV));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["V_TRANSPOSE"], devPtrV));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["dQ"], devPtrdQ));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["dK"], devPtrdK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["dV"], devPtrdV));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["dO"], devPtrdO));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["AttnScale"], &attnScale));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["DROPOUT_SCALE"], &dropoutScale));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["DROPOUT_SCALE_dOVt_OdO"], &dropoutScale_dOVt_OdO));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["DROPOUT_SEED"], devPtrDropoutSeed));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["DROPOUT_OFFSET"], devPtrDropoutOffset));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["M"], devPtrM));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["Z_INV"], devPtrZInv));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["O"], devPtrO));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleQ"], devPtrDescaleQ));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleK"], devPtrDescaleK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleV"], devPtrDescaleV));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleS"], devPtrDescaleS));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaledS"], devPtrDescaledS));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaleO"], devPtrDescaleO));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["descaledO"], devPtrDescaledO));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["scaleS"], devPtrScaleS));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["scaledS"], devPtrScaledS));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["scaledQ"], devPtrScaledQ));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["scaledK"], devPtrScaledK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["scaledV"], devPtrScaledV));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["amaxdS"], devPtrAmaxdS));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["amaxdQ"], devPtrAmaxdQ));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["amaxdK"], devPtrAmaxdK));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["amaxdV"], devPtrAmaxdV));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["QKV_RAGGED"], devPtrQKVRaggedOffset));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["O_RAGGED"], devPtrORaggedOffset));
+        data_ptrs.emplace(std::pair<uint64_t, void*>(tensor_name_to_uid["MNK_OVERRIDE"], devPtrMNKOverride));
+
+        auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                               .setWorkspacePointer(workspace_ptr)
+                               .setDataPointers(data_ptrs)
+                               .build();
+        std::cout << "variantPack " << variantPack.describe() << std::endl;
+        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
+        checkCudaErr(cudaDeviceSynchronize());
+        if (workspace_size > 0) {
+            checkCudaErr(cudaFree(workspace_ptr));
+        }
+
+        checkCudnnErr(cudnnDestroy(handle_));
+
+        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    } catch (cudnn_frontend::cudnnException& e) {
+        struct cudaDeviceProp prop;
+        checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
+        
+        // this example is only for GH100 cards (cudnn Version >= 8900)
+        if (!((prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8900)) && (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
+            std::cout << "Example is only supported for GH100 (cuDNN >= 8900) GPUs" << std::endl; 
+        }  else {
+            std::cout << "[ERROR] Exception " << e.what() << std::endl;
+            CHECK(false);
+        }
+    }
+}
+
+#endif

--- a/samples/fp8_flash_mha_sample.h
+++ b/samples/fp8_flash_mha_sample.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <iostream>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <cuda_runtime.h>
+#include <assert.h>
+#include <tuple>
+#include <functional>
+
+#include <cudnn.h>
+#include "fp16_dev.h"
+#include "fp16_emu.h"
+#include "helpers.h"
+
+#if (CUDNN_VERSION >= 8900)
+void 
+run_fp8_flash_mha_fprop(int64_t b, 
+                int64_t h, 
+                int64_t s_q,
+                int64_t s_kv,
+                int64_t d,
+                float attnScale,
+                bool isTraining,
+                float dropoutProbability,
+                MHA_Layout layout,
+                void* devPtrQKV, 
+                void* devPtrM,
+                void* devPtrZInv,
+                void* devPtrO,
+                void* devPtrDropoutSeed,
+                void* devPtrDropoutOffset,
+                void* devPtrDescaleQ,
+                void* devPtrDescaleK,
+                void* devPtrDescaleV,
+                void* devPtrDescaleS,
+                void* devPtrScaleS,
+                void* devPtrScaleO,
+                void* devPtrAmaxO,
+                void* devPtrAmaxS,
+                void* devPtrQKVRaggedOffset,
+                void* devPtrORaggedOffset,
+                void* devPtrMNKOverride,
+                cudnnDataType_t tensorType);
+
+#endif
+
+#if (CUDNN_VERSION >= 8900)
+void 
+run_fp8_flash_mha_bprop(int64_t b, 
+                int64_t h, 
+                int64_t s_q,
+                int64_t s_kv,
+                int64_t d,
+                float attnScale,
+                float dropoutProbability,
+                MHA_Layout layout,
+                void* devPtrQKV,
+                void* devPtrM,
+                void* devPtrZInv,
+                void* devPtrO,
+                void* devPtrdO,
+                void* devPtrdQKV,
+                void* devPtrDropoutSeed,
+                void* devPtrDropoutOffset,
+                void* devPtrDescaleQ,
+                void* devPtrDescaleK,
+                void* devPtrDescaleV,
+                void* devPtrDescaleO,
+                void* devPtrDescaledO,
+                void* devPtrDescaleS,
+                void* devPtrDescaledS,
+                void* devPtrScaleS,
+                void* devPtrScaledS,
+                void* devPtrScaledQ,
+                void* devPtrScaledK,
+                void* devPtrScaledV,
+                void* devPtrAmaxdS,
+                void* devPtrAmaxdQ,
+                void* devPtrAmaxdK,
+                void* devPtrAmaxdV,
+                void* devPtrQKVRaggedOffset,
+                void* devPtrORaggedOffset,
+                void* devPtrMNKOverride,
+                cudnnDataType_t tensorType);
+
+#endif

--- a/samples/fused_mha_sample.cpp
+++ b/samples/fused_mha_sample.cpp
@@ -49,13 +49,13 @@ allowAllConfig(cudnnBackendDescriptor_t engine_config) {
     return false;
 }
 
-static cudnn_frontend::Tensor tensor_create(cudnnDataType_t type, int64_t id, int64_t const * dim, 
+static cudnn_frontend::Tensor tensor_create(cudnnDataType_t type, int64_t id, int64_t const * dim,
                                 int64_t const * stride, bool is_virtual, bool is_value) {
     int nbDims = 4;
     auto tensor_created = cudnn_frontend::TensorBuilder()
             .setDim(nbDims, dim)
             .setStride(nbDims, stride)
-            .setId(id) 
+            .setId(id)
             .setAlignment(16) // 16B alignment is needed to run a tensor core engine
             .setDataType(type)
             .setVirtual(is_virtual)
@@ -70,12 +70,12 @@ static cudnn_frontend::PointWiseDesc pw_desc_create(cudnnDataType_t type, cudnnP
             .setMode(mode)
             .setComputeType(type)
             .build();
-    
+
     std::cout << pw_desc_created.describe() << std::endl;
     return pw_desc_created;
-} 
+}
 
-static cudnn_frontend::Operation unary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &yDesc, 
+static cudnn_frontend::Operation unary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &yDesc,
                                                     cudnn_frontend::PointWiseDesc const &pwDesc) {
     auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                         .setxDesc(xDesc)
@@ -86,7 +86,7 @@ static cudnn_frontend::Operation unary_pw_op_create(cudnn_frontend::Tensor const
     return pw_op_created;
 }
 
-static cudnn_frontend::Operation binary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc, 
+static cudnn_frontend::Operation binary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc,
                                                     cudnn_frontend::Tensor const &yDesc, cudnn_frontend::PointWiseDesc const &pwDesc) {
     auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                         .setxDesc(xDesc)
@@ -98,7 +98,7 @@ static cudnn_frontend::Operation binary_pw_op_create(cudnn_frontend::Tensor cons
     return pw_op_created;
 }
 
-static cudnn_frontend::Operation ternary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc, cudnn_frontend::Tensor const &tDesc, 
+static cudnn_frontend::Operation ternary_pw_op_create(cudnn_frontend::Tensor const &xDesc, cudnn_frontend::Tensor const &bDesc, cudnn_frontend::Tensor const &tDesc,
                                             cudnn_frontend::Tensor const &yDesc, cudnn_frontend::PointWiseDesc const &pwDesc) {
     auto pw_op_created = cudnn_frontend::OperationBuilder(CUDNN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR)
                         .setxDesc(xDesc)
@@ -123,7 +123,7 @@ run_b2b_batch_gemm(int64_t* q_dim,
                     void* devPtrV,
                     void* devPtrO,
                     cudnnDataType_t tensorType,
-                    int32_t nbDims,                         
+                    int32_t nbDims,
                     int64_t* q_stride,
                     int64_t* k_stride,
                     int64_t* s_stride,
@@ -144,7 +144,7 @@ run_b2b_batch_gemm(int64_t* q_dim,
         auto vTensor = tensor_create(tensorType, 'v', v_dim, v_stride, false, false);
 
         // second GEMM output
-        auto oTensor = tensor_create(tensorType, 'o', o_dim, o_stride, false, false);  
+        auto oTensor = tensor_create(tensorType, 'o', o_dim, o_stride, false, false);
 
         // Define the matmul 1 desc
         auto matmul_1_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
@@ -187,7 +187,7 @@ run_b2b_batch_gemm(int64_t* q_dim,
                     nullptr,
                     CUDNN_STATUS_NOT_SUPPORTED,
                     "run_b2b_batch_gemm: No config returned by the heuristics");
-        }   
+        }
 
         auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
 
@@ -220,10 +220,10 @@ run_b2b_batch_gemm(int64_t* q_dim,
     } catch (cudnn_frontend::cudnnException& e) {
         struct cudaDeviceProp prop;
         checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
-        
+
         // this example is only for GA100 cards and GH100 cards
         if (!((prop.major == 8 && prop.minor == 0) || (prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8800)) && (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
-            std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and GH100 (cuDNN >= 8800) GPUs" << std::endl; 
+            std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and GH100 (cuDNN >= 8800) GPUs" << std::endl;
         }  else {
             std::cout << "[ERROR] Exception " << e.what() << std::endl;
             CHECK(false);
@@ -231,13 +231,13 @@ run_b2b_batch_gemm(int64_t* q_dim,
     }
 }
 
-static void 
-createScale(int64_t b, 
-            int64_t h, 
+static void
+createScale(int64_t b,
+            int64_t h,
             int64_t s_q,
             int64_t s_kv,
             int64_t d,
-            MHA_Layout layout, 
+            MHA_Layout layout,
             cudnnDataType_t tensorType,
             std::vector<cudnn_frontend::Operation>& ops) {
 
@@ -247,7 +247,7 @@ createScale(int64_t b,
 
     int64_t k_dim [4] =  {b, h, d, s_kv};
     int64_t k_stride [4];
-    generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::K_Matrix);
+    generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::K_Matrix_Transpose);
 
     auto scaleTensor = tensor_create(tensorType, S_CONST_ID, scale_dim, scale_stride, false, true); // is by value
     auto kTensor = tensor_create(tensorType, K_ID, k_dim, k_stride, false, false);
@@ -263,8 +263,8 @@ createScale(int64_t b,
 }
 
 static cudnn_frontend::Tensor
-createBMM1(int64_t b, 
-           int64_t h, 
+createBMM1(int64_t b,
+           int64_t h,
            int64_t s_q,
            int64_t s_kv,
            int64_t d,
@@ -278,7 +278,7 @@ createBMM1(int64_t b,
 
     int64_t k_dim [4] =  {b, h, d, s_kv};
     int64_t k_stride [4];
-    generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::K_Matrix);
+    generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::K_Matrix_Transpose);
 
     int64_t p_dim [4] = {b, h, s_q, s_kv};
     int64_t p_stride [4];
@@ -291,7 +291,7 @@ createBMM1(int64_t b,
     auto afterScaleKTensor = tensor_create(tensorType, VIRTUAL_ID, k_dim, k_stride, true, false); // is virtual
     // first GEMM output
     auto pTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 1, p_dim, p_stride, true, false); // is virtual
-    
+
     auto seqlenQTensor = tensor_create(CUDNN_DATA_INT32, Q_SEQLEN_ID, seqlen_dim, seqlen_stride, false, false);
     auto seqlenKTensor = tensor_create(CUDNN_DATA_INT32, K_SEQLEN_ID, seqlen_dim, seqlen_stride, false, false);
 
@@ -317,8 +317,8 @@ createBMM1(int64_t b,
 }
 
 static cudnn_frontend::Tensor
-createBias(int64_t b, 
-           int64_t h, 
+createBias(int64_t b,
+           int64_t h,
            int64_t s_q,
            int64_t s_kv,
            int64_t d,
@@ -353,8 +353,8 @@ createBias(int64_t b,
 }
 
 static cudnn_frontend::Tensor
-createMask(int64_t b, 
-           int64_t h, 
+createMask(int64_t b,
+           int64_t h,
            int64_t s_q,
            int64_t s_kv,
            int64_t d,
@@ -381,7 +381,7 @@ createMask(int64_t b,
 
     int64_t maskVal_dim [4] =  {1, 1, 1, 1};
     int64_t maskVal_stride [4] = {1, 1, 1, 1};
-    
+
     // mask value to put in the masked pixels
     auto maskValTensor = tensor_create(CUDNN_DATA_FLOAT, MASK_VAL_ID, maskVal_dim, maskVal_stride, false, true); // is by value
 
@@ -401,7 +401,7 @@ createMask(int64_t b,
     auto rowGreaterColTensor = tensor_create(CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 105, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
     // create causal mask (padding && row >= col)
     auto causalMaskTensor = tensor_create(CUDNN_DATA_BOOLEAN, VIRTUAL_ID + 106, afterBMM1_dim, afterBMM1_stride, true, false); // is virtual
-    
+
     // output after masking
     int64_t maskOutputTensor_id = VIRTUAL_ID + 107;
     int64_t maskOutputTensor_virtual = true;
@@ -422,7 +422,7 @@ createMask(int64_t b,
             .setByValue(false)
             .setDataType(maskOutputTensor_dataType)
             .setVirtual(maskOutputTensor_virtual)
-            .setId(maskOutputTensor_id) 
+            .setId(maskOutputTensor_id)
             .setReorderType(maskOutputTensor_reorderType)
             .build();
 
@@ -502,8 +502,8 @@ createMask(int64_t b,
 }
 
 static cudnn_frontend::Tensor
-createSoftmaxForward(int64_t b, 
-                     int64_t h, 
+createSoftmaxForward(int64_t b,
+                     int64_t h,
                      int64_t s_q,
                      int64_t s_kv,
                      int64_t d,
@@ -538,7 +538,7 @@ createSoftmaxForward(int64_t b,
     auto afterDivisionTensor = cudnn_frontend::TensorBuilder()
             .setDim(4, afterBMM1_dim)
             .setStride(4, afterBMM1_stride)
-            .setId(softmaxOutputName) 
+            .setId(softmaxOutputName)
             .setAlignment(16) // 16B alignment is needed to run a tensor core engine
             .setDataType(softmaxOutputType)
             .setVirtual(softmax_output_virtual)
@@ -605,8 +605,8 @@ createSoftmaxForward(int64_t b,
 }
 
 static cudnn_frontend::Tensor
-createDropout(int64_t b, 
-              int64_t h, 
+createDropout(int64_t b,
+              int64_t h,
               int64_t s_q,
               int64_t s_kv,
               int64_t d,
@@ -615,9 +615,9 @@ createDropout(int64_t b,
               cudnnDataType_t tensorType,
               std::vector<cudnn_frontend::Operation>& ops,
               cudnn_frontend::Tensor& prevBlockOutputTensor) {
-    
+
     CUDNN_FRONTEND_UNUSED(d);
-    
+
     cudnn_frontend::throw_if(ops.size() == 0, "Dropout DAG constructed incorrectly as the first one", CUDNN_STATUS_BAD_PARAM);
 
     int64_t afterBMM1_dim [4] = {b, h, s_q, s_kv};
@@ -632,7 +632,7 @@ createDropout(int64_t b,
     auto afterDropoutTensor = cudnn_frontend::TensorBuilder()
             .setDim(4, afterBMM1_dim)
             .setStride(4, afterBMM1_stride)
-            .setId(S_ID) 
+            .setId(S_ID)
             .setAlignment(16) // 16B alignment is needed to run a tensor core engine
             .setDataType(tensorType)
             .setVirtual(false)
@@ -681,8 +681,8 @@ createDropout(int64_t b,
 }
 
 static void
-createBMM2(int64_t b, 
-           int64_t h, 
+createBMM2(int64_t b,
+           int64_t h,
            int64_t s_q,
            int64_t s_kv,
            int64_t d,
@@ -703,7 +703,7 @@ createBMM2(int64_t b,
     int64_t o_dim [4] =  {b, h, s_q, d};
     int64_t o_stride [4];
     generateMHAStrides(b, h, s_q, s_kv, d, o_stride, layout, MHA_Matrix::O_Matrix);
-    
+
     auto seqlenQTensor = tensor_create(CUDNN_DATA_INT32, Q_SEQLEN_ID, seqlen_dim, seqlen_stride, false, false);
     auto seqlenKTensor = tensor_create(CUDNN_DATA_INT32, K_SEQLEN_ID, seqlen_dim, seqlen_stride, false, false);
     auto vTensor = tensor_create(tensorType, V_ID, v_dim, v_stride, false, false);
@@ -730,8 +730,8 @@ createBMM2(int64_t b,
 }
 
 static cudnn_frontend::Tensor
-createSoftmaxBackward(int64_t b, 
-                     int64_t h, 
+createSoftmaxBackward(int64_t b,
+                     int64_t h,
                      int64_t s_q,
                      int64_t s_kv,
                      int64_t d,
@@ -809,9 +809,66 @@ createSoftmaxBackward(int64_t b,
     return dxTensor;
 }
 
-void 
-run_mha_fprop(int64_t b, 
-              int64_t h, 
+
+
+cudnnStatus_t
+execute_cached_plan(cudnnHandle_t handle,
+                    cudnn_frontend::ExecutionPlanCache &plan_cache,
+                    cudnn_frontend::OperationGraph &opGraph,
+                    std::set<std::pair<uint64_t, void*>> &data_ptrs) {
+
+    cudnnBackendDescriptor_t raw_plan;
+    int64_t workspace_size = 0;
+
+    cudnn_frontend::ExecutionPlan const *cached_plan;
+    if (plan_cache.get_plan_from_cache(opGraph, cached_plan)) {
+        std::cout << "Cached execution plan found." << cached_plan->getTag() << std::endl;
+        workspace_size = cached_plan->getWorkspaceSize();
+        raw_plan = cached_plan->get_raw_desc();
+    } else {
+        cudnn_frontend::EngineConfigList filtered_configs;
+        auto statuses = cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph, ::allowAllConfig, filtered_configs, true);
+
+        if (filtered_configs.size() == 0) {
+            cudnn_frontend::set_error_and_throw_exception(
+                    nullptr,
+                    CUDNN_STATUS_NOT_SUPPORTED,
+                    "run_mha_fprop: No config returned by the heuristics");
+        }
+
+        auto plan_ = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
+        plan_cache.add_plan_to_cache(opGraph, plan_);
+        workspace_size = plan_.getWorkspaceSize();
+        raw_plan = plan_.get_raw_desc();
+    }
+
+    void* workspace_ptr = nullptr;
+    if (workspace_size > 0) {
+        checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
+    }
+
+    auto variantPack  = cudnn_frontend::VariantPackBuilder()
+                            .setWorkspacePointer(workspace_ptr)
+                            .setDataPointers(data_ptrs)
+                            .build();
+
+    std::cout << "variantPack " << variantPack.describe() << std::endl;
+
+    cudnnStatus_t status = cudnnBackendExecute(handle, raw_plan, variantPack.get_raw_desc());    
+
+    if (workspace_size > 0) {
+        checkCudaErr(cudaFree(workspace_ptr));
+    }
+
+
+    cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
+
+    return status;
+}
+
+void
+run_mha_fprop(int64_t b,
+              int64_t h,
               int64_t s_q,
               int64_t s_kv,
               int64_t d,
@@ -821,16 +878,16 @@ run_mha_fprop(int64_t b,
               double dropout_probability,
               MHA_Bias_Type bias_type,
               bool is_causal_masking,
-              void* devPtrQ, 
-              void* devPtrK,   
-              void* devPtrV,   
+              void* devPtrQ,
+              void* devPtrK,
+              void* devPtrV,
               void* devPtrS,
               void* devPtrO,
               void* devPtrBias,
               void* devActualSeqlenQ,
               void* devActualSeqlenK,
               cudnnDataType_t tensorType) {
-                
+
     cudnnHandle_t handle_;
     try {
         // Create cudnn handle
@@ -879,28 +936,9 @@ run_mha_fprop(int64_t b,
                            .setOperationGraph(all_ops.size(), all_ops.data())
                            .build();
 
-
-        cudnn_frontend::EngineConfigList filtered_configs;
-        auto statuses = cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph, ::allowAllConfig, filtered_configs, true);
-
-        if (filtered_configs.size() == 0) {
-            cudnn_frontend::set_error_and_throw_exception(
-                    nullptr,
-                    CUDNN_STATUS_NOT_SUPPORTED,
-                    "run_mha_fprop: No config returned by the heuristics");
-        }   
-
-        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
-
-        std::cout << "Plan tag: " << plan.getTag() << std::endl;
-
-        auto workspace_size = plan.getWorkspaceSize();
-        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
-
-        void* workspace_ptr = nullptr;
-        if (workspace_size > 0) {
-            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
-        }
+        // {b, h, s_q, s_kv, d, seed, layout(enum class, should be int), bias_type(enum class, should be int), is_causal_masking(bool), tensorType(cudnnDataType_t)}
+        opGraph.setFeatureVector({b, h, s_q, s_kv, d, seed, static_cast<int64_t>(layout),
+                                 static_cast<int64_t>(bias_type), static_cast<int64_t>(is_causal_masking), static_cast<int64_t>(tensorType)});
 
         // add all the data pointers to be used in the variant pack
         data_ptrs.insert(std::pair<uint64_t, void*>(Q_ID, devPtrQ));
@@ -924,27 +962,21 @@ run_mha_fprop(int64_t b,
             data_ptrs.insert(std::pair<uint64_t, void*>(D_CONST_ID, &scale_dropout));
         }
 
-        auto variantPack  = cudnn_frontend::VariantPackBuilder()
-                               .setWorkspacePointer(workspace_ptr)
-                               .setDataPointers(data_ptrs)
-                               .build();
-        std::cout << "variantPack " << variantPack.describe() << std::endl;
-        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
-        if (workspace_size > 0) {
-            checkCudaErr(cudaFree(workspace_ptr));
-        }
+        cudnn_frontend::ExecutionPlanCache plan_cache("mha_fprop_cache");
+
+        execute_cached_plan(handle_, plan_cache, opGraph, data_ptrs);
+        
+        execute_cached_plan(handle_, plan_cache, opGraph, data_ptrs);
 
         checkCudnnErr(cudnnDestroy(handle_));
-
-        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
 
     } catch (cudnn_frontend::cudnnException& e) {
         struct cudaDeviceProp prop;
         checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
-        
+
         // this example is only for GA100 cards (cudnn Version >= 8700) and GH100 cards (cudnn Version >= 8800)
         if (!((prop.major == 8 && prop.minor == 0) || (prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8800)) && (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
-            std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and GH100 (cuDNN >= 8800) GPUs" << std::endl; 
+            std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and GH100 (cuDNN >= 8800) GPUs" << std::endl;
         }  else {
             std::cout << "[ERROR] Exception " << e.what() << std::endl;
             CHECK(false);
@@ -952,9 +984,9 @@ run_mha_fprop(int64_t b,
     }
 }
 
-void 
-run_mha_bprop(int64_t b, 
-              int64_t h, 
+void
+run_mha_bprop(int64_t b,
+              int64_t h,
               int64_t s_q,
               int64_t s_kv,
               int64_t d,
@@ -962,19 +994,19 @@ run_mha_bprop(int64_t b,
               float scaling_factor,
               float dropout_probability,
               bool is_causal_masking,
-              void* devPtrQ, 
-              void* devPtrK,   
-              void* devPtrV,   
+              void* devPtrQ,
+              void* devPtrK,
+              void* devPtrV,
               void* devPtrS,
-              void* devPtrdQ, 
-              void* devPtrdK,   
-              void* devPtrdV,   
+              void* devPtrdQ,
+              void* devPtrdK,
+              void* devPtrdV,
               void* devPtrdO,
               void* devPtrdS,
               void* devActualSeqlenQ,
               void* devActualSeqlenK,
               cudnnDataType_t tensorType) {
-                
+
     cudnnHandle_t handle_;
     try {
         // Create cudnn handle
@@ -991,11 +1023,11 @@ run_mha_bprop(int64_t b,
 
         int64_t k_dim [4] =  {b, h, s_kv, d};
         int64_t k_stride [4];
-        generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::V_Matrix); // type is correct as K is not transposed
+        generateMHAStrides(b, h, s_q, s_kv, d, k_stride, layout, MHA_Matrix::K_Matrix); // type is correct as K is not transposed
 
         int64_t v_dim [4] =  {b, h, d, s_kv};
         int64_t v_stride [4];
-        generateMHAStrides(b, h, s_q, s_kv, d, v_stride, layout, MHA_Matrix::K_Matrix); // type is correct as V is transposed
+        generateMHAStrides(b, h, s_q, s_kv, d, v_stride, layout, MHA_Matrix::V_Matrix_Transpose); // type is correct as V is transposed
 
         int64_t p_dim [4] = {b, h, s_q, s_kv};
         int64_t p_stride [4];
@@ -1027,12 +1059,12 @@ run_mha_bprop(int64_t b,
 
         // gradient of the output
         auto doTensor = tensor_create(tensorType, dO_ID, o_dim, o_stride, false, false);
-         
+
         // activation from fprop
         auto pTensor = cudnn_frontend::TensorBuilder()
             .setDim(4, p_dim)
             .setStride(4, p_stride)
-            .setId(S_ID) 
+            .setId(S_ID)
             .setAlignment(16) // 16B alignment is needed to run a tensor core engine
             .setDataType(tensorType)
             .setVirtual(false)
@@ -1056,7 +1088,7 @@ run_mha_bprop(int64_t b,
                                 .build();
 
         std::cout << reshape_op.describe() << std::endl;
-        ops.push_back(std::move(reshape_op));  
+        ops.push_back(std::move(reshape_op));
 
         // scale dropout
         auto dropoutScaleTensor = tensor_create(CUDNN_DATA_FLOAT, D_CONST_ID, scale_dim, scale_stride, false, true); // is by value
@@ -1091,7 +1123,7 @@ run_mha_bprop(int64_t b,
         ops.push_back(std::move(matmul_op0));
 
         // matmul to calculate dpTensor
-        auto dpTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 303, p_dim, p_stride, true, false); 
+        auto dpTensor = tensor_create(CUDNN_DATA_FLOAT, VIRTUAL_ID + 303, p_dim, p_stride, true, false);
 
         auto matmul_1_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
         std::cout << matmul_1_Desc.describe() << std::endl;
@@ -1138,7 +1170,7 @@ run_mha_bprop(int64_t b,
         auto selection_0_op = ternary_pw_op_create(dpAfterScaleTensor, zeroTensor, dropoutMaskTensor, dpAfterDropoutTensor, selection_0_desc);
         ops.push_back(std::move(selection_0_op));
 
-        // softmax backward 
+        // softmax backward
         auto dsTensor = createSoftmaxBackward(b, h, s_q, s_kv, d, layout, tensorType, ops, pAbsTensor, dpAfterDropoutTensor);
 
         // mask
@@ -1159,7 +1191,7 @@ run_mha_bprop(int64_t b,
 
         std::cout << matmul_op2.describe() << std::endl;
 
-        ops.push_back(std::move(matmul_op2)); 
+        ops.push_back(std::move(matmul_op2));
 
         // reshape for transpose of ds
         auto dsAfterMaskReshapeTensor = tensor_create(tensorType, VIRTUAL_ID + 308, p_transpose_dim, p_transpose_stride, true, false);
@@ -1170,7 +1202,7 @@ run_mha_bprop(int64_t b,
                                 .build();
 
         std::cout << reshape_2_op.describe() << std::endl;
-        ops.push_back(std::move(reshape_2_op));  
+        ops.push_back(std::move(reshape_2_op));
 
         // matmul to calculate dkTensor
         auto matmul_3_Desc = cudnn_frontend::MatMulDescBuilder().setComputeType(CUDNN_DATA_FLOAT).build();
@@ -1187,7 +1219,7 @@ run_mha_bprop(int64_t b,
 
         std::cout << matmul_op3.describe() << std::endl;
 
-        ops.push_back(std::move(matmul_op3));  
+        ops.push_back(std::move(matmul_op3));
 
         /////////////////////////////////////////////////////////////////
 
@@ -1203,28 +1235,9 @@ run_mha_bprop(int64_t b,
                            .setOperationGraph(all_ops.size(), all_ops.data())
                            .build();
 
-
-        cudnn_frontend::EngineConfigList filtered_configs;
-        auto statuses = cudnn_frontend::get_heuristics_list<1>({"heuristics_instant"}, opGraph, ::allowAllConfig, filtered_configs, true);
-
-        if (filtered_configs.size() == 0) {
-            cudnn_frontend::set_error_and_throw_exception(
-                    nullptr,
-                    CUDNN_STATUS_NOT_SUPPORTED,
-                    "run_mha_bprop: No config returned by the heuristics");
-        }   
-
-        auto plan = cudnn_frontend::ExecutionPlanBuilder().setHandle(handle_).setEngineConfig(filtered_configs[0], opGraph.getTag()).build();
-
-        std::cout << "Plan tag: " << plan.getTag() << std::endl;
-
-        auto workspace_size = plan.getWorkspaceSize();
-        std::cout << plan.describe() << " requires workspace " << workspace_size << std::endl;
-
-        void* workspace_ptr = nullptr;
-        if (workspace_size > 0) {
-            checkCudaErr(cudaMalloc(&workspace_ptr, workspace_size));
-        }
+        // {b, h, s_q, s_kv, d, seed, layout(enum class, should be int), bias_type(enum class, should be int), is_causal_masking(bool), tensorType(cudnnDataType_t)}
+        opGraph.setFeatureVector({b, h, s_q, s_kv, d, static_cast<int64_t>(0), static_cast<int64_t>(layout),
+                                 static_cast<int64_t>(0), static_cast<int64_t>(is_causal_masking), static_cast<int64_t>(tensorType)});
 
         // add all the data pointers to be used in the variant pack
         data_ptrs.insert(std::pair<uint64_t, void*>(dqTensor.getId(), devPtrdQ));
@@ -1247,27 +1260,21 @@ run_mha_bprop(int64_t b,
         data_ptrs.insert(std::pair<uint64_t, void*>(S_CONST_ID, &scaling_factor));
         data_ptrs.insert(std::pair<uint64_t, void*>(zeroTensor.getId(), &zeroVal));
 
-        auto variantPack  = cudnn_frontend::VariantPackBuilder()
-                               .setWorkspacePointer(workspace_ptr)
-                               .setDataPointers(data_ptrs)
-                               .build();
-        std::cout << "variantPack " << variantPack.describe() << std::endl;
-        cudnnStatus_t status = cudnnBackendExecute(handle_, plan.get_raw_desc(), variantPack.get_raw_desc());
-        if (workspace_size > 0) {
-            checkCudaErr(cudaFree(workspace_ptr));
-        }
+        cudnn_frontend::ExecutionPlanCache plan_cache("mha_bprop_cache");
+
+        execute_cached_plan(handle_, plan_cache, opGraph, data_ptrs);
+        
+        execute_cached_plan(handle_, plan_cache, opGraph, data_ptrs);
 
         checkCudnnErr(cudnnDestroy(handle_));
-
-        cudnn_frontend::throw_if([status]() { return (status != CUDNN_STATUS_SUCCESS); }, "Plan execute error", status);
 
     } catch (cudnn_frontend::cudnnException& e) {
         struct cudaDeviceProp prop;
         checkCudaErrors(cudaGetDeviceProperties( &prop, 0 ));
-        
+
         // this example is only for GA100 cards and GH100 cards
         if (!((prop.major == 8 && prop.minor == 0) || (prop.major == 9 && prop.minor == 0 && CUDNN_VERSION >= 8800)) && (e.getCudnnStatus() == CUDNN_STATUS_ARCH_MISMATCH || e.getCudnnStatus() == CUDNN_STATUS_NOT_SUPPORTED)) {
-            std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and GH100 (cuDNN >= 8800) GPUs" << std::endl; 
+            std::cout << "Example is only supported for GA100 (cuDNN >= 8700) and GH100 (cuDNN >= 8800) GPUs" << std::endl;
         }  else {
             std::cout << "[ERROR] Exception " << e.what() << std::endl;
             CHECK(false);

--- a/samples/helpers.h
+++ b/samples/helpers.h
@@ -44,15 +44,18 @@
 enum class MHA_Layout {
     NOT_INTERLEAVED = 0,
     QKV_INTERLEAVED = 1,
-    KV_INTERLEAVED = 2
+    KV_INTERLEAVED = 2,
+    SBH_INTERLEAVED = 3
 };
 
 enum class MHA_Matrix {
-    Q_Matrix = 0, // queries
-    K_Matrix = 1, // keys
-    V_Matrix = 2, // values
-    S_Matrix = 3, // output of GEMM1
-    O_Matrix = 4, // final output
+    Q_Matrix           = 0, // queries
+    K_Matrix           = 1, // keys
+    K_Matrix_Transpose = 2, // keys tranposed
+    V_Matrix           = 3, // values
+    V_Matrix_Transpose = 4, // values transposed
+    S_Matrix           = 5, // output of GEMM1
+    O_Matrix           = 6, // final output
 };
 
 enum class MHA_Bias_Type {
@@ -82,6 +85,7 @@ void initImage(float* image, int64_t imageSize);
 void initImage(half1* image, int64_t imageSize);
 void testinitImage(half1* image, int64_t imageSize, int test);
 void initImage(int8_t* image, int64_t imageSize);
+void initImage(uint8_t* image, int64_t imageSize);
 void initImage(int32_t* image, int64_t imageSize);
 void initImage(int64_t* image, int64_t imageSize);
 void initImage(bool* image, int64_t imageSize);

--- a/samples/resnet_block/include/layers/models/resnet/forward/cudnn_frontend_residual_forward_block.h
+++ b/samples/resnet_block/include/layers/models/resnet/forward/cudnn_frontend_residual_forward_block.h
@@ -101,7 +101,7 @@ class ResidualForwardBlock : public IBlock {
                     
                     void *zptr = params_.skip_residual_convolution(ResidualBlockParams::ForwardLocation::RESIDUAL) ?
                                     devPtrStore->XDevPtrs[ResidualBlockParams::ForwardLocation::ZERO] : 
-                                    intermediate_tensor_workspace_pointer;
+                                    devPtrStore->BNYDevPtrs[ResidualBlockParams::ForwardLocation::RESIDUAL];
 
                     void* bn_data_ptrs[] = {
                         devPtrStore->YDevPtrs[i],
@@ -156,7 +156,7 @@ class ResidualForwardBlock : public IBlock {
                     void* bn_data_ptrs[] = {
                         devPtrStore->YDevPtrs[i],
                         devPtrStore->BNXDescaleDevPtrs[i],
-                        intermediate_tensor_workspace_pointer,
+                        devPtrStore->BNYDevPtrs[i],
                         devPtrStore->BNYScaleDevPtrs[i],
                         devPtrStore->BNYAMaxDevPtrs[i],
                         devPtrStore->scaleDevPtrs[i],

--- a/samples/resnet_test_list.cpp
+++ b/samples/resnet_test_list.cpp
@@ -291,7 +291,7 @@ TEST_CASE("Residual block with residual conv", "[Resnet][Residual]") {
     Surface<fp8_e4m3> BNY0(N * K[0] * H * W, false);
     Surface<fp8_e4m3> BNY1(N * K[1] * H * W, false);
     Surface<fp8_e4m3> BNY2(N * K[2] * H * W, false);
-    // BNY3 has been moved to workspace
+    Surface<fp8_e4m3> BNY3(N * K[3] * H * W, false);
 
     Surface<float> BNYAmax0(1, false);
     Surface<float> BNYAmax1(1, false);
@@ -374,6 +374,7 @@ TEST_CASE("Residual block with residual conv", "[Resnet][Residual]") {
                                 {cudnn_frontend::ResidualBlockParams::ForwardLocation::ZERO, BNY0.devPtr}
                                 , {cudnn_frontend::ResidualBlockParams::ForwardLocation::ONE, BNY1.devPtr}
                                 , {cudnn_frontend::ResidualBlockParams::ForwardLocation::TWO, BNY2.devPtr}
+                                , {cudnn_frontend::ResidualBlockParams::ForwardLocation::RESIDUAL, BNY3.devPtr}
                             })
                 .setBNYScaleDevPtrs({
                                 {cudnn_frontend::ResidualBlockParams::ForwardLocation::ZERO, BNYScale0.devPtr}


### PR DESCRIPTION
[Enhancement] Added ability to filter by shape of tensors to errata filter.
[Enhancement] Added ability to override the default feature vector in the opGraph manually. 
[Enhancement] Added support for CUDNN_POINTWISE_RECIPROCAL pointwise operation. 
[Enhancement] Added an option to limit the number of kernels benchmarked in find-plan.

[Bug Fix] Fixed "Scale Bias Conv BNGenstats" test case where the sum and square sum channel dimensions were incorrect. 
[Bug Fix] Fixed a compiler error "dereferencing type-punned pointer will break strict-aliasing rules" seen in certain compiler while type-casting floating point alpha/beta to int64_t. 
[Bug Fix] Waived "ConvScaleBiasAct_int8 sample" for V100 because of lack of int8 support.

[Samples] Added BF16/FP16/FP8 Flash Attention Fprop/Bprop samples.