### PR TITLE
1.0.2 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.17)
 
-project(cudnn_frontend VERSION 1.0.1)
+project(cudnn_frontend VERSION 1.0.2)
 
 option(CUDNN_FRONTEND_BUILD_SAMPLES "Defines if samples are built or not." ON)
 option(CUDNN_FRONTEND_BUILD_UNIT_TESTS "Defines if unittests are built or not." OFF)

--- a/include/cudnn_frontend.h
+++ b/include/cudnn_frontend.h
@@ -98,7 +98,6 @@
  */
 
 #include <cudnn.h>
-#include <cudnn_backend.h>
 
 #include "cudnn_frontend_ConvDesc.h"
 #include "cudnn_frontend_Heuristics.h"
@@ -125,7 +124,7 @@
 
 #define CUDNN_FRONTEND_MAJOR_VERSION 1
 #define CUDNN_FRONTEND_MINOR_VERSION 0
-#define CUDNN_FRONTEND_PATCH_VERSION 1
+#define CUDNN_FRONTEND_PATCH_VERSION 2
 #define CUDNN_FRONTEND_VERSION \
     ((CUDNN_FRONTEND_MAJOR_VERSION * 10000) + (CUDNN_FRONTEND_MINOR_VERSION * 100) + CUDNN_FRONTEND_PATCH_VERSION)
 

--- a/samples/legacy_samples/conv_sample.h
+++ b/samples/legacy_samples/conv_sample.h
@@ -32,9 +32,6 @@
 #include <tuple>
 #include <functional>
 
-#include <cudnn.h>
-#include <cudnn_backend.h>
-
 #include <cudnn_frontend.h>
 
 #include "../utils/fp16_dev.h"

--- a/samples/legacy_samples/norm_samples.cpp
+++ b/samples/legacy_samples/norm_samples.cpp
@@ -22,7 +22,7 @@
 
 #include "norm_samples.h"
 #include <cudnn_frontend.h>
-#include "cudnn_backend.h"
+
 #include "../utils/error_util.h"
 #include "../utils/helpers.h"
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ class CMakeBuild(build_ext):
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
     name="cudnn",
-    version="1.0.0",
+    version="1.0.2",
     author="",
     author_email="",
     description="cudnn_frontend python package",


### PR DESCRIPTION
v1.0.2

[Cleanup] Remove the `cudnn_backend.h` dependency, since the correct header is already included in cudnn.h