### PR TITLE
Remove unreachable code

### DIFF
--- a/include/cudnn_frontend_Errata.h
+++ b/include/cudnn_frontend_Errata.h
@@ -183,9 +183,10 @@ check_rule(const json &json_handle,
                 "shape";
 #ifndef NV_CUDNN_DISABLE_EXCEPTION
             throw cudnnException(message.c_str(), CUDNN_STATUS_BAD_PARAM);
-#endif
+#else
             CUDNN_FE_LOG(message << std::endl);
             return blocked;
+#endif
         }
 
         std::array<ManagedOpaqueDescriptor, MAX_OPGRAPH_OPS> ops = opGraph.getOps();


### PR DESCRIPTION
We have experienced warning messages from the cuDNN frontend during the Transformer Engine build process:
```
/transformerengine/transformer_engine/common/../../3rdparty/cudnn-frontend/include/cudnn_frontend_Errata.h(187): warning #128-D: loop is not reachable
              do { if (isLoggingEnabled()) { getLogger() << message << std::endl; } } while (0);;
```
See https://github.com/NVIDIA/TransformerEngine/pull/1158.

This PR fixes this warning.