### PR TITLE
Fix hopper bprop surface check

### DIFF
--- a/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
+++ b/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
@@ -755,7 +755,7 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
 
                 // DeepSeek case, 9.11 only supports 192 hidden dim
                 if (detail::get_backend_version() >= 91100) {
-                    RETURN_CUDNN_FRONTEND_ERROR_IF( (d_v != 128) && (d_qk != 192),
+                    RETURN_CUDNN_FRONTEND_ERROR_IF( ((d_v == 128) && (d_qk == 192)) == false,
                                             error_code_t::GRAPH_NOT_SUPPORTED,
                                             "Num hidden_dim d_v should be equal to 128 if d_qk is 192");
                 }


### PR DESCRIPTION
Fix an issue where certain cases with d_qk=192 and d_v > 128 were allowed to pass through.