### PR TITLE
Fix support for system dlpack installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ pip install -v git+https://github.com/NVIDIA/cudnn-frontend.git
 Above command picks cuda and cudnn from default system paths.
 
 To provide a custom CUDA installation path, use environment variable: `CUDAToolkit_ROOT`.  
-To provide a custom CUDNN installation path, use environment variable: `CUDNN_PATH`.
+To provide a custom CUDNN installation path, use environment variable: `CUDNN_PATH`.  
+To specify a custom dlpack source directory, set environment variable: `FETCHCONTENT_SOURCE_DIR_DLPACK` to the path where the dlpack repository was cloned or unpacked.
 
 #### Checking the installation
 To test whether installation is successful, run:

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ class CMakeBuild(build_ext):
         if "CUDNN_PATH" in os.environ:
             cmake_args.append(f"-DCUDNN_PATH={os.environ['CUDNN_PATH']}")
 
+        if "FETCHCONTENT_SOURCE_DIR_DLPACK" in os.environ:
+            cmake_args.append(f"-DFETCHCONTENT_SOURCE_DIR_DLPACK={os.environ['FETCHCONTENT_SOURCE_DIR_DLPACK']}")
+
         # Using Ninja-build since it a) is available as a wheel and b)
         # multithreads automatically. MSVC would require all variables be
         # exported for Ninja to pick it up, which is a little tricky to do.


### PR DESCRIPTION
Add FETCHCONTENT_SOURCE_DIR_DLPACK environment variable to allow
specifying a custom dlpack source directory where the dlpack repository
was cloned or unpacked. Updates both README.md documentation and
setup.py build configuration.

Fixes #162

Signed-off-by: Emilien Macchi <emacchi@redhat.com>
