### PR TITLE
1.14.2 release to fix issue in sdpa backend selection logic

### DIFF
--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -279,9 +279,11 @@ class Graph : public ICudnn, public INode {
         }
 
         if (attributes.implementation == AttentionImplementation_t::AUTO) {
+            // Temporary WAR to not choose UNIFIED for now.
+            attributes.implementation = AttentionImplementation_t::COMPOSITE;
             // Sets attributes.implementation to a supporting implementation,
             // or leaves as AUTO if none found
-            attributes._auto_select_implementation(context);
+            // attributes._auto_select_implementation(context);
         }
 
         switch (attributes.implementation) {


### PR DESCRIPTION
Fix to work around an issue in auto selection logic which requires the strides of tensors to be present