### PR TITLE
Find cudnn libraries with NAMES_PER_DIR for python site

### DIFF
--- a/cmake/cuDNN.cmake
+++ b/cmake/cuDNN.cmake
@@ -19,7 +19,9 @@ function(find_cudnn_library NAME)
     endif()
 
     find_library(
-        ${NAME}_LIBRARY ${NAME} "lib${NAME}.so.${CUDNN_MAJOR_VERSION}"
+        ${NAME}_LIBRARY
+        NAMES ${NAME} "lib${NAME}.so.${CUDNN_MAJOR_VERSION}"
+        NAMES_PER_DIR
         HINTS $ENV{CUDNN_LIBRARY_PATH} ${CUDNN_LIBRARY_PATH} $ENV{CUDNN_PATH} ${CUDNN_PATH} ${Python_SITEARCH}/nvidia/cudnn ${CUDAToolkit_LIBRARY_DIR}
         PATH_SUFFIXES lib64 lib/x64 lib
         ${_cudnn_required}


### PR DESCRIPTION
Since `nvidia-cudnn-cu12` only contain version named libraries 
```
$ ls .direnv/python-3.12/lib/python3.12/site-packages/nvidia/cudnn/lib/
libcudnn_adv.so.9  libcudnn_engines_precompiled.so.9       libcudnn_graph.so.9      libcudnn_ops.so.9
libcudnn_cnn.so.9  libcudnn_engines_runtime_compiled.so.9  libcudnn_heuristic.so.9  libcudnn.so.9
```

I've read https://wheelnext.dev/proposals/pep778_symlink_support/ and this seems to solve these problems.
Can't waiting for it!