### PR TITLE
Fix issues in warmup function.

### DIFF
--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -969,7 +969,7 @@ class Graph : public ICudnn, public INode {
             extend_tensor_map_with_pass_by_value_tensors_(tensor_uid_to_pointer_map, deserialized_pass_by_value));
 
         auto cudnn_status = execute(handle, tensor_uid_to_pointer_map, tmp_pointer);
-        (void)cudnn_status;  // No need to check bad executes
+        [[maybe_unused]]cudnn_status;  // No need to check bad executes
 
         _CUDNN_CHECK_CUDA_ERROR(detail::cuda_graph_end_capture(fake_stream, &graph_obj));
 


### PR DESCRIPTION
- Make sure doing a cuda graph capture is not allowed when one is already in progress
- Teardown the cuda graph to prevent future errors when execute fails