### PR TITLE
Draft: Feature: add dLN + dReLU fusion pattern that doesn't use bitmask

### DIFF
--- a/include/cudnn_frontend/graph_properties.h
+++ b/include/cudnn_frontend/graph_properties.h
@@ -1006,7 +1006,7 @@ class Layernorm_attributes : public Attributes<Layernorm_attributes> {
     NormFwdPhase_t forward_phase = NormFwdPhase_t::NOT_SET;
 
    public:
-    enum class input_names { X, SCALE, BIAS, EPSILON };
+    enum class input_names { X, SCALE, BIAS, EPSILON, PREV_MEAN, PREV_INV_VARIANCE };
     std::unordered_map<input_names, std::shared_ptr<Tensor_attributes>> inputs;
     enum class output_names { Y, MEAN, INV_VARIANCE };
     std::unordered_map<output_names, std::shared_ptr<Tensor_attributes>> outputs;
@@ -1021,6 +1021,14 @@ class Layernorm_attributes : public Attributes<Layernorm_attributes> {
     Layernorm_attributes&
     set_epsilon(std::shared_ptr<Tensor_attributes>& value) {
         inputs[Layernorm_attributes::input_names::EPSILON] = value;
+        return *this;
+    }
+
+    Layernorm_attributes&
+    set_prev_mean_and_inv_variance(std::shared_ptr<Tensor_attributes>& mean,
+                                   std::shared_ptr<Tensor_attributes>& inv_variance) {
+        inputs[Layernorm_attributes::input_names::PREV_MEAN]         = mean;
+        inputs[Layernorm_attributes::input_names::PREV_INV_VARIANCE] = inv_variance;
         return *this;
     }
 };

--- a/include/cudnn_frontend/node/layernorm.h
+++ b/include/cudnn_frontend/node/layernorm.h
@@ -160,11 +160,24 @@ class LayerNormNode : public NodeCRTP<LayerNormNode> {
         CUDNN_FE_VALIDATE_AND_ASSIGN_OUTPUT_TENSOR(Y, Layernorm_attributes::output_names::Y);
         layernorm_operation_builder.setyDesc(*(tensors.at(Y->second->get_uid())));
 
+        // Set mean and inverse variance
+        // In TRAINING mode: these are OUTPUTS (what we compute), user should not use these PREV_* variables, see line 170 instead.
+        // In INFERENCE mode with pre-calculated stats: these are INPUTS (what the user provides)
+        auto PREV_MEAN_input         = attributes.inputs.find(Layernorm_attributes::input_names::PREV_MEAN);
+        auto PREV_INV_VARIANCE_input = attributes.inputs.find(Layernorm_attributes::input_names::PREV_INV_VARIANCE);
+
         if (attributes.forward_phase == NormFwdPhase_t::TRAINING) {
+            // TRAINING: Set mean/invvar as OUTPUTS
             CUDNN_FE_VALIDATE_AND_ASSIGN_OUTPUT_TENSOR(MEAN, Layernorm_attributes::output_names::MEAN);
             CUDNN_FE_VALIDATE_AND_ASSIGN_OUTPUT_TENSOR(INV_VARIANCE, Layernorm_attributes::output_names::INV_VARIANCE);
             layernorm_operation_builder.setSavedMeanAndInvVar(*(tensors.at(MEAN->second->get_uid())),
                                                               *(tensors.at(INV_VARIANCE->second->get_uid())));
+        } else if (PREV_MEAN_input != attributes.inputs.end() && PREV_MEAN_input->second != nullptr &&
+            PREV_INV_VARIANCE_input != attributes.inputs.end() && PREV_INV_VARIANCE_input->second != nullptr) {
+            // INFERENCE with pre-calculated: Set mean/invvar as INPUTS
+            layernorm_operation_builder.setSavedMeanAndInvVar(
+            *(tensors.at(PREV_MEAN_input->second->get_uid())),
+            *(tensors.at(PREV_INV_VARIANCE_input->second->get_uid())));
         }
 #ifdef NV_CUDNN_DISABLE_EXCEPTION
         // disable exception macro is defined. Calling build will not throw.

--- a/python/pygraph/norm.cpp
+++ b/python/pygraph/norm.cpp
@@ -43,6 +43,8 @@ PyGraph::layernorm(cudnn_frontend::NormFwdPhase_t const forward_phase,
                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& scale,
                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& bias,
                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& epsilon,
+                   std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> pre_calculated_mean,
+                   std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> pre_calculated_invvar,
                    cudnn_frontend::DataType_t const& compute_data_type,
                    std::string const& name) {
     auto attributes = cudnn_frontend::graph::Layernorm_attributes()
@@ -50,6 +52,10 @@ PyGraph::layernorm(cudnn_frontend::NormFwdPhase_t const forward_phase,
                           .set_compute_data_type(compute_data_type)
                           .set_epsilon(epsilon)
                           .set_name(name);
+
+     if (pre_calculated_mean && pre_calculated_invvar) {
+          attributes.set_prev_mean_and_inv_variance(pre_calculated_mean, pre_calculated_invvar);
+     }
 
     auto [Y, mean, inv_var] = graph->layernorm(x, scale, bias, attributes);
     return {Y, mean, inv_var};
@@ -232,6 +238,8 @@ init_pygraph_norm_submodule(py::class_<PyGraph>& m) {
              py::arg("scale"),
              py::arg("bias"),
              py::arg("epsilon"),
+             py::arg_v("pre_calculated_mean", nullptr),
+             py::arg_v("pre_calculated_invvar", nullptr),
              py::arg_v("compute_data_type", cudnn_frontend::DataType_t::NOT_SET),
              py::arg_v("name", ""))
         .def("adalayernorm",

--- a/python/pygraph/pygraph.h
+++ b/python/pygraph/pygraph.h
@@ -141,8 +141,10 @@ class PyGraph {
               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& scale,
               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& bias,
               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& epsilon,
-              cudnn_frontend::DataType_t const& compute_data_type,
-              std::string const& name);
+              std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> pre_calculated_mean   = nullptr,
+              std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> pre_calculated_invvar = nullptr,
+              cudnn_frontend::DataType_t const& compute_data_type = cudnn_frontend::DataType_t::NOT_SET,
+              std::string const& name                             = "");
 
     std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>
     batchnorm_inference(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& x,

--- a/samples/python/26_layernorm_forward_training_and_backward_with_relu_no_bitmask.ipynb
+++ b/samples/python/26_layernorm_forward_training_and_backward_with_relu_no_bitmask.ipynb
@@ -1,0 +1,796 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fused Layer Norm + ReLU without bitmask\n",
+    "\n",
+    "This notebook shows how to compute forward Layer Norm (training) + clamped ReLU, then compute the backward equivalent (DReLU + DLN) by determinining dReLU activations by recomputing the y output with a prologue forward layer norm inference fusion. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/NVIDIA/cudnn-frontend/blob/main/samples/python/25_layernorm_forward_training_and_backward_with_relu_bitmask.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites and Setup\n",
+    "This notebook requires an NVIDIA GPU. If `nvidia-smi` fails, go to Runtime -> Change runtime type -> Hardware accelerator and confirm a GPU is selected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#get_ipython().system('nvidia-smi')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If running on Colab, you will need to install the cudnn python interface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get_ipython().system('pip install nvidia-cudnn-cu12')\n",
+    "# get_ipython().system('pip install nvidia-cudnn-frontend')\n",
+    "# get_ipython().system('pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cu128')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following, we will apply layer norm to a tensor of the following shape:\n",
+    "\n",
+    "- Batch Size: 4\n",
+    "- Sequence Size: 1024\n",
+    "- Embedding Dimension: 768\n",
+    "\n",
+    "Let's define these dimensions as constants:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running with cudnn backend version: 91800\n"
+     ]
+    }
+   ],
+   "source": [
+    "import cudnn\n",
+    "import torch\n",
+    "\n",
+    "torch.manual_seed(1)\n",
+    "\n",
+    "handle = cudnn.create_handle()\n",
+    "print(\"Running with cudnn backend version:\", cudnn.backend_version())\n",
+    "\n",
+    "assert torch.cuda.is_available()\n",
+    "assert (\n",
+    "    cudnn.backend_version() >= 91800\n",
+    "), \"dLN + dReLU fusion pattern with no bitmask is only supported cuDNN version 9.18.0 or above\"\n",
+    "\n",
+    "batch, seq_size, embedding_dim = 4, 1024, 768\n",
+    "dtype = torch.float32\n",
+    "# Epsilon is a small number to prevent division by 0.\n",
+    "epsilon_value = 1e-3\n",
+    "# Set clamped ReLU limits\n",
+    "lower_clip_val = 0\n",
+    "upper_clip_val = 6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Wrapper"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### LayerNorm ReLU Training Forward Pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we define the input tensors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# random tensors as input\n",
+    "x_gpu = torch.randn(\n",
+    "    batch * seq_size,\n",
+    "    embedding_dim,\n",
+    "    1,\n",
+    "    1,\n",
+    "    device=\"cuda\",\n",
+    "    dtype=dtype,\n",
+    "    requires_grad=True,\n",
+    ").to(memory_format=torch.channels_last)\n",
+    "scale_gpu = torch.randn(\n",
+    "    1, embedding_dim, 1, 1, device=\"cuda\", dtype=dtype, requires_grad=True\n",
+    ").to(memory_format=torch.channels_last)\n",
+    "bias_gpu = torch.randn(\n",
+    "    1, embedding_dim, 1, 1, device=\"cuda\", dtype=dtype, requires_grad=True\n",
+    ").to(memory_format=torch.channels_last)\n",
+    "\n",
+    "# Epsilon must be a scalar value on the cpu.\n",
+    "epsilon_cpu = torch.full(\n",
+    "    (1, 1, 1, 1), epsilon_value, dtype=torch.float32, requires_grad=False, device=\"cpu\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, create the graph for the forward pass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hi\n"
+     ]
+    }
+   ],
+   "source": [
+    "with cudnn.Graph(\n",
+    "    io_data_type=cudnn.data_type.FLOAT,\n",
+    "    intermediate_data_type=cudnn.data_type.FLOAT,\n",
+    "    compute_data_type=cudnn.data_type.FLOAT,\n",
+    ") as fwd_graph:\n",
+    "    # layernorm forward pass\n",
+    "    norm_out, mean, inv_var = fwd_graph.layernorm(\n",
+    "        name=\"LN\",\n",
+    "        norm_forward_phase=cudnn.norm_forward_phase.TRAINING,\n",
+    "        input=x_gpu,\n",
+    "        scale=scale_gpu,\n",
+    "        bias=bias_gpu,\n",
+    "        epsilon=epsilon_cpu,\n",
+    "    )\n",
+    "    # relu on the layernorm output\n",
+    "    out = fwd_graph.relu(\n",
+    "        name=\"ReLU\",\n",
+    "        input=norm_out,\n",
+    "        lower_clip=lower_clip_val,\n",
+    "        upper_clip=upper_clip_val,\n",
+    "    )\n",
+    "    # mark the output tensors\n",
+    "    out.set_name(\"output\").set_output(True)\n",
+    "    mean.set_name(\"mean\").set_output(True).set_data_type(cudnn.data_type.FLOAT)\n",
+    "    inv_var.set_name(\"inv_var\").set_output(True).set_data_type(cudnn.data_type.FLOAT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, execute the graph and compare the output to the reference output from PyTorch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# allocated output tensors\n",
+    "out_gpu = torch.empty_like(x_gpu)\n",
+    "mean_gpu = torch.empty(batch * seq_size, 1, 1, 1, dtype=torch.float32, device=\"cuda\")\n",
+    "inv_var_gpu = torch.empty(batch * seq_size, 1, 1, 1, dtype=torch.float32, device=\"cuda\")\n",
+    "\n",
+    "# execute the graph\n",
+    "output = fwd_graph(\n",
+    "    {\n",
+    "        # input tensors\n",
+    "        \"LN::input\": x_gpu,\n",
+    "        \"LN::scale\": scale_gpu,\n",
+    "        \"LN::bias\": bias_gpu,\n",
+    "        \"LN::epsilon\": epsilon_cpu,\n",
+    "        # output tensors\n",
+    "        \"output\": out_gpu,\n",
+    "        \"mean\": mean_gpu,\n",
+    "        \"inv_var\": inv_var_gpu,\n",
+    "    },\n",
+    "    handle=handle,\n",
+    ")\n",
+    "\n",
+    "# PyTorch reference forward operation\n",
+    "normalized_x = torch.nn.functional.layer_norm(\n",
+    "    x_gpu,\n",
+    "    [embedding_dim, 1, 1],\n",
+    "    weight=scale_gpu.squeeze(0),\n",
+    "    bias=bias_gpu.squeeze(0),\n",
+    "    eps=epsilon_value,\n",
+    ")\n",
+    "out_ref = torch.clamp(normalized_x, min=lower_clip_val, max=upper_clip_val)\n",
+    "mean_ref = x_gpu.to(torch.float32).mean(dim=(1, 2, 3), keepdim=True)\n",
+    "inv_var_ref = torch.rsqrt(\n",
+    "    torch.var(x_gpu.to(torch.float32), dim=(1, 2, 3), keepdim=True) + epsilon_value\n",
+    ")\n",
+    "\n",
+    "# compare to reference output\n",
+    "torch.testing.assert_close(out_gpu, out_ref, rtol=5e-3, atol=5e-3)\n",
+    "torch.testing.assert_close(inv_var_gpu, inv_var_ref, rtol=5e-3, atol=5e-3)\n",
+    "torch.testing.assert_close(mean_gpu, mean_ref, rtol=5e-3, atol=5e-3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### LayerNorm ReLU Backward Pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the no bitmask implementation of dReLU, we determine dReLU activations by recomputing the y output with a prologue forward layer norm inference fusion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reference backward operation using PyTorch\n",
+    "target = torch.randn_like(out_ref)\n",
+    "criterion = torch.nn.MSELoss()\n",
+    "loss = criterion(out_ref, target)\n",
+    "\n",
+    "out_ref.retain_grad()\n",
+    "x_gpu.retain_grad()\n",
+    "scale_gpu.retain_grad()\n",
+    "bias_gpu.retain_grad()\n",
+    "\n",
+    "loss.backward()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "passed\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Backward pass\n",
+    "with cudnn.Graph(\n",
+    "    intermediate_data_type=cudnn.data_type.FLOAT,\n",
+    "    compute_data_type=cudnn.data_type.FLOAT,\n",
+    ") as bwd_graph:\n",
+    "    # layernorm forward inference to re-compute forward y output\n",
+    "    y_out, _, _ = bwd_graph.layernorm(\n",
+    "        name=\"LN_infer\",\n",
+    "        norm_forward_phase=cudnn.norm_forward_phase.INFERENCE,\n",
+    "        input=x_gpu,\n",
+    "        scale=scale_gpu,\n",
+    "        bias=bias_gpu,\n",
+    "        pre_calculated_mean=mean_gpu,\n",
+    "        pre_calculated_invvar=inv_var_gpu,\n",
+    "        epsilon=epsilon_cpu,\n",
+    "    )\n",
+    "    # dReLU computation using the re-computed y output\n",
+    "    drelu_dY = bwd_graph.relu_backward(\n",
+    "        name=\"DReLU\",\n",
+    "        loss=out_ref.grad,\n",
+    "        input=y_out,\n",
+    "        lower_clip=lower_clip_val,\n",
+    "        upper_clip=upper_clip_val,\n",
+    "    )\n",
+    "    # the layernorm backward operation\n",
+    "    d_x, d_scale, d_bias = bwd_graph.layernorm_backward(\n",
+    "        name=\"DLN\",\n",
+    "        grad=drelu_dY,\n",
+    "        input=x_gpu,\n",
+    "        scale=scale_gpu,\n",
+    "        mean=mean_gpu,\n",
+    "        inv_variance=inv_var_gpu,\n",
+    "    )\n",
+    "    # mark the output tensors\n",
+    "    d_x.set_output(True).set_name(\"dX\").set_data_type(dtype)\n",
+    "    d_scale.set_output(True).set_name(\"dScale\").set_data_type(dtype)\n",
+    "    d_bias.set_output(True).set_name(\"dBias\").set_data_type(dtype)\n",
+    "\n",
+    "# Execute the backward graph\n",
+    "output = bwd_graph(\n",
+    "    {\n",
+    "        # LN_infer inputs\n",
+    "        \"LN_infer::input\": x_gpu.detach(),\n",
+    "        \"LN_infer::scale\": scale_gpu.detach(),\n",
+    "        \"LN_infer::bias\": bias_gpu.detach(),\n",
+    "        \"LN_infer::epsilon\": epsilon_cpu,\n",
+    "        \"LN_infer::pre_calculated_mean\": mean_gpu.detach(),\n",
+    "        \"LN_infer::pre_calculated_invvar\": inv_var_gpu.detach(),\n",
+    "        # DReLU inputs (only loss, input is virtual from LN_infer)\n",
+    "        \"DReLU::loss\": out_ref.grad,\n",
+    "        # DLN inputs (grad is virtual from DReLU)\n",
+    "        \"DLN::input\": x_gpu.detach(),\n",
+    "        \"DLN::scale\": scale_gpu.detach(),\n",
+    "        \"DLN::mean\": mean_gpu.detach(),\n",
+    "        \"DLN::inv_variance\": inv_var_gpu.detach(),\n",
+    "        # Outputs\n",
+    "        \"dX\": torch.empty_like(x_gpu),\n",
+    "        \"dScale\": torch.empty_like(scale_gpu),\n",
+    "        \"dBias\": torch.empty_like(bias_gpu),\n",
+    "    },\n",
+    "    handle=handle,\n",
+    ")\n",
+    "\n",
+    "# Extract outputs\n",
+    "d_x_gpu = output[\"dX\"]\n",
+    "d_scale_gpu = output[\"dScale\"]\n",
+    "d_bias_gpu = output[\"dBias\"]\n",
+    "\n",
+    "# compare to reference output\n",
+    "torch.testing.assert_close(x_gpu.grad, d_x_gpu, atol=2e-4, rtol=2e-4)\n",
+    "torch.testing.assert_close(scale_gpu.grad, d_scale_gpu, atol=2e-4, rtol=2e-4)\n",
+    "torch.testing.assert_close(bias_gpu.grad, d_bias_gpu, atol=2e-4, rtol=2e-4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Python Binding APIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### LayerNorm ReLU Training Forward Pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create input tensor GPU buffers. We use PyTorch to allocate GPU tensors so we can reuse them easily when we calculate reference outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Allocate input tensor memory, initialize them to random numbers\n",
+    "x_gpu = torch.randn(\n",
+    "    batch * seq_size,\n",
+    "    embedding_dim,\n",
+    "    1,\n",
+    "    1,\n",
+    "    device=\"cuda\",\n",
+    "    dtype=dtype,\n",
+    "    requires_grad=True,\n",
+    ").to(memory_format=torch.channels_last)\n",
+    "scale_gpu = torch.randn(\n",
+    "    1, embedding_dim, 1, 1, device=\"cuda\", dtype=dtype, requires_grad=True\n",
+    ").to(memory_format=torch.channels_last)\n",
+    "bias_gpu = torch.randn(\n",
+    "    1, embedding_dim, 1, 1, device=\"cuda\", dtype=dtype, requires_grad=True\n",
+    ").to(memory_format=torch.channels_last)\n",
+    "\n",
+    "# Epsilon must be a scalar value on the cpu.\n",
+    "epsilon_cpu = torch.full(\n",
+    "    (1, 1, 1, 1), epsilon_value, dtype=torch.float32, requires_grad=False, device=\"cpu\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we create the graph for the forward pass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pased\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create the cuDNN graph.\n",
+    "graph = cudnn.pygraph(\n",
+    "    handle=handle,\n",
+    "    io_data_type=cudnn.data_type.FLOAT,\n",
+    "    intermediate_data_type=cudnn.data_type.FLOAT,\n",
+    "    compute_data_type=cudnn.data_type.FLOAT,\n",
+    ")\n",
+    "\n",
+    "# Create tensor handles with the graph API, assign UIDs.\n",
+    "x = graph.tensor_like(x_gpu.detach()).set_name(\"X\")\n",
+    "scale = graph.tensor_like(scale_gpu.detach()).set_name(\"scale\")\n",
+    "bias = graph.tensor_like(bias_gpu.detach()).set_name(\"bias\")\n",
+    "epsilon = graph.tensor_like(epsilon_cpu).set_name(\"epsilon\")\n",
+    "\n",
+    "# Add a layernorm operation\n",
+    "norm_out, mean, inv_var = graph.layernorm(\n",
+    "    name=\"layernorm\",\n",
+    "    norm_forward_phase=cudnn.norm_forward_phase.TRAINING,\n",
+    "    input=x,\n",
+    "    scale=scale,\n",
+    "    bias=bias,\n",
+    "    epsilon=epsilon,\n",
+    ")\n",
+    "\n",
+    "# Add a relu operation\n",
+    "out = graph.relu(\n",
+    "    name=\"relu\", input=norm_out, lower_clip=lower_clip_val, upper_clip=upper_clip_val\n",
+    ")\n",
+    "\n",
+    "# Enable all outputs, by default outputs are disabled\n",
+    "out.set_name(\"output\").set_output(True)\n",
+    "mean.set_name(\"mean\").set_output(True).set_data_type(cudnn.data_type.FLOAT)\n",
+    "inv_var.set_name(\"inv_var\").set_output(True).set_data_type(cudnn.data_type.FLOAT)\n",
+    "\n",
+    "# print(graph)\n",
+    "\n",
+    "# Build the graph\n",
+    "graph.build([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we assign UIDs for tensors. UIDs are a unique identifier that will allow us to provide a mapping from tensors created from cuDNN graph api calls, such as `graph.tensor_like()`, to the underlying device memory that will be used to store these tensors. Virtual tensors don't require explicit memory allocated for them, but non-vritual tensors like inputs or outputs will need to have UIDs assigned to them. \n",
+    "\n",
+    "Alternatively, one can use handles directly in the mapping, however using UIDs can be more convinient for caching of cuDNN graphs.\n",
+    "\n",
+    "For each of our inputs {X, Scale, Bias, Epsilon} and our outputs {Out, Mean, Inverse Variance}, we allocate a UID. \n",
+    "\n",
+    "After validating and building a cuDNN graph,  we can now execute it. To do this, we have to provide input and output buffers. We do this by using the previously allocated UIDs to associate between tensor handles generated from the graph API, and their underlying memory. \n",
+    "\n",
+    "The desired input values need to be stored in these buffers before the `graph.execute` call. Because we have done a reference computation, we can simply reuse the buffers we have allocated via PyTorch.\n",
+    "\n",
+    "Note that the EPISLON UID expects a cpu buffer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Allocate output tensor memory.\n",
+    "out_gpu = torch.empty_like(x_gpu)\n",
+    "mean_gpu = torch.empty(batch * seq_size, dtype=torch.float32, device=\"cuda\")\n",
+    "inv_var_gpu = torch.empty(batch * seq_size, dtype=torch.float32, device=\"cuda\")\n",
+    "\n",
+    "# mapping of handles -> memory\n",
+    "variant_pack = {\n",
+    "    x: x_gpu,\n",
+    "    scale: scale_gpu,\n",
+    "    bias: bias_gpu,\n",
+    "    epsilon: epsilon_cpu,\n",
+    "    out: out_gpu,\n",
+    "    mean: mean_gpu,\n",
+    "    inv_var: inv_var_gpu,\n",
+    "}\n",
+    "workspace = torch.empty(graph.get_workspace_size(), device=\"cuda\", dtype=torch.uint8)\n",
+    "graph.execute(variant_pack, workspace)\n",
+    "torch.cuda.synchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute reference ouputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reference forward operation using PyTorch\n",
+    "normalized_x = torch.nn.functional.layer_norm(\n",
+    "    x_gpu,\n",
+    "    [embedding_dim, 1, 1],\n",
+    "    weight=scale_gpu.squeeze(0),\n",
+    "    bias=bias_gpu.squeeze(0),\n",
+    "    eps=epsilon_value,\n",
+    ")\n",
+    "out_ref = torch.clamp(normalized_x, min=lower_clip_val, max=upper_clip_val)\n",
+    "mean_ref = x_gpu.to(torch.float32).mean(dim=(1, 2, 3))\n",
+    "inv_var_ref = torch.rsqrt(\n",
+    "    torch.var(x_gpu.to(torch.float32), dim=(1, 2, 3)) + epsilon_value\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test cuDNN's output against PyTorch's and check correctness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compare to reference output\n",
+    "torch.testing.assert_close(out_gpu, out_ref, rtol=5e-3, atol=5e-3)\n",
+    "torch.testing.assert_close(inv_var_gpu, inv_var_ref, rtol=5e-3, atol=5e-3)\n",
+    "torch.testing.assert_close(mean_gpu, mean_ref, rtol=5e-3, atol=5e-3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### LayerNorm ReLU Backward Pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Compute references values for backward graph"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reference backward operation using PyTorch\n",
+    "target = torch.randn_like(out_ref)\n",
+    "criterion = torch.nn.MSELoss()\n",
+    "loss = criterion(out_ref, target)\n",
+    "\n",
+    "out_ref.retain_grad()\n",
+    "x_gpu.retain_grad()\n",
+    "scale_gpu.retain_grad()\n",
+    "bias_gpu.retain_grad()\n",
+    "\n",
+    "loss.backward()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create cuDNN graph and tensors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bwd_graph = cudnn.pygraph(\n",
+    "    handle=handle,\n",
+    "    intermediate_data_type=cudnn.data_type.FLOAT,\n",
+    "    compute_data_type=cudnn.data_type.FLOAT,\n",
+    ")\n",
+    "\n",
+    "# Create tensors associated with the backwards graph. DO NOT reuse tensor handles from the forward graph.\n",
+    "d_out = bwd_graph.tensor(\n",
+    "    name=\"d_out\", dim=x_gpu.size(), stride=x_gpu.stride(), data_type=x_gpu.dtype\n",
+    ")\n",
+    "\n",
+    "x_bwd = bwd_graph.tensor_like(x, name=\"x\")\n",
+    "scale_bwd = bwd_graph.tensor_like(scale, name=\"scale\")\n",
+    "bias_bwd = bwd_graph.tensor_like(bias, name=\"bias\")\n",
+    "mean_bwd = bwd_graph.tensor_like(mean, name=\"mean\")\n",
+    "inv_var_bwd = bwd_graph.tensor_like(inv_var, name=\"inv_var\")\n",
+    "epsilon_bwd = graph.tensor_like(epsilon_cpu).set_name(\"epsilon\")\n",
+    "\n",
+    "\n",
+    "# layernorm forward inference to re-compute forward y output\n",
+    "y_out, _, _ = bwd_graph.layernorm(\n",
+    "    name=\"LN_infer\",\n",
+    "    norm_forward_phase=cudnn.norm_forward_phase.INFERENCE,\n",
+    "    input=x_bwd,\n",
+    "    scale=scale_bwd,\n",
+    "    bias=bias_bwd,\n",
+    "    pre_calculated_mean=mean_bwd,\n",
+    "    pre_calculated_invvar=inv_var_bwd,\n",
+    "    epsilon=epsilon_bwd,\n",
+    ")\n",
+    "\n",
+    "# dReLU computation using the re-computed y output\n",
+    "drelu_dY = bwd_graph.relu_backward(\n",
+    "    name=\"DReLU\",\n",
+    "    loss=d_out,\n",
+    "    input=y_out,\n",
+    "    lower_clip=lower_clip_val,\n",
+    "    upper_clip=upper_clip_val,\n",
+    ")\n",
+    "\n",
+    "# the layernorm backward operation\n",
+    "d_x, d_scale, d_bias = bwd_graph.layernorm_backward(\n",
+    "    name=\"DLN\",\n",
+    "    grad=drelu_dY,\n",
+    "    input=x_bwd,\n",
+    "    scale=scale_bwd,\n",
+    "    mean=mean_bwd,\n",
+    "    inv_variance=inv_var_bwd,\n",
+    ")\n",
+    "\n",
+    "# Enable outputs.\n",
+    "d_x.set_output(True).set_data_type(x_gpu.dtype)\n",
+    "d_scale.set_output(True).set_data_type(x_gpu.dtype)\n",
+    "d_bias.set_output(True).set_data_type(x_gpu.dtype)\n",
+    "\n",
+    "# print(bwd_graph)\n",
+    "\n",
+    "# Build the bwd_graph\n",
+    "bwd_graph.build([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Execute the graph "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create output buffers for gradients\n",
+    "d_x_gpu = torch.empty_like(x_gpu)\n",
+    "d_scale_gpu = torch.empty_like(scale_gpu)\n",
+    "d_bias_gpu = torch.empty_like(bias_gpu)\n",
+    "\n",
+    "workspace = torch.empty(\n",
+    "    bwd_graph.get_workspace_size(), device=\"cuda\", dtype=torch.uint8\n",
+    ")\n",
+    "\n",
+    "# For the inputs of the backwards graph (x_bwd, d_out, scale_bwd, mean_bwd, inv_var_bwd), we use the outputs of the forwards graph. For d_out we use pytorches autograd .grad functionality.\n",
+    "variant_pack = {\n",
+    "    x_bwd: x_gpu.detach(),\n",
+    "    scale_bwd: scale_gpu.detach(),\n",
+    "    bias_bwd: bias_gpu.detach(),\n",
+    "    epsilon_bwd: epsilon_cpu,\n",
+    "    d_out: out_ref.grad,\n",
+    "    mean_bwd: mean_gpu.detach(),\n",
+    "    inv_var_bwd: inv_var_gpu.detach(),\n",
+    "    d_x: d_x_gpu,\n",
+    "    d_scale: d_scale_gpu,\n",
+    "    d_bias: d_bias_gpu,\n",
+    "}\n",
+    "bwd_graph.execute(variant_pack, workspace)\n",
+    "torch.cuda.synchronize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test cuDNN's output against PyTorch's and check correctness"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "passed\n"
+     ]
+    }
+   ],
+   "source": [
+    "# compare to reference output\n",
+    "torch.testing.assert_close(x_gpu.grad, d_x_gpu, atol=2e-4, rtol=2e-4)\n",
+    "torch.testing.assert_close(scale_gpu.grad, d_scale_gpu, atol=2e-4, rtol=2e-4)\n",
+    "torch.testing.assert_close(bias_gpu.grad, d_bias_gpu, atol=2e-4, rtol=2e-4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perform Cleanup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cudnn.destroy_handle(handle)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Enables layernorm API to use additional pre-computed stats (mean, invvariance) for the dLN + dReLU (with no bitmask) optimization in CuDNN 9.18. The example pattern is in `samples/python/26_layernorm_forward_training_and_backward_with_relu_no_bitmask.ipynb`.