### PR TITLE
[bugfix] Fix block_descale_b batch stride in NVFP4/MXFP8 block scale matmul samples

### DIFF
--- a/samples/cpp/matmul/blackwell_nvfp4_mxfp8_block_scale_matmul.cpp
+++ b/samples/cpp/matmul/blackwell_nvfp4_mxfp8_block_scale_matmul.cpp
@@ -361,7 +361,7 @@ TEST_CASE("Blackwell Block Scale Matmul", "[matmul][graph][FP4]") {
                                             .set_name("block_descale_b")
                                             .set_data_type(datatype_block_scale)
                                             .set_dim({b, block_scale_dim_k, block_scale_dim_n})
-                                            .set_stride({block_scale_dim_m * block_scale_dim_k, 1, block_scale_dim_k})
+                                            .set_stride({block_scale_dim_n * block_scale_dim_k, 1, block_scale_dim_k})
                                             .set_reordering_type(cudnn_frontend::TensorReordering_t::F8_128x4));
 
     auto dequantize_attr_a = fe::graph::Block_scale_dequantize_attributes().set_block_size({1, block_size});
@@ -498,7 +498,7 @@ TEST_CASE("Blackwell Block Scale Matmul Quantize", "[matmul][graph][FP4]") {
                                             .set_name("block_descale_b")
                                             .set_data_type(datatype_block_scale)
                                             .set_dim({b, block_scale_dim_k, block_scale_dim_n})
-                                            .set_stride({block_scale_dim_m * block_scale_dim_k, 1, block_scale_dim_k})
+                                            .set_stride({block_scale_dim_n * block_scale_dim_k, 1, block_scale_dim_k})
                                             .set_reordering_type(cudnn_frontend::TensorReordering_t::F8_128x4));
 
     auto dequantize_attr_a = fe::graph::Block_scale_dequantize_attributes().set_block_size({1, block_size});
@@ -648,14 +648,14 @@ TEST_CASE("Block Scale Matmul Swiglu", "[matmul][graph][FP4]") {
                                              .set_name("block_descale_b")
                                              .set_data_type(datatype_block_scale)
                                              .set_dim({b, block_scale_dim_k, block_scale_dim_n})
-                                             .set_stride({block_scale_dim_m * block_scale_dim_k, 1, block_scale_dim_k})
+                                             .set_stride({block_scale_dim_n * block_scale_dim_k, 1, block_scale_dim_k})
                                              .set_reordering_type(cudnn_frontend::TensorReordering_t::F8_128x4));
 
     auto block_descale_b1 = graph.tensor(fe::graph::Tensor_attributes()
                                              .set_name("block_descale_b")
                                              .set_data_type(datatype_block_scale)
                                              .set_dim({b, block_scale_dim_k, block_scale_dim_n})
-                                             .set_stride({block_scale_dim_m * block_scale_dim_k, 1, block_scale_dim_k})
+                                             .set_stride({block_scale_dim_n * block_scale_dim_k, 1, block_scale_dim_k})
                                              .set_reordering_type(cudnn_frontend::TensorReordering_t::F8_128x4));
 
     auto dequantize_attr_a = fe::graph::Block_scale_dequantize_attributes().set_block_size({1, block_size});


### PR DESCRIPTION
fix https://github.com/NVIDIA/cudnn-frontend/issues/222
The batch stride (stride[0]) of block_descale_b was incorrectly using block_scale_dim_m instead of block_scale_dim_n. Since block_descale_b has dim {b, block_scale_dim_k, block_scale_dim_n}, the correct batch stride should be block_scale_dim_n * block_scale_dim_k.

This bug was masked when m == n (e.g., 128x128 cases) but produces incorrect strides when m != n.