### PR TITLE
Fix sidebar titles and enable Mermaid diagram rendering

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,19 @@
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   <link rel="icon" type="image/x-icon" href="{{ '/assets/favicon.ico' | relative_url }}">
   {% seo %}
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      // Convert Jekyll ```mermaid code blocks into mermaid-renderable divs
+      document.querySelectorAll('pre code.language-mermaid').forEach(function(el) {
+        var div = document.createElement('div');
+        div.className = 'mermaid';
+        div.textContent = el.textContent;
+        el.parentElement.replaceWith(div);
+      });
+      mermaid.initialize({ startOnLoad: true, theme: 'dark' });
+    });
+  </script>
 </head>
 <body>
   <div class="site-container">

--- a/_posts/2026-04-20-cudnn-backend-previews.md
+++ b/_posts/2026-04-20-cudnn-backend-previews.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "cuDNN Backend Now Has Preview Releases"
-sidebar_title: "Backend Previews"
+sidebar_title: "Backend Preview Builds"
 date: 2026-04-20
 description: "Try upcoming cuDNN backend features early with pip install --pre. Stable releases remain unchanged."
 ---

--- a/_posts/2026-04-20-mxfp8-attention-scaling.md
+++ b/_posts/2026-04-20-mxfp8-attention-scaling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "How Scales Are Applied in MXFP8 Attention"
-sidebar_title: "MXFP8 Scales"
+sidebar_title: "MXFP8 Attention"
 date: 2026-04-20
 description: "A deep dive into how cuDNN applies block-wise and fixed scaling in microscaling FP8 (MXFP8) attention for Blackwell GPUs."
 ---


### PR DESCRIPTION
- Rename MXFP8 sidebar title from "MXFP8 Scales" to "MXFP8 Attention"
- Rename backend previews sidebar title to "Backend Preview Builds"
- Add mermaid.js v10 to default layout with dark theme
- Convert Jekyll ```mermaid code blocks to mermaid divs at load time