### PR TITLE
Add post: cuDNN talk on GPU MODE

### DIFF
--- a/_posts/2026-05-02-gpu-mode-cudnn-talk.md
+++ b/_posts/2026-05-02-gpu-mode-cudnn-talk.md
@@ -1,0 +1,14 @@
+---
+title: "Watch: cuDNN on GPU MODE"
+sidebar_title: "Talk on GPU MODE"
+date: 2026-05-02
+description: "We joined the GPU MODE channel for a deep dive on cuDNN. Grab a coffee and watch on YouTube."
+---
+
+We swung by the **GPU MODE** YouTube channel for a conversation about cuDNN — the library, the design choices, and what makes those GEMMs and attention kernels go *brrr*.
+
+If you've ever wondered what's actually happening between `import cudnn` and your model finishing a step, this one's for you.
+
+[![cuDNN talk on GPU MODE — click to watch on YouTube](https://i.ytimg.com/vi/kxP-vp1dgFY/maxresdefault.jpg)](https://www.youtube.com/watch?v=kxP-vp1dgFY){:class="video-thumbnail"}
+
+**▶ [Watch on YouTube](https://www.youtube.com/watch?v=kxP-vp1dgFY)** — and while you're there, give the [GPU MODE channel](https://www.youtube.com/@GPUMODE) a subscribe. They run a great series of talks on GPU programming, kernel writing, and ML systems.

--- a/_posts/2026-05-02-gpu-mode-cudnn-talk.md
+++ b/_posts/2026-05-02-gpu-mode-cudnn-talk.md
@@ -1,14 +1,12 @@
 ---
-title: "Watch: cuDNN on GPU MODE"
+title: "Watch our talk on GPU MODE: design choices in cuDNN attention"
 sidebar_title: "Talk on GPU MODE"
 date: 2026-05-02
-description: "We joined the GPU MODE channel for a deep dive on cuDNN. Grab a coffee and watch on YouTube."
+description: "We joined the GPU MODE channel to walk through the design choices behind cuDNN's attention kernels. Watch on YouTube."
 ---
 
-We swung by the **GPU MODE** YouTube channel for a conversation about cuDNN — the library, the design choices, and what makes those GEMMs and attention kernels go *brrr*.
+Watch our talk on the **GPU MODE** channel, where we walk through the design choices behind cuDNN's attention kernels — what we picked, why, and the trade-offs we made along the way.
 
-If you've ever wondered what's actually happening between `import cudnn` and your model finishing a step, this one's for you.
+[![cuDNN attention talk on GPU MODE — click to watch on YouTube](https://i.ytimg.com/vi/kxP-vp1dgFY/maxresdefault.jpg)](https://www.youtube.com/watch?v=kxP-vp1dgFY){:class="video-thumbnail"}
 
-[![cuDNN talk on GPU MODE — click to watch on YouTube](https://i.ytimg.com/vi/kxP-vp1dgFY/maxresdefault.jpg)](https://www.youtube.com/watch?v=kxP-vp1dgFY){:class="video-thumbnail"}
-
-**▶ [Watch on YouTube](https://www.youtube.com/watch?v=kxP-vp1dgFY)** — and while you're there, give the [GPU MODE channel](https://www.youtube.com/@GPUMODE) a subscribe. They run a great series of talks on GPU programming, kernel writing, and ML systems.
+**▶ [Watch on YouTube](https://www.youtube.com/watch?v=kxP-vp1dgFY)**

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -248,6 +248,24 @@ pre code {
   border-bottom: 1px solid #2a2a3e;
 }
 
+.post-content img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 24px auto;
+}
+
+.post-content img.video-thumbnail {
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.post-content img.video-thumbnail:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(118, 185, 0, 0.25);
+}
+
 /* ============ Post Cards (Home Page) ============ */
 .post-list {
   list-style: none;


### PR DESCRIPTION
## Summary
- Adds `_posts/2026-05-02-gpu-mode-cudnn-talk.md` promoting the cuDNN talk on the [GPU MODE YouTube channel](https://www.youtube.com/watch?v=kxP-vp1dgFY).
- Embeds the YouTube thumbnail (`maxresdefault.jpg`) as a clickable card linking to the video.
- Adds `.post-content img` rules to `assets/css/style.scss` so embedded images stay within the 920px content column, plus a small hover treatment for `.video-thumbnail` (rounded corners, NVIDIA-green shadow on hover).

This is independent of the v1.23.0 release notes PR (#235) — both can land in either order.

## Test plan
- [ ] `bundle exec jekyll serve` (or the Docker preview) and confirm the post appears under **All Posts** in the sidebar with `Talk on GPU MODE` as the label.
- [ ] Verify the thumbnail renders inside the content column, doesn't overflow on desktop, and click-throughs go to the YouTube watch page.
- [ ] Sanity-check the home page card list shows the new post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)