### PR TITLE
test/python: cap peak GPU memory via PYTORCH_CUDA_ALLOC_CONF

### DIFF
--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,4 +1,14 @@
 import os
+
+# Caps peak GPU memory across long pytest-xdist runs (e.g. test_mhas_v2 ~2.5k
+# configs in one worker). Must precede any torch import (including the
+# transitive one via transformer_engine below) -- PyTorch reads this env var
+# once when its CUDA allocator initializes.
+os.environ.setdefault(
+    "PYTORCH_CUDA_ALLOC_CONF",
+    "expandable_segments:True,garbage_collection_threshold:0.6",
+)
+
 import sys
 import traceback
 import pytest


### PR DESCRIPTION
Long pytest-xdist runs (e.g. test_mhas_v2 ~2.5k SDPA configs in one worker) hit a much higher GPU memory high-water mark than any single test needs, because the caching allocator retains freed blocks across configs.

Setting PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True, garbage_collection_threshold:0.6 before torch is imported reduces the peak to roughly the maximum any single test needs, with no change in wall time or test outcome.

Use os.environ.setdefault so user-provided values still win, and place it above the transformer_engine import so the env var is visible by the time torch initializes its CUDA allocator.