### PR TITLE
Add row-scale support to grouped GEMM quant

### DIFF
--- a/python/cudnn/grouped_gemm/grouped_gemm_quant/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_quant/api.py
@@ -90,6 +90,7 @@ class GroupedGemmQuantSm100(APIBase):
         sample_amax: Optional[torch.Tensor] = None,
         sample_norm_const: Optional[torch.Tensor] = None,
         sample_prob: Optional[torch.Tensor] = None,
+        sample_row_scale: Optional[torch.Tensor] = None,
         # Configuration
         acc_dtype: torch.dtype = torch.float32,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
@@ -121,6 +122,9 @@ class GroupedGemmQuantSm100(APIBase):
         :param sample_amax: Optional amax tensor for quantization
         :param sample_norm_const: Optional normalization constant
         :param sample_prob: Optional probability tensor for gating
+        :param sample_row_scale: Optional 1-D FP32 row-scale tensor. When
+            provided, the epilogue scales GEMM accumulators by
+            ``alpha[expert] * row_scale[m]`` before output conversion.
         :param acc_dtype: Accumulator data type
         :param mma_tiler_mn: MMA tiler shape (M, N)
         :param cluster_shape_mn: Cluster shape (M, N)
@@ -174,6 +178,11 @@ class GroupedGemmQuantSm100(APIBase):
             "norm_const",
         )
         self.prob_desc = self._make_tensor_desc(sample_prob, name="sample_prob")
+        self.row_scale_desc = self._unpad_tensor_to_ndim(
+            self._make_tensor_desc(sample_row_scale, name="sample_row_scale"),
+            1,
+            "row_scale",
+        )
         self.bias_desc = self._make_tensor_desc(sample_bias, name="sample_bias")
 
         if self.weight_mode == MoEWeightMode.DENSE:
@@ -275,6 +284,7 @@ class GroupedGemmQuantSm100(APIBase):
             "Pass a tensor of ones with shape (valid_m, 1, 1) if no gating is needed.",
         )
         self._check_tensor_shape(self.prob_desc, (tensor_m, 1, 1), "prob")
+        self._check_tensor_shape(self.row_scale_desc, (tensor_m,), "row_scale")
         self._check_tensor_shape(self.bias_desc, (n, l), "bias")
         self._check_tensor_shape(self.amax_desc, (self.expert_cnt, 1), "amax")
         self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
@@ -311,6 +321,11 @@ class GroupedGemmQuantSm100(APIBase):
         _ = self._check_tensor_stride(
             self.bias_desc,
             stride=[(1, n)],
+        )
+        _ = self._check_tensor_stride(
+            self.row_scale_desc,
+            stride=[(1,)],
+            extra_error_msg="row_scale must be a contiguous 1-D tensor",
         )
 
         self._logger.debug("Checking data types")
@@ -417,6 +432,12 @@ class GroupedGemmQuantSm100(APIBase):
             dtype=self.d_dtype,
             name="D_col",
             extra_error_msg="D_col must have the same dtype as D",
+        )
+        self._check_dtype(
+            self.row_scale_desc,
+            dtype=torch.float32,
+            name="row_scale",
+            extra_error_msg="row_scale must be float32",
         )
 
         self._not_implemented_error_if(
@@ -624,6 +645,13 @@ class GroupedGemmQuantSm100(APIBase):
                     shape=(valid_m, *self.prob_desc.shape[1:]),
                     stride=self.prob_desc.stride,
                 )
+            row_scale_cute_fake = None
+            if self.row_scale_desc is not None:
+                row_scale_cute_fake = self._make_fake_cute_tensor(
+                    dtype=self.row_scale_desc.dtype,
+                    shape=(valid_m,),
+                    stride=self.row_scale_desc.stride,
+                )
 
             sfd_row_fake = None
             sfd_col_fake = None
@@ -712,6 +740,13 @@ class GroupedGemmQuantSm100(APIBase):
                     shape=(valid_m, *self.prob_desc.shape[1:]),
                     stride=self.prob_desc.stride,
                 )
+            row_scale_cute_fake = None
+            if self.row_scale_desc is not None:
+                row_scale_cute_fake = self._make_fake_cute_tensor(
+                    dtype=self.row_scale_desc.dtype,
+                    shape=(valid_m,),
+                    stride=self.row_scale_desc.stride,
+                )
 
             sfd_row_fake = None
             sfd_col_fake = None
@@ -762,6 +797,7 @@ class GroupedGemmQuantSm100(APIBase):
             norm_const_tensor=self._make_fake_cute_tensor_from_desc(self.norm_const_desc, assumed_align=16),
             padded_offsets=self._make_fake_cute_tensor_from_desc(self.padded_offsets_desc, assumed_align=16),
             alpha=self._make_fake_cute_tensor_from_desc(self.alpha_desc, assumed_align=16),
+            row_scale=row_scale_cute_fake,
             bias=bias_cute_fake,
             prob=prob_cute_fake,
             max_active_clusters=max_active_clusters,
@@ -784,6 +820,7 @@ class GroupedGemmQuantSm100(APIBase):
             norm_const_tensor: Optional[torch.Tensor],
             padded_offsets: torch.Tensor,
             alpha_tensor: torch.Tensor,
+            row_scale_tensor: Optional[torch.Tensor],
             prob_tensor: Optional[torch.Tensor],
             bias_tensor: Optional[torch.Tensor],
             stream: cuda.CUstream,
@@ -806,6 +843,7 @@ class GroupedGemmQuantSm100(APIBase):
                 norm_const_tensor,
                 padded_offsets,
                 alpha_tensor,
+                row_scale_tensor,
                 bias_tensor,
                 prob_tensor,
                 stream,
@@ -886,6 +924,7 @@ class GroupedGemmQuantSm100(APIBase):
             stride=self.prob_desc.stride,
             assumed_align=16,
         )
+        row_scale_tensor = self._make_fake_cute_tensor_from_desc(self.row_scale_desc, assumed_align=16)
         bias_cute_fake = self._make_fake_cute_tensor_from_desc(self.bias_desc, assumed_align=16)
 
         b_ptrs_placeholder = torch.empty((self.expert_cnt,), dtype=torch.int64, device="cuda")
@@ -914,6 +953,7 @@ class GroupedGemmQuantSm100(APIBase):
             norm_const_tensor=norm_const_tensor_cute,
             padded_offsets=padded_offsets_tensor,
             alpha=alpha_tensor,
+            row_scale=row_scale_tensor,
             bias=bias_cute_fake,
             prob=prob_tensor,
             max_active_clusters=max_active_clusters,
@@ -940,6 +980,7 @@ class GroupedGemmQuantSm100(APIBase):
             norm_const_tensor: Optional[torch.Tensor],
             padded_offsets: torch.Tensor,
             alpha_tensor: torch.Tensor,
+            row_scale_tensor: Optional[torch.Tensor],
             prob_tensor: Optional[torch.Tensor],
             bias_tensor: Optional[torch.Tensor],
             stream: cuda.CUstream,
@@ -964,6 +1005,7 @@ class GroupedGemmQuantSm100(APIBase):
                 norm_const_tensor,
                 padded_offsets,
                 alpha_tensor,
+                row_scale_tensor,
                 bias_tensor,
                 prob_tensor,
                 stream,
@@ -991,6 +1033,7 @@ class GroupedGemmQuantSm100(APIBase):
         amax_tensor: Optional[torch.Tensor] = None,
         norm_const_tensor: Optional[torch.Tensor] = None,
         prob_tensor: Optional[torch.Tensor] = None,
+        row_scale_tensor: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         """Execute the compiled kernel.
@@ -1013,6 +1056,10 @@ class GroupedGemmQuantSm100(APIBase):
         :param amax_tensor: Optional amax tensor
         :param norm_const_tensor: Optional normalization constant
         :param prob_tensor: Probability tensor for per-row gating. Required.
+        :param row_scale_tensor: Optional contiguous FP32 tensor of shape ``(valid_m,)``.
+            When provided, the epilogue multiplies accumulators by
+            ``alpha_tensor[expert] * row_scale_tensor[m]`` before output
+            conversion.
         :param current_stream: CUDA stream
         """
         self._logger.debug("Entering execute")
@@ -1047,6 +1094,16 @@ class GroupedGemmQuantSm100(APIBase):
                 bias_tensor is not None,
                 "bias_tensor must be omitted at execute() when the API was compiled without sample_bias",
             )
+        if self.row_scale_desc is None:
+            self._value_error_if(
+                row_scale_tensor is not None,
+                "row_scale_tensor must be omitted at execute() when the API was compiled without sample_row_scale",
+            )
+        else:
+            self._value_error_if(
+                row_scale_tensor is None,
+                "row_scale_tensor must be provided at execute() when the API was compiled with sample_row_scale",
+            )
 
         self._logger.debug("Executing grouped_gemm_quant kernel")
         if self.weight_mode == MoEWeightMode.DENSE:
@@ -1063,6 +1120,7 @@ class GroupedGemmQuantSm100(APIBase):
                 norm_const_tensor=norm_const_tensor,
                 padded_offsets=padded_offsets,
                 alpha_tensor=alpha_tensor,
+                row_scale_tensor=row_scale_tensor,
                 prob_tensor=prob_tensor,
                 bias_tensor=bias_tensor,
                 stream=current_stream,
@@ -1081,6 +1139,7 @@ class GroupedGemmQuantSm100(APIBase):
                 norm_const_tensor=norm_const_tensor,
                 padded_offsets=padded_offsets,
                 alpha_tensor=alpha_tensor,
+                row_scale_tensor=row_scale_tensor,
                 prob_tensor=prob_tensor,
                 bias_tensor=bias_tensor,
                 stream=current_stream,
@@ -1110,6 +1169,7 @@ def grouped_gemm_quant_wrapper_sm100(
     b_major: str = "k",
     norm_const_tensor: Optional[torch.Tensor] = None,
     prob_tensor: Optional[torch.Tensor] = None,
+    row_scale_tensor: Optional[torch.Tensor] = None,
     acc_dtype: torch.dtype = torch.float32,
     d_dtype: torch.dtype = torch.bfloat16,
     cd_major: str = "n",
@@ -1146,6 +1206,10 @@ def grouped_gemm_quant_wrapper_sm100(
             Should be None for FP4/BF16 input configurations.
         prob_tensor: Probability tensor for per-row gating (shape `(valid_m, 1, 1)`).
             This argument is required. Pass a tensor of ones when no gating is needed.
+        row_scale_tensor: Optional FP32 tensor of shape `(valid_m,)`.
+            When provided, the epilogue multiplies accumulators by
+            `alpha_tensor[expert] * row_scale_tensor[m]` before output
+            conversion.
         acc_dtype: Accumulator data type
         d_dtype: Output D tensor data type
         cd_major: CD major dimension (only "n"-major layout is supported)
@@ -1284,6 +1348,13 @@ def grouped_gemm_quant_wrapper_sm100(
             "prob_tensor is required: the kernel unconditionally multiplies output by per-row gating probability. "
             "Pass a tensor of ones with shape (valid_m, 1, 1) if no gating is needed."
         )
+    if row_scale_tensor is not None:
+        if row_scale_tensor.dtype != torch.float32:
+            raise ValueError(f"row_scale_tensor must be float32, got {row_scale_tensor.dtype}")
+        if tuple(row_scale_tensor.shape) != (valid_m,):
+            raise ValueError(f"row_scale_tensor must have shape {(valid_m,)}, got {tuple(row_scale_tensor.shape)}")
+        if tuple(row_scale_tensor.stride()) != (1,):
+            raise ValueError(f"row_scale_tensor must be contiguous with stride (1,), got {tuple(row_scale_tensor.stride())}")
 
     if valid_m == 0:
         _logger.debug("grouped_gemm_quant_wrapper_sm100: valid_m is zero, skipping kernel execution")
@@ -1340,6 +1411,7 @@ def grouped_gemm_quant_wrapper_sm100(
             *tensor_signature(alpha_tensor),
             *tensor_signature(norm_const_tensor),
             *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
+            *dynamic_m_tensor_signature(row_scale_tensor, ()),
             tuple(padded_offsets.shape),
             tuple(padded_offsets.stride()),
             padded_offsets.dtype,
@@ -1369,6 +1441,7 @@ def grouped_gemm_quant_wrapper_sm100(
             *tensor_signature(alpha_tensor),
             *tensor_signature(norm_const_tensor),
             *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
+            *dynamic_m_tensor_signature(row_scale_tensor, ()),
             tuple(b_ptrs.shape),
             tuple(b_ptrs.stride()),
             b_ptrs.dtype,
@@ -1413,6 +1486,7 @@ def grouped_gemm_quant_wrapper_sm100(
                 sample_sfd_col=sfd_col_tensor,
                 sample_norm_const=norm_const_tensor,
                 sample_prob=prob_tensor,
+                sample_row_scale=row_scale_tensor,
                 acc_dtype=acc_dtype,
                 mma_tiler_mn=mma_tiler_mn,
                 cluster_shape_mn=cluster_shape_mn,
@@ -1439,6 +1513,7 @@ def grouped_gemm_quant_wrapper_sm100(
                 sample_sfd_col=sfd_col_tensor,
                 sample_norm_const=norm_const_tensor,
                 sample_prob=prob_tensor,
+                sample_row_scale=row_scale_tensor,
                 acc_dtype=acc_dtype,
                 mma_tiler_mn=mma_tiler_mn,
                 cluster_shape_mn=cluster_shape_mn,
@@ -1469,6 +1544,7 @@ def grouped_gemm_quant_wrapper_sm100(
             amax_tensor=amax_tensor,
             norm_const_tensor=norm_const_tensor,
             prob_tensor=prob_tensor,
+            row_scale_tensor=row_scale_tensor,
             bias_tensor=bias_tensor,
             current_stream=current_stream,
         )
@@ -1487,6 +1563,7 @@ def grouped_gemm_quant_wrapper_sm100(
             amax_tensor=amax_tensor,
             norm_const_tensor=norm_const_tensor,
             prob_tensor=prob_tensor,
+            row_scale_tensor=row_scale_tensor,
             bias_tensor=bias_tensor,
             current_stream=current_stream,
         )

--- a/python/cudnn/grouped_gemm/grouped_gemm_quant/grouped_gemm_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_quant/grouped_gemm_quant.py
@@ -565,6 +565,7 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         norm_const_tensor: Optional[cute.Tensor],
         padded_offsets: cute.Tensor,
         alpha: cute.Tensor,
+        row_scale: Optional[cute.Tensor],
         bias: Optional[cute.Tensor],
         prob: cute.Tensor,
         max_active_clusters: cutlass.Constexpr,
@@ -863,6 +864,7 @@ class BlockScaledMoEGroupedGemmQuantKernel:
             amax_tensor,
             padded_offsets,
             alpha,
+            row_scale,
             bias,
             prob,
             workspace_ptr,
@@ -1097,6 +1099,7 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         mAmax_tensor: Optional[cute.Tensor],
         padded_offsets: cute.Tensor,
         alpha: cute.Tensor,
+        row_scale: Optional[cute.Tensor],
         mBias_nl: Optional[cute.Tensor],
         prob: cute.Tensor,
         workspace_ptr,
@@ -1810,6 +1813,17 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                 mPosition = epi_work_tile_info.tile_m_idx * self.cta_tile_shape_mnk[0] + tidx
                 real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
                 mProb = real_prob[mPosition, 0, 0]
+                acc_scale = cutlass.Float32(alpha_val)
+                # Optional per-row epilogue scale, applied together with the
+                # per-expert alpha before output conversion.
+                if cutlass.const_expr(row_scale is not None):
+                    real_row_scale, _ = epi_ext.get_gmem_tensor(
+                        "row_scale",
+                        row_scale,
+                        padded_offsets,
+                        epi_work_tile_info,
+                    )
+                    acc_scale = acc_scale * real_row_scale[mPosition]
 
                 # C1 fix: phase-based acc stage indexing for overlapping_accum
                 if cutlass.const_expr(self.overlapping_accum):
@@ -1859,26 +1873,26 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                                 )
                                 tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.fma_packed_f32x2(
                                     (tTR_rAcc[i], tTR_rAcc[i + 1]),
-                                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                                    (acc_scale, acc_scale),
                                     (bias_f32_0, bias_f32_1),
                                     rnd="rn",
                                     ftz=False,
                                 )
                         else:
                             for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                                tTR_rAcc[i] = tTR_rAcc[i] * cutlass.Float32(alpha_val) + bias_vec[i].to(cutlass.Float32) * mProb
+                                tTR_rAcc[i] = tTR_rAcc[i] * acc_scale + bias_vec[i].to(cutlass.Float32) * mProb
                     else:
                         if cutlass.const_expr(self.vectorized_f32):
                             for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc), 2):
                                 tTR_rAcc[i], tTR_rAcc[i + 1] = cute.arch.mul_packed_f32x2(
                                     (tTR_rAcc[i], tTR_rAcc[i + 1]),
-                                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                                    (acc_scale, acc_scale),
                                     rnd="rn",
                                     ftz=False,
                                 )
                         else:
                             for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                                tTR_rAcc[i] = tTR_rAcc[i] * cutlass.Float32(alpha_val)
+                                tTR_rAcc[i] = tTR_rAcc[i] * acc_scale
 
                     acc_vec = tTR_rAcc.load()
                     if cutlass.const_expr(not self.enable_bias):

--- a/python/cudnn/grouped_gemm/moe_sched_extension.py
+++ b/python/cudnn/grouped_gemm/moe_sched_extension.py
@@ -101,7 +101,8 @@ class DiscreteWeightScaledGemmSchedExtension(MoESchedExtension):
     MoE scheduler extension for discrete-weight block-scaled grouped GEMM
     with GLU and quantization fusion.
 
-    Handles domain conversion for: a, b, c, d, d_col, prob, dprob, sfa, sfd, sfd_col, sfb.
+    Handles domain conversion for: a, b, c, d, d_col, prob, dprob,
+    row_scale, sfa, sfd, sfd_col, sfb.
 
     B and SFB are discrete (per-expert pointer arrays) → use expert-wise
     TMA descriptors from workspace.
@@ -178,6 +179,11 @@ class DiscreteWeightScaledGemmSchedExtension(MoESchedExtension):
             # Bias: (N, L) → domain_offset L by expert_idx, global desc
             real = cute.domain_offset((0, expert_idx), gmem_tensor_in_moe_view)
             real = rewrite_tensor_shape(real, (shape[0], c1))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "row_scale"):
+            real = cute.domain_offset((token_offset,), gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(real, (tokens_i,))
             return (real, None)
 
         elif cutlass.const_expr(tensor_name in ("c", "d", "d_col", "d_srelu", "prob", "dprob")):
@@ -296,6 +302,11 @@ class ContiguousAndConsistentGroupedGemmSchedExtension(MoESchedExtension):
             # Bias: (N, L) → domain_offset L by expert_idx, global desc
             real = cute.domain_offset((0, expert_idx), gmem_tensor_in_moe_view)
             real = rewrite_tensor_shape(real, (shape[0], c1))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "row_scale"):
+            real = cute.domain_offset((token_offset,), gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(real, (tokens_i,))
             return (real, None)
 
         elif cutlass.const_expr(tensor_name in ("c", "d", "d_col", "d_srelu", "prob", "dprob")):

--- a/test/python/fe_api/test_grouped_gemm_quant.py
+++ b/test/python/fe_api/test_grouped_gemm_quant.py
@@ -88,6 +88,14 @@ def _check_ref_grouped_gemm_quant_discrete(inputs, outputs, cfg, skip_ref=False)
     )
 
 
+def _add_row_scale(inputs):
+    inputs["row_scale_tensor"] = torch.empty(
+        inputs["tensor_m"],
+        dtype=torch.float32,
+        device=inputs["a_tensor"].device,
+    ).uniform_(0.25, 1.75)
+
+
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 @with_scheduler_modes
@@ -399,6 +407,81 @@ def test_grouped_gemm_quant_compile_execute_rectangular_zero_alpha(request):
 
     assert torch.count_nonzero(outputs["d_tensor"][: inputs["valid_m"]]).item() == 0
     assert torch.count_nonzero(outputs["amax_tensor"]).item() == 0
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=3)
+@pytest.mark.parametrize("vector_f32", [False, True])
+def test_grouped_gemm_quant_compile_execute_fp4_row_scale(vector_f32, request):
+    def input_mutator(inputs, _cfg):
+        _add_row_scale(inputs)
+        inputs["prob_tensor"].fill_(1.0)
+
+    _test_grouped_gemm_quant_compile_execute(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=16,
+        sf_dtype=torch.float8_e4m3fn,
+        vector_f32=vector_f32,
+        discrete_col_sfd=False,
+        request=request,
+        input_mutator=input_mutator,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=4)
+def test_grouped_gemm_quant_wrapper_fp4_row_scale_with_bias(request):
+    def input_mutator(inputs, _cfg):
+        _add_row_scale(inputs)
+        inputs["prob_tensor"].uniform_(0.25, 1.25)
+        inputs["bias_ref"] = inputs["bias_tensor"]
+
+    _test_grouped_gemm_quant_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=16,
+        sf_dtype=torch.float8_e4m3fn,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        input_mutator=input_mutator,
+        cfg_overrides={
+            "group_m_list": [256, 128, 384, 256],
+        },
+        enable_bias=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=5)
+def test_grouped_gemm_quant_discrete_wrapper_fp4_row_scale(request):
+    _test_grouped_gemm_quant_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=16,
+        sf_dtype=torch.float8_e4m3fn,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        row_scale=True,
+    )
 
 
 @pytest.mark.L0
@@ -936,6 +1019,7 @@ def _test_grouped_gemm_quant_compile_execute(
         sample_amax=outputs.get("amax_tensor"),
         sample_norm_const=inputs.get("norm_const_tensor"),
         sample_prob=inputs["prob_tensor"],
+        sample_row_scale=inputs.get("row_scale_tensor"),
         acc_dtype=cfg["acc_dtype"],
         mma_tiler_mn=cfg["mma_tiler_mn"],
         cluster_shape_mn=cfg["cluster_shape_mn"],
@@ -965,6 +1049,7 @@ def _test_grouped_gemm_quant_compile_execute(
         sfd_col_tensor=outputs.get("sfd_col_tensor"),
         norm_const_tensor=inputs.get("norm_const_tensor"),
         prob_tensor=inputs["prob_tensor"],
+        row_scale_tensor=inputs.get("row_scale_tensor"),
         amax_tensor=outputs.get("amax_tensor"),
         current_stream=stream,
     )
@@ -994,6 +1079,7 @@ def _test_grouped_gemm_quant_wrapper(
     cfg_overrides=None,
     input_mutator=None,
     use_dynamic_sched=False,
+    enable_bias=False,
 ):
     """Test GroupedGemmQuant API via the wrapper function (with caching)."""
     try:
@@ -1029,6 +1115,7 @@ def _test_grouped_gemm_quant_wrapper(
         sf_dtype=cfg["sf_dtype"],
         sf_vec_size=cfg["sf_vec_size"],
         m_aligned=cfg["m_aligned"],
+        enable_bias=enable_bias,
     )
 
     if input_mutator is not None:
@@ -1041,10 +1128,12 @@ def _test_grouped_gemm_quant_wrapper(
                 b_tensor=inputs["b_tensor"],
                 sfa_tensor=inputs["sfa_tensor"],
                 sfb_tensor=inputs["sfb_tensor"],
+                bias_tensor=inputs["bias_tensor"],
                 padded_offsets=inputs["padded_offsets_tensor"],
                 alpha_tensor=inputs["alpha_tensor"],
                 norm_const_tensor=inputs.get("norm_const_tensor"),
                 prob_tensor=inputs["prob_tensor"],
+                row_scale_tensor=inputs.get("row_scale_tensor"),
                 acc_dtype=cfg["acc_dtype"],
                 d_dtype=cfg["d_dtype"],
                 cd_major=cfg["cd_major"],
@@ -1148,6 +1237,7 @@ def _test_grouped_gemm_quant_discrete_compile_execute(
         sample_amax=outputs.get("amax_tensor"),
         sample_norm_const=inputs.get("norm_const_tensor"),
         sample_prob=inputs["prob_tensor"],
+        sample_row_scale=inputs.get("row_scale_tensor"),
         acc_dtype=cfg["acc_dtype"],
         mma_tiler_mn=cfg["mma_tiler_mn"],
         cluster_shape_mn=cfg["cluster_shape_mn"],
@@ -1179,6 +1269,7 @@ def _test_grouped_gemm_quant_discrete_compile_execute(
         amax_tensor=outputs.get("amax_tensor"),
         norm_const_tensor=inputs.get("norm_const_tensor"),
         prob_tensor=inputs["prob_tensor"],
+        row_scale_tensor=inputs.get("row_scale_tensor"),
         current_stream=stream,
     )
 
@@ -1206,6 +1297,7 @@ def _test_grouped_gemm_quant_discrete_wrapper(
     discrete_col_sfd,
     request,
     use_dynamic_sched=False,
+    row_scale=False,
 ):
     try:
         from cudnn import grouped_gemm_quant_wrapper_sm100
@@ -1242,6 +1334,8 @@ def _test_grouped_gemm_quant_discrete_wrapper(
         m_aligned=cfg["m_aligned"],
         b_major=cfg["b_major"],
     )
+    if row_scale:
+        _add_row_scale(inputs)
 
     try:
         for _ in range(2):
@@ -1257,6 +1351,7 @@ def _test_grouped_gemm_quant_discrete_wrapper(
                 b_major=cfg["b_major"],
                 norm_const_tensor=inputs.get("norm_const_tensor"),
                 prob_tensor=inputs["prob_tensor"],
+                row_scale_tensor=inputs.get("row_scale_tensor"),
                 acc_dtype=cfg["acc_dtype"],
                 d_dtype=cfg["d_dtype"],
                 cd_major=cfg["cd_major"],

--- a/test/python/fe_api/test_grouped_gemm_quant.py
+++ b/test/python/fe_api/test_grouped_gemm_quant.py
@@ -94,6 +94,15 @@ def _add_row_scale(inputs):
         dtype=torch.float32,
         device=inputs["a_tensor"].device,
     ).uniform_(0.25, 1.75)
+    inputs["alpha_tensor"].copy_(
+        torch.linspace(
+            -1.5,
+            1.5,
+            inputs["alpha_tensor"].numel(),
+            dtype=torch.float32,
+            device=inputs["alpha_tensor"].device,
+        )
+    )
 
 
 @pytest.mark.L0
@@ -465,6 +474,27 @@ def test_grouped_gemm_quant_wrapper_fp4_row_scale_with_bias(request):
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=5)
+def test_grouped_gemm_quant_discrete_compile_execute_fp4_row_scale(request):
+    _test_grouped_gemm_quant_discrete_compile_execute(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=16,
+        sf_dtype=torch.float8_e4m3fn,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        row_scale=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=6)
 def test_grouped_gemm_quant_discrete_wrapper_fp4_row_scale(request):
     _test_grouped_gemm_quant_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -1173,6 +1203,7 @@ def _test_grouped_gemm_quant_discrete_compile_execute(
     discrete_col_sfd,
     request,
     use_dynamic_sched=False,
+    row_scale=False,
 ):
     try:
         from cudnn import GroupedGemmQuantSm100
@@ -1209,6 +1240,8 @@ def _test_grouped_gemm_quant_discrete_compile_execute(
         m_aligned=cfg["m_aligned"],
         b_major=cfg["b_major"],
     )
+    if row_scale:
+        _add_row_scale(inputs)
 
     outputs = allocate_grouped_gemm_quant_output_tensors(
         tensor_m=inputs["tensor_m"],

--- a/test/python/fe_api/test_grouped_gemm_quant_utils.py
+++ b/test/python/fe_api/test_grouped_gemm_quant_utils.py
@@ -276,6 +276,7 @@ def run_grouped_gemm_quant_ref(
     prob_tensor: torch.Tensor,
     aligned_group_m_list: List[int],
     valid_m: int,
+    row_scale_tensor: Optional[torch.Tensor] = None,
     generate_amax: bool = False,
     generate_sfd: bool = False,
     norm_const_tensor: Optional[torch.Tensor] = None,
@@ -315,7 +316,13 @@ def run_grouped_gemm_quant_ref(
         ref[start:end, :, 0] = ref[start:end, :, 0] * alpha_tensor[i].item()
         start = end
 
-    # Step 3: prob gating — without bias: multiply full result by prob. With bias: kernel
+    # Step 3: optional per-row epilogue scale. This intentionally scales only
+    # the GEMM accumulator path; fused bias keeps its existing bias * prob
+    # semantics.
+    if row_scale_tensor is not None:
+        ref = ref * row_scale_tensor[:valid_m].to(torch.float32).view(valid_m, 1, 1)
+
+    # Step 4: prob gating — without bias: multiply full result by prob. With bias: kernel
     # fuses (acc * alpha + bias * prob), so add bias * prob per row/expert and do not
     # multiply the GEMM part by prob again.
     if bias_ref is None:
@@ -486,6 +493,7 @@ def check_ref_grouped_gemm_quant(
         prob_tensor=inputs["prob_tensor"],
         aligned_group_m_list=inputs["aligned_group_m_list"],
         valid_m=inputs["valid_m"],
+        row_scale_tensor=inputs.get("row_scale_tensor"),
         generate_amax=(outputs.get("amax_tensor") is not None),
         generate_sfd=(outputs.get("sfd_row_tensor") is not None),
         norm_const_tensor=inputs.get("norm_const_tensor"),


### PR DESCRIPTION
## Summary
@humansand

Add an optional `row_scale_tensor` input to the SM100 grouped GEMM quant path. The new tensor is a contiguous FP32 vector with one scale per valid output row. When provided, the epilogue multiplies FP32 accumulators by `alpha[expert] * row_scale[m]` before output conversion.

This is intended for integrations that need an additional per-row accumulator scale, such as row-scaled NVFP4. The immediate motivation is TransformerEngine's row-scaled NVFP4 work in NVIDIA/TransformerEngine#2931. The kernel treats `row_scale_tensor` as an epilogue multiplier and does not interpret how the caller produced those values.

The existing bias and probability semantics are preserved: the row scale applies only to the accumulator path, while fused bias keeps the existing `bias * prob` behavior.

## Changes

- Add `sample_row_scale` / `row_scale_tensor` plumbing to `GroupedGemmQuantSm100`.
- Add scheduler tensor mapping for the row-scale input.
- Apply row-scale multiplication in the grouped GEMM quant epilogue.
- Include the row-scale tensor in wrapper validation and compile-cache signatures.
- Extend grouped GEMM quant tests and Python reference coverage for compile/execute, dense wrapper, and discrete wrapper paths.

## Validation

Current upstream-facing branch:

- `python3 -m py_compile python/cudnn/grouped_gemm/grouped_gemm_quant/api.py python/cudnn/grouped_gemm/grouped_gemm_quant/grouped_gemm_quant.py python/cudnn/grouped_gemm/moe_sched_extension.py test/python/fe_api/test_grouped_gemm_quant.py test/python/fe_api/test_grouped_gemm_quant_utils.py`
- `git diff --check upstream/develop...HEAD`
- B200 devbox: `python3 -m pytest -q test/python/fe_api/test_grouped_gemm_quant.py -k row_scale --tb=short` -> `5 passed, 309 deselected`

Notes:

- `pre-commit run --all-files` is unavailable in this checkout because `.pre-commit-config.yaml` is not present.
