### PR TITLE
Add per-expert reduction (group_offset) for MoE grouped GEMM

### DIFF
--- a/include/cudnn_frontend/graph_properties.h
+++ b/include/cudnn_frontend/graph_properties.h
@@ -1339,7 +1339,7 @@ class Reduction_attributes : public Attributes<Reduction_attributes> {
     bool is_deterministic = false;
 
    public:
-    enum class input_names { X };
+    enum class input_names { X, Group_offset };
     std::unordered_map<input_names, std::shared_ptr<Tensor_attributes>> inputs;
     enum class output_names { Y };
     std::unordered_map<output_names, std::shared_ptr<Tensor_attributes>> outputs;
@@ -1370,6 +1370,12 @@ class Reduction_attributes : public Attributes<Reduction_attributes> {
     Reduction_attributes&
     set_is_deterministic(bool value) {
         is_deterministic = value;
+        return *this;
+    }
+
+    Reduction_attributes&
+    set_group_offset(std::shared_ptr<Tensor_attributes> value) {
+        inputs[input_names::Group_offset] = std::move(value);
         return *this;
     }
 };

--- a/include/cudnn_frontend/node/reduction.h
+++ b/include/cudnn_frontend/node/reduction.h
@@ -115,6 +115,7 @@ class ReductionNode : public NodeCRTP<ReductionNode> {
 
         // Validate input tensors are set
         CUDNN_FE_VALIDATE_AND_ASSIGN_INPUT_TENSOR(X, Reduction_attributes::input_names::X);
+        auto Group_offset = attributes.inputs.find(Reduction_attributes::input_names::Group_offset);
         CUDNN_FE_VALIDATE_AND_ASSIGN_OUTPUT_TENSOR(Y, Reduction_attributes::output_names::Y);
 
         // 1. Create the backend operation descriptor
@@ -149,7 +150,27 @@ class ReductionNode : public NodeCRTP<ReductionNode> {
                                                        1,
                                                        &y_backend_desc));
 
-        // 5. Finalize the operation descriptor
+        // 5. Set the optional group offset tensor descriptor
+        if (Group_offset != attributes.inputs.end() && Group_offset->second != nullptr) {
+#if (CUDNN_VERSION >= 92400) && (CUDNN_VERSION < 99900)
+            RETURN_CUDNN_FRONTEND_ERROR_IF(
+                detail::get_backend_version() < 92400 || detail::get_backend_version() >= 99900,
+                error_code_t::GRAPH_NOT_SUPPORTED,
+                "Reduction group_offset is not supported in cudnn version < 9.24.0");
+            auto group_offset_backend_desc = tensors.at(Group_offset->second->get_uid())->get_raw_desc();
+
+            _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(reduction_operation.get_raw_desc(),
+                                                           CUDNN_ATTR_OPERATION_REDUCTION_GROUP_OFFSET_DESC,
+                                                           CUDNN_TYPE_BACKEND_DESCRIPTOR,
+                                                           1,
+                                                           &group_offset_backend_desc));
+#else
+            return {error_code_t::GRAPH_NOT_SUPPORTED,
+                    "Reduction group_offset is not supported in cudnn version < 9.24.0"};
+#endif
+        }
+
+        // 6. Finalize the operation descriptor
 
         _CUDNN_CHECK_CUDNN_ERROR(detail::finalize(reduction_operation.get_raw_desc()));
 
@@ -178,9 +199,32 @@ INode::reduction(std::shared_ptr<Tensor_attributes> a,
     sub_nodes.emplace_back(std::make_unique<ReductionNode>(std::move(attributes), context));
 }
 
+inline void
+INode::reduction(std::shared_ptr<Tensor_attributes> a,
+                 std::shared_ptr<Tensor_attributes> group_offset,
+                 Reduction_attributes attributes,
+                 std::shared_ptr<Tensor_attributes> c) {
+    attributes.inputs[Reduction_attributes::input_names::X]            = a;
+    attributes.inputs[Reduction_attributes::input_names::Group_offset] = group_offset;
+    attributes.outputs[Reduction_attributes::output_names::Y]          = c;
+    sub_nodes.emplace_back(std::make_unique<ReductionNode>(std::move(attributes), context));
+}
+
 inline std::shared_ptr<Tensor_attributes>
 INode::reduction(std::shared_ptr<Tensor_attributes> input, Reduction_attributes attributes) {
     attributes.inputs[Reduction_attributes::input_names::X] = input;
+    auto Y = attributes.outputs[Reduction_attributes::output_names::Y] = output_tensor(attributes.name + "::Y");
+
+    sub_nodes.emplace_back(std::make_unique<ReductionNode>(std::move(attributes), context));
+    return Y;
+}
+
+inline std::shared_ptr<Tensor_attributes>
+INode::reduction(std::shared_ptr<Tensor_attributes> input,
+                 std::shared_ptr<Tensor_attributes> group_offset,
+                 Reduction_attributes attributes) {
+    attributes.inputs[Reduction_attributes::input_names::X]            = input;
+    attributes.inputs[Reduction_attributes::input_names::Group_offset] = group_offset;
     auto Y = attributes.outputs[Reduction_attributes::output_names::Y] = output_tensor(attributes.name + "::Y");
 
     sub_nodes.emplace_back(std::make_unique<ReductionNode>(std::move(attributes), context));

--- a/include/cudnn_frontend/node/reduction.h
+++ b/include/cudnn_frontend/node/reduction.h
@@ -152,9 +152,9 @@ class ReductionNode : public NodeCRTP<ReductionNode> {
 
         // 5. Set the optional group offset tensor descriptor
         if (Group_offset != attributes.inputs.end() && Group_offset->second != nullptr) {
-#if (CUDNN_VERSION >= 92400) && (CUDNN_VERSION < 99900)
+#if (CUDNN_VERSION >= 92400)
             RETURN_CUDNN_FRONTEND_ERROR_IF(
-                detail::get_backend_version() < 92400 || detail::get_backend_version() >= 99900,
+                detail::get_backend_version() < 92400,
                 error_code_t::GRAPH_NOT_SUPPORTED,
                 "Reduction group_offset is not supported in cudnn version < 9.24.0");
             auto group_offset_backend_desc = tensors.at(Group_offset->second->get_uid())->get_raw_desc();

--- a/include/cudnn_frontend/node_interface.h
+++ b/include/cudnn_frontend/node_interface.h
@@ -213,6 +213,12 @@ class INode {
               std::shared_ptr<Tensor_attributes> c);
 
     void
+    reduction(std::shared_ptr<Tensor_attributes> a,
+              std::shared_ptr<Tensor_attributes> group_offset,
+              Reduction_attributes attributes,
+              std::shared_ptr<Tensor_attributes> c);
+
+    void
     rng(std::shared_ptr<Tensor_attributes> seed,
         std::shared_ptr<Tensor_attributes> offset,
         Rng_attributes attributes,
@@ -404,6 +410,9 @@ class INode {
                                                  Pointwise_attributes);
 
     std::shared_ptr<Tensor_attributes> reduction(std::shared_ptr<Tensor_attributes>, Reduction_attributes);
+    std::shared_ptr<Tensor_attributes> reduction(std::shared_ptr<Tensor_attributes>,
+                                                 std::shared_ptr<Tensor_attributes>,
+                                                 Reduction_attributes);
     std::array<std::shared_ptr<Tensor_attributes>, 2> resample(std::shared_ptr<Tensor_attributes>, Resample_attributes);
     std::shared_ptr<Tensor_attributes> reshape(std::shared_ptr<Tensor_attributes>, Reshape_attributes);
     std::shared_ptr<Tensor_attributes> transpose(std::shared_ptr<Tensor_attributes>, Transpose_attributes);

--- a/include/cudnn_frontend_Operation.h
+++ b/include/cudnn_frontend_Operation.h
@@ -336,8 +336,8 @@ class OperationBuilder_v8 {
             return std::move(m_operation);
         }
         if (m_operation.groupoffsetdesc != nullptr) {
-#if (CUDNN_VERSION >= 92400) && (CUDNN_VERSION < 99900)
-            if (detail::get_backend_version() < 92400 || detail::get_backend_version() >= 99900) {
+#if (CUDNN_VERSION >= 92400)
+            if (detail::get_backend_version() < 92400) {
                 set_error_and_throw_exception(&m_operation,
                                               CUDNN_STATUS_NOT_SUPPORTED,
                                               "CUDNN_BACKEND_OPERATION: Reduction group offset is not supported in "

--- a/include/cudnn_frontend_Operation.h
+++ b/include/cudnn_frontend_Operation.h
@@ -203,6 +203,7 @@ class Operation_v8 : public BackendDescriptor {
     ManagedOpaqueDescriptor pwdesc             = nullptr;
     ManagedOpaqueDescriptor matmuldesc         = nullptr;
     ManagedOpaqueDescriptor reductiondesc      = nullptr;
+    ManagedOpaqueDescriptor groupoffsetdesc    = nullptr;
     ManagedOpaqueDescriptor sumdesc            = nullptr;
     ManagedOpaqueDescriptor sqsumdesc          = nullptr;
     ManagedOpaqueDescriptor scaledesc          = nullptr;
@@ -333,6 +334,35 @@ class OperationBuilder_v8 {
                 status,
                 "CUDNN_BACKEND_OPERATION: SetAttribute CUDNN_ATTR_OPERATION_REDUCTION_YDESC Failed");
             return std::move(m_operation);
+        }
+        if (m_operation.groupoffsetdesc != nullptr) {
+#if (CUDNN_VERSION >= 92400) && (CUDNN_VERSION < 99900)
+            if (detail::get_backend_version() < 92400 || detail::get_backend_version() >= 99900) {
+                set_error_and_throw_exception(&m_operation,
+                                              CUDNN_STATUS_NOT_SUPPORTED,
+                                              "CUDNN_BACKEND_OPERATION: Reduction group offset is not supported in "
+                                              "cudnn version < 9.24.0");
+                return std::move(m_operation);
+            }
+            status = detail::set_attribute(m_operation.pointer->get_backend_descriptor(),
+                                           CUDNN_ATTR_OPERATION_REDUCTION_GROUP_OFFSET_DESC,
+                                           CUDNN_TYPE_BACKEND_DESCRIPTOR,
+                                           1,
+                                           &(m_operation.groupoffsetdesc->get_backend_descriptor()));
+            if (status != CUDNN_STATUS_SUCCESS) {
+                set_error_and_throw_exception(
+                    &m_operation,
+                    status,
+                    "CUDNN_BACKEND_OPERATION: SetAttribute CUDNN_ATTR_OPERATION_REDUCTION_GROUP_OFFSET_DESC Failed");
+                return std::move(m_operation);
+            }
+#else
+            set_error_and_throw_exception(&m_operation,
+                                          CUDNN_STATUS_NOT_SUPPORTED,
+                                          "CUDNN_BACKEND_OPERATION: Reduction group offset is not supported in cudnn "
+                                          "version < 9.24.0");
+            return std::move(m_operation);
+#endif
         }
         status = detail::finalize(m_operation.pointer->get_backend_descriptor());
         if (status != CUDNN_STATUS_SUCCESS) {
@@ -2843,6 +2873,28 @@ class OperationBuilder_v8 {
                 "CUDNN_BACKEND_OPERATION_*_DESCRIPTOR: Non Reduction operation does not need REDUCTION DESCRIPTOR");
         }
         m_operation.reductiondesc = reductionDesc.get_desc();
+        return *this;
+    }
+    auto
+    setGroupOffsetDesc(Tensor_v8 const &tensor) -> OperationBuilder_v8 & {
+        if (is_reduction_op == false) {
+            set_error_and_throw_exception(
+                &m_operation,
+                CUDNN_STATUS_BAD_PARAM,
+                "CUDNN_BACKEND_OPERATION_*_DESCRIPTOR: Non Reduction operation does not need GROUP OFFSET DESCRIPTOR");
+        }
+        m_operation.groupoffsetdesc = tensor.get_desc();
+        return *this;
+    }
+    auto
+    setGroupOffsetDesc(ManagedOpaqueDescriptor const &raw_tensor) -> OperationBuilder_v8 & {
+        if (is_reduction_op == false) {
+            set_error_and_throw_exception(
+                &m_operation,
+                CUDNN_STATUS_BAD_PARAM,
+                "CUDNN_BACKEND_OPERATION_*_DESCRIPTOR: Non Reduction operation does not need GROUP OFFSET DESCRIPTOR");
+        }
+        m_operation.groupoffsetdesc = raw_tensor;
         return *this;
     }
     auto

--- a/python/pygraph/pygraph.cpp
+++ b/python/pygraph/pygraph.cpp
@@ -345,11 +345,15 @@ std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>
 PyGraph::reduction(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& input,
                    cudnn_frontend::ReductionMode_t const mode,
                    cudnn_frontend::DataType_t const& compute_data_type,
-                   std::string const& name) {
+                   std::string const& name,
+                   std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> group_offset) {
     auto attributes = cudnn_frontend::graph::Reduction_attributes()
                           .set_mode(mode)
                           .set_compute_data_type(compute_data_type)
                           .set_name(name);
+    if (group_offset != nullptr) {
+        attributes.set_group_offset(std::move(group_offset));
+    }
 
     auto OUT_0 = graph->reduction(input, attributes);
     return OUT_0;
@@ -1065,6 +1069,7 @@ init_pygraph_submodule(py::module_& m) {
              py::arg("mode"),
              py::arg_v("compute_data_type", cudnn_frontend::DataType_t::NOT_SET),
              py::arg_v("name", ""),
+             py::arg_v("group_offset", nullptr),
              R"pbdoc(
                 Reduce an input tensor along certain dimensions. These dimensions to reduce on are inferred from output tensor shape.
 
@@ -1073,6 +1078,7 @@ init_pygraph_submodule(py::module_& m) {
                     mode (cudnn.reduction_mode): The mode to use to reduce along a dimension.
                     compute_data_type (Optional[cudnn.data_type]): The data type for computation. Default is NOT_SET.
                     name (Optional[str]): A name for the operation to be performed.
+                    group_offset (Optional[cudnn_tensor]): The group offset tensor for grouped reduction.
 
                 Returns:
                     cudnn_tensor: The result of reduction operation.

--- a/python/pygraph/pygraph.h
+++ b/python/pygraph/pygraph.h
@@ -333,7 +333,8 @@ class PyGraph {
     reduction(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& input,
               cudnn_frontend::ReductionMode_t const mode,
               cudnn_frontend::DataType_t const& compute_data_type,
-              std::string const& name);
+              std::string const& name,
+              std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> group_offset = nullptr);
 
     std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>
     reshape(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& input,


### PR DESCRIPTION
Adds optional group_offset support to the reduction node so cuDNN FE can express per-expert reductions for MoE grouped GEMM workloads.

- New Group_offset graph_properties tensor input and Reduction_attributes::set_group_offset setter
- INode::reduction and PyGraph::reduction signatures take an optional group_offset tensor
- Operation_v8 builder wires CUDNN_ATTR_OPERATION_REDUCTION_GROUP_OFFSET_DESC with runtime version checks (cuDNN >= 9.24.0)
- Python binding (pygraph) exposes the optional group_offset argument

Authoredby @yanqinz.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reduction operations now accept an optional group-offset tensor parameter in C++ and Python APIs, enabling advanced control over reduction behavior and computation.
  * The group-offset feature is supported on cuDNN version 9.24.0 and newer.
  * Existing reduction workflows remain fully compatible with this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->