### PR TITLE
fix: allow override libcudart via CUDNN_FRONTEND_CUDART_LIB_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,24 @@ export CUDNN_FRONTEND_LOG_FILE=execution_log.txt
 
 Alternatively, you can control logging programmatically via `cudnn_frontend::isLoggingEnabled()`.
 
+### Overriding the CUDA runtime library
+
+When the frontend is built with dynamic loading enabled, it locates the CUDA runtime
+(`libcudart.so.*`) at runtime by searching for the supported major versions. In some
+environments (for example, containers such as GKE where the TCPXO NCCL plugin mounts a
+different `libcudart` major version from the host) multiple versions of `libcudart` may be
+visible on the library search path, and the automatic detection aborts with a
+`Multiple libcudart libraries found` error.
+
+To resolve this, set the `CUDNN_FRONTEND_CUDART_LIB_NAME` environment variable to the
+library name (or full path) that should be loaded. This bypasses the automatic detection:
+
+```bash
+export CUDNN_FRONTEND_CUDART_LIB_NAME=libcudart.so.13
+# or an absolute path
+export CUDNN_FRONTEND_CUDART_LIB_NAME=/usr/local/cuda/lib64/libcudart.so.13
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/include/cudnn_frontend_shim.h
+++ b/include/cudnn_frontend_shim.h
@@ -38,6 +38,8 @@
 #endif
 #include <mutex>
 #include <stdexcept>
+#include <cstdlib>
+#include <string>
 #endif
 
 namespace cudnn_frontend {
@@ -83,6 +85,26 @@ inline HMODULE
 load_cudart_so() {
     // Clear any existing error
     dlerror();
+
+    // Allow the user to override the libcudart selection via an environment variable.
+    // This is useful in environments (e.g. containers such as GKE with the TCPXO NCCL
+    // plugin) where multiple major versions of libcudart are present in the library
+    // search path. In such cases the automatic detection below would otherwise abort
+    // with a "Multiple libcudart libraries found" error. Setting
+    // CUDNN_FRONTEND_CUDART_LIB_NAME to the desired library name (or path), e.g.
+    // "libcudart.so.13", bypasses the detection and loads exactly that library.
+    if (const char *user_lib = std::getenv("CUDNN_FRONTEND_CUDART_LIB_NAME")) {
+        if (user_lib[0] != '\0') {
+            HMODULE handle    = dlopen(user_lib, RTLD_NOW);
+            const char *error = reinterpret_cast<const char *>(dlerror());
+            if (!handle || error) {
+                throw std::runtime_error(
+                    "Unable to load libcudart library specified by CUDNN_FRONTEND_CUDART_LIB_NAME (" +
+                    std::string(user_lib) + "): " + std::string(error ? error : "Unknown error"));
+            }
+            return handle;
+        }
+    }
 
     // List of potential libcudart libraries (Adding major version to support python package)
     constexpr const char *libs[] = {"libcudart.so.12", "libcudart.so.13"};


### PR DESCRIPTION
CUDNN_FRONTEND_CUDART_LIB_NAME

When dynamic loading is enabled, load_cudart_so() searches for the supported libcudart major versions and aborts with "Multiple libcudart libraries found" when more than one is visible on the library search path. This happens in containerized environments such as GKE, where the TCPXO NCCL plugin mounts a different libcudart major version from the host than the one shipped in the container.

Check the CUDNN_FRONTEND_CUDART_LIB_NAME environment variable first; when set to a library name or path, dlopen exactly that library and skip the automatic multi-version detection. Behavior is unchanged when the variable is unset.

Fixes #267