### PR TITLE
Remove 9.99 tag and fix the CI issues

### DIFF
--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -1086,7 +1086,7 @@ class Graph : public ICudnn, public INode {
                                        "Runtime workspace query with override shapes requires cuDNN v9.23.0"};
         NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(92300, cudnn_ver_error);
 
-#if (CUDNN_VERSION < 92300) || (CUDNN_VERSION >= 99900)
+#if (CUDNN_VERSION < 92300)
         return cudnn_ver_error;
 #endif
 

--- a/include/cudnn_frontend/node/moe_grouped_matmul_bwd.h
+++ b/include/cudnn_frontend/node/moe_grouped_matmul_bwd.h
@@ -91,7 +91,7 @@ class MoeGroupedMatmulBwdNode : public NodeCRTP<MoeGroupedMatmulBwdNode> {
         auto cudnn_ver_error =
             error_t{error_code_t::GRAPH_NOT_SUPPORTED, "Moe grouped matmul bwd requires cuDNN v9.22.0"};
 
-#if (CUDNN_VERSION >= 92200) && (CUDNN_VERSION < 99900)
+#if (CUDNN_VERSION >= 92200)
         NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(92200, cudnn_ver_error);
         CUDNN_FRONTEND_UNUSED(operations);
 

--- a/include/cudnn_frontend_shim.h
+++ b/include/cudnn_frontend_shim.h
@@ -607,7 +607,7 @@ get_execution_plan_workspace_size(cudnnHandle_t handle,
                                   cudnnBackendDescriptor_t executionPlan,
                                   cudnnBackendDescriptor_t variantPack,
                                   size_t *workspaceSizeInBytes) {
-#if CUDNN_VERSION >= 92300 && CUDNN_VERSION < 99900
+#if CUDNN_VERSION >= 92300
     NV_FE_CALL_TO_BACKEND(get_execution_plan_workspace_size,
                           cudnnGetExecutionPlanWorkspaceSize,
                           handle,

--- a/include/cudnn_frontend_utils.h
+++ b/include/cudnn_frontend_utils.h
@@ -1703,7 +1703,7 @@ convert_to_cudnn_type(cudnn_frontend::DescriptorType_t const mode, cudnnBackendD
             return cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE;
 #endif
         case DescriptorType_t::OPERATION_MOE_GROUPED_MATMUL_BWD_DESCRIPTOR:
-#if (CUDNN_VERSION >= 92200) && (CUDNN_VERSION < 99900)
+#if (CUDNN_VERSION >= 92200)
             NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(92200, cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE);
             cudnn_mode = CUDNN_BACKEND_OPERATION_MOE_GROUPED_MATMUL_BWD_DESCRIPTOR;
             return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
@@ -1711,7 +1711,7 @@ convert_to_cudnn_type(cudnn_frontend::DescriptorType_t const mode, cudnnBackendD
             return cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE;
 #endif
         case DescriptorType_t::OPERATION_TRANSPOSE_DESCRIPTOR:
-#if (CUDNN_VERSION >= 92200) && (CUDNN_VERSION < 99900)
+#if (CUDNN_VERSION >= 92200)
             NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(92200, cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE);
             cudnn_mode = CUDNN_BACKEND_OPERATION_TRANSPOSE_DESCRIPTOR;
             return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
@@ -1719,7 +1719,7 @@ convert_to_cudnn_type(cudnn_frontend::DescriptorType_t const mode, cudnnBackendD
             return cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE;
 #endif
         case DescriptorType_t::OPERATION_SLICE_DESCRIPTOR:
-#if (CUDNN_VERSION >= 92200) && (CUDNN_VERSION < 99900)
+#if (CUDNN_VERSION >= 92200)
             NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(92200, cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE);
             cudnn_mode = CUDNN_BACKEND_OPERATION_SLICE_DESCRIPTOR;
             return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
@@ -2172,12 +2172,12 @@ convert_from_cudnn_type(cudnnBackendDescriptorType_t const cudnn_mode) {
         case CUDNN_BACKEND_OPERATION_MOE_GROUPED_MATMUL_DESCRIPTOR:
             return DescriptorType_t::OPERATION_MOE_GROUPED_MATMUL_DESCRIPTOR;
 #endif
-#if (CUDNN_VERSION >= 92200) && (CUDNN_VERSION < 99900)
+#if (CUDNN_VERSION >= 92200)
         case CUDNN_BACKEND_OPERATION_MOE_GROUPED_MATMUL_BWD_DESCRIPTOR:
             return DescriptorType_t::OPERATION_MOE_GROUPED_MATMUL_BWD_DESCRIPTOR;
 #endif
 
-#if (CUDNN_VERSION >= 92200) && (CUDNN_VERSION < 99900)
+#if (CUDNN_VERSION >= 92200)
         case CUDNN_BACKEND_OPERATION_TRANSPOSE_DESCRIPTOR:
             return DescriptorType_t::OPERATION_TRANSPOSE_DESCRIPTOR;
         case CUDNN_BACKEND_OPERATION_SLICE_DESCRIPTOR:

--- a/samples/cpp/matmul/blackwell_nvfp4_mxfp8_block_scale_matmul.cpp
+++ b/samples/cpp/matmul/blackwell_nvfp4_mxfp8_block_scale_matmul.cpp
@@ -885,8 +885,7 @@ TEST_CASE("Blackwell Block Scale Matmul dynamic shape overrides", "[matmul][grap
                                                                                        {C_UID, C_gpu.devPtr}};
 
         int64_t workspace_size = 0;
-        if (cudnn_frontend::detail::get_backend_version() >= 92300 &&
-            cudnn_frontend::detail::get_backend_version() < 99900) {
+        if (cudnn_frontend::detail::get_backend_version() >= 92300) {
             REQUIRE(graph->get_workspace_size(handle, workspace_size, override_uids, override_shapes, override_strides)
                         .is_good());
         } else {

--- a/samples/cpp/matmul/matmuls.cpp
+++ b/samples/cpp/matmul/matmuls.cpp
@@ -697,8 +697,7 @@ TEST_CASE("Matmul dynamic shape overrides", "[matmul][graph][dynamic_shape]") {
             {A_UID, A_gpu.devPtr}, {B_UID, B_gpu.devPtr}, {C_UID, C_gpu.devPtr}};
 
         int64_t workspace_size = 0;
-        if (cudnn_frontend::detail::get_backend_version() >= 92300 &&
-            cudnn_frontend::detail::get_backend_version() < 99900) {
+        if (cudnn_frontend::detail::get_backend_version() >= 92300) {
             REQUIRE(graph->get_workspace_size(handle, workspace_size, override_uids, override_shapes, override_strides)
                         .is_good());
         } else {

--- a/samples/cpp/moe_grouped_matmul/moe_grouped_matmul.cpp
+++ b/samples/cpp/moe_grouped_matmul/moe_grouped_matmul.cpp
@@ -162,6 +162,10 @@ TEST_CASE("BF16 MoeGroupedMatmulBwd", "[MoeGroupedMatmulBwd][graph]") {
         SKIP("Not supported by cublasLt version");
     }
 
+    if (get_compute_capability() < 90 || get_compute_capability() >= 120) {
+        SKIP("Test requires SM90 - SM119 architectures");
+    }
+
     if (is_arch_supported_by_cudnn() == false) {
         SKIP("Architecture is not supported by current cudnn version");
     }

--- a/samples/cpp/moe_grouped_matmul/moe_grouped_matmul.cpp
+++ b/samples/cpp/moe_grouped_matmul/moe_grouped_matmul.cpp
@@ -154,7 +154,7 @@ TEST_CASE("WoQ MoeGroupedMatmul", "[MoeGroupedMatmul][graph]") {
 }
 
 TEST_CASE("BF16 MoeGroupedMatmulBwd", "[MoeGroupedMatmulBwd][graph]") {
-#if (CUDNN_VERSION < 92200) || (CUDNN_VERSION >= 99900)
+#if (CUDNN_VERSION < 92200)
     SKIP("MoE is not supported in cudnn versions prior to 9.22.0");
 #endif
 

--- a/samples/cpp/sdpa/fp16_dynamic_shapes.cpp
+++ b/samples/cpp/sdpa/fp16_dynamic_shapes.cpp
@@ -253,8 +253,7 @@ TEST_CASE("Toy sdpa forward with dynamic shapes", "[graph][sdpa][flash][forward]
                                                           {h_q * d_v, d_v, override_b * h_q * d_v, 1}};
 
     int64_t override_workspace_size = 0;
-    if (cudnn_frontend::detail::get_backend_version() >= 92300 &&
-        cudnn_frontend::detail::get_backend_version() < 99900) {
+    if (cudnn_frontend::detail::get_backend_version() >= 92300) {
         REQUIRE(graph
                     ->get_workspace_size_plan_at_index(
                         handle, 0, override_workspace_size, override_uids, override_shapes, override_strides)

--- a/test/python/test_block_scale_quantize_dynamic_shape.py
+++ b/test/python/test_block_scale_quantize_dynamic_shape.py
@@ -225,7 +225,7 @@ class TestBlockScaleQuantizeMatmulDynamicShape:
                 C_UID: C_gpu,
             }
 
-            if cudnn.backend_version() >= 92300 and cudnn.backend_version() < 99900:
+            if cudnn.backend_version() >= 92300:
                 workspace_size = graph.get_workspace_size_plan_at_index(0, cudnn_handle, override_uids, override_shapes, override_strides)
             else:
                 workspace_size = graph.get_workspace_size()

--- a/test/python/test_moe_grouped_matmul.py
+++ b/test/python/test_moe_grouped_matmul.py
@@ -22,6 +22,11 @@ def get_cublaslt_version() -> int:
     return 0
 
 
+def get_compute_capability() -> int:
+    major, minor = torch.cuda.get_device_capability()
+    return major * 10 + minor
+
+
 @pytest.mark.skipif(
     cudnn.backend_version() < 91800,
     reason="moe_grouped_matmul requires cuDNN >= 9.18.0",
@@ -150,6 +155,10 @@ def test_bf16_moe_grouped_matmul_fwd(cudnn_handle):
 @pytest.mark.skipif(
     get_cublaslt_version() < 130500,
     reason="moe_grouped_matmul_bwd requires cublasLt >= 13.5",
+)
+@pytest.mark.skipif(
+    get_compute_capability() < 90 or get_compute_capability() >= 120,
+    reason="moe_grouped_matmul_bwd requires SM90 - SM119 architectures",
 )
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)


### PR DESCRIPTION
Update:
  - Remove cudnn 9.99 version tags
  - Skip MoE bwd test for sm < 90 and sm >= 120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Extended cuDNN compatibility for versions 9.99.0+ across workspace queries, operation creation, and descriptor conversions.
  * Added GPU compute capability validation for MoE grouped matmul backward operations.

* **Tests**
  * Improved test robustness with stricter hardware and version-aware skip conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->