### PR TITLE
Limit graph heuristic config queries

### DIFF
--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -1995,7 +1995,7 @@ class Graph : public ICudnn, public INode {
     }
 
     error_t
-    create_execution_plans(std::vector<HeurMode_t> const &mode);
+    create_execution_plans(std::vector<HeurMode_t> const &mode, int64_t max_engine_configs = -1);
 
     error_t
     create_execution_plan(int64_t const engine_id, std::unordered_map<KnobType_t, int64_t> const &knobs);
@@ -2716,7 +2716,7 @@ Graph::get_knobs_for_engine(int64_t const engine, std::vector<Knob> &knobs) {
 }
 
 inline error_t
-Graph::create_execution_plans(std::vector<HeurMode_t> const &mode) {
+Graph::create_execution_plans(std::vector<HeurMode_t> const &mode, int64_t max_engine_configs) {
     CUDNN_FE_LOG_BANNER("  CREATE EXECUTION PLANS  (HEURISTICS QUERY)  ");
 
     // CHECK IF NEED TO OVERRIDE HEURISTICS QUERY
@@ -2768,7 +2768,12 @@ Graph::create_execution_plans(std::vector<HeurMode_t> const &mode) {
     if (!cudnn_modes.empty()) {
         EngineConfigList op_graph_to_configs;
         CHECK_CUDNN_FRONTEND_ERROR(detail::query_cudnn_heuristics_impl(
-            operation_graph, op_graph_to_configs, cudnn_modes, context.get_target_sm_count(), device_properties));
+            operation_graph,
+            op_graph_to_configs,
+            cudnn_modes,
+            context.get_target_sm_count(),
+            device_properties,
+            max_engine_configs));
 
         CUDNN_FE_LOG_LABEL_ENDL("INFO: Extracting engine configs.");
 
@@ -2874,7 +2879,8 @@ Graph::build(cudnnHandle_t const &handle,
 #endif
     CHECK_CUDNN_FRONTEND_ERROR(this->validate());
     CHECK_CUDNN_FRONTEND_ERROR(this->build_operation_graph(handle));
-    CHECK_CUDNN_FRONTEND_ERROR(this->create_execution_plans(modes));
+    CHECK_CUDNN_FRONTEND_ERROR(
+        this->create_execution_plans(modes, policy == BuildPlanPolicy_t::HEURISTICS_CHOICE ? 1 : -1));
     CHECK_CUDNN_FRONTEND_ERROR(this->check_support());
     CHECK_CUDNN_FRONTEND_ERROR(this->build_plans(policy, do_multithreaded_builds));
     CUDNN_FE_LOG_BANNER("  BUILD ALL OK (with handle) ");
@@ -2890,7 +2896,8 @@ Graph::build(std::vector<HeurMode_t> const &modes, BuildPlanPolicy_t const polic
 #endif
     CHECK_CUDNN_FRONTEND_ERROR(this->validate());
     CHECK_CUDNN_FRONTEND_ERROR(this->build_operation_graph());
-    CHECK_CUDNN_FRONTEND_ERROR(this->create_execution_plans(modes));
+    CHECK_CUDNN_FRONTEND_ERROR(
+        this->create_execution_plans(modes, policy == BuildPlanPolicy_t::HEURISTICS_CHOICE ? 1 : -1));
     CHECK_CUDNN_FRONTEND_ERROR(this->check_support());
     CHECK_CUDNN_FRONTEND_ERROR(this->build_plans(policy, do_multithreaded_builds));
     CUDNN_FE_LOG_BANNER("  BUILD PLANS ALL OK (no handle) ");

--- a/include/cudnn_frontend/plans.h
+++ b/include/cudnn_frontend/plans.h
@@ -130,7 +130,8 @@ query_cudnn_heuristics_impl(std::shared_ptr<OperationGraph_v8> const& operation_
                             cudnn_frontend::EngineConfigList& configs,
                             std::vector<HeurMode_t> const& modes,
                             int32_t sm_count,
-                            std::shared_ptr<const DeviceProperties> device_properties = nullptr) {
+                            std::shared_ptr<const DeviceProperties> device_properties = nullptr,
+                            int64_t max_engine_configs                                = -1) {
     RETURN_CUDNN_FRONTEND_ERROR_IF(
         operation_graph == nullptr,
         error_code_t::HEURISTIC_QUERY_FAILED,
@@ -144,13 +145,13 @@ query_cudnn_heuristics_impl(std::shared_ptr<OperationGraph_v8> const& operation_
     // disable exception macro is defined. Calling build will not throw.
     // Check status of desc and return error.
     statuses = cudnn_frontend::get_heuristics_list(
-        modes, *operation_graph, allowAllConfig, configs, true, sm_count, device_properties);
+        modes, *operation_graph, allowAllConfig, configs, true, sm_count, device_properties, max_engine_configs);
 #else
     // build() can throw
     // wrap in try catch
     try {
         statuses = cudnn_frontend::get_heuristics_list(
-            modes, *operation_graph, allowAllConfig, configs, true, sm_count, device_properties);
+            modes, *operation_graph, allowAllConfig, configs, true, sm_count, device_properties, max_engine_configs);
     } catch (cudnn_frontend::cudnnException& e) {
         // Silly MSVC error that thinks below condition is constexpr
         // RETURN_CUDNN_FRONTEND_ERROR_IF(

--- a/include/cudnn_frontend_Heuristics.h
+++ b/include/cudnn_frontend_Heuristics.h
@@ -362,7 +362,8 @@ get_heuristics_list_impl(cudnnBackendHeurMode_t heur_mode,
                          std::function<bool(cudnnBackendDescriptor_t)> filter_fn,
                          int32_t sm_count,
                          EngineConfigList &filtered_configs,
-                         std::shared_ptr<const DeviceProperties> device_properties = nullptr) {
+                         std::shared_ptr<const DeviceProperties> device_properties = nullptr,
+                         int64_t max_engine_configs                              = -1) {
     auto heuristics = EngineHeuristicsBuilder_v8()
                           .setDeviceProperties(device_properties)
                           .setOperationGraph(opGraph)
@@ -370,9 +371,16 @@ get_heuristics_list_impl(cudnnBackendHeurMode_t heur_mode,
                           .setSMCount(sm_count)
                           .build();
     NV_CUDNN_RETURN_IF_ERROR(heuristics);
-    auto num_config = heuristics.getEngineConfigCount();
-    NV_CUDNN_RETURN_IF_ERROR(heuristics);
-    CUDNN_FE_LOG_LABEL_ENDL("Heuristic query for mode " << heur_mode << " has " << num_config << " configurations.");
+    int64_t num_config = max_engine_configs;
+    if (num_config <= 0) {
+        num_config = heuristics.getEngineConfigCount();
+        NV_CUDNN_RETURN_IF_ERROR(heuristics);
+        CUDNN_FE_LOG_LABEL_ENDL("Heuristic query for mode " << heur_mode << " has " << num_config
+                                                            << " configurations.");
+    } else {
+        CUDNN_FE_LOG_LABEL_ENDL("Heuristic query for mode " << heur_mode << " requesting up to " << num_config
+                                                            << " configurations.");
+    }
     auto &engine_config = heuristics.getEngineConfig(num_config);
     NV_CUDNN_RETURN_IF_ERROR(heuristics);
     CUDNN_FE_LOG_LABEL_ENDL("Backend heuristics recommendation count: " << engine_config.size());
@@ -387,7 +395,8 @@ get_heuristics_list(std::vector<std::string> const &modes,
                     EngineConfigList &filtered_configs,
                     bool evaluate_all                                         = false,
                     int32_t sm_count                                          = -1,
-                    std::shared_ptr<const DeviceProperties> device_properties = nullptr) {
+                    std::shared_ptr<const DeviceProperties> device_properties = nullptr,
+                    int64_t max_engine_configs                                = -1) {
     std::vector<cudnnStatus_t> statuses;
 
     // Try building the heuristics for each mode
@@ -397,30 +406,41 @@ get_heuristics_list(std::vector<std::string> const &modes,
             mode.find("heuristics_mode_a") != std::string::npos) {
             auto heur_mode = CUDNN_HEUR_MODE_A;
             NV_CUDNN_FE_TRY();
-            auto status_l =
-                get_heuristics_list_impl(heur_mode, opGraph, filter_fn, sm_count, filtered_configs, device_properties);
+            auto status_l = get_heuristics_list_impl(
+                heur_mode, opGraph, filter_fn, sm_count, filtered_configs, device_properties, max_engine_configs);
             NV_CUDNN_SET_STATUS_BREAK_OR_CONTINUE(status_l, true);
             NV_CUDNN_FE_CATCH(NV_CUDNN_SET_STATUS_BREAK_OR_CONTINUE(e.getCudnnStatus(), true));
 
         } else if (mode.find("heuristics_fallback") != std::string::npos) {
             NV_CUDNN_FE_TRY();
             auto status_l = get_heuristics_list_impl(
-                CUDNN_HEUR_MODE_FALLBACK, opGraph, filter_fn, sm_count, filtered_configs, device_properties);
+                CUDNN_HEUR_MODE_FALLBACK,
+                opGraph,
+                filter_fn,
+                sm_count,
+                filtered_configs,
+                device_properties,
+                max_engine_configs);
             NV_CUDNN_SET_STATUS_BREAK_OR_CONTINUE(status_l, true);
             NV_CUDNN_FE_CATCH(NV_CUDNN_SET_STATUS_BREAK_OR_CONTINUE(e.getCudnnStatus(), true));
         } else if (mode.find("heuristics_mode_b") != std::string::npos) {
             auto heur_mode = CUDNN_HEUR_MODE_B;
             NV_CUDNN_FE_TRY();
-            auto status_l =
-                get_heuristics_list_impl(heur_mode, opGraph, filter_fn, sm_count, filtered_configs, device_properties);
+            auto status_l = get_heuristics_list_impl(
+                heur_mode, opGraph, filter_fn, sm_count, filtered_configs, device_properties, max_engine_configs);
 
             // Between cudnn version 8.3 and 8.6, when heur_mode_b heuristics did not succeed,
             // there was no fallback to the instant mode. We are here manually adding instant mode
             // to the heur_mode_b to alleviate this issue.
 #if (CUDNN_VERSION >= 8300) && (CUDNN_VERSION < 8600)
             if (status_l != CUDNN_STATUS_SUCCESS) {
-                status_l = get_heuristics_list_impl(
-                    CUDNN_HEUR_MODE_INSTANT, opGraph, filter_fn, sm_count, filtered_configs, device_properties);
+                status_l = get_heuristics_list_impl(CUDNN_HEUR_MODE_INSTANT,
+                                                     opGraph,
+                                                     filter_fn,
+                                                     sm_count,
+                                                     filtered_configs,
+                                                     device_properties,
+                                                     max_engine_configs);
             }
 #endif
             NV_CUDNN_SET_STATUS_BREAK_OR_CONTINUE(status_l, true);
@@ -429,8 +449,8 @@ get_heuristics_list(std::vector<std::string> const &modes,
         }
         catch (cudnn_frontend::cudnnException &) {
             NV_CUDNN_FE_TRY();
-            auto status_ =
-                get_heuristics_list_impl(heur_mode, opGraph, filter_fn, sm_count, filtered_configs, device_properties);
+            auto status_ = get_heuristics_list_impl(
+                heur_mode, opGraph, filter_fn, sm_count, filtered_configs, device_properties, max_engine_configs);
             statuses.push_back(status_);
             NV_CUDNN_FE_CATCH(NV_CUDNN_SET_STATUS_BREAK_OR_CONTINUE(e.getCudnnStatus(), true));
         }
@@ -450,7 +470,8 @@ get_heuristics_list(std::vector<cudnn_frontend::HeurMode_t> const &modes,
                     EngineConfigList &filtered_configs,
                     bool evaluate_all                                         = false,
                     int32_t sm_count                                          = -1,
-                    std::shared_ptr<const DeviceProperties> device_properties = nullptr) {
+                    std::shared_ptr<const DeviceProperties> device_properties = nullptr,
+                    int64_t max_engine_configs                                = -1) {
     std::unordered_map<HeurMode_t, std::string> mode_to_string = {
         {HeurMode_t::A, "heuristics_mode_a"},
         {HeurMode_t::B, "heuristics_mode_b"},
@@ -462,8 +483,14 @@ get_heuristics_list(std::vector<cudnn_frontend::HeurMode_t> const &modes,
         return mode_to_string.at(mode);
     });
 
-    return get_heuristics_list(
-        string_modes, opGraph, filter_fn, filtered_configs, evaluate_all, sm_count, device_properties);
+    return get_heuristics_list(string_modes,
+                               opGraph,
+                               filter_fn,
+                               filtered_configs,
+                               evaluate_all,
+                               sm_count,
+                               device_properties,
+                               max_engine_configs);
 }
 
 template <std::size_t SIZE>

--- a/python/cudnn/wrapper.py
+++ b/python/cudnn/wrapper.py
@@ -291,7 +291,7 @@ class Graph:
         # prepare the graph and build plans: Each should return None or raise exception
         self.__graph.validate()
         self.__graph.build_operation_graph()
-        self.__graph.create_execution_plans(self.__heuristics)
+        self.__graph.create_execution_plans(self.__heuristics, max_engine_configs=1)
         # TODO: let user select_behavior_notes() and select_numeric_notes() here
         self.__graph.check_support()
         self.__graph.build_plans()

--- a/python/pygraph/pygraph.cpp
+++ b/python/pygraph/pygraph.cpp
@@ -477,8 +477,9 @@ PyGraph::get_behavior_notes_for_plan_at_index(int64_t const index) {
 }
 
 void
-PyGraph::create_execution_plans(std::vector<cudnn_frontend::HeurMode_t> const& modes) {
-    auto status = graph->create_execution_plans(modes);
+PyGraph::create_execution_plans(std::vector<cudnn_frontend::HeurMode_t> const& modes,
+                                int64_t const max_engine_configs) {
+    auto status = graph->create_execution_plans(modes, max_engine_configs);
     throw_if(status.is_bad(), status.get_code(), status.get_message());
 }
 
@@ -521,7 +522,8 @@ void
 PyGraph::build(std::vector<cudnn_frontend::HeurMode_t> const& modes) {
     validate();
     build_operation_graph();
-    create_execution_plans(modes);
+    auto status = graph->create_execution_plans(modes, 1);
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
     check_support();
     build_plans(cudnn_frontend::BuildPlanPolicy_t::HEURISTICS_CHOICE);
 }
@@ -1253,7 +1255,10 @@ init_pygraph_submodule(py::module_& m) {
         .def("validate", &PyGraph::validate)
         .def("key", &PyGraph::key)
         .def("build_operation_graph", &PyGraph::build_operation_graph)
-        .def("create_execution_plans", &PyGraph::create_execution_plans)
+        .def("create_execution_plans",
+             &PyGraph::create_execution_plans,
+             py::arg("modes"),
+             py::arg("max_engine_configs") = -1)
         .def("create_execution_plan",
              &PyGraph::create_execution_plan,
              R"pbdoc(

--- a/python/pygraph/pygraph.h
+++ b/python/pygraph/pygraph.h
@@ -643,7 +643,7 @@ class PyGraph {
     build_operation_graph();
 
     void
-    create_execution_plans(std::vector<cudnn_frontend::HeurMode_t> const&);
+    create_execution_plans(std::vector<cudnn_frontend::HeurMode_t> const&, int64_t const max_engine_configs = -1);
 
     void
     create_execution_plan(int64_t const engine_id, std::unordered_map<KnobType_t, int64_t> const& knobs);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to limit the number of engine configurations evaluated during graph execution plan creation. Users can specify a maximum via the new `max_engine_configs` parameter (default unlimited).
  * Graph optimization with heuristics-based policies now defaults to evaluating a single engine configuration for faster compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->