### PR TITLE
Skip flexible-graph SDPA bwd sample on SM120 and above

### DIFF
--- a/samples/cpp/sdpa/fp16_bwd_with_flexible_graphs.cpp
+++ b/samples/cpp/sdpa/fp16_bwd_with_flexible_graphs.cpp
@@ -161,8 +161,8 @@ TEST_CASE("Toy sdpa backward with flexible graph", "[graph][sdpa][flash][backwar
         return;
     }
 
-    if (get_compute_capability() == 120) {
-        SKIP("Backward pass with flexible graphs is not supported on SM version 120 yet");
+    if (get_compute_capability() >= 120) {
+        SKIP("Backward pass with flexible graphs is not supported on SM version 120 and above yet");
         return;
     }
 


### PR DESCRIPTION
## What

`samples/cpp/sdpa/fp16_bwd_with_flexible_graphs.cpp` skips the test on
SM 120 (consumer Blackwell), where the backward-with-flexible-graphs
path is not supported. The guard used an exact equality check:

```cpp
if (get_compute_capability() == 120) {
```

This missed **SM 121 (GB10 / DGX Spark)** and any later consumer
Blackwell arch, so the sample still ran — and failed — there.

## Change

Use `>= 120` so the sample is skipped on SM 120 and above:

```cpp
if (get_compute_capability() >= 120) {
```

## Context

Related to NVBug 5626162. FP8/flexible-graph SDPA bprop is correctly
`NOT_SUPPORTED` on consumer SM12x (not a regression); this is the one
residual sample guard that still used `== 120`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)