### PR TITLE
Skip TensorIR MemBound / compile-time-const samples on consumer Blackwell (SM12x)

### DIFF
--- a/samples/cpp/membound/boolean_fusion.cpp
+++ b/samples/cpp/membound/boolean_fusion.cpp
@@ -39,8 +39,8 @@ TEST_CASE("Boolean CMP_GT and LOGICAL_AND fusion", "[membound][boolean][pointwis
     if (cudnn_frontend::detail::get_backend_version() < 92200) {
         SKIP("Boolean fusion sample requires cuDNN backend 9.22.0 or newer at runtime.");
     }
-    if (!is_blackwell_arch()) {
-        SKIP("Boolean fusion requires Blackwell (SM100+) architecture.");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("Boolean fusion (TensorIR MemBound engine) is only supported on SM100-SM109 (data center Blackwell)");
     }
 
     constexpr int64_t d0 = 4, d1 = 8, d2 = 16;

--- a/samples/cpp/membound/concat.cpp
+++ b/samples/cpp/membound/concat.cpp
@@ -37,8 +37,8 @@ TEST_CASE("Membound concatenate on channel axis (no in-place index)", "[membound
     return;
 #endif
 
-    if (!check_device_arch_newer_than("blackwell")) {
-        SKIP("TEST requires device blackwell or newer");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("TensorIR MemBound engine is only supported on SM100-SM109 (data center Blackwell)");
     }
 
 #if (CUDNN_VERSION < 92200)

--- a/samples/cpp/membound/membound_fusion.cpp
+++ b/samples/cpp/membound/membound_fusion.cpp
@@ -33,8 +33,8 @@ TEST_CASE("Fusion reshape then ReLU", "[membound][fusion][reshape][graph]") {
     return;
 #endif
 
-    if (!check_device_arch_newer_than("blackwell")) {
-        SKIP("TEST requires device blackwell or newer");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("TensorIR MemBound engine is only supported on SM100-SM109 (data center Blackwell)");
     }
 
 #if (CUDNN_VERSION < 92200)
@@ -86,8 +86,8 @@ TEST_CASE("Fusion transpose then add bias tensor", "[membound][fusion][transpose
     return;
 #endif
 
-    if (!check_device_arch_newer_than("blackwell")) {
-        SKIP("TEST requires device blackwell or newer");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("TensorIR MemBound engine is only supported on SM100-SM109 (data center Blackwell)");
     }
 
 #if (CUDNN_VERSION < 92200)

--- a/samples/cpp/membound/reshape.cpp
+++ b/samples/cpp/membound/reshape.cpp
@@ -38,8 +38,8 @@ TEST_CASE("Membound reshape (3,4,5) to (6,10) lexicographic / LOGICAL mode",
     return;
 #endif
 
-    if (!check_device_arch_newer_than("blackwell")) {
-        SKIP("TEST requires device blackwell or newer");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("TensorIR MemBound engine is only supported on SM100-SM109 (data center Blackwell)");
     }
 
 #if (CUDNN_VERSION < 92200)

--- a/samples/cpp/membound/slice.cpp
+++ b/samples/cpp/membound/slice.cpp
@@ -33,8 +33,8 @@ TEST_CASE("Membound slice window with step", "[membound][slice][graph]") {
     return;
 #endif
 
-    if (!check_device_arch_newer_than("blackwell")) {
-        SKIP("TEST requires device blackwell or newer");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("TensorIR MemBound engine is only supported on SM100-SM109 (data center Blackwell)");
     }
 
 #if (CUDNN_VERSION < 92200)

--- a/samples/cpp/membound/transpose.cpp
+++ b/samples/cpp/membound/transpose.cpp
@@ -33,8 +33,8 @@ TEST_CASE("Membound transpose permutes dims", "[membound][transpose][graph]") {
     return;
 #endif
 
-    if (!check_device_arch_newer_than("blackwell")) {
-        SKIP("TEST requires device blackwell or newer");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("TensorIR MemBound engine is only supported on SM100-SM109 (data center Blackwell)");
     }
 
 #if (CUDNN_VERSION < 92200)

--- a/samples/cpp/misc/compile_time_constant_example.cpp
+++ b/samples/cpp/misc/compile_time_constant_example.cpp
@@ -34,8 +34,8 @@ TEST_CASE("Compile-time constant scalar multiply and add", "[compile_time_const]
     return;
 #endif
 
-    if (!check_device_arch_newer_than("blackwell")) {
-        SKIP("TEST requires device blackwell or newer");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("Compile-time constant scalar graph (TensorIR) is only supported on SM100-SM109 (data center Blackwell)");
     }
 
 #if (CUDNN_VERSION < 92200)

--- a/samples/python/70_boolean_cmp_logic.ipynb
+++ b/samples/python/70_boolean_cmp_logic.ipynb
@@ -21,7 +21,7 @@
       "source": [
         "## Prerequisites and Setup\n",
         "\n",
-        "This notebook requires an NVIDIA Blackwell GPU (SM100+) or later.\n",
+        "This notebook requires an NVIDIA **data center Blackwell** GPU (SM100-SM109). The TensorIR mem-bound engine that runs this boolean fusion does not support consumer Blackwell (SM120) or newer, so the cuDNN cells below are skipped on those devices.\n",
         "\n",
         "**Environment setup:**\n",
         "\n",
@@ -137,6 +137,16 @@
         "has_cuda = torch.cuda.is_available()\n",
         "device = torch.device(\"cuda\" if has_cuda else \"cpu\")\n",
         "\n",
+        "# The boolean (CMP_GT + LOGICAL_AND) fusion runs on the TensorIR mem-bound engine,\n",
+        "# which currently supports only data center Blackwell (SM100-SM109). On other\n",
+        "# architectures (e.g. SM120 consumer Blackwell) no supported engine exists, so the\n",
+        "# cuDNN cells below are skipped instead of silently producing wrong results.\n",
+        "_major, _minor = torch.cuda.get_device_capability() if has_cuda else (0, 0)\n",
+        "_sm = _major * 10 + _minor  # compute capability; matches C++ is_blackwell_computing_arch()\n",
+        "is_supported_arch = has_cuda and (100 <= _sm < 110)\n",
+        "if has_cuda and not is_supported_arch:\n",
+        "    print(f\"Skipping cuDNN boolean fusion: requires SM100-SM109 (data center Blackwell), got SM{_sm}\")\n",
+        "\n",
         "torch.manual_seed(42)\n",
         "\n",
         "x_gpu = torch.randn(*shape, dtype=torch.float16, device=device).contiguous()\n",
@@ -186,7 +196,7 @@
         }
       ],
       "source": [
-        "if has_cuda:\n",
+        "if is_supported_arch:\n",
         "    handle = cudnn.create_handle()\n",
         "\n",
         "    graph = cudnn.pygraph(\n",
@@ -234,7 +244,7 @@
         "    print(f\"after_and_gpu: {after_and_gpu.shape}, dtype={after_and_gpu.dtype}\")\n",
         "    print(f\"True count:    {after_and_gpu.sum().item()} / {after_and_gpu.numel()}\")\n",
         "else:\n",
-        "    print(\"Skipping cuDNN graph (no CUDA device).\")"
+        "    print(\"Skipping cuDNN graph (needs SM100-SM109, or no CUDA device).\")"
       ]
     },
     {
@@ -267,7 +277,7 @@
         }
       ],
       "source": [
-        "if has_cuda:\n",
+        "if is_supported_arch:\n",
         "    after_and_ref = (x_gpu.float() > threshold_gpu) & b_gpu\n",
         "    mismatches = (after_and_gpu != after_and_ref).sum().item()\n",
         "    total = after_and_ref.numel()\n",
@@ -277,7 +287,7 @@
         "    assert mismatches == 0, f\"FAILED: {mismatches} mismatches out of {total} elements\"\n",
         "    print(\"PASSED: cuDNN boolean fusion matches reference.\")\n",
         "else:\n",
-        "    print(\"Skipping verification (no CUDA device).\")"
+        "    print(\"Skipping verification (needs SM100-SM109, or no CUDA device).\")"
       ]
     },
     {
@@ -330,7 +340,7 @@
         }
       ],
       "source": [
-        "if has_cuda:\n",
+        "if is_supported_arch:\n",
         "    test_configs = [\n",
         "        {\"dim\": [8, 32],             \"x_dtype\": torch.float16},\n",
         "        {\"dim\": [4, 8, 16],          \"x_dtype\": torch.float16},\n",
@@ -391,7 +401,7 @@
         "\n",
         "    print(f\"\\nAll tests passed!\" if all_pass else \"\\nSome tests failed.\")\n",
         "else:\n",
-        "    print(\"Skipping multi-config tests (no CUDA device).\")"
+        "    print(\"Skipping multi-config tests (needs SM100-SM109, or no CUDA device).\")"
       ]
     },
     {
@@ -407,7 +417,7 @@
       },
       "outputs": [],
       "source": [
-        "if has_cuda:\n",
+        "if is_supported_arch:\n",
         "    cudnn.destroy_handle(handle)"
       ]
     }


### PR DESCRIPTION
## What

On consumer Blackwell (SM120 / RTX 50-series, and SM121 / GB10), 8 C++
sample test cases **FAIL** (not skip) with `No valid engine configs
returned from heuristics`:

| File | Test case(s) |
|---|---|
| `membound/transpose.cpp` | Membound transpose permutes dims |
| `membound/reshape.cpp` | Membound reshape … LOGICAL mode |
| `membound/slice.cpp` | Membound slice window with step |
| `membound/concat.cpp` | Membound concatenate on channel axis |
| `membound/membound_fusion.cpp` | Fusion reshape then ReLU / Fusion transpose then add bias |
| `membound/boolean_fusion.cpp` | Boolean CMP_GT and LOGICAL_AND fusion |
| `misc/compile_time_constant_example.cpp` | Compile-time constant scalar multiply and add |

## Root cause

These samples gate on `check_device_arch_newer_than("blackwell")` /
`is_blackwell_arch()`, both of which are **true for cc ≥ 100** — so SM120
consumer Blackwell falls through. But the TensorIR MemBound engine
(`cudnnTensorIrMemBoundEngine`) only supports **SM100–SM109** (data center
Blackwell): its arch gate is `[SM_100, SM_110)` and the DKG cubins it emits
are the `sm_100f` family-portable target, which the CUDA driver will not
load on `sm_120`. No engine serves the graph (the kernelgen runtime-fusion
fallback only targets SM70/80/90), so `create_execution_plans()` returns no
configs and the `REQUIRE` fails.

## Change

Narrow the guard to the existing `is_blackwell_computing_arch()` helper
(`100 ≤ cc < 110`), matching the backend engine's actual support range:

```cpp
-    if (!check_device_arch_newer_than("blackwell")) {
-        SKIP("TEST requires device blackwell or newer");
+    if (!is_blackwell_computing_arch()) {
+        SKIP("TensorIR MemBound engine is only supported on SM100-SM109 (data center Blackwell)");
```

Behavior change: SM100–109 unchanged (still run), Hopper/Ampere unchanged
(still skip); only SM120+ goes from **fail → clean skip**.

## Verification

Built and re-ran on RTX 5080 (`sm_120`, cuDNN 9.30): all 8 cases now SKIP
cleanly. 7 files / 16 lines, clang-formatted.

This is the same class of fix as #283 (flexible-graph SDPA backward skipped
on SM120+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized GPU gating across samples and a notebook to require supported data‑center Blackwell hardware (SM100–SM109) and updated skip/notification text. This ensures MemBound, cuDNN, and related examples only run on compatible GPUs, preventing unsupported executions and reducing misleading test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->