### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v21.1.6
+    hooks:
+    -   id: clang-format
+        types_or: [c++, c, cuda]
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.1.0
+    hooks:
+    -   id: black
+        name: black
+        description: "Black: The uncompromising Python code formatter"
+        entry: black
+        language: python
+        minimum_pre_commit_version: 2.9.2
+        require_serial: true
+        types_or: [python, pyi]
+        args: ["--line-length", "160"]
+    -   id: black-jupyter
+        name: black-jupyter
+        description:
+            "Black: The uncompromising Python code formatter (with Jupyter Notebook support)"
+        entry: black
+        language: python
+        minimum_pre_commit_version: 2.9.2
+        require_serial: true
+        types_or: [python, pyi, jupyter]
+        additional_dependencies: [".[jupyter]"]
+        args: ["--line-length", "160"]

--- a/include/cudnn_frontend/node/reduction.h
+++ b/include/cudnn_frontend/node/reduction.h
@@ -153,10 +153,9 @@ class ReductionNode : public NodeCRTP<ReductionNode> {
         // 5. Set the optional group offset tensor descriptor
         if (Group_offset != attributes.inputs.end() && Group_offset->second != nullptr) {
 #if (CUDNN_VERSION >= 92400)
-            RETURN_CUDNN_FRONTEND_ERROR_IF(
-                detail::get_backend_version() < 92400,
-                error_code_t::GRAPH_NOT_SUPPORTED,
-                "Reduction group_offset is not supported in cudnn version < 9.24.0");
+            RETURN_CUDNN_FRONTEND_ERROR_IF(detail::get_backend_version() < 92400,
+                                           error_code_t::GRAPH_NOT_SUPPORTED,
+                                           "Reduction group_offset is not supported in cudnn version < 9.24.0");
             auto group_offset_backend_desc = tensors.at(Group_offset->second->get_uid())->get_raw_desc();
 
             _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(reduction_operation.get_raw_desc(),

--- a/include/cudnn_frontend/node/reduction.h
+++ b/include/cudnn_frontend/node/reduction.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 #include "../graph_helpers.h"

--- a/include/cudnn_frontend/node/reduction.h
+++ b/include/cudnn_frontend/node/reduction.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "../graph_helpers.h"

--- a/test/python/test_matmul_bias_relu.py
+++ b/test/python/test_matmul_bias_relu.py
@@ -206,9 +206,7 @@ def test_matmul_bias(param_extract, cudnn_handle):
     X_gpu = torch.randn(b, s, e, requires_grad=False, device="cuda", dtype=input_type)
     W_gpu = torch.randn(1, e, e * 4, requires_grad=False, device="cuda", dtype=input_type)
     B_gpu = torch.randn(1, 1, e * 4, requires_grad=False, device="cuda", dtype=input_type)
-    Y_expected = torch.nn.functional.linear(
-        X_gpu.float(), W_gpu.squeeze().float().T, bias=B_gpu.squeeze().float()
-    ).to(input_type)
+    Y_expected = torch.nn.functional.linear(X_gpu.float(), W_gpu.squeeze().float().T, bias=B_gpu.squeeze().float()).to(input_type)
 
     stream = torch.cuda.current_stream().cuda_stream
     cudnn.set_stream(handle=cudnn_handle, stream=stream)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added pre-commit hooks to enforce consistent code formatting across C/C++, CUDA, Python, and Jupyter notebooks, standardizing line length to 160.

* **Style**
  * Reflowed an internal error-checking condition to improve readability with no behavior change.

* **Tests**
  * Simplified test expression formatting without changing test logic or outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->