### PR TITLE
experimental: grouped gemm AOT

### DIFF
--- a/python/cudnn/_cutedsl_aot.py
+++ b/python/cudnn/_cutedsl_aot.py
@@ -1,0 +1,355 @@
+import dataclasses
+import hashlib
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+from typing import Any, Callable, Dict, Optional, Tuple
+
+
+_DIGEST_LENGTH = 16
+_SYMBOL_RE = re.compile(r"[^0-9A-Za-z_]")
+_REGISTRY_RE = re.compile(r"[^0-9A-Za-z_.]")
+
+
+@dataclasses.dataclass(frozen=True)
+class AOTIdentity:
+    kernel_name: str
+    payload: Dict[str, Any]
+    digest: str
+
+
+@dataclasses.dataclass(frozen=True)
+class AOTArtifactPaths:
+    object_file: Path
+    shared_library: Path
+    metadata_file: Path
+
+
+@dataclasses.dataclass(frozen=True)
+class AOTMetadata:
+    identity: AOTIdentity
+    symbol: str
+    registry_name: Optional[str]
+    object_file: str
+    shared_library: str
+    metadata_file: str
+
+
+@dataclasses.dataclass(frozen=True)
+class AOTExportedArtifact:
+    metadata: AOTMetadata
+    paths: AOTArtifactPaths
+
+
+@dataclasses.dataclass(frozen=True)
+class AOTLoadedArtifact:
+    metadata: AOTMetadata
+    paths: AOTArtifactPaths
+    module: Any
+    function: Callable[..., Any]
+
+
+def _canonicalize(value: Any) -> Any:
+    if dataclasses.is_dataclass(value):
+        return _canonicalize(dataclasses.asdict(value))
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _canonicalize(value[key]) for key in sorted(value)}
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize(item) for item in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(_canonicalize(value), sort_keys=True, separators=(",", ":"))
+
+
+def _package_versions() -> Dict[str, Optional[str]]:
+    versions = {}
+    for package in ("nvidia-cudnn-frontend", "nvidia-cutlass-dsl", "apache-tvm-ffi", "tvm-ffi"):
+        try:
+            versions[package] = importlib.metadata.version(package)
+        except importlib.metadata.PackageNotFoundError:
+            versions[package] = None
+    return versions
+
+
+def build_aot_identity(
+    *,
+    kernel_name: str,
+    cache_key: Any,
+    compile_options: str,
+    compute_capability: Any,
+) -> AOTIdentity:
+    payload = {
+        "kernel_name": kernel_name,
+        "cache_key": _canonicalize(cache_key),
+        "compile_options": compile_options,
+        "compute_capability": str(compute_capability),
+        "package_versions": _package_versions(),
+    }
+    digest = hashlib.sha256(_stable_json(payload).encode("utf-8")).hexdigest()[:_DIGEST_LENGTH]
+    return AOTIdentity(kernel_name=kernel_name, payload=payload, digest=digest)
+
+
+def build_symbol_name(prefix: str, identity: AOTIdentity) -> str:
+    safe_prefix = _SYMBOL_RE.sub("_", prefix).strip("_")
+    if not safe_prefix:
+        safe_prefix = "cudnnfe_cutedslaot"
+    if safe_prefix[0].isdigit():
+        safe_prefix = f"_{safe_prefix}"
+    return f"{safe_prefix}_{identity.digest}"
+
+
+def build_registry_name(prefix: str, identity: AOTIdentity) -> str:
+    safe_prefix = _REGISTRY_RE.sub(".", prefix).strip(".")
+    if not safe_prefix:
+        safe_prefix = "cudnnfe.cutedsl_aot"
+    return f"{safe_prefix}.{identity.digest}"
+
+
+def artifact_paths(artifact_dir: os.PathLike[str] | str, symbol: str) -> AOTArtifactPaths:
+    base_dir = Path(artifact_dir)
+    base_name = _SYMBOL_RE.sub("_", symbol).strip("_")
+    if not base_name:
+        base_name = "cudnnfe_cutedslaot"
+    return AOTArtifactPaths(
+        object_file=base_dir / f"{base_name}.o",
+        shared_library=base_dir / f"{base_name}.so",
+        metadata_file=base_dir / f"{base_name}.json",
+    )
+
+
+def _identity_from_dict(value: Dict[str, Any]) -> AOTIdentity:
+    return AOTIdentity(
+        kernel_name=value["kernel_name"],
+        payload=value["payload"],
+        digest=value["digest"],
+    )
+
+
+def _metadata_to_dict(metadata: AOTMetadata) -> Dict[str, Any]:
+    return {
+        "identity": dataclasses.asdict(metadata.identity),
+        "symbol": metadata.symbol,
+        "registry_name": metadata.registry_name,
+        "object_file": metadata.object_file,
+        "shared_library": metadata.shared_library,
+        "metadata_file": metadata.metadata_file,
+    }
+
+
+def _metadata_from_dict(value: Dict[str, Any]) -> AOTMetadata:
+    return AOTMetadata(
+        identity=_identity_from_dict(value["identity"]),
+        symbol=value["symbol"],
+        registry_name=value.get("registry_name"),
+        object_file=value["object_file"],
+        shared_library=value["shared_library"],
+        metadata_file=value["metadata_file"],
+    )
+
+
+def write_metadata_atomic(metadata: AOTMetadata, path: os.PathLike[str] | str) -> None:
+    metadata_path = Path(path)
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = metadata_path.with_name(f".{metadata_path.name}.{os.getpid()}.tmp")
+    tmp_path.write_text(
+        json.dumps(_metadata_to_dict(metadata), sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(tmp_path, metadata_path)
+
+
+def read_metadata(path: os.PathLike[str] | str) -> AOTMetadata:
+    return _metadata_from_dict(json.loads(Path(path).read_text(encoding="utf-8")))
+
+
+def _artifact_paths_from_metadata(metadata: AOTMetadata, metadata_path: os.PathLike[str] | str) -> AOTArtifactPaths:
+    base_dir = Path(metadata_path).parent
+    return AOTArtifactPaths(
+        object_file=base_dir / metadata.object_file,
+        shared_library=base_dir / metadata.shared_library,
+        metadata_file=base_dir / metadata.metadata_file,
+    )
+
+
+def _runtime_libraries() -> Tuple[str, ...]:
+    import cutlass.cute as cute
+
+    finder = getattr(cute.runtime, "find_runtime_libraries", None)
+    if finder is None:
+        return ()
+    try:
+        libraries = finder(enable_tvm_ffi=True)
+    except TypeError:
+        libraries = finder()
+    if libraries is None:
+        return ()
+    return tuple(str(library) for library in libraries)
+
+
+def _link_shared_library(object_file: Path, shared_library: Path) -> None:
+    compiler = os.environ.get("CXX") or shutil.which("c++") or shutil.which("g++")
+    if compiler is None:
+        raise RuntimeError("Cannot link CuTe DSL AOT artifact: no C++ compiler found")
+
+    cmd = [compiler, "-shared", "-o", str(shared_library), str(object_file)]
+    cmd.extend(_runtime_libraries())
+    result = subprocess.run(cmd, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Failed to link CuTe DSL AOT shared library with command "
+            f"{cmd!r}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+def export_compiled_module(
+    compiled: Any,
+    paths: AOTArtifactPaths,
+    symbol: str,
+    metadata: AOTMetadata,
+    *,
+    force: bool = False,
+) -> None:
+    paths.object_file.parent.mkdir(parents=True, exist_ok=True)
+    if not force and paths.metadata_file.exists():
+        existing_metadata = read_metadata(paths.metadata_file)
+        if existing_metadata != metadata:
+            raise RuntimeError(
+                "Existing CuTe DSL AOT artifact metadata does not match the requested export "
+                f"for {symbol}; pass force=True to overwrite"
+            )
+        if paths.object_file.exists() and paths.shared_library.exists():
+            return
+    elif not force and (paths.object_file.exists() or paths.shared_library.exists()):
+        raise FileExistsError(
+            f"Partial AOT artifact exists for {symbol} without metadata; pass force=True to overwrite"
+        )
+    if not force and (paths.object_file.exists() or paths.shared_library.exists()):
+        paths.object_file.unlink(missing_ok=True)
+        paths.shared_library.unlink(missing_ok=True)
+
+    export_to_c = getattr(compiled, "export_to_c", None)
+    if export_to_c is None:
+        raise TypeError("Compiled CuTe DSL object does not expose export_to_c")
+
+    export_to_c(str(paths.object_file), function_name=symbol)
+    _link_shared_library(paths.object_file, paths.shared_library)
+    write_metadata_atomic(metadata, paths.metadata_file)
+
+
+def _get_module_function(module: Any, symbol: str) -> Callable[..., Any]:
+    candidates = (symbol, f"__tvm_ffi_{symbol}")
+    for candidate in candidates:
+        try:
+            func = module[candidate]
+        except (KeyError, TypeError, AttributeError):
+            pass
+        else:
+            if func is not None:
+                return func
+
+        for getter_name in ("get_function", "get_global_func", "get"):
+            getter = getattr(type(module), getter_name, None)
+            if getter is None:
+                continue
+            try:
+                func = getter(module, candidate)
+            except TypeError:
+                continue
+            if func is not None:
+                return func
+
+        try:
+            func = getattr(module, candidate)
+        except (AttributeError, RuntimeError):
+            continue
+        if func is not None:
+            return func
+    if callable(module):
+        return module
+    raise RuntimeError(f"Loaded CuTe DSL AOT module does not expose symbol {symbol}")
+
+
+def load_exported_module(paths: AOTArtifactPaths, symbol: str) -> Tuple[Any, Callable[..., Any]]:
+    import cutlass.cute as cute
+
+    module = cute.runtime.load_module(str(paths.shared_library), enable_tvm_ffi=True)
+    return module, _get_module_function(module, symbol)
+
+
+def load_aot_artifact(
+    metadata_path: os.PathLike[str] | str,
+    *,
+    registry_name: Optional[str] = None,
+    register: bool = False,
+    override: bool = False,
+) -> AOTLoadedArtifact:
+    metadata = read_metadata(metadata_path)
+    paths = _artifact_paths_from_metadata(metadata, metadata_path)
+    module, function = load_exported_module(paths, metadata.symbol)
+    resolved_registry_name = registry_name if registry_name is not None else metadata.registry_name
+    if register and resolved_registry_name is not None:
+        register_loaded_function(resolved_registry_name, function, override=override)
+    return AOTLoadedArtifact(metadata=metadata, paths=paths, module=module, function=function)
+
+
+def _registry_module() -> Any:
+    import tvm_ffi
+
+    return getattr(tvm_ffi, "registry", tvm_ffi)
+
+
+def register_loaded_function(name: str, function: Callable[..., Any], *, override: bool = False) -> None:
+    registry = _registry_module()
+    register = getattr(registry, "register_global_func", None)
+    if register is None:
+        register = getattr(registry, "register_func", None)
+    if register is None:
+        raise RuntimeError("TVM-FFI registry does not expose a global registration API")
+    try:
+        register(name, function, override=override)
+    except TypeError:
+        register(name, function, allow_override=override)
+
+
+def get_registered_function(name: str, *, allow_missing: bool = False) -> Optional[Callable[..., Any]]:
+    registry = _registry_module()
+    getter = getattr(registry, "get_global_func", None)
+    if getter is None:
+        getter = getattr(registry, "get_func", None)
+    if getter is None:
+        raise RuntimeError("TVM-FFI registry does not expose a global lookup API")
+    try:
+        return getter(name, allow_missing=allow_missing)
+    except TypeError:
+        if allow_missing:
+            try:
+                return getter(name)
+            except (KeyError, ValueError, RuntimeError):
+                return None
+        return getter(name)
+
+
+def remove_registered_function(name: str, *, allow_missing: bool = False) -> None:
+    registry = _registry_module()
+    remover = getattr(registry, "remove_global_func", None)
+    if remover is None:
+        remover = getattr(registry, "remove_func", None)
+    if remover is None:
+        if allow_missing:
+            return
+        raise RuntimeError("TVM-FFI registry does not expose a global removal API")
+    try:
+        remover(name)
+    except (KeyError, ValueError, RuntimeError):
+        if not allow_missing:
+            raise

--- a/python/cudnn/api_base.py
+++ b/python/cudnn/api_base.py
@@ -384,6 +384,8 @@ class APIBase(ABC):
         self._is_supported = False
         self._kernel = None
         self._compiled_kernel = None
+        self._raw_compiled_kernel = None
+        self._aot_loaded_artifact = None
         self._interpret_uint8_as_fp4x2 = False
         self._logger = logging.getLogger(self.__class__.__name__)
 
@@ -470,6 +472,111 @@ class APIBase(ABC):
             ...     self._compiled_kernel(input_tensor, output_tensor, current_stream)
         """
         pass
+
+    def _build_aot_symbol_and_paths(self, artifact_dir, cache_key):
+        from cudnn._cutedsl_aot import artifact_paths, build_aot_identity, build_symbol_name
+
+        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
+        device = torch.cuda.current_device()
+        major, minor = torch.cuda.get_device_capability(device)
+        compute_capability = major * 10 + minor
+        identity = build_aot_identity(
+            kernel_name=self.__class__.__name__,
+            cache_key=cache_key,
+            compile_options="--enable-tvm-ffi",
+            compute_capability=f"sm{compute_capability}",
+        )
+        symbol = build_symbol_name(f"cudnnfe_{self.__class__.__name__}", identity)
+        paths = artifact_paths(artifact_dir, symbol)
+        return identity, symbol, paths
+
+    def _wrap_tensor_api(self, function):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement _wrap_tensor_api()"
+        )
+
+    def export_aot(self, artifact_dir, cache_key, *, registry_name=None, force: bool = False):
+        self._logger.debug("Entering export_aot")
+        self._ensure_support_checked()
+        if self._compiled_kernel is None or self._raw_compiled_kernel is None:
+            self.compile()
+        self._runtime_error_if(
+            self._raw_compiled_kernel is None,
+            f"{self.__class__.__name__} raw compiled kernel is not available for AOT export",
+        )
+
+        from cudnn._cutedsl_aot import (
+            AOTExportedArtifact,
+            AOTMetadata,
+            build_registry_name,
+            export_compiled_module,
+        )
+
+        identity, symbol, paths = self._build_aot_symbol_and_paths(artifact_dir, cache_key)
+        resolved_registry_name = registry_name
+        if resolved_registry_name is None:
+            resolved_registry_name = build_registry_name(f"cudnnfe.{self.__class__.__name__}", identity)
+        metadata = AOTMetadata(
+            identity=identity,
+            symbol=symbol,
+            registry_name=resolved_registry_name,
+            object_file=paths.object_file.name,
+            shared_library=paths.shared_library.name,
+            metadata_file=paths.metadata_file.name,
+        )
+        export_compiled_module(
+            self._raw_compiled_kernel,
+            paths,
+            symbol,
+            metadata,
+            force=force,
+        )
+        self._logger.debug("AOT export completed successfully")
+        return AOTExportedArtifact(metadata=metadata, paths=paths)
+
+    def load_aot(self, artifact_dir, cache_key, *, registry_name=None, register: bool = False, override: bool = False):
+        self._logger.debug("Entering load_aot")
+        self._ensure_support_checked()
+
+        from cudnn._cutedsl_aot import load_aot_artifact, read_metadata
+
+        identity, symbol, paths = self._build_aot_symbol_and_paths(artifact_dir, cache_key)
+        missing = [
+            str(path)
+            for path in (paths.object_file, paths.shared_library, paths.metadata_file)
+            if not path.exists()
+        ]
+        self._runtime_error_if(
+            bool(missing),
+            "CuTe DSL AOT artifact set is incomplete; missing " + ", ".join(missing),
+        )
+        metadata = read_metadata(paths.metadata_file)
+        expected_metadata_files = (
+            paths.object_file.name,
+            paths.shared_library.name,
+            paths.metadata_file.name,
+        )
+        actual_metadata_files = (
+            metadata.object_file,
+            metadata.shared_library,
+            metadata.metadata_file,
+        )
+        self._runtime_error_if(
+            metadata.identity != identity
+            or metadata.symbol != symbol
+            or actual_metadata_files != expected_metadata_files,
+            f"CuTe DSL AOT metadata does not match {self.__class__.__name__} configuration",
+        )
+        loaded = load_aot_artifact(
+            paths.metadata_file,
+            registry_name=registry_name,
+            register=register,
+            override=override,
+        )
+        self._aot_loaded_artifact = loaded
+        self._compiled_kernel = self._wrap_tensor_api(loaded.function)
+        self._logger.debug("AOT load completed successfully")
+        return loaded
 
     def __call__(self, *args, **kwargs) -> Any:
         """Convenience method to execute the kernel.

--- a/python/cudnn/gemm_amax/api.py
+++ b/python/cudnn/gemm_amax/api.py
@@ -12,7 +12,7 @@ import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_stream
 
 from cudnn.datatypes import _convert_to_cutlass_data_type
-from cudnn.api_base import APIBase, TensorDesc, TupleDict, is_power_of_2, ceil_div
+from cudnn.api_base import APIBase, TupleDict, is_power_of_2, ceil_div
 
 
 class GemmAmaxSm100(APIBase):
@@ -305,7 +305,12 @@ class GemmAmaxSm100(APIBase):
             stream=fake_stream,
             options="--enable-tvm-ffi",
         )
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
 
+        self._logger.debug("Kernel compiled successfully")
+
+    def _wrap_tensor_api(self, function):
         def tensor_api(
             a_tensor: torch.Tensor,
             b_tensor: torch.Tensor,
@@ -317,7 +322,7 @@ class GemmAmaxSm100(APIBase):
         ):
             amax_tensor = self._pad_tensor_to_ndim(amax_tensor, 3, "amax")
 
-            return _compiled_kernel(
+            return function(
                 a_tensor,
                 b_tensor,
                 sfa_tensor,
@@ -327,13 +332,7 @@ class GemmAmaxSm100(APIBase):
                 stream,
             )
 
-        self._compiled_kernel = tensor_api
-
-        for attr_name in tuple(vars(self)):
-            if attr_name.startswith("sample_"):
-                setattr(self, attr_name, None)
-
-        self._logger.debug("Kernel compiled successfully")
+        return tensor_api
 
     def execute(
         self,
@@ -387,6 +386,15 @@ def gemm_amax_wrapper_sm100(
 ) -> TupleDict:
 
     _logger.debug("gemm_amax_wrapper_sm100: Creating empty output tensors c and amax")
+    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
+        raise ValueError(
+            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
+            f"got {aot_mode!r}"
+        )
+    if aot_mode and not aot_artifact_dir:
+        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
 
     m, _, l = a_tensor.shape
     n, _, l = b_tensor.shape
@@ -398,6 +406,7 @@ def gemm_amax_wrapper_sm100(
     else:
         raise ValueError(f"c_major must be either 'm' or 'n', got {c_major}")
     amax_tensor = torch.full((1, 1, 1), -float("inf"), device=a_tensor.device, dtype=torch.float32)
+    num_cluster_overlap_margin = int(os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"))
 
     cache_key = (
         a_tensor.shape,
@@ -418,10 +427,18 @@ def gemm_amax_wrapper_sm100(
         mma_tiler_mn,
         cluster_shape_mn,
         sf_vec_size,
+        num_cluster_overlap_margin,
     )
-    if cache_key in _cache_of_GemmAmaxSm100Objects:
+    use_cache = not aot_mode or aot_mode == "write"
+    if use_cache and cache_key in _cache_of_GemmAmaxSm100Objects:
         _logger.debug("gemm_amax_wrapper_sm100: Using previously cached GemmAmaxSm100 object")
         gemm_amax = _cache_of_GemmAmaxSm100Objects[cache_key]
+        if aot_mode == "write" and gemm_amax._raw_compiled_kernel is None:
+            gemm_amax = None
+    else:
+        gemm_amax = None
+
+    if gemm_amax is not None:
         gemm_amax.execute(
             a_tensor=a_tensor,
             b_tensor=b_tensor,
@@ -446,7 +463,18 @@ def gemm_amax_wrapper_sm100(
             sf_vec_size=sf_vec_size,
         )
         assert gemm_amax.check_support()
-        gemm_amax.compile()
+        if aot_mode == "read":
+            gemm_amax.load_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "readwrite":
+            _, _, aot_paths = gemm_amax._build_aot_symbol_and_paths(aot_artifact_dir, cache_key)
+            if aot_paths.metadata_file.exists() and aot_paths.object_file.exists() and aot_paths.shared_library.exists():
+                gemm_amax.load_aot(aot_artifact_dir, cache_key)
+            else:
+                gemm_amax.export_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "write":
+            gemm_amax.export_aot(aot_artifact_dir, cache_key)
+        else:
+            gemm_amax.compile()
         gemm_amax.execute(
             a_tensor=a_tensor,
             b_tensor=b_tensor,

--- a/python/cudnn/gemm_amax/api.py
+++ b/python/cudnn/gemm_amax/api.py
@@ -386,15 +386,12 @@ def gemm_amax_wrapper_sm100(
 ) -> TupleDict:
 
     _logger.debug("gemm_amax_wrapper_sm100: Creating empty output tensors c and amax")
-    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
-    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    aot_mode = os.getenv("NV_CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("NV_CUDNN_FE_AOT_DIR")
     if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
-        raise ValueError(
-            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
-            f"got {aot_mode!r}"
-        )
+        raise ValueError("NV_CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, " f"got {aot_mode!r}")
     if aot_mode and not aot_artifact_dir:
-        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+        raise ValueError("NV_CUDNN_FE_AOT_DIR is required when NV_CUDNN_FE_AOT_MODE is set")
 
     m, _, l = a_tensor.shape
     n, _, l = b_tensor.shape
@@ -429,12 +426,14 @@ def gemm_amax_wrapper_sm100(
         sf_vec_size,
         num_cluster_overlap_margin,
     )
-    use_cache = not aot_mode or aot_mode == "write"
-    if use_cache and cache_key in _cache_of_GemmAmaxSm100Objects:
+    if cache_key in _cache_of_GemmAmaxSm100Objects:
         _logger.debug("gemm_amax_wrapper_sm100: Using previously cached GemmAmaxSm100 object")
         gemm_amax = _cache_of_GemmAmaxSm100Objects[cache_key]
-        if aot_mode == "write" and gemm_amax._raw_compiled_kernel is None:
-            gemm_amax = None
+        if aot_mode == "write":
+            if gemm_amax._raw_compiled_kernel is None:
+                gemm_amax = None
+            else:
+                gemm_amax.export_aot(aot_artifact_dir, cache_key)
     else:
         gemm_amax = None
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/api.py
@@ -1066,6 +1066,7 @@ class GroupedGemmDgluSm100(APIBase):
         cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
 
         if self.weight_mode == MoEWeightMode.DENSE:
+
             def tensor_api(
                 a_tensor: torch.Tensor,
                 b_tensor: torch.Tensor,
@@ -1643,22 +1644,21 @@ def grouped_gemm_dglu_wrapper_sm100(
             num_experts,
         )
 
-    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
-    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    aot_mode = os.getenv("NV_CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("NV_CUDNN_FE_AOT_DIR")
     if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
-        raise ValueError(
-            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
-            f"got {aot_mode!r}"
-        )
+        raise ValueError("NV_CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, " f"got {aot_mode!r}")
     if aot_mode and not aot_artifact_dir:
-        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+        raise ValueError("NV_CUDNN_FE_AOT_DIR is required when NV_CUDNN_FE_AOT_MODE is set")
     # ---- Cache lookup or create + compile ----
-    use_cache = not aot_mode or aot_mode == "write"
-    if use_cache and cache_key in _cache_of_GroupedGemmDgluSm100Objects:
+    if cache_key in _cache_of_GroupedGemmDgluSm100Objects:
         _logger.debug("grouped_gemm_dglu_wrapper_sm100: Using cached object")
         api = _cache_of_GroupedGemmDgluSm100Objects[cache_key]
-        if aot_mode == "write" and api._raw_compiled_kernel is None:
-            api = None
+        if aot_mode == "write":
+            if api._raw_compiled_kernel is None:
+                api = None
+            else:
+                api.export_aot(aot_artifact_dir, cache_key)
     else:
         api = None
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/api.py
@@ -626,6 +626,26 @@ class GroupedGemmDgluSm100(APIBase):
     #  compile
     # --------------------------------------------------------------------- #
 
+    def _ensure_workspace(self, kernel=None) -> None:
+        if getattr(self, "_workspace", None) is not None:
+            return
+        if kernel is None:
+            kernel = self._kernel(
+                sf_vec_size=self.sf_vec_size,
+                acc_dtype=_convert_to_cutlass_data_type(self.acc_dtype),
+                use_2cta_instrs=self.use_2cta_instrs,
+                mma_tiler_mn=self.mma_tiler_mn,
+                cluster_shape_mn=self.cluster_shape_mn,
+                vectorized_f32=self.vector_f32,
+                discrete_col_sfd=self.discrete_col_sfd,
+                expert_cnt=self.expert_cnt,
+                weight_mode=self.weight_mode,
+                act_func=self.act_func,
+                use_dynamic_sched=self.use_dynamic_sched,
+            )
+        workspace_bytes = kernel.get_workspace_bytes()
+        self._workspace = torch.empty(max(workspace_bytes, 1), dtype=torch.uint8, device=self.a_desc.device)
+
     def compile(self) -> None:
         """Compile the kernel."""
         self._logger.debug("Entering compile")
@@ -661,9 +681,7 @@ class GroupedGemmDgluSm100(APIBase):
         )
         fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
 
-        # ---- Allocate workspace ----
-        workspace_bytes = gemm_dglu.get_workspace_bytes()
-        self._workspace = torch.empty(max(workspace_bytes, 1), dtype=torch.uint8, device="cuda")
+        self._ensure_workspace(gemm_dglu)
 
         if self.weight_mode == MoEWeightMode.DENSE:
             self._compile_dense(gemm_dglu, max_active_clusters, fake_stream)
@@ -894,64 +912,8 @@ class GroupedGemmDgluSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
-        # Cache workspace pointer for the tensor_api closure
-        cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
-
-        def tensor_api(
-            a_tensor: torch.Tensor,
-            b_tensor: torch.Tensor,
-            c_tensor: torch.Tensor,
-            d_row_tensor: torch.Tensor,
-            d_col_tensor: Optional[torch.Tensor],
-            sfa_tensor: torch.Tensor,
-            sfb_tensor: torch.Tensor,
-            sfd_row_tensor: Optional[torch.Tensor],
-            sfd_col_tensor: Optional[torch.Tensor],
-            amax_tensor: Optional[torch.Tensor],
-            norm_const_tensor: Optional[torch.Tensor],
-            padded_offsets: torch.Tensor,
-            alpha_tensor: torch.Tensor,
-            beta_tensor: torch.Tensor,
-            prob_tensor: torch.Tensor,
-            dprob_tensor: torch.Tensor,
-            dbias_tensor: Optional[torch.Tensor],
-            stream: cuda.CUstream,
-            linear_offset: float = 0.0,
-            geglu_alpha: float = 1.702,
-            glu_clamp_max: float = 7.0,
-            glu_clamp_min: float = -7.0,
-        ) -> None:
-            norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
-            _compiled_kernel(
-                a_tensor,
-                b_tensor,
-                sfb_tensor,
-                cutlass.Int32(0),
-                cutlass.Int32(0),
-                cutlass.Int64(0),
-                cached_workspace_ptr,
-                c_tensor,
-                d_row_tensor,
-                d_col_tensor,
-                sfa_tensor,
-                sfd_row_tensor,
-                sfd_col_tensor,
-                amax_tensor,
-                norm_const_tensor,
-                padded_offsets,
-                alpha_tensor,
-                beta_tensor,
-                prob_tensor,
-                dprob_tensor,
-                cutlass.Float32(linear_offset),
-                dbias_tensor,
-                stream,
-                cutlass.Float32(geglu_alpha),
-                cutlass.Float32(glu_clamp_max),
-                cutlass.Float32(glu_clamp_min),
-            )
-
-        self._compiled_kernel = tensor_api
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
 
     # -- Discrete compile path ---------------------------------------------- #
 
@@ -1096,11 +1058,78 @@ class GroupedGemmDgluSm100(APIBase):
         self._k = k
         self._b_stride_size = b_stride_size
 
-        # Cache constant values for execute() closure
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
+
+    def _wrap_tensor_api(self, function):
+        self._ensure_workspace()
         cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
-        cached_n = cutlass.Int32(self._n)
-        cached_k = cutlass.Int32(self._k)
-        cached_b_stride = cutlass.Int64(self._b_stride_size)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            def tensor_api(
+                a_tensor: torch.Tensor,
+                b_tensor: torch.Tensor,
+                c_tensor: torch.Tensor,
+                d_row_tensor: torch.Tensor,
+                d_col_tensor: Optional[torch.Tensor],
+                sfa_tensor: torch.Tensor,
+                sfb_tensor: torch.Tensor,
+                sfd_row_tensor: Optional[torch.Tensor],
+                sfd_col_tensor: Optional[torch.Tensor],
+                amax_tensor: Optional[torch.Tensor],
+                norm_const_tensor: Optional[torch.Tensor],
+                padded_offsets: torch.Tensor,
+                alpha_tensor: torch.Tensor,
+                beta_tensor: torch.Tensor,
+                prob_tensor: torch.Tensor,
+                dprob_tensor: torch.Tensor,
+                dbias_tensor: Optional[torch.Tensor],
+                stream: cuda.CUstream,
+                linear_offset: float = 0.0,
+                geglu_alpha: float = 1.702,
+                glu_clamp_max: float = 7.0,
+                glu_clamp_min: float = -7.0,
+            ) -> None:
+                norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
+                function(
+                    a_tensor,
+                    b_tensor,
+                    sfb_tensor,
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    cutlass.Int64(0),
+                    cached_workspace_ptr,
+                    c_tensor,
+                    d_row_tensor,
+                    d_col_tensor,
+                    sfa_tensor,
+                    sfd_row_tensor,
+                    sfd_col_tensor,
+                    amax_tensor,
+                    norm_const_tensor,
+                    padded_offsets,
+                    alpha_tensor,
+                    beta_tensor,
+                    prob_tensor,
+                    dprob_tensor,
+                    cutlass.Float32(linear_offset),
+                    dbias_tensor,
+                    stream,
+                    cutlass.Float32(geglu_alpha),
+                    cutlass.Float32(glu_clamp_max),
+                    cutlass.Float32(glu_clamp_min),
+                )
+
+            return tensor_api
+
+        if len(self.b_shape) == 2:
+            n, k = self.b_shape
+        else:
+            n, k, _ = self.b_shape
+        b_stride_size = k if self.b_major == "k" else n
+        cached_n = cutlass.Int32(n)
+        cached_k = cutlass.Int32(k)
+        cached_b_stride = cutlass.Int64(b_stride_size)
 
         def tensor_api(
             a_tensor: torch.Tensor,
@@ -1127,13 +1156,10 @@ class GroupedGemmDgluSm100(APIBase):
             glu_clamp_min: float = -7.0,
         ) -> None:
             norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
-            b_ptrs_addr = int(b_ptrs_device.data_ptr())
-            sfb_ptrs_addr = int(sfb_ptrs_device.data_ptr())
-
-            _compiled_kernel(
+            function(
                 a_tensor,
-                b_ptrs_addr,
-                sfb_ptrs_addr,
+                int(b_ptrs_device.data_ptr()),
+                int(sfb_ptrs_device.data_ptr()),
                 cached_n,
                 cached_k,
                 cached_b_stride,
@@ -1159,7 +1185,7 @@ class GroupedGemmDgluSm100(APIBase):
                 cutlass.Float32(glu_clamp_min),
             )
 
-        self._compiled_kernel = tensor_api
+        return tensor_api
 
     # --------------------------------------------------------------------- #
     #  execute
@@ -1617,11 +1643,26 @@ def grouped_gemm_dglu_wrapper_sm100(
             num_experts,
         )
 
+    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
+        raise ValueError(
+            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
+            f"got {aot_mode!r}"
+        )
+    if aot_mode and not aot_artifact_dir:
+        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
     # ---- Cache lookup or create + compile ----
-    if cache_key in _cache_of_GroupedGemmDgluSm100Objects:
+    use_cache = not aot_mode or aot_mode == "write"
+    if use_cache and cache_key in _cache_of_GroupedGemmDgluSm100Objects:
         _logger.debug("grouped_gemm_dglu_wrapper_sm100: Using cached object")
         api = _cache_of_GroupedGemmDgluSm100Objects[cache_key]
+        if aot_mode == "write" and api._raw_compiled_kernel is None:
+            api = None
     else:
+        api = None
+
+    if api is None:
         _logger.debug("grouped_gemm_dglu_wrapper_sm100: Creating new object")
         if is_dense:
             api = GroupedGemmDgluSm100(
@@ -1688,7 +1729,18 @@ def grouped_gemm_dglu_wrapper_sm100(
 
         if not api.check_support():
             raise RuntimeError("Unsupported configuration")
-        api.compile()
+        if aot_mode == "read":
+            api.load_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "readwrite":
+            _, _, aot_paths = api._build_aot_symbol_and_paths(aot_artifact_dir, cache_key)
+            if aot_paths.metadata_file.exists() and aot_paths.object_file.exists() and aot_paths.shared_library.exists():
+                api.load_aot(aot_artifact_dir, cache_key)
+            else:
+                api.export_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "write":
+            api.export_aot(aot_artifact_dir, cache_key)
+        else:
+            api.compile()
         _cache_of_GroupedGemmDgluSm100Objects[cache_key] = api
 
     # ---- Execute ----

--- a/python/cudnn/grouped_gemm/grouped_gemm_dswiglu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dswiglu/api.py
@@ -574,6 +574,12 @@ class GroupedGemmDswigluSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
+
+        self._logger.debug("Kernel compiled successfully")
+
+    def _wrap_tensor_api(self, function):
         def tensor_api(
             a_tensor: torch.Tensor,
             b_tensor: torch.Tensor,
@@ -594,7 +600,7 @@ class GroupedGemmDswigluSm100(APIBase):
             stream: cuda.CUstream,
         ) -> None:
             norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
-            _compiled_kernel(
+            function(
                 a_tensor,
                 b_tensor,
                 c_tensor,
@@ -614,9 +620,7 @@ class GroupedGemmDswigluSm100(APIBase):
                 stream,
             )
 
-        self._compiled_kernel = tensor_api
-
-        self._logger.debug("Kernel compiled successfully")
+        return tensor_api
 
     def execute(
         self,
@@ -833,7 +837,18 @@ def grouped_gemm_dswiglu_wrapper_sm100(
         mma_shape_col = (1, ceil_div(n * 2, 128), ceil_div(sf_k_col, 4), 32, 4, 4)
         sfd_col_tensor = torch.empty(mma_shape_col, dtype=sf_dtype, device=a_tensor.device).permute(mma_permute_order)
 
-    if cache_key in _cache_of_GroupedGemmDswigluSm100Objects:
+    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
+        raise ValueError(
+            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
+            f"got {aot_mode!r}"
+        )
+    if aot_mode and not aot_artifact_dir:
+        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+
+    use_cache = not aot_mode or aot_mode == "write"
+    if use_cache and cache_key in _cache_of_GroupedGemmDswigluSm100Objects:
         _logger.debug("group_gemm_dswiglu_wrapper_sm100: Using previously cached GroupedGemmDswigluSm100 object")
         grouped_gemm_dswiglu, cached_amax_tensor, cached_beta_tensor = _cache_of_GroupedGemmDswigluSm100Objects[cache_key]
         amax_tensor = amax_tensor_buf if amax_tensor_buf is not None else cached_amax_tensor
@@ -845,7 +860,12 @@ def grouped_gemm_dswiglu_wrapper_sm100(
             # Fallback: cache was populated without beta caching (non-NVFP4 path),
             # but caller now passes None (NVFP4 path). Create ones tensor on-the-fly.
             effective_beta = torch.ones(l, dtype=torch.float32, device=a_tensor.device)
+        if aot_mode == "write" and grouped_gemm_dswiglu._raw_compiled_kernel is None:
+            grouped_gemm_dswiglu = None
     else:
+        grouped_gemm_dswiglu = None
+
+    if grouped_gemm_dswiglu is None:
         _logger.debug(
             "group_gemm_dswiglu_wrapper_sm100: No previously cached GroupedGemmDswigluSm100 object found, creating new GroupedGemmDswigluSm100 object"
         )
@@ -890,7 +910,18 @@ def grouped_gemm_dswiglu_wrapper_sm100(
         )
 
         assert grouped_gemm_dswiglu.check_support(), "Unsupported configuration"
-        grouped_gemm_dswiglu.compile()
+        if aot_mode == "read":
+            grouped_gemm_dswiglu.load_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "readwrite":
+            _, _, aot_paths = grouped_gemm_dswiglu._build_aot_symbol_and_paths(aot_artifact_dir, cache_key)
+            if aot_paths.metadata_file.exists() and aot_paths.object_file.exists() and aot_paths.shared_library.exists():
+                grouped_gemm_dswiglu.load_aot(aot_artifact_dir, cache_key)
+            else:
+                grouped_gemm_dswiglu.export_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "write":
+            grouped_gemm_dswiglu.export_aot(aot_artifact_dir, cache_key)
+        else:
+            grouped_gemm_dswiglu.compile()
         _cache_of_GroupedGemmDswigluSm100Objects[cache_key] = (grouped_gemm_dswiglu, cached_amax_tensor, cached_beta_tensor)
 
     grouped_gemm_dswiglu.execute(

--- a/python/cudnn/grouped_gemm/grouped_gemm_dswiglu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dswiglu/api.py
@@ -837,18 +837,14 @@ def grouped_gemm_dswiglu_wrapper_sm100(
         mma_shape_col = (1, ceil_div(n * 2, 128), ceil_div(sf_k_col, 4), 32, 4, 4)
         sfd_col_tensor = torch.empty(mma_shape_col, dtype=sf_dtype, device=a_tensor.device).permute(mma_permute_order)
 
-    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
-    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    aot_mode = os.getenv("NV_CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("NV_CUDNN_FE_AOT_DIR")
     if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
-        raise ValueError(
-            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
-            f"got {aot_mode!r}"
-        )
+        raise ValueError("NV_CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, " f"got {aot_mode!r}")
     if aot_mode and not aot_artifact_dir:
-        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+        raise ValueError("NV_CUDNN_FE_AOT_DIR is required when NV_CUDNN_FE_AOT_MODE is set")
 
-    use_cache = not aot_mode or aot_mode == "write"
-    if use_cache and cache_key in _cache_of_GroupedGemmDswigluSm100Objects:
+    if cache_key in _cache_of_GroupedGemmDswigluSm100Objects:
         _logger.debug("group_gemm_dswiglu_wrapper_sm100: Using previously cached GroupedGemmDswigluSm100 object")
         grouped_gemm_dswiglu, cached_amax_tensor, cached_beta_tensor = _cache_of_GroupedGemmDswigluSm100Objects[cache_key]
         amax_tensor = amax_tensor_buf if amax_tensor_buf is not None else cached_amax_tensor
@@ -860,8 +856,11 @@ def grouped_gemm_dswiglu_wrapper_sm100(
             # Fallback: cache was populated without beta caching (non-NVFP4 path),
             # but caller now passes None (NVFP4 path). Create ones tensor on-the-fly.
             effective_beta = torch.ones(l, dtype=torch.float32, device=a_tensor.device)
-        if aot_mode == "write" and grouped_gemm_dswiglu._raw_compiled_kernel is None:
-            grouped_gemm_dswiglu = None
+        if aot_mode == "write":
+            if grouped_gemm_dswiglu._raw_compiled_kernel is None:
+                grouped_gemm_dswiglu = None
+            else:
+                grouped_gemm_dswiglu.export_aot(aot_artifact_dir, cache_key)
     else:
         grouped_gemm_dswiglu = None
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_glu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_glu/api.py
@@ -596,6 +596,28 @@ class GroupedGemmGluSm100(APIBase):
     #  compile
     # --------------------------------------------------------------------- #
 
+    def _ensure_workspace(self, kernel=None) -> None:
+        if getattr(self, "_workspace", None) is not None:
+            return
+        if kernel is None:
+            kernel = self._kernel(
+                sf_vec_size=self.sf_vec_size,
+                acc_dtype=_convert_to_cutlass_data_type(self.acc_dtype),
+                use_2cta_instrs=self.use_2cta_instrs,
+                mma_tiler_mn=self.mma_tiler_mn,
+                cluster_shape_mn=self.cluster_shape_mn,
+                vectorized_f32=self.vector_f32,
+                generate_sfd=self.generate_sfd,
+                discrete_col_sfd=self.discrete_col_sfd,
+                expert_cnt=self.expert_cnt,
+                weight_mode=self.weight_mode,
+                act_func=self.act_func,
+                enable_bias=self._has_bias,
+                use_dynamic_sched=self.use_dynamic_sched,
+            )
+        workspace_bytes = kernel.get_workspace_bytes()
+        self._workspace = torch.empty(max(workspace_bytes, 1), dtype=torch.uint8, device=self.a_desc.device)
+
     def compile(self) -> None:
         """Compile the kernel."""
         self._logger.debug("Entering compile")
@@ -633,9 +655,7 @@ class GroupedGemmGluSm100(APIBase):
         )
         fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
 
-        # ---- Allocate workspace ----
-        workspace_bytes = gemm_glu.get_workspace_bytes()
-        self._workspace = torch.empty(max(workspace_bytes, 1), dtype=torch.uint8, device="cuda")
+        self._ensure_workspace(gemm_glu)
 
         if self.weight_mode == MoEWeightMode.DENSE:
             self._compile_dense(gemm_glu, max_active_clusters, fake_stream)
@@ -859,60 +879,8 @@ class GroupedGemmGluSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
-        # Cache workspace pointer for the tensor_api closure
-        cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
-
-        def tensor_api(
-            a_tensor: torch.Tensor,
-            b_tensor: torch.Tensor,
-            c_tensor: torch.Tensor,
-            d_tensor: torch.Tensor,
-            d_col_tensor: Optional[torch.Tensor],
-            sfa_tensor: torch.Tensor,
-            sfb_tensor: torch.Tensor,
-            sfd_row_tensor: Optional[torch.Tensor],
-            sfd_col_tensor: Optional[torch.Tensor],
-            amax_tensor: Optional[torch.Tensor],
-            norm_const_tensor: Optional[torch.Tensor],
-            padded_offsets: torch.Tensor,
-            alpha_tensor: torch.Tensor,
-            prob_tensor: Optional[torch.Tensor],
-            bias_tensor: Optional[torch.Tensor],
-            stream: cuda.CUstream,
-            linear_offset: float = 0.0,
-            geglu_alpha: float = 1.702,
-            glu_clamp_max: float = 7.0,
-            glu_clamp_min: float = -7.0,
-        ) -> None:
-            norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
-            _compiled_kernel(
-                a_tensor,
-                b_tensor,
-                sfb_tensor,
-                cutlass.Int32(0),
-                cutlass.Int32(0),
-                cutlass.Int64(0),
-                cached_workspace_ptr,
-                c_tensor,
-                d_tensor,
-                d_col_tensor,
-                sfa_tensor,
-                sfd_row_tensor,
-                sfd_col_tensor,
-                amax_tensor,
-                norm_const_tensor,
-                padded_offsets,
-                alpha_tensor,
-                prob_tensor,
-                bias_tensor,
-                stream,
-                cutlass.Float32(linear_offset),
-                cutlass.Float32(geglu_alpha),
-                cutlass.Float32(glu_clamp_max),
-                cutlass.Float32(glu_clamp_min),
-            )
-
-        self._compiled_kernel = tensor_api
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
 
     # -- Discrete compile path ---------------------------------------------- #
 
@@ -1050,11 +1018,74 @@ class GroupedGemmGluSm100(APIBase):
         self._k = k
         self._b_stride_size = b_stride_size
 
-        # Cache constant values for execute() closure
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
+
+    def _wrap_tensor_api(self, function):
+        self._ensure_workspace()
         cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
-        cached_n = cutlass.Int32(self._n)
-        cached_k = cutlass.Int32(self._k)
-        cached_b_stride = cutlass.Int64(self._b_stride_size)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            def tensor_api(
+                a_tensor: torch.Tensor,
+                b_tensor: torch.Tensor,
+                c_tensor: torch.Tensor,
+                d_tensor: torch.Tensor,
+                d_col_tensor: Optional[torch.Tensor],
+                sfa_tensor: torch.Tensor,
+                sfb_tensor: torch.Tensor,
+                sfd_row_tensor: Optional[torch.Tensor],
+                sfd_col_tensor: Optional[torch.Tensor],
+                amax_tensor: Optional[torch.Tensor],
+                norm_const_tensor: Optional[torch.Tensor],
+                padded_offsets: torch.Tensor,
+                alpha_tensor: torch.Tensor,
+                prob_tensor: Optional[torch.Tensor],
+                bias_tensor: Optional[torch.Tensor],
+                stream: cuda.CUstream,
+                linear_offset: float = 0.0,
+                geglu_alpha: float = 1.702,
+                glu_clamp_max: float = 7.0,
+                glu_clamp_min: float = -7.0,
+            ) -> None:
+                norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
+                function(
+                    a_tensor,
+                    b_tensor,
+                    sfb_tensor,
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    cutlass.Int64(0),
+                    cached_workspace_ptr,
+                    c_tensor,
+                    d_tensor,
+                    d_col_tensor,
+                    sfa_tensor,
+                    sfd_row_tensor,
+                    sfd_col_tensor,
+                    amax_tensor,
+                    norm_const_tensor,
+                    padded_offsets,
+                    alpha_tensor,
+                    prob_tensor,
+                    bias_tensor,
+                    stream,
+                    cutlass.Float32(linear_offset),
+                    cutlass.Float32(geglu_alpha),
+                    cutlass.Float32(glu_clamp_max),
+                    cutlass.Float32(glu_clamp_min),
+                )
+
+            return tensor_api
+
+        if len(self.b_shape) == 2:
+            n, k = self.b_shape
+        else:
+            n, k, _ = self.b_shape
+        b_stride_size = k if self.b_major == "k" else n
+        cached_n = cutlass.Int32(n)
+        cached_k = cutlass.Int32(k)
+        cached_b_stride = cutlass.Int64(b_stride_size)
 
         def tensor_api(
             a_tensor: torch.Tensor,
@@ -1079,13 +1110,10 @@ class GroupedGemmGluSm100(APIBase):
             glu_clamp_min: float = -7.0,
         ) -> None:
             norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
-            b_ptrs_addr = int(b_ptrs_device.data_ptr())
-            sfb_ptrs_addr = int(sfb_ptrs_device.data_ptr())
-
-            _compiled_kernel(
+            function(
                 a_tensor,
-                b_ptrs_addr,
-                sfb_ptrs_addr,
+                int(b_ptrs_device.data_ptr()),
+                int(sfb_ptrs_device.data_ptr()),
                 cached_n,
                 cached_k,
                 cached_b_stride,
@@ -1109,7 +1137,7 @@ class GroupedGemmGluSm100(APIBase):
                 cutlass.Float32(glu_clamp_min),
             )
 
-        self._compiled_kernel = tensor_api
+        return tensor_api
 
     # --------------------------------------------------------------------- #
     #  execute
@@ -1561,11 +1589,26 @@ def grouped_gemm_glu_wrapper_sm100(
             num_experts,
         )
 
+    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
+        raise ValueError(
+            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
+            f"got {aot_mode!r}"
+        )
+    if aot_mode and not aot_artifact_dir:
+        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
     # ---- Cache lookup or create + compile ----
-    if cache_key in _cache_of_GroupedGemmGluSm100Objects:
+    use_cache = not aot_mode or aot_mode == "write"
+    if use_cache and cache_key in _cache_of_GroupedGemmGluSm100Objects:
         _logger.debug("grouped_gemm_glu_wrapper_sm100: Using cached object")
         api = _cache_of_GroupedGemmGluSm100Objects[cache_key]
+        if aot_mode == "write" and api._raw_compiled_kernel is None:
+            api = None
     else:
+        api = None
+
+    if api is None:
         _logger.debug("grouped_gemm_glu_wrapper_sm100: Creating new object")
         if is_dense:
             api = GroupedGemmGluSm100(
@@ -1626,7 +1669,18 @@ def grouped_gemm_glu_wrapper_sm100(
 
         if not api.check_support():
             raise RuntimeError("Unsupported configuration")
-        api.compile()
+        if aot_mode == "read":
+            api.load_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "readwrite":
+            _, _, aot_paths = api._build_aot_symbol_and_paths(aot_artifact_dir, cache_key)
+            if aot_paths.metadata_file.exists() and aot_paths.object_file.exists() and aot_paths.shared_library.exists():
+                api.load_aot(aot_artifact_dir, cache_key)
+            else:
+                api.export_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "write":
+            api.export_aot(aot_artifact_dir, cache_key)
+        else:
+            api.compile()
         _cache_of_GroupedGemmGluSm100Objects[cache_key] = api
 
     # ---- Execute ----

--- a/python/cudnn/grouped_gemm/grouped_gemm_glu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_glu/api.py
@@ -1026,6 +1026,7 @@ class GroupedGemmGluSm100(APIBase):
         cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
 
         if self.weight_mode == MoEWeightMode.DENSE:
+
             def tensor_api(
                 a_tensor: torch.Tensor,
                 b_tensor: torch.Tensor,
@@ -1589,22 +1590,21 @@ def grouped_gemm_glu_wrapper_sm100(
             num_experts,
         )
 
-    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
-    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    aot_mode = os.getenv("NV_CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("NV_CUDNN_FE_AOT_DIR")
     if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
-        raise ValueError(
-            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
-            f"got {aot_mode!r}"
-        )
+        raise ValueError("NV_CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, " f"got {aot_mode!r}")
     if aot_mode and not aot_artifact_dir:
-        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+        raise ValueError("NV_CUDNN_FE_AOT_DIR is required when NV_CUDNN_FE_AOT_MODE is set")
     # ---- Cache lookup or create + compile ----
-    use_cache = not aot_mode or aot_mode == "write"
-    if use_cache and cache_key in _cache_of_GroupedGemmGluSm100Objects:
+    if cache_key in _cache_of_GroupedGemmGluSm100Objects:
         _logger.debug("grouped_gemm_glu_wrapper_sm100: Using cached object")
         api = _cache_of_GroupedGemmGluSm100Objects[cache_key]
-        if aot_mode == "write" and api._raw_compiled_kernel is None:
-            api = None
+        if aot_mode == "write":
+            if api._raw_compiled_kernel is None:
+                api = None
+            else:
+                api.export_aot(aot_artifact_dir, cache_key)
     else:
         api = None
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_quant/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_quant/api.py
@@ -947,6 +947,7 @@ class GroupedGemmQuantSm100(APIBase):
         cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
 
         if self.weight_mode == MoEWeightMode.DENSE:
+
             def tensor_api(
                 a_tensor: torch.Tensor,
                 b_tensor: torch.Tensor,
@@ -1496,21 +1497,20 @@ def grouped_gemm_quant_wrapper_sm100(
             num_experts,
         )
 
-    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
-    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    aot_mode = os.getenv("NV_CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("NV_CUDNN_FE_AOT_DIR")
     if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
-        raise ValueError(
-            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
-            f"got {aot_mode!r}"
-        )
+        raise ValueError("NV_CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, " f"got {aot_mode!r}")
     if aot_mode and not aot_artifact_dir:
-        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
-    use_cache = not aot_mode or aot_mode == "write"
-    if use_cache and cache_key in _cache_of_GroupedGemmQuantSm100Objects:
+        raise ValueError("NV_CUDNN_FE_AOT_DIR is required when NV_CUDNN_FE_AOT_MODE is set")
+    if cache_key in _cache_of_GroupedGemmQuantSm100Objects:
         _logger.debug("grouped_gemm_quant_wrapper_sm100: Using previously cached GroupedGemmQuantSm100 object")
         grouped_gemm_quant = _cache_of_GroupedGemmQuantSm100Objects[cache_key]
-        if aot_mode == "write" and grouped_gemm_quant._raw_compiled_kernel is None:
-            grouped_gemm_quant = None
+        if aot_mode == "write":
+            if grouped_gemm_quant._raw_compiled_kernel is None:
+                grouped_gemm_quant = None
+            else:
+                grouped_gemm_quant.export_aot(aot_artifact_dir, cache_key)
     else:
         grouped_gemm_quant = None
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_quant/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_quant/api.py
@@ -547,6 +547,27 @@ class GroupedGemmQuantSm100(APIBase):
         self._logger.debug("check_support completed successfully")
         return True
 
+    def _ensure_workspace(self, kernel=None) -> None:
+        if getattr(self, "_workspace", None) is not None:
+            return
+        if kernel is None:
+            kernel = self._kernel(
+                sf_vec_size=self.sf_vec_size,
+                acc_dtype=_convert_to_cutlass_data_type(self.acc_dtype),
+                use_2cta_instrs=self.use_2cta_instrs,
+                mma_tiler_mn=self.mma_tiler_mn,
+                cluster_shape_mn=self.cluster_shape_mn,
+                vectorized_f32=self.vector_f32,
+                generate_sfd=self.generate_sfd,
+                discrete_col_sfd=self.discrete_col_sfd,
+                enable_bias=self._has_bias,
+                expert_cnt=self.expert_cnt,
+                weight_mode=self.weight_mode,
+                use_dynamic_sched=self.use_dynamic_sched,
+            )
+        workspace_bytes = kernel.get_workspace_bytes()
+        self._workspace = torch.empty(max(workspace_bytes, 1), dtype=torch.uint8, device=self.a_desc.device)
+
     def compile(self) -> None:
         """Compile the kernel."""
         self._logger.debug("Entering compile")
@@ -584,8 +605,7 @@ class GroupedGemmQuantSm100(APIBase):
         )
         fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
 
-        workspace_bytes = gemm_quant.get_workspace_bytes()
-        self._workspace = torch.empty(max(workspace_bytes, 1), dtype=torch.uint8, device="cuda")
+        self._ensure_workspace(gemm_quant)
 
         if self.weight_mode == MoEWeightMode.DENSE:
             self._compile_dense(gemm_quant, max_active_clusters, fake_stream)
@@ -805,51 +825,8 @@ class GroupedGemmQuantSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
-        cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
-
-        def tensor_api(
-            a_tensor: torch.Tensor,
-            b_tensor: torch.Tensor,
-            d_tensor: torch.Tensor,
-            d_col_tensor: Optional[torch.Tensor],
-            sfa_tensor: torch.Tensor,
-            sfb_tensor: torch.Tensor,
-            sfd_row_tensor: Optional[torch.Tensor],
-            sfd_col_tensor: Optional[torch.Tensor],
-            amax_tensor: Optional[torch.Tensor],
-            norm_const_tensor: Optional[torch.Tensor],
-            padded_offsets: torch.Tensor,
-            alpha_tensor: torch.Tensor,
-            row_scale_tensor: Optional[torch.Tensor],
-            prob_tensor: Optional[torch.Tensor],
-            bias_tensor: Optional[torch.Tensor],
-            stream: cuda.CUstream,
-        ) -> None:
-            norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
-            _compiled_kernel(
-                a_tensor,
-                b_tensor,
-                sfb_tensor,
-                cutlass.Int32(0),
-                cutlass.Int32(0),
-                cutlass.Int64(0),
-                cached_workspace_ptr,
-                d_tensor,
-                d_col_tensor,
-                sfa_tensor,
-                sfd_row_tensor,
-                sfd_col_tensor,
-                amax_tensor,
-                norm_const_tensor,
-                padded_offsets,
-                alpha_tensor,
-                row_scale_tensor,
-                bias_tensor,
-                prob_tensor,
-                stream,
-            )
-
-        self._compiled_kernel = tensor_api
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
 
     def _compile_discrete(self, gemm_quant, max_active_clusters, fake_stream) -> None:
         """Compile for discrete (per-expert pointer) weight mode."""
@@ -962,7 +939,63 @@ class GroupedGemmQuantSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
+
+    def _wrap_tensor_api(self, function):
+        self._ensure_workspace()
         cached_workspace_ptr = from_dlpack(self._workspace, assumed_align=128).iterator
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            def tensor_api(
+                a_tensor: torch.Tensor,
+                b_tensor: torch.Tensor,
+                d_tensor: torch.Tensor,
+                d_col_tensor: Optional[torch.Tensor],
+                sfa_tensor: torch.Tensor,
+                sfb_tensor: torch.Tensor,
+                sfd_row_tensor: Optional[torch.Tensor],
+                sfd_col_tensor: Optional[torch.Tensor],
+                amax_tensor: Optional[torch.Tensor],
+                norm_const_tensor: Optional[torch.Tensor],
+                padded_offsets: torch.Tensor,
+                alpha_tensor: torch.Tensor,
+                row_scale_tensor: Optional[torch.Tensor],
+                prob_tensor: Optional[torch.Tensor],
+                bias_tensor: Optional[torch.Tensor],
+                stream: cuda.CUstream,
+            ) -> None:
+                norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
+                function(
+                    a_tensor,
+                    b_tensor,
+                    sfb_tensor,
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    cutlass.Int64(0),
+                    cached_workspace_ptr,
+                    d_tensor,
+                    d_col_tensor,
+                    sfa_tensor,
+                    sfd_row_tensor,
+                    sfd_col_tensor,
+                    amax_tensor,
+                    norm_const_tensor,
+                    padded_offsets,
+                    alpha_tensor,
+                    row_scale_tensor,
+                    bias_tensor,
+                    prob_tensor,
+                    stream,
+                )
+
+            return tensor_api
+
+        if len(self.b_shape) == 2:
+            n, k = self.b_shape
+        else:
+            n, k, _ = self.b_shape
+        b_stride_size = k if self.b_major == "k" else n
         cached_n = cutlass.Int32(n)
         cached_k = cutlass.Int32(k)
         cached_b_stride = cutlass.Int64(b_stride_size)
@@ -986,12 +1019,10 @@ class GroupedGemmQuantSm100(APIBase):
             stream: cuda.CUstream,
         ) -> None:
             norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
-            b_ptrs_addr = int(b_ptrs_device.data_ptr())
-            sfb_ptrs_addr = int(sfb_ptrs_device.data_ptr())
-            _compiled_kernel(
+            function(
                 a_tensor,
-                b_ptrs_addr,
-                sfb_ptrs_addr,
+                int(b_ptrs_device.data_ptr()),
+                int(sfb_ptrs_device.data_ptr()),
                 cached_n,
                 cached_k,
                 cached_b_stride,
@@ -1011,7 +1042,7 @@ class GroupedGemmQuantSm100(APIBase):
                 stream,
             )
 
-        self._compiled_kernel = tensor_api
+        return tensor_api
 
     def execute(
         self,
@@ -1465,10 +1496,25 @@ def grouped_gemm_quant_wrapper_sm100(
             num_experts,
         )
 
-    if cache_key in _cache_of_GroupedGemmQuantSm100Objects:
+    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
+        raise ValueError(
+            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
+            f"got {aot_mode!r}"
+        )
+    if aot_mode and not aot_artifact_dir:
+        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+    use_cache = not aot_mode or aot_mode == "write"
+    if use_cache and cache_key in _cache_of_GroupedGemmQuantSm100Objects:
         _logger.debug("grouped_gemm_quant_wrapper_sm100: Using previously cached GroupedGemmQuantSm100 object")
         grouped_gemm_quant = _cache_of_GroupedGemmQuantSm100Objects[cache_key]
+        if aot_mode == "write" and grouped_gemm_quant._raw_compiled_kernel is None:
+            grouped_gemm_quant = None
     else:
+        grouped_gemm_quant = None
+
+    if grouped_gemm_quant is None:
         _logger.debug("grouped_gemm_quant_wrapper_sm100: No previously cached object found, creating new GroupedGemmQuantSm100 object")
         if is_dense:
             grouped_gemm_quant = GroupedGemmQuantSm100(
@@ -1526,7 +1572,18 @@ def grouped_gemm_quant_wrapper_sm100(
             )
 
         assert grouped_gemm_quant.check_support(), "Unsupported configuration"
-        grouped_gemm_quant.compile()
+        if aot_mode == "read":
+            grouped_gemm_quant.load_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "readwrite":
+            _, _, aot_paths = grouped_gemm_quant._build_aot_symbol_and_paths(aot_artifact_dir, cache_key)
+            if aot_paths.metadata_file.exists() and aot_paths.object_file.exists() and aot_paths.shared_library.exists():
+                grouped_gemm_quant.load_aot(aot_artifact_dir, cache_key)
+            else:
+                grouped_gemm_quant.export_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "write":
+            grouped_gemm_quant.export_aot(aot_artifact_dir, cache_key)
+        else:
+            grouped_gemm_quant.compile()
         _cache_of_GroupedGemmQuantSm100Objects[cache_key] = grouped_gemm_quant
 
     if is_dense:

--- a/python/cudnn/grouped_gemm/grouped_gemm_swiglu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_swiglu/api.py
@@ -663,6 +663,12 @@ class GroupedGemmSwigluSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
+        self._raw_compiled_kernel = _compiled_kernel
+        self._compiled_kernel = self._wrap_tensor_api(_compiled_kernel)
+
+        self._logger.debug("Kernel compiled successfully")
+
+    def _wrap_tensor_api(self, function):
         def tensor_api(
             a_tensor: torch.Tensor,
             b_tensor: torch.Tensor,
@@ -681,7 +687,7 @@ class GroupedGemmSwigluSm100(APIBase):
             stream: cuda.CUstream,
         ) -> None:
             norm_const_tensor = self._unpad_tensor_to_ndim(norm_const_tensor, 1, "norm_const")
-            _compiled_kernel(
+            function(
                 a_tensor,
                 b_tensor,
                 c_tensor,
@@ -699,9 +705,7 @@ class GroupedGemmSwigluSm100(APIBase):
                 stream,
             )
 
-        self._compiled_kernel = tensor_api
-
-        self._logger.debug("Kernel compiled successfully")
+        return tensor_api
 
     def execute(
         self,
@@ -959,9 +963,26 @@ def grouped_gemm_swiglu_wrapper_sm100(
         prob_tensor is not None,
     )
 
-    if cache_key in _cache_of_GroupedGemmSwigluSm100Objects:
+    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
+        raise ValueError(
+            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
+            f"got {aot_mode!r}"
+        )
+    if aot_mode and not aot_artifact_dir:
+        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+
+    use_cache = not aot_mode or aot_mode == "write"
+    if use_cache and cache_key in _cache_of_GroupedGemmSwigluSm100Objects:
         _logger.debug("group_gemm_swiglu_wrapper_sm100: Using previously cached GroupedGemmSwigluSm100 object")
         grouped_gemm_swiglu, amax_tensor = _cache_of_GroupedGemmSwigluSm100Objects[cache_key]
+        if aot_mode == "write" and grouped_gemm_swiglu._raw_compiled_kernel is None:
+            grouped_gemm_swiglu = None
+    else:
+        grouped_gemm_swiglu = None
+
+    if grouped_gemm_swiglu is not None:
         # The cuDNN graph API binds data pointers at execute time, not plan-build time.
         # During CUDA graph capture, padded_offsets is allocated in the graph pool
         # (stable address across replays), so passing it directly is graph-safe.
@@ -1013,7 +1034,18 @@ def grouped_gemm_swiglu_wrapper_sm100(
         )
 
         assert grouped_gemm_swiglu.check_support(), "Unsupported configuration"
-        grouped_gemm_swiglu.compile()
+        if aot_mode == "read":
+            grouped_gemm_swiglu.load_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "readwrite":
+            _, _, aot_paths = grouped_gemm_swiglu._build_aot_symbol_and_paths(aot_artifact_dir, cache_key)
+            if aot_paths.metadata_file.exists() and aot_paths.object_file.exists() and aot_paths.shared_library.exists():
+                grouped_gemm_swiglu.load_aot(aot_artifact_dir, cache_key)
+            else:
+                grouped_gemm_swiglu.export_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "write":
+            grouped_gemm_swiglu.export_aot(aot_artifact_dir, cache_key)
+        else:
+            grouped_gemm_swiglu.compile()
         grouped_gemm_swiglu.execute(
             a_tensor=a_tensor,
             b_tensor=b_tensor,

--- a/python/cudnn/grouped_gemm/grouped_gemm_swiglu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_swiglu/api.py
@@ -963,22 +963,21 @@ def grouped_gemm_swiglu_wrapper_sm100(
         prob_tensor is not None,
     )
 
-    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
-    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    aot_mode = os.getenv("NV_CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("NV_CUDNN_FE_AOT_DIR")
     if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
-        raise ValueError(
-            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
-            f"got {aot_mode!r}"
-        )
+        raise ValueError("NV_CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, " f"got {aot_mode!r}")
     if aot_mode and not aot_artifact_dir:
-        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+        raise ValueError("NV_CUDNN_FE_AOT_DIR is required when NV_CUDNN_FE_AOT_MODE is set")
 
-    use_cache = not aot_mode or aot_mode == "write"
-    if use_cache and cache_key in _cache_of_GroupedGemmSwigluSm100Objects:
+    if cache_key in _cache_of_GroupedGemmSwigluSm100Objects:
         _logger.debug("group_gemm_swiglu_wrapper_sm100: Using previously cached GroupedGemmSwigluSm100 object")
         grouped_gemm_swiglu, amax_tensor = _cache_of_GroupedGemmSwigluSm100Objects[cache_key]
-        if aot_mode == "write" and grouped_gemm_swiglu._raw_compiled_kernel is None:
-            grouped_gemm_swiglu = None
+        if aot_mode == "write":
+            if grouped_gemm_swiglu._raw_compiled_kernel is None:
+                grouped_gemm_swiglu = None
+            else:
+                grouped_gemm_swiglu.export_aot(aot_artifact_dir, cache_key)
     else:
         grouped_gemm_swiglu = None
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/api.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Optional, Tuple
 import logging
 
@@ -240,6 +241,23 @@ class GroupedGemmWgradSm100(APIBase):
         self._is_supported = True
         return True
 
+    def _ensure_workspace(self, kernel=None) -> None:
+        if getattr(self, "_workspace", None) is not None:
+            return
+        if kernel is None:
+            kernel = self._kernel(
+                sf_vec_size=self.sf_vec_size,
+                acc_dtype=_convert_to_cutlass_data_type(self.acc_dtype),
+                use_2cta_instrs=self.use_2cta_instrs,
+                mma_tiler_mn=self.mma_tiler_mn,
+                cluster_shape_mn=self.cluster_shape_mn,
+                accumulate_on_output=self.accumulate_on_output,
+                expert_cnt=self.expert_cnt,
+                weight_mode=self.weight_mode,
+                input_order=self.input_order,
+            )
+        self._workspace = torch.empty(max(kernel.get_workspace_bytes(), 1), dtype=torch.uint8, device=self.a_desc.device)
+
     def compile(self) -> None:
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -259,7 +277,7 @@ class GroupedGemmWgradSm100(APIBase):
 
         hardware_info = cutlass.utils.HardwareInfo()
         max_active_clusters = hardware_info.get_max_active_clusters(self.cluster_shape_mn[0] * self.cluster_shape_mn[1])
-        self._workspace = torch.empty(max(kernel.get_workspace_bytes(), 1), dtype=torch.uint8, device=self.a_desc.device)
+        self._ensure_workspace(kernel)
         fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
 
         if self.weight_mode == MoEWeightMode.DENSE:
@@ -344,34 +362,8 @@ class GroupedGemmWgradSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
-        cached_workspace = from_dlpack(self._workspace, assumed_align=128, enable_tvm_ffi=True)
-
-        def tensor_api(
-            a_tensor: torch.Tensor,
-            b_tensor: torch.Tensor,
-            sfa_tensor: torch.Tensor,
-            sfb_tensor: torch.Tensor,
-            wgrad_tensor: torch.Tensor,
-            offsets_tensor: torch.Tensor,
-            stream: cuda.CUstream,
-            global_scale_a: Optional[torch.Tensor],
-            global_scale_b: Optional[torch.Tensor],
-        ) -> None:
-            compiled(
-                a_tensor,
-                b_tensor,
-                sfa_tensor,
-                sfb_tensor,
-                wgrad_tensor,
-                offsets_tensor,
-                cached_workspace,
-                stream,
-                global_scale_a,
-                global_scale_b,
-                None,
-            )
-
-        self._compiled_kernel = tensor_api
+        self._raw_compiled_kernel = compiled
+        self._compiled_kernel = self._wrap_tensor_api(compiled)
 
     def _compile_discrete(self, kernel, max_active_clusters, fake_stream) -> None:
         a_fake = (
@@ -452,7 +444,41 @@ class GroupedGemmWgradSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
+        self._raw_compiled_kernel = compiled
+        self._compiled_kernel = self._wrap_tensor_api(compiled)
+
+    def _wrap_tensor_api(self, function):
+        self._ensure_workspace()
         cached_workspace = from_dlpack(self._workspace, assumed_align=128, enable_tvm_ffi=True)
+
+        if self.weight_mode == MoEWeightMode.DENSE:
+            def tensor_api(
+                a_tensor: torch.Tensor,
+                b_tensor: torch.Tensor,
+                sfa_tensor: torch.Tensor,
+                sfb_tensor: torch.Tensor,
+                wgrad_tensor: torch.Tensor,
+                offsets_tensor: torch.Tensor,
+                stream: cuda.CUstream,
+                global_scale_a: Optional[torch.Tensor],
+                global_scale_b: Optional[torch.Tensor],
+            ) -> None:
+                function(
+                    a_tensor,
+                    b_tensor,
+                    sfa_tensor,
+                    sfb_tensor,
+                    wgrad_tensor,
+                    offsets_tensor,
+                    cached_workspace,
+                    stream,
+                    global_scale_a,
+                    global_scale_b,
+                    None,
+                )
+
+            return tensor_api
+
         single_expert_placeholder = torch.empty_strided(
             self.single_expert_wgrad_desc.shape,
             self.single_expert_wgrad_desc.stride,
@@ -476,7 +502,7 @@ class GroupedGemmWgradSm100(APIBase):
             global_scale_a: Optional[torch.Tensor],
             global_scale_b: Optional[torch.Tensor],
         ) -> None:
-            compiled(
+            function(
                 a_tensor,
                 b_tensor,
                 sfa_tensor,
@@ -490,7 +516,7 @@ class GroupedGemmWgradSm100(APIBase):
                 cached_single_expert,
             )
 
-        self._compiled_kernel = tensor_api
+        return tensor_api
 
     def execute(
         self,
@@ -625,9 +651,24 @@ def grouped_gemm_wgrad_wrapper_sm100(
         input_order,
     )
 
-    if cache_key in _cache_of_GroupedGemmWgradSm100Objects:
+    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
+        raise ValueError(
+            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
+            f"got {aot_mode!r}"
+        )
+    if aot_mode and not aot_artifact_dir:
+        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
+    use_cache = not aot_mode or aot_mode == "write"
+    if use_cache and cache_key in _cache_of_GroupedGemmWgradSm100Objects:
         op = _cache_of_GroupedGemmWgradSm100Objects[cache_key]
+        if aot_mode == "write" and op._raw_compiled_kernel is None:
+            op = None
     else:
+        op = None
+
+    if op is None:
         if output_mode == "dense":
             op = GroupedGemmWgradSm100(
                 sample_a=a_tensor,
@@ -667,7 +708,18 @@ def grouped_gemm_wgrad_wrapper_sm100(
                 input_order=input_order,
             )
         assert op.check_support(), "Unsupported configuration"
-        op.compile()
+        if aot_mode == "read":
+            op.load_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "readwrite":
+            _, _, aot_paths = op._build_aot_symbol_and_paths(aot_artifact_dir, cache_key)
+            if aot_paths.metadata_file.exists() and aot_paths.object_file.exists() and aot_paths.shared_library.exists():
+                op.load_aot(aot_artifact_dir, cache_key)
+            else:
+                op.export_aot(aot_artifact_dir, cache_key)
+        elif aot_mode == "write":
+            op.export_aot(aot_artifact_dir, cache_key)
+        else:
+            op.compile()
         _cache_of_GroupedGemmWgradSm100Objects[cache_key] = op
 
     op.execute(

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/api.py
@@ -452,6 +452,7 @@ class GroupedGemmWgradSm100(APIBase):
         cached_workspace = from_dlpack(self._workspace, assumed_align=128, enable_tvm_ffi=True)
 
         if self.weight_mode == MoEWeightMode.DENSE:
+
             def tensor_api(
                 a_tensor: torch.Tensor,
                 b_tensor: torch.Tensor,
@@ -651,20 +652,19 @@ def grouped_gemm_wgrad_wrapper_sm100(
         input_order,
     )
 
-    aot_mode = os.getenv("CUDNN_FE_AOT_MODE", "").strip().lower()
-    aot_artifact_dir = os.getenv("CUDNN_FE_AOT_DIR")
+    aot_mode = os.getenv("NV_CUDNN_FE_AOT_MODE", "").strip().lower()
+    aot_artifact_dir = os.getenv("NV_CUDNN_FE_AOT_DIR")
     if aot_mode and aot_mode not in {"read", "write", "readwrite"}:
-        raise ValueError(
-            "CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, "
-            f"got {aot_mode!r}"
-        )
+        raise ValueError("NV_CUDNN_FE_AOT_MODE must be one of {'read', 'write', 'readwrite'}, " f"got {aot_mode!r}")
     if aot_mode and not aot_artifact_dir:
-        raise ValueError("CUDNN_FE_AOT_DIR is required when CUDNN_FE_AOT_MODE is set")
-    use_cache = not aot_mode or aot_mode == "write"
-    if use_cache and cache_key in _cache_of_GroupedGemmWgradSm100Objects:
+        raise ValueError("NV_CUDNN_FE_AOT_DIR is required when NV_CUDNN_FE_AOT_MODE is set")
+    if cache_key in _cache_of_GroupedGemmWgradSm100Objects:
         op = _cache_of_GroupedGemmWgradSm100Objects[cache_key]
-        if aot_mode == "write" and op._raw_compiled_kernel is None:
-            op = None
+        if aot_mode == "write":
+            if op._raw_compiled_kernel is None:
+                op = None
+            else:
+                op.export_aot(aot_artifact_dir, cache_key)
     else:
         op = None
 

--- a/test/python/fe_api/cutedsl_aot_cpp_smoke.cpp
+++ b/test/python/fe_api/cutedsl_aot_cpp_smoke.cpp
@@ -1,0 +1,41 @@
+#include <tvm/ffi/extra/module.h>
+#include <tvm/ffi/function.h>
+
+#include <exception>
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << "usage: cutedsl_aot_cpp_smoke <shared-library> <symbol>\n";
+    return 2;
+  }
+
+  const std::string shared_library = argv[1];
+  const std::string symbol = argv[2];
+
+  try {
+    tvm::ffi::Module module = tvm::ffi::Module::LoadFromFile(shared_library);
+    auto function = module->GetFunction(symbol);
+    if (!function.has_value()) {
+      function = module->GetFunction("__tvm_ffi_" + symbol);
+    }
+    if (!function.has_value()) {
+      std::cerr << "TVM-FFI module did not expose function " << symbol << "\n";
+      return 3;
+    }
+
+    try {
+      function.value()();
+    } catch (const std::exception& err) {
+      std::cout << "TVM-FFI function invocation reached expected argument validation: "
+                << err.what() << "\n";
+      return 0;
+    }
+  } catch (const std::exception& err) {
+    std::cerr << "TVM-FFI module smoke failed: " << err.what() << "\n";
+    return 4;
+  }
+
+  return 0;
+}

--- a/test/python/fe_api/test_cutedsl_aot.py
+++ b/test/python/fe_api/test_cutedsl_aot.py
@@ -46,8 +46,8 @@ def test_gemm_amax_aot_cpp_smoke(tmp_path, monkeypatch):
         "k",
     )
     gemm_amax_api._cache_of_GemmAmaxSm100Objects.clear()
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
     gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
     metadata_files = list(tmp_path.glob("*.json"))
     assert len(metadata_files) == 1
@@ -86,10 +86,7 @@ def test_gemm_amax_aot_cpp_smoke(tmp_path, monkeypatch):
     ]
     compile_result = subprocess.run(compile_cmd, text=True, capture_output=True)
     if compile_result.returncode != 0:
-        pytest.skip(
-            "TVM-FFI C++ smoke compiler setup is unavailable: "
-            + compile_result.stderr.strip()
-        )
+        pytest.skip("TVM-FFI C++ smoke compiler setup is unavailable: " + compile_result.stderr.strip())
 
     import cutlass.cute as cute
 
@@ -105,10 +102,7 @@ def test_gemm_amax_aot_cpp_smoke(tmp_path, monkeypatch):
     if runtime_library_dirs:
         env = {
             **os.environ,
-            "LD_LIBRARY_PATH": ":".join(
-                runtime_library_dirs
-                + ([os.environ["LD_LIBRARY_PATH"]] if "LD_LIBRARY_PATH" in os.environ else [])
-            ),
+            "LD_LIBRARY_PATH": ":".join(runtime_library_dirs + ([os.environ["LD_LIBRARY_PATH"]] if "LD_LIBRARY_PATH" in os.environ else [])),
         }
 
     run_result = subprocess.run(

--- a/test/python/fe_api/test_cutedsl_aot.py
+++ b/test/python/fe_api/test_cutedsl_aot.py
@@ -1,0 +1,120 @@
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+import torch
+
+from test_utils import torch_fork_set_rng
+
+pytestmark = pytest.mark.L0
+
+
+@torch_fork_set_rng(seed=0)
+def test_gemm_amax_aot_cpp_smoke(tmp_path, monkeypatch):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if shutil.which("g++") is None:
+        pytest.skip("g++ is not available for the TVM-FFI C++ smoke")
+
+    from cudnn import gemm_amax_wrapper_sm100
+    from cudnn._cutedsl_aot import read_metadata
+    from cudnn.gemm_amax import api as gemm_amax_api
+    from fe_api.test_gemm_amax_utils import (
+        allocate_input_tensors,
+    )
+
+    if importlib.util.find_spec("tvm_ffi") is None:
+        pytest.skip("TVM-FFI Python package is not installed")
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GemmAmax AOT requires SM100+, found SM{major}{minor}")
+
+    a_torch, _, b_torch, _, sfa_torch, _, sfb_torch, _ = allocate_input_tensors(
+        512,
+        256,
+        256,
+        1,
+        torch.float8_e5m2,
+        torch.float8_e8m0fnu,
+        32,
+        "k",
+        "k",
+    )
+    gemm_amax_api._cache_of_GemmAmaxSm100Objects.clear()
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = read_metadata(metadata_files[0])
+
+    smoke_src = tmp_path / "cutedsl_aot_cpp_smoke.cpp"
+    smoke_src.write_text(
+        (Path(__file__).parent / "cutedsl_aot_cpp_smoke.cpp").read_text(),
+        encoding="utf-8",
+    )
+    exe = tmp_path / "cutedsl_aot_cpp_smoke"
+    tvm_ffi_spec = importlib.util.find_spec("tvm_ffi")
+    if tvm_ffi_spec is None or tvm_ffi_spec.origin is None:
+        pytest.skip("TVM-FFI Python package path is unavailable for C++ smoke")
+    tvm_ffi_root = Path(tvm_ffi_spec.origin).parent
+    tvm_ffi_include = tvm_ffi_root / "include"
+    tvm_ffi_lib = tvm_ffi_root / "lib"
+    if not (tvm_ffi_include / "tvm" / "ffi" / "extra" / "module.h").exists():
+        pytest.skip(f"TVM-FFI C++ module headers are unavailable under {tvm_ffi_include}")
+    if not (tvm_ffi_lib / "libtvm_ffi.so").exists():
+        pytest.skip(f"TVM-FFI C++ runtime library is unavailable under {tvm_ffi_lib}")
+
+    compile_cmd = [
+        "g++",
+        "-std=c++17",
+        str(smoke_src),
+        "-I",
+        str(tvm_ffi_include),
+        "-L",
+        str(tvm_ffi_lib),
+        f"-Wl,-rpath,{tvm_ffi_lib}",
+        "-ltvm_ffi",
+        "-ldl",
+        "-o",
+        str(exe),
+    ]
+    compile_result = subprocess.run(compile_cmd, text=True, capture_output=True)
+    if compile_result.returncode != 0:
+        pytest.skip(
+            "TVM-FFI C++ smoke compiler setup is unavailable: "
+            + compile_result.stderr.strip()
+        )
+
+    import cutlass.cute as cute
+
+    finder = getattr(cute.runtime, "find_runtime_libraries", None)
+    runtime_libraries = ()
+    if finder is not None:
+        try:
+            runtime_libraries = finder(enable_tvm_ffi=True) or ()
+        except TypeError:
+            runtime_libraries = finder() or ()
+    runtime_library_dirs = [str(Path(library).parent) for library in runtime_libraries]
+    env = None
+    if runtime_library_dirs:
+        env = {
+            **os.environ,
+            "LD_LIBRARY_PATH": ":".join(
+                runtime_library_dirs
+                + ([os.environ["LD_LIBRARY_PATH"]] if "LD_LIBRARY_PATH" in os.environ else [])
+            ),
+        }
+
+    run_result = subprocess.run(
+        [str(exe), str(tmp_path / metadata.shared_library), metadata.symbol],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    assert run_result.returncode == 0, run_result.stderr

--- a/test/python/fe_api/test_gemm_amax.py
+++ b/test/python/fe_api/test_gemm_amax.py
@@ -1,3 +1,5 @@
+import json
+
 import torch
 
 import pytest
@@ -131,6 +133,67 @@ def test_gemm_amax_wrapper_fp8(
         cluster_shape_mn=cluster_shape_mn,
         request=request,
     )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_gemm_amax_aot_export_load(tmp_path, monkeypatch):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn import gemm_amax_wrapper_sm100
+    from cudnn.gemm_amax import api as gemm_amax_api
+    from fe_api.test_gemm_amax_utils import (
+        allocate_input_tensors,
+        check_ref_gemm_amax,
+    )
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GemmAmax AOT requires SM100+, found SM{major}{minor}")
+
+    a_torch, a_ref, b_torch, b_ref, sfa_torch, sfa_ref, sfb_torch, sfb_ref = allocate_input_tensors(
+        512,
+        256,
+        256,
+        1,
+        torch.float8_e5m2,
+        torch.float8_e8m0fnu,
+        32,
+        "k",
+        "k",
+    )
+    gemm_amax_api._cache_of_GemmAmaxSm100Objects.clear()
+    original_export_aot = gemm_amax_api.GemmAmaxSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(gemm_amax_api.GemmAmaxSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    exported = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GemmAmaxSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GemmAmaxSm100_")
+    check_ref_gemm_amax(a_ref, b_ref, sfa_ref, sfb_ref, exported["c_tensor"], exported["amax_tensor"])
+    assert export_calls == 1
+
+    cached = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
+    check_ref_gemm_amax(a_ref, b_ref, sfa_ref, sfb_ref, cached["c_tensor"], cached["amax_tensor"])
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    loaded = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
+
+    check_ref_gemm_amax(a_ref, b_ref, sfa_ref, sfb_ref, loaded["c_tensor"], loaded["amax_tensor"])
 
 
 """

--- a/test/python/fe_api/test_gemm_amax.py
+++ b/test/python/fe_api/test_gemm_amax.py
@@ -174,9 +174,20 @@ def test_gemm_amax_aot_export_load(tmp_path, monkeypatch):
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(gemm_amax_api.GemmAmaxSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.delenv("NV_CUDNN_FE_AOT_MODE", raising=False)
+    monkeypatch.delenv("NV_CUDNN_FE_AOT_DIR", raising=False)
+    compiled = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
+    compiled_entry = next(iter(gemm_amax_api._cache_of_GemmAmaxSm100Objects.values()))
+    assert compiled_entry._raw_compiled_kernel is not None
+    check_ref_gemm_amax(a_ref, b_ref, sfa_ref, sfb_ref, compiled["c_tensor"], compiled["amax_tensor"])
+    assert list(tmp_path.iterdir()) == []
+    assert export_calls == 0
+
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
     exported = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
+    assert next(iter(gemm_amax_api._cache_of_GemmAmaxSm100Objects.values())) is compiled_entry
+    assert export_calls == 1
 
     metadata_files = list(tmp_path.glob("*.json"))
     assert len(metadata_files) == 1
@@ -186,14 +197,39 @@ def test_gemm_amax_aot_export_load(tmp_path, monkeypatch):
     check_ref_gemm_amax(a_ref, b_ref, sfa_ref, sfb_ref, exported["c_tensor"], exported["amax_tensor"])
     assert export_calls == 1
 
+    artifact_contents = {path.name: path.read_bytes() for path in tmp_path.iterdir()}
     cached = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
     check_ref_gemm_amax(a_ref, b_ref, sfa_ref, sfb_ref, cached["c_tensor"], cached["amax_tensor"])
-    assert export_calls == 1
+    assert {path.name: path.read_bytes() for path in tmp_path.iterdir()} == artifact_contents
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    writer_entry = next(iter(gemm_amax_api._cache_of_GemmAmaxSm100Objects.values()))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    memory_hit = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
+    assert next(iter(gemm_amax_api._cache_of_GemmAmaxSm100Objects.values())) is writer_entry
+    check_ref_gemm_amax(
+        a_ref,
+        b_ref,
+        sfa_ref,
+        sfb_ref,
+        memory_hit["c_tensor"],
+        memory_hit["amax_tensor"],
+    )
+
+    gemm_amax_api._cache_of_GemmAmaxSm100Objects.clear()
     loaded = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
-
+    loaded_entry = next(iter(gemm_amax_api._cache_of_GemmAmaxSm100Objects.values()))
+    loaded_again = gemm_amax_wrapper_sm100(a_torch, b_torch, sfa_torch, sfb_torch)
+    assert next(iter(gemm_amax_api._cache_of_GemmAmaxSm100Objects.values())) is loaded_entry
     check_ref_gemm_amax(a_ref, b_ref, sfa_ref, sfb_ref, loaded["c_tensor"], loaded["amax_tensor"])
+    check_ref_gemm_amax(
+        a_ref,
+        b_ref,
+        sfa_ref,
+        sfb_ref,
+        loaded_again["c_tensor"],
+        loaded_again["amax_tensor"],
+    )
 
 
 """

--- a/test/python/fe_api/test_grouped_gemm_dglu.py
+++ b/test/python/fe_api/test_grouped_gemm_dglu.py
@@ -689,8 +689,8 @@ def test_grouped_gemm_dglu_dense_aot_export_load(tmp_path, monkeypatch, request)
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_dglu_api.GroupedGemmDgluSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     _test_grouped_gemm_dglu_dense_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -713,9 +713,10 @@ def test_grouped_gemm_dglu_dense_aot_export_load(tmp_path, monkeypatch, request)
     metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
     assert metadata["identity"]["kernel_name"] == "GroupedGemmDgluSm100"
     assert metadata["symbol"].startswith("cudnnfe_GroupedGemmDgluSm100_")
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_dglu_api._cache_of_GroupedGemmDgluSm100Objects.clear()
     _test_grouped_gemm_dglu_dense_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
         c_dtype=torch.bfloat16,
@@ -731,7 +732,24 @@ def test_grouped_gemm_dglu_dense_aot_export_load(tmp_path, monkeypatch, request)
         discrete_col_sfd=False,
         request=request,
     )
-    assert export_calls == 1
+    loaded_entry = next(iter(grouped_gemm_dglu_api._cache_of_GroupedGemmDgluSm100Objects.values()))
+    _test_grouped_gemm_dglu_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+    assert next(iter(grouped_gemm_dglu_api._cache_of_GroupedGemmDgluSm100Objects.values())) is loaded_entry
+    assert export_calls == 2
 
 
 @pytest.mark.L0
@@ -757,8 +775,8 @@ def test_grouped_gemm_dglu_discrete_aot_export_load(tmp_path, monkeypatch, reque
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_dglu_api.GroupedGemmDgluSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     _test_grouped_gemm_dglu_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -782,9 +800,10 @@ def test_grouped_gemm_dglu_discrete_aot_export_load(tmp_path, monkeypatch, reque
     metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
     assert metadata["identity"]["kernel_name"] == "GroupedGemmDgluSm100"
     assert metadata["symbol"].startswith("cudnnfe_GroupedGemmDgluSm100_")
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_dglu_api._cache_of_GroupedGemmDgluSm100Objects.clear()
     _test_grouped_gemm_dglu_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
         c_dtype=torch.bfloat16,
@@ -801,7 +820,25 @@ def test_grouped_gemm_dglu_discrete_aot_export_load(tmp_path, monkeypatch, reque
         request=request,
         skip_unsupported=False,
     )
-    assert export_calls == 1
+    loaded_entry = next(iter(grouped_gemm_dglu_api._cache_of_GroupedGemmDgluSm100Objects.values()))
+    _test_grouped_gemm_dglu_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        act_func="dswiglu",
+        request=request,
+        skip_unsupported=False,
+    )
+    assert next(iter(grouped_gemm_dglu_api._cache_of_GroupedGemmDgluSm100Objects.values())) is loaded_entry
+    assert export_calls == 2
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/test_grouped_gemm_dglu.py
+++ b/test/python/fe_api/test_grouped_gemm_dglu.py
@@ -5,6 +5,8 @@ Tests the GroupedGemmDgluSm100 API which supports both dense (contiguous)
 and discrete weight modes, with dSwiGLU and dGeGLU activations.
 """
 
+import json
+
 import torch
 import pytest
 from test_utils import torch_fork_set_rng
@@ -665,6 +667,144 @@ def _test_grouped_gemm_dglu_dense_wrapper(
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_dglu_dense_aot_export_load(tmp_path, monkeypatch, request):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn.grouped_gemm.grouped_gemm_dglu import api as grouped_gemm_dglu_api
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmDglu dense AOT requires SM100+, found SM{major}{minor}")
+
+    grouped_gemm_dglu_api._cache_of_GroupedGemmDgluSm100Objects.clear()
+    original_export_aot = grouped_gemm_dglu_api.GroupedGemmDgluSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_dglu_api.GroupedGemmDgluSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    _test_grouped_gemm_dglu_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmDgluSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmDgluSm100_")
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    _test_grouped_gemm_dglu_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+    assert export_calls == 1
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_dglu_discrete_aot_export_load(tmp_path, monkeypatch, request):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn.grouped_gemm.grouped_gemm_dglu import api as grouped_gemm_dglu_api
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmDglu discrete AOT requires SM100+, found SM{major}{minor}")
+
+    grouped_gemm_dglu_api._cache_of_GroupedGemmDgluSm100Objects.clear()
+    original_export_aot = grouped_gemm_dglu_api.GroupedGemmDgluSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_dglu_api.GroupedGemmDgluSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    _test_grouped_gemm_dglu_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        act_func="dswiglu",
+        request=request,
+        skip_unsupported=False,
+    )
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmDgluSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmDgluSm100_")
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    _test_grouped_gemm_dglu_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        act_func="dswiglu",
+        request=request,
+        skip_unsupported=False,
+    )
+    assert export_calls == 1
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=2)
 @pytest.mark.parametrize(
     "ab_dtype",
@@ -1149,6 +1289,7 @@ def _test_grouped_gemm_dglu_discrete_wrapper(
     b_major="k",
     generate_dbias=False,
     use_dynamic_sched=False,
+    skip_unsupported=True,
 ):
     try:
         from cudnn import grouped_gemm_dglu_wrapper_sm100
@@ -1221,6 +1362,8 @@ def _test_grouped_gemm_dglu_discrete_wrapper(
                 current_stream=stream,
             )
     except (ValueError, NotImplementedError) as e:
+        if not skip_unsupported:
+            raise
         pytest.skip(f"Unsupported testcase: {e}")
 
     torch.cuda.synchronize()

--- a/test/python/fe_api/test_grouped_gemm_dswiglu.py
+++ b/test/python/fe_api/test_grouped_gemm_dswiglu.py
@@ -5,6 +5,8 @@ This module tests the contiguous grouped block-scaled GEMM backward pass
 with dSwiGLU activation gradient for MoE (Mixture of Experts) workloads.
 """
 
+import json
+
 import torch
 import pytest
 from test_utils import torch_fork_set_rng
@@ -177,6 +179,159 @@ def test_grouped_gemm_dswiglu_wrapper_fp8(
         discrete_col_sfd=discrete_col_sfd,
         request=request,
     )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_dswiglu_aot_export_load(tmp_path, monkeypatch, request):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn import grouped_gemm_dswiglu_wrapper_sm100
+    from cudnn.grouped_gemm.grouped_gemm_dswiglu import api as grouped_gemm_dswiglu_api
+    from cuda.bindings import driver as cuda
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmDswiglu AOT requires SM100+, found SM{major}{minor}")
+
+    cfg = grouped_gemm_swiglu_init(
+        request=request,
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        b_major="k",
+    )
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    inputs = allocate_grouped_gemm_input_tensors(
+        n=cfg["n"],
+        k=cfg["k"],
+        l=cfg["l"],
+        group_m_list=cfg["group_m_list"],
+        ab_dtype=cfg["ab_dtype"],
+        b_major=cfg["b_major"],
+        sf_dtype=cfg["sf_dtype"],
+        sf_vec_size=cfg["sf_vec_size"],
+        m_aligned=cfg["m_aligned"],
+    )
+    inputs, _ = allocate_grouped_gemm_dswiglu_tensors(
+        tensor_m=inputs["tensor_m"],
+        n=cfg["n"],
+        l=cfg["l"],
+        ab_dtype=cfg["ab_dtype"],
+        c_dtype=cfg["c_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        sf_dtype=cfg["sf_dtype"],
+        sf_vec_size=cfg["sf_vec_size"],
+        input_tensors=inputs,
+    )
+
+    grouped_gemm_dswiglu_api._cache_of_GroupedGemmDswigluSm100Objects.clear()
+    original_export_aot = grouped_gemm_dswiglu_api.GroupedGemmDswigluSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_dswiglu_api.GroupedGemmDswigluSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    try:
+        exported = grouped_gemm_dswiglu_wrapper_sm100(
+            a_tensor=inputs["a_tensor"],
+            b_tensor=inputs["b_tensor"],
+            c_tensor=inputs["c_tensor"],
+            sfa_tensor=inputs["sfa_tensor"],
+            sfb_tensor=inputs["sfb_tensor"],
+            padded_offsets=inputs["padded_offsets_tensor"],
+            alpha_tensor=inputs["alpha_tensor"],
+            beta_tensor=inputs["beta_tensor"],
+            prob_tensor=inputs["prob_tensor"],
+            norm_const_tensor=inputs.get("norm_const_tensor"),
+            acc_dtype=cfg["acc_dtype"],
+            d_dtype=cfg["d_dtype"],
+            cd_major=cfg["cd_major"],
+            mma_tiler_mn=cfg["mma_tiler_mn"],
+            cluster_shape_mn=cfg["cluster_shape_mn"],
+            sf_vec_size=cfg["sf_vec_size"],
+            vector_f32=cfg["vector_f32"],
+            m_aligned=cfg["m_aligned"],
+            discrete_col_sfd=cfg["discrete_col_sfd"],
+            current_stream=stream,
+        )
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmDswigluSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmDswigluSm100_")
+    check_ref_grouped_gemm_dswiglu(inputs, exported, cfg, skip_ref=cfg["skip_ref"])
+    assert export_calls == 1
+
+    cached = grouped_gemm_dswiglu_wrapper_sm100(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        c_tensor=inputs["c_tensor"],
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        beta_tensor=inputs["beta_tensor"],
+        prob_tensor=inputs["prob_tensor"],
+        norm_const_tensor=inputs.get("norm_const_tensor"),
+        acc_dtype=cfg["acc_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        current_stream=stream,
+    )
+    check_ref_grouped_gemm_dswiglu(inputs, cached, cfg, skip_ref=cfg["skip_ref"])
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    loaded = grouped_gemm_dswiglu_wrapper_sm100(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        c_tensor=inputs["c_tensor"],
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        beta_tensor=inputs["beta_tensor"],
+        prob_tensor=inputs["prob_tensor"],
+        norm_const_tensor=inputs.get("norm_const_tensor"),
+        acc_dtype=cfg["acc_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        current_stream=stream,
+    )
+    check_ref_grouped_gemm_dswiglu(inputs, loaded, cfg, skip_ref=cfg["skip_ref"])
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/test_grouped_gemm_dswiglu.py
+++ b/test/python/fe_api/test_grouped_gemm_dswiglu.py
@@ -246,8 +246,8 @@ def test_grouped_gemm_dswiglu_aot_export_load(tmp_path, monkeypatch, request):
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_dswiglu_api.GroupedGemmDswigluSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     try:
         exported = grouped_gemm_dswiglu_wrapper_sm100(
@@ -306,9 +306,10 @@ def test_grouped_gemm_dswiglu_aot_export_load(tmp_path, monkeypatch, request):
         current_stream=stream,
     )
     check_ref_grouped_gemm_dswiglu(inputs, cached, cfg, skip_ref=cfg["skip_ref"])
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_dswiglu_api._cache_of_GroupedGemmDswigluSm100Objects.clear()
     loaded = grouped_gemm_dswiglu_wrapper_sm100(
         a_tensor=inputs["a_tensor"],
         b_tensor=inputs["b_tensor"],
@@ -331,7 +332,32 @@ def test_grouped_gemm_dswiglu_aot_export_load(tmp_path, monkeypatch, request):
         discrete_col_sfd=cfg["discrete_col_sfd"],
         current_stream=stream,
     )
+    loaded_entry = next(iter(grouped_gemm_dswiglu_api._cache_of_GroupedGemmDswigluSm100Objects.values()))
+    loaded_again = grouped_gemm_dswiglu_wrapper_sm100(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        c_tensor=inputs["c_tensor"],
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        beta_tensor=inputs["beta_tensor"],
+        prob_tensor=inputs["prob_tensor"],
+        norm_const_tensor=inputs.get("norm_const_tensor"),
+        acc_dtype=cfg["acc_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        current_stream=stream,
+    )
+    assert next(iter(grouped_gemm_dswiglu_api._cache_of_GroupedGemmDswigluSm100Objects.values())) is loaded_entry
     check_ref_grouped_gemm_dswiglu(inputs, loaded, cfg, skip_ref=cfg["skip_ref"])
+    check_ref_grouped_gemm_dswiglu(inputs, loaded_again, cfg, skip_ref=cfg["skip_ref"])
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/test_grouped_gemm_glu.py
+++ b/test/python/fe_api/test_grouped_gemm_glu.py
@@ -5,6 +5,8 @@ Tests the GroupedGemmGluSm100 API which supports both dense (contiguous)
 and discrete weight modes, with SwiGLU and GeGLU activations.
 """
 
+import json
+
 import torch
 import pytest
 from test_utils import torch_fork_set_rng
@@ -643,6 +645,142 @@ def _test_grouped_gemm_glu_dense_wrapper(
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_glu_dense_aot_export_load(tmp_path, monkeypatch, request):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn.grouped_gemm.grouped_gemm_glu import api as grouped_gemm_glu_api
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmGlu dense AOT requires SM100+, found SM{major}{minor}")
+
+    grouped_gemm_glu_api._cache_of_GroupedGemmGluSm100Objects.clear()
+    original_export_aot = grouped_gemm_glu_api.GroupedGemmGluSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_glu_api.GroupedGemmGluSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    _test_grouped_gemm_glu_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmGluSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmGluSm100_")
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    _test_grouped_gemm_glu_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+    assert export_calls == 1
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_glu_discrete_aot_export_load(tmp_path, monkeypatch, request):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn.grouped_gemm.grouped_gemm_glu import api as grouped_gemm_glu_api
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmGlu discrete AOT requires SM100+, found SM{major}{minor}")
+
+    grouped_gemm_glu_api._cache_of_GroupedGemmGluSm100Objects.clear()
+    original_export_aot = grouped_gemm_glu_api.GroupedGemmGluSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_glu_api.GroupedGemmGluSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    _test_grouped_gemm_glu_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        act_func="swiglu",
+        request=request,
+        skip_unsupported=False,
+    )
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmGluSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmGluSm100_")
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    _test_grouped_gemm_glu_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        act_func="swiglu",
+        request=request,
+        skip_unsupported=False,
+    )
+    assert export_calls == 1
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=1)
 @pytest.mark.parametrize(
     "ab_dtype",
@@ -1088,6 +1226,7 @@ def _test_grouped_gemm_glu_discrete_wrapper(
     b_major="k",
     enable_bias=False,
     use_dynamic_sched=False,
+    skip_unsupported=True,
 ):
     try:
         from cudnn import grouped_gemm_glu_wrapper_sm100
@@ -1157,6 +1296,8 @@ def _test_grouped_gemm_glu_discrete_wrapper(
                 current_stream=stream,
             )
     except (ValueError, NotImplementedError) as e:
+        if not skip_unsupported:
+            raise
         pytest.skip(f"Unsupported testcase: {e}")
 
     check_ref_discrete_grouped_gemm(inputs, outputs, cfg, skip_ref=cfg["skip_ref"])

--- a/test/python/fe_api/test_grouped_gemm_glu.py
+++ b/test/python/fe_api/test_grouped_gemm_glu.py
@@ -667,8 +667,8 @@ def test_grouped_gemm_glu_dense_aot_export_load(tmp_path, monkeypatch, request):
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_glu_api.GroupedGemmGluSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     _test_grouped_gemm_glu_dense_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -690,9 +690,10 @@ def test_grouped_gemm_glu_dense_aot_export_load(tmp_path, monkeypatch, request):
     metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
     assert metadata["identity"]["kernel_name"] == "GroupedGemmGluSm100"
     assert metadata["symbol"].startswith("cudnnfe_GroupedGemmGluSm100_")
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_glu_api._cache_of_GroupedGemmGluSm100Objects.clear()
     _test_grouped_gemm_glu_dense_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
         c_dtype=torch.bfloat16,
@@ -707,7 +708,23 @@ def test_grouped_gemm_glu_dense_aot_export_load(tmp_path, monkeypatch, request):
         discrete_col_sfd=False,
         request=request,
     )
-    assert export_calls == 1
+    loaded_entry = next(iter(grouped_gemm_glu_api._cache_of_GroupedGemmGluSm100Objects.values()))
+    _test_grouped_gemm_glu_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+    assert next(iter(grouped_gemm_glu_api._cache_of_GroupedGemmGluSm100Objects.values())) is loaded_entry
+    assert export_calls == 2
 
 
 @pytest.mark.L0
@@ -733,8 +750,8 @@ def test_grouped_gemm_glu_discrete_aot_export_load(tmp_path, monkeypatch, reques
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_glu_api.GroupedGemmGluSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     _test_grouped_gemm_glu_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -758,9 +775,10 @@ def test_grouped_gemm_glu_discrete_aot_export_load(tmp_path, monkeypatch, reques
     metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
     assert metadata["identity"]["kernel_name"] == "GroupedGemmGluSm100"
     assert metadata["symbol"].startswith("cudnnfe_GroupedGemmGluSm100_")
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_glu_api._cache_of_GroupedGemmGluSm100Objects.clear()
     _test_grouped_gemm_glu_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
         c_dtype=torch.bfloat16,
@@ -777,7 +795,25 @@ def test_grouped_gemm_glu_discrete_aot_export_load(tmp_path, monkeypatch, reques
         request=request,
         skip_unsupported=False,
     )
-    assert export_calls == 1
+    loaded_entry = next(iter(grouped_gemm_glu_api._cache_of_GroupedGemmGluSm100Objects.values()))
+    _test_grouped_gemm_glu_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        act_func="swiglu",
+        request=request,
+        skip_unsupported=False,
+    )
+    assert next(iter(grouped_gemm_glu_api._cache_of_GroupedGemmGluSm100Objects.values())) is loaded_entry
+    assert export_calls == 2
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/test_grouped_gemm_quant.py
+++ b/test/python/fe_api/test_grouped_gemm_quant.py
@@ -6,6 +6,8 @@ for MoE (Mixture of Experts) workloads in both dense and discrete weight modes.
 Used for FC2 (forward down-projection) and dFC1 (backward FC1 GEMMs).
 """
 
+import json
+
 import torch
 import pytest
 from test_utils import torch_fork_set_rng
@@ -1315,6 +1317,140 @@ def _test_grouped_gemm_quant_discrete_compile_execute(
     return inputs, outputs, cfg
 
 
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_quant_dense_aot_export_load(tmp_path, monkeypatch, request):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn.grouped_gemm.grouped_gemm_quant import api as grouped_gemm_quant_api
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmQuant dense AOT requires SM100+, found SM{major}{minor}")
+
+    grouped_gemm_quant_api._cache_of_GroupedGemmQuantSm100Objects.clear()
+    original_export_aot = grouped_gemm_quant_api.GroupedGemmQuantSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_quant_api.GroupedGemmQuantSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    _test_grouped_gemm_quant_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmQuantSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmQuantSm100_")
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    _test_grouped_gemm_quant_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+    assert export_calls == 1
+
+
+def test_grouped_gemm_quant_discrete_aot_export_load(tmp_path, monkeypatch, request):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn.grouped_gemm.grouped_gemm_quant import api as grouped_gemm_quant_api
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmQuant discrete AOT requires SM100+, found SM{major}{minor}")
+
+    grouped_gemm_quant_api._cache_of_GroupedGemmQuantSm100Objects.clear()
+    original_export_aot = grouped_gemm_quant_api.GroupedGemmQuantSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_quant_api.GroupedGemmQuantSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    _test_grouped_gemm_quant_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        skip_unsupported=False,
+    )
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmQuantSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmQuantSm100_")
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    _test_grouped_gemm_quant_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        skip_unsupported=False,
+    )
+    assert export_calls == 1
+
+
 def _test_grouped_gemm_quant_discrete_wrapper(
     ab_dtype,
     c_dtype,
@@ -1331,6 +1467,7 @@ def _test_grouped_gemm_quant_discrete_wrapper(
     request,
     use_dynamic_sched=False,
     row_scale=False,
+    skip_unsupported=True,
 ):
     try:
         from cudnn import grouped_gemm_quant_wrapper_sm100
@@ -1398,6 +1535,8 @@ def _test_grouped_gemm_quant_discrete_wrapper(
                 current_stream=stream,
             )
     except (ValueError, NotImplementedError) as e:
+        if not skip_unsupported:
+            raise
         pytest.skip(f"Unsupported testcase: {e}")
 
     _check_ref_grouped_gemm_quant_discrete(

--- a/test/python/fe_api/test_grouped_gemm_quant.py
+++ b/test/python/fe_api/test_grouped_gemm_quant.py
@@ -1340,8 +1340,8 @@ def test_grouped_gemm_quant_dense_aot_export_load(tmp_path, monkeypatch, request
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_quant_api.GroupedGemmQuantSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     _test_grouped_gemm_quant_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -1363,9 +1363,10 @@ def test_grouped_gemm_quant_dense_aot_export_load(tmp_path, monkeypatch, request
     metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
     assert metadata["identity"]["kernel_name"] == "GroupedGemmQuantSm100"
     assert metadata["symbol"].startswith("cudnnfe_GroupedGemmQuantSm100_")
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_quant_api._cache_of_GroupedGemmQuantSm100Objects.clear()
     _test_grouped_gemm_quant_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
         c_dtype=torch.bfloat16,
@@ -1380,9 +1381,26 @@ def test_grouped_gemm_quant_dense_aot_export_load(tmp_path, monkeypatch, request
         discrete_col_sfd=False,
         request=request,
     )
-    assert export_calls == 1
+    loaded_entry = next(iter(grouped_gemm_quant_api._cache_of_GroupedGemmQuantSm100Objects.values()))
+    _test_grouped_gemm_quant_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+    )
+    assert next(iter(grouped_gemm_quant_api._cache_of_GroupedGemmQuantSm100Objects.values())) is loaded_entry
+    assert export_calls == 2
 
 
+@pytest.mark.L0
 def test_grouped_gemm_quant_discrete_aot_export_load(tmp_path, monkeypatch, request):
     pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
     if not torch.cuda.is_available():
@@ -1404,8 +1422,8 @@ def test_grouped_gemm_quant_discrete_aot_export_load(tmp_path, monkeypatch, requ
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_quant_api.GroupedGemmQuantSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     _test_grouped_gemm_quant_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -1429,9 +1447,10 @@ def test_grouped_gemm_quant_discrete_aot_export_load(tmp_path, monkeypatch, requ
     metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
     assert metadata["identity"]["kernel_name"] == "GroupedGemmQuantSm100"
     assert metadata["symbol"].startswith("cudnnfe_GroupedGemmQuantSm100_")
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_quant_api._cache_of_GroupedGemmQuantSm100Objects.clear()
     _test_grouped_gemm_quant_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
         c_dtype=torch.bfloat16,
@@ -1448,7 +1467,25 @@ def test_grouped_gemm_quant_discrete_aot_export_load(tmp_path, monkeypatch, requ
         request=request,
         skip_unsupported=False,
     )
-    assert export_calls == 1
+    loaded_entry = next(iter(grouped_gemm_quant_api._cache_of_GroupedGemmQuantSm100Objects.values()))
+    _test_grouped_gemm_quant_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        skip_unsupported=False,
+    )
+    assert next(iter(grouped_gemm_quant_api._cache_of_GroupedGemmQuantSm100Objects.values())) is loaded_entry
+    assert export_calls == 2
 
 
 def _test_grouped_gemm_quant_discrete_wrapper(

--- a/test/python/fe_api/test_grouped_gemm_swiglu.py
+++ b/test/python/fe_api/test_grouped_gemm_swiglu.py
@@ -7,6 +7,8 @@ for MoE (Mixture of Experts) workloads.
 Reference: continugous_blockscaled_grouped_gemm_swiglu_quant_fusion.py
 """
 
+import json
+
 import torch
 import pytest
 from test_utils import torch_fork_set_rng
@@ -152,6 +154,142 @@ def test_grouped_gemm_swiglu_wrapper_fp8(
         discrete_col_sfd=discrete_col_sfd,
         request=request,
     )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_swiglu_aot_export_load(tmp_path, monkeypatch, request):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn import grouped_gemm_swiglu_wrapper_sm100
+    from cudnn.grouped_gemm.grouped_gemm_swiglu import api as grouped_gemm_swiglu_api
+    from cuda.bindings import driver as cuda
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmSwiglu AOT requires SM100+, found SM{major}{minor}")
+
+    cfg = grouped_gemm_swiglu_init(
+        request=request,
+        ab_dtype=torch.float4_e2m1fn_x2,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+    )
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    inputs = allocate_grouped_gemm_input_tensors(
+        n=cfg["n"],
+        k=cfg["k"],
+        l=cfg["l"],
+        group_m_list=cfg["group_m_list"],
+        ab_dtype=cfg["ab_dtype"],
+        sf_dtype=cfg["sf_dtype"],
+        sf_vec_size=cfg["sf_vec_size"],
+        m_aligned=cfg["m_aligned"],
+    )
+
+    grouped_gemm_swiglu_api._cache_of_GroupedGemmSwigluSm100Objects.clear()
+    original_export_aot = grouped_gemm_swiglu_api.GroupedGemmSwigluSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_swiglu_api.GroupedGemmSwigluSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    try:
+        exported = grouped_gemm_swiglu_wrapper_sm100(
+            a_tensor=inputs["a_tensor"],
+            b_tensor=inputs["b_tensor"],
+            sfa_tensor=inputs["sfa_tensor"],
+            sfb_tensor=inputs["sfb_tensor"],
+            padded_offsets=inputs["padded_offsets_tensor"],
+            alpha_tensor=inputs["alpha_tensor"],
+            norm_const_tensor=inputs.get("norm_const_tensor"),
+            prob_tensor=inputs.get("prob_tensor"),
+            acc_dtype=cfg["acc_dtype"],
+            c_dtype=cfg["c_dtype"],
+            d_dtype=cfg["d_dtype"],
+            cd_major=cfg["cd_major"],
+            mma_tiler_mn=cfg["mma_tiler_mn"],
+            cluster_shape_mn=cfg["cluster_shape_mn"],
+            sf_vec_size=cfg["sf_vec_size"],
+            vector_f32=cfg["vector_f32"],
+            m_aligned=cfg["m_aligned"],
+            discrete_col_sfd=cfg["discrete_col_sfd"],
+            current_stream=stream,
+        )
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmSwigluSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmSwigluSm100_")
+    check_ref_grouped_gemm_swiglu(inputs, exported, cfg, skip_ref=cfg["skip_ref"])
+    assert export_calls == 1
+
+    cached = grouped_gemm_swiglu_wrapper_sm100(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        norm_const_tensor=inputs.get("norm_const_tensor"),
+        prob_tensor=inputs.get("prob_tensor"),
+        acc_dtype=cfg["acc_dtype"],
+        c_dtype=cfg["c_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        current_stream=stream,
+    )
+    check_ref_grouped_gemm_swiglu(inputs, cached, cfg, skip_ref=cfg["skip_ref"])
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    loaded = grouped_gemm_swiglu_wrapper_sm100(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        norm_const_tensor=inputs.get("norm_const_tensor"),
+        prob_tensor=inputs.get("prob_tensor"),
+        acc_dtype=cfg["acc_dtype"],
+        c_dtype=cfg["c_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        current_stream=stream,
+    )
+    check_ref_grouped_gemm_swiglu(inputs, loaded, cfg, skip_ref=cfg["skip_ref"])
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/test_grouped_gemm_swiglu.py
+++ b/test/python/fe_api/test_grouped_gemm_swiglu.py
@@ -207,8 +207,8 @@ def test_grouped_gemm_swiglu_aot_export_load(tmp_path, monkeypatch, request):
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_swiglu_api.GroupedGemmSwigluSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     try:
         exported = grouped_gemm_swiglu_wrapper_sm100(
@@ -265,9 +265,10 @@ def test_grouped_gemm_swiglu_aot_export_load(tmp_path, monkeypatch, request):
         current_stream=stream,
     )
     check_ref_grouped_gemm_swiglu(inputs, cached, cfg, skip_ref=cfg["skip_ref"])
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_swiglu_api._cache_of_GroupedGemmSwigluSm100Objects.clear()
     loaded = grouped_gemm_swiglu_wrapper_sm100(
         a_tensor=inputs["a_tensor"],
         b_tensor=inputs["b_tensor"],
@@ -289,7 +290,31 @@ def test_grouped_gemm_swiglu_aot_export_load(tmp_path, monkeypatch, request):
         discrete_col_sfd=cfg["discrete_col_sfd"],
         current_stream=stream,
     )
+    loaded_entry = next(iter(grouped_gemm_swiglu_api._cache_of_GroupedGemmSwigluSm100Objects.values()))
+    loaded_again = grouped_gemm_swiglu_wrapper_sm100(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        norm_const_tensor=inputs.get("norm_const_tensor"),
+        prob_tensor=inputs.get("prob_tensor"),
+        acc_dtype=cfg["acc_dtype"],
+        c_dtype=cfg["c_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        current_stream=stream,
+    )
+    assert next(iter(grouped_gemm_swiglu_api._cache_of_GroupedGemmSwigluSm100Objects.values())) is loaded_entry
     check_ref_grouped_gemm_swiglu(inputs, loaded, cfg, skip_ref=cfg["skip_ref"])
+    check_ref_grouped_gemm_swiglu(inputs, loaded_again, cfg, skip_ref=cfg["skip_ref"])
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/test_grouped_gemm_wgrad.py
+++ b/test/python/fe_api/test_grouped_gemm_wgrad.py
@@ -192,8 +192,8 @@ def test_grouped_gemm_wgrad_dense_aot_export_load(tmp_path, monkeypatch):
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_wgrad_api.GroupedGemmWgradSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     _test_grouped_gemm_wgrad_dense_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -210,9 +210,10 @@ def test_grouped_gemm_wgrad_dense_aot_export_load(tmp_path, monkeypatch):
     metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
     assert metadata["identity"]["kernel_name"] == "GroupedGemmWgradSm100"
     assert metadata["symbol"].startswith("cudnnfe_GroupedGemmWgradSm100_")
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_wgrad_api._cache_of_GroupedGemmWgradSm100Objects.clear()
     _test_grouped_gemm_wgrad_dense_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
         wgrad_dtype=torch.bfloat16,
@@ -222,9 +223,21 @@ def test_grouped_gemm_wgrad_dense_aot_export_load(tmp_path, monkeypatch):
         sf_vec_size=32,
         sf_dtype=torch.float8_e8m0fnu,
     )
-    assert export_calls == 1
+    loaded_entry = next(iter(grouped_gemm_wgrad_api._cache_of_GroupedGemmWgradSm100Objects.values()))
+    _test_grouped_gemm_wgrad_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        wgrad_dtype=torch.bfloat16,
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+    )
+    assert next(iter(grouped_gemm_wgrad_api._cache_of_GroupedGemmWgradSm100Objects.values())) is loaded_entry
+    assert export_calls == 2
 
 
+@pytest.mark.L0
 def test_grouped_gemm_wgrad_discrete_aot_export_load(tmp_path, monkeypatch):
     pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
     if not torch.cuda.is_available():
@@ -246,8 +259,8 @@ def test_grouped_gemm_wgrad_discrete_aot_export_load(tmp_path, monkeypatch):
         return original_export_aot(self, *args, **kwargs)
 
     monkeypatch.setattr(grouped_gemm_wgrad_api.GroupedGemmWgradSm100, "export_aot", counting_export_aot)
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
-    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_DIR", str(tmp_path))
 
     _test_grouped_gemm_wgrad_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
@@ -265,9 +278,10 @@ def test_grouped_gemm_wgrad_discrete_aot_export_load(tmp_path, monkeypatch):
     metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
     assert metadata["identity"]["kernel_name"] == "GroupedGemmWgradSm100"
     assert metadata["symbol"].startswith("cudnnfe_GroupedGemmWgradSm100_")
-    assert export_calls == 1
+    assert export_calls == 2
 
-    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    monkeypatch.setenv("NV_CUDNN_FE_AOT_MODE", "read")
+    grouped_gemm_wgrad_api._cache_of_GroupedGemmWgradSm100Objects.clear()
     _test_grouped_gemm_wgrad_discrete_wrapper(
         ab_dtype=torch.float4_e2m1fn_x2,
         wgrad_dtype=torch.bfloat16,
@@ -278,7 +292,19 @@ def test_grouped_gemm_wgrad_discrete_aot_export_load(tmp_path, monkeypatch):
         sf_dtype=torch.float8_e8m0fnu,
         skip_unsupported=False,
     )
-    assert export_calls == 1
+    loaded_entry = next(iter(grouped_gemm_wgrad_api._cache_of_GroupedGemmWgradSm100Objects.values()))
+    _test_grouped_gemm_wgrad_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        wgrad_dtype=torch.bfloat16,
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        skip_unsupported=False,
+    )
+    assert next(iter(grouped_gemm_wgrad_api._cache_of_GroupedGemmWgradSm100Objects.values())) is loaded_entry
+    assert export_calls == 2
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/test_grouped_gemm_wgrad.py
+++ b/test/python/fe_api/test_grouped_gemm_wgrad.py
@@ -1,5 +1,7 @@
 """Tests for grouped GEMM wgrad FE API."""
 
+import json
+
 import pytest
 import torch
 import cudnn
@@ -169,6 +171,118 @@ def _test_grouped_gemm_wgrad_dense_wrapper(
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
+def test_grouped_gemm_wgrad_dense_aot_export_load(tmp_path, monkeypatch):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn.grouped_gemm.grouped_gemm_wgrad import api as grouped_gemm_wgrad_api
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmWgrad dense AOT requires SM100+, found SM{major}{minor}")
+
+    grouped_gemm_wgrad_api._cache_of_GroupedGemmWgradSm100Objects.clear()
+    original_export_aot = grouped_gemm_wgrad_api.GroupedGemmWgradSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_wgrad_api.GroupedGemmWgradSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    _test_grouped_gemm_wgrad_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        wgrad_dtype=torch.bfloat16,
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+    )
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmWgradSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmWgradSm100_")
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    _test_grouped_gemm_wgrad_dense_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        wgrad_dtype=torch.bfloat16,
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+    )
+    assert export_calls == 1
+
+
+def test_grouped_gemm_wgrad_discrete_aot_export_load(tmp_path, monkeypatch):
+    pytest.importorskip("cutlass", reason="CuTe DSL is not installed")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
+    from cudnn.grouped_gemm.grouped_gemm_wgrad import api as grouped_gemm_wgrad_api
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip(f"GroupedGemmWgrad discrete AOT requires SM100+, found SM{major}{minor}")
+
+    grouped_gemm_wgrad_api._cache_of_GroupedGemmWgradSm100Objects.clear()
+    original_export_aot = grouped_gemm_wgrad_api.GroupedGemmWgradSm100.export_aot
+    export_calls = 0
+
+    def counting_export_aot(self, *args, **kwargs):
+        nonlocal export_calls
+        export_calls += 1
+        return original_export_aot(self, *args, **kwargs)
+
+    monkeypatch.setattr(grouped_gemm_wgrad_api.GroupedGemmWgradSm100, "export_aot", counting_export_aot)
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "write")
+    monkeypatch.setenv("CUDNN_FE_AOT_DIR", str(tmp_path))
+
+    _test_grouped_gemm_wgrad_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        wgrad_dtype=torch.bfloat16,
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        skip_unsupported=False,
+    )
+
+    metadata_files = list(tmp_path.glob("*.json"))
+    assert len(metadata_files) == 1
+    metadata = json.loads(metadata_files[0].read_text(encoding="utf-8"))
+    assert metadata["identity"]["kernel_name"] == "GroupedGemmWgradSm100"
+    assert metadata["symbol"].startswith("cudnnfe_GroupedGemmWgradSm100_")
+    assert export_calls == 1
+
+    monkeypatch.setenv("CUDNN_FE_AOT_MODE", "read")
+    _test_grouped_gemm_wgrad_discrete_wrapper(
+        ab_dtype=torch.float4_e2m1fn_x2,
+        wgrad_dtype=torch.bfloat16,
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        skip_unsupported=False,
+    )
+    assert export_calls == 1
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
 @with_grouped_gemm_wgrad_params_fp4
 def test_grouped_gemm_wgrad_dense_wrapper_fp4(
     ab_dtype,
@@ -334,6 +448,7 @@ def _test_grouped_gemm_wgrad_discrete_wrapper(
     cluster_shape_mn,
     sf_vec_size,
     sf_dtype,
+    skip_unsupported=True,
 ):
     cfg = grouped_gemm_wgrad_init(
         ab_dtype=ab_dtype,
@@ -363,6 +478,8 @@ def _test_grouped_gemm_wgrad_discrete_wrapper(
                 sf_vec_size=cfg["sf_vec_size"],
             )
     except (ValueError, NotImplementedError) as e:
+        if not skip_unsupported:
+            raise
         pytest.skip(f"Unsupported testcase: {e}")
     torch.cuda.synchronize()
     check_ref_grouped_gemm_wgrad(result["wgrad_tensor"], inputs["ref_result"], cfg["tolerance"])


### PR DESCRIPTION
## Summary
- Add CuTe DSL AOT export/load helpers and artifact metadata handling.
- Wire `CUDNN_FE_AOT_MODE` / `CUDNN_FE_AOT_DIR` into GemmAmax and grouped GEMM wrapper paths.
- Add AOT export/load coverage for GemmAmax and grouped GEMM SM100 APIs, including C++ dlopen/dlsym smoke coverage.

## Validation
- Targeted SM100 pytest for GemmAmax AOT export/load and C++ smoke: passed.
- Targeted SM100 grouped GEMM dense/discrete AOT export/load regression: passed, `8 passed in 38.24s`.
- DeepSeek DSv3 `cudnn_jit_repro` in Dockerfile-built container:
  - `CUDNN_FE_AOT_MODE=write`: passed, exported 6 `.json`, 6 `.o`, and 6 `.so` artifacts.
  - `CUDNN_FE_AOT_MODE=read`: passed, 0 `cute.compile` lines and completed from AOT artifacts.
  - `CUDNN_FE_AOT_MODE=readwrite`: passed, first process exported artifacts; second process emitted 0 `cute.compile` lines and loaded artifacts.

## Notes
- The DeepSeek validation used the Dockerfile-built DSv3 container with local cudnn-frontend installed from this branch because the prebuilt NGC image required SSO access that was unavailable during setup.
