### PR TITLE
Align DSA indexer kernels and fix dense score-grad clipping

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -147,6 +147,7 @@ class IndexerBackward(APIBase):
         sample_topk_indices: torch.Tensor,  # (B, S_q, topk) INT32
         sm_scale: float = 1.0,
         block_I: int = 128,
+        topk_indices_global: bool = False,
     ):
         super().__init__()
         self.iq_desc = self._make_tensor_desc(sample_index_q, name="sample_index_q")
@@ -170,6 +171,7 @@ class IndexerBackward(APIBase):
         self.topk = topk
         self.sm_scale = float(sm_scale)
         self.block_I = int(block_I)
+        self.topk_indices_global = bool(topk_indices_global)
 
     def check_support(self) -> bool:
         major, _ = torch.cuda.get_device_capability()
@@ -206,6 +208,7 @@ class IndexerBackward(APIBase):
             self.topk,
             sm_scale=self.sm_scale,
             block_I=self.block_I,
+            topk_indices_global=self.topk_indices_global,
         )
 
     def execute(
@@ -423,6 +426,7 @@ def indexer_backward_wrapper(
     loss_coeff: float = 1.0,
     grad_loss: Union[float, torch.Tensor] = 1.0,
     block_I: int = 128,
+    topk_indices_global: bool = False,
     d_index_q: Optional[torch.Tensor] = None,
     d_weights: Optional[torch.Tensor] = None,
     d_index_k: Optional[torch.Tensor] = None,
@@ -435,6 +439,10 @@ def indexer_backward_wrapper(
     ``sum_grad`` during the score-grad precompute stage.
 
     Args:
+        topk_indices_global: whether ``topk_indices`` already contains global
+            flat KV ids. The cudnn top-k wrapper returns local per-batch ids by
+            default, so this wrapper defaults to ``False`` and lets the kernel
+            add the batch offset internally.
         sm_scale: indexer softmax scale baked into the forward via the
             weights-scaling trick.
         loss_coeff: coefficient scaling the KL-divergence loss in the
@@ -471,6 +479,7 @@ def indexer_backward_wrapper(
         topk,
         float(sm_scale),
         int(block_I),
+        bool(topk_indices_global),
     )
     obj = _cache_of_IndexerBackwardObjects.get(key)
     if obj is None:
@@ -486,6 +495,7 @@ def indexer_backward_wrapper(
             sample_topk_indices=topk_indices,
             sm_scale=sm_scale,
             block_I=block_I,
+            topk_indices_global=topk_indices_global,
         )
         assert obj.check_support()
         obj.compile()

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
@@ -278,10 +278,19 @@ class ScoreGradDense:
                     pr = mPredict_b[seq_local, pos]
                     tr = mTarget_b[seq_local, pos]
 
-                    predict = cute.math.exp2((pr - lse_val) * LOG2E, fastmath=True)
+                    score_minus_lse = pr - lse_val
+                    predict = cute.math.exp2(score_minus_lse * LOG2E, fastmath=True)
                     target = tr / (denom_val + Float32(DENOM_EPS))
-                    target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
-                    log_clip_mask = Float32(1.0) if predict >= Float32(CLIP_PROB_MIN) else Float32(0.0)
+                    target_eff = (
+                        target
+                        if target >= Float32(CLIP_PROB_MIN)
+                        else Float32(CLIP_PROB_MIN)
+                    )
+                    log_clip_mask = (
+                        Float32(1.0)
+                        if score_minus_lse >= Float32(CLIP_LOG_MIN)
+                        else Float32(0.0)
+                    )
                     g = -target_eff * log_clip_mask * grad_scale
 
                     local_sum = local_sum + g
@@ -302,10 +311,19 @@ class ScoreGradDense:
                     pr = mPredict_b[seq_local, pos]
                     tr = mTarget_b[seq_local, pos]
 
-                    predict = cute.math.exp2((pr - lse_val) * LOG2E, fastmath=True)
+                    score_minus_lse = pr - lse_val
+                    predict = cute.math.exp2(score_minus_lse * LOG2E, fastmath=True)
                     target = tr / (denom_val + Float32(DENOM_EPS))
-                    target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
-                    log_clip_mask = Float32(1.0) if predict >= Float32(CLIP_PROB_MIN) else Float32(0.0)
+                    target_eff = (
+                        target
+                        if target >= Float32(CLIP_PROB_MIN)
+                        else Float32(CLIP_PROB_MIN)
+                    )
+                    log_clip_mask = (
+                        Float32(1.0)
+                        if score_minus_lse >= Float32(CLIP_LOG_MIN)
+                        else Float32(0.0)
+                    )
                     g = -target_eff * log_clip_mask * grad_scale
 
                     grad_signal = g - predict * sum_grad

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
@@ -6,14 +6,14 @@ Three kernels launched sequentially on the same stream:
   Kernel 1 (CuTe DSL): ScoreGradDense — scalar elementwise + reduction kernel.
       From raw score + denom, normalize → softmax backprop reduction → compute
       grad_signal, in-place overwrite PredictRaw buffer.
-      Grid = (B, max_seqlen_q, 1), Block = (128, 1, 1), 4 warps.
+      Grid = (max_seqlen_q, B, 1), Block = (128, 1, 1), 4 warps.
 
   Kernel 2 (CuTe DSL): DenseIndexerBackward2QGemmSm100 — warp-specialized GEMM kernel.
       Three GEMMs (S, dK, dQ) with elementwise dS/dW computation.
       Two Q tokens per CTA (K-reuse): 6 GEMMs / K block.
       Reads pre-computed grad_signal from GMEM via Load warp (2-stage matching K).
       dK accumulated in float32 via cp.reduce.async.bulk.
-      Grid = (B, ceil(max_seqlen_q/2), 1), Block = (384, 1, 1), 12 warps.
+      Grid = (ceil(max_seqlen_q/2), B, 1), Block = (384, 1, 1), 12 warps.
 
   Kernel 3 (PyTorch): dk_convert — cast dK from float32 to output dtype.
 
@@ -193,7 +193,7 @@ class ScoreGradDense:
             max_seqlen_q,
             max_seqlen_k,
         ).launch(
-            grid=(batch_size, max_seqlen_q, 1),
+            grid=(max_seqlen_q, batch_size, 1),
             block=[self.THREADS_PER_CTA, 1, 1],
             stream=stream,
         )
@@ -213,8 +213,8 @@ class ScoreGradDense:
         seqlen_k_static: Int32,
     ):
         tidx = cute.arch.thread_idx()[0]
-        batch_idx = cute.arch.block_idx()[0]
-        seq_local = cute.arch.block_idx()[1]
+        seq_local = cute.arch.block_idx()[0]
+        batch_idx = cute.arch.block_idx()[1]
         warp_id = tidx // self.WARP_SIZE
         lane_id = tidx % self.WARP_SIZE
 
@@ -363,7 +363,7 @@ class DenseIndexerBackward2QGemmSm100:
       Offset 384:  dQ_q1  (128 cols) — Q token 1 persistent accumulator
 
     Barriers: 7 custom.
-    Grid: (batch, ceil(seqlen_q/2), 1).
+    Grid: (ceil(seqlen_q/2), batch, 1).
     """
 
     arch = 100
@@ -630,7 +630,7 @@ class DenseIndexerBackward2QGemmSm100:
             tma_atom_dQ_q1,
             sdQ_epi_layout,
         ).launch(
-            grid=(batch_size, grid_q, 1),
+            grid=(grid_q, batch_size, 1),
             block=[self.THREADS_PER_CTA, 1, 1],
             cluster=[1, 1, 1],
             stream=stream,
@@ -675,8 +675,8 @@ class DenseIndexerBackward2QGemmSm100:
     ):
         tidx = cute.arch.thread_idx()[0]
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        batch_idx = cute.arch.block_idx()[0]
-        seq_idx = cute.arch.block_idx()[1]
+        seq_idx = cute.arch.block_idx()[0]
+        batch_idx = cute.arch.block_idx()[1]
 
         is_varlen = const_expr(mCuSeqlensQ is not None)
 
@@ -2142,7 +2142,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
         s = _resolve_stream(current_stream)
 
         # Kernel 1 (CuTe DSL): in-place overwrites IdxScoreRaw with grad_signal.
-        # Grid = (B, max_seqlen_q, 1); CTAs past per-batch seqlen exit early.
+        # Grid = (max_seqlen_q, B, 1); CTAs past per-batch seqlen exit early.
         _ensure_compiled_score_grad(
             IdxScoreRaw,
             IdxLSE,
@@ -2168,7 +2168,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             )
 
         # Kernel 2 (CuTe DSL): 2Q three GEMMs — IdxScoreRaw now contains grad_signal.
-        # Grid = (B, ceil(max_seqlen_q/2), 1).
+        # Grid = (ceil(max_seqlen_q/2), B, 1).
         _run_gemm_only(
             IndexQ,
             Weights,

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm90.py
@@ -7,6 +7,7 @@ import cuda.bindings.driver as cuda
 
 import cutlass
 import cutlass.cute as cute
+from cutlass import Float32, Int32, const_expr
 
 from cudnn.deepseek_sparse_attention.utils.compiler import compile_options
 from cudnn.deepseek_sparse_attention.utils.runtime import (
@@ -16,79 +17,230 @@ from cudnn.deepseek_sparse_attention.utils.runtime import (
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor
 
 from .indexer_backward_sm90 import (
+    CLIP_LOG_MIN,
     CLIP_PROB_MIN,
     EPS,
     IndexerBackwardSm90,
 )
 
 _dense_compile_cache: dict = {}
+_dense_score_grad_compile_cache: dict = {}
 
 
-def _bottom_right_valid_mask(seqlen_q: int, seqlen_k: int, ratio: int, device) -> torch.Tensor:
-    q_start = seqlen_k * ratio - seqlen_q
-    q_idx = torch.arange(seqlen_q, device=device)
-    kv_idx = torch.arange(seqlen_k, device=device)
-    col_limit = ((q_start + q_idx + 1) // ratio).clamp(max=seqlen_k)
-    return kv_idx.unsqueeze(0) < col_limit.unsqueeze(1)
-
-
-def _score_grad_dense_slice_inplace(attn_slice, idx_slice, grad_scale, ratio):
-    seqlen_q, seqlen_k = idx_slice.shape
-    valid_mask = _bottom_right_valid_mask(seqlen_q, seqlen_k, ratio, idx_slice.device)
-
-    masked_idx_scores = idx_slice.masked_fill(~valid_mask, -1e9)
-    index_score = torch.softmax(masked_idx_scores, dim=-1)
-    attn_score_masked = attn_slice.masked_fill(~valid_mask, 0.0)
-    attn_score = attn_score_masked / attn_score_masked.sum(dim=-1, keepdim=True).clamp(min=EPS)
-
-    target_eff = attn_score.clamp(min=CLIP_PROB_MIN)
-    log_clip_mask = ((index_score >= CLIP_PROB_MIN) & valid_mask).to(attn_slice.dtype)
-    g = -target_eff * log_clip_mask * grad_scale
-    sum_grad = g.sum(dim=-1, keepdim=True)
-    grad_signal = (g - index_score * sum_grad).masked_fill(~valid_mask, 0.0)
-    attn_slice.copy_(grad_signal)
-
-
-def _score_grad_dense_inplace(
-    attn_scores_raw,
-    attn_l1norm,
-    idx_scores_raw,
-    idx_lse,
-    grad_scale,
-    ratio: int = 1,
-    cu_seqlens_q=None,
-    cu_seqlens_k=None,
+@cute.jit
+def _dense_seqlen_info(
+    mCuSeqlensQ,
+    mCuSeqlensK,
+    batch_idx: Int32,
+    seqlen_q_static: Int32,
+    seqlen_k_static: Int32,
 ):
-    """Compute dense grad_signal from raw scores and overwrite attn scores."""
-    assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
-    is_varlen = cu_seqlens_q is not None
-    if is_varlen:
-        assert cu_seqlens_k is not None
-        cu_q = cu_seqlens_q.detach().cpu().tolist()
-        cu_k = cu_seqlens_k.detach().cpu().tolist()
-        for b in range(len(cu_q) - 1):
-            qs, qe = cu_q[b], cu_q[b + 1]
-            ks, ke = cu_k[b], cu_k[b + 1]
-            sq_b = qe - qs
-            sk_b = ke - ks
-            if sq_b == 0 or sk_b == 0:
-                continue
-            _score_grad_dense_slice_inplace(
-                attn_scores_raw[qs:qe, :sk_b],
-                idx_scores_raw[qs:qe, :sk_b],
-                grad_scale,
-                ratio,
-            )
-            if sk_b < attn_scores_raw.shape[1]:
-                attn_scores_raw[qs:qe, sk_b:].zero_()
+    """Return batch-local offsets and lengths for BSHD or THD dense mode."""
+    if const_expr(mCuSeqlensQ is None):
+        return Int32(0), Int32(0), seqlen_q_static, seqlen_k_static
     else:
-        for b in range(idx_scores_raw.shape[0]):
-            _score_grad_dense_slice_inplace(
-                attn_scores_raw[b],
-                idx_scores_raw[b],
-                grad_scale,
-                ratio,
+        q_offset = mCuSeqlensQ[batch_idx]
+        seqlen_q_b = mCuSeqlensQ[batch_idx + Int32(1)] - q_offset
+        k_offset = mCuSeqlensK[batch_idx]
+        seqlen_k_b = mCuSeqlensK[batch_idx + Int32(1)] - k_offset
+        return q_offset, k_offset, seqlen_q_b, seqlen_k_b
+
+
+class ScoreGradDenseSm90:
+    """Dense score-grad precompute: raw scores + denoms -> grad_signal."""
+
+    WARP_SIZE = 32
+    THREADS_PER_CTA = 128
+
+    def __init__(self, ratio: int = 1):
+        assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
+        self.ratio = ratio
+
+    @cute.jit
+    def __call__(
+        self,
+        mIdxScoreRaw,
+        mAttnScoreRaw,
+        mIdxLSE,
+        mAttnL1Norm,
+        mCuSeqlensQ,
+        mCuSeqlensK,
+        grad_scale: Float32,
+        max_seqlen_q: Int32,
+        max_seqlen_k: Int32,
+        stream,
+    ):
+        # BSHD:
+        #   IdxScoreRaw/AttnScoreRaw: (B, S_q, S_k), IdxLSE/AttnL1Norm: (B, S_q)
+        # THD:
+        #   IdxScoreRaw/AttnScoreRaw: (T_q, max_K), IdxLSE/AttnL1Norm: (T_q,)
+        is_varlen = const_expr(mCuSeqlensQ is not None)
+
+        if const_expr(is_varlen):
+            batch_size = cute.size(mCuSeqlensQ.shape[0]) - 1
+        else:
+            mIdxScoreRaw = cute.make_tensor(
+                mIdxScoreRaw.iterator,
+                cute.select(mIdxScoreRaw.layout, mode=[1, 2, 0]),
             )
+            mAttnScoreRaw = cute.make_tensor(
+                mAttnScoreRaw.iterator,
+                cute.select(mAttnScoreRaw.layout, mode=[1, 2, 0]),
+            )
+            mIdxLSE = cute.make_tensor(
+                mIdxLSE.iterator,
+                cute.select(mIdxLSE.layout, mode=[1, 0]),
+            )
+            mAttnL1Norm = cute.make_tensor(
+                mAttnL1Norm.iterator,
+                cute.select(mAttnL1Norm.layout, mode=[1, 0]),
+            )
+            batch_size = cute.size(mIdxScoreRaw.shape[2])
+
+        seqlen_k_pad = cute.size(mIdxScoreRaw.shape[1])
+
+        self.kernel_score_grad(
+            mIdxScoreRaw,
+            mAttnScoreRaw,
+            mIdxLSE,
+            mAttnL1Norm,
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            grad_scale,
+            seqlen_k_pad,
+            max_seqlen_q,
+            max_seqlen_k,
+        ).launch(
+            grid=(max_seqlen_q, batch_size, 1),
+            block=[self.THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
+
+    @cute.kernel
+    def kernel_score_grad(
+        self,
+        mIdxScoreRaw,
+        mAttnScoreRaw,
+        mIdxLSE,
+        mAttnL1Norm,
+        mCuSeqlensQ,
+        mCuSeqlensK,
+        grad_scale: Float32,
+        seqlen_k_pad: Int32,
+        seqlen_q_static: Int32,
+        seqlen_k_static: Int32,
+    ):
+        tidx = cute.arch.thread_idx()[0]
+        seq_local = cute.arch.block_idx()[0]
+        batch_idx = cute.arch.block_idx()[1]
+        warp_id = tidx // self.WARP_SIZE
+
+        is_varlen = const_expr(mCuSeqlensQ is not None)
+        q_offset, _k_offset, seqlen_q_b, seqlen_k_b = _dense_seqlen_info(
+            mCuSeqlensQ,
+            mCuSeqlensK,
+            Int32(batch_idx),
+            seqlen_q_static,
+            seqlen_k_static,
+        )
+
+        if seq_local < seqlen_q_b:
+            smem = cutlass.utils.SmemAllocator()
+
+            @cute.struct
+            class SharedStorage:
+                sReduceScratch: cute.struct.Align[
+                    cute.struct.MemRange[Float32, 4],
+                    128,
+                ]
+
+            storage = smem.allocate(SharedStorage)
+            sReduceScratch = storage.sReduceScratch.get_tensor(
+                cute.make_layout((4,), stride=(1,))
+            )
+
+            if const_expr(is_varlen):
+                mIdxScore_b = cute.domain_offset((q_offset, Int32(0)), mIdxScoreRaw)
+                mAttnScore_b = cute.domain_offset((q_offset, Int32(0)), mAttnScoreRaw)
+                mIdxLSE_b = cute.domain_offset((q_offset,), mIdxLSE)
+                mAttnL1_b = cute.domain_offset((q_offset,), mAttnL1Norm)
+            else:
+                mIdxScore_b = mIdxScoreRaw[None, None, batch_idx]
+                mAttnScore_b = mAttnScoreRaw[None, None, batch_idx]
+                mIdxLSE_b = mIdxLSE[None, batch_idx]
+                mAttnL1_b = mAttnL1Norm[None, batch_idx]
+
+            idx_lse_val = mIdxLSE_b[seq_local]
+            attn_l1_val = mAttnL1_b[seq_local]
+            LOG2E = Float32(1.4426950408889634)
+
+            ratio = Int32(self.ratio)
+            q_start_b = seqlen_k_b * ratio - seqlen_q_b
+            col_limit_raw = (q_start_b + Int32(seq_local) + Int32(1)) // ratio
+            col_limit = col_limit_raw if col_limit_raw < seqlen_k_b else seqlen_k_b
+
+            local_sum = Float32(0.0)
+            pos = tidx
+            while pos < seqlen_k_pad:
+                if pos < col_limit:
+                    idx_raw = mIdxScore_b[seq_local, pos]
+                    attn_raw = mAttnScore_b[seq_local, pos]
+                    score_minus_lse = idx_raw - idx_lse_val
+                    predict = cute.math.exp2(
+                        score_minus_lse * LOG2E,
+                        fastmath=True,
+                    )
+                    target = attn_raw / (attn_l1_val + Float32(EPS))
+                    target_eff = (
+                        target
+                        if target >= Float32(CLIP_PROB_MIN)
+                        else Float32(CLIP_PROB_MIN)
+                    )
+                    log_clip_mask = (
+                        Float32(1.0)
+                        if score_minus_lse >= Float32(CLIP_LOG_MIN)
+                        else Float32(0.0)
+                    )
+                    local_sum = local_sum + (-target_eff * log_clip_mask * grad_scale)
+                pos = pos + Int32(128)
+
+            warp_sum = cute.arch.warp_reduction_sum(local_sum)
+            with cute.arch.elect_one():
+                sReduceScratch[warp_id] = warp_sum
+            cute.arch.sync_threads()
+            sum_grad = (
+                sReduceScratch[0]
+                + sReduceScratch[1]
+                + sReduceScratch[2]
+                + sReduceScratch[3]
+            )
+
+            pos = tidx
+            while pos < seqlen_k_pad:
+                if pos < col_limit:
+                    idx_raw = mIdxScore_b[seq_local, pos]
+                    attn_raw = mAttnScore_b[seq_local, pos]
+                    score_minus_lse = idx_raw - idx_lse_val
+                    predict = cute.math.exp2(
+                        score_minus_lse * LOG2E,
+                        fastmath=True,
+                    )
+                    target = attn_raw / (attn_l1_val + Float32(EPS))
+                    target_eff = (
+                        target
+                        if target >= Float32(CLIP_PROB_MIN)
+                        else Float32(CLIP_PROB_MIN)
+                    )
+                    log_clip_mask = (
+                        Float32(1.0)
+                        if score_minus_lse >= Float32(CLIP_LOG_MIN)
+                        else Float32(0.0)
+                    )
+                    g = -target_eff * log_clip_mask * grad_scale
+                    mIdxScore_b[seq_local, pos] = g - predict * sum_grad
+                else:
+                    mIdxScore_b[seq_local, pos] = Float32(0.0)
+                pos = pos + Int32(128)
 
 
 def dense_indexer_backward_sm90(
@@ -104,10 +256,8 @@ def dense_indexer_backward_sm90(
 ):
     """Factory for the dense indexer backward gradient kernel on SM90."""
     assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
-    # batch/seqlen are runtime (dynamic grid dim + Int32 args), so they're not
-    # keyed. seqlen_k IS kept: the dense K-load unrolls `range_constexpr(
-    # self.num_topk_blocks)` where num_topk_blocks = seqlen_k // block_I, so it
-    # changes generated code. sm_scale is a runtime Float32 arg (not keyed).
+    # batch/seqlen/seqlen_k are runtime (dynamic grid dims + Int32 args), so
+    # they're not keyed. sm_scale is a runtime Float32 arg (not keyed).
     return _build_cute_dsl_dense_kernel(
         batch,
         seqlen,
@@ -139,6 +289,7 @@ def _build_cute_dsl_dense_kernel(
         raise RuntimeError("Use SM100 kernel for Blackwell")
 
     topk = seqlen_k
+    score_grad_obj = ScoreGradDenseSm90(ratio=ratio)
     kernel_obj = IndexerBackwardSm90(
         head_dim=dim,
         heads=heads,
@@ -148,28 +299,51 @@ def _build_cute_dsl_dense_kernel(
         ratio=ratio,
     )
 
-    # Single-layer compile cache keyed only by params that change generated
-    # code. seqlen_k is runtime now (the dense K-load loops at runtime over
-    # num_k_blocks, like the compute warpgroup), so it's not keyed — batch/
-    # seqlen/sm_scale likewise. dummy_topk_holder is a per-device scratch
-    # tensor, not a compile cache.
-    compile_key = (is_varlen, heads, dim, block_I, ratio)
+    # Compile caches are keyed only by params that change generated code. In
+    # dense mode, K-block traversal is runtime-sized by seqlen_k.
+    score_grad_key = (is_varlen, ratio)
+    gemm_key = (is_varlen, heads, dim, block_I, ratio)
     dummy_topk_holder = [None]
 
     def _get_dummy_topk(device, current_stream=None):
         if dummy_topk_holder[0] is None or dummy_topk_holder[0].device != device:
             with _torch_stream_context(current_stream):
-                dummy_topk_holder[0] = torch.zeros(batch, seqlen, seqlen_k, device=device, dtype=torch.int32)
+                dummy_topk_holder[0] = torch.zeros(
+                    batch, seqlen, seqlen_k, device=device, dtype=torch.int32
+                )
         return dummy_topk_holder[0]
 
-    def _ensure_compiled(IndexQ, Weights, IndexK, dIndexQ, dWeights, dIndexK_f32, GradSignal, CuSeqlensQ, CuSeqlensK, current_stream=None):
+    def _ensure_compiled(
+        IndexQ,
+        Weights,
+        IndexK,
+        dIndexQ,
+        dWeights,
+        dIndexK_f32,
+        GradSignal,
+        CuSeqlensQ,
+        CuSeqlensK,
+        current_stream=None,
+    ):
         s = _resolve_stream(current_stream)
-        if compile_key not in _dense_compile_cache:
+        if gemm_key not in _dense_compile_cache:
             dummy_topk = _get_dummy_topk(IndexQ.device, current_stream=current_stream)
             cuq_arg = to_cute_tensor(CuSeqlensQ) if CuSeqlensQ is not None else None
             cuk_arg = to_cute_tensor(CuSeqlensK) if CuSeqlensK is not None else None
-            cute_args = [to_cute_tensor(t) for t in [IndexQ, Weights, IndexK, dIndexQ, dWeights, dIndexK_f32, GradSignal, dummy_topk]]
-            _dense_compile_cache[compile_key] = cute.compile(
+            cute_args = [
+                to_cute_tensor(t)
+                for t in [
+                    IndexQ,
+                    Weights,
+                    IndexK,
+                    dIndexQ,
+                    dWeights,
+                    dIndexK_f32,
+                    GradSignal,
+                    dummy_topk,
+                ]
+            ]
+            _dense_compile_cache[gemm_key] = cute.compile(
                 kernel_obj,
                 *cute_args,
                 cutlass.Float32(sm_scale),
@@ -181,17 +355,114 @@ def _build_cute_dsl_dense_kernel(
                 options=compile_options(),
             )
 
-    def _run_gemm_only(IndexQ, Weights, IndexK, dIndexQ, dWeights, dIndexK_f32, GradSignal, CuSeqlensQ=None, CuSeqlensK=None, current_stream=None):
+    def _ensure_compiled_score_grad(
+        IdxScoreRaw,
+        IdxLSE,
+        AttnScoreRaw,
+        AttnL1Norm,
+        CuSeqlensQ,
+        CuSeqlensK,
+        grad_scale,
+        current_stream=None,
+    ):
+        if score_grad_key not in _dense_score_grad_compile_cache:
+            s = _resolve_stream(current_stream)
+            cuq_arg = to_cute_tensor(CuSeqlensQ) if CuSeqlensQ is not None else None
+            cuk_arg = to_cute_tensor(CuSeqlensK) if CuSeqlensK is not None else None
+            _dense_score_grad_compile_cache[score_grad_key] = cute.compile(
+                score_grad_obj,
+                to_cute_tensor(IdxScoreRaw),
+                to_cute_tensor(AttnScoreRaw),
+                to_cute_tensor(IdxLSE),
+                to_cute_tensor(AttnL1Norm),
+                cuq_arg,
+                cuk_arg,
+                cutlass.Float32(float(grad_scale)),
+                cutlass.Int32(seqlen),
+                cutlass.Int32(seqlen_k),
+                s,
+                options=compile_options("--opt-level 3"),
+            )
+
+    def _run_score_grad_only(
+        IdxScoreRaw,
+        IdxLSE,
+        AttnScoreRaw,
+        AttnL1Norm,
+        grad_scale,
+        CuSeqlensQ=None,
+        CuSeqlensK=None,
+        current_stream=None,
+    ):
+        if is_varlen:
+            assert (
+                CuSeqlensQ is not None and CuSeqlensK is not None
+            ), "THD-compiled score-grad kernel requires cu_seqlens_q/k at runtime"
+        else:
+            assert (
+                CuSeqlensQ is None and CuSeqlensK is None
+            ), "BSHD-compiled score-grad kernel must not receive cu_seqlens_q/k"
+        s = _resolve_stream(current_stream)
+        _ensure_compiled_score_grad(
+            IdxScoreRaw,
+            IdxLSE,
+            AttnScoreRaw,
+            AttnL1Norm,
+            CuSeqlensQ,
+            CuSeqlensK,
+            grad_scale,
+            current_stream=current_stream,
+        )
+        _dense_score_grad_compile_cache[score_grad_key](
+            IdxScoreRaw,
+            AttnScoreRaw,
+            IdxLSE,
+            AttnL1Norm,
+            CuSeqlensQ,
+            CuSeqlensK,
+            cutlass.Float32(float(grad_scale)),
+            cutlass.Int32(seqlen),
+            cutlass.Int32(seqlen_k),
+            s,
+        )
+
+    def _run_gemm_only(
+        IndexQ,
+        Weights,
+        IndexK,
+        dIndexQ,
+        dWeights,
+        dIndexK_f32,
+        GradSignal,
+        CuSeqlensQ=None,
+        CuSeqlensK=None,
+        current_stream=None,
+    ):
         """Run fused dense Kernel 2. Caller must run score_grad first."""
         if is_varlen:
-            assert CuSeqlensQ is not None and CuSeqlensK is not None, "THD-compiled kernel requires cu_seqlens_q/k at runtime"
+            assert (
+                CuSeqlensQ is not None and CuSeqlensK is not None
+            ), "THD-compiled kernel requires cu_seqlens_q/k at runtime"
         else:
-            assert CuSeqlensQ is None and CuSeqlensK is None, "BSHD-compiled kernel must not receive cu_seqlens_q/k"
+            assert (
+                CuSeqlensQ is None and CuSeqlensK is None
+            ), "BSHD-compiled kernel must not receive cu_seqlens_q/k"
         dummy_topk = _get_dummy_topk(IndexQ.device, current_stream=current_stream)
         s = _resolve_stream(current_stream)
 
-        _ensure_compiled(IndexQ, Weights, IndexK, dIndexQ, dWeights, dIndexK_f32, GradSignal, CuSeqlensQ, CuSeqlensK, current_stream=current_stream)
-        _dense_compile_cache[compile_key](
+        _ensure_compiled(
+            IndexQ,
+            Weights,
+            IndexK,
+            dIndexQ,
+            dWeights,
+            dIndexK_f32,
+            GradSignal,
+            CuSeqlensQ,
+            CuSeqlensK,
+            current_stream=current_stream,
+        )
+        _dense_compile_cache[gemm_key](
             IndexQ,
             Weights,
             IndexK,
@@ -225,33 +496,57 @@ def _build_cute_dsl_dense_kernel(
         current_stream=None,
     ):
         if is_varlen:
-            assert CuSeqlensQ is not None and CuSeqlensK is not None, "THD-compiled kernel requires cu_seqlens_q/k at runtime"
+            assert (
+                CuSeqlensQ is not None and CuSeqlensK is not None
+            ), "THD-compiled kernel requires cu_seqlens_q/k at runtime"
         else:
-            assert CuSeqlensQ is None and CuSeqlensK is None, "BSHD-compiled kernel must not receive cu_seqlens_q/k"
-        # Keep the full SM90 dense pipeline aligned with /code/indexer: score-grad
-        # is still torch-based and therefore runs on PyTorch's current stream.
-        # Avoid mixing it with a non-current-stream GEMM until the score-grad
-        # stage has a DSL implementation upstream.
-        _score_grad_dense_inplace(
-            attn_scores_raw,
-            attn_l1norm,
+            assert (
+                CuSeqlensQ is None and CuSeqlensK is None
+            ), "BSHD-compiled kernel must not receive cu_seqlens_q/k"
+        _run_score_grad_only(
             idx_scores_raw,
             idx_lse,
+            attn_scores_raw,
+            attn_l1norm,
             grad_scale,
-            ratio=ratio,
-            cu_seqlens_q=CuSeqlensQ,
-            cu_seqlens_k=CuSeqlensK,
+            CuSeqlensQ,
+            CuSeqlensK,
+            current_stream=current_stream,
         )
-        grad_signal = attn_scores_raw
+        grad_signal = idx_scores_raw
 
         if dIndexK.dtype == torch.float32:
-            _run_gemm_only(IndexQ, Weights, IndexK, dIndexQ, dWeights, dIndexK, grad_signal, CuSeqlensQ, CuSeqlensK)
+            _run_gemm_only(
+                IndexQ,
+                Weights,
+                IndexK,
+                dIndexQ,
+                dWeights,
+                dIndexK,
+                grad_signal,
+                CuSeqlensQ,
+                CuSeqlensK,
+                current_stream=current_stream,
+            )
         else:
-            dIndexK_f32 = torch.zeros_like(dIndexK, dtype=torch.float32)
-            _run_gemm_only(IndexQ, Weights, IndexK, dIndexQ, dWeights, dIndexK_f32, grad_signal, CuSeqlensQ, CuSeqlensK)
-            dIndexK.copy_(dIndexK_f32)
+            with _torch_stream_context(current_stream):
+                dIndexK_f32 = torch.zeros_like(dIndexK, dtype=torch.float32)
+            _run_gemm_only(
+                IndexQ,
+                Weights,
+                IndexK,
+                dIndexQ,
+                dWeights,
+                dIndexK_f32,
+                grad_signal,
+                CuSeqlensQ,
+                CuSeqlensK,
+                current_stream=current_stream,
+            )
+            with _torch_stream_context(current_stream):
+                dIndexK.copy_(dIndexK_f32)
 
-    _run.score_grad = _score_grad_dense_inplace
+    _run.score_grad = _run_score_grad_only
     _run.gemm_only = _run_gemm_only
     _run.ratio = ratio
     _run.is_varlen = is_varlen

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py
@@ -340,7 +340,7 @@ class IndexerBackwardSm100:
             seqlen,
             batch_size,
         ).launch(
-            grid=(batch_size, seqlen, 1),
+            grid=(seqlen, batch_size, 1),
             block=[self.THREADS_PER_CTA, 1, 1],
             cluster=[1, 1, 1],
             stream=stream,
@@ -377,8 +377,8 @@ class IndexerBackwardSm100:
     ):
         tidx = cute.arch.thread_idx()[0]
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
-        batch_idx = cute.arch.block_idx()[0]
-        seq_idx = cute.arch.block_idx()[1]
+        seq_idx = cute.arch.block_idx()[0]
+        batch_idx = cute.arch.block_idx()[1]
         seqlen_k = cute.size(mK.shape[0])
 
         # TMA descriptor prefetch (load warp only)
@@ -1478,7 +1478,7 @@ class ScoreGradSm100:
         seqlen = cute.size(mAttnScore.shape[0])
         batch_size = cute.size(mAttnScore.shape[2]) if cute.rank(mAttnScore.shape) > 2 else 1
         self.kernel_score_grad(mAttnScore, mIndexScore, mGradLoss, grad_scale).launch(
-            grid=(batch_size, seqlen, 1),
+            grid=(seqlen, batch_size, 1),
             block=[self.THREADS_PER_CTA, 1, 1],
             cluster=[1, 1, 1],
             stream=stream,
@@ -1488,8 +1488,8 @@ class ScoreGradSm100:
     @cute.kernel
     def kernel_score_grad(self, mAttnScore, mIndexScore, mGradLoss, grad_scale: Float32 | float):
         tidx = cute.arch.thread_idx()[0]
-        batch_idx = cute.arch.block_idx()[0]
-        seq_idx = cute.arch.block_idx()[1]
+        seq_idx = cute.arch.block_idx()[0]
+        batch_idx = cute.arch.block_idx()[1]
         # grad_scale is a compile/runtime scalar (loss_coeff / (b*sq));
         # grad_loss lives in a shape-(1,) f32 GPU tensor (from autograd).
         # Fold them together once per CTA — the compiler will hoist.

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm90.py
@@ -34,7 +34,7 @@ Barriers:
   NamedBarrier(5): wg_sched_1  (ping-pong: WG1 syncs on this, WG0 arrives)
 
 SMEM (kernel 2): sGradSignal[topk] holds precomputed grad_signal from kernel 1.
-Grid: (batch, seqlen, 1). Each CTA handles one query position.
+Grid: (seqlen, batch, 1). Each CTA handles one query position.
 """
 
 from __future__ import annotations
@@ -340,7 +340,7 @@ class IndexerBackwardSm90:
             mCuSeqlensQ,
             mCuSeqlensK,
         ).launch(
-            grid=(batch_size, seqlen, 1),
+            grid=(seqlen, batch_size, 1),
             block=[self.THREADS_PER_CTA, 1, 1],
             cluster=[1, 1, 1],
             stream=stream,
@@ -377,8 +377,8 @@ class IndexerBackwardSm90:
         tidx = cute.arch.thread_idx()[0]
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         warp_group_idx = tidx // self.WARPGROUP_SIZE
-        batch_idx = cute.arch.block_idx()[0]
-        seq_idx = cute.arch.block_idx()[1]
+        seq_idx = cute.arch.block_idx()[0]
+        batch_idx = cute.arch.block_idx()[1]
         is_varlen = const_expr(self.is_dense and mCuSeqlensQ is not None)
         q_offset, k_offset, seqlen_q_b, seqlen_k_b = _seqlen_info(
             mCuSeqlensQ,
@@ -1401,7 +1401,7 @@ class ScoreGradSm90:
         seqlen = cute.size(mAttnScore.shape[0])
         batch_size = cute.size(mAttnScore.shape[2]) if cute.rank(mAttnScore.shape) > 2 else 1
         self.kernel_score_grad(mAttnScore, mIndexScore, mGradLoss, grad_scale).launch(
-            grid=(batch_size, seqlen, 1),
+            grid=(seqlen, batch_size, 1),
             block=[self.THREADS_PER_CTA, 1, 1],
             cluster=[1, 1, 1],
             stream=stream,
@@ -1411,8 +1411,8 @@ class ScoreGradSm90:
     @cute.kernel
     def kernel_score_grad(self, mAttnScore, mIndexScore, mGradLoss, grad_scale: Float32 | float):
         tidx = cute.arch.thread_idx()[0]
-        batch_idx = cute.arch.block_idx()[0]
-        seq_idx = cute.arch.block_idx()[1]
+        seq_idx = cute.arch.block_idx()[0]
+        batch_idx = cute.arch.block_idx()[1]
         # grad_scale is a compile/runtime scalar (loss_coeff / (b*sq));
         # grad_loss lives in a shape-(1,) f32 GPU tensor (from autograd).
         # Fold them together once per CTA — the compiler will hoist.

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
@@ -116,18 +116,12 @@ def indexer_fwd(
         assert out.dtype == torch.float32 and out.is_cuda
         assert out.is_contiguous(), "out must be contiguous"
 
-    # SM90 TMA store descriptors require the row stride in bytes to be 16B aligned.
-    # The old C++ BSHD path uses TMA store when that descriptor is legal; otherwise
-    # we keep the same warp-scalar writeback used by its varlen path.
-    use_tma_store = (not is_varlen) and (out.stride(1) * out.element_size()) % 16 == 0
-
     compile_key = (
         q.dtype,
         int(head_dim),
         int(qhead_per_kv_head),
         int(ratio),
         bool(is_varlen),
-        bool(use_tma_store),
     )
     current_stream = resolve_stream(current_stream)
     if compile_key not in _compile_cache:
@@ -143,7 +137,6 @@ def indexer_fwd(
             qhead_per_kvhead=int(qhead_per_kv_head),
             ratio=int(ratio),
             is_varlen=is_varlen,
-            use_tma_store=use_tma_store,
         )
         _compile_cache[compile_key] = cute.compile(
             kernel_obj,

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
@@ -1,14 +1,14 @@
 """SM90 indexer forward kernel - direct CuTeDSL port of the old C++ path.
 
-This kernel intentionally follows the old SM90 C++ forward topology:
+This kernel intentionally keeps the SM90 C++ Q/K staging topology:
   * 256 threads / 2 warpgroups
   * WG0 warp0 issues Q/K TMA loads and loads weights
-  * WG0 warp1 stores the score tile to global memory
-  * WG1 runs two 64x64x16 WGMMA stages and the head-reduce epilogue
+  * WG1 runs two 64x64x16 WGMMA stages and writes the reduced scores
 
 The algorithm computes the same score tensor as the C++ kernel:
     sm_scale * sum_h relu(Q_h @ K^T) * W_h
-with bottom-right ratio causal masking.
+with bottom-right ratio causal masking. Reduced BF16 scores are written directly
+from registers to global memory.
 """
 
 import math
@@ -28,7 +28,6 @@ from cudnn.deepseek_sparse_attention.utils import copy as copy_utils
 from cudnn.deepseek_sparse_attention.utils.seqlen import SeqlenInfoQK
 from cudnn.deepseek_sparse_attention.utils.sm90 import mma as sm90_mma
 from cudnn.deepseek_sparse_attention.utils.sm90 import primitives as sm90_ops
-from cudnn.deepseek_sparse_attention.utils.sm90.bwd_barriers import NamedBarrierBwd
 from cudnn.deepseek_sparse_attention.utils.sm90.mma import gemm_w_idx
 
 
@@ -53,7 +52,7 @@ class IndexerForwardSm90:
         qhead_per_kvhead: int = 64,
         ratio: int = 4,
         is_varlen: bool = False,
-        use_tma_store: bool = False,
+        clean_logits: bool = True,
     ):
         assert head_dim == 128, f"SM90 direct forward supports head_dim=128, got {head_dim}"
         assert qhead_per_kvhead in (
@@ -67,7 +66,7 @@ class IndexerForwardSm90:
         self.qhead_per_kvhead = qhead_per_kvhead
         self.ratio = ratio
         self.is_varlen = is_varlen
-        self.use_tma_store = use_tma_store and not is_varlen
+        self.clean_logits = clean_logits
 
         self.tile_m = 128
         self.tile_n = 64
@@ -117,10 +116,15 @@ class IndexerForwardSm90:
         )
 
     def _get_shared_storage_cls(self):
-        sQ_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(self.sQ_layout_staged)], 1024]
-        sKV_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, cute.cosize(self.sKV_layout_staged)], 1024]
-        sW_struct = cute.struct.Align[cute.struct.MemRange[self.dtype, self.tile_m], 128]
-        sScore_struct = cute.struct.Align[cute.struct.MemRange[Float32, self.q_tokens_per_tile * self.tile_n], 1024]
+        sQ_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, cute.cosize(self.sQ_layout_staged)], 1024
+        ]
+        sKV_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, cute.cosize(self.sKV_layout_staged)], 1024
+        ]
+        sW_struct = cute.struct.Align[
+            cute.struct.MemRange[self.dtype, self.tile_m], 128
+        ]
 
         @cute.struct
         class SharedStorage:
@@ -130,10 +134,7 @@ class IndexerForwardSm90:
             mbar_KV1: cute.struct.MemRange[cutlass.Int64, 2]
             mbar_KVEmpty0: cute.struct.MemRange[cutlass.Int64, 2]
             mbar_KVEmpty1: cute.struct.MemRange[cutlass.Int64, 2]
-            mbar_ScoreFull: cute.struct.MemRange[cutlass.Int64, 2]
-            mbar_ScoreEmpty: cute.struct.MemRange[cutlass.Int64, 2]
             sW: sW_struct
-            sScore: sScore_struct
             sQ: sQ_struct
             sKV: sKV_struct
 
@@ -191,18 +192,20 @@ class IndexerForwardSm90:
                     sW[row] = self.dtype(0.0)
 
     @cute.jit
-    def _epilogue_store_to_smem(
+    def _epilogue_store_to_gmem(
         self,
         q_stage_idx: cutlass.Constexpr[int],
         acc_S: cute.Tensor,
         tWeights: cute.Tensor,
-        sScore: cute.Tensor,
+        mOut: cute.Tensor,
         m_block: Int32,
         n_block: Int32,
         is_first_nblock: Boolean,
         seqlen_q: Int32,
         seqlen_k: Int32,
-        tidx_wg: Int32,
+        max_seqlen_k: Int32,
+        q_batch_offset: Int32,
+        batch_idx: Int32,
         sm_scale: Float32,
     ):
         acc_mn = sm90_ops.make_acc_tensor_mn_view(acc_S)
@@ -237,15 +240,27 @@ class IndexerForwardSm90:
             for qi in cutlass.range_constexpr(self.q_tokens_per_stage):
                 for mi in cutlass.range(kNRows, unroll_full=True):
                     kv_m = m_base + mi * 8
-                    q_offset = q_stage_idx * self.q_tokens_per_stage + qi
+                    q_local = q_token_base + qi
+                    k_local = n_block * self.tile_n + kv_m
                     score = ps[mi, qi]
+                    should_store = Boolean(True)
                     if is_first_nblock:
-                        kv_token = n_block * self.tile_n + kv_m
-                        col_lim = (q_global_start + q_token_base + qi + Int32(1)) // Int32(self.ratio)
-                        if kv_token >= seqlen_k or kv_token >= col_lim:
-                            score = -Float32.inf
-                    sScore[q_offset, kv_m] = score
-        cute.arch.fence_view_async_shared()
+                        col_lim = (
+                            q_global_start + q_local + Int32(1)
+                        ) // Int32(self.ratio)
+                        if k_local >= seqlen_k or k_local >= col_lim:
+                            if const_expr(self.clean_logits):
+                                score = -Float32.inf
+                            else:
+                                should_store = Boolean(False)
+                    elif k_local >= seqlen_k:
+                        should_store = Boolean(False)
+
+                    if should_store and q_local < seqlen_q and k_local < max_seqlen_k:
+                        if const_expr(self.is_varlen):
+                            mOut[q_batch_offset + q_local, k_local] = score
+                        else:
+                            mOut[batch_idx, q_local, k_local] = score
 
     @cute.jit
     def producer(
@@ -370,15 +385,13 @@ class IndexerForwardSm90:
         sQ_1: cute.Tensor,
         sKV_staged: cute.Tensor,
         sW: cute.Tensor,
-        sScore: cute.Tensor,
+        mOut: cute.Tensor,
         mbar_Q0_ptr,
         mbar_Q1_ptr,
         mbar_KV0_ptr,
         mbar_KV1_ptr,
         mbar_KVEmpty0_ptr,
         mbar_KVEmpty1_ptr,
-        mbar_ScoreFull_ptr,
-        mbar_ScoreEmpty_ptr,
         mCuSeqlensQ: cute.Tensor,
         mCuSeqlensK: cute.Tensor,
         max_seqlen_q: Int32,
@@ -429,7 +442,6 @@ class IndexerForwardSm90:
             q1_phase = Int32(0)
             kv0_phase = Int32(0)
             kv1_phase = Int32(0)
-            score_empty_phase = Int32(0)
             warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
 
             cute.arch.mbarrier_wait(mbar_Q0_ptr, q0_phase)
@@ -479,130 +491,38 @@ class IndexerForwardSm90:
                         with cute.arch.elect_one():
                             cute.arch.mbarrier_arrive(mbar_KVEmpty1_ptr, arrive_count=128)
 
-                if iter_idx > Int32(0):
-                    cute.arch.mbarrier_wait(mbar_ScoreEmpty_ptr, score_empty_phase)
-                    score_empty_phase = score_empty_phase ^ Int32(1)
-
                 is_first = Boolean(iter_idx == Int32(0))
-                self._epilogue_store_to_smem(
+                self._epilogue_store_to_gmem(
                     0,
                     acc0,
                     tWeights0,
-                    sScore,
+                    mOut,
                     m_block,
                     n_block,
                     is_first,
                     seqlen.seqlen_q,
                     seqlen.seqlen_k,
-                    wg_tidx,
+                    max_seqlen_k,
+                    seqlen.offset_q,
+                    batch_idx,
                     sm_scale,
                 )
-                self._epilogue_store_to_smem(
+                self._epilogue_store_to_gmem(
                     1,
                     acc1,
                     tWeights1,
-                    sScore,
+                    mOut,
                     m_block,
                     n_block,
                     is_first,
                     seqlen.seqlen_q,
                     seqlen.seqlen_k,
-                    wg_tidx,
+                    max_seqlen_k,
+                    seqlen.offset_q,
+                    batch_idx,
                     sm_scale,
                 )
 
-                cute.arch.mbarrier_arrive(mbar_ScoreFull_ptr)
-                iter_idx = iter_idx + Int32(1)
-
-    @cute.jit
-    def score_store(
-        self,
-        mOut: cute.Tensor,
-        mOut_tma: cute.Tensor,
-        tma_atom_Score: cute.CopyAtom,
-        sScore: cute.Tensor,
-        mbar_ScoreFull_ptr,
-        mbar_ScoreEmpty_ptr,
-        mCuSeqlensQ: cute.Tensor,
-        mCuSeqlensK: cute.Tensor,
-        max_seqlen_q: Int32,
-        max_seqlen_k: Int32,
-    ):
-        lane = cute.arch.lane_idx()
-        block_x, head_idx, batch_idx = cute.arch.block_idx()
-        del head_idx
-        seqlen = SeqlenInfoQK.create(
-            batch_idx,
-            max_seqlen_q,
-            max_seqlen_k,
-            mCuSeqlensQ,
-            mCuSeqlensK,
-            None,
-            None,
-            tile_m=self.tile_m,
-            tile_n=self.tile_n,
-        )
-        num_m_blocks = cute.ceil_div(seqlen.seqlen_q * self.qhead_per_kvhead, self.tile_m)
-        if block_x < num_m_blocks:
-            m_block = num_m_blocks - Int32(1) - block_x
-            n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k)
-
-            score_full_phase = Int32(0)
-            iter_idx = Int32(0)
-            while iter_idx < n_block_max:
-                n_block = self._iter_n_block(iter_idx, n_block_max)
-                cute.arch.mbarrier_wait(mbar_ScoreFull_ptr, score_full_phase)
-                score_full_phase = score_full_phase ^ Int32(1)
-
-                if const_expr(mCuSeqlensQ is not None):
-                    for idx in cutlass.range(lane, self.q_tokens_per_tile * self.tile_n, 32, unroll=1):
-                        qi = idx // self.tile_n
-                        kj = idx - qi * self.tile_n
-                        q_local = m_block * self.q_tokens_per_tile + qi
-                        k_local = n_block * self.tile_n + kj
-                        if q_local < seqlen.seqlen_q and k_local < max_seqlen_k:
-                            mOut[seqlen.offset_q + q_local, k_local] = sScore[qi, kj]
-                else:
-                    if const_expr(self.use_tma_store):
-                        q_tile_end = (m_block + Int32(1)) * Int32(self.q_tokens_per_tile)
-                        k_tile_end = (n_block + Int32(1)) * Int32(self.tile_n)
-                        if q_tile_end <= seqlen.seqlen_q and k_tile_end <= max_seqlen_k:
-                            score_tile = (self.q_tokens_per_tile, self.tile_n)
-                            gScore = cute.local_tile(
-                                mOut_tma[None, None, batch_idx],
-                                score_tile,
-                                (m_block, n_block),
-                            )
-                            store_fn, _, _ = copy_utils.tma_get_copy_fn(
-                                tma_atom_Score,
-                                0,
-                                cute.make_layout(1),
-                                sScore,
-                                gScore,
-                                single_stage=True,
-                            )
-                            with cute.arch.elect_one():
-                                store_fn()
-                                cute.arch.cp_async_bulk_commit_group()
-                                cute.arch.cp_async_bulk_wait_group(0, read=True)
-                        else:
-                            for idx in cutlass.range(lane, self.q_tokens_per_tile * self.tile_n, 32, unroll=1):
-                                qi = idx // self.tile_n
-                                kj = idx - qi * self.tile_n
-                                q_local = m_block * self.q_tokens_per_tile + qi
-                                k_local = n_block * self.tile_n + kj
-                                if q_local < seqlen.seqlen_q and k_local < max_seqlen_k:
-                                    mOut[batch_idx, q_local, k_local] = sScore[qi, kj]
-                    else:
-                        for idx in cutlass.range(lane, self.q_tokens_per_tile * self.tile_n, 32, unroll=1):
-                            qi = idx // self.tile_n
-                            kj = idx - qi * self.tile_n
-                            q_local = m_block * self.q_tokens_per_tile + qi
-                            k_local = n_block * self.tile_n + kj
-                            if q_local < seqlen.seqlen_q and k_local < max_seqlen_k:
-                                mOut[batch_idx, q_local, k_local] = sScore[qi, kj]
-                cute.arch.sync_warp()
-                cute.arch.mbarrier_arrive(mbar_ScoreEmpty_ptr)
                 iter_idx = iter_idx + Int32(1)
 
     @cute.jit
@@ -644,12 +564,6 @@ class IndexerForwardSm90:
         mK = _assume_strides(mK)
         mW = _assume_strides(mW)
         mOut = _assume_strides(mOut)
-
-        if const_expr(self.use_tma_store):
-            mOut_tma_view = cute.make_tensor(
-                mOut.iterator,
-                cute.select(mOut.layout, mode=[1, 2, 0]),
-            )
 
         mQ = sm90_ops.select(mQ, [0, 2, 1] if const_expr(is_varlen) else [1, 3, 2, 0])
         mK = sm90_ops.select(mK, [0, 2, 1] if const_expr(is_varlen) else [1, 3, 2, 0])
@@ -700,19 +614,6 @@ class IndexerForwardSm90:
             self.sKV_layout_single,
             (self.tile_n, self.tile_hdim),
         )
-        if const_expr(self.use_tma_store):
-            sScore_layout = cute.make_layout((self.q_tokens_per_tile, self.tile_n), stride=(self.tile_n, 1))
-            score_tile = (self.q_tokens_per_tile, self.tile_n)
-            score_cta_v_layout = cute.composition(cute.make_identity_layout(mOut_tma_view.shape), score_tile)
-            tma_atom_Score, mOut_tma = cpasync.make_tiled_tma_atom(
-                cpasync.CopyBulkTensorTileS2GOp(),
-                mOut_tma_view,
-                sScore_layout,
-                score_cta_v_layout,
-            )
-        else:
-            tma_atom_Score = tma_atom_Q
-            mOut_tma = mOut
 
         batch_size = cute.size(mCuSeqlensQ.shape[0]) - 1 if const_expr(is_varlen) else cute.size(mQ.shape[3])
         grid_x = cute.ceil_div(max_seqlen_q * self.qhead_per_kvhead, self.tile_m)
@@ -725,8 +626,6 @@ class IndexerForwardSm90:
             tma_atom_K,
             mW,
             mOut,
-            mOut_tma,
-            tma_atom_Score,
             self.sQ_layout_staged,
             self.sKV_layout_staged,
             tiled_mma_QK,
@@ -753,8 +652,6 @@ class IndexerForwardSm90:
         tma_atom_K: cute.CopyAtom,
         mW: cute.Tensor,
         mOut: cute.Tensor,
-        mOut_tma: cute.Tensor,
-        tma_atom_Score: cute.CopyAtom,
         sQ_layout_staged: cute.ComposedLayout,
         sKV_layout_staged: cute.ComposedLayout,
         tiled_mma_QK: cute.TiledMma,
@@ -772,8 +669,6 @@ class IndexerForwardSm90:
         if warp_idx == 0:
             cpasync.prefetch_descriptor(tma_atom_Q)
             cpasync.prefetch_descriptor(tma_atom_K)
-            if const_expr(self.use_tma_store):
-                cpasync.prefetch_descriptor(tma_atom_Score)
 
         smem = cutlass.utils.SmemAllocator()
         storage = smem.allocate(SharedStorage)
@@ -784,8 +679,6 @@ class IndexerForwardSm90:
         mbar_KV1_ptr = storage.mbar_KV1.data_ptr()
         mbar_KVEmpty0_ptr = storage.mbar_KVEmpty0.data_ptr()
         mbar_KVEmpty1_ptr = storage.mbar_KVEmpty1.data_ptr()
-        mbar_ScoreFull_ptr = storage.mbar_ScoreFull.data_ptr()
-        mbar_ScoreEmpty_ptr = storage.mbar_ScoreEmpty.data_ptr()
 
         if warp_idx == 0:
             cute.arch.mbarrier_init(mbar_Q0_ptr, 1)
@@ -794,8 +687,6 @@ class IndexerForwardSm90:
             cute.arch.mbarrier_init(mbar_KV1_ptr, 1)
             cute.arch.mbarrier_init(mbar_KVEmpty0_ptr, 128)
             cute.arch.mbarrier_init(mbar_KVEmpty1_ptr, 128)
-            cute.arch.mbarrier_init(mbar_ScoreFull_ptr, 128)
-            cute.arch.mbarrier_init(mbar_ScoreEmpty_ptr, 32)
         cute.arch.sync_threads()
 
         sQ_staged = storage.sQ.get_tensor(sQ_layout_staged.outer, swizzle=sQ_layout_staged.inner)
@@ -805,7 +696,6 @@ class IndexerForwardSm90:
         sKV_0 = sKV_staged[None, None, 0]
         sKV_1 = sKV_staged[None, None, 1]
         sW = storage.sW.get_tensor(cute.make_layout((self.tile_m,), stride=(1,)))
-        sScore = storage.sScore.get_tensor(cute.make_layout((self.q_tokens_per_tile, self.tile_n), stride=(self.tile_n, 1)))
 
         if warp_group_idx == 0:
             if warp_idx == 0:
@@ -831,19 +721,6 @@ class IndexerForwardSm90:
                     max_seqlen_q,
                     max_seqlen_k,
                 )
-            elif warp_idx == 1:
-                self.score_store(
-                    mOut,
-                    mOut_tma,
-                    tma_atom_Score,
-                    sScore,
-                    mbar_ScoreFull_ptr,
-                    mbar_ScoreEmpty_ptr,
-                    mCuSeqlensQ,
-                    mCuSeqlensK,
-                    max_seqlen_q,
-                    max_seqlen_k,
-                )
         else:
             self.consumer(
                 tiled_mma_QK,
@@ -851,15 +728,13 @@ class IndexerForwardSm90:
                 sQ_1,
                 sKV_staged,
                 sW,
-                sScore,
+                mOut,
                 mbar_Q0_ptr,
                 mbar_Q1_ptr,
                 mbar_KV0_ptr,
                 mbar_KV1_ptr,
                 mbar_KVEmpty0_ptr,
                 mbar_KVEmpty1_ptr,
-                mbar_ScoreFull_ptr,
-                mbar_ScoreEmpty_ptr,
                 mCuSeqlensQ,
                 mCuSeqlensK,
                 max_seqlen_q,

--- a/test/python/fe_api/dsa/dsa_reference.py
+++ b/test/python/fe_api/dsa/dsa_reference.py
@@ -576,18 +576,24 @@ def _dense_indexer_predict_distribution(
     weights: torch.Tensor,  # (B, S_q, H)
     sm_scale: float,
     ratio: int,
+    return_scores: bool = False,
 ) -> torch.Tensor:
     """Dense full-KV predict distribution for dense indexer backward."""
     b, s_q, h, d = q_indexer.shape
     _, s_k, _ = k_indexer.shape
 
-    scores_per_head = torch.einsum("bqhd,bkd->bqhk", q_indexer, k_indexer)
+    scores_per_head = torch.einsum(
+        "bqhd,bkd->bqhk",
+        q_indexer.to(torch.float32),
+        k_indexer.to(torch.float32),
+    )
     scores_per_head = torch.relu(scores_per_head)
     scores = (scores_per_head * (weights * sm_scale).unsqueeze(-1)).sum(dim=2)
 
     valid = _bottom_right_causal_mask(s_q, s_k, ratio, q_indexer.device)
     scores = scores.masked_fill(~valid.unsqueeze(0), float("-inf"))
-    return torch.softmax(scores, dim=-1)
+    predict = torch.softmax(scores, dim=-1)
+    return (predict, scores) if return_scores else predict
 
 
 def ref_dense_indexer_backward(
@@ -605,7 +611,9 @@ def ref_dense_indexer_backward(
     w = weights.detach().clone().requires_grad_(True)
     k = index_k.detach().clone().requires_grad_(True)
 
-    predict = _dense_indexer_predict_distribution(q, k, w, sm_scale, ratio)
+    predict, scores = _dense_indexer_predict_distribution(
+        q, k, w, sm_scale, ratio, return_scores=True
+    )
 
     _, s_q, _, _ = index_q.shape
     _, s_k, _ = index_k.shape
@@ -614,10 +622,14 @@ def ref_dense_indexer_backward(
     target = target / attn_l1norm.to(torch.float32).unsqueeze(-1).clamp(min=1e-10)
 
     eps = math.exp(-100.0)
-    predict_clipped = predict.to(torch.float32).clamp(min=eps)
     target_eff = target.clamp(min=eps)
-    loss = -grad_scale * (target_eff * torch.log(predict_clipped)).sum()
-    grads = torch.autograd.grad(loss, (q, w, k))
+    predict = predict.to(torch.float32)
+    log_clip_mask = (predict >= eps).to(torch.float32)
+    g = -target_eff * log_clip_mask * grad_scale
+    grad_signal = (g - predict * g.sum(dim=-1, keepdim=True)).masked_fill(
+        ~valid.unsqueeze(0), 0.0
+    )
+    grads = torch.autograd.grad(scores, (q, w, k), grad_outputs=grad_signal.to(scores.dtype))
 
     dq, dw, dk = grads
     return (


### PR DESCRIPTION
## Summary

  - Align SM90/SM100 indexer backward launch grids to use `(seqlen, batch)` ordering.
  - Add `topk_indices_global` plumbing so backward can handle local per-batch top-k indices by default.
  - Rework SM90 indexer forward to write reduced logits directly to global memory, removing the separate score-store path.
  - Fix dense score-grad clipping to use log-domain mask checks, and apply the same behavior to SM90 dense score-grad.
  - Keep SM90 dense GEMM compile caching independent of runtime `seqlen_k`.
  - Update the dense DSA reference to backprop through logits with an explicit grad signal matching clipped-log KL behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `topk_indices_global` parameter for flexible top-k indexing control
  * Introduced `clean_logits` option for improved masking configuration

* **Performance Optimizations**
  * Optimized kernel grid scheduling for better memory efficiency
  * Replaced torch-based computation with specialized kernel implementation
  * Streamlined forward indexer pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->