### PR TITLE
DSA bwd SM100 fix dropped dKV gradients when topk width > total_S_kv

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
@@ -1078,7 +1078,6 @@ class FlashAttentionDSABackwardSm100:
                 mdKV_acc,
                 mTopkIdxs,
                 sTopkIdxs,
-                max_seqlen_kv,
                 tile_count,
                 topk,
                 mma_reduce_dKV_pipeline,
@@ -2043,7 +2042,6 @@ class FlashAttentionDSABackwardSm100:
         mdKV_acc: cute.Tensor,
         mTopkIdxs: cute.Tensor,
         sTopkIdxs: cute.Tensor,
-        max_seqlen_kv: Int32,
         tile_count: Int32,
         topk: Int32,
         mma_reduce_dKV_pipeline,
@@ -2064,8 +2062,6 @@ class FlashAttentionDSABackwardSm100:
         tdKVtdKV3 = tdKVtdKV3[(None, None), 0, 0]
         if cutlass.const_expr(not self.same_hdim_kv):
             tdKVtdKV4 = tdKVtdKV4[(None, None), 0, 0]
-
-        cur_seqlen_kv = max_seqlen_kv
 
         # Set up identity tensor partition once (all dKV sub-tiles share the same layout)
         tmem_load_atom = cute.make_copy_atom(
@@ -2096,7 +2092,7 @@ class FlashAttentionDSABackwardSm100:
                 coord_base = i * 2 - i % 2
                 local_row_idx = cute.get(tTR_cdKV[coord_base], mode=[1])
                 global_row_idx = tile_index * self.block_tile + local_row_idx
-                if global_row_idx < topk and global_row_idx < cur_seqlen_kv:
+                if global_row_idx < topk:
                     if global_row_idx < self.smem_topk_capacity:
                         rTopkIdx[i] = sTopkIdxs[global_row_idx]
                     else:
@@ -2110,7 +2106,7 @@ class FlashAttentionDSABackwardSm100:
                     coord_base = i * 2 - i % 2
                     local_row_idx = cute.get(tTR_cdKV_64[coord_base], mode=[1])
                     global_row_idx = tile_index * self.block_tile + local_row_idx
-                    if global_row_idx < topk and global_row_idx < cur_seqlen_kv:
+                    if global_row_idx < topk:
                         if global_row_idx < self.smem_topk_capacity:
                             rTopkIdx_64[i] = sTopkIdxs[global_row_idx]
                         else:

--- a/test/python/fe_api/dsa/dsa_reference.py
+++ b/test/python/fe_api/dsa/dsa_reference.py
@@ -26,9 +26,9 @@ def _make_topk_mask(
     """Materialize a boolean (T, s_kv) mask from topk indices."""
     t, topk = topk_idxs.shape
     mask = torch.zeros(t, s_kv, dtype=torch.bool, device=topk_idxs.device)
-    valid_idx = topk_idxs.clamp(min=0, max=s_kv - 1)
     row_idx = torch.arange(t, device=topk_idxs.device).unsqueeze(1).expand(-1, topk)
-    mask[row_idx, valid_idx] = True
+    valid = (topk_idxs >= 0) & (topk_idxs < s_kv)
+    mask[row_idx[valid], topk_idxs[valid].long()] = True
     if topk_length is not None:
         positions = torch.arange(topk, device=topk_idxs.device).unsqueeze(0).expand(t, -1)
         invalid = positions >= topk_length.unsqueeze(1)


### PR DESCRIPTION
(global_row_idx) against max_seqlen_kv. A column position >= total_S_kv is not invalid -- with a non-compact topk_idxs layout (-1 sentinels, width > total_S_kv) valid indices can sit at any column. Entries past column total_S_kv were silently treated as -1 and their dKV contributions dropped, while dQ (whose load path correctly judges validity by the index value) stayed correct. With a [window | compressed] layout this zeroes the entire original-KV region of dkv bit-exactly. Drop the position-vs-seqlen comparison; the < topk bound plus the topk_idx >= 0 sentinel check in the store helpers already match the load-side and FlashMLA-forward semantics. Remove the now-unused max_seqlen_kv parameter from reduce_dKV.
Also fix the test reference _make_topk_mask: without topk_length it clamped -1 sentinels to index 0, spuriously marking KV row 0 as attended, which corrupted out/lse/gradient references for non-compact inputs.
Verified on B200: topk width 1024 > S_kv 256 now gives cos_sim(dkv) 0.9996 (was 0.498); wide non-compact layouts pass FP32 autograd checks; fe_api/dsa pytest suite passes (16 tests). Co-Authored-By: Claude Fable 5 noreply@anthropic.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized sparse attention backward computation to improve kernel efficiency by streamlining index validation logic during gradient reduction operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->