### PR TITLE
Add byte boolean frontend data type

### DIFF
--- a/include/cudnn_frontend_utils.h
+++ b/include/cudnn_frontend_utils.h
@@ -714,6 +714,7 @@ enum class DataType_t {
     BFLOAT16,
     INT64,
     BOOLEAN,
+    BYTE_BOOLEAN,
     FP8_E4M3,
     FP8_E5M2,
     FAST_FLOAT_FOR_FP8,
@@ -739,6 +740,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DataType_t,
                                  {DataType_t::BFLOAT16, "BFLOAT16"},
                                  {DataType_t::INT64, "INT64"},
                                  {DataType_t::BOOLEAN, "BOOLEAN"},
+                                 {DataType_t::BYTE_BOOLEAN, "BYTE_BOOLEAN"},
                                  {DataType_t::FP8_E4M3, "FP8_E4M3"},
                                  {DataType_t::FP8_E5M2, "FP8_E5M2"},
                                  {DataType_t::FAST_FLOAT_FOR_FP8, "FAST_FLOAT_FOR_FP8"},
@@ -1038,6 +1040,8 @@ get_data_type_size(DataType_t const data_type) {
         case DataType_t::FP8_E4M3:
         case DataType_t::FP8_E5M2:
             return 1;  // 8-bit float
+        case DataType_t::BYTE_BOOLEAN:
+            return 1;
         case DataType_t::NOT_SET:
         case DataType_t::BOOLEAN:
         default:
@@ -1112,6 +1116,14 @@ convert_to_cudnn_type(cudnn_frontend::DataType_t const mode, cudnnDataType_t& cu
         case DataType_t::BOOLEAN:
             cudnn_mode = CUDNN_DATA_BOOLEAN;
             return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
+        case DataType_t::BYTE_BOOLEAN:
+#if (CUDNN_VERSION >= 93000)
+            NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(93000, cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE);
+            cudnn_mode = CUDNN_DATA_BYTE_BOOLEAN;
+            return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
+#else
+            return cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE;
+#endif
         case DataType_t::FP8_E4M3:
 #if (CUDNN_VERSION >= 8600)
             NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(8600, cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE);
@@ -2336,6 +2348,10 @@ convert_from_cudnn_type(cudnnDataType_t const cudnn_mode) {
             return DataType_t::INT64;
         case CUDNN_DATA_BOOLEAN:
             return DataType_t::BOOLEAN;
+#if (CUDNN_VERSION >= 93000)
+        case CUDNN_DATA_BYTE_BOOLEAN:
+            return DataType_t::BYTE_BOOLEAN;
+#endif
 #if (CUDNN_VERSION >= 8600)
         case CUDNN_DATA_FP8_E4M3:
             return DataType_t::FP8_E4M3;
@@ -2423,6 +2439,9 @@ get_element_size_in_bits(cudnn_frontend::DataType_t datatype) {
 #endif
         case DataType_t::BOOLEAN:
             return 1;
+            break;
+        case DataType_t::BYTE_BOOLEAN:
+            return 8;
             break;
         default:
             return 0;

--- a/samples/cpp/membound/boolean_fusion.cpp
+++ b/samples/cpp/membound/boolean_fusion.cpp
@@ -51,6 +51,13 @@ TEST_CASE("Boolean CMP_GT and LOGICAL_AND fusion", "[membound][boolean][pointwis
     constexpr int64_t s1 = d2;
     constexpr int64_t s2 = 1;
 
+    auto boolean_storage_type = fe::DataType_t::BOOLEAN;
+#if (CUDNN_VERSION >= 93000)
+    if (cudnn_frontend::detail::get_backend_version() >= 93000) {
+        boolean_storage_type = fe::DataType_t::BYTE_BOOLEAN;
+    }
+#endif
+
     fe::graph::Graph graph{};
     graph.set_compute_data_type(fe::DataType_t::FLOAT);
 
@@ -70,7 +77,7 @@ TEST_CASE("Boolean CMP_GT and LOGICAL_AND fusion", "[membound][boolean][pointwis
                               .set_name("B")
                               .set_dim({d0, d1, d2})
                               .set_stride({s0, s1, s2})
-                              .set_data_type(fe::DataType_t::BOOLEAN));
+                              .set_data_type(boolean_storage_type));
 
     auto after_cmp = graph.pointwise(X,
                                      threshold,
@@ -78,7 +85,7 @@ TEST_CASE("Boolean CMP_GT and LOGICAL_AND fusion", "[membound][boolean][pointwis
                                          .set_name("cmp_gt")
                                          .set_mode(fe::PointwiseMode_t::CMP_GT)
                                          .set_compute_data_type(fe::DataType_t::FLOAT));
-    after_cmp->set_data_type(fe::DataType_t::BOOLEAN);
+    after_cmp->set_data_type(boolean_storage_type);
 
     auto Y = graph.pointwise(after_cmp,
                              B,
@@ -86,7 +93,7 @@ TEST_CASE("Boolean CMP_GT and LOGICAL_AND fusion", "[membound][boolean][pointwis
                                  .set_name("logical_and")
                                  .set_mode(fe::PointwiseMode_t::LOGICAL_AND)
                                  .set_compute_data_type(fe::DataType_t::BOOLEAN));
-    Y->set_output(true).set_data_type(fe::DataType_t::BOOLEAN);
+    Y->set_output(true).set_data_type(boolean_storage_type);
 
     REQUIRE(graph.validate().is_good());
 


### PR DESCRIPTION
Add DataType_t::BYTE_BOOLEAN and map it to CUDNN_DATA_BYTE_BOOLEAN for cuDNN 9.30+. Update the boolean membound sample to use byte-backed boolean tensor storage on 9.30+ backends while keeping logical compute precision as BOOLEAN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `BYTE_BOOLEAN` data type support with full serialization capabilities.
  * Implemented automatic version-aware detection to ensure compatibility with cuDNN 93000 and later.
  * Enhanced boolean operations to dynamically select optimal storage representation based on backend version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->