### PR TITLE
DSA: add q causal offsets and SM100F support

### DIFF
--- a/docs/fe-oss-apis/dsa.md
+++ b/docs/fe-oss-apis/dsa.md
@@ -132,19 +132,31 @@ dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
 ### 2. Indexer Forward (score-only)
 
 Computes dense indexer scores:
-``S[b, q, k] = sum_h ReLU(Q_h · K_h^T) · W_h`` with a ratio causal mask
-(positions with `k >= (S_k * ratio - S_q + q + 1)//ratio` masked; this
-reduces to `(q+1)//ratio` when `S_q == S_k * ratio`).
+``S[b, q, k] = sum_h ReLU(Q_h · K_h^T) · W_h`` with a ratio-causal mask.
+For local query row `q_local`, valid KV columns satisfy
+`k_local < clamp((q_causal_offsets[b] + q_local + 1) // ratio, 0, seqlen_k_b)`.
+When `q_causal_offsets` is omitted, all offsets are zero.
+
+`q_causal_offsets[b]` is the global uncompressed token index corresponding to
+local `q[0]` for batch or THD segment `b`. It is not the packed storage offset
+from `cu_seqlens_q`: `cu_seqlens_q` locates where a local Q segment is stored,
+while `q_causal_offsets` locates that segment in the global causal timeline.
+The K columns are assumed to be a compressed-KV prefix starting at global
+compressed column 0.
 
 - **Inputs**
   - `q`: `(B, S_q, H_q, D)` BF16
   - `k`: `(B, S_k, H_kv, D)` BF16
   - `w`: `(B, S_q, H_q)` BF16
+  - `q_causal_offsets` (optional): CUDA INT32 tensor with one entry per
+    batch/THD segment, on the same device as `q`.
 - **Output** — `scores`: `(B, S_q, S_k)` FP32
 - **Constraints** — SM100+, `head_dim == 128`, `qhead_per_kv_head ∈ {32, 64}`
 
 ```python
-result = DSA.indexer_forward_wrapper(q, k, w, ratio=4)
+result = DSA.indexer_forward_wrapper(
+    q, k, w, ratio=4, q_causal_offsets=q_causal_offsets,
+)
 scores = result["scores"]
 ```
 
@@ -194,8 +206,9 @@ L1-normalised head-summed softmax over top-K entries:
 ### 6. Dense Indexer / Dense Attn Score Recompute
 
 Full-KV (no top-K) analogues of §4 and §5. Each returns `{'out', 'denom'}`.
-They apply the same bottom-right ratio causal mask as Indexer Forward; masked
-positions are written as zero and excluded from `denom`.
+They apply the same ratio-causal mask as Indexer Forward; masked positions are
+written as zero and excluded from `denom`. Pass the same `q_causal_offsets` to
+all dense score tensors that feed the same loss path.
 
 ### 7. Indexer Backward
 
@@ -236,18 +249,27 @@ and denominators produced by Dense Indexer / Dense Attn Score Recompute.
   - `index_k`: `(B, S_k, D)` BF16
   - `attn_score`, `index_score`: `(B, S_q, S_k)` FP32 raw dense scores
   - `attn_l1norm`, `index_lse`: `(B, S_q)` FP32 denominators
+  - `q_causal_offsets` (optional): same offsets used for the corresponding
+    Dense Indexer / Dense Attn Score Recompute outputs.
 - **Outputs** — `d_index_q`, `d_weights`, `d_index_k`
 - **Constraints** — SM90 or SM100+, `H >= 64`, `ratio >= 1`
 
 ```python
-dense_index = DSA.dense_indexer_score_recompute_wrapper(index_q, index_k.unsqueeze(2), weights)
-dense_attn = DSA.dense_attn_score_recompute_wrapper(attn_q, attn_k, lse, softmax_scale)
+dense_index = DSA.dense_indexer_score_recompute_wrapper(
+    index_q, index_k.unsqueeze(2), weights,
+    q_causal_offsets=q_causal_offsets,
+)
+dense_attn = DSA.dense_attn_score_recompute_wrapper(
+    attn_q, attn_k, lse, softmax_scale,
+    q_causal_offsets=q_causal_offsets,
+)
 
 result = DSA.dense_indexer_backward_wrapper(
     index_q, weights, index_k,
     dense_attn["out"], dense_attn["denom"],
     dense_index["out"], dense_index["denom"],
     sm_scale=1.0, loss_coeff=1.0, grad_loss=1.0, block_I=128, ratio=1,
+    q_causal_offsets=q_causal_offsets,
 )
 ```
 

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -591,9 +591,7 @@ def dense_indexer_backward_wrapper(
             max_seqlen_q,
             max_seqlen_k,
         )
-        q_causal_offsets = validate_q_causal_offsets(
-            q_causal_offsets, int(batch), index_q_exec.device, stream=backend_stream
-        )
+        q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch), index_q_exec.device, stream=backend_stream)
 
         if d_index_q is None:
             d_index_q = torch.empty_like(index_q_exec)

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -453,12 +453,13 @@ def indexer_backward_wrapper(
             typically ``1.0`` when the KL loss is summed into the total
             training loss with unit weight. Accepts a 0-D tensor or float.
     """
-    if d_index_q is None:
-        d_index_q = torch.empty_like(index_q)
-    if d_weights is None:
-        d_weights = torch.empty_like(weights)
-    if d_index_k is None:
-        d_index_k = torch.empty_like(index_k)
+    with _torch_stream_context(stream):
+        if d_index_q is None:
+            d_index_q = torch.empty_like(index_q)
+        if d_weights is None:
+            d_weights = torch.empty_like(weights)
+        if d_index_k is None:
+            d_index_k = torch.empty_like(index_k)
 
     b, s_q, h, d = index_q.shape
     s_k = index_k.shape[1]
@@ -590,7 +591,9 @@ def dense_indexer_backward_wrapper(
             max_seqlen_q,
             max_seqlen_k,
         )
-        q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch), index_q_exec.device)
+        q_causal_offsets = validate_q_causal_offsets(
+            q_causal_offsets, int(batch), index_q_exec.device, stream=backend_stream
+        )
 
         if d_index_q is None:
             d_index_q = torch.empty_like(index_q_exec)

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -20,6 +20,7 @@ import cuda.bindings.driver as cuda
 from cudnn.api_base import APIBase, TupleDict
 from cudnn.deepseek_sparse_attention.utils.runtime import (
     torch_stream_context as _torch_stream_context,
+    validate_q_causal_offsets,
 )
 
 from .dense_indexer_backward_sm100 import dense_indexer_backward_sm100
@@ -275,6 +276,7 @@ class DenseIndexerBackward(APIBase):
         batch: Optional[int] = None,
         max_seqlen_q: Optional[int] = None,
         max_seqlen_k: Optional[int] = None,
+        has_q_causal_offsets: bool = False,
     ):
         super().__init__()
         self.iq_desc = self._make_tensor_desc(sample_index_q, name="sample_index_q")
@@ -292,6 +294,7 @@ class DenseIndexerBackward(APIBase):
         self.block_I = int(block_I)
         self.ratio = int(ratio)
         self.is_thd = bool(is_thd)
+        self.has_q_causal_offsets = bool(has_q_causal_offsets)
 
         if self.is_thd:
             total_q, heads, head_dim = sample_index_q.shape
@@ -333,10 +336,6 @@ class DenseIndexerBackward(APIBase):
         self._value_error_if(self.block_I <= 0, f"block_I must be positive, got {self.block_I}")
         self._value_error_if(self.ratio < 1, f"ratio must be >= 1, got {self.ratio}")
         self._value_error_if(self.heads < 64, f"DenseIndexerBackward requires heads >= 64, got {self.heads}")
-        self._value_error_if(
-            self.max_seqlen_q < self.max_seqlen_k * self.ratio,
-            "DenseIndexerBackward requires S_q >= S_k * ratio for bottom-right causal alignment",
-        )
         self._is_supported = True
         return True
 
@@ -357,6 +356,7 @@ class DenseIndexerBackward(APIBase):
             block_I=self.block_I,
             ratio=self.ratio,
             is_varlen=self.is_thd,
+            has_q_causal_offsets=self.has_q_causal_offsets,
         )
 
     def execute(
@@ -375,6 +375,7 @@ class DenseIndexerBackward(APIBase):
         grad_loss: Union[float, torch.Tensor] = 1.0,
         cu_seqlens_q: Optional[torch.Tensor] = None,
         cu_seqlens_k: Optional[torch.Tensor] = None,
+        q_causal_offsets: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         backend_stream = None if self._uses_current_stream_pipeline else current_stream
@@ -404,6 +405,7 @@ class DenseIndexerBackward(APIBase):
             grad_scale,
             cu_seqlens_q,
             cu_seqlens_k,
+            q_causal_offsets,
             backend_stream,
         )
 
@@ -538,6 +540,7 @@ def dense_indexer_backward_wrapper(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     d_index_q: Optional[torch.Tensor] = None,
     d_weights: Optional[torch.Tensor] = None,
     d_index_k: Optional[torch.Tensor] = None,
@@ -587,6 +590,7 @@ def dense_indexer_backward_wrapper(
             max_seqlen_q,
             max_seqlen_k,
         )
+        q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch), index_q_exec.device)
 
         if d_index_q is None:
             d_index_q = torch.empty_like(index_q_exec)
@@ -618,6 +622,7 @@ def dense_indexer_backward_wrapper(
         float(sm_scale),
         int(block_I),
         int(ratio),
+        q_causal_offsets is not None,
     )
     obj = _cache_of_DenseIndexerBackwardObjects.get(key)
     if obj is None:
@@ -639,6 +644,7 @@ def dense_indexer_backward_wrapper(
             batch=batch,
             max_seqlen_q=max_q,
             max_seqlen_k=max_k,
+            has_q_causal_offsets=q_causal_offsets is not None,
         )
         assert obj.check_support()
         obj.compile()
@@ -659,6 +665,7 @@ def dense_indexer_backward_wrapper(
         grad_loss=grad_loss,
         cu_seqlens_q=cu_seqlens_q,
         cu_seqlens_k=cu_seqlens_k,
+        q_causal_offsets=q_causal_offsets,
         current_stream=backend_stream,
     )
     with _torch_stream_context(backend_stream):

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -334,8 +334,8 @@ class DenseIndexerBackward(APIBase):
         self._value_error_if(self.ratio < 1, f"ratio must be >= 1, got {self.ratio}")
         self._value_error_if(self.heads < 64, f"DenseIndexerBackward requires heads >= 64, got {self.heads}")
         self._value_error_if(
-            self.max_seqlen_q > self.max_seqlen_k * self.ratio,
-            "DenseIndexerBackward requires S_q <= S_k * ratio for bottom-right causal alignment",
+            self.max_seqlen_q < self.max_seqlen_k * self.ratio,
+            "DenseIndexerBackward requires S_q >= S_k * ratio for bottom-right causal alignment",
         )
         self._is_supported = True
         return True

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
@@ -342,7 +342,7 @@ class ScoreGradDense:
 # Barrier indices
 MBAR_2Q_S_FULL = 0  # MMA → Compute (phase-flipped 2×/block)
 MBAR_2Q_DS_READY = 1  # Compute → MMA (phase-flipped 2×/block)
-MBAR_2Q_DK_FULL = 2  # MMA → Reduce (1×/block, after Phase B GEMM2)
+MBAR_2Q_DK_FULL = 2  # MMA → Reduce/Compute (1×/block, after dK/dQ GEMMs)
 MBAR_2Q_DK_EMPTY = 3  # Reduce → MMA (1×/block)
 MBAR_2Q_GS_LOADED_0 = 4  # Load → Compute (2-stage K pipeline)
 MBAR_2Q_GS_LOADED_1 = 5
@@ -1725,6 +1725,14 @@ class DenseIndexerBackward2QGemmSm100:
                 cute.arch.fence_proxy("async.shared", space="cta")
                 cute.arch.mbarrier_arrive(mbar + MBAR_2Q_DS_READY)
 
+        # DK_FULL is committed after both dQ GEMM3 phases for every K block.
+        # Observe its final phase before reading the persistent dQ TMEM
+        # accumulators.  There is no next S_FULL hand-off after the last block
+        # to provide this ordering, so omitting this wait races the epilogue
+        # against the final dQ accumulation.
+        final_dk_full_phase = (num_kv_blocks - Int32(1)) & Int32(1)
+        cute.arch.mbarrier_wait(mbar + MBAR_2Q_DK_FULL, final_dk_full_phase)
+
         # dQ staging via coordinate writes — same pattern as sdS.
         sdQ_gemm_view = cute.composition(
             sdQ_epi_slice,
@@ -1757,8 +1765,12 @@ class DenseIndexerBackward2QGemmSm100:
 
         # ---- Epilogue: dQ for q1 via TMA store (guarded) ----
         if has_q1:
-            # Wait for q0 TMA store to complete before reusing sdQ_epi SMEM
-            dQ_store_pipeline.producer_acquire()
+            # The TMA store async group belongs to the issuing warp.  Wait on
+            # that warp, then release the other compute warps together before
+            # they overwrite their portions of the shared dQ staging tile.
+            if warp_idx == compute_warp0:
+                dQ_store_pipeline.producer_acquire()
+            self.compute_sync_barrier.arrive_and_wait()
 
             tDQrDQ_q1 = cute.make_rmem_tensor(tDQrDQ_shape, Float32)
             cute.copy(tiled_tmem_load_dq1, tDqDq_1_t2r, tDQrDQ_q1)
@@ -1808,6 +1820,9 @@ class DenseIndexerBackward2QGemmSm100:
                 total = cute.arch.warp_reduction_sum(my_partial)
                 if lane_id == 0:
                     mdW_b[q1_local, h] = self.q_dtype(total)
+
+        # Ensure the final q0/q1 TMA store has completed before the CTA exits.
+        dQ_store_pipeline.producer_tail()
 
     # =========================================================================
     # Reduce warpgroup (2Q): Single-buffered dK

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
@@ -124,6 +124,7 @@ class ScoreGradDense:
     def __init__(
         self,
         ratio: int = 1,
+        block_I: int = 128,
     ):
         assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
         # Neither ``grad_scale`` nor ``max_seqlen_q/k`` are stored on the object:
@@ -134,6 +135,7 @@ class ScoreGradDense:
         # are passed as runtime ``Float32``/``Int32`` args on ``__call__`` so one
         # compiled kernel serves all seqlens / loss scales.
         self.ratio = ratio
+        self.block_I = block_I
 
     @cute.jit
     def __call__(
@@ -273,19 +275,18 @@ class ScoreGradDense:
             # --- Phase 1: Accumulate sum_grad ---
             local_sum = Float32(0.0)
             pos = tidx
-            while pos < seqlen_k_pad:
-                if pos < col_limit:
-                    pr = mPredict_b[seq_local, pos]
-                    tr = mTarget_b[seq_local, pos]
+            while pos < col_limit:
+                pr = mPredict_b[seq_local, pos]
+                tr = mTarget_b[seq_local, pos]
 
-                    score_minus_lse = pr - lse_val
-                    predict = cute.math.exp2(score_minus_lse * LOG2E, fastmath=True)
-                    target = tr / (denom_val + Float32(DENOM_EPS))
-                    target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
-                    log_clip_mask = Float32(1.0) if score_minus_lse >= Float32(CLIP_LOG_MIN) else Float32(0.0)
-                    g = -target_eff * log_clip_mask * grad_scale
+                score_minus_lse = pr - lse_val
+                predict = cute.math.exp2(score_minus_lse * LOG2E, fastmath=True)
+                target = tr / (denom_val + Float32(DENOM_EPS))
+                target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
+                log_clip_mask = Float32(1.0) if score_minus_lse >= Float32(CLIP_LOG_MIN) else Float32(0.0)
+                g = -target_eff * log_clip_mask * grad_scale
 
-                    local_sum = local_sum + g
+                local_sum = local_sum + g
                 pos = pos + Int32(128)
 
             # Cross-warp reduction (4 warps)
@@ -297,8 +298,23 @@ class ScoreGradDense:
 
             # --- Phase 2: Write grad_signal in-place to PredictRaw ---
             # Padding columns (pos >= seqlen_k_b in THD, or pos >= col_limit) get 0.
+            # Kernel 2 processes q tokens in reversed 2Q pairs and uses the
+            # larger q token's K-block bound. For the smaller q token, clear up
+            # to that pair bound so stale raw scores cannot be consumed as
+            # grad_signal, but skip the rest of the padded K row.
+            rel_from_last = (seqlen_q_b - Int32(1)) - Int32(seq_local)
+            pair_q0_local = Int32(seq_local) + (rel_from_last & Int32(1))
+            pair_col_limit_raw = (q_causal_offset_b + pair_q0_local + Int32(1)) // ratio
+            pair_col_limit = pair_col_limit_raw if pair_col_limit_raw < seqlen_k_b else seqlen_k_b
+            pair_col_limit = pair_col_limit if pair_col_limit > Int32(0) else Int32(0)
+            block_i = Int32(self.block_I)
+            zero_limit = ((pair_col_limit + block_i - Int32(1)) // block_i) * block_i
+            min_zero_limit = block_i if seqlen_k_b > Int32(0) else Int32(0)
+            zero_limit = min_zero_limit if zero_limit < min_zero_limit else zero_limit
+            zero_limit = zero_limit if zero_limit < seqlen_k_pad else seqlen_k_pad
+
             pos = tidx
-            while pos < seqlen_k_pad:
+            while pos < zero_limit:
                 if pos < col_limit:
                     pr = mPredict_b[seq_local, pos]
                     tr = mTarget_b[seq_local, pos]
@@ -1957,7 +1973,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
 
     # Kernel 1: ScoreGradDense — applies ratio causal mask so
     # masked / padding columns produce grad_signal=0 (won't contaminate GEMM).
-    score_grad_obj = ScoreGradDense(ratio=ratio)
+    score_grad_obj = ScoreGradDense(ratio=ratio, block_I=block_I)
 
     # Kernel 2: 2Q GEMM kernel (reads pre-computed grad_signal, 2 Q tokens per CTA).
     # is_varlen branches at compile time on whether CuSeqlens* are None.

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
@@ -46,7 +46,7 @@ Bottom-right ratio causal:
     q_start_b  = seqlen_k_b * ratio - seqlen_q_b
     col_limit  = min(seqlen_k_b, (q_start_b + q_local + 1) // ratio)
   When seqlen_q_b == seqlen_k_b * ratio, q_start_b == 0 (legacy behavior).
-  Constraint per batch: seqlen_q_b <= seqlen_k_b * ratio.
+  Constraint per batch: seqlen_q_b >= seqlen_k_b * ratio.
 """
 
 from __future__ import annotations
@@ -1917,7 +1917,7 @@ def dense_indexer_backward_sm100(
 
     ``ratio`` is the indexer compression ratio. Bottom-right causal mask is
     applied: kv_local < (seqlen_k_b * ratio - seqlen_q_b + q_local + 1) // ratio.
-    Per batch we require ``seqlen_q_b <= seqlen_k_b * ratio``. ``ratio`` must
+    Per batch we require ``seqlen_q_b >= seqlen_k_b * ratio``. ``ratio`` must
     be passed explicitly — auto-inferring from S_q / S_k is unsafe under THD.
 
     ``grad_scale`` is intentionally **not** an argument to this factory: it's

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
@@ -42,11 +42,11 @@ BSHD vs THD (explicit branches, no implicit packing):
     GradSignal / Score : (T_q, max_seqlen_k)   [second dim is batch-local k]
     LSE / L1Norm       : (T_q,)
 
-Bottom-right ratio causal:
-    q_start_b  = seqlen_k_b * ratio - seqlen_q_b
-    col_limit  = min(seqlen_k_b, (q_start_b + q_local + 1) // ratio)
-  When seqlen_q_b == seqlen_k_b * ratio, q_start_b == 0 (legacy behavior).
-  Constraint per batch: seqlen_q_b >= seqlen_k_b * ratio.
+Ratio causal mask:
+    q_abs      = q_causal_offset_b + q_local
+    col_limit  = clamp((q_abs + 1) // ratio, 0, seqlen_k_b)
+    valid if k_local < col_limit
+  q_causal_offset_b defaults to 0 when no offset tensor is provided.
 """
 
 from __future__ import annotations
@@ -144,6 +144,7 @@ class ScoreGradDense:
         mDenomTarget,
         mCuSeqlensQ,
         mCuSeqlensK,
+        mQCausalOffsets,
         grad_scale: Float32,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -188,6 +189,7 @@ class ScoreGradDense:
             mDenomTarget,
             mCuSeqlensQ,
             mCuSeqlensK,
+            mQCausalOffsets,
             grad_scale,
             seqlen_k_pad,
             max_seqlen_q,
@@ -207,6 +209,7 @@ class ScoreGradDense:
         mDenomTarget,
         mCuSeqlensQ,
         mCuSeqlensK,
+        mQCausalOffsets,
         grad_scale: Float32,
         seqlen_k_pad: Int32,
         seqlen_q_static: Int32,
@@ -227,6 +230,7 @@ class ScoreGradDense:
             seqlen_q_static,
             seqlen_k_static,
         )
+        q_causal_offset_b = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
 
         # Out-of-range CTAs (seq_local >= seqlen_q_b in this batch): skip work.
         # CuTe DSL forbids early `return`, so wrap the body in an `if` block.
@@ -261,14 +265,10 @@ class ScoreGradDense:
 
             LOG2E = Float32(1.4426950408889634)
 
-            # Bottom-right ratio causal:
-            #   q_start_b  = seqlen_k_b * ratio - seqlen_q_b
-            #   col_limit  = min(seqlen_k_b, (q_start_b + q_local + 1) // ratio)
-            # Equals legacy ((q_local+1)//ratio) when seqlen_q_b == seqlen_k_b * ratio.
             ratio = Int32(self.ratio)
-            q_start_b = seqlen_k_b * ratio - seqlen_q_b
-            col_limit_raw = (q_start_b + Int32(seq_local) + Int32(1)) // ratio
+            col_limit_raw = (q_causal_offset_b + Int32(seq_local) + Int32(1)) // ratio
             col_limit = col_limit_raw if col_limit_raw < seqlen_k_b else seqlen_k_b
+            col_limit = col_limit if col_limit > Int32(0) else Int32(0)
 
             # --- Phase 1: Accumulate sum_grad ---
             local_sum = Float32(0.0)
@@ -420,6 +420,7 @@ class DenseIndexerBackward2QGemmSm100:
         mGradSignal: cute.Tensor,
         mCuSeqlensQ,
         mCuSeqlensK,
+        mQCausalOffsets,
         sm_scale: Float32 | float,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -592,6 +593,7 @@ class DenseIndexerBackward2QGemmSm100:
             mGradSignal,
             mCuSeqlensQ,
             mCuSeqlensK,
+            mQCausalOffsets,
             sm_scale,
             Int32(max_seqlen_q),
             Int32(max_seqlen_k),
@@ -635,6 +637,7 @@ class DenseIndexerBackward2QGemmSm100:
         mGradSignal,
         mCuSeqlensQ,
         mCuSeqlensK,
+        mQCausalOffsets,
         sm_scale: Float32 | float,
         seqlen_q_static: Int32,
         seqlen_k_static: Int32,
@@ -674,6 +677,7 @@ class DenseIndexerBackward2QGemmSm100:
             seqlen_q_static,
             seqlen_k_static,
         )
+        q_causal_offset_b = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
 
         # 2Q pair indices are batch-local and scheduled from largest q to
         # smallest q. For odd seqlen_q_b this puts the singleton CTA at the
@@ -713,11 +717,10 @@ class DenseIndexerBackward2QGemmSm100:
             mGS_b = mGradSignal[None, None, batch_idx]
 
         # Causal-aware K-block bound for this 2Q CTA. GradSignal has already
-        # been zeroed past each q token's bottom-right causal column limit, but
+        # been zeroed past each q token's ratio-causal column limit, but
         # using that limit here avoids TMA/MMA work for wholly future K blocks.
         ratio = Int32(self.ratio)
-        q_start_b = seqlen_k_b * ratio - seqlen_q_b
-        max_kv_needed_raw = (q_start_b + q0_local + Int32(1)) // ratio
+        max_kv_needed_raw = (q_causal_offset_b + q0_local + Int32(1)) // ratio
         max_kv_needed = max_kv_needed_raw if max_kv_needed_raw > Int32(0) else Int32(0)
         max_kv_needed = max_kv_needed if max_kv_needed < seqlen_k_b else seqlen_k_b
         num_kv_blocks = (max_kv_needed + self.block_I - 1) // self.block_I
@@ -1905,6 +1908,7 @@ def dense_indexer_backward_sm100(
     block_I=128,
     ratio=1,
     is_varlen=False,
+    has_q_causal_offsets=False,
 ):
     """Build / fetch a compiled SM100 dense backward gradient kernel.
 
@@ -1915,10 +1919,10 @@ def dense_indexer_backward_sm100(
         grid + row stride. Inputs are packed (T_q, ...) tensors plus
         cu_seqlens_q / k.
 
-    ``ratio`` is the indexer compression ratio. Bottom-right causal mask is
-    applied: kv_local < (seqlen_k_b * ratio - seqlen_q_b + q_local + 1) // ratio.
-    Per batch we require ``seqlen_q_b >= seqlen_k_b * ratio``. ``ratio`` must
-    be passed explicitly — auto-inferring from S_q / S_k is unsafe under THD.
+    ``ratio`` is the indexer compression ratio. The causal rule is
+    ``kv_local < (q_causal_offset_b + q_local + 1) // ratio``, clamped to the
+    batch-local K length. ``ratio`` must be passed explicitly — auto-inferring
+    from S_q / S_k is unsafe under THD.
 
     ``grad_scale`` is intentionally **not** an argument to this factory: it's
     a host scalar consumed only as a multiplicative factor inside
@@ -1941,16 +1945,17 @@ def dense_indexer_backward_sm100(
         block_I,
         ratio,
         is_varlen,
+        has_q_causal_offsets,
     )
 
 
-def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_scale, block_I, ratio, is_varlen):
+def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_scale, block_I, ratio, is_varlen, has_q_causal_offsets):
     from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor
 
     if torch.cuda.get_device_capability()[0] < 10:
         raise RuntimeError("Requires SM100+")
 
-    # Kernel 1: ScoreGradDense — applies bottom-right ratio causal mask so
+    # Kernel 1: ScoreGradDense — applies ratio causal mask so
     # masked / padding columns produce grad_signal=0 (won't contaminate GEMM).
     score_grad_obj = ScoreGradDense(ratio=ratio)
 
@@ -1961,7 +1966,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
     # Only params that change generated code. max_seqlen_q/k are now runtime
     # Int32 args to ScoreGradDense (drive the launch grid + causal-mask bound)
     # and to the GEMM, so neither is keyed; batch/sm_scale likewise runtime.
-    compile_key = (is_varlen, heads, dim, block_I, ratio)
+    compile_key = (is_varlen, heads, dim, block_I, ratio, bool(has_q_causal_offsets))
 
     def _ensure_compiled_score_grad(
         IdxScoreRaw,
@@ -1970,6 +1975,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
         AttnL1Norm,
         CuSeqlensQ,
         CuSeqlensK,
+        QCausalOffsets,
         grad_scale,
         current_stream=None,
     ):
@@ -1990,6 +1996,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             s = _resolve_stream(current_stream)
             cuq_arg = to_cute_tensor(CuSeqlensQ) if CuSeqlensQ is not None else None
             cuk_arg = to_cute_tensor(CuSeqlensK) if CuSeqlensK is not None else None
+            q_offsets_arg = to_cute_tensor(QCausalOffsets) if QCausalOffsets is not None else None
             _score_grad_compile_cache[compile_key] = cute.compile(
                 score_grad_obj,
                 to_cute_tensor(IdxScoreRaw),
@@ -1998,6 +2005,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
                 to_cute_tensor(AttnL1Norm),
                 cuq_arg,
                 cuk_arg,
+                q_offsets_arg,
                 cutlass.Float32(float(grad_scale)),
                 cutlass.Int32(max_seqlen_q),
                 cutlass.Int32(max_seqlen_k),
@@ -2015,6 +2023,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
         GradSignal,
         CuSeqlensQ,
         CuSeqlensK,
+        QCausalOffsets,
         current_stream=None,
     ):
         """Lazy-compile kernel 2 (2Q GEMM).
@@ -2026,6 +2035,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             s = _resolve_stream(current_stream)
             cuq_arg = to_cute_tensor(CuSeqlensQ) if CuSeqlensQ is not None else None
             cuk_arg = to_cute_tensor(CuSeqlensK) if CuSeqlensK is not None else None
+            q_offsets_arg = to_cute_tensor(QCausalOffsets) if QCausalOffsets is not None else None
             _gemm_compile_cache[compile_key] = cute.compile(
                 gemm_obj,
                 to_cute_tensor(IndexQ),
@@ -2037,6 +2047,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
                 to_cute_tensor(GradSignal),
                 cuq_arg,
                 cuk_arg,
+                q_offsets_arg,
                 cutlass.Float32(sm_scale),
                 cutlass.Int32(max_seqlen_q),
                 cutlass.Int32(max_seqlen_k),
@@ -2054,6 +2065,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
         GradSignal,
         CuSeqlensQ=None,
         CuSeqlensK=None,
+        QCausalOffsets=None,
         current_stream=None,
     ):
         """Run only kernel 2 (2Q GEMM). Caller must have run kernel 1 and zeroed dIndexK_f32."""
@@ -2063,6 +2075,10 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             assert CuSeqlensQ is not None and CuSeqlensK is not None, "THD-compiled kernel requires cu_seqlens_q/k at runtime"
         else:
             assert CuSeqlensQ is None and CuSeqlensK is None, "BSHD-compiled kernel must not receive cu_seqlens_q/k"
+        if has_q_causal_offsets:
+            assert QCausalOffsets is not None, "offset-compiled kernel requires q_causal_offsets at runtime"
+        else:
+            assert QCausalOffsets is None, "non-offset compiled kernel must not receive q_causal_offsets"
         s = _resolve_stream(current_stream)
         _ensure_compiled_gemm(
             IndexQ,
@@ -2074,6 +2090,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             GradSignal,
             CuSeqlensQ,
             CuSeqlensK,
+            QCausalOffsets,
             current_stream=current_stream,
         )
         with torch.cuda.nvtx.range("indexer_backward_dsl_dense_gemm_2q"):
@@ -2087,6 +2104,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
                 GradSignal,
                 CuSeqlensQ,
                 CuSeqlensK,
+                QCausalOffsets,
                 cutlass.Float32(sm_scale),
                 cutlass.Int32(max_seqlen_q),
                 cutlass.Int32(max_seqlen_k),
@@ -2107,6 +2125,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
         grad_scale,
         CuSeqlensQ=None,
         CuSeqlensK=None,
+        QCausalOffsets=None,
         current_stream=None,
     ):
         """Full dense backward: kernel 1 (score grad) + kernel 2 (2Q GEMM).
@@ -2123,6 +2142,10 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             assert CuSeqlensQ is not None and CuSeqlensK is not None, "THD-compiled kernel requires cu_seqlens_q/k at runtime"
         else:
             assert CuSeqlensQ is None and CuSeqlensK is None, "BSHD-compiled kernel must not receive cu_seqlens_q/k"
+        if has_q_causal_offsets:
+            assert QCausalOffsets is not None, "offset-compiled kernel requires q_causal_offsets at runtime"
+        else:
+            assert QCausalOffsets is None, "non-offset compiled kernel must not receive q_causal_offsets"
         s = _resolve_stream(current_stream)
 
         # Kernel 1 (CuTe DSL): in-place overwrites IdxScoreRaw with grad_signal.
@@ -2134,6 +2157,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             AttnL1Norm,
             CuSeqlensQ,
             CuSeqlensK,
+            QCausalOffsets,
             grad_scale,
             current_stream=current_stream,
         )
@@ -2145,6 +2169,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
                 AttnL1Norm,
                 CuSeqlensQ,
                 CuSeqlensK,
+                QCausalOffsets,
                 cutlass.Float32(float(grad_scale)),
                 cutlass.Int32(max_seqlen_q),
                 cutlass.Int32(max_seqlen_k),
@@ -2163,6 +2188,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             IdxScoreRaw,
             CuSeqlensQ,
             CuSeqlensK,
+            QCausalOffsets,
             current_stream=current_stream,
         )
 

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm90.py
@@ -65,6 +65,7 @@ class ScoreGradDenseSm90:
         mAttnL1Norm,
         mCuSeqlensQ,
         mCuSeqlensK,
+        mQCausalOffsets,
         grad_scale: Float32,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -106,6 +107,7 @@ class ScoreGradDenseSm90:
             mAttnL1Norm,
             mCuSeqlensQ,
             mCuSeqlensK,
+            mQCausalOffsets,
             grad_scale,
             seqlen_k_pad,
             max_seqlen_q,
@@ -125,6 +127,7 @@ class ScoreGradDenseSm90:
         mAttnL1Norm,
         mCuSeqlensQ,
         mCuSeqlensK,
+        mQCausalOffsets,
         grad_scale: Float32,
         seqlen_k_pad: Int32,
         seqlen_q_static: Int32,
@@ -143,6 +146,7 @@ class ScoreGradDenseSm90:
             seqlen_q_static,
             seqlen_k_static,
         )
+        q_causal_offset_b = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
 
         if seq_local < seqlen_q_b:
             smem = cutlass.utils.SmemAllocator()
@@ -173,9 +177,9 @@ class ScoreGradDenseSm90:
             LOG2E = Float32(1.4426950408889634)
 
             ratio = Int32(self.ratio)
-            q_start_b = seqlen_k_b * ratio - seqlen_q_b
-            col_limit_raw = (q_start_b + Int32(seq_local) + Int32(1)) // ratio
+            col_limit_raw = (q_causal_offset_b + Int32(seq_local) + Int32(1)) // ratio
             col_limit = col_limit_raw if col_limit_raw < seqlen_k_b else seqlen_k_b
+            col_limit = col_limit if col_limit > Int32(0) else Int32(0)
 
             local_sum = Float32(0.0)
             pos = tidx
@@ -230,6 +234,7 @@ def dense_indexer_backward_sm90(
     block_I=128,
     ratio=1,
     is_varlen=False,
+    has_q_causal_offsets=False,
 ):
     """Factory for the dense indexer backward gradient kernel on SM90."""
     assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
@@ -245,6 +250,7 @@ def dense_indexer_backward_sm90(
         block_I,
         ratio,
         is_varlen,
+        has_q_causal_offsets,
     )
 
 
@@ -258,6 +264,7 @@ def _build_cute_dsl_dense_kernel(
     block_I,
     ratio,
     is_varlen,
+    has_q_causal_offsets,
 ):
     cap = torch.cuda.get_device_capability()[0]
     if cap < 9:
@@ -278,8 +285,8 @@ def _build_cute_dsl_dense_kernel(
 
     # Compile caches are keyed only by params that change generated code. In
     # dense mode, K-block traversal is runtime-sized by seqlen_k.
-    score_grad_key = (is_varlen, ratio)
-    gemm_key = (is_varlen, heads, dim, block_I, ratio)
+    score_grad_key = (is_varlen, ratio, bool(has_q_causal_offsets))
+    gemm_key = (is_varlen, heads, dim, block_I, ratio, bool(has_q_causal_offsets))
     dummy_topk_holder = [None]
 
     def _get_dummy_topk(device, current_stream=None):
@@ -298,6 +305,7 @@ def _build_cute_dsl_dense_kernel(
         GradSignal,
         CuSeqlensQ,
         CuSeqlensK,
+        QCausalOffsets,
         current_stream=None,
     ):
         s = _resolve_stream(current_stream)
@@ -305,6 +313,7 @@ def _build_cute_dsl_dense_kernel(
             dummy_topk = _get_dummy_topk(IndexQ.device, current_stream=current_stream)
             cuq_arg = to_cute_tensor(CuSeqlensQ) if CuSeqlensQ is not None else None
             cuk_arg = to_cute_tensor(CuSeqlensK) if CuSeqlensK is not None else None
+            q_offsets_arg = to_cute_tensor(QCausalOffsets) if QCausalOffsets is not None else None
             cute_args = [
                 to_cute_tensor(t)
                 for t in [
@@ -327,6 +336,7 @@ def _build_cute_dsl_dense_kernel(
                 cuk_arg,
                 cutlass.Int32(seqlen),
                 cutlass.Int32(seqlen_k),
+                q_offsets_arg,
                 options=compile_options(),
             )
 
@@ -337,6 +347,7 @@ def _build_cute_dsl_dense_kernel(
         AttnL1Norm,
         CuSeqlensQ,
         CuSeqlensK,
+        QCausalOffsets,
         grad_scale,
         current_stream=None,
     ):
@@ -344,6 +355,7 @@ def _build_cute_dsl_dense_kernel(
             s = _resolve_stream(current_stream)
             cuq_arg = to_cute_tensor(CuSeqlensQ) if CuSeqlensQ is not None else None
             cuk_arg = to_cute_tensor(CuSeqlensK) if CuSeqlensK is not None else None
+            q_offsets_arg = to_cute_tensor(QCausalOffsets) if QCausalOffsets is not None else None
             _dense_score_grad_compile_cache[score_grad_key] = cute.compile(
                 score_grad_obj,
                 to_cute_tensor(IdxScoreRaw),
@@ -352,6 +364,7 @@ def _build_cute_dsl_dense_kernel(
                 to_cute_tensor(AttnL1Norm),
                 cuq_arg,
                 cuk_arg,
+                q_offsets_arg,
                 cutlass.Float32(float(grad_scale)),
                 cutlass.Int32(seqlen),
                 cutlass.Int32(seqlen_k),
@@ -367,12 +380,17 @@ def _build_cute_dsl_dense_kernel(
         grad_scale,
         CuSeqlensQ=None,
         CuSeqlensK=None,
+        QCausalOffsets=None,
         current_stream=None,
     ):
         if is_varlen:
             assert CuSeqlensQ is not None and CuSeqlensK is not None, "THD-compiled score-grad kernel requires cu_seqlens_q/k at runtime"
         else:
             assert CuSeqlensQ is None and CuSeqlensK is None, "BSHD-compiled score-grad kernel must not receive cu_seqlens_q/k"
+        if has_q_causal_offsets:
+            assert QCausalOffsets is not None, "offset-compiled score-grad kernel requires q_causal_offsets at runtime"
+        else:
+            assert QCausalOffsets is None, "non-offset compiled score-grad kernel must not receive q_causal_offsets"
         s = _resolve_stream(current_stream)
         _ensure_compiled_score_grad(
             IdxScoreRaw,
@@ -381,6 +399,7 @@ def _build_cute_dsl_dense_kernel(
             AttnL1Norm,
             CuSeqlensQ,
             CuSeqlensK,
+            QCausalOffsets,
             grad_scale,
             current_stream=current_stream,
         )
@@ -391,6 +410,7 @@ def _build_cute_dsl_dense_kernel(
             AttnL1Norm,
             CuSeqlensQ,
             CuSeqlensK,
+            QCausalOffsets,
             cutlass.Float32(float(grad_scale)),
             cutlass.Int32(seqlen),
             cutlass.Int32(seqlen_k),
@@ -407,6 +427,7 @@ def _build_cute_dsl_dense_kernel(
         GradSignal,
         CuSeqlensQ=None,
         CuSeqlensK=None,
+        QCausalOffsets=None,
         current_stream=None,
     ):
         """Run fused dense Kernel 2. Caller must run score_grad first."""
@@ -414,6 +435,10 @@ def _build_cute_dsl_dense_kernel(
             assert CuSeqlensQ is not None and CuSeqlensK is not None, "THD-compiled kernel requires cu_seqlens_q/k at runtime"
         else:
             assert CuSeqlensQ is None and CuSeqlensK is None, "BSHD-compiled kernel must not receive cu_seqlens_q/k"
+        if has_q_causal_offsets:
+            assert QCausalOffsets is not None, "offset-compiled kernel requires q_causal_offsets at runtime"
+        else:
+            assert QCausalOffsets is None, "non-offset compiled kernel must not receive q_causal_offsets"
         dummy_topk = _get_dummy_topk(IndexQ.device, current_stream=current_stream)
         s = _resolve_stream(current_stream)
 
@@ -427,6 +452,7 @@ def _build_cute_dsl_dense_kernel(
             GradSignal,
             CuSeqlensQ,
             CuSeqlensK,
+            QCausalOffsets,
             current_stream=current_stream,
         )
         _dense_compile_cache[gemm_key](
@@ -444,6 +470,7 @@ def _build_cute_dsl_dense_kernel(
             CuSeqlensK,
             cutlass.Int32(seqlen),
             cutlass.Int32(seqlen_k),
+            QCausalOffsets,
         )
 
     def _run(
@@ -460,6 +487,7 @@ def _build_cute_dsl_dense_kernel(
         grad_scale,
         CuSeqlensQ=None,
         CuSeqlensK=None,
+        QCausalOffsets=None,
         current_stream=None,
     ):
         if is_varlen:
@@ -474,6 +502,7 @@ def _build_cute_dsl_dense_kernel(
             grad_scale,
             CuSeqlensQ,
             CuSeqlensK,
+            QCausalOffsets,
             current_stream=current_stream,
         )
         grad_signal = idx_scores_raw
@@ -489,6 +518,7 @@ def _build_cute_dsl_dense_kernel(
                 grad_signal,
                 CuSeqlensQ,
                 CuSeqlensK,
+                QCausalOffsets,
                 current_stream=current_stream,
             )
         else:
@@ -504,6 +534,7 @@ def _build_cute_dsl_dense_kernel(
                 grad_signal,
                 CuSeqlensQ,
                 CuSeqlensK,
+                QCausalOffsets,
                 current_stream=current_stream,
             )
             with _torch_stream_context(current_stream):

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm90.py
@@ -52,9 +52,10 @@ class ScoreGradDenseSm90:
     WARP_SIZE = 32
     THREADS_PER_CTA = 128
 
-    def __init__(self, ratio: int = 1):
+    def __init__(self, ratio: int = 1, block_I: int = 128):
         assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
         self.ratio = ratio
+        self.block_I = block_I
 
     @cute.jit
     def __call__(
@@ -183,19 +184,18 @@ class ScoreGradDenseSm90:
 
             local_sum = Float32(0.0)
             pos = tidx
-            while pos < seqlen_k_pad:
-                if pos < col_limit:
-                    idx_raw = mIdxScore_b[seq_local, pos]
-                    attn_raw = mAttnScore_b[seq_local, pos]
-                    score_minus_lse = idx_raw - idx_lse_val
-                    predict = cute.math.exp2(
-                        score_minus_lse * LOG2E,
-                        fastmath=True,
-                    )
-                    target = attn_raw / (attn_l1_val + Float32(EPS))
-                    target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
-                    log_clip_mask = Float32(1.0) if score_minus_lse >= Float32(CLIP_LOG_MIN) else Float32(0.0)
-                    local_sum = local_sum + (-target_eff * log_clip_mask * grad_scale)
+            while pos < col_limit:
+                idx_raw = mIdxScore_b[seq_local, pos]
+                attn_raw = mAttnScore_b[seq_local, pos]
+                score_minus_lse = idx_raw - idx_lse_val
+                predict = cute.math.exp2(
+                    score_minus_lse * LOG2E,
+                    fastmath=True,
+                )
+                target = attn_raw / (attn_l1_val + Float32(EPS))
+                target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
+                log_clip_mask = Float32(1.0) if score_minus_lse >= Float32(CLIP_LOG_MIN) else Float32(0.0)
+                local_sum = local_sum + (-target_eff * log_clip_mask * grad_scale)
                 pos = pos + Int32(128)
 
             warp_sum = cute.arch.warp_reduction_sum(local_sum)
@@ -204,8 +204,12 @@ class ScoreGradDenseSm90:
             cute.arch.sync_threads()
             sum_grad = sReduceScratch[0] + sReduceScratch[1] + sReduceScratch[2] + sReduceScratch[3]
 
+            block_i = Int32(self.block_I)
+            zero_limit = ((col_limit + block_i - Int32(1)) // block_i) * block_i
+            zero_limit = zero_limit if zero_limit < seqlen_k_pad else seqlen_k_pad
+
             pos = tidx
-            while pos < seqlen_k_pad:
+            while pos < zero_limit:
                 if pos < col_limit:
                     idx_raw = mIdxScore_b[seq_local, pos]
                     attn_raw = mAttnScore_b[seq_local, pos]
@@ -273,7 +277,7 @@ def _build_cute_dsl_dense_kernel(
         raise RuntimeError("Use SM100 kernel for Blackwell")
 
     topk = seqlen_k
-    score_grad_obj = ScoreGradDenseSm90(ratio=ratio)
+    score_grad_obj = ScoreGradDenseSm90(ratio=ratio, block_I=block_I)
     kernel_obj = IndexerBackwardSm90(
         head_dim=dim,
         heads=heads,
@@ -285,7 +289,7 @@ def _build_cute_dsl_dense_kernel(
 
     # Compile caches are keyed only by params that change generated code. In
     # dense mode, K-block traversal is runtime-sized by seqlen_k.
-    score_grad_key = (is_varlen, ratio, bool(has_q_causal_offsets))
+    score_grad_key = (is_varlen, ratio, block_I, bool(has_q_causal_offsets))
     gemm_key = (is_varlen, heads, dim, block_I, ratio, bool(has_q_causal_offsets))
     dummy_topk_holder = [None]
 

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm90.py
@@ -165,11 +165,10 @@ class IndexerBackwardSm90:
         self.SCHED_BARRIER_WG1 = 5
 
     @cute.jit
-    def _dense_num_k_blocks(self, q_token, seqlen_q, seqlen_k):
+    def _dense_num_k_blocks(self, q_token, seqlen_q, seqlen_k, q_causal_offset):
         """Return dense K blocks that can contain valid ratio-causal columns."""
         ratio = Int32(self.ratio)
-        q_global_start = seqlen_k * ratio - seqlen_q
-        col_limit = (q_global_start + q_token + Int32(1)) // ratio
+        col_limit = (q_causal_offset + q_token + Int32(1)) // ratio
         col_limit = col_limit if col_limit > Int32(0) else Int32(0)
         col_limit = col_limit if col_limit < seqlen_k else seqlen_k
         return cute.ceil_div(col_limit, self.block_I)
@@ -191,6 +190,7 @@ class IndexerBackwardSm90:
         mCuSeqlensK=None,
         max_seqlen_q: Int32 = None,
         max_seqlen_k: Int32 = None,
+        mQCausalOffsets=None,
     ):
         is_varlen = const_expr(self.is_dense and mCuSeqlensQ is not None)
         self.q_dtype = mQ.element_type
@@ -339,6 +339,7 @@ class IndexerBackwardSm90:
             tma_atom_K,
             mCuSeqlensQ,
             mCuSeqlensK,
+            mQCausalOffsets,
         ).launch(
             grid=(seqlen, batch_size, 1),
             block=[self.THREADS_PER_CTA, 1, 1],
@@ -373,6 +374,7 @@ class IndexerBackwardSm90:
         tma_atom_K: cute.CopyAtom = None,
         mCuSeqlensQ=None,
         mCuSeqlensK=None,
+        mQCausalOffsets=None,
     ):
         tidx = cute.arch.thread_idx()[0]
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -387,6 +389,7 @@ class IndexerBackwardSm90:
             seqlen,
             seqlen_k_static,
         )
+        q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
 
         if const_expr(is_varlen):
             mQ_b = cute.domain_offset((Int32(0), Int32(0), q_offset), mQ)
@@ -546,6 +549,7 @@ class IndexerBackwardSm90:
                     batch_idx,
                     seqlen_q_b,
                     seqlen_k_b,
+                    q_causal_offset,
                     tidx,
                     warp_idx,
                     mbar,
@@ -585,6 +589,7 @@ class IndexerBackwardSm90:
                     batch_idx,
                     seqlen_q_b,
                     seqlen_k_b,
+                    q_causal_offset,
                     tidx,
                     warp_idx,
                     mbar,
@@ -602,6 +607,7 @@ class IndexerBackwardSm90:
                         seq_idx,
                         seqlen_q_b,
                         seqlen_k_b,
+                        q_causal_offset,
                         tidx,
                         mbar,
                         tma_atom_K,
@@ -657,6 +663,7 @@ class IndexerBackwardSm90:
         batch_idx,
         seqlen_q,
         seqlen_k,
+        q_causal_offset,
         tidx,
         warp_idx,
         mbar,
@@ -789,7 +796,7 @@ class IndexerBackwardSm90:
             )
 
         if const_expr(self.is_dense):
-            num_topk_blocks_cur = self._dense_num_k_blocks(seq_idx, seqlen_q, seqlen_k)
+            num_topk_blocks_cur = self._dense_num_k_blocks(seq_idx, seqlen_q, seqlen_k, q_causal_offset)
         else:
             num_topk_blocks_cur = Int32(self.num_topk_blocks)
 
@@ -1211,6 +1218,7 @@ class IndexerBackwardSm90:
         seq_idx,
         seqlen_q,
         seqlen_k,
+        q_causal_offset,
         tidx,
         mbar,
         tma_atom_K,
@@ -1239,7 +1247,7 @@ class IndexerBackwardSm90:
         idx_in_group = wg_tidx % GROUP_SIZE
         group_idx_local = wg_tidx // GROUP_SIZE
 
-        num_k_blocks = self._dense_num_k_blocks(seq_idx, seqlen_q, seqlen_k)
+        num_k_blocks = self._dense_num_k_blocks(seq_idx, seqlen_q, seqlen_k, q_causal_offset)
         for bi in cutlass.range(0, num_k_blocks, unroll=1):
             stage = bi % NUM_K_STAGES
             n_block = bi

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
@@ -122,9 +122,7 @@ def indexer_fwd(
         device = q.device
         out_shape = (bs, seqlen_q_dim, seqlen_k_dim)
         out_buf_shape = None
-    q_causal_offsets = validate_q_causal_offsets(
-        q_causal_offsets, int(bs), q.device, stream=current_stream
-    )
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device, stream=current_stream)
 
     # TMA S2G requires globalStride aligned to 16 bytes.
     # For FP32, seqlen_k must be a multiple of 4 elements (4 × 4B = 16B).

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
@@ -20,6 +20,7 @@ from cudnn.deepseek_sparse_attention.utils.runtime import (
     device_major as _get_device_capability,
     maybe_contiguous as _maybe_contiguous,
     resolve_stream,
+    validate_q_causal_offsets,
 )
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor as _to_cute_tensor
 
@@ -44,13 +45,14 @@ def indexer_fwd(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream=None,
 ) -> torch.Tensor:
     """
     Indexer QK forward pass using CuTe DSL kernel.
 
-    Computes S_sum = sm_scale * sum_h [(Q @ K^T).relu() * W] with
-    bottom-right aligned ratio causal mask.
+    Computes S_sum = sm_scale * sum_h [(Q @ K^T).relu() * W] with a
+    ratio causal mask against compressed-KV positions.
     sm_scale is applied to the fp32 head-reduced score inside the kernel
     (higher precision than pre-multiplying onto bf16 W on the host).
 
@@ -65,6 +67,8 @@ def indexer_fwd(
         out: optional output tensor. BSHD: ``(bs, seqlen_q, seqlen_k)``.
              THD: ``(total_q, max_seqlen_k)`` with local-K columns.
         sm_scale: scalar applied to fp32 score post head-reduce; default 1.0
+        q_causal_offsets: optional int32 CUDA tensor of shape ``(batch,)``.
+             Each entry is the global uncompressed token index for local q[0].
 
     Returns:
         S_sum: BSHD ``(bs, seqlen_q, seqlen_k)`` or THD
@@ -114,10 +118,9 @@ def indexer_fwd(
         bs, seqlen_q_dim, n_heads_q, head_dim = q.shape
         _, seqlen_k_dim, n_heads_kv, _ = k.shape
         device = q.device
-        if seqlen_q_dim < seqlen_k_dim * ratio:
-            raise ValueError(f"seqlen_q ({seqlen_q_dim}) must be >= seqlen_k * ratio " f"({seqlen_k_dim * ratio})")
         out_shape = (bs, seqlen_q_dim, seqlen_k_dim)
         out_buf_shape = None
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device)
 
     # TMA S2G requires globalStride aligned to 16 bytes.
     # For FP32, seqlen_k must be a multiple of 4 elements (4 × 4B = 16B).
@@ -153,6 +156,7 @@ def indexer_fwd(
         q_stage,
         kv_stage,
         is_varlen,
+        q_causal_offsets is not None,
     )
 
     if compile_key not in _compile_cache:
@@ -162,6 +166,7 @@ def indexer_fwd(
         out_cute = _to_cute_tensor(out)
         cu_q_cute = _to_cute_tensor(cu_seqlens_q, leading_dim=0) if is_varlen else None
         cu_k_cute = _to_cute_tensor(cu_seqlens_k, leading_dim=0) if is_varlen else None
+        q_offsets_cute = _to_cute_tensor(q_causal_offsets, leading_dim=0) if q_causal_offsets is not None else None
 
         kernel_obj = IndexerForwardSm100(
             head_dim=head_dim,
@@ -191,6 +196,7 @@ def indexer_fwd(
             scale_arg,
             cu_q_cute,
             cu_k_cute,
+            q_offsets_cute,
             current_stream,
             options=compile_options(),
         )
@@ -213,6 +219,7 @@ def indexer_fwd(
             scale_arg,
             cu_seqlens_q if is_varlen else None,
             cu_seqlens_k if is_varlen else None,
+            q_causal_offsets,
             current_stream,
         )
 

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
@@ -114,8 +114,8 @@ def indexer_fwd(
         bs, seqlen_q_dim, n_heads_q, head_dim = q.shape
         _, seqlen_k_dim, n_heads_kv, _ = k.shape
         device = q.device
-        if seqlen_q_dim > seqlen_k_dim * ratio:
-            raise ValueError(f"seqlen_q ({seqlen_q_dim}) must be <= seqlen_k * ratio " f"({seqlen_k_dim * ratio})")
+        if seqlen_q_dim < seqlen_k_dim * ratio:
+            raise ValueError(f"seqlen_q ({seqlen_q_dim}) must be >= seqlen_k * ratio " f"({seqlen_k_dim * ratio})")
         out_shape = (bs, seqlen_q_dim, seqlen_k_dim)
         out_buf_shape = None
 

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
@@ -20,6 +20,7 @@ from cudnn.deepseek_sparse_attention.utils.runtime import (
     device_major as _get_device_capability,
     maybe_contiguous as _maybe_contiguous,
     resolve_stream,
+    torch_stream_context as _torch_stream_context,
     validate_q_causal_offsets,
 )
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor as _to_cute_tensor
@@ -74,7 +75,8 @@ def indexer_fwd(
         S_sum: BSHD ``(bs, seqlen_q, seqlen_k)`` or THD
                ``(total_q, max_seqlen_k)`` [FP32]
     """
-    q, k, w = [_maybe_contiguous(t) for t in (q, k, w)]
+    current_stream = resolve_stream(current_stream)
+    q, k, w = [_maybe_contiguous(t, current_stream) for t in (q, k, w)]
     for tensor, name in ((q, "q"), (k, "k"), (w, "w")):
         assert tensor.dtype == torch.bfloat16, f"{name} must be bfloat16, got {tensor.dtype}"
         assert tensor.is_cuda, f"{name} must be on CUDA device"
@@ -120,7 +122,9 @@ def indexer_fwd(
         device = q.device
         out_shape = (bs, seqlen_q_dim, seqlen_k_dim)
         out_buf_shape = None
-    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device)
+    q_causal_offsets = validate_q_causal_offsets(
+        q_causal_offsets, int(bs), q.device, stream=current_stream
+    )
 
     # TMA S2G requires globalStride aligned to 16 bytes.
     # For FP32, seqlen_k must be a multiple of 4 elements (4 × 4B = 16B).
@@ -131,10 +135,12 @@ def indexer_fwd(
 
     if need_pad:
         out_buf_shape = (total_q, seqlen_k_padded) if is_varlen else (bs, seqlen_q_dim, seqlen_k_padded)
-        out_buf = torch.empty(out_buf_shape, dtype=torch.float32, device=device)
+        with _torch_stream_context(current_stream):
+            out_buf = torch.empty(out_buf_shape, dtype=torch.float32, device=device)
         out = out_buf[:, :seqlen_k_dim] if is_varlen else out_buf[:, :, :seqlen_k_dim]
     elif out is None:
-        out = torch.empty(out_shape, dtype=torch.float32, device=device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty(out_shape, dtype=torch.float32, device=device)
     else:
         assert out.shape == out_shape, f"out must have shape {out_shape}, got {tuple(out.shape)}"
         assert out.dtype == torch.float32 and out.is_cuda
@@ -179,7 +185,6 @@ def indexer_fwd(
             kv_stage=kv_stage,
         )
 
-        current_stream = resolve_stream(current_stream)
         scale_arg = cutlass.Float32(sm_scale)
         max_q_arg = cutlass.Int32(seqlen_q_dim)
         max_k_arg = cutlass.Int32(seqlen_k_dim)
@@ -202,8 +207,8 @@ def indexer_fwd(
         )
 
     # Init to -inf: skipped causal n-blocks and masked positions stay -inf
-    out.fill_(float("-inf"))
-    current_stream = resolve_stream(current_stream)
+    with _torch_stream_context(current_stream):
+        out.fill_(float("-inf"))
     scale_arg = cutlass.Float32(sm_scale)
     max_q_arg = cutlass.Int32(seqlen_q_dim)
     max_k_arg = cutlass.Int32(seqlen_k_dim)
@@ -224,6 +229,7 @@ def indexer_fwd(
         )
 
     if out_orig is not None and out.data_ptr() != out_orig.data_ptr():
-        out_orig.copy_(out)
+        with _torch_stream_context(current_stream):
+            out_orig.copy_(out)
         return out_orig
     return out

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
@@ -110,9 +110,7 @@ def indexer_fwd(
         qhead_per_kv_head = n_heads_q // n_heads_kv
     assert qhead_per_kv_head == n_heads_q // n_heads_kv
     assert qhead_per_kv_head in _SUPPORTED_QHPKV, f"qhead_per_kv_head must be one of {_SUPPORTED_QHPKV}, got {qhead_per_kv_head}"
-    q_causal_offsets = validate_q_causal_offsets(
-        q_causal_offsets, int(batch_size), q.device, stream=current_stream
-    )
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device, stream=current_stream)
 
     if out is None:
         with _torch_stream_context(current_stream):

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
@@ -96,8 +96,8 @@ def indexer_fwd(
             seqlen_q_dim,
             n_heads_q,
         ), f"w shape must be {(batch_size, seqlen_q_dim, n_heads_q)}, got {tuple(w.shape)}"
-        if seqlen_q_dim > seqlen_k_dim * ratio:
-            raise ValueError(f"seqlen_q ({seqlen_q_dim}) must be <= seqlen_k * ratio ({seqlen_k_dim * ratio})")
+        if seqlen_q_dim < seqlen_k_dim * ratio:
+            raise ValueError(f"seqlen_q ({seqlen_q_dim}) must be >= seqlen_k * ratio ({seqlen_k_dim * ratio})")
         out_shape = (batch_size, seqlen_q_dim, seqlen_k_dim)
 
     assert head_dim == head_dim_k, f"q head_dim ({head_dim}) != k head_dim ({head_dim_k})"

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
@@ -14,6 +14,7 @@ from cudnn.deepseek_sparse_attention.utils.compiler import compile_options
 from cudnn.deepseek_sparse_attention.utils.runtime import (
     maybe_contiguous as _maybe_contiguous,
     resolve_stream,
+    torch_stream_context as _torch_stream_context,
     validate_q_causal_offsets,
 )
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import (
@@ -63,9 +64,10 @@ def indexer_fwd(
         raise ValueError("THD input requires both cu_seqlens_q and cu_seqlens_k")
     is_varlen = is_varlen_q
 
-    q = _maybe_contiguous(q)
-    k = _maybe_contiguous(k)
-    w = _maybe_contiguous(w)
+    current_stream = resolve_stream(current_stream)
+    q = _maybe_contiguous(q, current_stream)
+    k = _maybe_contiguous(k, current_stream)
+    w = _maybe_contiguous(w, current_stream)
 
     if is_varlen:
         assert cu_seqlens_q is not None and cu_seqlens_k is not None
@@ -108,10 +110,13 @@ def indexer_fwd(
         qhead_per_kv_head = n_heads_q // n_heads_kv
     assert qhead_per_kv_head == n_heads_q // n_heads_kv
     assert qhead_per_kv_head in _SUPPORTED_QHPKV, f"qhead_per_kv_head must be one of {_SUPPORTED_QHPKV}, got {qhead_per_kv_head}"
-    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device)
+    q_causal_offsets = validate_q_causal_offsets(
+        q_causal_offsets, int(batch_size), q.device, stream=current_stream
+    )
 
     if out is None:
-        out = torch.empty(out_shape, dtype=torch.float32, device=q.device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty(out_shape, dtype=torch.float32, device=q.device)
     else:
         assert out.shape == out_shape, f"out must have shape {out_shape}, got {tuple(out.shape)}"
         assert out.dtype == torch.float32 and out.is_cuda
@@ -125,7 +130,6 @@ def indexer_fwd(
         bool(is_varlen),
         q_causal_offsets is not None,
     )
-    current_stream = resolve_stream(current_stream)
     if compile_key not in _compile_cache:
         q_cute = _to_cute_tensor(q)
         k_cute = _to_cute_tensor(k)
@@ -158,7 +162,8 @@ def indexer_fwd(
             options=compile_options(),
         )
 
-    out.fill_(float("-inf"))
+    with _torch_stream_context(current_stream):
+        out.fill_(float("-inf"))
     with torch.cuda.nvtx.range("indexer_fwd_kernel_sm90_direct_dsl"):
         _compile_cache[compile_key](
             q,

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
@@ -14,6 +14,7 @@ from cudnn.deepseek_sparse_attention.utils.compiler import compile_options
 from cudnn.deepseek_sparse_attention.utils.runtime import (
     maybe_contiguous as _maybe_contiguous,
     resolve_stream,
+    validate_q_causal_offsets,
 )
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import (
     to_cute_tensor as _to_cute_tensor,
@@ -48,6 +49,7 @@ def indexer_fwd(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream=None,
 ) -> torch.Tensor:
     """Indexer QK forward pass using the direct SM90 CuTe DSL port."""
@@ -96,8 +98,6 @@ def indexer_fwd(
             seqlen_q_dim,
             n_heads_q,
         ), f"w shape must be {(batch_size, seqlen_q_dim, n_heads_q)}, got {tuple(w.shape)}"
-        if seqlen_q_dim < seqlen_k_dim * ratio:
-            raise ValueError(f"seqlen_q ({seqlen_q_dim}) must be >= seqlen_k * ratio ({seqlen_k_dim * ratio})")
         out_shape = (batch_size, seqlen_q_dim, seqlen_k_dim)
 
     assert head_dim == head_dim_k, f"q head_dim ({head_dim}) != k head_dim ({head_dim_k})"
@@ -108,6 +108,7 @@ def indexer_fwd(
         qhead_per_kv_head = n_heads_q // n_heads_kv
     assert qhead_per_kv_head == n_heads_q // n_heads_kv
     assert qhead_per_kv_head in _SUPPORTED_QHPKV, f"qhead_per_kv_head must be one of {_SUPPORTED_QHPKV}, got {qhead_per_kv_head}"
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device)
 
     if out is None:
         out = torch.empty(out_shape, dtype=torch.float32, device=q.device)
@@ -122,6 +123,7 @@ def indexer_fwd(
         int(qhead_per_kv_head),
         int(ratio),
         bool(is_varlen),
+        q_causal_offsets is not None,
     )
     current_stream = resolve_stream(current_stream)
     if compile_key not in _compile_cache:
@@ -131,6 +133,7 @@ def indexer_fwd(
         out_cute = _to_cute_tensor(out)
         cu_q_cute = _to_cute_tensor(cu_seqlens_q, leading_dim=0) if is_varlen else None
         cu_k_cute = _to_cute_tensor(cu_seqlens_k, leading_dim=0) if is_varlen else None
+        q_offsets_cute = _to_cute_tensor(q_causal_offsets, leading_dim=0) if q_causal_offsets is not None else None
         kernel_obj = IndexerForwardSm90(
             torch2cute_dtype_map[q.dtype],
             head_dim=int(head_dim),
@@ -150,6 +153,7 @@ def indexer_fwd(
             cutlass.Float32(float(sm_scale)),
             cu_q_cute,
             cu_k_cute,
+            q_offsets_cute,
             current_stream,
             options=compile_options(),
         )
@@ -167,6 +171,7 @@ def indexer_fwd(
             cutlass.Float32(float(sm_scale)),
             cu_seqlens_q if is_varlen else None,
             cu_seqlens_k if is_varlen else None,
+            q_causal_offsets,
             current_stream,
         )
     return out

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/api.py
@@ -231,11 +231,14 @@ def indexer_forward_wrapper(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
 ) -> TupleDict:
     """High-level wrapper. Allocates the output buffer with TMA padding on S_k.
 
     Returns ``{'scores': (B, S_q, S_k) FP32}``. The ratio causal mask marks
-    positions outside the valid KV range with -inf.
+    positions outside the valid KV range with -inf. ``q_causal_offsets`` may
+    specify the global uncompressed token index for each batch/THD segment's
+    local q[0].
     """
     if device_major() == 9:
         unsupported = []
@@ -265,6 +268,7 @@ def indexer_forward_wrapper(
             cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
+            q_causal_offsets=q_causal_offsets,
             current_stream=stream,
         )
         return TupleDict(scores=scores)
@@ -289,6 +293,7 @@ def indexer_forward_wrapper(
         cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max_seqlen_q,
         max_seqlen_k=max_seqlen_k,
+        q_causal_offsets=q_causal_offsets,
         current_stream=stream,
     )
     return TupleDict(scores=scores)

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm100.py
@@ -2,7 +2,7 @@
 Indexer QK Forward Kernel — SM100 Cute-DSL Implementation.
 
 Computes: S_sum(b,q,k) = sum_h [ReLU(Q_h · K_{g(h)}^T) · W_{b,q,h}]
-with bottom-right aligned ratio causal mask, output FP32.
+with ratio causal masking against compressed-KV positions, output FP32.
 
 Design: SwapAB (K as A, Q_packed as B), PackGQA,
         Ld32x32bOp head reduction, 2 epilogue warpgroups for 2 q_stages.
@@ -162,6 +162,7 @@ class IndexerForwardSm100:
         sm_scale: Float32 | float,
         mCuSeqlensQ: Optional[cute.Tensor],
         mCuSeqlensK: Optional[cute.Tensor],
+        mQCausalOffsets: Optional[cute.Tensor],
         stream: cuda.CUstream,
     ):
         """Host-side: layout transpose, PackGQA, TMA creation, kernel launch.
@@ -324,6 +325,7 @@ class IndexerForwardSm100:
             sm_scale,
             mCuSeqlensQ,
             mCuSeqlensK,
+            mQCausalOffsets,
         ).launch(
             grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
@@ -352,6 +354,7 @@ class IndexerForwardSm100:
         sm_scale: Float32 | float,
         mCuSeqlensQ: Optional[cute.Tensor],
         mCuSeqlensK: Optional[cute.Tensor],
+        mQCausalOffsets: Optional[cute.Tensor],
     ):
         """Device-side kernel entry with CLC persistent scheduling.
 
@@ -538,6 +541,7 @@ class IndexerForwardSm100:
                 while work_tile.is_valid_tile:
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
+                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
                         seqlen.seqlen_q * self.qhead_per_kvhead,
                         self.q_stage * self.m_block_size,
@@ -545,7 +549,7 @@ class IndexerForwardSm100:
                     is_valid_m_block = work_tile.tile_idx[0] < num_m_blocks_cur
                     if is_valid_m_block:
                         m_block = num_m_blocks_cur - 1 - work_tile.tile_idx[0]
-                        num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q)
+                        num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q, q_causal_offset)
                         # W load (double-buffered: even tiles → first half, odd tiles → second half)
                         sW_buf_off = (load_tile_count % 2) * self.q_stage * self.m_block_size
                         mW_cur = seqlen.offset_batch_Q(mW, batch_idx, dim=2)
@@ -631,6 +635,7 @@ class IndexerForwardSm100:
                 while work_tile.is_valid_tile:
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
+                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
                         seqlen.seqlen_q * self.qhead_per_kvhead,
                         self.q_stage * self.m_block_size,
@@ -638,7 +643,7 @@ class IndexerForwardSm100:
                     is_valid_m_block = work_tile.tile_idx[0] < num_m_blocks_cur
                     if is_valid_m_block:
                         m_block = num_m_blocks_cur - 1 - work_tile.tile_idx[0]
-                        num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q)
+                        num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q, q_causal_offset)
                         Q_consumer.reset()
                         handle_Q0 = Q_consumer.wait_and_advance()
                         handle_Q1 = Q_consumer.wait_and_advance()
@@ -741,6 +746,7 @@ class IndexerForwardSm100:
                 while work_tile.is_valid_tile:
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
+                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
                         seqlen.seqlen_q * self.qhead_per_kvhead,
                         self.q_stage * self.m_block_size,
@@ -748,7 +754,7 @@ class IndexerForwardSm100:
                     is_valid_m_block = work_tile.tile_idx[0] < num_m_blocks_cur
                     if is_valid_m_block:
                         m_block = num_m_blocks_cur - 1 - work_tile.tile_idx[0]
-                        num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q)
+                        num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q, q_causal_offset)
                         local_count = num_n_blocks if num_n_blocks < Int32(3) else Int32(3)
 
                         if const_expr(is_varlen):
@@ -915,6 +921,7 @@ class IndexerForwardSm100:
             while work_tile.is_valid_tile:
                 batch_idx = work_tile.tile_idx[2]
                 seqlen = SeqlenInfoCls(batch_idx)
+                q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                 num_m_blocks_cur = cute.ceil_div(
                     seqlen.seqlen_q * self.qhead_per_kvhead,
                     self.q_stage * self.m_block_size,
@@ -922,7 +929,7 @@ class IndexerForwardSm100:
                 is_valid_m_block = work_tile.tile_idx[0] < num_m_blocks_cur
                 if is_valid_m_block:
                     m_block = num_m_blocks_cur - 1 - work_tile.tile_idx[0]
-                    num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q)
+                    num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q, q_causal_offset)
                     epi0_sW_base = (epi0_tile_count % 2) * self.q_stage * self.m_block_size
                     epi_s_full_phase_0, score_empty_phase_0 = self._epilogue_warp(
                         0,
@@ -937,6 +944,7 @@ class IndexerForwardSm100:
                         num_n_blocks,
                         seqlen.seqlen_k,
                         seqlen.seqlen_q,
+                        q_causal_offset,
                         tidx,
                         epi_s_full_phase_0,
                         score_empty_phase_0,
@@ -963,6 +971,7 @@ class IndexerForwardSm100:
             while work_tile.is_valid_tile:
                 batch_idx = work_tile.tile_idx[2]
                 seqlen = SeqlenInfoCls(batch_idx)
+                q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                 num_m_blocks_cur = cute.ceil_div(
                     seqlen.seqlen_q * self.qhead_per_kvhead,
                     self.q_stage * self.m_block_size,
@@ -970,7 +979,7 @@ class IndexerForwardSm100:
                 is_valid_m_block = work_tile.tile_idx[0] < num_m_blocks_cur
                 if is_valid_m_block:
                     m_block = num_m_blocks_cur - 1 - work_tile.tile_idx[0]
-                    num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q)
+                    num_n_blocks = self._causal_num_n_blocks(m_block, seqlen.seqlen_k, seqlen.seqlen_q, q_causal_offset)
                     epi1_sW_base = (epi1_tile_count % 2) * self.q_stage * self.m_block_size
                     epi_s_full_phase_1, score_empty_phase_1 = self._epilogue_warp(
                         1,
@@ -985,6 +994,7 @@ class IndexerForwardSm100:
                         num_n_blocks,
                         seqlen.seqlen_k,
                         seqlen.seqlen_q,
+                        q_causal_offset,
                         tidx,
                         epi_s_full_phase_1,
                         score_empty_phase_1,
@@ -1004,18 +1014,17 @@ class IndexerForwardSm100:
     # Causal n-block computation
     # =========================================================================
     @cute.jit
-    def _causal_num_n_blocks(self, m_block, seqlen_k, seqlen_q):
+    def _causal_num_n_blocks(self, m_block, seqlen_k, seqlen_q, q_causal_offset):
         """Compute causal-aware number of KV n-blocks for a given m_block.
 
-        Under bottom-right ratio causal masking, kv_token >=
-        (q_global_start + q_token + 1) // ratio is masked, where
-        q_global_start = seqlen_k * ratio - seqlen_q.
+        Under ratio causal masking, kv_token >=
+        (q_causal_offset + q_token + 1) // ratio is masked.
         The largest q_token in this CTA tile determines the upper bound on kv_token,
         and therefore how many n-blocks are actually needed.
         """
-        q_global_start = seqlen_k * self.ratio - seqlen_q
         max_q_plus_1 = self.q_stage * (m_block + 1) * self.q_tokens_per_tile
-        max_kv_needed = (q_global_start + max_q_plus_1) // self.ratio
+        max_kv_needed = (q_causal_offset + max_q_plus_1) // self.ratio
+        max_kv_needed = max_kv_needed if max_kv_needed > Int32(0) else Int32(0)
         max_kv_needed = max_kv_needed if max_kv_needed < seqlen_k else seqlen_k
         num_n_blocks = cute.ceil_div(max_kv_needed, self.n_block_size)
         return num_n_blocks
@@ -1038,6 +1047,7 @@ class IndexerForwardSm100:
         num_n_blocks,
         seqlen_k,
         seqlen_q,
+        q_causal_offset,
         tidx,
         epi_s_full_phase,
         score_empty_phase,
@@ -1068,7 +1078,6 @@ class IndexerForwardSm100:
         _sW_base = Int32(0) if sW_base is None else sW_base
         qhpkv = self.qhead_per_kvhead
         ratio = Int32(self.ratio)
-        q_global_start = seqlen_k * ratio - seqlen_q
 
         rW_ILP = 4
         sW_f32_ptr = cute.make_ptr(
@@ -1162,7 +1171,7 @@ class IndexerForwardSm100:
                     q_token = q_token_base + qi
                     val = -Float32.inf
                     if q_token < seqlen_q and kv_token < seqlen_k:
-                        col_limit = (q_global_start + q_token + 1) // ratio
+                        col_limit = (q_causal_offset + q_token + 1) // ratio
                         if kv_token < col_limit:
                             val = rAcc[qi]
                     rAcc[qi] = val

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
@@ -32,7 +32,7 @@ from cudnn.deepseek_sparse_attention.utils.sm90.mma import gemm_w_idx
 
 
 def _mma_partition_fragment_AB(
-    thr_mma: cute.core.ThrMma,
+    thr_mma: cute.ThrMma,
     sA: cute.Tensor,
     sB: cute.Tensor,
     swap_AB: bool,

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
@@ -7,8 +7,8 @@ This kernel intentionally keeps the SM90 C++ Q/K staging topology:
 
 The algorithm computes the same score tensor as the C++ kernel:
     sm_scale * sum_h relu(Q_h @ K^T) * W_h
-with bottom-right ratio causal masking. Reduced BF16 scores are written directly
-from registers to global memory.
+with ratio causal masking against compressed-KV positions. Reduced BF16 scores
+are written directly from registers to global memory.
 """
 
 import math
@@ -135,10 +135,9 @@ class IndexerForwardSm90:
         return SharedStorage
 
     @cute.jit
-    def _compute_n_blocks(self, m_block: Int32, seqlen_q: Int32, seqlen_k: Int32) -> Int32:
-        q_global_start = seqlen_k * Int32(self.ratio) - seqlen_q
+    def _compute_n_blocks(self, m_block: Int32, seqlen_q: Int32, seqlen_k: Int32, q_causal_offset: Int32) -> Int32:
         last_q_token = (m_block + Int32(1)) * Int32(self.q_tokens_per_tile) - Int32(1)
-        kv_limit = (q_global_start + last_q_token + Int32(1)) // Int32(self.ratio)
+        kv_limit = (q_causal_offset + last_q_token + Int32(1)) // Int32(self.ratio)
         kv_limit = kv_limit if kv_limit < seqlen_k else seqlen_k
         kv_limit = kv_limit if kv_limit > Int32(0) else Int32(0)
         return cute.ceil_div(kv_limit, self.tile_n)
@@ -200,6 +199,7 @@ class IndexerForwardSm90:
         max_seqlen_k: Int32,
         q_batch_offset: Int32,
         batch_idx: Int32,
+        q_causal_offset: Int32,
         sm_scale: Float32,
     ):
         acc_mn = sm90_ops.make_acc_tensor_mn_view(acc_S)
@@ -213,7 +213,6 @@ class IndexerForwardSm90:
         warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
         m_base = t1 + warp_idx_in_wg * 16
         q_token_base = (self.q_stages * m_block + q_stage_idx) * self.q_tokens_per_stage
-        q_global_start = seqlen_k * Int32(self.ratio) - seqlen_q
 
         ps = cute.make_rmem_tensor((kNRows, self.q_tokens_per_stage), Float32)
         ps.fill(Float32(0.0))
@@ -239,7 +238,7 @@ class IndexerForwardSm90:
                     score = ps[mi, qi]
                     should_store = Boolean(True)
                     if is_first_nblock:
-                        col_lim = (q_global_start + q_local + Int32(1)) // Int32(self.ratio)
+                        col_lim = (q_causal_offset + q_local + Int32(1)) // Int32(self.ratio)
                         if k_local >= seqlen_k or k_local >= col_lim:
                             if const_expr(self.clean_logits):
                                 score = -Float32.inf
@@ -275,6 +274,7 @@ class IndexerForwardSm90:
         mbar_KVEmpty1_ptr,
         mCuSeqlensQ: cute.Tensor,
         mCuSeqlensK: cute.Tensor,
+        mQCausalOffsets: cute.Tensor,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
     ):
@@ -295,10 +295,11 @@ class IndexerForwardSm90:
             tile_m=self.tile_m,
             tile_n=self.tile_n,
         )
+        q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
         num_m_blocks = cute.ceil_div(seqlen.seqlen_q * self.qhead_per_kvhead, self.tile_m)
         if block_x < num_m_blocks:
             m_block = num_m_blocks - Int32(1) - block_x
-            n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k)
+            n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset)
 
             mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
             mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx]
@@ -386,6 +387,7 @@ class IndexerForwardSm90:
         mbar_KVEmpty1_ptr,
         mCuSeqlensQ: cute.Tensor,
         mCuSeqlensK: cute.Tensor,
+        mQCausalOffsets: cute.Tensor,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
         sm_scale: Float32,
@@ -405,10 +407,11 @@ class IndexerForwardSm90:
             tile_m=self.tile_m,
             tile_n=self.tile_n,
         )
+        q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
         num_m_blocks = cute.ceil_div(seqlen.seqlen_q * self.qhead_per_kvhead, self.tile_m)
         if block_x < num_m_blocks:
             m_block = num_m_blocks - Int32(1) - block_x
-            n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k)
+            n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset)
 
             thr_mma = tiled_mma_QK.get_slice(wg_tidx)
             tSrQ0, tSrK = _mma_partition_fragment_AB(thr_mma, sQ_0, sKV_staged, self.swap_AB)
@@ -497,6 +500,7 @@ class IndexerForwardSm90:
                     max_seqlen_k,
                     seqlen.offset_q,
                     batch_idx,
+                    q_causal_offset,
                     sm_scale,
                 )
                 self._epilogue_store_to_gmem(
@@ -512,6 +516,7 @@ class IndexerForwardSm90:
                     max_seqlen_k,
                     seqlen.offset_q,
                     batch_idx,
+                    q_causal_offset,
                     sm_scale,
                 )
 
@@ -530,6 +535,7 @@ class IndexerForwardSm90:
         sm_scale: Float32,
         mCuSeqlensQ: Optional[cute.Tensor],
         mCuSeqlensK: Optional[cute.Tensor],
+        mQCausalOffsets: Optional[cute.Tensor],
         stream: cuda.CUstream,
     ):
         is_varlen = mCuSeqlensQ is not None
@@ -624,6 +630,7 @@ class IndexerForwardSm90:
             SharedStorage,
             mCuSeqlensQ,
             mCuSeqlensK,
+            mQCausalOffsets,
             max_seqlen_q,
             max_seqlen_k,
             sm_scale,
@@ -650,6 +657,7 @@ class IndexerForwardSm90:
         SharedStorage: cutlass.Constexpr,
         mCuSeqlensQ: cute.Tensor,
         mCuSeqlensK: cute.Tensor,
+        mQCausalOffsets: cute.Tensor,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
         sm_scale: Float32,
@@ -710,6 +718,7 @@ class IndexerForwardSm90:
                     mbar_KVEmpty1_ptr,
                     mCuSeqlensQ,
                     mCuSeqlensK,
+                    mQCausalOffsets,
                     max_seqlen_q,
                     max_seqlen_k,
                 )
@@ -729,6 +738,7 @@ class IndexerForwardSm90:
                 mbar_KVEmpty1_ptr,
                 mCuSeqlensQ,
                 mCuSeqlensK,
+                mQCausalOffsets,
                 max_seqlen_q,
                 max_seqlen_k,
                 sm_scale,

--- a/python/cudnn/deepseek_sparse_attention/indexer_top_k/compactify.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_top_k/compactify.py
@@ -78,8 +78,8 @@ class CompactifyKernel:
         row = bidx * ROWS_PER_CTA + warp_id
 
         if row < rows:
-            local_vals = cute.make_fragment((chunk,), Int32)
-            local_is_valid = cute.make_fragment((chunk,), cutlass.Boolean)
+            local_vals = cute.make_rmem_tensor((chunk,), Int32)
+            local_is_valid = cute.make_rmem_tensor((chunk,), cutlass.Boolean)
             cnt_v = Int32(0)
             cnt_i = Int32(0)
 

--- a/python/cudnn/deepseek_sparse_attention/indexer_top_k/indexer_top_k_decode_varlen.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_top_k/indexer_top_k_decode_varlen.py
@@ -21,6 +21,8 @@ import cutlass.utils as utils
 import torch
 from cutlass.utils.distributed import atomicAdd
 
+from cudnn.deepseek_sparse_attention.utils.compiler import compile_options
+
 from .block_scan import block_prefix_sum_kernel
 from .indexer_top_k_varlen_util import IndexerTopKKernelVarlen
 
@@ -671,7 +673,7 @@ def cute_dsl_topk_wrapper(
             stream=fake_stream,
             enable_persistent_dynamic_scheduling=load_balance,
             min_blocks_per_mp=1,
-            options="--enable-tvm-ffi",
+            options=compile_options(),
         )
         _compile_cache[key] = compiled_kernel
     else:

--- a/python/cudnn/deepseek_sparse_attention/indexer_top_k/indexer_top_k_varlen_util.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_top_k/indexer_top_k_varlen_util.py
@@ -962,8 +962,8 @@ class IndexerTopKKernelVarlen:
             assert self.top_k % vecsize_out == 0
 
             nvec_per_thread = cutlass.const_expr(cute.ceil_div(self.top_k, vecsize_out * self.num_threads_per_cta))
-            topk_vals = cute.make_fragment((vecsize_out, nvec_per_thread), self.dtype)
-            topk_indices = cute.make_fragment((vecsize_out, nvec_per_thread), cutlass.Int32)
+            topk_vals = cute.make_rmem_tensor((vecsize_out, nvec_per_thread), self.dtype)
+            topk_indices = cute.make_rmem_tensor((vecsize_out, nvec_per_thread), cutlass.Int32)
 
             stride = self.num_threads_per_cta * vecsize_out
             for i in cutlass.range(nvec_per_thread, unroll_full=True):
@@ -1018,7 +1018,7 @@ class IndexerTopKKernelVarlen:
 
     @cute.jit
     def predicate_tile(self, tAcA: cute.Tensor, limit: cutlass.Int32) -> cute.Tensor:
-        tApA = cute.make_fragment(
+        tApA = cute.make_rmem_tensor(
             cute.make_layout(
                 (
                     cute.size(tAcA, mode=[0, 1]),

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm100.py
@@ -26,6 +26,7 @@ from cudnn.deepseek_sparse_attention.utils.runtime import (
     device_major as _get_device_capability,
     maybe_contiguous,
     resolve_stream as _resolve_stream,
+    torch_stream_context as _torch_stream_context,
     validate_q_causal_offsets,
 )
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor
@@ -67,8 +68,12 @@ def _sparse_indexer_score_recompute(
     Returns:
         predict: (bs, seqlen_q, topk) [FP32] — softmax of sparse index scores
     """
-    q_indexer, k_indexer, weights = [maybe_contiguous(t) for t in (q_indexer, k_indexer, weights)]
-    topk_indices = topk_indices.to(torch.int32).contiguous()
+    current_stream = _resolve_stream(current_stream)
+    q_indexer, k_indexer, weights = [
+        maybe_contiguous(t, current_stream) for t in (q_indexer, k_indexer, weights)
+    ]
+    with _torch_stream_context(current_stream):
+        topk_indices = topk_indices.to(torch.int32).contiguous()
 
     if qhead_per_kv_head is None:
         qhead_per_kv_head = q_indexer.shape[2]
@@ -84,12 +89,15 @@ def _sparse_indexer_score_recompute(
     have_topk_length = topk_length is not None
 
     if topk_length is None:
-        topk_length = torch.empty((1, 1), dtype=torch.int32, device=device)
+        with _torch_stream_context(current_stream):
+            topk_length = torch.empty((1, 1), dtype=torch.int32, device=device)
     else:
-        topk_length = topk_length.to(torch.int32).contiguous()
+        with _torch_stream_context(current_stream):
+            topk_length = topk_length.to(torch.int32).contiguous()
 
     if out is None:
-        out = torch.empty((bs, seqlen_q, topk), dtype=torch.float32, device=device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty((bs, seqlen_q, topk), dtype=torch.float32, device=device)
 
     # Compute kv_stage and topk_in_smem from SMEM budget (SM100: 228 KB)
     SM100_SMEM_BYTES = 228 * 1024
@@ -157,7 +165,6 @@ def _sparse_indexer_score_recompute(
                 topk_indices_global=topk_indices_global,
             )
 
-            current_stream = _resolve_stream(current_stream)
             scale_arg = cutlass.Float32(sm_scale)
 
             _sparse_indexer_score_recompute.compile_cache[compile_key] = cute.compile(
@@ -173,7 +180,6 @@ def _sparse_indexer_score_recompute(
                 options=compile_options(),
             )
 
-        current_stream = _resolve_stream(current_stream)
         scale_arg = cutlass.Float32(sm_scale)
         with torch.cuda.nvtx.range("sparse_indexer_score_recompute"):
             _sparse_indexer_score_recompute.compile_cache[compile_key](
@@ -284,8 +290,10 @@ def _sparse_attn_score_recompute(
         target: (bs, seqlen_q, topk) [FP32] — L1-normalized attention scores
     """
 
-    q_attn, k_attn = [maybe_contiguous(t) for t in (q_attn, k_attn)]
-    topk_indices = topk_indices.to(torch.int32).contiguous()
+    current_stream = _resolve_stream(current_stream)
+    q_attn, k_attn = [maybe_contiguous(t, current_stream) for t in (q_attn, k_attn)]
+    with _torch_stream_context(current_stream):
+        topk_indices = topk_indices.to(torch.int32).contiguous()
 
     if qhead_per_kv_head is None:
         qhead_per_kv_head = q_attn.shape[2]
@@ -301,16 +309,17 @@ def _sparse_attn_score_recompute(
     have_topk_length = topk_length is not None
 
     if topk_length is None:
-        topk_length = torch.empty((1, 1), dtype=torch.int32, device=device)
+        with _torch_stream_context(current_stream):
+            topk_length = torch.empty((1, 1), dtype=torch.int32, device=device)
     else:
-        topk_length = topk_length.to(torch.int32).contiguous()
+        with _torch_stream_context(current_stream):
+            topk_length = topk_length.to(torch.int32).contiguous()
 
-    # Pre-scale LSE: scaled_lse = -log2(e) * lse
-    log2_e = math.log2(math.e)
-    scaled_lse = (-log2_e * lse.float()).contiguous()
+    lse = maybe_contiguous(lse, current_stream)
 
     if out is None:
-        out = torch.empty((bs, seqlen_q, topk), dtype=torch.float32, device=device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty((bs, seqlen_q, topk), dtype=torch.float32, device=device)
 
     # Compute kv_stage and topk_in_smem from SMEM budget (SM100: 228 KB)
     SM100_SMEM_BYTES = 228 * 1024
@@ -358,7 +367,7 @@ def _sparse_attn_score_recompute(
         if compile_key not in _sparse_attn_score_recompute.compile_cache:
             q_cute = to_cute_tensor(q_attn)
             k_cute = to_cute_tensor(k_attn)
-            lse_cute = to_cute_tensor(scaled_lse)
+            lse_cute = to_cute_tensor(lse)
             topk_cute = to_cute_tensor(topk_indices)
             out_cute = to_cute_tensor(out)
             topk_length_cute = to_cute_tensor(topk_length)
@@ -377,8 +386,6 @@ def _sparse_attn_score_recompute(
                 topk_indices_global=topk_indices_global,
             )
 
-            current_stream = _resolve_stream(current_stream)
-
             _sparse_attn_score_recompute.compile_cache[compile_key] = cute.compile(
                 kernel_obj,
                 q_cute,
@@ -392,12 +399,11 @@ def _sparse_attn_score_recompute(
                 options=compile_options(),
             )
 
-        current_stream = _resolve_stream(current_stream)
         with torch.cuda.nvtx.range("sparse_attn_score_recompute"):
             _sparse_attn_score_recompute.compile_cache[compile_key](
                 q_attn,
                 k_attn,
-                scaled_lse,
+                lse,
                 topk_indices,
                 out,
                 topk_length,
@@ -714,7 +720,8 @@ def _dense_indexer_score_recompute(
     Returns:
         (out, denom_out)
     """
-    q, k, weights = [maybe_contiguous(t) for t in (q, k, weights)]
+    current_stream = _resolve_stream(current_stream)
+    q, k, weights = [maybe_contiguous(t, current_stream) for t in (q, k, weights)]
 
     is_varlen_q = cu_seqlens_q is not None
     is_varlen_k = cu_seqlens_k is not None
@@ -740,7 +747,9 @@ def _dense_indexer_score_recompute(
     else:
         bs, seqlen_q, n_heads_q, head_dim = q.shape
         _, seqlen_k, _, _ = k.shape
-    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device)
+    q_causal_offsets = validate_q_causal_offsets(
+        q_causal_offsets, int(bs), q.device, stream=current_stream
+    )
 
     if qhead_per_kv_head is None:
         qhead_per_kv_head = n_heads_q
@@ -751,10 +760,12 @@ def _dense_indexer_score_recompute(
 
     if out is None:
         out_shape = (q.shape[0], seqlen_k) if is_varlen else (bs, seqlen_q, seqlen_k)
-        out = torch.empty(out_shape, dtype=torch.float32, device=device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty(out_shape, dtype=torch.float32, device=device)
     if denom_out is None:
         denom_shape = (q.shape[0],) if is_varlen else (bs, seqlen_q)
-        denom_out = torch.empty(denom_shape, dtype=torch.float32, device=device)
+        with _torch_stream_context(current_stream):
+            denom_out = torch.empty(denom_shape, dtype=torch.float32, device=device)
 
     head_dim_padded = int(math.ceil(head_dim / 16) * 16)
     if k_block_size is None:
@@ -801,7 +812,6 @@ def _dense_indexer_score_recompute(
             is_varlen=is_varlen,
         )
 
-        current_stream = _resolve_stream(current_stream)
         scale_arg = cutlass.Float32(sm_scale)
         max_q_arg = cutlass.Int32(seqlen_q)
         max_k_arg = cutlass.Int32(seqlen_k)
@@ -823,13 +833,13 @@ def _dense_indexer_score_recompute(
             options=compile_options(),
         )
 
-    current_stream = _resolve_stream(current_stream)
     scale_arg = cutlass.Float32(sm_scale)
     max_q_arg = cutlass.Int32(seqlen_q)
     max_k_arg = cutlass.Int32(seqlen_k)
-    # The kernel only visits K blocks that can contain valid ratio-causal
-    # columns; skipped masked/padding columns must still appear as zero.
-    out.zero_()
+    # Dense indexer score is a raw-logit buffer, so masked/skipped positions
+    # must remain outside the softmax/logsumexp domain.
+    with _torch_stream_context(current_stream):
+        out.fill_(float("-inf"))
     with torch.cuda.nvtx.range("dense_indexer_score_recompute"):
         _dense_indexer_score_recompute.compile_cache[compile_key](
             q,
@@ -890,7 +900,8 @@ def _dense_attn_score_recompute(
     Returns:
         (out, denom_out)
     """
-    q, k = [maybe_contiguous(t) for t in (q, k)]
+    current_stream = _resolve_stream(current_stream)
+    q, k = [maybe_contiguous(t, current_stream) for t in (q, k)]
 
     is_varlen_q = cu_seqlens_q is not None
     is_varlen_k = cu_seqlens_k is not None
@@ -916,7 +927,9 @@ def _dense_attn_score_recompute(
     else:
         bs, seqlen_q, n_heads_q, head_dim = q.shape
         _, seqlen_k, _, _ = k.shape
-    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device)
+    q_causal_offsets = validate_q_causal_offsets(
+        q_causal_offsets, int(bs), q.device, stream=current_stream
+    )
 
     if qhead_per_kv_head is None:
         qhead_per_kv_head = n_heads_q
@@ -925,16 +938,16 @@ def _dense_attn_score_recompute(
 
     device = q.device
 
-    # Pre-scale LSE: scaled_lse = -log2(e) * lse
-    log2_e = math.log2(math.e)
-    scaled_lse = (-log2_e * lse.float()).contiguous()
+    lse = maybe_contiguous(lse, current_stream)
 
     if out is None:
         out_shape = (q.shape[0], seqlen_k) if is_varlen else (bs, seqlen_q, seqlen_k)
-        out = torch.empty(out_shape, dtype=torch.float32, device=device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty(out_shape, dtype=torch.float32, device=device)
     if denom_out is None:
         denom_shape = (q.shape[0],) if is_varlen else (bs, seqlen_q)
-        denom_out = torch.empty(denom_shape, dtype=torch.float32, device=device)
+        with _torch_stream_context(current_stream):
+            denom_out = torch.empty(denom_shape, dtype=torch.float32, device=device)
 
     head_dim_padded = int(math.ceil(head_dim / 16) * 16)
     if k_block_size is None:
@@ -962,7 +975,7 @@ def _dense_attn_score_recompute(
     if compile_key not in _dense_attn_score_recompute.compile_cache:
         q_cute = to_cute_tensor(q)
         k_cute = to_cute_tensor(k)
-        lse_cute = to_cute_tensor(scaled_lse)
+        lse_cute = to_cute_tensor(lse)
         out_cute = to_cute_tensor(out)
         denom_cute = to_cute_tensor(denom_out)
         cu_q_cute = to_cute_tensor(cu_seqlens_q, leading_dim=0) if is_varlen else None
@@ -981,7 +994,6 @@ def _dense_attn_score_recompute(
             is_varlen=is_varlen,
         )
 
-        current_stream = _resolve_stream(current_stream)
         max_q_arg = cutlass.Int32(seqlen_q)
         max_k_arg = cutlass.Int32(seqlen_k)
 
@@ -1002,16 +1014,17 @@ def _dense_attn_score_recompute(
             options=compile_options(),
         )
 
-    current_stream = _resolve_stream(current_stream)
     max_q_arg = cutlass.Int32(seqlen_q)
     max_k_arg = cutlass.Int32(seqlen_k)
-    # See dense indexer path above: skipped masked/padding columns are zero.
-    out.zero_()
+    # Dense score kernels skip K blocks that are wholly outside the
+    # ratio-causal region, so skipped masked/padding columns must be prefilled.
+    with _torch_stream_context(current_stream):
+        out.fill_(float("-inf"))
     with torch.cuda.nvtx.range("dense_attn_score_recompute"):
         _dense_attn_score_recompute.compile_cache[compile_key](
             q,
             k,
-            scaled_lse,
+            lse,
             out,
             denom_out,
             cutlass.Float32(softmax_scale),

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm100.py
@@ -26,6 +26,7 @@ from cudnn.deepseek_sparse_attention.utils.runtime import (
     device_major as _get_device_capability,
     maybe_contiguous,
     resolve_stream as _resolve_stream,
+    validate_q_causal_offsets,
 )
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor
 
@@ -690,6 +691,7 @@ def _dense_indexer_score_recompute(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
@@ -738,6 +740,7 @@ def _dense_indexer_score_recompute(
     else:
         bs, seqlen_q, n_heads_q, head_dim = q.shape
         _, seqlen_k, _, _ = k.shape
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device)
 
     if qhead_per_kv_head is None:
         qhead_per_kv_head = n_heads_q
@@ -773,6 +776,7 @@ def _dense_indexer_score_recompute(
         kv_stage,
         ratio,
         is_varlen,
+        q_causal_offsets is not None,
     )
 
     if compile_key not in _dense_indexer_score_recompute.compile_cache:
@@ -783,6 +787,7 @@ def _dense_indexer_score_recompute(
         denom_cute = to_cute_tensor(denom_out)
         cu_q_cute = to_cute_tensor(cu_seqlens_q, leading_dim=0) if is_varlen else None
         cu_k_cute = to_cute_tensor(cu_seqlens_k, leading_dim=0) if is_varlen else None
+        q_offsets_cute = to_cute_tensor(q_causal_offsets, leading_dim=0) if q_causal_offsets is not None else None
 
         kernel_obj = DenseScoreRecomputeSm100(
             head_dim=head_dim,
@@ -813,6 +818,7 @@ def _dense_indexer_score_recompute(
             max_k_arg,
             cu_q_cute,
             cu_k_cute,
+            q_offsets_cute,
             current_stream,
             options=compile_options(),
         )
@@ -833,6 +839,7 @@ def _dense_indexer_score_recompute(
             max_k_arg,
             cu_seqlens_q if is_varlen else None,
             cu_seqlens_k if is_varlen else None,
+            q_causal_offsets,
             current_stream,
         )
     return out, denom_out
@@ -857,6 +864,7 @@ def _dense_attn_score_recompute(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
@@ -905,6 +913,7 @@ def _dense_attn_score_recompute(
     else:
         bs, seqlen_q, n_heads_q, head_dim = q.shape
         _, seqlen_k, _, _ = k.shape
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device)
 
     if qhead_per_kv_head is None:
         qhead_per_kv_head = n_heads_q
@@ -944,6 +953,7 @@ def _dense_attn_score_recompute(
         kv_stage,
         ratio,
         is_varlen,
+        q_causal_offsets is not None,
     )
 
     if compile_key not in _dense_attn_score_recompute.compile_cache:
@@ -954,6 +964,7 @@ def _dense_attn_score_recompute(
         denom_cute = to_cute_tensor(denom_out)
         cu_q_cute = to_cute_tensor(cu_seqlens_q, leading_dim=0) if is_varlen else None
         cu_k_cute = to_cute_tensor(cu_seqlens_k, leading_dim=0) if is_varlen else None
+        q_offsets_cute = to_cute_tensor(q_causal_offsets, leading_dim=0) if q_causal_offsets is not None else None
 
         kernel_obj = DenseScoreRecomputeSm100(
             head_dim=head_dim,
@@ -983,6 +994,7 @@ def _dense_attn_score_recompute(
             max_k_arg,
             cu_q_cute,
             cu_k_cute,
+            q_offsets_cute,
             current_stream,
             options=compile_options(),
         )
@@ -1002,6 +1014,7 @@ def _dense_attn_score_recompute(
             max_k_arg,
             cu_seqlens_q if is_varlen else None,
             cu_seqlens_k if is_varlen else None,
+            q_causal_offsets,
             current_stream,
         )
     return out, denom_out
@@ -1026,6 +1039,7 @@ def dense_indexer_score_recompute(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
@@ -1071,6 +1085,7 @@ def dense_indexer_score_recompute(
         cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max_seqlen_q,
         max_seqlen_k=max_seqlen_k,
+        q_causal_offsets=q_causal_offsets,
         current_stream=current_stream,
     )
 
@@ -1088,6 +1103,7 @@ def dense_attn_score_recompute(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
@@ -1131,5 +1147,6 @@ def dense_attn_score_recompute(
         cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max_seqlen_q,
         max_seqlen_k=max_seqlen_k,
+        q_causal_offsets=q_causal_offsets,
         current_stream=current_stream,
     )

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm100.py
@@ -69,9 +69,7 @@ def _sparse_indexer_score_recompute(
         predict: (bs, seqlen_q, topk) [FP32] — softmax of sparse index scores
     """
     current_stream = _resolve_stream(current_stream)
-    q_indexer, k_indexer, weights = [
-        maybe_contiguous(t, current_stream) for t in (q_indexer, k_indexer, weights)
-    ]
+    q_indexer, k_indexer, weights = [maybe_contiguous(t, current_stream) for t in (q_indexer, k_indexer, weights)]
     with _torch_stream_context(current_stream):
         topk_indices = topk_indices.to(torch.int32).contiguous()
 
@@ -747,9 +745,7 @@ def _dense_indexer_score_recompute(
     else:
         bs, seqlen_q, n_heads_q, head_dim = q.shape
         _, seqlen_k, _, _ = k.shape
-    q_causal_offsets = validate_q_causal_offsets(
-        q_causal_offsets, int(bs), q.device, stream=current_stream
-    )
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device, stream=current_stream)
 
     if qhead_per_kv_head is None:
         qhead_per_kv_head = n_heads_q
@@ -927,9 +923,7 @@ def _dense_attn_score_recompute(
     else:
         bs, seqlen_q, n_heads_q, head_dim = q.shape
         _, seqlen_k, _, _ = k.shape
-    q_causal_offsets = validate_q_causal_offsets(
-        q_causal_offsets, int(bs), q.device, stream=current_stream
-    )
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device, stream=current_stream)
 
     if qhead_per_kv_head is None:
         qhead_per_kv_head = n_heads_q

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm100.py
@@ -827,6 +827,9 @@ def _dense_indexer_score_recompute(
     scale_arg = cutlass.Float32(sm_scale)
     max_q_arg = cutlass.Int32(seqlen_q)
     max_k_arg = cutlass.Int32(seqlen_k)
+    # The kernel only visits K blocks that can contain valid ratio-causal
+    # columns; skipped masked/padding columns must still appear as zero.
+    out.zero_()
     with torch.cuda.nvtx.range("dense_indexer_score_recompute"):
         _dense_indexer_score_recompute.compile_cache[compile_key](
             q,
@@ -1002,6 +1005,8 @@ def _dense_attn_score_recompute(
     current_stream = _resolve_stream(current_stream)
     max_q_arg = cutlass.Int32(seqlen_q)
     max_k_arg = cutlass.Int32(seqlen_k)
+    # See dense indexer path above: skipped masked/padding columns are zero.
+    out.zero_()
     with torch.cuda.nvtx.range("dense_attn_score_recompute"):
         _dense_attn_score_recompute.compile_cache[compile_key](
             q,

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm90.py
@@ -33,6 +33,7 @@ from cudnn.deepseek_sparse_attention.utils.runtime import (
     device_major as _get_device_capability,
     maybe_contiguous,
     resolve_stream as _resolve_stream,
+    validate_q_causal_offsets,
 )
 from .sparse_score_recompute_sm90 import SparseScoreRecomputeSm90
 from .dense_score_recompute_sm90 import DenseScoreRecomputeSm90
@@ -308,6 +309,7 @@ def _dense_score_recompute(
     num_threads: int,
     nvtx_range_name: str,
     ratio: int = 1,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Compile + launch the dense 3-WG score kernel."""
@@ -320,6 +322,7 @@ def _dense_score_recompute(
 
     batch_size, seqlen_q, num_head, head_dim = q.shape
     _, seqlen_k, num_head_kv, _ = kv.shape
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device)
     assert num_head > num_head_kv and num_head % num_head_kv == 0, f"MQA required: num_head={num_head}, num_head_kv={num_head_kv}"
     qhead_per_kvhead = num_head // num_head_kv
 
@@ -357,6 +360,7 @@ def _dense_score_recompute(
         False,
         False,
         ratio,  # has_topk_length, is_sparse, output_log_probs
+        q_causal_offsets is not None,
     )
 
     cache = _dense_score_recompute.compile_cache
@@ -366,6 +370,7 @@ def _dense_score_recompute(
         out_cute = to_cute_tensor(out)
         weights_cute = to_cute_tensor(weights_or_lse)
         denom_cute = to_cute_tensor(denom_out)
+        q_offsets_cute = to_cute_tensor(q_causal_offsets, leading_dim=0) if q_causal_offsets is not None else None
 
         kernel_obj = DenseScoreRecomputeSm90(
             dtype,
@@ -393,6 +398,7 @@ def _dense_score_recompute(
             weights_cute,
             None,  # mTopkLength (sparse-only)
             denom_cute,
+            q_offsets_cute,
             options=compile_options(),
         )
 
@@ -410,6 +416,7 @@ def _dense_score_recompute(
             weights_or_lse,
             None,
             denom_out,
+            q_causal_offsets,
         )
     return out, denom_out
 
@@ -429,6 +436,7 @@ def _dense_score_recompute_varlen(
     cu_seqlens_k: torch.Tensor,
     max_seqlen_q: Optional[int],
     max_seqlen_k: Optional[int],
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """THD packed dense score via per-batch BSHD SM90 launches.
@@ -446,6 +454,8 @@ def _dense_score_recompute_varlen(
     cu_seqlens_q = cu_seqlens_q.to(torch.int32).contiguous()
     cu_seqlens_k = cu_seqlens_k.to(torch.int32).contiguous()
     assert cu_seqlens_q.is_cuda and cu_seqlens_k.is_cuda
+    batch_size = cu_seqlens_q.shape[0] - 1
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device)
 
     total_q = q.shape[0]
     if max_seqlen_k is None:
@@ -476,6 +486,7 @@ def _dense_score_recompute_varlen(
             q_b = q[qs:qe].unsqueeze(0).contiguous()
             kv_b = kv[ks:ke].unsqueeze(0).contiguous()
             per_head_bhs = weights_or_lse[qs:qe].unsqueeze(0).transpose(1, 2).contiguous()
+            q_causal_offsets_b = q_causal_offsets[b : b + 1] if q_causal_offsets is not None else None
             out_b, denom_b = _dense_score_recompute(
                 q_b,
                 kv_b,
@@ -487,6 +498,7 @@ def _dense_score_recompute_varlen(
                 num_threads=num_threads,
                 nvtx_range_name=nvtx_range_name + "_bshd_slice",
                 ratio=ratio,
+                q_causal_offsets=q_causal_offsets_b,
                 current_stream=current_stream,
             )
             out[qs:qe, :sk_b].copy_(out_b[0])
@@ -512,6 +524,7 @@ def dense_indexer_score_recompute(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Dense indexer backward score over full KV:
@@ -541,6 +554,7 @@ def dense_indexer_score_recompute(
             cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
+            q_causal_offsets=q_causal_offsets,
             current_stream=current_stream,
         )
     w_bhs = weights.transpose(1, 2).contiguous()
@@ -555,6 +569,7 @@ def dense_indexer_score_recompute(
         num_threads=num_threads,
         nvtx_range_name="dense_indexer_score_recompute",
         ratio=ratio,
+        q_causal_offsets=q_causal_offsets,
         current_stream=current_stream,
     )
 
@@ -572,6 +587,7 @@ def dense_attn_score_recompute(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Dense attention backward score over full KV:
@@ -598,6 +614,7 @@ def dense_attn_score_recompute(
             cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
+            q_causal_offsets=q_causal_offsets,
             current_stream=current_stream,
         )
     lse_bhs = lse.transpose(1, 2).contiguous()
@@ -612,6 +629,7 @@ def dense_attn_score_recompute(
         num_threads=num_threads,
         nvtx_range_name="dense_attn_score_recompute",
         ratio=ratio,
+        q_causal_offsets=q_causal_offsets,
         current_stream=current_stream,
     )
 

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm90.py
@@ -33,6 +33,7 @@ from cudnn.deepseek_sparse_attention.utils.runtime import (
     device_major as _get_device_capability,
     maybe_contiguous,
     resolve_stream as _resolve_stream,
+    torch_stream_context as _torch_stream_context,
     validate_q_causal_offsets,
 )
 from .sparse_score_recompute_sm90 import SparseScoreRecomputeSm90
@@ -76,6 +77,7 @@ def _validate_and_prepare_common(
     kv: torch.Tensor,
     weights_or_lse: torch.Tensor,
     is_index_scores: bool,
+    stream: Optional[cuda.CUstream] = None,
 ):
     """Common validation + strided-contiguous pass for q, kv, weights_or_lse.
 
@@ -88,7 +90,7 @@ def _validate_and_prepare_common(
     else:
         assert weights_or_lse.dtype == torch.float32, f"lse must be float32, got {weights_or_lse.dtype}"
     assert all(t.is_cuda for t in (q, kv, weights_or_lse))
-    return [maybe_contiguous(t) for t in (q, kv, weights_or_lse)]
+    return [maybe_contiguous(t, stream) for t in (q, kv, weights_or_lse)]
 
 
 # =============================================================================
@@ -116,7 +118,10 @@ def _sparse_score_recompute(
     compute_capability = _get_device_capability()
     assert compute_capability == 9, f"SM90 kernel on compute capability {compute_capability}"
 
-    q, kv, weights_or_lse = _validate_and_prepare_common(q, kv, weights_or_lse, is_index_scores)
+    current_stream = _resolve_stream(current_stream)
+    q, kv, weights_or_lse = _validate_and_prepare_common(
+        q, kv, weights_or_lse, is_index_scores, current_stream
+    )
 
     batch_size, seqlen_q, num_head, head_dim = q.shape
     _, seqlen_k, num_head_kv, _ = kv.shape
@@ -125,23 +130,26 @@ def _sparse_score_recompute(
 
     tile_m, num_head_tiles = _compute_tile_m(qhead_per_kvhead)
 
-    topk_indices = topk_indices.to(torch.int32).contiguous()
+    with _torch_stream_context(current_stream):
+        topk_indices = topk_indices.to(torch.int32).contiguous()
     assert topk_indices.is_cuda
     topk_max = topk_indices.shape[-1]
 
     if topk_length is not None:
-        topk_length = topk_length.to(torch.int32).contiguous()
+        with _torch_stream_context(current_stream):
+            topk_length = topk_length.to(torch.int32).contiguous()
         assert topk_length.shape == (batch_size, seqlen_q)
     has_topk_length = topk_length is not None
 
     if out is None:
-        out = torch.zeros((batch_size, seqlen_q, topk_max), dtype=torch.float32, device=q.device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty((batch_size, seqlen_q, topk_max), dtype=torch.float32, device=q.device)
     else:
-        out = out if out.is_contiguous() else out.contiguous()
+        if not out.is_contiguous():
+            with _torch_stream_context(current_stream):
+                out = out.contiguous()
 
     dtype = torch2cute_dtype_map[q.dtype]
-    current_stream = _resolve_stream(current_stream)
-
     # Sparse path: num_threads fixed at 256 (1 producer WG + 1 consumer WG).
     num_threads = 256
 
@@ -242,7 +250,8 @@ def sparse_indexer_score_recompute(
     Defaults to 1.0 (identity).
     """
     kv = k_indexer.unsqueeze(2)
-    w_bhs = weights.transpose(1, 2).contiguous()
+    with _torch_stream_context(current_stream):
+        w_bhs = weights.transpose(1, 2).contiguous()
     return _sparse_score_recompute(
         q_indexer,
         kv,
@@ -276,7 +285,8 @@ def sparse_attn_score_recompute(
     target     = S / sum(S)  (L1-norm over topk)
     """
     kv = k_attn.unsqueeze(2)
-    lse_bhs = lse.transpose(1, 2).contiguous()
+    with _torch_stream_context(current_stream):
+        lse_bhs = lse.transpose(1, 2).contiguous()
     return _sparse_score_recompute(
         q_attn,
         kv,
@@ -318,28 +328,37 @@ def _dense_score_recompute(
     assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
     assert num_threads == _DENSE_NUM_THREADS, f"SM90 dense score is 3-WG-only (num_threads={_DENSE_NUM_THREADS}); got {num_threads}."
 
-    q, kv, weights_or_lse = _validate_and_prepare_common(q, kv, weights_or_lse, is_index_scores)
+    current_stream = _resolve_stream(current_stream)
+    q, kv, weights_or_lse = _validate_and_prepare_common(
+        q, kv, weights_or_lse, is_index_scores, current_stream
+    )
 
     batch_size, seqlen_q, num_head, head_dim = q.shape
     _, seqlen_k, num_head_kv, _ = kv.shape
-    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device)
+    q_causal_offsets = validate_q_causal_offsets(
+        q_causal_offsets, int(batch_size), q.device, stream=current_stream
+    )
     assert num_head > num_head_kv and num_head % num_head_kv == 0, f"MQA required: num_head={num_head}, num_head_kv={num_head_kv}"
     qhead_per_kvhead = num_head // num_head_kv
 
     tile_m, num_head_tiles = _compute_tile_m(qhead_per_kvhead)
 
     if out is None:
-        out = torch.zeros((batch_size, seqlen_q, seqlen_k), dtype=torch.float32, device=q.device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty((batch_size, seqlen_q, seqlen_k), dtype=torch.float32, device=q.device)
     else:
-        out = out if out.is_contiguous() else out.contiguous()
+        if not out.is_contiguous():
+            with _torch_stream_context(current_stream):
+                out = out.contiguous()
     if denom_out is None:
-        denom_out = torch.zeros((batch_size, seqlen_q), dtype=torch.float32, device=q.device)
+        with _torch_stream_context(current_stream):
+            denom_out = torch.zeros((batch_size, seqlen_q), dtype=torch.float32, device=q.device)
     else:
-        denom_out = denom_out if denom_out.is_contiguous() else denom_out.contiguous()
+        if not denom_out.is_contiguous():
+            with _torch_stream_context(current_stream):
+                denom_out = denom_out.contiguous()
 
     dtype = torch2cute_dtype_map[q.dtype]
-    current_stream = _resolve_stream(current_stream)
-
     # Dense path never consumes topk_idxs / topk_length; pass topk_max = seqlen_k
     # so the kernel iterates the full KV sequence like the legacy fused path did.
     topk_max = seqlen_k
@@ -403,9 +422,10 @@ def _dense_score_recompute(
         )
 
     # The SM90 dense score kernel skips K blocks that are wholly masked by
-    # the ratio-causal rule. Preserve the public contract that masked output
-    # positions are overwritten even when the caller supplies `out`.
-    out.zero_()
+    # the ratio-causal rule. Preserve raw-logit mask semantics for skipped
+    # positions even when the caller supplies `out`.
+    with _torch_stream_context(current_stream):
+        out.fill_(float("-inf"))
     with torch.cuda.nvtx.range(nvtx_range_name):
         cache[compile_key](
             q,
@@ -450,31 +470,45 @@ def _dense_score_recompute_varlen(
     assert compute_capability == 9, f"SM90 kernel on compute capability {compute_capability}"
     assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
     assert q.ndim == 3 and kv.ndim == 3 and weights_or_lse.ndim == 2
-    q, kv, weights_or_lse = _validate_and_prepare_common(q, kv, weights_or_lse, is_index_scores)
-    cu_seqlens_q = cu_seqlens_q.to(torch.int32).contiguous()
-    cu_seqlens_k = cu_seqlens_k.to(torch.int32).contiguous()
+    current_stream = _resolve_stream(current_stream)
+    q, kv, weights_or_lse = _validate_and_prepare_common(
+        q, kv, weights_or_lse, is_index_scores, current_stream
+    )
+    with _torch_stream_context(current_stream):
+        cu_seqlens_q = cu_seqlens_q.to(torch.int32).contiguous()
+        cu_seqlens_k = cu_seqlens_k.to(torch.int32).contiguous()
     assert cu_seqlens_q.is_cuda and cu_seqlens_k.is_cuda
     batch_size = cu_seqlens_q.shape[0] - 1
-    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device)
+    q_causal_offsets = validate_q_causal_offsets(
+        q_causal_offsets, int(batch_size), q.device, stream=current_stream
+    )
 
     total_q = q.shape[0]
     if max_seqlen_k is None:
-        k_lens = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
-        max_seqlen_k = int(k_lens.max().item())
+        with _torch_stream_context(current_stream):
+            k_lens = cu_seqlens_k[1:] - cu_seqlens_k[:-1]
+            max_seqlen_k = int(k_lens.max().item())
     if out is None:
-        out = torch.zeros((total_q, int(max_seqlen_k)), dtype=torch.float32, device=q.device)
+        with _torch_stream_context(current_stream):
+            out = torch.empty((total_q, int(max_seqlen_k)), dtype=torch.float32, device=q.device)
     else:
-        out = out if out.is_contiguous() else out.contiguous()
+        if not out.is_contiguous():
+            with _torch_stream_context(current_stream):
+                out = out.contiguous()
     if denom_out is None:
-        denom_out = torch.empty((total_q,), dtype=torch.float32, device=q.device)
+        with _torch_stream_context(current_stream):
+            denom_out = torch.empty((total_q,), dtype=torch.float32, device=q.device)
     else:
-        denom_out = denom_out if denom_out.is_contiguous() else denom_out.contiguous()
+        if not denom_out.is_contiguous():
+            with _torch_stream_context(current_stream):
+                denom_out = denom_out.contiguous()
 
     cu_q_host = cu_seqlens_q.detach().cpu().tolist()
     cu_k_host = cu_seqlens_k.detach().cpu().tolist()
-    # Native THD uses the same block-skipping kernel; pre-zero so skipped
+    # Native THD uses the same block-skipping kernel; prefill so skipped
     # masked/padding columns do not retain caller-provided values.
-    out.zero_()
+    with _torch_stream_context(current_stream):
+        out.fill_(float("-inf"))
     with torch.cuda.nvtx.range(nvtx_range_name + "_thd"):
         for b in range(len(cu_q_host) - 1):
             qs, qe = cu_q_host[b], cu_q_host[b + 1]
@@ -483,9 +517,10 @@ def _dense_score_recompute_varlen(
             sk_b = ke - ks
             if sq_b == 0 or sk_b == 0:
                 continue
-            q_b = q[qs:qe].unsqueeze(0).contiguous()
-            kv_b = kv[ks:ke].unsqueeze(0).contiguous()
-            per_head_bhs = weights_or_lse[qs:qe].unsqueeze(0).transpose(1, 2).contiguous()
+            with _torch_stream_context(current_stream):
+                q_b = q[qs:qe].unsqueeze(0).contiguous()
+                kv_b = kv[ks:ke].unsqueeze(0).contiguous()
+                per_head_bhs = weights_or_lse[qs:qe].unsqueeze(0).transpose(1, 2).contiguous()
             q_causal_offsets_b = q_causal_offsets[b : b + 1] if q_causal_offsets is not None else None
             out_b, denom_b = _dense_score_recompute(
                 q_b,
@@ -501,10 +536,9 @@ def _dense_score_recompute_varlen(
                 q_causal_offsets=q_causal_offsets_b,
                 current_stream=current_stream,
             )
-            out[qs:qe, :sk_b].copy_(out_b[0])
-            denom_out[qs:qe].copy_(denom_b[0])
-            if sk_b < out.shape[1]:
-                out[qs:qe, sk_b:].fill_(float("-inf"))
+            with _torch_stream_context(current_stream):
+                out[qs:qe, :sk_b].copy_(out_b[0])
+                denom_out[qs:qe].copy_(denom_b[0])
     return out, denom_out
 
 
@@ -557,7 +591,8 @@ def dense_indexer_score_recompute(
             q_causal_offsets=q_causal_offsets,
             current_stream=current_stream,
         )
-    w_bhs = weights.transpose(1, 2).contiguous()
+    with _torch_stream_context(current_stream):
+        w_bhs = weights.transpose(1, 2).contiguous()
     return _dense_score_recompute(
         q_indexer,
         k_indexer,
@@ -617,7 +652,8 @@ def dense_attn_score_recompute(
             q_causal_offsets=q_causal_offsets,
             current_stream=current_stream,
         )
-    lse_bhs = lse.transpose(1, 2).contiguous()
+    with _torch_stream_context(current_stream):
+        lse_bhs = lse.transpose(1, 2).contiguous()
     return _dense_score_recompute(
         q_attn,
         k_attn,

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/_interface_sm90.py
@@ -119,9 +119,7 @@ def _sparse_score_recompute(
     assert compute_capability == 9, f"SM90 kernel on compute capability {compute_capability}"
 
     current_stream = _resolve_stream(current_stream)
-    q, kv, weights_or_lse = _validate_and_prepare_common(
-        q, kv, weights_or_lse, is_index_scores, current_stream
-    )
+    q, kv, weights_or_lse = _validate_and_prepare_common(q, kv, weights_or_lse, is_index_scores, current_stream)
 
     batch_size, seqlen_q, num_head, head_dim = q.shape
     _, seqlen_k, num_head_kv, _ = kv.shape
@@ -329,15 +327,11 @@ def _dense_score_recompute(
     assert num_threads == _DENSE_NUM_THREADS, f"SM90 dense score is 3-WG-only (num_threads={_DENSE_NUM_THREADS}); got {num_threads}."
 
     current_stream = _resolve_stream(current_stream)
-    q, kv, weights_or_lse = _validate_and_prepare_common(
-        q, kv, weights_or_lse, is_index_scores, current_stream
-    )
+    q, kv, weights_or_lse = _validate_and_prepare_common(q, kv, weights_or_lse, is_index_scores, current_stream)
 
     batch_size, seqlen_q, num_head, head_dim = q.shape
     _, seqlen_k, num_head_kv, _ = kv.shape
-    q_causal_offsets = validate_q_causal_offsets(
-        q_causal_offsets, int(batch_size), q.device, stream=current_stream
-    )
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device, stream=current_stream)
     assert num_head > num_head_kv and num_head % num_head_kv == 0, f"MQA required: num_head={num_head}, num_head_kv={num_head_kv}"
     qhead_per_kvhead = num_head // num_head_kv
 
@@ -471,17 +465,13 @@ def _dense_score_recompute_varlen(
     assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
     assert q.ndim == 3 and kv.ndim == 3 and weights_or_lse.ndim == 2
     current_stream = _resolve_stream(current_stream)
-    q, kv, weights_or_lse = _validate_and_prepare_common(
-        q, kv, weights_or_lse, is_index_scores, current_stream
-    )
+    q, kv, weights_or_lse = _validate_and_prepare_common(q, kv, weights_or_lse, is_index_scores, current_stream)
     with _torch_stream_context(current_stream):
         cu_seqlens_q = cu_seqlens_q.to(torch.int32).contiguous()
         cu_seqlens_k = cu_seqlens_k.to(torch.int32).contiguous()
     assert cu_seqlens_q.is_cuda and cu_seqlens_k.is_cuda
     batch_size = cu_seqlens_q.shape[0] - 1
-    q_causal_offsets = validate_q_causal_offsets(
-        q_causal_offsets, int(batch_size), q.device, stream=current_stream
-    )
+    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device, stream=current_stream)
 
     total_q = q.shape[0]
     if max_seqlen_k is None:

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/api.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/api.py
@@ -560,6 +560,7 @@ class DenseIndexerScoreRecompute(_ScoreRecomputeBase):
         cu_seqlens_k: Optional[torch.Tensor] = None,
         max_seqlen_q: Optional[int] = None,
         max_seqlen_k: Optional[int] = None,
+        q_causal_offsets: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ):
         scale = self.sm_scale if sm_scale is None else float(sm_scale)
@@ -585,6 +586,7 @@ class DenseIndexerScoreRecompute(_ScoreRecomputeBase):
                 cu_seqlens_k=cu_seqlens_k,
                 max_seqlen_q=max_seqlen_q,
                 max_seqlen_k=max_seqlen_k,
+                q_causal_offsets=q_causal_offsets,
                 current_stream=current_stream,
             )
         return _iface_sm100.dense_indexer_score_recompute(
@@ -600,6 +602,7 @@ class DenseIndexerScoreRecompute(_ScoreRecomputeBase):
             cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
+            q_causal_offsets=q_causal_offsets,
             current_stream=current_stream,
         )
 
@@ -620,6 +623,7 @@ def dense_indexer_score_recompute_wrapper(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     is_thd, max_q, max_k, out_shape, denom_shape = _dense_sample_shapes(
@@ -646,6 +650,7 @@ def dense_indexer_score_recompute_wrapper(
         max_k,
         tuple(cu_seqlens_q.shape) if cu_seqlens_q is not None else None,
         tuple(cu_seqlens_k.shape) if cu_seqlens_k is not None else None,
+        q_causal_offsets is not None,
     )
     obj = _cache_of_DenseIndexerScoreRecomputeObjects.get(key)
     if obj is None:
@@ -694,6 +699,7 @@ def dense_indexer_score_recompute_wrapper(
         cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max_q if is_thd else max_seqlen_q,
         max_seqlen_k=max_k if is_thd else max_seqlen_k,
+        q_causal_offsets=q_causal_offsets,
         current_stream=stream,
     )
     return TupleDict(out=o, denom=d)
@@ -765,6 +771,7 @@ class DenseAttnScoreRecompute(_ScoreRecomputeBase):
         cu_seqlens_k: Optional[torch.Tensor] = None,
         max_seqlen_q: Optional[int] = None,
         max_seqlen_k: Optional[int] = None,
+        q_causal_offsets: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ):
         scale = self.softmax_scale if softmax_scale is None else float(softmax_scale)
@@ -790,6 +797,7 @@ class DenseAttnScoreRecompute(_ScoreRecomputeBase):
                 cu_seqlens_k=cu_seqlens_k,
                 max_seqlen_q=max_seqlen_q,
                 max_seqlen_k=max_seqlen_k,
+                q_causal_offsets=q_causal_offsets,
                 current_stream=current_stream,
             )
         return _iface_sm100.dense_attn_score_recompute(
@@ -805,6 +813,7 @@ class DenseAttnScoreRecompute(_ScoreRecomputeBase):
             cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
             max_seqlen_k=max_seqlen_k,
+            q_causal_offsets=q_causal_offsets,
             current_stream=current_stream,
         )
 
@@ -825,6 +834,7 @@ def dense_attn_score_recompute_wrapper(
     cu_seqlens_k: Optional[torch.Tensor] = None,
     max_seqlen_q: Optional[int] = None,
     max_seqlen_k: Optional[int] = None,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     is_thd, max_q, max_k, out_shape, denom_shape = _dense_sample_shapes(
@@ -851,6 +861,7 @@ def dense_attn_score_recompute_wrapper(
         max_k,
         tuple(cu_seqlens_q.shape) if cu_seqlens_q is not None else None,
         tuple(cu_seqlens_k.shape) if cu_seqlens_k is not None else None,
+        q_causal_offsets is not None,
     )
     obj = _cache_of_DenseAttnScoreRecomputeObjects.get(key)
     if obj is None:
@@ -899,6 +910,7 @@ def dense_attn_score_recompute_wrapper(
         cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max_q if is_thd else max_seqlen_q,
         max_seqlen_k=max_k if is_thd else max_seqlen_k,
+        q_causal_offsets=q_causal_offsets,
         current_stream=stream,
     )
     return TupleDict(out=o, denom=d)

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
@@ -61,9 +61,9 @@ from cudnn.deepseek_sparse_attention.utils.sm100.gemm import gemm_ptx_partial as
 from cudnn.deepseek_sparse_attention.utils import copy as copy_utils
 from cudnn.deepseek_sparse_attention.utils.seqlen import SeqlenInfoQK
 
-mul_packed_f32x2 = partial(cute.arch.mul_packed_f32x2, rnd='rn')
-add_packed_f32x2 = partial(cute.arch.add_packed_f32x2, rnd='rn')
-fma_packed_f32x2 = partial(cute.arch.fma_packed_f32x2, rnd='rn')
+mul_packed_f32x2 = partial(cute.arch.mul_packed_f32x2, rnd="rn")
+add_packed_f32x2 = partial(cute.arch.add_packed_f32x2, rnd="rn")
+fma_packed_f32x2 = partial(cute.arch.fma_packed_f32x2, rnd="rn")
 
 
 class DenseScoreRecomputeSm100:
@@ -121,21 +121,16 @@ class DenseScoreRecomputeSm100:
         self.num_clc_response_bytes = 16
 
         hdim_multiple_of = 16
-        self.head_dim_padded = int(
-            math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of
-        )
+        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
 
         self.k_block_size = k_block_size if k_block_size is not None else self.head_dim_padded
         assert self.head_dim_padded % self.k_block_size == 0, (
-            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of "
-            f"k_block_size ({self.k_block_size})"
+            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of " f"k_block_size ({self.k_block_size})"
         )
         self.num_k_chunks = self.head_dim_padded // self.k_block_size
 
         self.q_tokens_per_tile = m_block_size // qhead_per_kvhead
-        assert self.q_tokens_per_tile <= 2, (
-            f"q_tokens_per_tile ({self.q_tokens_per_tile}) must be 1 or 2"
-        )
+        assert self.q_tokens_per_tile <= 2, f"q_tokens_per_tile ({self.q_tokens_per_tile}) must be 1 or 2"
 
         self.tmem_repetition = self.m_block_size // 4
 
@@ -181,11 +176,11 @@ class DenseScoreRecomputeSm100:
     @cute.jit
     def __call__(
         self,
-        mQ: cute.Tensor,          # BSHD (bs, seqlen_q, n_heads_q, head_dim) or THD (total_q, n_heads_q, head_dim) BF16
-        mK: cute.Tensor,          # BSHD (bs, seqlen_k, n_heads_kv, head_dim) or THD (total_k, n_heads_kv, head_dim) BF16
-        mPerHead: cute.Tensor,    # BSH (bs, seqlen_q, n_heads_q) or TH (total_q, n_heads_q) — W (BF16) or LSE (FP32)
-        mOut: cute.Tensor,        # BSS (bs, seqlen_q, seqlen_k) or TS (total_q, max_seqlen_k) FP32
-        mDenom: cute.Tensor,      # BS (bs, seqlen_q) or T (total_q,) FP32
+        mQ: cute.Tensor,  # BSHD (bs, seqlen_q, n_heads_q, head_dim) or THD (total_q, n_heads_q, head_dim) BF16
+        mK: cute.Tensor,  # BSHD (bs, seqlen_k, n_heads_kv, head_dim) or THD (total_k, n_heads_kv, head_dim) BF16
+        mPerHead: cute.Tensor,  # BSH (bs, seqlen_q, n_heads_q) or TH (total_q, n_heads_q) — W (BF16) or LSE (FP32)
+        mOut: cute.Tensor,  # BSS (bs, seqlen_q, seqlen_k) or TS (total_q, max_seqlen_k) FP32
+        mDenom: cute.Tensor,  # BS (bs, seqlen_q) or T (total_q,) FP32
         softmax_scale: Float32 | float,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -235,9 +230,7 @@ class DenseScoreRecomputeSm100:
             mQ.stride[2] * self.qhead_per_kvhead,
             *mQ.stride[3:],
         )
-        mQ = cute.make_tensor(
-            mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed)
-        )
+        mQ = cute.make_tensor(mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed))
 
         cta_group = tcgen05.CtaGroup.ONE
         self.q_major_mode = cutlass.utils.LayoutEnum.from_tensor(mQ).mma_major_mode()
@@ -260,10 +253,16 @@ class DenseScoreRecomputeSm100:
 
         # --- SMEM layouts ---
         sK_layout = _make_smem_layout_a(
-            tiled_mma_qk, self.mma_tiler_qk, self.k_dtype, self.kv_stage,
+            tiled_mma_qk,
+            self.mma_tiler_qk,
+            self.k_dtype,
+            self.kv_stage,
         )
         sQ_layout = _make_smem_layout_b(
-            tiled_mma_qk, self.mma_tiler_qk, self.q_dtype, self.num_k_chunks,
+            tiled_mma_qk,
+            self.mma_tiler_qk,
+            self.q_dtype,
+            self.num_k_chunks,
         )
 
         # --- TMA atoms for both Q and K ---
@@ -305,28 +304,23 @@ class DenseScoreRecomputeSm100:
         # --- Grid and kernel dispatch (CLC persistent scheduling) ---
         # Grid sized using max_seqlen_q for varlen so persistent scheduling
         # can iterate over per-batch tiles up to the longest sequence.
-        seqlen_q_static = (
-            max_seqlen_q if const_expr(is_varlen)
-            else cute.size(mQ.shape[0]) // self.qhead_per_kvhead
-        )
+        seqlen_q_static = max_seqlen_q if const_expr(is_varlen) else cute.size(mQ.shape[0]) // self.qhead_per_kvhead
         num_m_blocks = cute.ceil_div(seqlen_q_static * self.qhead_per_kvhead, self.m_block_size)
-        batch_size = (
-            cute.size(mCuSeqlensQ.shape[0]) - 1
-            if const_expr(is_varlen)
-            else cute.size(mQ.shape[3])
-        )
-        tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams(
-            (num_m_blocks, 1, batch_size), (*self.cluster_shape_mn, 1)
-        )
-        grid_dim = utils.ClcDynamicPersistentTileScheduler.get_grid_shape(
-            tile_sched_params
-        )
+        batch_size = cute.size(mCuSeqlensQ.shape[0]) - 1 if const_expr(is_varlen) else cute.size(mQ.shape[3])
+        tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams((num_m_blocks, 1, batch_size), (*self.cluster_shape_mn, 1))
+        grid_dim = utils.ClcDynamicPersistentTileScheduler.get_grid_shape(tile_sched_params)
         self.kernel(
-            mQ, mK, mPerHead, mOut, mDenom,
+            mQ,
+            mK,
+            mPerHead,
+            mOut,
+            mDenom,
             softmax_scale,
-            tma_atom_Q, tma_atom_K,
+            tma_atom_Q,
+            tma_atom_K,
             tiled_mma_qk,
-            sQ_layout, sK_layout,
+            sQ_layout,
+            sK_layout,
             tile_sched_params,
             max_seqlen_q,
             max_seqlen_k,
@@ -346,11 +340,17 @@ class DenseScoreRecomputeSm100:
     @cute.kernel
     def kernel(
         self,
-        mQ, mK, mPerHead, mOut, mDenom,
+        mQ,
+        mK,
+        mPerHead,
+        mOut,
+        mDenom,
         softmax_scale: Float32 | float,
-        tma_atom_Q, tma_atom_K,
+        tma_atom_Q,
+        tma_atom_K,
         tiled_mma_qk,
-        sQ_layout, sK_layout,
+        sQ_layout,
+        sK_layout,
         tile_sched_params: utils.ClcDynamicPersistentTileSchedulerParams,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -366,14 +366,8 @@ class DenseScoreRecomputeSm100:
             assert not self.is_varlen
 
         # Static seqlens used as fallback when varlen is disabled.
-        seqlen_q_static = (
-            max_seqlen_q if const_expr(is_varlen)
-            else cute.size(mQ.shape[0]) // self.qhead_per_kvhead
-        )
-        seqlen_k_static = (
-            max_seqlen_k if const_expr(is_varlen)
-            else cute.size(mK.shape[0])
-        )
+        seqlen_q_static = max_seqlen_q if const_expr(is_varlen) else cute.size(mQ.shape[0]) // self.qhead_per_kvhead
+        seqlen_k_static = max_seqlen_k if const_expr(is_varlen) else cute.size(mK.shape[0])
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
             seqlen_q_static=seqlen_q_static,
@@ -439,12 +433,8 @@ class DenseScoreRecomputeSm100:
         clc_response_ptr = storage.clc_response.data_ptr()
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
         sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
-        sPerHead = storage.sPerHead.get_tensor(
-            cute.make_layout((self.m_block_size,), stride=(1,))
-        )
-        sScoreAll = storage.sScoreAll.get_tensor(
-            cute.make_layout((self.sScoreAll_size,), stride=(1,))
-        )
+        sPerHead = storage.sPerHead.get_tensor(cute.make_layout((self.m_block_size,), stride=(1,)))
+        sScoreAll = storage.sScoreAll.get_tensor(cute.make_layout((self.sScoreAll_size,), stride=(1,)))
 
         # =====================================================================
         # Pipeline setup
@@ -453,9 +443,7 @@ class DenseScoreRecomputeSm100:
             cute.make_layout(self.cluster_shape_mnk),
             (tiled_mma_qk.thr_id.shape,),
         )
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(
-            cute.arch.block_idx_in_cluster()
-        )
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         is_first_cta_in_cluster = cta_rank_in_cluster == 0
 
         # Q pipeline (1 stage)
@@ -491,9 +479,7 @@ class DenseScoreRecomputeSm100:
 
         # CLC persistent scheduling pipeline
         cluster_size = cute.size(self.cluster_shape_mn)
-        num_clc_consumer_threads = self.WARP_SIZE * (
-            1 + cluster_size * (1 + 1 + 4)
-        )
+        num_clc_consumer_threads = self.WARP_SIZE * (1 + cluster_size * (1 + 1 + 4))
         clc_pipeline = PipelineClcFetchAsync.create(
             barrier_storage=clc_mbar_ptr,
             num_stages=self.num_clc_stage,
@@ -508,9 +494,7 @@ class DenseScoreRecomputeSm100:
         cute.arch.sync_threads()
         pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
 
-        clc_consumer_state = make_pipeline_state(
-            PipelineUserType.Consumer, self.num_clc_stage
-        )
+        clc_consumer_state = make_pipeline_state(PipelineUserType.Consumer, self.num_clc_stage)
         tile_sched = utils.ClcDynamicPersistentTileScheduler.create(
             tile_sched_params,
             cute.arch.block_idx(),
@@ -525,9 +509,7 @@ class DenseScoreRecomputeSm100:
         thr_mma_qk = tiled_mma_qk.get_slice(0)
         qk_acc_shape = thr_mma_qk.partition_shape_C(self.mma_tiler_qk[:2])
         tStS_fake = thr_mma_qk.make_fragment_C(qk_acc_shape)
-        tmem_ptr = cute.make_ptr(
-            Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16
-        )
+        tmem_ptr = cute.make_ptr(Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16)
         tStS_ref = cute.make_tensor(tmem_ptr, tStS_fake.layout)
 
         warp_group_idx = tidx // self.WARPGROUP_SIZE
@@ -552,14 +534,18 @@ class DenseScoreRecomputeSm100:
                     seqlen = SeqlenInfoCls(batch_idx)
                     q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
-                        seqlen.seqlen_q * self.qhead_per_kvhead, self.m_block_size,
+                        seqlen.seqlen_q * self.qhead_per_kvhead,
+                        self.m_block_size,
                     )
                     is_valid_m_block = m_block_sched < num_m_blocks_cur
 
                     if is_valid_m_block:
                         m_block = num_m_blocks_cur - Int32(1) - m_block_sched
                         num_n_blocks_compute = self._dense_compute_n_blocks(
-                            m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset,
+                            m_block,
+                            seqlen.seqlen_q,
+                            seqlen.seqlen_k,
+                            q_causal_offset,
                         )
                         # PerHead data load (double-buffered)
                         per_head_buf_off = (tile_count % 2) * self.m_block_size
@@ -573,9 +559,7 @@ class DenseScoreRecomputeSm100:
                                 if m_idx < seqlen.seqlen_q:
                                     per_head_value = mPerHead_cur[m_idx, h_idx]
                                     if cutlass.const_expr(self.score_type == "attention"):
-                                        sPerHead[per_head_buf_off + row] = (
-                                            Float32(per_head_value) * neg_log2_e
-                                        )
+                                        sPerHead[per_head_buf_off + row] = Float32(per_head_value) * neg_log2_e
                                     else:
                                         sPerHead[per_head_buf_off + row] = Float32(per_head_value)
                                 else:
@@ -595,8 +579,12 @@ class DenseScoreRecomputeSm100:
                             )
                             sQ_cur = sQ[None, None, None, _kc]
                             load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(
-                                tma_atom_Q, 0, cute.make_layout(1),
-                                gQ, sQ_cur, single_stage=True,
+                                tma_atom_Q,
+                                0,
+                                cute.make_layout(1),
+                                gQ,
+                                sQ_cur,
+                                single_stage=True,
                             )
                             load_Q_fn(tma_bar_ptr=handle_Q.barrier)
 
@@ -614,8 +602,12 @@ class DenseScoreRecomputeSm100:
                                 )
                                 sK_stage = sK[None, None, None, handle_K.index]
                                 load_K_fn, _, _ = copy_utils.tma_get_copy_fn(
-                                    tma_atom_K, 0, cute.make_layout(1),
-                                    gK, sK_stage, single_stage=True,
+                                    tma_atom_K,
+                                    0,
+                                    cute.make_layout(1),
+                                    gK,
+                                    sK_stage,
+                                    single_stage=True,
                                 )
                                 load_K_fn(tma_bar_ptr=handle_K.barrier)
                             n_block_k = n_block_k - 1
@@ -637,23 +629,25 @@ class DenseScoreRecomputeSm100:
                 cute.arch.sync_warp()
 
                 s_empty_phase_bits = Int32((1 << self.num_tmem_slots) - 1)
-                K_mma_state = make_pipeline_state(
-                    PipelineUserType.Consumer, self.kv_stage
-                )
+                K_mma_state = make_pipeline_state(PipelineUserType.Consumer, self.kv_stage)
                 while work_tile.is_valid_tile:
                     m_block_sched = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
                     q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
-                        seqlen.seqlen_q * self.qhead_per_kvhead, self.m_block_size,
+                        seqlen.seqlen_q * self.qhead_per_kvhead,
+                        self.m_block_size,
                     )
                     is_valid_m_block = m_block_sched < num_m_blocks_cur
 
                     if is_valid_m_block:
                         m_block = num_m_blocks_cur - Int32(1) - m_block_sched
                         num_n_blocks_compute = self._dense_compute_n_blocks(
-                            m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset,
+                            m_block,
+                            seqlen.seqlen_q,
+                            seqlen.seqlen_k,
+                            q_causal_offset,
                         )
                         Q_consumer.reset()
                         handle_Q = Q_consumer.wait_and_advance()
@@ -677,9 +671,12 @@ class DenseScoreRecomputeSm100:
                                 tSrQ_kc = tSrQ[None, None, None, _kc]
                                 sQ_kc = sQ[None, None, None, _kc]
                                 _gemm_ptx_partial(
-                                    qk_mma_op, slot * self.tmem_s_stride,
-                                    tSrKi, tSrQ_kc,
-                                    sA=sK_cur, sB=sQ_kc,
+                                    qk_mma_op,
+                                    slot * self.tmem_s_stride,
+                                    tSrKi,
+                                    tSrQ_kc,
+                                    sA=sK_cur,
+                                    sB=sQ_kc,
                                     zero_init=const_expr(_kc == 0),
                                 )
 
@@ -690,7 +687,8 @@ class DenseScoreRecomputeSm100:
                                 tcgen05.commit(S_mbar_ptr + 2 * slot)
 
                             s_empty_phase_bits = self._toggle_phase_for_slot(
-                                s_empty_phase_bits, slot,
+                                s_empty_phase_bits,
+                                slot,
                             )
                             n_block = n_block - 1
 
@@ -705,7 +703,8 @@ class DenseScoreRecomputeSm100:
                 cute.arch.relinquish_tmem_alloc_permit()
                 cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
                 tmem_ptr_dealloc = cute.arch.retrieve_tmem_ptr(
-                    Float32, alignment=16,
+                    Float32,
+                    alignment=16,
                     ptr_to_buffer_holding_addr=tmem_holding_buf,
                 )
                 cute.arch.dealloc_tmem(tmem_ptr_dealloc, Int32(self.tmem_alloc_cols))
@@ -714,9 +713,7 @@ class DenseScoreRecomputeSm100:
             # Scheduler warp (warp 2): CLC producer loop
             # -----------------------------------------------------------------
             if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
-                clc_producer_state = make_pipeline_state(
-                    PipelineUserType.ProducerConsumer, self.num_clc_stage
-                )
+                clc_producer_state = make_pipeline_state(PipelineUserType.ProducerConsumer, self.num_clc_stage)
                 while work_tile.is_valid_tile:
                     clc_pipeline.producer_acquire(clc_producer_state)
                     mbarrier_addr = clc_pipeline.producer_get_barrier(clc_producer_state)
@@ -742,24 +739,35 @@ class DenseScoreRecomputeSm100:
                 seqlen = SeqlenInfoCls(batch_idx)
                 q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                 num_m_blocks_cur = cute.ceil_div(
-                    seqlen.seqlen_q * self.qhead_per_kvhead, self.m_block_size,
+                    seqlen.seqlen_q * self.qhead_per_kvhead,
+                    self.m_block_size,
                 )
                 is_valid_m_block = m_block_sched < num_m_blocks_cur
 
                 if is_valid_m_block:
                     m_block = num_m_blocks_cur - Int32(1) - m_block_sched
                     num_n_blocks_compute = self._dense_compute_n_blocks(
-                        m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset,
+                        m_block,
+                        seqlen.seqlen_q,
+                        seqlen.seqlen_k,
+                        q_causal_offset,
                     )
                     per_head_offset = (tile_count % 2) * self.m_block_size
                     mOut_cur = seqlen.offset_batch_Q(mOut, batch_idx, dim=2)
                     mDenom_cur = seqlen.offset_batch_Q(mDenom, batch_idx, dim=1)
                     if cutlass.const_expr(self.score_type == "attention"):
                         s_full_phase_bits, reduce_phase = self._epilogue_attention_dense(
-                            tiled_mma_qk, tStS_ref,
-                            sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-                            mOut_cur, mDenom_cur,
-                            num_n_blocks_compute, seqlen.seqlen_k, seqlen.seqlen_q,
+                            tiled_mma_qk,
+                            tStS_ref,
+                            sPerHead,
+                            sScoreAll,
+                            S_mbar_ptr,
+                            reduce_sync_mbar_ptr,
+                            mOut_cur,
+                            mDenom_cur,
+                            num_n_blocks_compute,
+                            seqlen.seqlen_k,
+                            seqlen.seqlen_q,
                             max_seqlen_k,
                             q_causal_offset,
                             m_block,
@@ -771,10 +779,17 @@ class DenseScoreRecomputeSm100:
                         )
                     else:
                         s_full_phase_bits, reduce_phase = self._epilogue_indexer_dense(
-                            tiled_mma_qk, tStS_ref,
-                            sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-                            mOut_cur, mDenom_cur,
-                            num_n_blocks_compute, seqlen.seqlen_k, seqlen.seqlen_q,
+                            tiled_mma_qk,
+                            tStS_ref,
+                            sPerHead,
+                            sScoreAll,
+                            S_mbar_ptr,
+                            reduce_sync_mbar_ptr,
+                            mOut_cur,
+                            mDenom_cur,
+                            num_n_blocks_compute,
+                            seqlen.seqlen_k,
+                            seqlen.seqlen_q,
                             max_seqlen_k,
                             q_causal_offset,
                             m_block,
@@ -799,9 +814,7 @@ class DenseScoreRecomputeSm100:
         ratio = Int32(self.ratio)
         q_token_base = m_block * self.q_tokens_per_tile
         q_token_last = q_token_base + Int32(self.q_tokens_per_tile - 1)
-        q_token_last = (
-            q_token_last if q_token_last < seqlen_q else seqlen_q - Int32(1)
-        )
+        q_token_last = q_token_last if q_token_last < seqlen_q else seqlen_q - Int32(1)
 
         max_kv_needed = (q_causal_offset + q_token_last + Int32(1)) // ratio
         max_kv_needed = max_kv_needed if max_kv_needed > Int32(0) else Int32(0)
@@ -821,8 +834,12 @@ class DenseScoreRecomputeSm100:
     # =========================================================================
     @cute.jit
     def _intra_inter_warp_reduce_max(
-        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
-        warp_id_in_wg, local_value,
+        self,
+        sScoreAll,
+        reduce_sync_mbar_ptr,
+        reduce_sync_phase,
+        warp_id_in_wg,
+        local_value,
     ):
         """Reduce local max across 4 warps via smem scratch + mbarrier sync."""
         warp_max = cute.arch.warp_redux_sync(local_value, "fmax")
@@ -842,8 +859,12 @@ class DenseScoreRecomputeSm100:
 
     @cute.jit
     def _intra_inter_warp_reduce_sum(
-        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
-        warp_id_in_wg, local_value,
+        self,
+        sScoreAll,
+        reduce_sync_mbar_ptr,
+        reduce_sync_phase,
+        warp_id_in_wg,
+        local_value,
     ):
         """Reduce local sum across 4 warps via smem scratch + mbarrier sync."""
         warp_sum = cute.arch.warp_reduction_sum(local_value)
@@ -862,8 +883,12 @@ class DenseScoreRecomputeSm100:
 
     @cute.jit
     def _inter_warp_sync_sum(
-        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
-        warp_id_in_wg, warp_sum,
+        self,
+        sScoreAll,
+        reduce_sync_mbar_ptr,
+        reduce_sync_phase,
+        warp_id_in_wg,
+        warp_sum,
     ):
         """Cross-warp sum sync with pre-computed warp-level sum."""
         with cute.arch.elect_one():
@@ -887,9 +912,15 @@ class DenseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        sW, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-        mOut, mDenom,
-        num_n_blocks_compute, seqlen_k, seqlen_q,
+        sW,
+        sScoreAll,
+        S_mbar_ptr,
+        reduce_sync_mbar_ptr,
+        mOut,
+        mDenom,
+        num_n_blocks_compute,
+        seqlen_k,
+        seqlen_q,
         max_seqlen_k,
         q_causal_offset,
         m_block,
@@ -930,13 +961,8 @@ class DenseScoreRecomputeSm100:
         log2_e = Float32(math.log2(math.e))
 
         q_token_base = m_block * q_tokens_per_tile
-        q_token_idxs = [
-            q_token_base + Int32(qi) for qi in range(q_tokens_per_tile)
-        ]
-        col_limits = [
-            (q_causal_offset + q_token_idxs[qi] + Int32(1)) // ratio
-            for qi in range(q_tokens_per_tile)
-        ]
+        q_token_idxs = [q_token_base + Int32(qi) for qi in range(q_tokens_per_tile)]
+        col_limits = [(q_causal_offset + q_token_idxs[qi] + Int32(1)) // ratio for qi in range(q_tokens_per_tile)]
         # Per-q_token online LSE accumulators
         local_max = [-Float32.inf for _ in range(q_tokens_per_tile)]
         local_sum_exp = [Float32(0.0) for _ in range(q_tokens_per_tile)]
@@ -945,22 +971,19 @@ class DenseScoreRecomputeSm100:
         n_blk = num_n_blocks_compute - 1
         while n_blk >= Int32(0):
             tmem_load_atom = cute.make_copy_atom(
-                tcgen05.copy.Ld32x32bOp(
-                    tcgen05.copy.Repetition(self.tmem_repetition)
-                ),
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tmem_repetition)),
                 Float32,
             )
             thr_tmem_load = tcgen05.make_tmem_copy(
-                tmem_load_atom, tStS_ref,
+                tmem_load_atom,
+                tStS_ref,
             ).get_slice(tidx_wg)
 
             thr_mma = tiled_mma_qk.get_slice(tidx_wg)
             cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
             tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
 
-            tSrS_shape = thr_tmem_load.partition_D(
-                cute.make_identity_tensor(tStS_ref.shape)
-            ).shape
+            tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
             tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
             slot = n_blk % Int32(self.num_tmem_slots)
@@ -972,8 +995,10 @@ class DenseScoreRecomputeSm100:
                 first_block = Int32(0)
 
             tmem_ptr_cur = cute.make_ptr(
-                Float32, slot * self.tmem_s_stride,
-                mem_space=cute.AddressSpace.tmem, assumed_align=16,
+                Float32,
+                slot * self.tmem_s_stride,
+                mem_space=cute.AddressSpace.tmem,
+                assumed_align=16,
             )
             tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
             tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
@@ -983,7 +1008,8 @@ class DenseScoreRecomputeSm100:
 
             cute.arch.mbarrier_arrive(S_mbar_ptr + 2 * slot + 1)
             s_full_phase_bits = self._toggle_phase_for_slot(
-                s_full_phase_bits, slot,
+                s_full_phase_bits,
+                slot,
             )
 
             kv_offset = tScS[0][0]
@@ -992,11 +1018,7 @@ class DenseScoreRecomputeSm100:
             for qi in cutlass.range_constexpr(q_tokens_per_tile):
                 q_token_idx = q_token_idxs[qi]
                 col_limit = col_limits[qi]
-                if (
-                    q_token_idx < seqlen_q
-                    and pos < col_limit
-                    and pos < seqlen_k
-                ):
+                if q_token_idx < seqlen_q and pos < col_limit and pos < seqlen_k:
                     local_sum_0 = (Float32(0.0), Float32(0.0))
                     local_sum_1 = (Float32(0.0), Float32(0.0))
                     local_sum_2 = (Float32(0.0), Float32(0.0))
@@ -1014,19 +1036,27 @@ class DenseScoreRecomputeSm100:
 
                             if cutlass.const_expr(ci < W_ILP // 4):
                                 local_sum_0 = fma_packed_f32x2(
-                                    (val0, val1), w_pair, local_sum_0,
+                                    (val0, val1),
+                                    w_pair,
+                                    local_sum_0,
                                 )
                             elif cutlass.const_expr(ci < W_ILP // 2):
                                 local_sum_1 = fma_packed_f32x2(
-                                    (val0, val1), w_pair, local_sum_1,
+                                    (val0, val1),
+                                    w_pair,
+                                    local_sum_1,
                                 )
                             elif cutlass.const_expr(ci < (W_ILP * 3) // 4):
                                 local_sum_2 = fma_packed_f32x2(
-                                    (val0, val1), w_pair, local_sum_2,
+                                    (val0, val1),
+                                    w_pair,
+                                    local_sum_2,
                                 )
                             else:
                                 local_sum_3 = fma_packed_f32x2(
-                                    (val0, val1), w_pair, local_sum_3,
+                                    (val0, val1),
+                                    w_pair,
+                                    local_sum_3,
                                 )
 
                     local_sum_lo = add_packed_f32x2(local_sum_0, local_sum_1)
@@ -1035,21 +1065,10 @@ class DenseScoreRecomputeSm100:
                     score = (local_sum[0] + local_sum[1]) * Float32(softmax_scale)
                     mOut[q_token_idx, pos] = score
                     new_max = score if score > local_max[qi] else local_max[qi]
-                    local_rescale = cute.math.exp2(
-                        (local_max[qi] - new_max) * log2_e
-                    )
-                    local_sum_exp[qi] = (
-                        local_sum_exp[qi] * local_rescale
-                        + cute.math.exp2(
-                            (score - new_max) * log2_e
-                        )
-                    )
+                    local_rescale = cute.math.exp2((local_max[qi] - new_max) * log2_e)
+                    local_sum_exp[qi] = local_sum_exp[qi] * local_rescale + cute.math.exp2((score - new_max) * log2_e)
                     local_max[qi] = new_max
-                elif (
-                    cutlass.const_expr(not self.is_varlen)
-                    and q_token_idx < seqlen_q
-                    and pos < max_seqlen_k
-                ):
+                elif cutlass.const_expr(not self.is_varlen) and q_token_idx < seqlen_q and pos < max_seqlen_k:
                     mOut[q_token_idx, pos] = -Float32.inf
 
             n_blk = n_blk - 1
@@ -1101,14 +1120,10 @@ class DenseScoreRecomputeSm100:
             adjusted_sum0 = Float32(0.0)
             adjusted_sum1 = Float32(0.0)
             if global_max0 > Float32(-1e30):
-                rescale0 = cute.math.exp2(
-                    (local_max[0] - global_max0) * log2_e
-                )
+                rescale0 = cute.math.exp2((local_max[0] - global_max0) * log2_e)
                 adjusted_sum0 = local_sum_exp[0] * rescale0
             if global_max1 > Float32(-1e30):
-                rescale1 = cute.math.exp2(
-                    (local_max[1] - global_max1) * log2_e
-                )
+                rescale1 = cute.math.exp2((local_max[1] - global_max1) * log2_e)
                 adjusted_sum1 = local_sum_exp[1] * rescale1
 
             warp_sum0 = cute.arch.warp_reduction_sum(adjusted_sum0)
@@ -1144,20 +1159,24 @@ class DenseScoreRecomputeSm100:
         else:
             for qi in cutlass.range_constexpr(q_tokens_per_tile):
                 global_max, reduce_phase = self._intra_inter_warp_reduce_max(
-                    sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
-                    warp_id_in_wg, local_max[qi],
+                    sScoreAll,
+                    reduce_sync_mbar_ptr,
+                    reduce_phase,
+                    warp_id_in_wg,
+                    local_max[qi],
                 )
 
                 lse_val = -Float32.inf
                 if global_max > Float32(-1e30):
-                    global_rescale = cute.math.exp2(
-                        (local_max[qi] - global_max) * log2_e
-                    )
+                    global_rescale = cute.math.exp2((local_max[qi] - global_max) * log2_e)
                     adjusted_sum = local_sum_exp[qi] * global_rescale
 
                     global_sum_exp, reduce_phase = self._intra_inter_warp_reduce_sum(
-                        sScoreAll_sum, reduce_sync_mbar_ptr, reduce_phase,
-                        warp_id_in_wg, adjusted_sum,
+                        sScoreAll_sum,
+                        reduce_sync_mbar_ptr,
+                        reduce_phase,
+                        warp_id_in_wg,
+                        adjusted_sum,
                     )
 
                     lse_val = global_max + cute.math.log2(global_sum_exp) * inv_log2_e
@@ -1181,9 +1200,15 @@ class DenseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        sLSE, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-        mOut, mDenom,
-        num_n_blocks_compute, seqlen_k, seqlen_q,
+        sLSE,
+        sScoreAll,
+        S_mbar_ptr,
+        reduce_sync_mbar_ptr,
+        mOut,
+        mDenom,
+        num_n_blocks_compute,
+        seqlen_k,
+        seqlen_q,
         max_seqlen_k,
         q_causal_offset,
         m_block,
@@ -1235,22 +1260,19 @@ class DenseScoreRecomputeSm100:
         n_blk = num_n_blocks_compute - 1
         while n_blk >= Int32(0):
             tmem_load_atom = cute.make_copy_atom(
-                tcgen05.copy.Ld32x32bOp(
-                    tcgen05.copy.Repetition(self.tmem_repetition)
-                ),
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tmem_repetition)),
                 Float32,
             )
             thr_tmem_load = tcgen05.make_tmem_copy(
-                tmem_load_atom, tStS_ref,
+                tmem_load_atom,
+                tStS_ref,
             ).get_slice(tidx_wg)
 
             thr_mma = tiled_mma_qk.get_slice(tidx_wg)
             cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
             tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
 
-            tSrS_shape = thr_tmem_load.partition_D(
-                cute.make_identity_tensor(tStS_ref.shape)
-            ).shape
+            tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
             tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
             slot = n_blk % Int32(self.num_tmem_slots)
@@ -1262,8 +1284,10 @@ class DenseScoreRecomputeSm100:
                 first_block = Int32(0)
 
             tmem_ptr_cur = cute.make_ptr(
-                Float32, slot * self.tmem_s_stride,
-                mem_space=cute.AddressSpace.tmem, assumed_align=16,
+                Float32,
+                slot * self.tmem_s_stride,
+                mem_space=cute.AddressSpace.tmem,
+                assumed_align=16,
             )
             tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
             tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
@@ -1273,7 +1297,8 @@ class DenseScoreRecomputeSm100:
 
             cute.arch.mbarrier_arrive(S_mbar_ptr + 2 * slot + 1)
             s_full_phase_bits = self._toggle_phase_for_slot(
-                s_full_phase_bits, slot,
+                s_full_phase_bits,
+                slot,
             )
 
             kv_offset = tScS[0][0]
@@ -1292,7 +1317,7 @@ class DenseScoreRecomputeSm100:
                         val0 = tSrS[idx0]
                         val1 = tSrS[idx1]
 
-                        (val0, val1) = fma_packed_f32x2(
+                        val0, val1 = fma_packed_f32x2(
                             (val0, val1),
                             (scale_log2_e, scale_log2_e),
                             lse_pair,
@@ -1365,10 +1390,7 @@ class DenseScoreRecomputeSm100:
             global_sum1 = sScoreAll[self.num_warps_in_epi_wg]
             for wi in cutlass.range_constexpr(self.num_warps_in_epi_wg - 1):
                 global_sum0 = global_sum0 + sScoreAll[wi + 1]
-                global_sum1 = (
-                    global_sum1
-                    + sScoreAll[self.num_warps_in_epi_wg + wi + 1]
-                )
+                global_sum1 = global_sum1 + sScoreAll[self.num_warps_in_epi_wg + wi + 1]
 
             if q_token_base < seqlen_q:
                 with cute.arch.elect_one():
@@ -1380,8 +1402,11 @@ class DenseScoreRecomputeSm100:
         else:
             warp_sum = cute.arch.warp_reduction_sum(local_sum_acc[0])
             global_sum, reduce_phase = self._inter_warp_sync_sum(
-                sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
-                warp_id_in_wg, warp_sum,
+                sScoreAll,
+                reduce_sync_mbar_ptr,
+                reduce_phase,
+                warp_id_in_wg,
+                warp_sum,
             )
 
             if q_token_base < seqlen_q:

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
@@ -184,6 +184,7 @@ class DenseScoreRecomputeSm100:
         max_seqlen_k: Int32,
         mCuSeqlensQ: cute.Tensor | None,
         mCuSeqlensK: cute.Tensor | None,
+        mQCausalOffsets: cute.Tensor | None,
         stream: cuda.CUstream,
     ):
         """Host-side: layout transpose, PackGQA, TMA creation, kernel launch."""
@@ -324,6 +325,7 @@ class DenseScoreRecomputeSm100:
             max_seqlen_k,
             mCuSeqlensQ,
             mCuSeqlensK,
+            mQCausalOffsets,
         ).launch(
             grid=grid_dim,
             block=[self.threads_per_cta, 1, 1],
@@ -353,6 +355,7 @@ class DenseScoreRecomputeSm100:
         max_seqlen_k: Int32,
         mCuSeqlensQ: cute.Tensor | None,
         mCuSeqlensK: cute.Tensor | None,
+        mQCausalOffsets: cute.Tensor | None,
     ):
         """Device-side kernel entry with CLC persistent scheduling."""
         is_varlen = mCuSeqlensQ is not None
@@ -712,6 +715,7 @@ class DenseScoreRecomputeSm100:
                 m_block = work_tile.tile_idx[0]
                 batch_idx = work_tile.tile_idx[2]
                 seqlen = SeqlenInfoCls(batch_idx)
+                q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                 num_m_blocks_cur = cute.ceil_div(
                     seqlen.seqlen_q * self.qhead_per_kvhead,
                     self.m_block_size,
@@ -737,6 +741,7 @@ class DenseScoreRecomputeSm100:
                             seqlen.seqlen_k,
                             seqlen.seqlen_q,
                             max_seqlen_k,
+                            q_causal_offset,
                             m_block,
                             tidx,
                             s_full_phase,
@@ -758,6 +763,7 @@ class DenseScoreRecomputeSm100:
                             seqlen.seqlen_k,
                             seqlen.seqlen_q,
                             max_seqlen_k,
+                            q_causal_offset,
                             m_block,
                             tidx,
                             s_full_phase,
@@ -867,6 +873,7 @@ class DenseScoreRecomputeSm100:
         seqlen_k,
         seqlen_q,
         max_seqlen_k,
+        q_causal_offset,
         m_block,
         tidx,
         s_full_phase,
@@ -904,10 +911,6 @@ class DenseScoreRecomputeSm100:
         qhpkv = self.qhead_per_kvhead
         q_tokens_per_tile = self.q_tokens_per_tile
         ratio = Int32(self.ratio)
-        # Bottom-right ratio causal mask: kv_token >= (q_global_start + q_token + 1) // ratio
-        # where q_global_start = seqlen_k * ratio - seqlen_q. For seqlen_q == seqlen_k * ratio
-        # this reduces to the original (q_token + 1) // ratio formula.
-        q_global_start = seqlen_k * ratio - seqlen_q
 
         W_ILP = 4
         sW_f32_ptr = cute.make_ptr(
@@ -993,7 +996,7 @@ class DenseScoreRecomputeSm100:
                 #     reach n_block_size-1 which may exceed the buffer width
                 #     for THD with seqlen_k_b < max_seqlen_k.
                 q_token_idx = q_token_base + qi
-                col_limit = (q_global_start + q_token_idx + 1) // ratio
+                col_limit = (q_causal_offset + q_token_idx + 1) // ratio
                 if q_token_idx < seqlen_q and pos < max_seqlen_k:
                     if pos >= col_limit or pos >= seqlen_k:
                         mOut[q_token_idx, pos] = Float32(0.0)
@@ -1058,6 +1061,7 @@ class DenseScoreRecomputeSm100:
         seqlen_k,
         seqlen_q,
         max_seqlen_k,
+        q_causal_offset,
         m_block,
         tidx,
         s_full_phase,
@@ -1091,9 +1095,6 @@ class DenseScoreRecomputeSm100:
         qhpkv = self.qhead_per_kvhead
         q_tokens_per_tile = self.q_tokens_per_tile
         ratio = Int32(self.ratio)
-        # Bottom-right ratio causal mask: kv_token >= (q_global_start + q_token + 1) // ratio
-        # where q_global_start = seqlen_k * ratio - seqlen_q.
-        q_global_start = seqlen_k * ratio - seqlen_q
 
         LSE_ILP = 4
         sLSE_f32_ptr = cute.make_ptr(
@@ -1180,7 +1181,7 @@ class DenseScoreRecomputeSm100:
                 # rationale (q row belonging to other batch, pos past buffer K
                 # extent under THD).
                 q_token_idx = q_token_base + qi
-                col_limit = (q_global_start + q_token_idx + 1) // ratio
+                col_limit = (q_causal_offset + q_token_idx + 1) // ratio
                 if pos >= col_limit or pos >= seqlen_k or q_token_idx >= seqlen_q:
                     score = Float32(0.0)
 

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
@@ -985,7 +985,7 @@ class DenseScoreRecomputeSm100:
 
                 score = (local_sum[0] + local_sum[1]) * Float32(softmax_scale)
 
-                # Bottom-right ratio causal mask + tail OOB. Masked positions
+                # Ratio-causal mask + tail OOB. Masked positions
                 # write 0 to mOut and skip the online LSE update (skipping
                 # avoids -inf-vs-empty edge case when q_token has no valid kv yet).
                 # Two OOB guards on the mOut write:
@@ -1173,7 +1173,7 @@ class DenseScoreRecomputeSm100:
 
                 score = local_sum[0] + local_sum[1]
 
-                # Bottom-right ratio causal mask + tail OOB. Masked positions
+                # Ratio-causal mask + tail OOB. Masked positions
                 # write 0 to mOut (P = exp(QK*scale - LSE) is naturally 0 at
                 # masked) so the warp_reduction_sum (collective; must be invoked
                 # by every lane) naturally excludes them from L1 denom.

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
@@ -530,11 +530,16 @@ class DenseScoreRecomputeSm100:
                     m_block = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
+                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
                         seqlen.seqlen_q * self.qhead_per_kvhead,
                         self.m_block_size,
                     )
-                    num_n_blocks_cur = cute.ceil_div(seqlen.seqlen_k, self.n_block_size)
+                    num_n_blocks_cur = self._causal_num_n_blocks(
+                        m_block,
+                        seqlen.seqlen_k,
+                        q_causal_offset,
+                    )
                     is_valid_m_block = m_block < num_m_blocks_cur
 
                     if is_valid_m_block:
@@ -622,11 +627,16 @@ class DenseScoreRecomputeSm100:
                     m_block = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
+                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
                         seqlen.seqlen_q * self.qhead_per_kvhead,
                         self.m_block_size,
                     )
-                    num_n_blocks_cur = cute.ceil_div(seqlen.seqlen_k, self.n_block_size)
+                    num_n_blocks_cur = self._causal_num_n_blocks(
+                        m_block,
+                        seqlen.seqlen_k,
+                        q_causal_offset,
+                    )
                     is_valid_m_block = m_block < num_m_blocks_cur
 
                     if is_valid_m_block:
@@ -720,7 +730,11 @@ class DenseScoreRecomputeSm100:
                     seqlen.seqlen_q * self.qhead_per_kvhead,
                     self.m_block_size,
                 )
-                num_n_blocks_cur = cute.ceil_div(seqlen.seqlen_k, self.n_block_size)
+                num_n_blocks_cur = self._causal_num_n_blocks(
+                    m_block,
+                    seqlen.seqlen_k,
+                    q_causal_offset,
+                )
                 is_valid_m_block = m_block < num_m_blocks_cur
 
                 if is_valid_m_block:
@@ -779,6 +793,18 @@ class DenseScoreRecomputeSm100:
             if warp_idx == self.epilogue_wg_warp_ids[-1]:
                 with cute.arch.elect_one():
                     cute.arch.mbarrier_arrive(tmem_dealloc_mbar_ptr)
+
+    # =========================================================================
+    # Causal n-block computation
+    # =========================================================================
+    @cute.jit
+    def _causal_num_n_blocks(self, m_block, seqlen_k, q_causal_offset):
+        """Return the K n-block count that can contain valid ratio-causal columns."""
+        max_q_plus_1 = (m_block + Int32(1)) * Int32(self.q_tokens_per_tile)
+        max_kv_needed = (q_causal_offset + max_q_plus_1) // Int32(self.ratio)
+        max_kv_needed = max_kv_needed if max_kv_needed > Int32(0) else Int32(0)
+        max_kv_needed = max_kv_needed if max_kv_needed < seqlen_k else seqlen_k
+        return cute.ceil_div(max_kv_needed, self.n_block_size)
 
     # =========================================================================
     # Cross-warp reduce helpers (epilogue warpgroup)
@@ -894,19 +920,6 @@ class DenseScoreRecomputeSm100:
         """
         tidx_wg = tidx % self.WARPGROUP_SIZE
 
-        tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tmem_repetition)),
-            Float32,
-        )
-        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
-
-        thr_mma = tiled_mma_qk.get_slice(tidx_wg)
-        cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
-        tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
-
-        tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
-        tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
-
         sW_off = Int32(0) if per_head_offset is None else per_head_offset
         qhpkv = self.qhead_per_kvhead
         q_tokens_per_tile = self.q_tokens_per_tile
@@ -926,7 +939,6 @@ class DenseScoreRecomputeSm100:
         rW_all = cute.make_rmem_tensor((self.m_block_size,), self.per_head_dtype)
         rW_all_f32 = cute.recast_tensor(rW_all, Float32)
 
-        kv_offset = tScS[0][0]
         warp_id_in_wg = tidx_wg // self.WARP_SIZE
 
         log2_e = Float32(math.log2(math.e))
@@ -937,16 +949,25 @@ class DenseScoreRecomputeSm100:
         # Per-q_token online LSE accumulators
         local_max = [-Float32.inf for _ in range(q_tokens_per_tile)]
         local_sum_exp = [Float32(0.0) for _ in range(q_tokens_per_tile)]
-        first_block = Int32(1)
 
-        n_blk = num_n_blocks - 1
-        while n_blk >= Int32(0):
+        for iter_idx in cutlass.range(num_n_blocks, unroll=1):
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tmem_repetition)),
+                Float32,
+            )
+            thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
+            thr_mma = tiled_mma_qk.get_slice(tidx_wg)
+            cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
+            tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
+            tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
+            tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
+
+            n_blk = num_n_blocks - Int32(1) - iter_idx
             slot = n_blk & NUM_SLOTS_MASK
             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * slot, s_full_phase)
 
-            if first_block == Int32(1):
+            if iter_idx == Int32(0):
                 cute.autovec_copy(sW_1d_f32, rW_all_f32)
-                first_block = Int32(0)
 
             tmem_ptr_cur = cute.make_ptr(
                 Float32,
@@ -964,6 +985,7 @@ class DenseScoreRecomputeSm100:
             if slot == Int32(0):
                 s_full_phase ^= 1
 
+            kv_offset = tScS[0][0]
             pos = kv_offset + n_blk * self.n_block_size
 
             # Head reduce per q_token: sum_h ReLU(QK) * W
@@ -1005,8 +1027,6 @@ class DenseScoreRecomputeSm100:
                         new_max = score if score > local_max[qi] else local_max[qi]
                         local_sum_exp[qi] = local_sum_exp[qi] * cute.math.exp2((local_max[qi] - new_max) * log2_e) + cute.math.exp2((score - new_max) * log2_e)
                         local_max[qi] = new_max
-
-            n_blk = n_blk - 1
 
         # Cross-warp reduce for global LSE — sequential per q_token
         sScoreAll_sum = cute.make_tensor(
@@ -1078,19 +1098,6 @@ class DenseScoreRecomputeSm100:
         """
         tidx_wg = tidx % self.WARPGROUP_SIZE
 
-        tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tmem_repetition)),
-            Float32,
-        )
-        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
-
-        thr_mma = tiled_mma_qk.get_slice(tidx_wg)
-        cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
-        tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
-
-        tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
-        tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
-
         sLSE_off = Int32(0) if per_head_offset is None else per_head_offset
         qhpkv = self.qhead_per_kvhead
         q_tokens_per_tile = self.q_tokens_per_tile
@@ -1109,7 +1116,6 @@ class DenseScoreRecomputeSm100:
         )
         rLSE_all = cute.make_rmem_tensor((self.m_block_size,), Float32)
 
-        kv_offset = tScS[0][0]
         warp_id_in_wg = tidx_wg // self.WARP_SIZE
 
         log2_e = Float32(math.log2(math.e))
@@ -1120,16 +1126,25 @@ class DenseScoreRecomputeSm100:
 
         # Per-q_token L1-norm denom accumulators
         warp_sum_acc = [Float32(0.0) for _ in range(q_tokens_per_tile)]
-        first_block = Int32(1)
 
-        n_blk = num_n_blocks - 1
-        while n_blk >= Int32(0):
+        for iter_idx in cutlass.range(num_n_blocks, unroll=1):
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tmem_repetition)),
+                Float32,
+            )
+            thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
+            thr_mma = tiled_mma_qk.get_slice(tidx_wg)
+            cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
+            tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
+            tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
+            tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
+
+            n_blk = num_n_blocks - Int32(1) - iter_idx
             slot = n_blk & NUM_SLOTS_MASK
             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * slot, s_full_phase)
 
-            if first_block == Int32(1):
+            if iter_idx == Int32(0):
                 cute.autovec_copy(sLSE_1d, rLSE_all)
-                first_block = Int32(0)
 
             tmem_ptr_cur = cute.make_ptr(
                 Float32,
@@ -1147,6 +1162,7 @@ class DenseScoreRecomputeSm100:
             if slot == Int32(0):
                 s_full_phase ^= 1
 
+            kv_offset = tScS[0][0]
             pos = kv_offset + n_blk * self.n_block_size
 
             # Head reduce per q_token: sum_h exp2(QK*scale_log2e + scaled_lse)
@@ -1189,8 +1205,6 @@ class DenseScoreRecomputeSm100:
                     mOut[q_token_idx, pos] = score
 
                 warp_sum_acc[qi] = warp_sum_acc[qi] + cute.arch.warp_reduction_sum(score)
-
-            n_blk = n_blk - 1
 
         # Cross-warp reduce for global L1 denom — sequential per q_token.
         # Each qi uses a separate sScoreAll region to avoid a write-read race:

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
@@ -1,5 +1,5 @@
 """
-Dense Score Recompute Kernel — SM100 Cute-DSL Implementation.
+Dense Backward Score Kernel — SM100 Cute-DSL Implementation.
 
 Dense variant: iterates over the full KV sequence via TMA (no topk_indices).
 
@@ -58,12 +58,12 @@ from cutlass.utils.blackwell_helpers import (
 )
 
 from cudnn.deepseek_sparse_attention.utils.sm100.gemm import gemm_ptx_partial as _gemm_ptx_partial
-from cudnn.deepseek_sparse_attention.utils import copy as copy_ops
+from cudnn.deepseek_sparse_attention.utils import copy as copy_utils
 from cudnn.deepseek_sparse_attention.utils.seqlen import SeqlenInfoQK
 
-mul_packed_f32x2 = partial(cute.arch.mul_packed_f32x2, rnd="rn")
-add_packed_f32x2 = partial(cute.arch.add_packed_f32x2, rnd="rn")
-fma_packed_f32x2 = partial(cute.arch.fma_packed_f32x2, rnd="rn")
+mul_packed_f32x2 = partial(cute.arch.mul_packed_f32x2, rnd='rn')
+add_packed_f32x2 = partial(cute.arch.add_packed_f32x2, rnd='rn')
+fma_packed_f32x2 = partial(cute.arch.fma_packed_f32x2, rnd='rn')
 
 
 class DenseScoreRecomputeSm100:
@@ -121,16 +121,21 @@ class DenseScoreRecomputeSm100:
         self.num_clc_response_bytes = 16
 
         hdim_multiple_of = 16
-        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        self.head_dim_padded = int(
+            math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of
+        )
 
         self.k_block_size = k_block_size if k_block_size is not None else self.head_dim_padded
         assert self.head_dim_padded % self.k_block_size == 0, (
-            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of " f"k_block_size ({self.k_block_size})"
+            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of "
+            f"k_block_size ({self.k_block_size})"
         )
         self.num_k_chunks = self.head_dim_padded // self.k_block_size
 
         self.q_tokens_per_tile = m_block_size // qhead_per_kvhead
-        assert self.q_tokens_per_tile <= 2, f"q_tokens_per_tile ({self.q_tokens_per_tile}) must be 1 or 2"
+        assert self.q_tokens_per_tile <= 2, (
+            f"q_tokens_per_tile ({self.q_tokens_per_tile}) must be 1 or 2"
+        )
 
         self.tmem_repetition = self.m_block_size // 4
 
@@ -151,6 +156,8 @@ class DenseScoreRecomputeSm100:
         SM100_TMEM_CAPACITY_COLUMNS = 512
         self.tmem_s_stride = self.m_block_size
         self.num_tmem_slots = SM100_TMEM_CAPACITY_COLUMNS // self.m_block_size
+        if score_type == "attention" and qhead_per_kvhead in (64, 128):
+            self.num_tmem_slots = 2
         self.tmem_total = self.tmem_s_stride * self.num_tmem_slots
         self.tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
@@ -174,11 +181,11 @@ class DenseScoreRecomputeSm100:
     @cute.jit
     def __call__(
         self,
-        mQ: cute.Tensor,  # BSHD (bs, seqlen_q, n_heads_q, head_dim) or THD (total_q, n_heads_q, head_dim) BF16
-        mK: cute.Tensor,  # BSHD (bs, seqlen_k, n_heads_kv, head_dim) or THD (total_k, n_heads_kv, head_dim) BF16
-        mPerHead: cute.Tensor,  # BSH (bs, seqlen_q, n_heads_q) or TH (total_q, n_heads_q) — W (BF16) or scaled_LSE (FP32)
-        mOut: cute.Tensor,  # BSS (bs, seqlen_q, seqlen_k) or TS (total_q, max_seqlen_k) FP32
-        mDenom: cute.Tensor,  # BS (bs, seqlen_q) or T (total_q,) FP32
+        mQ: cute.Tensor,          # BSHD (bs, seqlen_q, n_heads_q, head_dim) or THD (total_q, n_heads_q, head_dim) BF16
+        mK: cute.Tensor,          # BSHD (bs, seqlen_k, n_heads_kv, head_dim) or THD (total_k, n_heads_kv, head_dim) BF16
+        mPerHead: cute.Tensor,    # BSH (bs, seqlen_q, n_heads_q) or TH (total_q, n_heads_q) — W (BF16) or LSE (FP32)
+        mOut: cute.Tensor,        # BSS (bs, seqlen_q, seqlen_k) or TS (total_q, max_seqlen_k) FP32
+        mDenom: cute.Tensor,      # BS (bs, seqlen_q) or T (total_q,) FP32
         softmax_scale: Float32 | float,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -191,7 +198,6 @@ class DenseScoreRecomputeSm100:
 
         self.q_dtype = mQ.element_type
         self.k_dtype = mK.element_type
-        self.per_head_dtype = mPerHead.element_type
         is_varlen = mCuSeqlensQ is not None
 
         self.tma_copy_bytes = {
@@ -229,7 +235,9 @@ class DenseScoreRecomputeSm100:
             mQ.stride[2] * self.qhead_per_kvhead,
             *mQ.stride[3:],
         )
-        mQ = cute.make_tensor(mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed))
+        mQ = cute.make_tensor(
+            mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed)
+        )
 
         cta_group = tcgen05.CtaGroup.ONE
         self.q_major_mode = cutlass.utils.LayoutEnum.from_tensor(mQ).mma_major_mode()
@@ -252,16 +260,10 @@ class DenseScoreRecomputeSm100:
 
         # --- SMEM layouts ---
         sK_layout = _make_smem_layout_a(
-            tiled_mma_qk,
-            self.mma_tiler_qk,
-            self.k_dtype,
-            self.kv_stage,
+            tiled_mma_qk, self.mma_tiler_qk, self.k_dtype, self.kv_stage,
         )
         sQ_layout = _make_smem_layout_b(
-            tiled_mma_qk,
-            self.mma_tiler_qk,
-            self.q_dtype,
-            self.num_k_chunks,
+            tiled_mma_qk, self.mma_tiler_qk, self.q_dtype, self.num_k_chunks,
         )
 
         # --- TMA atoms for both Q and K ---
@@ -303,23 +305,28 @@ class DenseScoreRecomputeSm100:
         # --- Grid and kernel dispatch (CLC persistent scheduling) ---
         # Grid sized using max_seqlen_q for varlen so persistent scheduling
         # can iterate over per-batch tiles up to the longest sequence.
-        seqlen_q_static = max_seqlen_q if const_expr(is_varlen) else cute.size(mQ.shape[0]) // self.qhead_per_kvhead
+        seqlen_q_static = (
+            max_seqlen_q if const_expr(is_varlen)
+            else cute.size(mQ.shape[0]) // self.qhead_per_kvhead
+        )
         num_m_blocks = cute.ceil_div(seqlen_q_static * self.qhead_per_kvhead, self.m_block_size)
-        batch_size = cute.size(mCuSeqlensQ.shape[0]) - 1 if const_expr(is_varlen) else cute.size(mQ.shape[3])
-        tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams((num_m_blocks, 1, batch_size), (*self.cluster_shape_mn, 1))
-        grid_dim = utils.ClcDynamicPersistentTileScheduler.get_grid_shape(tile_sched_params)
+        batch_size = (
+            cute.size(mCuSeqlensQ.shape[0]) - 1
+            if const_expr(is_varlen)
+            else cute.size(mQ.shape[3])
+        )
+        tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams(
+            (num_m_blocks, 1, batch_size), (*self.cluster_shape_mn, 1)
+        )
+        grid_dim = utils.ClcDynamicPersistentTileScheduler.get_grid_shape(
+            tile_sched_params
+        )
         self.kernel(
-            mQ,
-            mK,
-            mPerHead,
-            mOut,
-            mDenom,
+            mQ, mK, mPerHead, mOut, mDenom,
             softmax_scale,
-            tma_atom_Q,
-            tma_atom_K,
+            tma_atom_Q, tma_atom_K,
             tiled_mma_qk,
-            sQ_layout,
-            sK_layout,
+            sQ_layout, sK_layout,
             tile_sched_params,
             max_seqlen_q,
             max_seqlen_k,
@@ -339,17 +346,11 @@ class DenseScoreRecomputeSm100:
     @cute.kernel
     def kernel(
         self,
-        mQ,
-        mK,
-        mPerHead,
-        mOut,
-        mDenom,
+        mQ, mK, mPerHead, mOut, mDenom,
         softmax_scale: Float32 | float,
-        tma_atom_Q,
-        tma_atom_K,
+        tma_atom_Q, tma_atom_K,
         tiled_mma_qk,
-        sQ_layout,
-        sK_layout,
+        sQ_layout, sK_layout,
         tile_sched_params: utils.ClcDynamicPersistentTileSchedulerParams,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -365,8 +366,14 @@ class DenseScoreRecomputeSm100:
             assert not self.is_varlen
 
         # Static seqlens used as fallback when varlen is disabled.
-        seqlen_q_static = max_seqlen_q if const_expr(is_varlen) else cute.size(mQ.shape[0]) // self.qhead_per_kvhead
-        seqlen_k_static = max_seqlen_k if const_expr(is_varlen) else cute.size(mK.shape[0])
+        seqlen_q_static = (
+            max_seqlen_q if const_expr(is_varlen)
+            else cute.size(mQ.shape[0]) // self.qhead_per_kvhead
+        )
+        seqlen_k_static = (
+            max_seqlen_k if const_expr(is_varlen)
+            else cute.size(mK.shape[0])
+        )
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
             seqlen_q_static=seqlen_q_static,
@@ -378,6 +385,7 @@ class DenseScoreRecomputeSm100:
         )
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         tidx = cute.arch.thread_idx()[0]
+        neg_log2_e = Float32(-math.log2(math.e))
 
         # --- TMA descriptor prefetch ---
         if warp_idx == 0:
@@ -402,7 +410,7 @@ class DenseScoreRecomputeSm100:
             clc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
             clc_response: cute.struct.MemRange[cutlass.Int32, 4]
             sPerHead: cute.struct.Align[
-                cute.struct.MemRange[self.per_head_dtype, sPerHead_size],
+                cute.struct.MemRange[Float32, sPerHead_size],
                 128,
             ]
             sScoreAll: cute.struct.Align[
@@ -431,8 +439,12 @@ class DenseScoreRecomputeSm100:
         clc_response_ptr = storage.clc_response.data_ptr()
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
         sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
-        sPerHead = storage.sPerHead.get_tensor(cute.make_layout((self.m_block_size,), stride=(1,)))
-        sScoreAll = storage.sScoreAll.get_tensor(cute.make_layout((self.sScoreAll_size,), stride=(1,)))
+        sPerHead = storage.sPerHead.get_tensor(
+            cute.make_layout((self.m_block_size,), stride=(1,))
+        )
+        sScoreAll = storage.sScoreAll.get_tensor(
+            cute.make_layout((self.sScoreAll_size,), stride=(1,))
+        )
 
         # =====================================================================
         # Pipeline setup
@@ -441,7 +453,9 @@ class DenseScoreRecomputeSm100:
             cute.make_layout(self.cluster_shape_mnk),
             (tiled_mma_qk.thr_id.shape,),
         )
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
         is_first_cta_in_cluster = cta_rank_in_cluster == 0
 
         # Q pipeline (1 stage)
@@ -477,7 +491,9 @@ class DenseScoreRecomputeSm100:
 
         # CLC persistent scheduling pipeline
         cluster_size = cute.size(self.cluster_shape_mn)
-        num_clc_consumer_threads = self.WARP_SIZE * (1 + cluster_size * (1 + 1 + 4))  # sched(1) + load(1) + mma(1) + epilogue(4) warps
+        num_clc_consumer_threads = self.WARP_SIZE * (
+            1 + cluster_size * (1 + 1 + 4)
+        )
         clc_pipeline = PipelineClcFetchAsync.create(
             barrier_storage=clc_mbar_ptr,
             num_stages=self.num_clc_stage,
@@ -492,7 +508,9 @@ class DenseScoreRecomputeSm100:
         cute.arch.sync_threads()
         pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
 
-        clc_consumer_state = make_pipeline_state(PipelineUserType.Consumer, self.num_clc_stage)
+        clc_consumer_state = make_pipeline_state(
+            PipelineUserType.Consumer, self.num_clc_stage
+        )
         tile_sched = utils.ClcDynamicPersistentTileScheduler.create(
             tile_sched_params,
             cute.arch.block_idx(),
@@ -507,7 +525,9 @@ class DenseScoreRecomputeSm100:
         thr_mma_qk = tiled_mma_qk.get_slice(0)
         qk_acc_shape = thr_mma_qk.partition_shape_C(self.mma_tiler_qk[:2])
         tStS_fake = thr_mma_qk.make_fragment_C(qk_acc_shape)
-        tmem_ptr = cute.make_ptr(Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16)
+        tmem_ptr = cute.make_ptr(
+            Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16
+        )
         tStS_ref = cute.make_tensor(tmem_ptr, tStS_fake.layout)
 
         warp_group_idx = tidx // self.WARPGROUP_SIZE
@@ -527,22 +547,20 @@ class DenseScoreRecomputeSm100:
                 tile_count = Int32(0)
 
                 while work_tile.is_valid_tile:
-                    m_block = work_tile.tile_idx[0]
+                    m_block_sched = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
                     q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
-                        seqlen.seqlen_q * self.qhead_per_kvhead,
-                        self.m_block_size,
+                        seqlen.seqlen_q * self.qhead_per_kvhead, self.m_block_size,
                     )
-                    num_n_blocks_cur = self._causal_num_n_blocks(
-                        m_block,
-                        seqlen.seqlen_k,
-                        q_causal_offset,
-                    )
-                    is_valid_m_block = m_block < num_m_blocks_cur
+                    is_valid_m_block = m_block_sched < num_m_blocks_cur
 
                     if is_valid_m_block:
+                        m_block = num_m_blocks_cur - Int32(1) - m_block_sched
+                        num_n_blocks_compute = self._dense_compute_n_blocks(
+                            m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset,
+                        )
                         # PerHead data load (double-buffered)
                         per_head_buf_off = (tile_count % 2) * self.m_block_size
                         mPerHead_cur = seqlen.offset_batch_Q(mPerHead, batch_idx, dim=2)
@@ -553,9 +571,15 @@ class DenseScoreRecomputeSm100:
                                 m_idx = m_packed_idx // self.qhead_per_kvhead
                                 h_idx = m_packed_idx - m_idx * self.qhead_per_kvhead
                                 if m_idx < seqlen.seqlen_q:
-                                    sPerHead[per_head_buf_off + row] = mPerHead_cur[m_idx, h_idx]
+                                    per_head_value = mPerHead_cur[m_idx, h_idx]
+                                    if cutlass.const_expr(self.score_type == "attention"):
+                                        sPerHead[per_head_buf_off + row] = (
+                                            Float32(per_head_value) * neg_log2_e
+                                        )
+                                    else:
+                                        sPerHead[per_head_buf_off + row] = Float32(per_head_value)
                                 else:
-                                    sPerHead[per_head_buf_off + row] = self.per_head_dtype(0)
+                                    sPerHead[per_head_buf_off + row] = Float32(0.0)
 
                         cute.arch.fence_view_async_shared()
 
@@ -570,20 +594,16 @@ class DenseScoreRecomputeSm100:
                                 (m_block, _kc),
                             )
                             sQ_cur = sQ[None, None, None, _kc]
-                            load_Q_fn, _, _ = copy_ops.tma_get_copy_fn(
-                                tma_atom_Q,
-                                0,
-                                cute.make_layout(1),
-                                gQ,
-                                sQ_cur,
-                                single_stage=True,
+                            load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(
+                                tma_atom_Q, 0, cute.make_layout(1),
+                                gQ, sQ_cur, single_stage=True,
                             )
                             load_Q_fn(tma_bar_ptr=handle_Q.barrier)
 
                         # TMA K load (reverse order, matching MMA direction)
                         K_producer.reset()
                         mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, 0]
-                        n_block_k = num_n_blocks_cur - 1
+                        n_block_k = num_n_blocks_compute - 1
                         while n_block_k >= Int32(0):
                             for _kc in cutlass.range_constexpr(self.num_k_chunks):
                                 handle_K = K_producer.acquire_and_advance()
@@ -593,13 +613,9 @@ class DenseScoreRecomputeSm100:
                                     (n_block_k, _kc),
                                 )
                                 sK_stage = sK[None, None, None, handle_K.index]
-                                load_K_fn, _, _ = copy_ops.tma_get_copy_fn(
-                                    tma_atom_K,
-                                    0,
-                                    cute.make_layout(1),
-                                    gK,
-                                    sK_stage,
-                                    single_stage=True,
+                                load_K_fn, _, _ = copy_utils.tma_get_copy_fn(
+                                    tma_atom_K, 0, cute.make_layout(1),
+                                    gK, sK_stage, single_stage=True,
                                 )
                                 load_K_fn(tma_bar_ptr=handle_K.barrier)
                             n_block_k = n_block_k - 1
@@ -620,26 +636,25 @@ class DenseScoreRecomputeSm100:
                 cute.arch.alloc_tmem(tmem_alloc_cols, tmem_holding_buf)
                 cute.arch.sync_warp()
 
-                s_empty_phase = Int32(1)
-                NUM_SLOTS_MASK = Int32(self.num_tmem_slots - 1)
-                K_mma_state = make_pipeline_state(PipelineUserType.Consumer, self.kv_stage)
+                s_empty_phase_bits = Int32((1 << self.num_tmem_slots) - 1)
+                K_mma_state = make_pipeline_state(
+                    PipelineUserType.Consumer, self.kv_stage
+                )
                 while work_tile.is_valid_tile:
-                    m_block = work_tile.tile_idx[0]
+                    m_block_sched = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
                     q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
-                        seqlen.seqlen_q * self.qhead_per_kvhead,
-                        self.m_block_size,
+                        seqlen.seqlen_q * self.qhead_per_kvhead, self.m_block_size,
                     )
-                    num_n_blocks_cur = self._causal_num_n_blocks(
-                        m_block,
-                        seqlen.seqlen_k,
-                        q_causal_offset,
-                    )
-                    is_valid_m_block = m_block < num_m_blocks_cur
+                    is_valid_m_block = m_block_sched < num_m_blocks_cur
 
                     if is_valid_m_block:
+                        m_block = num_m_blocks_cur - Int32(1) - m_block_sched
+                        num_n_blocks_compute = self._dense_compute_n_blocks(
+                            m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset,
+                        )
                         Q_consumer.reset()
                         handle_Q = Q_consumer.wait_and_advance()
 
@@ -647,10 +662,11 @@ class DenseScoreRecomputeSm100:
                         tSrQ = tiled_mma_qk.make_fragment_B(sQ)
                         qk_mma_op = tiled_mma_qk.op
 
-                        n_block = num_n_blocks_cur - 1
+                        n_block = num_n_blocks_compute - 1
 
                         while n_block >= Int32(0):
-                            slot = n_block & NUM_SLOTS_MASK
+                            slot = n_block % Int32(self.num_tmem_slots)
+                            s_empty_phase = self._phase_for_slot(s_empty_phase_bits, slot)
                             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * slot + 1, s_empty_phase)
 
                             for _kc in cutlass.range_constexpr(self.num_k_chunks):
@@ -661,12 +677,9 @@ class DenseScoreRecomputeSm100:
                                 tSrQ_kc = tSrQ[None, None, None, _kc]
                                 sQ_kc = sQ[None, None, None, _kc]
                                 _gemm_ptx_partial(
-                                    qk_mma_op,
-                                    slot * self.tmem_s_stride,
-                                    tSrKi,
-                                    tSrQ_kc,
-                                    sA=sK_cur,
-                                    sB=sQ_kc,
+                                    qk_mma_op, slot * self.tmem_s_stride,
+                                    tSrKi, tSrQ_kc,
+                                    sA=sK_cur, sB=sQ_kc,
                                     zero_init=const_expr(_kc == 0),
                                 )
 
@@ -676,8 +689,9 @@ class DenseScoreRecomputeSm100:
                             with cute.arch.elect_one():
                                 tcgen05.commit(S_mbar_ptr + 2 * slot)
 
-                            if slot == Int32(0):
-                                s_empty_phase ^= 1
+                            s_empty_phase_bits = self._toggle_phase_for_slot(
+                                s_empty_phase_bits, slot,
+                            )
                             n_block = n_block - 1
 
                         handle_Q.release()
@@ -691,8 +705,7 @@ class DenseScoreRecomputeSm100:
                 cute.arch.relinquish_tmem_alloc_permit()
                 cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
                 tmem_ptr_dealloc = cute.arch.retrieve_tmem_ptr(
-                    Float32,
-                    alignment=16,
+                    Float32, alignment=16,
                     ptr_to_buffer_holding_addr=tmem_holding_buf,
                 )
                 cute.arch.dealloc_tmem(tmem_ptr_dealloc, Int32(self.tmem_alloc_cols))
@@ -701,7 +714,9 @@ class DenseScoreRecomputeSm100:
             # Scheduler warp (warp 2): CLC producer loop
             # -----------------------------------------------------------------
             if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
-                clc_producer_state = make_pipeline_state(PipelineUserType.ProducerConsumer, self.num_clc_stage)
+                clc_producer_state = make_pipeline_state(
+                    PipelineUserType.ProducerConsumer, self.num_clc_stage
+                )
                 while work_tile.is_valid_tile:
                     clc_pipeline.producer_acquire(clc_producer_state)
                     mbarrier_addr = clc_pipeline.producer_get_barrier(clc_producer_state)
@@ -718,69 +733,53 @@ class DenseScoreRecomputeSm100:
         # =====================================================================
         if warp_group_idx == 1:
             cute.arch.setmaxregister_increase(self.num_regs_epilogue)
-            s_full_phase = Int32(0)
+            s_full_phase_bits = Int32(0)
             reduce_phase = Int32(0)
             tile_count = Int32(0)
             while work_tile.is_valid_tile:
-                m_block = work_tile.tile_idx[0]
+                m_block_sched = work_tile.tile_idx[0]
                 batch_idx = work_tile.tile_idx[2]
                 seqlen = SeqlenInfoCls(batch_idx)
                 q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
                 num_m_blocks_cur = cute.ceil_div(
-                    seqlen.seqlen_q * self.qhead_per_kvhead,
-                    self.m_block_size,
+                    seqlen.seqlen_q * self.qhead_per_kvhead, self.m_block_size,
                 )
-                num_n_blocks_cur = self._causal_num_n_blocks(
-                    m_block,
-                    seqlen.seqlen_k,
-                    q_causal_offset,
-                )
-                is_valid_m_block = m_block < num_m_blocks_cur
+                is_valid_m_block = m_block_sched < num_m_blocks_cur
 
                 if is_valid_m_block:
+                    m_block = num_m_blocks_cur - Int32(1) - m_block_sched
+                    num_n_blocks_compute = self._dense_compute_n_blocks(
+                        m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset,
+                    )
                     per_head_offset = (tile_count % 2) * self.m_block_size
                     mOut_cur = seqlen.offset_batch_Q(mOut, batch_idx, dim=2)
                     mDenom_cur = seqlen.offset_batch_Q(mDenom, batch_idx, dim=1)
                     if cutlass.const_expr(self.score_type == "attention"):
-                        s_full_phase, reduce_phase = self._epilogue_attention_dense(
-                            tiled_mma_qk,
-                            tStS_ref,
-                            sPerHead,
-                            sScoreAll,
-                            S_mbar_ptr,
-                            reduce_sync_mbar_ptr,
-                            mOut_cur,
-                            mDenom_cur,
-                            num_n_blocks_cur,
-                            seqlen.seqlen_k,
-                            seqlen.seqlen_q,
+                        s_full_phase_bits, reduce_phase = self._epilogue_attention_dense(
+                            tiled_mma_qk, tStS_ref,
+                            sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+                            mOut_cur, mDenom_cur,
+                            num_n_blocks_compute, seqlen.seqlen_k, seqlen.seqlen_q,
                             max_seqlen_k,
                             q_causal_offset,
                             m_block,
                             tidx,
-                            s_full_phase,
+                            s_full_phase_bits,
                             reduce_phase,
                             softmax_scale,
                             per_head_offset=per_head_offset,
                         )
                     else:
-                        s_full_phase, reduce_phase = self._epilogue_indexer_dense(
-                            tiled_mma_qk,
-                            tStS_ref,
-                            sPerHead,
-                            sScoreAll,
-                            S_mbar_ptr,
-                            reduce_sync_mbar_ptr,
-                            mOut_cur,
-                            mDenom_cur,
-                            num_n_blocks_cur,
-                            seqlen.seqlen_k,
-                            seqlen.seqlen_q,
+                        s_full_phase_bits, reduce_phase = self._epilogue_indexer_dense(
+                            tiled_mma_qk, tStS_ref,
+                            sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+                            mOut_cur, mDenom_cur,
+                            num_n_blocks_compute, seqlen.seqlen_k, seqlen.seqlen_q,
                             max_seqlen_k,
                             q_causal_offset,
                             m_block,
                             tidx,
-                            s_full_phase,
+                            s_full_phase_bits,
                             reduce_phase,
                             softmax_scale,
                             per_head_offset=per_head_offset,
@@ -794,29 +793,36 @@ class DenseScoreRecomputeSm100:
                 with cute.arch.elect_one():
                     cute.arch.mbarrier_arrive(tmem_dealloc_mbar_ptr)
 
-    # =========================================================================
-    # Causal n-block computation
-    # =========================================================================
     @cute.jit
-    def _causal_num_n_blocks(self, m_block, seqlen_k, q_causal_offset):
-        """Return the K n-block count that can contain valid ratio-causal columns."""
-        max_q_plus_1 = (m_block + Int32(1)) * Int32(self.q_tokens_per_tile)
-        max_kv_needed = (q_causal_offset + max_q_plus_1) // Int32(self.ratio)
+    def _dense_compute_n_blocks(self, m_block, seqlen_q, seqlen_k, q_causal_offset):
+        """Return dense K blocks that can contain at least one valid KV column."""
+        ratio = Int32(self.ratio)
+        q_token_base = m_block * self.q_tokens_per_tile
+        q_token_last = q_token_base + Int32(self.q_tokens_per_tile - 1)
+        q_token_last = (
+            q_token_last if q_token_last < seqlen_q else seqlen_q - Int32(1)
+        )
+
+        max_kv_needed = (q_causal_offset + q_token_last + Int32(1)) // ratio
         max_kv_needed = max_kv_needed if max_kv_needed > Int32(0) else Int32(0)
         max_kv_needed = max_kv_needed if max_kv_needed < seqlen_k else seqlen_k
         return cute.ceil_div(max_kv_needed, self.n_block_size)
+
+    @cute.jit
+    def _phase_for_slot(self, phase_bits, slot):
+        return (phase_bits >> slot) & Int32(1)
+
+    @cute.jit
+    def _toggle_phase_for_slot(self, phase_bits, slot):
+        return phase_bits ^ (Int32(1) << slot)
 
     # =========================================================================
     # Cross-warp reduce helpers (epilogue warpgroup)
     # =========================================================================
     @cute.jit
     def _intra_inter_warp_reduce_max(
-        self,
-        sScoreAll,
-        reduce_sync_mbar_ptr,
-        reduce_sync_phase,
-        warp_id_in_wg,
-        local_value,
+        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
+        warp_id_in_wg, local_value,
     ):
         """Reduce local max across 4 warps via smem scratch + mbarrier sync."""
         warp_max = cute.arch.warp_redux_sync(local_value, "fmax")
@@ -836,12 +842,8 @@ class DenseScoreRecomputeSm100:
 
     @cute.jit
     def _intra_inter_warp_reduce_sum(
-        self,
-        sScoreAll,
-        reduce_sync_mbar_ptr,
-        reduce_sync_phase,
-        warp_id_in_wg,
-        local_value,
+        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
+        warp_id_in_wg, local_value,
     ):
         """Reduce local sum across 4 warps via smem scratch + mbarrier sync."""
         warp_sum = cute.arch.warp_reduction_sum(local_value)
@@ -860,12 +862,8 @@ class DenseScoreRecomputeSm100:
 
     @cute.jit
     def _inter_warp_sync_sum(
-        self,
-        sScoreAll,
-        reduce_sync_mbar_ptr,
-        reduce_sync_phase,
-        warp_id_in_wg,
-        warp_sum,
+        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
+        warp_id_in_wg, warp_sum,
     ):
         """Cross-warp sum sync with pre-computed warp-level sum."""
         with cute.arch.elect_one():
@@ -889,20 +887,14 @@ class DenseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        sW,
-        sScoreAll,
-        S_mbar_ptr,
-        reduce_sync_mbar_ptr,
-        mOut,
-        mDenom,
-        num_n_blocks,
-        seqlen_k,
-        seqlen_q,
+        sW, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+        mOut, mDenom,
+        num_n_blocks_compute, seqlen_k, seqlen_q,
         max_seqlen_k,
         q_causal_offset,
         m_block,
         tidx,
-        s_full_phase,
+        s_full_phase_bits,
         reduce_phase,
         softmax_scale,
         per_head_offset=None,
@@ -925,55 +917,63 @@ class DenseScoreRecomputeSm100:
         q_tokens_per_tile = self.q_tokens_per_tile
         ratio = Int32(self.ratio)
 
-        W_ILP = 4
-        sW_f32_ptr = cute.make_ptr(
-            Float32,
-            (sW.iterator + sW_off).llvm_ptr,
-            cute.AddressSpace.smem,
-            assumed_align=16,
+        W_ILP = 8
+        sW_1d = cute.make_tensor(
+            sW.iterator + sW_off,
+            cute.make_layout((self.m_block_size,)),
         )
-        sW_1d_f32 = cute.make_tensor(
-            sW_f32_ptr,
-            cute.make_layout((self.m_block_size // 2,)),
-        )
-        rW_all = cute.make_rmem_tensor((self.m_block_size,), self.per_head_dtype)
-        rW_all_f32 = cute.recast_tensor(rW_all, Float32)
+        rW_all = cute.make_rmem_tensor((self.m_block_size,), Float32)
 
+        kv_offset = Int32(0)
         warp_id_in_wg = tidx_wg // self.WARP_SIZE
 
         log2_e = Float32(math.log2(math.e))
 
         q_token_base = m_block * q_tokens_per_tile
-        NUM_SLOTS_MASK = Int32(self.num_tmem_slots - 1)
-
+        q_token_idxs = [
+            q_token_base + Int32(qi) for qi in range(q_tokens_per_tile)
+        ]
+        col_limits = [
+            (q_causal_offset + q_token_idxs[qi] + Int32(1)) // ratio
+            for qi in range(q_tokens_per_tile)
+        ]
         # Per-q_token online LSE accumulators
         local_max = [-Float32.inf for _ in range(q_tokens_per_tile)]
         local_sum_exp = [Float32(0.0) for _ in range(q_tokens_per_tile)]
+        first_block = Int32(1)
 
-        for iter_idx in cutlass.range(num_n_blocks, unroll=1):
+        n_blk = num_n_blocks_compute - 1
+        while n_blk >= Int32(0):
             tmem_load_atom = cute.make_copy_atom(
-                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tmem_repetition)),
+                tcgen05.copy.Ld32x32bOp(
+                    tcgen05.copy.Repetition(self.tmem_repetition)
+                ),
                 Float32,
             )
-            thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
+            thr_tmem_load = tcgen05.make_tmem_copy(
+                tmem_load_atom, tStS_ref,
+            ).get_slice(tidx_wg)
+
             thr_mma = tiled_mma_qk.get_slice(tidx_wg)
             cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
             tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
-            tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
+
+            tSrS_shape = thr_tmem_load.partition_D(
+                cute.make_identity_tensor(tStS_ref.shape)
+            ).shape
             tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
-            n_blk = num_n_blocks - Int32(1) - iter_idx
-            slot = n_blk & NUM_SLOTS_MASK
+            slot = n_blk % Int32(self.num_tmem_slots)
+            s_full_phase = self._phase_for_slot(s_full_phase_bits, slot)
             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * slot, s_full_phase)
 
-            if iter_idx == Int32(0):
-                cute.autovec_copy(sW_1d_f32, rW_all_f32)
+            if first_block == Int32(1):
+                cute.autovec_copy(sW_1d, rW_all)
+                first_block = Int32(0)
 
             tmem_ptr_cur = cute.make_ptr(
-                Float32,
-                slot * self.tmem_s_stride,
-                mem_space=cute.AddressSpace.tmem,
-                assumed_align=16,
+                Float32, slot * self.tmem_s_stride,
+                mem_space=cute.AddressSpace.tmem, assumed_align=16,
             )
             tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
             tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
@@ -982,51 +982,91 @@ class DenseScoreRecomputeSm100:
             cute.arch.fence_view_async_tmem_load()
 
             cute.arch.mbarrier_arrive(S_mbar_ptr + 2 * slot + 1)
-            if slot == Int32(0):
-                s_full_phase ^= 1
+            s_full_phase_bits = self._toggle_phase_for_slot(
+                s_full_phase_bits, slot,
+            )
 
             kv_offset = tScS[0][0]
             pos = kv_offset + n_blk * self.n_block_size
 
-            # Head reduce per q_token: sum_h ReLU(QK) * W
             for qi in cutlass.range_constexpr(q_tokens_per_tile):
-                local_sum = (Float32(0.0), Float32(0.0))
-                for ho in cutlass.range_constexpr(qhpkv // 2 // W_ILP):
-                    for ci in cutlass.range_constexpr(W_ILP):
-                        idx0 = qi * qhpkv + (ho * W_ILP + ci) * 2
-                        idx1 = idx0 + 1
-                        w_pair = (Float32(rW_all[idx0]), Float32(rW_all[idx1]))
+                q_token_idx = q_token_idxs[qi]
+                col_limit = col_limits[qi]
+                if (
+                    q_token_idx < seqlen_q
+                    and pos < col_limit
+                    and pos < seqlen_k
+                ):
+                    local_sum_0 = (Float32(0.0), Float32(0.0))
+                    local_sum_1 = (Float32(0.0), Float32(0.0))
+                    local_sum_2 = (Float32(0.0), Float32(0.0))
+                    local_sum_3 = (Float32(0.0), Float32(0.0))
+                    for ho in cutlass.range_constexpr(qhpkv // 2 // W_ILP):
+                        for ci in cutlass.range_constexpr(W_ILP):
+                            idx0 = qi * qhpkv + (ho * W_ILP + ci) * 2
+                            idx1 = idx0 + 1
+                            w_pair = (rW_all[idx0], rW_all[idx1])
 
-                        val0 = tSrS[idx0]
-                        val0 = val0 if val0 > Float32(0.0) else Float32(0.0)
-                        val1 = tSrS[idx1]
-                        val1 = val1 if val1 > Float32(0.0) else Float32(0.0)
+                            val0 = tSrS[idx0]
+                            val0 = val0 if val0 > Float32(0.0) else Float32(0.0)
+                            val1 = tSrS[idx1]
+                            val1 = val1 if val1 > Float32(0.0) else Float32(0.0)
 
-                        prod = mul_packed_f32x2((val0, val1), w_pair)
-                        local_sum = add_packed_f32x2(local_sum, prod)
+                            if cutlass.const_expr(ci < W_ILP // 4):
+                                local_sum_0 = fma_packed_f32x2(
+                                    (val0, val1), w_pair, local_sum_0,
+                                )
+                            elif cutlass.const_expr(ci < W_ILP // 2):
+                                local_sum_1 = fma_packed_f32x2(
+                                    (val0, val1), w_pair, local_sum_1,
+                                )
+                            elif cutlass.const_expr(ci < (W_ILP * 3) // 4):
+                                local_sum_2 = fma_packed_f32x2(
+                                    (val0, val1), w_pair, local_sum_2,
+                                )
+                            else:
+                                local_sum_3 = fma_packed_f32x2(
+                                    (val0, val1), w_pair, local_sum_3,
+                                )
 
-                score = (local_sum[0] + local_sum[1]) * Float32(softmax_scale)
+                    local_sum_lo = add_packed_f32x2(local_sum_0, local_sum_1)
+                    local_sum_hi = add_packed_f32x2(local_sum_2, local_sum_3)
+                    local_sum = add_packed_f32x2(local_sum_lo, local_sum_hi)
+                    score = (local_sum[0] + local_sum[1]) * Float32(softmax_scale)
+                    mOut[q_token_idx, pos] = score
+                    new_max = score if score > local_max[qi] else local_max[qi]
+                    local_rescale = cute.math.exp2(
+                        (local_max[qi] - new_max) * log2_e
+                    )
+                    local_sum_exp[qi] = (
+                        local_sum_exp[qi] * local_rescale
+                        + cute.math.exp2(
+                            (score - new_max) * log2_e
+                        )
+                    )
+                    local_max[qi] = new_max
+                elif (
+                    cutlass.const_expr(not self.is_varlen)
+                    and q_token_idx < seqlen_q
+                    and pos < max_seqlen_k
+                ):
+                    mOut[q_token_idx, pos] = -Float32.inf
 
-                # Ratio-causal mask + tail OOB. Masked positions
-                # write 0 to mOut and skip the online LSE update (skipping
-                # avoids -inf-vs-empty edge case when q_token has no valid kv yet).
-                # Two OOB guards on the mOut write:
-                #   q_token_idx >= seqlen_q      — row belongs to a different
-                #     batch (THD) or doesn't exist (BSHD with non-aligned sq).
-                #   pos >= max_seqlen_k          — column past the buffer's K
-                #     extent. mOut is laid out (..., max_seqlen_k); pos can
-                #     reach n_block_size-1 which may exceed the buffer width
-                #     for THD with seqlen_k_b < max_seqlen_k.
-                q_token_idx = q_token_base + qi
-                col_limit = (q_causal_offset + q_token_idx + 1) // ratio
-                if q_token_idx < seqlen_q and pos < max_seqlen_k:
-                    if pos >= col_limit or pos >= seqlen_k:
-                        mOut[q_token_idx, pos] = Float32(0.0)
-                    else:
-                        mOut[q_token_idx, pos] = score
-                        new_max = score if score > local_max[qi] else local_max[qi]
-                        local_sum_exp[qi] = local_sum_exp[qi] * cute.math.exp2((local_max[qi] - new_max) * log2_e) + cute.math.exp2((score - new_max) * log2_e)
-                        local_max[qi] = new_max
+            n_blk = n_blk - 1
+
+        if cutlass.const_expr(not self.is_varlen):
+            # Fill wholly skipped future/tail output blocks with the raw-logit
+            # mask value. The main loop above only visits K blocks that can
+            # contain at least one valid causal column; BSHD keeps this local
+            # fill path, while THD relies on the launch-side prefill.
+            n_blk_zero = cute.ceil_div(max_seqlen_k, self.n_block_size) - Int32(1)
+            while n_blk_zero >= num_n_blocks_compute:
+                pos = kv_offset + n_blk_zero * self.n_block_size
+                for qi in cutlass.range_constexpr(q_tokens_per_tile):
+                    q_token_idx = q_token_base + qi
+                    if q_token_idx < seqlen_q and pos < max_seqlen_k:
+                        mOut[q_token_idx, pos] = -Float32.inf
+                n_blk_zero = n_blk_zero - 1
 
         # Cross-warp reduce for global LSE — sequential per q_token
         sScoreAll_sum = cute.make_tensor(
@@ -1035,33 +1075,103 @@ class DenseScoreRecomputeSm100:
         )
         inv_log2_e = Float32(1.0 / math.log2(math.e))
 
-        for qi in cutlass.range_constexpr(q_tokens_per_tile):
-            global_max, reduce_phase = self._intra_inter_warp_reduce_max(
-                sScoreAll,
-                reduce_sync_mbar_ptr,
-                reduce_phase,
-                warp_id_in_wg,
-                local_max[qi],
-            )
+        if cutlass.const_expr(q_tokens_per_tile == 2):
+            warp_max0 = cute.arch.warp_redux_sync(local_max[0], "fmax")
+            warp_max1 = cute.arch.warp_redux_sync(local_max[1], "fmax")
+            with cute.arch.elect_one():
+                sScoreAll[warp_id_in_wg] = warp_max0
+                sScoreAll_sum[warp_id_in_wg] = warp_max1
+            cute.arch.fence_view_async_shared()
+            cute.arch.mbarrier_arrive(reduce_sync_mbar_ptr)
+            cute.arch.mbarrier_wait(reduce_sync_mbar_ptr, reduce_phase)
+            reduce_phase = reduce_phase ^ 1
 
-            adjusted_sum = local_sum_exp[qi] * cute.math.exp2((local_max[qi] - global_max) * log2_e)
+            global_max0 = sScoreAll[0]
+            global_max1 = sScoreAll_sum[0]
+            for wi in cutlass.range_constexpr(self.num_warps_in_epi_wg - 1):
+                v0 = sScoreAll[wi + 1]
+                v1 = sScoreAll_sum[wi + 1]
+                global_max0 = v0 if v0 > global_max0 else global_max0
+                global_max1 = v1 if v1 > global_max1 else global_max1
 
-            global_sum_exp, reduce_phase = self._intra_inter_warp_reduce_sum(
-                sScoreAll_sum,
-                reduce_sync_mbar_ptr,
-                reduce_phase,
-                warp_id_in_wg,
-                adjusted_sum,
-            )
+            cute.arch.mbarrier_arrive(reduce_sync_mbar_ptr)
+            cute.arch.mbarrier_wait(reduce_sync_mbar_ptr, reduce_phase)
+            reduce_phase = reduce_phase ^ 1
 
-            lse_val = global_max + cute.math.log2(global_sum_exp) * inv_log2_e
+            adjusted_sum0 = Float32(0.0)
+            adjusted_sum1 = Float32(0.0)
+            if global_max0 > Float32(-1e30):
+                rescale0 = cute.math.exp2(
+                    (local_max[0] - global_max0) * log2_e
+                )
+                adjusted_sum0 = local_sum_exp[0] * rescale0
+            if global_max1 > Float32(-1e30):
+                rescale1 = cute.math.exp2(
+                    (local_max[1] - global_max1) * log2_e
+                )
+                adjusted_sum1 = local_sum_exp[1] * rescale1
 
-            q_token_idx = q_token_base + qi
-            if q_token_idx < seqlen_q:
+            warp_sum0 = cute.arch.warp_reduction_sum(adjusted_sum0)
+            warp_sum1 = cute.arch.warp_reduction_sum(adjusted_sum1)
+            with cute.arch.elect_one():
+                sScoreAll[warp_id_in_wg] = warp_sum0
+                sScoreAll_sum[warp_id_in_wg] = warp_sum1
+            cute.arch.fence_view_async_shared()
+            cute.arch.mbarrier_arrive(reduce_sync_mbar_ptr)
+            cute.arch.mbarrier_wait(reduce_sync_mbar_ptr, reduce_phase)
+            reduce_phase = reduce_phase ^ 1
+
+            global_sum_exp0 = sScoreAll[0]
+            global_sum_exp1 = sScoreAll_sum[0]
+            for wi in cutlass.range_constexpr(self.num_warps_in_epi_wg - 1):
+                global_sum_exp0 = global_sum_exp0 + sScoreAll[wi + 1]
+                global_sum_exp1 = global_sum_exp1 + sScoreAll_sum[wi + 1]
+
+            lse_val0 = -Float32.inf
+            lse_val1 = -Float32.inf
+            if global_max0 > Float32(-1e30):
+                lse_val0 = global_max0 + cute.math.log2(global_sum_exp0) * inv_log2_e
+            if global_max1 > Float32(-1e30):
+                lse_val1 = global_max1 + cute.math.log2(global_sum_exp1) * inv_log2_e
+
+            if q_token_base < seqlen_q:
                 with cute.arch.elect_one():
-                    mDenom[q_token_idx] = lse_val
+                    mDenom[q_token_base] = lse_val0
+            q_token_idx1 = q_token_base + Int32(1)
+            if q_token_idx1 < seqlen_q:
+                with cute.arch.elect_one():
+                    mDenom[q_token_idx1] = lse_val1
+        else:
+            for qi in cutlass.range_constexpr(q_tokens_per_tile):
+                global_max, reduce_phase = self._intra_inter_warp_reduce_max(
+                    sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
+                    warp_id_in_wg, local_max[qi],
+                )
 
-        return s_full_phase, reduce_phase
+                lse_val = -Float32.inf
+                if global_max > Float32(-1e30):
+                    global_rescale = cute.math.exp2(
+                        (local_max[qi] - global_max) * log2_e
+                    )
+                    adjusted_sum = local_sum_exp[qi] * global_rescale
+
+                    global_sum_exp, reduce_phase = self._intra_inter_warp_reduce_sum(
+                        sScoreAll_sum, reduce_sync_mbar_ptr, reduce_phase,
+                        warp_id_in_wg, adjusted_sum,
+                    )
+
+                    lse_val = global_max + cute.math.log2(global_sum_exp) * inv_log2_e
+                else:
+                    cute.arch.mbarrier_arrive(reduce_sync_mbar_ptr)
+                    cute.arch.mbarrier_wait(reduce_sync_mbar_ptr, reduce_phase)
+                    reduce_phase = reduce_phase ^ 1
+
+                q_token_idx = q_token_base + qi
+                if q_token_idx < seqlen_q:
+                    with cute.arch.elect_one():
+                        mDenom[q_token_idx] = lse_val
+
+        return s_full_phase_bits, reduce_phase
 
     # =========================================================================
     # Epilogue: dense attention — exp(QK*scale - LSE), head reduce, write + L1 denom
@@ -1071,20 +1181,14 @@ class DenseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        sLSE,
-        sScoreAll,
-        S_mbar_ptr,
-        reduce_sync_mbar_ptr,
-        mOut,
-        mDenom,
-        num_n_blocks,
-        seqlen_k,
-        seqlen_q,
+        sLSE, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+        mOut, mDenom,
+        num_n_blocks_compute, seqlen_k, seqlen_q,
         max_seqlen_k,
         q_causal_offset,
         m_block,
         tidx,
-        s_full_phase,
+        s_full_phase_bits,
         reduce_phase,
         softmax_scale,
         per_head_offset=None,
@@ -1116,41 +1220,50 @@ class DenseScoreRecomputeSm100:
         )
         rLSE_all = cute.make_rmem_tensor((self.m_block_size,), Float32)
 
+        kv_offset = Int32(0)
         warp_id_in_wg = tidx_wg // self.WARP_SIZE
 
         log2_e = Float32(math.log2(math.e))
         scale_log2_e = Float32(softmax_scale) * log2_e
 
         q_token_base = m_block * q_tokens_per_tile
-        NUM_SLOTS_MASK = Int32(self.num_tmem_slots - 1)
+        # Per-thread L1-norm denom accumulators. Reduce once at tile end
+        # instead of doing a warp reduction for every K block.
+        local_sum_acc = [Float32(0.0) for _ in range(q_tokens_per_tile)]
+        first_block = Int32(1)
 
-        # Per-q_token L1-norm denom accumulators
-        warp_sum_acc = [Float32(0.0) for _ in range(q_tokens_per_tile)]
-
-        for iter_idx in cutlass.range(num_n_blocks, unroll=1):
+        n_blk = num_n_blocks_compute - 1
+        while n_blk >= Int32(0):
             tmem_load_atom = cute.make_copy_atom(
-                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(self.tmem_repetition)),
+                tcgen05.copy.Ld32x32bOp(
+                    tcgen05.copy.Repetition(self.tmem_repetition)
+                ),
                 Float32,
             )
-            thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
+            thr_tmem_load = tcgen05.make_tmem_copy(
+                tmem_load_atom, tStS_ref,
+            ).get_slice(tidx_wg)
+
             thr_mma = tiled_mma_qk.get_slice(tidx_wg)
             cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
             tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
-            tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
+
+            tSrS_shape = thr_tmem_load.partition_D(
+                cute.make_identity_tensor(tStS_ref.shape)
+            ).shape
             tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
-            n_blk = num_n_blocks - Int32(1) - iter_idx
-            slot = n_blk & NUM_SLOTS_MASK
+            slot = n_blk % Int32(self.num_tmem_slots)
+            s_full_phase = self._phase_for_slot(s_full_phase_bits, slot)
             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * slot, s_full_phase)
 
-            if iter_idx == Int32(0):
+            if first_block == Int32(1):
                 cute.autovec_copy(sLSE_1d, rLSE_all)
+                first_block = Int32(0)
 
             tmem_ptr_cur = cute.make_ptr(
-                Float32,
-                slot * self.tmem_s_stride,
-                mem_space=cute.AddressSpace.tmem,
-                assumed_align=16,
+                Float32, slot * self.tmem_s_stride,
+                mem_space=cute.AddressSpace.tmem, assumed_align=16,
             )
             tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
             tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
@@ -1159,13 +1272,15 @@ class DenseScoreRecomputeSm100:
             cute.arch.fence_view_async_tmem_load()
 
             cute.arch.mbarrier_arrive(S_mbar_ptr + 2 * slot + 1)
-            if slot == Int32(0):
-                s_full_phase ^= 1
+            s_full_phase_bits = self._toggle_phase_for_slot(
+                s_full_phase_bits, slot,
+            )
 
             kv_offset = tScS[0][0]
             pos = kv_offset + n_blk * self.n_block_size
 
-            # Head reduce per q_token: sum_h exp2(QK*scale_log2e + scaled_lse)
+            # Head reduce per q_token. rLSE_all already holds
+            # -log2(e) * LSE, loaded by the producer warp.
             for qi in cutlass.range_constexpr(q_tokens_per_tile):
                 local_sum = (Float32(0.0), Float32(0.0))
                 for ho in cutlass.range_constexpr(qhpkv // 2 // LSE_ILP):
@@ -1177,56 +1292,100 @@ class DenseScoreRecomputeSm100:
                         val0 = tSrS[idx0]
                         val1 = tSrS[idx1]
 
-                        val0, val1 = fma_packed_f32x2(
+                        (val0, val1) = fma_packed_f32x2(
                             (val0, val1),
                             (scale_log2_e, scale_log2_e),
                             lse_pair,
                         )
-                        val0 = cute.math.exp2(val0)
-                        val1 = cute.math.exp2(val1)
+                        if cutlass.const_expr(qhpkv == 64):
+                            val0 = cute.math.exp2(val0, fastmath=True)
+                            val1 = cute.math.exp2(val1, fastmath=True)
+                        else:
+                            val0 = val0 if val0 > Float32(-126.0) else Float32(-126.0)
+                            val1 = val1 if val1 > Float32(-126.0) else Float32(-126.0)
+                            val0 = cute.math.exp2(val0, fastmath=True)
+                            val1 = cute.math.exp2(val1, fastmath=True)
 
                         local_sum = add_packed_f32x2(local_sum, (val0, val1))
 
                 score = local_sum[0] + local_sum[1]
 
-                # Ratio-causal mask + tail OOB. Masked positions
-                # write 0 to mOut (P = exp(QK*scale - LSE) is naturally 0 at
-                # masked) so the warp_reduction_sum (collective; must be invoked
-                # by every lane) naturally excludes them from L1 denom.
-                # Two OOB guards on the mOut write — see indexer epilogue for
-                # rationale (q row belonging to other batch, pos past buffer K
-                # extent under THD).
+                # Ratio causal mask + tail OOB. Keep the accumulation value at
+                # zero for invalid positions, but expose -inf in the score output.
                 q_token_idx = q_token_base + qi
                 col_limit = (q_causal_offset + q_token_idx + 1) // ratio
+                score_out = score
                 if pos >= col_limit or pos >= seqlen_k or q_token_idx >= seqlen_q:
                     score = Float32(0.0)
+                    score_out = -Float32.inf
 
                 if q_token_idx < seqlen_q and pos < max_seqlen_k:
-                    mOut[q_token_idx, pos] = score
+                    mOut[q_token_idx, pos] = score_out
 
-                warp_sum_acc[qi] = warp_sum_acc[qi] + cute.arch.warp_reduction_sum(score)
+                local_sum_acc[qi] = local_sum_acc[qi] + score
 
-        # Cross-warp reduce for global L1 denom — sequential per q_token.
-        # Each qi uses a separate sScoreAll region to avoid a write-read race:
-        # qi=0's barrier-wait lets threads proceed to read sScoreAll, but
-        # without separate regions qi=1's write could overwrite before a slow
-        # warp finishes reading qi=0's values.
-        for qi in cutlass.range_constexpr(q_tokens_per_tile):
-            sScoreAll_qi = cute.make_tensor(
-                sScoreAll.iterator + qi * self.num_warps_in_epi_wg,
-                cute.make_layout((self.num_warps_in_epi_wg,), stride=(1,)),
-            )
-            global_sum, reduce_phase = self._inter_warp_sync_sum(
-                sScoreAll_qi,
-                reduce_sync_mbar_ptr,
-                reduce_phase,
-                warp_id_in_wg,
-                warp_sum_acc[qi],
-            )
+            n_blk = n_blk - 1
 
-            q_token_idx = q_token_base + qi
-            if q_token_idx < seqlen_q:
+        # Fill wholly skipped future/tail output blocks with the score default.
+        # The main
+        # loop only visits K blocks that can contain valid causal columns; keep
+        # this local to skipped blocks instead of doing a full host-side
+        # memset before launch.
+        n_blk_zero = cute.ceil_div(max_seqlen_k, self.n_block_size) - Int32(1)
+        if cutlass.const_expr(q_tokens_per_tile == 1):
+            while n_blk_zero >= num_n_blocks_compute:
+                pos = kv_offset + n_blk_zero * self.n_block_size
+                if q_token_base < seqlen_q and pos < max_seqlen_k:
+                    mOut[q_token_base, pos] = -Float32.inf
+                n_blk_zero = n_blk_zero - 1
+        else:
+            while n_blk_zero >= num_n_blocks_compute:
+                pos = kv_offset + n_blk_zero * self.n_block_size
+                for qi in cutlass.range_constexpr(q_tokens_per_tile):
+                    q_token_idx = q_token_base + qi
+                    if q_token_idx < seqlen_q and pos < max_seqlen_k:
+                        mOut[q_token_idx, pos] = -Float32.inf
+                n_blk_zero = n_blk_zero - 1
+
+        # Cross-warp reduce for global L1 denom. The 2q path writes both
+        # per-warp partials before one barrier and then reduces both q tokens,
+        # avoiding the second mbarrier round-trip in the flash configuration.
+        if cutlass.const_expr(q_tokens_per_tile == 2):
+            warp_sum0 = cute.arch.warp_reduction_sum(local_sum_acc[0])
+            warp_sum1 = cute.arch.warp_reduction_sum(local_sum_acc[1])
+            with cute.arch.elect_one():
+                sScoreAll[warp_id_in_wg] = warp_sum0
+                sScoreAll[warp_id_in_wg + self.num_warps_in_epi_wg] = warp_sum1
+            cute.arch.fence_view_async_shared()
+            cute.arch.mbarrier_arrive(reduce_sync_mbar_ptr)
+            cute.arch.mbarrier_wait(reduce_sync_mbar_ptr, reduce_phase)
+            reduce_phase = reduce_phase ^ 1
+
+            global_sum0 = sScoreAll[0]
+            global_sum1 = sScoreAll[self.num_warps_in_epi_wg]
+            for wi in cutlass.range_constexpr(self.num_warps_in_epi_wg - 1):
+                global_sum0 = global_sum0 + sScoreAll[wi + 1]
+                global_sum1 = (
+                    global_sum1
+                    + sScoreAll[self.num_warps_in_epi_wg + wi + 1]
+                )
+
+            if q_token_base < seqlen_q:
                 with cute.arch.elect_one():
-                    mDenom[q_token_idx] = global_sum
+                    mDenom[q_token_base] = global_sum0
+            q_token_idx1 = q_token_base + Int32(1)
+            if q_token_idx1 < seqlen_q:
+                with cute.arch.elect_one():
+                    mDenom[q_token_idx1] = global_sum1
+        else:
+            warp_sum = cute.arch.warp_reduction_sum(local_sum_acc[0])
+            global_sum, reduce_phase = self._inter_warp_sync_sum(
+                sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
+                warp_id_in_wg, warp_sum,
+            )
 
-        return s_full_phase, reduce_phase
+            if q_token_base < seqlen_q:
+                with cute.arch.elect_one():
+                    mDenom[q_token_base] = global_sum
+
+        return s_full_phase_bits, reduce_phase

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm90.py
@@ -209,6 +209,7 @@ class DenseScoreRecomputeSm90:
         weights_or_lse: cute.Tensor = None,  # (batch, nheads, seqlen_q) Note: weights is half precision
         mTopkLength: cute.Tensor = None,  # (batch, seqlen_q) int32, per-q valid KV count
         mL1NormDenom: cute.Tensor = None,  # (batch, seqlen_q) float32, dense attn L1 norm denominator
+        mQCausalOffsets: cute.Tensor = None,
     ):
         self._check_type(mQ.element_type, mKV.element_type, weights_or_lse.element_type)
 
@@ -332,6 +333,7 @@ class DenseScoreRecomputeSm90:
             qhead_per_kvhead_divmod,
             mL1NormDenom,
             tma_atom_KV,
+            mQCausalOffsets,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -358,6 +360,7 @@ class DenseScoreRecomputeSm90:
         qhead_per_kvhead_divmod: FastDivmodDivisor = None,
         mL1NormDenom: cute.Tensor = None,
         tma_atom_KV: cute.CopyAtom = None,
+        mQCausalOffsets: cute.Tensor = None,
     ):
         # Dense path: no topk length (always full KV iteration).
         mTopkLength = None
@@ -435,6 +438,7 @@ class DenseScoreRecomputeSm90:
                 TileSchedulerCls,
                 softmax_scale_log2,
                 mL1NormDenom,
+                mQCausalOffsets,
             )
         elif warp_group_idx == 1:
             self.consumer(
@@ -454,6 +458,7 @@ class DenseScoreRecomputeSm90:
                 TileSchedulerCls,
                 softmax_scale_log2,
                 mL1NormDenom,
+                mQCausalOffsets,
             )
         else:
             producer_fn = self.producer_warp_split if const_expr(self.use_warp_split_producer) else self.producer
@@ -476,6 +481,7 @@ class DenseScoreRecomputeSm90:
                 tidx,
                 SeqlenInfoCls,
                 TileSchedulerCls,
+                mQCausalOffsets,
             )
 
     # --------------------------------------------------------------------- #
@@ -507,6 +513,7 @@ class DenseScoreRecomputeSm90:
         tidx: Int32,
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
+        mQCausalOffsets: cute.Tensor,
     ):
         wg_tidx = tidx % self.num_threads_per_warp_group
         warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
@@ -520,9 +527,10 @@ class DenseScoreRecomputeSm90:
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, _ = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+            q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
             head_idx_kv = head_idx
             topK = seqlen.seqlen_k
-            n_block_max = self._dense_compute_n_blocks(m_block, seqlen.seqlen_q, topK)
+            n_block_max = self._dense_compute_n_blocks(m_block, seqlen.seqlen_q, topK, q_causal_offset)
 
             mKV_cur = mKV[None, None, head_idx_kv, batch_idx]
             mQ_cur = mQ[None, None, head_idx, batch_idx]
@@ -691,6 +699,7 @@ class DenseScoreRecomputeSm90:
         tidx: Int32,
         SeqlenInfoCls: Callable,
         TileSchedulerCls: Callable,
+        mQCausalOffsets: cute.Tensor,
     ):
         wg_tidx = tidx % self.num_threads_per_warp_group
         warp_idx_in_wg = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
@@ -704,9 +713,10 @@ class DenseScoreRecomputeSm90:
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, _ = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+            q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
             head_idx_kv = head_idx
             topK = seqlen.seqlen_k
-            n_block_max = self._dense_compute_n_blocks(m_block, seqlen.seqlen_q, topK)
+            n_block_max = self._dense_compute_n_blocks(m_block, seqlen.seqlen_q, topK, q_causal_offset)
 
             mKV_cur = mKV[None, None, head_idx_kv, batch_idx]
             mQ_cur = mQ[None, None, head_idx, batch_idx]
@@ -917,6 +927,7 @@ class DenseScoreRecomputeSm90:
         TileSchedulerCls: Callable,
         softmax_scale_log2: Float32,
         mL1NormDenom: cute.Tensor,
+        mQCausalOffsets: cute.Tensor,
     ):
         wg_tidx = tidx % self.num_threads_per_warp_group
         lane = cute.arch.lane_idx()
@@ -970,8 +981,9 @@ class DenseScoreRecomputeSm90:
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, _ = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
+            q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
             topK = seqlen.seqlen_k
-            n_block_max = self._dense_compute_n_blocks(m_block, seqlen.seqlen_q, topK)
+            n_block_max = self._dense_compute_n_blocks(m_block, seqlen.seqlen_q, topK, q_causal_offset)
 
             mOut_cur = mOut[batch_idx, m_block, None]
 
@@ -1078,6 +1090,7 @@ class DenseScoreRecomputeSm90:
                         m_block,
                         batch_idx,
                         n_block,
+                        q_causal_offset,
                         tidx,
                         accumulate=accumulate,
                         mOut_cur=mOut_cur,
@@ -1223,6 +1236,7 @@ class DenseScoreRecomputeSm90:
         m_block: Int32,
         batch_idx: Int32,
         n_block: Int32,
+        q_causal_offset: Int32,
         tidx: Int32,
         accumulate: Boolean = Boolean(False),  # True when accumulating across head tiles
         mOut_cur: cute.Tensor = None,  # dense: direct write target
@@ -1249,9 +1263,9 @@ class DenseScoreRecomputeSm90:
         acc_S_mn = sm90_ops.make_acc_tensor_mn_view(acc_S)
         warp_col_sum = Float32(0.0)
         ratio = Int32(self.ratio)
-        q_global_start = topK * ratio - Int32(seqlen_q)
-        col_limit_raw = (q_global_start + m_block + Int32(1)) // ratio
+        col_limit_raw = (q_causal_offset + m_block + Int32(1)) // ratio
         col_limit = col_limit_raw if col_limit_raw < topK else topK
+        col_limit = col_limit if col_limit > Int32(0) else Int32(0)
 
         if const_expr(self.is_dense_attn):
             # === Dense attention path ===
@@ -1469,13 +1483,12 @@ class DenseScoreRecomputeSm90:
             load_fn(tma_bar_ptr=mbar_KV_ptr)
 
     @cute.jit
-    def _dense_compute_n_blocks(self, q_token_last, seqlen_q, seqlen_k):
+    def _dense_compute_n_blocks(self, q_token_last, seqlen_q, seqlen_k, q_causal_offset):
         """Return K blocks that can contain at least one valid causal column."""
         ratio = Int32(self.ratio)
         q_token_last = q_token_last if q_token_last < seqlen_q else seqlen_q - Int32(1)
 
-        q_global_start = seqlen_k * ratio - seqlen_q
-        max_kv_needed = (q_global_start + q_token_last + Int32(1)) // ratio
+        max_kv_needed = (q_causal_offset + q_token_last + Int32(1)) // ratio
         max_kv_needed = max_kv_needed if max_kv_needed > Int32(0) else Int32(0)
         max_kv_needed = max_kv_needed if max_kv_needed < seqlen_k else seqlen_k
         return cute.ceil_div(max_kv_needed, self.tile_n)

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/sparse_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/sparse_score_recompute_sm100.py
@@ -1,5 +1,5 @@
 """
-Sparse Score Recompute Kernel — SM100 Cute-DSL Implementation.
+Sparse Backward Score Kernel — SM100 Cute-DSL Implementation.
 
 Dual-mode kernel controlled by score_type ("indexer" or "attention"):
 
@@ -50,11 +50,11 @@ from cutlass.utils.blackwell_helpers import (
 )
 
 from cudnn.deepseek_sparse_attention.utils.sm100.gemm import gemm_ptx_partial as _gemm_ptx_partial
-from cudnn.deepseek_sparse_attention.utils import copy as copy_ops
+from cudnn.deepseek_sparse_attention.utils import copy as copy_utils
 
-mul_packed_f32x2 = partial(cute.arch.mul_packed_f32x2, rnd="rn")
-add_packed_f32x2 = partial(cute.arch.add_packed_f32x2, rnd="rn")
-fma_packed_f32x2 = partial(cute.arch.fma_packed_f32x2, rnd="rn")
+mul_packed_f32x2 = partial(cute.arch.mul_packed_f32x2, rnd='rn')
+add_packed_f32x2 = partial(cute.arch.add_packed_f32x2, rnd='rn')
+fma_packed_f32x2 = partial(cute.arch.fma_packed_f32x2, rnd='rn')
 
 
 class SparseScoreRecomputeSm100:
@@ -109,16 +109,21 @@ class SparseScoreRecomputeSm100:
         self.sched_warp_id = 2
         self.num_clc_stage = 1
         self.num_clc_response_bytes = 16
-        assert topk % n_block_size == 0, f"topk ({topk}) must be a multiple of n_block_size ({n_block_size})"
+        assert topk % n_block_size == 0, (
+            f"topk ({topk}) must be a multiple of n_block_size ({n_block_size})"
+        )
         self.num_n_blocks = topk // n_block_size
         self.have_topk_length = have_topk_length
         self.topk_in_smem = topk_in_smem
 
         # Pad head_dim to multiple of 16
         hdim_multiple_of = 16
-        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
+        self.head_dim_padded = int(
+            math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of
+        )
         assert self.head_dim_padded % 64 == 0, (
-            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of 64 " f"(K loading uses 8 threads × 8 elements = 64 per iteration)"
+            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of 64 "
+            f"(K loading uses 8 threads × 8 elements = 64 per iteration)"
         )
 
         # K-dimension splitting: process head_dim in num_k_chunks chunks of
@@ -126,10 +131,12 @@ class SparseScoreRecomputeSm100:
         # kv_stages for better K load / MMA overlap.
         self.k_block_size = k_block_size if k_block_size is not None else self.head_dim_padded
         assert self.head_dim_padded % self.k_block_size == 0, (
-            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of " f"k_block_size ({self.k_block_size})"
+            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of "
+            f"k_block_size ({self.k_block_size})"
         )
         assert self.k_block_size % 64 == 0, (
-            f"k_block_size ({self.k_block_size}) must be a multiple of 64 " f"(K loading uses 8 threads × 8 elements = 64 per iteration)"
+            f"k_block_size ({self.k_block_size}) must be a multiple of 64 "
+            f"(K loading uses 8 threads × 8 elements = 64 per iteration)"
         )
         self.num_k_chunks = self.head_dim_padded // self.k_block_size
 
@@ -204,12 +211,12 @@ class SparseScoreRecomputeSm100:
     @cute.jit
     def __call__(
         self,
-        mQ: cute.Tensor,  # (bs, seqlen_q, n_heads_q, head_dim) BF16
-        mK: cute.Tensor,  # (bs, seqlen_k, head_dim) BF16
-        mPerHead: cute.Tensor,  # (bs, seqlen_q, n_heads_q) — W (BF16) or scaled_LSE (FP32)
-        mTopkIdx: cute.Tensor,  # (bs, seqlen_q, topk) INT32
-        mOut: cute.Tensor,  # (bs, seqlen_q, topk) FP32
-        mTopkLength: cute.Tensor,  # (bs, seqlen_q) INT32 (dummy when unused)
+        mQ: cute.Tensor,          # (bs, seqlen_q, n_heads_q, head_dim) BF16
+        mK: cute.Tensor,          # (bs, seqlen_k, head_dim) BF16
+        mPerHead: cute.Tensor,    # (bs, seqlen_q, n_heads_q) — W (BF16) or LSE (FP32)
+        mTopkIdx: cute.Tensor,    # (bs, seqlen_q, topk) INT32
+        mOut: cute.Tensor,        # (bs, seqlen_q, topk) FP32
+        mTopkLength: cute.Tensor, # (bs, seqlen_q) INT32 (dummy when unused)
         softmax_scale: Float32 | float,
         stream: cuda.CUstream,
     ):
@@ -229,17 +236,19 @@ class SparseScoreRecomputeSm100:
         # --- PackGQA: reshape Q to pack qhpkv heads into seqlen_q dim ---
         shape_Q_packed = (
             (self.qhead_per_kvhead, mQ.shape[0]),  # packed M dim
-            mQ.shape[1],  # head_dim
-            1,  # n_heads_kv
-            *mQ.shape[3:],  # bs (and beyond)
+            mQ.shape[1],                           # head_dim
+            1,                                     # n_heads_kv
+            *mQ.shape[3:],                         # bs (and beyond)
         )
         stride_Q_packed = (
-            (mQ.stride[2], mQ.stride[0]),  # (stride_head, stride_seqlen)
-            mQ.stride[1],  # stride_hdim
+            (mQ.stride[2], mQ.stride[0]),          # (stride_head, stride_seqlen)
+            mQ.stride[1],                          # stride_hdim
             mQ.stride[2] * self.qhead_per_kvhead,  # stride across kv_head groups
-            *mQ.stride[3:],  # stride_bs
+            *mQ.stride[3:],                        # stride_bs
         )
-        mQ = cute.make_tensor(mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed))
+        mQ = cute.make_tensor(
+            mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed)
+        )
 
         # --- K layout: (bs, seqlen_k, head_dim) -> (seqlen_k, head_dim, bs) ---
         mK = cute.make_tensor(mK.iterator, cute.select(mK.layout, mode=[1, 2, 0]))
@@ -264,16 +273,10 @@ class SparseScoreRecomputeSm100:
 
         # --- SMEM layouts --- (K is A operand in swapAB; loaded via cp.async, not TMA)
         sK_layout = _make_smem_layout_a(
-            tiled_mma_qk,
-            self.mma_tiler_qk,
-            self.k_dtype,
-            self.kv_stage,
+            tiled_mma_qk, self.mma_tiler_qk, self.k_dtype, self.kv_stage,
         )
         sQ_layout = _make_smem_layout_b(
-            tiled_mma_qk,
-            self.mma_tiler_qk,
-            self.q_dtype,
-            self.num_k_chunks,
+            tiled_mma_qk, self.mma_tiler_qk, self.q_dtype, self.num_k_chunks,
         )
 
         # TMA atom for Q only (K is sparse-loaded, no TMA)
@@ -305,21 +308,22 @@ class SparseScoreRecomputeSm100:
         # --- Grid and kernel dispatch (CLC persistent scheduling) ---
         seqlen_q_packed = cute.size(mQ.shape[0])
         num_m_blocks = cute.ceil_div(seqlen_q_packed, self.m_block_size)
-        batch_size = cute.size(mQ.shape[3]) if cute.rank(mQ.shape) > 3 else 1
-        tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams((num_m_blocks, 1, batch_size), (*self.cluster_shape_mn, 1))
-        grid_dim = utils.ClcDynamicPersistentTileScheduler.get_grid_shape(tile_sched_params)
+        batch_size = (
+            cute.size(mQ.shape[3]) if cute.rank(mQ.shape) > 3 else 1
+        )
+        tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams(
+            (num_m_blocks, 1, batch_size), (*self.cluster_shape_mn, 1)
+        )
+        grid_dim = utils.ClcDynamicPersistentTileScheduler.get_grid_shape(
+            tile_sched_params
+        )
         self.kernel(
-            mQ,
-            mK,
-            mPerHead,
-            mTopkIdx,
-            mOut,
+            mQ, mK, mPerHead, mTopkIdx, mOut,
             mTopkLength,
             softmax_scale,
             tma_atom_Q,
             tiled_mma_qk,
-            sQ_layout,
-            sK_layout,
+            sQ_layout, sK_layout,
             tile_sched_params,
         ).launch(
             grid=grid_dim,
@@ -334,17 +338,12 @@ class SparseScoreRecomputeSm100:
     @cute.kernel
     def kernel(
         self,
-        mQ,
-        mK,
-        mPerHead,
-        mTopkIdx,
-        mOut,
+        mQ, mK, mPerHead, mTopkIdx, mOut,
         mTopkLength,
         softmax_scale: Float32 | float,
         tma_atom_Q,
         tiled_mma_qk,
-        sQ_layout,
-        sK_layout,
+        sQ_layout, sK_layout,
         tile_sched_params: utils.ClcDynamicPersistentTileSchedulerParams,
     ):
         """Device-side kernel entry with CLC persistent scheduling."""
@@ -352,6 +351,7 @@ class SparseScoreRecomputeSm100:
         seqlen_k = cute.size(mK.shape[0])
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         tidx = cute.arch.thread_idx()[0]
+        neg_log2_e = Float32(-math.log2(math.e))
 
         # --- TMA descriptor prefetch ---
         if warp_idx == 0:
@@ -362,7 +362,7 @@ class SparseScoreRecomputeSm100:
         # =====================================================================
         sQ_size = cute.cosize(sQ_layout)
         sK_size = cute.cosize(sK_layout)
-        sPerHead_size = self.m_block_size * 2  # double-buffer for LOAD/EPI overlap
+        sPerHead_size = self.m_block_size * 2      # double-buffer for LOAD/EPI overlap
         sTopkIdx_size = self.topk * 2 if self.topk_in_smem else 1
 
         @cute.struct
@@ -411,9 +411,15 @@ class SparseScoreRecomputeSm100:
         clc_response_ptr = storage.clc_response.data_ptr()
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
         sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
-        sPerHead = storage.sPerHead.get_tensor(cute.make_layout((self.m_block_size,), stride=(1,)))
-        sTopkIdx = storage.sTopkIdx.get_tensor(cute.make_layout((self.topk if self.topk_in_smem else 1,), stride=(1,)))
-        sScoreAll = storage.sScoreAll.get_tensor(cute.make_layout((self.sScoreAll_size,), stride=(1,)))
+        sPerHead = storage.sPerHead.get_tensor(
+            cute.make_layout((self.m_block_size,), stride=(1,))
+        )
+        sTopkIdx = storage.sTopkIdx.get_tensor(
+            cute.make_layout((self.topk if self.topk_in_smem else 1,), stride=(1,))
+        )
+        sScoreAll = storage.sScoreAll.get_tensor(
+            cute.make_layout((self.sScoreAll_size,), stride=(1,))
+        )
 
         # =====================================================================
         # Pipeline setup
@@ -422,7 +428,9 @@ class SparseScoreRecomputeSm100:
             cute.make_layout(self.cluster_shape_mnk),
             (tiled_mma_qk.thr_id.shape,),
         )
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
         is_first_cta_in_cluster = cta_rank_in_cluster == 0
 
         # Q pipeline (1 stage: all k_chunks share one barrier with combined tx_count)
@@ -456,7 +464,9 @@ class SparseScoreRecomputeSm100:
 
         # CLC persistent scheduling pipeline
         cluster_size = cute.size(self.cluster_shape_mn)
-        num_clc_consumer_threads = self.WARP_SIZE * (1 + cluster_size * (1 + 1 + 8))  # sched(1) + load(1) + mma(1) + epilogue+Kload(8) warps
+        num_clc_consumer_threads = self.WARP_SIZE * (
+            1 + cluster_size * (1 + 1 + 8)
+        )  # sched(1) + load(1) + mma(1) + epilogue+Kload(8) warps
         clc_pipeline = PipelineClcFetchAsync.create(
             barrier_storage=clc_mbar_ptr,
             num_stages=self.num_clc_stage,
@@ -471,7 +481,9 @@ class SparseScoreRecomputeSm100:
         cute.arch.sync_threads()
         pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
 
-        clc_consumer_state = make_pipeline_state(PipelineUserType.Consumer, self.num_clc_stage)
+        clc_consumer_state = make_pipeline_state(
+            PipelineUserType.Consumer, self.num_clc_stage
+        )
         tile_sched = utils.ClcDynamicPersistentTileScheduler.create(
             tile_sched_params,
             cute.arch.block_idx(),
@@ -486,7 +498,9 @@ class SparseScoreRecomputeSm100:
         thr_mma_qk = tiled_mma_qk.get_slice(0)
         qk_acc_shape = thr_mma_qk.partition_shape_C(self.mma_tiler_qk[:2])
         tStS_fake = thr_mma_qk.make_fragment_C(qk_acc_shape)
-        tmem_ptr = cute.make_ptr(Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16)
+        tmem_ptr = cute.make_ptr(
+            Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16
+        )
         tStS_ref = cute.make_tensor(tmem_ptr, tStS_fake.layout)
 
         warp_group_idx = tidx // self.WARPGROUP_SIZE
@@ -520,7 +534,13 @@ class SparseScoreRecomputeSm100:
                             m_idx = m_packed_idx // self.qhead_per_kvhead
                             h_idx = m_packed_idx - m_idx * self.qhead_per_kvhead
                             if m_idx < seqlen_q_load:
-                                sPerHead[per_head_buf_off + row] = mPerHead[m_idx, h_idx, batch_idx]
+                                per_head_value = mPerHead[m_idx, h_idx, batch_idx]
+                                if cutlass.const_expr(self.score_type == "attention"):
+                                    sPerHead[per_head_buf_off + row] = (
+                                        Float32(per_head_value) * neg_log2_e
+                                    )
+                                else:
+                                    sPerHead[per_head_buf_off + row] = per_head_value
                             else:
                                 sPerHead[per_head_buf_off + row] = self.per_head_dtype(0)
 
@@ -547,13 +567,9 @@ class SparseScoreRecomputeSm100:
                             (m_block, _kc),
                         )
                         sQ_cur = sQ[None, None, None, _kc]
-                        load_Q_fn, _, _ = copy_ops.tma_get_copy_fn(
-                            tma_atom_Q,
-                            0,
-                            cute.make_layout(1),
-                            gQ,
-                            sQ_cur,
-                            single_stage=True,
+                        load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(
+                            tma_atom_Q, 0, cute.make_layout(1),
+                            gQ, sQ_cur, single_stage=True,
                         )
                         load_Q_fn(tma_bar_ptr=handle_Q.barrier)
 
@@ -572,9 +588,11 @@ class SparseScoreRecomputeSm100:
                 cute.arch.alloc_tmem(tmem_alloc_cols, tmem_holding_buf)
                 cute.arch.sync_warp()
 
-                s_empty_phase = Int32(1)  # unblock first round's s_empty barriers
+                s_empty_phase = Int32(1) # unblock first round's s_empty barriers
                 NUM_SLOTS_MASK = Int32(self.num_tmem_slots - 1)
-                K_mma_state = make_pipeline_state(PipelineUserType.Consumer, self.kv_stage)
+                K_mma_state = make_pipeline_state(
+                    PipelineUserType.Consumer, self.kv_stage
+                )
                 while work_tile.is_valid_tile:
                     m_block = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
@@ -616,12 +634,9 @@ class SparseScoreRecomputeSm100:
                             tSrQ_kc = tSrQ[None, None, None, _kc]
                             sQ_kc = sQ[None, None, None, _kc]
                             _gemm_ptx_partial(
-                                qk_mma_op,
-                                slot * self.tmem_s_stride,
-                                tSrKi,
-                                tSrQ_kc,
-                                sA=sK_cur,
-                                sB=sQ_kc,
+                                qk_mma_op, slot * self.tmem_s_stride,
+                                tSrKi, tSrQ_kc,
+                                sA=sK_cur, sB=sQ_kc,
                                 zero_init=const_expr(_kc == 0),
                             )
 
@@ -645,8 +660,7 @@ class SparseScoreRecomputeSm100:
                 cute.arch.relinquish_tmem_alloc_permit()
                 cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
                 tmem_ptr_dealloc = cute.arch.retrieve_tmem_ptr(
-                    Float32,
-                    alignment=16,
+                    Float32, alignment=16,
                     ptr_to_buffer_holding_addr=tmem_holding_buf,
                 )
                 cute.arch.dealloc_tmem(tmem_ptr_dealloc, Int32(self.tmem_alloc_cols))
@@ -655,7 +669,9 @@ class SparseScoreRecomputeSm100:
             # Scheduler warp (warp 2): CLC producer loop
             # -----------------------------------------------------------------
             if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
-                clc_producer_state = make_pipeline_state(PipelineUserType.ProducerConsumer, self.num_clc_stage)
+                clc_producer_state = make_pipeline_state(
+                    PipelineUserType.ProducerConsumer, self.num_clc_stage
+                )
                 while work_tile.is_valid_tile:
                     clc_pipeline.producer_acquire(clc_producer_state)
                     mbarrier_addr = clc_pipeline.producer_get_barrier(clc_producer_state)
@@ -683,18 +699,11 @@ class SparseScoreRecomputeSm100:
                 if cutlass.const_expr(self.score_type == "attention"):
                     if cutlass.const_expr(self.n_block_size >= 128):
                         s_full_phase, reduce_phase = self._epilogue_attention_n128(
-                            tiled_mma_qk,
-                            tStS_ref,
-                            sPerHead,
-                            sScoreAll,
-                            S_mbar_ptr,
-                            reduce_sync_mbar_ptr,
-                            sTopkIdx,
-                            mTopkIdx,
-                            mOut,
+                            tiled_mma_qk, tStS_ref,
+                            sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+                            sTopkIdx, mTopkIdx, mOut,
                             mTopkLength,
-                            m_block,
-                            batch_idx,
+                            m_block, batch_idx,
                             tidx,
                             s_full_phase,
                             reduce_phase,
@@ -704,18 +713,11 @@ class SparseScoreRecomputeSm100:
                         )
                     else:
                         s_full_phase, reduce_phase = self._epilogue_attention(
-                            tiled_mma_qk,
-                            tStS_ref,
-                            sPerHead,
-                            sScoreAll,
-                            S_mbar_ptr,
-                            reduce_sync_mbar_ptr,
-                            sTopkIdx,
-                            mTopkIdx,
-                            mOut,
+                            tiled_mma_qk, tStS_ref,
+                            sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+                            sTopkIdx, mTopkIdx, mOut,
                             mTopkLength,
-                            m_block,
-                            batch_idx,
+                            m_block, batch_idx,
                             tidx,
                             s_full_phase,
                             reduce_phase,
@@ -725,19 +727,11 @@ class SparseScoreRecomputeSm100:
                         )
                 else:
                     s_full_phase, reduce_phase = self._epilogue_indexer(
-                        tiled_mma_qk,
-                        tStS_ref,
-                        mPerHead,
-                        sPerHead,
-                        sScoreAll,
-                        S_mbar_ptr,
-                        reduce_sync_mbar_ptr,
-                        sTopkIdx,
-                        mTopkIdx,
-                        mOut,
+                        tiled_mma_qk, tStS_ref,
+                        mPerHead, sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+                        sTopkIdx, mTopkIdx, mOut,
                         mTopkLength,
-                        m_block,
-                        batch_idx,
+                        m_block, batch_idx,
                         tidx,
                         s_full_phase,
                         reduce_phase,
@@ -785,8 +779,12 @@ class SparseScoreRecomputeSm100:
                 # stage s, keeping 2 groups in flight to improve L2 utilization.
                 # (Full-depth tested: worse — delaying MMA start hurts more
                 # than extra L2 parallelism helps.)
-                K_issue_state = make_pipeline_state(PipelineUserType.Producer, self.kv_stage)
-                K_commit_state = make_pipeline_state(PipelineUserType.Producer, self.kv_stage)
+                K_issue_state = make_pipeline_state(
+                    PipelineUserType.Producer, self.kv_stage
+                )
+                K_commit_state = make_pipeline_state(
+                    PipelineUserType.Producer, self.kv_stage
+                )
 
                 while work_tile.is_valid_tile:
                     m_block = work_tile.tile_idx[0]
@@ -802,23 +800,16 @@ class SparseScoreRecomputeSm100:
                         sK_stage = sK[None, None, None, K_issue_state.index]
                         sK_slice = cute.composition(
                             sK_stage,
-                            cute.make_layout((self.n_block_size, self.k_block_size)),
+                            cute.make_layout(
+                                (self.n_block_size, self.k_block_size)
+                            ),
                         )
                         k_offset = const_expr(_kc * self.k_block_size)
                         self._load_k_rows(
-                            mK,
-                            sK_slice,
-                            mTopkIdx,
-                            mTopkLength,
-                            async_copy_atom,
-                            async_thr_copy,
-                            n_block,
-                            q_token_idx,
-                            batch_idx,
-                            seqlen_k,
-                            topK_cur,
-                            idx_in_group,
-                            group_idx_local,
+                            mK, sK_slice, mTopkIdx, mTopkLength,
+                            async_copy_atom, async_thr_copy,
+                            n_block, q_token_idx, batch_idx, seqlen_k,
+                            topK_cur, idx_in_group, group_idx_local,
                             k_offset=k_offset,
                         )
                         cute.arch.cp_async_commit_group()
@@ -832,23 +823,16 @@ class SparseScoreRecomputeSm100:
                             sK_stage = sK[None, None, None, K_issue_state.index]
                             sK_slice = cute.composition(
                                 sK_stage,
-                                cute.make_layout((self.n_block_size, self.k_block_size)),
+                                cute.make_layout(
+                                    (self.n_block_size, self.k_block_size)
+                                ),
                             )
                             k_offset = const_expr(_kc * self.k_block_size)
                             self._load_k_rows(
-                                mK,
-                                sK_slice,
-                                mTopkIdx,
-                                mTopkLength,
-                                async_copy_atom,
-                                async_thr_copy,
-                                n_block,
-                                q_token_idx,
-                                batch_idx,
-                                seqlen_k,
-                                topK_cur,
-                                idx_in_group,
-                                group_idx_local,
+                                mK, sK_slice, mTopkIdx, mTopkLength,
+                                async_copy_atom, async_thr_copy,
+                                n_block, q_token_idx, batch_idx, seqlen_k,
+                                topK_cur, idx_in_group, group_idx_local,
                                 k_offset=k_offset,
                             )
                             cute.arch.cp_async_commit_group()
@@ -874,7 +858,9 @@ class SparseScoreRecomputeSm100:
                 # Attention: original K load with wait_group(0).
                 # 2-deep tested but regressed -14% (kv_stage=2 too tight,
                 # code bloat from prologue/drain outweighs L2 overlap gain).
-                K_load_state = make_pipeline_state(PipelineUserType.Producer, self.kv_stage)
+                K_load_state = make_pipeline_state(
+                    PipelineUserType.Producer, self.kv_stage
+                )
 
                 while work_tile.is_valid_tile:
                     m_block = work_tile.tile_idx[0]
@@ -894,23 +880,16 @@ class SparseScoreRecomputeSm100:
                             sK_stage = sK[None, None, None, K_load_state.index]
                             sK_slice = cute.composition(
                                 sK_stage,
-                                cute.make_layout((self.n_block_size, self.k_block_size)),
+                                cute.make_layout(
+                                    (self.n_block_size, self.k_block_size)
+                                ),
                             )
                             k_offset = const_expr(_kc * self.k_block_size)
                             self._load_k_rows(
-                                mK,
-                                sK_slice,
-                                mTopkIdx,
-                                mTopkLength,
-                                async_copy_atom,
-                                async_thr_copy,
-                                n_block,
-                                q_token_idx,
-                                batch_idx,
-                                seqlen_k,
-                                topK_cur,
-                                idx_in_group,
-                                group_idx_local,
+                                mK, sK_slice, mTopkIdx, mTopkLength,
+                                async_copy_atom, async_thr_copy,
+                                n_block, q_token_idx, batch_idx, seqlen_k,
+                                topK_cur, idx_in_group, group_idx_local,
                                 k_offset=k_offset,
                             )
                             cute.arch.cp_async_commit_group()
@@ -952,46 +931,43 @@ class SparseScoreRecomputeSm100:
         public global KV ids (``b * seqlen_k + local``); we decode back to
         local-per-batch before indexing into mK ``(seqlen_k, head_dim, bs)``.
         With the flag False, ids are already local (legacy callers — e.g.
-        ``indexer_backward``'s grad path that still expects local).
+        ``indexer_bwd``'s grad path that still expects local).
         """
         NUM_GROUPS = const_expr(self.WARPGROUP_SIZE // 8)
         ROWS_PER_GROUP = const_expr(self.n_block_size // NUM_GROUPS)
-        batch_offset = batch_idx * seqlen_k if const_expr(self.topk_indices_global) else Int32(0)
+        batch_offset = (
+            batch_idx * seqlen_k if const_expr(self.topk_indices_global)
+            else Int32(0)
+        )
         for r in cutlass.range_constexpr(ROWS_PER_GROUP):
             row = r * NUM_GROUPS + group_idx_local
             topk_pos = n_block * self.n_block_size + row
             if const_expr(self.have_topk_length and self.score_type == "attention"):
                 if topk_pos < topK_cur:
-                    topk_raw = Int32(mTopkIdx[q_token_idx, topk_pos, batch_idx])
+                    topk_raw = Int32(
+                        mTopkIdx[q_token_idx, topk_pos, batch_idx]
+                    )
                     topk_local = topk_raw - batch_offset
                     self._copy_row(
-                        mK,
-                        sK_slice,
-                        row,
-                        idx_in_group,
-                        copy_atom,
-                        thr_copy,
-                        topk_local,
-                        batch_idx,
+                        mK, sK_slice, row, idx_in_group,
+                        copy_atom, thr_copy,
+                        topk_local, batch_idx,
                         k_offset=k_offset,
                     )
             else:
                 topk_local = Int32(-1)
                 if topk_pos < topK_cur:
-                    topk_raw = Int32(mTopkIdx[q_token_idx, topk_pos, batch_idx])
+                    topk_raw = Int32(
+                        mTopkIdx[q_token_idx, topk_pos, batch_idx]
+                    )
                     # Invalid (-1) stays negative after the offset subtraction
                     # and is rejected by the bounds check below.
                     topk_local = topk_raw - batch_offset
                 if topk_local >= 0 and topk_local < seqlen_k:
                     self._copy_row(
-                        mK,
-                        sK_slice,
-                        row,
-                        idx_in_group,
-                        copy_atom,
-                        thr_copy,
-                        topk_local,
-                        batch_idx,
+                        mK, sK_slice, row, idx_in_group,
+                        copy_atom, thr_copy,
+                        topk_local, batch_idx,
                         k_offset=k_offset,
                     )
 
@@ -1049,12 +1025,8 @@ class SparseScoreRecomputeSm100:
     # =========================================================================
     @cute.jit
     def _intra_inter_warp_reduce_max(
-        self,
-        sScoreAll,
-        reduce_sync_mbar_ptr,
-        reduce_sync_phase,
-        warp_id_in_wg,
-        local_value,
+        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
+        warp_id_in_wg, local_value,
     ):
         """Reduce local max across 4 warps via smem scratch + mbarrier sync."""
         warp_max = cute.arch.warp_redux_sync(local_value, "fmax")
@@ -1074,12 +1046,8 @@ class SparseScoreRecomputeSm100:
 
     @cute.jit
     def _intra_inter_warp_reduce_sum(
-        self,
-        sScoreAll,
-        reduce_sync_mbar_ptr,
-        reduce_sync_phase,
-        warp_id_in_wg,
-        local_value,
+        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
+        warp_id_in_wg, local_value,
     ):
         """Reduce local sum across 4 warps via smem scratch + mbarrier sync."""
         warp_sum = cute.arch.warp_reduction_sum(local_value)
@@ -1098,12 +1066,8 @@ class SparseScoreRecomputeSm100:
 
     @cute.jit
     def _inter_warp_sync_sum(
-        self,
-        sScoreAll,
-        reduce_sync_mbar_ptr,
-        reduce_sync_phase,
-        warp_id_in_wg,
-        warp_sum,
+        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
+        warp_id_in_wg, warp_sum,
     ):
         """Cross-warp sum sync with pre-computed warp-level sum (skip warp_reduction_sum)."""
         with cute.arch.elect_one():
@@ -1127,17 +1091,10 @@ class SparseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        mPerHead,
-        sW,
-        sScoreAll,
-        S_mbar_ptr,
-        reduce_sync_mbar_ptr,
-        sTopkIdx,
-        mTopkIdx,
-        mOut,
+        mPerHead, sW, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+        sTopkIdx, mTopkIdx, mOut,
         mTopkLength,
-        m_block,
-        batch_idx,
+        m_block, batch_idx,
         tidx,
         s_full_phase,
         reduce_phase,
@@ -1167,7 +1124,9 @@ class SparseScoreRecomputeSm100:
         cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
         tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
 
-        tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
+        tSrS_shape = thr_tmem_load.partition_D(
+            cute.make_identity_tensor(tStS_ref.shape)
+        ).shape
         tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
         sW_off = Int32(0) if per_head_offset is None else per_head_offset
@@ -1213,10 +1172,8 @@ class SparseScoreRecomputeSm100:
             if const_expr(_ri == 0):
                 cute.autovec_copy(W_src_f32, rW_all_f32)
             tmem_ptr_cur = cute.make_ptr(
-                Float32,
-                _slot * self.tmem_s_stride,
-                mem_space=cute.AddressSpace.tmem,
-                assumed_align=16,
+                Float32, _slot * self.tmem_s_stride,
+                mem_space=cute.AddressSpace.tmem, assumed_align=16,
             )
             tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
             tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
@@ -1262,11 +1219,8 @@ class SparseScoreRecomputeSm100:
                 local_max = rScores[ei]
 
         global_max, reduce_phase = self._intra_inter_warp_reduce_max(
-            sScoreAll,
-            reduce_sync_mbar_ptr,
-            reduce_phase,
-            warp_id_in_wg,
-            local_max,
+            sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
+            warp_id_in_wg, local_max,
         )
 
         if global_max > Float32(-1e30):
@@ -1283,11 +1237,8 @@ class SparseScoreRecomputeSm100:
                 cute.make_layout((self.num_warps_in_epi_wg,), stride=(1,)),
             )
             global_sum, reduce_phase = self._intra_inter_warp_reduce_sum(
-                sScoreAll_sum,
-                reduce_sync_mbar_ptr,
-                reduce_phase,
-                warp_id_in_wg,
-                local_exp_sum,
+                sScoreAll_sum, reduce_sync_mbar_ptr, reduce_phase,
+                warp_id_in_wg, local_exp_sum,
             )
 
             inv_sum = Float32(1.0) / global_sum
@@ -1313,16 +1264,10 @@ class SparseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        sLSE,
-        sScoreAll,
-        S_mbar_ptr,
-        reduce_sync_mbar_ptr,
-        sTopkIdx,
-        mTopkIdx,
-        mOut,
+        sLSE, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+        sTopkIdx, mTopkIdx, mOut,
         mTopkLength,
-        m_block,
-        batch_idx,
+        m_block, batch_idx,
         tidx,
         s_full_phase,
         reduce_phase,
@@ -1337,19 +1282,6 @@ class SparseScoreRecomputeSm100:
         no shfl_xor or is_active gating needed.
         """
         tidx_wg = tidx % self.WARPGROUP_SIZE
-
-        tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(8)),
-            Float32,
-        )
-        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
-
-        thr_mma = tiled_mma_qk.get_slice(tidx_wg)
-        cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
-        tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
-
-        tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
-        tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
         sLSE_off = Int32(0) if per_head_offset is None else per_head_offset
         sTopkIdx_off = Int32(0) if topk_idx_offset is None else topk_idx_offset
@@ -1368,7 +1300,7 @@ class SparseScoreRecomputeSm100:
         )
         rLSE_all = cute.make_rmem_tensor((self.m_block_size,), Float32)
 
-        kv_offset = tScS[0][0]
+        kv_offset = Int32(0)
         warp_id_in_wg = tidx_wg // self.WARP_SIZE
 
         log2_e = Float32(math.log2(math.e))
@@ -1387,6 +1319,24 @@ class SparseScoreRecomputeSm100:
         for _ri in cutlass.range_constexpr(self.num_n_blocks):
             n_blk = self.num_n_blocks - 1 - _ri
             _slot = const_expr(n_blk % self.num_tmem_slots)
+
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(8)),
+                Float32,
+            )
+            thr_mma = tiled_mma_qk.get_slice(tidx_wg)
+            cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
+            tScS = tcgen05.make_tmem_copy(
+                tmem_load_atom, tStS_ref,
+            ).get_slice(tidx_wg).partition_D(thr_mma.partition_C(cS))
+            tSrS_shape = tcgen05.make_tmem_copy(
+                tmem_load_atom, tStS_ref,
+            ).get_slice(tidx_wg).partition_D(
+                cute.make_identity_tensor(tStS_ref.shape)
+            ).shape
+            tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
+            kv_offset = tScS[0][0]
+
             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * _slot, s_full_phase)
             if const_expr(_ri == 0):
                 cute.autovec_copy(sLSE_1d, rLSE_all)
@@ -1395,15 +1345,21 @@ class SparseScoreRecomputeSm100:
                 should_copy_tmem = n_blk < n_block_max_epi
             if should_copy_tmem:
                 tmem_ptr_cur = cute.make_ptr(
-                    Float32,
-                    _slot * self.tmem_s_stride,
-                    mem_space=cute.AddressSpace.tmem,
-                    assumed_align=16,
+                    Float32, _slot * self.tmem_s_stride,
+                    mem_space=cute.AddressSpace.tmem, assumed_align=16,
                 )
                 tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
-                tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
+                tStS_t2r_cur = tcgen05.make_tmem_copy(
+                    tmem_load_atom, tStS_ref,
+                ).get_slice(tidx_wg).partition_S(tStS_cur)
 
-                cute.copy(thr_tmem_load, tStS_t2r_cur, tSrS)
+                cute.copy(
+                    tcgen05.make_tmem_copy(
+                        tmem_load_atom, tStS_ref,
+                    ).get_slice(tidx_wg),
+                    tStS_t2r_cur,
+                    tSrS,
+                )
                 cute.arch.fence_view_async_tmem_load()
             cute.arch.mbarrier_arrive(S_mbar_ptr + 2 * _slot + 1)
             if const_expr(_slot == 0):
@@ -1422,7 +1378,7 @@ class SparseScoreRecomputeSm100:
                         val0 = tSrS[idx0]
                         val1 = tSrS[idx1]
 
-                        val0, val1 = fma_packed_f32x2(
+                        (val0, val1) = fma_packed_f32x2(
                             (val0, val1),
                             (scale_log2_e, scale_log2_e),
                             lse_pair,
@@ -1449,11 +1405,8 @@ class SparseScoreRecomputeSm100:
 
         # ---- Phase 2: L1-norm (scores already non-negative from exp) ----
         global_sum, reduce_phase = self._inter_warp_sync_sum(
-            sScoreAll,
-            reduce_sync_mbar_ptr,
-            reduce_phase,
-            warp_id_in_wg,
-            warp_sum_acc,
+            sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
+            warp_id_in_wg, warp_sum_acc,
         )
 
         if global_sum > Float32(1e-10):
@@ -1476,16 +1429,10 @@ class SparseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        sLSE,
-        sScoreAll,
-        S_mbar_ptr,
-        reduce_sync_mbar_ptr,
-        sTopkIdx,
-        mTopkIdx,
-        mOut,
+        sLSE, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
+        sTopkIdx, mTopkIdx, mOut,
         mTopkLength,
-        m_block,
-        batch_idx,
+        m_block, batch_idx,
         tidx,
         s_full_phase,
         reduce_phase,
@@ -1502,19 +1449,6 @@ class SparseScoreRecomputeSm100:
         m_block_size/2 heads; a single shfl_xor(2) combines the partial sums.
         """
         tidx_wg = tidx % self.WARPGROUP_SIZE
-
-        tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld16x64bOp(tcgen05.copy.Repetition(self.m_block_size // 2)),
-            Float32,
-        )
-        thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
-
-        thr_mma = tiled_mma_qk.get_slice(tidx_wg)
-        cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
-        tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
-
-        tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
-        tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
         sLSE_off = Int32(0) if per_head_offset is None else per_head_offset
         sTopkIdx_off = Int32(0) if topk_idx_offset is None else topk_idx_offset
@@ -1536,12 +1470,12 @@ class SparseScoreRecomputeSm100:
         # tSrLSE[i] pairs with tSrS[i] regardless of fragment layout.
         sLSE_2d = cute.make_tensor(
             sLSE_f32_ptr,
-            cute.make_layout((self.n_block_size, self.m_block_size), stride=(0, 1)),
+            cute.make_layout(
+                (self.n_block_size, self.m_block_size), stride=(0, 1)
+            ),
         )
-        tSsLSE = thr_tmem_load.partition_D(thr_mma.partition_C(sLSE_2d))
-        tSrLSE = cute.make_rmem_tensor(tSsLSE.shape, Float32)
 
-        kv_offset = tScS[0][0]
+        kv_offset = Int32(0)
         warp_id_in_wg = tidx_wg // self.WARP_SIZE
         # Thread i and Thread i^2 share a lane; only one should contribute
         # to warp-level sums / write output.  (tidx_wg % 4) < 2 selects
@@ -1564,23 +1498,56 @@ class SparseScoreRecomputeSm100:
         for _ri in cutlass.range_constexpr(self.num_n_blocks):
             n_blk = self.num_n_blocks - 1 - _ri
             _slot = const_expr(n_blk % self.num_tmem_slots)
+
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld16x64bOp(
+                    tcgen05.copy.Repetition(self.m_block_size // 2)
+                ),
+                Float32,
+            )
+
+            thr_mma = tiled_mma_qk.get_slice(tidx_wg)
+            cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
+            tScS = tcgen05.make_tmem_copy(
+                tmem_load_atom, tStS_ref,
+            ).get_slice(tidx_wg).partition_D(thr_mma.partition_C(cS))
+            tSrS_shape = tcgen05.make_tmem_copy(
+                tmem_load_atom, tStS_ref,
+            ).get_slice(tidx_wg).partition_D(
+                cute.make_identity_tensor(tStS_ref.shape)
+            ).shape
+            tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
+
+            tSsLSE = tcgen05.make_tmem_copy(
+                tmem_load_atom, tStS_ref,
+            ).get_slice(tidx_wg).partition_D(
+                thr_mma.partition_C(sLSE_2d)
+            )
+            tSrLSE = cute.make_rmem_tensor(tSsLSE.shape, Float32)
+            kv_offset = tScS[0][0]
+
             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * _slot, s_full_phase)
-            if const_expr(_ri == 0):
-                cute.autovec_copy(tSsLSE, tSrLSE)
+            cute.autovec_copy(tSsLSE, tSrLSE)
             should_copy_tmem = const_expr(True)
             if const_expr(self.have_topk_length):
                 should_copy_tmem = n_blk < n_block_max_epi
             if should_copy_tmem:
                 tmem_ptr_cur = cute.make_ptr(
-                    Float32,
-                    _slot * self.tmem_s_stride,
-                    mem_space=cute.AddressSpace.tmem,
-                    assumed_align=16,
+                    Float32, _slot * self.tmem_s_stride,
+                    mem_space=cute.AddressSpace.tmem, assumed_align=16,
                 )
                 tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
-                tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
+                tStS_t2r_cur = tcgen05.make_tmem_copy(
+                    tmem_load_atom, tStS_ref,
+                ).get_slice(tidx_wg).partition_S(tStS_cur)
 
-                cute.copy(thr_tmem_load, tStS_t2r_cur, tSrS)
+                cute.copy(
+                    tcgen05.make_tmem_copy(
+                        tmem_load_atom, tStS_ref,
+                    ).get_slice(tidx_wg),
+                    tStS_t2r_cur,
+                    tSrS,
+                )
                 cute.arch.fence_view_async_tmem_load()
             cute.arch.mbarrier_arrive(S_mbar_ptr + 2 * _slot + 1)
             if const_expr(_slot == 0):
@@ -1599,7 +1566,7 @@ class SparseScoreRecomputeSm100:
                         val0 = tSrS[idx0]
                         val1 = tSrS[idx1]
 
-                        val0, val1 = fma_packed_f32x2(
+                        (val0, val1) = fma_packed_f32x2(
                             (val0, val1),
                             (scale_log2_e, scale_log2_e),
                             lse_pair,
@@ -1627,20 +1594,14 @@ class SparseScoreRecomputeSm100:
                 warp_sum_acc = warp_sum_acc + cute.arch.warp_reduction_sum(partial_score)
 
                 partner_partial = cute.arch.shuffle_sync_bfly(
-                    partial_score,
-                    offset=2,
-                    mask=-1,
-                    mask_and_clamp=31,
+                    partial_score, offset=2, mask=-1, mask_and_clamp=31,
                 )
                 rScores[n_blk] = partial_score + partner_partial
 
         # ---- Phase 2: L1-norm (scores already non-negative from exp) ----
         global_sum, reduce_phase = self._inter_warp_sync_sum(
-            sScoreAll,
-            reduce_sync_mbar_ptr,
-            reduce_phase,
-            warp_id_in_wg,
-            warp_sum_acc,
+            sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
+            warp_id_in_wg, warp_sum_acc,
         )
 
         if is_active:

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/sparse_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/sparse_score_recompute_sm100.py
@@ -52,9 +52,9 @@ from cutlass.utils.blackwell_helpers import (
 from cudnn.deepseek_sparse_attention.utils.sm100.gemm import gemm_ptx_partial as _gemm_ptx_partial
 from cudnn.deepseek_sparse_attention.utils import copy as copy_utils
 
-mul_packed_f32x2 = partial(cute.arch.mul_packed_f32x2, rnd='rn')
-add_packed_f32x2 = partial(cute.arch.add_packed_f32x2, rnd='rn')
-fma_packed_f32x2 = partial(cute.arch.fma_packed_f32x2, rnd='rn')
+mul_packed_f32x2 = partial(cute.arch.mul_packed_f32x2, rnd="rn")
+add_packed_f32x2 = partial(cute.arch.add_packed_f32x2, rnd="rn")
+fma_packed_f32x2 = partial(cute.arch.fma_packed_f32x2, rnd="rn")
 
 
 class SparseScoreRecomputeSm100:
@@ -109,21 +109,16 @@ class SparseScoreRecomputeSm100:
         self.sched_warp_id = 2
         self.num_clc_stage = 1
         self.num_clc_response_bytes = 16
-        assert topk % n_block_size == 0, (
-            f"topk ({topk}) must be a multiple of n_block_size ({n_block_size})"
-        )
+        assert topk % n_block_size == 0, f"topk ({topk}) must be a multiple of n_block_size ({n_block_size})"
         self.num_n_blocks = topk // n_block_size
         self.have_topk_length = have_topk_length
         self.topk_in_smem = topk_in_smem
 
         # Pad head_dim to multiple of 16
         hdim_multiple_of = 16
-        self.head_dim_padded = int(
-            math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of
-        )
+        self.head_dim_padded = int(math.ceil(head_dim / hdim_multiple_of) * hdim_multiple_of)
         assert self.head_dim_padded % 64 == 0, (
-            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of 64 "
-            f"(K loading uses 8 threads × 8 elements = 64 per iteration)"
+            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of 64 " f"(K loading uses 8 threads × 8 elements = 64 per iteration)"
         )
 
         # K-dimension splitting: process head_dim in num_k_chunks chunks of
@@ -131,12 +126,10 @@ class SparseScoreRecomputeSm100:
         # kv_stages for better K load / MMA overlap.
         self.k_block_size = k_block_size if k_block_size is not None else self.head_dim_padded
         assert self.head_dim_padded % self.k_block_size == 0, (
-            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of "
-            f"k_block_size ({self.k_block_size})"
+            f"head_dim_padded ({self.head_dim_padded}) must be a multiple of " f"k_block_size ({self.k_block_size})"
         )
         assert self.k_block_size % 64 == 0, (
-            f"k_block_size ({self.k_block_size}) must be a multiple of 64 "
-            f"(K loading uses 8 threads × 8 elements = 64 per iteration)"
+            f"k_block_size ({self.k_block_size}) must be a multiple of 64 " f"(K loading uses 8 threads × 8 elements = 64 per iteration)"
         )
         self.num_k_chunks = self.head_dim_padded // self.k_block_size
 
@@ -211,12 +204,12 @@ class SparseScoreRecomputeSm100:
     @cute.jit
     def __call__(
         self,
-        mQ: cute.Tensor,          # (bs, seqlen_q, n_heads_q, head_dim) BF16
-        mK: cute.Tensor,          # (bs, seqlen_k, head_dim) BF16
-        mPerHead: cute.Tensor,    # (bs, seqlen_q, n_heads_q) — W (BF16) or LSE (FP32)
-        mTopkIdx: cute.Tensor,    # (bs, seqlen_q, topk) INT32
-        mOut: cute.Tensor,        # (bs, seqlen_q, topk) FP32
-        mTopkLength: cute.Tensor, # (bs, seqlen_q) INT32 (dummy when unused)
+        mQ: cute.Tensor,  # (bs, seqlen_q, n_heads_q, head_dim) BF16
+        mK: cute.Tensor,  # (bs, seqlen_k, head_dim) BF16
+        mPerHead: cute.Tensor,  # (bs, seqlen_q, n_heads_q) — W (BF16) or LSE (FP32)
+        mTopkIdx: cute.Tensor,  # (bs, seqlen_q, topk) INT32
+        mOut: cute.Tensor,  # (bs, seqlen_q, topk) FP32
+        mTopkLength: cute.Tensor,  # (bs, seqlen_q) INT32 (dummy when unused)
         softmax_scale: Float32 | float,
         stream: cuda.CUstream,
     ):
@@ -236,19 +229,17 @@ class SparseScoreRecomputeSm100:
         # --- PackGQA: reshape Q to pack qhpkv heads into seqlen_q dim ---
         shape_Q_packed = (
             (self.qhead_per_kvhead, mQ.shape[0]),  # packed M dim
-            mQ.shape[1],                           # head_dim
-            1,                                     # n_heads_kv
-            *mQ.shape[3:],                         # bs (and beyond)
+            mQ.shape[1],  # head_dim
+            1,  # n_heads_kv
+            *mQ.shape[3:],  # bs (and beyond)
         )
         stride_Q_packed = (
-            (mQ.stride[2], mQ.stride[0]),          # (stride_head, stride_seqlen)
-            mQ.stride[1],                          # stride_hdim
+            (mQ.stride[2], mQ.stride[0]),  # (stride_head, stride_seqlen)
+            mQ.stride[1],  # stride_hdim
             mQ.stride[2] * self.qhead_per_kvhead,  # stride across kv_head groups
-            *mQ.stride[3:],                        # stride_bs
+            *mQ.stride[3:],  # stride_bs
         )
-        mQ = cute.make_tensor(
-            mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed)
-        )
+        mQ = cute.make_tensor(mQ.iterator, cute.make_layout(shape_Q_packed, stride=stride_Q_packed))
 
         # --- K layout: (bs, seqlen_k, head_dim) -> (seqlen_k, head_dim, bs) ---
         mK = cute.make_tensor(mK.iterator, cute.select(mK.layout, mode=[1, 2, 0]))
@@ -273,10 +264,16 @@ class SparseScoreRecomputeSm100:
 
         # --- SMEM layouts --- (K is A operand in swapAB; loaded via cp.async, not TMA)
         sK_layout = _make_smem_layout_a(
-            tiled_mma_qk, self.mma_tiler_qk, self.k_dtype, self.kv_stage,
+            tiled_mma_qk,
+            self.mma_tiler_qk,
+            self.k_dtype,
+            self.kv_stage,
         )
         sQ_layout = _make_smem_layout_b(
-            tiled_mma_qk, self.mma_tiler_qk, self.q_dtype, self.num_k_chunks,
+            tiled_mma_qk,
+            self.mma_tiler_qk,
+            self.q_dtype,
+            self.num_k_chunks,
         )
 
         # TMA atom for Q only (K is sparse-loaded, no TMA)
@@ -308,22 +305,21 @@ class SparseScoreRecomputeSm100:
         # --- Grid and kernel dispatch (CLC persistent scheduling) ---
         seqlen_q_packed = cute.size(mQ.shape[0])
         num_m_blocks = cute.ceil_div(seqlen_q_packed, self.m_block_size)
-        batch_size = (
-            cute.size(mQ.shape[3]) if cute.rank(mQ.shape) > 3 else 1
-        )
-        tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams(
-            (num_m_blocks, 1, batch_size), (*self.cluster_shape_mn, 1)
-        )
-        grid_dim = utils.ClcDynamicPersistentTileScheduler.get_grid_shape(
-            tile_sched_params
-        )
+        batch_size = cute.size(mQ.shape[3]) if cute.rank(mQ.shape) > 3 else 1
+        tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams((num_m_blocks, 1, batch_size), (*self.cluster_shape_mn, 1))
+        grid_dim = utils.ClcDynamicPersistentTileScheduler.get_grid_shape(tile_sched_params)
         self.kernel(
-            mQ, mK, mPerHead, mTopkIdx, mOut,
+            mQ,
+            mK,
+            mPerHead,
+            mTopkIdx,
+            mOut,
             mTopkLength,
             softmax_scale,
             tma_atom_Q,
             tiled_mma_qk,
-            sQ_layout, sK_layout,
+            sQ_layout,
+            sK_layout,
             tile_sched_params,
         ).launch(
             grid=grid_dim,
@@ -338,12 +334,17 @@ class SparseScoreRecomputeSm100:
     @cute.kernel
     def kernel(
         self,
-        mQ, mK, mPerHead, mTopkIdx, mOut,
+        mQ,
+        mK,
+        mPerHead,
+        mTopkIdx,
+        mOut,
         mTopkLength,
         softmax_scale: Float32 | float,
         tma_atom_Q,
         tiled_mma_qk,
-        sQ_layout, sK_layout,
+        sQ_layout,
+        sK_layout,
         tile_sched_params: utils.ClcDynamicPersistentTileSchedulerParams,
     ):
         """Device-side kernel entry with CLC persistent scheduling."""
@@ -362,7 +363,7 @@ class SparseScoreRecomputeSm100:
         # =====================================================================
         sQ_size = cute.cosize(sQ_layout)
         sK_size = cute.cosize(sK_layout)
-        sPerHead_size = self.m_block_size * 2      # double-buffer for LOAD/EPI overlap
+        sPerHead_size = self.m_block_size * 2  # double-buffer for LOAD/EPI overlap
         sTopkIdx_size = self.topk * 2 if self.topk_in_smem else 1
 
         @cute.struct
@@ -411,15 +412,9 @@ class SparseScoreRecomputeSm100:
         clc_response_ptr = storage.clc_response.data_ptr()
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
         sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
-        sPerHead = storage.sPerHead.get_tensor(
-            cute.make_layout((self.m_block_size,), stride=(1,))
-        )
-        sTopkIdx = storage.sTopkIdx.get_tensor(
-            cute.make_layout((self.topk if self.topk_in_smem else 1,), stride=(1,))
-        )
-        sScoreAll = storage.sScoreAll.get_tensor(
-            cute.make_layout((self.sScoreAll_size,), stride=(1,))
-        )
+        sPerHead = storage.sPerHead.get_tensor(cute.make_layout((self.m_block_size,), stride=(1,)))
+        sTopkIdx = storage.sTopkIdx.get_tensor(cute.make_layout((self.topk if self.topk_in_smem else 1,), stride=(1,)))
+        sScoreAll = storage.sScoreAll.get_tensor(cute.make_layout((self.sScoreAll_size,), stride=(1,)))
 
         # =====================================================================
         # Pipeline setup
@@ -428,9 +423,7 @@ class SparseScoreRecomputeSm100:
             cute.make_layout(self.cluster_shape_mnk),
             (tiled_mma_qk.thr_id.shape,),
         )
-        cta_rank_in_cluster = cute.arch.make_warp_uniform(
-            cute.arch.block_idx_in_cluster()
-        )
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         is_first_cta_in_cluster = cta_rank_in_cluster == 0
 
         # Q pipeline (1 stage: all k_chunks share one barrier with combined tx_count)
@@ -464,9 +457,7 @@ class SparseScoreRecomputeSm100:
 
         # CLC persistent scheduling pipeline
         cluster_size = cute.size(self.cluster_shape_mn)
-        num_clc_consumer_threads = self.WARP_SIZE * (
-            1 + cluster_size * (1 + 1 + 8)
-        )  # sched(1) + load(1) + mma(1) + epilogue+Kload(8) warps
+        num_clc_consumer_threads = self.WARP_SIZE * (1 + cluster_size * (1 + 1 + 8))  # sched(1) + load(1) + mma(1) + epilogue+Kload(8) warps
         clc_pipeline = PipelineClcFetchAsync.create(
             barrier_storage=clc_mbar_ptr,
             num_stages=self.num_clc_stage,
@@ -481,9 +472,7 @@ class SparseScoreRecomputeSm100:
         cute.arch.sync_threads()
         pipeline_init_wait(cluster_shape_mn=cluster_layout_vmnk)
 
-        clc_consumer_state = make_pipeline_state(
-            PipelineUserType.Consumer, self.num_clc_stage
-        )
+        clc_consumer_state = make_pipeline_state(PipelineUserType.Consumer, self.num_clc_stage)
         tile_sched = utils.ClcDynamicPersistentTileScheduler.create(
             tile_sched_params,
             cute.arch.block_idx(),
@@ -498,9 +487,7 @@ class SparseScoreRecomputeSm100:
         thr_mma_qk = tiled_mma_qk.get_slice(0)
         qk_acc_shape = thr_mma_qk.partition_shape_C(self.mma_tiler_qk[:2])
         tStS_fake = thr_mma_qk.make_fragment_C(qk_acc_shape)
-        tmem_ptr = cute.make_ptr(
-            Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16
-        )
+        tmem_ptr = cute.make_ptr(Float32, 0, mem_space=cute.AddressSpace.tmem, assumed_align=16)
         tStS_ref = cute.make_tensor(tmem_ptr, tStS_fake.layout)
 
         warp_group_idx = tidx // self.WARPGROUP_SIZE
@@ -536,9 +523,7 @@ class SparseScoreRecomputeSm100:
                             if m_idx < seqlen_q_load:
                                 per_head_value = mPerHead[m_idx, h_idx, batch_idx]
                                 if cutlass.const_expr(self.score_type == "attention"):
-                                    sPerHead[per_head_buf_off + row] = (
-                                        Float32(per_head_value) * neg_log2_e
-                                    )
+                                    sPerHead[per_head_buf_off + row] = Float32(per_head_value) * neg_log2_e
                                 else:
                                     sPerHead[per_head_buf_off + row] = per_head_value
                             else:
@@ -568,8 +553,12 @@ class SparseScoreRecomputeSm100:
                         )
                         sQ_cur = sQ[None, None, None, _kc]
                         load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(
-                            tma_atom_Q, 0, cute.make_layout(1),
-                            gQ, sQ_cur, single_stage=True,
+                            tma_atom_Q,
+                            0,
+                            cute.make_layout(1),
+                            gQ,
+                            sQ_cur,
+                            single_stage=True,
                         )
                         load_Q_fn(tma_bar_ptr=handle_Q.barrier)
 
@@ -588,11 +577,9 @@ class SparseScoreRecomputeSm100:
                 cute.arch.alloc_tmem(tmem_alloc_cols, tmem_holding_buf)
                 cute.arch.sync_warp()
 
-                s_empty_phase = Int32(1) # unblock first round's s_empty barriers
+                s_empty_phase = Int32(1)  # unblock first round's s_empty barriers
                 NUM_SLOTS_MASK = Int32(self.num_tmem_slots - 1)
-                K_mma_state = make_pipeline_state(
-                    PipelineUserType.Consumer, self.kv_stage
-                )
+                K_mma_state = make_pipeline_state(PipelineUserType.Consumer, self.kv_stage)
                 while work_tile.is_valid_tile:
                     m_block = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
@@ -634,9 +621,12 @@ class SparseScoreRecomputeSm100:
                             tSrQ_kc = tSrQ[None, None, None, _kc]
                             sQ_kc = sQ[None, None, None, _kc]
                             _gemm_ptx_partial(
-                                qk_mma_op, slot * self.tmem_s_stride,
-                                tSrKi, tSrQ_kc,
-                                sA=sK_cur, sB=sQ_kc,
+                                qk_mma_op,
+                                slot * self.tmem_s_stride,
+                                tSrKi,
+                                tSrQ_kc,
+                                sA=sK_cur,
+                                sB=sQ_kc,
                                 zero_init=const_expr(_kc == 0),
                             )
 
@@ -660,7 +650,8 @@ class SparseScoreRecomputeSm100:
                 cute.arch.relinquish_tmem_alloc_permit()
                 cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
                 tmem_ptr_dealloc = cute.arch.retrieve_tmem_ptr(
-                    Float32, alignment=16,
+                    Float32,
+                    alignment=16,
                     ptr_to_buffer_holding_addr=tmem_holding_buf,
                 )
                 cute.arch.dealloc_tmem(tmem_ptr_dealloc, Int32(self.tmem_alloc_cols))
@@ -669,9 +660,7 @@ class SparseScoreRecomputeSm100:
             # Scheduler warp (warp 2): CLC producer loop
             # -----------------------------------------------------------------
             if warp_idx == self.sched_warp_id and is_first_cta_in_cluster:
-                clc_producer_state = make_pipeline_state(
-                    PipelineUserType.ProducerConsumer, self.num_clc_stage
-                )
+                clc_producer_state = make_pipeline_state(PipelineUserType.ProducerConsumer, self.num_clc_stage)
                 while work_tile.is_valid_tile:
                     clc_pipeline.producer_acquire(clc_producer_state)
                     mbarrier_addr = clc_pipeline.producer_get_barrier(clc_producer_state)
@@ -699,11 +688,18 @@ class SparseScoreRecomputeSm100:
                 if cutlass.const_expr(self.score_type == "attention"):
                     if cutlass.const_expr(self.n_block_size >= 128):
                         s_full_phase, reduce_phase = self._epilogue_attention_n128(
-                            tiled_mma_qk, tStS_ref,
-                            sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-                            sTopkIdx, mTopkIdx, mOut,
+                            tiled_mma_qk,
+                            tStS_ref,
+                            sPerHead,
+                            sScoreAll,
+                            S_mbar_ptr,
+                            reduce_sync_mbar_ptr,
+                            sTopkIdx,
+                            mTopkIdx,
+                            mOut,
                             mTopkLength,
-                            m_block, batch_idx,
+                            m_block,
+                            batch_idx,
                             tidx,
                             s_full_phase,
                             reduce_phase,
@@ -713,11 +709,18 @@ class SparseScoreRecomputeSm100:
                         )
                     else:
                         s_full_phase, reduce_phase = self._epilogue_attention(
-                            tiled_mma_qk, tStS_ref,
-                            sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-                            sTopkIdx, mTopkIdx, mOut,
+                            tiled_mma_qk,
+                            tStS_ref,
+                            sPerHead,
+                            sScoreAll,
+                            S_mbar_ptr,
+                            reduce_sync_mbar_ptr,
+                            sTopkIdx,
+                            mTopkIdx,
+                            mOut,
                             mTopkLength,
-                            m_block, batch_idx,
+                            m_block,
+                            batch_idx,
                             tidx,
                             s_full_phase,
                             reduce_phase,
@@ -727,11 +730,19 @@ class SparseScoreRecomputeSm100:
                         )
                 else:
                     s_full_phase, reduce_phase = self._epilogue_indexer(
-                        tiled_mma_qk, tStS_ref,
-                        mPerHead, sPerHead, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-                        sTopkIdx, mTopkIdx, mOut,
+                        tiled_mma_qk,
+                        tStS_ref,
+                        mPerHead,
+                        sPerHead,
+                        sScoreAll,
+                        S_mbar_ptr,
+                        reduce_sync_mbar_ptr,
+                        sTopkIdx,
+                        mTopkIdx,
+                        mOut,
                         mTopkLength,
-                        m_block, batch_idx,
+                        m_block,
+                        batch_idx,
                         tidx,
                         s_full_phase,
                         reduce_phase,
@@ -779,12 +790,8 @@ class SparseScoreRecomputeSm100:
                 # stage s, keeping 2 groups in flight to improve L2 utilization.
                 # (Full-depth tested: worse — delaying MMA start hurts more
                 # than extra L2 parallelism helps.)
-                K_issue_state = make_pipeline_state(
-                    PipelineUserType.Producer, self.kv_stage
-                )
-                K_commit_state = make_pipeline_state(
-                    PipelineUserType.Producer, self.kv_stage
-                )
+                K_issue_state = make_pipeline_state(PipelineUserType.Producer, self.kv_stage)
+                K_commit_state = make_pipeline_state(PipelineUserType.Producer, self.kv_stage)
 
                 while work_tile.is_valid_tile:
                     m_block = work_tile.tile_idx[0]
@@ -800,16 +807,23 @@ class SparseScoreRecomputeSm100:
                         sK_stage = sK[None, None, None, K_issue_state.index]
                         sK_slice = cute.composition(
                             sK_stage,
-                            cute.make_layout(
-                                (self.n_block_size, self.k_block_size)
-                            ),
+                            cute.make_layout((self.n_block_size, self.k_block_size)),
                         )
                         k_offset = const_expr(_kc * self.k_block_size)
                         self._load_k_rows(
-                            mK, sK_slice, mTopkIdx, mTopkLength,
-                            async_copy_atom, async_thr_copy,
-                            n_block, q_token_idx, batch_idx, seqlen_k,
-                            topK_cur, idx_in_group, group_idx_local,
+                            mK,
+                            sK_slice,
+                            mTopkIdx,
+                            mTopkLength,
+                            async_copy_atom,
+                            async_thr_copy,
+                            n_block,
+                            q_token_idx,
+                            batch_idx,
+                            seqlen_k,
+                            topK_cur,
+                            idx_in_group,
+                            group_idx_local,
                             k_offset=k_offset,
                         )
                         cute.arch.cp_async_commit_group()
@@ -823,16 +837,23 @@ class SparseScoreRecomputeSm100:
                             sK_stage = sK[None, None, None, K_issue_state.index]
                             sK_slice = cute.composition(
                                 sK_stage,
-                                cute.make_layout(
-                                    (self.n_block_size, self.k_block_size)
-                                ),
+                                cute.make_layout((self.n_block_size, self.k_block_size)),
                             )
                             k_offset = const_expr(_kc * self.k_block_size)
                             self._load_k_rows(
-                                mK, sK_slice, mTopkIdx, mTopkLength,
-                                async_copy_atom, async_thr_copy,
-                                n_block, q_token_idx, batch_idx, seqlen_k,
-                                topK_cur, idx_in_group, group_idx_local,
+                                mK,
+                                sK_slice,
+                                mTopkIdx,
+                                mTopkLength,
+                                async_copy_atom,
+                                async_thr_copy,
+                                n_block,
+                                q_token_idx,
+                                batch_idx,
+                                seqlen_k,
+                                topK_cur,
+                                idx_in_group,
+                                group_idx_local,
                                 k_offset=k_offset,
                             )
                             cute.arch.cp_async_commit_group()
@@ -858,9 +879,7 @@ class SparseScoreRecomputeSm100:
                 # Attention: original K load with wait_group(0).
                 # 2-deep tested but regressed -14% (kv_stage=2 too tight,
                 # code bloat from prologue/drain outweighs L2 overlap gain).
-                K_load_state = make_pipeline_state(
-                    PipelineUserType.Producer, self.kv_stage
-                )
+                K_load_state = make_pipeline_state(PipelineUserType.Producer, self.kv_stage)
 
                 while work_tile.is_valid_tile:
                     m_block = work_tile.tile_idx[0]
@@ -880,16 +899,23 @@ class SparseScoreRecomputeSm100:
                             sK_stage = sK[None, None, None, K_load_state.index]
                             sK_slice = cute.composition(
                                 sK_stage,
-                                cute.make_layout(
-                                    (self.n_block_size, self.k_block_size)
-                                ),
+                                cute.make_layout((self.n_block_size, self.k_block_size)),
                             )
                             k_offset = const_expr(_kc * self.k_block_size)
                             self._load_k_rows(
-                                mK, sK_slice, mTopkIdx, mTopkLength,
-                                async_copy_atom, async_thr_copy,
-                                n_block, q_token_idx, batch_idx, seqlen_k,
-                                topK_cur, idx_in_group, group_idx_local,
+                                mK,
+                                sK_slice,
+                                mTopkIdx,
+                                mTopkLength,
+                                async_copy_atom,
+                                async_thr_copy,
+                                n_block,
+                                q_token_idx,
+                                batch_idx,
+                                seqlen_k,
+                                topK_cur,
+                                idx_in_group,
+                                group_idx_local,
                                 k_offset=k_offset,
                             )
                             cute.arch.cp_async_commit_group()
@@ -935,39 +961,42 @@ class SparseScoreRecomputeSm100:
         """
         NUM_GROUPS = const_expr(self.WARPGROUP_SIZE // 8)
         ROWS_PER_GROUP = const_expr(self.n_block_size // NUM_GROUPS)
-        batch_offset = (
-            batch_idx * seqlen_k if const_expr(self.topk_indices_global)
-            else Int32(0)
-        )
+        batch_offset = batch_idx * seqlen_k if const_expr(self.topk_indices_global) else Int32(0)
         for r in cutlass.range_constexpr(ROWS_PER_GROUP):
             row = r * NUM_GROUPS + group_idx_local
             topk_pos = n_block * self.n_block_size + row
             if const_expr(self.have_topk_length and self.score_type == "attention"):
                 if topk_pos < topK_cur:
-                    topk_raw = Int32(
-                        mTopkIdx[q_token_idx, topk_pos, batch_idx]
-                    )
+                    topk_raw = Int32(mTopkIdx[q_token_idx, topk_pos, batch_idx])
                     topk_local = topk_raw - batch_offset
                     self._copy_row(
-                        mK, sK_slice, row, idx_in_group,
-                        copy_atom, thr_copy,
-                        topk_local, batch_idx,
+                        mK,
+                        sK_slice,
+                        row,
+                        idx_in_group,
+                        copy_atom,
+                        thr_copy,
+                        topk_local,
+                        batch_idx,
                         k_offset=k_offset,
                     )
             else:
                 topk_local = Int32(-1)
                 if topk_pos < topK_cur:
-                    topk_raw = Int32(
-                        mTopkIdx[q_token_idx, topk_pos, batch_idx]
-                    )
+                    topk_raw = Int32(mTopkIdx[q_token_idx, topk_pos, batch_idx])
                     # Invalid (-1) stays negative after the offset subtraction
                     # and is rejected by the bounds check below.
                     topk_local = topk_raw - batch_offset
                 if topk_local >= 0 and topk_local < seqlen_k:
                     self._copy_row(
-                        mK, sK_slice, row, idx_in_group,
-                        copy_atom, thr_copy,
-                        topk_local, batch_idx,
+                        mK,
+                        sK_slice,
+                        row,
+                        idx_in_group,
+                        copy_atom,
+                        thr_copy,
+                        topk_local,
+                        batch_idx,
                         k_offset=k_offset,
                     )
 
@@ -1025,8 +1054,12 @@ class SparseScoreRecomputeSm100:
     # =========================================================================
     @cute.jit
     def _intra_inter_warp_reduce_max(
-        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
-        warp_id_in_wg, local_value,
+        self,
+        sScoreAll,
+        reduce_sync_mbar_ptr,
+        reduce_sync_phase,
+        warp_id_in_wg,
+        local_value,
     ):
         """Reduce local max across 4 warps via smem scratch + mbarrier sync."""
         warp_max = cute.arch.warp_redux_sync(local_value, "fmax")
@@ -1046,8 +1079,12 @@ class SparseScoreRecomputeSm100:
 
     @cute.jit
     def _intra_inter_warp_reduce_sum(
-        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
-        warp_id_in_wg, local_value,
+        self,
+        sScoreAll,
+        reduce_sync_mbar_ptr,
+        reduce_sync_phase,
+        warp_id_in_wg,
+        local_value,
     ):
         """Reduce local sum across 4 warps via smem scratch + mbarrier sync."""
         warp_sum = cute.arch.warp_reduction_sum(local_value)
@@ -1066,8 +1103,12 @@ class SparseScoreRecomputeSm100:
 
     @cute.jit
     def _inter_warp_sync_sum(
-        self, sScoreAll, reduce_sync_mbar_ptr, reduce_sync_phase,
-        warp_id_in_wg, warp_sum,
+        self,
+        sScoreAll,
+        reduce_sync_mbar_ptr,
+        reduce_sync_phase,
+        warp_id_in_wg,
+        warp_sum,
     ):
         """Cross-warp sum sync with pre-computed warp-level sum (skip warp_reduction_sum)."""
         with cute.arch.elect_one():
@@ -1091,10 +1132,17 @@ class SparseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        mPerHead, sW, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-        sTopkIdx, mTopkIdx, mOut,
+        mPerHead,
+        sW,
+        sScoreAll,
+        S_mbar_ptr,
+        reduce_sync_mbar_ptr,
+        sTopkIdx,
+        mTopkIdx,
+        mOut,
         mTopkLength,
-        m_block, batch_idx,
+        m_block,
+        batch_idx,
         tidx,
         s_full_phase,
         reduce_phase,
@@ -1124,9 +1172,7 @@ class SparseScoreRecomputeSm100:
         cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
         tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
 
-        tSrS_shape = thr_tmem_load.partition_D(
-            cute.make_identity_tensor(tStS_ref.shape)
-        ).shape
+        tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
         tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
         sW_off = Int32(0) if per_head_offset is None else per_head_offset
@@ -1172,8 +1218,10 @@ class SparseScoreRecomputeSm100:
             if const_expr(_ri == 0):
                 cute.autovec_copy(W_src_f32, rW_all_f32)
             tmem_ptr_cur = cute.make_ptr(
-                Float32, _slot * self.tmem_s_stride,
-                mem_space=cute.AddressSpace.tmem, assumed_align=16,
+                Float32,
+                _slot * self.tmem_s_stride,
+                mem_space=cute.AddressSpace.tmem,
+                assumed_align=16,
             )
             tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
             tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
@@ -1219,8 +1267,11 @@ class SparseScoreRecomputeSm100:
                 local_max = rScores[ei]
 
         global_max, reduce_phase = self._intra_inter_warp_reduce_max(
-            sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
-            warp_id_in_wg, local_max,
+            sScoreAll,
+            reduce_sync_mbar_ptr,
+            reduce_phase,
+            warp_id_in_wg,
+            local_max,
         )
 
         if global_max > Float32(-1e30):
@@ -1237,8 +1288,11 @@ class SparseScoreRecomputeSm100:
                 cute.make_layout((self.num_warps_in_epi_wg,), stride=(1,)),
             )
             global_sum, reduce_phase = self._intra_inter_warp_reduce_sum(
-                sScoreAll_sum, reduce_sync_mbar_ptr, reduce_phase,
-                warp_id_in_wg, local_exp_sum,
+                sScoreAll_sum,
+                reduce_sync_mbar_ptr,
+                reduce_phase,
+                warp_id_in_wg,
+                local_exp_sum,
             )
 
             inv_sum = Float32(1.0) / global_sum
@@ -1264,10 +1318,16 @@ class SparseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        sLSE, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-        sTopkIdx, mTopkIdx, mOut,
+        sLSE,
+        sScoreAll,
+        S_mbar_ptr,
+        reduce_sync_mbar_ptr,
+        sTopkIdx,
+        mTopkIdx,
+        mOut,
         mTopkLength,
-        m_block, batch_idx,
+        m_block,
+        batch_idx,
         tidx,
         s_full_phase,
         reduce_phase,
@@ -1293,9 +1353,7 @@ class SparseScoreRecomputeSm100:
         cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
         tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
 
-        tSrS_shape = thr_tmem_load.partition_D(
-            cute.make_identity_tensor(tStS_ref.shape)
-        ).shape
+        tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
         tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
         sLSE_off = Int32(0) if per_head_offset is None else per_head_offset
@@ -1369,7 +1427,7 @@ class SparseScoreRecomputeSm100:
                         val0 = tSrS[idx0]
                         val1 = tSrS[idx1]
 
-                        (val0, val1) = fma_packed_f32x2(
+                        val0, val1 = fma_packed_f32x2(
                             (val0, val1),
                             (scale_log2_e, scale_log2_e),
                             lse_pair,
@@ -1396,8 +1454,11 @@ class SparseScoreRecomputeSm100:
 
         # ---- Phase 2: L1-norm (scores already non-negative from exp) ----
         global_sum, reduce_phase = self._inter_warp_sync_sum(
-            sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
-            warp_id_in_wg, warp_sum_acc,
+            sScoreAll,
+            reduce_sync_mbar_ptr,
+            reduce_phase,
+            warp_id_in_wg,
+            warp_sum_acc,
         )
 
         if global_sum > Float32(1e-10):
@@ -1420,10 +1481,16 @@ class SparseScoreRecomputeSm100:
         self,
         tiled_mma_qk,
         tStS_ref,
-        sLSE, sScoreAll, S_mbar_ptr, reduce_sync_mbar_ptr,
-        sTopkIdx, mTopkIdx, mOut,
+        sLSE,
+        sScoreAll,
+        S_mbar_ptr,
+        reduce_sync_mbar_ptr,
+        sTopkIdx,
+        mTopkIdx,
+        mOut,
         mTopkLength,
-        m_block, batch_idx,
+        m_block,
+        batch_idx,
         tidx,
         s_full_phase,
         reduce_phase,
@@ -1442,9 +1509,7 @@ class SparseScoreRecomputeSm100:
         tidx_wg = tidx % self.WARPGROUP_SIZE
 
         tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld16x64bOp(
-                tcgen05.copy.Repetition(self.m_block_size // 2)
-            ),
+            tcgen05.copy.Ld16x64bOp(tcgen05.copy.Repetition(self.m_block_size // 2)),
             Float32,
         )
         thr_tmem_load = tcgen05.make_tmem_copy(tmem_load_atom, tStS_ref).get_slice(tidx_wg)
@@ -1453,9 +1518,7 @@ class SparseScoreRecomputeSm100:
         cS = cute.make_identity_tensor(self.mma_tiler_qk[:2])
         tScS = thr_tmem_load.partition_D(thr_mma.partition_C(cS))
 
-        tSrS_shape = thr_tmem_load.partition_D(
-            cute.make_identity_tensor(tStS_ref.shape)
-        ).shape
+        tSrS_shape = thr_tmem_load.partition_D(cute.make_identity_tensor(tStS_ref.shape)).shape
         tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
 
         sLSE_off = Int32(0) if per_head_offset is None else per_head_offset
@@ -1478,9 +1541,7 @@ class SparseScoreRecomputeSm100:
         # tSrLSE[i] pairs with tSrS[i] regardless of fragment layout.
         sLSE_2d = cute.make_tensor(
             sLSE_f32_ptr,
-            cute.make_layout(
-                (self.n_block_size, self.m_block_size), stride=(0, 1)
-            ),
+            cute.make_layout((self.n_block_size, self.m_block_size), stride=(0, 1)),
         )
         tSsLSE = thr_tmem_load.partition_D(thr_mma.partition_C(sLSE_2d))
         tSrLSE = cute.make_rmem_tensor(tSsLSE.shape, Float32)
@@ -1543,7 +1604,7 @@ class SparseScoreRecomputeSm100:
                         val0 = tSrS[idx0]
                         val1 = tSrS[idx1]
 
-                        (val0, val1) = fma_packed_f32x2(
+                        val0, val1 = fma_packed_f32x2(
                             (val0, val1),
                             (scale_log2_e, scale_log2_e),
                             lse_pair,
@@ -1571,14 +1632,20 @@ class SparseScoreRecomputeSm100:
                 warp_sum_acc = warp_sum_acc + cute.arch.warp_reduction_sum(partial_score)
 
                 partner_partial = cute.arch.shuffle_sync_bfly(
-                    partial_score, offset=2, mask=-1, mask_and_clamp=31,
+                    partial_score,
+                    offset=2,
+                    mask=-1,
+                    mask_and_clamp=31,
                 )
                 rScores[n_blk] = partial_score + partner_partial
 
         # ---- Phase 2: L1-norm (scores already non-negative from exp) ----
         global_sum, reduce_phase = self._inter_warp_sync_sum(
-            sScoreAll, reduce_sync_mbar_ptr, reduce_phase,
-            warp_id_in_wg, warp_sum_acc,
+            sScoreAll,
+            reduce_sync_mbar_ptr,
+            reduce_phase,
+            warp_id_in_wg,
+            warp_sum_acc,
         )
 
         if is_active:

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
@@ -7,6 +7,7 @@ import torch
 import cutlass
 import cutlass.cute as cute
 
+from cudnn.deepseek_sparse_attention.utils.compiler import compile_options
 from cudnn.deepseek_sparse_attention.utils.runtime import resolve_stream
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor
 from .dsa_bwd_sm100 import FlashAttentionDSABackwardSm100
@@ -171,7 +172,7 @@ def flash_attn_bwd_sm100(
                 workspace_dKV_tensor,
                 softmax_scale,
                 current_stream,
-                options="--enable-tvm-ffi",
+                options=compile_options(),
             )
 
     with torch.cuda.nvtx.range("flash_attn_bwd_sm100_kernel"):

--- a/python/cudnn/deepseek_sparse_attention/utils/compiler.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/compiler.py
@@ -21,13 +21,14 @@ from functools import lru_cache
 import torch
 
 # (compute_capability) → cute DSL --gpu-arch flag value.
-# Both H100 and B200/B300 require the architecture-specific ``a`` variant
-# because the indexer kernels use TMA / tcgen05 instructions that are only
-# guaranteed to lower correctly under the ``a`` SASS gencode.
+# H100, B200/B300, and Rubin require architecture-specific variants because
+# the kernels use TMA / tcgen05 instructions that are only guaranteed to lower
+# correctly under the matching SASS gencode.
 _ARCH_MAP = {
     (9, 0): "sm_90a",  # Hopper H100
     (10, 0): "sm_100a",  # Blackwell B200
     (10, 3): "sm_103a",  # Blackwell Ultra B300
+    (10, 7): "sm_100f",  # Rubin
 }
 
 

--- a/python/cudnn/deepseek_sparse_attention/utils/compiler.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/compiler.py
@@ -21,14 +21,14 @@ from functools import lru_cache
 import torch
 
 # (compute_capability) → cute DSL --gpu-arch flag value.
-# H100, B200/B300, and Rubin require architecture-specific variants because
+# H100, B200/B300, and sm_100f require architecture-specific variants because
 # the kernels use TMA / tcgen05 instructions that are only guaranteed to lower
 # correctly under the matching SASS gencode.
 _ARCH_MAP = {
     (9, 0): "sm_90a",  # Hopper H100
     (10, 0): "sm_100a",  # Blackwell B200
     (10, 3): "sm_103a",  # Blackwell Ultra B300
-    (10, 7): "sm_100f",  # Rubin
+    (10, 7): "sm_100f",
 }
 
 

--- a/python/cudnn/deepseek_sparse_attention/utils/runtime.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/runtime.py
@@ -1,8 +1,8 @@
 """Runtime helpers shared by DSA Python wrappers."""
 
-from contextlib import nullcontext
+from contextlib import contextmanager
 from functools import lru_cache
-from typing import Optional
+from typing import Iterator, Optional
 
 import torch
 import cuda.bindings.driver as cuda
@@ -13,11 +13,22 @@ def device_major() -> int:
     return torch.cuda.get_device_capability()[0]
 
 
-def maybe_contiguous(x):
-    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
+def maybe_contiguous(
+    x: torch.Tensor | None,
+    stream: Optional[cuda.CUstream] = None,
+) -> torch.Tensor | None:
+    if x is None or x.stride(-1) == 1:
+        return x
+    with torch_stream_context(stream):
+        return x.contiguous()
 
 
-def validate_q_causal_offsets(q_causal_offsets, batch: int, device: torch.device):
+def validate_q_causal_offsets(
+    q_causal_offsets: torch.Tensor | None,
+    batch: int,
+    device: torch.device,
+    stream: Optional[cuda.CUstream] = None,
+) -> torch.Tensor | None:
     if q_causal_offsets is None:
         return None
     if q_causal_offsets.dtype != torch.int32:
@@ -28,7 +39,10 @@ def validate_q_causal_offsets(q_causal_offsets, batch: int, device: torch.device
         raise ValueError("q_causal_offsets must be a CUDA tensor")
     if q_causal_offsets.device != device:
         raise ValueError("q_causal_offsets must be on the same device as q")
-    return q_causal_offsets if q_causal_offsets.is_contiguous() else q_causal_offsets.contiguous()
+    if q_causal_offsets.is_contiguous():
+        return q_causal_offsets
+    with torch_stream_context(stream):
+        return q_causal_offsets.contiguous()
 
 
 def resolve_stream(current_stream: Optional[cuda.CUstream] = None) -> cuda.CUstream:
@@ -37,7 +51,10 @@ def resolve_stream(current_stream: Optional[cuda.CUstream] = None) -> cuda.CUstr
     return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
 
-def torch_stream_context(current_stream: Optional[cuda.CUstream] = None):
+@contextmanager
+def torch_stream_context(current_stream: Optional[cuda.CUstream] = None) -> Iterator[None]:
     if current_stream is None:
-        return nullcontext()
-    return torch.cuda.stream(torch.cuda.ExternalStream(int(current_stream)))
+        yield
+        return
+    with torch.cuda.stream(torch.cuda.ExternalStream(int(current_stream))):
+        yield

--- a/python/cudnn/deepseek_sparse_attention/utils/runtime.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/runtime.py
@@ -17,6 +17,20 @@ def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
 
+def validate_q_causal_offsets(q_causal_offsets, batch: int, device: torch.device):
+    if q_causal_offsets is None:
+        return None
+    if q_causal_offsets.dtype != torch.int32:
+        raise ValueError("q_causal_offsets must be int32")
+    if q_causal_offsets.ndim != 1 or q_causal_offsets.shape[0] != batch:
+        raise ValueError(f"q_causal_offsets must have shape ({batch},), got {tuple(q_causal_offsets.shape)}")
+    if not q_causal_offsets.is_cuda:
+        raise ValueError("q_causal_offsets must be a CUDA tensor")
+    if q_causal_offsets.device != device:
+        raise ValueError("q_causal_offsets must be on the same device as q")
+    return q_causal_offsets if q_causal_offsets.is_contiguous() else q_causal_offsets.contiguous()
+
+
 def resolve_stream(current_stream: Optional[cuda.CUstream] = None) -> cuda.CUstream:
     if current_stream is not None:
         return current_stream

--- a/python/cudnn/deepseek_sparse_attention/utils/sm90/mma.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/sm90/mma.py
@@ -91,7 +91,7 @@ def gemm_w_idx(
 
 
 def mma_partition_fragment_AB(
-    thr_mma: cute.core.ThrMma,
+    thr_mma: cute.ThrMma,
     sA: Optional[cute.Tensor],
     sB: Optional[cute.Tensor],
     swap_AB: bool,

--- a/test/python/fe_api/dsa/dsa_reference.py
+++ b/test/python/fe_api/dsa/dsa_reference.py
@@ -140,6 +140,7 @@ def ref_indexer_forward(
     k: torch.Tensor,  # (B, S_k, H_kv, D)
     w: torch.Tensor,  # (B, S_q, H_q)
     ratio: int,
+    q_causal_offsets: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Dense indexer score computation. Returns (B, S_q, S_k) FP32."""
     b, s_q, h_q, d = q.shape
@@ -158,8 +159,8 @@ def ref_indexer_forward(
     scores = scores * w_f.unsqueeze(-1)  # (B, S_q, H_q, S_k)
     out = scores.sum(dim=2)  # (B, S_q, S_k)
 
-    valid = _bottom_right_causal_mask(s_q, s_k, ratio, q.device)
-    out = out.masked_fill(~valid.unsqueeze(0), float("-inf"))
+    valid = _batched_ratio_causal_mask(s_q, s_k, ratio, q.device, b, q_causal_offsets)
+    out = out.masked_fill(~valid, float("-inf"))
     return out
 
 
@@ -169,10 +170,11 @@ def check_ref_indexer_forward(
     w,
     out_actual,
     ratio: int,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     atol: float = 1e-4,
     rtol: float = 1e-4,
 ):
-    out_ref = ref_indexer_forward(q, k, w, ratio)
+    out_ref = ref_indexer_forward(q, k, w, ratio, q_causal_offsets=q_causal_offsets)
     finite = torch.isfinite(out_ref)
     assert torch.equal(torch.isneginf(out_actual), torch.isneginf(out_ref))
     torch.testing.assert_close(
@@ -348,18 +350,46 @@ def check_ref_sparse_score_recompute(
 # ---------------------------------------------------------------------------
 
 
+def _ratio_causal_mask(
+    s_q: int,
+    s_k: int,
+    ratio: int,
+    device: torch.device,
+    q_causal_offset: int = 0,
+) -> torch.Tensor:
+    """Return ratio-causal validity mask for one local Q segment."""
+    q = q_causal_offset + torch.arange(s_q, device=device, dtype=torch.int64)
+    k_pos = torch.arange(s_k, device=device, dtype=torch.int64)
+    col_limit = torch.div(q + 1, ratio, rounding_mode="floor").clamp(0, s_k)
+    return k_pos.view(1, s_k) < col_limit.view(s_q, 1)
+
+
+def _batched_ratio_causal_mask(
+    s_q: int,
+    s_k: int,
+    ratio: int,
+    device: torch.device,
+    batch: int,
+    q_causal_offsets: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Return ``(B, S_q, S_k)`` ratio-causal masks with per-batch offsets."""
+    if q_causal_offsets is None:
+        return _ratio_causal_mask(s_q, s_k, ratio, device).unsqueeze(0).expand(batch, -1, -1)
+    offsets = q_causal_offsets.to(device=device, dtype=torch.int64)
+    q = torch.arange(s_q, device=device, dtype=torch.int64).view(1, s_q)
+    k_pos = torch.arange(s_k, device=device, dtype=torch.int64).view(1, 1, s_k)
+    col_limit = torch.div(offsets.view(batch, 1) + q + 1, ratio, rounding_mode="floor").clamp(0, s_k)
+    return k_pos < col_limit.unsqueeze(-1)
+
+
 def _bottom_right_causal_mask(
     s_q: int,
     s_k: int,
     ratio: int,
     device: torch.device,
 ) -> torch.Tensor:
-    """Return dense score validity mask with bottom-right causal alignment."""
-    q_global_start = s_k * ratio - s_q
-    q = torch.arange(s_q, device=device, dtype=torch.int64)
-    k_pos = torch.arange(s_k, device=device, dtype=torch.int64)
-    col_limit = torch.div(q_global_start + q + 1, ratio, rounding_mode="floor")
-    return k_pos.view(1, s_k) < col_limit.view(s_q, 1)
+    """Compatibility alias for the offset-0 ratio-causal mask."""
+    return _ratio_causal_mask(s_q, s_k, ratio, device)
 
 
 def ref_dense_indexer_score_recompute(
@@ -367,13 +397,14 @@ def ref_dense_indexer_score_recompute(
     k_indexer: torch.Tensor,  # (B, S_k, H_kv, D) — H_kv=1 for MQA
     weights: torch.Tensor,  # (B, S_q, H_q)
     ratio: int = 1,
+    q_causal_offsets: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Reference for ``DSA.dense_indexer_score_recompute_wrapper``.
 
     Computes per-query dense indexer scores
     ``S[b, q, k] = sum_h ReLU(Q_h · K_h^T) · W_h`` and the
     ``LogSumExp``-style denom ``log(sum_k exp(S[b, q, k]))`` over valid
-    bottom-right causal positions.
+    ratio-causal compressed-KV positions.
     """
     b, s_q, h_q, d = q_indexer.shape
     _, s_k, h_kv, _ = k_indexer.shape
@@ -388,10 +419,10 @@ def ref_dense_indexer_score_recompute(
     scores = torch.relu(scores)
     scores = (scores * w_f.unsqueeze(-1)).sum(dim=2)  # (B, S_q, S_k)
 
-    valid = _bottom_right_causal_mask(s_q, s_k, ratio, q_indexer.device)
-    scores_for_denom = scores.masked_fill(~valid.unsqueeze(0), float("-inf"))
+    valid = _batched_ratio_causal_mask(s_q, s_k, ratio, q_indexer.device, b, q_causal_offsets)
+    scores_for_denom = scores.masked_fill(~valid, float("-inf"))
     denom = torch.logsumexp(scores_for_denom, dim=-1)  # (B, S_q)
-    return scores.masked_fill(~valid.unsqueeze(0), 0.0), denom
+    return scores.masked_fill(~valid, 0.0), denom
 
 
 def ref_dense_attn_score_recompute(
@@ -400,12 +431,13 @@ def ref_dense_attn_score_recompute(
     lse: torch.Tensor,  # (B, S_q, H_q) FP32
     softmax_scale: float,
     ratio: int = 1,
+    q_causal_offsets: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Reference for ``DSA.dense_attn_score_recompute_wrapper``.
 
     ``P[b, q, h, k] = exp(Q_h · K_h^T · scale - LSE_h)``, sum over heads,
     returns unnormalized ``S`` and the per-query L1-norm denom over valid
-    bottom-right causal positions.
+    ratio-causal compressed-KV positions.
     """
     b, s_q, h_q, d = q_attn.shape
     _, s_k, h_kv, _ = k_attn.shape
@@ -419,8 +451,8 @@ def ref_dense_attn_score_recompute(
     p = torch.exp(qk - lse_f.unsqueeze(-1))  # (B, S_q, H_q, S_k)
     s = p.sum(dim=2)  # (B, S_q, S_k)
 
-    valid = _bottom_right_causal_mask(s_q, s_k, ratio, q_attn.device)
-    s = s.masked_fill(~valid.unsqueeze(0), 0.0)
+    valid = _batched_ratio_causal_mask(s_q, s_k, ratio, q_attn.device, b, q_causal_offsets)
+    s = s.masked_fill(~valid, 0.0)
     denom = s.sum(dim=-1)  # (B, S_q)
     return s, denom
 
@@ -434,6 +466,7 @@ def check_ref_dense_score_recompute(
     denom_actual,
     softmax_scale: Optional[float] = None,
     ratio: int = 1,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     atol_scores: float = 5e-3,
     rtol_scores: float = 5e-3,
     atol_denom: float = 5e-3,
@@ -447,7 +480,7 @@ def check_ref_dense_score_recompute(
     """
     if score_type == "indexer":
         # aux = weights
-        s_ref, denom_ref = ref_dense_indexer_score_recompute(q, k, aux, ratio)
+        s_ref, denom_ref = ref_dense_indexer_score_recompute(q, k, aux, ratio, q_causal_offsets=q_causal_offsets)
     else:
         # aux = lse
         s_ref, denom_ref = ref_dense_attn_score_recompute(
@@ -456,6 +489,7 @@ def check_ref_dense_score_recompute(
             aux,
             softmax_scale,
             ratio,
+            q_causal_offsets=q_causal_offsets,
         )
 
     finite = torch.isfinite(out_actual)
@@ -576,6 +610,7 @@ def _dense_indexer_predict_distribution(
     weights: torch.Tensor,  # (B, S_q, H)
     sm_scale: float,
     ratio: int,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     return_scores: bool = False,
 ) -> torch.Tensor:
     """Dense full-KV predict distribution for dense indexer backward."""
@@ -590,8 +625,8 @@ def _dense_indexer_predict_distribution(
     scores_per_head = torch.relu(scores_per_head)
     scores = (scores_per_head * (weights * sm_scale).unsqueeze(-1)).sum(dim=2)
 
-    valid = _bottom_right_causal_mask(s_q, s_k, ratio, q_indexer.device)
-    scores = scores.masked_fill(~valid.unsqueeze(0), float("-inf"))
+    valid = _batched_ratio_causal_mask(s_q, s_k, ratio, q_indexer.device, b, q_causal_offsets)
+    scores = scores.masked_fill(~valid, float("-inf"))
     predict = torch.softmax(scores, dim=-1)
     return (predict, scores) if return_scores else predict
 
@@ -605,18 +640,27 @@ def ref_dense_indexer_backward(
     sm_scale: float = 1.0,
     ratio: int = 1,
     grad_scale: float = 1.0,
+    q_causal_offsets: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """PyTorch autograd reference for ``DSA.dense_indexer_backward_wrapper``."""
     q = index_q.detach().clone().requires_grad_(True)
     w = weights.detach().clone().requires_grad_(True)
     k = index_k.detach().clone().requires_grad_(True)
 
-    predict, scores = _dense_indexer_predict_distribution(q, k, w, sm_scale, ratio, return_scores=True)
+    predict, scores = _dense_indexer_predict_distribution(
+        q,
+        k,
+        w,
+        sm_scale,
+        ratio,
+        q_causal_offsets=q_causal_offsets,
+        return_scores=True,
+    )
 
-    _, s_q, _, _ = index_q.shape
+    b, s_q, _, _ = index_q.shape
     _, s_k, _ = index_k.shape
-    valid = _bottom_right_causal_mask(s_q, s_k, ratio, index_q.device)
-    target = attn_score_raw.to(torch.float32).masked_fill(~valid.unsqueeze(0), 0.0)
+    valid = _batched_ratio_causal_mask(s_q, s_k, ratio, index_q.device, b, q_causal_offsets)
+    target = attn_score_raw.to(torch.float32).masked_fill(~valid, 0.0)
     target = target / attn_l1norm.to(torch.float32).unsqueeze(-1).clamp(min=1e-10)
 
     eps = math.exp(-100.0)
@@ -624,7 +668,7 @@ def ref_dense_indexer_backward(
     predict = predict.to(torch.float32)
     log_clip_mask = (predict >= eps).to(torch.float32)
     g = -target_eff * log_clip_mask * grad_scale
-    grad_signal = (g - predict * g.sum(dim=-1, keepdim=True)).masked_fill(~valid.unsqueeze(0), 0.0)
+    grad_signal = (g - predict * g.sum(dim=-1, keepdim=True)).masked_fill(~valid, 0.0)
     grads = torch.autograd.grad(scores, (q, w, k), grad_outputs=grad_signal.to(scores.dtype))
 
     dq, dw, dk = grads
@@ -714,6 +758,7 @@ def check_ref_dense_indexer_backward(
     sm_scale: float = 1.0,
     ratio: int = 1,
     grad_scale: float = 1.0,
+    q_causal_offsets: Optional[torch.Tensor] = None,
     cos_min: float = 0.97,
     rms_rel_max: float = 0.55,
 ):
@@ -726,6 +771,7 @@ def check_ref_dense_indexer_backward(
         sm_scale=sm_scale,
         ratio=ratio,
         grad_scale=grad_scale,
+        q_causal_offsets=q_causal_offsets,
     )
 
     for name, actual, ref in (

--- a/test/python/fe_api/dsa/test_DSA_dense_indexer_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_dense_indexer_backward.py
@@ -5,13 +5,13 @@ from test_utils import torch_fork_set_rng
 
 from fe_api.dsa.dsa_utils import dsa_init, with_dsa_dense_indexer_backward_params
 from fe_api.dsa.dsa_reference import (
-    _bottom_right_causal_mask,
+    _batched_ratio_causal_mask,
     check_ref_dense_indexer_backward,
     ref_dense_indexer_score_recompute,
 )
 
 
-def _allocate(cfg, sm_scale: float, ratio: int):
+def _allocate(cfg, sm_scale: float, ratio: int, q_causal_offsets: torch.Tensor):
     b = cfg["b"]
     s_q = cfg["s_q"]
     s_k = cfg["s_kv"]
@@ -29,18 +29,18 @@ def _allocate(cfg, sm_scale: float, ratio: int):
             index_k.unsqueeze(2),
             weights,
             ratio=ratio,
+            q_causal_offsets=q_causal_offsets,
         )
+        valid = _batched_ratio_causal_mask(s_q, s_k, ratio, device, b, q_causal_offsets)
         if sm_scale != 1.0:
             index_score = index_score * sm_scale
-            valid = _bottom_right_causal_mask(s_q, s_k, ratio, device)
             index_lse = torch.logsumexp(
-                index_score.masked_fill(~valid.unsqueeze(0), float("-inf")),
+                index_score.masked_fill(~valid, float("-inf")),
                 dim=-1,
             )
 
-        valid = _bottom_right_causal_mask(s_q, s_k, ratio, device)
         attn_score = torch.rand(b, s_q, s_k, dtype=torch.float32, device=device)
-        attn_score = attn_score.masked_fill(~valid.unsqueeze(0), 0.0).contiguous()
+        attn_score = attn_score.masked_fill(~valid, 0.0).contiguous()
         attn_l1norm = attn_score.sum(dim=-1).contiguous()
 
     return (
@@ -87,6 +87,7 @@ def test_DSA_dense_indexer_backward_wrapper(
     sm_scale = 1.0
     b_cfg = cfg["b"]
     s_q_cfg = cfg["s_q"]
+    q_causal_offsets = torch.full((b_cfg,), 8, dtype=torch.int32, device="cuda")
     loss_coeff = float(b_cfg * s_q_cfg)
     grad_loss = 1.0
     grad_scale_expected = (loss_coeff / (b_cfg * s_q_cfg)) * grad_loss
@@ -99,7 +100,7 @@ def test_DSA_dense_indexer_backward_wrapper(
         attn_l1norm,
         index_score,
         index_lse,
-    ) = _allocate(cfg, sm_scale=sm_scale, ratio=ratio)
+    ) = _allocate(cfg, sm_scale=sm_scale, ratio=ratio, q_causal_offsets=q_causal_offsets)
     torch_stream = torch.cuda.Stream()
     stream = cuda.CUstream(torch_stream.cuda_stream)
 
@@ -120,6 +121,7 @@ def test_DSA_dense_indexer_backward_wrapper(
             grad_loss=grad_loss,
             block_I=block_I,
             ratio=ratio,
+            q_causal_offsets=q_causal_offsets,
             stream=stream,
         )
     except (ValueError, NotImplementedError, RuntimeError) as e:
@@ -150,4 +152,5 @@ def test_DSA_dense_indexer_backward_wrapper(
             sm_scale=sm_scale,
             ratio=ratio,
             grad_scale=grad_scale_expected,
+            q_causal_offsets=q_causal_offsets,
         )

--- a/test/python/fe_api/dsa/test_DSA_dense_score_recompute.py
+++ b/test/python/fe_api/dsa/test_DSA_dense_score_recompute.py
@@ -6,7 +6,65 @@ import torch
 from test_utils import torch_fork_set_rng
 
 from fe_api.dsa.dsa_utils import dsa_init, with_dsa_score_recompute_params
-from fe_api.dsa.dsa_reference import check_ref_dense_score_recompute
+from fe_api.dsa.dsa_reference import (
+    _batched_ratio_causal_mask,
+    _ratio_causal_mask,
+    check_ref_dense_score_recompute,
+)
+
+
+@pytest.mark.L0
+def test_DSA_ratio_causal_mask_offsets_reference():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    expected_default = torch.tensor(
+        [
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+            [1, 0, 0],
+            [1, 0, 0],
+            [1, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [1, 1, 0],
+            [1, 1, 0],
+        ],
+        dtype=torch.bool,
+        device=device,
+    )
+    expected_cp = torch.tensor(
+        [
+            [1, 0, 0],
+            [1, 0, 0],
+            [1, 0, 0],
+            [1, 1, 0],
+            [1, 1, 0],
+        ],
+        dtype=torch.bool,
+        device=device,
+    )
+    expected_batched = torch.stack(
+        [
+            expected_default[:5],
+            expected_cp,
+            torch.tensor(
+                [
+                    [1, 1, 0],
+                    [1, 1, 0],
+                    [1, 1, 1],
+                    [1, 1, 1],
+                    [1, 1, 1],
+                ],
+                dtype=torch.bool,
+                device=device,
+            ),
+        ]
+    )
+
+    assert torch.equal(_ratio_causal_mask(10, 3, 4, device), expected_default)
+    assert torch.equal(_ratio_causal_mask(5, 3, 4, device, q_causal_offset=4), expected_cp)
+    offsets = torch.tensor([0, 4, 9], dtype=torch.int32, device=device)
+    assert torch.equal(_batched_ratio_causal_mask(5, 3, 4, device, 3, offsets), expected_batched)
 
 
 def _allocate(cfg, score_type: str):
@@ -56,6 +114,7 @@ def test_DSA_dense_score_recompute_wrapper(
         s_kv_default=1024,
     )
     q, k, aux = _allocate(cfg, score_type)
+    q_causal_offsets = torch.full((cfg["b"],), 8, dtype=torch.int32, device=q.device)
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
     try:
@@ -65,6 +124,7 @@ def test_DSA_dense_score_recompute_wrapper(
                 k,
                 aux,
                 qhead_per_kv_head=qhead_per_kv_head,
+                q_causal_offsets=q_causal_offsets,
                 stream=stream,
             )
         else:
@@ -75,6 +135,7 @@ def test_DSA_dense_score_recompute_wrapper(
                 aux,
                 softmax_scale,
                 qhead_per_kv_head=qhead_per_kv_head,
+                q_causal_offsets=q_causal_offsets,
                 stream=stream,
             )
     except (ValueError, NotImplementedError, RuntimeError) as e:
@@ -97,6 +158,7 @@ def test_DSA_dense_score_recompute_wrapper(
                 aux,
                 out,
                 denom,
+                q_causal_offsets=q_causal_offsets,
             )
         else:
             check_ref_dense_score_recompute(
@@ -107,4 +169,5 @@ def test_DSA_dense_score_recompute_wrapper(
                 out,
                 denom,
                 softmax_scale=softmax_scale,
+                q_causal_offsets=q_causal_offsets,
             )

--- a/test/python/fe_api/dsa/test_DSA_dense_score_recompute.py
+++ b/test/python/fe_api/dsa/test_DSA_dense_score_recompute.py
@@ -146,7 +146,8 @@ def test_DSA_dense_score_recompute_wrapper(
 
     assert out.shape == (cfg["b"], cfg["s_q"], cfg["s_kv"])
     assert denom.shape == (cfg["b"], cfg["s_q"])
-    assert torch.isfinite(out).all()
+    assert torch.isfinite(out).any()
+    assert (torch.isfinite(out) | torch.isneginf(out)).all()
     assert torch.isfinite(denom).all()
 
     if not cfg["skip_ref"]:

--- a/test/python/fe_api/dsa/test_DSA_indexer_forward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_forward.py
@@ -51,6 +51,7 @@ def test_DSA_indexer_forward_wrapper(
         min_compute_capability=90,
     )
     q, k, w = _allocate_inputs(cfg)
+    q_causal_offsets = torch.full((cfg["b"],), 4, dtype=torch.int32, device=q.device)
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
     try:
@@ -60,6 +61,7 @@ def test_DSA_indexer_forward_wrapper(
             w,
             ratio=ratio,
             qhead_per_kv_head=qhead_per_kv_head,
+            q_causal_offsets=q_causal_offsets,
             stream=stream,
         )
     except (ValueError, NotImplementedError, RuntimeError) as e:
@@ -67,4 +69,4 @@ def test_DSA_indexer_forward_wrapper(
 
     scores = result["scores"]
     if not cfg["skip_ref"]:
-        check_ref_indexer_forward(q, k, w, scores, ratio)
+        check_ref_indexer_forward(q, k, w, scores, ratio, q_causal_offsets=q_causal_offsets)


### PR DESCRIPTION
## Summary
  - Add optional `q_causal_offsets` plumbing for DSA ratio-causal masking across indexer forward, dense score recompute, and dense indexer backward.
  - Replace bottom-right-derived causal formulas with offset-aware compressed-KV causal limits.
  - Include `q_causal_offsets` presence, not values, in compile cache keys.
  - Cherry-pick Rubin SM100F CuTe DSL support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-batch `q_causal_offsets` support across indexer forward, dense indexer backward, and dense score recomputation.
  * Updated dense SM90/SM100 causal-masking logic to account for these offsets.
* **Bug Fixes**
  * Adjusted causal-region bounds and masking behavior for more accurate score/gradient handling.
  * Improved stream-scoped contiguity/output initialization to better respect CUDA stream ordering.
* **Documentation**
  * Updated DSA API documentation and examples to include `q_causal_offsets`.
* **Tests**
  * Extended reference + CUDA wrapper tests to validate offset-aware masking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->