### PR TITLE
Fix SM100 sparse score recompute compact top-k codegen

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/score_recompute/sparse_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/sparse_score_recompute_sm100.py
@@ -1390,21 +1390,20 @@ class SparseScoreRecomputeSm100:
             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * _slot, s_full_phase)
             if const_expr(_ri == 0):
                 cute.autovec_copy(sLSE_1d, rLSE_all)
-            should_copy_tmem = const_expr(True)
-            if const_expr(self.have_topk_length):
-                should_copy_tmem = n_blk < n_block_max_epi
-            if should_copy_tmem:
-                tmem_ptr_cur = cute.make_ptr(
-                    Float32,
-                    _slot * self.tmem_s_stride,
-                    mem_space=cute.AddressSpace.tmem,
-                    assumed_align=16,
-                )
-                tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
-                tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
+            # Keep the TMEM load unconditional: putting tcgen05 TMEM load ops
+            # under the top-k-length runtime guard trips CUTLASS DSL compile.
+            # Invalid blocks are ignored by should_accumulate_score below.
+            tmem_ptr_cur = cute.make_ptr(
+                Float32,
+                _slot * self.tmem_s_stride,
+                mem_space=cute.AddressSpace.tmem,
+                assumed_align=16,
+            )
+            tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
+            tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
 
-                cute.copy(thr_tmem_load, tStS_t2r_cur, tSrS)
-                cute.arch.fence_view_async_tmem_load()
+            cute.copy(thr_tmem_load, tStS_t2r_cur, tSrS)
+            cute.arch.fence_view_async_tmem_load()
             cute.arch.mbarrier_arrive(S_mbar_ptr + 2 * _slot + 1)
             if const_expr(_slot == 0):
                 s_full_phase ^= 1
@@ -1567,21 +1566,20 @@ class SparseScoreRecomputeSm100:
             cute.arch.mbarrier_wait(S_mbar_ptr + 2 * _slot, s_full_phase)
             if const_expr(_ri == 0):
                 cute.autovec_copy(tSsLSE, tSrLSE)
-            should_copy_tmem = const_expr(True)
-            if const_expr(self.have_topk_length):
-                should_copy_tmem = n_blk < n_block_max_epi
-            if should_copy_tmem:
-                tmem_ptr_cur = cute.make_ptr(
-                    Float32,
-                    _slot * self.tmem_s_stride,
-                    mem_space=cute.AddressSpace.tmem,
-                    assumed_align=16,
-                )
-                tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
-                tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
+            # Keep the TMEM load unconditional: putting tcgen05 TMEM load ops
+            # under the top-k-length runtime guard trips CUTLASS DSL compile.
+            # Invalid blocks are ignored by should_accumulate_score below.
+            tmem_ptr_cur = cute.make_ptr(
+                Float32,
+                _slot * self.tmem_s_stride,
+                mem_space=cute.AddressSpace.tmem,
+                assumed_align=16,
+            )
+            tStS_cur = cute.make_tensor(tmem_ptr_cur, tStS_ref.layout)
+            tStS_t2r_cur = thr_tmem_load.partition_S(tStS_cur)
 
-                cute.copy(thr_tmem_load, tStS_t2r_cur, tSrS)
-                cute.arch.fence_view_async_tmem_load()
+            cute.copy(thr_tmem_load, tStS_t2r_cur, tSrS)
+            cute.arch.fence_view_async_tmem_load()
             cute.arch.mbarrier_arrive(S_mbar_ptr + 2 * _slot + 1)
             if const_expr(_slot == 0):
                 s_full_phase ^= 1

--- a/test/python/fe_api/dsa/dsa_utils.py
+++ b/test/python/fe_api/dsa/dsa_utils.py
@@ -40,6 +40,7 @@ DSA_SCORE_RECOMPUTE_PARAM_MARKS = [
     pytest.mark.parametrize("head_dim", [128]),
     pytest.mark.parametrize("qhead_per_kv_head", [32]),
     pytest.mark.parametrize("score_type", ["indexer", "attention"]),
+    pytest.mark.parametrize("has_topk_length", [False, True]),
 ]
 
 DSA_INDEXER_BACKWARD_PARAM_MARKS = [

--- a/test/python/fe_api/dsa/dsa_utils.py
+++ b/test/python/fe_api/dsa/dsa_utils.py
@@ -40,6 +40,10 @@ DSA_SCORE_RECOMPUTE_PARAM_MARKS = [
     pytest.mark.parametrize("head_dim", [128]),
     pytest.mark.parametrize("qhead_per_kv_head", [32]),
     pytest.mark.parametrize("score_type", ["indexer", "attention"]),
+]
+
+DSA_SPARSE_SCORE_RECOMPUTE_PARAM_MARKS = [
+    *DSA_SCORE_RECOMPUTE_PARAM_MARKS,
     pytest.mark.parametrize("has_topk_length", [False, True]),
 ]
 
@@ -78,6 +82,10 @@ def with_dsa_indexer_top_k_params(func):
 
 def with_dsa_score_recompute_params(func):
     return _apply(DSA_PARAM_MARKS + DSA_SCORE_RECOMPUTE_PARAM_MARKS, func)
+
+
+def with_dsa_sparse_score_recompute_params(func):
+    return _apply(DSA_PARAM_MARKS + DSA_SPARSE_SCORE_RECOMPUTE_PARAM_MARKS, func)
 
 
 def with_dsa_indexer_backward_params(func):

--- a/test/python/fe_api/dsa/test_DSA_sparse_score_recompute.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_score_recompute.py
@@ -31,6 +31,8 @@ def _allocate(cfg, score_type: str, has_topk_length: bool):
     topk_length = None
     if has_topk_length:
         topk_length = torch.randint(1, topk_k + 1, (b, s_q), dtype=torch.int32, device=device)
+        positions = torch.arange(topk, device=device, dtype=torch.int32).view(1, 1, topk)
+        topk_indices = topk_indices.masked_fill(positions >= topk_length.unsqueeze(-1), -1)
 
     if score_type == "indexer":
         weights = torch.randn(b, s_q, qhpkv, dtype=torch.bfloat16, device=device)
@@ -54,6 +56,7 @@ def test_DSA_sparse_score_recompute_wrapper(
     head_dim,
     qhead_per_kv_head,
     score_type,
+    has_topk_length,
     request,
 ):
     try:
@@ -69,11 +72,16 @@ def test_DSA_sparse_score_recompute_wrapper(
         head_dim=head_dim,
         qhead_per_kv_head=qhead_per_kv_head,
         score_type=score_type,
+        has_topk_length=has_topk_length,
         min_compute_capability=90,
         s_q_default=256,
         s_kv_default=2048,
     )
-    q, k, aux, topk_indices, topk_length = _allocate(cfg, score_type, has_topk_length=False)
+    q, k, aux, topk_indices, topk_length = _allocate(
+        cfg,
+        score_type,
+        has_topk_length=has_topk_length,
+    )
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 
     try:
@@ -131,7 +139,8 @@ def test_DSA_sparse_score_recompute_wrapper(
 @pytest.mark.L0
 @torch_fork_set_rng(seed=1)
 @pytest.mark.parametrize("score_type", ["indexer", "attention"])
-def test_DSA_sparse_score_recompute_wrapper_batch_gt_one(score_type, request):
+@pytest.mark.parametrize("has_topk_length", [False, True])
+def test_DSA_sparse_score_recompute_wrapper_batch_gt_one(score_type, has_topk_length, request):
     try:
         from cudnn import DSA
         from cuda.bindings import driver as cuda
@@ -146,6 +155,7 @@ def test_DSA_sparse_score_recompute_wrapper_batch_gt_one(score_type, request):
         qhead_per_kv_head=32,
         topk=128,
         score_type=score_type,
+        has_topk_length=has_topk_length,
         min_compute_capability=90,
         b_default=2,
         s_q_default=32,
@@ -154,7 +164,7 @@ def test_DSA_sparse_score_recompute_wrapper_batch_gt_one(score_type, request):
     q, k, aux, topk_indices, topk_length = _allocate(
         cfg,
         score_type,
-        has_topk_length=False,
+        has_topk_length=has_topk_length,
     )
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
 

--- a/test/python/fe_api/dsa/test_DSA_sparse_score_recompute.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_score_recompute.py
@@ -5,7 +5,7 @@ import torch
 
 from test_utils import torch_fork_set_rng
 
-from fe_api.dsa.dsa_utils import dsa_init, with_dsa_score_recompute_params
+from fe_api.dsa.dsa_utils import dsa_init, with_dsa_sparse_score_recompute_params
 from fe_api.dsa.dsa_reference import check_ref_sparse_score_recompute
 
 
@@ -49,7 +49,7 @@ def _local_to_global_topk_indices(topk_indices: torch.Tensor, seqlen_k: int) -> 
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
-@with_dsa_score_recompute_params
+@with_dsa_sparse_score_recompute_params
 def test_DSA_sparse_score_recompute_wrapper(
     dtype,
     acc_dtype,


### PR DESCRIPTION
## Summary

This fixes the SM100 sparse attention score-recompute kernel when `topk_length`
is provided for compact top-k layouts.

The change removes the runtime `topk_length` branch around the TMEM copy in both
attention epilogues:

- `n_block_size >= 128` / `Ld32x32bOp`
- `n_block_size < 128` / `Ld16x64bOp`

The dynamic guard is still kept for score accumulation and output, so blocks past
`topk_length` continue to contribute zero.

## Why this is needed

Downstream DSA sparse indexer loss calls
`sparse_attn_score_recompute_wrapper(..., topk_length=...)` for packed THD / CP
workloads. With cuDNN Frontend 1.25.0 and CUTLASS DSL 4.5.0 on SM100, the compact
path currently fails during DSL compilation with an ICE like:

`failed to legalize unresolved materialization from !cute_nvgpu.atom.tmem_load ... to !cute.tiled_copy`, `cutlass.cute.nvgpu.common.OpError: expects the N-mode to satisfy 8 <= N <= 256 and N % 8 == 0, but got 4`

The failure happens at the TMEM copy construction inside the runtime
`should_copy_tmem` branch. Always materializing the TMEM copy avoids the compiler
legalization issue while preserving the existing `topk_length` masking semantics
for the values that are actually accumulated and written.

This is needed so the cuDNN DSA sparse indexer-loss path can stay fully on the
cuDNN Frontend implementation instead of requiring a framework-side fallback.

## Reproduction code

```python
# Run on Blackwell/SM100 with cuDNN FE sparse score recompute installed.

import math
import torch

from cudnn.deepseek_sparse_attention.score_recompute.api import (
    sparse_attn_score_recompute_wrapper,
)

assert torch.cuda.is_available()
assert torch.cuda.get_device_capability()[0] >= 10, torch.cuda.get_device_capability()

torch.manual_seed(1234)
device = "cuda"

bs = 1
seqlen_q = 1
seqlen_k = 128
qheads_per_kv = 4          # This is the important failing value.
head_dim = 128
topk = 64                  # Must be a multiple of cuDNN's n_block_size=64.

q = torch.randn(
    bs, seqlen_q, qheads_per_kv, head_dim,
    device=device,
    dtype=torch.bfloat16,
)
k = torch.randn(
    bs, seqlen_k, head_dim,
    device=device,
    dtype=torch.bfloat16,
)

# LSE shape is (B, Sq, Hq).
lse = torch.zeros(bs, seqlen_q, qheads_per_kv, device=device, dtype=torch.float32)

# Local top-k ids because topk_indices_global=False.
topk_indices = torch.arange(topk, device=device, dtype=torch.int32).view(bs, seqlen_q, topk)
topk_length = torch.full((bs, seqlen_q), topk, device=device, dtype=torch.int32)

torch.cuda.synchronize()

out = sparse_attn_score_recompute_wrapper(
    q,
    k,
    lse,
    topk_indices,
    1.0 / math.sqrt(head_dim),
    qhead_per_kv_head=qheads_per_kv,
    topk_length=topk_length,
    topk_indices_global=False,
)["target"]

torch.cuda.synchronize()
print(out.shape, out.dtype)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated sparse score recomputation epilogue processing to always stage on-chip attention data during the loop, with invalid positions still masked to keep results correct.
* **Tests**
  * Expanded sparse score recomputation coverage to run with `has_topk_length` both enabled and disabled.
  * Updated the wrapper and batch tests to generate and validate per-row `topk_length` behavior, including masking entries beyond each row’s length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->