### PR TITLE
Fix sort order in block_scale_quantize.h

### DIFF
--- a/include/cudnn_frontend/node/block_scale_quantize.h
+++ b/include/cudnn_frontend/node/block_scale_quantize.h
@@ -57,7 +57,7 @@ class BlockScaleQuantizeNode : public NodeCRTP<BlockScaleQuantizeNode> {
             std::sort(indices.begin(), indices.end(), [&X_dim, &X_stride](int64_t i, int64_t j) {
                 // Prioritize singleton dimensions
                 if (X_stride[i] == X_stride[j]) {
-                    return (X_dim[i] == 1) || (X_dim[j] != 1);
+                    return (X_dim[i] == 1) && (X_dim[j] != 1);
                 }
                 return X_stride[i] < X_stride[j];
             });


### PR DESCRIPTION
If I compile and run the `samples/cpp/norm/norm_block_scale.cpp` sample with clang in debug mode I get this error:

```
strict_weak_ordering_check.h:50: libc++ Hardening assertion !__comp(*(__first + __a), *(__first + __b)) failed: Your comparator is not a valid strict-weak ordering
```

The comparator indeed violates strict weak ordering. I.e. it in this case it will report that index 0 is smaller than index 1 and also that index 1 is smaller than index 0:

```
X_stride = {10, 10}
X_dim = {1, 1}
```

The fix makes the comparator a strict weak order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined stride index sorting logic for block-scale quantization operations with transposed and packed memory layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->