### PR TITLE
Add enforce_precompiled deserialize option

### DIFF
--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -1627,7 +1627,7 @@ class Graph : public ICudnn, public INode {
     }
 
     error_t
-    deserialize(cudnnHandle_t handle, std::vector<uint8_t> const &data) {
+    deserialize(cudnnHandle_t handle, std::vector<uint8_t> const &data, bool const enforce_precompiled = false) {
         CUDNN_FE_LOG_BANNER(" DESERIALIZE PLAN WITH HANDLE  ");
 
 #ifndef CUDNN_FRONTEND_SKIP_JSON_LIB
@@ -1654,8 +1654,12 @@ class Graph : public ICudnn, public INode {
             }
         }
 
-        auto serialized_plan = j["cudnn_backend_data"];
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            enforce_precompiled && !j.contains("cudnn_backend_data"),
+            error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+            "enforce_precompiled requested, but serialized graph has no precompiled execution plan");
 
+        auto serialized_plan = j["cudnn_backend_data"];
         CHECK_CUDNN_FRONTEND_ERROR(plans.build_plans(handle, serialized_plan));
 
         plans.behavior_notes = j["behavior_notes"].get<std::vector<std::vector<BehaviorNote_t>>>();
@@ -1721,6 +1725,7 @@ class Graph : public ICudnn, public INode {
 #else
         CUDNN_FRONTEND_UNUSED(handle);
         CUDNN_FRONTEND_UNUSED(data);
+        CUDNN_FRONTEND_UNUSED(enforce_precompiled);
         return {error_code_t::GRAPH_NOT_SUPPORTED, "unavailable when compiled with CUDNN_FRONTEND_SKIP_JSON_LIB"};
 #endif
     }
@@ -2462,7 +2467,12 @@ class Graph : public ICudnn, public INode {
     // TODO: temparorily placed in graphs class. This function needs to be a free standing function.
 #ifndef CUDNN_FRONTEND_SKIP_JSON_LIB
     error_t
-    deserialize(const json &j) {
+    deserialize(const json &j, bool const enforce_precompiled = false) {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            enforce_precompiled,
+            error_code_t::GRAPH_NOT_SUPPORTED,
+            "enforce_precompiled requires plan serialization; JSON deserialization reconstructs the graph");
+
         if (j.contains("context")) {
             const auto &j_context = j["context"];
             if (j_context.contains("compute_data_type") && !j_context["compute_data_type"].is_null()) {

--- a/python/pygraph/pygraph.cpp
+++ b/python/pygraph/pygraph.cpp
@@ -620,11 +620,11 @@ PyGraph::serialize() const {
 }
 
 void
-PyGraph::deserialize(std::optional<std::intptr_t> handle_, py::object const& pyobj) {
+PyGraph::deserialize(std::optional<std::intptr_t> handle_, py::object const& pyobj, bool const enforce_precompiled) {
     if (py::isinstance<py::str>(pyobj)) {
         json j = json::parse(pyobj.cast<std::string>());
 
-        auto status = graph->deserialize(j);
+        auto status = graph->deserialize(j, enforce_precompiled);
 
         throw_if(status.is_bad(), status.get_code(), status.get_message());
 
@@ -634,16 +634,16 @@ PyGraph::deserialize(std::optional<std::intptr_t> handle_, py::object const& pyo
             handle_.has_value() ? static_cast<cudnnHandle_t>((void*)(handle_.value())) : this->handle;
 
         std::vector<uint8_t> data = pyobj.cast<std::vector<uint8_t>>();
-        auto status               = graph->deserialize(handle, data);
+        auto status               = graph->deserialize(handle, data, enforce_precompiled);
 
         throw_if(status.is_bad(), status.get_code(), status.get_message());
     }
 }
 
 void
-PyGraph::deserialize(py::object const& pyobj) {
+PyGraph::deserialize(py::object const& pyobj, bool const enforce_precompiled) {
     // Call the overloaded version with default handle (nullopt)
-    deserialize(std::nullopt, pyobj);
+    deserialize(std::nullopt, pyobj, enforce_precompiled);
 }
 
 void
@@ -1378,10 +1378,14 @@ init_pygraph_submodule(py::module_& m) {
         .def("update_cuda_graph", &PyGraph::update_cuda_graph)
         .def("serialize", &PyGraph::serialize)
         .def("deserialize",
-             (void (PyGraph::*)(std::optional<std::intptr_t>, py::object const&))&PyGraph::deserialize,
+             (void (PyGraph::*)(std::optional<std::intptr_t>, py::object const&, bool const))&PyGraph::deserialize,
              py::arg("handle_"),
-             py::arg("pyobj"))
-        .def("deserialize", (void (PyGraph::*)(py::object const&))&PyGraph::deserialize, py::arg("pyobj"))
+             py::arg("pyobj"),
+             py::arg("enforce_precompiled") = false)
+        .def("deserialize",
+             (void (PyGraph::*)(py::object const&, bool const))&PyGraph::deserialize,
+             py::arg("pyobj"),
+             py::arg("enforce_precompiled") = false)
         .def("_execute_plan_at_index",
              &PyGraph::execute_plan_at_index,
              py::arg("var_pack"),

--- a/python/pygraph/pygraph.h
+++ b/python/pygraph/pygraph.h
@@ -776,10 +776,10 @@ class PyGraph {
     serialize() const;
 
     void
-    deserialize(std::optional<std::intptr_t> handle_, py::object const& pyobj);
+    deserialize(std::optional<std::intptr_t> handle_, py::object const& pyobj, bool const enforce_precompiled = false);
 
     void
-    deserialize(py::object const& pyobj);
+    deserialize(py::object const& pyobj, bool const enforce_precompiled = false);
 
     int64_t
     get_execution_plan_count() const {

--- a/test/cpp/serialize.cpp
+++ b/test/cpp/serialize.cpp
@@ -65,6 +65,10 @@ TEST_CASE("Context serialization", "[context][serialize]") {
 
     REQUIRE(j == j2);
 
+    auto status = fe::graph::Graph().deserialize(j, true);
+    REQUIRE(status.is_bad());
+    REQUIRE(status.get_message().find("enforce_precompiled") != std::string::npos);
+
     REQUIRE(graph.validate().is_good());
 }
 
@@ -584,7 +588,7 @@ TEST_CASE("Plan deserialize prepares variant pack template", "[graph][serialize]
     REQUIRE(graph.serialize(serialized_data).is_good());
 
     fe::graph::Graph graph_deserialized;
-    REQUIRE(graph_deserialized.deserialize(handle, serialized_data).is_good());
+    REQUIRE(graph_deserialized.deserialize(handle, serialized_data, true).is_good());
 
     // Variant pack template should already be populated; no execute needed.
     auto const user_uids = graph_deserialized.get_variant_pack_uids_sorted();

--- a/test/python/test_deviceless_aot_compilation.py
+++ b/test/python/test_deviceless_aot_compilation.py
@@ -9,6 +9,12 @@ Tests deviceless AoT compilation.
 """
 
 
+@pytest.mark.L0
+def test_deserialize_enforce_precompiled_rejects_json_graph():
+    with pytest.raises(Exception, match="enforce_precompiled requires plan serialization"):
+        cudnn.pygraph().deserialize("{}", enforce_precompiled=True)
+
+
 @pytest.mark.skipif(
     LooseVersion(cudnn.backend_version_string()) < "9.11",
     reason="requires cudnn 9.11 or higher",
@@ -74,7 +80,7 @@ def test_device_properties():
         cudnn.set_stream(handle=cudnn_handle, stream=stream)
 
         graph_deserialized = cudnn.pygraph()
-        graph_deserialized.deserialize(cudnn_handle, json_str)
+        graph_deserialized.deserialize(cudnn_handle, json_str, enforce_precompiled=True)
 
         Y_actual = torch.zeros_like(Y_ref)
 


### PR DESCRIPTION
## Summary
- add enforce_precompiled to graph plan deserialization and Python bindings
- reject graph JSON deserialization when enforce_precompiled is requested
- cover JSON rejection and binary plan deserialize success in tests

Fixes #254

@coderabbitai ignore

## Tests
- pip install -e . -v
- python3 -m pytest -s -vvv test/python/test_deviceless_aot_compilation.py::test_deserialize_enforce_precompiled_rejects_json_graph test/python/test_deviceless_aot_compilation.py::test_device_properties
- cmake -S . -B /tmp/cudnn-fe-enforce-precompiled-cpp -DCMAKE_BUILD_TYPE=Release -DCUDNN_FRONTEND_BUILD_SAMPLES=OFF -DCUDNN_FRONTEND_BUILD_TESTS=ON -DCUDNN_FRONTEND_BUILD_PYTHON_BINDINGS=OFF -DCUDNN_PATH=$CUDNN_PATH -DCUDAToolkit_ROOT=$CUDA_PATH
- cmake --build /tmp/cudnn-fe-enforce-precompiled-cpp --target tests -j 8
- /tmp/cudnn-fe-enforce-precompiled-cpp/bin/tests "Context serialization"
- /tmp/cudnn-fe-enforce-precompiled-cpp/bin/tests "Plan deserialize prepares variant pack template"