### PR TITLE
Fix d=256 SDPA

### DIFF
--- a/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
+++ b/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
@@ -1722,6 +1722,11 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
             sub_nodes.emplace_back(node_);
         }
 
+        // last_output = last_output - stats
+        last_output = pointwise(last_output,
+                                attributes.inputs[input_names::Stats],
+                                Pointwise_attributes().set_name("sub_s_m").set_mode(PointwiseMode_t::SUB));
+
         // (optional) Apply padding mask
         if (attributes.padding_mask) {
             auto graph_                  = std::make_shared<Graph>();
@@ -1733,11 +1738,6 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
                                                               attributes.inputs[input_names::SEQ_LEN_Q]);
             sub_nodes.emplace_back(node_);
         }
-
-        // last_output = last_output - stats
-        last_output = pointwise(last_output,
-                                attributes.inputs[input_names::Stats],
-                                Pointwise_attributes().set_name("sub_s_m").set_mode(PointwiseMode_t::SUB));
 
         // Explicitly put the padding value again after the stats have been loaded
         if (attributes.padding_mask && detail::get_backend_version() >= 90000 &&

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -478,7 +478,7 @@ def test_sdpa_random_bwd_ragged_L0(env_info, test_no, request, cudnn_handle):
     with RandomizationContext(
         batches=RandomBatchSize(min=8, max=16),
         s_q_s_kv = RandomSequenceLength(s_q_min=1, s_q_max=4096, s_kv_min=1, s_kv_max=4096, s_q_distribution={"s_q=1":0, "s_q=s_kv":5, "s_q=random":10}),
-        d_qk_d_v=RandomHiddenDimSize(d_qk_min=1, d_qk_max=192, d_v_min=1, d_v_max=128, head_dim_distribution={"d_qk=d_v":5, "d_qk=random":1}, with_high_probability=[(64,64), (128,128), (192,128)]),
+        d_qk_d_v=RandomHiddenDimSize(d_qk_min=1, d_qk_max=192, d_v_min=1, d_v_max=128, head_dim_distribution={"d_qk=d_v":5, "d_qk=random":1}, with_high_probability=[(64,64), (128,128), (192,128), (256,256)]),
         head_count=RandomHeadGenerator(min=1, max=8, head_group_options=(1, 4, 1)),
         data_type=RandomChoice({torch.float16 : 1, torch.bfloat16 : 2}),
         with_sliding_mask=SlidingWindowMaskGenerator(causal=10, left_window_only=5, right_window_only=5, band_around_diag=10, no_mask=10),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention backpropagation handling for certain masked inputs, helping gradient calculations follow the correct order.
  * Preserved padding-related behavior after loading attention statistics for more consistent results.

* **Tests**
  * Expanded test coverage for random hidden-dimension configurations to include an additional 256×256 case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->