### PR TITLE
Fix grid dim overflow in DSA backward convert kernel on SM100

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
@@ -572,8 +572,8 @@ class FlashAttentionDSABackwardSm100:
 
         convert_grid_x = (mKV.shape[0] + self.block_seq - 1) // self.block_seq
         convert_grid = [
-            1,
             convert_grid_x,
+            1,
             1,
         ]
         convert_block = [self.num_threads_D_convert, self.num_threads_seq, 1]
@@ -616,8 +616,8 @@ class FlashAttentionDSABackwardSm100:
     ):
         tidx, tidy, _ = cute.arch.thread_idx()
         (
-            _,
             seq_block_idx,
+            _,
             batch_idx,
         ) = cute.arch.block_idx()
 


### PR DESCRIPTION
The convert kernel grid was configured as [1, convert_grid_x, 1], placing the seq-block dimension on grid.y. CUDA caps grid.y/z at 65535, so large mKV.shape[0] / block_seq values trigger `invalid configuration argument`. grid.x supports up to 2^31-1, so move convert_grid_x to grid.x and update the corresponding block_idx() unpacking in the kernel accordingly. No behavior change for in-range sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how sparse attention backward work is distributed across compute tiles, improving consistency and correctness during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->