### PR TITLE
Bypass OSS d=256 path on cuDNN 9.23+

### DIFF
--- a/python/cudnn/experimental/ops/sdpa.py
+++ b/python/cudnn/experimental/ops/sdpa.py
@@ -89,14 +89,14 @@ def _device_supports_d256_oss(device: torch.device) -> bool:
     return major * 10 + minor >= 100
 
 
-# cuDNN 9.23.0 added native d=256 SDPA fprop and bprop support in the graph
-# backend. From this version on the OSS (cuteDSL) kernels are no longer needed.
-_CUDNN_NATIVE_D256_VERSION = 92300
+# cuDNN 9.23.0 added d=256 SDPA fprop and bprop support in the cuDNN backend.
+# From this version on the OSS (cuteDSL) kernels are no longer needed.
+_CUDNN_BACKEND_D256_VERSION = 92300
 
 
-def _cudnn_supports_native_d256() -> bool:
-    """Return True when the linked cuDNN handles d=256 SDPA natively in the graph backend."""
-    return cudnn.backend_version() >= _CUDNN_NATIVE_D256_VERSION
+def _cudnn_backend_supports_d256() -> bool:
+    """Return True when the linked cuDNN backend handles d=256 SDPA itself (no OSS kernel needed)."""
+    return cudnn.backend_version() >= _CUDNN_BACKEND_D256_VERSION
 
 
 def _torch_dtype_to_cudnn(dtype: torch.dtype):
@@ -648,10 +648,10 @@ def _sdpa_impl(
         cumulative_seq_len_q,
         cumulative_seq_len_kv,
     )
-    use_d256_oss_fwd = can_use_d256_oss_fwd and _device_supports_d256_oss(q.device) and not _cudnn_supports_native_d256()
+    use_d256_oss_fwd = can_use_d256_oss_fwd and _device_supports_d256_oss(q.device) and not _cudnn_backend_supports_d256()
     if can_use_d256_oss_fwd and not use_d256_oss_fwd:
         _logger.debug(
-            "Falling back to cuDNN graph d=256 forward path " "(cuDNN backend version %d, requires SM100+ device, got %s)",
+            "Routing d=256 forward through the cuDNN backend " "(cuDNN backend version %d, OSS path requires SM100+, got %s)",
             cudnn.backend_version(),
             q.device,
         )
@@ -672,7 +672,7 @@ def _sdpa_impl(
                 cumulative_seq_len_kv,
             )
         except ImportError as e:
-            _logger.warning("Falling back to cuDNN graph d=256 forward path because OSS dependencies are unavailable: %s", e)
+            _logger.warning("Falling back to cuDNN backend d=256 forward path because OSS dependencies are unavailable: %s", e)
 
     handle = _get_handle(q.device)
 
@@ -1146,7 +1146,7 @@ def _sdpa_backward(ctx, dO, dStats):
         cum_q,
         cum_kv,
     )
-    use_d256_oss_bwd = can_use_d256_oss_bwd and _device_supports_d256_oss(q.device) and not _cudnn_supports_native_d256()
+    use_d256_oss_bwd = can_use_d256_oss_bwd and _device_supports_d256_oss(q.device) and not _cudnn_backend_supports_d256()
 
     if is_d256:
         if use_d256_oss_bwd:
@@ -1169,7 +1169,7 @@ def _sdpa_backward(ctx, dO, dStats):
                     cum_kv,
                 )
             except ImportError as e:
-                _logger.warning("Falling back to cuDNN graph d=256 backward path because OSS dependencies are unavailable: %s", e)
+                _logger.warning("Falling back to cuDNN backend d=256 backward path because OSS dependencies are unavailable: %s", e)
                 dQ, dK, dV = torch.ops.cudnn.sdpa_bwd(
                     dO,
                     q,

--- a/python/cudnn/experimental/ops/sdpa.py
+++ b/python/cudnn/experimental/ops/sdpa.py
@@ -653,7 +653,7 @@ def _sdpa_impl(
     use_d256_oss_fwd = can_use_d256_oss_fwd and device_supports_d256_oss and not cudnn_backend_supports_d256
     if can_use_d256_oss_fwd and not use_d256_oss_fwd:
         _logger.debug(
-            "Routing d=256 forward through the cuDNN backend " "(cuDNN backend version %d, backend support=%s, OSS device support=%s, device=%s)",
+            "Routing d=256 forward through the cuDNN backend (cuDNN backend version %d, backend support=%s, OSS device support=%s, device=%s)",
             cudnn.backend_version(),
             cudnn_backend_supports_d256,
             device_supports_d256_oss,

--- a/python/cudnn/experimental/ops/sdpa.py
+++ b/python/cudnn/experimental/ops/sdpa.py
@@ -89,6 +89,16 @@ def _device_supports_d256_oss(device: torch.device) -> bool:
     return major * 10 + minor >= 100
 
 
+# cuDNN 9.23.0 added native d=256 SDPA fprop and bprop support in the graph
+# backend. From this version on the OSS (cuteDSL) kernels are no longer needed.
+_CUDNN_NATIVE_D256_VERSION = 92300
+
+
+def _cudnn_supports_native_d256() -> bool:
+    """Return True when the linked cuDNN handles d=256 SDPA natively in the graph backend."""
+    return cudnn.backend_version() >= _CUDNN_NATIVE_D256_VERSION
+
+
 def _torch_dtype_to_cudnn(dtype: torch.dtype):
     """Map a PyTorch dtype to a cuDNN data_type enum."""
     return _TORCH_DTYPE_TO_CUDNN[dtype]
@@ -638,9 +648,13 @@ def _sdpa_impl(
         cumulative_seq_len_q,
         cumulative_seq_len_kv,
     )
-    use_d256_oss_fwd = can_use_d256_oss_fwd and _device_supports_d256_oss(q.device)
+    use_d256_oss_fwd = can_use_d256_oss_fwd and _device_supports_d256_oss(q.device) and not _cudnn_supports_native_d256()
     if can_use_d256_oss_fwd and not use_d256_oss_fwd:
-        _logger.debug("Falling back to cuDNN graph d=256 forward path because OSS kernel requires SM100+, got device %s", q.device)
+        _logger.debug(
+            "Falling back to cuDNN graph d=256 forward path " "(cuDNN backend version %d, requires SM100+ device, got %s)",
+            cudnn.backend_version(),
+            q.device,
+        )
     if use_d256_oss_fwd:
         try:
             return sdpa_fwd_d256(
@@ -1132,7 +1146,7 @@ def _sdpa_backward(ctx, dO, dStats):
         cum_q,
         cum_kv,
     )
-    use_d256_oss_bwd = can_use_d256_oss_bwd and _device_supports_d256_oss(q.device)
+    use_d256_oss_bwd = can_use_d256_oss_bwd and _device_supports_d256_oss(q.device) and not _cudnn_supports_native_d256()
 
     if is_d256:
         if use_d256_oss_bwd:

--- a/python/cudnn/experimental/ops/sdpa.py
+++ b/python/cudnn/experimental/ops/sdpa.py
@@ -648,11 +648,15 @@ def _sdpa_impl(
         cumulative_seq_len_q,
         cumulative_seq_len_kv,
     )
-    use_d256_oss_fwd = can_use_d256_oss_fwd and _device_supports_d256_oss(q.device) and not _cudnn_backend_supports_d256()
+    device_supports_d256_oss = _device_supports_d256_oss(q.device)
+    cudnn_backend_supports_d256 = _cudnn_backend_supports_d256()
+    use_d256_oss_fwd = can_use_d256_oss_fwd and device_supports_d256_oss and not cudnn_backend_supports_d256
     if can_use_d256_oss_fwd and not use_d256_oss_fwd:
         _logger.debug(
-            "Routing d=256 forward through the cuDNN backend " "(cuDNN backend version %d, OSS path requires SM100+, got %s)",
+            "Routing d=256 forward through the cuDNN backend " "(cuDNN backend version %d, backend support=%s, OSS device support=%s, device=%s)",
             cudnn.backend_version(),
+            cudnn_backend_supports_d256,
+            device_supports_d256_oss,
             q.device,
         )
     if use_d256_oss_fwd:

--- a/test/python/test_cudnn_sdpa_op.py
+++ b/test/python/test_cudnn_sdpa_op.py
@@ -7,9 +7,11 @@ numerical correctness against a PyTorch reference for both O and dQ/dK/dV.
 All tensors use BHSD layout (batch, num_heads, seq_len, head_dim).
 """
 
+import importlib
+import math
+
 import pytest
 import torch
-import math
 
 import cudnn
 from cudnn.experimental.ops import sdpa as sdpa_module
@@ -157,8 +159,6 @@ def _skip_if_unsupported_d256(D):
     if major < 10:
         pytest.skip("d=256 backward path requires SM100+")
     try:
-        import importlib
-
         importlib.import_module("cudnn.sdpa")
     except ImportError:
         pytest.skip("d=256 OSS SDPA path requires optional cutedsl dependencies in this environment")
@@ -204,8 +204,6 @@ class TestCudnnSdpa:
             pytest.skip(f"cuDNN backend {cudnn.backend_version()} handles d=256 itself; OSS path is intentionally bypassed")
         _skip_if_unsupported_d256(256)
         try:
-            import importlib
-
             importlib.import_module("cudnn.sdpa")
         except ImportError:
             pytest.skip("OSS SDPA d=256 optional dependencies are not installed in this environment")

--- a/test/python/test_cudnn_sdpa_op.py
+++ b/test/python/test_cudnn_sdpa_op.py
@@ -149,9 +149,11 @@ def sdpa_reference_fwd_bwd(
 def _skip_if_unsupported_d256(D):
     if D != 256:
         return
+    major, _ = torch.cuda.get_device_capability()
     if cudnn.backend_version() >= _CUDNN_BACKEND_D256_VERSION:
+        if major < 9:
+            pytest.skip("d=256 backward path requires SM90+")
         return
-    major, minor = torch.cuda.get_device_capability()
     if major < 10:
         pytest.skip("d=256 backward path requires SM100+")
     try:
@@ -237,6 +239,7 @@ class TestCudnnSdpa:
             pytest.skip(
                 f"cuDNN backend {cudnn.backend_version()} < {_CUDNN_BACKEND_D256_VERSION}; " "the cuDNN backend d=256 path is not available in this build"
             )
+        _skip_if_unsupported_d256(256)
 
         oss_calls = []
 

--- a/test/python/test_cudnn_sdpa_op.py
+++ b/test/python/test_cudnn_sdpa_op.py
@@ -12,7 +12,12 @@ import torch
 import math
 
 import cudnn
-from cudnn.experimental.ops.sdpa import scaled_dot_product_attention, _fprop_cache, _bprop_cache
+from cudnn.experimental.ops.sdpa import (
+    _CUDNN_NATIVE_D256_VERSION,
+    _bprop_cache,
+    _fprop_cache,
+    scaled_dot_product_attention,
+)
 
 # ---------------------------------------------------------------------------
 # PyTorch reference implementation (differentiable)
@@ -143,11 +148,15 @@ def sdpa_reference_fwd_bwd(
 def _skip_if_unsupported_d256(D):
     if D != 256:
         return
+    if cudnn.backend_version() >= _CUDNN_NATIVE_D256_VERSION:
+        return
     major, minor = torch.cuda.get_device_capability()
     if major < 10:
         pytest.skip("d=256 backward path requires SM100+")
     try:
-        import cudnn.sdpa  # noqa: F401
+        import importlib
+
+        importlib.import_module("cudnn.sdpa")
     except ImportError:
         pytest.skip("d=256 OSS SDPA path requires optional cutedsl dependencies in this environment")
 
@@ -188,9 +197,13 @@ class TestCudnnSdpa:
 
     @pytest.mark.L0
     def test_d256_uses_oss_forward_path(self):
+        if cudnn.backend_version() >= _CUDNN_NATIVE_D256_VERSION:
+            pytest.skip(f"cuDNN {cudnn.backend_version()} supports d=256 natively; OSS path is intentionally bypassed")
         _skip_if_unsupported_d256(256)
         try:
-            import cudnn.sdpa  # noqa: F401
+            import importlib
+
+            importlib.import_module("cudnn.sdpa")
         except ImportError:
             pytest.skip("OSS SDPA d=256 optional dependencies are not installed in this environment")
 
@@ -208,6 +221,34 @@ class TestCudnnSdpa:
         o_ref, dq_ref, dk_ref, dv_ref = sdpa_reference_fwd_bwd(q, k, v)
 
         assert len(_fprop_cache) == 0, "D=256 OSS forward path should bypass the cuDNN graph cache"
+        torch.testing.assert_close(o.float(), o_ref.float(), atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(q.grad.float(), dq_ref.float(), atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(k.grad.float(), dk_ref.float(), atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(v.grad.float(), dv_ref.float(), atol=2e-2, rtol=2e-2)
+
+    @pytest.mark.L0
+    def test_d256_uses_graph_path_on_cudnn_9_23_plus(self):
+        """When cuDNN >= 9.23.0 supports d=256 natively, the cuDNN graph backend should be used
+        instead of the cuteDSL OSS kernels."""
+        if cudnn.backend_version() < _CUDNN_NATIVE_D256_VERSION:
+            pytest.skip(f"cuDNN {cudnn.backend_version()} < {_CUDNN_NATIVE_D256_VERSION}; native d=256 path not available")
+
+        B, H, S, D = 2, 8, 128, 256
+        _fprop_cache.clear()
+        _bprop_cache.clear()
+
+        q = torch.randn(B, H, S, D, dtype=torch.float16, device="cuda", requires_grad=True)
+        k = torch.randn(B, H, S, D, dtype=torch.float16, device="cuda", requires_grad=True)
+        v = torch.randn(B, H, S, D, dtype=torch.float16, device="cuda", requires_grad=True)
+
+        o = scaled_dot_product_attention(q, k, v)
+        loss = o.sum()
+        loss.backward()
+
+        o_ref, dq_ref, dk_ref, dv_ref = sdpa_reference_fwd_bwd(q, k, v)
+
+        assert len(_fprop_cache) == 1, "D=256 on cuDNN 9.23+ should populate the cuDNN graph cache (no OSS bypass)"
+        assert len(_bprop_cache) == 1, "D=256 on cuDNN 9.23+ should populate the cuDNN graph cache for bwd too"
         torch.testing.assert_close(o.float(), o_ref.float(), atol=2e-2, rtol=2e-2)
         torch.testing.assert_close(q.grad.float(), dq_ref.float(), atol=2e-2, rtol=2e-2)
         torch.testing.assert_close(k.grad.float(), dk_ref.float(), atol=2e-2, rtol=2e-2)

--- a/test/python/test_cudnn_sdpa_op.py
+++ b/test/python/test_cudnn_sdpa_op.py
@@ -12,8 +12,9 @@ import torch
 import math
 
 import cudnn
+from cudnn.experimental.ops import sdpa as sdpa_module
 from cudnn.experimental.ops.sdpa import (
-    _CUDNN_NATIVE_D256_VERSION,
+    _CUDNN_BACKEND_D256_VERSION,
     _bprop_cache,
     _fprop_cache,
     scaled_dot_product_attention,
@@ -148,7 +149,7 @@ def sdpa_reference_fwd_bwd(
 def _skip_if_unsupported_d256(D):
     if D != 256:
         return
-    if cudnn.backend_version() >= _CUDNN_NATIVE_D256_VERSION:
+    if cudnn.backend_version() >= _CUDNN_BACKEND_D256_VERSION:
         return
     major, minor = torch.cuda.get_device_capability()
     if major < 10:
@@ -197,8 +198,8 @@ class TestCudnnSdpa:
 
     @pytest.mark.L0
     def test_d256_uses_oss_forward_path(self):
-        if cudnn.backend_version() >= _CUDNN_NATIVE_D256_VERSION:
-            pytest.skip(f"cuDNN {cudnn.backend_version()} supports d=256 natively; OSS path is intentionally bypassed")
+        if cudnn.backend_version() >= _CUDNN_BACKEND_D256_VERSION:
+            pytest.skip(f"cuDNN backend {cudnn.backend_version()} handles d=256 itself; OSS path is intentionally bypassed")
         _skip_if_unsupported_d256(256)
         try:
             import importlib
@@ -227,11 +228,24 @@ class TestCudnnSdpa:
         torch.testing.assert_close(v.grad.float(), dv_ref.float(), atol=2e-2, rtol=2e-2)
 
     @pytest.mark.L0
-    def test_d256_uses_graph_path_on_cudnn_9_23_plus(self):
-        """When cuDNN >= 9.23.0 supports d=256 natively, the cuDNN graph backend should be used
-        instead of the cuteDSL OSS kernels."""
-        if cudnn.backend_version() < _CUDNN_NATIVE_D256_VERSION:
-            pytest.skip(f"cuDNN {cudnn.backend_version()} < {_CUDNN_NATIVE_D256_VERSION}; native d=256 path not available")
+    def test_d256_uses_cudnn_backend_on_cudnn_9_23_plus(self, monkeypatch):
+        """When the cuDNN backend supports d=256 itself (>= 9.23.0), the OSS (cuteDSL) custom ops
+        must not be invoked. Replaces both `sdpa_fwd_d256` and `sdpa_bwd_d256` on the module with
+        a sentinel that fails the test if it is ever called, and corroborates with the cuDNN
+        graph cache being populated."""
+        if cudnn.backend_version() < _CUDNN_BACKEND_D256_VERSION:
+            pytest.skip(
+                f"cuDNN backend {cudnn.backend_version()} < {_CUDNN_BACKEND_D256_VERSION}; " "the cuDNN backend d=256 path is not available in this build"
+            )
+
+        oss_calls = []
+
+        def _oss_sentinel(*args, **kwargs):
+            oss_calls.append(("oss", args, kwargs))
+            raise AssertionError("OSS d=256 custom op was invoked but the cuDNN backend should have handled it")
+
+        monkeypatch.setattr(sdpa_module, "sdpa_fwd_d256", _oss_sentinel)
+        monkeypatch.setattr(sdpa_module, "sdpa_bwd_d256", _oss_sentinel)
 
         B, H, S, D = 2, 8, 128, 256
         _fprop_cache.clear()
@@ -247,8 +261,9 @@ class TestCudnnSdpa:
 
         o_ref, dq_ref, dk_ref, dv_ref = sdpa_reference_fwd_bwd(q, k, v)
 
-        assert len(_fprop_cache) == 1, "D=256 on cuDNN 9.23+ should populate the cuDNN graph cache (no OSS bypass)"
-        assert len(_bprop_cache) == 1, "D=256 on cuDNN 9.23+ should populate the cuDNN graph cache for bwd too"
+        assert oss_calls == [], f"OSS d=256 custom op was invoked {len(oss_calls)} time(s); cuDNN backend should have handled the call"
+        assert len(_fprop_cache) == 1, "D=256 on cuDNN 9.23+ should populate the cuDNN backend fprop cache"
+        assert len(_bprop_cache) == 1, "D=256 on cuDNN 9.23+ should populate the cuDNN backend bprop cache"
         torch.testing.assert_close(o.float(), o_ref.float(), atol=2e-2, rtol=2e-2)
         torch.testing.assert_close(q.grad.float(), dq_ref.float(), atol=2e-2, rtol=2e-2)
         torch.testing.assert_close(k.grad.float(), dk_ref.float(), atol=2e-2, rtol=2e-2)


### PR DESCRIPTION
Revives #272 while Vedaanta is out of office. The original two commits and Vedaanta Agarwalla authorship are preserved, rebased onto current develop.

cuDNN 9.23 added backend SDPA forward/backward support for d=256, so bypass the SM100 OSS path when the linked backend is new enough. Keep OSS routing for older backends.

This revival also fixes the prior Ampere CI failure: combined d=256 forward/backward tests skip on SM80, where backward supports d <= 128, while cuDNN 9.23+ d=256 tests run on SM90+. It also clarifies the routing debug log.

Validation:
- Full test/python/test_cudnn_sdpa_op.py on B200: 19 passed, 1 skipped
- Capability routing check: SM80 skips; SM90/SM100 run
- Black formatting and git diff checks pass

Original work: @vedaanta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SDPA routing so d=256 workloads use the best available backend automatically.
  * Updated forward and backward behavior to prefer the cuDNN backend when it supports d=256, reducing unnecessary fallback to alternate paths.
  * Refined fallback messaging to better reflect the path used when one option is unavailable.

* **Tests**
  * Added coverage for d=256 execution when the cuDNN backend supports it.
  * Expanded validation to confirm results and gradients still match the reference implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->