### PR TITLE
Use BYTE_BOOLEAN for cuDNN 9.25+

### DIFF
--- a/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
+++ b/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
@@ -2644,9 +2644,9 @@ class UnifiedSDPANode : public SDPANodeBase<UnifiedSDPANode> {
         // FP8 per-tensor scaling attributes (descale Q/K/V/S, scale S/O inputs; amax S/O outputs).
         if (attributes.mma_core_mode == DataType_t::FP8_E4M3 || attributes.mma_core_mode == DataType_t::FP8_E5M2) {
             auto fp8_cudnn_ver_error =
-                error_t{error_code_t::GRAPH_NOT_SUPPORTED, "FP8/MXFP8 for the unified SDPA node requires cuDNN 9.30.0"};
-#if (CUDNN_VERSION >= 93000)
-            NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(93000, fp8_cudnn_ver_error);
+                error_t{error_code_t::GRAPH_NOT_SUPPORTED, "FP8/MXFP8 for the unified SDPA node requires cuDNN 9.25.0"};
+#if (CUDNN_VERSION >= 92500)
+            NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(92500, fp8_cudnn_ver_error);
 
             // Wire an optional FP8 scaling/descaling tensor (from either the input or output map) to
             // its backend descriptor, no-op if the caller did not provide it.
@@ -2685,7 +2685,7 @@ class UnifiedSDPANode : public SDPANodeBase<UnifiedSDPANode> {
                 attributes.outputs, SDPA_attributes::output_names::Amax_O, CUDNN_ATTR_OPERATION_SDPA_FWD_AMAX_ODESC));
 #else
             return fp8_cudnn_ver_error;
-#endif  // CUDNN_VERSION >= 93000
+#endif  // CUDNN_VERSION >= 92500
         }
 
         _CUDNN_CHECK_CUDNN_ERROR(detail::finalize(unified_sdpa_operation->get_backend_descriptor()));

--- a/include/cudnn_frontend/node/sdpa_support_surface.h
+++ b/include/cudnn_frontend/node/sdpa_support_surface.h
@@ -459,7 +459,7 @@ SDPA_attributes::verify_sdpa_support_surface_for_implementation(const detail::Co
                 allowed_input_msg += ", CU_SEQ_LEN_Q, CU_SEQ_LEN_KV";
             }
 
-            if (effective_cudnn_ver >= 93000) {
+            if (effective_cudnn_ver >= 92500) {
                 allowed_input_names.insert({input_names::Descale_Q,
                                             input_names::Descale_K,
                                             input_names::Descale_V,
@@ -484,7 +484,7 @@ SDPA_attributes::verify_sdpa_support_surface_for_implementation(const detail::Co
                 allowed_output_msg += ", RNG_DUMP, Max, Sum_exp";
             }
 
-            if (effective_cudnn_ver >= 93000) {
+            if (effective_cudnn_ver >= 92500) {
                 allowed_output_names.insert({output_names::Amax_S, output_names::Amax_O});
                 allowed_output_msg += ", Amax_S, Amax_O";
             }
@@ -538,10 +538,10 @@ SDPA_attributes::verify_sdpa_support_surface_for_implementation(const detail::Co
 
             if (mma_core_mode == DataType_t::FP8_E4M3 || mma_core_mode == DataType_t::FP8_E5M2) {
                 // Per-tensor FP8 and MXFP8 (block-scaled, E8M0 descales) are supported by the
-                // unified node starting from cuDNN 9.30.0.
-                if (effective_cudnn_ver < 93000) {
+                // unified node starting from cuDNN 9.25.0.
+                if (effective_cudnn_ver < 92500) {
                     return {error_code_t::GRAPH_NOT_SUPPORTED,
-                            "FP8/MXFP8 for the unified SDPA node requires cuDNN 9.30.0 or above"};
+                            "FP8/MXFP8 for the unified SDPA node requires cuDNN 9.25.0 or above"};
                 }
             }
         } break;

--- a/include/cudnn_frontend_utils.h
+++ b/include/cudnn_frontend_utils.h
@@ -1117,8 +1117,8 @@ convert_to_cudnn_type(cudnn_frontend::DataType_t const mode, cudnnDataType_t& cu
             cudnn_mode = CUDNN_DATA_BOOLEAN;
             return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
         case DataType_t::BYTE_BOOLEAN:
-#if (CUDNN_VERSION >= 93000)
-            NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(93000, cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE);
+#if (CUDNN_VERSION >= 92500)
+            NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION(92500, cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE);
             cudnn_mode = CUDNN_DATA_BYTE_BOOLEAN;
             return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
 #else
@@ -2348,7 +2348,7 @@ convert_from_cudnn_type(cudnnDataType_t const cudnn_mode) {
             return DataType_t::INT64;
         case CUDNN_DATA_BOOLEAN:
             return DataType_t::BOOLEAN;
-#if (CUDNN_VERSION >= 93000)
+#if (CUDNN_VERSION >= 92500)
         case CUDNN_DATA_BYTE_BOOLEAN:
             return DataType_t::BYTE_BOOLEAN;
 #endif

--- a/samples/cpp/membound/boolean_fusion.cpp
+++ b/samples/cpp/membound/boolean_fusion.cpp
@@ -52,8 +52,8 @@ TEST_CASE("Boolean CMP_GT and LOGICAL_AND fusion", "[membound][boolean][pointwis
     constexpr int64_t s2 = 1;
 
     auto boolean_storage_type = fe::DataType_t::BOOLEAN;
-#if (CUDNN_VERSION >= 93000)
-    if (cudnn_frontend::detail::get_backend_version() >= 93000) {
+#if (CUDNN_VERSION >= 92500)
+    if (cudnn_frontend::detail::get_backend_version() >= 92500) {
         boolean_storage_type = fe::DataType_t::BYTE_BOOLEAN;
     }
 #endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded boolean datatype support to work with an earlier cuDNN version, improving compatibility for affected setups.
  * Updated boolean handling to stay consistent between compile-time and runtime checks.
  * Lowered cuDNN version requirements for unified SDPA FP8/MXFP8 and related Descale/Scale/Amax feature gating, unlocking support on more configurations.
* **Tests**
  * Adjusted the boolean fusion sample’s storage type selection to match the updated cuDNN version thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->