### PR TITLE
Fix uncaught ValueError in flatten_pass_by_value on malformed hex input

### DIFF
--- a/tools/cudnn_repro/cudnn_repro/utils.py
+++ b/tools/cudnn_repro/cudnn_repro/utils.py
@@ -164,10 +164,9 @@ def flatten_pass_by_value(value: Any) -> list[int]:
     if isinstance(value, (int, float)):
         return [int(value)]
     if isinstance(value, str):
-        if value.startswith("0x"):
-            return [int(value, 16)]
+        base = 16 if value.startswith("0x") else 10
         try:
-            return [int(value)]
+            return [int(value, base)]
         except ValueError:
             return []
     if isinstance(value, list):

--- a/tools/cudnn_repro/tests/test_cudnn_repro_utils.py
+++ b/tools/cudnn_repro/tests/test_cudnn_repro_utils.py
@@ -1,0 +1,31 @@
+from cudnn_repro.utils import flatten_pass_by_value
+
+
+def test_flatten_pass_by_value_valid_hex():
+    assert flatten_pass_by_value("0x10") == [16]
+
+
+def test_flatten_pass_by_value_valid_decimal():
+    assert flatten_pass_by_value("42") == [42]
+
+
+def test_flatten_pass_by_value_malformed_hex_prefix_only():
+    assert flatten_pass_by_value("0x") == []
+
+
+def test_flatten_pass_by_value_malformed_hex_digits():
+    assert flatten_pass_by_value("0xZZ") == []
+
+
+def test_flatten_pass_by_value_malformed_decimal():
+    assert flatten_pass_by_value("abc") == []
+
+
+def test_flatten_pass_by_value_list_with_malformed_entries():
+    assert flatten_pass_by_value(["0x", "0x10", "7", "0xZZ"]) == [16, 7]
+
+
+def test_flatten_pass_by_value_none_and_numbers():
+    assert flatten_pass_by_value(None) == []
+    assert flatten_pass_by_value(3) == [3]
+    assert flatten_pass_by_value(2.0) == [2]


### PR DESCRIPTION
The hex branch of flatten_pass_by_value converted "0x"-prefixed strings without error handling, so malformed values such as "0x" or "0xZZ" in a log's pass_by_value field crashed the cudnn_repro CLI with an unhandled ValueError. Guard the conversion with the same try/except pattern the decimal branch already uses, returning an empty list for unparseable strings, and add regression tests.

Fixes https://github.com/NVIDIA/cudnn-frontend/issues/342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of numeric strings so values with a `0x` prefix are handled as hexadecimal, while other strings continue to be treated as decimal.
  * Non-convertible values still safely return an empty result, preserving existing behavior.

* **Tests**
  * Added coverage for valid hex and decimal inputs, malformed strings, mixed lists, and `None`/numeric values to verify parsing behavior across common cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->