### PR TITLE
cmake: include GNUInstallDirs before install interface paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.23)
 
 project(cudnn_frontend VERSION 1.26.0)
 
+# Introduce variables:
+# * CMAKE_INSTALL_LIBDIR
+# * CMAKE_INSTALL_BINDIR
+# * CMAKE_INSTALL_INCLUDEDIR
+include(GNUInstallDirs)
+
 option(CUDNN_FRONTEND_SKIP_JSON_LIB "Defines whether FE should not include nlohmann/json.hpp." OFF)
 option(CUDNN_FRONTEND_BUILD_SAMPLES "Defines if samples are built or not." ON)
 option(CUDNN_FRONTEND_BUILD_TESTS "Defines if unittests are built or not." ON)
@@ -60,12 +66,6 @@ endif()
 if (CUDNN_FRONTEND_BUILD_PYTHON_BINDINGS)
     add_subdirectory(python)
 endif()
-
-# Introduce variables:
-# * CMAKE_INSTALL_LIBDIR
-# * CMAKE_INSTALL_BINDIR
-# * CMAKE_INSTALL_INCLUDEDIR
-include(GNUInstallDirs)
 
 # See https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#example-generating-package-files
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
## Why
`CMAKE_INSTALL_INCLUDEDIR` could be empty when used in `target_include_directories()` before `GNUInstallDirs` is included, causing invalid installed include paths for package consumers.

## What changed
- Move `include(GNUInstallDirs)` to immediately after `project()` so `CMAKE_INSTALL_LIBDIR`, `CMAKE_INSTALL_BINDIR`, and `CMAKE_INSTALL_INCLUDEDIR` are defined before any usage.

## Validation
No tests were run per request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the build setup for installation paths, making standard install directories available earlier in the configuration process.
  * Removed a redundant configuration step to keep packaging and export handling cleaner and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->