### PR TITLE
cmake: switch python linker flags to target_link_options

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -104,13 +104,17 @@ else()
     add_compile_options(-fvisibility=hidden)
 endif()
 
+target_link_options(
+    _compiled_module
+    PRIVATE
+    -Wl,--no-as-needed
+    -Wl,--enable-new-dtags
+    -Wl,-rpath,'$ORIGIN',-rpath,'$ORIGIN/../lib',-rpath,'$ORIGIN/../nvidia/cudnn/lib'
+)
+
 set_target_properties(
     _compiled_module
-
     PROPERTIES
-    LINK_FLAGS "-Wl,--no-as-needed"
-    LINK_FLAGS "-Wl,--enable-new-dtags"
-    LINK_FLAGS "-Wl,-rpath,'$ORIGIN',-rpath,'$ORIGIN/../lib',-rpath,'$ORIGIN/../nvidia/cudnn/lib'"
     LINK_WHAT_YOU_USE TRUE
 )
 


### PR DESCRIPTION
## Why
`_compiled_module` set `LINK_FLAGS` three times in `set_target_properties`, which means earlier values can be overwritten and final exported flags may miss required linker options.

## What changed
- Replace repeated `LINK_FLAGS` assignments with a single `target_link_options(_compiled_module PRIVATE ...)` call.
- Preserve `LINK_WHAT_YOU_USE` in its existing `set_target_properties(...)` call.

## Verification
`cmake` configure/build in this environment is blocked by missing CUDA (`nvcc` not found).

Please validate with:

```bash
cmake -S . -B build-link-check -G Ninja \\\n  -DCUDNN_FRONTEND_BUILD_PYTHON_BINDINGS=ON \\\n  -DCUDNN_FRONTEND_BUILD_TESTS=OFF \\\n  -DCUDNN_FRONTEND_BUILD_SAMPLES=OFF
cmake --build build-link-check --target _compiled_module --verbose
```

Confirm the verbose link line contains all three flags:
- `-Wl,--no-as-needed`
- `-Wl,--enable-new-dtags`
- `-Wl,-rpath,\x27$ORIGIN\x27,-rpath,\x27$ORIGIN/../lib\x27,-rpath,\x27$ORIGIN/../nvidia/cudnn/lib\x27`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python build configuration to use a more standard linker options setup.
  * Preserved existing build behavior while improving how linker settings are applied during module compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->