### PR TITLE
benchmark: compute causal SDPA FLOP counts without allocating masks

### DIFF
--- a/benchmark/attention_training/benchmark_single_sdpa.py
+++ b/benchmark/attention_training/benchmark_single_sdpa.py
@@ -31,6 +31,11 @@ from typing import Optional, Dict, Any
 
 from torch.profiler import profile, record_function, ProfilerActivity
 
+if __package__:
+    from .flops import count_causal_nonmasked_elems
+else:
+    from flops import count_causal_nonmasked_elems
+
 # torch.profiler measures through CUPTI. If CUPTI cannot attach -- for any
 # reason: a device it does not recognise, a driver mismatch, missing profiling
 # permissions, or simply not being present -- it records no events at all, and
@@ -1477,21 +1482,7 @@ else:
         if attn_mask == "no_mask":
             num_nonmasked_elems = q_seqlen * kv_seqlen
         elif attn_mask in ("top_left", "bottom_right"):
-            if sliding_window_size is not None:
-                # With sliding window: each query attends to at most W keys
-                # (left_bound is exclusive, right_bound is inclusive)
-                # For positions 0 to W-1: 1, 2, ..., W keys (partial window)
-                # For positions W to S-1: W keys each (full window)
-                W = sliding_window_size
-                S = min(q_seqlen, kv_seqlen)
-                if S <= W:
-                    # Sequence shorter than window, use full causal
-                    num_nonmasked_elems = S * (S + 1) // 2
-                else:
-                    # Partial window (first W positions) + full window (remaining positions)
-                    num_nonmasked_elems = W * (W + 1) // 2 + (S - W) * W
-            else:
-                num_nonmasked_elems = torch.tril(torch.ones((q_seqlen, kv_seqlen), dtype=torch.bool)).sum()
+            num_nonmasked_elems = count_causal_nonmasked_elems(q_seqlen, kv_seqlen, attn_mask, sliding_window_size)
         else:
             raise ValueError(f"Unknown attn_mask: {attn_mask}")
         # BMM FLOPs: 2 * M * N * K.

--- a/benchmark/attention_training/flops.py
+++ b/benchmark/attention_training/flops.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for calculating attention operation counts."""
+
+from typing import Optional
+
+
+def count_causal_nonmasked_elems(
+    q_seqlen: int,
+    kv_seqlen: int,
+    attn_mask: str,
+    sliding_window_size: Optional[int] = None,
+) -> int:
+    """Count unmasked (query, key/value) pairs for a causal SDPA mask.
+
+    Args:
+        q_seqlen: Query sequence length.
+        kv_seqlen: Key/value sequence length.
+        attn_mask: ``top_left`` or ``bottom_right`` causal alignment.
+        sliding_window_size: Optional sliding window size.
+    """
+    if attn_mask not in ("top_left", "bottom_right"):
+        raise ValueError(f"Unsupported causal attn mask for counting: {attn_mask}")
+
+    diagonal_offset = kv_seqlen - q_seqlen if attn_mask == "bottom_right" else 0
+    total = 0
+
+    for q_idx in range(q_seqlen):
+        row_end = min(kv_seqlen - 1, q_idx + diagonal_offset)
+        if row_end < 0:
+            continue
+
+        if sliding_window_size is None:
+            row_start = 0
+        elif attn_mask == "top_left":
+            row_start = max(0, q_idx - sliding_window_size + 1)
+        else:
+            # For bottom-right alignment, anchor the window to the causal diagonal.
+            row_start = max(0, row_end - sliding_window_size + 1)
+
+        if row_start <= row_end:
+            total += row_end - row_start + 1
+
+    return total

--- a/test/python/test_sdpa_benchmark_single_sdpa.py
+++ b/test/python/test_sdpa_benchmark_single_sdpa.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from benchmark.attention_training.flops import count_causal_nonmasked_elems  # noqa: E402
+
+pytestmark = pytest.mark.L0
+
+
+def _reference_causal_nonmasked_elems(q_seqlen: int, kv_seqlen: int, attn_mask: str, sliding_window_size: Optional[int]):
+    diagonal_offset = kv_seqlen - q_seqlen if attn_mask == "bottom_right" else 0
+    total = 0
+
+    for q_idx in range(q_seqlen):
+        for kv_idx in range(kv_seqlen):
+            distance_from_diagonal = kv_idx - (q_idx + diagonal_offset)
+            if distance_from_diagonal > 0:
+                continue
+            if sliding_window_size is not None and distance_from_diagonal <= -sliding_window_size:
+                continue
+            total += 1
+
+    return total
+
+
+def test_count_causal_nonmasked_elems_square_top_left():
+    assert count_causal_nonmasked_elems(4, 4, "top_left") == 10
+
+
+def test_count_causal_nonmasked_elems_rectangular_top_left():
+    assert count_causal_nonmasked_elems(5, 3, "top_left") == 12
+    assert count_causal_nonmasked_elems(3, 6, "top_left") == 6
+
+
+def test_count_causal_nonmasked_elems_rectangular_bottom_right():
+    assert count_causal_nonmasked_elems(5, 3, "bottom_right") == 6
+    assert count_causal_nonmasked_elems(3, 6, "bottom_right") == 15
+
+
+def test_count_causal_nonmasked_elems_sliding_window():
+    assert count_causal_nonmasked_elems(6, 6, "top_left", sliding_window_size=3) == 15
+    assert count_causal_nonmasked_elems(5, 3, "bottom_right", sliding_window_size=2) == 5
+
+
+def test_count_causal_nonmasked_elems_matches_reference():
+    cases = [
+        (4, 4, "top_left", None),
+        (5, 3, "top_left", None),
+        (3, 6, "top_left", 2),
+        (4, 4, "bottom_right", None),
+        (5, 3, "bottom_right", 2),
+        (3, 6, "bottom_right", 3),
+    ]
+
+    for q_seqlen, kv_seqlen, attn_mask, sliding_window_size in cases:
+        assert count_causal_nonmasked_elems(
+            q_seqlen=q_seqlen,
+            kv_seqlen=kv_seqlen,
+            attn_mask=attn_mask,
+            sliding_window_size=sliding_window_size,
+        ) == _reference_causal_nonmasked_elems(
+            q_seqlen=q_seqlen,
+            kv_seqlen=kv_seqlen,
+            attn_mask=attn_mask,
+            sliding_window_size=sliding_window_size,
+        )


### PR DESCRIPTION
## Why
The benchmark FLOP helper allocated `torch.ones((q_seqlen, kv_seqlen))` for causal masks, which can allocate huge CPU masks (e.g. 32768 x 32768) before counting non-masked elements.

## What changed
- Added `count_causal_nonmasked_elems(...)` to compute causal non-masked element counts using row-bound arithmetic.
- Replaced `torch.tril(...).sum()` usage in `flops(...)` with the new helper.
- Added unit tests covering:
  - square masks
  - rectangular masks
  - top-left causal and bottom-right causal
  - sliding-window variants
  - reference cross-check against a brute-force boolean-mask computation

## Test coverage
Added `test/python/test_sdpa_benchmark_single_sdpa.py` with explicit assertions and a reference cross-check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FLOP counting support for causal attention with top-left and bottom-right mask alignment.
  * Added support for optional sliding-window attention and rectangular query/key-value dimensions.
  * Unsupported mask alignments are now reported clearly.

* **Tests**
  * Added coverage for square, rectangular, sliding-window, empty-row, and reference-comparison scenarios.
  * Improved confidence in benchmark FLOP calculations across supported attention configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->