### PR TITLE
benchmark: fix bench_moe repo root path resolution

### DIFF
--- a/benchmark/bench_moe.py
+++ b/benchmark/bench_moe.py
@@ -2,13 +2,14 @@
 Benchmark MoE Grouped Matmul with LLM-inspired shapes.
 
 Usage:
-    python benchmarks/bench_moe.py
-    python benchmarks/bench_moe.py --bench swiglu --mode e2e
-    python benchmarks/bench_moe.py --bench swiglu --autotune 10
+    python benchmark/bench_moe.py
+    python benchmark/bench_moe.py --bench swiglu --mode e2e
+    python benchmark/bench_moe.py --bench swiglu --autotune 10
 """
 
 import argparse
 import statistics
+from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
 import torch
@@ -265,11 +266,11 @@ def bench_grouped_gemm_glu_vs_cudnn(warmup: int, repeat: int):
     CuteDSL: BlockScaledMoEGroupedGemmGluBiasKernel (FP4 in, BF16 out, fused SwiGLU+AMAX)
     cuDNN:   fused graph (2x moe_grouped_matmul + swish + mul, BF16)
     """
-    import sys, os
+    import sys
 
-    _REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    sys.path.insert(0, os.path.join(_REPO, "cudnn_frontend/test/python/fe_api"))
-    sys.path.insert(0, os.path.join(_REPO, "cudnn_frontend/test/python"))
+    _REPO = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(_REPO / "test/python/fe_api"))
+    sys.path.insert(0, str(_REPO / "test/python"))
 
     print()
     print("=" * 130)


### PR DESCRIPTION
## Why
`bench_moe.py` currently uses `dirname(dirname(dirname(__file__)))` and adds `cudnn_frontend/test/python...` to `sys.path`, which can walk above the repo root in normal checkouts.

## What changed
- Use `Path(__file__).resolve().parents[1]` to compute the repository root from
  `benchmark/bench_moe.py`.
- Insert only repo-local path entries:
  - `repo_root / "test/python/fe_api"`
  - `repo_root / "test/python"`
- Update usage docs in the header from `benchmarks/bench_moe.py` to `benchmark/bench_moe.py`.

## Verification
Run a quick path sanity check from two working dirs:

```bash
python3 - <<'PY'
from pathlib import Path
repo_file = Path('benchmark/bench_moe.py').resolve()
repo_root = repo_file.parents[1]
print(repo_root / 'test/python', (repo_root / 'test/python').exists())
print(repo_root / 'test/python/fe_api', (repo_root / 'test/python/fe_api').exists())
PY

cd /tmp
python3 - <<'PY'
from pathlib import Path
repo_file = Path('/Users/hoangvu/Code/OSS/cudnn-frontend/benchmark/bench_moe.py').resolve()
repo_root = repo_file.parents[1]
print(repo_root / 'test/python', (repo_root / 'test/python').exists())
print(repo_root / 'test/python/fe_api', (repo_root / 'test/python/fe_api').exists())
PY
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark usage examples to show the correct command for running the MoE benchmark script.
  * Clarified example invocations for common modes, including end-to-end runs and autotuning.
* **Bug Fixes**
  * Corrected outdated benchmark path references in the usage text.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->