### PR TITLE
Preserve the CUDA default stream in DSA wrappers

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/utils/runtime.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/runtime.py
@@ -56,5 +56,5 @@ def torch_stream_context(current_stream: Optional[cuda.CUstream] = None) -> Iter
     if current_stream is None:
         yield
         return
-    with torch.cuda.stream(torch.cuda.ExternalStream(int(current_stream))):
+    with torch.cuda.stream(torch.cuda.get_stream_from_external(int(current_stream))):
         yield

--- a/test/python/fe_api/dsa/test_DSA_runtime.py
+++ b/test/python/fe_api/dsa/test_DSA_runtime.py
@@ -1,0 +1,17 @@
+import pytest
+import torch
+
+
+@pytest.mark.L0
+def test_torch_stream_context_preserves_legacy_default_stream():
+    try:
+        from cuda.bindings import driver as cuda
+        from cudnn.deepseek_sparse_attention.utils.runtime import torch_stream_context
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    outer_stream = torch.cuda.Stream()
+    with torch.cuda.stream(outer_stream):
+        with torch_stream_context(cuda.CUstream(0)):
+            assert torch.cuda.current_stream().cuda_stream == 0
+        assert torch.cuda.current_stream().cuda_stream == outer_stream.cuda_stream


### PR DESCRIPTION
## What

Use `torch.cuda.get_stream_from_external()` when entering a caller-supplied CUDA stream.

## Why

`torch.cuda.ExternalStream(0)` does not preserve the legacy default-stream handle. It produces a different pooled stream, so PyTorch setup or copy operations performed inside the wrapper can race a CuTe kernel launched on stream 0.

`get_stream_from_external()` preserves both the zero default-stream handle and nonzero external stream handles.

## Validation

Run on an H100 (SM90) with PyTorch 2.12, CUDA 13.2, and cuDNN Frontend built from current `develop`:

- New stream-identity regression on unpatched `develop`: **failed as expected** because the active handle was nonzero.
- Same regression with this change: **1 passed**.
- Complete `test/python/fe_api/dsa` suite: **22 passed**.
