### PR TITLE
Make DSA dense indexer backward CUDA Graph safe

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -380,8 +380,8 @@ class DenseIndexerBackward(APIBase):
     ) -> None:
         backend_stream = None if self._uses_current_stream_pipeline else current_stream
         with _torch_stream_context(backend_stream):
-            grad_loss_value = float(_as_grad_loss_tensor(grad_loss, index_q.device).item())
-            grad_scale = float(loss_coeff) * grad_loss_value / max(int(self.normalization_tokens), 1)
+            grad_loss_tensor = _as_grad_loss_tensor(grad_loss, index_q.device)
+            grad_scale = float(loss_coeff) / max(int(self.normalization_tokens), 1)
 
             # Dense backward's dK path uses atomic/bulk reductions into fp32.
             d_index_k_target = d_index_k
@@ -402,6 +402,7 @@ class DenseIndexerBackward(APIBase):
             attn_l1norm,
             index_score,
             index_lse,
+            grad_loss_tensor,
             grad_scale,
             cu_seqlens_q,
             cu_seqlens_k,

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
@@ -147,6 +147,7 @@ class ScoreGradDense:
         mCuSeqlensQ,
         mCuSeqlensK,
         mQCausalOffsets,
+        mGradLoss,
         grad_scale: Float32,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -192,6 +193,7 @@ class ScoreGradDense:
             mCuSeqlensQ,
             mCuSeqlensK,
             mQCausalOffsets,
+            mGradLoss,
             grad_scale,
             seqlen_k_pad,
             max_seqlen_q,
@@ -212,6 +214,7 @@ class ScoreGradDense:
         mCuSeqlensQ,
         mCuSeqlensK,
         mQCausalOffsets,
+        mGradLoss,
         grad_scale: Float32,
         seqlen_k_pad: Int32,
         seqlen_q_static: Int32,
@@ -233,6 +236,7 @@ class ScoreGradDense:
             seqlen_k_static,
         )
         q_causal_offset_b = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
+        grad_scale_f32 = Float32(grad_scale) * Float32(mGradLoss[0])
 
         # Out-of-range CTAs (seq_local >= seqlen_q_b in this batch): skip work.
         # CuTe DSL forbids early `return`, so wrap the body in an `if` block.
@@ -284,7 +288,7 @@ class ScoreGradDense:
                 target = tr / (denom_val + Float32(DENOM_EPS))
                 target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
                 log_clip_mask = Float32(1.0) if score_minus_lse >= Float32(CLIP_LOG_MIN) else Float32(0.0)
-                g = -target_eff * log_clip_mask * grad_scale
+                g = -target_eff * log_clip_mask * grad_scale_f32
 
                 local_sum = local_sum + g
                 pos = pos + Int32(128)
@@ -324,7 +328,7 @@ class ScoreGradDense:
                     target = tr / (denom_val + Float32(DENOM_EPS))
                     target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
                     log_clip_mask = Float32(1.0) if score_minus_lse >= Float32(CLIP_LOG_MIN) else Float32(0.0)
-                    g = -target_eff * log_clip_mask * grad_scale
+                    g = -target_eff * log_clip_mask * grad_scale_f32
 
                     grad_signal = g - predict * sum_grad
                     mPredict_b[seq_local, pos] = grad_signal
@@ -2007,6 +2011,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
         CuSeqlensQ,
         CuSeqlensK,
         QCausalOffsets,
+        GradLoss,
         grad_scale,
         current_stream=None,
     ):
@@ -2037,6 +2042,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
                 cuq_arg,
                 cuk_arg,
                 q_offsets_arg,
+                to_cute_tensor(GradLoss, assumed_align=4, leading_dim=0),
                 cutlass.Float32(float(grad_scale)),
                 cutlass.Int32(max_seqlen_q),
                 cutlass.Int32(max_seqlen_k),
@@ -2153,6 +2159,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
         AttnL1Norm,
         IdxScoreRaw,
         IdxLSE,
+        GradLoss,
         grad_scale,
         CuSeqlensQ=None,
         CuSeqlensK=None,
@@ -2177,6 +2184,8 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             assert QCausalOffsets is not None, "offset-compiled kernel requires q_causal_offsets at runtime"
         else:
             assert QCausalOffsets is None, "non-offset compiled kernel must not receive q_causal_offsets"
+        if GradLoss.ndim == 0:
+            GradLoss = GradLoss.reshape(1)
         s = _resolve_stream(current_stream)
 
         # Kernel 1 (CuTe DSL): in-place overwrites IdxScoreRaw with grad_signal.
@@ -2189,6 +2198,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
             CuSeqlensQ,
             CuSeqlensK,
             QCausalOffsets,
+            GradLoss,
             grad_scale,
             current_stream=current_stream,
         )
@@ -2201,6 +2211,7 @@ def _build_cute_dsl_kernel(batch, max_seqlen_q, max_seqlen_k, heads, dim, sm_sca
                 CuSeqlensQ,
                 CuSeqlensK,
                 QCausalOffsets,
+                GradLoss,
                 cutlass.Float32(float(grad_scale)),
                 cutlass.Int32(max_seqlen_q),
                 cutlass.Int32(max_seqlen_k),

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm90.py
@@ -67,6 +67,7 @@ class ScoreGradDenseSm90:
         mCuSeqlensQ,
         mCuSeqlensK,
         mQCausalOffsets,
+        mGradLoss,
         grad_scale: Float32,
         max_seqlen_q: Int32,
         max_seqlen_k: Int32,
@@ -109,6 +110,7 @@ class ScoreGradDenseSm90:
             mCuSeqlensQ,
             mCuSeqlensK,
             mQCausalOffsets,
+            mGradLoss,
             grad_scale,
             seqlen_k_pad,
             max_seqlen_q,
@@ -129,6 +131,7 @@ class ScoreGradDenseSm90:
         mCuSeqlensQ,
         mCuSeqlensK,
         mQCausalOffsets,
+        mGradLoss,
         grad_scale: Float32,
         seqlen_k_pad: Int32,
         seqlen_q_static: Int32,
@@ -148,6 +151,7 @@ class ScoreGradDenseSm90:
             seqlen_k_static,
         )
         q_causal_offset_b = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
+        grad_scale_f32 = Float32(grad_scale) * Float32(mGradLoss[0])
 
         if seq_local < seqlen_q_b:
             smem = cutlass.utils.SmemAllocator()
@@ -195,7 +199,7 @@ class ScoreGradDenseSm90:
                 target = attn_raw / (attn_l1_val + Float32(EPS))
                 target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
                 log_clip_mask = Float32(1.0) if score_minus_lse >= Float32(CLIP_LOG_MIN) else Float32(0.0)
-                local_sum = local_sum + (-target_eff * log_clip_mask * grad_scale)
+                local_sum = local_sum + (-target_eff * log_clip_mask * grad_scale_f32)
                 pos = pos + Int32(128)
 
             warp_sum = cute.arch.warp_reduction_sum(local_sum)
@@ -221,7 +225,7 @@ class ScoreGradDenseSm90:
                     target = attn_raw / (attn_l1_val + Float32(EPS))
                     target_eff = target if target >= Float32(CLIP_PROB_MIN) else Float32(CLIP_PROB_MIN)
                     log_clip_mask = Float32(1.0) if score_minus_lse >= Float32(CLIP_LOG_MIN) else Float32(0.0)
-                    g = -target_eff * log_clip_mask * grad_scale
+                    g = -target_eff * log_clip_mask * grad_scale_f32
                     mIdxScore_b[seq_local, pos] = g - predict * sum_grad
                 else:
                     mIdxScore_b[seq_local, pos] = Float32(0.0)
@@ -352,6 +356,7 @@ def _build_cute_dsl_dense_kernel(
         CuSeqlensQ,
         CuSeqlensK,
         QCausalOffsets,
+        GradLoss,
         grad_scale,
         current_stream=None,
     ):
@@ -369,6 +374,7 @@ def _build_cute_dsl_dense_kernel(
                 cuq_arg,
                 cuk_arg,
                 q_offsets_arg,
+                to_cute_tensor(GradLoss, assumed_align=4, leading_dim=0),
                 cutlass.Float32(float(grad_scale)),
                 cutlass.Int32(seqlen),
                 cutlass.Int32(seqlen_k),
@@ -381,12 +387,15 @@ def _build_cute_dsl_dense_kernel(
         IdxLSE,
         AttnScoreRaw,
         AttnL1Norm,
+        GradLoss,
         grad_scale,
         CuSeqlensQ=None,
         CuSeqlensK=None,
         QCausalOffsets=None,
         current_stream=None,
     ):
+        if GradLoss.ndim == 0:
+            GradLoss = GradLoss.reshape(1)
         if is_varlen:
             assert CuSeqlensQ is not None and CuSeqlensK is not None, "THD-compiled score-grad kernel requires cu_seqlens_q/k at runtime"
         else:
@@ -404,6 +413,7 @@ def _build_cute_dsl_dense_kernel(
             CuSeqlensQ,
             CuSeqlensK,
             QCausalOffsets,
+            GradLoss,
             grad_scale,
             current_stream=current_stream,
         )
@@ -415,6 +425,7 @@ def _build_cute_dsl_dense_kernel(
             CuSeqlensQ,
             CuSeqlensK,
             QCausalOffsets,
+            GradLoss,
             cutlass.Float32(float(grad_scale)),
             cutlass.Int32(seqlen),
             cutlass.Int32(seqlen_k),
@@ -488,6 +499,7 @@ def _build_cute_dsl_dense_kernel(
         attn_l1norm,
         idx_scores_raw,
         idx_lse,
+        GradLoss,
         grad_scale,
         CuSeqlensQ=None,
         CuSeqlensK=None,
@@ -503,6 +515,7 @@ def _build_cute_dsl_dense_kernel(
             idx_lse,
             attn_scores_raw,
             attn_l1norm,
+            GradLoss,
             grad_scale,
             CuSeqlensQ,
             CuSeqlensK,

--- a/test/python/fe_api/dsa/test_DSA_dense_indexer_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_dense_indexer_backward.py
@@ -154,3 +154,83 @@ def test_DSA_dense_indexer_backward_wrapper(
             grad_scale=grad_scale_expected,
             q_causal_offsets=q_causal_offsets,
         )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_dense_indexer_backward_cuda_graph():
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("Dense indexer backward requires SM90+")
+
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    cfg = {
+        "b": 1,
+        "s_q": 128,
+        "s_kv": 128,
+        "head_dim": 128,
+        "qhead_per_kv_head": 64,
+    }
+    (
+        index_q,
+        weights,
+        index_k,
+        attn_score,
+        attn_l1norm,
+        index_score,
+        index_lse,
+    ) = _allocate(cfg, sm_scale=1.0, ratio=1, q_causal_offsets=None)
+    attn_score_source = attn_score.clone()
+    index_score_source = index_score.clone()
+    d_index_q = torch.empty_like(index_q)
+    d_weights = torch.empty_like(weights)
+    d_index_k = torch.empty_like(index_k, dtype=torch.float32)
+    grad_loss = torch.ones(1, dtype=torch.float32, device="cuda")
+
+    def run():
+        attn_score.copy_(attn_score_source)
+        index_score.copy_(index_score_source)
+        DSA.dense_indexer_backward_wrapper(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            attn_l1norm,
+            index_score,
+            index_lse,
+            loss_coeff=float(cfg["b"] * cfg["s_q"]),
+            grad_loss=grad_loss,
+            block_I=128,
+            ratio=1,
+            d_index_q=d_index_q,
+            d_weights=d_weights,
+            d_index_k=d_index_k,
+        )
+
+    warmup_stream = torch.cuda.Stream()
+    warmup_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup_stream):
+        run()
+    torch.cuda.current_stream().wait_stream(warmup_stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+
+    for scale in (0.5, 1.5):
+        grad_loss.fill_(scale)
+        graph.replay()
+        check_ref_dense_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            attn_score_source,
+            attn_l1norm,
+            d_index_q,
+            d_weights,
+            d_index_k,
+            grad_scale=scale,
+        )


### PR DESCRIPTION
## What changed

- Keep `grad_loss` on the GPU in dense indexer backward instead of reading it with `.item()`.
- Pass the device scalar to the SM90 and SM100 dense score-gradient kernels and combine it with the host normalization scale in the kernel.
- Add a CUDA Graph test that replays the same graph with two different `grad_loss` values and checks all gradients against the PyTorch reference.

## Why

`DenseIndexerBackward.execute()` synchronously copied the CUDA `grad_loss` tensor to the host. That operation is forbidden during CUDA Graph capture and made the dense-loss DSA backward path impossible to capture. The scalar is runtime data, so consuming it directly in the score-gradient kernel also preserves its value across graph replays without changing any compile-cache key or GEMM metadata.

## Validation

Validated on one H100 80GB (SM90):

- Unpatched `develop`: the new targeted test fails at `grad_loss.item()` with `operation not permitted when stream is capturing`.
- Patched targeted CUDA Graph test: `1 passed`.
- Complete dense indexer backward test file: `2 passed`.
- Complete DSA test directory: `22 passed`, `0 skipped`.
- Repository `black` and `black-jupyter` pre-commit hooks passed for all changed files.

The runtime validation covers SM90. The SM100 score-gradient path receives the same shared API fix and was checked for matching compile/runtime argument order, but was not run on SM100 hardware in this validation.
