### PR TITLE
Fix FE-OSS SDPA links and DSA diagram fence

### DIFF
--- a/docs/fe-oss-apis/dsa.md
+++ b/docs/fe-oss-apis/dsa.md
@@ -36,7 +36,7 @@ The module packages the following operations:
 
 ### Architecture
 
-```
+```text
 Q, K, W ──► IndexerForward ──► scores ──► IndexerTopK ──► topk_idxs
                                                              │
                                                              v

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -22,8 +22,8 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [Block Sparse Attention (BSA)](bsa.md)
 - [Native Sparse Attention (NSA)](nsa.md)
 - [RMSNorm + RHT + Amax](rmsnorm_rht_amax.md)
-- [SDPA Forward FE OSS API (SM100, D=256)](../operations/Attention.md#sdpa-forward-fe-oss-sm100-d256)
-- [SDPA Backward FE OSS API (SM100, D=256)](../operations/Attention.md#sdpa-backward-fe-oss-sm100-d256)
+- [SDPA Forward FE OSS API (SM100, D=256)](https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/operations/Attention.html#sdpa-forward-fe-oss-sm100-d256)
+- [SDPA Backward FE OSS API (SM100, D=256)](https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/operations/Attention.html#sdpa-backward-fe-oss-sm100-d256)
 - [RMSNorm + SiLU](rmsnorm_silu.md)
 
 ## Installation and setup


### PR DESCRIPTION
## Summary
- Replace broken SDPA Markdown anchor links in `docs/fe-oss-apis/overview.md` with stable docs.nvidia.com URLs.
- Mark the DSA architecture diagram code block as `text` in `docs/fe-oss-apis/dsa.md`.

## Why
- The prior `../operations/Attention.md#...` links do not resolve to intended section anchors in GitHub and were causing strict docs-build reference issues downstream.
- The untyped diagram block can be misinterpreted by syntax highlighters due to Unicode drawing characters.

## Validation
- Built downstream docs with warnings treated as errors after applying equivalent fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified a code example formatting in the DSA docs for better readability.
  * Updated documentation links for SDPA Forward and SDPA Backward to point to the correct hosted references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->