### PR TITLE
Fix cutlass DSL deprecation: use .ptr for cute.struct scalar fields

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/dense_indexer_backward_sm100.py
@@ -788,9 +788,9 @@ class DenseIndexerBackward2QGemmSm100:
         Q_q1_mbar_ptr = storage.Q_q1_mbar.data_ptr()
         K_mbar_ptr = storage.K_mbar.data_ptr()
         mbar = storage.mbar.data_ptr()
-        tmem_holding_buf = storage.tmem_holding_buf
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.compute_warp_id[0],
         )

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py
@@ -442,9 +442,9 @@ class IndexerBackwardSm100:
         storage = smem.allocate(SharedStorage)
         Q_mbar_ptr = storage.Q_mbar.data_ptr()
         mbar = storage.mbar.data_ptr()
-        tmem_holding_buf = storage.tmem_holding_buf
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.compute_warp_id[0],
         )

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm100.py
@@ -435,7 +435,7 @@ class IndexerForwardSm100:
         S_mbar_ptr = storage.S_mbar_ptr.data_ptr()
         Score_store_mbar_ptr = storage.Score_store_mbar_ptr.data_ptr()
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.data_ptr()
-        tmem_holding_buf = storage.tmem_holding_buf
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
         clc_mbar_ptr = storage.clc_mbar_ptr.data_ptr()
         clc_response_ptr = storage.clc_response.data_ptr()
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
@@ -428,7 +428,7 @@ class DenseScoreRecomputeSm100:
         S_mbar_ptr = storage.S_mbar_ptr.data_ptr()
         reduce_sync_mbar_ptr = storage.reduce_sync_mbar_ptr.data_ptr()
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.data_ptr()
-        tmem_holding_buf = storage.tmem_holding_buf
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
         clc_mbar_ptr = storage.clc_mbar_ptr.data_ptr()
         clc_response_ptr = storage.clc_response.data_ptr()
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/sparse_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/sparse_score_recompute_sm100.py
@@ -407,7 +407,7 @@ class SparseScoreRecomputeSm100:
         S_mbar_ptr = storage.S_mbar_ptr.data_ptr()
         reduce_sync_mbar_ptr = storage.reduce_sync_mbar_ptr.data_ptr()
         tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.data_ptr()
-        tmem_holding_buf = storage.tmem_holding_buf
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
         clc_mbar_ptr = storage.clc_mbar_ptr.data_ptr()
         clc_response_ptr = storage.clc_response.data_ptr()
         sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)

--- a/python/cudnn/grouped_gemm/grouped_gemm_dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -1437,11 +1437,11 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         scheduler.internal_init()
 
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
             is_two_cta=use_2cta_instrs,
-            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
         )
 
         if cute.size(self.cluster_shape_mn) > 1:

--- a/python/cudnn/grouped_gemm/grouped_gemm_srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
@@ -1235,11 +1235,11 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         scheduler.internal_init()
 
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=self.tmem_alloc_barrier,
             allocator_warp_id=self.epilog_warp_id[0],
             is_two_cta=use_2cta_instrs,
-            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
         )
 
         if cute.size(self.cluster_shape_mn) > 1:

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -778,11 +778,11 @@ class BlockScaledMoEGroupedGemmWgradKernel:
             num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
         )
         tmem = utils.TmemAllocator(
-            storage.tmem_holding_buf,
+            storage.tmem_holding_buf.ptr,
             barrier_for_retrieve=tmem_alloc_barrier,
             allocator_warp_id=self.epilogue_warp_id[0],
             is_two_cta=use_2cta_instrs,
-            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
         )
 
         # Scheduler (CLC-based for 2Dx2D)


### PR DESCRIPTION
## What

Fixes the cutlass DSL deprecation warning emitted from `cutlass/cute/core.py` when running the DSA kernels with nvidia-cutlass-dsl >= 4.5.0:

```
DeprecationWarning: Use explicit `struct.scalar.ptr` for pointer instead.
```

## Why

cutlass-dsl 4.5+ deprecates using a scalar field of a `@cute.struct` directly as a pointer (via the `_ScalarData.value` property). The warning fires whenever `tmem_holding_buf` / `tmem_dealloc_mbar_ptr` struct scalars are passed to `cute.arch.alloc_tmem` / `cute.arch.retrieve_tmem_ptr` (directly or through `cutlass.utils.TmemAllocator`), which read `.value` on their pointer argument.

## How

Append the explicit `.ptr` accessor at the remaining call sites, matching the pattern already used by the other DSA kernels (e.g. `dense_gemm_persistent_swiglu.py`). No functional change; `.ptr` returns the same underlying pointer without going through the deprecated property.

- grouped_gemm: dsrelu / srelu / wgrad `TmemAllocator(...)` arguments
- deepseek_sparse_attention: indexer_forward, indexer_backward (sparse + dense), score_recompute (sparse + dense)

🤖 Generated with [Claude Code](https://claude.com/claude-code)