### PR TITLE
Update nvidia-cutlass-dsl version to 4.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ classifiers = [
 
 [project.optional-dependencies]
 cutedsl = [
-    "nvidia-cutlass-dsl[cu13]==4.5.0",
+    "nvidia-cutlass-dsl[cu13]==4.6.0",
     "cuda-python",
     "torch",
     "apache-tvm-ffi",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ classifiers = [
 
 [project.optional-dependencies]
 cutedsl = [
-    "nvidia-cutlass-dsl[cu13]==4.6.0",
+    "nvidia-cutlass-dsl[cu13]>=4.5.0",
     "cuda-python",
     "torch",
     "apache-tvm-ffi",

--- a/python/cudnn/discrete_grouped_gemm/discrete_grouped_gemm_dswiglu/discrete_B_blockscaled_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/discrete_grouped_gemm/discrete_grouped_gemm_dswiglu/discrete_B_blockscaled_grouped_gemm_dglu_dbias.py
@@ -69,7 +69,6 @@ from ..discrete_kernel_utils import (
     fmax,
     fmin_bf16x2,
     fmax_bf16x2,
-    warp_redux_sync,
     atomic_max_float32,
     atomic_add_float32,
     atomic_add_bf16x2,
@@ -1203,10 +1202,11 @@ class BlockScaledDiscreteWeightDgluDbiasGroupedGemmKernel:
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem) -> None:
         # Warp-level reduction using wrapper function
-        warp_amax = warp_redux_sync(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
-            kind=None,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
+            nan=True,
         )
         # Each epilogue warp's lane 0 writes warp amax to shared memory
         lane_idx = cute.arch.thread_idx()[0] % 32
@@ -1406,6 +1406,8 @@ class BlockScaledDiscreteWeightDgluDbiasGroupedGemmKernel:
         tCompute.store(src)
         tTR_rAcc_frg = cute.logical_divide(tCompute, cute.make_layout(self.sf_vec_size))
         acc_frg = tTR_rAcc_frg.load()
+        abs_acc_frg_ir = cutlass._mlir.dialects.math.absf(acc_frg.ir_value())
+        acc_frg = type(acc_frg)(abs_acc_frg_ir, acc_frg.shape, acc_frg.dtype)
 
         tmp_fp32 = cutlass.Float32(0.0)
         fp32_max = cutlass.Float32(3.40282346638528859812e38)
@@ -1413,31 +1415,35 @@ class BlockScaledDiscreteWeightDgluDbiasGroupedGemmKernel:
 
         for vi in cutlass.range_constexpr(0, acc_frg.shape[0], 4):
             max_value0 = cutlass.Float32(
-                warp_redux_sync(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi, 0],
-                    kind=None,
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value1 = cutlass.Float32(
-                warp_redux_sync(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 1, 0],
-                    kind=None,
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value2 = cutlass.Float32(
-                warp_redux_sync(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 2, 0],
-                    kind=None,
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value3 = cutlass.Float32(
-                warp_redux_sync(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 3, 0],
-                    kind=None,
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
 

--- a/python/cudnn/discrete_grouped_gemm/discrete_grouped_gemm_swiglu/discrete_B_blockscaled_grouped_gemm_glu_bias.py
+++ b/python/cudnn/discrete_grouped_gemm/discrete_grouped_gemm_swiglu/discrete_B_blockscaled_grouped_gemm_glu_bias.py
@@ -45,7 +45,6 @@ import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
-from cutlass._mlir.dialects.nvvm import ReduxKind
 from cutlass.cute.typing import Float32, Int32, AddressSpace
 from ..moe_persistent_scheduler import (
     MoEPersistentTileScheduler,
@@ -61,7 +60,6 @@ from ..moe_sched_extension import DiscreteWeightScaledGemmSchedExtension
 from ..discrete_kernel_utils import (
     fmin,
     fmax,
-    warp_redux_sync,
     atomic_max_float32,
     silu_f32,
     silu_f32_geglu_scaled,
@@ -1161,9 +1159,9 @@ class BlockScaledDiscreteWeightGroupedGemmBiasKernel:
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem) -> None:
         # Warp-level reduction using wrapper function
-        warp_amax = warp_redux_sync(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
-            kind=ReduxKind.MAX,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
             nan=True,
         )
@@ -1324,9 +1322,9 @@ class BlockScaledDiscreteWeightGroupedGemmBiasKernel:
         for vi in cutlass.range_constexpr(acc_frg.shape[0]):
             max_value_original = (
                 cutlass.Float32(
-                    warp_redux_sync(
+                    cute.arch.warp_redux_sync(
                         value=acc_frg[vi, 0],
-                        kind=ReduxKind.MAX,
+                        kind="fmax",
                         mask_and_clamp=0xFFFFFFFF,
                         nan=True,
                     )

--- a/python/cudnn/discrete_grouped_gemm/discrete_kernel_utils.py
+++ b/python/cudnn/discrete_grouped_gemm/discrete_kernel_utils.py
@@ -291,34 +291,6 @@ def atomic_add_bf16x2(ptr, val_fp32_lo, val_fp32_hi, *, loc=None, ip=None):
     )
 
 
-def warp_redux_sync(
-    value,
-    kind,
-    mask_and_clamp=0xFFFFFFFF,
-    abs: bool = False,
-    nan: bool = None,
-    *,
-    loc=None,
-    ip=None,
-):
-    value_type = type(value)
-    value_ir = value.ir_value(loc=loc, ip=ip)
-    mask_ir = Int32(mask_and_clamp).ir_value(loc=loc, ip=ip)
-    ptx_instr = f"redux.sync.max.abs.NaN.f32 $0, $1, $2;"
-
-    return value_type(
-        llvm.inline_asm(
-            T.f32(),
-            [value_ir, mask_ir],
-            f"{ptx_instr}",
-            f"=f,f,i",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-        )
-    )
-
-
 def atomic_max_float32(
     ptr,
     value: Float32,

--- a/python/cudnn/gemm_amax/dense_blockscaled_gemm_persistent_amax.py
+++ b/python/cudnn/gemm_amax/dense_blockscaled_gemm_persistent_amax.py
@@ -1300,16 +1300,12 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     self.epilog_sync_barrier.arrive_and_wait()
 
                 # Perform amax reduction after all subtiles are processed
-                _val_i32 = llvm.bitcast(T.i32(), thread_tile_amax.ir_value(), loc=None, ip=None)
-                _res_i32 = nvvm.redux_sync(
-                    res=T.i32(),
-                    val=_val_i32,
-                    kind=nvvm.ReduxKind.MAX,
-                    mask_and_clamp=cutlass.Int32(0xFFFFFFFF).ir_value(),
-                    loc=None,
-                    ip=None,
+                warp_amax = cute.arch.warp_redux_sync(
+                    value=thread_tile_amax,
+                    kind="fmax",
+                    mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
-                warp_amax = cutlass.Float32(llvm.bitcast(T.f32(), _res_i32, loc=None, ip=None))
 
                 # Each epilogue warp's lane 0 writes warp amax to shared memory
                 if cute.arch.lane_idx() == 0:

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
@@ -79,7 +79,6 @@ from ..moe_kernel_helpers import (
     fmax,
     fmin_bf16x2,
     fmax_bf16x2,
-    warp_redux_sync,
     atomic_max_float32,
     atomic_add_float32,
     atomic_add_bf16x2,
@@ -1215,10 +1214,11 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem) -> None:
         # Warp-level reduction using wrapper function
-        warp_amax = warp_redux_sync(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
-            kind=None,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
+            nan=True,
         )
         # Each epilogue warp's lane 0 writes warp amax to shared memory
         lane_idx = cute.arch.thread_idx()[0] % 32
@@ -1418,6 +1418,8 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
         tCompute.store(src)
         tTR_rAcc_frg = cute.logical_divide(tCompute, cute.make_layout(self.sf_vec_size))
         acc_frg = tTR_rAcc_frg.load()
+        abs_acc_frg_ir = cutlass._mlir.dialects.math.absf(acc_frg.ir_value())
+        acc_frg = type(acc_frg)(abs_acc_frg_ir, acc_frg.shape, acc_frg.dtype)
 
         tmp_fp32 = cutlass.Float32(0.0)
         fp32_max = cutlass.Float32(3.40282346638528859812e38)
@@ -1425,31 +1427,35 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
 
         for vi in cutlass.range_constexpr(0, acc_frg.shape[0], 4):
             max_value0 = cutlass.Float32(
-                warp_redux_sync(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi, 0],
-                    kind=None,
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value1 = cutlass.Float32(
-                warp_redux_sync(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 1, 0],
-                    kind=None,
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value2 = cutlass.Float32(
-                warp_redux_sync(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 2, 0],
-                    kind=None,
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value3 = cutlass.Float32(
-                warp_redux_sync(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 3, 0],
-                    kind=None,
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -36,7 +36,6 @@ import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
-from cutlass._mlir.dialects.nvvm import ReduxKind
 from cutlass._mlir.dialects import llvm
 from cutlass.cute.typing import Float32, Int32, AddressSpace
 
@@ -74,7 +73,6 @@ from ..moe_sched_extension import (
 from ..moe_kernel_helpers import (
     fmin,
     fmax,
-    warp_redux_sync,
     atomic_add_float32,
     atomic_max_float32,
     compute_stages,
@@ -1007,9 +1005,9 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
 
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem):
-        warp_amax = warp_redux_sync(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
-            kind=ReduxKind.MAX,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
             nan=True,
         )

--- a/python/cudnn/grouped_gemm/grouped_gemm_dswiglu/grouped_gemm_dswiglu_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dswiglu/grouped_gemm_dswiglu_quant.py
@@ -51,7 +51,6 @@ from ..utils import (
     search_expert_idx_full,
     search_expert_idx_incremental,
     fmin,
-    warp_redux_sync_fmax,
     atomic_max_float32,
     atomic_add_float32,
 )
@@ -1071,9 +1070,11 @@ class BlockScaledContiguousGroupedGemmKernel:
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem) -> None:
         # Warp-level reduction using wrapper function
-        warp_amax = warp_redux_sync_fmax(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
+            nan=True,
         )
         # Each epilogue warp's lane 0 writes warp amax to shared memory
         if cute.arch.lane_idx() == 0:
@@ -1272,6 +1273,8 @@ class BlockScaledContiguousGroupedGemmKernel:
         tCompute.store(src)
         tTR_rAcc_frg = cute.logical_divide(tCompute, cute.make_layout(self.sf_vec_size))
         acc_frg = tTR_rAcc_frg.load()
+        abs_acc_frg_ir = cutlass._mlir.dialects.math.absf(acc_frg.ir_value())
+        acc_frg = type(acc_frg)(abs_acc_frg_ir, acc_frg.shape, acc_frg.dtype)
 
         tmp_fp32 = cutlass.Float32(0.0)
         fp32_max = cutlass.Float32(3.40282346638528859812e38)
@@ -1279,27 +1282,35 @@ class BlockScaledContiguousGroupedGemmKernel:
 
         for vi in cutlass.range_constexpr(0, acc_frg.shape[0], 4):
             max_value0 = cutlass.Float32(
-                warp_redux_sync_fmax(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi, 0],
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value1 = cutlass.Float32(
-                warp_redux_sync_fmax(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 1, 0],
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value2 = cutlass.Float32(
-                warp_redux_sync_fmax(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 2, 0],
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
             max_value3 = cutlass.Float32(
-                warp_redux_sync_fmax(
+                cute.arch.warp_redux_sync(
                     value=acc_frg[vi + 3, 0],
+                    kind="fmax",
                     mask_and_clamp=0xFFFFFFFF,
+                    nan=True,
                 )
             )
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_glu/moe_blockscaled_grouped_gemm_glu_bias.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_glu/moe_blockscaled_grouped_gemm_glu_bias.py
@@ -53,7 +53,6 @@ import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
-from cutlass._mlir.dialects.nvvm import ReduxKind
 from cutlass.cute.typing import Float32, Int32, AddressSpace
 from ..moe_persistent_scheduler import (
     MoEPersistentTileScheduler,
@@ -73,7 +72,6 @@ from ..moe_sched_extension import (
 from ..moe_kernel_helpers import (
     fmin,
     fmax,
-    warp_redux_sync,
     atomic_max_float32,
     silu_f32,
     silu_f32_geglu_scaled,
@@ -1185,9 +1183,9 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem) -> None:
         # Warp-level reduction using wrapper function
-        warp_amax = warp_redux_sync(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
-            kind=ReduxKind.MAX,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
             nan=True,
         )
@@ -1348,9 +1346,9 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
         for vi in cutlass.range_constexpr(acc_frg.shape[0]):
             max_value_original = (
                 cutlass.Float32(
-                    warp_redux_sync(
+                    cute.arch.warp_redux_sync(
                         value=acc_frg[vi, 0],
-                        kind=ReduxKind.MAX,
+                        kind="fmax",
                         mask_and_clamp=0xFFFFFFFF,
                         nan=True,
                     )

--- a/python/cudnn/grouped_gemm/grouped_gemm_glu_hadamard/moe_blockscaled_grouped_gemm_glu_hadamard.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_glu_hadamard/moe_blockscaled_grouped_gemm_glu_hadamard.py
@@ -61,7 +61,6 @@ import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
-from cutlass._mlir.dialects.nvvm import ReduxKind
 from cutlass.cute.typing import Float32, Int32, AddressSpace
 from ..moe_persistent_scheduler import (
     MoEPersistentTileScheduler,
@@ -90,7 +89,6 @@ from ..moe_sched_extension import (
 from ..moe_kernel_helpers import (
     fmin,
     fmax,
-    warp_redux_sync,
     atomic_max_float32,
     silu_f32,
     silu_f32_geglu_scaled,
@@ -947,7 +945,7 @@ class BlockScaledMoEGroupedGemmGluHadamardKernel:
 
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem):
-        warp_amax = warp_redux_sync(value=amax_fp32, kind=ReduxKind.MAX, mask_and_clamp=0xFFFFFFFF, nan=True)
+        warp_amax = cute.arch.warp_redux_sync(value=amax_fp32, kind="fmax", mask_and_clamp=0xFFFFFFFF, nan=True)
         if cute.arch.lane_idx() == 0:
             amax_smem[warp_idx & 0x3] = cutlass.Float32(warp_amax)
         self.epilog_sync_barrier_group0.arrive_and_wait()
@@ -959,7 +957,7 @@ class BlockScaledMoEGroupedGemmGluHadamardKernel:
 
     @cute.jit
     def post_rht_amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem):
-        warp_amax = warp_redux_sync(value=amax_fp32, kind=ReduxKind.MAX, mask_and_clamp=0xFFFFFFFF, nan=True)
+        warp_amax = cute.arch.warp_redux_sync(value=amax_fp32, kind="fmax", mask_and_clamp=0xFFFFFFFF, nan=True)
         if cute.arch.lane_idx() == 0:
             amax_smem[warp_idx & 0x3] = cutlass.Float32(warp_amax)
         self.epilog_sync_barrier_group1.arrive_and_wait()

--- a/python/cudnn/grouped_gemm/grouped_gemm_quant/grouped_gemm_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_quant/grouped_gemm_quant.py
@@ -27,7 +27,6 @@ import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
-from cutlass._mlir.dialects.nvvm import ReduxKind
 from cutlass.cute.typing import Float32, Int32, AddressSpace
 from ..moe_persistent_scheduler import (
     MoEPersistentTileScheduler,
@@ -47,7 +46,6 @@ from ..moe_sched_extension import (
 from ..moe_kernel_helpers import (
     fmin,
     fmax,
-    warp_redux_sync,
     atomic_max_float32,
     compute_stages,
     compute_grid,
@@ -907,9 +905,9 @@ class BlockScaledMoEGroupedGemmQuantKernel:
 
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem):
-        warp_amax = warp_redux_sync(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
-            kind=ReduxKind.MAX,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
             nan=True,
         )
@@ -973,9 +971,9 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         for vi in cutlass.range_constexpr(acc_frg.shape[0]):
             max_value_original = (
                 cutlass.Float32(
-                    warp_redux_sync(
+                    cute.arch.warp_redux_sync(
                         value=acc_frg[vi, 0],
-                        kind=ReduxKind.MAX,
+                        kind="fmax",
                         mask_and_clamp=0xFFFFFFFF,
                         nan=True,
                     )

--- a/python/cudnn/grouped_gemm/grouped_gemm_srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
@@ -30,7 +30,6 @@ import cutlass.utils as utils
 import cutlass.pipeline as pipeline
 import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
-from cutlass._mlir.dialects.nvvm import ReduxKind
 from cutlass.cute.typing import Float32, Int32, AddressSpace
 from ..moe_persistent_scheduler import (
     MoEPersistentTileScheduler,
@@ -50,7 +49,6 @@ from ..moe_sched_extension import (
 from ..moe_kernel_helpers import (
     fmin,
     fmax,
-    warp_redux_sync,
     atomic_max_float32,
     compute_stages,
     compute_grid,
@@ -957,9 +955,9 @@ class BlockScaledMoEGroupedGemmQuantKernel:
 
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem):
-        warp_amax = warp_redux_sync(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
-            kind=ReduxKind.MAX,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
             nan=True,
         )

--- a/python/cudnn/grouped_gemm/grouped_gemm_swiglu/grouped_gemm_swiglu_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_swiglu/grouped_gemm_swiglu_quant.py
@@ -52,7 +52,6 @@ from ..utils import (
     search_expert_idx_full,
     search_expert_idx_incremental,
     fmin,
-    warp_redux_sync_fmax,
     atomic_max_float32,
     silu_f32,
 )
@@ -998,9 +997,11 @@ class BlockScaledContiguousGroupedGemmKernel:
     @cute.jit
     def amax_reduction_per_warp_and_cta(self, amax_fp32, warp_idx, amax_smem, amax_gmem) -> None:
         # Warp-level reduction using wrapper function
-        warp_amax = warp_redux_sync_fmax(
+        warp_amax = cute.arch.warp_redux_sync(
             value=amax_fp32,
+            kind="fmax",
             mask_and_clamp=0xFFFFFFFF,
+            nan=True,
         )
         # Each epilogue warp's lane 0 writes warp amax to shared memory
         if cute.arch.lane_idx() == 0:
@@ -1162,9 +1163,11 @@ class BlockScaledContiguousGroupedGemmKernel:
         for vi in cutlass.range_constexpr(acc_frg.shape[0]):
             max_value_original = (
                 cutlass.Float32(
-                    warp_redux_sync_fmax(
+                    cute.arch.warp_redux_sync(
                         value=acc_frg[vi, 0],
+                        kind="fmax",
                         mask_and_clamp=0xFFFFFFFF,
+                        nan=True,
                     )
                 )
                 * rcp_limit

--- a/python/cudnn/grouped_gemm/moe_kernel_helpers.py
+++ b/python/cudnn/grouped_gemm/moe_kernel_helpers.py
@@ -273,34 +273,6 @@ def atomic_add_bf16x2(ptr, val_fp32_lo, val_fp32_hi, *, loc=None, ip=None):
     )
 
 
-def warp_redux_sync(
-    value,
-    kind,
-    mask_and_clamp=0xFFFFFFFF,
-    abs: bool = False,
-    nan: bool = None,
-    *,
-    loc=None,
-    ip=None,
-):
-    value_type = type(value)
-    value_ir = value.ir_value(loc=loc, ip=ip)
-    mask_ir = Int32(mask_and_clamp).ir_value(loc=loc, ip=ip)
-    ptx_instr = f"redux.sync.max.abs.NaN.f32 $0, $1, $2;"
-
-    return value_type(
-        llvm.inline_asm(
-            T.f32(),
-            [value_ir, mask_ir],
-            f"{ptx_instr}",
-            f"=f,f,i",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-        )
-    )
-
-
 def atomic_max_float32(
     ptr,
     value: Float32,
@@ -1046,8 +1018,6 @@ def quant_sfd_col(
     d_dtype,
     use_fp8_ptx_cvt,
 ):
-    from cutlass._mlir.dialects.nvvm import ReduxKind
-
     tTR_rAcc_frg = cute.logical_divide(src, cute.make_layout(sf_vec_size))
     acc_frg = tTR_rAcc_frg.load()
     abs_acc_frg_ir = cutlass._mlir.dialects.math.absf(acc_frg.ir_value())
@@ -1056,10 +1026,10 @@ def quant_sfd_col(
     fp32_max = cutlass.Float32(3.40282346638528859812e38)
     tidx, _, _ = cute.arch.thread_idx()
     for vi in cutlass.range_constexpr(0, acc_frg.shape[0], 4):
-        max_value0 = cutlass.Float32(warp_redux_sync(value=acc_frg[vi, 0], kind=ReduxKind.MAX, mask_and_clamp=0xFFFFFFFF, nan=True))
-        max_value1 = cutlass.Float32(warp_redux_sync(value=acc_frg[vi + 1, 0], kind=ReduxKind.MAX, mask_and_clamp=0xFFFFFFFF, nan=True))
-        max_value2 = cutlass.Float32(warp_redux_sync(value=acc_frg[vi + 2, 0], kind=ReduxKind.MAX, mask_and_clamp=0xFFFFFFFF, nan=True))
-        max_value3 = cutlass.Float32(warp_redux_sync(value=acc_frg[vi + 3, 0], kind=ReduxKind.MAX, mask_and_clamp=0xFFFFFFFF, nan=True))
+        max_value0 = cutlass.Float32(cute.arch.warp_redux_sync(value=acc_frg[vi, 0], kind="fmax", mask_and_clamp=0xFFFFFFFF, nan=True))
+        max_value1 = cutlass.Float32(cute.arch.warp_redux_sync(value=acc_frg[vi + 1, 0], kind="fmax", mask_and_clamp=0xFFFFFFFF, nan=True))
+        max_value2 = cutlass.Float32(cute.arch.warp_redux_sync(value=acc_frg[vi + 2, 0], kind="fmax", mask_and_clamp=0xFFFFFFFF, nan=True))
+        max_value3 = cutlass.Float32(cute.arch.warp_redux_sync(value=acc_frg[vi + 3, 0], kind="fmax", mask_and_clamp=0xFFFFFFFF, nan=True))
 
         scale = rcp_limit * norm_const
         max_value0, max_value1 = cute.arch.mul_packed_f32x2((max_value0, max_value1), (scale, scale), rnd="rn", ftz=False)

--- a/python/cudnn/grouped_gemm/utils.py
+++ b/python/cudnn/grouped_gemm/utils.py
@@ -201,31 +201,6 @@ def fmax(a: Union[float, Float32], b: Union[float, Float32], *, loc=None, ip=Non
     )
 
 
-def warp_redux_sync_fmax(
-    value,
-    mask_and_clamp=0xFFFFFFFF,
-    *,
-    loc=None,
-    ip=None,
-):
-    value_type = type(value)
-    value_ir = value.ir_value(loc=loc, ip=ip)
-    mask_ir = Int32(mask_and_clamp).ir_value(loc=loc, ip=ip)
-    ptx_instr = f"redux.sync.max.abs.NaN.f32 $0, $1, $2;"
-
-    return value_type(
-        llvm.inline_asm(
-            T.f32(),
-            [value_ir, mask_ir],
-            f"{ptx_instr}",
-            f"=f,f,i",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-        )
-    )
-
-
 def logical_shape_fp4x2_aware(tensor: torch.Tensor) -> Tuple[int, ...]:
     """Return correct shapes for NVFP4 tensor."""
     if tensor.dtype == torch.float4_e2m1fn_x2:

--- a/python/cudnn/rmsnorm_rht_amax/kernel.py
+++ b/python/cudnn/rmsnorm_rht_amax/kernel.py
@@ -51,23 +51,6 @@ def fmax_f32(a, b, *, loc=None, ip=None):
     return Float32(result)
 
 
-@dsl_user_op
-def redux_sync_max_f32(val, *, loc=None, ip=None):
-    val_ir = val.ir_value(loc=loc, ip=ip)
-    result = llvm.inline_asm(
-        T.f32(),
-        [val_ir],
-        "redux.sync.max.f32 $0, $1, 0xffffffff;",
-        "=f,f",
-        has_side_effects=False,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-    return Float32(result)
-
-
 class RMSNormRHTAmaxKernel:
     """Fused RMSNorm + block-diagonal Hadamard + running per-CTA amax."""
 
@@ -228,7 +211,7 @@ class RMSNormRHTAmaxKernel:
             if row_idx < cfg.rows_per_cta - 1:
                 cute.arch.cp_async_wait_group(0)
 
-        warp_max = redux_sync_max_f32(running_max)
+        warp_max = cute.arch.warp_redux_sync(running_max, "fmax")
         if lane_id == 0:
             amax_buffer[0, warp_id] = warp_max
         cute.arch.barrier()
@@ -236,7 +219,7 @@ class RMSNormRHTAmaxKernel:
         amax_val = cutlass.Float32(0.0)
         if lane_id < cfg.warps_per_row:
             amax_val = amax_buffer[0, lane_id]
-        cta_max = redux_sync_max_f32(amax_val)
+        cta_max = cute.arch.warp_redux_sync(amax_val, "fmax")
         if tid == cutlass.Int32(0):
             m_amax[bid] = cta_max
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the optional `cutedsl` dependency to a newer compatible version.
* **Performance / Reliability**
  * Improved the FP32 max/amax reduction behavior used across grouped GEMM and RMSNorm+RHT paths, including quantization scale-factor (SFD) and NaN-aware max handling.
* **Refactor**
  * Consolidated internal warp-level reduction logic to use the library’s native warp reduction primitive across affected kernels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->