### PR TITLE
Fix BSA backward hang on cute-dsl 4.6.0: version-gate elect_one around bulk stats copies

### DIFF
--- a/python/cudnn/block_sparse_attention/csrc/bwd/sm100_blk128/bsa_bwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/bwd/sm100_blk128/bsa_bwd_sm100.py
@@ -161,7 +161,7 @@ def produce_bsa_k2q_csr_q_loads_bwd_sm100(
             load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
             pipeline_Q.producer_commit(producer_state_Q_LSE)
             pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-            with cute.arch.elect_one():
+            with copy_utils.bulk_copy_elect_one():
                 copy_stats(
                     gLSE[None, m_block_safe],
                     sLSE[None, producer_state_Q_LSE.index],
@@ -174,7 +174,7 @@ def produce_bsa_k2q_csr_q_loads_bwd_sm100(
             load_dO(m_block_safe, producer_state=producer_state_dO_dPsum)
             pipeline_dO.producer_commit(producer_state_dO_dPsum)
             pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-            with cute.arch.elect_one():
+            with copy_utils.bulk_copy_elect_one():
                 copy_stats(
                     gdPsum[None, m_block_safe],
                     sdPsum[None, producer_state_dO_dPsum.index],
@@ -186,7 +186,7 @@ def produce_bsa_k2q_csr_q_loads_bwd_sm100(
             load_Q(m_block_safe, producer_state=producer_state_Q_LSE)
             pipeline_Q.producer_commit(producer_state_Q_LSE)
             pipeline_LSE.producer_acquire(producer_state_Q_LSE)
-            with cute.arch.elect_one():
+            with copy_utils.bulk_copy_elect_one():
                 copy_stats(
                     gLSE[None, m_block_safe],
                     sLSE[None, producer_state_Q_LSE.index],
@@ -198,7 +198,7 @@ def produce_bsa_k2q_csr_q_loads_bwd_sm100(
             load_dO(m_block_safe, producer_state=producer_state_dO_dPsum)
             pipeline_dO.producer_commit(producer_state_dO_dPsum)
             pipeline_dPsum.producer_acquire(producer_state_dO_dPsum)
-            with cute.arch.elect_one():
+            with copy_utils.bulk_copy_elect_one():
                 copy_stats(
                     gdPsum[None, m_block_safe],
                     sdPsum[None, producer_state_dO_dPsum.index],

--- a/python/cudnn/block_sparse_attention/csrc/utils/copy_utils.py
+++ b/python/cudnn/block_sparse_attention/csrc/utils/copy_utils.py
@@ -4,6 +4,7 @@
 # Selected helpers are adapted from quack-kernels 0.4.1 (Apache-2.0) and
 # maintained locally so BSA does not require Quack at runtime.
 
+import contextlib
 from typing import Callable, Optional, Tuple, Type
 
 import cutlass
@@ -15,6 +16,31 @@ import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cutlass_dsl import dsl_user_op
 from cutlass._mlir.dialects import llvm
 import cutlass.pipeline
+
+
+def _cute_dsl_bulk_copy_self_elects() -> bool:
+    try:
+        return tuple(int(p) for p in cutlass.__version__.split(".")[:2]) >= (4, 6)
+    except (AttributeError, ValueError):
+        return True
+
+
+_BULK_COPY_SELF_ELECTS = _cute_dsl_bulk_copy_self_elects()
+
+
+def bulk_copy_elect_one():
+    """elect_one() guard for bulk-async copies (cpasync.CopyBulk*, TMA atoms).
+
+    On cute-dsl <= 4.5.x the bulk copy does not elect a lane internally, so the
+    caller must wrap it in cute.arch.elect_one() to issue it once per warp.
+    On cute-dsl >= 4.6.0 cute.copy elects internally via a warp-collective
+    elect; an outer elect_one() leaves only one lane active at that inner
+    collective and deadlocks the warp. Use this guard instead of a bare
+    elect_one() around such copies.
+    """
+    if _BULK_COPY_SELF_ELECTS:
+        return contextlib.nullcontext()
+    return cute.arch.elect_one()
 
 
 @dsl_user_op


### PR DESCRIPTION
## Problem

With `nvidia-cutlass-dsl 4.6.0` (#368), the SM100 block-sparse-attention **backward** kernel deadlocks on-device: the GPU pegs at 100% SM utilization and never returns. In CI this surfaced as the `oss:rel [Blackwell]` job hanging at ~93% suite progress until the 1h job timeout, with `[gw0] node down`. Three tests hang:

- `test_bsa_attention_backward_fixed_blocks`
- `test_bsa_attention_backward_blk128_dk_zero_init_accumulate_transition[1]` and `[4]`

## Root cause

cute-dsl 4.6.0 changed `cute.copy` lowering for bulk-async atoms (`cpasync.CopyBulkG2SOp`, TMA): the copy now **elects a single lane internally** via a warp-collective `WARPSYNC.COLLECTIVE + ELECT` (the 4.6.0 `elect_one` docs now warn that wrapping such copies in `elect_one()` can deadlock).

`bsa_bwd_sm100`'s load warp wrapped its LSE/dPsum stats copies (`cute.copy` with `CopyBulkG2SOp`) in `cute.arch.elect_one()` — required on <= 4.5.x where the bulk copy did **not** self-elect. On 4.6.0 the two elects nest: lane 0, alone inside the outer elect region, reaches the copy's internal warp-collective elect, which waits for all 32 lanes and deadlocks the warp. Q/LSE/dO/dPsum stop flowing and all other warps spin in mbarrier waits.

Diagnosed with cuda-gdb break-in on the live hang (2 TMA-load warps parked at `WARPSYNC.COLLECTIVE; ELECT` inside the stats copy; 26 warps spinning in `SYNCS.PHASECHK` downstream) plus a PTX A/B diff (`CUTE_DSL_KEEP=ptx`) showing stacked double `elect.sync` at the stats-copy sites on 4.6.0 vs a single one on 4.5.0.

## Fix

Add `copy_utils.bulk_copy_elect_one()` — returns `cute.arch.elect_one()` on cute-dsl <= 4.5.x and a `nullcontext` on >= 4.6.0 — and use it at the four `copy_stats` sites. All other `elect_one` uses (mbarrier init/arrive, `consumer_release`, tcgen05 commits, `cp.reduce.async.bulk` inline asm) still require the guard and are unchanged.

## Verification (Blackwell, SM 10.0)

| cutlass-dsl | `test/python/fe_api/block_sparse_attention` |
|---|---|
| 4.6.0 | **17 passed in 31.7s** (previously 3 device-side hangs) |
| 4.5.0 | 17 passed in 52.7s (unchanged via version gate) |

Note: this removes the *hang* blocking #368. The `ReduxKind` removal in 4.6.0 still breaks the gemm_amax / grouped-gemm kernels and needs a separate migration to `cute.arch.warp_redux_sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block-sparse attention processing across supported CUTLASS versions.
  * Prevented redundant asynchronous copy operations while preserving correct attention results.
  * Enhanced compatibility with environments where bulk-copy operations manage thread election automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->