### PR TITLE
Support SM90 DSA qh16 indexer forward and fix qh32 sparse backward

### DIFF
--- a/docs/fe-oss-apis/dsa.md
+++ b/docs/fe-oss-apis/dsa.md
@@ -6,8 +6,8 @@
 
 The DeepSeek Sparse Attention (DSA) module integrates a set of CuTe-DSL
 kernels that support the sparse-attention path used by DeepSeek-style models.
-Most kernels target Hopper (SM90) and Blackwell (SM100+) GPUs; Indexer
-Forward and Indexer Top-K remain SM100+ only. The kernels are
+Most kernels target Hopper (SM90) and Blackwell (SM100+) GPUs; Indexer Top-K
+remains SM100+ only. The kernels are
 delivered as Python classes / wrappers that follow the same `APIBase`
 pattern as other cuDNN Frontend operations.
 

--- a/docs/fe-oss-apis/dsa.md
+++ b/docs/fe-oss-apis/dsa.md
@@ -151,7 +151,9 @@ compressed column 0.
   - `q_causal_offsets` (optional): CUDA INT32 tensor with one entry per
     batch/THD segment, on the same device as `q`.
 - **Output** — `scores`: `(B, S_q, S_k)` FP32
-- **Constraints** — SM100+, `head_dim == 128`, `qhead_per_kv_head ∈ {32, 64}`
+- **Constraints** — `head_dim == 128`. The SM90 direct path supports
+  `qhead_per_kv_head ∈ {16, 32, 64}` and currently requires `H_kv == 1`;
+  SM100 supports `qhead_per_kv_head ∈ {32, 64}`.
 
 ```python
 result = DSA.indexer_forward_wrapper(
@@ -279,12 +281,13 @@ result = DSA.dense_indexer_backward_wrapper(
 
 ## Limitations
 
-- **Architecture support** — Sparse Attention Backward, Score Recompute, and
-  Indexer Backward support SM90 and SM100; Indexer Forward and Indexer Top-K
-  remain SM100+ only.
+- **Architecture support** — Sparse Attention Backward, Score Recompute,
+  Indexer Forward, and Indexer Backward support SM90 and SM100; Indexer Top-K
+  remains SM100+ only.
 - **No fused forward** — the production forward is FlashMLA (C++); this
   module ships only the CuTe-DSL kernels.
-- **Indexer Forward only supports `head_dim = 128`** and
+- **Indexer Forward only supports `head_dim = 128`**. SM90 supports
+  `qhead_per_kv_head ∈ {16, 32, 64}` with `H_kv = 1`; SM100 supports
   `qhead_per_kv_head ∈ {32, 64}`.
 - **Top-K only up to 2048**; `top_k > 2048` is not supported by the
   underlying radix top-K kernel.

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
@@ -21,7 +21,7 @@ from cudnn.deepseek_sparse_attention.utils.tensor_conversion import (
     to_cute_tensor as _to_cute_tensor,
 )
 
-_SUPPORTED_QHPKV = (32, 64)
+_SUPPORTED_QHPKV = (16, 32, 64)
 _compile_cache: dict = {}
 
 torch2cute_dtype_map = {

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
@@ -55,10 +55,7 @@ class IndexerForwardSm90:
         clean_logits: bool = True,
     ):
         assert head_dim == 128, f"SM90 direct forward supports head_dim=128, got {head_dim}"
-        assert qhead_per_kvhead in (
-            32,
-            64,
-        ), f"SM90 direct forward supports qhpkv in (32, 64), got {qhead_per_kvhead}"
+        assert qhead_per_kvhead in (16, 32, 64), f"SM90 direct forward supports qhpkv in (16, 32, 64), got {qhead_per_kvhead}"
         assert ratio >= 1, f"ratio must be >=1, got {ratio}"
         self.dtype = dtype
         self.head_dim = head_dim
@@ -77,6 +74,11 @@ class IndexerForwardSm90:
         self.q_tokens_per_stage = self.q_tokens_per_tile // self.q_stages
         assert self.q_per_stage == 64
         assert self.q_tokens_per_stage * self.qhead_per_kvhead == self.q_per_stage
+        # qh16 packs eight query tokens into one CTA. Their ratio-causal limits
+        # can straddle a 64-column boundary, so both rightmost N blocks need
+        # elementwise masking. Keep the existing one-block path unchanged for
+        # qh32/qh64 so those specializations lower exactly as before.
+        self.mask_two_rightmost_nblocks = self.qhead_per_kvhead == 16
 
         self.num_threads = 256
         self.num_threads_per_warp_group = 128
@@ -193,7 +195,7 @@ class IndexerForwardSm90:
         mOut: cute.Tensor,
         m_block: Int32,
         n_block: Int32,
-        is_first_nblock: Boolean,
+        apply_causal_mask: Boolean,
         seqlen_q: Int32,
         seqlen_k: Int32,
         max_seqlen_k: Int32,
@@ -237,7 +239,7 @@ class IndexerForwardSm90:
                     k_local = n_block * self.tile_n + kv_m
                     score = ps[mi, qi]
                     should_store = Boolean(True)
-                    if is_first_nblock:
+                    if apply_causal_mask:
                         col_lim = (q_causal_offset + q_local + Int32(1)) // Int32(self.ratio)
                         if k_local >= seqlen_k or k_local >= col_lim:
                             if const_expr(self.clean_logits):
@@ -486,7 +488,7 @@ class IndexerForwardSm90:
                         with cute.arch.elect_one():
                             cute.arch.mbarrier_arrive(mbar_KVEmpty1_ptr, arrive_count=128)
 
-                is_first = Boolean(iter_idx == Int32(0))
+                apply_causal_mask = Boolean(iter_idx < Int32(2)) if const_expr(self.mask_two_rightmost_nblocks) else Boolean(iter_idx == Int32(0))
                 self._epilogue_store_to_gmem(
                     0,
                     acc0,
@@ -494,7 +496,7 @@ class IndexerForwardSm90:
                     mOut,
                     m_block,
                     n_block,
-                    is_first,
+                    apply_causal_mask,
                     seqlen.seqlen_q,
                     seqlen.seqlen_k,
                     max_seqlen_k,
@@ -510,7 +512,7 @@ class IndexerForwardSm90:
                     mOut,
                     m_block,
                     n_block,
-                    is_first,
+                    apply_causal_mask,
                     seqlen.seqlen_q,
                     seqlen.seqlen_k,
                     max_seqlen_k,

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm90.py
@@ -238,6 +238,8 @@ def flash_attn_bwd_sm90(
         dtype,
         head_dim,
         head_dim_v,
+        # The kernel specializes its query-head tile and masks unused MMA rows.
+        # Keep this explicit even though tensor shapes also differ by head count.
         qhead_per_kvhead,
         m_block_size,
         n_block_size,

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -9,9 +9,7 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.utils.hopper_helpers as sm90_utils_basic
 from cutlass import Boolean, Float32, Int32, const_expr
-from cutlass.cute import FastDivmodDivisor
 from cutlass.cute.nvgpu import cpasync, warpgroup
-from cutlass.cutlass_dsl import dsl_user_op
 from cutlass.utils import LayoutEnum
 
 from cudnn.deepseek_sparse_attention.utils.copy import (
@@ -48,56 +46,26 @@ from cudnn.deepseek_sparse_attention.utils.sm90.primitives import (
 )
 
 
-@dsl_user_op
-def _elem_pointer_packed_mh_i64(
-    base_ptr_i64: cute.typing.Int,
-    h_idx: cute.typing.Int,
-    m_idx: cute.typing.Int,
-    num_head: cute.typing.Int,
-    elem_type: type,
-    memspace: cute.AddressSpace,
-    *,
-    loc=None,
-    ip=None,
-) -> cute.Pointer:
-    linear_idx = cutlass.Int64(m_idx) * cutlass.Int64(num_head) + cutlass.Int64(h_idx)
-    byte_offset = linear_idx * elem_type.width // 8
-    return cute.make_ptr(
-        elem_type,
-        cutlass.Int64(base_ptr_i64) + byte_offset,
-        memspace,
-        assumed_align=16,
-    )
-
-
 @cute.jit
-def _load_f32_packed_mh_to_smem(
-    base_ptr_i64: cutlass.Int64,
+def _load_f32_head_to_smem(
+    src: cute.Tensor,
     dst: cute.Tensor,
-    m_block: cutlass.Int32,
     tile_m: cutlass.Constexpr[int],
     tidx: cutlass.Int32,
     num_threads: cutlass.Constexpr[int],
-    qhead_per_kvhead: cutlass.Constexpr[int],
-    num_head: cutlass.Constexpr[int],
+    total_rows: cutlass.Constexpr[int],
+    head_tile: cutlass.Int32,
+    fill_value: Float32,
 ):
     rows_per_thread = cute.ceil_div(tile_m, num_threads)
     for i in cutlass.range_constexpr(rows_per_thread):
         row = i * num_threads + tidx
         if row < tile_m:
-            idx = m_block * tile_m + row
-            m_idx = idx // qhead_per_kvhead
-            h_idx = idx - m_idx * qhead_per_kvhead
-            ptr = _elem_pointer_packed_mh_i64(
-                base_ptr_i64,
-                h_idx,
-                m_idx,
-                num_head,
-                cutlass.Float32,
-                cute.AddressSpace.gmem,
-            )
-            gmem_val = cute.make_tensor(ptr, (1,))
-            dst[row] = gmem_val[0]
+            head = head_tile * tile_m + row
+            if head < total_rows:
+                dst[row] = src[head]
+            else:
+                dst[row] = fill_value
 
 
 class _FlashAttentionDSABackwardPreprocessSm90:
@@ -457,6 +425,7 @@ class FlashAttentionDSABackwardSm90:
         self.is_local = False
 
         self.tile_m = tile_m
+        self.qhead_tiles = (qhead_per_kvhead + tile_m - 1) // tile_m
         self.tile_n = tile_n
         self.num_threads = num_threads
         self.KV_stage = KV_stage
@@ -714,15 +683,19 @@ class FlashAttentionDSABackwardSm90:
         accum_transpose = [2, 1, 0]  # (b, n_kv, s*h) -> (s*h, n_kv, b)
         mdKV = select(mdKV, accum_transpose)
 
-        # Reshape tensor layouts so q-heads within a KV head are packed into M.
+        # Keep query position separate from the query-head tile. A Hopper MMA
+        # still consumes 64 rows, but qhpkv=32 is represented as a 32-row
+        # tensor extent so TMA zero-fills the remaining rows. This makes every
+        # CTA consume exactly one query's top-k row instead of letting a packed
+        # 64-row tile straddle two queries.
         qhpkv = self.qhead_per_kvhead
         num_head_kv = mKV.shape[2]
         mQ, mdO, mdQ = [
             cute.make_tensor(
                 mT.iterator,
                 cute.make_layout(
-                    ((qhpkv, mT.shape[0]), mT.shape[1], num_head_kv, *mT.shape[3:]),
-                    stride=((mT.stride[2], mT.stride[0]), mT.stride[1], mT.stride[2] * qhpkv, *mT.stride[3:]),
+                    (qhpkv, mT.shape[1], num_head_kv, mT.shape[0], *mT.shape[3:]),
+                    stride=(mT.stride[2], mT.stride[1], mT.stride[2] * qhpkv, mT.stride[0], *mT.stride[3:]),
                 ),
             )
             for mT in (mQ, mdO, mdQ)
@@ -731,8 +704,8 @@ class FlashAttentionDSABackwardSm90:
             cute.make_tensor(
                 mT.iterator,
                 cute.make_layout(
-                    ((qhpkv, mT.shape[1]), num_head_kv, mT.shape[0]),
-                    stride=((mT.stride[2], mT.stride[1]), mT.stride[2] * qhpkv, mT.stride[0]),
+                    (qhpkv, num_head_kv, mT.shape[1], mT.shape[0]),
+                    stride=(mT.stride[2], mT.stride[2] * qhpkv, mT.stride[1], mT.stride[0]),
                 ),
             )
             for mT in (mLSE, mdPsum)
@@ -782,21 +755,21 @@ class FlashAttentionDSABackwardSm90:
             (self.tile_m, 64),
         )
 
-        # TileScheduler by Q dimension (m_blocks)
+        # One CTA per query and query-head tile. The final head tile may be
+        # smaller than tile_m; TMA predicates the unused rows in that case.
         TileScheduler = SingleTileScheduler
         tile_sched_args = TileSchedulerArguments(
-            cute.ceil_div(cute.size(mQ.shape[0]), self.tile_m),
-            cute.size(mQ.shape[2]),
             cute.size(mQ.shape[3]),
+            cute.size(mQ.shape[2]) * self.qhead_tiles,
+            cute.size(mQ.shape[4]),
             1,  # num_splits
             cute.size(mKV.shape[0]),
             mQ.shape[1],
             mKV.shape[1],
-            total_q=cute.size(mQ.shape[0]) * cute.size(mQ.shape[3]),
+            total_q=cute.size(mQ.shape[3]) * cute.size(mQ.shape[4]),
             tile_shape_mn=(self.tile_m, self.tile_n),
             mCuSeqlensQ=None,
             mSeqUsedQ=None,
-            qhead_per_kvhead_packgqa=self.qhead_per_kvhead,
             element_size=self.dtype.width // 8,
         )
         tile_sched_params = TileScheduler.to_underlying_arguments(tile_sched_args)
@@ -804,8 +777,6 @@ class FlashAttentionDSABackwardSm90:
 
         LOG2_E = math.log2(math.e)
         softmax_scale_log2 = softmax_scale * LOG2_E
-
-        qhead_per_kvhead_divmod = FastDivmodDivisor(self.qhead_per_kvhead)
 
         self.kernel(
             tma_tensor_Q,
@@ -845,7 +816,6 @@ class FlashAttentionDSABackwardSm90:
             tile_sched_params,
             TileScheduler,
             SharedStorage,
-            qhead_per_kvhead_divmod,
         ).launch(
             grid=grid_dim,
             block=[self.num_threads, 1, 1],
@@ -894,7 +864,6 @@ class FlashAttentionDSABackwardSm90:
         tile_sched_params: ParamsBase,
         TileScheduler: cutlass.Constexpr[Callable],
         SharedStorage: cutlass.Constexpr[Callable],
-        qhead_per_kvhead_divmod: FastDivmodDivisor,
     ):
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
 
@@ -986,7 +955,6 @@ class FlashAttentionDSABackwardSm90:
                 softmax_scale_log2,
                 softmax_scale,
                 TileSchedulerCls,
-                qhead_per_kvhead_divmod,
             )
         else:
             cute.arch.setmaxregister_increase(self.num_mma_regs)
@@ -1019,7 +987,6 @@ class FlashAttentionDSABackwardSm90:
                 mTopkIdxs,  # per-q length + scatter indices
                 tidx,
                 TileSchedulerCls,
-                qhead_per_kvhead_divmod,
             )
 
     @cute.jit
@@ -1056,7 +1023,6 @@ class FlashAttentionDSABackwardSm90:
         softmax_scale_log2: Float32,
         softmax_scale: Float32,
         TileSchedulerCls: Callable,
-        qhead_per_kvhead_divmod: FastDivmodDivisor,
     ):
         """WG0 mainloop: identical to V3.1 — dQ[0:256] = 128+128, no 576-specific logic."""
         wg_tidx = tidx % self.num_threads_per_warp_group  # 0..127
@@ -1165,12 +1131,11 @@ class FlashAttentionDSABackwardSm90:
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, _ = work_tile.tile_idx
-            head_idx_kv = head_idx
+            head_idx_kv = head_idx // self.qhead_tiles
+            head_tile = head_idx - head_idx_kv * self.qhead_tiles
 
-            # m_block indexes the packed M dimension (qhpkv * seqlen_q / tile_m).
-            # topk tensors are indexed by sequence position, not packed m_block.
-            # seq_idx = (m_block * tile_m) // qhead_per_kvhead
-            seq_idx = (m_block * self.tile_m) // qhead_per_kvhead_divmod
+            # The scheduler maps one CTA to exactly one query.
+            seq_idx = m_block
 
             if const_expr(self.have_topk_length):
                 topK = mTopkLength[batch_idx, seq_idx]
@@ -1183,10 +1148,10 @@ class FlashAttentionDSABackwardSm90:
             mKV_cur = mKV[None, None, head_idx_kv, batch_idx]
             mTopkIdxs_cur = mTopkIdxs[batch_idx, seq_idx, None]
 
-            mQ_cur = mQ[None, None, head_idx, batch_idx]
-            gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (m_block, 0))
-            mdO_cur = mdO[None, None, head_idx, batch_idx]
-            gdO = cute.local_tile(mdO_cur, (self.tile_m, self.tile_hdimv), (m_block, 0))
+            mQ_cur = mQ[None, None, head_idx_kv, seq_idx, batch_idx]
+            gQ = cute.local_tile(mQ_cur, (self.tile_m, self.tile_hdim), (head_tile, 0))
+            mdO_cur = mdO[None, None, head_idx_kv, seq_idx, batch_idx]
+            gdO = cute.local_tile(mdO_cur, (self.tile_m, self.tile_hdimv), (head_tile, 0))
 
             load_Q, _, _ = tma_get_copy_fn(tma_atom_Q, 0, cute.make_layout(1), gQ, sQ, single_stage=True)
             load_dO, _, _ = tma_get_copy_fn(tma_atom_dO, 0, cute.make_layout(1), gdO, sdO, single_stage=True)
@@ -1197,29 +1162,29 @@ class FlashAttentionDSABackwardSm90:
                 load_Q(tma_bar_ptr=mbar_QdO_ptr)
                 load_dO(tma_bar_ptr=mbar_QdO_ptr)
 
-            # All 128 threads: load packed-M LSE/dPsum from GMEM to SMEM.
-            mLSE_cur = mLSE[None, head_idx, batch_idx]
-            mdPsum_cur = mdPsum[None, head_idx, batch_idx]
-            num_head = self.qhead_per_kvhead * mLSE.shape[1]
-            _load_f32_packed_mh_to_smem(
-                mLSE_cur.iterator.toint(),
+            # All 128 threads load the query's head values. Rows beyond qhpkv
+            # are neutralized for the 64-row MMA tile.
+            mLSE_cur = mLSE[None, head_idx_kv, seq_idx, batch_idx]
+            mdPsum_cur = mdPsum[None, head_idx_kv, seq_idx, batch_idx]
+            _load_f32_head_to_smem(
+                mLSE_cur,
                 sLSE,
-                m_block,
                 self.tile_m,
                 wg_tidx,
                 self.num_threads_per_warp_group,
                 self.qhead_per_kvhead,
-                num_head,
+                head_tile,
+                Float32.inf,
             )
-            _load_f32_packed_mh_to_smem(
-                mdPsum_cur.iterator.toint(),
+            _load_f32_head_to_smem(
+                mdPsum_cur,
                 sdPsum,
-                m_block,
                 self.tile_m,
                 wg_tidx,
                 self.num_threads_per_warp_group,
                 self.qhead_per_kvhead,
-                num_head,
+                head_tile,
+                Float32(0.0),
             )
 
             # Fence SMEM writes (LSE/dPsum stores) + barrier to ensure visibility
@@ -1616,7 +1581,6 @@ class FlashAttentionDSABackwardSm90:
         mTopkIdxs: cute.Tensor,  # (batch, seqlen_q, topk_max) int32 for scatter
         tidx: Int32,
         TileSchedulerCls: Callable,
-        qhead_per_kvhead_divmod: FastDivmodDivisor,
     ):
         """WG1 mainloop: 9-chunk dKV pipeline + 2 G4_half (dQ) + AtomicAdd scatter."""
         wg_tidx = tidx % self.num_threads_per_warp_group  # 0..127
@@ -1684,10 +1648,9 @@ class FlashAttentionDSABackwardSm90:
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, _ = work_tile.tile_idx
-            head_idx_kv = head_idx
+            head_idx_kv = head_idx // self.qhead_tiles
 
-            # Convert packed-M m_block to sequence index for topk tensors.
-            seq_idx = (m_block * self.tile_m) // qhead_per_kvhead_divmod
+            seq_idx = m_block
 
             if const_expr(self.have_topk_length):
                 topK = mTopkLength[batch_idx, seq_idx]
@@ -2086,8 +2049,10 @@ class FlashAttentionDSABackwardSm90:
         # TMA S2G: sQ_half(256) → gdQ[:, 256:512]
         warp_idx_in_wg = wg_tidx // 32
         if warp_idx_in_wg == 0:
-            mdQ_cur = mdQ[None, None, head_idx, batch_idx]
-            gdQ_half = cute.local_tile(mdQ_cur, (self.tile_m, 256), (m_block, 1))  # col_block=1 → offset 256
+            head_idx_kv = head_idx // self.qhead_tiles
+            head_tile = head_idx - head_idx_kv * self.qhead_tiles
+            mdQ_cur = mdQ[None, None, head_idx_kv, m_block, batch_idx]
+            gdQ_half = cute.local_tile(mdQ_cur, (self.tile_m, 256), (head_tile, 1))  # col_block=1 → offset 256
             with cute.arch.elect_one():
                 store_dQ, _, _ = tma_get_copy_fn(tma_atom_dQ, 0, cute.make_layout(1), sQ_half, gdQ_half, single_stage=True)
                 store_dQ()
@@ -2097,8 +2062,10 @@ class FlashAttentionDSABackwardSm90:
         # Tail TMA: sQ_64_epi(64) → gdQ[:, 512:576] (only for d=576)
         if const_expr(not self.same_hdim_kv):
             if warp_idx_in_wg == 0:
-                mdQ_64_cur = mdQ_64[None, None, head_idx, batch_idx]
-                gdQ_64 = cute.local_tile(mdQ_64_cur, (self.tile_m, 64), (m_block, 8))  # col_block=8 → offset 512
+                head_idx_kv = head_idx // self.qhead_tiles
+                head_tile = head_idx - head_idx_kv * self.qhead_tiles
+                mdQ_64_cur = mdQ_64[None, None, head_idx_kv, m_block, batch_idx]
+                gdQ_64 = cute.local_tile(mdQ_64_cur, (self.tile_m, 64), (head_tile, 8))  # col_block=8 → offset 512
                 with cute.arch.elect_one():
                     store_dQ_64, _, _ = tma_get_copy_fn(tma_atom_dQ_64, 0, cute.make_layout(1), sQ_64_epi, gdQ_64, single_stage=True)
                     store_dQ_64()
@@ -2154,8 +2121,10 @@ class FlashAttentionDSABackwardSm90:
 
         warp_idx_in_wg = wg_tidx // 32
         if warp_idx_in_wg == 0:
-            mdQ_cur = mdQ[None, None, head_idx, batch_idx]
-            gdQ_half = cute.local_tile(mdQ_cur, (self.tile_m, 256), (m_block, wg_idx))
+            head_idx_kv = head_idx // self.qhead_tiles
+            head_tile = head_idx - head_idx_kv * self.qhead_tiles
+            mdQ_cur = mdQ[None, None, head_idx_kv, m_block, batch_idx]
+            gdQ_half = cute.local_tile(mdQ_cur, (self.tile_m, 256), (head_tile, wg_idx))
             with cute.arch.elect_one():
                 store_dQ, _, _ = tma_get_copy_fn(tma_atom_dQ, 0, cute.make_layout(1), sQ_half, gdQ_half, single_stage=True)
                 store_dQ()

--- a/test/python/fe_api/dsa/dsa_reference.py
+++ b/test/python/fe_api/dsa/dsa_reference.py
@@ -66,7 +66,10 @@ def ref_sparse_attention_forward(
 
     q_f = q.to(torch.float32)
     k_f = kv.to(torch.float32)
-    v_f = kv.to(torch.float32)
+    # The 576-wide MLA path uses all 576 dimensions for QK and the first 512
+    # dimensions for V. The 512-wide path keeps K and V identical.
+    head_dim_v = 512 if d == 576 else d
+    v_f = kv[:, :head_dim_v].to(torch.float32)
 
     mask = _make_topk_mask(topk_idxs, topk_length, t_kv)  # (T, T_kv)
     mask = mask.unsqueeze(1).expand(t, h, t_kv)  # (T, H, T_kv)

--- a/test/python/fe_api/dsa/dsa_utils.py
+++ b/test/python/fe_api/dsa/dsa_utils.py
@@ -10,6 +10,12 @@ from typing import Optional, Tuple
 import pytest
 import torch
 
+
+def _require_sm90():
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9:
+        pytest.skip("SM90 GPU required")
+
+
 # Parameterization marks shared by every DSA test
 DSA_PARAM_MARKS = [
     pytest.mark.parametrize("dtype", [torch.bfloat16]),
@@ -17,9 +23,15 @@ DSA_PARAM_MARKS = [
 ]
 
 DSA_SPARSE_ATTENTION_BACKWARD_PARAM_MARKS = [
-    pytest.mark.parametrize("head_dim", [512]),
-    pytest.mark.parametrize("head_dim_v", [512]),
-    pytest.mark.parametrize("num_heads", [64]),
+    pytest.mark.parametrize(
+        "head_dim,head_dim_v,num_heads",
+        [
+            (512, 512, 64),
+            # Regression for a packed-M tile crossing query boundaries. This
+            # is the MLA shape that exposed catastrophic dQ/dKV corruption.
+            (576, 512, 32),
+        ],
+    ),
     pytest.mark.parametrize("topk", [512]),
     pytest.mark.parametrize("has_topk_length", [False, True]),
 ]

--- a/test/python/fe_api/dsa/test_DSA_indexer_forward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_forward.py
@@ -3,7 +3,11 @@ import torch
 
 from test_utils import torch_fork_set_rng
 
-from fe_api.dsa.dsa_utils import dsa_init, with_dsa_indexer_forward_params
+from fe_api.dsa.dsa_utils import (
+    _require_sm90,
+    dsa_init,
+    with_dsa_indexer_forward_params,
+)
 from fe_api.dsa.dsa_reference import check_ref_indexer_forward
 
 
@@ -70,3 +74,112 @@ def test_DSA_indexer_forward_wrapper(
     scores = result["scores"]
     if not cfg["skip_ref"]:
         check_ref_indexer_forward(q, k, w, scores, ratio, q_causal_offsets=q_causal_offsets)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=13)
+def test_DSA_indexer_forward_wrapper_qh16_causal_block_boundary():
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    _require_sm90()
+    device = torch.device("cuda")
+    b, s_q, s_k, h_q, h_kv, d = 1, 8, 128, 16, 1, 128
+    ratio = 4
+    q = torch.randn(b, s_q, h_q, d, dtype=torch.bfloat16, device=device)
+    k = torch.randn(b, s_k, h_kv, d, dtype=torch.bfloat16, device=device)
+    w = torch.randn(b, s_q, h_q, dtype=torch.bfloat16, device=device)
+    q_causal_offsets = torch.tensor([252], dtype=torch.int32, device=device)
+
+    scores = DSA.indexer_forward_wrapper(
+        q,
+        k,
+        w,
+        ratio=ratio,
+        qhead_per_kv_head=h_q,
+        q_causal_offsets=q_causal_offsets,
+    )["scores"]
+    torch.cuda.synchronize()
+
+    # The causal limit moves from 63 to 64 inside the CTA. In particular,
+    # k=63 is masked for q=0..2, then becomes valid at q=3.
+    assert bool(torch.isneginf(scores[0, :3, 63]).all())
+    assert bool(torch.isfinite(scores[0, 3:, 63]).all())
+    assert bool(torch.isneginf(scores[0, :7, 64]).all())
+    assert bool(torch.isfinite(scores[0, 7, 64]))
+    check_ref_indexer_forward(
+        q,
+        k,
+        w,
+        scores,
+        ratio,
+        q_causal_offsets=q_causal_offsets,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=14)
+def test_DSA_indexer_forward_wrapper_qh16_thd_varlen_tails():
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    _require_sm90()
+    device = torch.device("cuda")
+    shapes = [(7, 67), (11, 70)]
+    ratio, h_q, h_kv, d = 4, 16, 1, 128
+    q_lengths = [s_q for s_q, _ in shapes]
+    k_lengths = [s_k for _, s_k in shapes]
+    cu_seqlens_q = torch.tensor(
+        [0, *torch.tensor(q_lengths).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_seqlens_k = torch.tensor(
+        [0, *torch.tensor(k_lengths).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+    total_q, total_k = int(cu_seqlens_q[-1]), int(cu_seqlens_k[-1])
+    q = torch.randn(total_q, h_q, d, dtype=torch.bfloat16, device=device)
+    k = torch.randn(total_k, h_kv, d, dtype=torch.bfloat16, device=device)
+    w = torch.randn(total_q, h_q, dtype=torch.bfloat16, device=device)
+    q_causal_offsets = torch.tensor(
+        [s_k * ratio - s_q for s_q, s_k in shapes],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    scores = DSA.indexer_forward_wrapper(
+        q,
+        k,
+        w,
+        ratio=ratio,
+        qhead_per_kv_head=h_q,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max(q_lengths),
+        max_seqlen_k=max(k_lengths),
+        q_causal_offsets=q_causal_offsets,
+    )["scores"]
+    torch.cuda.synchronize()
+
+    cu_q_host = cu_seqlens_q.tolist()
+    cu_k_host = cu_seqlens_k.tolist()
+    max_seqlen_k = max(k_lengths)
+    for batch, (_, s_k) in enumerate(shapes):
+        q0, q1 = cu_q_host[batch : batch + 2]
+        k0, k1 = cu_k_host[batch : batch + 2]
+        check_ref_indexer_forward(
+            q[q0:q1].unsqueeze(0),
+            k[k0:k1].unsqueeze(0),
+            w[q0:q1].unsqueeze(0),
+            scores[q0:q1, :s_k].unsqueeze(0),
+            ratio,
+            q_causal_offsets=q_causal_offsets[batch : batch + 1],
+        )
+        if s_k < max_seqlen_k:
+            assert bool(torch.isneginf(scores[q0:q1, s_k:]).all())

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -12,7 +12,11 @@ import torch
 
 from test_utils import torch_fork_set_rng
 
-from fe_api.dsa.dsa_utils import dsa_init, with_dsa_sparse_attention_backward_params
+from fe_api.dsa.dsa_utils import (
+    _require_sm90,
+    dsa_init,
+    with_dsa_sparse_attention_backward_params,
+)
 from fe_api.dsa.dsa_reference import (
     ref_sparse_attention_forward,
     check_ref_dsa_sparse_attention_backward,
@@ -130,3 +134,85 @@ def test_DSA_sparse_attention_backward_wrapper(
             atol=5e-2,
             rtol=5e-2,
         )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=385)
+def test_DSA_sparse_attention_backward_qh32_uses_per_query_topk_without_padding(monkeypatch):
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda
+        from cudnn.deepseek_sparse_attention.sparse_attention_backward import _interface_sm90
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    _require_sm90()
+    device = torch.device("cuda")
+    s_q, s_kv, num_heads = 2, 128, 32
+    head_dim, head_dim_v, topk = 576, 512, 64
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    q = torch.randn(s_q, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(s_kv, head_dim, dtype=torch.bfloat16, device=device)
+    attn_sink = torch.randn(num_heads, dtype=torch.float32, device=device)
+    # The old packed-M mapping used row 0 for both queries in one CTA. Make
+    # the two rows disjoint so sharing a top-k row is unambiguously incorrect.
+    topk_idxs = torch.stack(
+        (
+            torch.arange(0, topk, dtype=torch.int32, device=device),
+            torch.arange(topk, 2 * topk, dtype=torch.int32, device=device),
+        )
+    )
+
+    out, lse = ref_sparse_attention_forward(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        softmax_scale=softmax_scale,
+    )
+    # Match the head-major backing used by the original #385 reproduction.
+    out = out.transpose(0, 1).contiguous().transpose(0, 1)
+    dout = torch.randn(num_heads, s_q, head_dim_v, dtype=torch.bfloat16, device=device).transpose(0, 1)
+    assert out.stride() == dout.stride() == (head_dim_v, s_q * head_dim_v, 1)
+
+    def fail_on_pad(*args, **kwargs):
+        pytest.fail("qh32 must be handled by the SM90 main kernel without torch padding")
+
+    monkeypatch.setattr(torch.nn.functional, "pad", fail_on_pad)
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    result = DSA.sparse_attention_backward_wrapper(
+        q,
+        kv,
+        out,
+        dout,
+        lse,
+        attn_sink,
+        topk_idxs,
+        softmax_scale=softmax_scale,
+        stream=stream,
+    )
+    torch.cuda.synchronize()
+
+    # qhpkv controls the query-head tiling and must remain part of the main
+    # compile key, independently of the runtime tensor shape.
+    assert any(key[1:4] == (head_dim, head_dim_v, num_heads) for key in _interface_sm90.flash_attn_bwd_sm90.compile_cache)
+
+    dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
+    assert torch.isfinite(dq).all()
+    assert torch.isfinite(dkv).all()
+    check_ref_dsa_sparse_attention_backward(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        out,
+        dout,
+        lse,
+        dq,
+        dkv,
+        d_sink,
+        softmax_scale=softmax_scale,
+        atol=5e-2,
+        rtol=5e-2,
+    )


### PR DESCRIPTION
  ## Summary

  - Add SM90 DSA indexer-forward support for `qhead_per_kv_head=16`.
  - Fix catastrophic SM90 sparse-attention backward errors for `qhead_per_kv_head=32`.
  - Handle qh32 directly inside the main kernel without introducing padding or copy kernels.
  - Update DSA documentation and regression coverage.

  ## Details

  ### SM90 indexer forward with qh16

  A qh16 CTA packs eight query tokens. Their ratio-causal limits can cross a 64-column boundary, so masking only the rightmost N tile is insufficient.

  This change:

  - Enables qh16 in the SM90 interface.
  - Applies elementwise causal masking to both rightmost N tiles for qh16.
  - Adds coverage for causal block boundaries and THD variable-length tails.

  ### SM90 sparse-attention backward

  The backward kernel previously flattened query heads and query positions into a packed-M dimension. With qh32, one 64-row CTA covered two queries
  while loading only the first query's top-k row. The second query therefore combined its Q/LSE/dPsum values with the wrong KV indices, producing
  catastrophically large gradients.

  This change:

  - Separates query position from the query-head tile in the kernel layout.
  - Schedules each CTA for exactly one query and one head tile.
  - Keeps the physical 64-row WGMMA tile and lets TMA zero-fill unused qh32 rows.
  - Neutralizes invalid rows with `LSE=+inf` and `dPsum=0`.
  - Uses the current query's top-k row in both warp groups.
  - Drops invalid dQ rows through TMA out-of-bounds predication.
  - Keeps `qhead_per_kv_head` in the main-kernel compile key.
  - Removes the Python padding fallback and its additional pad/copy kernels.

  The DSA reference was also updated for the MLA shape where QK uses 576 dimensions and V uses the first 512 dimensions.

  ## Testing

  Validated on an NVIDIA H100 (SM90):

  - SM90 qh16 indexer-forward regressions: `2 passed`
  - Sparse-attention backward qh32/qh64 matrix, with and without `topk_length`: `5 passed`
  - Verified qh32, qh64, and qh128 against the PyTorch reference.
  - Verified head-major `out`/`dout` layouts from the original reproduction.
  - Verified that the qh32 path does not call `torch.nn.functional.pad`.

  Using the original #385 kernel dump:

  - `dq absmax`: approximately `6.786e11` → `15.3125`
  - dKV FP32 accumulator absmax: approximately `1.256e11` → `165.75`

  The corrected values match the reported reference magnitudes.

  Closes #373
  Fixes #385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled additional SM90 Indexer Forward configurations with `qhead_per_kv_head=16`.
  - Improved support for MLA-style value tensors using 576-wide dimensions.
- **Bug Fixes**
  - Updated causal-masking at query-to-key block boundaries for the new `qh16` behavior.
  - Strengthened masking correctness for variable-length, multi-batch runs, including tail key positions.
- **Documentation**
  - Clarified DSA Indexer Forward constraints and hardware support (e.g., `head_dim=128`, SM90 vs SM100, and `H_kv` requirements).
- **Tests**
  - Added SM90 Indexer Forward and sparse-attention backward coverage, including `qh32` without padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->