### PR TITLE
BSA: remove dead SM100 block-128 fragment allocations

### DIFF
--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk128/bsa_fwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk128/bsa_fwd_sm100.py
@@ -1506,16 +1506,6 @@ class BlockSparseAttnForwardSm100Blk128:
         tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.correction_warp_ids))
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
 
-        tScS = thr_mma_qk.partition_C(cute.make_identity_tensor(self.mma_tiler_qk[:2]))
-        tStScale_layout = cute.composition(tStS.layout, cute.make_layout((self.m_block_size, 1)))
-        tStScales = tuple(cute.make_tensor(tStS.iterator + self.tmem_vec_offset[stage], tStScale_layout) for stage in range(self.s_stage))
-        tScScale = cute.composition(tScS, cute.make_layout((self.m_block_size, 1)))
-        tmem_load_v_atom = cute.make_copy_atom(tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(1)), self.qk_acc_dtype)
-        thr_tmem_load_vec = tcgen05.make_tmem_copy(tmem_load_v_atom, tStScales[0]).get_slice(tidx)
-
-        tStScales_t2r = [thr_tmem_load_vec.partition_S(tStScales[stage]) for stage in range(self.s_stage)]
-        tSrScale_t2r_shape = thr_tmem_load_vec.partition_D(tScScale).shape
-
         # First iter: no correction is required
         # Notify mma warp that O has been rescaled
         for stage in cutlass.range(self.s_stage):
@@ -1546,7 +1536,6 @@ class BlockSparseAttnForwardSm100Blk128:
                 sm_stats_barrier.arrive_and_wait_w_index(index=1 * 4 + warp_idx)
                 sm_stats_consumer_phase ^= 1
 
-                tSrScale_t2r = cute.make_rmem_tensor(tSrScale_t2r_shape, Float32)
                 # q_stage=1 correction loop
                 if const_expr(mBlockNums is not None):
                     block_iter_count = (mBlockNums[batch_idx, head_idx, m_block] + 1) & ~1
@@ -1715,7 +1704,6 @@ class BlockSparseAttnForwardSm100Blk128:
         tOtO_r2t = thr_tmem_store.partition_D(tOtO_i)
 
         frg_count = self.head_dim_v_padded // corr_tile_size
-        tOrO_frg = cute.make_rmem_tensor((tOrO_t2r_shape, frg_count), self.pv_acc_dtype)
         for i in cutlass.range_constexpr(frg_count):
             tOrO_frg = cute.make_rmem_tensor(tOrO_t2r_shape, self.pv_acc_dtype)
             tOtO_t2r_i = cute.make_tensor(tOtO_t2r.iterator + i * corr_tile_size, tOtO_t2r.layout)


### PR DESCRIPTION
 ## Summary

  - Remove an unused TMEM scale-load setup chain from the SM100 block-128 correction warp.
  - Remove an RMEM scale tensor allocation whose result was never consumed.
  - Remove an outer `tOrO_frg` allocation that was unconditionally overwritten before use.
  - Keep the per-iteration `make_rmem_tensor` allocation to preserve the original fragment layout, dtype, and lifetime.

  ## Motivation

  `nvidia-cutlass-dsl` 4.6 removed the deprecated top-level `cute.make_fragment` API and private `cute.core.ThrMma` type. The BSA implementation had
  already migrated its live register tensors and type annotations to `cute.make_rmem_tensor` and `cute.ThrMma`.

  That migration exposed several pre-existing dead allocations in the SM100 block-128 correction path. This change removes only those unused
  constructs, following the cleanup in [FlashInfer PR #3922](https://github.com/flashinfer-ai/flashinfer/pull/3922).

  No copies, barriers, reductions, indexing operations, TMEM loads/stores, or architecture instructions are changed.

  ## Compatibility

  Verified with:

  - `nvidia-cutlass-dsl==4.5.2`
  - `nvidia-cutlass-dsl==4.6.1`

  The `block_sparse_attention` tree contains no remaining uses of:

  - `cute.make_fragment(...)`
  - `cute.core.ThrMma`
  - `cute.core.ThrCopy`

  MMA object methods such as `make_fragment_A/B/C` remain unchanged because they are still valid public APIs.

  ## Validation

  Tested on NVIDIA B200 / SM100:

  - BSA forward and backward correctness tests: `17 passed` with CUTLASS DSL 4.5.2.
  - BSA forward and backward correctness tests: `17 passed` with CUTLASS DSL 4.6.1.
  - Cold-cache 4.6.1 JIT trace and compilation of the SM100 block-128 forward kernel succeeded.
  - All 39 files under `python/cudnn/block_sparse_attention` parsed and imported successfully with both versions.
  - Black 26.3.1 formatting check passed.
  - `git diff --check` passed.

  The tests cover SM100 block-128 and block-64 forward/backward kernels. SM90 and SM120 modules were statically imported under both DSL versions but
  were not executed because the validation machine was SM100.
