### PR TITLE
Fix two latent synchronization bugs in the SM100 DSA backward kernel

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
@@ -106,8 +106,10 @@ class FlashAttentionDSABackwardSm100:
             num_threads=(self.num_reduce_warps + 1) * self.threads_per_warp,
         )
         # TMEM dealloc (compute warp 0) must be ordered after the reduce
-        # warps' final dKV T2R has drained; otherwise a successor CTA can
-        # re-allocate the columns while T2R is still in flight. Participants:
+        # warps have drained their final dKV T2R reads (the reads that feed
+        # store_dKV); deallocating the TMEM columns while those T2R loads
+        # are still in flight would race them within the CTA. This is a
+        # within-CTA read-before-dealloc ordering. Participants:
         # num_reduce_warps (arrive) + compute warp 0 (arrive_and_wait).
         self.tmem_dealloc_barrier = pipeline.NamedBarrier(
             barrier_id=9,
@@ -1037,8 +1039,8 @@ class FlashAttentionDSABackwardSm100:
 
             if warp_idx == self.compute_warp_id[0]:
                 # Wait until every reduce warp has finished (and fenced) its
-                # final dKV T2R before freeing the TMEM columns for successor
-                # CTAs.
+                # final dKV T2R read before freeing the TMEM columns, so the
+                # dealloc cannot race those in-flight reads within the CTA.
                 self.tmem_dealloc_barrier.arrive_and_wait()
                 cute.arch.dealloc_tmem(tmem_ptr_base, self.num_tmem_alloc_cols)
 

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
@@ -105,6 +105,14 @@ class FlashAttentionDSABackwardSm100:
             barrier_id=8,
             num_threads=(self.num_reduce_warps + 1) * self.threads_per_warp,
         )
+        # TMEM dealloc (compute warp 0) must be ordered after the reduce
+        # warps' final dKV T2R has drained; otherwise a successor CTA can
+        # re-allocate the columns while T2R is still in flight. Participants:
+        # num_reduce_warps (arrive) + compute warp 0 (arrive_and_wait).
+        self.tmem_dealloc_barrier = pipeline.NamedBarrier(
+            barrier_id=9,
+            num_threads=(self.num_reduce_warps + 1) * self.threads_per_warp,
+        )
 
         self.tmem_S_offset = 0
         self.tmem_dP_offset = 0
@@ -1028,6 +1036,10 @@ class FlashAttentionDSABackwardSm100:
             )
 
             if warp_idx == self.compute_warp_id[0]:
+                # Wait until every reduce warp has finished (and fenced) its
+                # final dKV T2R before freeing the TMEM columns for successor
+                # CTAs.
+                self.tmem_dealloc_barrier.arrive_and_wait()
                 cute.arch.dealloc_tmem(tmem_ptr_base, self.num_tmem_alloc_cols)
 
         elif warp_idx in self.reduce_warp_id:
@@ -1048,6 +1060,11 @@ class FlashAttentionDSABackwardSm100:
                 topk,
                 mma_reduce_dKV_pipeline,
             )
+            # All T2R reads issued by this warp are complete here (each
+            # store_dKV / T2R block fences before its pipeline release);
+            # signal compute warp 0 that TMEM dealloc is now safe.
+            # arrive() only -- the reduce warps need not stall.
+            self.tmem_dealloc_barrier.arrive()
 
         elif warp_idx in self.load_KV_warp_id:
             cute.arch.setmaxregister_decrease(self.num_regs_load_KV)

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
@@ -343,7 +343,7 @@ class FlashAttentionDSABackwardSm100:
         dOT_smem_layout_staged = sm100_utils.make_smem_layout_a(dOP_tiled_mma, self.dOP_cta_tiler, self.element_dtype, self.load_mma_QdO_stage)
         P_smem_layout_staged = sm100_utils.make_smem_layout_b(dOP_tiled_mma, self.dOP_mma_tiler, self.element_dtype, self.compute_mma_P_stage)
         P_smem_layout_store_staged = sm100_utils.make_smem_layout_epi(
-            self.element_dtype, utils.LayoutEnum.COL_MAJOR, self.QK_mma_tiler[:2], self.load_mma_K_stage
+            self.element_dtype, utils.LayoutEnum.COL_MAJOR, self.QK_mma_tiler[:2], self.compute_mma_P_stage
         )
         K_smem_layout_staged_2 = sm100_utils.make_smem_layout_a(KdS_tiled_mma, self.KdS_cta_tiler, self.element_dtype, self.load_mma_K_stage)
         if cutlass.const_expr(not self.same_hdim_kv):
@@ -364,7 +364,7 @@ class FlashAttentionDSABackwardSm100:
             QT_tail_smem_layout_staged = None
         dS_smem_layout_staged = sm100_utils.make_smem_layout_b(QdS_tiled_mma, self.QdS_mma_tiler, self.element_dtype, self.compute_mma_dS_stage)
         dS_smem_layout_store_staged = sm100_utils.make_smem_layout_epi(
-            self.element_dtype, utils.LayoutEnum.COL_MAJOR, self.dOV_mma_tiler[:2], self.load_mma_K_stage
+            self.element_dtype, utils.LayoutEnum.COL_MAJOR, self.dOV_mma_tiler[:2], self.compute_mma_dS_stage
         )
 
         dQ_smem_layout_staged = sm100_utils.make_smem_layout_epi(
@@ -1776,13 +1776,13 @@ class FlashAttentionDSABackwardSm100:
         thr_t2r_dP = tiled_t2r_dP.get_slice(tidx % 128)
 
         tTR_cS = thr_t2r_S.partition_D(cS)
-        tTR_sS = thr_t2r_S.partition_D(sP_store[None, None, compute_mma_P_producer_state.index])
+        tTR_sS = thr_t2r_S.partition_D(sP_store[None, None, 0])
         tTR_rS = cute.make_rmem_tensor(tTR_sS.shape, self.acc_dtype)
 
         tTR_tS = thr_t2r_S.partition_S(tStS)
 
         tTR_cdP = thr_t2r_dP.partition_D(cdP)
-        tTR_sdP = thr_t2r_dP.partition_D(sdS_store[None, None, compute_mma_dS_producer_state.index])
+        tTR_sdP = thr_t2r_dP.partition_D(sdS_store[None, None, 0])
         tTR_rdP = cute.make_rmem_tensor(tTR_sdP.shape, self.acc_dtype)
 
         tTR_tdP = thr_t2r_dP.partition_S(tdPtdP)
@@ -1799,15 +1799,15 @@ class FlashAttentionDSABackwardSm100:
         )
         smem_store_p = cute.make_tiled_copy_D(smem_store_atom, tiled_t2r_S)
         thr_smem_store_p = smem_store_p.get_slice(tidx % 128)
-        sP_store_slice = sP_store[None, None, compute_mma_P_producer_state.index]
-        tRS_sP = thr_smem_store_p.partition_D(sP_store_slice)
-        tRS_rP = cute.make_rmem_tensor(tRS_sP.shape, self.element_dtype)
+        # Keep the stage mode: the store slot must follow the producer state
+        # when compute_mma_P_stage > 1 (slot selection happens at the copy).
+        tRS_sP = thr_smem_store_p.partition_D(sP_store)
+        tRS_rP = cute.make_rmem_tensor(tRS_sP[None, None, None, 0].shape, self.element_dtype)
 
         smem_store_ds = cute.make_tiled_copy_D(smem_store_atom, tiled_t2r_dP)
         thr_smem_store_ds = smem_store_ds.get_slice(tidx % 128)
-        sdS_store_slice = sdS_store[None, None, compute_mma_dS_producer_state.index]
-        tRS_sdS = thr_smem_store_ds.partition_D(sdS_store_slice)
-        tRS_rdS = cute.make_rmem_tensor(tRS_sdS.shape, self.element_dtype)
+        tRS_sdS = thr_smem_store_ds.partition_D(sdS_store)
+        tRS_rdS = cute.make_rmem_tensor(tRS_sdS[None, None, None, 0].shape, self.element_dtype)
 
         tile_index = tile_count - 1
         while tile_index >= 0:
@@ -1838,7 +1838,10 @@ class FlashAttentionDSABackwardSm100:
 
             # ======= stsm ============
             tRS_rP.store(smem_store_p.retile(tTR_rS_f16).load())
-            cute.copy(smem_store_p, tRS_rP, tRS_sP)
+            if cutlass.const_expr(self.compute_mma_P_stage == 1):
+                cute.copy(smem_store_p, tRS_rP, tRS_sP[None, None, None, 0])
+            else:
+                cute.copy(smem_store_p, tRS_rP, tRS_sP[None, None, None, compute_mma_P_producer_state.index])
 
             # Fence for shared memory
             cute.arch.fence_proxy(
@@ -1883,7 +1886,10 @@ class FlashAttentionDSABackwardSm100:
             mma_compute_dP_consumer_state.advance()
 
             tRS_rdS.store(smem_store_ds.retile(tTR_rdP_f16).load())
-            cute.copy(smem_store_ds, tRS_rdS, tRS_sdS)
+            if cutlass.const_expr(self.compute_mma_dS_stage == 1):
+                cute.copy(smem_store_ds, tRS_rdS, tRS_sdS[None, None, None, 0])
+            else:
+                cute.copy(smem_store_ds, tRS_rdS, tRS_sdS[None, None, None, compute_mma_dS_producer_state.index])
 
             # self.compute_sync_barrier.arrive_and_wait()
 

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -216,3 +216,89 @@ def test_DSA_sparse_attention_backward_qh32_uses_per_query_topk_without_padding(
         atol=5e-2,
         rtol=5e-2,
     )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_sparse_attention_backward_staged_store():
+    """Regression test for the staged P/dS store paths of the SM100 kernel.
+
+    The compute->MMA smem handoff for P and dS must stay correct when
+    compute_mma_P_stage / compute_mma_dS_stage are raised above 1: the
+    store-side layouts and the per-iteration store slot have to follow the
+    producer pipeline state. This test deepens both pipelines to 2 and
+    requires dq to match the stage-1 baseline bitwise (dq is written by TMA
+    with a single writer per element, hence deterministic; dkv/d_sink are
+    fp32 atomic reductions, so they are only gated on NaN and relative
+    parity).
+    """
+    try:
+        from cudnn import DSA
+        from cudnn.deepseek_sparse_attention.sparse_attention_backward import (
+            api as _dsa_bwd_api,
+            _interface_sm100 as _dsa_bwd_iface,
+            dsa_bwd_sm100 as _dsa_bwd_kmod,
+        )
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip("staged-store regression test targets the SM100 kernel")
+
+    s_q = s_kv = 512
+    h, d, topk = 64, 512, 256  # topk/64 = 4 tiles -> the pipelines really cycle
+    device = "cuda"
+    q = torch.randn(s_q, h, d, dtype=torch.bfloat16, device=device) / 10
+    kv = torch.randn(s_kv, d, dtype=torch.bfloat16, device=device) / 10
+    attn_sink = torch.randn(h, dtype=torch.float32, device=device)
+    topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
+    topk_length = torch.full((s_q,), topk, dtype=torch.int32, device=device)
+    softmax_scale = 1.0 / math.sqrt(d)
+
+    out, lse = ref_sparse_attention_forward(q, kv, attn_sink, topk_idxs, topk_length=topk_length, softmax_scale=softmax_scale)
+    dout = torch.randn_like(out)
+
+    orig_setup = _dsa_bwd_kmod.FlashAttentionDSABackwardSm100._setup_attributes
+
+    def run(stage_overrides):
+        def patched(self):
+            orig_setup(self)
+            for name, value in stage_overrides.items():
+                setattr(self, name, value)
+
+        _dsa_bwd_kmod.FlashAttentionDSABackwardSm100._setup_attributes = patched
+        _dsa_bwd_iface.flash_attn_bwd_sm100.compile_cache.clear()
+        _dsa_bwd_api._cache_of_SparseAttentionBackwardObjects.clear()
+        try:
+            result = DSA.sparse_attention_backward_wrapper(
+                q,
+                kv,
+                out,
+                dout,
+                lse,
+                attn_sink,
+                topk_idxs,
+                softmax_scale=softmax_scale,
+                topk_length=topk_length,
+            )
+            torch.cuda.synchronize()
+            return result["dq"], result["dkv"], result["d_sink"]
+        finally:
+            _dsa_bwd_kmod.FlashAttentionDSABackwardSm100._setup_attributes = orig_setup
+            _dsa_bwd_iface.flash_attn_bwd_sm100.compile_cache.clear()
+            _dsa_bwd_api._cache_of_SparseAttentionBackwardObjects.clear()
+
+    dq_ref, dkv_ref, d_sink_ref = run({})
+    assert not torch.isnan(dq_ref).any(), "stage-1 baseline produced NaN"
+
+    dq, dkv, d_sink = run({"compute_mma_P_stage": 2, "compute_mma_dS_stage": 2})
+
+    assert not torch.isnan(dq).any() and not torch.isnan(dkv).any() and not torch.isnan(d_sink).any(), "staged store paths produced NaN gradients"
+    assert torch.equal(dq, dq_ref), "dq must be bitwise-identical between stage 1 and stage 2"
+
+    def rel_l2(a, b):
+        return ((a.float() - b.float()).norm() / b.float().norm().clamp_min(1e-30)).item()
+
+    assert rel_l2(dkv, dkv_ref) < 1e-4, "dkv parity vs stage-1 baseline"
+    assert rel_l2(d_sink, d_sink_ref) < 1e-4, "d_sink parity vs stage-1 baseline"


### PR DESCRIPTION
### Before submitting
- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes. (clang-format skipped — no C/CUDA files; black + black-jupyter pass.)

### Affected area
FE OSS kernels or CuTeDSL

### Summary
`dsa_bwd_sm100.py` (`FlashAttentionDSABackwardSm100`) carries two latent
synchronization bugs. Neither changes any current numeric result, but each
corrupts gradients under a configuration the code already anticipates:

1. **Staged compute→MMA store views for P and dS.**
   `P_smem_layout_store_staged` / `dS_smem_layout_store_staged` are built with
   `self.load_mma_K_stage` instead of `self.compute_mma_P_stage` /
   `self.compute_mma_dS_stage`, and in `compute()` the store-side partitions
   `tRS_sP` / `tRS_sdS` are sliced at the producer's initial index once before
   the tile loop, so `stsm` always writes slot 0 while `producer_state.advance()`
   cycles the mbarrier phases and the MMA consumer reads slots 0..N-1. Dormant
   only because every compute→MMA stage count is 1 today; deepening either
   pipeline yields silent NaNs.

2. **TMEM dealloc lifetime at the kernel tail.**
   Compute warp 0 calls `dealloc_tmem` as soon as its own `compute()` finishes;
   nothing orders that after the reduce warps' final dKV T2R. The existing
   `t2r_dKV01/4_done` barriers sync reduce with the MMA warp only — compute
   warp 0 is in neither. A successor CTA can re-allocate and overwrite the
   columns while a T2R is still in flight.

### Why
1. With e.g. `compute_mma_dS_stage = 2` the MMA warp consumes odd tiles from a
   smem slot the compute warps never wrote; dQ/dKV pick up NaNs within one tile
   pair. Deepening these pipelines is a natural next step (overlapping
   softmax-scale work with the dKV/dQ GEMMs) and hits silent corruption with no
   hint the store paths are the cause. The #318 rewrite additionally hoisted the
   store partition out of the loop (item 3 of this bug).
2. `tcgen05.dealloc` frees the TMEM columns for a successor CTA on the same SM;
   if that CTA allocates and its MMA starts writing while the predecessor's T2R
   is still in flight, the drained dKV values are silently corrupted. The window
   is the kernel tail (compute finishing its dQ stores while reduce is still
   draining the last dKV tile) — timing-dependent and silent, i.e. incorrect by
   construction even though today's scheduling happens to win the race.

Fixes: (1) build both store-view layouts with their pipeline's stage count and
select the store slot from the producer state, keeping the `stage == 1` slot-0
path behind `cutlass.const_expr` (byte-identical default); (2) a dedicated named
barrier (id 9) — reduce warps arrive after `reduce_dKV()` returns (all their T2R
already fenced: `store_dKV` runs `fence_view_async_tmem_load` internally, the
split `t2r_dKV` paths fence at their call sites), compute warp 0 arrive-and-waits
right before `dealloc_tmem`.

### Related issues
None filed; found by code inspection + staged-configuration experiments while
porting downstream optimizations onto the DSA backward.

### API and compatibility impact
No functional change to any current result.
- Bug 1: at the committed (all-1) stage settings the emitted SM100 cubin is
  **byte-identical** (same sha256) — zero change for every current config; only
  unblocks future work that deepens the compute→MMA pipelines (within the 227 KB
  smem budget; the 576/512 variant's existing SharedStorage assert still guards
  the over-budget case).
- Bug 2: no measurable cost at the production-like shape (S=8192, H=64, D=512,
  topk=1024, bf16, sink on) on B200 — paired interleaved A/B, 200+ samples/side,
  sides swapped; medians within noise, minimums differ 0.006%. dq bitwise;
  dkv/d_sink unchanged within fp32-atomic run-to-run jitter.

### Testing
B200 (SM100), CUDA 13.3, nvidia-cutlass-dsl[cu13] 4.5.2, torch 2.13. `pre-commit run`
on both files: black + black-jupyter pass (clang-format n/a).

**Bug 1.** New L0 regression test `test_DSA_sparse_attention_backward_staged_store`
(deepens both compute→MMA stages to 2, requires dq bitwise == stage-1 baseline):
`1 passed`; fails with NaN on the unpatched parent. Standalone repro on unpatched
`fe7c8b0` (S=2048 topk=512 H=64 D=512 bf16):

| variant | dq NaNs | dkv NaNs | dq bitwise vs stock |
|---|---|---|---|
| stock (all stages 1) | 0 | 0 | — |
| compute_mma_dS_stage=2 | 7168 | 28672 | no |
| compute_mma_P_stage=2 | 0 | 28672 | yes (P feeds only dKV) |
| both = 2 | 28672 | 110592 | no |

Patched tree: every staged variant dq-bitwise vs stock, dkv/d_sink within
fp32-atomic run-to-run jitter (control in script). Default-config cubin sha256
identical before/after.

**Bug 2.** dq bitwise; paired A/B no measurable cost (above).

Pre-existing `test_DSA_sparse_attention_backward_wrapper[...512...]` cases OOM on
our heavily shared B200 (fp32 reference ~1 GiB vs <1 GiB free) identically on the
unpatched base — unrelated to this change; maintainer CI with a dedicated GPU
should pass them (stage-1 cubin is identical).

<details><summary>Repro script (self-contained; flips stage constants via monkeypatch, no tree edit)</summary>
```python
#!/usr/bin/env python3
"""Repro for the latent staged-store bugs in the SM100 DSA backward kernel
(cudnn-frontend, python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py).

Self-contained: needs only torch + an importable `cudnn` python package with
the DSA CuTe-DSL path (no other files). It does NOT modify the installed
tree: the stage constants are flipped by monkeypatching _setup_attributes,
which is exactly what future in-tree staging work would do by editing them.

  variant 'stock' : stages as committed (all 1)  -> reference
  variant 'ds2'   : compute_mma_dS_stage = 2
  variant 'p2'    : compute_mma_P_stage  = 2
  variant 'ds2p2' : both = 2

On an UNFIXED tree: ds2/p2/ds2p2 produce NaNs (dq and/or dkv)   -> exit 2
On a FIXED tree   : dq bitwise == stock for every variant, dkv /
                    d_sink within fp32-atomic run-to-run jitter -> exit 0

Judging criteria: dq is TMA-stored with a single writer per element, hence
deterministic -> bitwise gate. dkv and d_sink are fp32 atomic reductions and
are NOT bitwise-stable run to run even at fixed config -> gated on NaN count
and relative L2 against a measured stock-rerun jitter control.

Usage:  CUDA_VISIBLE_DEVICES=<gpu> python3 repro_staged_store_standalone.py
"""

import sys

import torch

from cudnn import DSA
import cudnn.deepseek_sparse_attention.sparse_attention_backward.dsa_bwd_sm100 as kmod
import cudnn.deepseek_sparse_attention.sparse_attention_backward._interface_sm100 as imod
import cudnn.deepseek_sparse_attention.sparse_attention_backward.api as amod

S, TOPK, H, D = 2048, 512, 64, 512  # topk/64 = 8 tiles: pipelines really cycle
DTYPE = torch.bfloat16


def make_case(seed=0):
    g = torch.Generator(device="cuda").manual_seed(seed)
    q = torch.randn(S, H, D, device="cuda", dtype=torch.float32, generator=g).to(DTYPE) / 10
    kv = torch.randn(S, D, device="cuda", dtype=torch.float32, generator=g).to(DTYPE) / 10
    dout = torch.randn(S, H, D, device="cuda", dtype=torch.float32, generator=g).to(DTYPE) / 10
    sink = torch.linspace(-2.0, 2.0, H, device="cuda", dtype=torch.float32)
    idx = torch.empty(S, TOPK, device="cuda", dtype=torch.int32)
    for i in range(0, S, 1024):
        r = torch.rand(min(1024, S - i), S, device="cuda", generator=g)
        idx[i : i + r.shape[0]] = r.argsort(dim=-1)[:, :TOPK].to(torch.int32)
    tl = torch.full((S,), TOPK, dtype=torch.int32, device="cuda")
    scale = D ** -0.5
    # chunked reference forward (produces out + KV-only natural-log lse)
    out = torch.empty(S, H, D, dtype=DTYPE, device="cuda")
    lse = torch.empty(S, H, dtype=torch.float32, device="cuda")
    for i in range(0, S, 128):
        kv_g = kv[idx[i : i + 128].long()].float()
        sc = torch.einsum("chd,ckd->chk", q[i : i + 128].float(), kv_g) * scale
        l = torch.logsumexp(sc, dim=-1)
        p = torch.exp(sc - torch.logaddexp(l, sink.view(1, H)).unsqueeze(-1))
        out[i : i + 128] = torch.einsum("chk,ckv->chv", p, kv_g).to(DTYPE)
        lse[i : i + 128] = l
    return q, kv, sink, dout, idx, tl, out, lse, scale


def main():
    q, kv, sink, dout, idx, tl, out, lse, scale = make_case()
    orig = kmod.FlashAttentionDSABackwardSm100._setup_attributes

    def run(overrides):
        def patched(self):
            orig(self)
            for k, v in overrides.items():
                setattr(self, k, v)

        kmod.FlashAttentionDSABackwardSm100._setup_attributes = patched
        imod.flash_attn_bwd_sm100.compile_cache.clear()
        amod._cache_of_SparseAttentionBackwardObjects.clear()
        try:
            dq = torch.full_like(q, float("nan"))
            dkv = torch.zeros_like(kv)
            res = DSA.sparse_attention_backward_wrapper(
                q, kv, out, dout, lse, sink, idx,
                softmax_scale=scale, topk_length=tl, dq=dq, dkv=dkv)
            torch.cuda.synchronize()
            return dq, dkv, res["d_sink"].clone()
        finally:
            kmod.FlashAttentionDSABackwardSm100._setup_attributes = orig
            imod.flash_attn_bwd_sm100.compile_cache.clear()
            amod._cache_of_SparseAttentionBackwardObjects.clear()

    def rel_l2(a, b):
        return ((a.float() - b.float()).norm() / b.float().norm().clamp_min(1e-30)).item()

    variants = {"stock": {}, "ds2": {"compute_mma_dS_stage": 2},
                "p2": {"compute_mma_P_stage": 2},
                "ds2p2": {"compute_mma_dS_stage": 2, "compute_mma_P_stage": 2}}
    results = {name: run(ov) for name, ov in variants.items()}
    for name, (dq, dkv, ds) in results.items():
        print(f"[{name:>6}] dq NaNs={int(torch.isnan(dq).sum())}  dkv NaNs={int(torch.isnan(dkv).sum())}")

    dq0, dkv0, ds0 = results["stock"]
    assert not torch.isnan(dq0).any(), "baseline NaN: environment problem"
    dq_r, dkv_r, ds_r = run({})  # jitter control
    assert torch.equal(dq_r, dq0), "stock dq not deterministic run-to-run"
    dkv_tol = max(10 * rel_l2(dkv_r, dkv0), 1e-5)
    ds_tol = max(10 * rel_l2(ds_r, ds0), 1e-5)
    print(f"[control] stock rerun: dkv relL2={rel_l2(dkv_r, dkv0):.3e} (atomic jitter baseline)")

    bug = False
    for name, (dq, dkv, ds) in results.items():
        if name == "stock":
            continue
        nan = int(torch.isnan(dq).sum() + torch.isnan(dkv).sum() + torch.isnan(ds).sum())
        ok = (torch.equal(dq, dq0) and nan == 0
              and rel_l2(dkv, dkv0) <= dkv_tol and rel_l2(ds, ds0) <= ds_tol)
        print(f"{name:>6} vs stock: {'OK' if ok else 'CORRUPTED'} "
              f"(dq bitwise={torch.equal(dq, dq0)}, NaNs={nan}, dkv relL2={rel_l2(dkv, dkv0):.3e})")
        bug |= not ok

    print("VERDICT:", "BUG REPRODUCED" if bug else "CLEAN")
    sys.exit(2 if bug else 0)


if __name__ == "__main__":
    main()
```
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sparse-attention backward execution to ensure shared-memory deallocation happens only after all required asynchronous reduce steps complete.
  * Fixed staged storage selection for intermediate attention data to behave consistently across different pipeline stage settings.
* **Tests**
  * Added a CUDA-only SM100 regression test covering the staged-store backward path.
  * Verifies no NaNs in gradients and checks staged results match the stage-1 baseline with tight numerical tolerances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->