### PR TITLE
Fix BatchNorm sample handle leak issue

### DIFF
--- a/samples/legacy_samples/norm_samples.cpp
+++ b/samples/legacy_samples/norm_samples.cpp
@@ -183,7 +183,8 @@ run_batch_norm_forward(cudnnHandle_t &handle_,
     auto plan = plan_builder();
     std::cout << "Plan tag: " << plan.getTag() << std::endl;
 
-    handle_ptr.release();
+    // Transfer the cuDNN handle to the caller without leaking the pointer storage owned by handle_ptr.
+    delete handle_ptr.release();
     return plan;
 }
 
@@ -206,8 +207,8 @@ execute_batch_norm_forward(cudnnHandle_t &handle_,
                            double epsilon_val,
                            double exponential_decay_factor) {
     // This function completes the ownership transfer started by run_batch_norm_forward().
-    auto handle_ptr = std::unique_ptr<cudnnHandle_t, CudnnHandleDeleter>(new cudnnHandle_t(handle_),
-                                                                         CudnnHandleDeleter());
+    auto handle_ptr =
+        std::unique_ptr<cudnnHandle_t, CudnnHandleDeleter>(new cudnnHandle_t(handle_), CudnnHandleDeleter());
     try {
         auto workspace_size = plan.getWorkspaceSize();
         std::cout << plan.describe() << std::endl;

--- a/samples/legacy_samples/norm_samples.cpp
+++ b/samples/legacy_samples/norm_samples.cpp
@@ -43,8 +43,9 @@ run_batch_norm_forward(cudnnHandle_t &handle_,
 
 {
     std::cout << "================ Running Batch Norm Forward ======================= " << std::endl;
-    // Create the cudnn handle
-    checkCudnnErr(cudnnCreate(&handle_));
+    // The returned plan is executed by execute_batch_norm_forward(), which takes ownership of this handle.
+    auto handle_ptr = create_cudnn_handle();
+    handle_         = *handle_ptr;
 
     // Creates the necessary tensor descriptors
     int64_t tensor_stride[4];
@@ -182,6 +183,7 @@ run_batch_norm_forward(cudnnHandle_t &handle_,
     auto plan = plan_builder();
     std::cout << "Plan tag: " << plan.getTag() << std::endl;
 
+    handle_ptr.release();
     return plan;
 }
 
@@ -203,6 +205,9 @@ execute_batch_norm_forward(cudnnHandle_t &handle_,
 
                            double epsilon_val,
                            double exponential_decay_factor) {
+    // This function completes the ownership transfer started by run_batch_norm_forward().
+    auto handle_ptr = std::unique_ptr<cudnnHandle_t, CudnnHandleDeleter>(new cudnnHandle_t(handle_),
+                                                                         CudnnHandleDeleter());
     try {
         auto workspace_size = plan.getWorkspaceSize();
         std::cout << plan.describe() << std::endl;
@@ -275,7 +280,6 @@ run_batch_norm_backward(int64_t *tensorDims,
                         cudnnDataType_t data_type)
 
 {
-    cudnnHandle_t handle_;
     std::cout << "================ Running Batch Norm Backward =======================" << std::endl;
     (void)xDevPtr;
     (void)dyDevPtr;
@@ -290,8 +294,9 @@ run_batch_norm_backward(int64_t *tensorDims,
 
     (void)epsilon_val;
     try {
-        // Create the cudnn handle
-        checkCudnnErr(cudnnCreate(&handle_));
+        // The handle is automatically destroyed when leaving this scope.
+        auto handle_ptr = create_cudnn_handle();
+        auto handle_    = *handle_ptr;
 
         // Creates the necessary tensor descriptors
         int64_t tensor_stride[4];


### PR DESCRIPTION
## Affected area

Documentation or samples

## Summary

Fix BatchNorm sample cuDNN handle leak issue.

## Why

Ensure the BatchNorm forward and backward paths release cuDNN handles correctly.

## Testing

Passed on B100 with cuDNN 9.25.0.8:

```bash
cmake --build build --target legacy_samples -j
valgrind --leak-check=full --show-leak-kinds=definite \
  ./build/bin/legacy_samples "Batch normalization"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cuDNN handle lifecycle management in batch normalization sample workflows.
  * Added automatic cleanup and clearer ownership handling for forward and backward operations.
  * No user-facing functionality or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->