### PR TITLE
Support installing python bindings via cmake --install (fixes #149)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ cmake --build . -j16
 ./bin/samples
 ```
 
+**4. Installing the Python Bindings with CMake (for system packagers)**
+
+If you cannot go through `pip` (e.g., distro or system packaging), the Python bindings can be built and installed directly with CMake:
+
+```bash
+mkdir build && cd build
+cmake -DCUDNN_FRONTEND_BUILD_PYTHON_BINDINGS=ON \
+      -DCUDNN_FRONTEND_INSTALL_PYTHON_BINDINGS=ON \
+      -DCUDNN_FRONTEND_BUILD_SAMPLES=OFF \
+      -DCUDNN_FRONTEND_BUILD_TESTS=OFF ../
+cmake --build . -j16
+cmake --install .
+```
+
+This installs the `cudnn` package (Python sources plus the compiled module) and a PEP 376 `.dist-info` directory into the site-packages of the Python interpreter found by CMake, so the install is visible to `pip list`, `importlib.metadata`, and can be removed with `pip uninstall nvidia-cudnn-frontend`. The destination can be overridden with `-DCUDNN_FRONTEND_PYTHON_INSTALL_DIR=<path>` (absolute, or relative to `CMAKE_INSTALL_PREFIX`), and `DESTDIR` staging is supported. Use `-DCUDNN_FRONTEND_FETCH_PYBINDS_IN_CMAKE=OFF` and `-DCUDNN_FRONTEND_USE_SYSTEM_DLPACK=ON` to build against system-provided `pybind11` and `dlpack` instead of fetching them.
+
 ## Documentation & Examples
 
 *   **Developer Guide:** [Official NVIDIA Documentation (latest)](https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -114,8 +114,6 @@ set_target_properties(
     LINK_WHAT_YOU_USE TRUE
 )
 
-# using python bindings directly with cmake build system is not supported
-# Temparorily use below parameter
 option(CUDNN_FRONTEND_KEEP_PYBINDS_IN_BINARY_DIR "Whether pybinds should be kept inside build/cudnn directory." ON)
 if(CUDNN_FRONTEND_KEEP_PYBINDS_IN_BINARY_DIR)
 set_target_properties(
@@ -125,4 +123,94 @@ set_target_properties(
         LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/cudnn
     )
     file(COPY ${PROJECT_SOURCE_DIR}/python/cudnn DESTINATION ${PROJECT_BINARY_DIR})
+endif()
+
+# Optionally install the python bindings with `cmake --install`, for system
+# packagers and users who cannot go through pip/setup.py (see issue #149).
+# The layout matches what the wheel produces: the `cudnn` package (python
+# sources + compiled module) plus a PEP 376 `.dist-info` directory so the
+# install is visible to pip, importlib.metadata and other packaging tools.
+option(CUDNN_FRONTEND_INSTALL_PYTHON_BINDINGS "Whether `cmake --install` should install the python bindings into the python site-packages." OFF)
+if(CUDNN_FRONTEND_INSTALL_PYTHON_BINDINGS)
+    # Destination: absolute path, or path relative to CMAKE_INSTALL_PREFIX.
+    # Defaults to the platlib (site-packages) of the interpreter found above,
+    # which honors virtual environments.
+    set(CUDNN_FRONTEND_PYTHON_INSTALL_DIR "${Python_SITEARCH}" CACHE PATH "Directory the cudnn python package is installed to.")
+
+    if(IS_ABSOLUTE "${CUDNN_FRONTEND_PYTHON_INSTALL_DIR}")
+        set(_cudnn_fe_python_install_dir "${CUDNN_FRONTEND_PYTHON_INSTALL_DIR}")
+    else()
+        set(_cudnn_fe_python_install_dir "${CMAKE_INSTALL_PREFIX}/${CUDNN_FRONTEND_PYTHON_INSTALL_DIR}")
+    endif()
+    message(STATUS "cudnn python bindings will be installed to ${_cudnn_fe_python_install_dir}")
+
+    # Pure python sources of the `cudnn` package
+    install(
+        DIRECTORY ${PROJECT_SOURCE_DIR}/python/cudnn
+        DESTINATION ${_cudnn_fe_python_install_dir}
+        FILES_MATCHING PATTERN "*.py"
+        PATTERN "__pycache__" EXCLUDE
+    )
+
+    # Compiled extension module. cudnn/__init__.py imports it from
+    # `cudnn.Release` on Windows (multi-config layout), from `cudnn` elsewhere.
+    if(WIN32)
+        set(_cudnn_fe_module_subdir cudnn/Release)
+    else()
+        set(_cudnn_fe_module_subdir cudnn)
+    endif()
+    install(
+        TARGETS _compiled_module
+        LIBRARY DESTINATION ${_cudnn_fe_python_install_dir}/${_cudnn_fe_module_subdir}
+    )
+
+    # PEP 376 .dist-info so the install is discoverable by packaging tools
+    set(_cudnn_fe_dist_info "nvidia_cudnn_frontend-${PROJECT_VERSION}.dist-info")
+    file(CONFIGURE
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist-info/METADATA
+        CONTENT
+"Metadata-Version: 2.1
+Name: nvidia-cudnn-frontend
+Version: @PROJECT_VERSION@
+Summary: NVIDIA cuDNN Frontend — Python and C++ Graph API
+Home-page: https://github.com/NVIDIA/cudnn-frontend
+License: MIT
+Requires-Python: >=3.9
+"
+        @ONLY
+    )
+    file(CONFIGURE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist-info/INSTALLER CONTENT "cmake\n" @ONLY)
+    file(CONFIGURE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist-info/top_level.txt CONTENT "cudnn\n" @ONLY)
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/dist-info/METADATA
+            ${CMAKE_CURRENT_BINARY_DIR}/dist-info/INSTALLER
+            ${CMAKE_CURRENT_BINARY_DIR}/dist-info/top_level.txt
+        DESTINATION ${_cudnn_fe_python_install_dir}/${_cudnn_fe_dist_info}
+    )
+
+    # Generate the RECORD file at install time, once all files are in place,
+    # so that `pip uninstall nvidia-cudnn-frontend` works.
+    file(CONFIGURE
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist-info/GenerateRecord.cmake
+        CONTENT
+[[set(_site_dir "$ENV{DESTDIR}@_cudnn_fe_python_install_dir@")
+set(_dist_info "@_cudnn_fe_dist_info@")
+file(GLOB_RECURSE _installed_files LIST_DIRECTORIES false
+    RELATIVE "${_site_dir}"
+    "${_site_dir}/cudnn/*"
+    "${_site_dir}/${_dist_info}/*"
+)
+list(REMOVE_ITEM _installed_files "${_dist_info}/RECORD")
+set(_record "")
+foreach(_file IN LISTS _installed_files)
+    string(APPEND _record "${_file},,\n")
+endforeach()
+string(APPEND _record "${_dist_info}/RECORD,,\n")
+file(WRITE "${_site_dir}/${_dist_info}/RECORD" "${_record}")
+message(STATUS "Generated: ${_site_dir}/${_dist_info}/RECORD")
+]]
+        @ONLY
+    )
+    install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/dist-info/GenerateRecord.cmake)
 endif()


### PR DESCRIPTION
## Summary

Fixes #149 — adds first-class support for installing the Python bindings directly from the CMake build system, so system packagers (and anyone who cannot go through `pip`/`setup.py`) no longer need a fork to ship the bindings. This follows the same approach Z3 uses for its CMake-installed Python bindings, including a `.dist-info` in `site-packages`.

## Solution

A new option `CUDNN_FRONTEND_INSTALL_PYTHON_BINDINGS` (default `OFF`, so nothing changes for existing wheel/`setup.py` builds) makes `cmake --install` produce a complete, pip-visible installation:

```bash
cmake -DCUDNN_FRONTEND_BUILD_PYTHON_BINDINGS=ON \
      -DCUDNN_FRONTEND_INSTALL_PYTHON_BINDINGS=ON \
      -DCUDNN_FRONTEND_BUILD_SAMPLES=OFF -DCUDNN_FRONTEND_BUILD_TESTS=OFF ..
cmake --build . -j
cmake --install .
```

What gets installed into `site-packages`:

1. **The `cudnn` package** — pure-Python sources (`python/cudnn/**/*.py`) plus the compiled `_compiled_module` extension, in the same layout the wheel produces (on Windows the module goes to `cudnn/Release/`, matching what `cudnn/__init__.py` expects).
2. **A PEP 376 `nvidia_cudnn_frontend-<version>.dist-info` directory** containing:
   - `METADATA` (name/version generated from the CMake project version, which matches `cudnn.__version__`)
   - `INSTALLER` (`cmake`) and `top_level.txt`
   - `RECORD`, generated at *install time* by an `install(SCRIPT)` step after all files are in place — so `pip uninstall nvidia-cudnn-frontend` works.

Destination handling:
- Defaults to the found interpreter's `Python_SITEARCH` (honors virtualenvs).
- Overridable with `-DCUDNN_FRONTEND_PYTHON_INSTALL_DIR=<path>` — absolute, or relative to `CMAKE_INSTALL_PREFIX`.
- `DESTDIR` staging is supported (the `RECORD` generator prefixes `$ENV{DESTDIR}`).

Also removes the stale "using python bindings directly with cmake build system is not supported" comment, and documents the new workflow in the README ("Building from Source" section), including how to combine it with the existing `CUDNN_FRONTEND_FETCH_PYBINDS_IN_CMAKE=OFF` / `CUDNN_FRONTEND_USE_SYSTEM_DLPACK=ON` options for fully system-provided dependencies.

## Verification

Built and installed on Linux x86_64 (CMake 3.31, CUDA 13.2, Python 3.14) with `DESTDIR` staging:

- `cmake --install` produced `cudnn/` (201 files incl. the `.so`) and `nvidia_cudnn_frontend-1.27.0.dist-info/` with a 204-entry `RECORD` (including itself).
- `import cudnn` from the installed location works; `cudnn.__version__ == '1.27.0'`.
- `importlib.metadata.version('nvidia-cudnn-frontend')` → `1.27.0`.
- `pip list --path <site-packages>` shows `nvidia-cudnn-frontend 1.27.0`.
- Default configuration (option OFF) is unchanged — no new install rules run, `setup.py`/wheel path untouched.

cc @BwL1289 — this should allow deprecating the meson fork (`eugo-inc/cudnn-frontend-meson-python`); feedback welcome on whether this covers your use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing the Python bindings through CMake.
  * Installed packages now include standard Python metadata, making them visible to package and metadata tools.
  * Added options for customizing the Python installation directory and using `DESTDIR`.
  * Added configuration controls for bundled or system-provided build dependencies.

* **Documentation**
  * Documented the CMake-based Python installation, customization options, and uninstall workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->