### PR TITLE
DSA indexer_top_k: fall back to scalar stores for odd top_k

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/indexer_top_k/indexer_top_k_varlen_util.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_top_k/indexer_top_k_varlen_util.py
@@ -965,7 +965,9 @@ class IndexerTopKKernelVarlen:
                     cute.ceil_div(self.top_k, self.num_threads_per_cta),
                     self.num_copy_bits // self.dtype.width,
                     # TODO: only tested for float32. need to check for other dtypes.
-                    2,
+                    # Odd top_k cannot be tiled by width-2 vectorized stores (there is
+                    # no scalar tail), so fall back to scalar stores in that case.
+                    2 if self.top_k % 2 == 0 else 1,
                 )
             )
             assert self.top_k % vecsize_out == 0

--- a/test/python/fe_api/dsa/dsa_utils.py
+++ b/test/python/fe_api/dsa/dsa_utils.py
@@ -43,7 +43,9 @@ DSA_INDEXER_FORWARD_PARAM_MARKS = [
 ]
 
 DSA_INDEXER_TOP_K_PARAM_MARKS = [
-    pytest.mark.parametrize("top_k", [512]),
+    # 705: regression for odd top_k > threads-per-CTA, which used to fail the
+    # width-2 vectorized-store assert at JIT compile time.
+    pytest.mark.parametrize("top_k", [512, 705]),
     pytest.mark.parametrize("next_n", [1]),
     pytest.mark.parametrize("return_val", [True, False]),
 ]


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Cap the DSA indexer_top_k output-store vector width at 1 when `top_k` is odd, so odd `top_k` values JIT-compile instead of failing `assert self.top_k % vecsize_out == 0`. Adds `top_k=705` (odd, greater than threads-per-CTA) to the indexer_top_k test parametrization as a regression case.

## Why

Fixes #406. `check_support()` and the documented constraint permit any `top_k` in `(0, 2048]`, but the output phase selected `vecsize_out = 2` whenever `top_k > num_threads_per_cta`, and the width-2 vectorized index/value store has no scalar tail — so odd `top_k` above that threshold asserted at compile time. Real workloads hit this when clamping `top_k = min(index_topk, visible_keys)` on context-parallel shards (see the issue for the exact `[235, 705]` / `top_k=705` production case).

Scalar stores (`vecsize_out == 1`) are the path every `top_k <= num_threads_per_cta` config already takes; this change extends that path to odd `top_k` rather than adding a tail case to the vectorized writer. Only the output-phase store width changes — the selection phases and all even-`top_k` codegen are untouched.

## Related issues

Fixes #406

## API and compatibility impact

None for previously-working configs: `vecsize_out` is unchanged for even `top_k` and for odd `top_k <= num_threads_per_cta`. Previously-asserting odd `top_k` values now compile, using scalar output stores.

## Testing

- `black --line-length 160` on both changed files.
- I don't have an SM90/SM100 machine available in this environment, so I could not run the GPU tests myself. The added `top_k=705` parametrization exercises the previously-asserting configuration in both `test_DSA_indexer_top_k_compile_execute` and `test_DSA_indexer_top_k_wrapper` (default shapes give 256–512 threads per CTA, so 705 previously resolved `vecsize_out = 2` and failed the assert). Happy to iterate on CI results or run additional cases on a B200 and report back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed top-k attention processing for odd top-k values, improving correctness when results exceed standard vectorized widths.

* **Tests**
  * Expanded coverage to include an additional odd top-k scenario, helping prevent regressions in variable-length attention processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->