### PR TITLE
Use professional wording in env report docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
         ### Environment (where applicable)
 
         <!-- Python users: run `python -m cudnn.collect_env` and paste its output
-             here instead of filling the fields below. If `import cudnn` is broken,
+             here instead of filling the fields below. If `import cudnn` fails,
              download and run the script standalone with any Python:
              https://raw.githubusercontent.com/NVIDIA/cudnn-frontend/main/python/cudnn/collect_env.py -->
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ When filing a bug, include the output of the environment collector — it report
 python -m cudnn.collect_env
 ```
 
-If `import cudnn` itself is broken, download [collect_env.py](python/cudnn/collect_env.py) and run it standalone with any Python.
+If `import cudnn` itself fails, download [collect_env.py](python/cudnn/collect_env.py) and run it standalone with any Python.
 
 ### Overriding the CUDA runtime library
 

--- a/python/cudnn/collect_env.py
+++ b/python/cudnn/collect_env.py
@@ -33,7 +33,7 @@ import sys
 # Keys are display names, values are regexes matched against .so basenames.
 # libcudnn intentionally also matches the sublibraries (libcudnn_ops,
 # libcudnn_engines_precompiled, ...) — an install with mixed sublibrary
-# versions is a known inconsistent state this report must surface.
+# versions are a known inconsistent state this report must surface.
 _LIB_FAMILIES = {
     "libcudnn": r"libcudnn(?:_[a-z_]+)?\.so",
     "libcublas": r"libcublas(?:Lt)?\.so",

--- a/python/cudnn/collect_env.py
+++ b/python/cudnn/collect_env.py
@@ -4,13 +4,13 @@ Usage (any of):
 
     python -m cudnn.collect_env
     python -m cudnn.collect_env --json
-    # If `import cudnn` itself is broken, download and run standalone:
+    # If `import cudnn` itself fails, download and run standalone:
     curl -OL https://raw.githubusercontent.com/NVIDIA/cudnn-frontend/main/python/cudnn/collect_env.py
     python collect_env.py
 
 Design constraints (please preserve when editing):
 - Only stdlib imports at module level, so the file runs standalone even when
-  cudnn / torch are broken or absent.
+  cudnn / torch fail to import or are absent.
 - Every probe is individually guarded; a failure becomes a value in the
   report, never an exception. The report must always print.
 - Strictly offline and read-only.
@@ -33,7 +33,7 @@ import sys
 # Keys are display names, values are regexes matched against .so basenames.
 # libcudnn intentionally also matches the sublibraries (libcudnn_ops,
 # libcudnn_engines_precompiled, ...) — an install with mixed sublibrary
-# versions is a classic broken state this report must surface.
+# versions is a known inconsistent state this report must surface.
 _LIB_FAMILIES = {
     "libcudnn": r"libcudnn(?:_[a-z_]+)?\.so",
     "libcublas": r"libcublas(?:Lt)?\.so",

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_grouped_gemm_dglu_dbias.py
@@ -1771,7 +1771,6 @@ class MoEGroupedGemmDgluDbiasBf16Kernel:
                     #
                     # Load accumulator from tensor memory buffer to register
                     #
-                    # The AST does not reliably track constexpr values to loop arguments.
                     copy_atom_t2r = sm100_utils.get_tmem_load_op(
                         self.cta_tile_shape_mnk,
                         self.d_layout,

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_grouped_gemm_dglu_dbias.py
@@ -1771,6 +1771,7 @@ class MoEGroupedGemmDgluDbiasBf16Kernel:
                     #
                     # Load accumulator from tensor memory buffer to register
                     #
+                    # The AST does not reliably track constexpr values to loop arguments.
                     copy_atom_t2r = sm100_utils.get_tmem_load_op(
                         self.cta_tile_shape_mnk,
                         self.d_layout,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated the bug report template’s environment guidance to say `import cudnn` **fails** (instead of being “broken”).
  * Refined the README “Environment report” instructions while keeping the same troubleshooting flow (download and run `collect_env.py` standalone with any Python).
  * Reworded related in-script documentation/comments for clarity, without changing behavior or output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->