### PR TITLE
Minor errata to #280

### DIFF
--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -2510,6 +2510,24 @@ class Graph : public ICudnn, public INode {
         j["nodes"]                  = json::array();
         j["tensors"]                = json::array();
         std::map<Tensor_attributes::uid_t, json> tensors;
+        std::vector<std::shared_ptr<Tensor_attributes>> tensors_in_graph;
+        status = collect_tensor_attributes_subtree(tensors_in_graph);
+        if (status.is_bad()) {
+            throw std::runtime_error(status.get_message());
+        }
+        std::unordered_set<Tensor_attributes const *> collected_ragged_offsets;
+        auto add_ragged_offsets = [&](auto const &self, std::shared_ptr<Tensor_attributes> const &tensor) -> void {
+            if (tensor == nullptr || !collected_ragged_offsets.insert(tensor.get()).second) {
+                return;
+            }
+            tensors.emplace(tensor->get_uid(), json(*tensor));
+            self(self, tensor->get_ragged_offset());
+        };
+        for (auto const &tensor : tensors_in_graph) {
+            if (tensor != nullptr) {
+                add_ragged_offsets(add_ragged_offsets, tensor->get_ragged_offset());
+            }
+        }
         auto add_tensor = [&](json &refs, std::string const &port_name, json const &tensor_info) {
             if (tensor_info.is_null()) {
                 return;


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] Formatting checked with clang-format.

## Affected area

- C++ frontend API or graph construction

## Summary

Include complete ragged-offset tensor descriptors in the graph JSON v2 tensors table. Recursively follows nested ragged offsets and deduplicates shared descriptors.

## Why

PR #280 serialized only `ragged_offset_uid` on parent tensors. Deserialization therefore created UID-only placeholders without the offset dimensions, strides, or data type, causing operation-graph construction to fail for ragged graphs.

## Related issues

Related to #280.

## API and compatibility impact

None. This completes the existing graph JSON v2 schema for ragged tensors.

## Testing

- `clang-format --dry-run --Werror include/cudnn_frontend/graph_interface.h`
- `cmake --build build --target tests -j2`
- `build/bin/tests [serialize]`: 58 assertions in 11 test cases passed
- Standalone ragged-offset JSON round-trip and operation-graph build probe: passed

@coderabbitai ignore