### PR TITLE
DSA: fix SM100 sink normalization for 576/512 backward

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
@@ -581,25 +581,24 @@ class FlashAttentionDSABackwardSm100:
             stream=stream,
         )
 
-        if cutlass.const_expr(self.same_hdim_kv):
-            dSink_grid = (
-                cute.ceil_div(problem_shape[0], self.dSink_block_q),
-                problem_shape[3][0],
-                problem_shape[3][1],
-            )
-            self.sum_dSink(
-                sum_OdO,
-                scaled_LSE,
-                mAttnSink,
-                mdSink,
-                problem_shape,
-            ).launch(
-                grid=dSink_grid,
-                block=[self.dSink_num_threads, 1, 1],
-                cluster=[1, 1, 1],
-                stream=stream,
-                min_blocks_per_mp=1,
-            )
+        dSink_grid = (
+            cute.ceil_div(problem_shape[0], self.dSink_block_q),
+            problem_shape[3][0],
+            problem_shape[3][1],
+        )
+        self.sum_dSink(
+            sum_OdO,
+            scaled_LSE,
+            mAttnSink,
+            mdSink,
+            problem_shape,
+        ).launch(
+            grid=dSink_grid,
+            block=[self.dSink_num_threads, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
 
     @cute.kernel
     def convert(
@@ -683,21 +682,20 @@ class FlashAttentionDSABackwardSm100:
                     lse_bhq = lse[bidy, (idx_q + offset, bidz)]
                     sum_OdO_bhq = sum_OdO_scale * acc
 
-                    if cutlass.const_expr(self.same_hdim_kv):
-                        attn_sink_bh = attn_sink[bidy, (0, bidz)]
+                    # FlashMLA LSE excludes the sink for every head-dim
+                    # specialization, so always fold it into the denominator.
+                    attn_sink_bh = attn_sink[bidy, (0, bidz)]
 
-                        log2_e = -lse_scale
-                        lse_log2 = lse_bhq * log2_e
-                        sink_log2 = attn_sink_bh * log2_e
-                        lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
-                        sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
-                        lse_with_sink_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
-                        scaled_lse_bhq = -lse_with_sink_log2
+                    log2_e = -lse_scale
+                    lse_log2 = lse_bhq * log2_e
+                    sink_log2 = attn_sink_bh * log2_e
+                    lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
+                    sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
+                    lse_with_sink_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
+                    scaled_lse_bhq = -lse_with_sink_log2
 
-                        if lse_bhq == Float32(float("inf")):
-                            scaled_lse_bhq = Float32(float("-inf"))
-                    else:
-                        scaled_lse_bhq = lse_scale * lse_bhq
+                    if lse_bhq == Float32(float("inf")):
+                        scaled_lse_bhq = Float32(float("-inf"))
 
                     sum_OdO[bidy, (idx_q + offset, bidz)] = sum_OdO_bhq
                     scaled_lse[bidy, (idx_q + offset, bidz)] = scaled_lse_bhq

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -137,6 +137,80 @@ def test_DSA_sparse_attention_backward_wrapper(
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("has_topk_length", [False, True], ids=["full-topk", "lengths"])
+@torch_fork_set_rng(seed=418)
+def test_DSA_sparse_attention_backward_sm100_576_includes_sink_in_normalization(has_topk_length):
+    """The 576/512 specialization must include sink mass in every gradient."""
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip("sink-normalization regression test targets the SM100 kernel")
+
+    device = torch.device("cuda")
+    s_q = 5
+    s_kv = topk = 512
+    num_heads, head_dim = 32, 576
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    q = torch.randn(s_q, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(s_kv, head_dim, dtype=torch.bfloat16, device=device)
+    # Keep the sink probability significant even for the full-top-k row so
+    # both compiled variants fail clearly if they normalize by KV-only LSE.
+    attn_sink = torch.full((num_heads,), math.log(topk), dtype=torch.float32, device=device)
+    topk_idxs = torch.arange(topk, dtype=torch.int32, device=device).expand(s_q, -1).contiguous()
+    lengths = torch.tensor([1, 63, 64, 65, 512], dtype=torch.int32, device=device)
+    topk_length = lengths if has_topk_length else None
+
+    out, lse = ref_sparse_attention_forward(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        topk_length=topk_length,
+        softmax_scale=softmax_scale,
+    )
+    # O.dO is positive for every head, so a zero d_sink cannot pass by
+    # landing inside the absolute tolerance.
+    dout = out.clone()
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    result = DSA.sparse_attention_backward_wrapper(
+        q,
+        kv,
+        out,
+        dout,
+        lse,
+        attn_sink,
+        topk_idxs,
+        softmax_scale=softmax_scale,
+        topk_length=topk_length,
+        stream=stream,
+    )
+
+    check_ref_dsa_sparse_attention_backward(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        out,
+        dout,
+        lse,
+        result["dq"],
+        result["dkv"],
+        result["d_sink"],
+        softmax_scale=softmax_scale,
+        topk_length=topk_length,
+        atol=5e-2,
+        rtol=5e-2,
+    )
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=385)
 def test_DSA_sparse_attention_backward_qh32_uses_per_query_topk_without_padding(monkeypatch):
     try:


### PR DESCRIPTION
  ## Before submitting

  - [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
  - [x] I ran `pre-commit run` and committed any formatting changes.

  ## Affected area

  FE OSS kernels or CuTeDSL

  ## Summary

  - Fold the attention sink into the FlashMLA KV-only LSE for every SM100 head-dimension specialization.
  - Launch the existing `sum_dSink` reduction for the `D_qk=576, D_v=512` path.
  - Add deterministic SM100 regression coverage for both full top-k and per-query `topk_length`, including lengths around the 64-entry tile boundary.

  ## Why

  `same_hdim_kv` is intended to control dimension-dependent layouts and the 64-dimensional RoPE tail. It was also incorrectly used to guard two
  dimension-independent sink operations.

  For `D_qk=576, D_v=512`, this caused:

  1. The backward kernel to reconstruct attention probabilities using the KV-only denominator:


  Z_KV


  instead of the sink-inclusive denominator:


  Z_KV + exp(sink)


  This produced incorrect `dq` and `dkv`, especially for queries with short `topk_length`, where the sink probability is significant.

  2. The existing `sum_dSink` kernel to be skipped entirely, leaving `d_sink` zero.

  This change reuses the existing stable sink-folding implementation and `sum_dSink` kernel. It does not add a PyTorch-side epilogue or duplicate the
  `O * dO` reduction.

  ## Related issues

  Fixes #418.

  Related to #405.

  ## API and compatibility impact

  No public API changes.

  The existing `D_qk=D_v` path is unchanged semantically. The `576/512` specialization now performs the same sink normalization and sink-gradient
  reduction as the equal-dimension path.

  ## Testing

  Tested on NVIDIA B300, SM103:

  - `test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py`
  - 7 passed
  - 1 skipped (SM90-only test)
  - All four existing sparse-attention backward parameter combinations passed, including the two previously failing `576/512` cases.
  - Added regression coverage for:
  - full top-k without `topk_length`
  - `topk_length = [1, 63, 64, 65, 512]`
  - `dq`, `dkv`, and `d_sink`
  - `black --check --fast --line-length 160 ...`
  - `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured sparse attention backward normalization consistently includes sink contributions across SM100 configurations.
  * Improved gradient correctness when sink mass must be folded into the normalization, including explicit per-query top-k length cases.

* **Tests**
  * Added an SM100-only regression test covering the 576/512 specialization, parameterized to validate both full-top-k and explicit per-query top-k length behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->