### PR TITLE
Support F64 compute data type for convolutions

### DIFF
--- a/include/cudnn_frontend/node/conv_dgrad.h
+++ b/include/cudnn_frontend/node/conv_dgrad.h
@@ -169,20 +169,20 @@ class DgradNode : public NodeCRTP<DgradNode> {
                                                        1,
                                                        &conv_desc_ptr));
 
-        float alpha = 1.0f;
-        float beta  = 0.0f;
+        bool const is_double = (attributes.compute_data_type == DataType_t::DOUBLE);
+        cudnnBackendAttributeType_t const attr_type = is_double ? CUDNN_TYPE_DOUBLE : CUDNN_TYPE_FLOAT;
 
-        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(dgrad_operation.get_raw_desc(),
-                                                       CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_DATA_ALPHA,
-                                                       CUDNN_TYPE_FLOAT,
-                                                       1,
-                                                       &alpha));
+        double const alpha_d = 1.0, beta_d = 0.0;
+        float  const alpha_f = 1.0f, beta_f = 0.0f;
 
-        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(dgrad_operation.get_raw_desc(),
-                                                       CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_DATA_BETA,
-                                                       CUDNN_TYPE_FLOAT,
-                                                       1,
-                                                       &beta));
+        void const* alpha = is_double ? static_cast<void const*>(&alpha_d) : static_cast<void const*>(&alpha_f);
+        void const* beta  = is_double ? static_cast<void const*>(&beta_d)  : static_cast<void const*>(&beta_f);
+
+        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(
+            dgrad_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_DATA_ALPHA, attr_type, 1, alpha));
+
+        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(
+            dgrad_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_DATA_BETA, attr_type, 1, beta));
 
         _CUDNN_CHECK_CUDNN_ERROR(detail::finalize(dgrad_operation.get_raw_desc()));
 

--- a/include/cudnn_frontend/node/conv_fprop.h
+++ b/include/cudnn_frontend/node/conv_fprop.h
@@ -217,21 +217,20 @@ class ConvolutionNode : public NodeCRTP<ConvolutionNode> {
                                                        1,
                                                        &conv_desc_ptr));
 
-        // Set alpha and beta
-        float alpha = 1.0f;
-        float beta  = 0.0f;
+        bool const is_double = (attributes.compute_data_type == DataType_t::DOUBLE);
+        cudnnBackendAttributeType_t const attr_type = is_double ? CUDNN_TYPE_DOUBLE : CUDNN_TYPE_FLOAT;
 
-        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(convolution_operation.get_raw_desc(),
-                                                       CUDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_ALPHA,
-                                                       CUDNN_TYPE_FLOAT,
-                                                       1,
-                                                       &alpha));
+        double const alpha_d = 1.0, beta_d = 0.0;
+        float  const alpha_f = 1.0f, beta_f = 0.0f;
 
-        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(convolution_operation.get_raw_desc(),
-                                                       CUDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_BETA,
-                                                       CUDNN_TYPE_FLOAT,
-                                                       1,
-                                                       &beta));
+        void const* alpha = is_double ? static_cast<void const*>(&alpha_d) : static_cast<void const*>(&alpha_f);
+        void const* beta  = is_double ? static_cast<void const*>(&beta_d)  : static_cast<void const*>(&beta_f);
+
+        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(
+            convolution_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_ALPHA, attr_type, 1, alpha));
+
+        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(
+            convolution_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_CONVOLUTION_FORWARD_BETA, attr_type, 1, beta));
 
         _CUDNN_CHECK_CUDNN_ERROR(detail::finalize(convolution_operation.get_raw_desc()));
 

--- a/include/cudnn_frontend/node/conv_wgrad.h
+++ b/include/cudnn_frontend/node/conv_wgrad.h
@@ -165,20 +165,20 @@ class WgradNode : public NodeCRTP<WgradNode> {
                                                        1,
                                                        &conv_desc_ptr));
 
-        float alpha = 1.0f;
-        float beta  = 0.0f;
+        bool const is_double = (attributes.compute_data_type == DataType_t::DOUBLE);
+        cudnnBackendAttributeType_t const attr_type = is_double ? CUDNN_TYPE_DOUBLE : CUDNN_TYPE_FLOAT;
 
-        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(wgrad_operation.get_raw_desc(),
-                                                       CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_FILTER_ALPHA,
-                                                       CUDNN_TYPE_FLOAT,
-                                                       1,
-                                                       &alpha));
+        double const alpha_d = 1.0, beta_d = 0.0;
+        float  const alpha_f = 1.0f, beta_f = 0.0f;
 
-        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(wgrad_operation.get_raw_desc(),
-                                                       CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_FILTER_BETA,
-                                                       CUDNN_TYPE_FLOAT,
-                                                       1,
-                                                       &beta));
+        void const* alpha = is_double ? static_cast<void const*>(&alpha_d) : static_cast<void const*>(&alpha_f);
+        void const* beta  = is_double ? static_cast<void const*>(&beta_d)  : static_cast<void const*>(&beta_f);
+
+        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(
+            wgrad_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_FILTER_ALPHA, attr_type, 1, alpha));
+
+        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(
+            wgrad_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_CONVOLUTION_BWD_FILTER_BETA, attr_type, 1, beta));
 
         _CUDNN_CHECK_CUDNN_ERROR(detail::finalize(wgrad_operation.get_raw_desc()));
 

--- a/include/cudnn_frontend/node/pointwise.h
+++ b/include/cudnn_frontend/node/pointwise.h
@@ -262,15 +262,20 @@ class PointwiseNode : public NodeCRTP<PointwiseNode> {
             }
         }
 
-        // Set alpha scaling factors (always set to 1.0)
-        float alpha1 = 1.0f;
-        float alpha2 = 1.0f;
+        bool const is_double = (attributes.compute_data_type == DataType_t::DOUBLE);
+        cudnnBackendAttributeType_t const attr_type = is_double ? CUDNN_TYPE_DOUBLE : CUDNN_TYPE_FLOAT;
+
+        double const alpha1_d = 1.0, alpha2_d = 1.0;
+        float  const alpha1_f = 1.0f, alpha2_f = 1.0f;
+
+        void const* alpha1 = is_double ? static_cast<void const*>(&alpha1_d) : static_cast<void const*>(&alpha1_f);
+        void const* alpha2 = is_double ? static_cast<void const*>(&alpha2_d) : static_cast<void const*>(&alpha2_f);
 
         _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(
-            pointwise_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_POINTWISE_ALPHA1, CUDNN_TYPE_FLOAT, 1, &alpha1));
+            pointwise_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_POINTWISE_ALPHA1, attr_type, 1, alpha1));
 
         _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(
-            pointwise_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_POINTWISE_ALPHA2, CUDNN_TYPE_FLOAT, 1, &alpha2));
+            pointwise_operation.get_raw_desc(), CUDNN_ATTR_OPERATION_POINTWISE_ALPHA2, attr_type, 1, alpha2));
 
         _CUDNN_CHECK_CUDNN_ERROR(detail::finalize(pointwise_operation.get_raw_desc()));
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated convolution forward, backward-data, and backward-filter operations to use alpha/beta scaling parameters in the correct precision for double-precision compute.
  * Adjusted pointwise operations to apply alpha scaling factors using matching double vs float attribute types, improving numerical consistency.
  * These changes ensure scaling parameters align with the selected compute data type for more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->