### PR TITLE
DSA backward SM100: reject topk_length entries < 1 (a zero entry hangs the kernel)

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
@@ -8,7 +8,7 @@ import cutlass
 import cutlass.cute as cute
 
 from cudnn.deepseek_sparse_attention.utils.compiler import compile_options
-from cudnn.deepseek_sparse_attention.utils.runtime import resolve_stream
+from cudnn.deepseek_sparse_attention.utils.runtime import resolve_stream, torch_stream_context
 from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor
 from .dsa_bwd_sm100 import FlashAttentionDSABackwardSm100
 
@@ -57,9 +57,11 @@ def flash_attn_bwd_sm100(
 
     Raises:
         ValueError: if any entry of ``topk_length`` is < 1 (validated outside
-            CUDA graph capture only -- during capture the required
-            device-to-host sync is not possible, and the caller must uphold
-            the precondition). A row with ``topk_length == 0`` gives the
+            CUDA graph capture only -- capture is detected on the resolved
+            launch stream, i.e. the explicit ``current_stream`` when one is
+            given, and the required device-to-host sync runs on that stream;
+            during capture the sync is not possible, and the caller must
+            uphold the precondition). A row with ``topk_length == 0`` gives the
             kernel zero KV tiles to process, for which it has no defined
             behavior: on the configuration we tested (B200, head_dim 512,
             topk 512) the kernel never terminates -- the launch hangs at
@@ -84,22 +86,30 @@ def flash_attn_bwd_sm100(
         tensors_to_check.append(topk_length)
     assert all(t.is_cuda for t in tensors_to_check)
 
-    if topk_length is not None and not torch.cuda.is_current_stream_capturing():
+    current_stream = resolve_stream(current_stream)
+
+    if topk_length is not None:
         # topk_length == 0 makes tile_count == 0 in the kernel, which has no
         # defined behavior: measured on B200 (head_dim 512, topk 512) the
         # launch hangs at 100% SM until killed. Code inspection suggests a
         # zero-tile pipeline deadlock, and that a zero-tile token reaching
         # the dq epilogue would store accumulator TMEM no MMA has written.
-        # Fail loudly here instead. Skipped under CUDA graph capture, where
-        # the required device-to-host sync is illegal -- the precondition
-        # itself still applies (documented above).
-        if bool((topk_length < 1).any()):
-            raise ValueError(
-                "topk_length must be >= 1 for every query: a row with topk_length == 0 "
-                "gives the SM100 backward kernel zero KV tiles, for which it has no "
-                "defined behavior (observed to hang the launch). Drop empty rows from "
-                "the batch or prevent them upstream."
-            )
+        # Fail loudly here instead. The guard binds to the resolved launch
+        # stream: capture detection and the device-to-host sync both run on
+        # ``current_stream`` (not on whatever torch stream happens to be
+        # current), so an explicit-stream capture is skipped correctly and
+        # the sync is ordered after the caller's producer work on that
+        # stream. Skipped under CUDA graph capture, where the required
+        # device-to-host sync is illegal -- the precondition itself still
+        # applies (documented above).
+        with torch_stream_context(current_stream):
+            if not torch.cuda.is_current_stream_capturing() and bool((topk_length < 1).any()):
+                raise ValueError(
+                    "topk_length must be >= 1 for every query: a row with topk_length == 0 "
+                    "gives the SM100 backward kernel zero KV tiles, for which it has no "
+                    "defined behavior (observed to hang the launch). Drop empty rows from "
+                    "the batch or prevent them upstream."
+                )
 
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
@@ -159,7 +169,6 @@ def flash_attn_bwd_sm100(
     problem_shape = (total_S_q, total_S_kv, head_dim, (num_head, batch_size))
 
     dtype = torch2cute_dtype_map[q.dtype]
-    current_stream = resolve_stream(current_stream)
 
     has_topk_length = topk_length is not None
     max_topk = topk_idxs.shape[1]

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm100.py
@@ -47,12 +47,27 @@ def flash_attn_bwd_sm100(
         attn_sink: (nheads,) float32
         topk_idxs: (total_S_q, topk_max) int32, global indices
         softmax_scale: float (default: 1/sqrt(headdim))
-        topk_length: (total_S_q,) int32, per-query valid count, optional
+        topk_length: (total_S_q,) int32, per-query valid count, optional.
+            Every entry must be >= 1 (see Raises).
         dq: pre-allocated (total_S_q, nheads, headdim), optional
         dkv: pre-allocated (total_S_kv, headdim), optional
 
     Returns:
         (dq, dkv, d_sink) -- flat layout gradients
+
+    Raises:
+        ValueError: if any entry of ``topk_length`` is < 1 (validated outside
+            CUDA graph capture only -- during capture the required
+            device-to-host sync is not possible, and the caller must uphold
+            the precondition). A row with ``topk_length == 0`` gives the
+            kernel zero KV tiles to process, for which it has no defined
+            behavior: on the configuration we tested (B200, head_dim 512,
+            topk 512) the kernel never terminates -- the launch hangs at
+            100% SM until killed. Code inspection suggests a zero-tile
+            pipeline deadlock, and that a zero-tile token reaching the dq
+            epilogue would store accumulator TMEM no MMA has written. Drop
+            empty rows from the batch (or prevent them upstream of this
+            call).
     """
     total_S_q, num_head, head_dim = q.shape
     total_S_kv = kv.shape[0]
@@ -68,6 +83,23 @@ def flash_attn_bwd_sm100(
     if topk_length is not None:
         tensors_to_check.append(topk_length)
     assert all(t.is_cuda for t in tensors_to_check)
+
+    if topk_length is not None and not torch.cuda.is_current_stream_capturing():
+        # topk_length == 0 makes tile_count == 0 in the kernel, which has no
+        # defined behavior: measured on B200 (head_dim 512, topk 512) the
+        # launch hangs at 100% SM until killed. Code inspection suggests a
+        # zero-tile pipeline deadlock, and that a zero-tile token reaching
+        # the dq epilogue would store accumulator TMEM no MMA has written.
+        # Fail loudly here instead. Skipped under CUDA graph capture, where
+        # the required device-to-host sync is illegal -- the precondition
+        # itself still applies (documented above).
+        if bool((topk_length < 1).any()):
+            raise ValueError(
+                "topk_length must be >= 1 for every query: a row with topk_length == 0 "
+                "gives the SM100 backward kernel zero KV tiles, for which it has no "
+                "defined behavior (observed to hang the launch). Drop empty rows from "
+                "the batch or prevent them upstream."
+            )
 
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/api.py
@@ -152,6 +152,13 @@ def sparse_attention_backward_wrapper(
 
     Dispatches to SM90 or SM100 based on the active CUDA device. The returned
     ``d_sink`` is computed from ``attn_sink`` and ``dout``.
+
+    ``topk_length``, when provided, must be >= 1 for every query. The SM100
+    path validates this outside CUDA graph capture and raises ``ValueError``
+    (under capture the required sync is not possible and the caller must
+    uphold the precondition): a row with ``topk_length == 0`` has no defined
+    kernel behavior -- on the configuration we tested the launch hangs until
+    killed (see ``_interface_sm100.flash_attn_bwd_sm100``).
     """
     key = (
         q.dtype,

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/api.py
@@ -154,7 +154,8 @@ def sparse_attention_backward_wrapper(
     ``d_sink`` is computed from ``attn_sink`` and ``dout``.
 
     ``topk_length``, when provided, must be >= 1 for every query. The SM100
-    path validates this outside CUDA graph capture and raises ``ValueError``
+    path validates this on the launch stream (the explicit ``stream`` when
+    one is given) outside CUDA graph capture and raises ``ValueError``
     (under capture the required sync is not possible and the caller must
     uphold the precondition): a row with ``topk_length == 0`` has no defined
     kernel behavior -- on the configuration we tested the launch hangs until

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -357,7 +357,7 @@ def test_DSA_sparse_attention_backward_topk_length_zero_raises():
             )
 
 
-@pytest.mark.L0
+@pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 def test_DSA_sparse_attention_backward_topk_length_guard_explicit_stream():
     """The topk_length guard must bind to the resolved launch stream.

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -315,14 +315,19 @@ def test_DSA_sparse_attention_backward_topk_length_zero_raises():
     whose topk_length contains zeros hangs until killed. The interface
     validates the precondition (outside CUDA graph capture) and raises
     before launch; this test exercises that guard path.
+
+    L0 is intentional: the guard raises before the interface consults its
+    compile cache, and ``SparseAttentionBackward.compile()`` defers kernel
+    compilation to ``execute()`` (see api.py), so this test pays no CuTe
+    compilation cost even on a cold cache.
     """
     try:
         from cudnn import DSA
     except ImportError:
         pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
 
-    major, _ = torch.cuda.get_device_capability()
-    if major != 10:
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
         pytest.skip("the topk_length >= 1 guard is implemented on the SM100 interface")
 
     s_q, s_kv, h, d, d_v, topk = 8, 256, 64, 576, 512, 64
@@ -350,3 +355,86 @@ def test_DSA_sparse_attention_backward_topk_length_zero_raises():
                 softmax_scale=1.0 / math.sqrt(d),
                 topk_length=topk_length,
             )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_sparse_attention_backward_topk_length_guard_explicit_stream():
+    """The topk_length guard must bind to the resolved launch stream.
+
+    ``sparse_attention_backward_wrapper(..., stream=...)`` forwards an
+    explicit launch stream to the SM100 interface; the guard's capture
+    detection and its device-to-host sync must run on that stream, not on
+    whatever torch stream happens to be current at call time:
+
+    - outside capture, a zero row is rejected even when the launch targets
+      an explicit, non-current stream (the sync is ordered on that stream);
+    - while the explicit stream IS capturing and the torch-current stream
+      is a different, non-capturing stream, the guard must detect the
+      capture on the resolved stream and skip validation -- the documented
+      capture semantics (the caller upholds the precondition) -- instead of
+      syncing mid-capture. The captured graph is never replayed (a replay
+      would launch the kernel with a zero-length row).
+    """
+    try:
+        import cuda.bindings.driver as cuda_driver
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip("the topk_length >= 1 guard is implemented on the SM100 interface")
+
+    s_q, s_kv, h, d, d_v, topk = 8, 256, 64, 576, 512, 64
+    device = "cuda"
+    q = torch.randn(s_q, h, d, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(s_kv, d, dtype=torch.bfloat16, device=device)
+    out = torch.randn(s_q, h, d_v, dtype=torch.bfloat16, device=device)
+    dout = torch.randn_like(out)
+    lse = torch.randn(s_q, h, dtype=torch.float32, device=device)
+    attn_sink = torch.randn(h, dtype=torch.float32, device=device)
+    topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
+
+    side_stream = torch.cuda.Stream()
+
+    def call(topk_length):
+        return DSA.sparse_attention_backward_wrapper(
+            q,
+            kv,
+            out,
+            dout,
+            lse,
+            attn_sink,
+            topk_idxs,
+            softmax_scale=1.0 / math.sqrt(d),
+            topk_length=topk_length,
+            stream=cuda_driver.CUstream(side_stream.cuda_stream),
+        )
+
+    bad_topk_length = torch.full((s_q,), topk, dtype=torch.int32, device=device)
+    bad_topk_length[3] = 0
+
+    # Outside capture, an explicit non-current launch stream still rejects
+    # zero rows (raises before the interface's compile cache is consulted).
+    with pytest.raises(ValueError, match="topk_length"):
+        call(bad_topk_length)
+
+    # Warm the compile cache off the capture path: capture must not compile.
+    good_topk_length = torch.full((s_q,), topk, dtype=torch.int32, device=device)
+    call(good_topk_length)
+    torch.cuda.synchronize()
+
+    # Capture on the explicit stream while the torch-current stream is a
+    # different, non-capturing stream. The guard must see the capture on the
+    # resolved stream and skip its sync; the pre-fix guard consulted the
+    # torch-current stream instead, ran the validation mid-capture, and
+    # raised here. Relaxed capture mode keeps the interface's unrelated
+    # eager work (output/workspace allocation) legal during capture.
+    other_stream = torch.cuda.Stream()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=side_stream, capture_error_mode="relaxed"):
+        with torch.cuda.stream(other_stream):
+            assert not torch.cuda.is_current_stream_capturing(), "the guard must not rely on the torch-current stream"
+            call(bad_topk_length)
+    del graph

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -302,3 +302,51 @@ def test_DSA_sparse_attention_backward_staged_store():
 
     assert rel_l2(dkv, dkv_ref) < 1e-4, "dkv parity vs stage-1 baseline"
     assert rel_l2(d_sink, d_sink_ref) < 1e-4, "d_sink parity vs stage-1 baseline"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_sparse_attention_backward_topk_length_zero_raises():
+    """Rows with topk_length == 0 must be rejected loudly on SM100.
+
+    A zero entry gives the kernel zero KV tiles for that token
+    (tile_count == 0 in dsa_bwd_sm100), which has no defined behavior:
+    measured at s_q=128, s_kv=4096, head_dim=512, topk=512 on B200, a call
+    whose topk_length contains zeros hangs until killed. The interface
+    validates the precondition (outside CUDA graph capture) and raises
+    before launch; this test exercises that guard path.
+    """
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    major, _ = torch.cuda.get_device_capability()
+    if major != 10:
+        pytest.skip("the topk_length >= 1 guard is implemented on the SM100 interface")
+
+    s_q, s_kv, h, d, d_v, topk = 8, 256, 64, 576, 512, 64
+    device = "cuda"
+    q = torch.randn(s_q, h, d, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(s_kv, d, dtype=torch.bfloat16, device=device)
+    out = torch.randn(s_q, h, d_v, dtype=torch.bfloat16, device=device)
+    dout = torch.randn_like(out)
+    lse = torch.randn(s_q, h, dtype=torch.float32, device=device)
+    attn_sink = torch.randn(h, dtype=torch.float32, device=device)
+    topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
+
+    for bad_value in (0, -3):
+        topk_length = torch.full((s_q,), topk, dtype=torch.int32, device=device)
+        topk_length[3] = bad_value
+        with pytest.raises(ValueError, match="topk_length"):
+            DSA.sparse_attention_backward_wrapper(
+                q,
+                kv,
+                out,
+                dout,
+                lse,
+                attn_sink,
+                topk_idxs,
+                softmax_scale=1.0 / math.sqrt(d),
+                topk_length=topk_length,
+            )


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran the repo's Python formatting hook (black 26.3.1 `-l 160`) and committed any changes — files unchanged. (clang-format n/a: Python only.)

## Affected area

FE OSS kernels or CuTeDSL

## Summary

`sparse_attention_backward` accepts a per-query `topk_length`, but the SM100
kernel has no defined behavior for a zero entry. In `dsa_bwd_sm100.py` the
per-token tile count is

```python
topk = mTopkLength[token_idx]
...
tile_count = cute.ceil_div(topk, self.block_tile)
```

with no zero guard. In practice a `topk_length` containing zero entries
**hangs the launch**: on the configuration we measured, the call never
returns — 100% SM utilization until the process is SIGKILLed — while the
identical call with every length >= 1 completes normally. Code inspection
suggests a zero-tile pipeline deadlock (the warp-specialized stages have no
tiles to hand through for that token), and that a zero-tile token reaching
the dq epilogue would store accumulator TMEM that no MMA has written; the
mathematically correct dq for a query attending to nothing is exactly 0.

This PR adds minimal interface validation, with no kernel changes:

- `_interface_sm100.flash_attn_bwd_sm100` raises `ValueError` when any
  `topk_length` entry is `< 1`. Zero entries are the measured hazard;
  negative values are rejected by the same check. The check needs a
  device-to-host sync, so it runs **outside CUDA graph capture only** —
  under capture the caller must uphold the precondition, which the
  docstrings state explicitly;
- the precondition is documented on the interface and on
  `sparse_attention_backward_wrapper`;
- a test locks the guard in (`0` and a negative value both raise).

We deliberately did **not** implement kernel-side support (skipping the
pipeline handshake and zero-filling dq for zero-tile tokens): that is a
semantic decision about whether empty rows are supported input, and it
touches the same kernel region #421 is currently changing. If you would
rather support `topk_length == 0` in the kernel, we are happy to follow up
with that variant instead — this guard simply becomes removable in that
world.

## Why

Repro on unmodified develop @3a9ed3f (B200, CUDA 13.3, nvidia-cutlass-dsl
4.6.1, torch 2.13): s_q=128, s_kv=4096, h=64, head_dim=head_dim_v=512,
topk=512; `topk_length[{3, 64, 127}] = 0` (3 of 128 rows), all other rows
512:

```
STEP: priming...                                   # all topk_length = 512
priming run finished; max|dq_ok| = 5.71875         # ~40 s incl. first-call JIT
STEP: bad run 1...                                 # topk_length[{3,64,127}] = 0
<never returns — killed after 66 minutes>
```

While hung: GPU at 100% utilization, host thread parked in
`torch.cuda.synchronize()` (py-spy), no forward progress. Reproduces from a
fresh process. With this PR the same call raises `ValueError` up front.

The current test generator floors lengths at 1
(`torch.randint(1, topk_k + 1, ...)`), so nothing in CI exercises 0 — the
case is reachable only from user input, which is exactly the case that
should fail loudly rather than hang the device.

## Related issues

None filed; found while auditing the DSA OSS kernel contracts. Adjacent but
independent of #421 (which changes the same kernel's sink normalization and
extends the same test file — this PR touches only the Python interface layer
plus one appended test; trivial to rebase in either order).

## API and compatibility impact

- Calls with any `topk_length` entry `< 1` now raise `ValueError` outside
  CUDA graph capture (previously: zero entries hung the device on the
  configuration we measured). Under capture the check cannot run and the
  documented precondition applies. Calls satisfying the precondition are
  unaffected in behavior.
- Cost on valid calls: one `(topk_length < 1).any()` reduction + D2H sync
  per call on the SM100 path (skipped under capture). If that is unwanted on
  hot paths, we can gate it behind an env var or debug flag instead —
  maintainer preference.
- SM90 path: not investigated (we have no SM90 evidence either way), so the
  guard is scoped to the SM100 interface where the failure is demonstrated.

## Testing

Environment: B200 (SM100), CUDA 13.3, nvidia-cutlass-dsl 4.6.1, torch 2.13.

- Full `test/python/fe_api/dsa` suite on this branch: **4 failed, 27 passed,
  4 skipped** — the failure set is identical to unpatched develop @3a9ed3f
  (2× `test_DSA_indexer_top_k[705]`, 2×
  `test_DSA_sparse_attention_backward_wrapper[576]`, pre-existing and in
  #421's scope); the +1 passed is the new guard test.
- New test: `test_DSA_sparse_attention_backward_topk_length_zero_raises`
  (the guard raises before any kernel compile/launch, so it runs in ~1 s).
  The hang itself was demonstrated with the separate repro configuration
  above, not by this test.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added SM100-specific pre-launch validation for sparse-attention backward to reject `topk_length` entries less than 1 (including `0` and negatives), raising a clear `ValueError`.
  * Clarified that this validation is skipped during CUDA graph capture due to undefined behavior for `topk_length == 0`.
  * Improved behavior guidance when invalid values are provided outside capture (callers should prevent empty rows upstream).

* **Tests**
  * Added regression coverage for invalid `topk_length` rejection.
  * Added capture-aware tests, including scenarios with an explicitly provided non-current launch stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->