### PR TITLE
Remove personal copyright notice from SM90 backward barriers

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/utils/sm90/bwd_barriers.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/sm90/bwd_barriers.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2025, Jay Shah, Ganesh Bikshandi, Ying Zhang, Vijay Thakkar, Pradeep Ramani, Tri Dao.
-# Copyright (c) 2026, Jerry Chen
 """SM90 named-barrier id table for the FA / DSA backward kernels.
 
 SM90 hardware named barriers are addressed by a 4-bit operand: only ids in


### PR DESCRIPTION
  ## Before submitting

  - [ ] I agree to license this contribution under the terms of LICENSE.txt.
  - [ ] I ran `pre-commit run` and committed any formatting changes.

  ## Affected area

  FE OSS kernels or CuTeDSL

  ## Summary

  Remove the personal Jerry Chen copyright notice from
  `python/cudnn/deepseek_sparse_attention/utils/sm90/bwd_barriers.py`.

  The existing multi-author copyright notice and all executable code remain unchanged.

  ## Why

  This is a narrowly scoped licensing cleanup ahead of the repository's transition to Apache-2.0.

  ## Related issues

  None.

  ## API and compatibility impact

  None.

  ## Testing

  - `git diff --check` passed.
  - Python AST parsing passed.
  - No runtime tests were required because this is a comment-only change.
  - `pre-commit` was not available in the local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright attribution and year information.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->