### PR TITLE
Optimize single-group grouped GEMM metadata

### DIFF
--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dglu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dglu.md
@@ -546,6 +546,10 @@ Returns a `TupleDict` (dictionary + tuple unpacking):
 - Expert count must be `<= 1024`
 - Each group's M dimension is aligned to `m_aligned` (256)
 - In the class API, `dbias` is compiled in only when `sample_dbias` is provided; passing a runtime `dbias_tensor` without `sample_dbias` raises `ValueError`
+- `use_single_group_runtime_offsets=True` is supported only by the block-scaled
+  kernel with exactly one expert. In this mode the kernel derives
+  `padded_offsets[0]` from runtime `A.shape[0]` and does not load its value from
+  device memory; the argument must still be an int32 tensor with shape `(1,)`.
 
 ### Environment
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_glu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_glu.md
@@ -519,6 +519,10 @@ Returns a `TupleDict` (dictionary + tuple unpacking):
 - Expert count must be `<= 1024`
 - Each group's M dimension is aligned to `m_aligned` (256)
 - All supported kernel configurations require `mma_tiler_mn[1] == 256`
+- `use_single_group_runtime_offsets=True` is supported only by the block-scaled
+  kernel with exactly one expert. In this mode the kernel derives
+  `padded_offsets[0]` from runtime `A.shape[0]` and does not load its value from
+  device memory; the argument must still be an int32 tensor with shape `(1,)`.
 
 ### Environment
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_quant_unified.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_quant_unified.md
@@ -239,6 +239,10 @@ Returns `TupleDict`: `d_tensor`, `d_col_tensor` (optional; `None` for `bfloat16`
 - Expert count `<= 1024`; M aligned to 256
 - SM100+ compute capability required
 - `prob_tensor` is unconditionally required
+- `use_single_group_runtime_offsets=True` requires exactly one expert. The
+  kernel derives `padded_offsets[0]` from runtime `A.shape[0]` and does not load
+  its value from device memory; the argument must still be an int32 tensor with
+  shape `(1,)`.
 
 ---
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/_blockscaled_api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/_blockscaled_api.py
@@ -109,8 +109,8 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
         sample_padded_offsets: torch.Tensor,
         sample_alpha: torch.Tensor,
         sample_beta: torch.Tensor,
-        sample_prob: torch.Tensor,
-        sample_dprob: torch.Tensor,
+        sample_prob: Optional[torch.Tensor],
+        sample_dprob: Optional[torch.Tensor],
         # Dense mode (contiguous) -- provide these. sample_dbias is optional:
         sample_b: Optional[torch.Tensor] = None,
         sample_sfb: Optional[torch.Tensor] = None,
@@ -136,6 +136,7 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
         b_major: str = "k",
         epilogue_op: Optional[str] = None,
         use_dynamic_sched: bool = False,
+        use_single_group_runtime_offsets: bool = False,
         linear_offset: Optional[float] = None,
         geglu_alpha: float = 1.702,
         glu_clamp_max: float = 7.0,
@@ -266,6 +267,11 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
             raise ValueError(f"Invalid epilogue operation: {epilogue_op}. " f"Valid values: None, 'none', 'identity', 'relu', 'srelu'")
 
         self.use_dynamic_sched = use_dynamic_sched
+        self._value_error_if(
+            use_single_group_runtime_offsets and self.expert_cnt != 1,
+            "use_single_group_runtime_offsets requires exactly one expert",
+        )
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
         if linear_offset is None:
             self.linear_offset = 1.0 if self.act_func == "dgeglu" else 0.0
         else:
@@ -682,6 +688,7 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
             weight_mode=self.weight_mode,
             act_func=self.act_func,
             use_dynamic_sched=self.use_dynamic_sched,
+            use_single_group_runtime_offsets=self.use_single_group_runtime_offsets,
         )
 
         hardware_info = cutlass.utils.HardwareInfo()
@@ -751,16 +758,20 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
             sfb_cute_fake = self._make_fake_cute_tensor_from_desc(self.sfb_desc, assumed_align=16)
 
             beta_cute_fake = self._make_fake_cute_tensor_from_desc(self.beta_desc, assumed_align=16)
-            prob_cute_fake = self._make_fake_cute_compact_tensor(
-                dtype=self.prob_desc.dtype,
-                shape=(valid_m, 1, 1),
-                stride_order=self.prob_desc.stride_order,
-            )
-            dprob_cute_fake = self._make_fake_cute_compact_tensor(
-                dtype=self.dprob_desc.dtype,
-                shape=(valid_m, 1, 1),
-                stride_order=self.dprob_desc.stride_order,
-            )
+            prob_cute_fake = None
+            if self.prob_desc is not None:
+                prob_cute_fake = self._make_fake_cute_compact_tensor(
+                    dtype=self.prob_desc.dtype,
+                    shape=(valid_m, 1, 1),
+                    stride_order=self.prob_desc.stride_order,
+                )
+            dprob_cute_fake = None
+            if self.dprob_desc is not None:
+                dprob_cute_fake = self._make_fake_cute_compact_tensor(
+                    dtype=self.dprob_desc.dtype,
+                    shape=(valid_m, 1, 1),
+                    stride_order=self.dprob_desc.stride_order,
+                )
 
             sfd_row_fake = None
             sfd_col_fake = None
@@ -852,16 +863,20 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
             )
 
             beta_cute_fake = self._make_fake_cute_tensor_from_desc(self.beta_desc, assumed_align=16)
-            prob_cute_fake = self._make_fake_cute_tensor(
-                dtype=self.prob_desc.dtype,
-                shape=(valid_m, *self.prob_desc.shape[1:]),
-                stride=self.prob_desc.stride,
-            )
-            dprob_cute_fake = self._make_fake_cute_tensor(
-                dtype=self.dprob_desc.dtype,
-                shape=(valid_m, *self.dprob_desc.shape[1:]),
-                stride=self.dprob_desc.stride,
-            )
+            prob_cute_fake = None
+            if self.prob_desc is not None:
+                prob_cute_fake = self._make_fake_cute_tensor(
+                    dtype=self.prob_desc.dtype,
+                    shape=(valid_m, *self.prob_desc.shape[1:]),
+                    stride=self.prob_desc.stride,
+                )
+            dprob_cute_fake = None
+            if self.dprob_desc is not None:
+                dprob_cute_fake = self._make_fake_cute_tensor(
+                    dtype=self.dprob_desc.dtype,
+                    shape=(valid_m, *self.dprob_desc.shape[1:]),
+                    stride=self.dprob_desc.stride,
+                )
 
             sfd_row_fake = None
             sfd_col_fake = None
@@ -940,8 +955,8 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
             padded_offsets: torch.Tensor,
             alpha_tensor: torch.Tensor,
             beta_tensor: torch.Tensor,
-            prob_tensor: torch.Tensor,
-            dprob_tensor: torch.Tensor,
+            prob_tensor: Optional[torch.Tensor],
+            dprob_tensor: Optional[torch.Tensor],
             dbias_tensor: Optional[torch.Tensor],
             stream: cuda.CUstream,
         ) -> None:
@@ -1051,18 +1066,22 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
         padded_offsets_tensor = self._make_fake_cute_tensor_from_desc(self.padded_offsets_desc, assumed_align=16)
         alpha_tensor = self._make_fake_cute_tensor_from_desc(self.alpha_desc, assumed_align=16)
         beta_tensor = self._make_fake_cute_tensor_from_desc(self.beta_desc, assumed_align=16)
-        prob_tensor = self._make_fake_cute_tensor(
-            dtype=self.prob_desc.dtype,
-            shape=(valid_m, *self.prob_desc.shape[1:]),
-            stride=self.prob_desc.stride,
-            assumed_align=16,
-        )
-        dprob_tensor = self._make_fake_cute_tensor(
-            dtype=self.dprob_desc.dtype,
-            shape=(valid_m, *self.dprob_desc.shape[1:]),
-            stride=self.dprob_desc.stride,
-            assumed_align=16,
-        )
+        prob_tensor = None
+        if self.prob_desc is not None:
+            prob_tensor = self._make_fake_cute_tensor(
+                dtype=self.prob_desc.dtype,
+                shape=(valid_m, *self.prob_desc.shape[1:]),
+                stride=self.prob_desc.stride,
+                assumed_align=16,
+            )
+        dprob_tensor = None
+        if self.dprob_desc is not None:
+            dprob_tensor = self._make_fake_cute_tensor(
+                dtype=self.dprob_desc.dtype,
+                shape=(valid_m, *self.dprob_desc.shape[1:]),
+                stride=self.dprob_desc.stride,
+                assumed_align=16,
+            )
         dbias_tensor = self._make_fake_cute_tensor_from_desc(self.dbias_desc, assumed_align=16)
 
         # Compile-time pointer placeholders
@@ -1133,8 +1152,8 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
             padded_offsets: torch.Tensor,
             alpha_tensor: torch.Tensor,
             beta_tensor: torch.Tensor,
-            prob_tensor: torch.Tensor,
-            dprob_tensor: torch.Tensor,
+            prob_tensor: Optional[torch.Tensor],
+            dprob_tensor: Optional[torch.Tensor],
             dbias_tensor: Optional[torch.Tensor],
             stream: cuda.CUstream,
         ) -> None:
@@ -1183,8 +1202,8 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
         padded_offsets: torch.Tensor,
         alpha_tensor: torch.Tensor,
         beta_tensor: torch.Tensor,
-        prob_tensor: torch.Tensor,
-        dprob_tensor: torch.Tensor,
+        prob_tensor: Optional[torch.Tensor],
+        dprob_tensor: Optional[torch.Tensor],
         # Dense mode:
         b_tensor: Optional[torch.Tensor] = None,
         sfb_tensor: Optional[torch.Tensor] = None,

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/api.py
@@ -85,8 +85,8 @@ class DgluCall:
     padded_offsets: torch.Tensor
     alpha_tensor: torch.Tensor
     beta_tensor: torch.Tensor
-    prob_tensor: torch.Tensor
-    dprob_tensor: torch.Tensor
+    prob_tensor: Optional[torch.Tensor]
+    dprob_tensor: Optional[torch.Tensor]
     b_tensor: Optional[torch.Tensor] = None
     sfb_tensor: Optional[torch.Tensor] = None
     generate_dbias: bool = False
@@ -112,6 +112,7 @@ class DgluCall:
     glu_clamp_min: float = -7.0
     epilogue_op: Optional[str] = None
     use_dynamic_sched: bool = False
+    use_single_group_runtime_offsets: bool = False
     current_stream: Optional[cuda.CUstream] = None
     weight_mode: Optional[MoEWeightMode] = None
     b_shape: Optional[Tuple[int, ...]] = None
@@ -151,8 +152,8 @@ class GroupedGemmDgluSm100(APIBase):
         sample_padded_offsets: torch.Tensor,
         sample_alpha: torch.Tensor,
         sample_beta: torch.Tensor,
-        sample_prob: torch.Tensor,
-        sample_dprob: torch.Tensor,
+        sample_prob: Optional[torch.Tensor],
+        sample_dprob: Optional[torch.Tensor],
         *args: Any,
         **kwargs: Any,
     ) -> None: ...
@@ -167,8 +168,8 @@ class GroupedGemmDgluSm100(APIBase):
         sample_padded_offsets: torch.Tensor,
         sample_alpha: torch.Tensor,
         sample_beta: torch.Tensor,
-        sample_prob: torch.Tensor,
-        sample_dprob: torch.Tensor,
+        sample_prob: Optional[torch.Tensor],
+        sample_dprob: Optional[torch.Tensor],
         sample_b: Optional[torch.Tensor] = None,
         sample_sfb: Optional[torch.Tensor] = None,
         sample_dbias: Optional[torch.Tensor] = None,
@@ -190,6 +191,7 @@ class GroupedGemmDgluSm100(APIBase):
         b_major: str = "k",
         epilogue_op: Optional[str] = None,
         use_dynamic_sched: bool = False,
+        use_single_group_runtime_offsets: bool = False,
         linear_offset: Optional[float] = None,
         geglu_alpha: float = 1.702,
         glu_clamp_max: float = 7.0,
@@ -309,8 +311,8 @@ class GroupedGemmDgluSm100(APIBase):
         padded_offsets: torch.Tensor,
         alpha_tensor: torch.Tensor,
         beta_tensor: torch.Tensor,
-        prob_tensor: torch.Tensor,
-        dprob_tensor: torch.Tensor,
+        prob_tensor: Optional[torch.Tensor],
+        dprob_tensor: Optional[torch.Tensor],
         b_tensor: Optional[torch.Tensor] = None,
         *,
         sfb_tensor: Optional[torch.Tensor] = None,
@@ -331,8 +333,8 @@ class GroupedGemmDgluSm100(APIBase):
         padded_offsets: torch.Tensor,
         alpha_tensor: torch.Tensor,
         beta_tensor: torch.Tensor,
-        prob_tensor: torch.Tensor,
-        dprob_tensor: torch.Tensor,
+        prob_tensor: Optional[torch.Tensor],
+        dprob_tensor: Optional[torch.Tensor],
         b_tensor: Optional[torch.Tensor] = None,
         sfb_tensor: Optional[torch.Tensor] = None,
         dbias_tensor: Optional[torch.Tensor] = None,
@@ -508,6 +510,7 @@ def _grouped_gemm_dglu_block_scaled_call(call: DgluCall) -> TupleDict:
     glu_clamp_min = call.glu_clamp_min
     epilogue_op = call.epilogue_op
     use_dynamic_sched = call.use_dynamic_sched
+    use_single_group_runtime_offsets = call.use_single_group_runtime_offsets
     current_stream = call.current_stream
 
     # Resolve linear_offset default: None means "use the activation-derived
@@ -666,6 +669,7 @@ def _grouped_gemm_dglu_block_scaled_call(call: DgluCall) -> TupleDict:
             m_aligned,
             discrete_col_sfd,
             use_dynamic_sched,
+            use_single_group_runtime_offsets,
         )
     else:
         cache_key = (
@@ -703,6 +707,7 @@ def _grouped_gemm_dglu_block_scaled_call(call: DgluCall) -> TupleDict:
             m_aligned,
             discrete_col_sfd,
             use_dynamic_sched,
+            use_single_group_runtime_offsets,
             b_major,
             num_experts,
         )
@@ -742,6 +747,7 @@ def _grouped_gemm_dglu_block_scaled_call(call: DgluCall) -> TupleDict:
                 act_func=act_func,
                 epilogue_op=epilogue_op,
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
                 linear_offset=linear_offset,
                 geglu_alpha=geglu_alpha,
                 glu_clamp_max=glu_clamp_max,
@@ -778,6 +784,7 @@ def _grouped_gemm_dglu_block_scaled_call(call: DgluCall) -> TupleDict:
                 b_major=b_major,
                 epilogue_op=epilogue_op,
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
                 linear_offset=linear_offset,
                 geglu_alpha=geglu_alpha,
                 glu_clamp_max=glu_clamp_max,
@@ -922,6 +929,11 @@ def _normalize_dglu_call(
     )
     if backend is GroupedGemmBackend.BLOCK_SCALED:
         return normalized, backend
+
+    if call.use_single_group_runtime_offsets:
+        raise ValueError("use_single_group_runtime_offsets is supported only by the block-scaled kernel")
+    if call.prob_tensor is None or call.dprob_tensor is None:
+        raise ValueError("BF16 grouped GEMM dGLU requires prob_tensor and dprob_tensor")
 
     if call.cd_major != "n":
         raise ValueError(f"cd_major must be 'n', got {call.cd_major}")
@@ -1128,8 +1140,8 @@ def grouped_gemm_dglu_wrapper_sm100(
     padded_offsets: torch.Tensor,
     alpha_tensor: torch.Tensor,
     beta_tensor: torch.Tensor,
-    prob_tensor: torch.Tensor,
-    dprob_tensor: torch.Tensor,
+    prob_tensor: Optional[torch.Tensor],
+    dprob_tensor: Optional[torch.Tensor],
     b_tensor: Optional[torch.Tensor] = None,
     sfb_tensor: Optional[torch.Tensor] = None,
     generate_dbias: bool = False,
@@ -1155,6 +1167,7 @@ def grouped_gemm_dglu_wrapper_sm100(
     glu_clamp_min: float = -7.0,
     epilogue_op: Optional[str] = None,
     use_dynamic_sched: bool = False,
+    use_single_group_runtime_offsets: bool = False,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Dispatch grouped GEMM dGLU once from an immutable normalized call."""
@@ -1192,6 +1205,7 @@ def grouped_gemm_dglu_wrapper_sm100(
         glu_clamp_min=glu_clamp_min,
         epilogue_op=epilogue_op,
         use_dynamic_sched=use_dynamic_sched,
+        use_single_group_runtime_offsets=use_single_group_runtime_offsets,
         current_stream=current_stream,
     )
     normalized, backend = _normalize_dglu_call(call)

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/api.py
@@ -233,6 +233,10 @@ class GroupedGemmDgluSm100(APIBase):
             if self.linear_offset is None:
                 self.linear_offset = 1.0 if kwargs["act_func"] == "dgeglu" else 0.0
             if backend is GroupedGemmBackend.BF16:
+                self._value_error_if(
+                    kwargs["use_single_group_runtime_offsets"],
+                    "use_single_group_runtime_offsets is supported only by the block-scaled kernel",
+                )
                 self._implementation = GroupedGemmDgluBf16API(
                     sample_a=kwargs["sample_a"],
                     sample_c=kwargs["sample_c"],

--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_blockscaled_grouped_gemm_dglu_dbias.py
@@ -285,6 +285,7 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
         weight_mode: MoEWeightMode = MoEWeightMode.DISCRETE,
         use_dynamic_sched: bool = False,
         act_func: str = "dswiglu",
+        use_single_group_runtime_offsets: bool = False,
     ):
         """Initializes the configuration for a Blackwell blockscaled grouped GEMM dGLU kernel.
 
@@ -327,11 +328,14 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
             )
         if expert_cnt > 1024:
             raise ValueError("Expert count > 1024 is not supported.")
+        if use_single_group_runtime_offsets and expert_cnt != 1:
+            raise ValueError("use_single_group_runtime_offsets requires exactly one expert")
         if not isinstance(weight_mode, MoEWeightMode):
             raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
 
         self.sf_vec_size = sf_vec_size
         self.expert_cnt = expert_cnt
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn
@@ -587,9 +591,6 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
         # To prefetch more accumulator when overlapping_accum is enabled in epilogue
         self.epilogue_prefetch_more = self.d_dtype.width == 8 and self.a_dtype.width == 8
 
-        # To generate dprob
-        self.generate_dprob = True
-
         # Use ptx fp8 fp32 convert
         self.use_fp8_ptx_cvt = True
 
@@ -785,6 +786,8 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
         # dBias configuration
         self.generate_dbias = dbias_tensor is not None
         self.dbias_cross_warp_reduce = self.generate_dbias  # always cross-warp reduce
+        self.has_prob = prob is not None
+        self.generate_dprob = dprob is not None
 
         # Check if input data types are compatible with MMA instruction
         if cutlass.const_expr(self.a_dtype != self.b_dtype):
@@ -1800,10 +1803,12 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
                         (acc_vec[i + 0], acc_vec[i + 1]),
                     )
                 # calculate dswiglu
-                acc_vec_prob = cute.arch.mul_packed_f32x2(
-                    (acc_vec[i + 0], acc_vec[i + 1]),
-                    (mProb, mProb),
-                )
+                acc_vec_prob = (acc_vec[i + 0], acc_vec[i + 1])
+                if cutlass.const_expr(self.has_prob):
+                    acc_vec_prob = cute.arch.mul_packed_f32x2(
+                        acc_vec_prob,
+                        (mProb, mProb),
+                    )
                 # calculate d2_vec
                 (
                     d2_vec[i + 0],
@@ -1888,8 +1893,11 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
                 dprob_swiglu = acc_vec * dprob_swiglu
 
             # calculate dswiglu
-            d1_vec = acc_vec * mProb * ab2_vec_load * sig * (1 + ab1_vec_load * (1 - sig))
-            d2_vec = acc_vec * mProb * swish
+            acc_vec_prob = acc_vec
+            if cutlass.const_expr(self.has_prob):
+                acc_vec_prob = acc_vec * mProb
+            d1_vec = acc_vec_prob * ab2_vec_load * sig * (1 + ab1_vec_load * (1 - sig))
+            d2_vec = acc_vec_prob * swish
             return d1_vec, d2_vec, dprob_swiglu
 
     @cute.jit
@@ -1968,7 +1976,9 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
 
                 # g * sigmoid_out
                 acc_mul_sigmoid_out = fmul2(acc, (sigmoid_out_0, sigmoid_out_1))
-                acc_mul_sigmoid_prob = fmul2(acc_mul_sigmoid_out, mprob2)
+                acc_mul_sigmoid_prob = acc_mul_sigmoid_out
+                if cutlass.const_expr(self.has_prob):
+                    acc_mul_sigmoid_prob = fmul2(acc_mul_sigmoid_out, mprob2)
 
                 # y1 = 1 + alpha * y1 * (1 - sigmoid_out)
                 one_minus_sigmoid_0, one_minus_sigmoid_1 = fadd2(ones2, (-sigmoid_out_0, -sigmoid_out_1))
@@ -1987,7 +1997,8 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
                 )
                 # dy1 = g * sigmoid_out * (y2 + linear_offset) * (1 + alpha * y1 * (1 - sigmoid_out)) * mProb
                 dy1_0, dy1_1 = fmul2((dy1_pre_0, dy1_pre_1), y1_scaled)
-                dy1_0, dy1_1 = fmul2((dy1_0, dy1_1), mprob2)
+                if cutlass.const_expr(self.has_prob):
+                    dy1_0, dy1_1 = fmul2((dy1_0, dy1_1), mprob2)
 
                 x1_filter_0 = cutlass.Float32(1.0) if x1_0 <= geglu_max_value else cutlass.Float32(0.0)
                 x1_filter_1 = cutlass.Float32(1.0) if x1_1 <= geglu_max_value else cutlass.Float32(0.0)
@@ -2023,7 +2034,9 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
             # y1 = clamp(x1, max=glu_clamp_max); y2 = clamp(x2, min=glu_clamp_min, max=glu_clamp_max)
             for i in cutlass.range_constexpr(element_count):
                 fc2_dgrad = acc_vec[i] * square_alpha
-                g = fc2_dgrad * mProb
+                g = fc2_dgrad
+                if cutlass.const_expr(self.has_prob):
+                    g = fc2_dgrad * mProb
                 y1 = min(x1_vec_load[i], geglu_max_value_f32)
                 y2 = min(x2_vec_load[i], geglu_max_value_f32)
                 y2 = max(y2, geglu_min_value_f32)
@@ -2043,7 +2056,9 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
                     prob_grad = y1 * sigmoid_out * (y2 + linear_offset) * fc2_dgrad
                     dprob_swiglu[i] = prob_grad
 
-            return dx1_vec.load(), dx2_vec.load(), dprob_swiglu.load()
+            if cutlass.const_expr(self.generate_dprob):
+                dprob_swiglu = dprob_swiglu.load()
+            return dx1_vec.load(), dx2_vec.load(), dprob_swiglu
 
     # GPU device kernel
     @cute.kernel
@@ -2099,6 +2114,10 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
         warp_idx = tidx // 32
         warp_idx = cute.arch.make_warp_uniform(warp_idx)
 
+        if cutlass.const_expr(self.use_single_group_runtime_offsets):
+            runtime_padded_offsets = cute.make_rmem_tensor((1,), cutlass.Int32)
+            runtime_padded_offsets[0] = cutlass.Int32(cute.size(mA_mkl.shape[0]))
+            padded_offsets = runtime_padded_offsets
         total_tokens = padded_offsets[self.expert_cnt - 1]
 
         #
@@ -2921,13 +2940,15 @@ class BlockScaledMoEGroupedGemmDgluDbiasKernel:
                 #
                 # Get PROB (per-expert local M position)
                 #
-                real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
                 mPosition = (
                     (epi_work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)) * self.mma_tiler[0]
                     + mma_tile_coord_v * (self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape))
                     + tidx
                 )
-                mProb = real_prob[mPosition, 0, 0]
+                mProb = cutlass.Float32(1.0)
+                if cutlass.const_expr(self.has_prob):
+                    real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
+                    mProb = real_prob[mPosition, 0, 0]
                 if cutlass.const_expr(self.generate_dprob):
                     dProbVal = cutlass.Float32(0.0)
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_glu/_blockscaled_api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_glu/_blockscaled_api.py
@@ -130,6 +130,7 @@ class GroupedGemmGluBlockScaledAPI(APIBase):
         act_func: str = "swiglu",
         b_major: str = "k",
         use_dynamic_sched: bool = False,
+        use_single_group_runtime_offsets: bool = False,
     ):
         """Initialize the GroupedGemmGluSm100 API.
 
@@ -233,6 +234,11 @@ class GroupedGemmGluBlockScaledAPI(APIBase):
             self.b_major = b_major  # stored for both modes
 
         self.use_dynamic_sched = use_dynamic_sched
+        self._value_error_if(
+            use_single_group_runtime_offsets and self.expert_cnt != 1,
+            "use_single_group_runtime_offsets requires exactly one expert",
+        )
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
 
         self._interpret_uint8_as_fp4x2 = True
         self._has_bias = self.bias_desc is not None
@@ -622,6 +628,7 @@ class GroupedGemmGluBlockScaledAPI(APIBase):
             act_func=self.act_func,
             enable_bias=self._has_bias,
             use_dynamic_sched=self.use_dynamic_sched,
+            use_single_group_runtime_offsets=self.use_single_group_runtime_offsets,
         )
 
         hardware_info = cutlass.utils.HardwareInfo()

--- a/python/cudnn/grouped_gemm/grouped_gemm_glu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_glu/api.py
@@ -211,6 +211,10 @@ class GroupedGemmGluSm100(APIBase):
             )
             self.backend = backend
             if backend is GroupedGemmBackend.BF16:
+                self._value_error_if(
+                    kwargs["use_single_group_runtime_offsets"],
+                    "use_single_group_runtime_offsets is supported only by the block-scaled kernel",
+                )
                 self._implementation = GroupedGemmGluBf16API(
                     sample_a=kwargs["sample_a"],
                     sample_c=kwargs["sample_c"],

--- a/python/cudnn/grouped_gemm/grouped_gemm_glu/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_glu/api.py
@@ -108,6 +108,7 @@ class GluCall:
     glu_clamp_max: float = 7.0
     glu_clamp_min: float = -7.0
     use_dynamic_sched: bool = False
+    use_single_group_runtime_offsets: bool = False
     current_stream: Optional[cuda.CUstream] = None
     generate_c: bool = False
     weight_mode: Optional[MoEWeightMode] = None
@@ -178,6 +179,7 @@ class GroupedGemmGluSm100(APIBase):
         act_func: str = "swiglu",
         b_major: str = "k",
         use_dynamic_sched: bool = False,
+        use_single_group_runtime_offsets: bool = False,
         generate_c: bool = False,
     ) -> None:
         super().__init__()
@@ -495,6 +497,7 @@ def _grouped_gemm_glu_block_scaled_call(call: GluCall) -> TupleDict:
     glu_clamp_max = call.glu_clamp_max
     glu_clamp_min = call.glu_clamp_min
     use_dynamic_sched = call.use_dynamic_sched
+    use_single_group_runtime_offsets = call.use_single_group_runtime_offsets
     current_stream = call.current_stream
 
     # Resolve linear_offset default: None means "use the activation-derived legacy
@@ -643,6 +646,7 @@ def _grouped_gemm_glu_block_scaled_call(call: GluCall) -> TupleDict:
             m_aligned,
             discrete_col_sfd,
             use_dynamic_sched,
+            use_single_group_runtime_offsets,
             *(dynamic_m_tensor_signature(prob_tensor, (1, 1)) if not use_full_dynamic else dynamic_tensor_signature(prob_tensor)),
         )
     else:
@@ -682,6 +686,7 @@ def _grouped_gemm_glu_block_scaled_call(call: GluCall) -> TupleDict:
             m_aligned,
             discrete_col_sfd,
             use_dynamic_sched,
+            use_single_group_runtime_offsets,
             b_major,
             num_experts,
         )
@@ -720,6 +725,7 @@ def _grouped_gemm_glu_block_scaled_call(call: GluCall) -> TupleDict:
                 discrete_col_sfd=discrete_col_sfd,
                 act_func=act_func,
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
             )
         else:
             api = GroupedGemmGluSm100(
@@ -749,6 +755,7 @@ def _grouped_gemm_glu_block_scaled_call(call: GluCall) -> TupleDict:
                 act_func=act_func,
                 b_major=b_major,
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
             )
 
         if not api.check_support():
@@ -892,6 +899,8 @@ def _normalize_glu_call(call: GluCall) -> tuple[GluCall, GroupedGemmBackend]:
     if backend is GroupedGemmBackend.BLOCK_SCALED:
         return normalized, backend
 
+    if call.use_single_group_runtime_offsets:
+        raise ValueError("use_single_group_runtime_offsets is supported only by the block-scaled kernel")
     if call.prob_tensor is None:
         raise ValueError("prob_tensor is required for BF16")
     if call.cd_major != "n":
@@ -1117,6 +1126,7 @@ def grouped_gemm_glu_wrapper_sm100(
     glu_clamp_max: float = 7.0,
     glu_clamp_min: float = -7.0,
     use_dynamic_sched: bool = False,
+    use_single_group_runtime_offsets: bool = False,
     current_stream: Optional[cuda.CUstream] = None,
     generate_c: bool = False,
 ) -> TupleDict:
@@ -1152,6 +1162,7 @@ def grouped_gemm_glu_wrapper_sm100(
         glu_clamp_max=glu_clamp_max,
         glu_clamp_min=glu_clamp_min,
         use_dynamic_sched=use_dynamic_sched,
+        use_single_group_runtime_offsets=use_single_group_runtime_offsets,
         current_stream=current_stream,
         generate_c=generate_c,
     )

--- a/python/cudnn/grouped_gemm/grouped_gemm_glu/moe_blockscaled_grouped_gemm_glu_bias.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_glu/moe_blockscaled_grouped_gemm_glu_bias.py
@@ -290,6 +290,7 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
         use_dynamic_sched: bool = False,
         act_func: str = "swiglu",
         enable_bias: bool = False,
+        use_single_group_runtime_offsets: bool = False,
     ):
         """Initializes the configuration for a Blackwell blockscaled grouped GEMM GLU kernel.
 
@@ -332,11 +333,14 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
             )
         if expert_cnt > 1024:
             raise ValueError("Expert count > 1024 is not supported.")
+        if use_single_group_runtime_offsets and expert_cnt != 1:
+            raise ValueError("use_single_group_runtime_offsets requires exactly one expert")
         if not isinstance(weight_mode, MoEWeightMode):
             raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
 
         self.sf_vec_size = sf_vec_size
         self.expert_cnt = expert_cnt
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn
@@ -832,6 +836,7 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
             sfd_col_tensor = cute.make_tensor(sfd_col_tensor.iterator, sfd_col_layout)
 
         self.generate_amax = amax_tensor is not None
+        self.has_prob = prob is not None
 
         tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
             self.a_dtype,
@@ -1498,20 +1503,22 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
                     rnd="rn",
                     ftz=False,
                 )
-                (
-                    tCompute[i],
-                    tCompute[i + 1],
-                ) = cute.arch.mul_packed_f32x2(
-                    (tCompute[i], tCompute[i + 1]),
-                    (mProb, mProb),
-                    rnd="rn",
-                    ftz=False,
-                )
+                if cutlass.const_expr(self.has_prob):
+                    (
+                        tCompute[i],
+                        tCompute[i + 1],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (tCompute[i], tCompute[i + 1]),
+                        (mProb, mProb),
+                        rnd="rn",
+                        ftz=False,
+                    )
         else:
             # GeGlu Unpacked Version
             for i in cutlass.range_constexpr(cute.size(tCompute)):
                 tCompute[i] = (acc_vec_up[i] + linear_offset) * silu_f32_scaled(acc_vec_gate[i], alpha=alpha, fastmath=True)
-                tCompute[i] = tCompute[i] * mProb
+                if cutlass.const_expr(self.has_prob):
+                    tCompute[i] = tCompute[i] * mProb
 
     @cute.jit
     def swiglu_act(self, tCompute: cute.Tensor, acc_vec_up: cute.Tensor, acc_vec_gate: cute.Tensor, mProb: cute.Tensor):
@@ -1555,20 +1562,22 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
                     rnd="rn",
                     ftz=False,
                 )
-                (
-                    tCompute[i],
-                    tCompute[i + 1],
-                ) = cute.arch.mul_packed_f32x2(
-                    (tCompute[i], tCompute[i + 1]),
-                    (mProb, mProb),
-                    rnd="rn",
-                    ftz=False,
-                )
+                if cutlass.const_expr(self.has_prob):
+                    (
+                        tCompute[i],
+                        tCompute[i + 1],
+                    ) = cute.arch.mul_packed_f32x2(
+                        (tCompute[i], tCompute[i + 1]),
+                        (mProb, mProb),
+                        rnd="rn",
+                        ftz=False,
+                    )
         else:
             # SwiGlu Unpacked Version
             for i in cutlass.range_constexpr(cute.size(tCompute)):
                 tCompute[i] = acc_vec_up[i] * silu_f32(acc_vec_gate[i], fastmath=True)
-                tCompute[i] = tCompute[i] * mProb
+                if cutlass.const_expr(self.has_prob):
+                    tCompute[i] = tCompute[i] * mProb
 
     # GPU device kernel
     @cute.kernel
@@ -1638,6 +1647,10 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
                 cpasync.prefetch_descriptor(tma_atom_d_col)
 
         use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+        if cutlass.const_expr(self.use_single_group_runtime_offsets):
+            runtime_padded_offsets = cute.make_rmem_tensor((1,), cutlass.Int32)
+            runtime_padded_offsets[0] = cutlass.Int32(cute.size(mA_mkl.shape[0]))
+            padded_offsets = runtime_padded_offsets
         total_token = padded_offsets[self.expert_cnt - 1]
 
         #
@@ -2608,13 +2621,15 @@ class BlockScaledMoEGroupedGemmGluBiasKernel:
                 # Get PROB (per-expert via domain_offset)
                 # Note, it always assumes T2R_M/EPI_M is 1, otherwise it will break the result.
                 #
-                real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
                 mPosition = (
                     (epi_work_tile_info.tile_m_idx // cute.size(tiled_mma.thr_id.shape)) * self.mma_tiler[0]
                     + mma_tile_coord_v * (self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape))
                     + tidx
                 )
-                mProb = real_prob[mPosition, 0, 0]
+                mProb = cutlass.Float32(1.0)
+                if cutlass.const_expr(self.has_prob):
+                    real_prob, _ = epi_ext.get_gmem_tensor("prob", prob, padded_offsets, epi_work_tile_info)
+                    mProb = real_prob[mPosition, 0, 0]
 
                 #
                 # Wait for accumulator buffer full

--- a/python/cudnn/grouped_gemm/grouped_gemm_quant/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_quant/api.py
@@ -101,6 +101,7 @@ class GroupedGemmQuantSm100(APIBase):
         discrete_col_sfd: bool = False,
         b_major: str = "k",
         use_dynamic_sched: bool = False,
+        use_single_group_runtime_offsets: bool = False,
     ):
         """Initialize the GroupedGemmQuantSm100 API.
 
@@ -212,6 +213,11 @@ class GroupedGemmQuantSm100(APIBase):
         self.m_aligned = m_aligned
         self.discrete_col_sfd = discrete_col_sfd
         self.use_dynamic_sched = use_dynamic_sched
+        self._value_error_if(
+            use_single_group_runtime_offsets and self.expert_cnt != 1,
+            "use_single_group_runtime_offsets requires exactly one expert",
+        )
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
         if self.weight_mode == MoEWeightMode.DENSE:
             self.b_major = b_major
 
@@ -573,6 +579,7 @@ class GroupedGemmQuantSm100(APIBase):
             expert_cnt=self.expert_cnt,
             weight_mode=self.weight_mode,
             use_dynamic_sched=self.use_dynamic_sched,
+            use_single_group_runtime_offsets=self.use_single_group_runtime_offsets,
         )
 
         hardware_info = cutlass.utils.HardwareInfo()
@@ -1181,6 +1188,7 @@ def grouped_gemm_quant_wrapper_sm100(
     m_aligned: int = 256,
     discrete_col_sfd: bool = False,
     use_dynamic_sched: bool = False,
+    use_single_group_runtime_offsets: bool = False,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Convenience wrapper for grouped GEMM Quant operation.
@@ -1443,6 +1451,7 @@ def grouped_gemm_quant_wrapper_sm100(
             m_aligned,
             discrete_col_sfd,
             use_dynamic_sched,
+            use_single_group_runtime_offsets,
         )
     else:
         cache_key = (
@@ -1479,6 +1488,7 @@ def grouped_gemm_quant_wrapper_sm100(
             m_aligned,
             discrete_col_sfd,
             use_dynamic_sched,
+            use_single_group_runtime_offsets,
             b_major,
             num_experts,
         )
@@ -1513,6 +1523,7 @@ def grouped_gemm_quant_wrapper_sm100(
                 m_aligned=m_aligned,
                 discrete_col_sfd=discrete_col_sfd,
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
             )
         else:
             grouped_gemm_quant = GroupedGemmQuantSm100(
@@ -1540,6 +1551,7 @@ def grouped_gemm_quant_wrapper_sm100(
                 m_aligned=m_aligned,
                 discrete_col_sfd=discrete_col_sfd,
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
                 b_major=b_major,
             )
 

--- a/python/cudnn/grouped_gemm/grouped_gemm_quant/grouped_gemm_quant.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_quant/grouped_gemm_quant.py
@@ -131,6 +131,7 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         expert_cnt: int,
         weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
         use_dynamic_sched: bool = False,
+        use_single_group_runtime_offsets: bool = False,
     ):
         mma_tile_m = mma_tiler_mn[0]
         if self.FIX_PAD_SIZE % mma_tile_m != 0:
@@ -139,11 +140,14 @@ class BlockScaledMoEGroupedGemmQuantKernel:
             )
         if expert_cnt > 1024:
             raise ValueError("Expert count > 1024 is not supported.")
+        if use_single_group_runtime_offsets and expert_cnt != 1:
+            raise ValueError("use_single_group_runtime_offsets requires exactly one expert")
         if not isinstance(weight_mode, MoEWeightMode):
             raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
 
         self.sf_vec_size = sf_vec_size
         self.expert_cnt = expert_cnt
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn
@@ -1129,6 +1133,10 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                 cpasync.prefetch_descriptor(tma_atom_d_col)
 
         use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+        if cutlass.const_expr(self.use_single_group_runtime_offsets):
+            runtime_padded_offsets = cute.make_rmem_tensor((1,), cutlass.Int32)
+            runtime_padded_offsets[0] = cutlass.Int32(cute.size(mA_mkl.shape[0]))
+            padded_offsets = runtime_padded_offsets
         total_token = padded_offsets[self.expert_cnt - 1]
 
         bidx, bidy, bidz = cute.arch.block_idx()

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dglu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dglu.py
@@ -368,6 +368,28 @@ def test_grouped_gemm_dglu_dense_compile_execute_rectangular_zero_prob(request):
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
+def test_grouped_gemm_dglu_dense_wrapper_without_prob_or_dprob(request):
+    _test_grouped_gemm_dglu_dense_wrapper(
+        ab_dtype=torch.float8_e4m3fn,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.float8_e4m3fn,
+        b_major="n",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=True,
+        request=request,
+        cfg_overrides={"group_m_list": [256]},
+        omit_prob=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
 @with_grouped_gemm_dswiglu_params_dbias_fp4
 def test_grouped_gemm_dglu_dense_compile_execute_with_dbias_fp4(
     ab_dtype,
@@ -533,6 +555,8 @@ def _test_grouped_gemm_dglu_dense_compile_execute(
     input_mutator=None,
     generate_dbias=False,
     use_dynamic_sched=False,
+    omit_prob=False,
+    use_single_group_runtime_offsets=False,
 ):
     try:
         from cudnn import GroupedGemmDgluSm100
@@ -619,6 +643,7 @@ def _test_grouped_gemm_dglu_dense_compile_execute(
         discrete_col_sfd=cfg["discrete_col_sfd"],
         act_func="dswiglu",
         use_dynamic_sched=use_dynamic_sched,
+        use_single_group_runtime_offsets=use_single_group_runtime_offsets,
     )
 
     try:
@@ -676,6 +701,8 @@ def _test_grouped_gemm_dglu_dense_wrapper(
     input_mutator=None,
     generate_dbias=False,
     use_dynamic_sched=False,
+    omit_prob=False,
+    use_single_group_runtime_offsets=False,
 ):
     try:
         from cudnn import grouped_gemm_dglu_wrapper_sm100
@@ -733,7 +760,8 @@ def _test_grouped_gemm_dglu_dense_wrapper(
 
     try:
         for _ in range(2):  # Run twice to test caching path
-            outputs["dprob_tensor"].zero_()
+            if not omit_prob:
+                outputs["dprob_tensor"].zero_()
             wrapper_outputs = grouped_gemm_dglu_wrapper_sm100(
                 a_tensor=inputs["a_tensor"],
                 c_tensor=inputs["c_tensor"],
@@ -741,8 +769,8 @@ def _test_grouped_gemm_dglu_dense_wrapper(
                 padded_offsets=inputs["padded_offsets_tensor"],
                 alpha_tensor=inputs["alpha_tensor"],
                 beta_tensor=inputs["beta_tensor"],
-                prob_tensor=inputs["prob_tensor"],
-                dprob_tensor=outputs["dprob_tensor"],
+                prob_tensor=None if omit_prob else inputs["prob_tensor"],
+                dprob_tensor=None if omit_prob else outputs["dprob_tensor"],
                 generate_dbias=generate_dbias,
                 # Dense mode:
                 b_tensor=inputs["b_tensor"],
@@ -760,6 +788,7 @@ def _test_grouped_gemm_dglu_dense_wrapper(
                 discrete_col_sfd=cfg["discrete_col_sfd"],
                 act_func="dswiglu",
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
                 current_stream=stream,
             )
     except (ValueError, NotImplementedError) as e:
@@ -2047,4 +2076,32 @@ def test_grouped_gemm_dglu_discrete_wrapper_alpha_default_is_1702(request):
         out_explicit["dprob_tensor"][:valid_m].cpu(),
         atol=0.0,
         rtol=0.0,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_dglu_single_group_runtime_offsets(request):
+    """The single-group kernel derives padded_offsets=[M] instead of loading the input value."""
+
+    def invalidate_runtime_offset(inputs, _cfg):
+        inputs["padded_offsets_tensor"].zero_()
+
+    _test_grouped_gemm_dglu_dense_wrapper(
+        ab_dtype=torch.float8_e4m3fn,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.float8_e4m3fn,
+        b_major="k",
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        cfg_overrides={"group_m_list": [256]},
+        input_mutator=invalidate_runtime_offset,
+        use_single_group_runtime_offsets=True,
     )

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dglu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dglu.py
@@ -176,6 +176,38 @@ def test_grouped_gemm_dglu_wrapper_bf16(discrete, b_major):
 
 
 @pytest.mark.L0
+def test_grouped_gemm_dglu_class_bf16_rejects_single_group_runtime_offsets():
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("Requires SM100+ for grouped GEMM dGLU BF16 kernel.")
+
+    problem = make_grouped_gemm_dglu_bf16_problem(discrete=False, b_major="k")
+    expected_d, _, _ = grouped_gemm_dglu_bf16_reference(
+        problem,
+        act_func="dswiglu",
+        linear_offset=0.0,
+        generate_dbias=False,
+    )
+    api = cudnn.GroupedGemmDgluSm100(
+        sample_a=problem["a"],
+        sample_c=problem["c"],
+        sample_d_row=torch.empty_like(expected_d),
+        sample_d_col=None,
+        sample_sfa=None,
+        sample_padded_offsets=problem["offsets"],
+        sample_alpha=problem["alpha"],
+        sample_beta=problem["beta"],
+        sample_prob=problem["prob"],
+        sample_dprob=problem["dprob"],
+        sample_b=problem["b"],
+        sample_sfb=None,
+        use_single_group_runtime_offsets=True,
+    )
+
+    with pytest.raises(ValueError, match="supported only by the block-scaled kernel"):
+        api.check_support()
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 @with_scheduler_modes
 @with_grouped_gemm_dswiglu_params_fp4

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu.py
@@ -277,6 +277,31 @@ def test_grouped_gemm_glu_dense_compile_execute_rectangular_zero_prob(request):
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
+def test_grouped_gemm_glu_dense_wrapper_without_prob(request):
+    def input_mutator(inputs, _cfg):
+        inputs["prob_tensor"].fill_(1.0)
+
+    _test_grouped_gemm_glu_dense_wrapper(
+        ab_dtype=torch.float8_e4m3fn,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.float8_e4m3fn,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=True,
+        request=request,
+        cfg_overrides={"group_m_list": [256]},
+        input_mutator=input_mutator,
+        omit_prob=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
 @with_grouped_gemm_swiglu_params_bias_fp4
 def test_grouped_gemm_glu_dense_compile_execute_with_bias_fp4(
     ab_dtype,
@@ -475,6 +500,8 @@ def _test_grouped_gemm_glu_dense_compile_execute(
     input_mutator=None,
     enable_bias=False,
     use_dynamic_sched=False,
+    omit_prob=False,
+    use_single_group_runtime_offsets=False,
 ):
     try:
         from cudnn import GroupedGemmGluSm100
@@ -557,6 +584,7 @@ def _test_grouped_gemm_glu_dense_compile_execute(
         discrete_col_sfd=cfg["discrete_col_sfd"],
         act_func="swiglu",
         use_dynamic_sched=use_dynamic_sched,
+        use_single_group_runtime_offsets=use_single_group_runtime_offsets,
     )
 
     try:
@@ -610,6 +638,8 @@ def _test_grouped_gemm_glu_dense_wrapper(
     input_mutator=None,
     enable_bias=False,
     use_dynamic_sched=False,
+    omit_prob=False,
+    use_single_group_runtime_offsets=False,
 ):
     try:
         from cudnn import grouped_gemm_glu_wrapper_sm100
@@ -664,7 +694,7 @@ def _test_grouped_gemm_glu_dense_wrapper(
                 sfb_tensor=inputs["sfb_tensor"],
                 # Common:
                 norm_const_tensor=inputs.get("norm_const_tensor"),
-                prob_tensor=inputs.get("prob_tensor"),
+                prob_tensor=None if omit_prob else inputs.get("prob_tensor"),
                 acc_dtype=cfg["acc_dtype"],
                 c_dtype=cfg["c_dtype"],
                 d_dtype=cfg["d_dtype"],
@@ -677,6 +707,7 @@ def _test_grouped_gemm_glu_dense_wrapper(
                 discrete_col_sfd=cfg["discrete_col_sfd"],
                 act_func="swiglu",
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
                 current_stream=stream,
             )
     except (ValueError, NotImplementedError) as e:
@@ -1855,4 +1886,31 @@ def test_grouped_gemm_glu_discrete_wrapper_alpha_default_is_1702(request):
         out_explicit["d_tensor"][:valid_m].float().cpu(),
         atol=0.0,
         rtol=0.0,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_glu_single_group_runtime_offsets(request):
+    """The single-group kernel derives padded_offsets=[M] instead of loading the input value."""
+
+    def invalidate_runtime_offset(inputs, _cfg):
+        inputs["padded_offsets_tensor"].zero_()
+
+    _test_grouped_gemm_glu_dense_wrapper(
+        ab_dtype=torch.float8_e4m3fn,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.float8_e4m3fn,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        cfg_overrides={"group_m_list": [256]},
+        input_mutator=invalidate_runtime_offset,
+        use_single_group_runtime_offsets=True,
     )

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu.py
@@ -95,6 +95,39 @@ def test_grouped_gemm_glu_wrapper_bf16(discrete, b_major):
 
 
 @pytest.mark.L0
+def test_grouped_gemm_glu_class_bf16_rejects_single_group_runtime_offsets():
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("Requires SM100+ for grouped GEMM GLU BF16 kernel.")
+
+    problem = make_grouped_gemm_glu_bf16_problem(discrete=False, b_major="k")
+    expected_c, expected_d = grouped_gemm_glu_bf16_reference(
+        problem,
+        act_func="swiglu",
+        linear_offset=0.0,
+        geglu_alpha=1.702,
+        glu_clamp_max=7.0,
+        glu_clamp_min=-7.0,
+    )
+    api = cudnn.GroupedGemmGluSm100(
+        sample_a=problem["a"],
+        sample_c=torch.empty_like(expected_c),
+        sample_d=torch.empty_like(expected_d),
+        sample_sfa=None,
+        sample_padded_offsets=problem["offsets"],
+        sample_alpha=problem["alpha"],
+        sample_d_col=None,
+        sample_b=problem["b"],
+        sample_sfb=None,
+        sample_bias=problem["bias"],
+        sample_prob=problem["prob"],
+        use_single_group_runtime_offsets=True,
+    )
+
+    with pytest.raises(ValueError, match="supported only by the block-scaled kernel"):
+        api.check_support()
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 @with_scheduler_modes
 @with_grouped_gemm_swiglu_params_fp4

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_quant.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_quant.py
@@ -1112,6 +1112,7 @@ def _test_grouped_gemm_quant_wrapper(
     use_dynamic_sched=False,
     enable_bias=False,
     provide_d_tensor=False,
+    use_single_group_runtime_offsets=False,
 ):
     """Test GroupedGemmQuant API via the wrapper function (with caching)."""
     try:
@@ -1187,6 +1188,7 @@ def _test_grouped_gemm_quant_wrapper(
                 m_aligned=cfg["m_aligned"],
                 discrete_col_sfd=cfg["discrete_col_sfd"],
                 use_dynamic_sched=use_dynamic_sched,
+                use_single_group_runtime_offsets=use_single_group_runtime_offsets,
                 current_stream=stream,
             )
     except (ValueError, NotImplementedError) as e:
@@ -1329,6 +1331,33 @@ def _test_grouped_gemm_quant_discrete_compile_execute(
         skip_ref=cfg["skip_ref"],
     )
     return inputs, outputs, cfg
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_quant_single_group_runtime_offsets(request):
+    """The single-group kernel derives padded_offsets=[M] instead of loading the input value."""
+
+    def invalidate_runtime_offset(inputs, _cfg):
+        inputs["padded_offsets_tensor"].zero_()
+
+    _test_grouped_gemm_quant_wrapper(
+        ab_dtype=torch.float8_e4m3fn,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.float8_e4m3fn,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        request=request,
+        cfg_overrides={"group_m_list": [256]},
+        input_mutator=invalidate_runtime_offset,
+        use_single_group_runtime_offsets=True,
+    )
 
 
 def _test_grouped_gemm_quant_discrete_wrapper(


### PR DESCRIPTION
## Before submitting

- [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [ ] I ran `pre-commit run` and committed any formatting changes.

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `use_single_group_runtime_offsets` support for grouped GEMM GLU, dGLU, and quant operations (single expert + block-scaled mode), deriving `padded_offsets` from runtime shapes.
  * Added support for omitting `prob`/`dprob` inputs in block-scaled backward paths (treated as absent when not provided).
* **Documentation**
  * Updated API docs with the new runtime-offset and optional probability input constraints.
* **Tests**
  * Added coverage for omitted probability tensors, runtime-derived offsets, and BF16 rejection when the flag is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->