### PR TITLE
fix: remove guardwords-breaking dGLU comment

### DIFF
--- a/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_grouped_gemm_dglu_dbias.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_grouped_gemm_dglu_dbias.py
@@ -1771,7 +1771,6 @@ class MoEGroupedGemmDgluDbiasBf16Kernel:
                     #
                     # Load accumulator from tensor memory buffer to register
                     #
-                    # Don't ask why, AST is shit tracking the constexpr values to loop args.
                     copy_atom_t2r = sm100_utils.get_tmem_load_op(
                         self.cta_tile_shape_mnk,
                         self.d_layout,


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Remove an unprofessional comment from the BF16 grouped GEMM dGLU kernel.

## Why

The comment triggers the guardwords `COMMENT:broken` CI check and does not add
useful maintainer context. Removing it resolves the reported failure without
changing executable code.

## Related issues

None.

## API and compatibility impact

None. The change removes one comment and leaves executable Python tokens
unchanged.

## Testing

- `pre-commit run --files python/cudnn/grouped_gemm/grouped_gemm_dglu/moe_grouped_gemm_dglu_dbias.py`
  - `black`: passed
  - `black-jupyter`: passed
  - `clang-format`: skipped because no applicable files changed
- Audited comments in all 19 Python files added by PR #415 using Python's
  standard-library tokenizer: 908 post-change comment tokens, zero prohibited
  candidates, and unchanged executable token streams.
- `git diff --check`: passed.
- GPU/runtime tests were not run because the change is comment-only.
- The guardwords checker is not available in the repository checkout; its
  authoritative result is expected from CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an outdated internal code comment; no user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->