### PR TITLE
CFK-38052: pin nvidia-cutlass-dsl to 4.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ classifiers = [
 
 [project.optional-dependencies]
 cutedsl = [
-    "nvidia-cutlass-dsl[cu13]>=4.5.0",
+    "nvidia-cutlass-dsl[cu13]==4.5.0",
     "cuda-python",
     "torch",
     "apache-tvm-ffi",


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.

## Affected area

Build, packaging, or installation

## Summary

Pin the optional CuTeDSL dependency to the known-good `nvidia-cutlass-dsl[cu13]==4.5.0` release.

## Why

The dependency was broadened from `==4.5.0` to `>=4.5.0`, which allows pip to resolve CUTLASS DSL 4.6.x. The libNVVM bundled with 4.6.x fails to compile the large SM100 grouped GEMM DGLU FP8 kernels, while the same kernels compile and pass with 4.5.0.

Restoring the exact pin prevents GPT OSS 20B and DeepSeek V3 environments from silently resolving to the affected compiler release while the forward compiler fix is being validated.

## Related issues

Related to #397.

Internal tracking: NvBug 6503977 / CFK-38052.

## API and compatibility impact

No public API changes. Installing the `[cutedsl]` extra now deterministically selects CUTLASS DSL 4.5.0 instead of accepting affected 4.6.x releases.

## Testing

- `git diff --check`
- Verified the `[project.optional-dependencies].cutedsl` entry resolves to the exact known-good version.
- GPU kernel tests were not rerun for this dependency-only rollback; issue #397 documents the same DGLU FP8 kernels passing with 4.5.0 and failing with 4.6.x.

Created by dkg-ai-bugfix agent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the optional NVIDIA CUTLASS DSL dependency to version 4.5.0 for more consistent installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->