### PR TITLE
DSA indexer_top_k: exclude OOB tile-fill lanes from radix selection

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/indexer_top_k/indexer_top_k_varlen_util.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_top_k/indexer_top_k_varlen_util.py
@@ -525,12 +525,18 @@ class IndexerTopKKernelVarlen:
                     -tXrX.element_type.inf,
                 )
 
+                # Skip out-of-bounds lanes: the last tile can extend past
+                # aligned_size, and its -inf-filled lanes must not be counted
+                # as real elements.
+                cur_tXcX = tXcX[None, None, None, tile_idx]
                 for i in cutlass.range(cute.size(tXrX), unroll_full=True):
-                    bin_val = self.to_coarse_key(tXrX[i])
-                    atomicAdd(
-                        s_histogram.iterator + cutlass.Int32(bin_val),
-                        val_one,
-                    )
+                    col = cur_tXcX[i // vec_size][1] + i % vec_size
+                    if col < aligned_size:
+                        bin_val = self.to_coarse_key(tXrX[i])
+                        atomicAdd(
+                            s_histogram.iterator + cutlass.Int32(bin_val),
+                            val_one,
+                        )
 
             # for initial scalar load part.
             for j in range(tidx, prologue_elems, self.num_threads_per_cta):
@@ -594,11 +600,13 @@ class IndexerTopKKernelVarlen:
                     )
                     for i in cutlass.range(cute.size(tXrX), unroll_full=True):
                         cur_tXcX = tXcX[None, None, None, tile_idx]
-                        bin_val = self.to_coarse_key(tXrX[i])
-                        if bin_val < threshold_bin:
-                            pos = atomicAdd(s_counter.iterator, val_one)
-                            idx = self.index_type(cur_tXcX[i // vec_size][1] + i % vec_size + vec_start)
-                            s_indices[pos] = idx
+                        col = cur_tXcX[i // vec_size][1] + i % vec_size
+                        if col < aligned_size:
+                            bin_val = self.to_coarse_key(tXrX[i])
+                            if bin_val < threshold_bin:
+                                pos = atomicAdd(s_counter.iterator, val_one)
+                                idx = self.index_type(col + vec_start)
+                                s_indices[pos] = idx
 
                 # for initial scalar load part.
                 for j in range(tidx, prologue_elems, self.num_threads_per_cta):
@@ -651,39 +659,42 @@ class IndexerTopKKernelVarlen:
                         raw_input = tXrX[i]
                         bin_val = self.to_coarse_key(raw_input)
                         cur_tXcX = tXcX[None, None, None, tile_idx]
-                        idx = self.index_type(cur_tXcX[i // vec_size][1] + i % vec_size + vec_start)
-                        if bin_val < threshold_bin:
-                            pos = atomicAdd(s_counter.iterator, val_one)
-                            s_indices[pos] = idx
-                        elif bin_val == threshold_bin:
-                            # pos = atomicAdd(s_num_input[0], 1)
-                            pos = atomicAdd(s_num_input.iterator, val_one)
-                            if cutlass.const_expr(self.enable_gmem_store):
-                                if pos < self.indexer_topk_smem_input_size:
-                                    s_input_idx[0, pos] = idx
-                                else:
-                                    buffer_pos = atomicAdd(
-                                        g_num_input.iterator,
+                        col = cur_tXcX[i // vec_size][1] + i % vec_size
+                        # Skip out-of-bounds lanes filled with -inf by _fill_oob.
+                        if col < aligned_size:
+                            idx = self.index_type(col + vec_start)
+                            if bin_val < threshold_bin:
+                                pos = atomicAdd(s_counter.iterator, val_one)
+                                s_indices[pos] = idx
+                            elif bin_val == threshold_bin:
+                                # pos = atomicAdd(s_num_input[0], 1)
+                                pos = atomicAdd(s_num_input.iterator, val_one)
+                                if cutlass.const_expr(self.enable_gmem_store):
+                                    if pos < self.indexer_topk_smem_input_size:
+                                        s_input_idx[0, pos] = idx
+                                    else:
+                                        buffer_pos = atomicAdd(
+                                            g_num_input.iterator,
+                                            val_one,
+                                        )
+                                        buffer[0, buffer_pos] = cutlass.Int32(cutlass.Uint32(idx))
+                                    ordered = self.to_ordered(raw_input)
+                                    sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                                    # atomicAdd(s_histogram[sub_bin], 1)
+                                    atomicAdd(
+                                        s_histogram.iterator + cutlass.Int32(sub_bin),
                                         val_one,
                                     )
-                                    buffer[0, buffer_pos] = cutlass.Int32(cutlass.Uint32(idx))
-                                ordered = self.to_ordered(raw_input)
-                                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
-                                # atomicAdd(s_histogram[sub_bin], 1)
-                                atomicAdd(
-                                    s_histogram.iterator + cutlass.Int32(sub_bin),
-                                    val_one,
-                                )
-                            else:
-                                if pos < self.indexer_topk_smem_input_size:
-                                    s_input_idx[0, pos] = idx
-                                ordered = self.to_ordered(raw_input)
-                                sub_bin = (ordered >> self.first_refine_shift) & 0xFF
-                                # atomicAdd(s_histogram[sub_bin], 1)
-                                atomicAdd(
-                                    s_histogram.iterator + cutlass.Int32(sub_bin),
-                                    val_one,
-                                )
+                                else:
+                                    if pos < self.indexer_topk_smem_input_size:
+                                        s_input_idx[0, pos] = idx
+                                    ordered = self.to_ordered(raw_input)
+                                    sub_bin = (ordered >> self.first_refine_shift) & 0xFF
+                                    # atomicAdd(s_histogram[sub_bin], 1)
+                                    atomicAdd(
+                                        s_histogram.iterator + cutlass.Int32(sub_bin),
+                                        val_one,
+                                    )
 
                 # for initial scalar load part.
                 for j in range(tidx, prologue_elems, self.num_threads_per_cta):

--- a/test/python/fe_api/dsa/test_DSA_indexer_top_k.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_top_k.py
@@ -143,3 +143,72 @@ def test_DSA_indexer_top_k_wrapper(
             values,
             return_val,
         )
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("trigger_dist", ["identical", "distinct"])
+def test_DSA_indexer_top_k_oob_tile_lanes(trigger_dist):
+    """Regression test: -inf-filled OOB lanes of a row's final vector tile must
+    not participate in the radix top-k.
+
+    The kernel reads each row in fixed-width vector tiles and fills the final
+    partial tile's out-of-bounds lanes with -inf. Those phantom lanes were
+    counted as real elements by the histogram and candidate-collection passes.
+    When a row's top-k threshold lands in the fp16 -inf coarse bin (fewer than
+    top_k values above ~-65504, since to_coarse_key converts fp32 scores to
+    fp16 first), the phantom lanes flood the threshold bin's candidate list and
+    overflow the per-row candidate buffers in the large-occupancy compile
+    (>148 rows), producing out-of-bounds shared/global writes
+    (cudaErrorIllegalAddress) or silently out-of-range selected indices.
+
+    This test's batch deterministically places row 0 in that regime: 149 rows
+    (>148 -> large_occupancy), a 4310-wide matrix, and a 4122-long row whose
+    values below the fp16 negative-overflow point plus the phantom lanes
+    outnumber the candidate-buffer capacity.
+    """
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("indexer top-k kernel requires SM90+")
+
+    num_rows, num_cols, top_k, trigger_len, num_above = 149, 4310, 2048, 4122, 1122
+    scores = torch.empty(num_rows, num_cols, dtype=torch.float32)
+    scores[1:] = torch.arange(num_cols, dtype=torch.float32).expand(num_rows - 1, -1)
+    row0 = torch.empty(num_cols, dtype=torch.float32)
+    row0[:num_above] = torch.arange(num_above, dtype=torch.float32)
+    if trigger_dist == "identical":
+        row0[num_above:trigger_len] = -100000.0
+    else:
+        row0[num_above:trigger_len] = torch.linspace(-66000.0, -200000.0, trigger_len - num_above)
+    row0[trigger_len:] = float("-inf")
+    scores[0] = row0
+    seq_lens = torch.full((num_rows,), num_cols, dtype=torch.int32)
+    seq_lens[0] = trigger_len
+
+    input_values = scores.cuda()
+    seq_lens = seq_lens.cuda()
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    result = DSA.indexer_top_k_wrapper(
+        input_values,
+        seq_lens,
+        top_k,
+        next_n=1,
+        return_val=True,
+        stream=stream,
+    )
+    torch.cuda.synchronize()
+
+    indices = result["indices"].cpu()
+    values = result["values"].cpu()
+    for r in range(num_rows):
+        L = int(seq_lens[r].cpu())
+        k = min(top_k, L)
+        valid = indices[r] >= 0
+        assert int(valid.sum()) == k, f"row {r}: expected {k} valid indices, got {int(valid.sum())}"
+        assert int(indices[r].max()) < L, f"row {r}: out-of-range index {int(indices[r].max())} >= seq_len {L}"
+        got = values[r][valid].sort(descending=True).values
+        ref = torch.topk(scores[r, :L], k).values.sort(descending=True).values
+        torch.testing.assert_close(got, ref, atol=1e-6, rtol=1e-5)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of LICENSE.txt.
- [x] I ran `black --line-length 160` on the changed files.

Fixes #446

## Affected area

FE OSS kernels or CuTeDSL (DSA `indexer_top_k`).

## Summary

The CuTe-DSL radix top-k kernel reads each row in fixed-width vector tiles. The final partial tile's out-of-bounds lanes are filled with `-inf` by `_fill_oob` so the predicated copy is memory-safe — but the histogram and candidate-collection loops then iterate **every** fragment lane without a bounds check, counting those phantom `-inf` lanes as real elements.

This is harmless while a row's top-k threshold sits above the phantom bin, because phantom `-inf` lanes sort last and are dropped. However, `to_coarse_key` computes the coarse radix bin from the **fp16 conversion** of the fp32 score, so every score below fp16's −65504 minimum collapses into the fp16 `-inf` bin — the same bin the phantom lanes occupy. When a row's top-k threshold lands inside that bin (fewer than `top_k` values above ~−65504), the threshold bin's candidate list becomes `real_count + up-to-tile-width phantom lanes`:

- in the `large_occupancy` compile (`num_rows > 148`), the per-row candidate buffers (512-entry smem + `num_cols` gmem) overflow → out-of-bounds shared/global writes → `cudaErrorIllegalAddress`;
- in any configuration, phantom lanes can be selected as winners, yielding silently out-of-range indices.

## Observed in production

A GLM-5.2 context-parallel (CP32) training run on B200s crashed with Xid 43 (`illegal memory access`) mid-`forward_backward` — once in 5 hours, sequence-length-independent, no ECC errors. The crash is **deterministically data-dependent**: the captured score tensor reproduces it in a fresh process, on both B200 and B300, at the same call for the same data. `CUDA_LAUNCH_BLOCKING=1` attributes the fault to this kernel; `compute-sanitizer` reports invalid 2-byte shared writes; bisection isolated the trigger to a single row (seq_len 4122 of width 4310, 2242 values below −65504) plus the >148-row compile.

## Fix

Skip lanes whose tile column coordinate is out of bounds (`col < aligned_size`) in the three vectorized histogram/collection loops — the same bound the predicated copy already computes via `predicate_tile`. The scalar prologue/leftover loops are exact-bounded and unchanged. Selection semantics for in-bounds elements are untouched.

## Testing

- New L0 regression test `test_DSA_indexer_top_k_oob_tile_lanes` deterministically drives a row into the flood regime (149 rows → `large_occupancy`; 4310-wide; a 4122-long row with < `top_k` values above the fp16 negative-overflow point), in two variants: identical collapsed values (fails pre-patch with out-of-range indices) and distinct collapsed values (pre-patch: `cudaErrorIllegalAddress`). Both pass post-patch.
- GPU validation was performed against the v1.26.0 release (the affected version; the patched region is byte-identical on `develop`) on B200 and B300: previously-crashing inputs complete with in-range indices, `compute-sanitizer` reports no invalid accesses, and 12/12 randomized parity trials against `torch.topk` pass (rows 37–862, widths 4097–51720, fp16-overflow and exact-tie distributions, both kernel compiles).
- Kernel microbench, (862, 51720) k=2048: 0.115 → 0.129 ms/call (+12% on a 0.1 ms kernel).

## Related

- Complements #407 (odd `top_k` store width) — same kernel, disjoint code (that fix is the phase-3 output store; this one is phases 1–2 selection).
- #312 fixed a different IMA (int32 scratch overflow); this one is the data-dependent candidate flood.
