### PR TITLE
Add MoE + expert-parallel (MoeEp) Python API with MegaMoE CuTe DSL backend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
         require_serial: true
         types_or: [python, pyi]
         args: ["--line-length", "160"]
+        # verbatim vendored copy of the megamoe/CuTe DSL kernel sources
+        exclude: ^python/cudnn/moe_ep/_megamoe_backend/
     -   id: black-jupyter
         name: black-jupyter
         description:
@@ -27,3 +29,4 @@ repos:
         types_or: [python, pyi, jupyter]
         additional_dependencies: [".[jupyter]"]
         args: ["--line-length", "160"]
+        exclude: ^python/cudnn/moe_ep/_megamoe_backend/

--- a/docs/fe-oss-apis/moe_ep.md
+++ b/docs/fe-oss-apis/moe_ep.md
@@ -493,6 +493,8 @@ more surface area:
 - no implicit top-k normalization;
 - no capacity factor or implicit route drop;
 - backward semantics are fixed by `MoeEpReference.backward` (consuming the
-  `generate_c=True` stash); a fused device backward kernel and the
-  `torch.autograd` wrapper are not part of this first version;
+  `generate_c=True` stash); the bundled device backward (bprop) implementation
+  (`python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel`) comes from the
+  Flashinfer team, not the FastKernel team; the `torch.autograd` wrapper is
+  not part of this first version;
 - logical scales at the Python boundary, backend swizzle internally.

--- a/docs/fe-oss-apis/moe_ep.md
+++ b/docs/fe-oss-apis/moe_ep.md
@@ -71,6 +71,18 @@ class MoeEp:
         | BlockScaledTensor
         | tuple[Tensor | BlockScaledTensor, Tensor, Tensor]
     ): ...
+
+    def backward(
+        self,
+        grad_output: Tensor,
+        activation: Tensor | BlockScaledTensor,
+        fc1_weight: Tensor | BlockScaledTensor,
+        fc2_weight: Tensor | BlockScaledTensor,
+        topk_idx: Tensor,
+        topk_weights: Tensor,
+        fc1_c: Tensor,
+        route_metadata: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]: ...
 ```
 
 An initialized `ep_group` enables EP. `None` deliberately means a one-rank
@@ -138,6 +150,32 @@ below.
 
 The return type is fixed by the constructor, so an individual module instance
 does not change its output structure across calls.
+
+### Backward call contract
+
+`backward` requires the operator to be constructed with `generate_c=True`; it
+consumes the forward stash and is executable today as
+`MoeEpReference.backward` (the device implementation is pending, like
+forward). It is a collective: every rank in `ep_group` must call it, because
+gradients re-dispatch along the identical forward routes.
+
+| Argument | Shape | Provided by |
+|---|---:|---|
+| `grad_output` | `(T, H)` | incoming gradient of the *dequantized* public output (all encodes are straight-through). |
+| `activation`, `fc1_weight`, `fc2_weight`, `topk_idx`, `topk_weights` | as in forward | the framework re-supplies the same forward inputs; `topk_idx` deterministically regenerates the dispatch plan. |
+| `fc1_c`, `route_metadata` | `(local_routes, 2I)`, `(local_routes, 4)` | the `generate_c=True` forward stash, passed back unchanged. |
+
+Returns four FP32 tensors:
+
+| Return | Shape | Meaning |
+|---|---:|---|
+| `grad_activation` | `(T, H)` | summed over this token's valid routes; gradients w.r.t. the dequantized activation values. |
+| `grad_fc1_weight` | `(E_local, H, 2I)` | accumulated over every route this rank's experts processed, from all source ranks. |
+| `grad_fc2_weight` | `(E_local, I, H)` | same accumulation domain as `grad_fc1_weight`. |
+| `grad_topk_weights` | `(T, K)` | per-route router-weight gradient; exact zero at `-1` slots. |
+
+The save-set, recompute rules, and numerical conventions behind this
+signature are specified in "Saved tensors for backward" below.
 
 ### Example
 

--- a/docs/fe-oss-apis/moe_ep.md
+++ b/docs/fe-oss-apis/moe_ep.md
@@ -1,0 +1,448 @@
+# MoE + Expert Parallel API proposal
+
+Status: public API stub, implementation proposal, and executable PyTorch
+reference. The API currently allocates uninitialized output storage without
+launching a device kernel. Its numerical comparison is therefore marked as a
+strict expected failure under `test/python/fe_api/moe_ep`; remove that marker
+when backend execution is connected.
+
+This design is based on `mxfp8_glu_mega_instro.html`. It preserves that
+kernel's routing, contiguous expert placement, SwiGLU, optional early router
+weight, internal per-top-k combine plane, and final top-k reduction. It removes
+workspace pointers, peer pointer mappers, streams, and scheduler tuning from the
+semantic user interface.
+
+## Decision summary
+
+- The constructor contains static model, EP, capacity, and numerical choices.
+- `__call__` contains only runtime tensors.
+- Each rank supplies local tokens and local expert weights. Expert IDs in the
+  routing table are global.
+- Expert ownership is contiguous and uniform. EP rank `r` owns
+  `[r * E_local, (r + 1) * E_local)`.
+- `-1` is the only dropped/unused route value. Other out-of-range IDs are
+  errors.
+- The first half of FC1 is `gate`; the second half is `up`. SwiGLU is
+  `silu(gate) * up`.
+- `output_format` means the public, post-top-k-reduction `(T, H)` result. This is
+  an extension of the HTML interface, whose public result is BF16.
+- `combine_format` independently describes each per-route FC2 contribution on
+  the EP return path. This corresponds to the HTML's internal `combine_quant`
+  and `combine_sf` planes.
+- BF16, MXFP8, and NVFP4 are supported for both choices. Quantized output is a
+  data-plus-scale object; it is never represented as a scale-free PyTorch
+  tensor.
+
+The distinction between public output and combine traffic is intentional. If
+"MXFP8/NVFP4 output" is meant only as a transport optimization, set
+`combine_format` to that format and keep `output_format="bf16"`.
+
+## Proposed API
+
+The production class should be named `MoeEp`. The checked-in semantic
+implementation is named `MoeEpReference` so it cannot be confused with a fused
+kernel.
+
+```python
+class MoeEp:
+    def __init__(
+        self,
+        *,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        top_k: int,
+        ep_group: Optional[torch.distributed.ProcessGroup] = None,
+        max_tokens_per_rank: Optional[int] = None,
+        output_format: Literal["bf16", "mxfp8", "nvfp4"] = "bf16",
+        combine_format: Literal["bf16", "mxfp8", "nvfp4"] = "bf16",
+        apply_topk_in_fc1: bool = True,
+        gate_up_clamp: Optional[float] = None,
+        generate_c: bool = False,
+    ) -> None: ...
+
+    def __call__(
+        self,
+        activation: Tensor | BlockScaledTensor,
+        fc1_weight: Tensor | BlockScaledTensor,
+        fc2_weight: Tensor | BlockScaledTensor,
+        topk_idx: Tensor,
+        topk_weights: Tensor,
+    ) -> (
+        Tensor
+        | BlockScaledTensor
+        | tuple[Tensor | BlockScaledTensor, Tensor, Tensor]
+    ): ...
+```
+
+An initialized `ep_group` enables EP. `None` deliberately means a one-rank
+execution, even if a default distributed process group exists. This prevents an
+operator from silently communicating on the wrong group.
+
+### Constructor contract
+
+| Argument | Meaning |
+|---|---|
+| `num_experts` | Global expert count `E`; must be divisible by EP size. |
+| `hidden_size` | Model hidden dimension `H`. |
+| `intermediate_size` | Post-SwiGLU dimension `I`; FC1 has `2 * I` columns. |
+| `top_k` | Fixed routing width `K`, with `1 <= K <= E`. |
+| `ep_group` | Process group whose group-relative rank determines expert ownership. |
+| `max_tokens_per_rank` | Maximum local input tokens `T`; optional in the reference and required by a static-workspace implementation. |
+| `output_format` | Encoding returned after top-k reduction. |
+| `combine_format` | Encoding/rounding of each route contribution before top-k reduction. |
+| `apply_topk_in_fc1` | Multiply the post-SwiGLU intermediate by the router weight before FC2; otherwise multiply FC2 output. |
+| `gate_up_clamp` | If set, use `gate = min(gate, abs(limit))` and `up = clamp(up, -abs(limit), abs(limit))`. |
+| `generate_c` | Training integration: additionally return `fc1_c` (raw pre-SwiGLU FC1 accumulator of every route this rank's experts processed) and its row-aligned `route_metadata`. |
+
+The constructor validates static format alignment. MXFP8 output requires
+`H % 32 == 0`; NVFP4 output requires `H % 16 == 0`. A production implementation
+may also validate SM architecture, NVSHMEM availability, symmetric heap size,
+and CUDA graph constraints here.
+
+Scheduler settings such as `token_back_mode`, `group_hint`, `flag_batch`,
+`epi_flag_batch`, and scheduler stages belong in an optional backend/tuning
+object. They do not change the result and should not be positional API
+arguments.
+
+`fc2_in_kernel_topk_reduce` is different: BF16 atomic reduction can change the
+rounding order. The first contract therefore specifies Form A semantics
+(round each route to `combine_format`, reduce in FP32, encode once). Form B may
+be used behind the API only if it satisfies the agreed tolerance; otherwise it
+must become an explicit numerical mode rather than an invisible tuning flag.
+
+### Forward tensor contract
+
+Let `T` be this rank's token count and `E_local = E / ep_size`.
+
+| Tensor | Logical shape | Required properties |
+|---|---:|---|
+| `activation` | `(T, H)` | BF16/FP tensor, or block-scaled along axis 1. |
+| `fc1_weight` | `(E_local, H, 2I)` | Local experts only; block-scaled weights use axis 1. |
+| `fc2_weight` | `(E_local, I, H)` | Local experts only; block-scaled weights use axis 1. |
+| `topk_idx` | `(T, K)` | INT32 or INT64 global expert IDs; `-1` means unused. |
+| `topk_weights` | `(T, K)` | Floating router/combine weights. They are not implicitly normalized. |
+
+All tensors must be on one device. Quantized data and its scale tensor must
+also share a device. Biases, shared experts, nonuniform expert placement, and
+capacity-based route dropping are outside this first API.
+
+### Return value
+
+- BF16: a `torch.bfloat16` tensor with logical shape `(T, H)`.
+- MXFP8/NVFP4: a `BlockScaledTensor` containing `data`, `scale`, `format`,
+  `logical_shape`, and the scaled axis. `dequantize()` reconstructs a regular
+  tensor.
+
+The return type is fixed by the constructor, so an individual module instance
+does not change its output structure across calls.
+
+### Example
+
+```python
+moe = MoeEpReference(
+    num_experts=8,
+    hidden_size=4096,
+    intermediate_size=14336,
+    top_k=2,
+    ep_group=ep_group,
+    max_tokens_per_rank=2048,
+    combine_format="mxfp8",
+    output_format="nvfp4",
+)
+
+# Each rank passes its own tokens and its contiguous E_local weight shard.
+output = moe(activation, local_fc1, local_fc2, topk_idx, topk_weights)
+assert output.logical_shape == (activation.shape[0], 4096)
+output_bf16 = output.dequantize(torch.bfloat16)
+```
+
+## Mathematical semantics
+
+For valid route `(t, k)` with global expert `e` and router weight `p[t, k]`:
+
+```text
+z[t,k]       = fp32(x[t]) @ fp32(W1[e])
+gate, up     = split(z[t,k], I)
+hidden[t,k]  = silu(gate) * up
+
+if apply_topk_in_fc1:
+    hidden[t,k] *= p[t,k]
+
+expert[t,k]  = hidden[t,k] @ fp32(W2[e])
+
+if not apply_topk_in_fc1:
+    expert[t,k] *= p[t,k]
+
+combine[t,k] = dequantize(quantize(expert[t,k], combine_format))
+result[t]    = sum_k(combine[t,k])
+output       = encode(result, output_format)
+```
+
+For BF16 combine, `quantize/dequantize` above means a BF16 round trip. Invalid
+slots contribute exact zero. Accumulation across top-k slots is FP32 and the
+public encoding is applied after reduction.
+
+Moving the router weight across FC2 is algebraically equivalent in exact
+arithmetic, but not necessarily after low-precision rounding. The option is
+therefore semantic and is fixed in the constructor, matching the HTML kernel.
+
+## Block-scaled representation
+
+The API uses logical, unswizzled scales. Backend-specific F8_128x4 swizzling is
+an implementation detail performed while constructing tensor maps or staging
+weights.
+
+| Format | Payload | Scale | Block | Quantized axis |
+|---|---|---|---:|---|
+| BF16 | BF16 | none | n/a | n/a |
+| MXFP8 | FP8 E4M3 | FP8 E8M0 | 32 | reduction/output axis |
+| NVFP4 | packed FP4 E2M1, low nibble first | FP8 E4M3 | 16 | reduction/output axis |
+
+MXFP8 scale calculation is:
+
+```text
+raw_scale = amax(block) / 448
+scale = 2 ** ceil(log2(raw_scale))       # E8M0 round toward +infinity
+data = e4m3(clamp(block / scale, -448, 448))
+```
+
+NVFP4 scale calculation is:
+
+```text
+raw_scale = amax(block) / 6
+scale = e4m3(raw_scale)                  # round to nearest, saturate finite
+data = e2m1(clamp(block / scale, -6, 6)) # two values per byte
+```
+
+E2M1 conversion in the reference uses round-to-nearest, ties-to-even. Logical
+shapes may be padded to a complete block internally, but padding is not visible
+through `logical_shape`.
+
+Examples of scale shapes are:
+
+| Logical tensor | MXFP8 scale | NVFP4 scale |
+|---|---:|---:|
+| activation `(T, H)` | `(T, ceil(H/32))` | `(T, ceil(H/16))` |
+| FC1 `(E_local, H, 2I)` | `(E_local, ceil(H/32), 2I)` | `(E_local, ceil(H/16), 2I)` |
+| FC2 `(E_local, I, H)` | `(E_local, ceil(I/32), H)` | `(E_local, ceil(I/16), H)` |
+| output `(T, H)` | `(T, ceil(H/32))` | `(T, ceil(H/16))` |
+
+NVFP4 payload shape replaces the quantized axis by `ceil(axis_extent / 2)`.
+
+## Expert-parallel execution
+
+The semantic data flow is:
+
+```text
+local x, topk_idx, topk_weights
+              |
+              v
+flatten valid routes -> stable sort by destination EP rank
+              |
+              v
+variable all-to-all dispatch (token, local expert id, route weight)
+              |
+              v
+group by local expert -> FC1 -> SwiGLU -> FC2 -> combine-format round trip
+              |
+              v
+reverse variable all-to-all in the exact dispatch order
+              |
+              v
+scatter to local [token, top-k, hidden] plane -> FP32 top-k sum
+              |
+              v
+encode public output
+```
+
+The reference uses two variable-split `all_to_all_single` phases. The target
+MegaMoE kernel can use NVSHMEM pull for dispatch and direct remote stores or
+token-back warps for return. Those are different transport mechanisms with the
+same observable mapping.
+
+Stable ordering is required only so the reverse exchange can return results
+without sending source token metadata to the expert rank. The source rank keeps
+its local `(token, top-k slot)` permutation and scatters returned rows back into
+the combine plane.
+
+Ranks may have different `T`. Zero-token ranks and zero-count peer splits must
+participate in all collectives. A production workspace must reserve enough
+inbound assignments for its documented capacity policy. The conservative bound
+is `ep_size * max_tokens_per_rank * top_k`; a smaller bound requires an explicit
+router capacity/drop contract.
+
+## Mapping to the MegaMoE HTML interface
+
+| HTML concept | Proposed API |
+|---|---|
+| `static_expert_shape=(E, 2I, H)` | `num_experts`, `intermediate_size`, `hidden_size` |
+| `world_size` | inferred from `ep_group` |
+| `num_topk` | `top_k` |
+| `max_tokens_per_rank` | same name |
+| `activation` + `activation_sf` | one `BlockScaledTensor` |
+| `fc1_weight` + `fc1_weight_sf` | one `BlockScaledTensor` |
+| `fc2_weight` + `fc2_weight_sf` | one `BlockScaledTensor` |
+| `topk_idx`, `topk_weights` | same runtime tensors |
+| internal `combine_quant`, `combine_sf` | selected by `combine_format`, not passed by the caller |
+| BF16 `output_activation` | BF16 case of the returned value |
+| new quantized public output | `BlockScaledTensor` selected by `output_format` |
+| `local_workspace`, `shared_workspace` | owned/cached by the implementation |
+| `peer_rank_ptr_mapper_host` | derived from the EP communication backend |
+| `max_active_clusters`, `stream` | backend launch state; current PyTorch stream is used |
+| `token_comm_args` | private lowering/kernel argument bundle |
+| `generate_c`, `fc1_c` | same names; `fc1_c` is the second returned value |
+| `src_token_topk_idx`, `token_src_metadata` | `route_metadata`, the third returned value |
+
+### `fc1_c` and `route_metadata` (training integration)
+
+With `generate_c=True`, `__call__` returns `(output, fc1_c, route_metadata)`.
+`fc1_c` is BF16 with shape `(local_routes, 2 * intermediate_size)`, where
+`local_routes` is the data-dependent number of valid routes assigned to this
+rank's experts. It stays **expert-rank-local** — matching the kernel, which
+writes `fc1_c` where FC1 ran and never ships it back — because the backward
+pass re-dispatches gradients to the expert ranks, which is where the stashed
+activations are consumed.
+
+Row semantics: grouped by local expert (ascending); within an expert, ordered
+by source rank, then the source rank's token-major route order. Values are the
+raw FC1 accumulator captured **before** SwiGLU, before the gate/up clamp, and
+without the router weight (which applies after SwiGLU when
+`apply_topk_in_fc1=True`). The kernel's 128-row per-expert padding is a layout
+detail and is absent from the logical contract.
+
+`route_metadata` is Int32 `(local_routes, 4)` with columns
+`(local_expert, src_rank, src_token, src_slot)`; row `i` identifies the route
+behind `fc1_c` row `i`. This is the information the backward pass needs to
+re-dispatch output gradients to the right expert-rank rows and to scatter
+input gradients back to `(src_token, src_slot)` on the source ranks. It is
+the public form of the kernel's `src_token_topk_idx`/`token_src_metadata`
+routing words, which the dispatch phase already materializes on the expert
+rank.
+
+### Saved tensors for backward
+
+`MoeEpReference.backward(grad_output, activation, fc1_weight, fc2_weight,
+topk_idx, topk_weights, fc1_c, route_metadata)` returns
+`(grad_activation, grad_fc1_weight, grad_fc2_weight, grad_topk_weights)` and
+is the executable statement of the save-set. What must survive from forward
+to backward:
+
+| Tensor | Where it lives | Why backward needs it |
+|---|---|---|
+| `fc1_c` | expert rank (stash) | Sole recompute source: gate/up split, clamp masks, SwiGLU, and the FC2 input `h` are rebuilt from it. Also yields `dW1 = xᵀ · d_c` and `d_x = d_c · W1ᵀ`. |
+| `route_metadata` | expert rank (stash) | Reconstructs the receive-order ↔ `fc1_c`-row permutation (sort by `(src_rank, src_token, src_slot)`), groups rows by local expert, and drives the gradient return scatter. |
+| `fc1_weight`, `fc2_weight` | expert rank (resident params) | `d_x = d_c · W1ᵀ`, `d_h = d_y · W2ᵀ`. |
+| `activation` | source rank (framework input) | FC1 input `x` for `dW1`. Re-dispatched in backward along the identical routes (`topk_idx` is deterministic), or alternatively the forward's dispatched copy `(pool, H)` is stashed on the expert rank to trade memory for the second dispatch. |
+| `topk_idx`, `topk_weights` | source rank (framework inputs) | `topk_idx` regenerates the exact dispatch plan; `topk_weights` reconstructs `h' = w·h` for `dW2` and produces `d_w` (returned per `(src_token, src_slot)`). |
+| `grad_output` | source rank (incoming) | One row per route is dispatched to the expert rank: `d_y[route] = grad_output[src_token]` (top-k reduce is a sum). |
+
+Deliberately **not** saved: the post-SwiGLU `fc1_output`/`fc1_output_sf`
+(recomputed from `fc1_c`), the `combine_quant`/`combine_sf` planes, the
+public output, and all counters/flags.
+
+Numerical conventions of the reference backward, to be matched by a fused
+kernel: all quantization round-trips (input decode, `combine_format`,
+`output_format`) are straight-through — `grad_output` is the gradient of the
+dequantized `(T, H)` output; the bf16 `fc1_c` stash is the recompute source,
+so backward SwiGLU math runs on bf16-rounded accumulator values (standard
+stash precision); clamp gradients are inclusive at the bounds, matching
+`torch.clamp`; when `apply_topk_in_fc1=True` the router-weight gradient is
+`d_w = ⟨d_h', h⟩` with `h` pre-weight, otherwise `d_w = ⟨d_y, y_pre⟩`.
+
+## Production implementation plan
+
+1. **Constructor and plan cache**
+   - Resolve group-relative EP rank/size and local expert range.
+   - Validate static dimensions, format combinations, architecture, and capacity.
+   - Build a cache key from static configuration plus runtime data/scale dtypes
+     and strides.
+   - Size local and symmetric workspaces. Allocate through a backend context,
+     not on every call.
+
+2. **Forward validation and views**
+   - Flatten `BlockScaledTensor` objects into payload/scale kernel arguments.
+   - Validate `(T, K)` routing and local weight descriptors.
+   - Slice internal dispatch, counter, FC1, combine, and scale planes from owned
+     workspaces. The caller never passes these pointers.
+
+3. **Dispatch**
+   - Count valid routes per destination and expert.
+   - Prefix-sum counts, place routing words, and transfer activation payload,
+     activation scale, and router weight.
+   - Preserve `(source rank, source token, source slot)` in compact metadata or
+     in a reversible placement order.
+
+4. **Local expert kernel**
+   - Use one specialization per input/weight family and combine format.
+   - Accumulate GEMMs in FP32.
+   - Apply the documented gate/up clamp and router-weight location.
+   - Quantize route contributions with block boundaries aligned to `H`.
+
+5. **Return and reduction**
+   - Direct epilogue remote stores are the default fast path.
+   - Standalone/reused token-back warps remain tuning choices.
+   - Reduce the internal top-k plane in FP32.
+   - BF16-cast or block-quantize the reduced result according to
+     `output_format`.
+
+6. **Runtime behavior**
+   - Use the current PyTorch CUDA stream.
+   - Avoid host synchronization after plan creation.
+   - Reset counters in-kernel so repeated calls and CUDA graph replay are safe.
+   - Keep peer-visible allocation addresses stable for the lifetime of the
+     plan/workspace object.
+
+For quantized public output, the fused final top-k reducer should emit payload
+and logical scales together. It should not first materialize a BF16 `(T, H)`
+buffer unless that fallback is selected.
+
+## Reference implementation
+
+The executable reference is
+`test/python/fe_api/moe_ep/moe_ep_reference.py`. It accepts ordinary floating
+tensors or `BlockScaledTensor` inputs and weights. With an explicit process
+group it executes actual variable-size PyTorch collectives, so it checks both
+MoE math and EP ordering.
+
+The reference is a correctness oracle, not a performance model:
+
+- GEMMs and top-k accumulation use FP32.
+- It models combine and public-output rounding, but not CTA tile-dependent
+  accumulation order.
+- Scale tensors are logical, not atom-swizzled.
+- It uses collective push communication rather than NVSHMEM pull/remote store.
+- Distributed PyTorch collectives in this reference are not an autograd
+  implementation. The initial scope is inference forward.
+- It has no expert-capacity drop policy beyond explicit `-1` routes.
+
+## Validation and test matrix
+
+The accompanying tests cover:
+
+- MXFP8 and NVFP4 quantize/dequantize shape and dtype contracts;
+- quantization along the weight reduction axis;
+- BF16 output for both router-weight locations and gate/up clamp;
+- MXFP8 and NVFP4 public outputs;
+- mixed block-scaled activation, FC1, and FC2 inputs;
+- invalid expert IDs;
+- two EP ranks with unequal local token counts and cross-rank routes.
+
+Production validation should add CUDA/NVSHMEM runs for every pair of
+`combine_format` and `output_format`, skewed/all-to-one routing, empty experts,
+zero-token ranks, duplicate expert selections, maximum capacity, CUDA graph
+replay, and comparisons against this reference after dequantization.
+
+## Proposed first-version boundaries
+
+These choices should remain explicit until there is a concrete model requiring
+more surface area:
+
+- contiguous, equal expert partition only;
+- no expert bias;
+- no shared/dense expert inside this operator;
+- no implicit top-k normalization;
+- no capacity factor or implicit route drop;
+- no backward API;
+- no auxiliary FC1 capture;
+- logical scales at the Python boundary, backend swizzle internally.

--- a/docs/fe-oss-apis/moe_ep.md
+++ b/docs/fe-oss-apis/moe_ep.md
@@ -1,16 +1,14 @@
 # MoE + Expert Parallel API proposal
 
 Status: public API stub, implementation proposal, and executable PyTorch
-reference. The API currently allocates uninitialized output storage without
-launching a device kernel. Its numerical comparison is therefore marked as a
-strict expected failure under `test/python/fe_api/moe_ep`; remove that marker
-when backend execution is connected.
+reference for both forward and backward. The API currently allocates
+uninitialized output storage without launching a device kernel. Its numerical
+comparison is therefore marked as a strict expected failure under
+`test/python/fe_api/moe_ep`; remove that marker when backend execution is
+connected.
 
-This design is based on `mxfp8_glu_mega_instro.html`. It preserves that
-kernel's routing, contiguous expert placement, SwiGLU, optional early router
-weight, internal per-top-k combine plane, and final top-k reduction. It removes
-workspace pointers, peer pointer mappers, streams, and scheduler tuning from the
-semantic user interface.
+The design removes workspace pointers, peer pointer mappers, streams, and
+scheduler tuning from the semantic user interface.
 
 ## Decision summary
 
@@ -25,9 +23,9 @@ semantic user interface.
 - The first half of FC1 is `gate`; the second half is `up`. SwiGLU is
   `silu(gate) * up`.
 - `output_format` means the public, post-top-k-reduction `(T, H)` result. This is
-  an extension of the HTML interface, whose public result is BF16.
+  an extension of the MegaMoE kernel interface, whose public result is BF16.
 - `combine_format` independently describes each per-route FC2 contribution on
-  the EP return path. This corresponds to the HTML's internal `combine_quant`
+  the EP return path. This corresponds to the `combine_quant`
   and `combine_sf` planes.
 - BF16, MXFP8, and NVFP4 are supported for both choices. Quantized output is a
   data-plus-scale object; it is never represented as a scale-free PyTorch
@@ -134,6 +132,10 @@ capacity-based route dropping are outside this first API.
   `logical_shape`, and the scaled axis. `dequantize()` reconstructs a regular
   tensor.
 
+With `generate_c=True`, the call instead returns
+`(output, fc1_c, route_metadata)`; see the training-integration sections
+below.
+
 The return type is fixed by the constructor, so an individual module instance
 does not change its output structure across calls.
 
@@ -185,7 +187,7 @@ public encoding is applied after reduction.
 
 Moving the router weight across FC2 is algebraically equivalent in exact
 arithmetic, but not necessarily after low-precision rounding. The option is
-therefore semantic and is fixed in the constructor, matching the HTML kernel.
+therefore semantic and is fixed in the constructor, matching the MegaMoE kernel.
 
 ## Block-scaled representation
 
@@ -272,9 +274,9 @@ inbound assignments for its documented capacity policy. The conservative bound
 is `ep_size * max_tokens_per_rank * top_k`; a smaller bound requires an explicit
 router capacity/drop contract.
 
-## Mapping to the MegaMoE HTML interface
+## Mapping to the MegaMoE interface
 
-| HTML concept | Proposed API |
+| concept | Proposed API |
 |---|---|
 | `static_expert_shape=(E, 2I, H)` | `num_experts`, `intermediate_size`, `hidden_size` |
 | `world_size` | inferred from `ep_group` |
@@ -412,8 +414,9 @@ The reference is a correctness oracle, not a performance model:
   accumulation order.
 - Scale tensors are logical, not atom-swizzled.
 - It uses collective push communication rather than NVSHMEM pull/remote store.
-- Distributed PyTorch collectives in this reference are not an autograd
-  implementation. The initial scope is inference forward.
+- Backward is an explicit `backward` method that re-dispatches gradients with
+  the same collectives; the reference is not wrapped in a
+  `torch.autograd.Function`, so framework integration supplies that layer.
 - It has no expert-capacity drop policy beyond explicit `-1` routes.
 
 ## Validation and test matrix
@@ -423,10 +426,18 @@ The accompanying tests cover:
 - MXFP8 and NVFP4 quantize/dequantize shape and dtype contracts;
 - quantization along the weight reduction axis;
 - BF16 output for both router-weight locations and gate/up clamp;
-- MXFP8 and NVFP4 public outputs;
+- MXFP8 and NVFP4 quantized combine round-trips;
 - mixed block-scaled activation, FC1, and FC2 inputs;
-- invalid expert IDs;
-- two EP ranks with unequal local token counts and cross-rank routes.
+- `fc1_c`/`route_metadata` capture: values, expert grouping, and row order;
+- backward against autograd replicas — fp32 and block-scaled inputs, both
+  router-weight locations, gate/up clamp, and zero gradient for `-1` routes;
+- four EP ranks (one GPU each, NCCL) with unequal local token counts and
+  cross-rank routes: forward, `fc1_c`/`route_metadata`, and backward gradients;
+- API acceptance of block-scaled inputs and the `generate_c` allocation
+  contract;
+- strict expected-failure gates comparing the API against the reference for
+  every output format, quantized inputs, and `generate_c`, armed until the
+  device kernel lands.
 
 Production validation should add CUDA/NVSHMEM runs for every pair of
 `combine_format` and `output_format`, skewed/all-to-one routing, empty experts,
@@ -443,6 +454,7 @@ more surface area:
 - no shared/dense expert inside this operator;
 - no implicit top-k normalization;
 - no capacity factor or implicit route drop;
-- no backward API;
-- no auxiliary FC1 capture;
+- backward semantics are fixed by `MoeEpReference.backward` (consuming the
+  `generate_c=True` stash); a fused device backward kernel and the
+  `torch.autograd` wrapper are not part of this first version;
 - logical scales at the Python boundary, backend swizzle internally.

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -26,6 +26,7 @@ This folder documents the Python FE APIs implemented under `python/cudnn`. For d
 - [SDPA Forward FE OSS API (SM100, D=256)](https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/operations/Attention.html#sdpa-forward-fe-oss-sm100-d256)
 - [SDPA Backward FE OSS API (SM100, D=256)](https://docs.nvidia.com/deeplearning/cudnn/frontend/latest/operations/Attention.html#sdpa-backward-fe-oss-sm100-d256)
 - [RMSNorm + SiLU](rmsnorm_silu.md)
+- [MoE + Expert Parallel API proposal](moe_ep.md)
 
 ## Installation and setup
 

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -278,6 +278,9 @@ from typing import Any
 _OPTIONAL_DEPENDENCY_INSTALL_HINT = "Install with 'pip install nvidia-cudnn-frontend[cutedsl]'"
 
 _LAZY_OPTIONAL_IMPORTS = {
+    "moe_ep": (".moe_ep", None),
+    "MoeEp": (".moe_ep", "MoeEp"),
+    "MoeFormat": (".moe_ep", "MoeFormat"),
     "BSA": (".block_sparse_attention", "BSA"),
     "block_sparse_attention_forward": (".block_sparse_attention", "block_sparse_attention_forward"),
     "block_sparse_attention_backward": (".block_sparse_attention", "block_sparse_attention_backward"),

--- a/python/cudnn/moe_ep/__init__.py
+++ b/python/cudnn/moe_ep/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+from .api import BlockScaledTensor, MoeEp, MoeFormat, MoeTensor
+
+__all__ = ["BlockScaledTensor", "MoeEp", "MoeFormat", "MoeTensor"]

--- a/python/cudnn/moe_ep/_megamoe.py
+++ b/python/cudnn/moe_ep/_megamoe.py
@@ -16,9 +16,11 @@ Environment:
 - ``CUDNN_MOE_EP_BACKEND``: ``auto`` (default; use megamoe when possible,
   warn once and fall back otherwise), ``megamoe`` (required; raise if the
   backend cannot be built), ``none`` (never use a backend).
-- ``CUDNN_MEGAMOE_ROOT``: path to the ``moe_ep_training`` checkout that
-  contains the ``megamoe`` package (with its sibling ``cutedsl_megamoe``
-  kernel clone).  Not needed when ``megamoe`` is already importable.
+- ``CUDNN_MEGAMOE_ROOT``: optional override pointing at a ``moe_ep_training``
+  checkout that contains the ``megamoe`` package (with its sibling
+  ``cutedsl_megamoe`` kernel clone).  By default the copy vendored in
+  ``_megamoe_backend/`` (kernels included) is used, so no external checkout
+  is needed.
 
 Backend requirements and deviations from the pure reference:
 
@@ -74,6 +76,17 @@ class BackendUnavailable(RuntimeError):
     """Raised when the megamoe backend cannot serve this MoeEp config."""
 
 
+def bundled_root() -> Optional[str]:
+    """Path of the vendored ``_megamoe_backend`` tree (megamoe + pt +
+    cutedsl_megamoe kernels), or ``None`` if it was stripped from this
+    install."""
+
+    root = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_megamoe_backend")
+    if os.path.isdir(os.path.join(root, "megamoe")):
+        return root
+    return None
+
+
 def _policy() -> str:
     value = os.environ.get("CUDNN_MOE_EP_BACKEND", "auto").lower()
     if value in ("", "auto"):
@@ -95,7 +108,7 @@ def _import_megamoe(single_rank: bool):
             raise BackendUnavailable(f"megamoe already imported in {_state['mode']!r} mode; cannot " f"serve a {want!r} MoeEp in the same process")
         return _state["modules"]
 
-    root = os.environ.get("CUDNN_MEGAMOE_ROOT")
+    root = os.environ.get("CUDNN_MEGAMOE_ROOT") or bundled_root()
     if root and root not in sys.path:
         sys.path.insert(0, root)
     if single_rank:

--- a/python/cudnn/moe_ep/_megamoe.py
+++ b/python/cudnn/moe_ep/_megamoe.py
@@ -63,8 +63,8 @@ _COMBINE_WIRE = {
 }
 
 _state = {
-    "modules": None,       # imported megamoe modules, once per process
-    "mode": None,          # "no_dist" | "dist"
+    "modules": None,  # imported megamoe modules, once per process
+    "mode": None,  # "no_dist" | "dist"
     "nvshmem_ready": False,
     "warned": False,
 }
@@ -92,10 +92,7 @@ def _import_megamoe(single_rank: bool):
     if _state["modules"] is not None:
         want = "no_dist" if single_rank else "dist"
         if _state["mode"] != want:
-            raise BackendUnavailable(
-                f"megamoe already imported in {_state['mode']!r} mode; cannot "
-                f"serve a {want!r} MoeEp in the same process"
-            )
+            raise BackendUnavailable(f"megamoe already imported in {_state['mode']!r} mode; cannot " f"serve a {want!r} MoeEp in the same process")
         return _state["modules"]
 
     root = os.environ.get("CUDNN_MEGAMOE_ROOT")
@@ -160,42 +157,23 @@ def _check_supported(op) -> None:
         raise BackendUnavailable("CUDA is not available")
     major, _ = torch.cuda.get_device_capability()
     if major < 10:
-        raise BackendUnavailable(
-            f"MegaMoE kernels need SM100+, found SM{major}x"
-        )
+        raise BackendUnavailable(f"MegaMoE kernels need SM100+, found SM{major}x")
     if not op.apply_topk_in_fc1:
         raise BackendUnavailable("kernel supports apply_topk_in_fc1=True only")
     if op.hidden_size % 32 or op.intermediate_size % 32:
-        raise BackendUnavailable(
-            "hidden_size and intermediate_size must be multiples of 32"
-        )
+        raise BackendUnavailable("hidden_size and intermediate_size must be multiples of 32")
     if op.generate_c and (op.hidden_size % 128 or op.intermediate_size % 128):
-        raise BackendUnavailable(
-            "generate_c/backward path needs hidden_size and intermediate_size "
-            "to be multiples of 128"
-        )
+        raise BackendUnavailable("generate_c/backward path needs hidden_size and intermediate_size " "to be multiples of 128")
     if op.combine_format not in _COMBINE_WIRE:
-        raise BackendUnavailable(
-            f"combine_format={op.combine_format.value!r} has no MXFP8-kernel "
-            "wire format"
-        )
+        raise BackendUnavailable(f"combine_format={op.combine_format.value!r} has no MXFP8-kernel " "wire format")
     if op.generate_c and op.combine_format is not MoeFormat.BF16:
-        raise BackendUnavailable(
-            "generate_c/backward needs combine_format='bf16' (dtw reads the "
-            "bf16 combine staging)"
-        )
+        raise BackendUnavailable("generate_c/backward needs combine_format='bf16' (dtw reads the " "bf16 combine staging)")
     if op.ep_group is None:
         if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
-            raise BackendUnavailable(
-                "ep_group=None (one-rank execution) inside an initialized "
-                "multi-rank process is not supported"
-            )
+            raise BackendUnavailable("ep_group=None (one-rank execution) inside an initialized " "multi-rank process is not supported")
     else:
         if dist.get_world_size(op.ep_group) != dist.get_world_size():
-            raise BackendUnavailable(
-                "ep_group must span the entire torch.distributed world "
-                "(NVSHMEM is bootstrapped over the global world)"
-            )
+            raise BackendUnavailable("ep_group must span the entire torch.distributed world " "(NVSHMEM is bootstrapped over the global world)")
 
 
 def maybe_create(op, device: torch.device, token_count: int):
@@ -313,9 +291,9 @@ class _MegamoeBackend:
             raise BackendUnavailable("cannot size kernel buffers for 0 tokens")
         self._max_tokens = max_tokens
 
-        self._layer = None            # built on first forward (needs weights)
+        self._layer = None  # built on first forward (needs weights)
         self._weight_sig = None
-        self._stash_serial = 0        # forward serial whose pools are live
+        self._stash_serial = 0  # forward serial whose pools are live
         self._done_serial = 0
 
     # -- construction ---------------------------------------------------
@@ -388,8 +366,7 @@ class _MegamoeBackend:
         T = x.shape[0]
         if T > self._max_tokens:
             raise RuntimeError(
-                f"token count {T} exceeds the backend capacity {self._max_tokens} "
-                "(pass max_tokens_per_rank to MoeEp to size the kernel buffers)"
+                f"token count {T} exceeds the backend capacity {self._max_tokens} " "(pass max_tokens_per_rank to MoeEp to size the kernel buffers)"
             )
         self._sync_weights(fc1_weight, fc2_weight)
         idx = topk_idx.to(torch.int64)
@@ -428,45 +405,29 @@ class _MegamoeBackend:
                 group=op.ep_group,
             )
             if not bool((t_all == T).all().item()):
-                raise RuntimeError(
-                    "megamoe backend requires the same token count on every "
-                    f"EP rank, got {t_all.tolist()}"
-                )
+                raise RuntimeError("megamoe backend requires the same token count on every " f"EP rank, got {t_all.tolist()}")
             ids_all = torch.empty((world, T, K), dtype=topk_idx.dtype, device=device)
-            dist.all_gather_into_tensor(
-                ids_all, topk_idx.contiguous(), group=op.ep_group
-            )
+            dist.all_gather_into_tensor(ids_all, topk_idx.contiguous(), group=op.ep_group)
         else:
             ids_all = topk_idx.view(1, T, K)
 
         local = ids_all.reshape(-1) - op.ep_rank * E_local
-        counts = torch.bincount(
-            local[(local >= 0) & (local < E_local)], minlength=E_local
-        )
+        counts = torch.bincount(local[(local >= 0) & (local < E_local)], minlength=E_local)
         counts_list = counts.tolist()
         padded = [-(-n // 128) * 128 for n in counts_list]
         Mp = max(sum(padded), 128)
         doffs = [sum(padded[:i]) for i in range(E_local)]
         if sum(counts_list):
-            valid = torch.cat(
-                [
-                    torch.arange(o, o + n, device=device)
-                    for o, n in zip(doffs, counts_list)
-                ]
-            )
+            valid = torch.cat([torch.arange(o, o + n, device=device) for o, n in zip(doffs, counts_list)])
         else:
             valid = torch.empty(0, dtype=torch.long, device=device)
 
         lv = mods["local_pool_views"](fwd)
-        src_rank, src_token, src_topk, _, _ = mods["decode_token_src_metadata"](
-            lv["token_src_metadata"][:Mp]
-        )
+        src_rank, src_token, src_topk, _, _ = mods["decode_token_src_metadata"](lv["token_src_metadata"][:Mp])
         sr = src_rank[valid].long()
         st = src_token[valid].long()
         sk = src_topk[valid].long()
-        expert = torch.repeat_interleave(
-            torch.arange(E_local, dtype=torch.long, device=device), counts
-        )
+        expert = torch.repeat_interleave(torch.arange(E_local, dtype=torch.long, device=device), counts)
 
         # contract row order: expert asc, then (src_rank, src_token, src_slot)
         key = ((expert * world + sr) * T + st) * K + sk
@@ -475,13 +436,9 @@ class _MegamoeBackend:
         rows = fwd.fc1_c[:Mp][valid][order]
         n = rows.shape[0]
         pair = rows.view(n, I // 32, 2, 32)
-        fc1_c = torch.cat(
-            [pair[:, :, 0].reshape(n, I), pair[:, :, 1].reshape(n, I)], dim=-1
-        ).contiguous()
+        fc1_c = torch.cat([pair[:, :, 0].reshape(n, I), pair[:, :, 1].reshape(n, I)], dim=-1).contiguous()
 
-        route_metadata = torch.stack(
-            [expert[order], sr[order], st[order], sk[order]], dim=-1
-        ).to(torch.int32)
+        route_metadata = torch.stack([expert[order], sr[order], st[order], sk[order]], dim=-1).to(torch.int32)
         return fc1_c, route_metadata
 
     # -- backward ---------------------------------------------------------
@@ -501,10 +458,7 @@ class _MegamoeBackend:
         if self._layer is None or self._stash_serial == 0:
             raise RuntimeError("backward called before any forward on this MoeEp")
         if self._done_serial == self._stash_serial:
-            raise RuntimeError(
-                "backward already consumed this forward's stash; run another "
-                "forward first"
-            )
+            raise RuntimeError("backward already consumed this forward's stash; run another " "forward first")
         self._sync_weights(fc1_weight, fc2_weight)
 
         layer = self._layer

--- a/python/cudnn/moe_ep/_megamoe.py
+++ b/python/cudnn/moe_ep/_megamoe.py
@@ -1,0 +1,531 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""MegaMoE (CuTe DSL) device backend for :class:`cudnn.MoeEp`.
+
+This module wires the ``megamoe`` training package (the SM100 MegaMoE MXFP8
+mega-kernel: NVSHMEM dispatch -> grouped FC1/SwiGLU/FC2 -> combine in one
+launch, plus the ``bwd_impl="mega"`` backward kernel) behind the public
+``MoeEp`` contract.  ``api.MoeEp`` calls :func:`maybe_create` lazily on the
+first ``__call__``; when the environment or the operator configuration is not
+supported the call returns ``None`` and ``MoeEp`` keeps its allocate-only
+behavior.
+
+Environment:
+
+- ``CUDNN_MOE_EP_BACKEND``: ``auto`` (default; use megamoe when possible,
+  warn once and fall back otherwise), ``megamoe`` (required; raise if the
+  backend cannot be built), ``none`` (never use a backend).
+- ``CUDNN_MEGAMOE_ROOT``: path to the ``moe_ep_training`` checkout that
+  contains the ``megamoe`` package (with its sibling ``cutedsl_megamoe``
+  kernel clone).  Not needed when ``megamoe`` is already importable.
+
+Backend requirements and deviations from the pure reference:
+
+- SM100 (GB200) GPU, ``nvidia-cutlass-dsl``, ``nvshmem4py``; the first call
+  pays the one-time ``cute.compile`` (minutes per kernel).
+- Internal compute is MXFP8: bf16 activations/weights are quantized on
+  device, so outputs match the FP32 reference at MXFP8 tolerance (~1e-2
+  relative), not bitwise.  Block-scaled inputs are dequantized and
+  re-quantized (straight-through, matching the reference's gradient
+  convention but adding one rounding).
+- ``apply_topk_in_fc1=False`` is not supported by the kernel.
+- ``combine_format="mxfp8"`` is forward-only (kernel wire format
+  ``32e4m3xe8m0``); ``generate_c``/backward need bf16 combine staging.
+  ``combine_format="nvfp4"`` is unsupported (the NVFP4 wire format belongs
+  to the NVFP4 kernel, which has no training path).
+- Quantized ``output_format`` is produced by quantizing the kernel's bf16
+  result on the host side of the launch (reference-identical algorithm).
+- ``backward`` consumes the kernel's persistent pools from the immediately
+  preceding forward on the same operator (the passed ``fc1_c``/
+  ``route_metadata`` are validated but the pool stash is the source of
+  truth).  One forward per backward; a second forward overwrites the stash.
+- With an ``ep_group`` every rank must call forward/backward collectively,
+  the group must span the whole NVSHMEM/torch.distributed world, and all
+  ranks must pass the same token count ``T``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+from typing import Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+from .api import BlockScaledTensor, MoeFormat, MoeTensor
+
+_COMBINE_WIRE = {
+    MoeFormat.BF16: "bf16",
+    MoeFormat.MXFP8: "32e4m3xe8m0",
+}
+
+_state = {
+    "modules": None,       # imported megamoe modules, once per process
+    "mode": None,          # "no_dist" | "dist"
+    "nvshmem_ready": False,
+    "warned": False,
+}
+
+
+class BackendUnavailable(RuntimeError):
+    """Raised when the megamoe backend cannot serve this MoeEp config."""
+
+
+def _policy() -> str:
+    value = os.environ.get("CUDNN_MOE_EP_BACKEND", "auto").lower()
+    if value in ("", "auto"):
+        return "auto"
+    if value in ("none", "0", "off"):
+        return "none"
+    if value == "megamoe":
+        return "megamoe"
+    raise ValueError(f"CUDNN_MOE_EP_BACKEND must be auto|megamoe|none, got {value!r}")
+
+
+def _import_megamoe(single_rank: bool):
+    """Import the megamoe package once; the dist/no-dist mode is frozen at
+    first import (``MEGA_NO_DIST`` is read at module import time)."""
+
+    if _state["modules"] is not None:
+        want = "no_dist" if single_rank else "dist"
+        if _state["mode"] != want:
+            raise BackendUnavailable(
+                f"megamoe already imported in {_state['mode']!r} mode; cannot "
+                f"serve a {want!r} MoeEp in the same process"
+            )
+        return _state["modules"]
+
+    root = os.environ.get("CUDNN_MEGAMOE_ROOT")
+    if root and root not in sys.path:
+        sys.path.insert(0, root)
+    if single_rank:
+        os.environ.setdefault("MEGA_NO_DIST", "1")
+
+    import megamoe.repo_path  # noqa: F401  (sys.path shim for the kernel clone)
+    from megamoe.forward import MegaMoeForwardConfig, MegaMoeMxfp8Forward  # noqa: F401
+    from megamoe.training import MegaMoeHybridMxfp8Layer
+    from megamoe.pools import (
+        decode_token_src_metadata,
+        local_pool_views,
+    )
+    from pt.config import EpConfig
+    from pt.quant import QuantConfig
+
+    _state["modules"] = {
+        "MegaMoeForwardConfig": MegaMoeForwardConfig,
+        "MegaMoeHybridMxfp8Layer": MegaMoeHybridMxfp8Layer,
+        "decode_token_src_metadata": decode_token_src_metadata,
+        "local_pool_views": local_pool_views,
+        "EpConfig": EpConfig,
+        "QuantConfig": QuantConfig,
+    }
+    _state["mode"] = "no_dist" if single_rank else "dist"
+    return _state["modules"]
+
+
+def _ensure_single_rank_dist():
+    """The hybrid layer's comm needs an initialized process group even for
+    ``ep_size=1``; bootstrap a world-1 NCCL group like the megamoe tests."""
+
+    if dist.is_available() and dist.is_initialized():
+        return
+    import tempfile
+
+    store_path = tempfile.mktemp(prefix="cudnn_moe_ep_pg_")
+    dist.init_process_group(
+        "nccl",
+        store=dist.FileStore(store_path, 1),
+        world_size=1,
+        rank=0,
+    )
+
+
+def _ensure_nvshmem():
+    if _state["nvshmem_ready"]:
+        return
+    from src.bootstrap import init_dist_and_nvshmem  # via megamoe.repo_path
+
+    init_dist_and_nvshmem()
+    _state["nvshmem_ready"] = True
+
+
+def _check_supported(op) -> None:
+    """Raise :class:`BackendUnavailable` when this MoeEp configuration cannot
+    run on the MegaMoE kernel."""
+
+    if not torch.cuda.is_available():
+        raise BackendUnavailable("CUDA is not available")
+    major, _ = torch.cuda.get_device_capability()
+    if major < 10:
+        raise BackendUnavailable(
+            f"MegaMoE kernels need SM100+, found SM{major}x"
+        )
+    if not op.apply_topk_in_fc1:
+        raise BackendUnavailable("kernel supports apply_topk_in_fc1=True only")
+    if op.hidden_size % 32 or op.intermediate_size % 32:
+        raise BackendUnavailable(
+            "hidden_size and intermediate_size must be multiples of 32"
+        )
+    if op.generate_c and (op.hidden_size % 128 or op.intermediate_size % 128):
+        raise BackendUnavailable(
+            "generate_c/backward path needs hidden_size and intermediate_size "
+            "to be multiples of 128"
+        )
+    if op.combine_format not in _COMBINE_WIRE:
+        raise BackendUnavailable(
+            f"combine_format={op.combine_format.value!r} has no MXFP8-kernel "
+            "wire format"
+        )
+    if op.generate_c and op.combine_format is not MoeFormat.BF16:
+        raise BackendUnavailable(
+            "generate_c/backward needs combine_format='bf16' (dtw reads the "
+            "bf16 combine staging)"
+        )
+    if op.ep_group is None:
+        if dist.is_available() and dist.is_initialized() and dist.get_world_size() > 1:
+            raise BackendUnavailable(
+                "ep_group=None (one-rank execution) inside an initialized "
+                "multi-rank process is not supported"
+            )
+    else:
+        if dist.get_world_size(op.ep_group) != dist.get_world_size():
+            raise BackendUnavailable(
+                "ep_group must span the entire torch.distributed world "
+                "(NVSHMEM is bootstrapped over the global world)"
+            )
+
+
+def maybe_create(op, device: torch.device, token_count: int):
+    """Return a live backend for ``op`` or ``None`` (allocate-only fallback)."""
+
+    policy = _policy()
+    if policy == "none":
+        return None
+    try:
+        _check_supported(op)
+        return _MegamoeBackend(op, device, token_count)
+    except Exception as exc:  # noqa: BLE001 - fold every failure into policy
+        if policy == "megamoe":
+            raise
+        if not _state["warned"]:
+            _state["warned"] = True
+            warnings.warn(
+                f"cudnn.MoeEp: megamoe backend unavailable ({exc}); "
+                "returning uninitialized allocations (set "
+                "CUDNN_MOE_EP_BACKEND=megamoe to make this an error)",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+        return None
+
+
+def _dequant_to_bf16(tensor: MoeTensor) -> torch.Tensor:
+    if isinstance(tensor, BlockScaledTensor):
+        return tensor.dequantize(torch.bfloat16)
+    return tensor.to(torch.bfloat16)
+
+
+def _weight_signature(tensor: MoeTensor) -> Tuple:
+    data = tensor.data if isinstance(tensor, BlockScaledTensor) else tensor
+    return (data.data_ptr(), data._version)
+
+
+def _quantize_output(values: torch.Tensor, fmt: MoeFormat) -> BlockScaledTensor:
+    """Quantize the kernel's bf16 (T, H) result along axis 1, matching the
+    reference ``quantize_blockwise`` bit for bit."""
+
+    logical_shape = tuple(values.shape)
+    block = 32 if fmt is MoeFormat.MXFP8 else 16
+    limit = 448.0 if fmt is MoeFormat.MXFP8 else 6.0
+    blocks = values.float().reshape(values.shape[0], -1, block)
+
+    scale_float = blocks.abs().amax(dim=-1) / limit
+    if fmt is MoeFormat.MXFP8:
+        safe = torch.where(scale_float > 0, scale_float, torch.ones_like(scale_float))
+        scale_float = torch.where(
+            scale_float > 0,
+            torch.pow(2.0, torch.ceil(torch.log2(safe))),
+            torch.zeros_like(scale_float),
+        )
+        scale = scale_float.to(torch.float8_e8m0fnu)
+    else:
+        scale = scale_float.to(torch.float8_e4m3fn)
+
+    scale_math = scale.float()
+    reciprocal = torch.where(scale_math > 0, scale_math.reciprocal(), torch.zeros_like(scale_math))
+    normalized = (blocks * reciprocal.unsqueeze(-1)).clamp(-limit, limit)
+
+    if fmt is MoeFormat.MXFP8:
+        data = normalized.to(torch.float8_e4m3fn).reshape(logical_shape)
+    else:
+        codes = _nearest_e2m1_codes(normalized).reshape(logical_shape)
+        data = (codes[..., 0::2] | (codes[..., 1::2] << 4)).to(torch.uint8)
+
+    return BlockScaledTensor(
+        data=data.contiguous(),
+        scale=scale.contiguous(),
+        format=fmt,
+        logical_shape=logical_shape,
+        axis=-1,
+    )
+
+
+def _nearest_e2m1_codes(values: torch.Tensor) -> torch.Tensor:
+    """E2M1 nibble codes, round-to-nearest ties-to-even (reference copy)."""
+
+    levels = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+        dtype=torch.float32,
+        device=values.device,
+    )
+    magnitudes = values.abs().unsqueeze(-1)
+    distances = (magnitudes - levels).abs()
+    minimum = distances.amin(dim=-1, keepdim=True)
+    candidates = distances == minimum
+    codes = torch.arange(8, dtype=torch.int64, device=values.device)
+    any_code = torch.where(candidates, codes, 8).amin(dim=-1)
+    even_code = torch.where(candidates & ((codes & 1) == 0), codes, 8).amin(dim=-1)
+    magnitude_code = torch.where(even_code < 8, even_code, any_code)
+    sign_code = torch.signbit(values).to(torch.int64) << 3
+    return magnitude_code | sign_code
+
+
+class _MegamoeBackend:
+    """Owns one ``MegaMoeHybridMxfp8Layer`` for one ``MoeEp`` instance."""
+
+    def __init__(self, op, device: torch.device, token_count: int) -> None:
+        self._op = op
+        self._device = device
+        single_rank = op.ep_group is None
+        self._mods = _import_megamoe(single_rank)
+        if single_rank:
+            _ensure_single_rank_dist()
+        else:
+            _ensure_nvshmem()
+
+        max_tokens = op.max_tokens_per_rank
+        if max_tokens is None:
+            max_tokens = token_count
+        if max_tokens <= 0:
+            raise BackendUnavailable("cannot size kernel buffers for 0 tokens")
+        self._max_tokens = max_tokens
+
+        self._layer = None            # built on first forward (needs weights)
+        self._weight_sig = None
+        self._stash_serial = 0        # forward serial whose pools are live
+        self._done_serial = 0
+
+    # -- construction ---------------------------------------------------
+
+    def _build_layer(self, w13: torch.Tensor, w2: torch.Tensor):
+        op = self._op
+        mods = self._mods
+        ep_cfg = mods["EpConfig"](
+            num_experts=op.num_experts,
+            top_k=op.top_k,
+            hidden_size=op.hidden_size,
+            intermediate_size=op.intermediate_size,
+            ep_size=op.ep_size,
+            ep_rank=op.ep_rank,
+            process_group=op.ep_group,
+        )
+        mm_cfg = mods["MegaMoeForwardConfig"](
+            max_tokens_per_rank=self._max_tokens,
+            hidden=op.hidden_size,
+            intermediate=op.intermediate_size,
+            num_total_experts=op.num_experts,
+            num_topk=op.top_k,
+            gate_up_clamp=op.gate_up_clamp,
+            combine_format=_COMBINE_WIRE[op.combine_format],
+        )
+        mm_cfg.impl.generate_c = bool(op.generate_c)
+        qcfg = mods["QuantConfig"](fprop_fmt="mxfp8", quant_bprop=True)
+        self._layer = mods["MegaMoeHybridMxfp8Layer"](
+            ep_cfg,
+            mm_cfg,
+            w13,
+            w2,
+            qcfg=qcfg,
+            comm="torch_dist",
+            bwd_impl="mega" if op.generate_c else "replay",
+        )
+
+    # -- layout adapters --------------------------------------------------
+
+    def _to_kernel_weights(self, fc1_weight: MoeTensor, fc2_weight: MoeTensor):
+        """(E,H,2I) gate-first / (E,I,H)  ->  w13 (E,2I,H) up-first / w2 (E,H,I)."""
+
+        I = self._op.intermediate_size
+        fc1 = _dequant_to_bf16(fc1_weight)
+        gate = fc1[..., :I].transpose(1, 2)
+        up = fc1[..., I:].transpose(1, 2)
+        w13 = torch.cat([up, gate], dim=1).contiguous()
+        w2 = _dequant_to_bf16(fc2_weight).transpose(1, 2).contiguous()
+        return w13, w2
+
+    def _sync_weights(self, fc1_weight: MoeTensor, fc2_weight: MoeTensor) -> None:
+        sig = (_weight_signature(fc1_weight), _weight_signature(fc2_weight))
+        if sig == self._weight_sig:
+            return
+        w13, w2 = self._to_kernel_weights(fc1_weight, fc2_weight)
+        if self._layer is None:
+            self._build_layer(w13, w2)
+        else:
+            with torch.no_grad():
+                self._layer.w13.data.copy_(w13)
+                self._layer.w2.data.copy_(w2)
+            self._layer.refresh_weights()
+        self._weight_sig = sig
+
+    # -- forward ----------------------------------------------------------
+
+    def forward(self, activation, fc1_weight, fc2_weight, topk_idx, topk_weights):
+        op = self._op
+        x = _dequant_to_bf16(activation)
+        T = x.shape[0]
+        if T > self._max_tokens:
+            raise RuntimeError(
+                f"token count {T} exceeds the backend capacity {self._max_tokens} "
+                "(pass max_tokens_per_rank to MoeEp to size the kernel buffers)"
+            )
+        self._sync_weights(fc1_weight, fc2_weight)
+        idx = topk_idx.to(torch.int64)
+        tw = topk_weights.to(torch.float32)
+
+        out_view = self._layer._fwd(x, idx, tw)
+        self._stash_serial += 1
+
+        if op.output_format is MoeFormat.BF16:
+            output = out_view[:T].clone()
+        else:
+            output = _quantize_output(out_view[:T], op.output_format)
+        if not op.generate_c:
+            return output
+        fc1_c, route_metadata = self._extract_stash(idx, T)
+        return output, fc1_c, route_metadata
+
+    def _extract_stash(self, topk_idx: torch.Tensor, T: int):
+        """Kernel pools -> the logical (fc1_c, route_metadata) contract:
+        rows grouped by local expert, sorted by (src_rank, src_token,
+        src_slot); fc1_c de-interleaved from the kernel's 32-block (gate, up)
+        pairs into plain [gate | up] halves."""
+
+        op = self._op
+        mods = self._mods
+        fwd = self._layer._fwd
+        device = topk_idx.device
+        E_local, I, K = op.experts_per_rank, op.intermediate_size, op.top_k
+        world = op.ep_size
+
+        if world > 1:
+            t_all = torch.full((world,), T, dtype=torch.int64, device=device)
+            dist.all_gather_into_tensor(
+                t_all,
+                torch.tensor([T], dtype=torch.int64, device=device),
+                group=op.ep_group,
+            )
+            if not bool((t_all == T).all().item()):
+                raise RuntimeError(
+                    "megamoe backend requires the same token count on every "
+                    f"EP rank, got {t_all.tolist()}"
+                )
+            ids_all = torch.empty((world, T, K), dtype=topk_idx.dtype, device=device)
+            dist.all_gather_into_tensor(
+                ids_all, topk_idx.contiguous(), group=op.ep_group
+            )
+        else:
+            ids_all = topk_idx.view(1, T, K)
+
+        local = ids_all.reshape(-1) - op.ep_rank * E_local
+        counts = torch.bincount(
+            local[(local >= 0) & (local < E_local)], minlength=E_local
+        )
+        counts_list = counts.tolist()
+        padded = [-(-n // 128) * 128 for n in counts_list]
+        Mp = max(sum(padded), 128)
+        doffs = [sum(padded[:i]) for i in range(E_local)]
+        if sum(counts_list):
+            valid = torch.cat(
+                [
+                    torch.arange(o, o + n, device=device)
+                    for o, n in zip(doffs, counts_list)
+                ]
+            )
+        else:
+            valid = torch.empty(0, dtype=torch.long, device=device)
+
+        lv = mods["local_pool_views"](fwd)
+        src_rank, src_token, src_topk, _, _ = mods["decode_token_src_metadata"](
+            lv["token_src_metadata"][:Mp]
+        )
+        sr = src_rank[valid].long()
+        st = src_token[valid].long()
+        sk = src_topk[valid].long()
+        expert = torch.repeat_interleave(
+            torch.arange(E_local, dtype=torch.long, device=device), counts
+        )
+
+        # contract row order: expert asc, then (src_rank, src_token, src_slot)
+        key = ((expert * world + sr) * T + st) * K + sk
+        order = torch.argsort(key)
+
+        rows = fwd.fc1_c[:Mp][valid][order]
+        n = rows.shape[0]
+        pair = rows.view(n, I // 32, 2, 32)
+        fc1_c = torch.cat(
+            [pair[:, :, 0].reshape(n, I), pair[:, :, 1].reshape(n, I)], dim=-1
+        ).contiguous()
+
+        route_metadata = torch.stack(
+            [expert[order], sr[order], st[order], sk[order]], dim=-1
+        ).to(torch.int32)
+        return fc1_c, route_metadata
+
+    # -- backward ---------------------------------------------------------
+
+    def backward(
+        self,
+        grad_output,
+        activation,
+        fc1_weight,
+        fc2_weight,
+        topk_idx,
+        topk_weights,
+        fc1_c,
+        route_metadata,
+    ):
+        op = self._op
+        if self._layer is None or self._stash_serial == 0:
+            raise RuntimeError("backward called before any forward on this MoeEp")
+        if self._done_serial == self._stash_serial:
+            raise RuntimeError(
+                "backward already consumed this forward's stash; run another "
+                "forward first"
+            )
+        self._sync_weights(fc1_weight, fc2_weight)
+
+        layer = self._layer
+        if layer._mega_bwd is None:
+            from megamoe.bwd_kernel.backward import MegaMoeMxfp8Backward
+
+            layer._mega_bwd = MegaMoeMxfp8Backward(layer._fwd, layer.ep_cfg)
+        from megamoe.bwd_kernel.backward import mega_backward
+
+        idx = topk_idx.to(torch.int64)
+        tw = topk_weights.to(torch.float32)
+        T = idx.shape[0]
+        dx, dtw, dw13, dw2 = mega_backward(layer, idx, tw, grad_output, T)
+        self._done_serial = self._stash_serial
+
+        I = op.intermediate_size
+        dw13 = dw13.float()
+        grad_fc1 = torch.cat(
+            [dw13[:, I:, :].transpose(1, 2), dw13[:, :I, :].transpose(1, 2)],
+            dim=-1,
+        ).contiguous()
+        grad_fc2 = dw2.float().transpose(1, 2).contiguous()
+        grad_tw = (dtw.float() * (idx != -1)).contiguous()
+        return dx.float(), grad_fc1, grad_fc2, grad_tw

--- a/python/cudnn/moe_ep/_megamoe.py
+++ b/python/cudnn/moe_ep/_megamoe.py
@@ -16,11 +16,11 @@ Environment:
 - ``CUDNN_MOE_EP_BACKEND``: ``auto`` (default; use megamoe when possible,
   warn once and fall back otherwise), ``megamoe`` (required; raise if the
   backend cannot be built), ``none`` (never use a backend).
-- ``CUDNN_MEGAMOE_ROOT``: optional override pointing at a ``moe_ep_training``
-  checkout that contains the ``megamoe`` package (with its sibling
-  ``cutedsl_megamoe`` kernel clone).  By default the copy vendored in
-  ``_megamoe_backend/`` (kernels included) is used, so no external checkout
-  is needed.
+
+The ``megamoe`` package and its CuTe DSL kernel sources ship inside cuDNN
+under ``_megamoe_backend/``.  Note: the backward (bprop) implementation in
+``megamoe/bwd_kernel`` comes from the Flashinfer team, not the FastKernel
+team.
 
 Backend requirements and deviations from the pure reference:
 
@@ -76,15 +76,14 @@ class BackendUnavailable(RuntimeError):
     """Raised when the megamoe backend cannot serve this MoeEp config."""
 
 
-def bundled_root() -> Optional[str]:
-    """Path of the vendored ``_megamoe_backend`` tree (megamoe + pt +
-    cutedsl_megamoe kernels), or ``None`` if it was stripped from this
-    install."""
+def bundled_root() -> str:
+    """Path of the bundled ``_megamoe_backend`` tree (megamoe + pt +
+    cutedsl_megamoe kernels)."""
 
     root = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_megamoe_backend")
-    if os.path.isdir(os.path.join(root, "megamoe")):
-        return root
-    return None
+    if not os.path.isdir(os.path.join(root, "megamoe")):
+        raise BackendUnavailable(f"bundled megamoe backend missing at {root!r}")
+    return root
 
 
 def _policy() -> str:
@@ -108,7 +107,7 @@ def _import_megamoe(single_rank: bool):
             raise BackendUnavailable(f"megamoe already imported in {_state['mode']!r} mode; cannot " f"serve a {want!r} MoeEp in the same process")
         return _state["modules"]
 
-    root = os.environ.get("CUDNN_MEGAMOE_ROOT") or bundled_root()
+    root = bundled_root()
     if root and root not in sys.path:
         sys.path.insert(0, root)
     if single_rank:

--- a/python/cudnn/moe_ep/_megamoe_backend/README.md
+++ b/python/cudnn/moe_ep/_megamoe_backend/README.md
@@ -1,0 +1,30 @@
+# Vendored MegaMoE (CuTe DSL) device backend
+
+Verbatim copy of the MegaMoE training package and the CuTe DSL kernel
+sources that back `cudnn.MoeEp` (see `../_megamoe.py`), so the PR is
+self-sufficient — no external checkout or `CUDNN_MEGAMOE_ROOT` needed.
+
+Contents (import layout is preserved; `megamoe/repo_path.py` puts this
+directory, `cutedsl_megamoe/`, and `cutedsl_megamoe/moe_nvfp4_swapab/` on
+`sys.path`):
+
+| Folder | What it is |
+|---|---|
+| `megamoe/` | Training-side package: MXFP8 forward wrapper (`forward.py`), NVFP4 forward wrapper (`forward_nvfp4.py`), hybrid training layer (`training.py`), FP8 mega backward (`bwd_kernel/`, `fp8_bwd.py`), pools/quant utilities. |
+| `pt/` | Pure-PyTorch MoE+EP config/reference package (`EpConfig`, `QuantConfig`, references). |
+| `cutedsl_megamoe/moe_mxfp8_glu/` | SM100 MXFP8 GLU mega-kernel (CuTe DSL): dispatch → grouped FC1/SwiGLU/FC2 → combine in one launch. |
+| `cutedsl_megamoe/moe_nvfp4_swapab/` | SM100 NVFP4 (E2M1, swap-AB) mega-kernel — the FP4 forward; also provides shared runner/epilogue infrastructure imported by the MXFP8 kernel. |
+| `cutedsl_megamoe/common/` | Host utilities and kernel constants shared by both kernels. |
+| `cutedsl_megamoe/src/` | Dispatch/combine comm layer: NVSHMEM bootstrap, token comm, symmetric buffers, PTX helpers. |
+
+Provenance (copied 2026-08-05, excluding only `__pycache__`/`.git`):
+
+- `moe_ep_training` @ `f97c469ba98e9f264ba53d12edd4ed046a305663`
+  (source of `megamoe/`, `pt/`)
+- `cutedsl_megamoe` @ `8ff233d6040d522dba536a6179a5e67af950c52f`
+  (https://gitlab-master.nvidia.com/bangyus/cutedsl_megamoe; only the four
+  subpackages above plus `README.md` are vendored — `ci/`, `tester/`,
+  `scripts/`, `tests/` are not needed at runtime)
+
+`CUDNN_MEGAMOE_ROOT` still overrides this bundled copy when set (useful for
+kernel development against a live checkout).

--- a/python/cudnn/moe_ep/_megamoe_backend/README.md
+++ b/python/cudnn/moe_ep/_megamoe_backend/README.md
@@ -23,5 +23,6 @@ Provenance (copied 2026-08-05, excluding only `__pycache__`/`.git`):
   (source of `megamoe/`, `pt/`)
 - `cutedsl_megamoe` @ `8ff233d6040d522dba536a6179a5e67af950c52f`
   (https://gitlab-master.nvidia.com/bangyus/cutedsl_megamoe; only the four
-  subpackages above plus `README.md` are vendored — `ci/`, `tester/`,
+  subpackages above plus `README.md` and `ci/requirements.txt` (the pip
+  environment pins) are vendored — the rest of `ci/`, `tester/`,
   `scripts/`, `tests/` are not needed at runtime)

--- a/python/cudnn/moe_ep/_megamoe_backend/README.md
+++ b/python/cudnn/moe_ep/_megamoe_backend/README.md
@@ -1,8 +1,8 @@
 # Vendored MegaMoE (CuTe DSL) device backend
 
-Verbatim copy of the MegaMoE training package and the CuTe DSL kernel
-sources that back `cudnn.MoeEp` (see `../_megamoe.py`), so the PR is
-self-sufficient — no external checkout or `CUDNN_MEGAMOE_ROOT` needed.
+The MegaMoE training package and the CuTe DSL kernel sources that back
+`cudnn.MoeEp` (see `../_megamoe.py`).  The kernel source ships here, inside
+cuDNN — nothing is loaded from an external checkout.
 
 Contents (import layout is preserved; `megamoe/repo_path.py` puts this
 directory, `cutedsl_megamoe/`, and `cutedsl_megamoe/moe_nvfp4_swapab/` on
@@ -10,7 +10,7 @@ directory, `cutedsl_megamoe/`, and `cutedsl_megamoe/moe_nvfp4_swapab/` on
 
 | Folder | What it is |
 |---|---|
-| `megamoe/` | Training-side package: MXFP8 forward wrapper (`forward.py`), NVFP4 forward wrapper (`forward_nvfp4.py`), hybrid training layer (`training.py`), FP8 mega backward (`bwd_kernel/`, `fp8_bwd.py`), pools/quant utilities. |
+| `megamoe/` | Training-side package: MXFP8 forward wrapper (`forward.py`), NVFP4 forward wrapper (`forward_nvfp4.py`), hybrid training layer (`training.py`), FP8 mega backward (`bwd_kernel/`, `fp8_bwd.py`), pools/quant utilities. Note: the backward (bprop) implementation is from the **Flashinfer team**, not the FastKernel team. |
 | `pt/` | Pure-PyTorch MoE+EP config/reference package (`EpConfig`, `QuantConfig`, references). |
 | `cutedsl_megamoe/moe_mxfp8_glu/` | SM100 MXFP8 GLU mega-kernel (CuTe DSL): dispatch → grouped FC1/SwiGLU/FC2 → combine in one launch. |
 | `cutedsl_megamoe/moe_nvfp4_swapab/` | SM100 NVFP4 (E2M1, swap-AB) mega-kernel — the FP4 forward; also provides shared runner/epilogue infrastructure imported by the MXFP8 kernel. |
@@ -25,6 +25,3 @@ Provenance (copied 2026-08-05, excluding only `__pycache__`/`.git`):
   (https://gitlab-master.nvidia.com/bangyus/cutedsl_megamoe; only the four
   subpackages above plus `README.md` are vendored — `ci/`, `tester/`,
   `scripts/`, `tests/` are not needed at runtime)
-
-`CUDNN_MEGAMOE_ROOT` still overrides this bundled copy when set (useful for
-kernel development against a live checkout).

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/README.md
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/README.md
@@ -1,0 +1,156 @@
+# mega_moe_cutedsl_dispatch
+
+Single cuTeDSL (`nvidia-cutlass-dsl==4.4.2` substituted for the plan-pinned `4.5.0dev0`, see OI-5) kernel replicating the dispatch phase of mega_moe (DeepGEMM `sm100_fp8_fp4_mega_moe.cuh:432-766`). All four sub-flows live in one `@cute.kernel`: Dispatch_Prep, Dispatch_Barrier, Dispatch_Pull, plus a kernel-tail NVLink barrier that takes the place of mega_moe's dispatch-combine handoff. A separate host-callable `cleanup_kernel` zeroes the workspace between dispatch invocations.
+
+**Status: V1 fully validated end-to-end on 4× GB200 (sm_100a) via NVSHMEM.** All 12 acceptance criteria from the plan are satisfied (AC-10 reproducibility is partial — counters deterministic, advertise/pool slot order races; matches mega_moe's same-hardware behaviour, see OI-20).
+
+Plan: `docs/plans/dispatch_cutedsl_plan.md` · Goal tracker: `.humanize/rlcr/2026-04-29_07-34-03/goal-tracker.md`
+
+## Architecture
+
+The kernel runs across `num_sms = 152` SMs per rank and `num_ranks = 4` GPUs. Inside each CTA, warps 0..3 are dispatch warps; later warps idle in the V1 dispatch-only kernel. The four sub-flows execute sequentially on the dispatch warps:
+
+1. **Dispatch_Prep** scans `input_topk_idx_buffer` three times. Round 1 builds a per-CTA SMEM histogram via `atomicAdd_block`. Round 2 fans the 256 global experts across 4×32 lanes and FAA's `expert_send_count` with a `(1<<32 | local_count)` u64 delta, so the rank's send-count high32 accumulates to `num_sms` and the low32 returns the SM's `base_slot`. Round 3 re-scans topk and writes `peer_src_token_topk_idx[dst_rank][local_expert][local_rank][base_slot + atomicAdd_block]`.
+2. **Dispatch_Barrier** publishes per-rank `expert_send_count` to peer `expert_recv_count` (low32 STG) and `expert_recv_count_sum` (release/sys u64 atom-add for both publisher count and token sum), runs `software_grid_sync`, then runs the 3-stage NVLink barrier (SM-0 lanes 0..world_size atom.release.sys.add.s32 +1 on each peer signal; SM-0 thread 0 ld.acquire.sys.s32 spin until local signal == world_size; epilogue grid_sync to release all SMs).
+3. **Dispatch_Pull** iterates the local pool by expert order and round-robin min-peeling source ranks (matching `src/reference.py::_round_robin_pool_order`). Each pool slot: read `src_token_topk_idx`, `mbarrier_arrive_and_expect_tx`, `tma_load_1d` from peer, 32-lane SF LDG/STG with `transform_sf_token_idx`, `mbarrier_wait` + phase flip, `tma_store_1d` to `l1_token_buffer[pool_token_idx]`, write 12-byte metadata, `cp_async_bulk_commit_group` + `wait_group(0)`, and finally `atom.release.gpu.global.add.u32` on `l1_arrival_count[expert_pool_block_offset + token_idx_in_expert/block_m]`.
+4. **Kernel-tail NVLink barrier** replaces the dispatch-combine `sync_unaligned` pairing in mega_moe.
+
+## Module map
+
+| File                       | Purpose |
+|----------------------------|---------|
+| `src/config.py`            | `V1Config` (formula-derived pool sizes), `transform_sf_token_idx_numpy`, `MAX_SLOT`, `TOKEN_METADATA_BYTES`. Pure-Python, zero GPU deps. |
+| `src/bootstrap.py`         | `init_nvshmem` (UID broadcast), `alloc_workspace` (15 symmetric tensors + `grid_sync_counter`), `peer_views`, `finalize_nvshmem`. Note dtype substitutions (uint32→int32, uint64→int64) needed for nvshmem4py 0.3.0. |
+| `src/ptx_helpers.py`       | `tma_load_1d`, `tma_store_1d`, `fns_b32` inline-PTX wrappers. |
+| `src/grid_sync.py`         | `software_grid_sync` (single-slot phase-flip pattern from `barrier.cuh`, `kFinishSumTag = 0x80000000`). |
+| `src/sf_swizzle.py`        | Device-side `transform_sf_token_idx` (4×32 UTCCP swizzle, integer-div based). |
+| `src/dispatch_kernel.py`   | The 1500-line dispatch kernel (`@cute.kernel dispatch_kernel`) with five inline-PTX atomic helpers. |
+| `src/cleanup_kernel.py`    | Host-callable workspace cleanup; replicates mega_moe `:723-766`. |
+| `src/reference.py`         | NumPy CPU oracle producing 9 expected buffers + `assert_buffer_equal`. |
+| `scripts/compile_smoke.py` | `cute.compile`-only smoke test (no kernel launch). |
+| `scripts/single_rank_validate.py` | world_size=1 functional test against the oracle (4 byte-exact + 4 invariant checks). |
+| `scripts/repro_validate.py`       | 5x repeat-launch determinism check. |
+| `scripts/degenerate_validate.py`  | T_actual=0, extreme skew, 50%-mask, single-token. |
+| `scripts/cleanup_validate.py`     | dispatch -> cleanup -> dispatch round-trip. |
+| `scripts/multi_rank_validate.py`  | **`torchrun --nproc_per_node=4 -m scripts.multi_rank_validate`** — full 4-GPU NVSHMEM end-to-end. |
+| `tests/`                   | pytest suite stubs (skipped without `LOCAL_RANK`). |
+
+## V1 testing config
+
+The `V1Config` constants are formula-derived from `layout/mega_moe.cuh::get_num_max_pool_tokens` and `get_num_padded_sf_pool_tokens`, NOT the literal `kNumPaddedSFPoolTokens=1088` mentioned in the plan (which was internally inconsistent — see goal-tracker OI-1).
+
+| Constant                       | V1 value |
+|--------------------------------|---------|
+| `num_ranks`                    | 4       |
+| `num_tokens_per_rank`          | 1024    |
+| `hidden`                       | 7168 (FP8) |
+| `num_topk`                     | 6       |
+| `num_experts_per_rank`         | 64      |
+| `num_total_experts`            | 256     |
+| `block_m`                      | 192     |
+| `sf_block_m`                   | 256     |
+| `num_sms`                      | 152     |
+| `sf_uint32_per_token`          | 56      |
+| `num_max_pool_tokens` (computed) | 36864 |
+| `num_padded_sf_pool_tokens` (computed) | 49152 |
+| `num_max_pool_blocks` (computed) | 192   |
+
+## Validation results (latest)
+
+### Host-only oracle (no GPU required)
+```bash
+venv/bin/python -m pytest tests/test_oracle.py -v
+# 14 passed in 0.3s
+```
+
+### Single-rank GB200 functional
+```bash
+venv/bin/python -m scripts.single_rank_validate
+# Order-sensitive byte-exact: expert_send/recv_count, expert_recv_count_sum,
+#                             l1_arrival_count -> all PASS
+# Order-invariant invariants:  6144/6144 metadata-data self-consistent for
+#                              src_token_topk_idx, l1_token_buffer,
+#                              l1_topk_weights_buf, l1_sf_buffer (incl. swizzle)
+# ALL INVARIANTS PASS.
+```
+
+### Degenerate scenarios
+```bash
+venv/bin/python -m scripts.degenerate_validate
+# A (extreme skew):           PASS
+# B (all masked, T_actual=0): PASS
+# C (50% masked):             PASS
+# D (single token):           PASS
+```
+
+### Cleanup re-launch
+```bash
+venv/bin/python -m scripts.cleanup_validate
+# Counters zeroed by cleanup:                              PASS
+# Counters identical across cleanup-flanked dispatch runs: PASS
+```
+
+### **4-rank multi-GPU (NVSHMEM)** — the gating test for V1
+```bash
+torchrun --nproc_per_node=4 --standalone -m scripts.multi_rank_validate
+# [rank 0] populated=6045, expected=6045, counters=PASS, invariants=PASS
+# [rank 1] populated=6082, expected=6082, counters=PASS, invariants=PASS
+# [rank 2] populated=6290, expected=6290, counters=PASS, invariants=PASS
+# [rank 3] populated=6159, expected=6159, counters=PASS, invariants=PASS
+```
+
+### Reproducibility (intentional non-determinism, see OI-20)
+```bash
+venv/bin/python -m scripts.repro_validate
+# 5 launches, fixed seed:
+#   esc, erc, ercs, lac:    byte-identical across all 5 runs
+#   sti, tsm, ltb, lsb, ltw: ~6000 entries differ between runs
+# (advertise / pool slot order races across 152 SMs; matches mega_moe behaviour)
+```
+
+## Environment provisioning
+
+```bash
+# cuTeDSL — pip-installable; 4.4.2 is the latest published version. The
+# plan-pinned 4.5.0dev0 is a CI-only dev build (use `dkg-fetch-ci-tarball`
+# skill with URM_TOKEN if you specifically need it).
+venv/bin/pip install nvidia-cutlass-dsl
+
+# nvshmem4py 0.3.0 — distributed under the cu13 / cu12 suffix.
+venv/bin/pip install nvshmem4py-cu13
+```
+
+## Open issues (live list in goal-tracker)
+
+Highlights of the 25 tracked open issues:
+
+- **OI-1**: V1 pool sizes use mega_moe formulas, not the plan's `1088` literal.
+- **OI-2**: `tma_store_1d` uses 3-operand bulk_group (no L2 hint); mega_moe uses 4-operand `.L2::cache_hint` variant — may need adjustment.
+- **OI-3**: `software_grid_sync` uses named PTX labels; verify no link-time collision under multi-callsite inlining.
+- **OI-9..OI-19, OI-21..OI-25**: cuTeDSL pattern fixes for `cute.compile` end-to-end (see goal-tracker for the full chain). Resolved.
+- **OI-20**: AC-10 reproducibility — counters deterministic, slot order races. Mega_moe has the same property.
+
+## Key cuTeDSL gotchas discovered (4.4.2 / 4.5.0dev0)
+
+These were the painful lessons from getting cute.compile to lower this kernel:
+
+1. **`cute.compile` must wrap a `@cute.jit` launcher**, not a `@cute.kernel` directly. Calling `cute.compile(@cute.kernel, ...)` puts the kernel on the host code path and routes inline asm through the host (ARM/x86) assembler, producing "unrecognized instruction mnemonic" errors.
+2. **PTX inline-asm constraint for global-memory pointers must be `l` (64-bit), not `r`**. Using `r` for a global pointer makes PTXAS think the module uses 32-bit ABI and rejects sm_90+ targets with `"32-Bit ABI ... is not supported"`.
+3. **Dynamic-index SMEM tensor writes (`smem_tensor[dyn_idx] = val`) are unsupported**. Use `tensor.fill(value)` for bulk init, or inline-PTX `ld.shared.u32` / `st.shared.u32` for element-wise dynamic access.
+4. **`@cute.struct` decorator inspects type annotations at decoration time** — incompatible with `from __future__ import annotations`.
+5. **Helper functions called from `@cute.kernel` need `@cute.jit`** so the AST preprocessor reaches `range_constexpr` and `if`-region SSA tracking inside them.
+6. **List comprehensions over `range_constexpr` are NOT preprocessed** — only `for` statements are. Use explicit constexpr-for + `.append()`.
+7. **`if cute.arch.elect_one():` is wrong** — it returns an `IfOpRegion` context manager. Use `with cute.arch.elect_one():`.
+8. **Tensor type cannot change inside a dynamic `if`** — `sf_val = Uint32(0)` then `sf_val = peer_int32_buffer[...]` raises "type changes inside dynamic if". Match initial type to the read source.
+9. **Constexpr-fanout for dynamic peer-list indexing**: `peer_X[dynamic_idx]` fails Python's `__index__`. Use `for r in range_constexpr(0, world_size, 1): if dyn_idx == Int32(r): peer_X[r][...]`.
+10. **`tensor + int` is unsupported**; use `tensor.iterator + int` to get a `Pointer` for atomic-target / TMA-source addresses.
+11. **Mutating a tensor inside a constexpr-fanout `if` breaks SSA dominance**. Hoist the destination write outside the inner `if` (mirror the `sf_val` accumulator pattern).
+12. **`from __future__ import annotations` + cute.struct**: the decorator inspects annotations as live Python expressions, not strings.
+13. **`nvshmem4py 0.3.0` only supports signed dtypes** in `nvshmem.core.tensor`. Substitute `int32`/`int64` for `uint32`/`uint64`.
+
+## Constraints
+
+- V1 locked to (4 ranks, 7168 hidden, 6 topk, 64 experts/rank). V2 will generalize `num_ranks ∈ {2, 4, 8}` only.
+- Single `cute.jit` kernel — no splitting into multiple kernels.
+- Must preserve the receiver-driven advertise + pull two-stage architecture; no NCCL all-to-all replacement.
+- All SF writes apply the 4×32 UTCCP swizzle — no row-major fallback.

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/ci/requirements.txt
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/ci/requirements.txt
@@ -1,0 +1,8 @@
+nvidia-cutlass-dsl[cu13]==4.5.2
+torch>=2.10
+nvshmem4py-cu13>=0.1.3
+numpy>=1.26
+pytest>=8.0
+cuda-python
+nvtx
+apache-tvm-ffi>=0.1.11

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/common/__init__.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/common/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""MegaMoE Common package."""

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/common/host_utils.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/common/host_utils.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Host utility helpers shared across NVFP4 and MXFP8 runners."""
+
+import argparse
+import os
+import sys
+from typing import List, Optional, Tuple
+import torch
+
+from common.megamoe_constants import (
+    Fp8E5M2Max,
+    Fp8E4M3FNMax,
+    Nvfp4E2M1Max,
+    Nvfp4BlockSize,
+    Mxfp8BlockSize,
+    SfPaddingBlock,
+    TmaLeadingDimByteAlign,
+    Nvfp4E2M1RcpLimit,
+    Fp8E4M3RcpLimit,
+    Fp8E5M2RcpLimit,
+)
+
+# ---------------------------------------------------------------------------
+# Dtype constants
+# ---------------------------------------------------------------------------
+
+_Nvfp4DataDtype: torch.dtype = torch.float4_e2m1fn_x2
+_Nvfp4ScaleDtype: torch.dtype = torch.float8_e4m3fn
+_Mxfp8DataDtype_e4m3: torch.dtype = torch.float8_e4m3fn
+_Mxfp8DataDtype_e5m2: torch.dtype = torch.float8_e5m2
+_Mxfp8ScaleDtype: torch.dtype = torch.float8_e8m0fnu
+
+# ---------------------------------------------------------------------------
+# kind_* helpers
+# ---------------------------------------------------------------------------
+
+def kind_data_dtype(kind: str) -> torch.dtype:
+    if kind == "nvfp4":
+        return _Nvfp4DataDtype
+    if kind == "mxfp8_e4m3":
+        return _Mxfp8DataDtype_e4m3
+    if kind == "mxfp8_e5m2":
+        return _Mxfp8DataDtype_e5m2
+    raise ValueError(f"Unknown kind: {kind!r}")
+
+
+def kind_scale_dtype(kind: str) -> torch.dtype:
+    return _Nvfp4ScaleDtype if kind == "nvfp4" else _Mxfp8ScaleDtype
+
+
+def kind_sf_vec_size(kind: str) -> int:
+    return Nvfp4BlockSize if kind == "nvfp4" else Mxfp8BlockSize
+
+
+# ---------------------------------------------------------------------------
+# Mxfp8 quantize function. May move function to mxfp8 folder later
+# ---------------------------------------------------------------------------
+
+def mxfp8_quantize_per_block_32(
+    c_fp32: torch.Tensor,
+    data_dtype: torch.dtype,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """MXFP8-quantize along the trailing dim with per-32 E8M0 block scales."""
+    M, N = c_fp32.shape
+    if N % Mxfp8BlockSize != 0:
+        raise ValueError(
+            f"Trailing dim ({N}) must be a multiple of sf_vec_size ({Mxfp8BlockSize})."
+        )
+    n_blocks = N // Mxfp8BlockSize
+    data_max_rcp_limit = Fp8E4M3RcpLimit if data_dtype == torch.float8_e4m3fn else Fp8E5M2RcpLimit
+    blocked = c_fp32.view(M, n_blocks, Mxfp8BlockSize)
+    absmax = blocked.abs().amax(dim=-1)
+    safe_absmax = torch.clamp(absmax, min=1e-30)
+    scale_exp = torch.ceil(torch.log2(safe_absmax * data_max_rcp_limit))
+    e_uint8 = torch.clamp(scale_exp + 127.0, min=0.0, max=254.0).to(torch.int32)
+    e_uint8 = torch.where(absmax == 0, torch.zeros_like(e_uint8), e_uint8)
+    sfc_e8m0 = e_uint8.to(torch.uint8).view(_Mxfp8ScaleDtype)
+    scale_fp32 = torch.pow(2.0, e_uint8.float() - 127.0)
+    scale_expanded = scale_fp32.unsqueeze(-1).expand_as(blocked).reshape(M, N)
+    scaled = c_fp32 / scale_expanded
+    c_fp8 = scaled.to(data_dtype)
+    return c_fp8, sfc_e8m0
+
+
+# ---------------------------------------------------------------------------
+# referench check helper
+# ---------------------------------------------------------------------------
+
+def compare_and_report_mismatches(
+    gpu_tensor,
+    ref_tensor,
+    name="Tensor",
+    atol=1e-05,
+    rtol=1e-05,
+    max_mismatches=8,
+    print_first_8=False,
+):
+    import torch as _torch  # host-only helper, keep out of module-level imports
+    """
+    Compare two tensors and report the first N mismatched elements.
+
+    Args:
+        gpu_tensor: Results computed on GPU
+        ref_tensor: Reference results (CPU)
+        name: Name of the tensor
+        atol: Absolute tolerance
+        rtol: Relative tolerance
+        max_mismatches: Maximum number of mismatches to report
+    """
+    # Ensure both are on CPU for comparison
+    if gpu_tensor.is_cuda:
+        gpu_data = gpu_tensor.cpu()
+    else:
+        gpu_data = gpu_tensor
+
+    if ref_tensor.is_cuda:
+        ref_data = ref_tensor.cpu()
+    else:
+        ref_data = ref_tensor
+
+    # Ensure shapes match
+    assert gpu_data.shape == ref_data.shape, (
+        f"Shape mismatch: {gpu_data.shape} vs {ref_data.shape}"
+    )
+
+    if print_first_8:
+        # Print first 8 elements (regardless of match)
+        print(f"\n{name} - First 8 elements:")
+        print(
+            f"{'Index':<6} {'Coordinate':<30} {'GPU Data':<20} {'CPU Data':<20} {'Abs Error':<20}"
+        )
+        print("-" * 100)
+        print(f"\n")
+
+        flat_gpu = gpu_data.flatten()
+        flat_ref = ref_data.flatten()
+        num_elements = min(8, flat_gpu.numel())
+
+        for i in range(num_elements):
+            # Get multi-dimensional coordinate
+            idx_tuple = _torch.unravel_index(_torch.tensor(i), gpu_data.shape)
+            coord = tuple(idx.item() for idx in idx_tuple)
+            gpu_val = flat_gpu[i].item()
+            ref_val = flat_ref[i].item()
+            abs_error = abs(gpu_val - ref_val)
+            print(
+                f"{i + 1:<6} {str(coord):<30} {gpu_val:<20.6f} {ref_val:<20.6f} {abs_error:<20.6f}"
+            )
+
+    # Compute differences
+    diff = _torch.abs(gpu_data.float() - ref_data.float())
+    threshold = atol + rtol * _torch.abs(ref_data.float())
+    mismatch_mask = diff > threshold
+
+    # Find all mismatch indices
+    mismatch_indices = _torch.nonzero(mismatch_mask, as_tuple=False)
+    num_mismatches = mismatch_indices.shape[0]
+
+    if num_mismatches == 0:
+        print(f"✓ {name} passed validation! All elements are within tolerance.")
+        return True
+    else:
+        print(f"✗ {name} failed validation!")
+        print(
+            f"  Total {num_mismatches} mismatched elements (total elements: {gpu_data.numel()}, mismatch rate: {100.0 * num_mismatches / gpu_data.numel():.4f}%)"
+        )
+        print(f"  Tolerance settings: atol={atol}, rtol={rtol}")
+        print(f"\nFirst {min(max_mismatches, num_mismatches)} mismatched elements:")
+        print(
+            f"{'Index':<6} {'Coordinate':<30} {'GPU Data':<20} {'CPU Data':<20} {'Abs Error':<20}"
+        )
+        print("-" * 100)
+
+        for i in range(min(max_mismatches, num_mismatches)):
+            idx = mismatch_indices[i]
+            coord = tuple(idx.tolist())
+            gpu_val = gpu_data[coord].item()
+            ref_val = ref_data[coord].item()
+            abs_error = diff[coord].item()
+
+            print(
+                f"{i + 1:<6} {str(coord):<30} {gpu_val:<20.6f} {ref_val:<20.6f} {abs_error:<20.6f}"
+            )
+
+        # Still raise assertion error to maintain original behavior
+        raise AssertionError(
+            f"{name} validation failed with {num_mismatches} mismatches"
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/common/megamoe_constants.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/common/megamoe_constants.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Shared constants for the fused fc1+fc2 MegaMoE path."""
+
+from cutlass.cutlass_dsl import Float32
+
+Log2E = Float32(1.4426950408889634)
+Fp32Max = Float32(3.40282346638528859812e38)
+
+Nvfp4BlockSize = 16
+Mxfp8BlockSize = 32
+SfPaddingBlock = 128
+TmaLeadingDimByteAlign = 16
+
+Nvfp4E2M1Max = 6.0
+Fp8E4M3FNMax = 448.0
+Fp8E5M2Max   = 57344.0
+
+Nvfp4E2M1RcpLimit = 1.0 / Nvfp4E2M1Max
+Fp8E4M3RcpLimit   = 1.0 / Fp8E4M3FNMax
+Fp8E5M2RcpLimit   = 1.0 / Fp8E5M2Max
+
+Nvfp4E2M1RcpLimit = 1.0 / Nvfp4E2M1Max
+Fp8E4M3RcpLimit   = 1.0 / Fp8E4M3FNMax
+Fp8E5M2RcpLimit   = 1.0 / Fp8E5M2Max
+
+SupportedMmaTileM = (128, 256)
+SupportedMmaTileN = (64, 128, 256)

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/common/moe_utils.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/common/moe_utils.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Shared MoE scheduler utilities and online TMA descriptor helpers."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Literal, Optional, Tuple, Type, Union
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import AddressSpace, Numeric, Pointer
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.arch import nvvm_wrappers
+from cutlass.cutlass_dsl import dsl_user_op, Boolean, Int32, Float32, T
+from cutlass._mlir import ir
+from common.megamoe_constants import Log2E, Fp32Max, Fp8E4M3RcpLimit, Fp8E5M2RcpLimit
+from cutlass._mlir.dialects import llvm
+from cutlass._mlir.dialects import cute as _cute_ir
+from cutlass._mlir.dialects import vector, arith
+from cutlass._mlir.dialects import cute_nvgpu as _cute_nvgpu_ir
+from dataclasses import dataclass
+
+
+# -----------------------------------------------------------------
+# MoE Helper functions
+# -----------------------------------------------------------------
+
+
+@cute.jit
+def swiglu_act(
+    t_swiglu: cute.Tensor,
+    t_up: cute.Tensor,
+    t_gate: cute.Tensor,
+    prob: Optional[Float32] = None,
+) -> None:
+    """
+    SwiGLU activation with prob function.
+    """
+    for i in cutlass.range_constexpr(0, cute.size(t_swiglu), 2):
+        t_swiglu_log2e = cute.arch.mul_packed_f32x2(
+            (t_gate[i], t_gate[i + 1]),
+            (-Log2E, -Log2E),
+            rnd='rn',
+            ftz=False,
+        )
+        (
+            t_swiglu[i],
+            t_swiglu[i + 1],
+        ) = cute.arch.add_packed_f32x2(
+            (
+                cute.math.exp2(t_swiglu_log2e[0], fastmath=True),
+                cute.math.exp2(t_swiglu_log2e[1], fastmath=True),
+            ),
+            (1.0, 1.0),
+        )
+        t_swiglu[i] = cute.arch.rcp_approx(t_swiglu[i])
+        t_swiglu[i + 1] = cute.arch.rcp_approx(t_swiglu[i + 1])
+        (
+            t_swiglu[i],
+            t_swiglu[i + 1],
+        ) = cute.arch.mul_packed_f32x2(
+            (t_swiglu[i], t_swiglu[i + 1]),
+            (t_gate[i + 0], t_gate[i + 1]),
+            rnd='rn',
+            ftz=False,
+        )
+        (
+            t_swiglu[i],
+            t_swiglu[i + 1],
+        ) = cute.arch.mul_packed_f32x2(
+            (t_swiglu[i], t_swiglu[i + 1]),
+            (t_up[i], t_up[i + 1]),
+            rnd='rn',
+            ftz=False,
+        )
+        if cutlass.const_expr(prob is not None):
+            (
+                t_swiglu[i],
+                t_swiglu[i + 1],
+            ) = cute.arch.mul_packed_f32x2(
+                (t_swiglu[i], t_swiglu[i + 1]),
+                (prob, prob),
+                rnd='rn',
+                ftz=False,
+            )
+
+
+def fmin(
+    a: Union[float, Float32],
+    b: Union[float, Float32],
+    *,
+    nan: bool = True,
+    loc=None,
+    ip=None,
+) -> Float32:
+    if nan:
+        ptx_instr = f"min.NaN.f32 $0, $1, $2;"
+    else:
+        ptx_instr = f"min.f32 $0, $1, $2;"
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip)],
+            f"{ptx_instr}",
+            f"=f,f,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+def fmax(
+    a: Union[float, Float32],
+    b: Union[float, Float32],
+    *,
+    nan: bool = True,
+    loc=None,
+    ip=None,
+) -> Float32:
+    if nan:
+        ptx_instr = f"max.NaN.f32 $0, $1, $2;"
+    else:
+        ptx_instr = f"max.f32 $0, $1, $2;"
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [Float32(a).ir_value(loc=loc, ip=ip), Float32(b).ir_value(loc=loc, ip=ip)],
+            f"{ptx_instr}",
+            f"=f,f,f",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
+def cvt_f32_to_f8_to_f32(fp32x1, fp8_type, loc=None, ip=None):
+    src_fp32 = Float32(fp32x1).ir_value(loc=loc, ip=ip)
+
+    cvt_instruction_downcast = ""
+    cvt_instruction_upcast = ""
+    if cutlass.const_expr(fp8_type == cutlass.Float8E8M0FNU):
+        cvt_instruction_downcast = "cvt.rp.satfinite.ue8m0x2.f32"
+        cvt_instruction_upcast = "cvt.rn.bf16x2.ue8m0x2"
+    elif cutlass.const_expr(fp8_type == cutlass.Float8E4M3FN):
+        cvt_instruction_downcast = "cvt.rn.satfinite.e4m3x2.f32"
+        cvt_instruction_upcast = "cvt.rn.bf16x2.e4m3x2"
+    elif cutlass.const_expr(fp8_type == cutlass.Float8E5M2):
+        cvt_instruction_downcast = "cvt.rn.satfinite.e5m2x2.f32"
+        cvt_instruction_upcast = "cvt.rn.bf16x2.e5m2x2"
+    else:
+        with cute.arch.elect_one():
+            cute.printf("error: unsupported fp8 element type")
+        return
+
+    asm_tmpl = (
+        "{\n"
+        "  .reg .b16 bf_lo;\n"
+        f"  {cvt_instruction_downcast} bf_lo, 0f00000000, $1;\n"
+        f"  {cvt_instruction_upcast}  $0, bf_lo;\n"
+        "}"
+    )
+    packed_i32 = llvm.inline_asm(
+        T.i32(),
+        [src_fp32],
+        asm_tmpl,
+        "=r,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+    vec_bf16_ty = ir.Type.parse("vector<2xbf16>")
+    bf2_lo = llvm.bitcast(vec_bf16_ty, packed_i32, loc=loc, ip=ip)
+    h0 = vector.extract(bf2_lo, [], [0], loc=loc, ip=ip)
+    dst_f32 = arith.extf(Float32.mlir_type, h0, loc=loc, ip=ip)
+
+    return dst_f32
+
+
+
+@cute.jit
+def cvt_f32x4_to_f8x4_pack_i32(fp32x4, fp8_type, loc=None, ip=None):
+    fp32x4 = fp32x4.load()
+    src_vec4 = (
+        fp32x4.ir_value(loc=loc, ip=ip) if hasattr(fp32x4, "ir_value") else fp32x4
+    )
+
+    src0 = Float32(vector.extract(src_vec4, [], [0])).ir_value(loc=loc, ip=ip)
+    src1 = Float32(vector.extract(src_vec4, [], [1])).ir_value(loc=loc, ip=ip)
+    src2 = Float32(vector.extract(src_vec4, [], [2])).ir_value(loc=loc, ip=ip)
+    src3 = Float32(vector.extract(src_vec4, [], [3])).ir_value(loc=loc, ip=ip)
+
+    cvt_instruction = ""
+    if cutlass.const_expr(fp8_type == cutlass.Float8E8M0FNU):
+        cvt_instruction = "cvt.rp.satfinite.ue8m0x2.f32"
+    elif cutlass.const_expr(fp8_type == cutlass.Float8E4M3FN):
+        cvt_instruction = "cvt.rn.satfinite.e4m3x2.f32"
+    elif cutlass.const_expr(fp8_type == cutlass.Float8E5M2):
+        cvt_instruction = "cvt.rn.satfinite.e5m2x2.f32"
+    else:
+        with cute.arch.elect_one():
+            cute.printf("error: unsupported fp8 element type")
+        return
+
+    asm_tmpl = (
+        "{\n"
+        "  .reg .b16 lo;\n"
+        "  .reg .b16 hi;\n"
+        f"  {cvt_instruction} lo, $2, $1;\n"
+        f"  {cvt_instruction} hi, $4, $3;\n"
+        "  mov.b32 $0, {lo, hi};\n"
+        "}"
+    )
+    packed_i32 = llvm.inline_asm(
+        T.i32(),
+        [src0, src1, src2, src3],
+        asm_tmpl,
+        "=r,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+    return packed_i32
+
+
+@cute.jit
+def quant_sfd_row(
+    src, dst, norm_const,
+    sf_vec_size, sf_dtype, d_dtype,
+) -> None:
+    rcp_limit = Fp8E4M3RcpLimit if d_dtype == cutlass.Float8E4M3FN else Fp8E5M2RcpLimit
+    acc_frg = src.load()
+    abs_acc_frg_ir = cutlass._mlir.dialects.math.absf(acc_frg.ir_value())
+    abs_acc_frg = type(acc_frg)(abs_acc_frg_ir, acc_frg.shape, acc_frg.dtype)
+    avg_fp32 = (
+        abs_acc_frg.reduce(cute.ReductionOp.MAX, Float32(0.0), 0)
+        * rcp_limit * norm_const
+    )
+    qpvscale_up = cvt_f32_to_f8_to_f32(avg_fp32, sf_dtype)
+    acc_scale = norm_const * cute.arch.rcp_approx(qpvscale_up)
+    acc_scale = fmin(acc_scale, Fp32Max, nan=True)
+    for ei in cutlass.range_constexpr(0, sf_vec_size, 2):
+        src[ei], src[ei + 1] = cute.arch.mul_packed_f32x2(
+            (src[ei], src[ei + 1]), (acc_scale, acc_scale), rnd="rn", ftz=False,
+        )
+    dst_i32 = cute.recast_tensor(dst, cutlass.Int32)
+    for ei in cutlass.range_constexpr(0, sf_vec_size, 4):
+        fp32x4 = cute.make_rmem_tensor(4, Float32)
+        fp32x4[0] = src[ei + 0]
+        fp32x4[1] = src[ei + 1]
+        fp32x4[2] = src[ei + 2]
+        fp32x4[3] = src[ei + 3]
+        fp8x4_i32 = cvt_f32x4_to_f8x4_pack_i32(fp32x4, d_dtype)
+        dst_i32[ei // 4] = cutlass.Int32(fp8x4_i32)
+    return qpvscale_up

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/__init__.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""MegaMoE MXFP8 GLU mega kernel package."""

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/epilogue_mxfp8.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/epilogue_mxfp8.py
@@ -1,0 +1,1452 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Autonomous epilogue for the fused fc1+fc2 swap-AB MegaMoE kernel.
+
+Component boundaries use ``TensorWithContract`` to keep per-thread RMEM layout
+semantics explicit.  See ``megamoe_design.md`` for the epilogue dataflow.
+"""
+
+from typing import Optional, Tuple, Type, Union, Any
+import dataclasses
+
+import cutlass
+import cutlass.cute as cute
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.typing import AddressSpace
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import arith as _arith
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op, Int32 as _epi_Int32, Int64
+
+from src.flag_batch import GpuReleaseFlagBatchTracker
+from src.token_comm import CombineFormat, TokenSrcMetadata
+from src.ptx_helpers import stg_e8m0_from_f32, stg_e8m0x8_from_f32
+
+from moe_nvfp4_swapab.contract import (
+    Contract,
+    FunctionMapping,
+    Space,
+    TensorWithContract,
+    assert_contract_equivalent,
+)
+from moe_nvfp4_swapab.fc1_fc2_fuse_sched import BlockPhase
+from common.megamoe_constants import Nvfp4BlockSize
+
+from common.moe_utils import fmin, fmax, swiglu_act, quant_sfd_row
+from cutlass.cute.typing import Float32
+from moe_nvfp4_swapab.epilogue import (
+    _TmemTranspose16x32Core,
+    _red_add_release_gpu_s32,
+    _red_add_relaxed_sys_v2_bf16x2,
+    SwapABSwigluFp4Epilogue,
+    EpilogueTokenTile,
+    Fc2AccLoadAndPack,
+    TmemTranspose16x32Packed,
+    Fc2UnpackPermuteStg,
+    Region,
+)
+
+Fc1GateUpInterleave = 32
+EpilogueTileN = 32
+Fc1EpilogueOutputTileM = 256
+Fc1EpilogueOutputTileN = 128
+WarpThreadCount = 32
+EpiWarpCount = 4
+Fc1CTMAStages = 1
+
+
+# =============================================================================
+# Fc2OutputDest  (MegaMoE fc2 STG destination resolver, non-swap MXFP8 path)
+# =============================================================================
+
+
+@dataclasses.dataclass(frozen=True)
+class Fc2OutputDest:
+    """fc2 output destination in MoE-domain ``(token_max, topk, hidden)`` layout.
+
+    Mirrors the indirect-mode resolution used by the NVFP4 ``Fc2ReturnTile``
+    (``moe_nvfp4_swapab.epilogue``) but specialised for the non-swap-AB MXFP8
+    epilogue, whose fc2 STG is already a simple per-(token_row, hidden) store.
+
+    * ``metadata`` / ``peer_rank_ptr_mapper`` both ``None`` -- **direct mode**:
+      the row is ``tensor[pool_token, 0, :]`` on the local rank.
+    * Both non-``None`` -- **indirect mode** (MegaMoE form A): each lane LDGs
+      ``(src_rank, src_token, src_topk)`` from ``metadata[pool_token, :]`` and
+      writes to ``peer(src_rank).tensor[src_token, src_topk, :]`` via
+      ``peer_rank_ptr_mapper.ptr_map_to_rank(local_addr, src_rank)``.
+
+    ``metadata`` is the ``(pool_token_count, TokenSrcMetadata.nbytes)`` Uint8 view
+    (or any recast with the same base pointer) of the dispatch warps'
+    ``token_src_metadata`` record; each record is one packed Int64 decoded by
+    ``TokenSrcMetadata.load()``.  ``peer_rank_ptr_mapper``
+    is a ``SymBuffer{world_size}`` instance (returns a zero delta when
+    ``src_rank == local_rank``, so single-rank runs fold to a no-op).
+    """
+
+    tensor: cute.Tensor
+    metadata: Optional[cute.Tensor] = None
+    peer_rank_ptr_mapper: Any = None
+    reduce_topk_in_kernel: bool = False
+
+    def __post_init__(self) -> None:
+        if (self.metadata is None) != (self.peer_rank_ptr_mapper is None):
+            raise ValueError(
+                "Fc2OutputDest: ``metadata`` and ``peer_rank_ptr_mapper`` must be "
+                "both None (direct mode) or both non-None (MegaMoE / indirect "
+                "mode).  Got metadata="
+                f"{'set' if self.metadata is not None else 'None'}, "
+                f"peer_rank_ptr_mapper="
+                f"{'set' if self.peer_rank_ptr_mapper is not None else 'None'}."
+            )
+
+    @cute.jit
+    def resolve_token_row(self, pool_token_global) -> cute.Tensor:
+        """Return the ``(hidden,)`` BF16 GMEM row this pool token's STG lands on.
+
+        Direct mode: ``tensor[pool_token_global, 0, :]`` on the local rank.
+        Indirect mode: LDG packed i64 from ``metadata`` at byte offset
+        ``pool_token_global * TokenSrcMetadata.nbytes``, unpack via
+        ``TokenSrcMetadata.load()`` to get ``(src_rank, src_token, src_topk)``,
+        build the local-rank row view, then rebase the row's GMEM pointer
+        through ``peer_rank_ptr_mapper.ptr_map_to_rank`` so the iterator points
+        at the source rank's combine slot.
+        """
+        if cutlass.const_expr(self.metadata is None):
+            return cute.slice_(self.tensor, (pool_token_global, 0, None))
+
+        md = TokenSrcMetadata.load(
+            self.metadata.iterator.toint()
+            + Int64(pool_token_global) * Int64(TokenSrcMetadata.nbytes)
+        )
+        src_rank = md.src_rank
+        src_token = md.src_token
+        if cutlass.const_expr(self.reduce_topk_in_kernel):
+            src_topk = cutlass.Int32(0)
+        else:
+            src_topk = md.src_topk
+        local_row = cute.slice_(self.tensor, (src_token, src_topk, None))
+        peer_iter = self.peer_rank_ptr_mapper.ptr_map_to_rank(
+            local_row.iterator, src_rank,
+        )
+        return cute.make_tensor(peer_iter, local_row.layout)
+
+
+# =============================================================================
+# GluMxfp8Epilogue
+# =============================================================================
+
+class GluMxfp8Epilogue:
+
+    _SubtileBarIdBase = 4
+    # Named barrier for cross-warp sync during raw-C TMA stores.
+    _CStoreBarId = 10
+
+    def __init__(
+        self,
+        *,
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        use_2cta_instrs: bool,
+        sf_vec_size: int,
+        fc1_output_dtype: Type[cutlass.Numeric],
+        fc1_output_layout: utils.LayoutEnum,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        sf_dtype: Type[cutlass.Numeric] = cutlass.Float8E8M0FNU,
+        c_dtype: Type[cutlass.Numeric] = cutlass.BFloat16,
+        glu_clamp: Optional[float] = None,
+        allow_overlap_acc: bool = True,
+        epilog_sync_bar_id: int = 1,
+        epilogue_warp_ids: Tuple[int, ...] = (0, 1, 2, 3),
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,
+        fc2_in_kernel_topk_reduce: bool = False,
+        token_back_by_dispatch: bool = False,
+        epi_flag_batch: Union[int, Tuple[int, int]] = 1,
+        apply_topk_in_fc1: bool = False,
+        generate_c: bool = False,
+        use_stg_fc1: bool = False,
+        combine_format: Optional[Any] = None,
+    ) -> None:
+        self.fc1_output_dtype = fc1_output_dtype
+        self.fc1_output_layout = fc1_output_layout
+        self.acc_dtype = acc_dtype
+        self.sf_dtype = sf_dtype
+        self._sf_vec_size = sf_vec_size
+        self._c_dtype = c_dtype
+        self._epilog_sync_bar_id = epilog_sync_bar_id
+        self._epilogue_warp_ids = epilogue_warp_ids
+        self._use_2cta_instrs = use_2cta_instrs
+
+        self._atom_thr_size = 2 if use_2cta_instrs else 1
+        self._cta_tile_m = mma_tiler_mnk[0] // self._atom_thr_size
+        self._cta_tile_n = mma_tiler_mnk[1]
+        self._mma_tiler_k = mma_tiler_mnk[2]
+        self._cta_tile_n_sfb = ((mma_tiler_mnk[1] + 127) // 128) * 128
+        self._static_expert_shape = static_expert_shape
+        if (
+            static_expert_shape is not None
+            and static_expert_shape[2] % (self._cta_tile_m * cluster_shape_mn[0]) == 0
+        ):
+            self._fc2_stg_needs_predicate: bool = False
+        else:
+            self._fc2_stg_needs_predicate: bool = True
+
+        # Non-swap-AB: TMA tile is (EpilogueTileN tokens, Fc1EpilogueOutputTileN intermediates)
+        self._epi_tile = (EpilogueTileN, Fc1EpilogueOutputTileN)
+        self._subtile_cnt = self._cta_tile_n // 2 // EpilogueTileN
+
+        self._overlapping_accum = allow_overlap_acc and (
+            self._cta_tile_n == EpiWarpCount * EpilogueTileN * 2
+        )
+        self._overlapping_accum = True
+
+        self._num_acc_stage = 2
+        self._num_acc_pipeline_stages = (
+            1 if self._overlapping_accum else self._num_acc_stage
+        )
+
+        k = self._mma_tiler_k
+        self._num_sfa_tmem_cols = self._cta_tile_m * k // sf_vec_size * 4 // 4 // 128
+        self._num_sfb_tmem_cols = (
+            self._cta_tile_n_sfb * k // sf_vec_size * 4 // 4 // 128
+        )
+        self._num_sf_tmem_cols = 32 # self._num_sfa_tmem_cols + self._num_sfb_tmem_cols
+
+        self._num_accumulator_tmem_cols = self._cta_tile_n * self._num_acc_stage - (
+            self._num_sf_tmem_cols if self._overlapping_accum else 0
+        )
+
+        self._iter_acc_early_release = (
+            self._num_sf_tmem_cols + EpilogueTileN - 1
+        ) // EpilogueTileN
+
+        self._fc2_in_kernel_topk_reduce = fc2_in_kernel_topk_reduce
+        self._token_back_by_dispatch = token_back_by_dispatch
+        self._apply_topk_in_fc1 = apply_topk_in_fc1
+        self._generate_c = generate_c
+        self._use_stg_fc1 = use_stg_fc1
+        # combine_format determines fc2 output encoding: bf16 (default) or quantized.
+        if combine_format is None:
+            combine_format = CombineFormat.parse("bf16")
+        self._combine_format = combine_format
+        self._combine_mxfp8 = combine_format.is_quantized
+        # sf_block_pad for fc2 MXFP8 combine: number of E8M0 entries per pool
+        # token, padded to 16 (= 16-byte TMA alignment for E8M0 1 byte/element).
+        # EpilogueTileN = 32 = sf_vec_size, so hidden // EpilogueTileN = sf_blocks.
+        if self._combine_mxfp8 and static_expert_shape is not None:
+            _hidden_fc2 = static_expert_shape[2]
+            _sf_blocks_fc2 = _hidden_fc2 // EpilogueTileN
+            self._fc2_sf_block_pad = ((_sf_blocks_fc2 + 15) // 16) * 16
+            self._hidden_fc2 = _hidden_fc2
+        else:
+            self._fc2_sf_block_pad = 0
+            self._hidden_fc2 = 0
+        # stg.64 SF batching: when hidden is a whole multiple of cta_tile_n every
+        # scheduled fc2 N-tile owns a full run of fc2_subtile_cnt (= 8) contiguous,
+        # in-bounds E8M0 blocks per token (the plane is token-row-major, block
+        # stride 1), so a thread's 8 per-subtile scales flush as one 64-bit store.
+        # Otherwise the ragged tail tile falls back to per-block 1-byte stores.
+        self._fc2_sf_batch8 = (
+            self._combine_mxfp8
+            and self._hidden_fc2 > 0
+            and (self._hidden_fc2 % self._cta_tile_n == 0)
+            and (self._cta_tile_n // EpilogueTileN == 8)
+        )
+        self._epi_tile_c = (self._cta_tile_m, 2 * Fc1GateUpInterleave)
+        if isinstance(epi_flag_batch, tuple):
+            self._epi_fc1_batch = max(1, epi_flag_batch[0])
+            self._epi_fc2_batch = max(1, epi_flag_batch[1])
+        else:
+            self._epi_fc1_batch = max(1, epi_flag_batch)
+            self._epi_fc2_batch = max(1, epi_flag_batch)
+
+        self.glu_clamp = (
+            cutlass.Float32(glu_clamp) if glu_clamp is not None else None
+        )
+
+    # -- Codegen-time queries  --
+
+    @property
+    def epi_tile(self) -> Tuple[int, int]:
+        return self._epi_tile
+
+    @property
+    def overlapping_accum(self) -> bool:
+        return self._overlapping_accum
+
+    @property
+    def num_acc_pipeline_stages(self) -> int:
+        return self._num_acc_pipeline_stages
+
+    @property
+    def num_acc_stage(self) -> int:
+        return self._num_acc_stage
+
+    @property
+    def iter_acc_early_release(self) -> int:
+        return self._iter_acc_early_release
+
+    @property
+    def subtile_cnt(self) -> int:
+        return self._subtile_cnt
+
+    @property
+    def cta_tile_n(self) -> int:
+        return self._cta_tile_n
+
+    @property
+    def num_sf_tmem_cols(self) -> int:
+        return self._num_sf_tmem_cols
+
+    @property
+    def num_sfa_tmem_cols(self) -> int:
+        return self._num_sfa_tmem_cols
+
+    @property
+    def num_sfb_tmem_cols(self) -> int:
+        return self._num_sfb_tmem_cols
+
+    @property
+    def num_accumulator_tmem_cols(self) -> int:
+        return self._num_accumulator_tmem_cols
+
+    def staged_smem_layout(
+        self,
+        n_stages: int,
+    ) -> Union[cute.Layout, cute.ComposedLayout]:
+        return sm100_utils.make_smem_layout_epi(
+            self.fc1_output_dtype,
+            self.fc1_output_layout,
+            self._epi_tile,
+            n_stages,
+        )
+
+    @property
+    def smem_layout_one_stage(self) -> Union[cute.Layout, cute.ComposedLayout]:
+        staged = self.staged_smem_layout(1)
+        return cute.select(staged, mode=[0, 1])
+
+    @property
+    def bytes_per_stage(self) -> int:
+        return cute.size_in_bytes(self.fc1_output_dtype, self.smem_layout_one_stage)
+
+    @property
+    def epi_tile_c(self) -> Tuple[int, int]:
+        """TMA tile for raw gate+up output: (cta_tile_m=128, 2*Fc1GateUpInterleave=64) fp32."""
+        return self._epi_tile_c
+
+    def staged_c_smem_layout(self, n_stages: int):
+        """SMEM layout for n_stages of raw gate+up (Float32, row-major, epi_tile_c)."""
+        return sm100_utils.make_smem_layout_epi(
+            self._c_dtype,
+            self.fc1_output_layout,  # same N-major direction as fc1 output
+            self._epi_tile_c,
+            n_stages,
+        )
+
+    @property
+    def c_smem_layout_one_stage(self):
+        return cute.select(self.staged_c_smem_layout(1), mode=[0, 1])
+
+    @property
+    def c_bytes_per_stage(self) -> int:
+        return cute.size_in_bytes(self._c_dtype, self.c_smem_layout_one_stage)
+
+    @staticmethod
+    @cute.jit
+    def tma_store_fc1_output(
+        warp_idx,
+        sC,
+        store_idx,
+        tma_atom_fc1_output: cute.CopyAtom,
+        g_fc1_output_subtile_view: cute.Tensor,
+        valid_tokens,
+    ) -> None:
+        """
+        Per-warp TMA store for non-swap-AB MXFP8 FC1 output.
+        Uses rotated-leader pattern (leader = warp store_idx).
+        SMEM stage store_idx has (EpilogueTileN tokens × Fc1EpilogueOutputTileN intermediates).
+        All 4 warps arrive at barrier store_idx+_SubtileBarIdBase, leader issues TMA.
+        """
+        cute.arch.fence_proxy("async.shared", space="cta")
+        sC_stage = cute.slice_(sC, (None, None, store_idx))
+        g_fc1_output_2d = cute.slice_(g_fc1_output_subtile_view, (None, None, 0))
+        bSG_sC, bSG_g = cpasync.tma_partition(
+            tma_atom_fc1_output,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sC_stage, 0, 2),
+            cute.group_modes(g_fc1_output_2d, 0, 2),
+        )
+
+        leader_warp = store_idx
+        tile_has_valid = (
+            store_idx * cutlass.Int32(EpilogueTileN) < valid_tokens
+        )
+
+        bar_id = store_idx + cutlass.Int32(GluMxfp8Epilogue._SubtileBarIdBase)
+        bar = pipeline.NamedBarrier(
+            barrier_id=bar_id,
+            num_threads=EpiWarpCount * WarpThreadCount,
+        )
+        if warp_idx == leader_warp:
+            bar.arrive_and_wait()
+            # TMA bulk-tensor stores are all-or-nothing per issue (no per-element
+            # `pred` mask, no scalar predicate arg), so guard the whole copy with
+            # a runtime `if`.  Skips fully-padding token-tiles that would alias
+            # the next expert's region.
+            if tile_has_valid:
+                cute.copy(tma_atom_fc1_output, bSG_sC, bSG_g)
+        else:
+            bar.arrive()
+
+    @cute.jit
+    def _store_fc1_c_subtile(
+        self,
+        r_gate: cute.Tensor,
+        r_up: cute.Tensor,
+        smem_c_buffer: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        gmem_c_subtile_view: cute.Tensor,
+        c_buffer_idx,
+        work_tile_info,
+        warp_idx: int,
+        tidx,
+        c_pipeline,
+    ) -> None:
+        """Store pre-SwiGLU gate/up accumulators to the global C tensor via SMEM staging."""
+        r_layout = cute.make_layout((((Fc1GateUpInterleave,), 1),), stride=(((1,), 0),))
+
+        # Cast acc_dtype (Float32) → c_dtype (e.g. BFloat16) before R2S.
+        # smem stage is guaranteed free by the producer_acquire() from the previous call.
+        r_gate_c = cute.make_rmem_tensor(r_layout.shape, self._c_dtype)
+        r_up_c = cute.make_rmem_tensor(r_layout.shape, self._c_dtype)
+        r_gate_c.store(r_gate.load().to(self._c_dtype))
+        r_up_c.store(r_up.load().to(self._c_dtype))
+
+        r2s_c_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self._c_dtype, num_bits_per_copy=128,
+        )
+        thread_in_warp_c = tidx % cutlass.Int32(WarpThreadCount)
+        c_row = cutlass.Int32(warp_idx * EpilogueTileN) + thread_in_warp_c
+        sC_raw_stage = cute.slice_(smem_c_buffer, (None, None, c_buffer_idx))
+        c_gate_smem = cute.local_tile(
+            sC_raw_stage, (1, Fc1GateUpInterleave), (c_row, cutlass.Int32(0)),
+        )
+        cute.copy(r2s_c_atom, cute.coalesce(r_gate_c), cute.coalesce(c_gate_smem))
+        c_up_smem = cute.local_tile(
+            sC_raw_stage, (1, Fc1GateUpInterleave), (c_row, cutlass.Int32(1)),
+        )
+        cute.copy(r2s_c_atom, cute.coalesce(r_up_c), cute.coalesce(c_up_smem))
+
+        # Fence + barrier: ensure all warps have written before TMA issue.
+        cute.arch.fence_proxy("async.shared", space="cta")
+        c_store_bar = pipeline.NamedBarrier(
+            barrier_id=self._CStoreBarId,
+            num_threads=EpiWarpCount * WarpThreadCount,
+        )
+        c_store_bar.arrive_and_wait()
+
+        # Warp 0 issues TMA S2G, commits, then pre-acquires the next stage so
+        # smem is guaranteed free before the next call's R2S writes.
+        if warp_idx == 0:
+            if work_tile_info.valid_tokens_in_cta_tile > cutlass.Int32(0):
+                g_c_2d = cute.slice_(gmem_c_subtile_view, (None, None, 0))
+                bSG_sC, bSG_gC = cpasync.tma_partition(
+                    tma_atom_c, 0, cute.make_layout(1),
+                    cute.group_modes(sC_raw_stage, 0, 2),
+                    cute.group_modes(g_c_2d, 0, 2),
+                )
+                cute.copy(tma_atom_c, bSG_sC, bSG_gC)
+            c_pipeline.producer_commit()
+
+    def _subtile_local_tmem_tensor_pair(
+        self,
+        tmem_acc_tensor: cute.Tensor,
+        subtile_idx,
+        warp_idx,
+    ) -> cute.Tensor:
+        """
+        Build a (gate, up) pair of TMEM tensor views for the MXFP8 fc1 epilogue.
+
+        Owns the per-warp lane offset, per-stage col offset (overlap-acc
+        phase aware), and per-subtile col offset arithmetic.  Returned
+        tensor is what ``_run_fc{1,2}_subtile`` and
+        ``_TmemTranspose16x32Core.load_subtile_raw_acc`` consume.
+
+        ``cute.assume(divby=16)`` is applied here once -- callees can
+        derive ``+32`` first/second-half ptrs from the returned tensor's
+        iterator without re-asserting alignment (16-aligned base + 32 is
+        still 16-aligned).
+        """
+        base = tmem_acc_tensor.iterator
+        warp_lane_off = warp_idx * WarpThreadCount
+        subtile_col_off = subtile_idx * EpilogueTileN * 2
+        total = (warp_lane_off << 16) + subtile_col_off
+        subtile_gate_ptr = base + cute.assume(total, divby=16)
+        subtile_up_ptr = base + cute.assume(total + Fc1GateUpInterleave, divby=16)
+        return (
+            cute.make_tensor(
+                subtile_gate_ptr,
+                _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+            ),
+            cute.make_tensor(
+                subtile_up_ptr,
+                _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+            )
+        )
+
+    def _subtile_forward_tmem_tensor(
+        self,
+        tmem_gate_tensor: cute.Tensor,
+        tmem_up_tensor: cute.Tensor,
+        col_offset: int,
+    ) -> (cute.Tensor, cute.Tensor):
+        """Move the tmem tensor to the correct position."""
+        tmem_gate_ptr = tmem_gate_tensor.iterator + cute.assume(col_offset, divby=16)
+        tmem_up_ptr = tmem_up_tensor.iterator + cute.assume(col_offset, divby=16)
+        return (
+            cute.make_tensor(
+                tmem_gate_ptr,
+                _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+            ),
+            cute.make_tensor(
+                tmem_up_ptr,
+                _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+            )
+        )
+
+    # -- fc1 subtile: SM100 path --
+    @cute.jit
+    def _run_fc1_task_tile(
+        self,
+        work_tile_info,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn,
+        smem_fc1_output_buffer: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        sched_ext,
+        gmem_fc1_output: cute.Tensor,
+        gmem_fc1_output_sf: cute.Tensor,
+        gmem_topk_scores: cute.Tensor,
+        warp_idx: int,
+        tidx,
+        alpha,
+        norm_const,
+        smem_c_buffer: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        gmem_c: cute.Tensor,
+        c_pipeline,
+    ) -> None:
+        """MXFP8 fc1 task-tile: TmemTranspose16x32 TMEM loading + cross-warp E8M0 exchange."""
+        real_fc1_output, _    = sched_ext.get_gmem_tensor("d",    gmem_fc1_output,    work_tile_info)
+        real_fc1_output_sf, _ = sched_ext.get_gmem_tensor("sfd",  gmem_fc1_output_sf, work_tile_info)
+        real_topk_scores, _   = sched_ext.get_gmem_tensor("topk", gmem_topk_scores,   work_tile_info)
+
+        if cutlass.const_expr(self._generate_c):
+            real_c, _ = sched_ext.get_gmem_tensor("c", gmem_c, work_tile_info)
+            c_n_base = work_tile_info.tile_n_idx * cutlass.Int32(self._subtile_cnt)
+
+        acc_pipeline.consumer_wait(acc_consumer_state)
+        iket.range_push("mxfp8_fc1_epi_tile")
+
+        if cutlass.const_expr(self._overlapping_accum):
+            acc_stage_col_offset = cutlass.Int32(acc_consumer_state.phase) * (
+                256 - self._num_sf_tmem_cols
+            )
+        else:
+            acc_stage_col_offset = (
+                cutlass.Int32(acc_consumer_state.index) * self._cta_tile_n
+            )
+
+        subtile_cnt  = self._subtile_cnt
+        tmem_gate, tmem_up = self._subtile_local_tmem_tensor_pair(
+            tmem_acc_tensor, subtile_cnt - 1 if is_odd_turn else 0, warp_idx,
+        )
+        tmem_forward_cols = Fc1GateUpInterleave * 2
+        if cutlass.const_expr(self._overlapping_accum):
+            if is_odd_turn:
+                tmem_forward_cols = -Fc1GateUpInterleave * 2
+
+        layout_sf = cute.make_layout(4)
+        rmem_sf = cute.make_rmem_tensor(layout_sf.shape, self.acc_dtype)
+
+        # ── Set up RMEM→SMEM copy atom (direct CopyUniversalOp) ──
+        r2s_copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.fc1_output_dtype,
+            num_bits_per_copy=128,
+        )
+        tRS_sC = None
+
+        for i in cutlass.range(0, subtile_cnt, 1, unroll=1):
+            if cutlass.const_expr(self._overlapping_accum):
+                subtile_idx = cutlass.Int32(i)
+                if is_odd_turn:
+                    subtile_idx = cutlass.Int32(subtile_cnt - 1 - i)
+            else:
+                subtile_idx = cutlass.Int32(i)
+
+            if cutlass.const_expr(self._generate_c):
+                c_buffer_idx = cutlass.Int32(i % Fc1CTMAStages)
+                g_c_subtile = cute.local_tile(
+                    real_c,
+                    (self._cta_tile_m, 2 * Fc1GateUpInterleave, 1),
+                    (work_tile_info.tile_m_idx, c_n_base + subtile_idx, cutlass.Int32(0)),
+                )
+                smem_c_buf_arg = smem_c_buffer
+                tma_atom_c_arg = tma_atom_c
+                gmem_c_subtile_arg = g_c_subtile
+            else:
+                # Dummy values — never accessed due to const_expr guard in _run_fc1_subtile.
+                c_buffer_idx = cutlass.Int32(0)
+                smem_c_buf_arg = smem_fc1_output_buffer
+                tma_atom_c_arg = tma_atom_fc1_output
+                gmem_c_subtile_arg = real_fc1_output
+
+            self._run_fc1_subtile(
+                subtile_idx=subtile_idx,
+                tmem_gate_tensor=tmem_gate,
+                tmem_up_tensor=tmem_up,
+                real_fc1_output=real_fc1_output,
+                real_fc1_output_sf=real_fc1_output_sf,
+                real_topk_scores=real_topk_scores,
+                work_tile_info=work_tile_info,
+                smem_fc1_output_buffer=smem_fc1_output_buffer,
+                tma_atom_fc1_output=tma_atom_fc1_output,
+                r2s_copy_atom=r2s_copy_atom,
+                warp_idx=warp_idx,
+                tidx=tidx,
+                alpha=alpha,
+                norm_const=norm_const,
+                rmem_sf=rmem_sf,
+                acc_is_release=(i == 0),
+                acc_pipeline=acc_pipeline,
+                acc_consumer_state=acc_consumer_state,
+                smem_c_buffer=smem_c_buf_arg,
+                tma_atom_c=tma_atom_c_arg,
+                gmem_c_subtile_view=gmem_c_subtile_arg,
+                c_buffer_idx=c_buffer_idx,
+                c_pipeline=c_pipeline,
+            )
+
+            tmem_gate, tmem_up = self._subtile_forward_tmem_tensor(tmem_gate, tmem_up, tmem_forward_cols)
+
+        if not cutlass.const_expr(self._overlapping_accum):
+            self._acc_pipeline_consumer_release(acc_pipeline, acc_consumer_state, True)
+
+        self._stg_sf_fc1(rmem_sf, real_fc1_output_sf, work_tile_info, tidx)
+
+        # ── TMA store: 4 stores (one per warp group) after all subtiles ──
+        if cutlass.const_expr(not self._use_stg_fc1):
+            base_token_tile = (
+                work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m // EpilogueTileN)
+            )
+            for idx in cutlass.range_constexpr(EpiWarpCount):
+                g_fc1_output_warp_view = cute.local_tile(
+                    real_fc1_output,
+                    (EpilogueTileN, Fc1EpilogueOutputTileN, 1),
+                    (base_token_tile + idx, work_tile_info.tile_n_idx, 0),
+                )
+                GluMxfp8Epilogue.tma_store_fc1_output(
+                    warp_idx, smem_fc1_output_buffer, idx,
+                    tma_atom_fc1_output, g_fc1_output_warp_view,
+                    work_tile_info.valid_tokens_in_cta_tile,
+                )
+
+        iket.range_pop()
+
+    @cute.jit
+    def _run_fc1_subtile(
+        self,
+        subtile_idx,
+        tmem_gate_tensor: cute.Tensor,
+        tmem_up_tensor: cute.Tensor,
+        real_fc1_output: cute.Tensor,
+        real_fc1_output_sf: cute.Tensor,
+        real_topk_scores: cute.Tensor,
+        work_tile_info,
+        smem_fc1_output_buffer: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        r2s_copy_atom: cute.CopyAtom,
+        warp_idx: int,
+        tidx,
+        alpha,
+        norm_const,
+        rmem_sf: cute.Tensor,
+        acc_is_release: bool,
+        acc_pipeline,
+        acc_consumer_state,
+        smem_c_buffer: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        gmem_c_subtile_view: cute.Tensor,
+        c_buffer_idx,
+        c_pipeline,
+    ) -> None:
+        """MXFP8 fc1 subtile: GLU + E8M0 SF + fp8 R2S."""
+        iket.range_push("mxfp8_fc1_epilogue_subtile")
+
+        r_layout = cute.make_layout((((Fc1GateUpInterleave,), 1),), stride=(((1,), 0),))
+        r_gate = cute.make_rmem_tensor(r_layout.shape, self.acc_dtype)
+        r_up = cute.make_rmem_tensor(r_layout.shape, self.acc_dtype)
+
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.Ld32x32bOp(tcgen05.Repetition.x32), self.acc_dtype,
+        )
+        cute.copy(atom_t2r, tmem_gate_tensor, r_gate)
+        cute.copy(atom_t2r, tmem_up_tensor, r_up)
+
+        self._acc_pipeline_consumer_release(acc_pipeline, acc_consumer_state, acc_is_release)
+
+        # ── generate_c: store raw gate+up to GMEM C tensor via SMEM staging ──
+        if cutlass.const_expr(self._generate_c):
+            self._store_fc1_c_subtile(
+                r_gate=r_gate,
+                r_up=r_up,
+                smem_c_buffer=smem_c_buffer,
+                tma_atom_c=tma_atom_c,
+                gmem_c_subtile_view=gmem_c_subtile_view,
+                c_buffer_idx=c_buffer_idx,
+                work_tile_info=work_tile_info,
+                warp_idx=warp_idx,
+                tidx=tidx,
+                c_pipeline=c_pipeline,
+            )
+
+        if cutlass.const_expr(self.glu_clamp is not None):
+            for i in cutlass.range_constexpr(cute.size(r_up)):
+                r_gate[i] = fmin(r_gate[i], self.glu_clamp)
+                r_up[i] = fmin(r_up[i], self.glu_clamp)
+                r_up[i] = fmax(r_up[i], -self.glu_clamp)
+
+        topk = None
+        if cutlass.const_expr(self._apply_topk_in_fc1):
+            thread_in_warp = tidx % cutlass.Int32(WarpThreadCount)
+            token_in_tile = (
+                work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                + cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+            )
+            topk = Float32(real_topk_scores[token_in_tile])
+
+        swiglu = cute.make_rmem_tensor(r_layout.shape, self.acc_dtype)
+        swiglu_act(swiglu, r_up, r_gate, topk)
+
+        c = cute.make_rmem_tensor(r_layout.shape, self.fc1_output_dtype)
+        qpvscale = quant_sfd_row(swiglu, c, norm_const, self._sf_vec_size, self.sf_dtype, self.fc1_output_dtype)
+        if subtile_idx == 0:
+            rmem_sf[0] = qpvscale
+        elif subtile_idx == 1:
+            rmem_sf[1] = qpvscale
+        elif subtile_idx == 2:
+            rmem_sf[2] = qpvscale
+        elif subtile_idx == 3:
+            rmem_sf[3] = qpvscale
+
+        thread_in_warp = tidx % WarpThreadCount
+        if cutlass.const_expr(self._use_stg_fc1):
+            # Direct STG.256 to GMEM — no SMEM staging or TMA store needed.
+            token_in_tile = cutlass.Int32(warp_idx * EpilogueTileN) + thread_in_warp
+            if token_in_tile < work_tile_info.valid_tokens_in_cta_tile:
+                abs_token = (
+                    work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                    + cutlass.Int32(warp_idx * EpilogueTileN) + thread_in_warp
+                )
+                # absolute column start (element index in the intermediate axis)
+                col_elem = (
+                    (work_tile_info.tile_n_idx * cutlass.Int32(self._subtile_cnt) + subtile_idx)
+                    * cutlass.Int32(Fc1GateUpInterleave)
+                )
+                # (1,1,1) tile gives pointer to element at (abs_token, col_elem, 0).
+                g_base = cute.local_tile(
+                    real_fc1_output,
+                    (1, 1, 1),
+                    (abs_token, col_elem, cutlass.Int32(0)),
+                )
+                stg_atom = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), self.fc1_output_dtype, num_bits_per_copy=256,
+                )
+                # col_elem is always a multiple of Fc1GateUpInterleave=32 (FP8 elements),
+                # so the pointer is 32-byte aligned — matching STG.256 requirement.
+                aligned_iter = cute.make_ptr(
+                    self.fc1_output_dtype,
+                    g_base.iterator.toint(),
+                    cute.AddressSpace.gmem,
+                    assumed_align=32,
+                )
+                g_vec = cute.make_tensor(aligned_iter, cute.make_layout(Fc1GateUpInterleave))
+                cute.copy(stg_atom, cute.coalesce(c), g_vec)
+        else:
+            sC_stage = cute.slice_(smem_fc1_output_buffer, (None, None, warp_idx))
+            sC_thread_row = cute.local_tile(
+                sC_stage, (1, Fc1GateUpInterleave), (thread_in_warp, subtile_idx)
+            )
+            cute.copy(r2s_copy_atom, cute.coalesce(c), cute.coalesce(sC_thread_row))
+
+
+        if cutlass.const_expr(self._generate_c):
+            if warp_idx == 0:
+                c_pipeline.producer_acquire()
+            c_store_bar = pipeline.NamedBarrier(
+                barrier_id=self._CStoreBarId,
+                num_threads=EpiWarpCount * WarpThreadCount,
+            )
+            c_store_bar.arrive_and_wait()
+
+        iket.range_pop()
+
+    @cute.jit
+    def _subtile_fc2_tmem_tensor(
+        self,
+        tmem_acc_tensor: cute.Tensor,
+        subtile_idx,
+        warp_idx,
+    ) -> cute.Tensor:
+        """
+        Per-warp TMEM view for one fc2 subtile (EpilogueTileN=32 cols).
+        """
+        base = tmem_acc_tensor.iterator
+        warp_lane_off = warp_idx * WarpThreadCount
+        subtile_col_off = subtile_idx * EpilogueTileN
+        total = (warp_lane_off << 16) + subtile_col_off
+        subtile_ptr = base + cute.assume(total, divby=16)
+        return cute.make_tensor(
+            subtile_ptr,
+            _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+        )
+
+    @cute.jit
+    def _advance_fc2_tmem_tensor(
+        self,
+        tmem_tensor: cute.Tensor,
+        col_offset: int,
+    ) -> cute.Tensor:
+        """Advance the fc2 TMEM tensor by col_offset cols (mirrors _subtile_forward_tmem_tensor)."""
+        new_ptr = tmem_tensor.iterator + cute.assume(col_offset, divby=16)
+        return cute.make_tensor(
+            new_ptr,
+            _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+        )
+
+    @cute.jit
+    def _acc_pipeline_consumer_release(
+        self,
+        acc_pipeline,
+        acc_consumer_state,
+        is_release: bool,
+    ) -> None:
+        """Release the acc pipeline consumer."""
+        if is_release:
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+    @cute.jit
+    def _run_fc2_subtile(
+        self,
+        subtile_idx,
+        tmem_subtile_tensor: cute.Tensor,
+        real_fc2_output: cute.Tensor,
+        work_tile_info,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+        token_comm_args=None,
+        rmem_sf_fc2=None,
+        *,
+        preload_acc=None,
+    ) -> None:
+        """fc2 subtile: LDTM + encode + STG.
+
+        Encoding follows ``self._combine_format``:
+          * BF16 (default): fp32->bf16 conversion, 256-bit STG × 2 half-tiles.
+          * MXFP8: quant_sfd_row fp32->e4m3 (32 elems = one block), single
+            256-bit STG for data; E8M0 scale written to local fc2_output_sf.
+
+        When ``token_comm_args`` is not None (MegaMoE path), the data STG is
+        routed to ``combine_output[src_token, src_topk, :]`` on the source rank
+        via ``Fc2OutputDest``; for token_back_by_dispatch the epilogue writes to
+        the local ``fc2_output_workspace`` pool instead.
+        """
+        iket.range_push("mxfp8_fc2_epilogue_subtile")
+
+        fc2_subtile_cnt = self._cta_tile_n // EpilogueTileN  # = 8
+        hidden_group = (
+            work_tile_info.tile_n_idx * cutlass.Int32(fc2_subtile_cnt) + subtile_idx
+        )
+        hidden_col_start = (
+            work_tile_info.tile_n_idx * cutlass.Int32(self._cta_tile_n)
+            + subtile_idx * cutlass.Int32(EpilogueTileN)
+        )
+        r_acc_layout = cute.make_layout((((EpilogueTileN,), 1),), stride=(((1,), 0),))
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.Ld32x32bOp(tcgen05.Repetition.x32), self.acc_dtype,
+        )
+        r_acc = cute.make_rmem_tensor(r_acc_layout.shape, self.acc_dtype)
+        cute.copy(atom_t2r, tmem_subtile_tensor, r_acc)
+        thread_in_warp = tidx % WarpThreadCount
+        token_row_in_cta = cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+        valid_tokens = work_tile_info.valid_tokens_in_cta_tile
+        if token_row_in_cta < valid_tokens and hidden_col_start < valid_hidden:
+            if cutlass.const_expr(
+                token_comm_args is not None
+                and not self._token_back_by_dispatch
+                and self._combine_mxfp8
+            ):
+                # MegaMoE Form A, quantized combine:
+                # 1. Quantize fp32 → fp8 + compute E8M0 block scale.
+                # 2. STG fp8 data to peer's combine_output.
+                # 3. Write E8M0 scale to local fc2_output_sf for token-back push.
+                fp8_dtype = self._combine_format.act_dtype
+                r_fp8 = cute.make_rmem_tensor(r_acc_layout.shape, fp8_dtype)
+                qpvscale = quant_sfd_row(
+                    r_acc, r_fp8, 1.0, EpilogueTileN,
+                    cutlass.Float8E8M0FNU, fp8_dtype,
+                )
+                pool_token_global = (
+                    work_tile_info.cumulative_data_physical_row
+                    + work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                    + token_row_in_cta
+                )
+                metadata_u32 = cute.recast_tensor(
+                    token_comm_args.token_src_metadata, cutlass.Uint32,
+                )
+                fc2_output_dest = Fc2OutputDest(
+                    tensor=token_comm_args.combine_output,
+                    metadata=metadata_u32,
+                    peer_rank_ptr_mapper=token_comm_args.peer_rank_ptr_mapper,
+                )
+                dest_row = fc2_output_dest.resolve_token_row(pool_token_global)
+                # STG 32 fp8 elements = 256 bits in one shot.
+                r_fp8_flat = cute.make_tensor(r_fp8.iterator, cute.make_layout(32))
+                stg_fp8_atom = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), fp8_dtype,
+                    num_bits_per_copy=256,
+                )
+                dest_fp8_ptr = cute.make_ptr(
+                    fp8_dtype,
+                    dest_row.iterator.toint() + Int64(hidden_col_start),
+                    cute.AddressSpace.gmem,
+                    assumed_align=32,
+                )
+                cute.copy(
+                    stg_fp8_atom, r_fp8_flat,
+                    cute.make_tensor(dest_fp8_ptr, cute.make_layout(32)),
+                )
+                # Buffer the E8M0 scale; the whole task tile's 8 scales are
+                # flushed together by _stg_sf_fc2 (single stg.64 when aligned).
+                self._write_sf_fc2_buffer(rmem_sf_fc2, subtile_idx, qpvscale)
+            elif cutlass.const_expr(
+                self._token_back_by_dispatch and self._combine_mxfp8
+            ):
+                # MegaMoE token-back-by-dispatch + quantized combine:
+                # Epilogue writes fp8 data to local pool; dispatch warps push
+                # both data (fc2_output_workspace) and SF (fc2_output_sf) to peers.
+                pool_token_global = (
+                    work_tile_info.cumulative_data_physical_row
+                    + work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                    + token_row_in_cta
+                )
+                fp8_dtype = self._combine_format.act_dtype
+                r_fp8 = cute.make_rmem_tensor(r_acc_layout.shape, fp8_dtype)
+                qpvscale = quant_sfd_row(
+                    r_acc, r_fp8, 1.0, EpilogueTileN,
+                    cutlass.Float8E8M0FNU, fp8_dtype,
+                )
+                # Write 32 fp8 elements to local fc2_output_workspace pool.
+                fp8_byte_addr = (
+                    token_comm_args.fc2_output_workspace.iterator.toint()
+                    + Int64(pool_token_global) * Int64(self._hidden_fc2)
+                    + Int64(hidden_col_start)
+                )
+                stg_fp8_atom = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), fp8_dtype,
+                    num_bits_per_copy=256,
+                )
+                aligned_fp8_iter = cute.make_ptr(
+                    fp8_dtype,
+                    fp8_byte_addr,
+                    cute.AddressSpace.gmem,
+                    assumed_align=32,
+                )
+                r_fp8_flat = cute.make_tensor(r_fp8.iterator, cute.make_layout(EpilogueTileN))
+                cute.copy(
+                    stg_fp8_atom, r_fp8_flat,
+                    cute.make_tensor(aligned_fp8_iter, cute.make_layout(EpilogueTileN)),
+                )
+                # Buffer the E8M0 scale; flushed together by _stg_sf_fc2 after
+                # the subtile loop (single stg.64 when hidden-aligned).
+                self._write_sf_fc2_buffer(rmem_sf_fc2, subtile_idx, qpvscale)
+            else:
+                # BF16 path (default): fp32->bf16, two 256-bit STGs.
+                r_bf16 = cute.make_rmem_tensor(r_acc_layout.shape, cutlass.BFloat16)
+                r_bf16.store(r_acc.load().to(cutlass.BFloat16))
+                stg_atom = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), cutlass.BFloat16, num_bits_per_copy=256,
+                )
+                for stg_half in cutlass.range_constexpr(EpilogueTileN // 16):
+                    reg_view = cute.make_tensor(
+                        r_bf16.iterator + stg_half * 16,
+                        cute.make_layout(16),
+                    )
+                    if cutlass.const_expr(
+                        token_comm_args is not None and not self._token_back_by_dispatch
+                    ):
+                        metadata_u32 = cute.recast_tensor(
+                            token_comm_args.token_src_metadata, cutlass.Uint32,
+                        )
+                        fc2_output_dest = Fc2OutputDest(
+                            tensor=token_comm_args.combine_output,
+                            metadata=metadata_u32,
+                            peer_rank_ptr_mapper=token_comm_args.peer_rank_ptr_mapper,
+                            reduce_topk_in_kernel=self._fc2_in_kernel_topk_reduce,
+                        )
+                        pool_token_global = (
+                            work_tile_info.cumulative_data_physical_row
+                            + work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                            + token_row_in_cta
+                        )
+                        dest_row = fc2_output_dest.resolve_token_row(pool_token_global)
+                        hidden_off = hidden_col_start + cutlass.Int32(stg_half * 16)
+                        dest_ptr = cute.make_ptr(
+                            cutlass.BFloat16,
+                            dest_row.iterator.toint() + hidden_off * cutlass.Int64(2),
+                            cute.AddressSpace.gmem,
+                            assumed_align=32,
+                        )
+                        if cutlass.const_expr(self._fc2_in_kernel_topk_reduce):
+                            reg_u32 = cute.recast_tensor(reg_view, cutlass.Uint32)
+                            for pair in cutlass.range_constexpr(16 // 4):
+                                _red_add_relaxed_sys_v2_bf16x2(
+                                    dest_ptr + cutlass.Int32(pair * 4),
+                                    cutlass.Uint32(reg_u32[pair * 2]),
+                                    cutlass.Uint32(reg_u32[pair * 2 + 1]),
+                                )
+                        else:
+                            cute.copy(
+                                stg_atom, reg_view,
+                                cute.make_tensor(dest_ptr, cute.make_layout(16)),
+                            )
+                    else:
+                        g_fc2_output_tile = cute.local_tile(
+                            real_fc2_output,
+                            (self._cta_tile_m, EpilogueTileN, 1),
+                            (work_tile_info.tile_m_idx, hidden_group, 0),
+                        )
+                        g_fc2_slice = cute.slice_(g_fc2_output_tile, (None, None, 0))
+                        g_thread_row = cute.local_tile(
+                            g_fc2_slice, (1, 16), (token_row_in_cta, stg_half),
+                        )
+                        g_flat = cute.coalesce(g_thread_row)
+                        aligned_iter = cute.make_ptr(
+                            cutlass.BFloat16,
+                            g_flat.iterator.toint(),
+                            cute.AddressSpace.gmem,
+                            assumed_align=32,
+                        )
+                        cute.copy(stg_atom, reg_view, cute.make_tensor(aligned_iter, g_flat.layout))
+
+        iket.range_pop()
+
+
+    @cute.jit
+    def _write_sf_fc2_buffer(self, rmem_sf_fc2, subtile_idx, qpvscale) -> None:
+        """Scatter one subtile's E8M0 scale into the per-tile SF buffer.
+
+        ``subtile_idx`` is runtime (the overlap-acc walk reverses it on odd
+        turns), so index with a const_expr if-chain -- mirrors fc1's rmem_sf.
+        """
+        for j in cutlass.range_constexpr(self._cta_tile_n // EpilogueTileN):
+            if subtile_idx == cutlass.Int32(j):
+                rmem_sf_fc2[j] = qpvscale
+
+    @cute.jit
+    def _stg_sf_fc2(
+        self,
+        rmem_sf_fc2: cute.Tensor,
+        token_comm_args,
+        work_tile_info,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+    ) -> None:
+        """Flush a task tile's fc2 E8M0 scales to local ``fc2_output_sf``.
+
+        The SF plane is token-row-major (blocks contiguous, stride 1), so this
+        thread's ``fc2_subtile_cnt`` scales land on contiguous bytes at
+        ``pool_token * sf_block_pad + tile_n * fc2_subtile_cnt``.  When hidden is
+        a whole multiple of ``cta_tile_n`` every N-tile is fully in-bounds, so
+        the 8 scales go out as one 64-bit store; otherwise fall back to per-block
+        predicated 1-byte stores for the ragged tail tile.
+
+        Token predicate mirrors ``_run_fc2_subtile``'s data STG: thread owns one
+        token row, so a single ``token_row_in_cta < valid_tokens`` guards the
+        whole flush (all subtiles share the token, only the block index moves).
+        """
+        fc2_subtile_cnt = self._cta_tile_n // EpilogueTileN
+        thread_in_warp = tidx % WarpThreadCount
+        token_row_in_cta = cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+        if token_row_in_cta < work_tile_info.valid_tokens_in_cta_tile:
+            pool_token_global = (
+                work_tile_info.cumulative_data_physical_row
+                + work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                + token_row_in_cta
+            )
+            hidden_group_base = (
+                work_tile_info.tile_n_idx * cutlass.Int32(fc2_subtile_cnt)
+            )
+            sf_byte_addr = (
+                token_comm_args.fc2_output_sf.iterator.toint()
+                + Int64(pool_token_global) * Int64(self._fc2_sf_block_pad)
+                + Int64(hidden_group_base)
+            )
+            if cutlass.const_expr(self._fc2_sf_batch8):
+                stg_e8m0x8_from_f32(
+                    sf_byte_addr,
+                    rmem_sf_fc2[0], rmem_sf_fc2[1], rmem_sf_fc2[2], rmem_sf_fc2[3],
+                    rmem_sf_fc2[4], rmem_sf_fc2[5], rmem_sf_fc2[6], rmem_sf_fc2[7],
+                )
+            else:
+                for j in cutlass.range_constexpr(fc2_subtile_cnt):
+                    block_hidden_start = (
+                        work_tile_info.tile_n_idx * cutlass.Int32(self._cta_tile_n)
+                        + cutlass.Int32(j * EpilogueTileN)
+                    )
+                    if block_hidden_start < valid_hidden:
+                        stg_e8m0_from_f32(sf_byte_addr + Int64(j), rmem_sf_fc2[j])
+
+    @cute.jit
+    def _run_fc2_task_tile(
+        self,
+        work_tile_info,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn,
+        sched_ext,
+        gmem_fc2_output: cute.Tensor,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+        token_comm_args=None,
+    ) -> None:
+        """fc2 (Linear2) task-tile body following fc1 pattern exactly.
+
+        Key alignment with fc1:
+          - acc_stage_col_offset = 0 for overlapping_accum (single physical stage)
+          - is_odd_turn determines start subtile (7 odd, 0 even) and direction
+          - consumer_release after first subtile (i==0) when overlapping_accum
+          - TMEM tensor advances by +/- EpilogueTileN each iteration
+        """
+        real_fc2_output, _ = sched_ext.get_gmem_tensor(
+            "d", gmem_fc2_output, work_tile_info,
+        )
+        acc_pipeline.consumer_wait(acc_consumer_state)
+        iket.range_push("mxfp8_fc2_epi_tile")
+
+        # For overlapping_accum: phase selects which TMEM stage holds the result,
+        # mirroring the fc1 epilogue formula.  When a cluster processes an fc1 tile
+        # before fc2, acc_consumer_state.phase is 1 and the result lives in the
+        # second physical stage (col offset 256-num_sf_tmem_cols).  Hardcoding 0
+        # reads the wrong stage for phase=1 clusters.
+        # For non-overlapping: stage index selects the physical region.
+        if cutlass.const_expr(self._overlapping_accum):
+            acc_stage_col_offset = cutlass.Int32(acc_consumer_state.phase) * (
+                256 - self._num_sf_tmem_cols
+            )
+        else:
+            acc_stage_col_offset = (
+                cutlass.Int32(acc_consumer_state.index) * self._cta_tile_n
+            )
+
+        fc2_subtile_cnt = self._cta_tile_n // EpilogueTileN  # = 8
+
+        # Start subtile mirrors fc1: last for odd turn, first for even.
+        start_subtile = fc2_subtile_cnt - 1 if is_odd_turn else 0
+        tmem_t = self._subtile_fc2_tmem_tensor(
+            tmem_acc_tensor, cutlass.Int32(start_subtile), warp_idx,
+        )
+
+        # Step direction mirrors fc1 gate/up: +EpilogueTileN (even) or -EpilogueTileN (odd).
+        tmem_forward_cols = EpilogueTileN
+        if cutlass.const_expr(self._overlapping_accum):
+            if is_odd_turn:
+                tmem_forward_cols = -EpilogueTileN
+
+        # Quantized combine: buffer the per-subtile E8M0 scales and flush them in
+        # one stg.64 after the loop (see _stg_sf_fc2).  Indexed by subtile_idx, so
+        # the reversed odd-turn walk fills the same slots.
+        if cutlass.const_expr(self._combine_mxfp8 and token_comm_args is not None):
+            layout_sf_fc2 = cute.make_layout(fc2_subtile_cnt)
+            rmem_sf_fc2 = cute.make_rmem_tensor(layout_sf_fc2.shape, self.acc_dtype)
+        else:
+            rmem_sf_fc2 = None
+
+        for i in cutlass.range(0, fc2_subtile_cnt, 1, unroll=1):
+            if cutlass.const_expr(self._overlapping_accum):
+                subtile_idx = cutlass.Int32(i)
+                if is_odd_turn:
+                    subtile_idx = cutlass.Int32(fc2_subtile_cnt - 1 - i)
+            else:
+                subtile_idx = cutlass.Int32(i)
+
+            self._run_fc2_subtile(
+                subtile_idx=subtile_idx,
+                tmem_subtile_tensor=tmem_t,
+                real_fc2_output=real_fc2_output,
+                work_tile_info=work_tile_info,
+                valid_hidden=valid_hidden,
+                warp_idx=warp_idx,
+                tidx=tidx,
+                token_comm_args=token_comm_args,
+                rmem_sf_fc2=rmem_sf_fc2,
+            )
+
+            if cutlass.const_expr(self._overlapping_accum):
+                self._acc_pipeline_consumer_release(acc_pipeline, acc_consumer_state, i == 0)
+
+            tmem_t = self._advance_fc2_tmem_tensor(tmem_t, tmem_forward_cols)
+
+        # Release AFTER all subtile reads (never early-release for FC2).
+        if not cutlass.const_expr(self._overlapping_accum):
+            self._acc_pipeline_consumer_release(acc_pipeline, acc_consumer_state, True)
+
+        # Flush the buffered E8M0 scales (one stg.64 per thread when aligned).
+        if cutlass.const_expr(self._combine_mxfp8 and token_comm_args is not None):
+            self._stg_sf_fc2(
+                rmem_sf_fc2=rmem_sf_fc2,
+                token_comm_args=token_comm_args,
+                work_tile_info=work_tile_info,
+                valid_hidden=valid_hidden,
+                warp_idx=warp_idx,
+                tidx=tidx,
+            )
+
+        iket.range_pop()
+
+
+    @cute.jit
+    def _stg_sf_fc1(
+        self,
+        rmem_sf_f32: cute.Tensor,
+        real_fc1_output_sf: cute.Tensor,
+        work_tile_info,
+        tidx,
+    ) -> None:
+        """Compute gmem SF tile coords and store fc1 scale factors to gmem.
+
+        Predicated on ``valid_tokens_in_cta_tile``: thread ``tidx`` owns the
+        CTA-relative token ``tidx``, so padding threads
+        (``tidx >= valid_tokens``) must skip the store.  SF is only padded to
+        ``SfPaddingBlock`` (128), but a CTA tile spans 128 tokens / a cluster
+        block 256, so an over-padded thread's SF GMEM row aliases the START of
+        the NEXT expert's SF region -- writing it corrupts that expert's scale
+        factors (off-by-one E8M0 exponent -> factor-of-2 output error).  Mirror
+        of the predicate in ``tma_store_fc1_output`` for the data store.
+        """
+        bx, _, _ = cute.arch.block_idx()
+        sf_idx = work_tile_info.tile_n_idx
+        token_idx = (
+            work_tile_info.tile_m_idx * self._cta_tile_m
+            + tidx
+        )
+        if tidx < work_tile_info.valid_tokens_in_cta_tile:
+            sf_base = cute.local_tile(
+                real_fc1_output_sf,
+                (1, 1, 1),
+                (token_idx, sf_idx * cutlass.Int32(Fc1EpilogueOutputTileN), cutlass.Int32(0)),
+            )
+            # local_tile() with a runtime token_idx drops the pointer's
+            # assumed_align to 1 byte (the E8M0 element size), but the region
+            # base is 4B-aligned -- reassert that so the 4 bytes coalesce
+            # into a single STG.E.U32.
+            sf_ptr = cute.make_ptr(
+                self.sf_dtype,
+                sf_base.iterator.toint(),
+                cute.AddressSpace.gmem,
+                assumed_align=4,
+            )
+            gmem_sf_f8 = cute.make_tensor(sf_ptr, cute.make_layout(4))
+            sf_layout = cute.make_layout(4)
+            r_sf_f8 = cute.make_rmem_tensor(sf_layout.shape, self.sf_dtype)
+            r_sf_f8.store(rmem_sf_f32.load().to(self.sf_dtype))
+            cute.autovec_copy(r_sf_f8, gmem_sf_f8)
+
+
+    @cute.jit
+    def run(
+        self,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        sched_consumer,
+        sched_ext,
+        smem_fc1_output_buffer: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        gmem_fc1_output: cute.Tensor,
+        gmem_fc1_output_sf: cute.Tensor,
+        gmem_topk_scores: cute.Tensor,
+        gmem_fc2_output: cute.Tensor,
+        gmem_fc1_done_counter: cute.Tensor,
+        warp_idx: int,
+        tidx,
+        alpha,
+        norm_const,
+        token_comm_args=None,
+        # generate_c: pass real sC / tma_atom_c / tma_tensor_c when True;
+        # pass smem_fc1_output_buffer / tma_atom_fc1_output / gmem_fc1_output as
+        # dummies when False — const_expr guards ensure no access.
+        smem_c_buffer: cute.Tensor = None,
+        tma_atom_c: cute.CopyAtom = None,
+        gmem_c: cute.Tensor = None,
+    ) -> None:
+        """
+        Run the full MXFP8 fc1+fc2-fused epilogue task-tile loop.
+
+        ``token_comm_args`` (MegaMoE path) is forwarded to the fc2 task tile so
+        the fc2 STG is routed to the source rank's combine output.
+        """
+        acc_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self._num_acc_pipeline_stages
+        )
+
+        if cutlass.const_expr(self._generate_c):
+            _c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=Fc1CTMAStages,
+                producer_group=pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread,
+                    EpiWarpCount * WarpThreadCount,
+                ),
+            )
+        else:
+            _c_pipeline = None
+
+        task_tile_boundary_bar = pipeline.NamedBarrier(
+            barrier_id=self._epilog_sync_bar_id,
+            num_threads=32 * len(self._epilogue_warp_ids),
+        )
+
+        valid_hidden = cutlass.Int32(gmem_fc2_output.shape[1])
+
+        # Init=1 (reverse): overlap-acc path walks subtiles N-1, 0, ..., N-2
+        # so the overlap-region TMEM cols are released first.
+        is_odd_turn = cutlass.Int32(1)
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        work_tile_info = sched_consumer.consume_work()
+
+        flag_tracker = GpuReleaseFlagBatchTracker(
+            flag_addr=Int64(0),
+            cumulated_flags=cutlass.Int32(0),
+            phase=cutlass.Int32(work_tile_info.phase),
+            tid=tidx % (len(self._epilogue_warp_ids) * WarpThreadCount),
+        )
+
+        while work_tile_info.is_valid_tile:
+            acc_stage_index = 0 if is_odd_turn else 1
+            tmem_acc_stage_tesnor = tmem_acc_tensor[(None, None, None, acc_stage_index)]
+
+            if work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1):
+                if cutlass.const_expr(self._generate_c):
+                    _smem_c_buf = smem_c_buffer
+                    _tma_atom_c  = tma_atom_c
+                    _gmem_c      = gmem_c
+                else:
+                    _smem_c_buf = smem_fc1_output_buffer
+                    _tma_atom_c  = tma_atom_fc1_output
+                    _gmem_c      = gmem_fc1_output
+                self._run_fc1_task_tile(
+                    work_tile_info=work_tile_info,
+                    tmem_acc_tensor=tmem_acc_stage_tesnor,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                    is_odd_turn=is_odd_turn,
+                    smem_fc1_output_buffer=smem_fc1_output_buffer,
+                    tma_atom_fc1_output=tma_atom_fc1_output,
+                    sched_ext=sched_ext,
+                    gmem_fc1_output=gmem_fc1_output,
+                    gmem_fc1_output_sf=gmem_fc1_output_sf,
+                    gmem_topk_scores=gmem_topk_scores,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                    alpha=alpha,
+                    norm_const=norm_const,
+                    smem_c_buffer=_smem_c_buf,
+                    tma_atom_c=_tma_atom_c,
+                    gmem_c=_gmem_c,
+                    c_pipeline=_c_pipeline,
+                )
+            else:
+                self._run_fc2_task_tile(
+                    work_tile_info=work_tile_info,
+                    tmem_acc_tensor=tmem_acc_stage_tesnor,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                    is_odd_turn=is_odd_turn,
+                    sched_ext=sched_ext,
+                    gmem_fc2_output=gmem_fc2_output,
+                    valid_hidden=valid_hidden,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                    token_comm_args=token_comm_args,
+                )
+
+            acc_consumer_state.advance()
+            if cutlass.const_expr(self._overlapping_accum):
+                is_odd_turn = cutlass.Int32(1) - is_odd_turn
+
+            cur_was_linear1 = work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+            # Use tile_m_idx // atom_thr_size (= cluster-level token block index)
+            # NOT tile_n_idx (= intermediate N-tile index).  Both fc1 N-tiles
+            # for the same token block share the same tile_m_idx, so all their
+            # increments target the same counter slot.  Using tile_n_idx splits
+            # increments across slots and deadlocks fc2's spin-wait.
+            cur_fc1_counter_slot = (
+                work_tile_info.cumulative_token_block_count
+                + work_tile_info.tile_m_idx // cutlass.Int32(self._atom_thr_size)
+            )
+            cur_fc2_expert_idx = work_tile_info.expert_idx
+
+            work_tile_info = sched_consumer.consume_work()
+
+            # Drain fc1 TMA/STG stores before publishing the fc1-done counter.
+            if cur_was_linear1:
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+                cute.arch.fence_acq_rel_gpu()
+
+            task_tile_boundary_bar.arrive_and_wait()
+
+            if cur_was_linear1:
+                flag_tracker = flag_tracker.accumulate(
+                    work_tile_info.phase,
+                    self._epi_fc1_batch,
+                    (gmem_fc1_done_counter.iterator + cur_fc1_counter_slot).toint(),
+                )
+            else:
+                if cutlass.const_expr(self._token_back_by_dispatch):
+                    # Fence before (deferred) counter release: make the fc2
+                    # pool-output STG writes device-visible.  The release
+                    # atomic in flag_tracker.fire() then signals completion.
+                    cute.arch.fence_acq_rel_gpu()
+                    fc2_flag_addr = (
+                        token_comm_args.fc2_done_counter.iterator + cur_fc2_expert_idx
+                    ).toint()
+                else:
+                    fc2_flag_addr = Int64(0)
+                no_fire: cutlass.Constexpr = not self._token_back_by_dispatch
+                flag_tracker = flag_tracker.accumulate(
+                    work_tile_info.phase,
+                    self._epi_fc2_batch,
+                    fc2_flag_addr,
+                    no_fire,
+                )
+
+        flag_tracker.fire()
+

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/kernel_mxfp8_glu_fc12.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/kernel_mxfp8_glu_fc12.py
@@ -1,0 +1,2322 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Fused fc1+fc2 GLU MXFP8 MegaMoE kernel for SM100.
+"""
+
+from typing import Literal, Optional, Tuple, Type, Union
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+
+from moe_nvfp4_swapab.epilogue import SwapABSwigluFp4Epilogue, _TmemTranspose16x32Core
+from moe_mxfp8_glu.epilogue_mxfp8 import GluMxfp8Epilogue
+from moe_nvfp4_swapab.fc1_fc2_fuse_sched import (
+    BlockPhase,
+    MoEFusedFc12SchedulerParams,
+)
+from moe_nvfp4_swapab.custom_ext import GluMxFp8Fc12SchedExtension
+from common.megamoe_constants import (
+    Mxfp8BlockSize,
+    Nvfp4BlockSize,
+    SupportedMmaTileM,
+    SupportedMmaTileN,
+)
+from moe_nvfp4_swapab.moe_utils import spin_wait
+
+
+# =============================================================================
+# Sm100SwigluMxfp8Fc12Kernel
+# =============================================================================
+
+class Sm100SwigluMxfp8Fc12Kernel:
+
+    # SMEM budget for all "non-problem-tensor" buffers (mbarriers, sched
+    # work-tile buffer, TMEM allocator state).  Reserved at host side in
+    # ``_compute_stages``.  Bump if ``SharedStorage`` over-allocates SMEM.
+    _SmemMiscBudget = 1024
+
+    # Supported (ab_dtype, sf_vec_size) pairings.
+    # MXFP8 → Float8E4M3FN / Float8E5M2 + sf_vec_size=32  (FP8-E8M0 scales, MmaMXF8Op)
+    VALID_AB_DTYPE_SF_SIZE: dict = {
+        32: (cutlass.Float8E4M3FN, cutlass.Float8E5M2,),
+    }
+
+    # Interleave granularity for gate and up in SwiGLU / GeGlu
+    GateUpInterleave: int = 32
+
+    def __init__(
+        self,
+        # Geometry (no defaults; perf-sensitive + coupled by the validator:
+        # mma_tiler_m / cluster_m == 128;  use_2cta_instrs ⇔ mma_tiler_m == 256)
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mnk: Tuple[int, int, int],
+        use_2cta_instrs: bool,
+        # Fused fc1+fc2 sched-side knobs
+        group_hint: int,
+        token_padding_block: int,
+        sf_padding_block: int,
+        load_balance_mode: Literal["static", "atomic_counter"] = "static",
+        # Optional sched knobs (None = sane internal default).
+        # ``static_expert_shape`` binds (experts, intermediate_gateup, hidden)
+        # at codegen time; None keeps those dims runtime-dynamic.
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,
+        force_static_sched: bool = True,
+        clc_bundle_size: Optional[int] = None,
+        num_sched_stages: Optional[int] = None,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        sf_vec_size: int = 32,
+        ab_dtype: Type[cutlass.Numeric] = cutlass.Float4E2M1FN,
+        scenario: Literal["2Dx3D"] = "2Dx3D",
+        fc2_in_kernel_topk_reduce: bool = False,
+        token_back_by_dispatch: bool = False,
+        epi_flag_batch: Optional[Tuple[int, int]] = (1, 1),
+        gate_up_clamp: Optional[float] = None,
+        apply_topk_in_fc1: bool = False,
+        generate_c: bool = False,
+        use_stg_fc1: bool = False,
+    ) -> None:
+        # v1 only the lean static-sched path; dyn_2d3d 12-warp path
+        # (empty + drain_aux warps) is future work.
+        if not force_static_sched:
+            raise NotImplementedError(
+                "v1 only implements force_static_sched=True (lean 7-warp). "
+                "Dynamic CLC (force_static_sched=False) is future work."
+            )
+
+        # Validate (ab_dtype, sf_vec_size) pairing.
+        if sf_vec_size in self.VALID_AB_DTYPE_SF_SIZE:
+            valid_ab = self.VALID_AB_DTYPE_SF_SIZE[sf_vec_size]
+            if ab_dtype not in valid_ab:
+                raise ValueError(
+                    f"ab_dtype={ab_dtype.__name__} is not valid for "
+                    f"sf_vec_size={sf_vec_size}. "
+                    f"Expected one of: {[t.__name__ for t in valid_ab_tuple]}."
+                )
+        else:
+            raise NotImplementedError(
+                f"sf_vec_size must be {Mxfp8BlockSize} (MXFP8)"
+            )
+
+
+        if scenario != "2Dx3D":
+            raise NotImplementedError(
+                f"v1 fused fc12 only supports scenario='2Dx3D' (forward); "
+                f"got {scenario!r}."
+            )
+        if load_balance_mode not in ("static", "atomic_counter"):
+            raise ValueError(
+                f"load_balance_mode must be 'static' or 'atomic_counter'; "
+                f"got {load_balance_mode!r}."
+            )
+
+        # Only (M=256, N=256) with 2-CTA instructions is validated now.
+        m, n, _k = mma_tiler_mnk
+        if (m, n) != (256, 256) or not use_2cta_instrs:
+            raise ValueError(
+                "Sm100SwigluMxfp8Fc12Kernel only supports mma_tiler (M, N) = "
+                "(256, 256) with use_2cta_instrs=True; "
+                f"got mma_tiler_mnk={mma_tiler_mnk}, use_2cta_instrs={use_2cta_instrs}."
+            )
+
+        # Store ab_dtype so workspace-size helpers can use it without tensors.
+        self.ab_dtype = ab_dtype
+        self.c_dtype = cutlass.BFloat16
+
+        self.fc2_in_kernel_topk_reduce = fc2_in_kernel_topk_reduce
+        self.token_back_by_dispatch = token_back_by_dispatch
+        self.epi_flag_batch = epi_flag_batch
+        self.apply_topk_in_fc1 = apply_topk_in_fc1
+        self.generate_c = generate_c
+        self.use_stg_fc1 = use_stg_fc1
+        self.gate_up_clamp = (
+            abs(gate_up_clamp) if gate_up_clamp is not None else None
+        )
+
+        self.acc_dtype = acc_dtype
+        self.mma_tiler_mnk = mma_tiler_mnk
+        self.cluster_shape_mn = (cluster_shape_mnk[0], cluster_shape_mnk[1])
+        self.use_2cta_instrs = use_2cta_instrs
+        self.force_static_sched = force_static_sched
+        # static_expert_shape / clc_bundle_size / num_sched_stages: accepted
+        # for API parity with the runner; scheduler reads expert_cnt from
+        # ``offs.shape[0]`` at runtime when ``static_expert_shape`` is None.
+        self.static_expert_shape = static_expert_shape
+        self.clc_bundle_size = clc_bundle_size
+        self.num_sched_stages = num_sched_stages
+
+        # Fused fc12 sched-side knobs
+        self.group_hint = group_hint
+        self.token_padding_block = token_padding_block
+        self.sf_padding_block = sf_padding_block
+        self.load_balance_mode = load_balance_mode
+
+        self.sf_vec_size = sf_vec_size
+        self.scenario = scenario
+        self.arch = "sm_100"
+
+        self._validate_mma_tiler_and_cluster_shape()
+        self.mma_tiler = mma_tiler_mnk
+
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        # Warp specialization (lean 8-warp / 256 thread)
+        self.occupancy = 1
+        self.epilogue_warp_id = (0, 1, 2, 3)
+        self.mma_warp_id = 4
+        self.tma_a_warp_id = 5
+        self.tma_b_warp_id = 6
+        self.sched_warp_id = 7
+        self.threads_per_cta = 32 * len(
+            (
+                self.mma_warp_id,
+                self.tma_a_warp_id,
+                self.tma_b_warp_id,
+                self.sched_warp_id,
+                *self.epilogue_warp_id,
+            )
+        )
+
+        # NamedBarrier IDs.
+        #
+        # Per-subtile rotated-leader scheme lives inside the epilogue; this
+        # kernel only owns the four reserved IDs and forwards
+        # them via ``self.epilog_sync_bar_id`` to the epilogue ctor.
+        # IDs 8 and 9 are reserved for MXFP8 warp-pair absmax exchange.
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+        self.tmem_dealloc_sync_bar_id = 3
+        self.epi_subtile_bar_ids = (4, 5, 6, 7)
+
+        # MegaMoE toggle.  False for the lean base; subclasses (e.g.
+        # ``Sm100MegaMoEMxfp8Kernel``) set this to True in their own
+        # ``__init__`` after ``super().__init__`` returns.
+        # ``_setup_attributes()`` reads it inside ``__call__`` to expand the
+        # warp topology to the 12-warp MegaMoE layout.
+        self.enable_token_comm: bool = False
+        self.dispatch_warp_id: Optional[Tuple[int, int, int, int]] = None
+        self.token_back_warp_id: Optional[Tuple[int, int, int, int]] = None
+        self.token_back_standalone: bool = False
+
+        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
+
+    def _validate_mma_tiler_and_cluster_shape(self) -> None:
+        """Validate user-provided geometry against v1 fused-fc12 constraints.
+
+        ``mma_tiler_n`` is restricted to {128, 256}.  Short-N is handled by
+        the swap-AB scheduler via subtile-level early-exit.
+        """
+        m, n, k = self.mma_tiler_mnk
+        cm, cn = self.cluster_shape_mn
+
+        if m not in SupportedMmaTileM:
+            raise ValueError(
+                f"mma_tiler M ({m}) must be one of {SupportedMmaTileM}"
+            )
+
+        per_cta_m = m // (2 if self.use_2cta_instrs else 1)
+        if per_cta_m != 128:
+            raise ValueError(
+                f"per-CTA mma_tiler M must be 128, got {per_cta_m} "
+                f"(mma_tiler_m={m}, use_2cta_instrs={self.use_2cta_instrs})"
+            )
+
+        if n not in SupportedMmaTileN:
+            raise ValueError(
+                f"mma_tiler N ({n}) must be one of {SupportedMmaTileN} in fused fc12 "
+                f"(N=64 SFB hack is dropped; swap-AB sched handles short-N "
+                f"via subtile early-exit)."
+            )
+
+        sf_k_granularity = self.sf_vec_size * 4
+        if k % sf_k_granularity != 0:
+            raise ValueError(
+                f"mma_tiler K ({k}) must be a multiple of "
+                f"sf_vec_size * 4 = {sf_k_granularity}"
+            )
+
+        if cm % (2 if self.use_2cta_instrs else 1) != 0:
+            raise ValueError(
+                f"cluster_shape M ({cm}) must be even when use_2cta_instrs=True"
+            )
+
+        is_pow2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        if cm * cn > 16 or not is_pow2(cm) or not is_pow2(cn) or cm > 4 or cn > 4:
+            raise ValueError(
+                f"Invalid cluster_shape ({cm}, {cn}): each dim must be "
+                f"a power of 2 and <= 4, product must be <= 16"
+            )
+
+        # v1 swap-AB requires cluster_n == 1.
+        if cn != 1:
+            raise NotImplementedError(
+                f"v1 fused fc12 requires cluster_n == 1 (got {cn}).  "
+                f"cluster_n > 1 needs sentinel-style acc/ab pipeline release."
+            )
+
+    def _create_tiled_mmas(self) -> Tuple[cute.TiledMma, cute.TiledMma]:
+        """Return ``(tiled_mma, tiled_mma_sfb)``.
+
+        Both phases share the same MMA configuration because ``mma_tiler_mnk``
+        is shared.  Phase selection is
+        purely a matter of which TMA load fills SMEM / which acc TMEM stage
+        the MMA writes -- the tiled MMA atoms themselves are phase-invariant.
+
+        SFB always uses ``CtaGroup.ONE``: SFB is not multicast across the
+        2-CTA pair under ``use_2cta_instrs``.
+        """
+        common = (
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+        )
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            *common, self.cta_group, self.mma_inst_shape_mn,
+        )
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            *common, tcgen05.CtaGroup.ONE, self.mma_inst_shape_mn_sfb,
+        )
+        return tiled_mma, tiled_mma_sfb
+
+    def _setup_attributes(self) -> None:
+        """Set up MMA / cluster / tile shapes, SMEM layouts, stage counts.
+
+        The fc12 path shares ``mma_tiler_mnk`` and SMEM layouts across phases.
+        """
+        if self.enable_token_comm:
+            self.dispatch_warp_id = (8, 9, 10, 11)
+            num_token_back_warps = (
+                len(self.token_back_warp_id) if self.token_back_standalone else 0
+            )
+            self.threads_per_cta = 32 * (
+                len(self.epilogue_warp_id)
+                + 1  # mma
+                + 1  # tma_a
+                + 1  # tma_b
+                + 1  # sched
+                + len(self.dispatch_warp_id)
+                + num_token_back_warps
+            )
+
+        self.mma_inst_shape_mn = (self.mma_tiler[0], self.mma_tiler[1])
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma, tiled_mma_sfb = self._create_tiled_mmas()
+
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        assert self.mma_tiler[2] % mma_inst_shape_k == 0, (
+            f"mma_tiler K ({self.mma_tiler[2]}) must be a multiple of "
+            f"MMA instruction K ({mma_inst_shape_k})"
+        )
+
+        # SFB-specific tiler: rounded-up MN; same K as main tiler.
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Multicast CTA counts
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+
+        # Epilogue is autonomous: it owns all epi-side decisions (overlap,
+        # acc stages, subtile dispatch, TMA commit/drain, piggyback red.add).
+        # We pass kernel-level params + ``allow_overlap_acc`` hint and read
+        # the decisions back via @property below.
+        _epi_common = dict(
+            mma_tiler_mnk=self.mma_tiler,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_2cta_instrs=self.use_2cta_instrs,
+            sf_vec_size=self.sf_vec_size,
+            fc1_output_dtype=self.fc1_output_dtype,
+            fc1_output_layout=self.fc1_output_layout,
+            acc_dtype=self.acc_dtype,
+            allow_overlap_acc=True,
+            epilog_sync_bar_id=self.epilog_sync_bar_id,
+            epilogue_warp_ids=self.epilogue_warp_id,
+            static_expert_shape=self.static_expert_shape,
+            fc2_in_kernel_topk_reduce=self.fc2_in_kernel_topk_reduce,
+            token_back_by_dispatch=self.token_back_by_dispatch,
+            epi_flag_batch=self.epi_flag_batch,
+            glu_clamp=self.gate_up_clamp,
+            apply_topk_in_fc1=self.apply_topk_in_fc1,
+            generate_c=self.generate_c,
+            use_stg_fc1=self.use_stg_fc1,
+            combine_format=getattr(self, "combine_format", None),
+        )
+        self.epilogue = GluMxfp8Epilogue(**_epi_common)
+
+        if self.num_sched_stages is None:
+            self.num_sched_stages = 2
+
+        # sD stages locked to subtile_cnt: one full CTA output tile lives in
+        # sD at a time.  Per-subtile producer_acquire/commit go
+        # away — only one batched commit + drain happens per task tile (in
+        # the epilogue's ``run`` loop body).
+        self.num_d_stage = self.epilogue.subtile_cnt
+        # fc1 output (fp8 quantised) SMEM — always present.
+        d_bytes_total = self.epilogue.bytes_per_stage * self.num_d_stage
+        # Raw gate+up SMEM (BF16, ping-pong) — only when generate_c=True.
+        c_bytes_total = 0
+        if self.generate_c:
+            from moe_mxfp8_glu.epilogue_mxfp8 import Fc1CTMAStages
+            self.num_c_raw_stage = Fc1CTMAStages
+            c_bytes_total += self.epilogue.c_bytes_per_stage * self.num_c_raw_stage
+        else:
+            self.num_c_raw_stage = 0
+
+        (
+            self.num_acc_stage,
+            self.num_a_stage,
+            self.num_b_stage,
+            self.num_sched_stages,
+        ) = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.sf_dtype,
+            self.sf_vec_size,
+            c_bytes_total + d_bytes_total,
+            self.smem_capacity,
+            self.occupancy,
+            self.num_sched_stages,
+        )
+
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_a_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_b_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_a_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_b_stage,
+        )
+        self.d_smem_layout_staged = self.epilogue.staged_smem_layout(
+            self.num_d_stage,
+        )
+        # Raw gate+up SMEM layout (only meaningful when generate_c=True; pass as
+        # dummy to kernel when False).
+        if self.generate_c:
+            self.c_smem_layout_staged = self.epilogue.staged_c_smem_layout(
+                self.num_c_raw_stage
+            )
+        else:
+            self.c_smem_layout_staged = None
+
+        # Read epilogue's autonomous decisions.
+        self.overlapping_accum = self.epilogue.overlapping_accum
+        self.num_acc_pipeline_stages = self.epilogue.num_acc_pipeline_stages
+        self.num_acc_stage = self.epilogue.num_acc_stage
+        self.num_sfa_tmem_cols = self.epilogue.num_sfa_tmem_cols
+        self.num_sfb_tmem_cols = self.epilogue.num_sfb_tmem_cols
+        self.num_sf_tmem_cols = self.epilogue.num_sf_tmem_cols
+        self.num_accumulator_tmem_cols = self.epilogue.num_accumulator_tmem_cols
+        self.iter_acc_early_release_in_epilogue = self.epilogue.iter_acc_early_release
+
+        # TMA load bytes per stage (A + B + SFA + SFB).
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+        self.atom_thr_size = atom_thr_size  # store as Python int for use in @cute.kernel
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_a_bytes = (a_copy_size + sfa_copy_size) * atom_thr_size
+        self.num_tma_load_b_bytes = (b_copy_size + sfb_copy_size) * atom_thr_size
+
+    def _smem_misc_budget_bytes(self) -> int:
+        """Per-CTA SMEM reserved outside the AB-stage pipeline.
+
+        Lean fc12 path: only the fixed ``_SmemMiscBudget``.  Subclasses (the
+        MegaMoE wrapper) extend this to also reserve SMEM for the dispatch
+        warps' pull_buffer / pull_mbar / smem_expert_count regions;
+        ``_compute_stages`` reads this hook so the AB-stage count comes out
+        small enough to leave room for those extra regions.
+        """
+        return self._SmemMiscBudget
+
+    def _compute_stages(
+        self,
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_bytes_total: int,
+        smem_capacity: int,
+        occupancy: int,
+        num_sched_stages: int,
+    ) -> Tuple[int, int, int]:
+        """Compute stage counts for ACC, AB+SF, and scheduler.
+        """
+        num_acc_stage = 2
+
+        a_smem_layout_staged_one = sm100_utils.make_smem_layout_a(
+            tiled_mma, mma_tiler_mnk, a_dtype, 1,
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma, mma_tiler_mnk, b_dtype, 1,
+        )
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma, mma_tiler_mnk, sf_vec_size, 1,
+        )
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma, mma_tiler_mnk, sf_vec_size, 1,
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_staged_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+        b_bytes_per_stage = (
+            cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+
+        fixed_overhead = (
+            self._smem_misc_budget_bytes() + c_bytes_total
+        )
+
+        num_ab_stage = (
+            smem_capacity // occupancy - fixed_overhead
+        ) // ab_bytes_per_stage
+        num_a_stage = num_ab_stage
+        num_b_stage = num_ab_stage
+
+        smem_per_cta = smem_capacity // occupancy
+        unused_smem = smem_per_cta - fixed_overhead - num_ab_stage * ab_bytes_per_stage
+        if unused_smem > b_bytes_per_stage:
+            num_b_stage = num_b_stage + 1
+            unused_smem = unused_smem - b_bytes_per_stage
+        print(
+            f"[fc12 stages] num_ab_stage={num_a_stage, num_b_stage} "
+            f"num_acc_stage={num_acc_stage} "
+            f"misc_budget={self._smem_misc_budget_bytes()} "
+            f"c_bytes_total={c_bytes_total} "
+            f"smem_cap={smem_capacity} "
+            f"unused_smem={unused_smem}"
+        )
+
+        return num_acc_stage, num_a_stage, num_b_stage, num_sched_stages
+
+    def get_workspace_size_in_bytes(
+        self,
+        fc1_activation_tensor,
+        fc1_weight_tensor,
+    ) -> int:
+        """Compute opaque workspace size for one fused fc1+fc2 launch."""
+        sf_padding_block = self.sf_padding_block
+        sf_vec_size = self.sf_vec_size
+
+        mma_tiler_n = self.mma_tiler_mnk[1]
+
+        data_total_rows, _hidden = fc1_activation_tensor.shape
+        experts, _hidden_w, intermediate_gateup = fc1_weight_tensor.shape
+        intermediate_downproj = intermediate_gateup // 2
+
+        # Conservative upper bound for sf_total_rows.
+        sf_total_rows_upper = data_total_rows + experts * sf_padding_block
+
+        # fc1_output byte size depends on the ab_dtype element width:
+        #   MXFP8 (Float8E4M3FN/Float8E5M2, 8-bit): 1 element per byte → inter bytes/row
+        fc1_output_bytes = (
+            data_total_rows * intermediate_downproj * self.ab_dtype.width // 8
+        )
+
+        # fc1_output_sf sf_vec_size matches the kernel's sf_vec_size.
+        fc1_out_sf_vec_size = self.sf_vec_size
+        sf_block_cols = (
+            (intermediate_downproj // fc1_out_sf_vec_size) + 3
+        ) // 4 * 4
+        fc1_output_sf_bytes = sf_total_rows_upper * sf_block_cols
+
+        # fc1_done_counter: one Int32 per global token block, plus expert slack.
+        counter_slots_upper = (
+            (data_total_rows + mma_tiler_n - 1) // mma_tiler_n
+            + experts
+        )
+        fc1_done_counter_bytes = counter_slots_upper * 4
+
+        # load_balance_counter: Int32 scalar.
+        if self.load_balance_mode == "atomic_counter":
+            load_balance_counter_bytes = 4
+        else:
+            load_balance_counter_bytes = 0
+
+        total = (
+            fc1_output_bytes
+            + fc1_output_sf_bytes
+            + fc1_done_counter_bytes
+            + load_balance_counter_bytes
+        )
+
+        # 128B align (TMA tensor base address alignment requirement).
+        alignment = 128
+        total = ((total + alignment - 1) // alignment) * alignment
+        return total
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """SMEM → TMEM tiled copy + partition for SFA / SFB."""
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t, tCsSF_compact_s2t_
+        )
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    # ── MegaMoE communication hook stubs ─────────────────────────────────────
+    #
+    # No-op base implementations for the lean fc1+fc2 path.  Mirroring the
+    # identically-named stubs in the NVFP4 base (``kernel_fc12.py``).
+    # ``Sm100MegaMoEMxfp8Kernel`` (megamoe_kernel_mxfp8.py) overrides all of
+    # them to delegate to ``src/token_comm.py``.
+
+    def token_comm_extra_smem_storage_class(self) -> type:
+        """Return a ``@cute.struct`` for dispatch-warp SMEM, or None."""
+        return None
+
+    def token_comm_hook_fc1_ready_counter_ptr(self, token_comm_args):
+        """Return dispatch->fc1 release counter pointer, or None (lean: disabled)."""
+        return None
+
+    def sched_ext_fc1_peek_threshold(self) -> int:
+        """Return the fc1 ready-counter peek threshold for GluMxFp8Fc12SchedExtension.
+
+        Must match the spin threshold in ``token_comm_hook_fc1_tma_b_predispatch_spin``
+        so that an early peek hit does not skip the spin and expose stale pool rows.
+        Default 0 → use ``valid_tokens_in_tile`` (no cluster, base class behaviour).
+        MegaMoE overrides to return ``cluster_tile_tokens`` to match the cluster spin.
+        """
+        return 0
+
+    def sched_ext_fc1_counter_cumul_scale(self) -> int:
+        """Return the scale factor for the fc1 ready-counter slot formula.
+
+        Slot = scale * (cumul + fc1_counter_index) + tile_m_idx % scale.
+        Default 1 = cluster-level granularity (slot = cumul + cluster_token_block_idx).
+        A MegaMoE subclass can override to cluster_m for per-CTA granularity.
+        """
+        return 1
+
+    @cute.jit
+    def token_comm_hook_sched_warp_pre_init_wait(self, token_comm_args):
+        """Sched warp: wait for dispatch barrier before reading sizes.  No-op base."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_fc1_tma_b_predispatch_spin(self, token_comm_args, work_tile_info):
+        """TMA warp: spin until dispatch-pulled tokens are resident.  No-op base."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_dispatch_warp_body(
+        self, token_comm_args, token_comm_storage, *, warp_idx, lane_idx, tidx,
+    ):
+        """Body for dispatch warps 8-11 (MegaMoE-only).  No-op base."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_token_back_warp_body(
+        self, token_comm_args, token_comm_storage, *, warp_idx, lane_idx, tidx,
+    ):
+        """Body for standalone token-back warps 12-15 (MegaMoE-only).  No-op base."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_kernel_tail(self, token_comm_args, *, warp_idx, lane_idx, tidx):
+        """All-warp kernel tail (NVLink release, etc.).  No-op base."""
+        pass
+
+    @cute.jit
+    def __call__(
+        self,
+        # ── fc1 (Linear1) problem tensors ────────────────────────────────
+        activation: cute.Tensor,           # (token_sum_padded, hidden)
+        fc1_weight: cute.Tensor,           # (experts, hidden, intermediate_gateup)
+        activation_sf: cute.Tensor,         # (token_sum_padded_sf, hidden / sf_vec_size)
+        fc1_weight_sf: cute.Tensor,         # (experts, intermediate_gateup_padded * hidden / sf_vec_size)
+        # ── fc1 workspace consumed as fc2 GEMM-B ─────────────────────────
+        fc1_output: cute.Tensor,         # (token_sum_padded, intermediate_downproj)
+        fc1_output_sf: cute.Tensor,      # (token_sum_padded_sf, intermediate_downproj / sf_vec_size)
+        # ── fc2 (Linear2) problem tensors ────────────────────────────────
+        fc2_weight: cute.Tensor,          # (experts, intermediate_downproj, hidden)
+        fc2_weight_sf: cute.Tensor,        # (experts, hidden_padded * intermediate_downproj / sf_vec_size)
+        fc2_output: cute.Tensor,         # (token_sum_padded, hidden) BFloat16, hidden stride-1
+        # ── topk weights (Path A) ────────────────────────────────────────
+        topk_scores: cute.Tensor,     # (token_sum_padded,) Float32
+        # ── Cross-phase workspace ────────────────────────────────────────
+        fc1_done_counter: cute.Tensor,  # (max_token_block_per_rank,) Int32
+        # ── Sched / runtime ──────────────────────────────────────────────
+        offs: Optional[cute.Tensor] = None,  # (experts,) Int32 cumulative end offsets
+        max_active_clusters: cutlass.Constexpr = None,
+        stream: cuda.CUstream = None,
+        # ── Optional epi-side scaling ────────────────────────────────────
+        norm_const_tensor: Optional[cute.Tensor] = None,
+        global_activation_sf: Optional[cute.Tensor] = None,
+        global_fc1_weight_sf: Optional[cute.Tensor] = None,
+        # ── Optional dynamic load-balance counter ────────────────────────
+        load_balance_counter: Optional[cute.Tensor] = None,
+        # ── Sizes-mode per-expert token count (MegaMoE path) ─────────────
+        # Exactly one of ``offs`` / ``expert_token_sizes`` must be non-None.
+        # MegaMoE subclass passes a zero-copy ``i32 stride=(2,)`` view onto
+        # ``expert_recv_count_sum`` filled by the dispatch warps.
+        expert_token_sizes: Optional[cute.Tensor] = None,
+        # ── MegaMoE token-comm bundle (None on the lean path) ────────────
+        # All MegaMoE-specific device branches are gated by
+        # ``cutlass.const_expr(token_comm_args is not None)`` so they vanish
+        # at codegen time on the lean path.
+        token_comm_args=None,
+        # ── Raw fc1 accumulator output (generate_c path) ─────────────────
+        # Shape: (token_sum_padded, intermediate_gateup) Float32.
+        fc1_c: Optional[cute.Tensor] = None,
+    ) -> None:
+        """Launch the fused fc1+fc2 GLU MXFP8 kernel."""
+
+        # Bind data-tensor shapes to codegen-time expert dims when requested.
+        # Strides, token rows, and SF tensors stay runtime-dynamic because they
+        # encode host padding/swizzle choices.
+        if cutlass.const_expr(self.static_expert_shape is not None):
+            (
+                experts_static,
+                intermediate_gateup_static,
+                hidden_static,
+            ) = self.static_expert_shape
+            intermediate_downproj_static = intermediate_gateup_static // 2
+
+            fc1_weight = cute.make_tensor(
+                fc1_weight.iterator,
+                cute.make_layout(
+                    (experts_static, hidden_static, intermediate_gateup_static),
+                    stride=fc1_weight.stride,
+                ),
+            )
+            fc2_weight = cute.make_tensor(
+                fc2_weight.iterator,
+                cute.make_layout(
+                    (experts_static, intermediate_downproj_static, hidden_static),
+                    stride=fc2_weight.stride,
+                ),
+            )
+            activation = cute.make_tensor(
+                activation.iterator,
+                cute.make_layout(
+                    (activation.shape[0], hidden_static),
+                    stride=activation.stride,
+                ),
+            )
+            fc1_output = cute.make_tensor(
+                fc1_output.iterator,
+                cute.make_layout(
+                    (fc1_output.shape[0], intermediate_downproj_static),
+                    stride=fc1_output.stride,
+                ),
+            )
+            # fc2_output is 2D (tokens, hidden) on the lean path and 3D
+            # (max_tokens, topk, hidden) on the MegaMoE path.  Bind only the
+            # hidden dim to a codegen-time const; keep the other dims dynamic.
+            if cutlass.const_expr(len(fc2_output.shape) == 3):
+                fc2_output = cute.make_tensor(
+                    fc2_output.iterator,
+                    cute.make_layout(
+                        (fc2_output.shape[0], fc2_output.shape[1], hidden_static),
+                        stride=fc2_output.stride,
+                    ),
+                )
+            else:
+                fc2_output = cute.make_tensor(
+                    fc2_output.iterator,
+                    cute.make_layout(
+                        (fc2_output.shape[0], hidden_static),
+                        stride=fc2_output.stride,
+                    ),
+                )
+
+        # ── GEMM-domain transform for fc1 phase (non-swap-AB) ──
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int32(0)
+
+        # A_gemm (fc1 activations): (tokens_sum, hidden) -> (M=tokens, K=hidden, L=1).
+        tokens_sum, hidden = activation.shape
+        activation_gemm = cute.make_tensor(
+            activation.iterator,
+            cute.make_layout(
+                (tokens_sum, hidden, 1),
+                stride=(activation.stride[0], activation.stride[1], 0),
+            ),
+        )
+
+        # B_gemm (fc1 weights): (experts, hidden, intermediate_gateup) with hidden stride-1 (K-major)
+        # -> (N=intermediate_gateup, K=hidden, L=experts).
+        experts, hidden_b, intermediate_gateup = fc1_weight.shape
+        fc1_weight_gemm = cute.make_tensor(
+            fc1_weight.iterator,
+            cute.make_layout(
+                (intermediate_gateup, hidden_b, experts),
+                stride=(fc1_weight.stride[2], fc1_weight.stride[1], fc1_weight.stride[0]),
+            ),
+        )
+
+        # D_gemm is a user-view output tensor; epilogue owns its store path.
+        intermediate_downproj = fc1_output.shape[1]
+        fc1_output_gemm = cute.make_tensor(
+            fc1_output.iterator,
+            cute.make_layout(
+                (tokens_sum, intermediate_downproj, 1),
+                stride=(fc1_output.stride[0], fc1_output.stride[1], 0),
+            ),
+        )
+
+        # SFA / SFB scale tensors (atom-tiled) — fc1 phase.
+        #   SFA (mma M-side) = activation_sf (activation scales, A-side)
+        #   SFB (mma N-side) = fc1_weight_sf (weight scales, B-side)
+        tokens_sum_padded = activation_sf.shape[0]
+        hidden_padded = activation_sf.shape[1] * self.sf_vec_size
+        activation_sf_gemm = cute.make_tensor(
+            activation_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded, hidden_padded, 1), self.sf_vec_size
+            ),
+        )
+        intermediate_gateup_padded_mul_hidden_padded = fc1_weight_sf.shape[1]
+        intermediate_gateup_padded = (
+            intermediate_gateup_padded_mul_hidden_padded * self.sf_vec_size
+        ) // hidden_padded
+        fc1_weight_sf_gemm = cute.make_tensor(
+            fc1_weight_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (intermediate_gateup_padded, hidden_padded, experts),
+                self.sf_vec_size,
+            ),
+        )
+
+        # ── GEMM-domain transform for fc2 phase ──
+        #
+        # fc2 roles: M=hidden, N=tokens_sum, K=intermediate_downproj.
+
+        # A_gemm (fc2 weights): (experts, intermediate_downproj, hidden)
+        # -> (M=hidden, K=intermediate_downproj, L=experts).
+        experts2, intermediate_downproj_b2, hidden_b2 = fc2_weight.shape
+        fc2_weight_gemm = cute.make_tensor(
+            fc2_weight.iterator,
+            cute.make_layout(
+                (hidden_b2, intermediate_downproj_b2, experts2),
+                stride=(fc2_weight.stride[2], fc2_weight.stride[1], fc2_weight.stride[0]),
+            ),
+        )
+
+        # fc2 phase B operand = fc1 output reused (no new view needed:
+        # ``fc1_output_gemm`` was built from ``fc1_output.iterator`` with the same
+        # (tokens_sum, intermediate_downproj, fake-L=1) layout that fc2's
+        # GEMM-B view wants; reuse it directly when wiring fc2 TMA-B atom).
+
+        # C_gemm (fc2 output, BFloat16; STG.256-driven by the epilogue's
+        # ``Fc2UnpackPermuteStg`` — no TMA store path).
+        # We still build a GEMM-domain view so ``ext.get_gmem_tensor("d", ...)``
+        # can apply the per-expert offset.  TMA atom is NOT built for fc2_output.
+        # MegaMoE passes a 3D (max_tokens, topk, hidden) combine output; the lean
+        # path passes 2D (tokens, hidden).  In both cases build a 3D GEMM-domain
+        # view (rows, hidden, fake-L=1) folding the topk axis into the row
+        # stride.  In MegaMoE mode the epilogue bypasses this view for STG (it
+        # uses Fc2OutputDest from token_comm_args), but get_gmem_tensor("d", ...)
+        # is still called, so the layout must be valid.
+        if cutlass.const_expr(len(fc2_output.shape) == 3):
+            fc2_hidden_out = fc2_output.shape[2]
+            fc2_output_gemm = cute.make_tensor(
+                fc2_output.iterator,
+                cute.make_layout(
+                    (fc2_output.shape[0], fc2_hidden_out, c1),
+                    stride=(fc2_output.stride[0], fc2_output.stride[2], c0),
+                ),
+            )
+        else:
+            fc2_hidden_out = fc2_output.shape[1]
+            fc2_output_gemm = cute.make_tensor(
+                fc2_output.iterator,
+                cute.make_layout(
+                    (tokens_sum, fc2_hidden_out, c1),
+                    stride=(fc2_output.stride[0], fc2_output.stride[1], c0),
+                ),
+            )
+
+        # SFA / SFB for fc2:
+        #   SFA (mma M-side) = fc2_weight_sf (fc2 weight scales, sf_vec_size)
+        #   SFB (mma N-side) = fc1_output_sf (fc1 epilogue SFs, uses sf_vec_size)
+        # Both paths produce SFs with self.sf_vec_size:
+        fc1_out_sf_vec_size = self.sf_vec_size
+        tokens_sum_padded_sf = fc1_output_sf.shape[0]
+        intermediate_downproj_padded = fc1_output_sf.shape[1] * fc1_out_sf_vec_size
+        fc1_output_sf_gemm_for_fc2_load = cute.make_tensor(
+            fc1_output_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded_sf, intermediate_downproj_padded, 1),
+                fc1_out_sf_vec_size,
+            ),
+        )
+
+        hidden_padded_fc2_mul_intermediate_downproj_padded = fc2_weight_sf.shape[1]
+        hidden_padded_fc2 = (
+            hidden_padded_fc2_mul_intermediate_downproj_padded * self.sf_vec_size
+        ) // intermediate_downproj_padded
+        fc2_weight_sf_gemm = cute.make_tensor(
+            fc2_weight_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (hidden_padded_fc2, intermediate_downproj_padded, experts2),
+                self.sf_vec_size,
+            ),
+        )
+
+        expert_cnt = experts
+        # ``intermediate_gateup`` (= fc1_weight.shape[2]) is what we pass to the
+        # scheduler via ``expert_shape``; see ``MoESchedulerParamsBase``
+        # docstring for the precise contract.
+        hidden_dim = hidden
+
+        # ── Infer dtypes and major modes ──
+        # Phases share dtypes by construction. For MXFP8: A/B/fc1_output
+        # are Float8E4M3FN/Float8E5M2 and SFs are Float8E8M0FNU.
+        # ``self.fc1_output_dtype`` drives the sD SMEM element type and flows
+        # into the epilogue ctor as ``fc1_output_dtype``.
+        self.a_dtype: Type[cutlass.Numeric] = activation_gemm.element_type
+        self.b_dtype: Type[cutlass.Numeric] = fc1_weight_gemm.element_type
+        self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = activation_sf_gemm.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(activation_gemm).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(fc1_weight_gemm).mma_major_mode()
+        self.fc1_output_layout = utils.LayoutEnum.from_tensor(fc1_output_gemm)
+
+        self._setup_attributes()
+        tiled_mma, tiled_mma_sfb = self._create_tiled_mmas()
+
+        # ── fc1 TMA atoms ──
+
+        # TMA load A1 (= fc1 activations, non-swap-AB: A=activations)
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_fc1_activation, tma_tensor_fc1_activation = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            activation_gemm,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load B1 (= fc1 weights, non-swap-AB: B=weights)
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_fc1_weight, tma_tensor_fc1_weight = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            fc1_weight_gemm,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load SFA1 (= activation_sf, non-swap-AB: SFA=activation SFs, A-side)
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_fc1_activation_sf, tma_tensor_fc1_activation_sf = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            activation_sf_gemm,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+
+        # TMA load SFB1 (= fc1_weight_sf, non-swap-AB: SFB=weight SFs, B-side)
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_fc1_weight_sf, tma_tensor_fc1_weight_sf = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            fc1_weight_sf_gemm,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+
+        # TMA store for fc1 MXFP8 output.
+        # Per-subtile issue lives in
+        # ``self.epilogue.tma_store_fc1_output``; commit / drain lives
+        # inside the epilogue's ``run`` loop body.
+        fc1_output_tma_op = cpasync.CopyBulkTensorTileS2GOp()
+        tma_atom_fc1_output, tma_tensor_fc1_output = cpasync.make_tiled_tma_atom(
+            fc1_output_tma_op,
+            fc1_output_gemm,
+            self.epilogue.smem_layout_one_stage,
+            self.epilogue.epi_tile,
+        )
+
+        # TMA store for raw fc1 accumulator (gate+up, Float32) — generate_c path.
+        # GMEM shape: (tokens_sum, intermediate_gateup, 1) fp32.
+        # TMA tile: self.epilogue.epi_tile_c = (cta_tile_m=128, 64).
+        if cutlass.const_expr(self.generate_c):
+            c_gemm = cute.make_tensor(
+                fc1_c.iterator,
+                cute.make_layout(
+                    (tokens_sum, intermediate_gateup, 1),
+                    stride=(fc1_c.stride[0], fc1_c.stride[1], 0),
+                ),
+            )
+            tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                c_gemm,
+                self.epilogue.c_smem_layout_one_stage,
+                self.epilogue.epi_tile_c,
+            )
+        else:
+            # Dummy — never used by the kernel (const_expr gated).
+            tma_atom_c = tma_atom_fc1_output
+            tma_tensor_c = tma_tensor_fc1_output
+
+        # fc1 SFC GMEM tensor (= fc1_output_sf user view).  No TMA atom; it is
+        # per-thread STG.
+        fc1_output_sf_gemm = cute.make_tensor(
+            fc1_output_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded, intermediate_downproj, 1),
+                self.sf_vec_size,
+            ),
+        )
+
+        # ── fc2 TMA atoms: fc1_output → A-side (M=tokens), fc2_weight → B-side (N=hidden) ──
+        # Non-swap-AB fc2: activation (fc1_output) is GEMM-A (M=tokens),
+        # weight (fc2_weight) is GEMM-B (N=hidden). Same SMEM layouts as fc1.
+
+        tma_atom_fc2_activation, tma_tensor_fc2_activation = (
+            cute.nvgpu.make_tiled_tma_atom_A(
+                a_op,
+                fc1_output_gemm,
+                a_smem_layout,
+                self.mma_tiler,
+                tiled_mma,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_atom_fc2_weight, tma_tensor_fc2_weight = (
+            cute.nvgpu.make_tiled_tma_atom_B(
+                b_op,
+                fc2_weight_gemm,
+                b_smem_layout,
+                self.mma_tiler,
+                tiled_mma,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_atom_fc2_activation_sf, tma_tensor_fc2_activation_sf = (
+            cute.nvgpu.make_tiled_tma_atom_A(
+                sfa_op,
+                fc1_output_sf_gemm_for_fc2_load,
+                sfa_smem_layout,
+                self.mma_tiler,
+                tiled_mma,
+                self.cluster_layout_vmnk.shape,
+                internal_type=cutlass.Uint64,
+            )
+        )
+        tma_atom_fc2_weight_sf, tma_tensor_fc2_weight_sf = (
+            cute.nvgpu.make_tiled_tma_atom_B(
+                sfb_op,
+                fc2_weight_sf_gemm,
+                sfb_smem_layout,
+                self.mma_tiler_sfb,
+                tiled_mma_sfb,
+                self.cluster_layout_sfb_vmnk.shape,
+                internal_type=cutlass.Uint64,
+            )
+        )
+
+        # ── Scheduler params + grid + launch ──
+        #
+        # ``expert_cnt`` / ``intermediate_gateup`` / ``hidden_dim`` are
+        # extracted from the (possibly rewritten) tensor shapes above:
+        #   - static path (``static_expert_shape`` bound): they are
+        #     codegen-time Python int constants; the new base
+        #     ``MoESchedulerParamsBase.__init__`` preserves the Python
+        #     int type and ``__extract_mlir_values__`` skips them, so
+        #     they remain inlined literals across the scheduler's scf
+        #     region boundaries (no demotion to iter_arg / kernel-arg).
+        #   - dynamic path: they are runtime Int32 from tensor metadata.
+        #
+        # ``expert_shape[1]`` carries ``intermediate_gateup`` semantics
+        # (= fc1_weight.shape[2]) per the ``MoESchedulerParamsBase.__init__``
+        # contract.  The fused fc12 scheduler reads it as fc1 GEMM-M
+        # (under swap-AB) and derives ``num_fc1_intermediate_blocks``
+        # from it.
+        # atomic_counter mode requires a host-allocated GMEM Int32 scalar
+        # whose pointer lives in scheduler params; static mode passes
+        # None (params validate this).  Caller's contract from __call__:
+        # ``load_balance_counter`` is required iff ``load_balance_mode ==
+        # 'atomic_counter'``; otherwise may be None.
+        if cutlass.const_expr(self.load_balance_mode == "atomic_counter"):
+            if cutlass.const_expr(load_balance_counter is None):
+                raise ValueError(
+                    "load_balance_counter must be provided when "
+                    "load_balance_mode == 'atomic_counter'"
+                )
+            load_balance_counter_ptr = load_balance_counter.iterator
+        else:
+            load_balance_counter_ptr = None
+
+        if cutlass.const_expr((offs is None) == (expert_token_sizes is None)):
+            raise ValueError(
+                "Exactly one of `offs` / `expert_token_sizes` must be "
+                "provided; got "
+                f"offs={'set' if offs is not None else 'None'}, "
+                f"expert_token_sizes="
+                f"{'set' if expert_token_sizes is not None else 'None'}."
+            )
+
+        sched_params = MoEFusedFc12SchedulerParams(
+            scenario=self.scenario,
+            expert_shape=(expert_cnt, intermediate_gateup, hidden_dim),
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            group_hint=self.group_hint,
+            token_padding_block=self.token_padding_block,
+            sf_padding_block=self.sf_padding_block,
+            load_balance_mode=self.load_balance_mode,
+            load_balance_counter_ptr=load_balance_counter_ptr,
+            override_num_stages=self.num_sched_stages,
+            is_swap_ab=False,
+            expert_token_prefix_sum=offs,
+            expert_token_sizes=expert_token_sizes,
+        )
+        grid = sched_params.get_grid_shape(max_active_clusters)
+
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            # fc1 TMA atoms / tensors (non-swap-AB: A=activations, B=weights)
+            tma_atom_fc1_activation,
+            tma_tensor_fc1_activation,
+            tma_atom_fc1_weight,
+            tma_tensor_fc1_weight,
+            tma_atom_fc1_activation_sf,
+            tma_tensor_fc1_activation_sf,
+            tma_atom_fc1_weight_sf,
+            tma_tensor_fc1_weight_sf,
+            tma_atom_fc1_output,
+            tma_tensor_fc1_output,
+            # fc2 TMA atoms / tensors (fc1_output→A, fc2_weight→B)
+            tma_atom_fc2_activation,
+            tma_tensor_fc2_activation,
+            tma_atom_fc2_weight,
+            tma_tensor_fc2_weight,
+            tma_atom_fc2_activation_sf,
+            tma_tensor_fc2_activation_sf,
+            tma_atom_fc2_weight_sf,
+            tma_tensor_fc2_weight_sf,
+            # GEMM-domain tensors (fc1)
+            activation_gemm,
+            fc1_weight_gemm,
+            fc1_output_gemm,
+            activation_sf_gemm,
+            fc1_weight_sf_gemm,
+            fc1_output_sf_gemm,
+            # GEMM-domain tensors (fc2)
+            fc2_weight_gemm,
+            fc2_output_gemm,
+            fc2_weight_sf_gemm,
+            fc1_output_sf_gemm_for_fc2_load,
+            # topk + cross-phase sync workspace
+            topk_scores,
+            fc1_done_counter,
+            # Scheduling
+            offs,
+            sched_params,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            # SMEM layouts
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.d_smem_layout_staged,
+            self.c_smem_layout_staged,
+            tma_atom_c,
+            tma_tensor_c,
+            token_comm_args,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=self.occupancy,
+        )
+
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        # fc1 TMA atoms / tensors
+        tma_atom_fc1_activation_1: cute.CopyAtom,
+        tma_tensor_fc1_activation_1: cute.Tensor,
+        tma_atom_weight: cute.CopyAtom,
+        tma_tensor_weight: cute.Tensor,
+        tma_atom_fc1_activation_1_sf: cute.CopyAtom,
+        tma_tensor_fc1_activation_1_sf: cute.Tensor,
+        tma_atom_fc1_weight_sf: cute.CopyAtom,
+        tma_tensor_fc1_weight_sf: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        tma_tensor_fc1_output: cute.Tensor,
+        # fc2 TMA atoms / tensors (fc1_output→A, fc2_weight→B)
+        tma_atom_fc2_activation: cute.CopyAtom,
+        tma_tensor_fc2_activation: cute.Tensor,
+        tma_atom_fc2_weight: cute.CopyAtom,
+        tma_tensor_fc2_weight: cute.Tensor,
+        tma_atom_fc2_activation_sf: cute.CopyAtom,
+        tma_tensor_fc2_activation_sf: cute.Tensor,
+        tma_atom_fc2_weight_sf: cute.CopyAtom,
+        tma_tensor_fc2_weight_sf: cute.Tensor,
+        # GEMM-domain tensors (fc1)
+        activation_gemm: cute.Tensor,
+        fc1_weight_gemm: cute.Tensor,
+        fc1_output_gemm: cute.Tensor,
+        activation_sf_gemm: cute.Tensor,
+        fc1_weight_sf_gemm: cute.Tensor,
+        fc1_output_sf_gemm: cute.Tensor,
+        # GEMM-domain tensors (fc2)
+        fc2_weight_gemm: cute.Tensor,
+        fc2_output_gemm: cute.Tensor,
+        fc2_weight_sf_gemm: cute.Tensor,
+        fc1_output_sf_gemm_for_fc2_load: cute.Tensor,
+        # topk + cross-phase sync workspace
+        topk_scores: cute.Tensor,
+        fc1_done_counter: cute.Tensor,
+        # debug: (total_tokens, intermediate_half*3) fp32 for swiglu comparison
+        # Scheduling
+        offs: Optional[cute.Tensor],
+        sched_params: MoEFusedFc12SchedulerParams,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        # SMEM layouts
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        d_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
+        c_smem_layout_staged:  Optional[Union[cute.Layout, cute.ComposedLayout]] = None,
+        tma_atom_c: Optional[cute.CopyAtom] = None,
+        tma_tensor_c: Optional[cute.Tensor] = None,
+        token_comm_args=None,
+    ):
+        """Device kernel for fused fc1+fc2 swap-AB GLU MXFP8 grouped GEMM.
+
+        Lean (``force_static_sched=True``) path: 7-warp specialization with
+        no empty / drain_aux warps and no expert-wise TMA desc rewriting
+        (every desc is tile-invariant under swap-AB).
+
+        Epilogue is fully owned by ``self.epilogue.run(...)`` -- the four epi
+        warps make a single call that drives the entire 2-phase task-tile
+        loop (acc consumer state, subtile dispatch, TMA commit/drain, and
+        the piggyback ``red.release.gpu.add.s32`` to ``fc1_done_counter``).
+        """
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, None, 0))
+        sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, None, 0))
+
+        # fc2 waits for all fc1 intermediate N-tiles in the same token block.
+        # Each N-tile is processed by atom_thr_size CTAs (both CTA0 and CTA1 increment
+        # the counter), so the threshold must account for both CTAs' contributions.
+        ext_fc2_spin_threshold = (
+            fc1_weight_gemm.shape[0] + self.cta_tile_shape_mnk[1] - 1
+        ) // self.cta_tile_shape_mnk[1] * self.epilogue._atom_thr_size
+
+        ext = GluMxFp8Fc12SchedExtension(
+            sf_vec_size=self.sf_vec_size,
+            fc1_done_counter_ptr=fc1_done_counter.iterator,
+            fc2_spin_threshold=ext_fc2_spin_threshold,
+            fc1_ready_counter_ptr=self.token_comm_hook_fc1_ready_counter_ptr(
+                token_comm_args
+            ),
+            cluster_m=self.epilogue._atom_thr_size,
+        )
+
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        bidx, _, _ = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+
+        # SharedStorage.
+        SchedCls = sched_params.get_scheduler_type()
+        SchedStorage = SchedCls.make_storage_struct(
+            sched_params, ext, num_drain_warps=0
+        )
+
+        @cute.struct
+        class SharedStorage:
+            a_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_a_stage * 2]
+            b_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_b_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.num_acc_pipeline_stages * 2
+            ]
+            sched_storage: SchedStorage
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        # MegaMoE-only dispatch-warp SMEM (pull_buffer, mbarriers, etc.).
+        # Kept out of ``SharedStorage`` so the lean path never allocates it.
+        TokenCommStorageCls = self.token_comm_extra_smem_storage_class()
+        if cutlass.const_expr(TokenCommStorageCls is not None):
+            token_comm_storage = smem.allocate(TokenCommStorageCls)
+        else:
+            token_comm_storage = None
+
+        # ── Pipelines: separate producer/consumer groups for A and B. ──
+
+        a_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, 1
+        )
+        a_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mcast_ctas_a
+        )
+        a_producer, a_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.a_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_a_stage,
+            producer_group=a_pipeline_producer_group,
+            consumer_group=a_pipeline_consumer_group,
+            tx_count=self.num_tma_load_a_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        b_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, 1
+        )
+        b_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mcast_ctas_b
+        )
+        b_producer, b_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.b_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_b_stage,
+            producer_group=b_pipeline_producer_group,
+            consumer_group=b_pipeline_consumer_group,
+            tx_count=self.num_tma_load_b_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = (
+            len(self.epilogue_warp_id) * 32 * (2 if use_2cta_instrs else 1)
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_pipeline_stages,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # TMEM allocator
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+        )
+
+        # Sched
+        num_sched_consumer_threads = 32 * len(
+            (
+                self.tma_a_warp_id,
+                self.tma_b_warp_id,
+                self.mma_warp_id,
+                *self.epilogue_warp_id,
+            )
+        )
+        scheduler = SchedCls.create(
+            sched_params,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            sched_storage=storage.sched_storage,
+            num_consumer_threads=num_sched_consumer_threads,
+            ext=ext,
+        )
+        sched_consumer = scheduler.make_consumer()
+
+        # Issue the first scheduler claim before cluster init wait so the
+        # atomic/offsets latency overlaps with pipeline setup.
+        # Under MegaMoE + static load-balance, ``internal_init`` walks
+        # per-expert sizes from ``expert_recv_count_sum`` -- those are not
+        # valid until the dispatch barrier completes, so we defer init to the
+        # sched warp (after ``token_comm_hook_sched_warp_pre_init_wait``).
+        early_internal_init = (
+            (self.load_balance_mode == "atomic_counter")
+            or (not self.enable_token_comm)
+        )
+
+        if cutlass.const_expr(early_internal_init):
+            scheduler.internal_init(
+                warp_idx=warp_idx,
+                sched_warp_id=self.sched_warp_id,
+            )
+
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        # ── SMEM tensors A / B / SFA / SFB (shared by fc1 / fc2) ──
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+        sSFA = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfa_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sSFB = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfb_smem_layout_staged,
+            byte_alignment=128,
+        )
+
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+
+        # acc_fake layout: (MMA, MMA_M, MMA_N, STAGE).  Under
+        # ``overlapping_accum`` the two acc buffers share TMEM with SF
+        # columns; we shrink the stage stride so the second buffer
+        # starts at ``(256 - num_sf_tmem_cols)`` cols instead of 256.
+        acc_fake = tiled_mma.make_fragment_C(
+            cute.append(acc_shape, self.num_acc_stage)
+        )
+        if cutlass.const_expr(self.overlapping_accum):
+            acc_fake = cute.make_tensor(
+                acc_fake.iterator,
+                cute.make_layout(
+                    acc_fake.shape,
+                    stride=(
+                        acc_fake.stride[0],
+                        acc_fake.stride[1],
+                        acc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * acc_fake.stride[0][1],
+                    ),
+                ),
+            )
+
+        # Cluster wait before TMEM alloc.
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        mma_tiler_k = self.mma_tiler[2]
+        # ``fc1_weight_gemm.shape[1]`` / ``fc2_weight_gemm.shape[1]``
+        # both resolve to ``hidden`` / ``intermediate_downproj``.  Under
+        # ``static_expert_shape`` they are codegen-time Python ints
+        # (rewritten on ``fc1_weight`` / ``fc2_weight`` at ``__call__``
+        # entry); otherwise they are runtime Int32 from tensor metadata.
+        # The arithmetic below folds to an immediate in the static path.
+        k_tile_cnt_fc1 = (fc1_weight_gemm.shape[1] + mma_tiler_k - 1) // mma_tiler_k
+        k_tile_cnt_fc2 = (fc2_weight_gemm.shape[1] + mma_tiler_k - 1) // mma_tiler_k
+        # fc2 spin threshold: each fc1 N-tile (intermediate direction) is incremented
+        # by atom_thr_size CTAs.  In non-swap-AB, fc1_weight_gemm.shape[0] is the N
+        # dimension (intermediate_gateup), so divide by cta_tile_shape_mnk[1] (N tile),
+        # not cta_tile_shape_mnk[0] (M/token tile).  Matches ext_fc2_spin_threshold.
+        fc2_spin_threshold = (
+            (fc1_weight_gemm.shape[0] + self.cta_tile_shape_mnk[1] - 1)
+            // self.cta_tile_shape_mnk[1]
+        ) * self.epilogue._atom_thr_size
+
+        # ════════════════════════════════════════════════════════════════════
+        # Scheduler warp (warp 7) — lean path
+        # ════════════════════════════════════════════════════════════════════
+        if warp_idx == self.sched_warp_id:
+            self.token_comm_hook_sched_warp_pre_init_wait(token_comm_args)
+            if cutlass.const_expr(not early_internal_init):
+                scheduler.internal_init(
+                    warp_idx=warp_idx,
+                    sched_warp_id=self.sched_warp_id,
+                )
+            scheduler.gen_next_work()
+            while scheduler.current_work.is_valid_tile:
+                ext.prefetch_for_expert(scheduler.current_work.expert_idx)
+                scheduler.publish_work()
+                scheduler.gen_next_work()
+            # Sentinel publish (current_work is already invalid here).
+            scheduler.publish_work()
+            scheduler.produce_tail()
+
+        # ════════════════════════════════════════════════════════════════════
+        # TMA load warps (warps 5 / 6)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # TMA-A loads activations/SFA into the A pipeline.
+        # TMA-B loads weights/SFB into the B pipeline and waits for
+        # fc1 workspace readiness in the fc2 phase.
+
+        # ── TMA-A warp (warp 5) ─────────────────────────────────────────────
+        if warp_idx == self.tma_a_warp_id:
+            _iket_active = (tidx == cutlass.Int32(160))
+            a_full_mcast_mask = None
+            sfa_full_mcast_mask = None
+            if cutlass.const_expr(self.is_a_mcast or use_2cta_instrs):
+                a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+                sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+
+            # non-swap-AB FC1: activation (A) is partitioned per-CTA (like original B).
+            # b_cta_layout=(2,) and mcast_mode=1 → each CTA loads its own token range.
+            b_full_mcast_mask = None
+            if cutlass.const_expr(self.is_b_mcast or use_2cta_instrs):
+                b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+                )
+            b_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+            )
+
+            a_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+            )
+            sfa_cta_layout = a_cta_layout
+
+            thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+                if is_phase_linear1:
+                    # ── fc1 phase A-side (non-swap-AB: A=activations, per-CTA partitioned) ──
+                    # Activations are split per CTA (tokens 0-127 for CTA 0, 128-255 for CTA 1).
+                    # Use b_cta_layout + m-coord so each CTA loads its own token range.
+                    # mcast_mode=1 → same M-coord = only self → no actual multicast. ✓
+                    if _iket_active:
+                        iket.range_push("tma_weight_fc1")
+                    # MegaMoE: spin until the dispatch warps have pulled this
+                    # task tile's token activations into the L1 token buffer.
+                    # No-op on the lean path (activations resident at launch).
+                    self.token_comm_hook_fc1_tma_b_predispatch_spin(
+                        token_comm_args, work_tile_info,
+                    )
+
+                    k_tile_cnt = k_tile_cnt_fc1
+                    real_a, desc_ptr_a = ext.get_gmem_tensor(
+                        "fc1_activation", tma_tensor_fc1_activation_1, work_tile_info,
+                    )
+                    real_sfa, desc_ptr_sfa = ext.get_gmem_tensor(
+                        "fc1_activation_sf", tma_tensor_fc1_activation_1_sf, work_tile_info,
+                    )
+
+                    gA_mkl = cute.local_tile(
+                        real_a,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    gSFA_mkl = cute.local_tile(
+                        real_sfa,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    tCgA = thr_mma.partition_A(gA_mkl)
+                    tCgSFA = thr_mma.partition_A(gSFA_mkl)
+
+                    tAsA, tAgA = cpasync.tma_partition(
+                        tma_atom_fc1_activation_1,
+                        block_in_cluster_coord_vmnk[2],
+                        a_cta_layout,
+                        cute.group_modes(sA, 0, 3),
+                        cute.group_modes(tCgA, 0, 3),
+                    )
+                    tAsSFA, tAgSFA = cpasync.tma_partition(
+                        tma_atom_fc1_activation_1_sf,
+                        block_in_cluster_coord_vmnk[2],
+                        sfa_cta_layout,
+                        cute.group_modes(sSFA, 0, 3),
+                        cute.group_modes(tCgSFA, 0, 3),
+                    )
+                    tAsSFA = cute.filter_zeros(tAsSFA)
+                    tAgSFA = cute.filter_zeros(tAgSFA)
+
+                    mma_tile_m = work_tile_info.tile_m_idx // cute.size(
+                        tiled_mma.thr_id.shape
+                    )
+                    tAgA_slice = tAgA[(None, mma_tile_m, None, 0)]
+                    tAgSFA_slice = tAgSFA[(None, mma_tile_m, None, 0)]
+
+                    a_producer.reset()
+                    peek_a_empty_status = a_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = a_producer.acquire_and_advance(
+                            peek_a_empty_status
+                        )
+                        peek_a_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_a_empty_status = a_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc1_activation_1,
+                            tAgA_slice[(None, handle.count)],
+                            tAsA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_a,
+                            mcast_mask=a_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc1_activation_1_sf,
+                            tAgSFA_slice[(None, handle.count)],
+                            tAsSFA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfa,
+                            mcast_mask=sfa_full_mcast_mask,
+                        )
+                else:
+                    # ── fc2 phase A-side: load fc1_output (M=tokens) + wait for fc1 done ──
+                    #
+                    # Non-swap-AB fc2: A=fc1_output (M=tokens). tile_m_idx is the
+                    # CTA-level token block. Counter wait moved here from TMA-B.
+                    if _iket_active:
+                        iket.range_push("tma_token_fc2")
+                    counter_slot = (
+                        work_tile_info.cumulative_token_block_count
+                        + work_tile_info.tile_m_idx // cutlass.Int32(self.epilogue._atom_thr_size)
+                    )
+                    counter_ptr = fc1_done_counter.iterator + counter_slot
+                    # Always spin (no peek shortcut) to guarantee counter=4 in this warp,
+                    # then use acquire semantics + cross-proxy fence to ensure fc1_output
+                    # writes (from generic proxy) are visible to the TMA async proxy load.
+                    if _iket_active:
+                        iket.range_push("tma_token_fc2_a_wait")
+                    spin_wait(
+                        counter_ptr,
+                        lambda v: v >= fc2_spin_threshold,
+                        fail_sleep_cycles=20,
+                    )
+                    if _iket_active:
+                        iket.range_pop()
+                    cute.arch.load(counter_ptr, counter_ptr.dtype, sem="acquire", scope="gpu")
+                    cute.arch.fence_proxy("async")
+                    cute.arch.fence_proxy("async.global")
+
+                    # DEBUG: print counter slot/value after spin exits for first hidden N-tile only.
+                    # Using tidx == tma_a_warp_id*32 since tidx==0 never fires in warp 5.
+                    if (
+                        tidx == cutlass.Int32(32 * self.tma_a_warp_id)
+                        and work_tile_info.tile_n_idx == cutlass.Int32(0)
+                    ):
+                        counter_val_post = cute.arch.load(
+                            counter_ptr, counter_ptr.dtype, cop="cg"
+                        )
+                        # Also load first Int32 from fc1_output for this tile to
+                        # check if TMA S2G stores are visible (non-zero = stored).
+                        fc1_byte_offset = (
+                            work_tile_info.cumulative_data_physical_row
+                            + work_tile_info.tile_m_idx
+                            // cutlass.Int32(self.epilogue._atom_thr_size)
+                            * cutlass.Int32(self.epilogue._cta_tile_m)
+                        ) * fc1_output_gemm.stride[0]
+                        fc1_probe_ptr = cute.make_ptr(
+                            cutlass.Int32,
+                            fc1_output_gemm.iterator.toint() + fc1_byte_offset,
+                            cute.AddressSpace.gmem,
+                        )
+                        fc1_first_i32 = cute.arch.load(fc1_probe_ptr, cutlass.Int32, cop="cg")
+                        # cute.printf(
+                        #     "[fc2_spin_exit] slot=%d counter=%d thresh=%d "
+                        #     "tile_m=%d cumul=%d fc1_first_i32=0x%08x",
+                        #     counter_slot,
+                        #     counter_val_post,
+                        #     fc2_spin_threshold,
+                        #     work_tile_info.tile_m_idx,
+                        #     work_tile_info.cumulative_token_block_count,
+                        #     fc1_first_i32,
+                        # )
+
+                    k_tile_cnt = k_tile_cnt_fc2
+                    real_a, desc_ptr_a = ext.get_gmem_tensor(
+                        "fc2_activation", tma_tensor_fc2_activation, work_tile_info,
+                    )
+                    real_sfa, desc_ptr_sfa = ext.get_gmem_tensor(
+                        "fc2_activation_sf", tma_tensor_fc2_activation_sf, work_tile_info,
+                    )
+
+                    gA_mkl = cute.local_tile(
+                        real_a,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    gSFA_mkl = cute.local_tile(
+                        real_sfa,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    tCgA = thr_mma.partition_A(gA_mkl)
+                    tCgSFA = thr_mma.partition_A(gSFA_mkl)
+
+                    tAsA, tAgA = cpasync.tma_partition(
+                        tma_atom_fc2_activation,
+                        block_in_cluster_coord_vmnk[2],
+                        a_cta_layout,
+                        cute.group_modes(sA, 0, 3),
+                        cute.group_modes(tCgA, 0, 3),
+                    )
+                    tAsSFA, tAgSFA = cpasync.tma_partition(
+                        tma_atom_fc2_activation_sf,
+                        block_in_cluster_coord_vmnk[2],
+                        sfa_cta_layout,
+                        cute.group_modes(sSFA, 0, 3),
+                        cute.group_modes(tCgSFA, 0, 3),
+                    )
+                    tAsSFA = cute.filter_zeros(tAsSFA)
+                    tAgSFA = cute.filter_zeros(tAgSFA)
+
+                    # fc2 A-side = fc1_output (M=tokens). tAgA is cluster-level
+                    # indexed, so divide tile_m_idx by cluster_m to get the
+                    # cluster block index — same formula as fc1 A-side.
+                    mma_tile_m = work_tile_info.tile_m_idx // cute.size(
+                        tiled_mma.thr_id.shape
+                    )
+                    tAgA_slice = tAgA[(None, mma_tile_m, None, 0)]
+                    tAgSFA_slice = tAgSFA[(None, mma_tile_m, None, 0)]
+
+                    a_producer.reset()
+                    peek_a_empty_status = a_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = a_producer.acquire_and_advance(
+                            peek_a_empty_status
+                        )
+                        peek_a_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_a_empty_status = a_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc2_activation,
+                            tAgA_slice[(None, handle.count)],
+                            tAsA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_a,
+                            mcast_mask=a_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc2_activation_sf,
+                            tAgSFA_slice[(None, handle.count)],
+                            tAsSFA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfa,
+                            mcast_mask=sfa_full_mcast_mask,
+                        )
+
+                if _iket_active:
+                    iket.range_pop()
+                work_tile_info = sched_consumer.consume_work()
+
+            a_producer.tail()
+
+        # ── TMA-B warp (warp 6) ─────────────────────────────────────────────
+        if warp_idx == self.tma_b_warp_id:
+            _iket_active = (tidx == cutlass.Int32(192))
+            b_full_mcast_mask = None
+            sfb_full_mcast_mask = None
+            if cutlass.const_expr(self.is_b_mcast or use_2cta_instrs):
+                b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+                )
+                sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_sfb_vmnk,
+                    block_in_cluster_coord_sfb_vmnk,
+                    mcast_mode=1,
+                )
+
+            # non-swap-AB FC1: weight (B) is multicast (like original A).
+            # a_full_mcast_mask with mcast_mode=2 → covers all CTAs with same N-coord = all CTAs.
+            a_full_mcast_mask = None
+            if cutlass.const_expr(self.is_a_mcast or use_2cta_instrs):
+                a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+            a_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+            )
+
+            b_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+            )
+            sfb_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+            )
+
+            thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+            thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+
+                if is_phase_linear1:
+                    # ── fc1 phase B-side (fc1_weight, N-side GEMM-B) ──
+                    # Weight is expert-indexed (key "a") and N-side: use tile_n_idx
+                    # (not tile_m_idx) to select the N-tile. tile_m_idx counts token
+                    # blocks and grows with more tokens, causing OOB on the weight's
+                    # N-dimension when tile_m_idx >= 2.
+                    if _iket_active:
+                        iket.range_push("tma_token_fc1")
+
+                    k_tile_cnt = k_tile_cnt_fc1
+                    real_b, desc_ptr_b = ext.get_gmem_tensor(
+                        "fc1_weight", tma_tensor_weight, work_tile_info,
+                    )
+                    real_sfb, desc_ptr_sfb = ext.get_gmem_tensor(
+                        "fc1_weight_sf", tma_tensor_fc1_weight_sf, work_tile_info,
+                    )
+
+                    # N-K tiling for N-side weight (N=intermediate, K=hidden).
+                    gB_nkl = cute.local_tile(
+                        real_b,
+                        cute.slice_(self.mma_tiler, (0, None, None)),
+                        (None, None, None),
+                    )
+                    gSFB_nkl = cute.local_tile(
+                        real_sfb,
+                        cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+                        (None, None, None),
+                    )
+                    # No coord flip for MXFP8 (non-swap-AB); partition_B for N-side.
+                    tCgB = thr_mma.partition_B(gB_nkl)
+                    tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                    tBsB, tBgB = cpasync.tma_partition(
+                        tma_atom_weight,
+                        block_in_cluster_coord_vmnk[1],
+                        b_cta_layout,
+                        cute.group_modes(sB, 0, 3),
+                        cute.group_modes(tCgB, 0, 3),
+                    )
+                    tBsSFB, tBgSFB = cpasync.tma_partition(
+                        tma_atom_fc1_weight_sf,
+                        block_in_cluster_coord_sfb_vmnk[1],
+                        sfb_cta_layout,
+                        cute.group_modes(sSFB, 0, 3),
+                        cute.group_modes(tCgSFB, 0, 3),
+                    )
+                    tBsSFB = cute.filter_zeros(tBsSFB)
+                    tBgSFB = cute.filter_zeros(tBgSFB)
+
+                    # Use tile_n_idx for N-side weight: invariant across token blocks.
+                    tBgB_slice = tBgB[(None, work_tile_info.tile_n_idx, None, 0)]
+                    tBgSFB_slice = tBgSFB[(None, work_tile_info.tile_n_idx, None, 0)]
+
+                    b_producer.reset()
+                    peek_b_empty_status = b_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = b_producer.acquire_and_advance(
+                            peek_b_empty_status
+                        )
+                        peek_b_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_b_empty_status = b_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_weight,
+                            tBgB_slice[(None, handle.count)],
+                            tBsB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_b,
+                            mcast_mask=a_full_mcast_mask,  # same as A-loading for weights
+                        )
+                        cute.copy(
+                            tma_atom_fc1_weight_sf,
+                            tBgSFB_slice[(None, handle.count)],
+                            tBsSFB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfb,
+                            mcast_mask=sfb_full_mcast_mask,
+                        )
+                else:
+                    # ── fc2 phase B-side: load fc2_weight (N=hidden), no counter wait ──
+                    # fc2_weight is independent of fc1; counter wait is in TMA-A.
+                    if _iket_active:
+                        iket.range_push("tma_weight_fc2")
+                    k_tile_cnt = k_tile_cnt_fc2
+                    real_b, desc_ptr_b = ext.get_gmem_tensor(
+                        "fc2_weight", tma_tensor_fc2_weight, work_tile_info,
+                    )
+                    real_sfb, desc_ptr_sfb = ext.get_gmem_tensor(
+                        "fc2_weight_sf", tma_tensor_fc2_weight_sf, work_tile_info,
+                    )
+
+                    gB_nkl = cute.local_tile(
+                        real_b,
+                        cute.slice_(self.mma_tiler, (0, None, None)),
+                        (None, None, None),
+                    )
+                    gSFB_nkl = cute.local_tile(
+                        real_sfb,
+                        cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+                        (None, None, None),
+                    )
+                    tCgB = thr_mma.partition_B(gB_nkl)
+                    tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                    tBsB, tBgB = cpasync.tma_partition(
+                        tma_atom_fc2_weight,
+                        block_in_cluster_coord_vmnk[1],
+                        b_cta_layout,
+                        cute.group_modes(sB, 0, 3),
+                        cute.group_modes(tCgB, 0, 3),
+                    )
+                    tBsSFB, tBgSFB = cpasync.tma_partition(
+                        tma_atom_fc2_weight_sf,
+                        block_in_cluster_coord_sfb_vmnk[1],
+                        sfb_cta_layout,
+                        cute.group_modes(sSFB, 0, 3),
+                        cute.group_modes(tCgSFB, 0, 3),
+                    )
+                    tBsSFB = cute.filter_zeros(tBsSFB)
+                    tBgSFB = cute.filter_zeros(tBgSFB)
+
+                    # fc2 B-side = fc2_weight (N=hidden). tile_n_idx is the
+                    # CTA-level hidden block index; invariant across token blocks.
+                    fc2_b_hidden_tile = work_tile_info.tile_n_idx
+                    tBgB_slice = tBgB[(None, fc2_b_hidden_tile, None, 0)]
+                    tBgSFB_slice = tBgSFB[(None, fc2_b_hidden_tile, None, 0)]
+
+                    b_producer.reset()
+                    peek_b_empty_status = b_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = b_producer.acquire_and_advance(
+                            peek_b_empty_status
+                        )
+                        peek_b_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_b_empty_status = b_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc2_weight,
+                            tBgB_slice[(None, handle.count)],
+                            tBsB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_b,
+                            mcast_mask=b_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc2_weight_sf,
+                            tBgSFB_slice[(None, handle.count)],
+                            tBsSFB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfb,
+                            mcast_mask=sfb_full_mcast_mask,
+                        )
+                if _iket_active:
+                    iket.range_pop()
+                work_tile_info = sched_consumer.consume_work()
+
+            b_producer.tail()
+
+        # ════════════════════════════════════════════════════════════════════
+        # MMA warp (warp 4)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # Both phases share tiled_mma and TMEM; only K-tile count differs.
+        if warp_idx == self.mma_warp_id:
+            _iket_active = (tidx == cutlass.Int32(128))
+
+            tCrA = tiled_mma.make_fragment_A(sA)
+            tCrB = tiled_mma.make_fragment_B(sB)
+
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            acc_base = cute.make_tensor(acc_tmem_ptr, acc_fake.layout)
+
+            # SFA TMEM tensor (placed after the acc cols).
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # SFB TMEM tensor (after acc + SFA cols).
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_pipeline_stages
+            )
+
+            # K-tile counts ``k_tile_cnt_fc1`` / ``k_tile_cnt_fc2`` come
+            # from the enclosing scope (computed once before the TMA warps).
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+                # Prebind k_tile_cnt due to DSL AST.
+                k_tile_cnt = cutlass.Int32(0)
+                if is_phase_linear1:
+                    k_tile_cnt = k_tile_cnt_fc1
+                    if _iket_active:
+                        iket.range_push("mma_fc1")
+                else:
+                    k_tile_cnt = k_tile_cnt_fc2
+                    if _iket_active:
+                        iket.range_push("mma_fc2")
+
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+
+                if is_leader_cta:
+                    tCtAcc = acc_base[(None, None, None, acc_stage_index)]
+
+                    if _iket_active:
+                        iket.range_push("mma_ab_wait")
+                    a_consumer.reset()
+                    b_consumer.reset()
+                    peek_a_full_status = cutlass.Boolean(1)
+                    peek_b_full_status = cutlass.Boolean(1)
+                    if k_tile_cnt > 0:
+                        peek_a_full_status = a_consumer.try_wait()
+                        peek_b_full_status = b_consumer.try_wait()
+                        acc_pipeline.producer_acquire(acc_producer_state)
+                    if _iket_active:
+                        iket.range_pop()
+
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle_a = a_consumer.wait_and_advance(peek_a_full_status)
+                        handle_b = b_consumer.wait_and_advance(peek_b_full_status)
+                        peek_a_full_status = cutlass.Boolean(1)
+                        peek_b_full_status = cutlass.Boolean(1)
+                        if handle_a.count + 1 < k_tile_cnt:
+                            peek_a_full_status = a_consumer.try_wait()
+                            peek_b_full_status = b_consumer.try_wait()
+
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[(None, None, None, None, handle_a.index)],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[(None, None, None, None, handle_b.index)],
+                            tCtSFB_compact_s2t,
+                        )
+
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc,
+                            [tCrA[(None, None, None, handle_a.index)], tCtSFA],
+                            [tCrB[(None, None, None, handle_b.index)], tCtSFB],
+                            tCtAcc,
+                        )
+                        handle_a.release()
+                        handle_b.release()
+
+                    if k_tile_cnt > 0:
+                        acc_pipeline.producer_commit(acc_producer_state)
+                if k_tile_cnt > 0:
+                    acc_producer_state.advance()
+
+                if _iket_active:
+                    iket.range_pop()
+
+                work_tile_info = sched_consumer.consume_work()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        # ── sD SMEM (fc1 output staging; fc2 doesn't use it) ──
+        # Always allocated for correct typing in const_expr-gated TMA dead branches.
+        sD = smem.allocate_tensor(
+            element_type=self.fc1_output_dtype,
+            layout=d_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=d_smem_layout_staged.inner,
+        )
+
+        # ── sC SMEM (raw gate+up Float32, ping-pong; only when generate_c=True) ──
+        if cutlass.const_expr(self.generate_c):
+            sC = smem.allocate_tensor(
+                element_type=self.epilogue._c_dtype,
+                layout=c_smem_layout_staged.outer,
+                byte_alignment=128,
+                swizzle=c_smem_layout_staged.inner,
+            )
+
+        # ════════════════════════════════════════════════════════════════════
+        # Epilogue warps (warps 0-3)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # Fully delegated to ``self.epilogue.run(...)`` -- the epilogue owns
+        # the entire 2-phase task-tile loop.
+        if warp_idx < self.mma_warp_id:
+            epi_warp_idx = warp_idx
+
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            acc_tensor = cute.make_tensor(acc_tmem_ptr, acc_fake.layout)
+
+            #acc_tensor = cute.make_tensor(
+            #    acc_tmem_ptr,
+            #    cute.make_layout(
+            #        (((128, self.cta_tile_shape_mnk[1]), 1),),
+            #        stride=(((1 << 16, 1), 0),),
+            #    ),
+            #)
+
+            # Build common kwargs shared by both epilogue flavours.
+            if cutlass.const_expr(self.generate_c):
+                _smem_c_raw_arg = sC
+                _tma_atom_c_arg = tma_atom_c
+                _gmem_c_arg = tma_tensor_c
+            else:
+                _smem_c_raw_arg = None
+                _tma_atom_c_arg = None
+                _gmem_c_arg = None
+            if cutlass.const_expr(self.use_stg_fc1):
+                _gmem_fc1_output_arg = fc1_output_gemm
+            else:
+                _gmem_fc1_output_arg = tma_tensor_fc1_output
+            _run_kwargs = dict(
+                tmem_acc_tensor=acc_tensor,
+                acc_pipeline=acc_pipeline,
+                sched_consumer=sched_consumer,
+                sched_ext=ext,
+                smem_fc1_output_buffer=sD,
+                tma_atom_fc1_output=tma_atom_fc1_output,
+                gmem_fc1_output=_gmem_fc1_output_arg,
+                gmem_fc1_output_sf=fc1_output_sf_gemm,
+                gmem_topk_scores=topk_scores,
+                gmem_fc2_output=fc2_output_gemm,
+                gmem_fc1_done_counter=fc1_done_counter,
+                smem_c_buffer=_smem_c_raw_arg,
+                tma_atom_c=_tma_atom_c_arg,
+                gmem_c=_gmem_c_arg,
+                warp_idx=epi_warp_idx,
+                tidx=tidx,
+                alpha=cutlass.Float32(1.0),
+                norm_const=cutlass.Float32(1.0),
+            )
+
+            # MegaMoE: pass token_comm_args only when it is a real bundle (not
+            # None).  Passing Python None explicitly to @cute.jit methods
+            # triggers a CuteDSL codegen issue; const_expr dispatch avoids any
+            # None-as-JIT-argument path.
+            if cutlass.const_expr(token_comm_args is not None):
+                self.epilogue.run(**_run_kwargs, token_comm_args=token_comm_args)
+            else:
+                self.epilogue.run(**_run_kwargs)
+
+            tmem.relinquish_alloc_permit()
+            tmem.free(acc_tmem_ptr)
+            if cutlass.const_expr(self.enable_token_comm):
+                cute.arch.fence_acq_rel_sys()
+
+        # ════════════════════════════════════════════════════════════════════
+        # Dispatch warps hook (warps 8-11; MegaMoE-only)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # ``enable_token_comm=False`` → warps 8-11 don't exist (threads_per_cta
+        # = 256), so the guard is const_expr-eliminated in the lean path.
+        if cutlass.const_expr(self.enable_token_comm):
+            if warp_idx >= self.dispatch_warp_id[0]:
+                lane_idx_for_dispatch = cute.arch.lane_idx()
+                if cutlass.const_expr(self.token_back_standalone):
+                    if warp_idx < self.token_back_warp_id[0]:
+                        self.token_comm_hook_dispatch_warp_body(
+                            token_comm_args,
+                            token_comm_storage,
+                            warp_idx=warp_idx,
+                            lane_idx=lane_idx_for_dispatch,
+                            tidx=tidx,
+                        )
+                    else:
+                        self.token_comm_hook_token_back_warp_body(
+                            token_comm_args,
+                            token_comm_storage,
+                            warp_idx=warp_idx,
+                            lane_idx=lane_idx_for_dispatch,
+                            tidx=tidx,
+                        )
+                else:
+                    self.token_comm_hook_dispatch_warp_body(
+                        token_comm_args,
+                        token_comm_storage,
+                        warp_idx=warp_idx,
+                        lane_idx=lane_idx_for_dispatch,
+                        tidx=tidx,
+                    )
+
+            # ════════════════════════════════════════════════════════════════════
+            # Kernel tail hook (MegaMoE-only; lean base = no-op)
+            # ════════════════════════════════════════════════════════════════════
+            lane_idx = cute.arch.lane_idx()
+            self.token_comm_hook_kernel_tail(
+                token_comm_args,
+                warp_idx=warp_idx,
+                lane_idx=lane_idx,
+                tidx=tidx,
+            )
+

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/mega_reference_mxfp8.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/mega_reference_mxfp8.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Pure-torch MoE reference for the multi-rank MXFP8 MegaMoE kernel.
+
+Standalone MXFP8 counterpart of ``moe_nvfp4_swapab.mega_reference`` (the NVFP4
+ground truth).  It takes already-MXFP8 inputs (1-byte fp8 data + E8M0 block
+scales, ``sf_vec_size = 32``) plus a routing table ``topk_idx`` and computes
+``combine_output[r, t, k] = fc12(input[r, t], expert[topk_idx[r, t, k]])`` for
+every ``(rank, token, topk_slot)``.
+
+Topk weighting: controlled by ``apply_topk_in_fc1`` (default False).
+
+* ``apply_topk_in_fc1=False``: the reference produces *unweighted*
+  per-(token, topk) fc12 outputs; the caller compares them per-(token,
+  topk) cell or sums without weighting.
+* ``apply_topk_in_fc1=True``: each token's SwiGLU output is multiplied by
+  its per-(rank, token, topk_slot) routing weight *before* the MXFP8
+  round-trip, matching the kernel epilogue exactly.  fc2 therefore sees the
+  already-weighted intermediate and the reference output encodes the weight.
+
+The per-expert chain (dequant input -> gather -> fc1 -> swiglu fold + fc1-out
+MXFP8 round-trip -> fc2 -> scatter back) mirrors the MXFP8 fc12 reference in
+``runner_fc12_common._build_reference`` so kernel-vs-reference disagreement is
+bounded by the fc1-out MXFP8 RTNE quant and fp32 GEMM accumulation noise.
+
+Zero cuTeDSL / NVSHMEM dependency: importable on CPU-only hosts (the helpers
+run on whatever device the input tensors live on).
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+import torch
+
+from common.megamoe_constants import Mxfp8BlockSize
+from moe_nvfp4_swapab.runner_common import (
+    dequant_block_scale_to_fp32,
+    transpose_rhs_for_block_dequant,
+    _swiglu_pair_hw_match_cuda,
+)
+from moe_nvfp4_swapab.mega_reference import combine_roundtrip_to_fp32
+from common.host_utils import mxfp8_quantize_per_block_32
+from src.token_comm import CombineFormat
+
+
+def compute_megamoe_reference_mxfp8(
+    # MXFP8 tensors carry LOGICAL shape (fp8 = 1 byte/element, no packing).
+    input_activation: torch.Tensor,        # (num_ranks, num_tokens_per_rank, hidden) fp8
+    input_activation_sf: torch.Tensor,     # (num_ranks, num_tokens_per_rank, hidden//32) E8M0
+    input_topk_idx: torch.Tensor,          # (num_ranks, num_tokens_per_rank, num_topk) int64
+    input_topk_weights: torch.Tensor,      # (num_ranks, num_tokens_per_rank, num_topk) fp32
+    fc1_weight: torch.Tensor,              # (num_ranks, num_experts_per_rank, hidden, intermediate) fp8, hidden stride-1
+    fc1_weight_sf: torch.Tensor,           # (num_ranks, num_experts_per_rank, intermediate, hidden//32) E8M0
+    fc2_weight: torch.Tensor,              # (num_ranks, num_experts_per_rank, intermediate//2, hidden) fp8, inter//2 stride-1
+    fc2_weight_sf: torch.Tensor,           # (num_ranks, num_experts_per_rank, hidden, (intermediate//2)//32) E8M0
+    ab_dtype: torch.dtype,                 # torch.float8_e4m3fn or torch.float8_e5m2
+    norm_const: float = 1.0,
+    ref_compute_graph: Literal["transformers", "deepgemm"] = "deepgemm",
+    fc2_output_dtype: torch.dtype = torch.bfloat16,
+    combine_format: Optional[CombineFormat] = None,
+    gate_up_clamp: Optional[float] = None,
+    apply_topk_in_fc1: bool = False,
+    return_fc1_gateup: bool = False,
+):
+    """Return ``(num_ranks, num_tokens_per_rank, num_topk, hidden)`` combine reference.
+
+    ``norm_const`` / ``ref_compute_graph`` are accepted for API parity with the
+    NVFP4 reference but carry no topk weighting on the MXFP8 path (see module
+    docstring); ``norm_const`` is not applied to the fc1-out quant because the
+    MXFP8 kernel hard-codes a 1.0 norm const and ``mxfp8_quantize_per_block_32``
+    takes no norm-const argument.
+
+    When ``apply_topk_in_fc1=True`` the per-token topk weight is multiplied into
+    the SwiGLU output *before* the MXFP8 round-trip, mirroring what the kernel
+    epilogue does.  This is NOT mathematically equivalent to post-weighting
+    because the quantisation step changes the effective magnitude.
+
+    When ``combine_format`` is quantized (e.g. ``32e4m3xe8m0`` / ``32e5m2xe8m0``),
+    each expert's ``fc2_output_fp32`` is additionally round-tripped through the
+    combine wire format (quantize then dequantize, matching the device combine
+    encoder + ``TopkReduce``) via ``combine_roundtrip_to_fp32``
+
+    When ``return_fc1_gateup=True``, returns a tuple
+    ``(combine_ref, fc1_gateup_per_expert)`` where ``fc1_gateup_per_expert`` is a
+    dict ``{global_expert_id: Tensor(v_e, 2*intermediate, dtype=bfloat16)}``
+    holding the raw pre-SwiGLU fc1 accumulator (the quantity stored by the kernel
+    when ``generate_c=True``).  Only experts that received at least one token have
+    an entry.  When False, returns ``combine_ref`` only (original behaviour).
+    """
+    if fc2_output_dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(
+            f"fc2_output_dtype must be torch.bfloat16 or torch.float16, "
+            f"got {fc2_output_dtype}."
+        )
+
+    num_ranks, num_tokens_per_rank, num_topk = input_topk_idx.shape
+    num_experts_per_rank = fc1_weight.shape[1]
+    num_total_experts = num_ranks * num_experts_per_rank
+
+    hidden = fc2_weight.shape[-1]
+    intermediate = fc1_weight.shape[-1]
+    intermediate_downproj = intermediate // 2
+
+    if fc1_weight.shape[0] != num_ranks or fc2_weight.shape[0] != num_ranks:
+        raise ValueError(
+            f"fc1_weight / fc2_weight must have leading dim num_ranks={num_ranks}, "
+            f"got {tuple(fc1_weight.shape)}, {tuple(fc2_weight.shape)}."
+        )
+    if input_activation.shape[-1] != hidden:
+        raise ValueError(
+            f"input_activation last dim ({input_activation.shape[-1]}) "
+            f"!= hidden ({hidden})."
+        )
+    if fc1_weight.shape[2] != hidden:
+        raise ValueError(
+            f"fc1_weight K dim ({fc1_weight.shape[2]}) != hidden ({hidden})."
+        )
+    if fc2_weight.shape[2] != intermediate_downproj:
+        raise ValueError(
+            f"fc2_weight K dim ({fc2_weight.shape[2]}) != intermediate_downproj "
+            f"({intermediate_downproj}); fc2's K is intermediate//2 "
+            f"(post-SwiGLU-fold)."
+        )
+
+    # 1. Dequant all input activations once (flatten (rank, token) to 2D).
+    input_act_fp32 = dequant_block_scale_to_fp32(
+        input_activation.reshape(num_ranks * num_tokens_per_rank, hidden),
+        input_activation_sf.reshape(num_ranks * num_tokens_per_rank, -1),
+        Mxfp8BlockSize,
+        global_scale=None,
+    ).reshape(num_ranks, num_tokens_per_rank, hidden)
+
+    combine_ref = torch.zeros(
+        (num_ranks, num_tokens_per_rank, num_topk, hidden),
+        dtype=fc2_output_dtype,
+        device=input_activation.device,
+    )
+    fc1_gateup_per_expert = {} if return_fc1_gateup else None
+
+    # 2. Per-expert GEMM chain over routed tokens.
+    for global_expert in range(num_total_experts):
+        target_rank = global_expert // num_experts_per_rank
+        local_expert = global_expert % num_experts_per_rank
+
+        routing_mask = input_topk_idx == global_expert
+        if not routing_mask.any():
+            continue
+        routed = routing_mask.nonzero(as_tuple=False)
+        source_ranks = routed[:, 0]
+        source_tokens = routed[:, 1]
+        source_topk_slots = routed[:, 2]
+
+        gathered_act = input_act_fp32[source_ranks, source_tokens]  # (R, hidden)
+
+        # fc1: dequant weight (transpose so K=hidden trailing for block dequant,
+        # transpose back to (hidden, intermediate)) + GEMM.
+        fc1_weight_t_fp32 = dequant_block_scale_to_fp32(
+            transpose_rhs_for_block_dequant(fc1_weight[target_rank, local_expert]),
+            fc1_weight_sf[target_rank, local_expert],
+            Mxfp8BlockSize,
+            global_scale=None,
+        )
+        fc1_weight_fp32 = fc1_weight_t_fp32.transpose(0, 1)         # (hidden, intermediate)
+        fc1_output_fp32 = gathered_act @ fc1_weight_fp32           # (R, intermediate)
+
+        if return_fc1_gateup:
+            fc1_gateup_per_expert[global_expert] = fc1_output_fp32.to(torch.bfloat16)
+
+        # SwiGLU fold: gate/up interleaved at Mxfp8BlockSize (=32) granularity,
+        # matching the kernel's PostSwigluHalf interleave for MXFP8.
+        _M, _N = fc1_output_fp32.shape
+        _n_pairs = _N // (2 * Mxfp8BlockSize)
+        _reshaped = fc1_output_fp32.view(_M, _n_pairs, 2, Mxfp8BlockSize)
+        _gate = _reshaped[:, :, 0, :]
+        _up = _reshaped[:, :, 1, :]
+        if gate_up_clamp is not None:
+            limit = abs(float(gate_up_clamp))
+            _gate = _gate.clamp(max=limit)
+            _up = _up.clamp(min=-limit, max=limit)
+        swiglu_output = _swiglu_pair_hw_match_cuda(_gate, _up).reshape(
+            _M, _N // 2
+        )                                                          # (R, intermediate//2)
+
+        if apply_topk_in_fc1:
+            # Mirror the kernel: weight applied before fp8 quantisation.
+            topk_w = input_topk_weights[
+                source_ranks, source_tokens, source_topk_slots
+            ].float().unsqueeze(-1)                                # (R, 1)
+            swiglu_output = swiglu_output * topk_w
+
+        # fc1-out MXFP8 round-trip (the only step that introduces kernel-vs-ref
+        # disagreement above fp32 accumulation noise).
+        fc1_quant, fc1_sf = mxfp8_quantize_per_block_32(swiglu_output, ab_dtype)
+        fc1_dequant = dequant_block_scale_to_fp32(
+            fc1_quant, fc1_sf, Mxfp8BlockSize, global_scale=None
+        )
+
+        fc2_weight_t_fp32 = dequant_block_scale_to_fp32(
+            transpose_rhs_for_block_dequant(fc2_weight[target_rank, local_expert]),
+            fc2_weight_sf[target_rank, local_expert],
+            Mxfp8BlockSize,
+            global_scale=None,
+        )
+        fc2_weight_fp32 = fc2_weight_t_fp32.transpose(0, 1)        # (intermediate//2, hidden)
+        fc2_output_fp32 = fc1_dequant @ fc2_weight_fp32            # (R, hidden)
+
+        # Quantized combine: the device epilogue quantizes the raw fp32
+        # accumulator directly (quant_sfd_row's r_acc is acc_dtype=Float32,
+        # never bf16-rounded first) -- round-trip fc2_output_fp32 here, BEFORE
+        # any bf16 cast, so the reference quantizes the same full-precision
+        # value the kernel does.
+        if combine_format is not None and combine_format.is_quantized:
+            fc2_output_fp32 = combine_roundtrip_to_fp32(fc2_output_fp32, combine_format)
+
+        combine_ref[source_ranks, source_tokens, source_topk_slots, :] = (
+            fc2_output_fp32.to(fc2_output_dtype)
+        )
+
+    if return_fc1_gateup:
+        return combine_ref, fc1_gateup_per_expert
+    return combine_ref
+
+
+__all__ = ["compute_megamoe_reference_mxfp8", "Mxfp8BlockSize"]

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/mega_runner.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/mega_runner.py
@@ -1,0 +1,925 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Standalone multi-rank MegaMoE host driver for the MXFP8 GLU path.
+
+Mirror of ``moe_nvfp4_swapab.mega_runner`` (NVFP4) specialised for MXFP8: 1-byte
+fp8 data (``e4m3`` / ``e5m2``) + E8M0 block scales (``sf_vec_size = 32``),
+non-swap-AB.  It subclasses the NVFP4 ``MegaMoETester`` and reuses all of its
+distributed bootstrap, routing-table generation, symmetric-heap allocation,
+workspace allocation, validation and teardown; only the three kind-specific
+stages are overridden:
+
+  * ``generate_inputs``   -- fp8 / E8M0 input + weight generation + sym staging
+  * ``compute_reference`` -- ``compute_megamoe_reference_mxfp8``
+  * ``run_kernel``        -- instantiate ``Sm100MegaMoEMxfp8Kernel``
+
+Launcher::
+
+    torchrun --nproc_per_node=4 -m moe_mxfp8_glu.mega_runner \\
+        --kind mxfp8_e4m3 --num_total_experts 32 --route_distribution balanced
+"""
+
+import argparse
+import gc
+import os
+import sys
+from typing import List, Optional, Tuple
+
+import torch
+
+## TODO: some common modules currently live in moe_nvfp4_swapab; these path
+## dependencies can be removed once the modules move to a shared package.
+_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+_PARENT_DIR = os.path.dirname(_PKG_DIR)
+_NVFP4_DIR = os.path.join(_PARENT_DIR, "moe_nvfp4_swapab")
+for _p in (_PARENT_DIR, _NVFP4_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from common.megamoe_constants import Mxfp8BlockSize
+from common.host_utils import compare_and_report_mismatches
+from moe_nvfp4_swapab.runner_common import (
+    ceil_div,
+    round_up,
+    to_blocked,
+    _stack_byte_reinterpretable_tensors,
+    Mxfp8ScaleDtype,
+)
+from moe_nvfp4_swapab.mega_runner import (
+    TokenCommProblemDesc,
+    MiscDesc,
+    MegaMoETester,
+    _generate_topk_idx_balanced,
+    _generate_topk_idx_power_law,
+    _generate_topk_weights,
+    _print_remote_rank_comm_matrices,
+    _sym_zeros,
+    _compute_peer_offsets,
+    _parse_tuple,
+    _parse_output_dtype,
+    _NO_DIST,
+)
+from src.token_comm import CombineFormat
+from moe_mxfp8_glu.runner_common import TrainingImplDesc
+from moe_mxfp8_glu.mega_reference_mxfp8 import compute_megamoe_reference_mxfp8
+
+
+# =============================================================================
+# kind <-> dtype maps
+# =============================================================================
+
+_KIND_TO_TORCH_DTYPE = {
+    "mxfp8_e4m3": torch.float8_e4m3fn,
+    "mxfp8_e5m2": torch.float8_e5m2,
+}
+
+
+def _kind_to_cutlass_dtype(kind: str):
+    import cutlass
+    return {
+        "mxfp8_e4m3": cutlass.Float8E4M3FN,
+        "mxfp8_e5m2": cutlass.Float8E5M2,
+    }[kind]
+
+
+# =============================================================================
+# MXFP8 host-side tensor builders (torch rng)
+# =============================================================================
+
+
+def _make_fp8_tensor(
+    torch_rng: torch.Generator,
+    shape: Tuple[int, ...],
+    data_dtype: torch.dtype,
+    *,
+    perf_run: bool,
+) -> torch.Tensor:
+    """Build an fp8 (e4m3 / e5m2) data tensor (1 byte/element, not packed).
+
+    perf:        random finite fp8 bytes (timing only); ``randint`` skips
+                 dtype-specific NaN/Inf encodings (e4m3: 0x7F/0xFF;
+                 e5m2: 0x7C-0x7F / 0xFC-0xFF).
+    correctness: sparse {0, +0.5, -0.5}.  The nonzero DENSITY is bounded so the
+                 fc1/fc2 dot products stay small in magnitude (K up to ~7168 for
+                 fc1).  Dense data pushes fc1-output values near MXFP8 quant-bin
+                 boundaries where the kernel's ``quant_sfd_row`` and the host
+                 ``mxfp8_quantize_per_block_32`` can round to adjacent bins -- a
+                 discrete ~1-fp8-step difference that survives the topk-combine
+                 and trips the validator on a handful of cells.  Low density
+                 keeps the bf16 fc2 output below the validator's atol floor.
+                 Tune via ``MXFP8_NONZERO_PCT`` (each sign gets PCT%; default
+                 1% + 1% = 2% nonzero), matching the reference runner.
+    """
+    n = 1
+    for s in shape:
+        n *= s
+    if perf_run:
+        if data_dtype == torch.float8_e4m3fn:
+            # E4M3FN NaN: 0x7F, 0xFF → sample 254 codes, skip 127.
+            idx = torch.randint(
+                0, 254, (n,), device="cuda", generator=torch_rng,
+            )
+            flat_bytes = torch.where(idx < 127, idx, idx + 1).to(torch.uint8)
+        elif data_dtype == torch.float8_e5m2:
+            # E5M2 Inf/NaN: 0x7C-0x7F, 0xFC-0xFF → sample 248 codes, skip 4.
+            idx = torch.randint(
+                0, 248, (n,), device="cuda", generator=torch_rng,
+            )
+            flat_bytes = torch.where(idx < 124, idx, idx + 4).to(torch.uint8)
+        else:
+            raise ValueError(f"Unsupported fp8 data_dtype: {data_dtype}")
+        return flat_bytes.view(data_dtype).reshape(shape)
+    nz_pct = float(os.environ.get("MXFP8_NONZERO_PCT", "1")) / 100.0
+    fp32 = torch.zeros((n,), dtype=torch.float32, device="cuda")
+    rand = torch.rand((n,), device="cuda", generator=torch_rng)
+    fp32[rand < nz_pct] = 0.5
+    fp32[(rand >= nz_pct) & (rand < 2.0 * nz_pct)] = -0.5
+    return fp32.to(data_dtype).reshape(shape)
+
+
+def _make_e8m0_scale_tensor(
+    torch_rng: torch.Generator,
+    non_k_size: int,
+    k_size: int,
+    blocksize: int,
+) -> torch.Tensor:
+    """Plain ``(non_k_size, ceil_div(k_size, blocksize))`` E8M0 SF tensor.
+
+    Uses 80% scale=1.0 (E8M0 byte 0x7F = 127) / 20% scale=2.0 (0x80 = 128).
+    """
+    num_scale_cols = ceil_div(k_size, blocksize)
+    rand = torch.rand((non_k_size, num_scale_cols), device="cuda", generator=torch_rng)
+    scale_bytes = torch.where(
+        rand < 0.80,
+        torch.full_like(rand, 127.0),
+        torch.full_like(rand, 128.0),
+    ).to(torch.uint8)
+    return scale_bytes.view(Mxfp8ScaleDtype).reshape(non_k_size, num_scale_cols)
+
+
+def _sym_zeros_byte_view_1b(
+    logical_shape: Tuple[int, ...], target_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Sym-heap allocation for 1-byte dtypes (fp8 e4m3/e5m2, E8M0) that
+    nvshmem4py doesn't natively support: allocate a uint8 byte buffer and
+    ``.view(target_dtype)`` (shape preserved -- all are 1 byte/element).
+    """
+    total_bytes = 1
+    for dim_size in logical_shape:
+        total_bytes *= dim_size
+    return (
+        _sym_zeros((total_bytes,), torch.uint8)
+        .view(target_dtype)
+        .reshape(logical_shape)
+    )
+
+
+# =============================================================================
+# MXFP8 MegaMoE tester
+# =============================================================================
+
+
+class MegaMoEMxfp8Tester(MegaMoETester):
+    """MXFP8 specialisation of the multi-rank MegaMoE host driver."""
+
+    def __init__(
+        self,
+        problem: TokenCommProblemDesc,
+        impl: TrainingImplDesc,
+        misc: MiscDesc,
+        *,
+        rank: int,
+        kind: str = "mxfp8_e4m3",
+        combine_format: Optional[CombineFormat] = None,
+    ) -> None:
+        super().__init__(problem, impl, misc, rank=rank)
+        if kind not in _KIND_TO_TORCH_DTYPE:
+            raise ValueError(
+                f"kind must be one of {sorted(_KIND_TO_TORCH_DTYPE)}, got {kind!r}."
+            )
+        self.kind = kind
+        self.torch_ab_dtype = _KIND_TO_TORCH_DTYPE[kind]
+        self._apply_topk_in_fc1 = True
+        self._combine_format = combine_format if combine_format is not None else CombineFormat.parse("bf16")
+        if impl.in_kernel_fc2_reduce and impl.token_back_by_dispatch:
+            raise ValueError(
+                "in_kernel_fc2_reduce and token_back_by_dispatch cannot both be True."
+            )
+        if impl.in_kernel_fc2_reduce and self._combine_format.is_quantized:
+            raise ValueError(
+                "in_kernel_fc2_reduce and quantized combine_format cannot both be True."
+            )
+
+    # ------------------------------------------------------------------
+    # Step 1: deterministic input + weight generation (MXFP8)
+    # ------------------------------------------------------------------
+
+    def generate_inputs(self) -> None:
+        problem = self.problem
+        rng = self._np_rng
+        num_ranks = problem.world_size
+        num_tokens_per_rank = problem.num_tokens_per_rank
+        num_topk = problem.num_topk
+        hidden = problem.hidden
+        intermediate = problem.intermediate
+        intermediate_downproj = intermediate // 2
+        num_experts_per_rank = problem.num_experts_per_rank
+        scale_blocksize = Mxfp8BlockSize
+        data_dtype = self.torch_ab_dtype
+        hidden_sf_cols = ceil_div(hidden, scale_blocksize)
+        intermediate_downproj_sf_cols = ceil_div(intermediate_downproj, scale_blocksize)
+
+        # ---- Activation (fp8, not packed) + plain K-major E8M0 SF.  The SF
+        # stays in the user-facing plain layout; the kernel's dispatch warps
+        # re-stage it into the SFB atom layout inside l1_sf_buffer before fc1
+        # reads it, so the host reference can dequant from the plain layout.
+        self._global_activation = _make_fp8_tensor(
+            self._torch_cuda_rng, (num_ranks, num_tokens_per_rank, hidden),
+            data_dtype, perf_run=self.misc.perf_run,
+        )
+        self._global_activation_sf = _make_e8m0_scale_tensor(
+            self._torch_cuda_rng,
+            num_ranks * num_tokens_per_rank, hidden, blocksize=scale_blocksize,
+        ).reshape(num_ranks, num_tokens_per_rank, hidden_sf_cols)
+
+        # ---- Routing table.
+        if problem.route_distribution == "balanced":
+            topk_idx_np = _generate_topk_idx_balanced(
+                num_ranks, num_tokens_per_rank, num_topk,
+                problem.num_total_experts, rng,
+            )
+        else:
+            topk_idx_np = _generate_topk_idx_power_law(
+                num_ranks, num_tokens_per_rank, num_topk,
+                problem.num_total_experts, problem.power_law_exponent, rng,
+            )
+        topk_weights = _generate_topk_weights(
+            num_ranks, num_tokens_per_rank, num_topk, self._torch_cuda_rng,
+        )
+        if self.rank == 0:
+            _print_remote_rank_comm_matrices(
+                topk_idx_np, num_ranks, problem.num_total_experts,
+            )
+        self._global_topk_idx = torch.from_numpy(topk_idx_np).cuda()
+        self._global_topk_weights = topk_weights
+
+        # ---- Weights.  fc1: logical (experts, intermediate, hidden) permuted
+        # to (experts, hidden, intermediate) with hidden stride-1 (K-major).
+        # fc2: logical (experts, hidden, inter//2) permuted to
+        # (experts, inter//2, hidden) with inter//2 stride-1.
+        self._global_fc1_weight = _make_fp8_tensor(
+            self._torch_cuda_rng,
+            (num_ranks, num_experts_per_rank, intermediate, hidden),
+            data_dtype, perf_run=self.misc.perf_run,
+        ).permute(0, 1, 3, 2)
+        self._global_fc1_weight_sf = _make_e8m0_scale_tensor(
+            self._torch_cuda_rng,
+            num_ranks * num_experts_per_rank * intermediate,
+            hidden, blocksize=scale_blocksize,
+        ).reshape(num_ranks, num_experts_per_rank, intermediate, hidden_sf_cols)
+
+        self._global_fc2_weight = _make_fp8_tensor(
+            self._torch_cuda_rng,
+            (num_ranks, num_experts_per_rank, hidden, intermediate_downproj),
+            data_dtype, perf_run=self.misc.perf_run,
+        ).permute(0, 1, 3, 2)
+        self._global_fc2_weight_sf = _make_e8m0_scale_tensor(
+            self._torch_cuda_rng,
+            num_ranks * num_experts_per_rank * hidden,
+            intermediate_downproj, blocksize=scale_blocksize,
+        ).reshape(
+            num_ranks, num_experts_per_rank, hidden, intermediate_downproj_sf_cols,
+        )
+
+        # ---- Atom-swizzle the weight SFs (the base kernel consumes weight SFs
+        # in the 32x4x4 atom-swizzled flat layout that tile_atom_to_shape_SF /
+        # the TMA SFA descriptor expect).  Plain ``_global_fc1/2_weight_sf`` are
+        # kept untouched for ``compute_megamoe_reference_mxfp8``.
+        fc1_sf_swizzled = [
+            to_blocked(self._global_fc1_weight_sf[r, e])
+            for r in range(num_ranks)
+            for e in range(num_experts_per_rank)
+        ]
+        fc1_flat_sf_size = fc1_sf_swizzled[0].numel()
+        self._global_fc1_weight_sf_swizzled = (
+            _stack_byte_reinterpretable_tensors(fc1_sf_swizzled, dim=0)
+            .view(num_ranks, num_experts_per_rank, fc1_flat_sf_size)
+        )
+
+        fc2_sf_swizzled = [
+            to_blocked(self._global_fc2_weight_sf[r, e])
+            for r in range(num_ranks)
+            for e in range(num_experts_per_rank)
+        ]
+        fc2_flat_sf_size = fc2_sf_swizzled[0].numel()
+        self._global_fc2_weight_sf_swizzled = (
+            _stack_byte_reinterpretable_tensors(fc2_sf_swizzled, dim=0)
+            .view(num_ranks, num_experts_per_rank, fc2_flat_sf_size)
+        )
+
+        # ---- Stage own-rank inputs into the symmetric heap.
+        own_activation = self._global_activation[self.rank]
+        own_activation_sf = self._global_activation_sf[self.rank]
+        own_topk_idx = self._global_topk_idx[self.rank]
+        own_topk_weights = self._global_topk_weights[self.rank]
+
+        # fp8 goes through a uint8 byte-buf view (nvshmem4py doesn't natively
+        # support fp8); copy via uint8 to dodge fp8 assignment quirks.
+        self.my_activation = _sym_zeros_byte_view_1b(
+            (num_tokens_per_rank, hidden), data_dtype,
+        )
+        self.my_activation.view(torch.uint8).copy_(own_activation.view(torch.uint8))
+
+        # SF leg caller contract: the K_sf axis (= ceil(hidden, 32)) must be a
+        # multiple of 4 E8M0 SFs so dispatch_pull's LDG.32 byte stride matches
+        # the host row stride.  Pad-to-mult-of-4 + zero-fill on the host side;
+        # the trailing padded SFs pair with fp8 data in TMA's OOB-fill-0 region.
+        hidden_sf_cols_padded = round_up(hidden_sf_cols, 4)
+        self.my_activation_sf = _sym_zeros_byte_view_1b(
+            (num_tokens_per_rank, hidden_sf_cols_padded), Mxfp8ScaleDtype,
+        )
+        self.my_activation_sf.view(torch.uint8)[:, :hidden_sf_cols].copy_(
+            own_activation_sf.view(torch.uint8)
+        )
+
+        self.my_topk_idx = _sym_zeros(tuple(own_topk_idx.shape), torch.int64)
+        self.my_topk_idx.copy_(own_topk_idx)
+
+        self.my_topk_weights = _sym_zeros(tuple(own_topk_weights.shape), torch.float32)
+        self.my_topk_weights.copy_(own_topk_weights)
+
+        # ---- Own-rank weights stay on regular cuda.  DO NOT ``.contiguous()``:
+        # the permute above puts the K dim mid-tensor (stride-1); contiguity
+        # would re-pack to row-major and break the K-as-stride-1 invariant the
+        # dequant + GEMM path depends on.
+        self.my_fc1_weight = self._global_fc1_weight[self.rank]
+        self.my_fc1_weight_sf = self._global_fc1_weight_sf_swizzled[self.rank]
+        self.my_fc2_weight = self._global_fc2_weight[self.rank]
+        self.my_fc2_weight_sf = self._global_fc2_weight_sf_swizzled[self.rank]
+
+        # ---- Public 2D (T, hidden) combined output.  The kernel owns the per-topk
+        # (T, K, H) combine staging internally on the sym heap (combine_quant inside
+        # shared_workspace, allocated by allocate_workspaces via the kernel's
+        # _build_shared_region_specs); the caller only provides / consumes the final
+        # reduced result.  Placement depends on the reduce mode:
+        #   * in_kernel_reduce (Form B): this IS the cross-rank REDG target, so it
+        #     MUST live on the sym heap; _sym_zeros also gives the atomic-add
+        #     accumulate-from-zero caller contract.
+        #   * separate_kernel_reduce: peers write the internal staging instead; this
+        #     only receives the local TopkReduce, so allocate it locally.
+        if self.impl.in_kernel_fc2_reduce:
+            self.output_activation = _sym_zeros(
+                (num_tokens_per_rank, hidden), torch.bfloat16,
+            )
+        else:
+            self.output_activation = torch.zeros(
+                (num_tokens_per_rank, hidden), dtype=torch.bfloat16, device="cuda",
+            )
+        self.combine_sf = None  # lives inside shared_workspace; None for free-list
+
+        torch.cuda.synchronize()
+        self._check_cuda_rng_consistency()
+
+    # ------------------------------------------------------------------
+    # Step 2: reference (MXFP8)
+    # ------------------------------------------------------------------
+
+    def compute_reference(self) -> None:
+        if self.misc.skip_ref_check:
+            return
+        if self._global_activation is None:
+            raise RuntimeError("compute_reference requires generate_inputs first.")
+
+        ref_result = compute_megamoe_reference_mxfp8(
+            input_activation=self._global_activation,
+            input_activation_sf=self._global_activation_sf,
+            input_topk_idx=self._global_topk_idx,
+            input_topk_weights=self._global_topk_weights,
+            fc1_weight=self._global_fc1_weight,
+            fc1_weight_sf=self._global_fc1_weight_sf,
+            fc2_weight=self._global_fc2_weight,
+            fc2_weight_sf=self._global_fc2_weight_sf,
+            ab_dtype=self.torch_ab_dtype,
+            norm_const=1.0,
+            ref_compute_graph=self.misc.ref_compute_graph,
+            fc2_output_dtype=self.problem.fc2_output_dtype,
+            combine_format=self._combine_format,
+            gate_up_clamp=self.problem.gate_up_clamp,
+            apply_topk_in_fc1=self._apply_topk_in_fc1,
+            return_fc1_gateup=self.impl.generate_c,
+        )
+
+        if self.impl.generate_c:
+            combine_ref_global, fc1_gateup_global = ref_result
+            expert_start = self.rank * self.problem.num_experts_per_rank
+            self._ref_fc1_gateup_per_expert = {
+                e: fc1_gateup_global.get(expert_start + e)
+                for e in range(self.problem.num_experts_per_rank)
+            }
+        else:
+            combine_ref_global = ref_result
+            self._ref_fc1_gateup_per_expert = None
+
+        self.combine_output_ref = combine_ref_global[self.rank].contiguous()
+
+    # ------------------------------------------------------------------
+    # Step 5: validation (MXFP8)
+    # ------------------------------------------------------------------
+
+    def validate(self) -> None:
+        """Compare the rank's 2D combined output against the reduced reference.
+
+        Both reduce modes now expose the same public 2D ``(T, hidden)``
+        ``output_activation``; the per-topk combine staging is internal to the
+        kernel.  The reference is per-topk ``(T, K, H)``; reduce it over the topk
+        axis the same way the kernel does -- weighting follows the compute graph:
+        ``apply_topk_in_fc1`` folds the routing weight into fc1 (reference cells
+        already weighted -> plain K-sum); otherwise the weight is applied at the
+        reduce (kernel via TopkReduce ``score``, reference via the weighted sum).
+        """
+        if self.misc.skip_ref_check:
+            return
+        if self.output_activation is None:
+            raise RuntimeError("validate requires run_kernel first.")
+        if self.combine_output_ref is None:
+            raise RuntimeError("validate requires compute_reference first.")
+
+        actual_reduced = self.output_activation.to(torch.float32)
+        ref = self.combine_output_ref.to(torch.float32)  # (T, K, H)
+        if self._apply_topk_in_fc1:
+            ref_reduced = ref.sum(dim=1)
+        else:
+            topk_w = self.my_topk_weights.to(torch.float32)  # (T, K)
+            ref_reduced = (ref * topk_w[:, :, None]).sum(dim=1)
+
+        compare_and_report_mismatches(
+            actual_reduced,
+            ref_reduced,
+            name=f"combine_output[rank{self.rank}]",
+            atol=1e-2,
+            rtol=1e-2,
+        )
+
+        self._validate_c_output()
+
+    def _validate_c_output(self) -> None:
+        """Compare kernel c_output vs reference pre-SwiGLU fc1 gate+up per expert.
+
+        Token order within each expert's pool slot is non-deterministic in the
+        multi-rank dispatch path, so we sort both sides flat before comparing.
+        This catches value-level errors (wrong magnitudes, wrong elements) while
+        being robust to dispatch-ordering differences across runs or ranks.
+        """
+        if not self.impl.generate_c:
+            return
+        c = getattr(self, "_c_output", None)
+        if c is None:
+            if self.rank == 0:
+                print("[generate_c] c_output not allocated — skipped.")
+            return
+        ref_map = getattr(self, "_ref_fc1_gateup_per_expert", None)
+        if not ref_map:
+            if self.rank == 0:
+                print("[generate_c] reference fc1 gate+up not available — skipped.")
+            return
+
+        valid = self._c_valid_tokens_per_expert
+        doff = self._c_data_physical_offsets
+
+        print(f"\n{'=' * 60}")
+        print(f"[generate_c][rank{self.rank}] kernel c_output vs reference fc1 gate+up:")
+        any_checked = False
+        for e in range(self.problem.num_experts_per_rank):
+            v_e = valid[e]
+            ref = ref_map.get(e)
+            if v_e == 0 or ref is None:
+                continue
+            any_checked = True
+            kernel_c = c[doff[e] : doff[e] + v_e].float().cpu().flatten().sort().values
+            ref_c = ref.float().cpu().flatten().sort().values
+            compare_and_report_mismatches(
+                kernel_c,
+                ref_c,
+                name=f"c_output[rank{self.rank}]expert{e}",
+                atol=1e-2,
+                rtol=1e-2,
+                max_mismatches=5,
+            )
+        if not any_checked:
+            print("  (no valid tokens routed to any local expert)")
+        print("=" * 60)
+
+    # ------------------------------------------------------------------
+    # Step 4: kernel launch (MXFP8)
+    # ------------------------------------------------------------------
+
+    def run_kernel(self) -> None:
+        """Compile + launch ``Sm100MegaMoEMxfp8Kernel`` on the current stream.
+
+        Mirrors ``MegaMoETester.run_kernel`` step-for-step; only the kernel
+        instantiation (class + ``ab_dtype`` / ``sf_vec_size``) is MXFP8-specific.
+        """
+        if (
+            self.my_activation is None
+            or self.my_activation_sf is None
+            or self.my_topk_idx is None
+            or self.my_topk_weights is None
+            or self.my_fc1_weight is None
+            or self.my_fc1_weight_sf is None
+            or self.my_fc2_weight is None
+            or self.my_fc2_weight_sf is None
+            or self.output_activation is None
+        ):
+            raise RuntimeError("run_kernel requires generate_inputs first.")
+
+        if self.my_activation_sf.shape[-1] % 4 != 0:
+            raise ValueError(
+                f"activation_sf.shape[-1] ({self.my_activation_sf.shape[-1]}) "
+                f"must be a multiple of 4 (4 E8M0 SFs per uint32 dispatch "
+                f"LDG.32 wire format)."
+            )
+
+        import cuda.bindings.driver as cuda
+        import cutlass
+        import cutlass.cute as cute
+        import cutlass.torch as cutlass_torch
+        import cutlass.utils as utils
+
+        from moe_nvfp4_swapab.epilogue import EpilogueTokenTile
+        from common.megamoe_constants import SfPaddingBlock
+        from moe_mxfp8_glu.megamoe_kernel_mxfp8 import Sm100MegaMoEMxfp8Kernel
+        from src.sym_buffer import SymBufferHost
+
+        # -- 1. Kernel instance (MXFP8 requires static_expert_shape != None) --
+        static_expert_shape = (
+            self.problem.num_experts_per_rank,
+            self.problem.intermediate,
+            self.problem.hidden,
+        )
+
+        cluster_size = (
+            self.impl.cluster_shape_mnk[0] * self.impl.cluster_shape_mnk[1]
+        )
+        max_active_clusters = utils.HardwareInfo().get_max_active_clusters(
+            cluster_size
+        )
+        group_hint = self.impl.group_hint
+        if group_hint is None:
+            group_hint = max_active_clusters
+
+        # generate_c TMA tile height is cta_tile_m=128; physical row offsets must
+        # be 128-aligned so the scheduler's data_physical_offsets land on tile
+        # boundaries.  Fall back to the default EpilogueTokenTile otherwise.
+        c_token_padding = 128 if self.impl.generate_c else EpilogueTokenTile
+
+        self._kernel = Sm100MegaMoEMxfp8Kernel(
+            mma_tiler_mnk=self.impl.mma_tiler_mnk,
+            cluster_shape_mnk=self.impl.cluster_shape_mnk,
+            use_2cta_instrs=self.impl.use_2cta_instrs,
+            group_hint=group_hint,
+            token_padding_block=c_token_padding,
+            sf_padding_block=SfPaddingBlock,
+            load_balance_mode=self.impl.load_balance_mode,
+            static_expert_shape=static_expert_shape,
+            force_static_sched=self.impl.force_static_sched,
+            clc_bundle_size=self.impl.clc_bundle_size,
+            num_sched_stages=self.impl.num_sched_stages,
+            ab_dtype=_kind_to_cutlass_dtype(self.kind),
+            sf_vec_size=Mxfp8BlockSize,
+            world_size=self.world_size,
+            local_rank=self.rank,
+            num_topk=self.problem.num_topk,
+            max_tokens_per_rank=self.problem.num_tokens_per_rank,
+            hidden=self.problem.hidden,
+            fc2_in_kernel_topk_reduce=self.impl.in_kernel_fc2_reduce,
+            token_back_mode=self.impl.token_back_mode,
+            epi_flag_batch=self.impl.epi_flag_batch,
+            flag_batch=self.impl.flag_batch,
+            gate_up_clamp=self.problem.gate_up_clamp,
+            apply_topk_in_fc1=self._apply_topk_in_fc1,
+            generate_c=self.impl.generate_c,
+            use_stg_fc1=self.impl.use_stg_fc1,
+            combine_format=self._combine_format,
+        )
+
+        # -- generate_c: allocate output tensor and compute per-expert offsets --
+        self._c_output = None
+        self._c_valid_tokens_per_expert = None
+        self._c_data_physical_offsets = None
+        if self.impl.generate_c:
+            expert_start = self.rank * self.problem.num_experts_per_rank
+            valid_tokens = [
+                int((self._global_topk_idx == expert_start + e).sum().item())
+                for e in range(self.problem.num_experts_per_rank)
+            ]
+            doff = [0]
+            for v in valid_tokens:
+                doff.append(doff[-1] + round_up(v, 128))
+            tokens_sum = max(1, doff[-1])
+            # problem.intermediate is already the full gate+up width here
+            # (unlike lean fc12 where it's the post-SwiGLU half-size).
+            self._c_output = torch.zeros(
+                (tokens_sum, self.problem.intermediate),
+                dtype=torch.bfloat16, device="cuda",
+            )
+            self._c_valid_tokens_per_expert = valid_tokens
+            self._c_data_physical_offsets = doff[:-1]
+
+        # -- 2. Workspaces (local cuda + sym-heap) --
+        self.allocate_workspaces()
+
+        # -- 3. Torch -> cute --
+        def _to_cute(tensor: torch.Tensor, assumed_align: int = 16, force_static_layout=False):
+            cute_tensor = cutlass_torch.from_dlpack(
+                tensor, assumed_align=assumed_align,
+            )
+            if force_static_layout:
+                return cute_tensor
+            leading_dim = cutlass_torch.get_leading_dim(tensor)
+            return cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+
+        activation_cute = _to_cute(self.my_activation)
+        activation_sf_cute = _to_cute(self.my_activation_sf)
+        topk_idx_cute = _to_cute(self.my_topk_idx)
+        topk_weights_cute = _to_cute(self.my_topk_weights)
+        fc1_weight_cute = _to_cute(self.my_fc1_weight)
+        fc1_weight_sf_cute = _to_cute(self.my_fc1_weight_sf)
+        fc2_weight_cute = _to_cute(self.my_fc2_weight)
+        fc2_weight_sf_cute = _to_cute(self.my_fc2_weight_sf)
+        output_activation_cute = _to_cute(self.output_activation)
+        local_workspace_cute = _to_cute(self.local_workspace, force_static_layout=True)
+        shared_workspace_cute = _to_cute(self.shared_workspace)
+
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+        # -- 4. cute.compile --
+        peer_rank_ptr_mapper_host = SymBufferHost(
+            base_addr=self.symmetric_base,
+            offsets=tuple(self.peer_offsets_list),
+            rank_idx=self.rank,
+            num_max_ranks=self.world_size,
+        )
+
+        runtime_kwargs = dict(
+            activation=activation_cute,
+            activation_sf=activation_sf_cute,
+            topk_idx=topk_idx_cute,
+            topk_weights=topk_weights_cute,
+            fc1_weight=fc1_weight_cute,
+            fc1_weight_sf=fc1_weight_sf_cute,
+            fc2_weight=fc2_weight_cute,
+            fc2_weight_sf=fc2_weight_sf_cute,
+            output_activation=output_activation_cute,
+            local_workspace=local_workspace_cute,
+            shared_workspace=shared_workspace_cute,
+            peer_rank_ptr_mapper_host=peer_rank_ptr_mapper_host,
+            stream=stream,
+        )
+        if self.impl.generate_c and self._c_output is not None:
+            runtime_kwargs["fc1_c"] = _to_cute(self._c_output)
+        else:
+            runtime_kwargs["fc1_c"] = None
+        compile_kwargs = dict(runtime_kwargs)
+        compile_kwargs["max_active_clusters"] = max_active_clusters
+        if self.misc.enable_iket:
+            compile_kwargs["options"] = "iket"
+
+        self._compiled_kernel = cute.compile(self._kernel, **compile_kwargs)
+
+        # -- 5. Launch (with optional profile-friendly barriers) --
+        if self.misc.profile_friendly:
+            import nvtx
+            torch.cuda.synchronize()
+            _dist_active = (
+                torch.distributed.is_available()
+                and torch.distributed.is_initialized()
+            )
+            if _dist_active:
+                torch.distributed.barrier()
+                torch.cuda.synchronize()
+            with nvtx.annotate("cute_dsl_prof"):
+                self._launch_target_kernels_with_optional_torch_profiler(
+                    runtime_kwargs,
+                )
+            if _dist_active:
+                torch.distributed.barrier()
+                torch.cuda.synchronize()
+        else:
+            self._launch_target_kernels_with_optional_torch_profiler(
+                runtime_kwargs,
+            )
+
+
+# =============================================================================
+# CLI entry point
+# =============================================================================
+
+
+
+def _parse_combine_format(argument: str) -> CombineFormat:
+    try:
+        return CombineFormat.parse(argument)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="MegaMoE MXFP8 GLU multi-rank fused dispatch+fc12+combine runner",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--kind", type=str, default="mxfp8_e4m3",
+        choices=["mxfp8_e4m3", "mxfp8_e5m2"],
+        help="MXFP8 element format for activations and weights.",
+    )
+    parser.add_argument("--num_tokens_per_rank", type=int, default=128)
+    parser.add_argument("--num_topk", type=int, default=4)
+    parser.add_argument("--num_total_experts", type=int, default=32)
+    parser.add_argument("--hidden", type=int, default=2048)
+    parser.add_argument("--intermediate", type=int, default=1024)
+    parser.add_argument(
+        "--fc2_output_dtype", type=_parse_output_dtype, default=torch.bfloat16,
+    )
+    parser.add_argument(
+        "--route_distribution", type=str, default="balanced",
+        choices=["balanced", "power_law"],
+    )
+    parser.add_argument(
+        "--power_law_exponent", type=float, default=1.0,
+        help="Zipf exponent for --route_distribution power_law.",
+    )
+    parser.add_argument(
+        "--gate_up_clamp", type=float, default=None,
+        help="DeepSeek-V4 swiglu_limit: clamp gate/up pre-activations before SiLU.",
+    )
+
+    # MXFP8 fused fc12 is validated for the (M=256, N=256) 2-CTA tile only.
+    parser.add_argument("--mma_tiler_mnk", type=str, default="256,256,128")
+    parser.add_argument("--cluster_shape_mnk", type=str, default="2,1,1")
+    parser.add_argument("--use_2cta_instrs", action="store_true", default=True)
+    parser.add_argument("--enable_static_expert_shape", action="store_true", default=False)
+    parser.add_argument("--dynamic_sched", action="store_true", default=False)
+    parser.add_argument("--clc_bundle_size", type=int, default=None)
+    parser.add_argument("--num_sched_stages", type=int, default=None)
+    parser.add_argument(
+        "--load_balance_mode", type=str, default="static",
+        choices=["static", "atomic_counter"],
+    )
+    parser.add_argument("--group_hint", type=int, default=None)
+    parser.add_argument("--perf_run", action="store_true", default=False)
+    parser.add_argument("--skip_ref_check", action="store_true", default=False)
+    parser.add_argument("--profile_friendly", action="store_true", default=False)
+    parser.add_argument("--use_torch_profiler", action="store_true", default=False)
+    parser.add_argument("--perf_warmup", type=int, default=1)
+    parser.add_argument("--perf_iters", type=int, default=10)
+    parser.add_argument("--enable_debug_checks", action="store_true", default=False)
+    parser.add_argument(
+        "--ref_compute_graph", type=str, default="deepgemm",
+        choices=["transformers", "deepgemm"],
+    )
+    parser.add_argument("--enable_iket", action="store_true", default=False)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument(
+        "--in_kernel_fc2_reduce", action="store_true", default=False,
+        help="Form B: REDG in-kernel topk-reduce to combine_output[t, 0, :]",
+    )
+    parser.add_argument(
+        "--generate_c", action="store_true", default=False,
+        help="Store raw pre-SwiGLU fc1 accumulator (gate+up, BF16) to a separate tensor.",
+    )
+    parser.add_argument(
+        "--use_stg_fc1", action="store_true", default=False,
+        help="Write fc1 FP8 output directly to GMEM via STG.256 instead of R2S+TMA. "
+             "Eliminates sD SMEM staging (saves 16 KB); may increase AB pipeline stages.",
+    )
+    parser.add_argument(
+        "--combine_format", type=_parse_combine_format,
+        default=CombineFormat.parse("bf16"),
+        help="Wire format for the cross-rank combine payload. "
+             "Choices: 'bf16' (no quantization, default), "
+             "'32e4m3xe8m0' (MXFP8 e4m3: fp8 e4m3 data + E8M0 block scale, ~2x bandwidth saving), "
+             "'32e5m2xe8m0' (MXFP8 e5m2: fp8 e5m2 data + E8M0 block scale, ~2x bandwidth saving). "
+             "e.g. --combine_format 32e4m3xe8m0",
+    )
+    parser.add_argument(
+        "--token_back_mode", type=str, default="standalone_warps",
+        choices=["epi_warps", "standalone_warps", "reuse_dispatch_warps"],
+        help="Where the cross-rank fc2 push-back runs: epi_warps (epilogue "
+             "STG redirect), standalone_warps (dedicated warps 12-15), "
+             "or reuse_dispatch_warps (dispatch warps 8-11, default).",
+    )
+    parser.add_argument(
+        "--epi_flag_batch", type=str, default="2,4",
+        help="Done-counter publish batching as 'fc1,fc2' (e.g. '2,4'). "
+             "Each component must be in [1, 32].",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if _NO_DIST:
+        torch.cuda.set_device(0)
+        rank = 0
+        world_size = 1
+    else:
+        from src.bootstrap import (
+            init_dist_and_nvshmem,
+            finalize_dist_and_nvshmem,
+        )
+        _local_rank, rank, world_size, _ = init_dist_and_nvshmem()
+
+    problem = TokenCommProblemDesc(
+        world_size=world_size,
+        num_tokens_per_rank=args.num_tokens_per_rank,
+        num_topk=args.num_topk,
+        num_total_experts=args.num_total_experts,
+        hidden=args.hidden,
+        intermediate=args.intermediate,
+        fc2_output_dtype=args.fc2_output_dtype,
+        combine_format=args.combine_format,
+        route_distribution=args.route_distribution,
+        power_law_exponent=args.power_law_exponent,
+        gate_up_clamp=args.gate_up_clamp,
+    )
+
+    impl = TrainingImplDesc(
+        mma_tiler_mnk=_parse_tuple(args.mma_tiler_mnk),
+        cluster_shape_mnk=_parse_tuple(args.cluster_shape_mnk),
+        use_2cta_instrs=args.use_2cta_instrs,
+        enable_static_expert_shape=args.enable_static_expert_shape,
+        force_static_sched=not args.dynamic_sched,
+        clc_bundle_size=args.clc_bundle_size,
+        num_sched_stages=args.num_sched_stages,
+        load_balance_mode=args.load_balance_mode,
+        group_hint=args.group_hint,
+        non_ubulk_fc2_store=True,
+        in_kernel_fc2_reduce=args.in_kernel_fc2_reduce,
+        token_back_mode=args.token_back_mode,
+        epi_flag_batch=_parse_tuple(args.epi_flag_batch),
+        flag_batch=1,
+        generate_c=args.generate_c,
+        use_stg_fc1=args.use_stg_fc1,
+    )
+
+    misc = MiscDesc(
+        perf_run=args.perf_run,
+        skip_ref_check=args.skip_ref_check,
+        run_target_kernel_only=args.profile_friendly,
+        enable_debug_checks=args.enable_debug_checks,
+        ref_compute_graph=args.ref_compute_graph,
+        enable_iket=args.enable_iket,
+        seed=args.seed,
+    )
+
+    tester = MegaMoEMxfp8Tester(
+        problem, impl, misc, rank=rank, kind=args.kind,
+        combine_format=args.combine_format,
+    )
+    tester.set_torch_profiler_enabled(args.use_torch_profiler)
+    tester.set_perf_iters(args.perf_warmup, args.perf_iters)
+
+    return_code = 0
+    try:
+        tester.run()
+    except NotImplementedError as exc:
+        if rank == 0:
+            print(f"[mega_runner_mxfp8] kernel launch skipped: {exc}")
+
+    if not _NO_DIST:
+        tester._compiled_kernel = None
+        tester._kernel = None
+        gc.collect()
+        torch.cuda.synchronize()
+        try:
+            import nvshmem.core
+            # output_activation is on the sym heap only under in_kernel_reduce
+            for sym_tensor in (
+                tester.my_activation, tester.my_activation_sf,
+                tester.my_topk_idx, tester.my_topk_weights,
+                tester.output_activation, tester.combine_sf, tester.shared_workspace,
+            ):
+                if sym_tensor is not None:
+                    try:
+                        nvshmem.core.free_tensor(sym_tensor)
+                    except Exception:  # noqa: BLE001
+                        pass
+            tester.my_activation = None
+            tester.my_activation_sf = None
+            tester.my_topk_idx = None
+            tester.my_topk_weights = None
+            tester.output_activation = None
+            tester.shared_workspace = None
+        except ImportError:
+            pass
+
+        gc.collect()
+        finalize_dist_and_nvshmem()
+    return return_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/megamoe_kernel_mxfp8.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/megamoe_kernel_mxfp8.py
@@ -1,0 +1,1198 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""MegaMoE fused dispatch + fc1 + fc2 + combine kernel (MXFP8, non-swap-AB).
+
+Parallel to ``moe_nvfp4_swapab.megamoe_kernel.Sm100MegaMoEKernel`` but extends
+the MXFP8 fused fc1+fc2 base (``Sm100SwigluMxfp8Fc12Kernel``) instead of the
+NVFP4 swap-AB base.  The token-communication machinery (dispatch prep / barrier
+/ pull, NVLink barrier, kernel tail) is reused verbatim from
+``src/token_comm.py`` via the ``TokenInPullTokenBackPush`` helper; only the
+data-format-dependent workspace layout and one non-swap-AB hook differ:
+
+  - ``hidden_bytes = hidden``                 (fp8 = 1 byte/element vs NVFP4 /2)
+  - ``fc1_output`` region dtype = ``ab_dtype``  (Float8E4M3FN or Float8E5M2)
+  - ``fc1_output_sf`` region dtype = ``Float8E8M0FNU``  (E8M0 block scales)
+  - ``sf_vec_size = 32``                       (MXFP8 block size)
+  - ``fc1_tma_b_predispatch_spin`` in ``token_comm.py`` selects the
+    non-swap-AB counter path when ``fc1_token_dtype.width != 4`` (MXFP8 fp8).
+
+The caller only ever provides/consumes the public 2D ``output_activation``
+``(max_tokens_per_rank, hidden)``; the per-topk combine staging is internal to
+the kernel (``combine_quant`` on the symmetric heap inside ``shared_workspace``,
+mirroring the NVFP4 path).  Three fc2 output modes are supported:
+
+  * **Form A** (default, ``separate_kernel_reduce``): epilogue ``Fc2OutputDest``
+    STGs one cell per ``[src_token, src_topk, :]`` into the internal
+    ``combine_quant`` staging ``(max_tokens_per_rank, num_topk, hidden)``; after
+    the fused kernel, ``TopkReduce`` reduces the topk axis into
+    ``output_activation``.
+  * **Form B** (``fc2_in_kernel_topk_reduce``): ``combine_quant`` is a
+    ``(max_tokens_per_rank, 1, hidden)`` view of ``output_activation``; the
+    epilogue issues ``red.relaxed.sys.global.add.v2.bf16x2`` to
+    ``[src_token, 0, :]``, reducing the topk axis in kernel (no ``TopkReduce``).
+  * **token_back_mode != "epi_warps"**: epilogue STGs to a local fc2 pool
+    workspace; dispatch warps push results back to source ranks' internal
+    ``combine_quant`` staging via TMA, then ``TopkReduce`` reduces as in Form A.
+
+``static_expert_shape`` is required because dispatch storage and pool sizes are
+codegen-time quantities.
+"""
+
+# NOTE: ``from __future__ import annotations`` is intentionally NOT used here
+# (PEP 563 string-ifies class-body annotations, which breaks ``@cute.struct``
+# element-type introspection).  See moe_nvfp4_swapab/megamoe_kernel.py.
+
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import AddressSpace
+from cutlass.cutlass_dsl import Int64, Int32
+
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+
+from moe_mxfp8_glu.kernel_mxfp8_glu_fc12 import Sm100SwigluMxfp8Fc12Kernel
+from moe_nvfp4_swapab.moe_utils import spin_wait
+from moe_nvfp4_swapab.topk_reduce import TopkReduce
+from src.token_comm import (
+    CombineFormat,
+    TokenCommArgs as ExtractedTokenCommArgs,
+    TokenInPullTokenBackPush,
+)
+
+# Reuse the region-layout helpers + module constants from the NVFP4 mega kernel
+# so the two paths stay byte-for-byte consistent in their workspace plumbing.
+from moe_nvfp4_swapab.megamoe_kernel import (
+    _RegionSpec,
+    _round_up,
+    _layout_regions,
+    _DispatchWarpCount,
+    _TokenMetadataBytes,
+    _GridSyncSlotCount,
+    _NvlinkSlotCount,
+)
+
+
+# =============================================================================
+# Sm100MegaMoEMxfp8Kernel
+# =============================================================================
+
+
+class Sm100MegaMoEMxfp8Kernel(Sm100SwigluMxfp8Fc12Kernel):
+    """MegaMoE-complete fused dispatch + fc1 + fc2 + combine kernel (MXFP8)."""
+
+    def __init__(
+        self,
+        # Base-class kwargs (forwarded 1:1 to ``super().__init__``).
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mnk: Tuple[int, int, int],
+        use_2cta_instrs: bool,
+        group_hint: int,
+        token_padding_block: int,
+        sf_padding_block: int,
+        load_balance_mode: str = "static",
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,
+        force_static_sched: bool = True,
+        clc_bundle_size: Optional[int] = None,
+        num_sched_stages: Optional[int] = None,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        ab_dtype: Type[cutlass.Numeric] = cutlass.Float8E4M3FN,
+        sf_vec_size: int = 32,
+        scenario: str = "2Dx3D",
+        # MegaMoE-specific independent constants.
+        *,
+        world_size: int,
+        local_rank: int,
+        num_topk: int,
+        max_tokens_per_rank: int,
+        hidden: int,
+        fc2_in_kernel_topk_reduce: bool = False,
+        token_back_mode: Literal[
+            "epi_warps", "standalone_warps", "reuse_dispatch_warps"
+        ] = "epi_warps",
+        epi_flag_batch: Union[int, Tuple[int, int]] = 1,
+        flag_batch: int = 1,
+        gate_up_clamp: Optional[float] = None,
+        apply_topk_in_fc1: bool = True,
+        generate_c: bool = False,
+        use_stg_fc1: bool = False,
+        combine_format: Optional[CombineFormat] = None,
+        dedup_dispatch: bool = False,
+        combine_in_flight_reduce: bool = False,
+        combine_pre_reduce: bool = False,
+    ) -> None:
+        if static_expert_shape is None:
+            raise NotImplementedError(
+                "Sm100MegaMoEMxfp8Kernel requires static_expert_shape != None "
+                "(dynamic-shape MegaMoE is not wired)."
+            )
+        if hidden != static_expert_shape[2]:
+            raise ValueError(
+                f"hidden ({hidden}) must equal "
+                f"static_expert_shape[2] ({static_expert_shape[2]})."
+            )
+        token_back_by_dispatch = token_back_mode != "epi_warps"
+        if fc2_in_kernel_topk_reduce and token_back_by_dispatch:
+            raise ValueError(
+                "fc2_in_kernel_topk_reduce and token_back_mode != 'epi_warps' "
+                "cannot both be True."
+            )
+        if combine_format is None:
+            combine_format = CombineFormat.parse("bf16")
+        if fc2_in_kernel_topk_reduce and combine_format.is_quantized:
+            raise ValueError(
+                "fc2_in_kernel_topk_reduce requires a non-quantized (bf16) combine "
+                "format; quantized combine_format is incompatible."
+            )
+        if fc2_in_kernel_topk_reduce and not apply_topk_in_fc1:
+            raise ValueError(
+                "fc2_in_kernel_topk_reduce requires apply_topk_in_fc1=True; "
+                "the in-kernel REDG collapses the topk axis on the fly, so the "
+                "routing weight must already be folded into fc1."
+            )
+        if token_back_mode not in (
+            "epi_warps", "standalone_warps", "reuse_dispatch_warps",
+        ):
+            raise ValueError(f"unsupported token_back_mode={token_back_mode!r}.")
+
+        super().__init__(
+            mma_tiler_mnk=mma_tiler_mnk,
+            cluster_shape_mnk=cluster_shape_mnk,
+            use_2cta_instrs=use_2cta_instrs,
+            group_hint=group_hint,
+            token_padding_block=token_padding_block,
+            sf_padding_block=sf_padding_block,
+            load_balance_mode=load_balance_mode,
+            static_expert_shape=static_expert_shape,
+            force_static_sched=force_static_sched,
+            clc_bundle_size=clc_bundle_size,
+            num_sched_stages=num_sched_stages,
+            acc_dtype=acc_dtype,
+            ab_dtype=ab_dtype,
+            sf_vec_size=sf_vec_size,
+            scenario=scenario,
+            fc2_in_kernel_topk_reduce=fc2_in_kernel_topk_reduce,
+            token_back_by_dispatch=token_back_by_dispatch,
+            epi_flag_batch=epi_flag_batch,
+            gate_up_clamp=gate_up_clamp,
+            apply_topk_in_fc1=apply_topk_in_fc1,
+            generate_c=generate_c,
+            use_stg_fc1=use_stg_fc1,
+        )
+
+        self.enable_token_comm = True
+        self.dispatch_warp_id = (8, 9, 10, 11)
+        # Standalone token-back: a dedicated 4-warp group (12-15) pushing fc2
+        # results back to source ranks concurrently with dispatch_pull.
+        self.token_back_mode = token_back_mode
+        self.token_back_standalone = (
+            token_back_by_dispatch
+            and token_back_mode == "standalone_warps"
+        )
+        self.token_back_warp_id = (12, 13, 14, 15) if self.token_back_standalone else None
+        num_token_back_warps = len(self.token_back_warp_id) if self.token_back_standalone else 0
+        self.combine_format = combine_format
+        # Per-(token, topk) SF block padded to a 16 B multiple so the token-back
+        # cp.async.bulk push moves one aligned block per shot.  None for bf16.
+        self.sf_block_pad = (
+            _round_up(
+                hidden // self.combine_format.scale_block,
+                16 // (int(self.combine_format.scale_dtype.width) // 8),
+            )
+            if self.combine_format.is_quantized
+            else None
+        )
+        # Token-back warps run when pushing DATA (dispatch modes) OR SF
+        # (any quantized combine, including epi_warps data path where the
+        # epilogue STGs data to the peer but SF still needs the staged push).
+        self.token_back_enabled = (
+            token_back_by_dispatch or self.combine_format.is_quantized
+        )
+        self.token_back_schedule_mode = (
+            self.load_balance_mode if self.token_back_enabled else "static"
+        )
+        self.threads_per_cta = 32 * (
+            len(self.epilogue_warp_id)
+            + 1  # mma
+            + 1  # tma_a
+            + 1  # tma_b
+            + 1  # sched
+            + len(self.dispatch_warp_id)
+            + num_token_back_warps
+        )
+
+        # Independent MegaMoE-specific constants.
+        self.world_size = world_size
+        self.local_rank = local_rank
+        self.num_topk = num_topk
+        self.max_tokens_per_rank = max_tokens_per_rank
+        self.hidden = hidden
+        self.fc2_in_kernel_topk_reduce = fc2_in_kernel_topk_reduce
+        self.dedup_dispatch = dedup_dispatch and num_topk > 1
+        if dedup_dispatch and max_tokens_per_rank * num_topk > (1 << 18):
+            raise ValueError(
+                "dedup_dispatch: max_tokens_per_rank * num_topk must fit the "
+                f"18-bit dup_link slot field, got {max_tokens_per_rank * num_topk}."
+            )
+        # In-flight combine reduce: token-back REDG-adds each row straight
+        # into the source rank's 2D output (skipping the (T, topk, hidden)
+        # staging plane AND the post-kernel TopkReduce launch).
+        self.combine_in_flight_reduce = combine_in_flight_reduce
+        if combine_in_flight_reduce:
+            if not token_back_by_dispatch:
+                raise ValueError(
+                    "combine_in_flight_reduce requires a dispatch token-back "
+                    "mode (token_back_mode != 'epi_warps')."
+                )
+            if combine_format.is_quantized:
+                raise ValueError(
+                    "combine_in_flight_reduce requires the bf16 combine "
+                    "format (REDG add is bf16)."
+                )
+            if not apply_topk_in_fc1:
+                raise ValueError(
+                    "combine_in_flight_reduce requires apply_topk_in_fc1=True "
+                    "(the REDG collapses the topk axis on the fly)."
+                )
+            if fc2_in_kernel_topk_reduce:
+                raise ValueError(
+                    "combine_in_flight_reduce and fc2_in_kernel_topk_reduce "
+                    "are mutually exclusive."
+                )
+        # Same-rank combine pre-reduce: partner rows fold into their group's
+        # anchor locally, so combine crosses NVLink once per (token, rank).
+        self.combine_pre_reduce = (
+            combine_pre_reduce and self.dedup_dispatch
+        )
+        if combine_pre_reduce and not (dedup_dispatch and combine_in_flight_reduce):
+            raise ValueError(
+                "combine_pre_reduce requires dedup_dispatch=True and "
+                "combine_in_flight_reduce=True."
+            )
+
+        # static_expert_shape = (num_experts_per_rank, intermediate_gateup, hidden).
+        self.num_experts_per_rank = static_expert_shape[0]
+        self.intermediate_gateup = static_expert_shape[1]
+        self.intermediate_downproj = self.intermediate_gateup // 2
+
+        # MXFP8: 8 bits/elem = 1 byte/element (NVFP4 packs 2 per byte).
+        self.hidden_bytes = self.hidden
+        # Dispatch pulls SF in uint32 units; host activation_sf rows must pad
+        # to this ceiling with zero-filled bytes.
+        sf_atom_k_elements = 4 * self.sf_vec_size
+        self.sf_uint32_per_token = (
+            (self.hidden + sf_atom_k_elements - 1) // sf_atom_k_elements
+        )
+        # Cross-rank totals: per-rank count * world_size.
+        self.num_total_experts = world_size * self.num_experts_per_rank
+
+        # Per-cluster-tile token count.  Non-swap-AB: token axis is M so the
+        # cluster tile is mma_tiler_mnk[0] (the M-dimension of the 2-CTA
+        # instruction, shared across both CTAs in the cluster).  The old
+        # formula ``mma_tiler_mnk[1] * cluster_shape_mnk[1]`` copied swap-AB
+        # thinking (N-axis × cluster_n) and happens to give the same value for
+        # the M256/N256/cluster_m2 config, but is semantically wrong.
+        self.cluster_tile_tokens = mma_tiler_mnk[0]
+
+        # Cache region sizing inputs used by workspace layout and __call__.
+        (
+            self.pool_token_capacity,
+            self.pool_sf_capacity,
+            self.pool_task_tile_capacity,
+        ) = self._pool_shapes()
+        if self.combine_pre_reduce and self.pool_token_capacity >= (1 << 24):
+            raise ValueError(
+                "combine_pre_reduce: pool_token_capacity must fit the 24-bit "
+                f"reduce_list row field, got {self.pool_token_capacity}."
+            )
+
+        # Cohabiting warps outside the dispatch group: epilogue + mma + tma_a
+        # + tma_b + sched.
+        num_other_warps = len(self.epilogue_warp_id) + 1 + 1 + 1 + 1
+
+        # For token_back_by_dispatch, the dispatch warp pushes fc2 results
+        # from the local pool workspace back to each source rank's combine_output.
+        # fc2_publishes_per_token_cluster_tile = ceil(hidden / mma_tiler_m) * cluster_m:
+        # for each cluster token tile, each of cluster_m CTAs publishes once per
+        # hidden N-tile it processes (N-tile width = mma_tiler[1]).
+        if token_back_by_dispatch:
+            _ctt_n = self.mma_tiler_mnk[1]
+            fc2_publishes = (
+                (self.hidden + _ctt_n - 1) // _ctt_n
+            ) * self.cluster_shape_mn[0]
+        else:
+            fc2_publishes = 0
+
+        self.token_comm = TokenInPullTokenBackPush(
+            world_size=self.world_size,
+            num_topk=self.num_topk,
+            num_experts_per_rank=self.num_experts_per_rank,
+            num_total_experts=self.num_total_experts,
+            hidden=self.hidden,
+            fc1_token_dtype=self.ab_dtype,
+            combine_format=self.combine_format,
+            token_back_by_dispatch=token_back_by_dispatch,
+            fc2_publishes_per_token_cluster_tile=fc2_publishes,
+            token_back_standalone=self.token_back_standalone,
+            sf_uint32_per_token=self.sf_uint32_per_token,
+            token_padding_block=self.token_padding_block,
+            sf_padding_block=self.sf_padding_block,
+            cluster_tile_tokens=self.cluster_tile_tokens,
+            cluster_shape_mn=self.cluster_shape_mn,
+            dispatch_warp_start=self.dispatch_warp_id[0],
+            num_other_warps=num_other_warps,
+            is_swap_ab=False,
+            flag_batch=flag_batch,
+            token_back_schedule_mode=self.token_back_schedule_mode,
+            dedup_dispatch=dedup_dispatch,
+            token_back_reduce_topk=combine_in_flight_reduce,
+            combine_pre_reduce=combine_pre_reduce,
+        )
+
+        # Region layout (same call drives both get_workspace_sizes() and the
+        # __call__ partition).
+        self._local_region_specs = self._build_local_region_specs()
+        self._shared_region_specs = self._build_shared_region_specs()
+        self._local_offsets, self._local_total = _layout_regions(
+            self._local_region_specs
+        )
+        self._shared_offsets, self._shared_total = _layout_regions(
+            self._shared_region_specs
+        )
+        self._local_region_by_name: Dict[str, _RegionSpec] = {
+            r.name: r for r in self._local_region_specs
+        }
+        self._shared_region_by_name: Dict[str, _RegionSpec] = {
+            r.name: r for r in self._shared_region_specs
+        }
+        local_leading = self._local_offsets["l1_token_buffer"]
+        shared_leading = self._shared_offsets["src_token_topk_idx"]
+        self.local_zero_i32_count = local_leading // 4
+        self.shared_zero_i32_count = shared_leading // 4
+
+    def sched_ext_fc1_peek_threshold(self) -> int:
+        # Peek threshold must match the spin threshold (cluster_tile_tokens = 256)
+        # so an early peek hit does not skip the spin and expose stale pool rows.
+        return self.cluster_tile_tokens
+
+    # =========================================================================
+    # SMEM budget hook (base override)
+    # =========================================================================
+
+    def _dispatch_smem_bytes(self) -> int:
+        """SMEM for dispatch pull mbarriers, expert scratch, and token buffer.
+
+        Must match ``TokenInPullTokenBackPush.extra_smem_storage_class``:
+        ``pull_mbar[Int64, 4] + smem_expert_count[Int32, num_total_experts]
+        + pull_buffer[Uint8, 4 * hidden_bytes]``.
+        Standalone token-back adds ``tb_pull_mbar[Int64, 4]`` and
+        ``tb_pull_buffer[Uint8, 4 * tb_chunk_bytes]``.
+        """
+        pull_mbar_bytes = _DispatchWarpCount * 8
+        expert_count_bytes = self.num_total_experts * 4
+        pull_buffer_bytes = _DispatchWarpCount * self.hidden_bytes
+        total = (
+            _round_up(pull_mbar_bytes, 16)
+            + _round_up(expert_count_bytes, 16)
+            + _round_up(pull_buffer_bytes, 128)
+        )
+        if self.token_back_standalone:
+            total += (
+                _round_up(_DispatchWarpCount * 8, 16)
+                + _round_up(
+                    _DispatchWarpCount * self.token_comm.tb_chunk_bytes, 128
+                )
+            )
+        return total
+
+    def _smem_misc_budget_bytes(self) -> int:
+        """Base misc reservation plus dispatch-warp SMEM."""
+        return super()._smem_misc_budget_bytes() + self._dispatch_smem_bytes()
+
+    # =========================================================================
+    # Pool sizing (first-principles; identical to the NVFP4 path)
+    # =========================================================================
+
+    def _pool_shapes(self) -> Tuple[int, int, int]:
+        world_size = self.world_size
+        max_tokens_per_rank = self.max_tokens_per_rank
+        num_topk = self.num_topk
+        num_experts_per_rank = self.num_experts_per_rank
+        token_padding_block = self.token_padding_block
+        sf_padding_block = self.sf_padding_block
+        cluster_tile_tokens = self.cluster_tile_tokens
+
+        max_recv = world_size * max_tokens_per_rank
+        max_per_token = min(num_topk, num_experts_per_rank)
+        raw = (
+            max_recv * max_per_token
+            + num_experts_per_rank * (token_padding_block - 1)
+        )
+        pool_token_capacity = _round_up(raw, token_padding_block)
+        pool_sf_capacity = (
+            (pool_token_capacity // token_padding_block) * sf_padding_block
+        )
+        cluster_m = self.cluster_shape_mn[0]
+        pool_task_tile_capacity = (
+            (pool_token_capacity + cluster_tile_tokens - 1) // cluster_tile_tokens
+            + num_experts_per_rank
+        )
+        return (
+            pool_token_capacity,
+            pool_sf_capacity,
+            pool_task_tile_capacity,
+        )
+
+    # =========================================================================
+    # Region tables
+    # =========================================================================
+
+    def _build_local_region_specs(self) -> List[_RegionSpec]:
+        pool_token_capacity = self.pool_token_capacity
+        pool_sf_capacity = self.pool_sf_capacity
+        pool_task_tile_capacity = self.pool_task_tile_capacity
+        num_experts_per_rank = self.num_experts_per_rank
+        num_total_experts = self.num_total_experts
+        hidden_bytes = self.hidden_bytes
+        sf_uint32_per_token = self.sf_uint32_per_token
+        intermediate_downproj = self.intermediate_downproj
+        mma_tiler_m = self.mma_tiler_mnk[0]
+        sf_vec_size = self.sf_vec_size
+        sf_padding_block = self.sf_padding_block
+
+        sf_total_rows_upper = (
+            pool_token_capacity + num_experts_per_rank * sf_padding_block
+        )
+        sf_block_cols = (
+            (((intermediate_downproj // sf_vec_size) + 3) // 4) * 4
+        )
+        fc1_done_slots = (
+            (pool_token_capacity + mma_tiler_m - 1) // mma_tiler_m
+            + num_experts_per_rank
+        )
+
+        # Accumulating-counter prefix: tail_reset_counters bulk-zeros all bytes
+        # before l1_token_buffer so back-to-back launches do not inherit counters.
+        specs: List[_RegionSpec] = [
+            _RegionSpec(
+                "l1_arrival_count",
+                cutlass.Int32,
+                (pool_task_tile_capacity,),
+                16,
+            ),
+            _RegionSpec(
+                "expert_send_count",
+                cutlass.Int64,
+                (num_total_experts,),
+                16,
+            ),
+            _RegionSpec(
+                "grid_sync_counter",
+                cutlass.Int32,
+                (_GridSyncSlotCount,),
+                16,
+            ),
+            _RegionSpec(
+                "fc1_done_counter",
+                cutlass.Int32,
+                (fc1_done_slots,),
+                16,
+            ),
+        ]
+        if self.token_back_enabled:
+            specs.append(
+                _RegionSpec(
+                    "fc2_done_counter",
+                    cutlass.Int32,
+                    (num_experts_per_rank,),
+                    16,
+                )
+            )
+            if self.token_back_schedule_mode == "atomic_counter":
+                specs.append(
+                    _RegionSpec(
+                        "token_back_schedule_counter",
+                        cutlass.Int32,
+                        (1,),
+                        16,
+                    )
+                )
+        if self.load_balance_mode == "atomic_counter":
+            specs.append(
+                _RegionSpec(
+                    "load_balance_counter",
+                    cutlass.Int32,
+                    (1,),
+                    16,
+                )
+            )
+
+        # Data buffers. l1_token_buffer must be the first data region because
+        # __init__ derives local_zero_i32_count from its offset.
+        specs += [
+            # L1 input pool (dispatch_pull writes -> fc1 reads).  Stored as
+            # Uint8 bytes; the fp8 view at the same offset is built in __call__.
+            _RegionSpec(
+                "l1_token_buffer",
+                cutlass.Uint8,
+                (pool_token_capacity, hidden_bytes),
+                128,
+            ),
+            # Persisted across launches; the sense-reversing nvlink barrier rides
+            # this phase counter across non-ncu relaunches.
+            _RegionSpec(
+                "nvlink_barrier_counter",
+                cutlass.Int32,
+                (1,),
+                16,
+            ),
+            # 1D Int32 atom-flat SF buffer (dispatch_pull's 32b read/write); the
+            # E8M0 view is built at the same offset in __call__.
+            _RegionSpec(
+                "l1_sf_buffer",
+                cutlass.Int32,
+                (pool_sf_capacity * sf_uint32_per_token,),
+                16,
+            ),
+            _RegionSpec(
+                "l1_topk_weights_buffer",
+                cutlass.Float32,
+                (pool_token_capacity,),
+                16,
+            ),
+            _RegionSpec(
+                "token_src_metadata",
+                cutlass.Uint8,
+                (pool_token_capacity, _TokenMetadataBytes),
+                16,
+            ),
+            # MXFP8: fc1_output uses ab_dtype (Float8E4M3FN or Float8E5M2).
+            _RegionSpec(
+                "fc1_output",
+                self.ab_dtype,
+                (pool_token_capacity, intermediate_downproj),
+                128,
+            ),
+            # MXFP8: fc1_output_sf uses Float8E8M0FNU (E8M0 block scales).
+            _RegionSpec(
+                "fc1_output_sf",
+                cutlass.Float8E8M0FNU,
+                (sf_total_rows_upper, sf_block_cols),
+                128,
+            ),
+        ]
+
+        if self.token_back_by_dispatch:
+            specs.append(
+                _RegionSpec(
+                    "fc2_output_workspace",
+                    self.combine_format.act_dtype,
+                    (pool_token_capacity, 1, self.hidden),
+                    128,
+                )
+            )
+        # Combine pre-reduce: per-anchor partner pool-row lists.  Only the
+        # first reduce_n entries of an anchor row are ever read (roles live in
+        # token_src_metadata, written for every row), so no zeroing needed.
+        if self.combine_pre_reduce:
+            specs.append(
+                _RegionSpec(
+                    "reduce_list",
+                    cutlass.Int32,
+                    (pool_token_capacity, self.num_topk - 1),
+                    16,
+                )
+            )
+        # Staged local SF plane for quantized combine (epi writes per-block E8M0
+        # here; token-back warps push it token-contiguously to peers' combine_sf).
+        if self.combine_format.is_quantized:
+            specs.append(
+                _RegionSpec(
+                    "fc2_output_sf",
+                    self.combine_format.scale_dtype,
+                    (pool_token_capacity * self.sf_block_pad,),
+                    128,
+                )
+            )
+
+        return specs
+
+    def _build_shared_region_specs(self) -> List[_RegionSpec]:
+        world_size = self.world_size
+        num_topk = self.num_topk
+        max_tokens_per_rank = self.max_tokens_per_rank
+        num_experts_per_rank = self.num_experts_per_rank
+
+        max_slot = max_tokens_per_rank * num_topk
+
+        # Shared counter prefix is bulk-zeroed between tail barriers; keep
+        # src_token_topk_idx as the first data region used to derive the prefix.
+        specs = [
+            _RegionSpec(
+                "expert_recv_count",
+                cutlass.Int64,
+                (world_size, num_experts_per_rank),
+                16,
+            ),
+            _RegionSpec(
+                "expert_recv_count_sum",
+                cutlass.Int64,
+                (num_experts_per_rank,),
+                16,
+            ),
+            _RegionSpec(
+                "src_token_topk_idx",
+                cutlass.Int32,
+                (num_experts_per_rank, world_size, max_slot),
+                16,
+            ),
+            _RegionSpec(
+                "nvlink_barrier_signal",
+                cutlass.Int32,
+                (_NvlinkSlotCount,),
+                16,
+            ),
+        ]
+        # Rank-dedup dispatch: per-primary flat duplicate lists mirroring
+        # src_token_topk_idx's (expert, src_rank, slot) coordinates plus a
+        # trailing per-duplicate axis.  Written remotely by the source rank's
+        # dispatch_prep, read locally by dispatch_pull's fan-out; only the
+        # first n entries of a primary's list (n from its index word) are
+        # ever read, so no per-launch zeroing is needed.
+        if self.dedup_dispatch:
+            specs.append(
+                _RegionSpec(
+                    "dup_link",
+                    cutlass.Int32,
+                    (num_experts_per_rank, world_size, max_slot, num_topk - 1),
+                    16,
+                )
+            )
+        # separate_kernel_reduce: the per-topk (token, topk, hidden) combine data
+        # plane is internalized here instead of being a caller tensor, so the
+        # public output is the 2D (T, hidden) reduce result.  It is the cross-rank
+        # combine STG target, hence must live on the symmetric heap (= this shared
+        # workspace); appended after the data regions so it stays out of the
+        # per-launch zero prefix.  in_kernel_reduce instead REDGs straight into the
+        # caller's 2D output_activation, so no staging plane is needed.
+        if not (self.fc2_in_kernel_topk_reduce or self.combine_in_flight_reduce):
+            # combine_quant: the cross-rank combine data plane, one cell per
+            # (token, topk).  dtype follows the wire format (bf16 baseline, or
+            # fp8 for quantized combine).
+            specs.append(
+                _RegionSpec(
+                    "combine_quant",
+                    self.combine_format.act_dtype,
+                    (max_tokens_per_rank, num_topk, self.hidden),
+                    128,
+                )
+            )
+            # combine_sf: per-block scale plane staged locally then pushed
+            # token-contiguously to peers' combine_sf; quantized formats only.
+            if self.combine_format.is_quantized:
+                specs.append(
+                    _RegionSpec(
+                        "combine_sf",
+                        self.combine_format.scale_dtype,
+                        (max_tokens_per_rank * num_topk * self.sf_block_pad,),
+                        128,
+                    )
+                )
+        return specs
+
+    # =========================================================================
+    # Public: workspace size query
+    # =========================================================================
+
+    def get_workspace_sizes(self) -> Tuple[int, int]:
+        """Return ``(local_ws_bytes, shared_ws_bytes)``."""
+        return self._local_total, self._shared_total
+
+    # =========================================================================
+    # Workspace partition helpers (mirror the NVFP4 mega kernel)
+    # =========================================================================
+
+    @staticmethod
+    def _make_typed_view(
+        byte_workspace: cute.Tensor,
+        byte_offset: int,
+        cute_dtype: Any,
+        shape: Tuple[int, ...],
+        stride: Optional[Tuple[int, ...]],
+        assumed_align: int,
+    ) -> cute.Tensor:
+        """Build a typed cute view at ``byte_offset`` of the opaque workspace."""
+        byte_ptr = byte_workspace.iterator + Int64(byte_offset)
+        typed_iter = cute.make_ptr(
+            cute_dtype,
+            byte_ptr.toint(),
+            AddressSpace.gmem,
+            assumed_align=assumed_align,
+        )
+        return cute.make_tensor(typed_iter, cute.make_layout(shape, stride=stride))
+
+    def _view_local(
+        self,
+        local_workspace: cute.Tensor,
+        name: str,
+        *,
+        cute_dtype: Optional[Any] = None,
+        shape: Optional[Tuple[int, ...]] = None,
+        stride: Optional[Tuple[int, ...]] = None,
+    ) -> cute.Tensor:
+        return self._partition_region(
+            local_workspace,
+            self._local_offsets,
+            self._local_region_by_name[name],
+            cute_dtype=cute_dtype,
+            shape=shape,
+            stride=stride,
+        )
+
+    def _view_shared(
+        self,
+        shared_workspace: cute.Tensor,
+        name: str,
+        *,
+        cute_dtype: Optional[Any] = None,
+        shape: Optional[Tuple[int, ...]] = None,
+        stride: Optional[Tuple[int, ...]] = None,
+    ) -> cute.Tensor:
+        return self._partition_region(
+            shared_workspace,
+            self._shared_offsets,
+            self._shared_region_by_name[name],
+            cute_dtype=cute_dtype,
+            shape=shape,
+            stride=stride,
+        )
+
+    def _partition_region(
+        self,
+        byte_workspace: cute.Tensor,
+        offsets: Dict[str, int],
+        spec: _RegionSpec,
+        *,
+        cute_dtype: Optional[Any],
+        shape: Optional[Tuple[int, ...]],
+        stride: Optional[Tuple[int, ...]],
+    ) -> cute.Tensor:
+        dt = cute_dtype if cute_dtype is not None else spec.cute_dtype
+        sh = shape if shape is not None else spec.shape
+        st = stride
+        if st is None:
+            if cute_dtype is None and shape is None:
+                st = spec.stride_row_major
+            else:
+                out: List[int] = [1]
+                for d in reversed(list(sh)[1:]):
+                    out.append(out[-1] * d)
+                out.reverse()
+                st = tuple(out)
+        return self._make_typed_view(
+            byte_workspace, offsets[spec.name], dt, sh, st, spec.align,
+        )
+
+    # =========================================================================
+    # __call__
+    # =========================================================================
+
+    @cute.jit
+    def __call__(
+        self,
+        # User-domain inputs (peer-mapped on the symmetric heap).
+        activation: cute.Tensor,           # (T, hidden) fp8
+        activation_sf: cute.Tensor,        # (T, round_up(hidden, sf_atom_block_k)) E8M0
+        topk_idx: cute.Tensor,             # (T, num_topk) Int64
+        topk_weights: cute.Tensor,         # (T, num_topk) Float32
+        # Per-rank model weights (local-only; not in workspace).
+        fc1_weight: cute.Tensor,
+        fc1_weight_sf: cute.Tensor,
+        fc2_weight: cute.Tensor,
+        fc2_weight_sf: cute.Tensor,
+        fc1_c: Optional[cute.Tensor],      # fc1 c output
+        # Final combined output the caller consumes: 2D (T, hidden) BF16.
+        output_activation: cute.Tensor,    # (T, hidden) BF16
+        # Opaque workspaces.
+        local_workspace: cute.Tensor,      # (local_ws_bytes,) Uint8
+        shared_workspace: cute.Tensor,     # (shared_ws_bytes,) Uint8
+        # Runtime host payload; packed into ``SymBuffer{world_size}``.
+        peer_rank_ptr_mapper_host,
+        # Codegen / runtime.
+        max_active_clusters: cutlass.Constexpr,
+        stream,
+    ) -> None:
+        """Launch the MXFP8 MegaMoE-complete fused kernel.
+
+        Pointer-mapping contract mirrors the NVFP4 path:
+          * ``activation`` / ``activation_sf`` / ``topk_weights`` MUST point
+            into memory reachable via ``peer_rank_ptr_mapper.ptr_map_to_rank(...)``
+            (NVSHMEM symmetric heap).  The per-topk combine staging lives on the
+            same heap inside ``shared_workspace`` (``combine_quant``).  Single-rank
+            degenerate runs are allowed.
+          * ``topk_idx`` is read on the local rank only.
+          * ``fc1_weight`` / ``fc1_weight_sf`` / ``fc2_weight`` /
+            ``fc2_weight_sf`` are local-only.
+
+        The caller only sees the 2D ``output_activation`` (T, hidden) BF16:
+
+          * ``fc2_in_kernel_topk_reduce`` (Form B): the epilogue REDGs the
+            topk-collapsed result straight into a ``(T, 1, hidden)`` view of
+            ``output_activation`` on the sym heap.
+          * otherwise (separate_kernel_reduce): the epilogue writes one cell per
+            ``[src_token, src_topk, :]`` into the internal ``combine_quant``
+            staging (bf16 baseline, or fp8+``combine_sf`` E8M0 for quantized
+            combine); after the fused kernel, TopkReduce dequantizes and reduces
+            the topk axis into ``output_activation``.
+        """
+        cluster_size = self.cluster_shape_mn[0] * self.cluster_shape_mn[1]
+        sm_count = max_active_clusters * cluster_size
+        peer_rank_ptr_mapper = peer_rank_ptr_mapper_host.make_device_obj()
+
+        pool_token_capacity = self.pool_token_capacity
+        pool_sf_capacity = self.pool_sf_capacity
+        hidden = self.hidden
+        sf_per_token_fp8 = self.sf_uint32_per_token * 4  # 4 E8M0 SFs per Int32
+
+        # L1 token buffer: Uint8 view (dispatch_pull byte arith) + fp8 view
+        # (fc1 GEMM mainloop).  Same byte offset.
+        l1_token_buffer_u8 = self._view_local(local_workspace, "l1_token_buffer")
+        l1_token_buffer_fp8 = self._make_typed_view(
+            local_workspace,
+            self._local_offsets["l1_token_buffer"],
+            self.ab_dtype,
+            (pool_token_capacity, hidden),
+            (hidden, 1),
+            self._local_region_by_name["l1_token_buffer"].align,
+        )
+
+        # L1 SF buffer: Int32 view (dispatch_pull's [j, t] 2D indexing) + E8M0
+        # view (base.activation_sf re-views via tile_atom_to_shape_SF off the
+        # iterator, so the stride here is informational only).
+        l1_sf_buffer_i32 = self._view_local(local_workspace, "l1_sf_buffer")
+        l1_sf_buffer_e8m0 = self._make_typed_view(
+            local_workspace,
+            self._local_offsets["l1_sf_buffer"],
+            cutlass.Float8E8M0FNU,
+            (pool_sf_capacity, sf_per_token_fp8),
+            (sf_per_token_fp8, 1),
+            self._local_region_by_name["l1_sf_buffer"].align,
+        )
+
+        l1_topk_weights_buffer = self._view_local(
+            local_workspace, "l1_topk_weights_buffer",
+        )
+        l1_arrival_count = self._view_local(local_workspace, "l1_arrival_count")
+        # token_src_metadata storage = (pool_token_capacity, TokenSrcMetadata.nbytes) Uint8;
+        # dispatch_pull writes one packed Int64 per pool token row (see TokenSrcMetadata).
+        token_src_metadata = self._view_local(
+            local_workspace, "token_src_metadata",
+        )
+        expert_send_count = self._view_local(local_workspace, "expert_send_count")
+        grid_sync_counter = self._view_local(local_workspace, "grid_sync_counter")
+        nvlink_barrier_counter = self._view_local(
+            local_workspace, "nvlink_barrier_counter",
+        )
+        fc1_output = self._view_local(local_workspace, "fc1_output")
+        fc1_output_sf = self._view_local(local_workspace, "fc1_output_sf")
+        fc1_done_counter = self._view_local(local_workspace, "fc1_done_counter")
+
+        load_balance_counter: Optional[cute.Tensor] = None
+        if cutlass.const_expr(self.load_balance_mode == "atomic_counter"):
+            load_balance_counter = self._view_local(
+                local_workspace, "load_balance_counter",
+            )
+
+        token_back_schedule_counter = None
+        if cutlass.const_expr(self.token_back_schedule_mode == "atomic_counter"):
+            token_back_schedule_counter = self._view_local(
+                local_workspace, "token_back_schedule_counter",
+            ).iterator
+
+        # MoE-domain (token, topk, hidden) combine data plane.
+        #   * in_kernel_reduce (Form B): REDG collapses topk on the fly, so
+        #     combine_target is a ``(max_tokens, 1, hidden)`` view of the caller's
+        #     2D output_activation (the epilogue's topk index is a constexpr 0).
+        #   * separate_kernel_reduce: peers STG one cell per (token, topk) into the
+        #     internal sym-heap ``combine_quant`` staging; TopkReduce below
+        #     collapses topk into output_activation.
+        if cutlass.const_expr(
+            self.fc2_in_kernel_topk_reduce or self.combine_in_flight_reduce
+        ):
+            combine_target = cute.make_tensor(
+                output_activation.iterator,
+                cute.make_layout(
+                    (self.max_tokens_per_rank, 1, hidden),
+                    stride=(hidden, hidden, 1),
+                ),
+            )
+        else:
+            combine_target = self._view_shared(shared_workspace, "combine_quant")
+
+        if cutlass.const_expr(self.token_back_by_dispatch):
+            act_dtype = self.combine_format.act_dtype
+            act_bytes = int(act_dtype.width) // 8
+            fc2_output_workspace_native = self._view_local(
+                local_workspace, "fc2_output_workspace",
+            )
+            fc2_output_workspace_u8 = self._make_typed_view(
+                local_workspace,
+                self._local_offsets["fc2_output_workspace"],
+                cutlass.Uint8,
+                (pool_token_capacity * hidden * act_bytes,),
+                None,
+                self._local_region_by_name["fc2_output_workspace"].align,
+            )
+            combine_output_u8 = cute.recast_tensor(combine_target, cutlass.Uint8)
+            fc2_output_target = fc2_output_workspace_native
+        else:
+            fc2_output_workspace_native = None
+            fc2_output_workspace_u8 = None
+            combine_output_u8 = cute.recast_tensor(combine_target, cutlass.Uint8)
+            fc2_output_target = combine_target
+
+        if cutlass.const_expr(self.token_back_enabled):
+            fc2_done_counter = self._view_local(local_workspace, "fc2_done_counter")
+        else:
+            fc2_done_counter = None
+
+        # Quantized combine: assemble logical (pool_token, 1, valid_blocks) view
+        # of fc2_output_sf and (max_tokens, num_topk, valid_blocks) of combine_sf.
+        sf_blocks = (
+            hidden // self.combine_format.scale_block
+            if self.combine_format.is_quantized else 0
+        )
+        if cutlass.const_expr(self.combine_format.is_quantized):
+            fc2_output_sf_phys = self._view_local(
+                local_workspace, "fc2_output_sf",
+                shape=(pool_token_capacity, 1, sf_blocks),
+                stride=(self.sf_block_pad, self.sf_block_pad, 1),
+            )
+            sf_vec = self.combine_format.scale_block
+            sf_layout = fc2_output_sf_phys.layout
+            fc2_output_sf = cute.make_tensor(
+                fc2_output_sf_phys.iterator,
+                cute.make_layout(
+                    (sf_layout.shape[0], sf_layout.shape[1], (sf_vec, sf_layout.shape[2])),
+                    stride=(sf_layout.stride[0], sf_layout.stride[1], (0, sf_layout.stride[2])),
+                ),
+            )
+            combine_sf = self._view_shared(
+                shared_workspace, "combine_sf",
+                shape=(self.max_tokens_per_rank, self.num_topk, sf_blocks),
+                stride=(self.num_topk * self.sf_block_pad, self.sf_block_pad, 1),
+            )
+        else:
+            fc2_output_sf = None
+            combine_sf = None
+
+        # Shared regions.
+        src_token_topk_idx = self._view_shared(
+            shared_workspace, "src_token_topk_idx",
+        )
+        expert_recv_count = self._view_shared(shared_workspace, "expert_recv_count")
+        expert_recv_count_sum = self._view_shared(
+            shared_workspace, "expert_recv_count_sum",
+        )
+        nvlink_barrier_signal = self._view_shared(
+            shared_workspace, "nvlink_barrier_signal",
+        )
+        if cutlass.const_expr(self.dedup_dispatch):
+            dup_link = self._view_shared(shared_workspace, "dup_link")
+        else:
+            dup_link = None
+        if cutlass.const_expr(self.combine_pre_reduce):
+            reduce_list = self._view_local(local_workspace, "reduce_list")
+        else:
+            reduce_list = None
+
+        # i32 stride=(2,) view onto the i64 ``expert_recv_count_sum`` buffer --
+        # low32 bits hold per-expert total token count after _dispatch_barrier;
+        # zero-copy alias for sizes-mode scheduling.
+        expert_token_sizes = self._view_shared(
+            shared_workspace,
+            "expert_recv_count_sum",
+            cute_dtype=cutlass.Int32,
+            shape=(self.num_experts_per_rank,),
+            stride=(2,),
+        )
+        local_zero_prefix = self._make_typed_view(
+            local_workspace, 0, cutlass.Int32, (self.local_zero_i32_count,), (1,), 16,
+        )
+        shared_zero_prefix = self._make_typed_view(
+            shared_workspace, 0, cutlass.Int32, (self.shared_zero_i32_count,), (1,), 16,
+        )
+
+        token_comm_args = ExtractedTokenCommArgs(
+            input_token_buffer=activation,
+            input_sf_buffer=activation_sf,
+            topk_idx=topk_idx,
+            input_topk_weights_buffer=topk_weights,
+            expert_send_count=expert_send_count,
+            expert_recv_count=expert_recv_count,
+            expert_recv_count_sum=expert_recv_count_sum,
+            src_token_topk_idx=src_token_topk_idx,
+            dup_link=dup_link,
+            reduce_list=reduce_list,
+            fc1_input_token_buffer=l1_token_buffer_u8,
+            fc1_input_sf_buffer=l1_sf_buffer_i32,
+            fc1_input_topk_weights_buffer=l1_topk_weights_buffer,
+            fc1_ready_counter=l1_arrival_count,
+            token_src_metadata=token_src_metadata,
+            combine_output=combine_output_u8,
+            combine_sf=combine_sf,
+            fc2_output_workspace=fc2_output_workspace_u8,
+            fc2_output_sf=fc2_output_sf,
+            fc2_done_counter=fc2_done_counter,
+            token_back_schedule_counter=token_back_schedule_counter,
+            nvlink_barrier_signal=nvlink_barrier_signal,
+            nvlink_barrier_counter=nvlink_barrier_counter,
+            grid_sync_counter=grid_sync_counter,
+            local_zero_prefix=local_zero_prefix,
+            shared_zero_prefix=shared_zero_prefix,
+            peer_rank_ptr_mapper=peer_rank_ptr_mapper,
+            world_size=self.world_size,
+            local_rank=peer_rank_ptr_mapper_host.rank_idx,
+            num_total_experts=self.num_total_experts,
+            num_experts_per_rank=self.num_experts_per_rank,
+            num_topk=self.num_topk,
+            hidden_bytes=self.hidden_bytes,
+            sf_uint32_per_token=self.sf_uint32_per_token,
+            token_padding_block=self.token_padding_block,
+            sf_padding_block=self.sf_padding_block,
+            sm_count=sm_count,
+        )
+
+        super().__call__(
+            activation=l1_token_buffer_fp8,
+            fc1_weight=fc1_weight,
+            activation_sf=l1_sf_buffer_e8m0,
+            fc1_weight_sf=fc1_weight_sf,
+            fc1_output=fc1_output,
+            fc1_output_sf=fc1_output_sf,
+            fc1_c=fc1_c,
+            fc2_weight=fc2_weight,
+            fc2_weight_sf=fc2_weight_sf,
+            fc2_output=fc2_output_target,
+            topk_scores=l1_topk_weights_buffer,
+            fc1_done_counter=fc1_done_counter,
+            offs=None,
+            max_active_clusters=max_active_clusters,
+            stream=stream,
+            load_balance_counter=load_balance_counter,
+            expert_token_sizes=expert_token_sizes,
+            token_comm_args=token_comm_args,
+        )
+
+        # separate_kernel_reduce: collapse the per-topk ``combine_quant`` staging
+        # into the public 2D output via the shared TopkReduce launcher (it
+        # dequantizes per combine_format -- bf16 pass-through, or fp8+E8M0 -- and
+        # reduces over the topk axis).  Same stream, so it is ordered strictly
+        # after the cross-rank combine writes landed (the mega kernel's nvlink
+        # barrier guarantees all peer combine STGs to this rank completed before it
+        # exits, so combine_quant and combine_sf are fully populated).  Weighting
+        # follows the compute graph: apply_topk_in_fc1 folded the routing weight
+        # into fc1 -> plain K-sum; otherwise topk_weights is applied here.
+        if cutlass.const_expr(
+            not (self.fc2_in_kernel_topk_reduce or self.combine_in_flight_reduce)
+        ):
+            score = (
+                topk_weights if cutlass.const_expr(not self.apply_topk_in_fc1)
+                else None
+            )
+            TopkReduce(self.hidden, self.num_topk, self.combine_format)(
+                combine_target, combine_sf, output_activation, score, stream,
+            )
+
+    # =========================================================================
+    # TokenComm delegation surface consumed by the fc1/fc2 base kernel
+    # =========================================================================
+
+    def token_comm_extra_smem_storage_class(self) -> type:
+        return self.token_comm.extra_smem_storage_class()
+
+    def token_comm_hook_fc1_ready_counter_ptr(self, token_comm_args):
+        return self.token_comm.fc1_ready_counter_ptr(token_comm_args)
+
+    @cute.jit
+    def token_comm_hook_sched_warp_pre_init_wait(self, token_comm_args):
+        self.token_comm.sched_warp_pre_init_wait(token_comm_args)
+
+    @cute.jit
+    def token_comm_hook_fc1_tma_b_predispatch_spin(
+        self, token_comm_args, work_tile_info,
+    ):
+        self.token_comm.fc1_tma_b_predispatch_spin(
+            token_comm_args, work_tile_info,
+        )
+
+    @cute.jit
+    def token_comm_hook_dispatch_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        self.token_comm.dispatch_warp_body(
+            token_comm_args,
+            token_comm_storage,
+            warp_idx=warp_idx,
+            lane_idx=lane_idx,
+            tidx=tidx,
+        )
+
+    @cute.jit
+    def token_comm_hook_token_back_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        self.token_comm.token_back_warp_body(
+            token_comm_args,
+            token_comm_storage,
+            warp_idx=warp_idx,
+            lane_idx=lane_idx,
+            tidx=tidx,
+        )
+
+    @cute.jit
+    def token_comm_hook_tail_reset_shared_counters(
+        self,
+        token_comm_args,
+        *,
+        cta_linear_id,
+        local_warp_idx,
+        lane_idx,
+    ):
+        self.token_comm.tail_reset_shared_counters(
+            token_comm_args,
+            cta_linear_id=cta_linear_id,
+            local_warp_idx=local_warp_idx,
+            lane_idx=lane_idx,
+        )
+
+    @cute.jit
+    def token_comm_hook_kernel_tail(
+        self,
+        token_comm_args,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        self.token_comm.kernel_tail(
+            token_comm_args,
+            warp_idx=warp_idx,
+            lane_idx=lane_idx,
+            tidx=tidx,
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/run_functional_tests.sh
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/run_functional_tests.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Functional test harness for the MXFP8 GLU fused fc1+fc2 runner.
+# It resolves runner_fc12.py (co-located in this moe_mxfp8_glu/ folder)
+# relative to this script, so CWD is irrelevant.
+#
+# MXFP8 tile constraint: the kernel only supports mma tile 256,256,128 WITH
+# --use_2cta_instrs --cluster_shape_mnk 2,1,1 (FP8 MMA K=128).  Other configs
+# that work for NVFP4 do NOT work for MXFP8 and were confirmed broken:
+#   * tile 128,128,256 (K=256)  -> CUDA illegal memory access
+#   * cluster_m=4 (4,1,1)       -> kernel deadlock (GPU spins, no progress)
+#   * tile_n=64 / 1-CTA tiles   -> not supported
+# So every case below fixes --mma_tiler_mnk 256,256,128 --use_2cta_instrs
+# --cluster_shape_mnk 2,1,1 and varies only the rest (static/atomic
+# scheduling, dyn/static expert shape, balanced/dirichlet routing, e4m3/e5m2
+# element format, problem sizes).  Output dtype is bf16 (the only dtype the
+# kernel emits).
+#
+# Usage:
+#   bash <abs path>/run_functional_tests.sh
+#   PYTHON=python3.11 bash .../run_functional_tests.sh
+#   bash .../run_functional_tests.sh --fail-fast
+#   bash .../run_functional_tests.sh --list
+#   bash .../run_functional_tests.sh --help
+#
+# Selective execution (positional args; substring match against test names,
+# OR-combined across multiple selectors):
+#   bash .../run_functional_tests.sh M1                    # run M1 only
+#   bash .../run_functional_tests.sh M1 M3 M7             # run those three
+#   bash .../run_functional_tests.sh e5m2                  # run anything with "e5m2"
+#   bash .../run_functional_tests.sh dirichlet --fail-fast # combine with flags
+#
+# Exit code: number of failed tests (0 = all pass).  Per-test runner stdout /
+# stderr is passed through verbatim; the [CMD] line printed before each test
+# is the exact command to copy-paste for standalone debugging.
+
+export PATH=/usr/bin:$PATH
+export LD=/usr/bin/ld
+export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
+export CUDAHOSTCXX=/usr/bin/g++
+export TRITON_CC=/usr/bin/gcc
+export CFLAGS="-B/usr/bin"
+export CXXFLAGS="-B/usr/bin"
+export LDFLAGS="-B/usr/bin -fuse-ld=bfd"
+
+set -u  # fail on undefined vars; do NOT set -e (we want to continue on failures)
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+RUNNER="${SCRIPT_DIR}/runner_fc12.py"
+PYTHON="${PYTHON:-python}"
+
+if [ ! -f "$RUNNER" ]; then
+    echo "ERROR: runner_fc12.py not found at ${RUNNER}" >&2
+    exit 2
+fi
+
+FAIL_FAST=0
+LIST_ONLY=0
+declare -a SELECTORS=()
+for arg in "$@"; do
+    case "$arg" in
+        --fail-fast)
+            FAIL_FAST=1
+            ;;
+        --list)
+            LIST_ONLY=1
+            ;;
+        -h|--help)
+            sed -n '2,/^# Exit code/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown flag: $arg (use --help)" >&2
+            exit 2
+            ;;
+        *)
+            # Positional arg: test name selector (substring match).  Multiple
+            # selectors are OR-combined; empty list means "run all".
+            SELECTORS+=("$arg")
+            ;;
+    esac
+done
+
+# Returns 0 (true) if the test name matches any selector, OR if the selector
+# list is empty (default = run all).
+test_matches_selectors() {
+    local name="$1"
+    if [ "${#SELECTORS[@]}" -eq 0 ]; then
+        return 0
+    fi
+    local sel
+    for sel in "${SELECTORS[@]}"; do
+        if [[ "$name" == *"$sel"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Each entry: "name | space-separated runner CLI args".
+# All cases fix: --mma_tiler_mnk 256,256,128 --use_2cta_instrs (MXFP8 constraint).
+declare -a TESTS=(
+    # ── Group M: cluster_m=2, e4m3 ──
+    "M1_e4m3_static_dynShape_c2     | --kind mxfp8_e4m3 --tokens_after_topk 2400 --experts 8  --hidden 1792 --intermediate 1536 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode static"
+    "M2_e4m3_static_statShape_c2    | --kind mxfp8_e4m3 --tokens_after_topk 2400 --experts 12 --hidden 1792 --intermediate 1536 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode static --enable_static_expert_shape --generate_c"
+    "M3_e4m3_atomic_dynShape_c2     | --kind mxfp8_e4m3 --tokens_after_topk 2400 --experts 16 --hidden 1792 --intermediate 1536 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode atomic_counter"
+
+    # ── Group M: atomic + static expert shape, e4m3 ──
+    "M4_e4m3_atomic_statShape_c2    | --kind mxfp8_e4m3 --tokens_after_topk 4500 --experts 19 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode atomic_counter --enable_static_expert_shape --generate_c"
+
+    # ── Group M: dirichlet routing, e4m3 ──
+    "M5_e4m3_dirichlet_static_c2    | --kind mxfp8_e4m3 --tokens_after_topk 3000 --experts 23 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --load_balance_mode static"
+    "M6_e4m3_dirichlet_atomic_c2    | --kind mxfp8_e4m3 --tokens_after_topk 9000 --experts 31 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --load_balance_mode atomic_counter --enable_static_expert_shape --generate_c"
+
+    # ── Group M: large shape (DeepSeek-ish) ──
+    "M7_e4m3_large_atomic_balanced  | --kind mxfp8_e4m3 --tokens_after_topk 17000 --experts 8 --hidden 7168 --intermediate 4096 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode atomic_counter"
+
+    # NOTE: mxfp8_e5m2 is intentionally NOT covered here.  The e5m2 fc1
+    # quantize path is currently broken in the kernel epilogue
+    # (moe_mxfp8_glu/epilogue_mxfp8.py -> moe_nvfp4_swapab/moe_utils.py
+    # quant_sfd_row raises "None to integer conversion is not supported"),
+    # so every e5m2 launch fails regardless of the runner.  Re-add e5m2
+    # cases once that kernel path is fixed.
+)
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+declare -a FAIL_NAMES=()
+TOTAL=${#TESTS[@]}
+START_TIME=$SECONDS
+
+# --list mode: print all test names (with selector filter applied) and exit.
+if [ "$LIST_ONLY" -eq 1 ]; then
+    for entry in "${TESTS[@]}"; do
+        name="${entry%%|*}"
+        name="${name%"${name##*[![:space:]]}"}"
+        if test_matches_selectors "$name"; then
+            echo "$name"
+        fi
+    done
+    exit 0
+fi
+
+for entry in "${TESTS[@]}"; do
+    # Split on first '|'; trim trailing/leading whitespace on both halves.
+    name="${entry%%|*}"
+    name="${name%"${name##*[![:space:]]}"}"   # rstrip
+    args="${entry#*|}"
+    args="${args#"${args%%[![:space:]]*}"}"   # lstrip
+
+    if ! test_matches_selectors "$name"; then
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        continue
+    fi
+
+    echo
+    echo "==========================================================================="
+    echo "[TEST] $name"
+    echo "[CMD]  $PYTHON $RUNNER $args"
+    echo "==========================================================================="
+
+    test_start=$SECONDS
+    # shellcheck disable=SC2086  # intentional word-splitting on $args
+    "$PYTHON" "$RUNNER" $args
+    rc=$?
+    elapsed=$((SECONDS - test_start))
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[RESULT] PASS  (${elapsed}s) $name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "[RESULT] FAIL  (rc=${rc}, ${elapsed}s) $name"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAIL_NAMES+=("$name")
+        if [ "$FAIL_FAST" -eq 1 ]; then
+            echo "[--fail-fast] aborting after first failure"
+            break
+        fi
+    fi
+done
+
+TOTAL_ELAPSED=$((SECONDS - START_TIME))
+RAN_COUNT=$((PASS_COUNT + FAIL_COUNT))
+echo
+echo "==========================================================================="
+if [ "${#SELECTORS[@]}" -gt 0 ]; then
+    echo "SUMMARY: ${PASS_COUNT}/${RAN_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped (selectors: ${SELECTORS[*]}; wallclock ${TOTAL_ELAPSED}s)"
+else
+    echo "SUMMARY: ${PASS_COUNT}/${TOTAL} passed, ${FAIL_COUNT} failed (wallclock ${TOTAL_ELAPSED}s)"
+fi
+echo "==========================================================================="
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "Failed tests:"
+    for name in "${FAIL_NAMES[@]}"; do
+        echo "  - $name"
+    done
+fi
+if [ "${#SELECTORS[@]}" -gt 0 ] && [ "$RAN_COUNT" -eq 0 ]; then
+    echo "WARNING: selectors matched 0 tests (use --list to see all available test names)"
+fi
+
+exit "$FAIL_COUNT"

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/run_mega_tests.sh
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/run_mega_tests.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# Functional test harness for the MXFP8 distributed MegaMoE fused dispatch +
+# fc1/fc2 + combine runner.  M01 runs single-rank with MEGA_NO_DIST=1; other
+# cases run through torchrun using MEGA_NPROC/MEGA_NNODES overrides when present.
+#
+# MXFP8 tile constraints (apply to ALL tests below):
+#   * Only mma_tiler_mnk 256,256,128 with --use_2cta_instrs --cluster_shape_mnk
+#     2,1,1 is validated.  Specifically:
+#       - cluster_m=4 (cluster_shape_mnk 4,1,1) -> not supported
+#       - tile 256,256,256 (K=256)              -> not supported
+#       - tile_n=64 / 1-CTA tiles               -> not supported
+#   * hidden must be divisible by 256 (fc2 N tile)
+#   * intermediate must be divisible by 128 (fc2 K tile / fc1 N tile / 2)
+#   * e5m2 element format is currently broken (fc1 epilogue quant path raises
+#     "None to integer conversion"); all tests below use --kind mxfp8_e4m3
+#
+# Coverage dimensions mixed across the list below:
+#   balanced/power_law routing, static/atomic_counter scheduling, topk range,
+#   static/dynamic expert shape, and varied hidden/intermediate shapes (including wide
+#   intermediate and large DeepSeek-ish sizes).
+#
+# Usage:
+#   bash <abs path>/run_mega_tests.sh
+#   PYTHON=python3.11 bash .../run_mega_tests.sh
+#   MEGA_NPROC=4 bash .../run_mega_tests.sh
+#   bash .../run_mega_tests.sh --fail-fast
+#   bash .../run_mega_tests.sh --list
+#   bash .../run_mega_tests.sh --help
+#
+# Selective execution (positional args; substring match against test names,
+# OR-combined across multiple selectors):
+#   bash .../run_mega_tests.sh M01
+#   bash .../run_mega_tests.sh M01 M03 M12
+#   bash .../run_mega_tests.sh balanced --fail-fast
+#
+# Exit code: number of failed tests (0 = all pass).
+
+export PATH=/usr/bin:$PATH
+export LD=/usr/bin/ld
+export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
+export CUDAHOSTCXX=/usr/bin/g++
+export TRITON_CC=/usr/bin/gcc
+export CFLAGS="-B/usr/bin"
+export CXXFLAGS="-B/usr/bin"
+export LDFLAGS="-B/usr/bin -fuse-ld=bfd"
+
+set -u  # fail on undefined vars; do NOT set -e (continue on failures)
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+RUNNER="${SCRIPT_DIR}/mega_runner.py"
+PYTHON="${PYTHON:-python}"
+
+if [ ! -f "$RUNNER" ]; then
+    echo "ERROR: mega_runner.py not found at ${RUNNER}" >&2
+    exit 2
+fi
+
+# Resolve the multi-rank world size.  Order of precedence:
+#   1. MEGA_NPROC env override
+#   2. CUDA_VISIBLE_DEVICES list length
+#   3. nvidia-smi visible GPU count
+#   4. fallback to 2
+if [ -n "${MEGA_NPROC:-}" ]; then
+    NPROC="$MEGA_NPROC"
+elif [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "$CUDA_VISIBLE_DEVICES" != "NoDevFiles" ]; then
+    IFS=',' read -r -a _VISIBLE_DEVICES <<< "$CUDA_VISIBLE_DEVICES"
+    NPROC="${#_VISIBLE_DEVICES[@]}"
+elif command -v nvidia-smi >/dev/null 2>&1; then
+    NPROC=$(nvidia-smi --list-gpus 2>/dev/null | wc -l | tr -d '[:space:]')
+    if [ -z "$NPROC" ] || [ "$NPROC" -le 0 ]; then
+        NPROC=2
+    fi
+else
+    NPROC=2
+fi
+
+MEGA_NNODES="${MEGA_NNODES:-1}"
+MEGA_NODE_RANK="${MEGA_NODE_RANK:-0}"
+MEGA_MASTER_ADDR="${MEGA_MASTER_ADDR:-localhost}"
+MEGA_MASTER_PORT="${MEGA_MASTER_PORT:-29500}"
+WORLD_SIZE=$((NPROC * MEGA_NNODES))
+
+FAIL_FAST=0
+LIST_ONLY=0
+declare -a SELECTORS=()
+for arg in "$@"; do
+    case "$arg" in
+        --fail-fast)
+            FAIL_FAST=1
+            ;;
+        --list)
+            LIST_ONLY=1
+            ;;
+        -h|--help)
+            sed -n '2,/^# Exit code/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown flag: $arg (use --help)" >&2
+            exit 2
+            ;;
+        *)
+            SELECTORS+=("$arg")
+            ;;
+    esac
+done
+
+test_matches_selectors() {
+    local name="$1"
+    if [ "${#SELECTORS[@]}" -eq 0 ]; then
+        return 0
+    fi
+    local sel
+    for sel in "${SELECTORS[@]}"; do
+        if [[ "$name" == *"$sel"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Common MXFP8 tile args (the only supported config):
+#   --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs
+# All entries below include these explicitly for clarity.
+
+declare -a TESTS=(
+    # ── M01: single-rank sanity ──
+    "M01_single_balanced_topk2       | single | --kind mxfp8_e4m3 --num_tokens_per_rank 192  --num_topk 2  --num_total_experts 8   --hidden 1024 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --ref_compute_graph transformers"
+
+    # ── M02..M06: balanced routing, static expert shape ──
+    "M02_mr_balanced_topk2_tiny      | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 96   --num_topk 2  --num_total_experts 8   --hidden 1024 --intermediate 1024 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape"
+    "M03_mr_balanced_topk3_atomic    | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 256  --num_topk 3  --num_total_experts 24  --hidden 1536 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --load_balance_mode atomic_counter"
+    "M04_mr_balanced_topk5           | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 384  --num_topk 5  --num_total_experts 40  --hidden 1792 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape"
+    "M05_mr_balanced_topk7           | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 448  --num_topk 7  --num_total_experts 56  --hidden 2048 --intermediate 2304 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape"
+    "M06_mr_balanced_topk11          | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 880  --num_topk 11 --num_total_experts 88  --hidden 1792 --intermediate 3072 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape"
+
+    # ── M07..M09: power-law routing ──
+    "M07_mr_power_law_topk3          | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 320  --num_topk 3  --num_total_experts 24  --hidden 1536 --intermediate 1792 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --route_distribution power_law"
+    "M08_mr_power_law_topk7_atomic   | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 640  --num_topk 7  --num_total_experts 56  --hidden 1280 --intermediate 1920 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --route_distribution power_law --load_balance_mode atomic_counter --ref_compute_graph transformers"
+    "M09_mr_power_law_topk13         | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 832  --num_topk 13 --num_total_experts 104 --hidden 2560 --intermediate 4096 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --route_distribution power_law"
+
+    # ── M10..M11: large shapes ──
+    "M10_mr_large_topk5              | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 768  --num_topk 5  --num_total_experts 40  --hidden 2304 --intermediate 3456 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape"
+    "M11_mr_large_topk11_atomic      | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 1792 --num_topk 11 --num_total_experts 88  --hidden 2816 --intermediate 4096 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --load_balance_mode atomic_counter"
+
+    # ── M12..M14: atomic_counter focused ──
+    "M12_mr_atomic_balanced_topk3    | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 128  --num_topk 3  --num_total_experts 24  --hidden 1280 --intermediate 2432 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --load_balance_mode atomic_counter"
+    "M13_mr_atomic_pl_topk7         | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 512  --num_topk 7  --num_total_experts 56  --hidden 1792 --intermediate 1792 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --load_balance_mode atomic_counter --route_distribution power_law"
+    "M14_mr_atomic_topk5             | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 1152 --num_topk 5  --num_total_experts 40  --hidden 2816 --intermediate 3584 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --load_balance_mode atomic_counter"
+
+    # ── M15..M16: misc shape coverage ──
+    "M15_mr_balanced_wide_intermed   | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 64   --num_topk 3  --num_total_experts 24  --hidden 1792 --intermediate 4864 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --load_balance_mode atomic_counter --ref_compute_graph transformers"
+    "M16_mr_pl_topk13_large_atomic   | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 1280 --num_topk 13 --num_total_experts 104 --hidden 2816 --intermediate 4352 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --load_balance_mode atomic_counter --route_distribution power_law --ref_compute_graph transformers"
+
+    # ── M17..M18: dynamic expert shape (no --enable_static_expert_shape) ──
+    "M17_mr_dynshape_balanced_topk4  | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 384  --num_topk 4  --num_total_experts 32  --hidden 2048 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs"
+    "M18_mr_dynshape_pl_topk7        | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 576  --num_topk 7  --num_total_experts 64  --hidden 1536 --intermediate 2688 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --route_distribution power_law --load_balance_mode atomic_counter"
+
+    # ── GC01..GC03: generate_c — raw pre-SwiGLU fc1 accumulator output ──
+    # Token padding is bumped to 128 (cta_tile_m) for TMA alignment; these
+    # cases verify that physical row offsets are 128-aligned on every rank and
+    # that the stored gate+up values match the reference fc1 accumulator.
+    "GC01_single_generate_c          | single | --kind mxfp8_e4m3 --num_tokens_per_rank 192  --num_topk 2  --num_total_experts 8   --hidden 1024 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --generate_c"
+    "GC02_mr_balanced_generate_c     | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 256  --num_topk 3  --num_total_experts 24  --hidden 1536 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --load_balance_mode atomic_counter --generate_c"
+    "GC03_mr_power_law_generate_c    | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 320  --num_topk 3  --num_total_experts 24  --hidden 1536 --intermediate 1792 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --route_distribution power_law --generate_c"
+
+    # ── CM01..CM05: combine_format 32e4m3xe8m0 — fp8 e4m3+E8M0 quantized NVLink combine ──
+    # fc2 output is quantized to fp8 (e4m3) + per-32 E8M0 block scale before the
+    # NVLink combine; TopkReduce dequantizes and reduces to BF16 after the kernel.
+    # quantized combine_format is incompatible with --in_kernel_fc2_reduce (Form B).
+    "CM01_single_combine_mxfp8          | single | --kind mxfp8_e4m3 --num_tokens_per_rank 192  --num_topk 2  --num_total_experts 8   --hidden 1024 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --combine_format 32e4m3xe8m0"
+    "CM02_mr_balanced_topk2             | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 256  --num_topk 2  --num_total_experts 16  --hidden 1024 --intermediate 1024 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --combine_format 32e4m3xe8m0"
+    "CM03_mr_balanced_topk8             | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 512  --num_topk 8  --num_total_experts 64  --hidden 2048 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --combine_format 32e4m3xe8m0"
+    "CM04_mr_power_law_topk5            | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 320  --num_topk 5  --num_total_experts 40  --hidden 1280 --intermediate 1920 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --combine_format 32e4m3xe8m0 --route_distribution power_law"
+    "CM05_mr_atomic_topk6               | multi  | --kind mxfp8_e4m3 --num_tokens_per_rank 384  --num_topk 6  --num_total_experts 48  --hidden 1792 --intermediate 2304 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --combine_format 32e4m3xe8m0 --load_balance_mode atomic_counter"
+
+    # ── CM06..CM07: combine_format 32e5m2xe8m0 — fp8 e5m2+E8M0 quantized NVLink combine ──
+    # Same bandwidth saving as e4m3 but using the e5m2 element format (wider dynamic
+    # range, lower precision).  Uses --kind mxfp8_e5m2 so fc1/fc2 weights and
+    # activations are also e5m2; the combine wire format matches the compute dtype.
+    "CM06_single_combine_e5m2           | single | --kind mxfp8_e5m2 --num_tokens_per_rank 192  --num_topk 2  --num_total_experts 8   --hidden 1024 --intermediate 2048 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --combine_format 32e5m2xe8m0"
+    "CM07_mr_balanced_combine_e5m2      | multi  | --kind mxfp8_e5m2 --num_tokens_per_rank 256  --num_topk 4  --num_total_experts 32  --hidden 1024 --intermediate 1024 --mma_tiler_mnk 256,256,128 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --enable_static_expert_shape --combine_format 32e5m2xe8m0"
+)
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+declare -a FAIL_NAMES=()
+TOTAL=${#TESTS[@]}
+START_TIME=$SECONDS
+
+if [ "$LIST_ONLY" -eq 1 ]; then
+    for entry in "${TESTS[@]}"; do
+        name="${entry%%|*}"
+        name="${name%"${name##*[![:space:]]}"}"
+        if test_matches_selectors "$name"; then
+            echo "$name"
+        fi
+    done
+    exit 0
+fi
+
+echo "==========================================================================="
+echo "MegaMoE MXFP8 functional tests"
+echo "  RUNNER : ${RUNNER}"
+echo "  PYTHON : ${PYTHON}"
+echo "  NPROC  : ${NPROC}"
+echo "  NNODES : ${MEGA_NNODES}"
+echo "  WORLD  : ${WORLD_SIZE}"
+if [ "$MEGA_NNODES" -gt 1 ]; then
+    echo "  NODE   : rank ${MEGA_NODE_RANK}, master ${MEGA_MASTER_ADDR}:${MEGA_MASTER_PORT}"
+fi
+echo "  TOTAL  : ${TOTAL} tests"
+if [ "${#SELECTORS[@]}" -gt 0 ]; then
+    echo "  FILTER : ${SELECTORS[*]}"
+fi
+echo "==========================================================================="
+
+for entry in "${TESTS[@]}"; do
+    # Parse "name | mode | args".  Strip whitespace around each segment.
+    name="${entry%%|*}"
+    name="${name%"${name##*[![:space:]]}"}"
+    rest="${entry#*|}"
+    mode="${rest%%|*}"
+    mode="${mode#"${mode%%[![:space:]]*}"}"
+    mode="${mode%"${mode##*[![:space:]]}"}"
+    args="${rest#*|}"
+    args="${args#"${args%%[![:space:]]*}"}"
+
+    if ! test_matches_selectors "$name"; then
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        continue
+    fi
+
+    echo
+    echo "==========================================================================="
+    echo "[TEST] $name"
+    case "$mode" in
+        single)
+            echo "[CMD]  MEGA_NO_DIST=1 $PYTHON $RUNNER $args"
+            ;;
+        multi)
+            if [ "$MEGA_NNODES" -gt 1 ]; then
+                echo "[CMD]  torchrun --nnodes=$MEGA_NNODES --node_rank=$MEGA_NODE_RANK --nproc_per_node=$NPROC --master_addr=$MEGA_MASTER_ADDR --master_port=$MEGA_MASTER_PORT $RUNNER $args"
+            else
+                echo "[CMD]  torchrun --nproc_per_node=$NPROC $RUNNER $args"
+            fi
+            ;;
+        *)
+            echo "[ERROR] unknown launch mode '$mode' for test '$name'; skipping" >&2
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            FAIL_NAMES+=("$name (bad-mode)")
+            continue
+            ;;
+    esac
+    echo "==========================================================================="
+
+    test_start=$SECONDS
+    # shellcheck disable=SC2086  # intentional word-splitting on $args
+    case "$mode" in
+        single)
+            timeout 300 env MEGA_NO_DIST=1 "$PYTHON" "$RUNNER" $args
+            rc=$?
+            ;;
+        multi)
+            if [ "$MEGA_NNODES" -gt 1 ]; then
+                timeout 300 torchrun \
+                    --nnodes="$MEGA_NNODES" --node_rank="$MEGA_NODE_RANK" \
+                    --nproc_per_node="$NPROC" \
+                    --master_addr="$MEGA_MASTER_ADDR" --master_port="$MEGA_MASTER_PORT" \
+                    "$RUNNER" $args
+            else
+                timeout 300 torchrun --nproc_per_node="$NPROC" "$RUNNER" $args
+            fi
+            rc=$?
+            ;;
+    esac
+    if [ "$rc" -eq 124 ]; then
+        echo "[TIMEOUT] test exceeded 300s limit — killed"
+    fi
+    elapsed=$((SECONDS - test_start))
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[RESULT] PASS  (${elapsed}s) $name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "[RESULT] FAIL  (rc=${rc}, ${elapsed}s) $name"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAIL_NAMES+=("$name")
+        if [ "$FAIL_FAST" -eq 1 ]; then
+            echo "[--fail-fast] aborting after first failure"
+            break
+        fi
+    fi
+done
+
+TOTAL_ELAPSED=$((SECONDS - START_TIME))
+RAN_COUNT=$((PASS_COUNT + FAIL_COUNT))
+echo
+echo "==========================================================================="
+if [ "${#SELECTORS[@]}" -gt 0 ]; then
+    echo "SUMMARY: ${PASS_COUNT}/${RAN_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped (selectors: ${SELECTORS[*]}; wallclock ${TOTAL_ELAPSED}s)"
+else
+    echo "SUMMARY: ${PASS_COUNT}/${TOTAL} passed, ${FAIL_COUNT} failed (wallclock ${TOTAL_ELAPSED}s)"
+fi
+echo "==========================================================================="
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "Failed tests:"
+    for name in "${FAIL_NAMES[@]}"; do
+        echo "  - $name"
+    done
+fi
+if [ "${#SELECTORS[@]}" -gt 0 ] && [ "$RAN_COUNT" -eq 0 ]; then
+    echo "WARNING: selectors matched 0 tests (use --list to see all available test names)"
+fi
+
+exit "$FAIL_COUNT"

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/runner_common.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/runner_common.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Shared runner descriptors for the MXFP8 GLU fused fc1+fc2 path."""
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from moe_nvfp4_swapab.runner_fc12_common import ImplDesc
+
+
+@dataclass
+class TrainingImplDesc(ImplDesc):
+    """Kernel configuration for MXFP8 GLU training.
+
+    Extends :class:`ImplDesc` with the validated MXFP8 tile/cluster geometry
+    and training-oriented defaults.  ``generate_c`` defaults to ``True`` so the
+    kernel retains the pre-SwiGLU fc1 gate+up activations needed for backward.
+    """
+
+    mma_tiler_mnk: Tuple[int, int, int] = (256, 256, 128)
+    cluster_shape_mnk: Tuple[int, int, int] = (2, 1, 1)
+    use_2cta_instrs: bool = True
+    generate_c: bool = True
+    use_stg_fc1: bool = False
+    # Rank-level dispatch dedup: a token routed to multiple experts on the
+    # same destination rank crosses NVLink once (receiver fans out locally).
+    dedup_dispatch: bool = False
+    # Token-back REDG-adds rows straight into the source's 2D output
+    # (drops the (T, topk, hidden) staging plane and the TopkReduce launch).
+    combine_in_flight_reduce: bool = False
+    # Same-rank partial top-k sums fold into one anchor row locally before
+    # the push (combine crosses NVLink once per (token, source rank)).
+    # Requires dedup_dispatch and combine_in_flight_reduce.
+    combine_pre_reduce: bool = False
+
+    def __str__(self) -> str:
+        base = super().__str__().replace("ImplDesc:", "TrainingImplDesc:", 1)
+        return (
+            f"{base} generate_c={self.generate_c} "
+            f"use_stg_fc1={self.use_stg_fc1} "
+            f"dedup_dispatch={self.dedup_dispatch} "
+            f"combine_in_flight_reduce={self.combine_in_flight_reduce} "
+            f"combine_pre_reduce={self.combine_pre_reduce}"
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/runner_fc12.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_mxfp8_glu/runner_fc12.py
@@ -1,0 +1,433 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Host driver for the MegaMoE MXFP8 GLU fused fc1+fc2 kernel.
+"""
+
+
+import argparse
+import os
+import sys
+from typing import List, Optional, Tuple
+
+import torch
+
+## TODO: currently some common modules are located in moe_nvfp4_swapab,
+## which will be moved to common package later. These paths dependency
+## could be removed once the modules are moved.
+_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+_PARENT_DIR = os.path.dirname(_PKG_DIR)
+_NVFP4_DIR = os.path.join(_PARENT_DIR, "moe_nvfp4_swapab")
+for _p in (_PARENT_DIR, _NVFP4_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from moe_nvfp4_swapab.runner_fc12_common import (
+    ProblemDesc,
+    MiscDesc,
+    Fc12TesterBase,
+    add_common_fc12_arguments,
+    parse_tuple,
+)
+from moe_mxfp8_glu.runner_common import TrainingImplDesc
+from moe_nvfp4_swapab.runner_common import (
+    from_blocked,
+    dequant_block_scale_to_fp32,
+)
+from common.host_utils import (
+    kind_data_dtype,
+    kind_sf_vec_size,
+    mxfp8_quantize_per_block_32,
+)
+
+
+# =============================================================================
+# MXFP8 tester
+# =============================================================================
+
+
+class SwigluMxfp8Fc12Tester(Fc12TesterBase):
+    """MXFP8 host-side input/reference/launch/validation driver."""
+
+    def __init__(
+        self,
+        problem: ProblemDesc,
+        impl: TrainingImplDesc,
+        misc: MiscDesc,
+    ) -> None:
+        super().__init__(problem, impl, misc)
+        # MXFP8 currently only supports the (M=256, N=256) mma tile with
+        # 2-CTA instructions.
+        m, n, _k = impl.mma_tiler_mnk
+        if (m, n) != (256, 256) or not impl.use_2cta_instrs:
+            raise ValueError(
+                "MXFP8 fused fc12 currently only supports mma_tiler (M, N) = "
+                "(256, 256) with use_2cta_instrs=True (the only validated "
+                f"config); got mma_tiler_mnk={impl.mma_tiler_mnk}, "
+                f"use_2cta_instrs={impl.use_2cta_instrs}."
+            )
+
+    @property
+    def _epilogue_token_tile(self) -> int:
+        # generate_c stores a (cta_tile_m=128)-row TMA tile, so physical row
+        # offsets must be 128-aligned.  Override to 128 when generate_c=True so
+        # the scheduler uses 128-aligned data_physical_offsets for all tensors.
+        if self.impl.generate_c:
+            return 128
+        from moe_nvfp4_swapab.epilogue import EpilogueTokenTile
+        return EpilogueTokenTile
+
+    # ------------------------------------------------------------------
+    # FP8 tensor creation
+    # ------------------------------------------------------------------
+
+    def _create_fp8_tensor(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Create an FP8 (e4m3 / e5m2) tensor.
+
+        Two modes (selected by ``misc.perf_run``):
+          - correctness: sparse {0, +1, -1} (80 % zeros / 10 % +1 / 10 % -1).
+          - perf: random finite fp8 bytes (timing only); ``randint`` skips
+            dtype-specific NaN/Inf encodings (e4m3: 0x7F/0xFF;
+            e5m2: 0x7C-0x7F / 0xFC-0xFF).
+        """
+        if self.misc.perf_run:
+            n = 1
+            for s in shape:
+                n *= s
+            if dtype == torch.float8_e4m3fn:
+                idx = torch.randint(0, 254, (n,), device="cuda")
+                flat_bytes = torch.where(idx < 127, idx, idx + 1).to(torch.uint8)
+            elif dtype == torch.float8_e5m2:
+                idx = torch.randint(0, 248, (n,), device="cuda")
+                flat_bytes = torch.where(idx < 124, idx, idx + 4).to(torch.uint8)
+            else:
+                raise ValueError(f"Unsupported fp8 dtype: {dtype}")
+            return flat_bytes.view(dtype).reshape(shape)
+        fp32 = torch.zeros(shape, dtype=torch.float32, device="cuda")
+        rand = torch.rand(shape, device="cuda")
+        fp32[rand < 0.10] = 1.0
+        fp32[(rand >= 0.10) & (rand < 0.20)] = -1.0
+        return fp32.to(dtype)
+
+    # ------------------------------------------------------------------
+    # Kind hooks: input / output tensor creation
+    # ------------------------------------------------------------------
+
+    def _fc2_output_shape(self, data_total_rows: int) -> Tuple[int, ...]:
+        # MXFP8: 2D (token_max, hidden) -- epilogue_mxfp8.py uses shape[1].
+        return (data_total_rows, self.problem.hidden)
+
+    def _create_input_data_tensors(self, data_total_rows: int) -> None:
+        problem = self.problem
+        hidden = problem.hidden
+        intermediate = problem.intermediate
+        experts = problem.experts
+        data_dtype = kind_data_dtype(problem.kind)
+
+        # -- activation: (data_total_rows, hidden) fp8, hidden stride-1 --
+        self.activation = self._create_fp8_tensor(
+            (data_total_rows, hidden), data_dtype
+        )
+
+        # -- fc1_weight: (experts, intermediate, hidden) -> permute ->
+        #    (experts, hidden, intermediate), hidden stride-1 --
+        self.fc1_weight = self._create_fp8_tensor(
+            (experts, intermediate, hidden), data_dtype
+        ).permute(0, 2, 1)
+
+        # -- fc2_weight: (experts, hidden, inter//2) -> permute ->
+        #    (experts, inter//2, hidden), inter//2 stride-1 --
+        self.fc2_weight = self._create_fp8_tensor(
+            (experts, hidden, intermediate // 2), data_dtype
+        ).permute(0, 2, 1)
+
+    def _init_topk_scores(self, data_total_rows: int) -> None:
+        """MXFP8 fc12 does not apply topk weighting; use 1.0 on valid rows."""
+        valid_tokens = self.valid_tokens_per_expert
+        data_offsets = self.data_physical_offsets
+        self.topk_scores = torch.zeros(
+            (data_total_rows,), dtype=torch.float32, device="cuda",
+        )
+        for e in range(self.problem.experts):
+            v_e = valid_tokens[e]
+            if v_e == 0:
+                continue
+            phys = data_offsets[e]
+            self.topk_scores[phys : phys + v_e] = 1.0
+
+    def _alloc_fc2_output(self, data_total_rows: int) -> None:
+        # 0xFF byte fill: bf16/fp16 0xFFFF = NaN -- kernel output overwriting
+        # valid rows is easy to distinguish from "kernel never touched this
+        # row".  MXFP8 stores a flat 2D ``(token_max, hidden)`` output.
+        problem = self.problem
+        hidden = problem.hidden
+        fc2_output_bytes = torch.full(
+            (data_total_rows, hidden * problem.fc2_output_dtype.itemsize),
+            0xFF,
+            dtype=torch.uint8, device="cuda",
+        )
+        self.fc2_output = fc2_output_bytes.view(problem.fc2_output_dtype).reshape(
+            data_total_rows, hidden
+        )
+
+    # ------------------------------------------------------------------
+    # Kind hooks: reference compute
+    # ------------------------------------------------------------------
+
+    def _quantize_fc1(
+        self, swiglu: torch.Tensor, norm_const_val: float
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        data_dtype = kind_data_dtype(self.problem.kind)
+        return mxfp8_quantize_per_block_32(swiglu, data_dtype)
+
+    # ------------------------------------------------------------------
+    # Kind hooks: kernel + validation
+    # ------------------------------------------------------------------
+
+    def _instantiate_kernel(self, common_kwargs: dict):
+        import cutlass
+        from moe_mxfp8_glu.kernel_mxfp8_glu_fc12 import Sm100SwigluMxfp8Fc12Kernel
+
+        _kind_to_cutlass_dtype = {
+            "mxfp8_e4m3": cutlass.Float8E4M3FN,
+            "mxfp8_e5m2": cutlass.Float8E5M2,
+        }
+        kernel = Sm100SwigluMxfp8Fc12Kernel(
+            **common_kwargs,
+            ab_dtype=_kind_to_cutlass_dtype[self.problem.kind],
+            gate_up_clamp=self.problem.gate_up_clamp,
+            generate_c=self.impl.generate_c,
+            use_stg_fc1=self.impl.use_stg_fc1,
+        )
+        self._kernel_c_dtype = kernel.c_dtype
+        return kernel
+
+    def _extra_runtime_kwargs(self) -> dict:
+        if not self.impl.generate_c:
+            return {}
+        import cutlass
+        import cutlass.torch as cutlass_torch
+
+        _cutlass_to_torch = {
+            cutlass.BFloat16: torch.bfloat16,
+            cutlass.Float32: torch.float32,
+            cutlass.Float16: torch.float16,
+        }
+        torch_c_dtype = _cutlass_to_torch[self._kernel_c_dtype]
+        tokens_total = self.fc2_output.shape[0]
+        intermediate_gateup = self.problem.intermediate
+        self._c_output = torch.zeros(
+            (tokens_total, intermediate_gateup), dtype=torch_c_dtype, device="cuda"
+        )
+        c_cute = cutlass_torch.from_dlpack(self._c_output, assumed_align=16)
+        leading_dim = cutlass_torch.get_leading_dim(self._c_output)
+        c_cute = c_cute.mark_layout_dynamic(leading_dim=leading_dim)
+        return {"fc1_c": c_cute}
+
+    def _fc2_tolerance(self) -> Tuple[float, float]:
+        # BF16 output: minimum representable relative error = 1/128 ≈ 0.78%
+        # (1 BF16 ULP at any value v is v/128, which always exceeds
+        # rtol=1e-5 × v regardless of magnitude).  With {0.5, 1.0} input
+        # scales the fc2 output reaches ±3K; at that scale 1 BF16 ULP = 8
+        # while 1e-5 × 3K = 0.03 — a 267× gap.  1e-2 covers 1 BF16 ULP
+        # at all magnitudes (1/128 ≈ 0.78% < 1%) without masking real bugs
+        # (genuine GEMM errors are O(1) relative, not 0.78%).
+        return 1e-5, 1e-2
+
+    def _validate_fc1_phase(self) -> None:
+        """Compare kernel-written fc1 workspace to reference per expert.
+
+        Uses ``compare_and_report_mismatches`` rather than the NVFP4 detail
+        loop (the fp4 nibble decode in that loop is meaningless for fp8).
+        """
+        if (
+            self._ws_fc1_output_torch is None
+            or self._ws_fc1_output_sf_torch is None
+            or not self._ref_fc1_q_per_expert
+        ):
+            print("[fc1 phase ablation] skipped (workspace or ref not populated)")
+            return
+
+        from common.host_utils import compare_and_report_mismatches
+
+        sf_vec_size = kind_sf_vec_size(self.problem.kind)
+        K_sf = (self.problem.intermediate // 2) // sf_vec_size
+        valid = self.valid_tokens_per_expert
+        doff = self.data_physical_offsets
+        soff = self.sf_physical_offsets
+
+        print("\n" + "=" * 60)
+        print("[DEBUG fc1] compare_and_report_mismatches per expert:")
+        for e in range(self.problem.experts):
+            v_e = valid[e]
+            ref_q = self._ref_fc1_q_per_expert[e]
+            ref_sf = self._ref_fc1_raw_sf_per_expert[e]
+            if v_e == 0 or ref_q is None or ref_sf is None:
+                continue
+            kq = self._ws_fc1_output_torch[doff[e] : doff[e] + v_e]
+            ksf_sw = self._ws_fc1_output_sf_torch[soff[e] : soff[e + 1]]
+            ksf = from_blocked(ksf_sw.contiguous().view(-1), v_e, K_sf)
+            kfp32 = dequant_block_scale_to_fp32(kq, ksf, sf_vec_size, None)
+            ref_fp32 = dequant_block_scale_to_fp32(ref_q, ref_sf, sf_vec_size, None)
+            ### TODO: replace to silent check when kernel stable.
+            compare_and_report_mismatches(
+                kfp32.cpu(),
+                ref_fp32.cpu(),
+                name=f"fc1_expert{e}",
+                atol=5e-2, rtol=5e-2, max_mismatches=5,
+            )
+        print("=" * 60)
+
+    def validate(self) -> None:
+        super().validate()
+        self._validate_c_output()
+
+    def _validate_c_output(self) -> None:
+        """Per-element comparison of kernel C output vs reference fc1 gate+up."""
+        if not self.impl.generate_c:
+            return
+        c = getattr(self, "_c_output", None)
+        if c is None:
+            print("[generate_c] c_output not allocated — skipped.")
+            return
+        if not self._ref_fc1_gateup_per_expert:
+            print("[generate_c] reference fc1 gate+up not available — skipped.")
+            return
+
+        from common.host_utils import compare_and_report_mismatches
+
+        valid = self.valid_tokens_per_expert
+        doff = self.data_physical_offsets
+
+        print("\n" + "=" * 60)
+        print("[generate_c] kernel c_output vs reference fc1 gate+up (per-element):")
+        any_checked = False
+        for e in range(self.problem.experts):
+            v_e = valid[e]
+            ref = self._ref_fc1_gateup_per_expert[e]
+            if v_e == 0 or ref is None:
+                continue
+            any_checked = True
+            kernel_c = c[doff[e] : doff[e] + v_e].float().cpu()
+            ref_c = ref.float().cpu()
+            compare_and_report_mismatches(
+                kernel_c, ref_c,
+                name=f"c_output_expert{e}",
+                atol=1e-5, rtol=1e-2, max_mismatches=5,
+            )
+        if not any_checked:
+            print("  (no valid tokens routed to any expert)")
+        print("=" * 60)
+
+
+# =============================================================================
+# CLI entry point
+# =============================================================================
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """argparse setup for the MXFP8 fused fc12 path."""
+    parser = argparse.ArgumentParser(
+        description="MoE MXFP8 GLU fused fc1+fc2 SwiGLU (host-ready harness)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    add_common_fc12_arguments(parser)
+
+    # -- MXFP8-only Problem --
+    parser.add_argument(
+        "--kind", type=str, default="mxfp8_e4m3",
+        choices=["mxfp8_e4m3", "mxfp8_e5m2"],
+        help="MXFP8 element format: mxfp8_e4m3 (default) or mxfp8_e5m2.",
+    )
+    parser.add_argument(
+        "--flag_batch", type=int, default=1,
+        help="dispatch_pull release-flag batch size; 1 == per-token "
+        "baseline, larger amortizes the device fence over more tokens.",
+    )
+    parser.add_argument(
+        "--token_back_mode", type=str, default="epi_warps",
+        choices=["epi_warps", "standalone_warps", "reuse_dispatch_warps"],
+        help="Where the cross-rank fc2 push-back runs: epi_warps (epilogue "
+             "STG redirect, default), standalone_warps (dedicated warps 12-15), "
+             "or reuse_dispatch_warps (dispatch warps 8-11).",
+    )
+    parser.add_argument(
+        "--epi_flag_batch", type=str, default="1,1",
+        help="Done-counter publish batching as 'fc1,fc2' (e.g. '2,4'). "
+             "Each component must be in [1, 32].",
+    )
+    parser.add_argument(
+        "--gate_up_clamp", type=float, default=None,
+        help="DeepSeek-V4 swiglu_limit: clamp gate/up pre-activations before SiLU.",
+    )
+    parser.add_argument(
+        "--generate_c", action="store_true", default=False,
+        help="Save raw fc1 accumulator (gate+up, Float32) to a separate C tensor "
+             "before SwiGLU.  Allocates extra SMEM; reduces AB pipeline stages.",
+    )
+    parser.add_argument(
+        "--use_stg_fc1", action="store_true", default=False,
+        help="Write fc1 FP8 output directly to GMEM via STG.256 (RMEM→GMEM) "
+             "instead of the default R2S+TMA path.  Eliminates sD SMEM staging "
+             "(saves 16 KB); may increase AB pipeline stages.",
+    )
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    problem = ProblemDesc(
+        tokens_after_topk=args.tokens_after_topk,
+        experts=args.experts,
+        balance_route=args.balance_route,
+        hidden=args.hidden,
+        intermediate=args.intermediate,
+        simulate_ep=args.simulate_ep,
+        fc2_output_dtype=args.fc2_output_dtype,
+        kind=args.kind,
+        gate_up_clamp=args.gate_up_clamp,
+    )
+
+    impl = TrainingImplDesc(
+        mma_tiler_mnk=parse_tuple(args.mma_tiler_mnk),
+        cluster_shape_mnk=parse_tuple(args.cluster_shape_mnk),
+        use_2cta_instrs=args.use_2cta_instrs,
+        enable_static_expert_shape=args.enable_static_expert_shape,
+        force_static_sched=not args.dynamic_sched,
+        clc_bundle_size=args.clc_bundle_size,
+        num_sched_stages=args.num_sched_stages,
+        load_balance_mode=args.load_balance_mode,
+        group_hint=args.group_hint,
+        flag_batch=args.flag_batch,
+        token_back_mode=args.token_back_mode,
+        epi_flag_batch=parse_tuple(args.epi_flag_batch),
+        generate_c=args.generate_c,
+        use_stg_fc1=args.use_stg_fc1,
+    )
+
+    misc = MiscDesc(
+        perf_run=args.perf_run,
+        skip_ref_check=args.skip_ref_check,
+        run_target_kernel_only=args.run_target_kernel_only,
+        enable_debug_checks=args.enable_debug_checks,
+        ref_compute_graph=args.ref_compute_graph,
+        enable_iket=args.enable_iket,
+        seed=args.seed,
+        verbose=args.verbose,
+    )
+
+    tester = SwigluMxfp8Fc12Tester(problem, impl, misc)
+    tester.run()
+
+
+if __name__ == "__main__":
+    main()
+    exit(0)

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/__init__.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/__init__.py
@@ -1,0 +1,1 @@
+"""MegaMoE NVFP4 swap-AB fused fc1+fc2 kernel package."""

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/benchmark_p2p.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/benchmark_p2p.py
@@ -1,0 +1,742 @@
+#!/usr/bin/env python3
+# pyright: reportMissingImports=false
+"""Single-file two-GPU raw UBLKCP P2P bandwidth benchmark.
+
+This script intentionally does not import any local project modules.  It uses
+PyTorch for allocation/timing, cuda-python for peer access, and CuTeDSL for the
+small inline-PTX kernel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Literal
+
+import torch
+
+import cutlass
+import cutlass.cute as cute
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.runtime import from_dlpack, make_ptr
+from cutlass.cutlass_dsl import Int32, Int64, T, Uint8, dsl_user_op
+
+
+Mode = Literal["pull", "push"]
+
+DEFAULT_BUFFER_MIB = 300
+DEFAULT_WARMUPS = 2
+DEFAULT_REPEATS = 5
+NUM_WARPS = 4
+THREADS_PER_CTA = NUM_WARPS * 32
+TMA_CACHE_HINT_EVICT_NORMAL = 0x1000000000000000
+TMA_CACHE_HINT_EVICT_FIRST = 0x12F0000000000000
+
+
+@dsl_user_op
+def ublkcp_pull_raw(dst_smem, src_gmem_addr: Int64, mbar_smem, num_bytes: Int32, *, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [
+            dst_smem.toint(loc=loc, ip=ip).ir_value(),
+            src_gmem_addr.ir_value(),
+            num_bytes.ir_value(),
+            mbar_smem.toint(loc=loc, ip=ip).ir_value(),
+            Int64(TMA_CACHE_HINT_EVICT_FIRST).ir_value(),
+        ],
+        "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint "
+        "[$0], [$1], $2, [$3], $4;",
+        "r,l,r,r,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def ublkcp_push_raw(dst_gmem_addr: Int64, src_smem, num_bytes: Int32, *, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [
+            dst_gmem_addr.ir_value(),
+            src_smem.toint(loc=loc, ip=ip).ir_value(),
+            num_bytes.ir_value(),
+            Int64(TMA_CACHE_HINT_EVICT_NORMAL).ir_value(),
+        ],
+        "cp.async.bulk.global.shared::cta.bulk_group.L2::cache_hint "
+        "[$0], [$1], $2, $3;",
+        "l,r,r,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def ld_shared_u32(smem_ptr, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_ptr.toint(loc=loc, ip=ip).ir_value()],
+            "ld.shared.u32 $0, [$1];",
+            "=r,r",
+            has_side_effects=False,
+            asm_dialect=0,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def read_clock64(*, loc=None, ip=None) -> Int64:
+    return Int64(
+        llvm.inline_asm(
+            T.i64(),
+            [],
+            "mov.u64 $0, %clock64;",
+            "=l",
+            has_side_effects=True,
+            asm_dialect=0,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.kernel
+def ublkcp_bench_kernel(
+    local_sink: cute.Tensor,
+    clock_stats: cute.Tensor,
+    remote_base_ptr: cute.Pointer,
+    base_offset: Int32,
+    iters: Int32,
+    mode: cutlass.Constexpr[str],
+    pull_clock_stats: cutlass.Constexpr[bool],
+    push_clock_stats: cutlass.Constexpr[bool],
+    x_ctas: cutlass.Constexpr[int],
+    y_copy_per_iter: cutlass.Constexpr[int],
+    z_bytes_per_inst: cutlass.Constexpr[int],
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    warp_idx = cute.arch.make_warp_uniform(tidx // Int32(32))
+    lane_idx = cute.arch.lane_idx()
+
+    smem = cutlass.utils.SmemAllocator()
+    pull_mbar = smem.allocate_array(Int64, NUM_WARPS)
+    payload = smem.allocate_array(Uint8, NUM_WARPS * y_copy_per_iter * z_bytes_per_inst)
+
+    if cutlass.const_expr(mode == "pull"):
+        if lane_idx == Int32(0):
+            cute.arch.mbarrier_init(pull_mbar + warp_idx, 1)
+        cute.arch.sync_warp()
+
+    remote_base_addr = remote_base_ptr.toint()
+    clock_min_cycles = Int64(0x7FFFFFFFFFFFFFFF)
+    clock_max_cycles = Int64(0)
+    phase = Int32(0)
+    iter_idx = Int32(0)
+    while iter_idx < iters:
+        iter_t0 = Int64(0)
+        if cutlass.const_expr(
+            (mode == "push" and push_clock_stats)
+            or (mode == "pull" and pull_clock_stats)
+        ):
+            if lane_idx == Int32(0):
+                iter_t0 = read_clock64()
+
+        for u in cutlass.range_constexpr(0, y_copy_per_iter, 1):
+            copy_linear = (
+                (
+                    (Int64(iter_idx) * Int64(x_ctas) + Int64(bidx))
+                    * Int64(NUM_WARPS)
+                    + Int64(warp_idx)
+                )
+                * Int64(y_copy_per_iter)
+                + Int64(u)
+            )
+            remote_addr = (
+                remote_base_addr
+                + Int64(base_offset)
+                + copy_linear * Int64(z_bytes_per_inst)
+            )
+            smem_off = (warp_idx * Int32(y_copy_per_iter) + Int32(u)) * Int32(
+                z_bytes_per_inst
+            )
+            smem_ptr = payload + smem_off
+            with cute.arch.elect_one():
+                if cutlass.const_expr(mode == "pull"):
+                    ublkcp_pull_raw(
+                        smem_ptr,
+                        remote_addr,
+                        pull_mbar + warp_idx,
+                        Int32(z_bytes_per_inst),
+                    )
+                else:
+                    ublkcp_push_raw(remote_addr, smem_ptr, Int32(z_bytes_per_inst))
+
+        if cutlass.const_expr(mode == "pull"):
+            if lane_idx == Int32(0):
+                cute.arch.mbarrier_arrive_and_expect_tx(
+                    pull_mbar + warp_idx,
+                    Int32(y_copy_per_iter * z_bytes_per_inst),
+                )
+                cute.arch.mbarrier_wait(pull_mbar + warp_idx, phase)
+                if cutlass.const_expr(pull_clock_stats):
+                    pull_delta = read_clock64() - iter_t0
+                    clock_min_cycles = cutlass.min(clock_min_cycles, pull_delta)
+                    clock_max_cycles = cutlass.max(clock_max_cycles, pull_delta)
+                sample = ld_shared_u32(
+                    payload + warp_idx * Int32(y_copy_per_iter * z_bytes_per_inst)
+                )
+                sink_idx = (
+                    (iter_idx * Int32(x_ctas) + Int32(bidx)) * Int32(NUM_WARPS)
+                    + warp_idx
+                )
+                local_sink[sink_idx] = sample
+        else:
+            if lane_idx == Int32(0):
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0)
+                if cutlass.const_expr(push_clock_stats):
+                    push_delta = read_clock64() - iter_t0
+                    clock_min_cycles = cutlass.min(clock_min_cycles, push_delta)
+                    clock_max_cycles = cutlass.max(clock_max_cycles, push_delta)
+        cute.arch.sync_warp()
+
+        if cutlass.const_expr(mode == "pull"):
+            phase = phase ^ Int32(1)
+        iter_idx = iter_idx + Int32(1)
+
+    if cutlass.const_expr(
+        (mode == "push" and push_clock_stats)
+        or (mode == "pull" and pull_clock_stats)
+    ):
+        if lane_idx == Int32(0):
+            stats_base = (Int32(bidx) * Int32(NUM_WARPS) + warp_idx) * Int32(2)
+            clock_stats[stats_base] = clock_min_cycles
+            clock_stats[stats_base + Int32(1)] = clock_max_cycles
+
+    if cutlass.const_expr(mode == "push"):
+        if tidx == Int32(0):
+            cute.arch.fence_acq_rel_sys()
+
+
+@cute.jit
+def launch_ublkcp_bench(
+    local_sink: cute.Tensor,
+    clock_stats: cute.Tensor,
+    remote_base_ptr: cute.Pointer,
+    base_offset: Int32,
+    iters: Int32,
+    mode: cutlass.Constexpr[str],
+    pull_clock_stats: cutlass.Constexpr[bool],
+    push_clock_stats: cutlass.Constexpr[bool],
+    x_ctas: cutlass.Constexpr[int],
+    y_copy_per_iter: cutlass.Constexpr[int],
+    z_bytes_per_inst: cutlass.Constexpr[int],
+):
+    ublkcp_bench_kernel(
+        local_sink,
+        clock_stats,
+        remote_base_ptr,
+        base_offset,
+        iters,
+        mode,
+        pull_clock_stats,
+        push_clock_stats,
+        x_ctas,
+        y_copy_per_iter,
+        z_bytes_per_inst,
+    ).launch(grid=[x_ctas, 1, 1], block=[THREADS_PER_CTA, 1, 1])
+
+
+@dataclass(frozen=True)
+class BenchConfig:
+    mode: Mode
+    x_ctas: int
+    y_copy_per_iter: int
+    z_bytes_per_inst: int
+    w_comm_mbytes: int
+    pull_clock_stats: bool
+    push_clock_stats: bool
+
+
+@dataclass
+class BenchResult:
+    mode: Mode
+    x_ctas: int
+    y_copy_per_iter: int
+    z_bytes_per_inst: int
+    w_comm_mbytes: int
+    iters: int
+    requested_bytes: int
+    actual_bytes: int
+    ms_min: float
+    ms_median: float
+    ms_mean: float
+    gbps_min_time: float
+    gbps_median_time: float
+    request_128b_count: int
+    request_128b_ns_min_time: float
+    request_128b_ns_median_time: float
+    shared_bytes_per_cta: int
+    buffer_mib: int
+    skipped: str = ""
+
+
+def parse_int_list(text: str) -> list[int]:
+    values = []
+    for part in text.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        values.append(int(part))
+    if not values:
+        raise ValueError(f"empty integer list: {text!r}")
+    return values
+
+
+def default_x_ctas(sm_count: int) -> str:
+    candidates = [1, 2, 4, 8, 16, 32, 64, 96, 128, sm_count]
+    values = []
+    for value in candidates:
+        if value <= sm_count and value not in values:
+            values.append(value)
+    return ",".join(str(v) for v in values)
+
+
+def mib_to_bytes(value: int) -> int:
+    return value * 1024 * 1024
+
+
+def round_up(value: int, alignment: int) -> int:
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def import_cudart():
+    try:
+        from cuda.bindings import runtime as cudart  # type: ignore
+
+        return cudart
+    except Exception:
+        from cuda import cudart  # type: ignore
+
+        return cudart
+
+
+def check_cuda_error(cudart, result, what: str):
+    err = result[0] if isinstance(result, tuple) else result
+    success = cudart.cudaError_t.cudaSuccess
+    if err != success:
+        raise RuntimeError(f"{what} failed: {err}")
+    return result[1:] if isinstance(result, tuple) else ()
+
+
+def enable_peer_access_0_to_1() -> None:
+    cudart = import_cudart()
+    check_cuda_error(cudart, cudart.cudaSetDevice(0), "cudaSetDevice(0)")
+    can_access = check_cuda_error(
+        cudart,
+        cudart.cudaDeviceCanAccessPeer(0, 1),
+        "cudaDeviceCanAccessPeer(0, 1)",
+    )[0]
+    if int(can_access) == 0:
+        raise RuntimeError("device 0 cannot access peer device 1")
+
+    result = cudart.cudaDeviceEnablePeerAccess(1, 0)
+    err = result[0] if isinstance(result, tuple) else result
+    already = getattr(cudart.cudaError_t, "cudaErrorPeerAccessAlreadyEnabled", None)
+    if err != cudart.cudaError_t.cudaSuccess and err != already:
+        raise RuntimeError(f"cudaDeviceEnablePeerAccess(1) failed: {err}")
+
+
+def pointer_owner_device(ptr: int) -> int | None:
+    cudart = import_cudart()
+    result = cudart.cudaPointerGetAttributes(ptr)
+    try:
+        attrs = check_cuda_error(cudart, result, "cudaPointerGetAttributes")[0]
+    except Exception:
+        return None
+    return getattr(attrs, "device", None)
+
+
+def smem_capacity_bytes() -> int:
+    major, minor = torch.cuda.get_device_capability(0)
+    arch = f"sm_{major}{minor}"
+    try:
+        return int(cutlass.utils.get_smem_capacity_in_bytes(arch))
+    except Exception:
+        if major >= 10:
+            return 227 * 1024
+        return 99 * 1024
+
+
+def validate_environment() -> int:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available")
+    if torch.cuda.device_count() != 2:
+        raise RuntimeError(
+            f"this benchmark requires exactly 2 CUDA devices, got {torch.cuda.device_count()}"
+        )
+    major, _minor = torch.cuda.get_device_capability(0)
+    if major < 10:
+        raise RuntimeError("UBLKCP benchmark expects a Blackwell-class GPU (sm_100+)")
+    sm_count = torch.cuda.get_device_properties(0).multi_processor_count
+    enable_peer_access_0_to_1()
+    return sm_count
+
+
+def make_arg_parser(sm_count: int) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--x_ctas", default=default_x_ctas(sm_count))
+    parser.add_argument("--y_copy_per_iter", default="1,2,4,8")
+    parser.add_argument("--z_bytes_per_inst", default="128,256,512,1024,2048")
+    parser.add_argument("--w_comm_mbytes", default="256")
+    parser.add_argument("--mode", choices=("pull", "push", "all"), default="all")
+    parser.add_argument(
+        "--pull_clock_stats",
+        action="store_true",
+        help=(
+            "For pull, record per-warp min/max cycles from issuing the first "
+            "UBLKCP.S.G in an iter to mbarrier_wait completion."
+        ),
+    )
+    parser.add_argument(
+        "--push_clock_stats",
+        action="store_true",
+        help=(
+            "For push, record per-warp min/max cycles from issuing the first "
+            "UBLKCP.G.S in an iter to cp_async_bulk_wait_group(0)."
+        ),
+    )
+    parser.add_argument("--csv", default=None, help="Optional CSV output path.")
+    return parser
+
+
+def iter_configs(args: argparse.Namespace) -> Iterable[BenchConfig]:
+    modes: list[Mode] = ["pull", "push"] if args.mode == "all" else [args.mode]
+    for mode in modes:
+        for x in parse_int_list(args.x_ctas):
+            for y in parse_int_list(args.y_copy_per_iter):
+                for z in parse_int_list(args.z_bytes_per_inst):
+                    for w in parse_int_list(args.w_comm_mbytes):
+                        yield BenchConfig(
+                            mode,
+                            x,
+                            y,
+                            z,
+                            w,
+                            args.pull_clock_stats,
+                            args.push_clock_stats,
+                        )
+
+
+def compile_config(config: BenchConfig, local_sink, clock_stats, remote_base_ptr, iters: int):
+    @cute.jit
+    def launcher(
+        local_sink: cute.Tensor,
+        clock_stats: cute.Tensor,
+        remote_base_ptr: cute.Pointer,
+        base_offset: Int32,
+    ):
+        launch_ublkcp_bench(
+            local_sink,
+            clock_stats,
+            remote_base_ptr,
+            base_offset,
+            iters,
+            config.mode,
+            config.pull_clock_stats,
+            config.push_clock_stats,
+            config.x_ctas,
+            config.y_copy_per_iter,
+            config.z_bytes_per_inst,
+        )
+
+    return cute.compile(
+        launcher,
+        local_sink,
+        clock_stats,
+        remote_base_ptr,
+        0,
+    )
+
+
+def run_one_config(
+    config: BenchConfig,
+    sm_count: int,
+    smem_capacity: int,
+    remote_buf: torch.Tensor,
+) -> BenchResult:
+    if config.x_ctas <= 0 or config.x_ctas > sm_count:
+        return skipped_result(config, f"x_ctas must be in [1, {sm_count}]")
+    if config.y_copy_per_iter <= 0:
+        return skipped_result(config, "y_copy_per_iter must be positive")
+    if config.z_bytes_per_inst <= 0 or config.z_bytes_per_inst % 128 != 0:
+        return skipped_result(config, "z_bytes_per_inst must be a positive multiple of 128")
+    if config.w_comm_mbytes <= 0:
+        return skipped_result(config, "w_comm_mbytes must be positive")
+
+    bytes_per_iter = (
+        config.x_ctas
+        * NUM_WARPS
+        * config.y_copy_per_iter
+        * config.z_bytes_per_inst
+    )
+    requested_bytes = mib_to_bytes(config.w_comm_mbytes)
+    iters = max(1, math.ceil(requested_bytes / bytes_per_iter))
+    actual_bytes = iters * bytes_per_iter
+    shared_bytes = NUM_WARPS * config.y_copy_per_iter * config.z_bytes_per_inst
+    shared_bytes_with_mbar = round_up(NUM_WARPS * 8, 16) + shared_bytes
+    if shared_bytes_with_mbar > smem_capacity:
+        return skipped_result(
+            config,
+            f"shared memory required {shared_bytes_with_mbar} B > capacity {smem_capacity} B",
+            iters=iters,
+            requested_bytes=requested_bytes,
+            actual_bytes=actual_bytes,
+            shared_bytes=shared_bytes_with_mbar,
+        )
+
+    buffer_bytes = max(mib_to_bytes(DEFAULT_BUFFER_MIB), actual_bytes)
+    buffer_bytes = round_up(buffer_bytes, 128)
+    buffer_mib = math.ceil(buffer_bytes / (1024 * 1024))
+
+    torch.cuda.set_device(0)
+    local_sink_t = torch.empty((config.x_ctas * NUM_WARPS * iters,), dtype=torch.int32, device="cuda")
+    local_sink = from_dlpack(local_sink_t).mark_layout_dynamic()
+    clock_stats_t = torch.empty((config.x_ctas * NUM_WARPS * 2,), dtype=torch.int64, device="cuda")
+    clock_stats = from_dlpack(clock_stats_t).mark_layout_dynamic()
+
+    if remote_buf.numel() < buffer_bytes:
+        raise RuntimeError(
+            f"remote buffer has {remote_buf.numel()} bytes, need {buffer_bytes}; "
+            "internal allocation bug"
+        )
+    remote_ptr = int(remote_buf.data_ptr())
+    if remote_ptr % 128 != 0:
+        raise RuntimeError(f"remote buffer pointer is not 128B aligned: 0x{remote_ptr:x}")
+    owner = pointer_owner_device(remote_ptr)
+    if owner is not None and int(owner) != 1:
+        raise RuntimeError(f"remote pointer owner device is {owner}, expected 1")
+    remote_base_ptr = make_ptr(Uint8, remote_ptr, cute.AddressSpace.gmem, assumed_align=128)
+
+    print(
+        f"compile mode={config.mode} x={config.x_ctas} y={config.y_copy_per_iter} "
+        f"z={config.z_bytes_per_inst} w={config.w_comm_mbytes}MiB iters={iters}"
+    )
+    compiled = compile_config(config, local_sink, clock_stats, remote_base_ptr, iters)
+
+    def run_once(offset: int) -> float:
+        local_sink_t.zero_()
+        if (config.mode == "push" and config.push_clock_stats) or (
+            config.mode == "pull" and config.pull_clock_stats
+        ):
+            clock_stats_t.zero_()
+        torch.cuda.synchronize(0)
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        compiled(
+            local_sink,
+            clock_stats,
+            remote_base_ptr,
+            offset,
+        )
+        end.record()
+        end.synchronize()
+        return float(start.elapsed_time(end))
+
+    max_offset = max(0, buffer_bytes - actual_bytes)
+    offset_step = round_up(actual_bytes, 128)
+    for i in range(DEFAULT_WARMUPS):
+        offset = 0 if max_offset == 0 else (i * offset_step) % (max_offset + 1)
+        offset -= offset % 128
+        run_once(offset)
+
+    timings = []
+    for i in range(DEFAULT_REPEATS):
+        raw_offset = (DEFAULT_WARMUPS + i) * offset_step
+        offset = 0 if max_offset == 0 else raw_offset % (max_offset + 1)
+        offset -= offset % 128
+        timings.append(run_once(offset))
+
+    ms_min = min(timings)
+    ms_median = statistics.median(timings)
+    ms_mean = statistics.mean(timings)
+    if config.mode == "push" and config.push_clock_stats:
+        print_clock_stats(clock_stats_t, "push_smem_reuse_wait_cycles")
+    if config.mode == "pull" and config.pull_clock_stats:
+        print_clock_stats(clock_stats_t, "pull_data_arrival_wait_cycles")
+    return BenchResult(
+        mode=config.mode,
+        x_ctas=config.x_ctas,
+        y_copy_per_iter=config.y_copy_per_iter,
+        z_bytes_per_inst=config.z_bytes_per_inst,
+        w_comm_mbytes=config.w_comm_mbytes,
+        iters=iters,
+        requested_bytes=requested_bytes,
+        actual_bytes=actual_bytes,
+        ms_min=ms_min,
+        ms_median=ms_median,
+        ms_mean=ms_mean,
+        gbps_min_time=actual_bytes / (ms_min * 1.0e6),
+        gbps_median_time=actual_bytes / (ms_median * 1.0e6),
+        request_128b_count=actual_bytes // 128,
+        request_128b_ns_min_time=ms_min * 1.0e6 / (actual_bytes // 128),
+        request_128b_ns_median_time=ms_median * 1.0e6 / (actual_bytes // 128),
+        shared_bytes_per_cta=shared_bytes_with_mbar,
+        buffer_mib=buffer_mib,
+    )
+
+
+def skipped_result(
+    config: BenchConfig,
+    reason: str,
+    *,
+    iters: int = 0,
+    requested_bytes: int = 0,
+    actual_bytes: int = 0,
+    shared_bytes: int = 0,
+) -> BenchResult:
+    return BenchResult(
+        mode=config.mode,
+        x_ctas=config.x_ctas,
+        y_copy_per_iter=config.y_copy_per_iter,
+        z_bytes_per_inst=config.z_bytes_per_inst,
+        w_comm_mbytes=config.w_comm_mbytes,
+        iters=iters,
+        requested_bytes=requested_bytes,
+        actual_bytes=actual_bytes,
+        ms_min=float("nan"),
+        ms_median=float("nan"),
+        ms_mean=float("nan"),
+        gbps_min_time=float("nan"),
+        gbps_median_time=float("nan"),
+        request_128b_count=actual_bytes // 128 if actual_bytes else 0,
+        request_128b_ns_min_time=float("nan"),
+        request_128b_ns_median_time=float("nan"),
+        shared_bytes_per_cta=shared_bytes,
+        buffer_mib=0,
+        skipped=reason,
+    )
+
+
+def print_result(result: BenchResult) -> None:
+    if result.skipped:
+        print(
+            f"SKIP mode={result.mode} x={result.x_ctas} y={result.y_copy_per_iter} "
+            f"z={result.z_bytes_per_inst} w={result.w_comm_mbytes}MiB: {result.skipped}"
+        )
+        return
+    print(
+        f"{result.mode:4s} x={result.x_ctas:3d} y={result.y_copy_per_iter:2d} "
+        f"z={result.z_bytes_per_inst:5d} w={result.w_comm_mbytes:5d}MiB "
+        f"iters={result.iters:6d} min={result.ms_min:8.3f} ms "
+        f"median={result.ms_median:8.3f} ms "
+        f"BW(min-time)={result.gbps_min_time:8.2f} GB/s "
+        f"request_128B={result.request_128b_count} "
+        f"request_128B_ns(min/median)="
+        f"{result.request_128b_ns_min_time:.3f}/{result.request_128b_ns_median_time:.3f} "
+        f"smem={result.shared_bytes_per_cta} B"
+    )
+
+
+def _format_stat_entry(flat_idx: int, cycles: int) -> str:
+    cta_warp, slot = divmod(flat_idx, 2)
+    cta, warp = divmod(cta_warp, NUM_WARPS)
+    name = "min" if slot == 0 else "max"
+    return f"(cta={cta}, warp={warp}, {name}={cycles})"
+
+
+def print_clock_stats(clock_stats_t: torch.Tensor, label: str, topk: int = 10) -> None:
+    stats_cpu = clock_stats_t.detach().cpu().reshape(-1)
+    stats_3d = clock_stats_t.detach().cpu().reshape(-1, NUM_WARPS, 2)
+    mins = stats_3d[:, :, 0].reshape(-1)
+    maxs = stats_3d[:, :, 1].reshape(-1)
+
+    min_order = torch.argsort(mins)[:topk].tolist()
+    max_order = torch.argsort(maxs, descending=True)[:topk].tolist()
+
+    print(f"  {label}_min_top10:")
+    for idx in min_order:
+        flat_idx = idx * 2
+        print(f"    {_format_stat_entry(flat_idx, int(stats_cpu[flat_idx]))}")
+
+    print(f"  {label}_max_top10:")
+    for idx in max_order:
+        flat_idx = idx * 2 + 1
+        print(f"    {_format_stat_entry(flat_idx, int(stats_cpu[flat_idx]))}")
+
+
+def write_csv(path: str | Path, results: list[BenchResult]) -> None:
+    fieldnames = list(BenchResult.__dataclass_fields__.keys())
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for result in results:
+            writer.writerow(result.__dict__)
+
+
+def allocate_remote_buffer(configs: list[BenchConfig], sm_count: int) -> torch.Tensor:
+    max_actual = 0
+    for config in configs:
+        if config.x_ctas <= 0 or config.x_ctas > sm_count:
+            continue
+        if config.y_copy_per_iter <= 0 or config.z_bytes_per_inst <= 0:
+            continue
+        bytes_per_iter = (
+            config.x_ctas
+            * NUM_WARPS
+            * config.y_copy_per_iter
+            * config.z_bytes_per_inst
+        )
+        requested = mib_to_bytes(config.w_comm_mbytes)
+        actual = max(1, math.ceil(requested / bytes_per_iter)) * bytes_per_iter
+        max_actual = max(max_actual, actual)
+    buffer_bytes = round_up(max(mib_to_bytes(DEFAULT_BUFFER_MIB), max_actual), 128)
+    torch.cuda.set_device(1)
+    remote = torch.empty((buffer_bytes,), dtype=torch.uint8, device="cuda")
+    remote.fill_(0x5A)
+    torch.cuda.synchronize(1)
+    return remote
+
+
+def main() -> int:
+    sm_count = validate_environment()
+    parser = make_arg_parser(sm_count)
+    args = parser.parse_args()
+
+    configs = list(iter_configs(args))
+    remote_buf = allocate_remote_buffer(configs, sm_count)
+    smem_capacity = smem_capacity_bytes()
+
+    print(
+        f"device0={torch.cuda.get_device_name(0)!r} device1={torch.cuda.get_device_name(1)!r} "
+        f"sm_count={sm_count} smem_capacity={smem_capacity} B "
+        f"remote_buffer={remote_buf.numel() / (1024 * 1024):.1f} MiB"
+    )
+
+    results = []
+    for config in configs:
+        result = run_one_config(config, sm_count, smem_capacity, remote_buf)
+        results.append(result)
+        print_result(result)
+
+    if args.csv:
+        write_csv(args.csv, results)
+        print(f"wrote CSV: {args.csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/contract.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/contract.py
@@ -1,0 +1,430 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Codegen-time finite mapping contracts for RMEM tensor handoff."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping as MappingABC, Sequence as SequenceABC
+from dataclasses import dataclass
+from math import prod
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence
+
+
+class ContractError(ValueError):
+    """Base error for malformed or mismatched contracts."""
+
+
+class ContractMismatchError(ContractError):
+    """Raised when two contracts do not describe the same mapping."""
+
+
+class MappingSpec(Protocol):
+    """Protocol for objects that can produce a canonical mapping table."""
+
+    def normalize(self, *, domain: "Space", codomain: "Space") -> tuple[int, ...]:
+        ...
+
+
+def _as_tuple(value: Iterable[object], *, name: str) -> tuple[object, ...]:
+    try:
+        return tuple(value)
+    except TypeError as exc:
+        raise TypeError(f"{name} must be iterable") from exc
+
+
+@dataclass(frozen=True)
+class Space:
+    """A finite coordinate space; axis 0 is fastest for linearization."""
+
+    names: tuple[str, ...]
+    sizes: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        names = _as_tuple(self.names, name="names")
+        sizes = _as_tuple(self.sizes, name="sizes")
+        if len(names) != len(sizes):
+            raise ContractError(
+                f"Space names/sizes rank mismatch: {len(names)} != {len(sizes)}"
+            )
+        if not names:
+            raise ContractError("Space must have at least one axis")
+        if any(not isinstance(n, str) or not n for n in names):
+            raise ContractError("Space names must be non-empty strings")
+        if len(set(names)) != len(names):
+            raise ContractError(f"Space names must be unique, got {names!r}")
+        if any(not isinstance(s, int) or s <= 0 for s in sizes):
+            raise ContractError(f"Space sizes must be positive integers, got {sizes!r}")
+
+        object.__setattr__(self, "names", names)
+        object.__setattr__(self, "sizes", sizes)
+
+    @property
+    def rank(self) -> int:
+        return len(self.names)
+
+    @property
+    def size(self) -> int:
+        return prod(self.sizes)
+
+    def coordinates(self) -> tuple[tuple[int, ...], ...]:
+        """Enumerate all coordinates in canonical CuTe-style order."""
+        return tuple(self.delinearize(i) for i in range(self.size))
+
+    def linearize(self, coord: Sequence[int]) -> int:
+        """Convert a coordinate tuple into a CuTe-style linear index."""
+        coord_tuple = tuple(coord)
+        if len(coord_tuple) != self.rank:
+            raise ContractError(
+                f"Coordinate rank mismatch for {self.names!r}: "
+                f"{len(coord_tuple)} != {self.rank}"
+            )
+
+        linear = 0
+        stride = 1
+        for axis, (idx, size) in enumerate(zip(coord_tuple, self.sizes)):
+            if not isinstance(idx, int):
+                raise ContractError(
+                    f"Coordinate {self.names[axis]!r} must be int, got {type(idx)!r}"
+                )
+            if idx < 0 or idx >= size:
+                raise ContractError(
+                    f"Coordinate {self.names[axis]!r}={idx} out of bounds [0, {size})"
+                )
+            linear += idx * stride
+            stride *= size
+        return linear
+
+    def delinearize(self, linear: int) -> tuple[int, ...]:
+        """Convert a CuTe-style linear index into a coordinate tuple."""
+        if not isinstance(linear, int):
+            raise ContractError(f"Linear index must be int, got {type(linear)!r}")
+        if linear < 0 or linear >= self.size:
+            raise ContractError(f"Linear index {linear} out of bounds [0, {self.size})")
+
+        remaining = linear
+        coord = [0] * self.rank
+        for axis in range(self.rank):
+            size = self.sizes[axis]
+            coord[axis] = remaining % size
+            remaining //= size
+        return tuple(coord)
+
+    def rename(self, rename_map: Mapping[str, str]) -> "Space":
+        """Return a space with selected axis names renamed."""
+        return Space(
+            names=tuple(rename_map.get(name, name) for name in self.names),
+            sizes=self.sizes,
+        )
+
+
+@dataclass(frozen=True)
+class TableMapping:
+    """Canonical mapping table.
+
+    ``table[domain_linear_idx] == codomain_linear_idx``.
+    """
+
+    table: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        table = _as_tuple(self.table, name="table")
+        if any(not isinstance(v, int) for v in table):
+            raise ContractError("TableMapping entries must be integers")
+        object.__setattr__(self, "table", table)
+
+    @classmethod
+    def identity(cls, space: Space) -> "TableMapping":
+        """Build an identity mapping for equal domain/codomain spaces."""
+        return cls(tuple(range(space.size)))
+
+    @classmethod
+    def from_codomain_coords(
+        cls,
+        *,
+        domain: Space,
+        codomain: Space,
+        coords: Sequence[Sequence[int]],
+    ) -> "TableMapping":
+        """Build a table from one codomain coordinate per domain coordinate."""
+        coord_tuple = tuple(tuple(coord) for coord in coords)
+        if len(coord_tuple) != domain.size:
+            raise ContractError(
+                f"Expected {domain.size} codomain coords, got {len(coord_tuple)}"
+            )
+        return cls(tuple(codomain.linearize(coord) for coord in coord_tuple))
+
+    def normalize(self, *, domain: Space, codomain: Space) -> tuple[int, ...]:
+        """Validate and return the canonical table for the given spaces."""
+        if len(self.table) != domain.size:
+            raise ContractError(
+                f"TableMapping length must equal domain size {domain.size}, "
+                f"got {len(self.table)}"
+            )
+        for idx, value in enumerate(self.table):
+            if value < 0 or value >= codomain.size:
+                raise ContractError(
+                    f"TableMapping entry {idx} maps to {value}, outside "
+                    f"codomain bounds [0, {codomain.size})"
+                )
+        return self.table
+
+
+@dataclass(frozen=True)
+class FunctionMapping:
+    """Mapping generated by a Python pure function.
+
+    The function signature must match the domain axis names by name.  Parameter
+    order does not matter because calls are made with keyword arguments.
+
+    The return value is interpreted as a codomain coordinate:
+      - ``int`` is accepted for rank-1 codomains.
+      - ``tuple``/``list`` values are interpreted in ``codomain.names`` order.
+      - ``Mapping[str, int]`` values are interpreted by codomain axis name.
+
+    The function is expected to be deterministic and side-effect free.  This
+    module cannot prove purity; it only calls the function while normalizing.
+    """
+
+    function: Callable[..., int | Sequence[int] | Mapping[str, int]]
+
+    def __post_init__(self) -> None:
+        if not callable(self.function):
+            raise ContractError("FunctionMapping function must be callable")
+
+    @staticmethod
+    def _function_name(function: Callable[..., object]) -> str:
+        return getattr(function, "__qualname__", getattr(function, "__name__", repr(function)))
+
+    @classmethod
+    def _validate_signature(
+        cls,
+        function: Callable[..., object],
+        domain: Space,
+    ) -> inspect.Signature:
+        signature = inspect.signature(function)
+        params = signature.parameters
+        bad_params = [
+            name
+            for name, param in params.items()
+            if param.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.VAR_POSITIONAL,
+                inspect.Parameter.VAR_KEYWORD,
+            )
+        ]
+        if bad_params:
+            raise ContractError(
+                f"FunctionMapping {cls._function_name(function)} has unsupported "
+                f"parameters {bad_params!r}; use named positional-or-keyword or "
+                f"keyword-only parameters"
+            )
+
+        default_params = [
+            name
+            for name, param in params.items()
+            if param.default is not inspect.Parameter.empty
+        ]
+        if default_params:
+            raise ContractError(
+                f"FunctionMapping {cls._function_name(function)} parameters must "
+                f"not have defaults, got {default_params!r}"
+            )
+
+        param_names = tuple(params.keys())
+        if set(param_names) != set(domain.names):
+            raise ContractError(
+                f"FunctionMapping {cls._function_name(function)} parameters must "
+                f"match domain names {domain.names!r}, got {param_names!r}"
+            )
+        return signature
+
+    @staticmethod
+    def _result_to_codomain_coord(
+        result: int | Sequence[int] | Mapping[str, int],
+        *,
+        codomain: Space,
+        domain_coord: tuple[int, ...],
+        function_name: str,
+    ) -> tuple[int, ...]:
+        if isinstance(result, MappingABC):
+            result_keys = tuple(result.keys())
+            if set(result_keys) != set(codomain.names):
+                raise ContractError(
+                    f"FunctionMapping {function_name} returned mapping keys "
+                    f"{result_keys!r} at domain coord {domain_coord!r}; expected "
+                    f"codomain names {codomain.names!r}"
+                )
+            coord = tuple(result[name] for name in codomain.names)
+        elif isinstance(result, int) and codomain.rank == 1:
+            coord = (result,)
+        elif isinstance(result, SequenceABC) and not isinstance(result, (str, bytes)):
+            coord = tuple(result)
+            if len(coord) != codomain.rank:
+                raise ContractError(
+                    f"FunctionMapping {function_name} returned rank {len(coord)} "
+                    f"at domain coord {domain_coord!r}; expected codomain rank "
+                    f"{codomain.rank}"
+                )
+        else:
+            raise ContractError(
+                f"FunctionMapping {function_name} returned unsupported value "
+                f"{result!r} at domain coord {domain_coord!r}"
+            )
+
+        if any(not isinstance(v, int) for v in coord):
+            raise ContractError(
+                f"FunctionMapping {function_name} returned non-integer codomain "
+                f"coordinate {coord!r} at domain coord {domain_coord!r}"
+            )
+        return coord
+
+    def normalize(self, *, domain: Space, codomain: Space) -> tuple[int, ...]:
+        """Enumerate the function over ``domain`` and return a canonical table."""
+        self._validate_signature(self.function, domain)
+        function_name = self._function_name(self.function)
+
+        table: list[int] = []
+        for domain_coord in domain.coordinates():
+            binding = dict(zip(domain.names, domain_coord))
+            result = self.function(**binding)
+            codomain_coord = self._result_to_codomain_coord(
+                result,
+                codomain=codomain,
+                domain_coord=domain_coord,
+                function_name=function_name,
+            )
+            table.append(codomain.linearize(codomain_coord))
+        return TableMapping(tuple(table)).normalize(domain=domain, codomain=codomain)
+
+
+@dataclass(frozen=True)
+class Contract:
+    """A normalized finite mapping contract."""
+
+    domain: Space
+    codomain: Space
+    mapping: MappingSpec
+
+    def __post_init__(self) -> None:
+        # Validate eagerly so malformed contracts fail at construction time.
+        self.mapping.normalize(domain=self.domain, codomain=self.codomain)
+
+    @property
+    def table(self) -> tuple[int, ...]:
+        return self.mapping.normalize(domain=self.domain, codomain=self.codomain)
+
+    def rename_domain(self, rename_map: Mapping[str, str]) -> "Contract":
+        return Contract(
+            domain=self.domain.rename(rename_map),
+            codomain=self.codomain,
+            mapping=self.mapping,
+        )
+
+    def rename_codomain(self, rename_map: Mapping[str, str]) -> "Contract":
+        return Contract(
+            domain=self.domain,
+            codomain=self.codomain.rename(rename_map),
+            mapping=self.mapping,
+        )
+
+    def is_equivalent_to(self, other: "Contract") -> bool:
+        return (
+            self.domain == other.domain
+            and self.codomain == other.codomain
+            and self.table == other.table
+        )
+
+    def assert_equivalent_to(self, other: "Contract", *, context: str = "") -> None:
+        """Raise a readable error unless two contracts are exactly equivalent."""
+        if self.is_equivalent_to(other):
+            return
+
+        prefix = f"{context}: " if context else ""
+        details: list[str] = []
+        if self.domain != other.domain:
+            details.append(f"domain mismatch: {self.domain!r} != {other.domain!r}")
+        if self.codomain != other.codomain:
+            details.append(
+                f"codomain mismatch: {self.codomain!r} != {other.codomain!r}"
+            )
+        if self.table != other.table:
+            mismatch_idx = next(
+                (
+                    idx
+                    for idx, (lhs, rhs) in enumerate(zip(self.table, other.table))
+                    if lhs != rhs
+                ),
+                None,
+            )
+            if mismatch_idx is None and len(self.table) != len(other.table):
+                details.append(
+                    f"table length mismatch: {len(self.table)} != {len(other.table)}"
+                )
+            elif mismatch_idx is not None:
+                details.append(
+                    f"table mismatch at domain linear index {mismatch_idx}: "
+                    f"{self.table[mismatch_idx]} != {other.table[mismatch_idx]}"
+                )
+
+        raise ContractMismatchError(prefix + "; ".join(details))
+
+
+def assert_contract_equivalent(
+    actual: Contract,
+    expected: Contract,
+    *,
+    context: str = "",
+) -> None:
+    """Function-style wrapper for contract equivalence checks."""
+    actual.assert_equivalent_to(expected, context=context)
+
+
+@dataclass(frozen=True)
+class TensorWithContract:
+    """A handle pairing a runtime tensor with its codegen-time contract.
+
+    Used when handing per-thread RMEM tensors between epilogue components.
+    A bare RMEM tensor is thread-distributed and has no logical shape on its
+    own; the contract supplies the ``(thread, reg) -> (logical)`` mapping
+    that gives the tensor a meaning across the warp.
+
+    The ``tensor`` field is typed as ``Any`` because this module stays
+    independent of CuTe runtime types; in practice it carries a ``cute.Tensor``.
+    The ``contract`` field is a pure-Python codegen-time object that can be
+    compared against another contract via ``assert_contract_equivalent``.
+
+    Both fields are immutable: a TensorWithContract is a passive label, not
+    a mutable container.  Mutations to the underlying RMEM happen through
+    the runtime tensor object directly (its identity is preserved).
+    """
+
+    tensor: Any
+    contract: Contract
+
+
+def eval_function_mapping(contract: Contract, **domain_coord):
+    """Evaluate a FunctionMapping contract at runtime."""
+    if not isinstance(contract.mapping, FunctionMapping):
+        raise TypeError("runtime contract eval requires a FunctionMapping")
+
+    result = contract.mapping.function(**domain_coord)
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, (tuple, list)):
+        if len(result) != contract.codomain.rank:
+            raise ValueError(
+                "FunctionMapping result rank does not match codomain rank: "
+                f"{len(result)} vs {contract.codomain.rank}"
+            )
+        return {
+            name: result[i]
+            for i, name in enumerate(contract.codomain.names)
+        }
+    if contract.codomain.rank == 1:
+        return {contract.codomain.names[0]: result}
+    raise TypeError(
+        "FunctionMapping runtime eval must return dict/tuple/list, or scalar "
+        "for rank-1 codomain"
+    )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/custom_ext.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/custom_ext.py
@@ -1,0 +1,776 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Sched extension for fused fc1+fc2 work-tile enrichment and GMEM slicing."""
+
+from typing import List, Optional, Tuple, Union
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import Pointer
+from cutlass.cutlass_dsl import Int32, extract_mlir_values, new_from_mlir_values
+from cutlass._mlir import ir
+
+from cutlass.utils.blockscaled_layout import tile_atom_to_shape_SF
+from .fc1_fc2_fuse_sched import BlockPhase
+from .moe_utils import rewrite_tensor_shape, spin_wait
+from .moe_persistent_scheduler import MoESchedExtension, MoEWorkTileInfo
+
+PhaseBits = 16
+PhaseMask = (1 << PhaseBits) - 1
+PeekReadyBit = 1 << PhaseBits
+
+
+# =============================================================================
+# Fused FC1+FC2 WorkTileInfo
+# =============================================================================
+
+
+class SwapABSwigluFp4Fc12WorkTileInfo(MoEWorkTileInfo):
+    """8-field fc12 work tile; slot 3 aliases base k_tile_cnt."""
+
+    TotalFields = 8  # 4 base + 4 extra (4 new fields beyond the alias)
+
+    def __init__(
+        self,
+        expert_idx: Int32,
+        tile_m_idx: Int32,
+        tile_n_idx: Int32,
+        cumulative_data_physical_row: Int32,
+        cumulative_sf_physical_row: Int32,
+        cumulative_token_block_count: Int32,
+        valid_tokens_in_cta_tile: Int32,
+        phase_and_peek: Int32,
+    ):
+        super().__init__(
+            expert_idx,
+            tile_m_idx,
+            tile_n_idx,
+            cumulative_data_physical_row,
+        )
+        self.cumulative_data_physical_row = self.k_tile_cnt
+        self.cumulative_sf_physical_row = cumulative_sf_physical_row
+        self.cumulative_token_block_count = cumulative_token_block_count
+        self.valid_tokens_in_cta_tile = valid_tokens_in_cta_tile
+        # Slot 7 is the packed (BlockPhase | (peek_ready << 16)) field.
+        # The ``.phase`` and ``.peek_ready`` properties below unpack it;
+        # consumers call them directly so the codebase reads as if the
+        # two pieces were separate fields.
+        self.phase_and_peek = phase_and_peek
+
+    @property
+    def phase(self) -> Int32:
+
+        """Decode the BlockPhase from slot 7's low 16 bits."""
+        return self.phase_and_peek & Int32(PhaseMask)
+
+    @property
+    def peek_ready(self):
+        """Decode the sched-warp counter peek result from slot 7's bit 16.
+
+        Returns a Boolean SSA: True iff the sched-warp's enrich-time
+        peek of the fc1_done_counter (for this fc2 work tile) observed
+        saturation, allowing the TMA-B warp to skip its own spin_wait.
+        For fc1 tiles or when peek wasn't done, returns False (fc12 sched
+        ext only sets the bit on Linear2 phase work tiles).
+        """
+        return ((self.phase_and_peek >> Int32(PhaseBits)) & Int32(1)) != Int32(0)
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        # Base's __extract_mlir_values__ already emits the first 4 slots
+        # (slot 3 = self.k_tile_cnt = cumulative_data_physical_row).
+        values = super().__extract_mlir_values__()
+        values.extend(extract_mlir_values(self.cumulative_sf_physical_row))
+        values.extend(extract_mlir_values(self.cumulative_token_block_count))
+        values.extend(extract_mlir_values(self.valid_tokens_in_cta_tile))
+        values.extend(extract_mlir_values(self.phase_and_peek))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "SwapABSwigluFp4Fc12WorkTileInfo":
+        assert len(values) == 8
+        return type(self)(
+            expert_idx=new_from_mlir_values(self.expert_idx, [values[0]]),
+            tile_m_idx=new_from_mlir_values(self.tile_m_idx, [values[1]]),
+            tile_n_idx=new_from_mlir_values(self.tile_n_idx, [values[2]]),
+            cumulative_data_physical_row=new_from_mlir_values(
+                self.cumulative_data_physical_row, [values[3]]
+            ),
+            cumulative_sf_physical_row=new_from_mlir_values(
+                self.cumulative_sf_physical_row, [values[4]]
+            ),
+            cumulative_token_block_count=new_from_mlir_values(
+                self.cumulative_token_block_count, [values[5]]
+            ),
+            valid_tokens_in_cta_tile=new_from_mlir_values(
+                self.valid_tokens_in_cta_tile, [values[6]]
+            ),
+            phase_and_peek=new_from_mlir_values(self.phase_and_peek, [values[7]]),
+        )
+
+    def to_rmem(self) -> cute.Tensor:
+        rmem = cute.make_rmem_tensor((self.TotalFields,), Int32)
+        rmem[0] = self.expert_idx
+        rmem[1] = self.tile_m_idx
+        rmem[2] = self.tile_n_idx
+        rmem[3] = self.k_tile_cnt              # = cumulative_data_physical_row
+        rmem[4] = self.cumulative_sf_physical_row
+        rmem[5] = self.cumulative_token_block_count
+        rmem[6] = self.valid_tokens_in_cta_tile
+        rmem[7] = self.phase_and_peek
+        return rmem
+
+    @classmethod
+    def from_rmem(cls, rmem: cute.Tensor) -> "SwapABSwigluFp4Fc12WorkTileInfo":
+        return cls(
+            expert_idx=rmem[0],  # type: ignore[arg-type]
+            tile_m_idx=rmem[1],  # type: ignore[arg-type]
+            tile_n_idx=rmem[2],  # type: ignore[arg-type]
+            cumulative_data_physical_row=rmem[3],  # type: ignore[arg-type]
+            cumulative_sf_physical_row=rmem[4],  # type: ignore[arg-type]
+            cumulative_token_block_count=rmem[5],  # type: ignore[arg-type]
+            valid_tokens_in_cta_tile=rmem[6],  # type: ignore[arg-type]
+            phase_and_peek=rmem[7],  # type: ignore[arg-type]
+        )
+
+
+# =============================================================================
+# MXFP8 WorkTileInfo (non-swapAB)
+# =============================================================================
+
+
+class GluMxFp8WorkTileInfo(MoEWorkTileInfo):
+    """WorkTileInfo for the MXFP8 non-swapAB kernel.
+
+    Inherits directly from ``MoEWorkTileInfo`` (not from the swap-AB subclass)
+    because the MXFP8 field layout is distinct: slot 6 holds
+    ``valid_tokens_in_cta_cluster_tile`` — a packed Int32 (high 16 bits =
+    per-CTA tile count, low 16 bits = cluster-level count).
+
+    Class-level constant ``_cluster_m`` must be set by
+    ``GluMxFp8Fc12SchedExtension.__init__`` before JIT compilation.
+    """
+
+    TotalFields = 8
+    _cluster_m: int = 1
+
+    def __init__(
+        self,
+        expert_idx: Int32,
+        tile_m_idx: Int32,
+        tile_n_idx: Int32,
+        cumulative_data_physical_row: Int32,
+        cumulative_sf_physical_row: Int32,
+        cumulative_token_block_count: Int32,
+        # Packed token counts: high 16 bits = per-CTA valid_tokens_in_cta_tile,
+        #                      low  16 bits = valid_tokens_in_cluster_tile.
+        valid_tokens_in_cta_cluster_tile: Int32,
+        phase_and_peek: Int32,
+        # Transient scheduler field — carried through MLIR but NOT written to SMEM.
+        # fc1_counter_index: cluster_token_block_idx (intra-expert cluster token-block index).
+        fc1_counter_index: Int32,
+    ):
+        super().__init__(expert_idx, tile_m_idx, tile_n_idx, cumulative_data_physical_row)
+        self.cumulative_data_physical_row = self.k_tile_cnt
+        self.cumulative_sf_physical_row = cumulative_sf_physical_row
+        self.cumulative_token_block_count = cumulative_token_block_count
+        self.valid_tokens_in_cta_cluster_tile = valid_tokens_in_cta_cluster_tile
+        self.phase_and_peek = phase_and_peek
+        self.fc1_counter_index = fc1_counter_index
+
+    @property
+    def phase(self) -> Int32:
+        return self.phase_and_peek & Int32(PhaseMask)
+
+    @property
+    def peek_ready(self):
+        return ((self.phase_and_peek >> Int32(PhaseBits)) & Int32(1)) != Int32(0)
+
+    @property
+    def valid_tokens_in_cta_tile(self) -> Int32:
+        return self.valid_tokens_in_cta_cluster_tile >> Int32(16)
+
+    @property
+    def valid_tokens_in_cluster_tile(self) -> Int32:
+        return self.valid_tokens_in_cta_cluster_tile & Int32(0xFFFF)
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = super().__extract_mlir_values__()                                   # [0..3]
+        values.extend(extract_mlir_values(self.cumulative_sf_physical_row))          # [4]
+        values.extend(extract_mlir_values(self.cumulative_token_block_count))        # [5]
+        values.extend(extract_mlir_values(self.valid_tokens_in_cta_cluster_tile))    # [6]
+        values.extend(extract_mlir_values(self.phase_and_peek))                      # [7]
+        values.extend(extract_mlir_values(self.fc1_counter_index))                   # [8]
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "GluMxFp8WorkTileInfo":
+        assert len(values) == 9
+        return type(self)(
+            expert_idx=new_from_mlir_values(self.expert_idx, [values[0]]),
+            tile_m_idx=new_from_mlir_values(self.tile_m_idx, [values[1]]),
+            tile_n_idx=new_from_mlir_values(self.tile_n_idx, [values[2]]),
+            cumulative_data_physical_row=new_from_mlir_values(
+                self.cumulative_data_physical_row, [values[3]]
+            ),
+            cumulative_sf_physical_row=new_from_mlir_values(
+                self.cumulative_sf_physical_row, [values[4]]
+            ),
+            cumulative_token_block_count=new_from_mlir_values(
+                self.cumulative_token_block_count, [values[5]]
+            ),
+            valid_tokens_in_cta_cluster_tile=new_from_mlir_values(
+                self.valid_tokens_in_cta_cluster_tile, [values[6]]
+            ),
+            phase_and_peek=new_from_mlir_values(self.phase_and_peek, [values[7]]),
+            fc1_counter_index=new_from_mlir_values(self.fc1_counter_index, [values[8]]),
+        )
+
+    def to_rmem(self) -> cute.Tensor:
+        rmem = cute.make_rmem_tensor((self.TotalFields,), cutlass.Int32)
+        rmem[0] = self.expert_idx
+        rmem[1] = self.tile_m_idx
+        rmem[2] = self.tile_n_idx
+        rmem[3] = self.k_tile_cnt          # = cumulative_data_physical_row
+        rmem[4] = self.cumulative_sf_physical_row
+        rmem[5] = self.cumulative_token_block_count
+        rmem[6] = self.valid_tokens_in_cta_cluster_tile
+        rmem[7] = self.phase_and_peek
+        return rmem
+
+    @classmethod
+    def from_rmem(cls, rmem: cute.Tensor) -> "GluMxFp8WorkTileInfo":
+        return cls(
+            expert_idx=rmem[0],  # type: ignore[arg-type]
+            tile_m_idx=rmem[1],  # type: ignore[arg-type]
+            tile_n_idx=rmem[2],  # type: ignore[arg-type]
+            cumulative_data_physical_row=rmem[3],  # type: ignore[arg-type]
+            cumulative_sf_physical_row=rmem[4],  # type: ignore[arg-type]
+            cumulative_token_block_count=rmem[5],  # type: ignore[arg-type]
+            valid_tokens_in_cta_cluster_tile=rmem[6],  # type: ignore[arg-type]
+            phase_and_peek=rmem[7],  # type: ignore[arg-type]
+            fc1_counter_index=rmem[1] // cutlass.Int32(cls._cluster_m),  # type: ignore[arg-type]
+        )
+
+
+# =============================================================================
+# Fused FC1+FC2 SchedExtension
+# =============================================================================
+
+
+class SwapABSwigluFp4Fc12SchedExtension(MoESchedExtension):
+    """Sched extension for the fused fc1+fc2 swap-AB SwiGLU NVFP4 kernel.
+
+    ``WorkTileInfo = SwapABSwigluFp4Fc12WorkTileInfo``.  The 8th slot stores
+    ``phase_and_peek`` (low 16 bit BlockPhase, bit 16 sched-warp peek result);
+    consumers read it through ``.phase`` and ``.peek_ready``.
+
+    `enrich_work_tile_info` packs a sched-warp counter peek for fc2 tiles.
+    `get_gmem_tensor` is phase-invariant; the caller supplies the phase-specific
+    physical tensor.
+    """
+
+    WorkTileInfo = SwapABSwigluFp4Fc12WorkTileInfo
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        fc1_done_counter_ptr: Pointer,
+        fc2_spin_threshold: Union[int, Int32],
+        # MegaMoE-only: when set, ``enrich_work_tile_info`` also peeks the
+        # dispatch->fc1 release-counter for fc1 phase tiles, so the fc1
+        # TMA-B warp can skip its blocking spin when the counter already
+        # shows enough arrivals.  Mirrors ``fc1_done_counter_ptr`` for the
+        # fc1->fc2 link: this side is "fc1 input ready", that side is
+        # "fc1 output done".  The threshold per-tile is the tile's
+        # ``valid_tokens_in_cta_tile`` (dispatch does not pull padding
+        # tokens), read straight off the base work tile -- no separate
+        # threshold field needed.  ``None`` in the lean fc1+fc2 path keeps
+        # ``enrich_work_tile_info`` to its existing fc2-only peek shape and
+        # this pointer is not carried through MLIR.
+        fc1_ready_counter_ptr: Optional[Pointer] = None,
+    ):
+        super().__init__(workspace=None)
+        if sf_vec_size <= 0:
+            raise ValueError(f"sf_vec_size must be positive, got {sf_vec_size}.")
+        self.sf_vec_size = sf_vec_size
+        self.fc1_done_counter_ptr = fc1_done_counter_ptr
+        # Coerce to Int32 SSA so downstream serialization / arithmetic
+        # never has to type-discriminate.  Python-int callers (the
+        # ``static_expert_shape`` path) get a constant SSA op which IR
+        # canonicalize folds to an immediate; runtime-Int32 callers
+        # passthrough.  Net IR is identical.
+        self.fc2_spin_threshold = Int32(fc2_spin_threshold)
+        self.fc1_ready_counter_ptr = fc1_ready_counter_ptr
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values: List[ir.Value] = []
+        values.extend(extract_mlir_values(self.fc1_done_counter_ptr))
+        values.extend(extract_mlir_values(self.fc2_spin_threshold))
+        if self.fc1_ready_counter_ptr is not None:
+            values.extend(extract_mlir_values(self.fc1_ready_counter_ptr))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "SwapABSwigluFp4Fc12SchedExtension":
+        ptr_len = len(extract_mlir_values(self.fc1_done_counter_ptr))
+        thresh_len = len(extract_mlir_values(self.fc2_spin_threshold))
+        idx = 0
+        new_ptr = new_from_mlir_values(
+            self.fc1_done_counter_ptr, values[idx : idx + ptr_len]
+        )
+        idx += ptr_len
+        new_threshold = new_from_mlir_values(
+            self.fc2_spin_threshold, values[idx : idx + thresh_len]
+        )
+        idx += thresh_len
+        # fc1_ready_counter_ptr: prototype tells us whether it is carried.
+        if self.fc1_ready_counter_ptr is not None:
+            ready_ptr_len = len(extract_mlir_values(self.fc1_ready_counter_ptr))
+            new_ready_ptr = new_from_mlir_values(
+                self.fc1_ready_counter_ptr, values[idx : idx + ready_ptr_len]
+            )
+            idx += ready_ptr_len
+        else:
+            new_ready_ptr = None
+        assert idx == len(values), (
+            f"SwapABSwigluFp4Fc12SchedExtension serialization mismatch: "
+            f"idx={idx} len(values)={len(values)}"
+        )
+        result = SwapABSwigluFp4Fc12SchedExtension.__new__(
+            SwapABSwigluFp4Fc12SchedExtension
+        )
+        result.workspace = None
+        result.sf_vec_size = self.sf_vec_size  # codegen const passthrough
+        result.fc1_done_counter_ptr = new_ptr
+        result.fc2_spin_threshold = new_threshold
+        result.fc1_ready_counter_ptr = new_ready_ptr
+        return result
+
+    # --------------------------------------------------------------
+    # enrich_work_tile_info — sched-warp fc2 counter peek + pack
+    # --------------------------------------------------------------
+
+    @cute.jit
+    def enrich_work_tile_info(
+        self,
+        base_work: SwapABSwigluFp4Fc12WorkTileInfo,
+    ) -> SwapABSwigluFp4Fc12WorkTileInfo:
+        """Pack a non-blocking counter peek into ``phase_and_peek``.
+
+        - fc2 tiles always peek the fc1->fc2 ``fc1_done_counter`` at
+          ``cumulative_token_block_count + tile_n_idx`` against
+          ``self.fc2_spin_threshold`` (work-tile-invariant const).
+        - fc1 tiles peek the dispatch->fc1 ``fc1_ready_counter`` at the
+          same slot index (``tile_n_idx``) but with ``valid_tokens_in_cta_tile`` as threshold
+          (per-tile dynamic).  This branch only emits when
+          ``self.fc1_ready_counter_ptr is not None`` (MegaMoE mode).
+        """
+        # Invalid tiles keep (None_ | 0); do not index an arbitrary counter slot.
+        is_valid = base_work.is_valid_tile
+
+        new_phase_and_peek = base_work.phase_and_peek
+        if is_valid:
+            # Same slot index for both phases -- fc1 release-add (dispatch
+            # pull) and fc2 release-add (fc1 epi) target the per-task-tile
+            # counter slot indexed by ``cumulative_token_block_count + tile_n_idx``.
+            counter_slot = (
+                base_work.cumulative_token_block_count + base_work.tile_n_idx
+            )
+            is_fc1 = base_work.phase == Int32(int(BlockPhase.Linear1))
+            is_fc2 = base_work.phase == Int32(int(BlockPhase.Linear2))
+
+            # MegaMoE-only: fc1 phase peek on fc1_ready_counter.  Threshold
+            # is dynamic (per-tile valid count) because dispatch does not
+            # pull padding tokens, so the counter's terminal value matches
+            # the tile's valid_tokens_in_cta_tile (cluster_tile_m for full
+            # tiles, less for an expert's last partial tile).
+            if cutlass.const_expr(self.fc1_ready_counter_ptr is not None):
+                if is_fc1:
+                    counter_ptr = self.fc1_ready_counter_ptr + counter_slot
+                    peek_ready = spin_wait(
+                        counter_ptr,
+                        lambda v: v >= base_work.valid_tokens_in_cta_tile,
+                        peek_only=True,
+                    )
+                    peek_bit = Int32(0)
+                    if peek_ready:
+                        peek_bit = Int32(PeekReadyBit)
+                    new_phase_and_peek = base_work.phase_and_peek | peek_bit
+
+            # fc2 tiles can skip the later TMA-B spin (existing path).
+            if is_fc2:
+                counter_ptr = self.fc1_done_counter_ptr + counter_slot
+                # peek_only=True: single ld.cg + cmp, returns Boolean.
+                # ``self.fc2_spin_threshold`` was Int32-coerced in __init__.
+                peek_ready = spin_wait(
+                    counter_ptr,
+                    lambda v: v >= self.fc2_spin_threshold,
+                    peek_only=True,
+                )
+                # Pack peek bit into slot 7's bit 16.  Use the runtime-if
+                # assign-an-iter-arg-int idiom (same pattern as
+                # ``_advance_expert_within_phase`` for phase-aware tile
+                # count selection); avoids relying on Boolean->Int32
+                # implicit casts whose presence is dialect-version-dependent.
+                peek_bit = Int32(0)
+                if peek_ready:
+                    peek_bit = Int32(PeekReadyBit)
+                new_phase_and_peek = base_work.phase_and_peek | peek_bit
+
+        return SwapABSwigluFp4Fc12WorkTileInfo(
+            expert_idx=base_work.expert_idx,
+            tile_m_idx=base_work.tile_m_idx,
+            tile_n_idx=base_work.tile_n_idx,
+            cumulative_data_physical_row=base_work.cumulative_data_physical_row,
+            cumulative_sf_physical_row=base_work.cumulative_sf_physical_row,
+            cumulative_token_block_count=base_work.cumulative_token_block_count,
+            valid_tokens_in_cta_tile=base_work.valid_tokens_in_cta_tile,
+            phase_and_peek=new_phase_and_peek,
+        )
+
+    # --------------------------------------------------------------
+    # get_gmem_tensor — phase-aware
+    # --------------------------------------------------------------
+
+    @cute.jit
+    def get_gmem_tensor(
+        self,
+        tensor_name: str,
+        gmem_tensor_in_moe_view: cute.Tensor,
+        work_tile_info: SwapABSwigluFp4Fc12WorkTileInfo,
+    ) -> Tuple[cute.Tensor, Optional[Pointer]]:
+        """Phase-invariant GMEM slice for the 6 operands.
+
+        Weight operands anchor at expert; data and SF operands use separate
+        token offsets because their padding granularities differ.  Caller
+        passes the phase-specific physical tensor.  Desc-ptr is always None.
+        """
+        expert_idx = work_tile_info.expert_idx
+        data_token_offset = work_tile_info.cumulative_data_physical_row
+        sf_token_offset = work_tile_info.cumulative_sf_physical_row
+
+        shape = gmem_tensor_in_moe_view.shape
+        stride = gmem_tensor_in_moe_view.stride
+        c1 = cutlass.Int32(1)
+        sf_vec_size = self.sf_vec_size
+
+        if cutlass.const_expr(tensor_name == "a"):
+            real = cute.domain_offset((0, 0, expert_idx), gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "b"):
+            real = cute.domain_offset(
+                (data_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "sfa"):
+            real = cute.domain_offset((0, 0, expert_idx), gmem_tensor_in_moe_view)
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride)
+            )
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "sfb"):
+            real = cute.domain_offset(
+                (sf_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride)
+            )
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "c"):
+            real = cute.domain_offset(
+                (data_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "sfc"):
+            # Linear1 phase only — fc2 has no output SF.  Caller must not
+            # invoke this branch with ``work_tile_info.phase == Linear2``.
+            real = cute.domain_offset(
+                (sf_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride)
+            )
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "topk"):
+            # Linear1 phase only — fc2 doesn't consume topk weights (Path A:
+            # topk weight is pre-multiplied into fc1's swiglu fp32 output
+            # before NVFP4 quantize, so fc2 mainloop already reads the
+            # weight-scaled values from fc1's output buffer).
+            #
+            # ``gmem_tensor_in_moe_view`` here is the global per-token
+            # ``topk_scores`` 1D tensor of shape ``(data_total_rows,)``.
+            # Caller passes the global tensor; we shift to the current
+            # expert's slice via ``data_token_offset`` (data-side physical
+            # row offset, same shift used by ``b`` / ``c`` operands).
+            #
+            # Returned view shape is ``(this_expert_padded_rows,)`` (same
+            # length as the input but offset to the right slice).  The
+            # epilogue then indexes it with the **expert-local** token
+            # coord — symmetric with the SFC write pattern.
+            real = cute.domain_offset(
+                (data_token_offset,), gmem_tensor_in_moe_view
+            )
+            return (real, None)
+
+        raise ValueError(f"Unknown tensor_name: {tensor_name!r}.")
+
+    # --------------------------------------------------------------
+    # prefetch_for_expert
+    # --------------------------------------------------------------
+
+    @cute.jit
+    def prefetch_for_expert(self, expert_idx: Int32) -> None:
+        """No-op: swap-AB makes every TMA desc tile-invariant in both phases."""
+        pass
+
+
+class GluMxFp8Fc12SchedExtension(SwapABSwigluFp4Fc12SchedExtension):
+    """Sched extension for the fused fc1+fc2 GLU MXFP8 kernel.
+    """
+
+    WorkTileInfo = GluMxFp8WorkTileInfo
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        fc1_done_counter_ptr: Pointer,
+        fc2_spin_threshold: Union[int, Int32],
+        fc1_ready_counter_ptr: Optional[Pointer] = None,
+        cluster_m: int = 1,
+    ):
+        super().__init__(
+            sf_vec_size=sf_vec_size,
+            fc1_done_counter_ptr=fc1_done_counter_ptr,
+            fc2_spin_threshold=fc2_spin_threshold,
+            fc1_ready_counter_ptr=fc1_ready_counter_ptr,
+        )
+        self.cluster_m = cluster_m
+        GluMxFp8WorkTileInfo._cluster_m = cluster_m
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "GluMxFp8Fc12SchedExtension":
+        base = super().__new_from_mlir_values__(values)
+        result = GluMxFp8Fc12SchedExtension.__new__(GluMxFp8Fc12SchedExtension)
+        result.workspace = base.workspace
+        result.sf_vec_size = base.sf_vec_size
+        result.fc1_done_counter_ptr = base.fc1_done_counter_ptr
+        result.fc2_spin_threshold = base.fc2_spin_threshold
+        result.fc1_ready_counter_ptr = base.fc1_ready_counter_ptr
+        result.cluster_m = self.cluster_m
+        return result
+
+    @cute.jit
+    def enrich_work_tile_info(
+        self,
+        base_work: GluMxFp8WorkTileInfo,
+    ) -> GluMxFp8WorkTileInfo:
+        """MXFP8 (non-swapAB) override: use cluster-level slot for FC1 arrival counter.
+
+        The swap-AB extension uses ``tile_n_idx`` directly for the
+        dispatch->fc1 ready-counter slot.  For NVFP4 swap-AB that is correct
+        because N is the token direction.  For MXFP8 non-swap-AB, M is the
+        token direction, so the FC1 peek must index by
+        ``cumulative_token_block_count + tile_m_idx // cluster_m``
+        to match the cluster-granular slot that dispatch_pull increments.
+
+        The scheduler packs per-CTA and cluster-level token counts into
+        ``valid_tokens_in_cta_cluster_tile``; this function passes it through
+        unchanged and uses the ``valid_tokens_in_cluster_tile`` property for the
+        FC1 peek threshold.
+        """
+        is_valid = base_work.is_valid_tile
+        new_phase_and_peek = base_work.phase_and_peek
+
+        if is_valid:
+            is_fc1 = base_work.phase == Int32(int(BlockPhase.Linear1))
+            is_fc2 = base_work.phase == Int32(int(BlockPhase.Linear2))
+
+            # FC1 arrival peek: cluster-granular slot = cumul + tile_m_idx // cluster_m.
+            if cutlass.const_expr(self.fc1_ready_counter_ptr is not None):
+                if is_fc1:
+                    fc1_counter_slot = (
+                        base_work.cumulative_token_block_count
+                        + base_work.tile_m_idx // Int32(self.cluster_m)
+                    )
+                    counter_ptr = self.fc1_ready_counter_ptr + fc1_counter_slot
+                    peek_ready = spin_wait(
+                        counter_ptr,
+                        lambda v: v >= base_work.valid_tokens_in_cluster_tile,
+                        peek_only=True,
+                    )
+                    peek_bit = Int32(0)
+                    if peek_ready:
+                        peek_bit = Int32(PeekReadyBit)
+                    new_phase_and_peek = base_work.phase_and_peek | peek_bit
+
+            # FC2 peek: MXFP8 TMA-A always spins (peek_ready never checked)
+            if is_fc2:
+                fc2_counter_slot = (
+                    base_work.cumulative_token_block_count + base_work.fc1_counter_index
+                )
+                counter_ptr = self.fc1_done_counter_ptr + fc2_counter_slot
+                peek_ready = spin_wait(
+                    counter_ptr,
+                    lambda v: v >= self.fc2_spin_threshold,
+                    peek_only=True,
+                )
+                peek_bit = Int32(0)
+                if peek_ready:
+                    peek_bit = Int32(PeekReadyBit)
+                new_phase_and_peek = base_work.phase_and_peek | peek_bit
+
+        return GluMxFp8WorkTileInfo(
+            expert_idx=base_work.expert_idx,
+            tile_m_idx=base_work.tile_m_idx,
+            tile_n_idx=base_work.tile_n_idx,
+            cumulative_data_physical_row=base_work.cumulative_data_physical_row,
+            cumulative_sf_physical_row=base_work.cumulative_sf_physical_row,
+            cumulative_token_block_count=base_work.cumulative_token_block_count,
+            valid_tokens_in_cta_cluster_tile=base_work.valid_tokens_in_cta_cluster_tile,
+            phase_and_peek=new_phase_and_peek,
+            fc1_counter_index=base_work.fc1_counter_index,
+        )
+
+    @cute.jit
+    def prefetch_for_expert(self, expert_idx: Int32) -> None:
+        """No-op on subclass for the same reason as ``enrich_work_tile_info``."""
+        pass
+
+    @cute.jit
+    def get_gmem_tensor(
+        self,
+        tensor_name: str,
+        gmem_tensor_in_moe_view: cute.Tensor,
+        work_tile_info: SwapABSwigluFp4Fc12WorkTileInfo,
+    ) -> Tuple[cute.Tensor, Optional[Pointer]]:
+        """Phase-invariant GMEM slice for the operands."""
+        expert_idx = work_tile_info.expert_idx
+        data_token_offset = work_tile_info.cumulative_data_physical_row
+        sf_token_offset = work_tile_info.cumulative_sf_physical_row
+
+        shape = gmem_tensor_in_moe_view.shape
+        stride = gmem_tensor_in_moe_view.stride
+        c1 = cutlass.Int32(1)
+        sf_vec_size = self.sf_vec_size
+
+        if cutlass.const_expr(tensor_name == "fc1_activation"):
+            real = cute.domain_offset(
+                (data_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc1_weight"):
+            real = cute.domain_offset((0, 0, expert_idx), gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc1_activation_sf"):
+            real = cute.domain_offset(
+                (sf_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride)
+            )
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc1_weight_sf"):
+            real = cute.domain_offset((0, 0, expert_idx), gmem_tensor_in_moe_view)
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride)
+            )
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "c"):
+            # Raw fc1 accumulator output (gate+up FP32, pre-SwiGLU).
+            # Token-indexed like "d" but distinct tensor with intermediate_gateup columns.
+            real = cute.domain_offset(
+                (data_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "d"):
+            real = cute.domain_offset(
+                (data_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "sfd"):
+            real = cute.domain_offset(
+                (sf_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride)
+            )
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "topk"):
+            real = cute.domain_offset(
+                (data_token_offset,), gmem_tensor_in_moe_view
+            )
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc2_activation"):
+            # fc2 A-side = fc1_output (token-indexed, same formula as "b")
+            real = cute.domain_offset(
+                (data_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc2_activation_sf"):
+            # fc2 SFA = fc1_output_sf (token-indexed sf)
+            real = cute.domain_offset(
+                (sf_token_offset, 0, 0), gmem_tensor_in_moe_view
+            )
+            per_expert_shape = (shape[0], shape[1], c1)
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride)
+            )
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc2_weight"):
+            # fc2 B-side = fc2_weight (expert-indexed)
+            real = cute.domain_offset((0, 0, expert_idx), gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc2_weight_sf"):
+            # fc2 SFB = fc2_weight_sf (expert-indexed)
+            real = cute.domain_offset((0, 0, expert_idx), gmem_tensor_in_moe_view)
+            per_expert_shape = (shape[0], shape[1], c1)
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride)
+            )
+            return (real, None)
+
+        raise ValueError(f"Unknown tensor_name: {tensor_name!r}.")

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/dynamic_mainloop.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/dynamic_mainloop.py
@@ -1,0 +1,335 @@
+# Dynamic UMMA N for fused fc1+fc2 swap-AB MegaMoE kernel.
+#
+# Emits the block-scaled UMMA instruction as literal PTX text (via
+# ``llvm.inline_asm``) so the instruction descriptor (``idesc``) is under our
+# control -- specifically so its ``n_dim_`` bitfield becomes a runtime SSA
+# value (= ``align16(valid_tokens_in_tile) >> 3``).
+#
+# Why PTX text instead of ``cutlass._mlir.dialects.nvvm`` (the dialect Python
+# binding): that binding is a private/unstable surface that has already
+# broken once across a cutedsl upgrade (enum classes and kwargs renamed:
+# ``Tcgen05GroupKind``/``mma_kind``/``Tcgen05MMAScaleVecSize.X4`` ->
+# ``CTAGroupKind``/``kind``/``Tcgen05MMABlockScale.BLOCK16``). The PTX ISA
+# text syntax for ``tcgen05.mma...block_scale`` has been stable across CUDA
+# 12.9-13.3 (PTX ISA 8.8-9.3): the only change in that window was the
+# addition of the ``.block16``/``.block32`` aliases in 8.8, and the old
+# spelling was never removed. This module targets CUDA >= 13 and always
+# emits the ``.block16`` spelling.
+
+from typing import Optional
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import dsl_user_op, Int32, Boolean
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import builtin
+from cutlass._mlir.dialects import llvm
+
+
+# =============================================================================
+# Alignment policy (single source of truth)
+# =============================================================================
+
+
+def _align16(x):
+    """Round Int32 SSA ``x`` up to a multiple of 16 (mask off bottom 4 bits)."""
+    return (Int32(x) + Int32(15)) & Int32(-16)
+
+
+@dsl_user_op
+def compute_non_leader_cta_load_shift(
+    *,
+    valid_tokens_in_tile,  # Int32 SSA
+    mma_tiler_n: int,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Int32:
+    """Token offset that non-leader CTA's TMA-B read must shift by under 2cta.
+
+    Under dynamic UMMA + 2cta:
+      - MMA splits N at align16(valid) / 2
+      - TMA static partition splits at mma_tiler_n / 2
+
+    The result ∈ (-mma_tiler_n/2, 0]; apply via
+    ``cute.domain_offset((shift, 0, 0), real_b)`` on non-leader CTA only.
+    """
+    return (_align16(valid_tokens_in_tile) >> Int32(1)) - Int32(mma_tiler_n // 2)
+
+
+# =============================================================================
+# Static idesc base builder (compile-time Python int)
+# =============================================================================
+#
+# Bit layout of the block-scaled instruction descriptor:
+#
+#   bit [ 0, 2) : sparse_id2_      (0)
+#   bit [ 2, 3) : sparse_flag_     (0 = dense)
+#   bit [ 3, 4) : saturate_        (0)
+#   bit [ 4, 6) : b_sf_id_         (runtime, OR'd in)
+#   bit [ 6, 7) : sparse_format_   (0)
+#   bit [ 7,10) : a_format_        (1 for NVFP4 mxf4nvf4)
+#   bit [10,13) : b_format_        (1 for NVFP4 mxf4nvf4)
+#   bit [13,14) : a_negate_        (0)
+#   bit [14,15) : b_negate_        (0)
+#   bit [15,16) : a_major_         (0 = K-major)
+#   bit [16,17) : b_major_         (0 = K-major)
+#   bit [17,23) : n_dim_           (runtime, OR'd in: align16(valid) >> 3)
+#   bit [23,24) : scale_format_    (0 = E4M3 SF)
+#   bit [24,29) : m_dim_           (M >> 4: 256 -> 16, 128 -> 8)
+#   bit [29,31) : a_sf_id_         (runtime, OR'd in)
+#   bit [31,32) : k_size_          (0 for NVFP4 K=64)
+
+_BIT_A_FORMAT = 7  # width 3
+_BIT_B_FORMAT = 10  # width 3
+_BIT_A_MAJOR = 15  # width 1
+_BIT_B_MAJOR = 16  # width 1
+_BIT_N_DIM = 17  # width 6
+_BIT_SCALE_FORMAT = 23  # width 1
+_BIT_M_DIM = 24  # width 5
+_BIT_A_SF_ID = 29  # width 2
+_BIT_B_SF_ID = 4  # width 2
+_BIT_K_SIZE = 31  # width 1
+
+# tcgen05.mma atom K-size for NVFP4 (UMMA_K = 64 for mxf4nvf4).
+_UMMA_K_NVFP4 = 64
+
+
+def build_static_idesc_base(
+    *,
+    umma_m: int,  # 64, 128, or 256
+    a_format: int = 1,  # NVFP4 mxf4nvf4
+    b_format: int = 1,
+    a_major: int = 0,  # 0 = K-major
+    b_major: int = 0,
+    scale_format: int = 0,  # 0 = E4M3 SF
+    k_size_bit: int = 0,  # 0 for NVFP4 (K=64)
+) -> int:
+    """Pack the static-field portion of the idesc into a u32.
+
+    Runtime fields (n_dim_, a_sf_id_, b_sf_id_, a_negate_, b_negate_) are left
+    at zero; the call site OR's them in.  For UMMA_M=256 / NVFP4 / K-major /
+    E4M3 SF the base is ``0x10000480``; for UMMA_M=128 it is ``0x08000480``.
+    """
+    assert umma_m in (64, 128, 256), f"Unsupported UMMA_M={umma_m}"
+    assert 0 <= a_format < (1 << 3)
+    assert 0 <= b_format < (1 << 3)
+    assert 0 <= scale_format < (1 << 1)
+
+    m_dim = umma_m >> 4  # 256 -> 16, 128 -> 8, 64 -> 4
+
+    desc = 0
+    desc |= (a_format & 0x7) << _BIT_A_FORMAT
+    desc |= (b_format & 0x7) << _BIT_B_FORMAT
+    desc |= (a_major & 0x1) << _BIT_A_MAJOR
+    desc |= (b_major & 0x1) << _BIT_B_MAJOR
+    desc |= (scale_format & 0x1) << _BIT_SCALE_FORMAT
+    desc |= (m_dim & 0x1F) << _BIT_M_DIM
+    desc |= (k_size_bit & 0x1) << _BIT_K_SIZE
+    return desc & 0xFFFFFFFF
+
+
+# =============================================================================
+# Runtime idesc finalization (per-MMA-call OR steps)
+# =============================================================================
+
+
+@dsl_user_op
+def compute_idesc(
+    *,
+    static_base: int,  # from build_static_idesc_base()
+    n_dim_value,  # Int32 SSA (= align16(valid_tokens_in_tile) >> 3)
+    sfa_tmem_addr_i32,  # i32 SSA -- runtime SF-A TMEM address
+    sfb_tmem_addr_i32,  # i32 SSA -- runtime SF-B TMEM address
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Int32:
+    """OR runtime fields (n_dim_, a_sf_id_, b_sf_id_) into the static base."""
+    idesc = Int32(static_base) | (Int32(n_dim_value) << _BIT_N_DIM)
+    sfa_top = Int32(sfa_tmem_addr_i32) & Int32(0xC0000000)
+    sfb_top = Int32(sfb_tmem_addr_i32) & Int32(0xC0000000)
+    # SF address top 2 bits -> idesc.{a,b}_sf_id_ slots.
+    idesc = idesc | (sfa_top >> Int32(30 - _BIT_A_SF_ID))
+    idesc = idesc | (sfb_top >> Int32(30 - _BIT_B_SF_ID))
+    return idesc
+
+
+# =============================================================================
+# Type-cast helpers
+# =============================================================================
+
+
+def _smem_desc_to_i64(smem_desc_value: ir.Value) -> ir.Value:
+    """Bit-cast cute_nvgpu.smem_desc value -> i64."""
+    i64_ty = ir.IntegerType.get_signless(64)
+    return builtin.unrealized_conversion_cast([i64_ty], [smem_desc_value])
+
+
+def _tmem_ptr_to_i32(tmem_ptr_value: ir.Value) -> ir.Value:
+    """Bit-cast cute.ptr<tmem> -> i32."""
+    i32_ty = ir.IntegerType.get_signless(32)
+    return builtin.unrealized_conversion_cast([i32_ty], [tmem_ptr_value])
+
+
+def _as_value(it) -> ir.Value:
+    """Unwrap to underlying ir.Value (cute Pointer has .value)."""
+    return it.value if hasattr(it, "value") else it
+
+
+# =============================================================================
+# PTX-text MMA emission (see module docstring for why this isn't the nvvm
+# dialect binding)
+# =============================================================================
+
+
+@dsl_user_op
+def _tcgen05_mma_mxf4nvf4_block_scale_block16(
+    *,
+    cta_group: int,  # 1 or 2 (Python int, folds into the asm mnemonic)
+    d_tmem_i32,  # ir.Value (i32) -- accumulator TMEM address
+    a_desc_i64,  # ir.Value (i64) -- A operand smem descriptor
+    b_desc_i64,  # ir.Value (i64) -- B operand smem descriptor
+    idesc_i32,  # ir.Value (i32) -- instruction descriptor
+    enable_input_d_i32,  # ir.Value (i32) -- 0/1, D = A@B (+ C if nonzero)
+    sfa_tmem_i32,  # ir.Value (i32) -- SFA TMEM address
+    sfb_tmem_i32,  # ir.Value (i32) -- SFB TMEM address
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Emit ``tcgen05.mma.cta_group::{1,2}.kind::mxf4nvf4.block_scale.block16``.
+
+    Mirrors CUTLASS's own reference lowering for this instruction
+    (``cute/arch/mma_sm100_umma.hpp``, ``SM100_MMA_MXF4_2x1SM_SS::fma``):
+    ``enable_input_d`` travels as a plain u32 register and is turned into the
+    hardware predicate in-asm via ``setp.ne.b32``, so no operand needs a
+    dialect-specific predicate type.
+    """
+    assert cta_group in (1, 2), f"cta_group must be 1 or 2, got {cta_group}"
+    llvm.inline_asm(
+        None,
+        [
+            d_tmem_i32,
+            a_desc_i64,
+            b_desc_i64,
+            idesc_i32,
+            enable_input_d_i32,
+            sfa_tmem_i32,
+            sfb_tmem_i32,
+        ],
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, $4, 0;\n\t"
+        f"tcgen05.mma.cta_group::{cta_group}.kind::mxf4nvf4.block_scale.block16 "
+        "[$0], $1, $2, $3, [$5], [$6], p;\n\t"
+        "}\n",
+        "r,l,l,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# =============================================================================
+# Main entry: 1 K-tile = (mma_tiler_k / UMMA_K) inner-K MMAs
+# =============================================================================
+
+
+@dsl_user_op
+def issue_dynamic_block_scaled_mma_tile(
+    *,
+    # Acc cute tensor (TMEM cute.ptr-typed iterator).  Carries the full
+    # per-task-tile TMEM region; K-axis advance is encoded in its layout.
+    acc_tensor,
+    # A/B fragment tensors at current AB pipeline stage (smem_desc iterators),
+    # shape (V, M_count, K_count) where K_count = mma_tiler_k / UMMA_K.
+    a_frag_tile,
+    b_frag_tile,
+    # SFA / SFB cute tensors (TMEM cute.ptr-typed iterators).
+    sfa_tensor,
+    sfb_tensor,
+    # Outer K-tile index (Int32 SSA).  Drives accumulate flag.
+    k_tile_idx,
+    # Logical valid token count for this tile (Int32 SSA).  Rounded up to 16
+    # before encoding into idesc.n_dim_.
+    valid_tokens_in_tile,
+    # ``cta_group`` (1 vs 2) is inferred from M: 256 -> 2cta, 128 -> 1cta
+    # (kernel constraint per_cta_m == 128).
+    mma_tiler_mnk: tuple = (256, 256, 256),
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue (mma_tiler_k / UMMA_K) block-scaled MMAs for one K-tile.
+
+    ``idesc.n_dim_ = align16(valid_tokens_in_tile) >> 3``.
+
+    For 2cta MMA, HW's ``cta_group::2`` semantics encode ``n_dim_ * 8`` as the
+    cluster-total N (CTA0 + CTA1 combined).  Each CTA writes half in its own
+    TMEM.  The caller aligns the per-CTA TMA load offset with HW's split via
+    a ``cute.domain_offset`` on non-leader CTA's GMEM tensor, so we just
+    encode the cluster-total directly here.
+
+    Pipeline / mbarrier / TMEM alloc / arrive are owned by the caller.
+    """
+    # Compile-time-fold base idesc from the per-config static fields.
+    static_idesc_base = build_static_idesc_base(umma_m=mma_tiler_mnk[0])
+
+    # Runtime n_dim_ field: align16(valid) >> 3.
+    n_dim_value = _align16(valid_tokens_in_tile) >> Int32(3)
+
+    num_k_inner = mma_tiler_mnk[2] // _UMMA_K_NVFP4  # = 4 for NVFP4 K=256
+
+    # 256 -> 2cta, 128 -> 1cta (kernel constraint per_cta_m == 128).
+    cta_group = 2 if mma_tiler_mnk[0] == 256 else 1
+
+    # m / n inner indices both 0 for v1 (m_count = n_count = 1).
+    m_inner = 0
+    n_inner = 0
+
+    for k_inner in range(num_k_inner):  # Python int -> compile-time unroll
+        a_atom = a_frag_tile[(None, m_inner, k_inner)]
+        b_atom = b_frag_tile[(None, n_inner, k_inner)]
+        # SF id per-K-iter is encoded in SF TMEM address top bits; the
+        # per-k_inner slice advances those bits via the SF layout.
+        sfa_atom = sfa_tensor[(None, m_inner, k_inner)]
+        sfb_atom = sfb_tensor[(None, n_inner, k_inner)]
+        acc_atom = acc_tensor[(None, m_inner, n_inner)]
+
+        # Cast operands to plain integer registers (PTX operand types).
+        a_iter_val = _as_value(a_atom.iterator)
+        b_iter_val = _as_value(b_atom.iterator)
+        acc_iter_val = _as_value(acc_atom.iterator)
+        sfa_iter_val = _as_value(sfa_atom.iterator)
+        sfb_iter_val = _as_value(sfb_atom.iterator)
+
+        operand_a = _smem_desc_to_i64(a_iter_val)
+        operand_b = _smem_desc_to_i64(b_iter_val)
+        operand_sfa_i32 = _tmem_ptr_to_i32(sfa_iter_val)
+        operand_sfb_i32 = _tmem_ptr_to_i32(sfb_iter_val)
+        operand_acc_i32 = _tmem_ptr_to_i32(acc_iter_val)
+
+        idesc = compute_idesc(
+            static_base=static_idesc_base,
+            n_dim_value=n_dim_value,
+            sfa_tmem_addr_i32=operand_sfa_i32,
+            sfb_tmem_addr_i32=operand_sfb_i32,
+        )
+
+        # Accumulate flag: True except for the very first iter
+        # (k_tile_idx == 0 AND k_inner == 0).
+        if k_inner == 0:
+            accum_flag = k_tile_idx != 0
+        else:
+            accum_flag = True
+
+        with cute.arch.elect_one():
+            _tcgen05_mma_mxf4nvf4_block_scale_block16(
+                cta_group=cta_group,
+                d_tmem_i32=operand_acc_i32,
+                a_desc_i64=operand_a,
+                b_desc_i64=operand_b,
+                idesc_i32=idesc.ir_value(),
+                enable_input_d_i32=Int32(Boolean(accum_flag)).ir_value(),
+                sfa_tmem_i32=operand_sfa_i32,
+                sfb_tmem_i32=operand_sfb_i32,
+            )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/epilogue.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/epilogue.py
@@ -1,0 +1,3605 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Autonomous epilogue for the fused fc1+fc2 swap-AB MegaMoE kernel.
+
+Component boundaries use ``TensorWithContract`` to keep per-thread RMEM layout
+semantics explicit at the handoff between transpose, SwiGLU, quantize, and fc2
+store components.
+"""
+
+import dataclasses
+from typing import Any, List, Literal, Optional, Tuple, Type, Union
+
+import cutlass
+import cutlass.cute as cute
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.typing import AddressSpace
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+
+from .contract import (
+    Contract,
+    FunctionMapping,
+    Space,
+    TensorWithContract,
+    assert_contract_equivalent,
+)
+from .fc1_fc2_fuse_sched import BlockPhase
+from common.megamoe_constants import Nvfp4BlockSize
+from src.token_comm import TokenSrcMetadata
+
+Fc1GateUpInterleave = 16
+EpilogueTokenTile = 64
+Fc1EpilogueOutputTile = 64
+WarpThreadCount = 32
+EpiWarpCount = 4
+
+# Done-counter publish batching (``epi_flag_batch``, passed from the runner):
+# amortize the device-scope fence (``fence_acq_rel_gpu``) over this many
+# publishing task tiles.  1 == per-tile baseline.  The per-tile
+# ``task_tile_boundary_bar`` already orders every epilogue warp's stores at CTA
+# scope, so the batched fence + relaxed reductions run on a single (tidx==0)
+# thread after that barrier.  A batch is flushed on every fc1<->fc2 phase switch
+# (see run loop) so it never straddles a phase boundary -- this keeps the fc1
+# done-counter (which feeds back into the fc2 MMA) from deadlocking.
+
+
+# =============================================================================
+# Module-local helpers
+# =============================================================================
+
+
+@dsl_user_op
+def _red_add_relaxed_sys_v2_bf16x2(
+    addr,
+    val0_packed_bf16x2,
+    val1_packed_bf16x2,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue ``red.relaxed.sys.global.add.v2.bf16x2 [addr], {v0, v1};``.
+
+    Used by the fc2 REDG path to atomic-add 4 bf16 cells.  Inline asm is
+    used because cuTeDSL has no vector-form ``red.v2.bf16x2`` surface; the
+    operands are packed bf16x2 bit patterns carried in 32-bit registers.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            addr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            val0_packed_bf16x2.ir_value(loc=loc, ip=ip),
+            val1_packed_bf16x2.ir_value(loc=loc, ip=ip),
+        ],
+        "red.relaxed.sys.global.add.noftz.v2.bf16x2 [$0], {$1, $2};",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _red_add_release_gpu_s32(
+    counter_ptr,
+    value,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue ``red.release.gpu.add.s32`` to a GMEM int32 location.
+
+    Publishes fc1 task-tile completion after the caller has flushed the fc1
+    output stores.  Single-thread helper; caller guards the thread predicate.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            counter_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            value.ir_value(loc=loc, ip=ip),
+        ],
+        "red.release.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _red_add_relaxed_gpu_s32(
+    counter_ptr,
+    value,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue ``red.relaxed.gpu.add.s32`` to a GMEM int32 location.
+
+    Relaxed-ordering variant of :func:`_red_add_release_gpu_s32`: drops the
+    release memory-ordering semantics so the reduction carries no fence.  Use
+    only where a separate fence already orders the prior stores.  Single-thread
+    helper; caller guards the thread predicate.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            counter_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            value.ir_value(loc=loc, ip=ip),
+        ],
+        "red.relaxed.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _red_add_relaxed_gpu_s32_addr(
+    addr,
+    value,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """``red.relaxed.gpu.add.s32`` to a GMEM int32 given its raw int64 address.
+
+    Same as :func:`_red_add_relaxed_gpu_s32` but takes the target address as an
+    ``Int64`` value (e.g. ``(counter.iterator + off).toint()``) instead of a
+    pointer, so a batch of pre-computed done-counter targets can be replayed
+    from an RMEM scratch buffer under a single device fence.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            addr.ir_value(loc=loc, ip=ip),
+            value.ir_value(loc=loc, ip=ip),
+        ],
+        "red.relaxed.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _cp_async_bulk_s2g(
+    dst_gmem,
+    src_smem,
+    size_bytes,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue non-tensor descriptor-free ``cp.async.bulk`` SMEM->GMEM.
+
+    cuTeDSL does expose ``cpasync.CopyBulkS2GOp`` / ``cute.copy`` for this
+    instruction family, but that abstraction bakes the transfer size into
+    the copy atom / static tensor layout: CuteNvGPU lowers it as an
+    ``arch.copy.SM90.bulk_copy_s2g`` op whose ``size`` is an ``I32Attr``.
+    The fc2 UBLK epilogue needs a runtime byte count for the hidden-tail
+    row (still 16B-aligned, but not necessarily the full 128-hidden row).
+    Using the cute copy atom would silently encode the wrong semantic
+    contract, so keep the raw PTX here until the dialect grows a dynamic-size
+    descriptor-free bulk-copy op.
+
+    This helper only issues the instruction.  The caller owns
+    ``cp_async_bulk_commit_group`` so copy and reduce bulk paths share the
+    same group boundary.
+    """
+    # with cute.arch.elect_one():
+    llvm.inline_asm(
+        None,
+        [
+            dst_gmem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            src_smem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            size_bytes.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.global.shared::cta.bulk_group [$0], [$1], $2;",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+@dsl_user_op
+def _cp_reduce_async_bulk_add_noftz_bf16_s2g(
+    dst_gmem,
+    src_smem,
+    size_bytes,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue non-tensor ``cp.reduce.async.bulk`` for BF16 add.
+
+    cuTeDSL currently exposes descriptor-free ``CopyBulkS2GOp`` but not the
+    matching descriptor-free reduce atom.  Keep the fallback local to this
+    epilogue path so the rest of the bulk pipeline can still share the same
+    tensor/layout front-end.
+    """
+    # with cute.arch.elect_one():
+    llvm.inline_asm(
+        None,
+        [
+            dst_gmem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            src_smem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            size_bytes.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.noftz.bf16 "
+        "[$0], [$1], $2;",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# =============================================================================
+# Region tag
+# =============================================================================
+
+
+class Region:
+    """Codegen-time region tag for a 16x32 sub-region within a 32x32 tile."""
+
+    Top = 0
+    Bottom = 1
+
+
+# =============================================================================
+# TmemTranspose16x32
+# =============================================================================
+
+
+class _TmemTranspose16x32Core:
+    """Contract-naive physical implementation of the 16x32 -> 32x16 TMEM
+    in-place transpose.  Shared by:
+
+      - ``TmemTranspose16x32``       : fc1 epi codomain naming
+                                       (``intermediate_output_idx``);
+                                       elements are fp32 (swiglu fold output).
+      - ``TmemTranspose16x32Packed`` : fc2 epi codomain naming
+                                       (``hidden_pair_idx``); elements are
+                                       32-bit packed ``(bf16, bf16)`` pairs.
+
+    The (lane_idx, elem_idx) physical distribution is identical for both
+    subclasses -- the underlying tcgen05 atoms are 32-bit element atoms,
+    agnostic to whether each 32-bit slot holds an fp32 or a packed bf16x2.
+    Only the codomain semantic names differ, expressed via the subclass's
+    ``InputContract`` / ``OutputContract`` class attributes.
+
+    Per-thread RMEM coordinate convention (used by both subclasses' contracts):
+
+      - ``lane_idx`` -- warp lane id (= thread index within warp), in [0, 32).
+      - ``elem_idx`` -- per-thread reg index, in [0, 16).
+
+    Subclasses MUST override these two class attributes:
+      ``InputContract``  -- (lane_idx, elem_idx) -> codomain mapping after
+                            R1.Load (or after ``reg_tensor`` is fed in for
+                            skip-R1.Load mode).
+      ``OutputContract`` -- (lane_idx, elem_idx) -> codomain mapping after
+                            ``r4_perm`` has run all four rounds.
+
+    The Core's ``__init__`` reads ``self.InputContract`` / ``self.OutputContract``
+    via Python's normal MRO attribute lookup; the subclass's overrides take
+    precedence at construction time.
+    """
+
+    # Subclasses MUST override these.
+    InputContract: Contract
+    OutputContract: Contract
+
+    _PermR1 = (0, 8, 2, 10, 4, 12, 6, 14, 1, 9, 3, 11, 5, 13, 7, 15)
+    _PermR3 = (0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15)
+    _PermR4 = (0, 8, 2, 10, 4, 12, 6, 14, 1, 9, 3, 11, 5, 13, 7, 15)
+
+    _TmemRowStride = 1 << 16
+    _io_dtype = cutlass.Float32
+
+    @staticmethod
+    def _tmem_layout(num_lanes: int, num_cols: int) -> cute.Layout:
+        return cute.make_layout(
+            (((num_lanes, num_cols), 1),),
+            stride=(((_TmemTranspose16x32Core._TmemRowStride, 1), 0),),
+        )
+
+    @staticmethod
+    def _rmem_copy_view(
+        rmem: cute.Tensor, num_regs: int, offset: int = 0
+    ) -> cute.Tensor:
+        return cute.make_tensor(
+            rmem.iterator + offset,
+            cute.make_layout((((num_regs,), 1),), stride=(((1,), 0),)),
+        )
+
+    @staticmethod
+    def load_subtile_raw_acc(
+        tmem_subtile_tensor: cute.Tensor,
+    ) -> Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor]:
+        """LDTM the entire 32-lane x 64-col raw acc region of one epi
+        subtile into 4 independent (16,) fp32 RMEM tensors.
+
+        Used by the overlap-acc unroll path in
+        ``_run_fc{1,2}_task_tile`` to extract all raw acc data of the
+        first 2 subtiles up front, so that the acc TMEM can be released
+        to the next mma right after the first subtile's 4 LDTMs (instead
+        of waiting for a full subtile body to complete).
+
+        ``tmem_subtile_tensor`` is the (32 lanes, 64 cols) view onto a
+        single epi subtile's acc TMEM region (already offset by
+        ``warp_lane_offset + acc_stage_col_offset + subtile_col_offset``;
+        see ``SwapABSwigluFp4Epilogue._subtile_local_tmem_tensor``).
+
+        Returns a 4-tuple of (16,) fp32 RMEM tensors, each carrying
+        the (lane_idx, elem_idx) -> codomain distribution described by
+        ``TmemTranspose16x32.InputContract`` /
+        ``TmemTranspose16x32Packed.InputContract`` (physically identical
+        for fc1 and fc2, only codomain semantic names differ):
+
+          [0] gate_lo / first-half top   -- subtile cols 0..31, lanes 0..15
+          [1] up_lo   / first-half bot   -- subtile cols 0..31, lanes 16..31
+          [2] raw_top / second-half top  -- subtile cols 32..63, lanes 0..15
+          [3] raw_bot / second-half bot  -- subtile cols 32..63, lanes 16..31
+
+        4 atom calls of ``Ld16x64bOp(Repetition.x16) Float32`` -- the
+        same atom currently used by the per-subtile entry LDTM in
+        ``_run_fc1_subtile`` and by ``second_t.r1_load`` /
+        ``Fc2AccLoadAndPack`` per-half LDTMs.  Caller is expected to
+        wrap each output in ``TensorWithContract`` with
+        ``TmemTranspose16x32{,Packed}.InputContract`` before handing
+        them downstream.
+        """
+        atom_ld16x64 = cute.make_copy_atom(
+            tcgen05.Ld16x64bOp(tcgen05.Repetition.x16),
+            _TmemTranspose16x32Core._io_dtype,
+        )
+
+        ptr = tmem_subtile_tensor.iterator
+        half_lane_off = 16 * _TmemTranspose16x32Core._TmemRowStride
+
+        # 4 source 16-lane x 32-col views over the (32, 64) subtile region:
+        #   first  half (cols 0..31): top  lanes 0..15  / bot lanes 16..31
+        #   second half (cols 32..63): top lanes 0..15  / bot lanes 16..31
+        # All offsets are Python ints (compile-time const) so cute can
+        # const-fold them and infer the correct (>= 8 B / 2 col) ptr
+        # alignment that the LDTM atom requires.  Using ``cutlass.Int32``
+        # offsets here would wrap them as SSA values that cute treats as
+        # alignment-unknown, tripping the atom's verifier.
+        first_top_view = cute.make_tensor(
+            ptr,
+            _TmemTranspose16x32Core._tmem_layout(16, 32),
+        )
+        first_bot_view = cute.make_tensor(
+            ptr + half_lane_off,
+            _TmemTranspose16x32Core._tmem_layout(16, 32),
+        )
+        second_top_view = cute.make_tensor(
+            ptr + 32,
+            _TmemTranspose16x32Core._tmem_layout(16, 32),
+        )
+        second_bot_view = cute.make_tensor(
+            ptr + 32 + half_lane_off,
+            _TmemTranspose16x32Core._tmem_layout(16, 32),
+        )
+
+        first_top = cute.make_rmem_tensor((16,), _TmemTranspose16x32Core._io_dtype)
+        first_bot = cute.make_rmem_tensor((16,), _TmemTranspose16x32Core._io_dtype)
+        second_top = cute.make_rmem_tensor((16,), _TmemTranspose16x32Core._io_dtype)
+        second_bot = cute.make_rmem_tensor((16,), _TmemTranspose16x32Core._io_dtype)
+
+        cute.copy(
+            atom_ld16x64,
+            first_top_view,
+            _TmemTranspose16x32Core._rmem_copy_view(first_top, 16),
+        )
+        cute.copy(
+            atom_ld16x64,
+            first_bot_view,
+            _TmemTranspose16x32Core._rmem_copy_view(first_bot, 16),
+        )
+        cute.copy(
+            atom_ld16x64,
+            second_top_view,
+            _TmemTranspose16x32Core._rmem_copy_view(second_top, 16),
+        )
+        cute.copy(
+            atom_ld16x64,
+            second_bot_view,
+            _TmemTranspose16x32Core._rmem_copy_view(second_bot, 16),
+        )
+
+        return (first_top, first_bot, second_top, second_bot)
+
+    def __init__(
+        self,
+        tmem_ptr,
+        region: int,
+        reg_tensor: Optional[TensorWithContract] = None,
+    ) -> None:
+        half_lane_off = 16 * self._TmemRowStride
+        if region == Region.Top:
+            src_ptr = tmem_ptr
+            dst_ptr = tmem_ptr
+        elif region == Region.Bottom:
+            src_ptr = tmem_ptr + half_lane_off
+            dst_ptr = tmem_ptr + 16
+        else:
+            raise ValueError("region must be Region.Top or Region.Bottom")
+
+        self.region = region
+
+        self._tmem_src_full = cute.make_tensor(src_ptr, self._tmem_layout(16, 32))
+        self._tmem_dst_full = cute.make_tensor(dst_ptr, self._tmem_layout(32, 16))
+        self._tmem_dst_top = cute.make_tensor(dst_ptr, self._tmem_layout(16, 16))
+        self._tmem_dst_bot = cute.make_tensor(
+            dst_ptr + half_lane_off, self._tmem_layout(16, 16)
+        )
+
+        self._atom_ld16x64 = cute.make_copy_atom(
+            tcgen05.Ld16x64bOp(tcgen05.Repetition.x16), self._io_dtype,
+        )
+        self._atom_st16x128 = cute.make_copy_atom(
+            tcgen05.St16x128bOp(tcgen05.Repetition.x8), self._io_dtype,
+        )
+        self._atom_st32x32 = cute.make_copy_atom(
+            tcgen05.St32x32bOp(tcgen05.Repetition.x16), self._io_dtype,
+        )
+        self._atom_ld16x256 = cute.make_copy_atom(
+            tcgen05.Ld16x256bOp(tcgen05.Repetition.x2), self._io_dtype,
+        )
+        self._atom_ld16x128 = cute.make_copy_atom(
+            tcgen05.Ld16x128bOp(tcgen05.Repetition.x4), self._io_dtype,
+        )
+
+        self._src_regs = cute.make_rmem_tensor((16,), self._io_dtype)
+        output_tensor = cute.make_rmem_tensor((16,), self._io_dtype)
+        self.output = TensorWithContract(
+            tensor=output_tensor,
+            contract=self.OutputContract,
+        )
+
+        self._reg_tensor = reg_tensor
+        if reg_tensor is not None:
+            assert_contract_equivalent(
+                reg_tensor.contract,
+                self.InputContract,
+                context=f"{type(self).__name__} skip-R1.Load reg_tensor",
+            )
+            for r in range(16):
+                self._src_regs[r] = reg_tensor.tensor[r]
+
+    # -- R1 ------------------------------------------------------------------
+
+    def r1_load(self) -> None:
+        """LDTM src region -> ``_src_regs``.  No-op in skip-R1.Load mode."""
+        if self._reg_tensor is not None:
+            return
+        cute.copy(
+            self._atom_ld16x64,
+            self._tmem_src_full,
+            self._rmem_copy_view(self._src_regs, 16),
+        )
+
+    def r1_perm(self) -> None:
+        for r in range(16):
+            self.output.tensor[r] = self._src_regs[self._PermR1[r]]
+
+    def r1_store(self) -> None:
+        cute.copy(
+            self._atom_st16x128,
+            self._rmem_copy_view(self.output.tensor, 16),
+            self._tmem_src_full,
+        )
+
+    # -- R2 ------------------------------------------------------------------
+
+    def r2_load(self) -> None:
+        cute.copy(
+            self._atom_ld16x64,
+            self._tmem_src_full,
+            self._rmem_copy_view(self._src_regs, 16),
+        )
+
+    def r2_store(self) -> None:
+        cute.copy(
+            self._atom_st32x32,
+            self._rmem_copy_view(self._src_regs, 16),
+            self._tmem_dst_full,
+        )
+
+    # -- R3 ------------------------------------------------------------------
+
+    def r3_load_top(self) -> None:
+        cute.copy(
+            self._atom_ld16x256,
+            self._tmem_dst_top,
+            self._rmem_copy_view(self._src_regs, 8, offset=0),
+        )
+
+    def r3_load_bot(self) -> None:
+        cute.copy(
+            self._atom_ld16x256,
+            self._tmem_dst_bot,
+            self._rmem_copy_view(self._src_regs, 8, offset=8),
+        )
+
+    def r3_perm(self) -> None:
+        for r in range(16):
+            self.output.tensor[r] = self._src_regs[self._PermR3[r]]
+
+    def r3_store(self) -> None:
+        cute.copy(
+            self._atom_st32x32,
+            self._rmem_copy_view(self.output.tensor, 16),
+            self._tmem_dst_full,
+        )
+
+    # -- R4 ------------------------------------------------------------------
+
+    def r4_load_top(self) -> None:
+        cute.copy(
+            self._atom_ld16x128,
+            self._tmem_dst_top,
+            self._rmem_copy_view(self._src_regs, 8, offset=0),
+        )
+
+    def r4_load_bot(self) -> None:
+        cute.copy(
+            self._atom_ld16x128,
+            self._tmem_dst_bot,
+            self._rmem_copy_view(self._src_regs, 8, offset=8),
+        )
+
+    def r4_perm(self) -> None:
+        for r in range(16):
+            self.output.tensor[r] = self._src_regs[self._PermR4[r]]
+
+    def r4_store(self) -> None:
+        cute.copy(
+            self._atom_st32x32,
+            self._rmem_copy_view(self.output.tensor, 16),
+            self._tmem_dst_full,
+        )
+
+
+class TmemTranspose16x32(_TmemTranspose16x32Core):
+    """fc1 epi 16x32 -> 32x16 TMEM in-place transpose.
+
+    Contract summary:
+      - input : ``token_idx = elem_idx * 2 + ((lane_idx // 2) % 2)``
+      - output: ``token_idx = lane_idx``
+    The second codomain axis is ``intermediate_output_idx``.
+    """
+
+    _domain = Space(("lane_idx", "elem_idx"), (32, 16))
+    _codomain = Space(("token_idx", "intermediate_output_idx"), (32, 16))
+
+    InputContract = Contract(
+        domain=_domain,
+        codomain=_codomain,
+        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
+            "token_idx": elem_idx * 2 + ((lane_idx // 2) % 2),
+            "intermediate_output_idx": (lane_idx % 2) * 8 + lane_idx // 4,
+        }),
+    )
+    OutputContract = Contract(
+        domain=_domain,
+        codomain=_codomain,
+        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
+            "token_idx": lane_idx,
+            "intermediate_output_idx": elem_idx,
+        }),
+    )
+
+
+class TmemTranspose16x32Packed(_TmemTranspose16x32Core):
+    """fc2 epi 16x32 -> 32x16 TMEM in-place transpose, 32-bit packed
+    bf16x2 elements.
+
+    Same physical atom sequence as ``TmemTranspose16x32``; codomain is
+    ``(token_idx, hidden_pair_idx)`` and each slot holds one packed bf16x2.
+    """
+
+    _domain = Space(("lane_idx", "elem_idx"), (32, 16))
+    _codomain = Space(("token_idx", "hidden_pair_idx"), (32, 16))
+
+    InputContract = Contract(
+        domain=_domain,
+        codomain=_codomain,
+        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
+            "token_idx": elem_idx * 2 + ((lane_idx // 2) % 2),
+            "hidden_pair_idx": (lane_idx % 2) * 8 + lane_idx // 4,
+        }),
+    )
+    OutputContract = Contract(
+        domain=_domain,
+        codomain=_codomain,
+        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
+            "token_idx": lane_idx,
+            "hidden_pair_idx": elem_idx,
+        }),
+    )
+
+
+# =============================================================================
+# TmemTranspose32x32Inplace
+# =============================================================================
+
+
+class TmemTranspose32x32Inplace:
+    """fc1 epi 32x32 in-place TMEM transpose: two ``TmemTranspose16x32``
+    sub-instances (``top`` = lanes 0..15, ``bot`` = lanes 16..31).
+
+    Optional ``reg_tensor_top`` / ``reg_tensor_bot`` enable skip-R1.Load mode
+    for both halves; they must be provided or omitted together.
+    """
+
+    def __init__(
+        self,
+        tmem_ptr,
+        reg_tensor_top: Optional[TensorWithContract] = None,
+        reg_tensor_bot: Optional[TensorWithContract] = None,
+    ) -> None:
+        if (reg_tensor_top is None) != (reg_tensor_bot is None):
+            raise ValueError(
+                "TmemTranspose32x32Inplace: reg_tensor_top and reg_tensor_bot "
+                "must be provided or omitted together (both halves either "
+                "skip-R1.Load or do R1.Load)."
+            )
+        self.top = TmemTranspose16x32(tmem_ptr, Region.Top, reg_tensor=reg_tensor_top)
+        self.bot = TmemTranspose16x32(tmem_ptr, Region.Bottom, reg_tensor=reg_tensor_bot)
+
+
+# =============================================================================
+# SwigluCompute
+# =============================================================================
+
+
+class SwigluCompute:
+    """Element-wise SwiGLU fold over a configurable reg range
+    (packed_f32x2 path).
+
+    SwigluCompute does NOT have a fixed ``InputContract``: the caller
+    determines the input distribution by what it hands in.  At
+    construction time we validate that ``gate.contract`` and ``up.contract``
+    are equal -- the fold is element-wise, so they must share the same
+    physical (lane_idx, elem_idx) -> (logical) distribution; only the
+    semantic label differs (gate slice vs up slice).
+
+    ``self.output`` inherits the input contract: the fold is element-wise,
+    so the output has the same (lane_idx, elem_idx) -> physical mapping
+    as the input.  Only the codomain semantic label changes (intermediate
+    input slot -> intermediate output slot); since both labels are
+    logically the same axis, the contract object is reused as-is.
+
+    ``fold(start, end)`` writes ``self.output.tensor[start:end]`` only.
+    The caller may invoke ``fold`` with disjoint ranges to disperse SwiGLU's
+    MUFU traffic across surrounding transpose STTM boundaries.
+    """
+
+    _Log2E = 1.4426950408889634
+
+    def __init__(
+        self,
+        gate: TensorWithContract,
+        up: TensorWithContract,
+        alpha,
+    ) -> None:
+        assert_contract_equivalent(
+            gate.contract,
+            up.contract,
+            context="SwigluCompute gate/up contract",
+        )
+
+        self._gate = gate.tensor
+        self._up = up.tensor
+        self._alpha = alpha
+
+        output_tensor = cute.make_rmem_tensor((16,), cutlass.Float32)
+        self.output = TensorWithContract(
+            tensor=output_tensor,
+            contract=gate.contract,
+        )
+
+    def fold(self, start: int = 0, end: int = 16) -> None:
+        """Fold pairs ``(i, i+1)`` for ``i in range(start, end, 2)``::
+
+            out[i, i+1] = (alpha^2) * up[i, i+1] * gate[i, i+1] *
+                          sigmoid(alpha * gate[i, i+1])
+            sigmoid(x)  = rcp(1 + exp2(-x * log2(e)))
+
+        Reassociated to put the FMUL2 first so the inner mul collapses to
+        one FMUL2 per pair.  ``mul``/``add`` go through packed_f32x2;
+        ``exp2``/``rcp_approx`` run scalar but on adjacent pairs ptxas
+        back-to-backs them on the MUFU pipe.
+
+        ``start`` / ``end`` must be pair-aligned.
+        """
+        alpha_f32 = cutlass.Float32(self._alpha)
+        neg_alpha_log2e = alpha_f32 * cutlass.Float32(-self._Log2E)
+        neg_alpha_log2e_pair = (neg_alpha_log2e, neg_alpha_log2e)
+        alpha_sq = alpha_f32 * alpha_f32
+        alpha_sq_pair = (alpha_sq, alpha_sq)
+        one_pair = (cutlass.Float32(1.0), cutlass.Float32(1.0))
+
+        out = self.output.tensor
+        for i in range(start, end, 2):
+            ug = cute.arch.mul_packed_f32x2(
+                (self._up[i], self._up[i + 1]),
+                (self._gate[i], self._gate[i + 1]),
+            )
+
+            neg_g_log2e = cute.arch.mul_packed_f32x2(
+                (self._gate[i], self._gate[i + 1]), neg_alpha_log2e_pair
+            )
+            exp_pair = (
+                cute.math.exp2(neg_g_log2e[0], fastmath=True),
+                cute.math.exp2(neg_g_log2e[1], fastmath=True),
+            )
+            one_plus_exp = cute.arch.add_packed_f32x2(exp_pair, one_pair)
+            sigmoid_pair = (
+                cute.arch.rcp_approx(one_plus_exp[0]),
+                cute.arch.rcp_approx(one_plus_exp[1]),
+            )
+
+            ug_sig = cute.arch.mul_packed_f32x2(ug, sigmoid_pair)
+            out_pair = cute.arch.mul_packed_f32x2(ug_sig, alpha_sq_pair)
+
+            out[i] = out_pair[0]
+            out[i + 1] = out_pair[1]
+
+
+# =============================================================================
+# PostSwigluHalf
+# =============================================================================
+
+
+class PostSwigluHalf:
+    """Per-half SwiGLU finalize: topk-weight broadcast mul + gen_sf + quantize
+    at construction, then ``stg_sfc`` / ``r2s`` as later atomic actions.
+
+    The post-transpose contract gives each thread one token's 16 values, so
+    topk broadcast is one scalar multiply across local regs.  The kernel applies
+    topk weights before NVFP4 quantization so the fc2 mainloop reads already
+    weighted fc1 output.
+    """
+
+    # InputContract: explicit definition (NOT an alias of
+    # ``TmemTranspose16x32.OutputContract``).  Two distinct Contract objects
+    # carrying the same mapping function let the construct-time
+    # ``assert_contract_equivalent(swiglu.contract, self.InputContract)``
+    # check actually exercise the equivalence comparison: if anyone later
+    # mutates the upstream OutputContract without updating this one, the
+    # mismatch is caught at codegen time.  Aliasing would silently
+    # short-circuit the validation.
+    _domain = Space(("lane_idx", "elem_idx"), (32, 16))
+    _codomain = Space(("token_idx", "intermediate_output_idx"), (32, 16))
+    InputContract = Contract(
+        domain=_domain,
+        codomain=_codomain,
+        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
+            "token_idx": lane_idx,
+            "intermediate_output_idx": elem_idx,
+        }),
+    )
+
+    _Nvfp4RcpLimit = 1.0 / 6.0  # 1 / max abs of Float4E2M1FN (= 6.0)
+    _Fp32Max = 3.40282346638528859812e38
+
+    def __init__(
+        self,
+        swiglu: TensorWithContract,
+        *,
+        sC: cute.Tensor,
+        gSFC: cute.Tensor,
+        preloaded_topk_weight: cutlass.Float32,
+        warp_idx,
+        norm_const,
+        sf_vec_size: int,
+        half_idx: int,
+        token_idx,
+        thread_in_warp,
+        intermediate_downproj_idx,
+        intermediate_downproj,
+        cga_cluster_tile_intermediate_downproj: int,
+    ) -> None:
+        assert_contract_equivalent(
+            swiglu.contract,
+            self.InputContract,
+            context="PostSwigluHalf swiglu input",
+        )
+
+        self._sC = sC
+        self._gSFC = gSFC
+        self._warp_idx = warp_idx
+        self._sf_vec_size = sf_vec_size
+
+        self._half_idx = half_idx
+        self._token_idx = token_idx
+        self._thread_in_warp = thread_in_warp
+        self._intermediate_downproj_idx = intermediate_downproj_idx
+        self._intermediate_downproj = intermediate_downproj
+        self._cga_cluster_tile_intermediate_downproj = (
+            cga_cluster_tile_intermediate_downproj
+        )
+
+        self._sfc_reg, self._scaled_regs = self._gen_sfc_quantize(
+            swiglu.tensor, norm_const, preloaded_topk_weight
+        )
+
+    def _gen_sfc_quantize(
+        self, swiglu_rmem: cute.Tensor, norm_const, topk_weight
+    ):
+        """Compute SFC + pre-quantized scaled fp32 regs in RMEM."""
+        sfc_reg = cute.make_rmem_tensor((1,), cutlass.Float8E4M3FN)
+        weighted_regs = cute.make_rmem_tensor((16,), cutlass.Float32)
+        scaled_regs = cute.make_rmem_tensor((16,), cutlass.Float32)
+
+        # Path A: multiply topk before NVFP4 quantize.
+        topk_pair = (topk_weight, topk_weight)
+        for i in range(0, 16, 2):
+            w0, w1 = cute.arch.mul_packed_f32x2(
+                (cutlass.Float32(swiglu_rmem[i]), cutlass.Float32(swiglu_rmem[i + 1])),
+                topk_pair,
+            )
+            weighted_regs[i] = w0
+            weighted_regs[i + 1] = w1
+
+        # Step 1: absmax over the weighted regs.
+        absmax = cutlass.Float32(0.0)
+        for i in range(16):
+            v = weighted_regs[i]
+            abs_v = cute.arch.fmax(v, -v)
+            absmax = cute.arch.fmax(absmax, abs_v)
+
+        sfc_fp32 = absmax * cutlass.Float32(self._Nvfp4RcpLimit) * norm_const
+        sfc_reg[0] = sfc_fp32.to(cutlass.Float8E4M3FN)
+        sfc_fp32_rt = cutlass.Float32(sfc_reg[0])
+
+        acc_scale = norm_const * cute.arch.rcp_approx(sfc_fp32_rt)
+        acc_scale = cute.arch.fmin(acc_scale, cutlass.Float32(self._Fp32Max))
+        mask = cute.arch.fmin(
+            sfc_fp32_rt * cutlass.Float32(1e30), cutlass.Float32(1.0)
+        )
+        acc_scale = acc_scale * mask
+
+        acc_scale_pair = (acc_scale, acc_scale)
+        for i in range(0, 16, 2):
+            s0, s1 = cute.arch.mul_packed_f32x2(
+                (weighted_regs[i], weighted_regs[i + 1]),
+                acc_scale_pair,
+            )
+            scaled_regs[i] = s0
+            scaled_regs[i + 1] = s1
+
+        return sfc_reg, scaled_regs
+
+    @cute.jit
+    def stg_sfc(self) -> None:
+        """RMEM -> GMEM: 1 fp8 SFC byte for this token/SF block.
+
+        Skip when the warp's intermediate_downproj position is past the
+        valid bound; corresponding fp4 is TMA-OOB-fill-0 on fc2 data leg.
+
+        ``self._intermediate_downproj`` is one of three flavors:
+
+          * Python int that is a multiple of
+            ``_cga_cluster_tile_intermediate_downproj``: the predicate is
+            statically True; const_expr collapses the entire branch into
+            an unconditional STG (no runtime cmp / branch).
+
+          * Python int that is NOT statically aligned (static_expert_shape
+            path with e.g. ``intermediate_downproj == 96`` and
+            ``cga_cluster_tile_intermediate_downproj == 64``): the
+            second branch runs a runtime predicate against a const SSA
+            (the Python int folds to an immediate cmp).
+
+          * Int32 SSA (static_expert_shape is None, i.e. dynamic-shape
+            mode): the second branch runs a full runtime cmp.  The
+            ``isinstance`` short-circuit prevents the first branch from
+            trying to ``%`` an SSA value at trace time.
+        """
+        if cutlass.const_expr(
+            isinstance(self._intermediate_downproj, int)
+            and self._intermediate_downproj
+            % self._cga_cluster_tile_intermediate_downproj == 0
+        ):
+            self._gSFC[
+                self._token_idx, self._intermediate_downproj_idx, 0
+            ] = self._sfc_reg[0]
+            return
+
+        # Runtime predicate.  Works for both the unaligned-static and the
+        # dynamic-shape paths; subtile size assumption (1 fp8 / warp /
+        # subtile) is unchanged from the previous implementation.
+        if self._intermediate_downproj_idx < self._intermediate_downproj:
+            cute.copy(cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Uint8, num_bits_per_copy=8), self._sfc_reg, cute.composition(self._gSFC[self._token_idx, self._intermediate_downproj_idx, None], self._sfc_reg.shape))
+
+    def r2s(self, subtile_idx) -> None:
+        """RMEM -> SMEM: per-thread STS.64 of 16 fp4 to ``sC[subtile_idx]``."""
+        fp4_regs = cute.make_rmem_tensor((16,), cutlass.Float4E2M1FN)
+        fp4_vec = self._scaled_regs.load().to(cutlass.Float4E2M1FN)
+        fp4_regs.store(fp4_vec)
+
+        sC_stage = cute.slice_(self._sC, (None, None, subtile_idx))
+        token_coord = self._thread_in_warp + 32 * self._half_idx
+        sC_thread_row = cute.local_tile(
+            sC_stage,
+            (1, 16),
+            (token_coord, self._warp_idx),
+        )
+
+        copy_atom_64b = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            cutlass.Float4E2M1FN,
+            num_bits_per_copy=64,
+        )
+        cute.copy(
+            copy_atom_64b,
+            cute.coalesce(fp4_regs),
+            cute.coalesce(sC_thread_row),
+        )
+
+
+# =============================================================================
+# Fc2AccLoadAndPack
+# =============================================================================
+
+
+class Fc2AccLoadAndPack:
+    """fc2 epi: LDTM x 2 + cvt.rn.bf16x2.f32 fuse + pair packing.
+
+    Output is a ``TensorWithContract`` matching
+    ``TmemTranspose16x32Packed.InputContract``; each 32-bit slot stores one
+    bf16x2 pair ``(hidden_i, hidden_i + 16)``.
+    """
+
+    # OutputContract: explicit definition (NOT an alias of
+    # ``TmemTranspose16x32Packed.InputContract``).  Two distinct Contract
+    # objects carrying the same mapping function let the construct-time
+    # equivalence check inside ``TmemTranspose16x32Packed.__init__`` (when
+    # given ``reg_tensor=self.output``) actually exercise the check: if
+    # either side's mapping drifts, the codegen-time assertion catches it.
+    # Aliasing would silently short-circuit the validation.
+    _domain = Space(("lane_idx", "elem_idx"), (32, 16))
+    _codomain = Space(("token_idx", "hidden_pair_idx"), (32, 16))
+    OutputContract = Contract(
+        domain=_domain,
+        codomain=_codomain,
+        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
+            "token_idx": elem_idx * 2 + ((lane_idx // 2) % 2),
+            "hidden_pair_idx": (lane_idx % 2) * 8 + lane_idx // 4,
+        }),
+    )
+
+    _io_dtype = cutlass.Float32  # 32-bit slot dtype for downstream atoms
+    _TmemRowStride = _TmemTranspose16x32Core._TmemRowStride
+
+    @staticmethod
+    def _tmem_layout(num_lanes: int, num_cols: int) -> cute.Layout:
+        return _TmemTranspose16x32Core._tmem_layout(num_lanes, num_cols)
+
+    @staticmethod
+    def _rmem_copy_view(
+        rmem: cute.Tensor, num_regs: int, offset: int = 0
+    ) -> cute.Tensor:
+        return _TmemTranspose16x32Core._rmem_copy_view(rmem, num_regs, offset)
+
+    def __init__(
+        self,
+        tmem_ptr=None,
+        *,
+        preload_acc: Optional[Tuple[cute.Tensor, cute.Tensor]] = None,
+        fc2_output_dtype: Type[cutlass.Numeric],
+    ) -> None:
+        """Create the packed-bf16x2 RMEM view from TMEM or preloaded acc."""
+        if (tmem_ptr is None) == (preload_acc is None):
+            raise ValueError(
+                "Fc2AccLoadAndPack: exactly one of tmem_ptr / preload_acc "
+                "must be provided (LDTM mode vs skip-LDTM preload mode)."
+            )
+
+        # Gather top/bottom hidden halves into one 32-reg fp32 vector.
+        acc_full = cute.make_rmem_tensor((32,), self._io_dtype)
+        if preload_acc is None:
+            # Two LDTMs cover top and bottom hidden halves.
+            atom_ld16x64 = cute.make_copy_atom(
+                tcgen05.Ld16x64bOp(tcgen05.Repetition.x16),
+                self._io_dtype,
+            )
+            tmem_top_view = cute.make_tensor(
+                tmem_ptr,
+                self._tmem_layout(16, 32),
+            )
+            tmem_bot_view = cute.make_tensor(
+                tmem_ptr + 16 * self._TmemRowStride,
+                self._tmem_layout(16, 32),
+            )
+            cute.copy(
+                atom_ld16x64,
+                tmem_top_view,
+                self._rmem_copy_view(acc_full, 16, offset=0),
+            )
+            cute.copy(
+                atom_ld16x64,
+                tmem_bot_view,
+                self._rmem_copy_view(acc_full, 16, offset=16),
+            )
+        else:
+            top_reg, bot_reg = preload_acc
+            for i in range(16):
+                acc_full[i] = top_reg[i]
+                acc_full[i + 16] = bot_reg[i]
+
+        # Interleave so bf16x2 pairs become (hidden_i, hidden_i+16).
+        reordered_fp32 = cute.make_rmem_tensor((32,), self._io_dtype)
+        for i in range(16):
+            reordered_fp32[2 * i] = acc_full[i]
+            reordered_fp32[2 * i + 1] = acc_full[i + 16]
+
+        # Bulk cast lets NVVM form cvt.rn.bf16x2.f32 for adjacent pairs.
+        packed_bf16 = cute.make_rmem_tensor((32,), fc2_output_dtype)
+        packed_bf16.store(reordered_fp32.load().to(fc2_output_dtype))
+
+        # Recast 32 bf16 elements as 16 32-bit slots for downstream atoms.
+        packed_fp32 = cute.recast_tensor(packed_bf16, self._io_dtype)
+
+        # Contract matches what the packed transpose expects as input.
+        self.output = TensorWithContract(
+            tensor=packed_fp32,
+            contract=self.OutputContract,
+        )
+
+
+# =============================================================================
+# Fc2 return tile -- full CTA-token-tile return routing
+# =============================================================================
+
+
+class Fc2ReturnTokenContract:
+    """Physical token-issue contract for one full fc2 CTA token tile.
+
+    Subclasses answer only the local token coordinate:
+
+        (epi_tidx, token_iter) -> token_idx_within_cta_token_tile
+
+    ``pool_token_global`` is deliberately outside the contract; it is derived
+    by ``Fc2ReturnTile`` as ``cta_token_tile_start + token_idx``.  This keeps
+    the contract reusable across task tiles and prevents return routing from
+    depending on per-tile row offsets.
+    """
+
+    num_token_iters: int
+    contract: Contract
+
+    @cute.jit
+    def token_idx_within_cta_tile(self, epi_tidx, token_iter):
+        raise NotImplementedError
+
+
+@dataclasses.dataclass(frozen=True)
+class TransposeStgReturnTokenContract(Fc2ReturnTokenContract):
+    """STG.256 token issue: each epi thread owns one token per 32-row chunk."""
+
+    cta_token_count: int
+
+    def __post_init__(self) -> None:
+        if self.cta_token_count % 32 != 0:
+            raise ValueError(
+                "TransposeStgReturnTokenContract requires cta_token_count "
+                f"divisible by 32, got {self.cta_token_count}."
+            )
+        domain = Space(
+            ("epi_tidx", "token_iter"),
+            (EpiWarpCount * WarpThreadCount, self.cta_token_count // 32),
+        )
+        codomain = Space(("token_idx_within_cta_token_tile",), (self.cta_token_count,))
+        contract = Contract(
+            domain=domain,
+            codomain=codomain,
+            mapping=FunctionMapping(lambda epi_tidx, token_iter: {
+                "token_idx_within_cta_token_tile":
+                    token_iter * 32 + (epi_tidx % 32),
+            }),
+        )
+        object.__setattr__(self, "num_token_iters", self.cta_token_count // 32)
+        object.__setattr__(self, "contract", contract)
+
+    @cute.jit
+    def token_idx_within_cta_tile(self, epi_tidx, token_iter):
+        lane_idx = epi_tidx % cutlass.Int32(32)
+        return token_iter * cutlass.Int32(32) + lane_idx
+
+
+@dataclasses.dataclass(frozen=True)
+class TransposeRedgReturnTokenContract(Fc2ReturnTokenContract):
+    """REDG token issue for transpose epilogue.
+
+    For each 64-token subtile, one lane issues 8 token metadata lookups:
+    4 for the first half and 4 for the second half.  The hidden REDG pair
+    loop is intentionally not part of this token contract.
+    """
+
+    cta_token_count: int
+
+    def __post_init__(self) -> None:
+        if self.cta_token_count % EpilogueTokenTile != 0:
+            raise ValueError(
+                "TransposeRedgReturnTokenContract requires cta_token_count "
+                f"divisible by {EpilogueTokenTile}, got {self.cta_token_count}."
+            )
+        num_iters = (self.cta_token_count // EpilogueTokenTile) * 8
+        domain = Space(
+            ("epi_tidx", "token_iter"),
+            (EpiWarpCount * WarpThreadCount, num_iters),
+        )
+        codomain = Space(("token_idx_within_cta_token_tile",), (self.cta_token_count,))
+        contract = Contract(
+            domain=domain,
+            codomain=codomain,
+            mapping=FunctionMapping(lambda epi_tidx, token_iter: {
+                "token_idx_within_cta_token_tile":
+                    (token_iter // 8) * EpilogueTokenTile
+                    + ((token_iter % 8) // 4) * 32
+                    + ((epi_tidx % 32) // 4)
+                    + ((token_iter % 4) * 8),
+            }),
+        )
+        object.__setattr__(self, "num_token_iters", num_iters)
+        object.__setattr__(self, "contract", contract)
+
+    @cute.jit
+    def token_idx_within_cta_tile(self, epi_tidx, token_iter):
+        lane_idx = epi_tidx % cutlass.Int32(32)
+        subtile_idx = token_iter // cutlass.Int32(8)
+        iter_in_subtile = token_iter % cutlass.Int32(8)
+        return (
+            subtile_idx * cutlass.Int32(EpilogueTokenTile)
+            + (iter_in_subtile // cutlass.Int32(4)) * cutlass.Int32(32)
+            + lane_idx // cutlass.Int32(4)
+            + (iter_in_subtile % cutlass.Int32(4)) * cutlass.Int32(8)
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class BulkReturnTokenContract(Fc2ReturnTokenContract):
+    """UBLK token issue: each epi thread owns one row per 128-token group."""
+
+    cta_token_count: int
+
+    def __post_init__(self) -> None:
+        if self.cta_token_count % 128 != 0:
+            raise ValueError(
+                "BulkReturnTokenContract requires cta_token_count divisible "
+                f"by 128, got {self.cta_token_count}."
+            )
+        num_iters = self.cta_token_count // 128
+        domain = Space(
+            ("epi_tidx", "token_iter"),
+            (EpiWarpCount * WarpThreadCount, num_iters),
+        )
+        codomain = Space(("token_idx_within_cta_token_tile",), (self.cta_token_count,))
+        contract = Contract(
+            domain=domain,
+            codomain=codomain,
+            mapping=FunctionMapping(lambda epi_tidx, token_iter: {
+                "token_idx_within_cta_token_tile":
+                    token_iter * 128
+                    + ((epi_tidx % 32) // 8) * 32
+                    + (epi_tidx // 32) * 8
+                    + (epi_tidx % 8),
+            }),
+        )
+        object.__setattr__(self, "num_token_iters", num_iters)
+        object.__setattr__(self, "contract", contract)
+
+    @cute.jit
+    def token_idx_within_cta_tile(self, epi_tidx, token_iter):
+        warp_idx = epi_tidx // cutlass.Int32(32)
+        lane_idx = epi_tidx % cutlass.Int32(32)
+        return (
+            token_iter * cutlass.Int32(128)
+            + (lane_idx // cutlass.Int32(8)) * cutlass.Int32(32)
+            + warp_idx * cutlass.Int32(8)
+            + lane_idx % cutlass.Int32(8)
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class Fc2ReturnTile:
+    """Full CTA-token-tile return-side view for fc2 output.
+
+    The tile owns push-based return routing for both lean direct mode and
+    MegaMoE metadata-driven mode.  Store paths provide only a token contract;
+    this object decides whether metadata is prefetched for the full CTA tile
+    or loaded just in time by ``resolve``.
+    """
+
+    tensor: cute.Tensor
+    metadata: Optional[cute.Tensor] = None
+    peer_rank_ptr_mapper: Any = None
+    cta_token_tile_start: Any = None
+    valid_token_row_end: Any = None
+    reduce_topk_in_kernel: bool = False
+    token_contract: Fc2ReturnTokenContract = None
+    prefetch: bool = True
+
+    def __post_init__(self) -> None:
+        if (self.metadata is None) != (self.peer_rank_ptr_mapper is None):
+            raise ValueError(
+                "Fc2ReturnTile: ``metadata`` and ``peer_rank_ptr_mapper`` must be "
+                "both None (lean / direct mode) or both non-None (MegaMoE / "
+                "indirect mode).  Got metadata="
+                f"{'set' if self.metadata is not None else 'None'}, "
+                f"peer_rank_ptr_mapper={'set' if self.peer_rank_ptr_mapper is not None else 'None'}."
+            )
+        if self.reduce_topk_in_kernel and self.metadata is None:
+            raise ValueError(
+                "Fc2ReturnTile: reduce_topk_in_kernel=True is only valid in "
+                "indirect mode (metadata + peer_rank_ptr_mapper both set).  The "
+                "lean / direct path has no topk axis to reduce."
+            )
+        if self.token_contract is None:
+            raise ValueError("Fc2ReturnTile requires a token_contract.")
+        if self.cta_token_tile_start is None:
+            raise ValueError("Fc2ReturnTile requires cta_token_tile_start.")
+        if self.valid_token_row_end is None:
+            raise ValueError("Fc2ReturnTile requires valid_token_row_end.")
+
+    @cute.jit
+    def prefetch_for_epi_thread(self, epi_tidx):
+        if cutlass.const_expr(not self.prefetch):
+            return None
+
+        token_count: cutlass.Constexpr[int] = self.token_contract.num_token_iters
+        pool_tokens = cute.make_rmem_tensor((token_count,), cutlass.Int32)
+        dst_ranks = cute.make_rmem_tensor((token_count,), cutlass.Int32)
+        dst_tokens = cute.make_rmem_tensor((token_count,), cutlass.Int32)
+        topks = cute.make_rmem_tensor((token_count,), cutlass.Int32)
+        valid = cute.make_rmem_tensor((token_count,), cutlass.Int32)
+
+        for token_iter in cutlass.range_constexpr(token_count):
+            token_offset = self.token_contract.token_idx_within_cta_tile(
+                epi_tidx, cutlass.Int32(token_iter),
+            )
+            pool_token = self.cta_token_tile_start + token_offset
+            pool_tokens[token_iter] = pool_token
+            valid[token_iter] = cutlass.Int32(0)
+            dst_ranks[token_iter] = cutlass.Int32(0)
+            if cutlass.const_expr(self.metadata is None):
+                dst_tokens[token_iter] = pool_token
+            else:
+                dst_tokens[token_iter] = cutlass.Int32(0)
+            topks[token_iter] = cutlass.Int32(0)
+
+            if pool_token < self.valid_token_row_end:
+                valid[token_iter] = cutlass.Int32(1)
+                if cutlass.const_expr(self.metadata is not None):
+                    md = TokenSrcMetadata.load(
+                        self.metadata.iterator.toint()
+                        + cutlass.Int64(pool_token)
+                        * cutlass.Int64(TokenSrcMetadata.nbytes)
+                    )
+                    dst_ranks[token_iter] = md.src_rank
+                    dst_tokens[token_iter] = md.src_token
+                    if cutlass.const_expr(not self.reduce_topk_in_kernel):
+                        topks[token_iter] = md.src_topk
+
+        return Fc2ReturnTilePrefetch(
+            tile=self,
+            pool_tokens=pool_tokens,
+            dst_ranks=dst_ranks,
+            dst_tokens=dst_tokens,
+            topks=topks,
+            valid=valid,
+        )
+
+    @cute.jit
+    def resolve(self, epi_tidx, token_iter, prefetch):
+        if cutlass.const_expr(prefetch is not None):
+            return prefetch.row(token_iter), prefetch.is_valid(token_iter)
+
+        token_offset = self.token_contract.token_idx_within_cta_tile(
+            epi_tidx, token_iter,
+        )
+        pool_token = self.cta_token_tile_start + token_offset
+        valid = pool_token < self.valid_token_row_end
+        if cutlass.const_expr(self.metadata is None):
+            return cute.slice_(self.tensor, (pool_token, 0, None)), valid
+
+        dst_rank = cutlass.Int32(0)
+        dst_token = cutlass.Int32(0)
+        topk = cutlass.Int32(0)
+        if valid:
+            md = TokenSrcMetadata.load(
+                self.metadata.iterator.toint()
+                + cutlass.Int64(pool_token)
+                * cutlass.Int64(TokenSrcMetadata.nbytes)
+            )
+            dst_rank = md.src_rank
+            dst_token = md.src_token
+            if cutlass.const_expr(not self.reduce_topk_in_kernel):
+                topk = md.src_topk
+        local_row = cute.slice_(self.tensor, (dst_token, topk, None))
+        peer_iter = self.peer_rank_ptr_mapper.ptr_map_to_rank(
+            local_row.iterator, dst_rank,
+        )
+        return cute.make_tensor(peer_iter, local_row.layout), valid
+
+
+@dataclasses.dataclass(frozen=True)
+class Fc2ReturnTilePrefetch:
+    """Per-epi-thread full-tile materialized return metadata."""
+
+    tile: Fc2ReturnTile
+    pool_tokens: cute.Tensor
+    dst_ranks: cute.Tensor
+    dst_tokens: cute.Tensor
+    topks: cute.Tensor
+    valid: cute.Tensor
+
+    @cute.jit
+    def is_valid(self, token_iter):
+        return self.valid[token_iter] != cutlass.Int32(0)
+
+    @cute.jit
+    def row(self, token_iter) -> cute.Tensor:
+        if cutlass.const_expr(self.tile.metadata is None):
+            return cute.slice_(
+                self.tile.tensor, (self.pool_tokens[token_iter], 0, None),
+            )
+
+        local_row = cute.slice_(
+            self.tile.tensor,
+            (self.dst_tokens[token_iter], self.topks[token_iter], None),
+        )
+        peer_iter = self.tile.peer_rank_ptr_mapper.ptr_map_to_rank(
+            local_row.iterator,
+            self.dst_ranks[token_iter],
+        )
+        return cute.make_tensor(peer_iter, local_row.layout)
+
+
+# =============================================================================
+# Fc2UnpackPermuteStg
+# =============================================================================
+
+
+class Fc2UnpackPermuteStg:
+    """fc2 epi RMEM -> GMEM dispatcher: STG.256 (default) or topk-collapsing
+    REDG (form B), const_expr-switched on the full-tile return view.
+
+    Input contract maps ``lane_idx`` to token and ``elem_idx`` to hidden
+    pair (one packed bf16x2 = 2 bf16 per 32-bit slot).  This is the
+    output contract of ``TmemTranspose16x32Packed`` -- the per-half fc2
+    transpose hands the packed regs to this class verbatim.
+
+    The destination row is resolved through ``Fc2ReturnTilePrefetch``:
+
+      * **STG.256 mode (default)**: 2 x STG.256 (32 B each = 16 bf16)
+        per thread; each warp lane lands its 32 hidden in 64 B onto a
+        unique destination row.  No cross-thread coalescing across
+        lanes (each lane targets a distinct token).
+
+      * **REDG mode**: STTM-then-2xLDTM-then-8xREDG.v2.bf16x2 per
+        thread (8 B atomic-add per call).  The STTM+LDTM shuffle
+        (see below) puts 4 consecutive lanes on the SAME token row's
+        contiguous 32 B segment, so the warp-wide
+        ``red.global.add.v2.bf16x2`` traffic naturally coalesces
+        into sector-aligned 32 B atomic transactions.
+
+    REDG-path register reshuffle -- post-LDTM contract
+    ===================================================
+
+    Source TMEM: after STTM ``St32x32b(Repetition.x16)``, this warp's
+    32 token rows x 32 hidden cells (packed as 32 lanes x 16
+    bf16x2 cols) sit in a contiguous 32-lane x 16-col TMEM slab.
+
+    The slab is then read back through TWO calls of
+    ``Ld16x256b(Repetition.x2)``:
+
+      iter 0: source = (TMEM lanes  0..15, cols 0..15)  -- first 16 tokens
+      iter 1: source = (TMEM lanes 16..31, cols 0..15)  -- second 16 tokens
+
+    For each call (Rep.x2 = the 4-reg image-1 16dp pattern in cols 0..7
+    followed by the same pattern in cols 8..15, yielding 8 reg/thread),
+    the per-thread register layout is:
+
+      tmem_lane_in_ldtm = (lane_idx // 4) + 8 * ((elem_idx // 2) % 2)
+      tmem_col          = (lane_idx %  4) * 2 + (elem_idx % 2)
+                                              + 8 * (elem_idx // 4)
+
+    -- captured as ``_RedgPerLdtmContract`` below.  Concretely, the 8 regs split into FOUR adjacent
+    8 B pairs, each pair = 2 contiguous bf16x2 cells along the hidden
+    axis of a single token row:
+
+      pair 0 = (Rx+0, Rx+1) -> row (lane//4),     cols (lane%4)*2 .. +1
+      pair 1 = (Rx+2, Rx+3) -> row (lane//4)+8,   cols (lane%4)*2 .. +1
+      pair 2 = (Rx+4, Rx+5) -> row (lane//4),     cols (lane%4)*2+8 .. +9
+      pair 3 = (Rx+6, Rx+7) -> row (lane//4)+8,   cols (lane%4)*2+8 .. +9
+
+    Coalescing invariant (the whole reason we do this shuffle):
+    for each fixed (ldtm_iter, pair_idx) the four lanes {T_{4k+0..3}}
+    sweep the SAME token row's 8 cells (= 32 B) with stride (2 cells
+    = 8 B) per lane.  When all 4 lanes simultaneously fire
+    ``red.global.add.v2.bf16x2`` (8 B each), the memory subsystem
+    coalesces into one sector-aligned 32 B atomic transaction.
+
+    Per-thread REDG count per subtile-half: 2 ldtm_iter * 4 reg-pair =
+    8 REDG.v2.bf16x2 = 64 B (same byte budget as the STG.256-mode
+    path's 2 x STG.256).
+
+    Per-thread metadata LDG count: 4 distinct token rows
+    (= ``(lane//4) + {0, 8, 16, 24}``); no cross-thread shuffle, every
+    thread LDGs its own copy (4 lanes per token row redundantly read
+    the same 3 uint32s -- acceptable now, would be the first thing to
+    optimise if metadata LDG ever shows up as a profile bottleneck).
+    """
+
+    # Direct-path input contract -- shared by both modes, both consume
+    # ``TmemTranspose16x32Packed.OutputContract``-shaped RMEM.
+    _domain = Space(("lane_idx", "elem_idx"), (32, 16))
+    _codomain = Space(("token_idx", "hidden_pair_idx"), (32, 16))
+    InputContract = Contract(
+        domain=_domain,
+        codomain=_codomain,
+        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
+            "token_idx": lane_idx,
+            "hidden_pair_idx": elem_idx,
+        }),
+    )
+
+    # REDG-path per-LDTM RMEM contract: the (lane_idx, elem_idx) ->
+    # (TMEM lane within the LDTM source slab, TMEM col within the slab)
+    # distribution that ONE ``Ld16x256b(Repetition.x2)`` call produces
+    # off a 16-lane x 16-col TMEM slab.  See the class docstring for
+    # the pair semantics + coalescing invariant.
+    _redg_per_ldtm_domain = Space(("lane_idx", "elem_idx"), (32, 8))
+    _redg_per_ldtm_codomain = Space(
+        ("tmem_lane_in_ldtm", "tmem_col"), (16, 16)
+    )
+    _RedgPerLdtmContract = Contract(
+        domain=_redg_per_ldtm_domain,
+        codomain=_redg_per_ldtm_codomain,
+        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
+            "tmem_lane_in_ldtm":
+                (lane_idx // 4) + 8 * ((elem_idx // 2) % 2),
+            "tmem_col":
+                (lane_idx % 4) * 2
+                + (elem_idx % 2)
+                + 8 * (elem_idx // 4),
+        }),
+    )
+
+    # Per-warp hidden tile width (warp w handles hidden [w*32, w*32+32)).
+    _HiddenPerWarp = 32
+    # Bits per STG.256 store.
+    _StgBitsPerCopy = 256
+    # REDG-path layout constants.
+    _RedgLdtmIterCount = 2          # 2 x Ld16x256b(Repetition.x2)
+    _RedgRegPerLdtm = 8             # reg/thread per LDTM call
+    _RedgRegPairsPerLdtm = 4        # = _RedgRegPerLdtm / 2
+    _RedgBf16PerPair = 4            # 8 B pair = 2 bf16x2 = 4 bf16
+
+    def __init__(
+        self,
+        packed: TensorWithContract,
+        *,
+        return_prefetch: Fc2ReturnTilePrefetch,
+        token_iter,
+        warp_idx,
+        epi_tidx,
+        valid_hidden,
+        tile_hidden_idx,
+        hidden_tile_size: int,
+        needs_hidden_predicate: bool,
+        fc2_output_dtype: Type[cutlass.Numeric],
+        # REDG-only: the (32 lanes, 64 cols) TMEM view onto this warp's
+        # acc subtile region (i.e. the ``tmem_subtile_tensor`` the caller
+        # built via ``_subtile_local_tmem_tensor``).  We carve a
+        # 32-lane x 16-col STTM+LDTM reshuffle slab out of it based on
+        # ``half_idx`` (cols 0..15 for half 0, cols 32..47 for half 1 --
+        # matching the per-half ``tmem_first_ptr`` / ``tmem_second_ptr``
+        # split inside ``_run_fc2_subtile``).  The slab is overwritten
+        # by this class's STTM and consumed by its two LDTM reads, both
+        # inside the same task tile body -- the next mma (and any acc
+        # release) only fires after this body returns, so the reuse is
+        # race-free (see ``_run_fc2_subtile`` comments).  Required iff
+        # ``return_prefetch.tile.reduce_topk_in_kernel=True``; rejected if
+        # that flag is False AND a non-None value is passed (to catch
+        # confused call-sites).
+        tmem_subtile_scratch: Optional[cute.Tensor] = None,
+    ) -> None:
+        assert_contract_equivalent(
+            packed.contract,
+            self.InputContract,
+            context="Fc2UnpackPermuteStg packed input",
+        )
+        if cutlass.const_expr(return_prefetch.tile.reduce_topk_in_kernel):
+            if tmem_subtile_scratch is None:
+                raise ValueError(
+                    "Fc2UnpackPermuteStg: tmem_subtile_scratch is required "
+                    "when return_prefetch.tile.reduce_topk_in_kernel=True "
+                    "(needs the (32, 64) subtile TMEM view to carve a "
+                    "STTM+LDTM reshuffle slab out of)."
+                )
+        else:
+            if tmem_subtile_scratch is not None:
+                raise ValueError(
+                    "Fc2UnpackPermuteStg: tmem_subtile_scratch must be None "
+                    "when reduce_topk_in_kernel=False."
+                )
+
+        self._return_prefetch = return_prefetch
+        self._token_iter = token_iter
+        self._warp_idx = warp_idx
+        self._epi_tidx = epi_tidx
+        self._lane_idx = epi_tidx % cutlass.Int32(32)
+        self._valid_hidden = valid_hidden
+        self._tile_hidden_base = hidden_tile_size * tile_hidden_idx
+        self._needs_hidden_predicate = needs_hidden_predicate
+        self._fc2_output_dtype = fc2_output_dtype
+
+        if cutlass.const_expr(return_prefetch.tile.reduce_topk_in_kernel):
+            self._init_redg(packed, tmem_subtile_scratch)
+        else:
+            self._init_direct(packed)
+
+    # ------------------------------------------------------------------
+    # STG.256 mode -- original direct path
+    # ------------------------------------------------------------------
+
+    def _init_direct(self, packed: TensorWithContract) -> None:
+        """Direct-path setup: unpack + permute packed bf16x2 RMEM back
+        to natural hidden order and pre-resolve the destination row.
+
+        Direct STG.256 mode: resolve one destination row per lane.
+        """
+        self._token_row_global = self._return_prefetch.pool_tokens[self._token_iter]
+        self._token_row_1d = self._return_prefetch.row(self._token_iter)
+        self._token_valid = self._return_prefetch.is_valid(self._token_iter)
+
+        # -- Step 2: recast (16, Float32) view back to (32, fc2_output_dtype)
+        packed_bf16 = cute.recast_tensor(packed.tensor, self._fc2_output_dtype)
+
+        # -- Step 3: unpack + permute back to natural hidden order ---------
+        natural = cute.make_rmem_tensor((32,), self._fc2_output_dtype)
+        for h in range(16):
+            natural[h]      = packed_bf16[2 * h]      # lo lane = hidden h
+            natural[h + 16] = packed_bf16[2 * h + 1]  # hi lane = hidden h+16
+
+        # -- Step 4: cache for stg() ---------------------------------------
+        self._bf16_regs = natural
+
+    @cute.jit
+    def _stg_direct(self) -> None:
+        """RMEM -> GMEM: 2 x STG.256 of 16 bf16 each.
+
+        Slices:
+          - STG #1: ``natural[0 : 16]``  -> hidden cols ``[w*32, w*32+16)``
+          - STG #2: ``natural[16 : 32]`` -> hidden cols ``[w*32+16, w*32+32)``
+          (where ``w = warp_idx``).
+
+        The destination ``(hidden,)`` row view was pre-resolved in
+        ``_init_direct`` and cached as ``self._token_row_1d``; this
+        body just slices it at the per-warp / per-STG hidden offset
+        and fires STG.256.  No LDG / no peer arithmetic here.
+        """
+        copy_atom_256b = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self._fc2_output_dtype,
+            num_bits_per_copy=self._StgBitsPerCopy,
+        )
+
+        token_row_1d = self._token_row_1d
+
+        # Every STG.256 below is gated by hand-rolled predicates +
+        # hand-computed offsets:
+        #   * ``hidden_base`` = ``tile_hidden_base + warp_hidden_base +
+        #     stg_idx*16`` indexed into ``token_row_1d``, a hand-resolved
+        #     FULL ``(hidden,)`` row from the full-tile return prefetch
+        #     (token / topk resolved, hidden NOT shifted).  This is how the
+        #     ``hidden > cta_tile_m`` bug landed -- the base lean path used
+        #     a caller-shifted ``_gOut_subtile`` so the stg body only saw
+        #     subtile-local offsets, but the MegaMoE rewrite dropped that
+        #     shift on the floor.
+        #   * ``token_row_global < valid_token_row_end`` is the (always-on)
+        #     row predicate that filters out per-expert padding rows whose
+        #     destination ``src_token`` metadata is uninitialised.  Without
+        #     it last-task-tile padding STGs corrupt ``combine_output[0]``
+        #     (or any row whose ``src_token`` slot is 0 / stale).
+        # The whole offset + predicate chain should be redone properly:
+        # either a ``TensorWithContract`` that pins the per-tile hidden /
+        # token / peer axes (and the valid range) by construction, or a
+        # tile-level cute tensor the caller hands down already sliced down
+        # to the valid (token, hidden) window.  Until then this is glue.
+        if self._token_valid:
+            warp_hidden_base = self._warp_idx * self._HiddenPerWarp
+
+            for stg_idx in range(2):
+                reg_view = cute.make_tensor(
+                    self._bf16_regs.iterator + stg_idx * 16,
+                    cute.make_layout((((16,), 1),), stride=(((1,), 0),)),
+                )
+
+                hidden_base = (
+                    self._tile_hidden_base + warp_hidden_base + stg_idx * 16
+                )
+
+                gOut_thread_row = cute.local_tile(
+                    token_row_1d,
+                    (16,),
+                    (hidden_base // 16,),
+                )
+
+                aligned_row_iter = cute.make_ptr(
+                    gOut_thread_row.element_type,
+                    gOut_thread_row.iterator.toint(),
+                    AddressSpace.gmem,
+                    assumed_align=32,
+                )
+                gOut_thread_row = cute.make_tensor(
+                    aligned_row_iter, gOut_thread_row.layout
+                )
+
+                if cutlass.const_expr(self._needs_hidden_predicate):
+                    if hidden_base < self._valid_hidden:
+                        cute.copy(
+                            copy_atom_256b,
+                            cute.coalesce(reg_view),
+                            cute.coalesce(gOut_thread_row),
+                        )
+                else:
+                    cute.copy(
+                        copy_atom_256b,
+                        cute.coalesce(reg_view),
+                        cute.coalesce(gOut_thread_row),
+                    )
+
+    # ------------------------------------------------------------------
+    # REDG mode -- STTM + 2x LDTM + 8x REDG.v2.bf16x2
+    # ------------------------------------------------------------------
+
+    def _init_redg(
+        self,
+        packed: TensorWithContract,
+        tmem_subtile_scratch: cute.Tensor,
+    ) -> None:
+        """REDG-path setup: fire STTM(St32x32b.x16) immediately so its
+        latency overlaps with the upcoming 4 metadata LDGs + 2 LDTMs.
+
+        Also pre-resolves the 4 destination rows (one per distinct
+        token this lane holds across both LDTM iterations) so the
+        metadata LDGs are issued early too.  Row resolution + STTM
+        are independent (the row resolution reads ``metadata`` GMEM +
+        the in-param-bank ``peer_rank_ptr_mapper``; STTM writes TMEM), so the
+        two latency chains run in parallel.
+
+        ``tmem_subtile_scratch`` is the caller's (32 lanes, 64 cols)
+        ``tmem_subtile_tensor`` view onto this warp's acc TMEM subtile
+        region.  We carve a 32-lane x 16-col slab out of it at column
+        offset ``32 * half_idx`` -- matching the per-half base used by
+        the upstream in-place transpose (``tmem_first_ptr`` at col 0,
+        ``tmem_second_ptr`` at col 32).  By the time this body runs,
+        the transpose has already finished reading the slab back into
+        RMEM (``r4_perm`` was the last consumer), so STTM-overwriting
+        the slab is race-free; the next mma cannot reclaim the subtile
+        until acc release fires at task-tile boundary, well after both
+        per-half ``stg()`` calls have completed.
+        """
+        # Carve the per-half 32x16 slab.  Col stride in the
+        # ``_tmem_layout`` is 1 (see ``_TmemTranspose16x32Core``), so
+        # a per-col pointer offset of ``32 * half_idx`` matches the
+        # ``tmem_second_ptr = tmem_first_ptr + 32`` arithmetic in
+        # ``_run_fc2_subtile``.
+        redg_iter_in_subtile = self._token_iter % cutlass.Int32(8)
+        half_idx = redg_iter_in_subtile // cutlass.Int32(4)
+        scratch_iter = tmem_subtile_scratch.iterator + cute.assume(
+            32 * half_idx, divby=32,
+        )
+        # Per-LDTM source views: each is 16 lanes x 16 cols, addressing
+        # rows 0..15 (iter 0) and rows 16..31 (iter 1) of the slab.
+        # The 16-lane offset in TMEM cell units = 16 *
+        # ``_TmemTranspose16x32Core._TmemRowStride``.
+        ldtm_half_lane_off = (
+            16 * _TmemTranspose16x32Core._TmemRowStride
+        )
+        self._redg_ldtm_src_views = (
+            cute.make_tensor(
+                scratch_iter,
+                _TmemTranspose16x32Core._tmem_layout(16, 16),
+            ),
+            cute.make_tensor(
+                scratch_iter + ldtm_half_lane_off,
+                _TmemTranspose16x32Core._tmem_layout(16, 16),
+            ),
+        )
+
+        # -- Natural-order permute + STTM to TMEM scratch -----------------
+        packed_bf16 = cute.recast_tensor(packed.tensor, self._fc2_output_dtype)
+        natural = cute.make_rmem_tensor((32,), self._fc2_output_dtype)
+        for h in range(16):
+            natural[h]      = packed_bf16[2 * h]
+            natural[h + 16] = packed_bf16[2 * h + 1]
+        natural_fp32 = cute.recast_tensor(natural, cutlass.Float32)
+
+        sttm_atom = cute.make_copy_atom(
+            tcgen05.St32x32bOp(tcgen05.Repetition.x16),
+            cutlass.Float32,
+        )
+        rmem_view = cute.make_tensor(
+            natural_fp32.iterator,
+            cute.make_layout((((16,), 1),), stride=(((1,), 0),)),
+        )
+        sttm_dst_view = cute.make_tensor(
+            scratch_iter,
+            _TmemTranspose16x32Core._tmem_layout(32, 16),
+        )
+        cute.copy(sttm_atom, rmem_view, sttm_dst_view)
+
+        # -- Pre-resolve the 4 destination rows ----------------------------
+        # Lane t (in half) holds 4 distinct token rows across the two
+        # LDTM iterations:
+        #
+        #   ldtm_iter 0:  token_in_half = (lane % 32 // 4) + {0, 8}
+        #   ldtm_iter 1:  token_in_half = (lane % 32 // 4) + {16, 24}
+        #
+        # The 4 lanes {T_{4k+0..3}} all share the SAME 4 tokens (one
+        # for each (iter, pair_parity) slot), so 4 lanes redundantly
+        # LDG the same metadata + ``peer_rank_ptr_mapper.map`` redirect; no shuffle,
+        # simple but suboptimal (acceptable per design decision).
+        #
+        # Per-half token base = 32 * half_idx (NOT lane-dependent --
+        # ``lane // 4 + {0, 8, 16, 24}`` covers all 32 token slots
+        # within the half).
+        # Per-lane full-tile token rows + matching dest-row tensors.
+        self._redg_token_row_globals = tuple(
+            self._return_prefetch.pool_tokens[self._token_iter + cutlass.Int32(i)]
+            for i in range(self._RedgRegPairsPerLdtm)
+        )
+        self._redg_token_rows_1d = tuple(
+            self._return_prefetch.row(self._token_iter + cutlass.Int32(i))
+            for i in range(self._RedgRegPairsPerLdtm)
+        )
+        self._redg_token_valid = tuple(
+            self._return_prefetch.is_valid(self._token_iter + cutlass.Int32(i))
+            for i in range(self._RedgRegPairsPerLdtm)
+        )
+
+    @cute.jit
+    def _stg_redg(self) -> None:
+        """TMEM scratch -> RMEM -> GMEM REDG path.
+
+        For each of 2 LDTM iterations, this body:
+
+          1. Calls ``Ld16x256b(Repetition.x2)`` on the per-iter
+             16-lane x 16-col TMEM slab.  Each call produces 8
+             reg/thread following ``_RedgPerLdtmContract`` (see the
+             class docstring for the (lane, elem) -> (tmem_lane, tmem_col)
+             mapping and the reg-pair semantics).
+          2. For each of 4 reg-pairs, emits 1
+             ``red.global.add.v2.bf16x2`` call (= 2 packed bf16x2 = 4
+             bf16 = 8 B atomic-add) onto the destination row
+             corresponding to that pair's (token, hidden_seg) slot.
+
+        Total per thread per subtile-half: 2 LDTM + 8 REDG.v2.bf16x2
+        = 64 B written = same byte budget as the STG.256-mode path.
+
+        Predicates: a single per-token-row valid predicate gates the
+        REDGs targetting that row.  Hidden predicate (when the warp's
+        hidden segment is past ``valid_hidden``) is checked once per
+        pair (every pair = 1 hidden segment of 4 contiguous bf16).
+        """
+        ldtm_atom = cute.make_copy_atom(
+            tcgen05.Ld16x256bOp(tcgen05.Repetition.x2),
+            cutlass.Float32,
+        )
+
+        warp_hidden_base = self._warp_idx * self._HiddenPerWarp
+
+        # Per-pair token-row global + dest-row picker.  Pairs 0/2 share
+        # token A = base_in_half + 0/16; pairs 1/3 share token B = +8/+24.
+        # Combined into a (iter, pair_idx_in_iter) -> token_slot table
+        # so the inner loop can index it directly.
+        #
+        # pair_idx_in_iter -> token_slot in self._redg_token_rows_1d:
+        #   iter 0 pair 0: slot 0  (base + 0)
+        #   iter 0 pair 1: slot 1  (base + 8)
+        #   iter 0 pair 2: slot 0
+        #   iter 0 pair 3: slot 1
+        #   iter 1 pair 0: slot 2  (base + 16)
+        #   iter 1 pair 1: slot 3  (base + 24)
+        #   iter 1 pair 2: slot 2
+        #   iter 1 pair 3: slot 3
+        pair_to_token_slot = (0, 1, 0, 1)
+
+        # Address-side per-pair hidden offset in bf16 elements:
+        #   pair 0/1 -> low  segment, starting at  hidden_pair_col * 2
+        #               (= (lane%4) * 2 * 2 = (lane%4) * 4 bf16 from
+        #               the warp's hidden base)
+        #   pair 2/3 -> high segment, +16 bf16 from low
+        # Computed once outside the inner loop because lane-relative.
+        lane_quad = self._lane_idx % cutlass.Int32(4)
+        # Per-pair low-end hidden offset within the warp's 32-hidden
+        # segment, in bf16 element units.
+        per_pair_hidden_in_warp_lo = (
+            lane_quad * cutlass.Int32(4),                     # pair 0
+            lane_quad * cutlass.Int32(4),                     # pair 1
+            lane_quad * cutlass.Int32(4) + cutlass.Int32(16),  # pair 2
+            lane_quad * cutlass.Int32(4) + cutlass.Int32(16),  # pair 3
+        )
+
+        for ldtm_iter in cutlass.range_constexpr(self._RedgLdtmIterCount):
+            regs = cute.make_rmem_tensor(
+                (self._RedgRegPerLdtm,), cutlass.Float32,
+            )
+            cute.copy(
+                ldtm_atom,
+                self._redg_ldtm_src_views[ldtm_iter],
+                cute.make_tensor(
+                    regs.iterator,
+                    cute.make_layout(
+                        (((self._RedgRegPerLdtm,), 1),),
+                        stride=(((1,), 0),),
+                    ),
+                ),
+            )
+            # ``regs`` is 8 fp32 slots; each slot's 32-bit bit-pattern
+            # is one packed bf16x2 (= 2 bf16 along hidden), inherited
+            # from ``Fc2AccLoadAndPack`` upstream.  We pass the fp32
+            # ir.Value straight into the bf16x2 REDG inline asm -- PTX
+            # constraint ``r`` only cares about the 32-bit register
+            # payload, see ``_red_add_relaxed_sys_v2_bf16x2`` docstring.
+
+            for pair_idx in cutlass.range_constexpr(self._RedgRegPairsPerLdtm):
+                token_slot = pair_to_token_slot[pair_idx] + (
+                    2 if ldtm_iter == 1 else 0
+                )
+                token_row_1d = self._redg_token_rows_1d[token_slot]
+                token_valid = self._redg_token_valid[token_slot]
+                hidden_in_warp_lo = per_pair_hidden_in_warp_lo[pair_idx]
+                hidden_base = (
+                    cutlass.Int32(self._tile_hidden_base)
+                    + cutlass.Int32(warp_hidden_base)
+                    + hidden_in_warp_lo
+                )
+
+                # One v2.bf16x2 REDG = the pair's full 8 B payload (4
+                # bf16) in a single PTX op.  4 consecutive lanes hold
+                # adjacent (hidden_base + lane_quad * 4 ..
+                # + (lane_quad+1)*4) ranges of the same row, which the
+                # memory subsystem coalesces into a sector-aligned 32 B
+                # atomic transaction (the whole reason we did the
+                # STTM+LDTM shuffle).  Pair occupies fp32 regs
+                # ``[pair_idx*2, pair_idx*2 + 1]`` -- each fp32 slot is
+                # one packed bf16x2 cell along the hidden axis.
+                if token_valid:
+                    addr = token_row_1d.iterator + hidden_base
+                    val0 = cutlass.Float32(regs[pair_idx * 2])
+                    val1 = cutlass.Float32(regs[pair_idx * 2 + 1])
+                    if cutlass.const_expr(self._needs_hidden_predicate):
+                        if hidden_base < self._valid_hidden:
+                            _red_add_relaxed_sys_v2_bf16x2(
+                                addr, val0, val1,
+                            )
+                    else:
+                        _red_add_relaxed_sys_v2_bf16x2(
+                            addr, val0, val1,
+                        )
+
+    # ------------------------------------------------------------------
+    # Public entry
+    # ------------------------------------------------------------------
+
+    @cute.jit
+    def stg(self) -> None:
+        """Const_expr dispatch to the STG.256 (default) or REDG path."""
+        if cutlass.const_expr(self._return_prefetch.tile.reduce_topk_in_kernel):
+            self._stg_redg()
+        else:
+            self._stg_direct()
+
+
+# =============================================================================
+# SwapABSwigluFp4Epilogue
+# =============================================================================
+
+
+class SwapABSwigluFp4Epilogue:
+    """Autonomous epilogue for the swap-AB SwiGLU NVFP4 kernel.
+
+    ``run()`` is the single entry point the kernel calls inside the epi
+    warp body.  The kernel's responsibility is reduced to:
+
+      - allocate / free TMEM and build ``acc_tensor``
+      - construct the AB / acc pipelines
+      - obtain the scheduler consumer
+
+    Everything else (acc consumer state, task-tile loop, overlap rotation,
+    early release, TMA store commit / drain, per-subtile dispatch) lives
+    inside this class.
+    """
+
+    # Per-subtile rotated-leader sync constants.
+    _SubtileBarIdBase = 4
+
+    def __init__(
+        self,
+        *,
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        use_2cta_instrs: bool,
+        sf_vec_size: int,
+        fc1_output_dtype: Type[cutlass.Numeric],
+        fc1_output_layout: utils.LayoutEnum,
+        fc2_output_dtype: Type[cutlass.Numeric],
+        non_ubulk_fc2_store: bool,
+        in_kernel_fc2_reduce: bool,
+        token_back_by_dispatch: bool = False,
+        epi_flag_batch: int = 1,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        sf_dtype: Type[cutlass.Numeric] = cutlass.Float8E4M3FN,
+        allow_overlap_acc: bool = True,
+        epilog_sync_bar_id: int = 1,
+        epilogue_warp_ids: Tuple[int, ...] = (0, 1, 2, 3),
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,
+    ) -> None:
+        if fc1_output_dtype is not cutlass.Float4E2M1FN:
+            raise NotImplementedError(
+                "SwapABSwigluFp4Epilogue currently assumes fc1 output in "
+                f"sC is NVFP4 Float4E2M1FN; got {fc1_output_dtype}. "
+                "Changing this dtype requires redesigning the fixed 8KB "
+                "shared epilogue scratch layout."
+            )
+        if token_back_by_dispatch and not non_ubulk_fc2_store:
+            raise ValueError(
+                "token_back_by_dispatch=True requires non_ubulk_fc2_store=True; "
+                "bulk fc2 store is incompatible with dispatch-warp token back "
+                "(STG is strictly more efficient for that pipeline)."
+            )
+        if token_back_by_dispatch:
+            in_kernel_fc2_reduce = False
+        self._fc2_use_bulk = not non_ubulk_fc2_store
+        self._reduce_topk_in_kernel = in_kernel_fc2_reduce
+        self._token_back_by_dispatch = token_back_by_dispatch
+        # Done-counter publish batch granularity (per-tile == 1).  Plain Python
+        # int -> usable as a compile-time shape / range_constexpr bound below.
+        self._epi_flag_batch = max(1, int(epi_flag_batch))
+        self._fc2_output_dtype = fc2_output_dtype
+
+        self.fc1_output_dtype = fc1_output_dtype
+        self.fc1_output_layout = fc1_output_layout
+        self.acc_dtype = acc_dtype
+        self.sf_dtype = sf_dtype
+        self._sf_vec_size = sf_vec_size
+        self._epilog_sync_bar_id = epilog_sync_bar_id
+        self._epilogue_warp_ids = epilogue_warp_ids
+
+        atom_thr_size = 2 if use_2cta_instrs else 1
+        self._cta_tile_m = mma_tiler_mnk[0] // atom_thr_size
+        self._cta_tile_n = mma_tiler_mnk[1]
+        self._mma_tiler_k = mma_tiler_mnk[2]
+        self._cta_tile_n_sfb = ((mma_tiler_mnk[1] + 127) // 128) * 128
+        self._static_expert_shape = static_expert_shape
+        if self._fc2_use_bulk:
+            if static_expert_shape is None:
+                raise NotImplementedError(
+                    "fc2_ublkcp/fc2_ublkredg currently require "
+                    "static_expert_shape so the 128-hidden bulk tail is "
+                    "known at codegen time."
+                )
+            if static_expert_shape[2] % 8 != 0:
+                raise NotImplementedError(
+                    "fc2_ublkcp/fc2_ublkredg currently require hidden to be "
+                    f"a multiple of 8 BF16 elements (16B bulk alignment); "
+                    f"got hidden={static_expert_shape[2]}."
+                )
+        if (
+            static_expert_shape is not None
+            and static_expert_shape[2] % (self._cta_tile_m * cluster_shape_mn[0]) == 0
+        ):
+            self._fc2_hidden_needs_predicate: bool = False
+        else:
+            self._fc2_hidden_needs_predicate: bool = True
+
+        # K-padding gate for fc1 epi SF writes; see PostSwigluHalf.stg_sfc.
+        # ``cga_cluster_tile_intermediate_downproj`` is the CGA-level
+        # alignment unit on the intermediate_downproj axis; when
+        # ``intermediate_downproj`` is an integer multiple of it the
+        # predicate is statically True and elided.
+        self._cga_cluster_tile_intermediate_downproj: int = (
+            (self._cta_tile_m // 2) * cluster_shape_mn[0]
+        )
+        if static_expert_shape is not None:
+            intermediate_downproj = static_expert_shape[1] // 2
+            if intermediate_downproj % sf_vec_size != 0:
+                raise NotImplementedError(
+                    f"intermediate_downproj ({intermediate_downproj}) must "
+                    f"be a multiple of sf_vec_size ({sf_vec_size}); sub-SF-"
+                    f"block K-masking is not implemented."
+                )
+            self._intermediate_downproj: Optional[int] = intermediate_downproj
+        else:
+            self._intermediate_downproj: Optional[int] = None
+
+        self._epi_tile = (EpilogueTokenTile, Fc1EpilogueOutputTile)
+        self._subtile_cnt = self._cta_tile_n // EpilogueTokenTile
+
+        self._overlapping_accum = allow_overlap_acc and (
+            self._cta_tile_n == EpiWarpCount * EpilogueTokenTile
+        )
+
+        self._num_acc_stage = 2
+        self._num_acc_pipeline_stages = (
+            1 if self._overlapping_accum else self._num_acc_stage
+        )
+
+        k = self._mma_tiler_k
+        self._num_sfa_tmem_cols = self._cta_tile_m * k // sf_vec_size * 4 // 4 // 128
+        self._num_sfb_tmem_cols = (
+            self._cta_tile_n_sfb * k // sf_vec_size * 4 // 4 // 128
+        )
+        self._num_sf_tmem_cols = self._num_sfa_tmem_cols + self._num_sfb_tmem_cols
+
+        self._num_accumulator_tmem_cols = self._cta_tile_n * self._num_acc_stage - (
+            self._num_sf_tmem_cols if self._overlapping_accum else 0
+        )
+
+        self._iter_acc_early_release = (
+            self._num_sf_tmem_cols + EpilogueTokenTile - 1
+        ) // EpilogueTokenTile
+
+    # -- Codegen-time queries (read by kernel) --------------------------------
+
+    @property
+    def epi_tile(self) -> Tuple[int, int]:
+        return self._epi_tile
+
+    @property
+    def overlapping_accum(self) -> bool:
+        return self._overlapping_accum
+
+    @property
+    def num_acc_pipeline_stages(self) -> int:
+        return self._num_acc_pipeline_stages
+
+    @property
+    def num_acc_stage(self) -> int:
+        return self._num_acc_stage
+
+    @property
+    def iter_acc_early_release(self) -> int:
+        return self._iter_acc_early_release
+
+    @property
+    def subtile_cnt(self) -> int:
+        return self._subtile_cnt
+
+    @property
+    def cta_tile_n(self) -> int:
+        return self._cta_tile_n
+
+    @property
+    def num_sf_tmem_cols(self) -> int:
+        return self._num_sf_tmem_cols
+
+    @property
+    def num_sfa_tmem_cols(self) -> int:
+        return self._num_sfa_tmem_cols
+
+    @property
+    def num_sfb_tmem_cols(self) -> int:
+        return self._num_sfb_tmem_cols
+
+    @property
+    def num_accumulator_tmem_cols(self) -> int:
+        return self._num_accumulator_tmem_cols
+
+    # -- sC SMEM layout queries -----------------------------------------------
+
+    def staged_smem_layout(
+        self,
+        n_stages: int,
+    ) -> Union[cute.Layout, cute.ComposedLayout]:
+        return sm100_utils.make_smem_layout_epi(
+            self.fc1_output_dtype,
+            self.fc1_output_layout,
+            self._epi_tile,
+            n_stages,
+        )
+
+    @property
+    def smem_layout_one_stage(self) -> Union[cute.Layout, cute.ComposedLayout]:
+        staged = self.staged_smem_layout(1)
+        return cute.select(staged, mode=[0, 1])
+
+    @property
+    def bytes_per_stage(self) -> int:
+        return cute.size_in_bytes(self.fc1_output_dtype, self.smem_layout_one_stage)
+
+    @property
+    def num_fc1_c_stages(self) -> int:
+        # sC is a fixed 8KB epilogue scratch.  fc1 views it as four 2KB
+        # NVFP4 C stages; fc2 UBLK views the same bytes as one 32x128 BF16
+        # scratch tile.
+        return 4
+
+    @staticmethod
+    def _fc2_bulk_smem_layout() -> cute.Layout:
+        return cute.make_layout((32, 128), stride=(128, 1))
+
+    def fc2_bulk_scratch_view(self, smem_fc1_output_buffer: cute.Tensor) -> cute.Tensor:
+        scratch_iter = cute.recast_ptr(
+            smem_fc1_output_buffer.iterator,
+            dtype=self._fc2_output_dtype,
+        )
+        return cute.make_tensor(scratch_iter, self._fc2_bulk_smem_layout())
+
+    # -- Subtile-local TMEM view helper ---------------------------------------
+
+    def _subtile_local_tmem_tensor(
+        self,
+        tmem_acc_tensor: cute.Tensor,
+        subtile_idx,
+        warp_idx,
+        acc_stage_col_offset,
+    ) -> cute.Tensor:
+        """Build a (32 lanes, 64 cols) cute.Tensor view onto one epi
+        subtile's per-warp acc TMEM region.
+
+        Owns the per-warp lane offset, per-stage col offset (overlap-acc
+        phase aware), and per-subtile col offset arithmetic.  Returned
+        tensor is what ``_run_fc{1,2}_subtile`` and
+        ``_TmemTranspose16x32Core.load_subtile_raw_acc`` consume.
+
+        ``cute.assume(divby=16)`` is applied here once -- callees can
+        derive ``+32`` first/second-half ptrs from the returned tensor's
+        iterator without re-asserting alignment (16-aligned base + 32 is
+        still 16-aligned).
+
+        ``divby=16`` (instead of 64) so the assume holds even under
+        ``overlapping_accum=True`` with phase=1, where
+        ``acc_stage_col_offset = phase * (256 - num_sf_tmem_cols) = 208``
+        (when ``num_sf_tmem_cols = 48``) and ``208 % 64 = 16``.
+        ``divby=16`` still satisfies the downstream alignment check that
+        ``cute.assume`` exists to bypass; the codegen optimisation
+        difference between ``divby=16`` and ``divby=64`` is negligible
+        for this offset arithmetic.
+        """
+        base = tmem_acc_tensor.iterator
+        warp_lane_off = warp_idx * WarpThreadCount
+        subtile_col_off = subtile_idx * EpilogueTokenTile
+        total = (warp_lane_off << 16) + acc_stage_col_offset + subtile_col_off
+        subtile_ptr = base + cute.assume(total, divby=16)
+        return cute.make_tensor(
+            subtile_ptr,
+            _TmemTranspose16x32Core._tmem_layout(32, EpilogueTokenTile),
+        )
+
+    # -- Subtile-level TMA store cmd issue ------------------------------------
+
+    @staticmethod
+    @dsl_user_op
+    @cute.jit
+    def tma_store_fc1_output(
+        warp_idx,
+        sC,
+        subtile_idx,
+        tma_atom_fc1_output,
+        g_fc1_output_subtile_view: cute.Tensor,
+        *,
+        loc=None,
+        ip=None,
+    ) -> None:
+        """Per-subtile fence + rotated-leader TMA store cmd issue.
+
+        Subtile-level operation -- it is not per-half, so it lives on the
+        epilogue rather than on ``PostSwigluHalf``.  All 4 epi warps call
+        this; ``subtile_idx`` doubles as the sC stage index AND drives both
+        the leader-warp choice and the NamedBarrier id::
+
+            leader_warp_idx = subtile_idx              (warp s leads sC[s])
+            subtile_bar_id  = _SubtileBarIdBase + subtile_idx
+
+        Each subtile owns its own bar id, so producer warps fire-and-forget
+        arrive on this bar and race ahead into the next subtile without
+        phase-mismatch on a shared bar.  The leader does ``arrive_and_wait``
+        and issues the bulk-tensor store; the other 3 warps only ``arrive``.
+        No commit / acquire here -- task-tile-boundary commit + drain lives
+        inside ``run()``.
+
+        ``@staticmethod @dsl_user_op @cute.jit``: jit is required for the
+        ``if warp_idx == leader_warp_idx`` runtime conditional to lower to
+        scf.if; making it a free-form static keeps live-locals serialization
+        simple (only cute-native types in scope).
+        """
+        cute.arch.fence_proxy("async.shared", space="cta")
+        sC_stage = cute.slice_(sC, (None, None, subtile_idx))
+        g_fc1_output_2d = cute.slice_(g_fc1_output_subtile_view, (None, None, 0))
+        bSG_sC, bSG_g_fc1_output = cpasync.tma_partition(
+            tma_atom_fc1_output,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sC_stage, 0, 2),
+            cute.group_modes(g_fc1_output_2d, 0, 2),
+        )
+
+        # Warp 0 issues all fc1 TMA stores so the task-tile commit/wait covers
+        # every subtile before the release-add to fc1_done_counter.
+        leader_warp_idx = cutlass.Int32(0)
+        subtile_bar_id = subtile_idx + cutlass.Int32(
+            SwapABSwigluFp4Epilogue._SubtileBarIdBase
+        )
+        subtile_bar = pipeline.NamedBarrier(
+            barrier_id=subtile_bar_id,
+            num_threads=EpiWarpCount * WarpThreadCount,
+        )
+        if warp_idx == leader_warp_idx:
+            subtile_bar.arrive_and_wait()
+            cute.copy(tma_atom_fc1_output, bSG_sC, bSG_g_fc1_output)
+        else:
+            subtile_bar.arrive()
+
+    # -- Full task-tile loop --------------------------------------------------
+
+    @cute.jit
+    def run(
+        self,
+        # ── Acc TMEM + acc pipeline (shared, both phases) ────────────────
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        # ── Sched ────────────────────────────────────────────────────────
+        sched_consumer,
+        sched_ext,
+        # ── fc1 (Linear1 phase) outputs ──────────────────────────────────
+        # NVFP4 packed output staged through SMEM and dispatched by TMA
+        # bulk store.
+        smem_fc1_output_buffer: cute.Tensor,        # sC SMEM (subtile_cnt slots)
+        tma_atom_fc1_output: cute.CopyAtom,          # TMA store atom for fc1 NVFP4 out
+        gmem_fc1_output: cute.Tensor,                # GMEM target for the TMA store
+        gmem_fc1_output_sf: cute.Tensor,             # GMEM fp8 SFC, written by per-thread STG
+        # ── topk weights (applied before fc1-output NVFP4 quantize) ─────
+        gmem_topk_scores: cute.Tensor,
+        # ── fc2 (Linear2 phase) output ───────────────────────────────────
+        # MoE-domain ``(token_max, topk, hidden)`` output.
+        gmem_fc2_output: cute.Tensor,
+        # ── fc1 -> fc2 release-acquire signal ──────────────────────────
+        # GMEM int32 counter, 1D shape (max_token_block_per_rank,). Indexed by
+        # ``cumulative_token_block_count + tile_n_idx`` as carried by
+        # ``SwapABSwigluFp4Fc12WorkTileInfo``.
+        gmem_fc1_done_counter: cute.Tensor,
+        # ── Per-warp / per-thread ────────────────────────────────────────
+        warp_idx: int,
+        tidx,
+        # ── Epi-side runtime scaling (fc1 only) ─────────────────────────
+        alpha,
+        norm_const,
+        # ── MegaMoE-only routing bundle (Optional) ──────────────────────
+        # None = direct local output; non-None = metadata-driven peer output.
+        token_comm_args=None,
+    ) -> None:
+        """Run the full fc1+fc2-fused epilogue task-tile loop.
+
+        After each task tile, the next scheduler tile is consumed before the
+        previous fc1 TMA stores are drained and the fc1_done_counter is
+        release-added.  That ordering overlaps scheduler latency while still
+        publishing fc1 output before any fc2 tile can pass its spin.
+        """
+        acc_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self._num_acc_pipeline_stages
+        )
+        task_tile_boundary_bar = pipeline.NamedBarrier(
+            barrier_id=self._epilog_sync_bar_id,
+            num_threads=32 * len(self._epilogue_warp_ids),
+        )
+
+        # gmem_fc2_output is MoE-domain (token_max, topk, hidden); valid
+        # hidden cols = axis 2 size.
+        valid_hidden = cutlass.Int32(gmem_fc2_output.shape[2])
+
+        # In-bound fc1 tile count (= ext_fc2_spin_threshold mirror).
+        # gmem_fc1_output is (tokens_sum_padded, intermediate_downproj);
+        # tile step (post-swiglu) = cta_tile_m // 2.
+        intermediate_downproj_tile_count = (
+            gmem_fc1_output.shape[1] + (self._cta_tile_m // 2) - 1
+        ) // (self._cta_tile_m // 2)
+
+        # Init=1 (= reverse): under overlapping_accum the first task tile
+        # walks subtiles N-1, 0, 1, ..., N-2 so the rightmost subtile
+        # (containing the staggered overlap region cols) is processed first
+        # and its TMEM cols are released to the next phase's mma immediately.
+        # Shared across phases -- fc2 inherits the same overlap rotation.
+        # Constexpr-elided under non-overlap.
+        is_odd_turn = cutlass.Int32(1)
+
+        # Done-counter publish batch scratch: accumulate up to epi_batch
+        # reduction target addresses (fc1 or fc2, unified) and flush them under
+        # one device fence.  Only tidx==0 reads/writes the buffer; epi_pend_n is
+        # kept warp-uniform (updated under uniform conditions) so all epilogue
+        # threads agree on flush points.  epi_batch is a plain Python int, usable
+        # as a compile-time tensor shape / range_constexpr bound.
+        epi_batch = self._epi_flag_batch
+        epi_pend_n = cutlass.Int32(0)
+        epi_pend_is_fc1 = cutlass.Int32(0)
+        epi_pend_addr = cute.make_rmem_tensor((epi_batch,), cutlass.Int64)
+
+        def _flush_done_batch(_pend_n, _pend_addr, _tidx, _batch):
+            # tidx==0 publishes the accumulated batch: ONE device fence (the
+            # preceding task_tile_boundary_bar already ordered every epilogue
+            # warp's stores at CTA scope) then one relaxed reduction per
+            # recorded target.  Returns the reset count.  cuTeDSL forbids
+            # closures over ANY local (even a Python int), so the buffer / tid /
+            # batch-size are all passed explicitly.
+            if _tidx == 0:
+                cute.arch.fence_acq_rel_gpu()
+                for _b in cutlass.range_constexpr(0, _batch, 1):
+                    if cutlass.Int32(_b) < _pend_n:
+                        _red_add_relaxed_gpu_s32_addr(
+                            _pend_addr[_b], cutlass.Int32(1)
+                        )
+            return cutlass.Int32(0)
+
+        work_tile_info = sched_consumer.consume_work()
+        while work_tile_info.is_valid_tile:
+            if work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1):
+                self._run_fc1_task_tile(
+                    work_tile_info=work_tile_info,
+                    tmem_acc_tensor=tmem_acc_tensor,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                    is_odd_turn=is_odd_turn,
+                    smem_fc1_output_buffer=smem_fc1_output_buffer,
+                    tma_atom_fc1_output=tma_atom_fc1_output,
+                    sched_ext=sched_ext,
+                    gmem_fc1_output=gmem_fc1_output,
+                    gmem_fc1_output_sf=gmem_fc1_output_sf,
+                    gmem_topk_scores=gmem_topk_scores,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                    alpha=alpha,
+                    norm_const=norm_const,
+                )
+            else:
+                self._run_fc2_task_tile(
+                    work_tile_info=work_tile_info,
+                    tmem_acc_tensor=tmem_acc_tensor,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                    is_odd_turn=is_odd_turn,
+                    sched_ext=sched_ext,
+                    smem_fc1_output_buffer=smem_fc1_output_buffer,
+                    gmem_fc2_output=gmem_fc2_output,
+                    valid_hidden=valid_hidden,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                    token_comm_args=token_comm_args,
+                )
+            iket.range_pop()
+
+            cur_was_linear1 = work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+            cur_fc1_counter_slot = (
+                work_tile_info.cumulative_token_block_count
+                + work_tile_info.tile_n_idx
+            )
+            # Only valid fc1 N-tiles signal the buffer ready. ``tile_m_idx`` in swap_ab is the
+            # ``intermediate_downproj_tile_idx``.
+            cur_intermediate_downproj_tile_in_bound = (
+                work_tile_info.tile_m_idx < intermediate_downproj_tile_count
+            )
+            cur_fc2_expert_idx = work_tile_info.expert_idx
+
+            acc_consumer_state.advance()
+            if cutlass.const_expr(self._overlapping_accum):
+                is_odd_turn = cutlass.Int32(1) - is_odd_turn
+
+            work_tile_info = sched_consumer.consume_work()
+
+            iket.range_push("epi_flag")
+            # Drain fc1 TMA stores locally (per-tile).  The device-scope fence
+            # that publishes them is batched with the done-counter reduction
+            # below -- the fence orders fc1 TMA and fc2 STG stores alike, so we
+            # only record the reduction target here.
+            if cur_was_linear1:
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+            task_tile_boundary_bar.arrive_and_wait()
+
+            # Publish completion.  fc1_done_counter feeds back into the fc2 MMA
+            # (whose acc the epilogue later consumes), so a batch must never
+            # straddle an fc1<->fc2 phase boundary: when the publishing phase
+            # flips, flush the accumulated batch FIRST so the next phase never
+            # waits on a flag still trapped in the buffer (else deadlock).
+            # Within a phase, batch the device fence + relaxed reductions across
+            # up to epi_batch tiles.  epi_pend_n / epi_pend_is_fc1 are kept
+            # warp-uniform so every epilogue thread agrees on flush points.
+            if cur_was_linear1:
+                if cur_intermediate_downproj_tile_in_bound:
+                    if epi_pend_n > cutlass.Int32(0):
+                        if epi_pend_is_fc1 == cutlass.Int32(0):
+                            epi_pend_n = _flush_done_batch(
+                                epi_pend_n, epi_pend_addr, tidx, epi_batch
+                            )
+                    if tidx == 0:
+                        epi_pend_addr[epi_pend_n] = (
+                            gmem_fc1_done_counter.iterator + cur_fc1_counter_slot
+                        ).toint()
+                    epi_pend_is_fc1 = cutlass.Int32(1)
+                    epi_pend_n = epi_pend_n + cutlass.Int32(1)
+                    if epi_pend_n == cutlass.Int32(epi_batch):
+                        epi_pend_n = _flush_done_batch(
+                            epi_pend_n, epi_pend_addr, tidx, epi_batch
+                        )
+            else:
+                if cutlass.const_expr(self._token_back_by_dispatch):
+                    if epi_pend_n > cutlass.Int32(0):
+                        if epi_pend_is_fc1 == cutlass.Int32(1):
+                            epi_pend_n = _flush_done_batch(
+                                epi_pend_n, epi_pend_addr, tidx, epi_batch
+                            )
+                    if tidx == 0:
+                        epi_pend_addr[epi_pend_n] = (
+                            token_comm_args.fc2_done_counter.iterator
+                            + cur_fc2_expert_idx
+                        ).toint()
+                    epi_pend_is_fc1 = cutlass.Int32(0)
+                    epi_pend_n = epi_pend_n + cutlass.Int32(1)
+                    if epi_pend_n == cutlass.Int32(epi_batch):
+                        epi_pend_n = _flush_done_batch(
+                            epi_pend_n, epi_pend_addr, tidx, epi_batch
+                        )
+            iket.range_pop()
+
+        # Tail flush: publish any leftover (< epi_batch) accumulated targets with
+        # one final device fence.  Each leftover tile's stores were already
+        # ordered by its per-tile boundary barrier inside the loop.
+        if epi_pend_n > cutlass.Int32(0):
+            epi_pend_n = _flush_done_batch(epi_pend_n, epi_pend_addr, tidx, epi_batch)
+
+    # -- Per-phase task-tile dispatch ------------------------------------------
+
+    @cute.jit
+    def _run_fc1_task_tile(
+        self,
+        work_tile_info,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn,
+        smem_fc1_output_buffer: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        sched_ext,
+        gmem_fc1_output: cute.Tensor,
+        gmem_fc1_output_sf: cute.Tensor,
+        gmem_topk_scores: cute.Tensor,
+        warp_idx: int,
+        tidx,
+        alpha,
+        norm_const,
+    ) -> None:
+        """Linear1 task-tile body."""
+        real_fc1_output, _ = sched_ext.get_gmem_tensor(
+            "c", gmem_fc1_output, work_tile_info,
+        )
+        real_fc1_output_sf, _ = sched_ext.get_gmem_tensor(
+            "sfc", gmem_fc1_output_sf, work_tile_info,
+        )
+        # Shifted topk view; downstream indexing is expert-local.
+        real_topk_scores, _ = sched_ext.get_gmem_tensor(
+            "topk", gmem_topk_scores, work_tile_info,
+        )
+
+        iket.range_push("fc1_epi_wait")
+        acc_pipeline.consumer_wait(acc_consumer_state)
+        iket.range_pop()
+        iket.range_push("fc1_epi")
+
+        if cutlass.const_expr(self._overlapping_accum):
+            acc_stage_col_offset = cutlass.Int32(acc_consumer_state.phase) * (
+                256 - self._num_sf_tmem_cols
+            )
+        else:
+            acc_stage_col_offset = (
+                cutlass.Int32(acc_consumer_state.index)
+                * self._cta_tile_n
+            )
+
+        valid_tokens = work_tile_info.valid_tokens_in_cta_tile
+        subtile_cnt = self._subtile_cnt
+
+        # Overlap path preloads two subtiles before releasing acc TMEM.
+        unroll_tile_cnt = 2 if cutlass.const_expr(self._overlapping_accum) else 0
+        remain_subtile_cnt = subtile_cnt - unroll_tile_cnt
+
+        if cutlass.const_expr(unroll_tile_cnt > 0):
+            subtile_idx_first = (
+                cutlass.Int32(subtile_cnt) - is_odd_turn
+            ) % cutlass.Int32(subtile_cnt)
+            subtile_idx_second = (
+                cutlass.Int32(subtile_cnt + 1) - is_odd_turn
+            ) % cutlass.Int32(subtile_cnt)
+
+            tmem_subtile_first = self._subtile_local_tmem_tensor(
+                tmem_acc_tensor, subtile_idx_first, warp_idx,
+                acc_stage_col_offset,
+            )
+            tmem_subtile_second = self._subtile_local_tmem_tensor(
+                tmem_acc_tensor, subtile_idx_second, warp_idx,
+                acc_stage_col_offset,
+            )
+
+            # Always preload before unconditional acc release.
+            preload_subtile_first = _TmemTranspose16x32Core.load_subtile_raw_acc(
+                tmem_subtile_first
+            )
+
+            # Release acc to next MMA unconditionally.
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+            preload_subtile_second = _TmemTranspose16x32Core.load_subtile_raw_acc(
+                tmem_subtile_second
+            )
+
+            # Both unrolled subtiles borrow tmem_subtile_second as workspace.
+            preload_pair = (preload_subtile_first, preload_subtile_second)
+            subtile_idx_pair = (subtile_idx_first, subtile_idx_second)
+            for i in cutlass.range_constexpr(unroll_tile_cnt):
+                if subtile_idx_pair[i] * cutlass.Int32(64) < valid_tokens:
+                    self._run_fc1_subtile(
+                        subtile_idx=subtile_idx_pair[i],
+                        tmem_subtile_tensor=tmem_subtile_second,
+                        real_fc1_output=real_fc1_output,
+                        real_fc1_output_sf=real_fc1_output_sf,
+                        real_topk_scores=real_topk_scores,
+                        work_tile_info=work_tile_info,
+                        smem_fc1_output_buffer=smem_fc1_output_buffer,
+                        tma_atom_fc1_output=tma_atom_fc1_output,
+                        warp_idx=warp_idx,
+                        tidx=tidx,
+                        alpha=alpha,
+                        norm_const=norm_const,
+                        preload_acc=preload_pair[i],
+                    )
+
+        for i in cutlass.range(remain_subtile_cnt, unroll=1):
+            real_i = i + unroll_tile_cnt
+            if cutlass.const_expr(self._overlapping_accum):
+                subtile_idx = (
+                    cutlass.Int32(real_i + subtile_cnt) - is_odd_turn
+                ) % cutlass.Int32(subtile_cnt)
+            else:
+                subtile_idx = cutlass.Int32(real_i)
+
+            if subtile_idx * cutlass.Int32(64) < valid_tokens:
+                self._run_fc1_subtile(
+                    subtile_idx=subtile_idx,
+                    tmem_subtile_tensor=self._subtile_local_tmem_tensor(
+                        tmem_acc_tensor, subtile_idx, warp_idx,
+                        acc_stage_col_offset,
+                    ),
+                    real_fc1_output=real_fc1_output,
+                    real_fc1_output_sf=real_fc1_output_sf,
+                    real_topk_scores=real_topk_scores,
+                    work_tile_info=work_tile_info,
+                    smem_fc1_output_buffer=smem_fc1_output_buffer,
+                    tma_atom_fc1_output=tma_atom_fc1_output,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                    alpha=alpha,
+                    norm_const=norm_const,
+                )
+
+        # Non-overlap-path release: at the natural task-tile boundary.
+        if cutlass.const_expr(not self._overlapping_accum):
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+    @cute.jit
+    def _run_fc2_task_tile(
+        self,
+        work_tile_info,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn,
+        sched_ext,
+        smem_fc1_output_buffer: cute.Tensor,
+        gmem_fc2_output: cute.Tensor,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+        token_comm_args=None,
+    ) -> None:
+        """fc2 (Linear2) task-tile body.
+
+        Mirrors ``_run_fc1_task_tile``'s shape -- same acc_pipeline
+        wait/release lifecycle, same subtile loop with overlap rotation
+        and valid_tokens early-exit.  The transpose path uses
+        ``_run_fc2_subtile`` per subtile; the UBLK path delegates the
+        task-tile body to ``_run_fc2_bulk_task_tile``.
+
+        Path A: fc2 epi takes no topk weight (the per-token scalar was
+        already pre-multiplied into the swiglu fp32 output by the upstream
+        fc1 ``PostSwigluHalf``).  The default transpose path is LDTM + cvt
+        + pack + transpose + unpack-permute + STG.256.  The UBLK path uses
+        LDTM + BF16 scratch staging + descriptor-free bulk copy/reduce.
+
+        ``gmem_fc2_output`` is the MoE-domain ``(token_max, topk, hidden)``
+        tensor; return routing is owned by ``Fc2ReturnTile`` at full CTA
+        token tile granularity.
+        """
+        metadata_u32 = None
+        peer_rank_ptr_mapper = None
+        if cutlass.const_expr(
+            token_comm_args is None or self._token_back_by_dispatch
+        ):
+            if cutlass.const_expr(self._reduce_topk_in_kernel):
+                raise ValueError(
+                    "in_kernel_fc2_reduce requires token_comm metadata + a "
+                    "peer_rank_ptr_mapper and does not coexist with "
+                    "token_back_by_dispatch; STG to a local fc2 workspace "
+                    "instead."
+                )
+        else:
+            metadata_u32 = cute.recast_tensor(
+                token_comm_args.token_src_metadata, cutlass.Uint32,
+            )
+            peer_rank_ptr_mapper = token_comm_args.peer_rank_ptr_mapper
+
+        valid_tokens = work_tile_info.valid_tokens_in_cta_tile
+        subtile_cnt = self._subtile_cnt
+        task_tile_data_row_start = (
+            work_tile_info.cumulative_data_physical_row
+            + work_tile_info.tile_n_idx * cutlass.Int32(self._cta_tile_n)
+        )
+        valid_token_row_end = task_tile_data_row_start + valid_tokens
+        thread_in_warp = tidx % 32
+
+        if cutlass.const_expr(self._fc2_use_bulk):
+            token_contract = BulkReturnTokenContract(self._cta_tile_n)
+        elif cutlass.const_expr(self._reduce_topk_in_kernel):
+            token_contract = TransposeRedgReturnTokenContract(self._cta_tile_n)
+        else:
+            token_contract = TransposeStgReturnTokenContract(self._cta_tile_n)
+
+        return_tile = Fc2ReturnTile(
+            tensor=gmem_fc2_output,
+            metadata=metadata_u32,
+            peer_rank_ptr_mapper=peer_rank_ptr_mapper,
+            cta_token_tile_start=task_tile_data_row_start,
+            valid_token_row_end=valid_token_row_end,
+            reduce_topk_in_kernel=self._reduce_topk_in_kernel,
+            token_contract=token_contract,
+        )
+        epi_tidx = cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+
+        acc_ready = cutlass.Boolean(False)
+        if not work_tile_info.peek_ready:
+            acc_pipeline.consumer_wait(acc_consumer_state)
+            acc_ready = cutlass.Boolean(True)
+        return_prefetch = return_tile.prefetch_for_epi_thread(epi_tidx)
+
+        iket.range_push("fc2_epi_wait")
+        acc_pipeline.consumer_wait(acc_consumer_state, acc_ready)
+        iket.range_pop()
+        iket.range_push("fc2_epi")
+
+        if cutlass.const_expr(self._overlapping_accum):
+            acc_stage_col_offset = cutlass.Int32(acc_consumer_state.phase) * (
+                256 - self._num_sf_tmem_cols
+            )
+        else:
+            acc_stage_col_offset = (
+                cutlass.Int32(acc_consumer_state.index)
+                * self._cta_tile_n
+            )
+
+        if cutlass.const_expr(self._fc2_use_bulk):
+            self._run_fc2_bulk_task_tile(
+                work_tile_info=work_tile_info,
+                tmem_acc_tensor=tmem_acc_tensor,
+                acc_pipeline=acc_pipeline,
+                acc_consumer_state=acc_consumer_state,
+                is_odd_turn=is_odd_turn,
+                smem_fc1_output_buffer=smem_fc1_output_buffer,
+                return_prefetch=return_prefetch,
+                valid_tokens=valid_tokens,
+                valid_hidden=valid_hidden,
+                warp_idx=warp_idx,
+                tidx=tidx,
+                acc_stage_col_offset=acc_stage_col_offset,
+            )
+            return
+
+        # Same overlap-acc structure as fc1; downstream subtile body differs.
+        unroll_tile_cnt = 2 if cutlass.const_expr(self._overlapping_accum) else 0
+        remain_subtile_cnt = subtile_cnt - unroll_tile_cnt
+
+        if cutlass.const_expr(unroll_tile_cnt > 0):
+            subtile_idx_first = (
+                cutlass.Int32(subtile_cnt) - is_odd_turn
+            ) % cutlass.Int32(subtile_cnt)
+            subtile_idx_second = (
+                cutlass.Int32(subtile_cnt + 1) - is_odd_turn
+            ) % cutlass.Int32(subtile_cnt)
+
+            tmem_subtile_first = self._subtile_local_tmem_tensor(
+                tmem_acc_tensor, subtile_idx_first, warp_idx,
+                acc_stage_col_offset,
+            )
+            tmem_subtile_second = self._subtile_local_tmem_tensor(
+                tmem_acc_tensor, subtile_idx_second, warp_idx,
+                acc_stage_col_offset,
+            )
+
+            preload_subtile_first = _TmemTranspose16x32Core.load_subtile_raw_acc(
+                tmem_subtile_first
+            )
+
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+            preload_subtile_second = _TmemTranspose16x32Core.load_subtile_raw_acc(
+                tmem_subtile_second
+            )
+
+            preload_pair = (preload_subtile_first, preload_subtile_second)
+            subtile_idx_pair = (subtile_idx_first, subtile_idx_second)
+            for i in cutlass.range_constexpr(unroll_tile_cnt):
+                if subtile_idx_pair[i] * cutlass.Int32(64) < valid_tokens:
+                    self._run_fc2_subtile(
+                        subtile_idx=subtile_idx_pair[i],
+                        tmem_subtile_tensor=tmem_subtile_second,
+                        return_prefetch=return_prefetch,
+                        work_tile_info=work_tile_info,
+                        valid_hidden=valid_hidden,
+                        warp_idx=warp_idx,
+                        tidx=tidx,
+                        preload_acc=preload_pair[i],
+                    )
+
+        for i in cutlass.range(remain_subtile_cnt, unroll=1):
+            real_i = i + unroll_tile_cnt
+            if cutlass.const_expr(self._overlapping_accum):
+                subtile_idx = (
+                    cutlass.Int32(real_i + subtile_cnt) - is_odd_turn
+                ) % cutlass.Int32(subtile_cnt)
+            else:
+                subtile_idx = cutlass.Int32(real_i)
+
+            if subtile_idx * cutlass.Int32(64) < valid_tokens:
+                self._run_fc2_subtile(
+                    subtile_idx=subtile_idx,
+                    tmem_subtile_tensor=self._subtile_local_tmem_tensor(
+                        tmem_acc_tensor, subtile_idx, warp_idx,
+                        acc_stage_col_offset,
+                    ),
+                    return_prefetch=return_prefetch,
+                    work_tile_info=work_tile_info,
+                    valid_hidden=valid_hidden,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                )
+
+        if cutlass.const_expr(not self._overlapping_accum):
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+    @cute.jit
+    def _run_fc2_bulk_task_tile(
+        self,
+        work_tile_info,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn,
+        smem_fc1_output_buffer: cute.Tensor,
+        return_prefetch: Fc2ReturnTilePrefetch,
+        valid_tokens,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+        acc_stage_col_offset,
+    ) -> None:
+        """Run one fc2 task tile through the UBLK bulk-copy epilogue path."""
+        scratch = self.fc2_bulk_scratch_view(smem_fc1_output_buffer)
+        subtile_cnt = self._subtile_cnt
+
+        if cutlass.const_expr(self._overlapping_accum):
+            first_subtile_idx = (
+                cutlass.Int32(subtile_cnt) - is_odd_turn
+            ) % cutlass.Int32(subtile_cnt)
+            if first_subtile_idx * cutlass.Int32(64) >= valid_tokens:
+                cute.arch.fence_view_async_tmem_load()
+                acc_pipeline.consumer_release(acc_consumer_state)
+
+        scratch_lifetime_bar = pipeline.NamedBarrier(
+            barrier_id=self._epilog_sync_bar_id,
+            num_threads=EpiWarpCount * WarpThreadCount,
+        )
+
+        for i in cutlass.range(subtile_cnt, unroll=1):
+            if cutlass.const_expr(self._overlapping_accum):
+                subtile_idx = (
+                    cutlass.Int32(i + subtile_cnt) - is_odd_turn
+                ) % cutlass.Int32(subtile_cnt)
+            else:
+                subtile_idx = cutlass.Int32(i)
+
+            release_after_ldtm = (
+                cutlass.const_expr(self._overlapping_accum)
+                and i == cutlass.Int32(0)
+            )
+            if subtile_idx * cutlass.Int32(64) < valid_tokens:
+                self._run_fc2_bulk_subtile(
+                    subtile_idx=subtile_idx,
+                    tmem_subtile_tensor=self._subtile_local_tmem_tensor(
+                        tmem_acc_tensor, subtile_idx, warp_idx,
+                        acc_stage_col_offset,
+                    ),
+                    scratch=scratch,
+                    return_prefetch=return_prefetch,
+                    work_tile_info=work_tile_info,
+                    valid_hidden=valid_hidden,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                    release_after_ldtm=release_after_ldtm,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                )
+                # Drain each UBLK group before the fixed 8KB scratch is reused
+                # by the next subtile or task tile.
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+                scratch_lifetime_bar.arrive_and_wait()
+
+        if cutlass.const_expr(not self._overlapping_accum):
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+    # -- Per-subtile dispatch -------------------------------------------------
+
+
+    @cute.jit
+    def _run_fc1_subtile(
+        self,
+        subtile_idx,
+        tmem_subtile_tensor: cute.Tensor,
+        real_fc1_output: cute.Tensor,
+        real_fc1_output_sf: cute.Tensor,
+        real_topk_scores: cute.Tensor,
+        work_tile_info,
+        smem_fc1_output_buffer: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        warp_idx: int,
+        tidx,
+        alpha,
+        norm_const,
+        *,
+        preload_acc: Optional[
+            Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor]
+        ] = None,
+    ) -> None:
+        """Run one fc1 epi subtile with contract-backed component wiring.
+
+        ``tmem_subtile_tensor`` is a (32 lanes, 64 cols) view onto the
+        per-warp acc TMEM region (or, in the overlap-acc unroll path,
+        onto a *workspace* subtile's region that this subtile is
+        borrowing for its in-place transpose STTMs).  Caller-built via
+        ``_subtile_local_tmem_tensor``.
+
+        ``preload_acc`` (4-tuple of (16,) fp32 RMEM tensors) is
+        non-None **only** in the overlap-acc unroll path -- it carries
+        the raw acc data that has already been LDTM'd out by
+        ``_TmemTranspose16x32Core.load_subtile_raw_acc`` *before* the
+        acc TMEM was released to the next mma.  Tuple ordering:
+
+            preload_acc[0]: gate_lo  (subtile cols 0..31, lanes 0..15)
+            preload_acc[1]: up_lo    (subtile cols 0..31, lanes 16..31)
+            preload_acc[2]: raw_top  (subtile cols 32..63, lanes 0..15)
+            preload_acc[3]: raw_bot  (subtile cols 32..63, lanes 16..31)
+
+        When provided, the per-subtile entry LDTM x 2 (gate / up) is
+        skipped and ``second_t`` is constructed in skip-R1.Load mode
+        with raw_top / raw_bot fed through ``reg_tensor_top`` /
+        ``reg_tensor_bot``; the rest of the body (transpose rounds,
+        SwiGLU folds, post-half quantize, R2S, TMA cmd) is identical.
+
+        When ``preload_acc is None`` the body matches the original
+        sequential-per-subtile path bit-for-bit -- fine-grained ILP
+        interleaving of transpose rounds, SwiGLU folds, and post-SwiGLU
+        tasks is preserved exactly.
+        """
+        # -- Per-half TMEM ptrs derived from the (32, 64) subtile view ------
+        #
+        # ``tmem_subtile_tensor.iterator`` is the (lane 0, col 0) corner
+        # of this subtile's 64-col region, already 16-aligned by the
+        # ``cute.assume(divby=16)`` inside ``_subtile_local_tmem_tensor``.
+        # +32 second-half offset uses a Python int (compile-time const)
+        # so cute const-folds it into the ptr and propagates the 16-col
+        # alignment to the LDTM/STTM atoms; a ``cutlass.Int32(32)`` here
+        # would be an SSA value that cute treats as alignment-unknown,
+        # tripping the LDTM atom's "tmem aligned at >= 2 cols" verifier.
+        tmem_first_ptr = tmem_subtile_tensor.iterator
+        tmem_second_ptr = tmem_first_ptr + 32
+
+        # -- Per-subtile GMEM views and per-half meta -------------------------
+
+        subtile_token_tile_idx = (
+            work_tile_info.tile_n_idx * (self._cta_tile_n // EpilogueTokenTile)
+            + subtile_idx
+        )
+        g_fc1_output_subtile_view = cute.local_tile(
+            real_fc1_output,
+            (EpilogueTokenTile, Fc1EpilogueOutputTile, 1),
+            (subtile_token_tile_idx, work_tile_info.tile_m_idx, 0),
+        )
+
+        thread_in_warp = tidx % 32
+        subtile_token_start = (
+            work_tile_info.tile_n_idx * self._cta_tile_n
+            + subtile_idx * EpilogueTokenTile
+        )
+        token_left = subtile_token_start + thread_in_warp
+        token_right = token_left + 32
+        intermediate_downproj_idx = (
+            work_tile_info.tile_m_idx * (self._cta_tile_m // 2)
+            + warp_idx * Nvfp4BlockSize
+        )
+
+        # Resolve ``intermediate_downproj`` for the PostSwigluHalf SFC
+        # predicate. 
+        if cutlass.const_expr(self._intermediate_downproj is not None):
+            intermediate_downproj_value = self._intermediate_downproj
+        else:
+            intermediate_downproj_value = real_fc1_output.shape[1]
+
+        # -- Pre-LDG topk weights ---------------------------------------------
+        #
+        # Hoisted ahead of the LDTM x 2 below so the per-thread topk-weight
+        # GMEM round trip overlaps with the entire LDTM + transpose +
+        # quantize pipeline.  The PostSwigluHalf instances at the end of
+        # this subtile receive these as ``preloaded_topk_weight`` instead
+        # of running their own LDG inside __init__ -- saving the LDG +
+        # cvt latency from the critical path.
+        #
+        # Each thread reads exactly 2 fp32: ``token_left`` for the
+        # left-half post (covering tokens 0..31 of this subtile) and
+        # ``token_right`` for the right-half post (tokens 32..63).
+        # ``real_topk_scores`` is the per-expert-shifted view of the
+        # global topk_scores 1D tensor (produced by
+        # ``SwapABSwigluFp4Fc12SchedExtension.get_gmem_tensor("topk", ...)``).
+        # Indexing it with the EXPERT-LOCAL token coord matches the SFC
+        # write-side coord convention.
+        topk_left = cutlass.Float32(real_topk_scores[token_left])
+        topk_right = cutlass.Float32(real_topk_scores[token_right])
+
+        # -- raw f_gate / f_up: either LDTM here or take from preload_acc ----
+        #
+        # Both paths produce RMEM tensors that, by definition, carry
+        # ``TmemTranspose16x32.InputContract`` -- the (lane_idx, elem_idx)
+        # -> (token_idx, intermediate_output_idx) distribution that
+        # ``Ld16x64bOp(Repetition.x16) Float32`` LDTM produces, and that
+        # ``load_subtile_raw_acc`` (using the very same atom) reproduces.
+        # Wrap them as TensorWithContract so they cross the boundary into
+        # SwigluCompute under the contract-backed handoff rule.
+        if cutlass.const_expr(preload_acc is None):
+            f_gate_tensor = cute.make_rmem_tensor((16,), cutlass.Float32)
+            f_up_tensor = cute.make_rmem_tensor((16,), cutlass.Float32)
+            atom_ld16x64 = cute.make_copy_atom(
+                tcgen05.Ld16x64bOp(tcgen05.Repetition.x16),
+                cutlass.Float32,
+            )
+            tmem_gate_view = cute.make_tensor(
+                tmem_first_ptr,
+                TmemTranspose16x32._tmem_layout(16, 32),
+            )
+            tmem_up_view = cute.make_tensor(
+                tmem_first_ptr + (16 << 16),
+                TmemTranspose16x32._tmem_layout(16, 32),
+            )
+            cute.copy(
+                atom_ld16x64, tmem_gate_view,
+                TmemTranspose16x32._rmem_copy_view(f_gate_tensor, 16),
+            )
+            cute.copy(
+                atom_ld16x64, tmem_up_view,
+                TmemTranspose16x32._rmem_copy_view(f_up_tensor, 16),
+            )
+        else:
+            f_gate_tensor = preload_acc[0]
+            f_up_tensor = preload_acc[1]
+
+        f_gate = TensorWithContract(
+            tensor=f_gate_tensor, contract=TmemTranspose16x32.InputContract,
+        )
+        f_up = TensorWithContract(
+            tensor=f_up_tensor, contract=TmemTranspose16x32.InputContract,
+        )
+
+        # -- SwiGLU fold first half (0..8 now; 8..16 dispersed below) --------
+
+        first_swiglu = SwigluCompute(gate=f_gate, up=f_up, alpha=alpha)
+        first_swiglu.fold(0, 8)
+
+        # -- Second 32x32 in-place transpose (R4 has no STTM) ----------------
+        #
+        # preload_acc=None: standard path (R1.Load LDTMs from TMEM).
+        # preload_acc!=None: skip-R1.Load mode -- raw_top / raw_bot have
+        # already been LDTM'd out by ``load_subtile_raw_acc`` and are
+        # being fed in via reg_tensor_{top,bot}.  R1.Store then writes
+        # them into the borrowed workspace cols (= ``tmem_second_ptr``,
+        # which under the unroll path points to the *workspace* subtile's
+        # second-half cols, NOT this subtile's own second-half cols).
+
+        if cutlass.const_expr(preload_acc is None):
+            second_t = TmemTranspose32x32Inplace(tmem_second_ptr)
+            second_t.bot.r1_load();   second_t.top.r1_load()
+        else:
+            second_t = TmemTranspose32x32Inplace(
+                tmem_second_ptr,
+                reg_tensor_top=TensorWithContract(
+                    tensor=preload_acc[2],
+                    contract=TmemTranspose16x32.InputContract,
+                ),
+                reg_tensor_bot=TensorWithContract(
+                    tensor=preload_acc[3],
+                    contract=TmemTranspose16x32.InputContract,
+                ),
+            )
+            # skip-R1.Load: r1_load is a no-op inside _TmemTranspose16x32Core,
+            # so we don't call it here.
+        second_t.bot.r1_perm();   second_t.top.r1_perm()
+        second_t.bot.r1_store();  second_t.top.r1_store()
+
+        second_t.bot.r2_load();   second_t.top.r2_load()
+        second_t.top.r2_store();  second_t.bot.r2_store()
+
+        second_t.top.r3_load_top()
+        second_t.top.r3_load_bot()
+        second_t.bot.r3_load_top()
+        second_t.bot.r3_load_bot()
+        first_swiglu.fold(8, 16)
+        second_t.top.r3_perm()
+        second_t.bot.r3_perm()
+        second_t.top.r3_store()
+        second_t.bot.r3_store()
+
+        second_t.top.r4_load_top()
+        second_t.top.r4_load_bot()
+        second_t.bot.r4_load_top()
+        second_t.bot.r4_load_bot()
+        second_t.top.r4_perm()
+        second_t.bot.r4_perm()
+
+        # -- SwiGLU fold second half (0..8 now; 8..16 dispersed below) ------
+        #
+        # second_t.top.output / second_t.bot.output carry
+        # ``TmemTranspose16x32.OutputContract``; SwigluCompute validates
+        # gate/up contracts are equal at construction time.
+
+        second_swiglu = SwigluCompute(
+            gate=second_t.top.output,
+            up=second_t.bot.output,
+            alpha=alpha,
+        )
+        second_swiglu.fold(0, 8)
+
+        # -- First 16x32 transpose (skip-R1.Load; R4 has no STTM) -----------
+        #
+        # ``first_swiglu.output.contract == TmemTranspose16x32.InputContract``
+        # (SwigluCompute inherits from f_gate's contract, which IS
+        # ``InputContract``).  TmemTranspose16x32.__init__ validates the
+        # reg_tensor contract against InputContract.
+
+        first_t = TmemTranspose16x32(
+            tmem_first_ptr,
+            Region.Top,
+            reg_tensor=first_swiglu.output,
+        )
+        first_t.r1_perm()
+        first_t.r1_store()
+        first_t.r2_load()
+        first_t.r2_store()
+        first_t.r3_load_top()
+        first_t.r3_load_bot()
+        second_swiglu.fold(8, 16)
+        first_t.r3_perm()
+        first_t.r3_store()
+        first_t.r4_load_top()
+        first_t.r4_load_bot()
+
+        # gen_sf + quantize for the right half (second_swiglu.output is
+        # ready; first_t.r4_perm hasn't run yet, so left half waits below).
+        # The per-thread topk-weight LDG was hoisted to the subtile prologue
+        # (``topk_right`` is now a ready fp32 register); PostSwigluHalf
+        # consumes it via ``preloaded_topk_weight`` and pre-multiplies it
+        # into the swiglu fp32 values BEFORE NVFP4 quantize (Path A).
+        # ``token_right`` is the EXPERT-LOCAL token coord (same coord
+        # that indexes ``real_fc1_output_sf`` for the SFC write).
+        post_right = PostSwigluHalf(
+            second_swiglu.output,
+            sC=smem_fc1_output_buffer,
+            gSFC=real_fc1_output_sf,
+            warp_idx=warp_idx,
+            norm_const=norm_const,
+            sf_vec_size=Nvfp4BlockSize,
+            half_idx=1,
+            token_idx=token_right,
+            thread_in_warp=thread_in_warp,
+            preloaded_topk_weight=topk_right,
+            intermediate_downproj_idx=intermediate_downproj_idx,
+            intermediate_downproj=intermediate_downproj_value,
+            cga_cluster_tile_intermediate_downproj=(
+                self._cga_cluster_tile_intermediate_downproj
+            ),
+        )
+
+        first_t.r4_perm()
+
+        # -- Quant + R2S + STG SFC, right then left half ---------------------
+        #
+        # No per-subtile-entry barrier wait: each subtile owns its own bar
+        # id (``subtile_bar_id``), so producer warps can fire-and-forget
+        # arrive on the previous subtile's bar and immediately start the
+        # next subtile's R2S without throttle.  Phase correctness is
+        # guaranteed by single-arrive-per-warp-per-bar within a task tile.
+
+        post_right.stg_sfc()
+
+        post_left = PostSwigluHalf(
+            first_t.output,
+            sC=smem_fc1_output_buffer,
+            gSFC=real_fc1_output_sf,
+            warp_idx=warp_idx,
+            norm_const=norm_const,
+            sf_vec_size=Nvfp4BlockSize,
+            half_idx=0,
+            token_idx=token_left,
+            thread_in_warp=thread_in_warp,
+            preloaded_topk_weight=topk_left,
+            intermediate_downproj_idx=intermediate_downproj_idx,
+            intermediate_downproj=intermediate_downproj_value,
+            cga_cluster_tile_intermediate_downproj=(
+                self._cga_cluster_tile_intermediate_downproj
+            ),
+        )
+        post_left.stg_sfc()
+
+        post_right.r2s(subtile_idx)
+        post_left.r2s(subtile_idx)
+
+        # -- TMA store C cmd issue (per-subtile; task-tile commit lives in
+        #    the run() body, not here) -------------------------------------
+
+        SwapABSwigluFp4Epilogue.tma_store_fc1_output(
+            warp_idx,
+            smem_fc1_output_buffer,
+            subtile_idx,
+            tma_atom_fc1_output,
+            g_fc1_output_subtile_view,
+        )
+
+    @cute.jit
+    def _load_fc2_bulk_raw_acc(
+        self,
+        tmem_subtile_tensor: cute.Tensor,
+    ) -> cute.Tensor:
+        """LDTM one 64-token fc2 subtile as raw fp32 accumulators.
+
+        Swap-AB makes the TMEM data path row the hidden coordinate and the
+        TMEM column the token coordinate.  ``Ld32x32b.x64`` therefore gives
+        each lane one hidden row and 64 consecutive token registers.
+        """
+        raw_regs = cute.make_rmem_tensor((64,), cutlass.Float32)
+        atom_ld32x32_x64 = cute.make_copy_atom(
+            tcgen05.Ld32x32bOp(tcgen05.Repetition.x64),
+            cutlass.Float32,
+        )
+        cute.copy(
+            atom_ld32x32_x64,
+            tmem_subtile_tensor,
+            _TmemTranspose16x32Core._rmem_copy_view(raw_regs, 64),
+        )
+        return raw_regs
+
+    @cute.jit
+    def _store_fc2_bulk_token_group_to_smem(
+        self,
+        raw_regs: cute.Tensor,
+        scratch: cute.Tensor,
+        *,
+        token_group_idx: int,
+        warp_idx: int,
+        tidx,
+    ) -> None:
+        """F2FP + warp-collective STS for one 32-token group.
+
+        For token iteration t, lanes 0..31 of each epi warp collectively
+        store hidden-contiguous BF16 values into ``scratch[t, hidden]``.
+        """
+        lane_idx = tidx % 32
+        warp_hidden_base = cutlass.Int32(warp_idx * 32)
+
+        for token_i in cutlass.range_constexpr(32):
+            src_reg = token_i + 32 * token_group_idx
+            scratch[token_i, warp_hidden_base + lane_idx] = raw_regs[src_reg].to(
+                self._fc2_output_dtype
+            )
+
+    @cute.jit
+    def _issue_fc2_bulk_token_group(
+        self,
+        scratch: cute.Tensor,
+        return_prefetch: Fc2ReturnTilePrefetch,
+        *,
+        subtile_idx,
+        token_group_idx: int,
+        tile_hidden_idx,
+        hidden_tile_size: int,
+        valid_hidden,
+        warp_idx,
+        tidx,
+    ) -> None:
+        """Issue one 32-token x 128-hidden scratch tile via UBLKCP/UBLKREDG."""
+        pair_idx = subtile_idx // cutlass.Int32(2)
+        issue_group = (
+            (subtile_idx % cutlass.Int32(2)) * cutlass.Int32(2)
+            + cutlass.Int32(token_group_idx)
+        )
+        lane_idx = tidx % 32
+        lane_group = lane_idx // cutlass.Int32(8)
+        lane_in_group = lane_idx % cutlass.Int32(8)
+        scratch_row = cutlass.Int32(warp_idx * 8) + lane_in_group
+        slot = pair_idx
+        hidden_base = cutlass.Int32(tile_hidden_idx * hidden_tile_size)
+        # Metadata is prefetched once per CTA tile: warp W owns tokens
+        # [8*W, 8*W+8) within each active 32-token group.  All epi warps
+        # issue their own 8 row-bulk operations for the active lane group.
+        if lane_group == issue_group:
+            if cutlass.const_expr(self._fc2_hidden_needs_predicate):
+                if hidden_base < valid_hidden:
+                    copy_elems = cutlass.Int32(128)
+                    if hidden_base + cutlass.Int32(128) > valid_hidden:
+                        copy_elems = valid_hidden - hidden_base
+                    self._issue_fc2_bulk_row(
+                        scratch,
+                        return_prefetch,
+                        slot=slot,
+                        scratch_row=scratch_row,
+                        hidden_base=hidden_base,
+                        copy_bytes=copy_elems * cutlass.Int32(2),
+                    )
+            else:
+                self._issue_fc2_bulk_row(
+                    scratch,
+                    return_prefetch,
+                    slot=slot,
+                    scratch_row=scratch_row,
+                    hidden_base=hidden_base,
+                    copy_bytes=cutlass.Int32(256),
+                )
+
+    @cute.jit
+    def _issue_fc2_bulk_row(
+        self,
+        scratch: cute.Tensor,
+        return_prefetch: Fc2ReturnTilePrefetch,
+        *,
+        slot,
+        scratch_row,
+        hidden_base,
+        copy_bytes,
+    ) -> None:
+        src_row = cute.slice_(scratch, (scratch_row, None))
+        token_row_1d = return_prefetch.row(slot)
+        dst_ptr = token_row_1d.iterator + hidden_base
+        dst_ptr = cute.make_ptr(
+            token_row_1d.element_type,
+            dst_ptr.toint(),
+            AddressSpace.gmem,
+            assumed_align=16,
+        )
+        if return_prefetch.is_valid(slot):
+            if cutlass.const_expr(self._reduce_topk_in_kernel):
+                _cp_reduce_async_bulk_add_noftz_bf16_s2g(
+                    dst_ptr,
+                    src_row.iterator,
+                    copy_bytes,
+                )
+            else:
+                _cp_async_bulk_s2g(
+                    dst_ptr,
+                    src_row.iterator,
+                    copy_bytes,
+                )
+
+    @cute.jit
+    def _run_fc2_bulk_subtile(
+        self,
+        subtile_idx,
+        tmem_subtile_tensor: cute.Tensor,
+        scratch: cute.Tensor,
+        return_prefetch: Fc2ReturnTilePrefetch,
+        work_tile_info,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+        *,
+        release_after_ldtm,
+        acc_pipeline,
+        acc_consumer_state,
+    ) -> None:
+        """Run one fc2 UBLK subtile.
+
+        Both 32-token groups are LDTM'd before any SMEM reuse, so overlap
+        mode can release accumulator TMEM immediately after this prologue.
+        The two groups then reuse the same 32x128 BF16 scratch tile.
+        """
+        raw_acc = self._load_fc2_bulk_raw_acc(tmem_subtile_tensor)
+
+        if release_after_ldtm:
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+        task_tile_bar = pipeline.NamedBarrier(
+            barrier_id=self._epilog_sync_bar_id,
+            num_threads=EpiWarpCount * WarpThreadCount,
+        )
+
+        # token 0..31 of this 64-token subtile
+        self._store_fc2_bulk_token_group_to_smem(
+            raw_acc, scratch, token_group_idx=0, warp_idx=warp_idx, tidx=tidx,
+        )
+        cute.arch.fence_proxy("async.shared", space="cta")
+        cute.arch.sync_warp()
+        task_tile_bar.arrive_and_wait()
+        self._issue_fc2_bulk_token_group(
+            scratch,
+            return_prefetch,
+            subtile_idx=subtile_idx,
+            token_group_idx=0,
+            tile_hidden_idx=work_tile_info.tile_m_idx,
+            hidden_tile_size=self._cta_tile_m,
+            valid_hidden=valid_hidden,
+            warp_idx=warp_idx,
+            tidx=tidx,
+        )
+        cute.arch.cp_async_bulk_commit_group()
+
+        # token 32..63 of this 64-token subtile
+        cute.arch.cp_async_bulk_wait_group(0, read=True)
+        cute.arch.sync_warp()
+        task_tile_bar.arrive_and_wait()
+        self._store_fc2_bulk_token_group_to_smem(
+            raw_acc, scratch, token_group_idx=1, warp_idx=warp_idx, tidx=tidx,
+        )
+        cute.arch.fence_proxy("async.shared", space="cta")
+        cute.arch.sync_warp()
+        task_tile_bar.arrive_and_wait()
+        self._issue_fc2_bulk_token_group(
+            scratch,
+            return_prefetch,
+            subtile_idx=subtile_idx,
+            token_group_idx=1,
+            tile_hidden_idx=work_tile_info.tile_m_idx,
+            hidden_tile_size=self._cta_tile_m,
+            valid_hidden=valid_hidden,
+            warp_idx=warp_idx,
+            tidx=tidx,
+        )
+        cute.arch.cp_async_bulk_commit_group()
+
+    @cute.jit
+    def _run_fc2_subtile(
+        self,
+        subtile_idx,
+        tmem_subtile_tensor: cute.Tensor,
+        return_prefetch: Fc2ReturnTilePrefetch,
+        work_tile_info,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+        *,
+        preload_acc: Optional[
+            Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor]
+        ] = None,
+    ) -> None:
+        """Run one fc2 epi subtile: LDTM + cvt + pack + transpose + STG.
+
+        Per fc2 epi subtile (64 token x cta_tile_m hidden):
+
+          - 4 epi warp share the subtile.  Per warp = 32 hidden x 64 token.
+          - Split into first/second halves (32 token left / 32 token right);
+            each half is 32 hidden x 32 token (= one warp-region of acc TMEM).
+
+        Per-half pipeline:
+
+          1. ``Fc2AccLoadAndPack``           : LDTM x 2 + cvt.rn.bf16x2.f32 +
+                                               pack pairs into (16, Float32)
+                                               packed-bf16x2 RMEM tensor
+                                               carrying TmemTranspose16x32-
+                                               Packed.InputContract.
+          2. ``TmemTranspose16x32Packed``    : 4-round in-place transpose
+                                               (skip-R1.Load mode -- the
+                                               packed tensor is fed directly
+                                               via reg_tensor=).  Output
+                                               carries TmemTranspose16x32-
+                                               Packed.OutputContract.
+          3. ``Fc2UnpackPermuteStg``         : recast packed view back to
+                                               (32, BFloat16), permute to
+                                               natural hidden order, fire
+                                               2 x STG.256 to GMEM out2.
+
+        first half (token 0..31) and second half (token 32..63) are
+        sequential; we let the compiler interleave LDTMs / STTMs / STGs
+        across the two halves for ILP rather than driving an explicit
+        cross-half action ordering (fc2 has no SwiGLU coupling between
+        halves, so a simpler structure is fine here).
+
+        ``tmem_subtile_tensor`` (32 hidden lanes, 64 token cols): per-warp
+        acc TMEM region of this fc2 subtile (or, in the overlap-acc unroll
+        path, a workspace subtile's region this subtile is borrowing).
+        Caller-built via ``_subtile_local_tmem_tensor``.
+
+        ``preload_acc`` (4-tuple of (16,) fp32 RMEM tensors): non-None
+        only in the overlap-acc unroll path.  Carries the raw acc data
+        of this subtile already LDTM'd out by
+        ``_TmemTranspose16x32Core.load_subtile_raw_acc`` *before* the
+        acc TMEM was released.  Tuple ordering (matches fc1):
+
+            preload_acc[0]: first-half top  (cols 0..31, hidden lanes 0..15)
+            preload_acc[1]: first-half bot  (cols 0..31, hidden lanes 16..31)
+            preload_acc[2]: second-half top (cols 32..63, hidden lanes 0..15)
+            preload_acc[3]: second-half bot (cols 32..63, hidden lanes 16..31)
+
+        When provided, ``Fc2AccLoadAndPack`` for each half is constructed
+        with ``preload_acc=(top, bot)`` instead of ``tmem_ptr=...``,
+        skipping the per-half LDTM x 2.  The downstream
+        ``TmemTranspose16x32Packed`` (already skip-R1.Load) and
+        ``Fc2UnpackPermuteStg`` are unchanged.
+        """
+        # -- Per-half TMEM ptrs derived from the (32, 64) subtile view ------
+        # Same Python-int alignment propagation convention as fc1.
+        tmem_first_ptr = tmem_subtile_tensor.iterator
+        tmem_second_ptr = tmem_first_ptr + 32
+
+        thread_in_warp = tidx % 32
+        epi_tidx = cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+
+        # ``redg_subtile_scratch``: the same (32 lanes, 64 cols) view
+        # the caller already built for the upstream transpose
+        # (= ``tmem_subtile_tensor`` from ``_subtile_local_tmem_tensor``).
+        # In REDG mode ``Fc2UnpackPermuteStg`` carves a per-half
+        # 32-lane x 16-col STTM+LDTM reshuffle slab out of it at col
+        # offset ``32 * half_idx``, matching the per-half tmem_*_ptr
+        # split used by the transpose.  Race-free reasoning:
+        #   * tile_n=256 (overlap-acc unroll path): in-place transpose
+        #     runs on the NEXT subtile's TMEM region, so the per-half
+        #     slab here belongs to that next-subtile region and the
+        #     next acc mma does not touch it until after the epilogue
+        #     body returns.
+        #   * tile_n=128: transpose runs on the CURRENT subtile's TMEM
+        #     region, but acc_pipeline.consumer_release is hoisted to
+        #     AFTER the full per-subtile loop (see
+        #     ``_run_fc2_task_tile``), so the next mma is gated by the
+        #     same task-tile-boundary fence the REDG STTM has already
+        #     cleared by the time release fires.
+        if cutlass.const_expr(return_prefetch.tile.reduce_topk_in_kernel):
+            redg_subtile_scratch = tmem_subtile_tensor
+        else:
+            redg_subtile_scratch = None
+
+        # -- First half (token 0..31): LDTM + pack + transpose + STG -------
+        if cutlass.const_expr(preload_acc is None):
+            first_pack = Fc2AccLoadAndPack(
+                tmem_first_ptr,
+                fc2_output_dtype=self._fc2_output_dtype,
+            )
+        else:
+            first_pack = Fc2AccLoadAndPack(
+                preload_acc=(preload_acc[0], preload_acc[1]),
+                fc2_output_dtype=self._fc2_output_dtype,
+            )
+        first_t = TmemTranspose16x32Packed(
+            tmem_first_ptr,
+            Region.Top,
+            reg_tensor=first_pack.output,
+        )
+        first_t.r1_perm()
+        first_t.r1_store()
+        first_t.r2_load()
+        first_t.r2_store()
+        first_t.r3_load_top()
+        first_t.r3_load_bot()
+        first_t.r3_perm()
+        first_t.r3_store()
+        first_t.r4_load_top()
+        first_t.r4_load_bot()
+        first_t.r4_perm()
+
+        first_stg = Fc2UnpackPermuteStg(
+            first_t.output,
+            return_prefetch=return_prefetch,
+            fc2_output_dtype=self._fc2_output_dtype,
+            token_iter=subtile_idx * cutlass.Int32(8)
+            if cutlass.const_expr(return_prefetch.tile.reduce_topk_in_kernel)
+            else subtile_idx * cutlass.Int32(2),
+            warp_idx=warp_idx,
+            epi_tidx=epi_tidx,
+            valid_hidden=valid_hidden,
+            tile_hidden_idx=work_tile_info.tile_m_idx,
+            hidden_tile_size=self._cta_tile_m,
+            needs_hidden_predicate=self._fc2_hidden_needs_predicate,
+            tmem_subtile_scratch=redg_subtile_scratch,
+        )
+        first_stg.stg()
+
+        # -- Second half (token 32..63): same pipeline -----------------------
+        if cutlass.const_expr(preload_acc is None):
+            second_pack = Fc2AccLoadAndPack(
+                tmem_second_ptr,
+                fc2_output_dtype=self._fc2_output_dtype,
+            )
+        else:
+            second_pack = Fc2AccLoadAndPack(
+                preload_acc=(preload_acc[2], preload_acc[3]),
+                fc2_output_dtype=self._fc2_output_dtype,
+            )
+        second_t = TmemTranspose16x32Packed(
+            tmem_second_ptr,
+            Region.Top,
+            reg_tensor=second_pack.output,
+        )
+        second_t.r1_perm()
+        second_t.r1_store()
+        second_t.r2_load()
+        second_t.r2_store()
+        second_t.r3_load_top()
+        second_t.r3_load_bot()
+        second_t.r3_perm()
+        second_t.r3_store()
+        second_t.r4_load_top()
+        second_t.r4_load_bot()
+        second_t.r4_perm()
+
+        second_stg = Fc2UnpackPermuteStg(
+            second_t.output,
+            return_prefetch=return_prefetch,
+            fc2_output_dtype=self._fc2_output_dtype,
+            token_iter=(
+                subtile_idx * cutlass.Int32(8) + cutlass.Int32(4)
+                if cutlass.const_expr(return_prefetch.tile.reduce_topk_in_kernel)
+                else subtile_idx * cutlass.Int32(2) + cutlass.Int32(1)
+            ),
+            warp_idx=warp_idx,
+            epi_tidx=epi_tidx,
+            valid_hidden=valid_hidden,
+            tile_hidden_idx=work_tile_info.tile_m_idx,
+            hidden_tile_size=self._cta_tile_m,
+            needs_hidden_predicate=self._fc2_hidden_needs_predicate,
+            tmem_subtile_scratch=redg_subtile_scratch,
+        )
+        second_stg.stg()

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/epilogue_refactor.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/epilogue_refactor.py
@@ -1,0 +1,2841 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Autonomous epilogue for the fused fc1+fc2 swap-AB MegaMoE kernel.
+
+Per-thread RMEM tensors flow between the transpose / SwiGLU / quantize / fc2
+store steps as bare ``cute.Tensor`` fragments; their thread distribution is a
+fixed physical property of the surrounding atom sequence and is documented in
+local comments.  A ``Contract`` is only kept where it earns its keep: the fc2
+store-out mapping (``Fc2ProcessPipeline.store_out_mapping``) is evaluated at
+runtime to drive which token/hidden cell each issue targets and therefore how
+the per-token metadata is fetched.
+"""
+
+import dataclasses
+from typing import Any, Callable, ClassVar, List, Literal, Optional, Tuple, Type, Union
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import Int64, T
+from src.iket_compat import iket
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.typing import AddressSpace
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm, vector
+
+from .contract import (
+    Contract,
+    FunctionMapping,
+    Space,
+    eval_function_mapping,
+)
+from .fc1_fc2_fuse_sched import BlockPhase
+from .moe_persistent_scheduler import MoESchedConsumer, MoESchedExtension, MoEWorkTileInfo
+from common.megamoe_constants import (
+    Nvfp4BlockSize,
+    Mxfp8BlockSize,
+    Nvfp4E2M1RcpLimit,
+    Fp8E4M3RcpLimit,
+    Fp8E5M2RcpLimit,
+    Fp32Max,
+)
+from common.moe_utils import cvt_f32_to_f8_to_f32
+from src.token_comm import CombineFormat, TokenCommArgs, TokenSrcMetadata
+from src.ptx_helpers import (
+    cp_async_bulk_s2g as _cp_async_bulk_s2g,
+    cp_reduce_async_bulk_add_noftz_bf16_s2g as _cp_reduce_async_bulk_add_noftz_bf16_s2g,
+    red_add_relaxed_sys_v2_bf16x2 as _red_add_relaxed_sys_v2_bf16x2,
+)
+from src.flag_batch import GpuReleaseFlagBatchTracker
+from src.sym_buffer import SymBufferDeviceBase
+
+@dataclasses.dataclass(frozen=True)
+class QuantImpl:
+    """Register-level block quantizer shared by the fc1 / fc2 epilogues.
+
+    Returns ``(data_regs, sf_regs)`` ONLY: the caller pre-multiplies the topk
+    weight / global scale into ``prequant_reg`` beforehand and owns the data /
+    sf plane stores afterwards. ``sf_vec_direction`` selects the per-block amax
+    reduction:
+
+      * ``regs_in_thread``            -- a block is ``sf_vec`` contiguous regs of
+        one thread; amax is thread-local (packed bf16x2 abs-max for combine,
+        fp32 ``fmax`` for orthodox).
+      * ``threads_with_the_same_reg`` -- a block is one reg across ``sf_vec`` warp
+        lanes; amax is a warp CREDUX (full warp for vec=32, lane-predicated
+        halves for vec=16) and is fp32-only, so bf16 is upconverted first.
+
+    ``prequant_reg`` must be 1D with size divisible by ``sf_vec``. Combine inputs
+    are bf16 (fc2's bf16 reorder regs); orthodox nvfp4 input is fp32 (swiglu).
+    """
+
+    quant_kind: Union[str, CombineFormat]
+    sf_vec_direction: Literal["regs_in_thread", "threads_with_the_same_reg"]
+    lane_idx: Optional[Any] = None   # Int32; only the across-lane path needs it
+
+    _orthodox_kinds: ClassVar[Tuple[str, ...]] = ("nvfp4", "mxfp4", "mxfp8_e4m3", "mxfp8_e5m2")
+
+    # -- config / validation --------------------------------------------------
+
+    def __post_init__(self):
+        if isinstance(self.quant_kind, CombineFormat):
+            if not self.quant_kind.is_quantized:
+                raise ValueError(
+                    f"QuantImpl combine path needs a quantized CombineFormat, "
+                    f"got {self.quant_kind}."
+                )
+        elif self.quant_kind in self._orthodox_kinds:
+            if self.quant_kind != "nvfp4":
+                raise NotImplementedError(
+                    f"orthodox {self.quant_kind} quant is reserved but not wired "
+                    f"(only orthodox 'nvfp4' is implemented)."
+                )
+        else:
+            raise ValueError(
+                f"quant_kind must be a CombineFormat or one of "
+                f"{self._orthodox_kinds}, got {self.quant_kind!r}."
+            )
+        if self.sf_vec_direction not in (
+            "regs_in_thread", "threads_with_the_same_reg"
+        ):
+            raise ValueError(
+                f"sf_vec_direction must be 'regs_in_thread' or "
+                f"'threads_with_the_same_reg', got {self.sf_vec_direction!r}."
+            )
+        # Orthodox nvfp4 only sees the transposed (regs-in-thread) layout fc1
+        # produces via its TMEM transpose.
+        if not isinstance(self.quant_kind, CombineFormat) and (
+            self.sf_vec_direction != "regs_in_thread"
+        ):
+            raise NotImplementedError("orthodox nvfp4 quant is regs_in_thread only.")
+        if self.sf_vec_direction == "threads_with_the_same_reg" and (
+            self.lane_idx is None
+        ):
+            raise ValueError(
+                "across-lane quant needs lane_idx for the CREDUX half-warp predicate."
+            )
+
+    @property
+    def data_dtype(self):
+        if isinstance(self.quant_kind, CombineFormat):
+            return self.quant_kind.act_dtype
+        return cutlass.Float4E2M1FN          # orthodox nvfp4
+
+    @property
+    def scale_dtype(self):
+        if isinstance(self.quant_kind, CombineFormat):
+            return self.quant_kind.scale_dtype
+        return cutlass.Float8E4M3FN          # orthodox nvfp4 e4m3 sfc
+
+    @property
+    def sf_vec_size(self) -> int:
+        if isinstance(self.quant_kind, CombineFormat):
+            return self.quant_kind.scale_block
+        return Nvfp4BlockSize                # 16
+
+    @property
+    def _is_combine(self) -> bool:
+        return isinstance(self.quant_kind, CombineFormat)
+
+    @property
+    def _data_rcp_limit(self) -> float:
+        # 1 / max representable magnitude of the data element type.
+        dt = self.data_dtype
+        if dt is cutlass.Float4E2M1FN:
+            return Nvfp4E2M1RcpLimit         # 1/6
+        if dt is cutlass.Float8E4M3FN:
+            return Fp8E4M3RcpLimit           # 1/448
+        return Fp8E5M2RcpLimit               # 1/57344
+
+    # -- dispatch -------------------------------------------------------------
+
+    @cute.jit
+    def __call__(self, prequant_reg: cute.Tensor, *, norm_const=None):
+        if cutlass.const_expr(cute.size(prequant_reg) % self.sf_vec_size != 0):
+            raise ValueError("prequant_reg size must be divisible by sf_vec.")
+        # Combine quantizes fc2's bf16 reorder regs; orthodox nvfp4 the fp32 swiglu.
+        expected_in = cutlass.BFloat16 if self._is_combine else cutlass.Float32
+        if cutlass.const_expr(prequant_reg.element_type is not expected_in):
+            raise TypeError(
+                f"QuantImpl({self.quant_kind}) expects {expected_in} prequant "
+                f"input, got {prequant_reg.element_type}."
+            )
+        if cutlass.const_expr(not self._is_combine):
+            return self.nvfp4_quant_impl(prequant_reg, norm_const=norm_const)
+        if cutlass.const_expr(self.data_dtype is cutlass.Float4E2M1FN):
+            if cutlass.const_expr(self.sf_vec_direction == "regs_in_thread"):
+                return self.nvfp4_combine_quant_regs_in_thread_impl(prequant_reg)
+            return self.nvfp4_combine_quant_threads_with_the_same_reg_impl(prequant_reg)
+        if cutlass.const_expr(self.sf_vec_direction == "regs_in_thread"):
+            return self.mxfp8_combine_quant_regs_in_thread_impl(prequant_reg)
+        return self.mxfp8_combine_quant_threads_with_the_same_reg_impl(prequant_reg)
+
+    # -- impls ----------------------------------------------------------------
+
+    # regs_in_thread only; fc1 promises the vec direction via its TMEM transpose.
+    @cute.jit
+    def nvfp4_quant_impl(
+        self,
+        prequant_reg: cute.Tensor,
+        *,
+        norm_const: Optional[cutlass.Float32] = None,
+    ) -> Tuple[cute.Tensor, cute.Tensor]:
+        # fp32 in -> e2m1 data + e4m3 sfc. Mirrors the prior nvfp4_quant scale
+        # math (sfc -> capped/masked acc_scale); topk pre-mult + sf store are the
+        # caller's job now.
+        vec = self.sf_vec_size
+        n_blocks = cute.size(prequant_reg) // vec
+        data = cute.make_rmem_tensor((cute.size(prequant_reg),), cutlass.Float4E2M1FN)
+        sf = cute.make_rmem_tensor((n_blocks,), cutlass.Float8E4M3FN)
+        in_blocks = cute.zipped_divide(prequant_reg, (vec,))   # ((vec,), (n_blocks,))
+        data_blocks = []
+        sf_values = []
+        rcp_limit = cutlass.Float32(self._data_rcp_limit)
+        for vec_block_idx in cutlass.range_constexpr(n_blocks):
+            block = in_blocks[None, vec_block_idx]
+            amax = self._amax_thread_fp32(block)
+            if cutlass.const_expr(norm_const is not None):
+                sfc_fp32 = amax * rcp_limit * norm_const
+            else:
+                sfc_fp32 = amax * rcp_limit
+            sfc_e4m3 = sfc_fp32.to(cutlass.Float8E4M3FN)
+            sfc_rt = cutlass.Float32(sfc_e4m3)
+            if cutlass.const_expr(norm_const is not None):
+                acc_scale = norm_const * cute.arch.rcp_approx(sfc_rt)
+            else:
+                acc_scale = cute.arch.rcp_approx(sfc_rt)
+            acc_scale = cute.arch.fmin(acc_scale, Fp32Max)
+            mask = cute.arch.fmin(sfc_rt * cutlass.Float32(1e30), cutlass.Float32(1.0))
+            acc_scale = acc_scale * mask
+            sf_values.append(sfc_e4m3)
+            data_blocks.append(self._scale_to_e2m1_ssa(block, acc_scale))
+        self._store_packed_blocks(data, data_blocks)
+        sf.store(self._values_to_ssa(sf_values, cutlass.Float8E4M3FN))
+        return data, sf
+
+    @cute.jit
+    def nvfp4_combine_quant_regs_in_thread_impl(
+        self, prequant_reg: cute.Tensor,
+    ) -> Tuple[cute.Tensor, cute.Tensor]:
+        # bf16 in -> e2m1 data + per-16 bf16 amax. amax found on bf16 (packed).
+        vec = self.sf_vec_size
+        n_blocks = cute.size(prequant_reg) // vec
+        data = cute.make_rmem_tensor((cute.size(prequant_reg),), cutlass.Float4E2M1FN)
+        sf = cute.make_rmem_tensor((n_blocks,), cutlass.BFloat16)
+        in_blocks = cute.zipped_divide(prequant_reg, (vec,))   # ((vec,), (n_blocks,))
+        data_blocks = []
+        sf_values = []
+        for vec_block_idx in cutlass.range_constexpr(n_blocks):
+            block = in_blocks[None, vec_block_idx]
+            amax = self._amax_thread_bf16(block)
+            sf_values.append(amax)
+            decode_scale = cutlass.Float32(amax) * cutlass.Float32(self._data_rcp_limit)
+            data_blocks.append(
+                self._scale_to_e2m1_ssa(block, self._enc_nvfp4(decode_scale))
+            )
+        self._store_packed_blocks(data, data_blocks)
+        sf.store(self._values_to_ssa(sf_values, cutlass.BFloat16))
+        return data, sf
+
+    # Mapping: (lane_idx, selected_sf_idx) -> (token_64, hidden_32)
+    # token_idx = lane_idx % 16 + selected_sf_idx * 16
+    # hidden_idx = lane_idx // 16 * 16
+    @cute.jit
+    def nvfp4_combine_quant_threads_with_the_same_reg_impl(
+        self, prequant_reg: cute.Tensor,
+    ) -> Tuple[cute.Tensor, cute.Tensor]:
+        # UBLK has lane == hidden, so the warp's 32 lanes are 32 consecutive
+        # hidden. A scale block = sf_vec hidden, so the lanes split along hidden
+        # into 32 // sf_vec blocks of sf_vec lanes each (warp = blocks_per_warp *
+        # lanes_per_block, the EP x TP split). Only the sf_vec lanes inside a
+        # block share its CREDUX scale, so they pool the subtile tokens: sf_vec
+        # == 32 pools the whole warp, sf_vec < 32 pools fewer (more per lane).
+        lanes_per_block = self.sf_vec_size
+        n_tokens = cute.size(prequant_reg)
+        lane_in_block = self.lane_idx % cutlass.Int32(lanes_per_block)
+        data = cute.make_rmem_tensor((n_tokens,), cutlass.Float4E2M1FN)
+        selected_sf = cute.make_rmem_tensor((n_tokens // lanes_per_block,), cutlass.BFloat16)
+        scaled_vec = cute.full((n_tokens,), cutlass.Float32(0.0), cutlass.Float32)
+        for token_idx in cutlass.range_constexpr(n_tokens):
+            value = cutlass.Float32(prequant_reg[token_idx])
+            amax_bf16 = self._amax_lane(value).to(cutlass.BFloat16)
+            slot = token_idx // lanes_per_block
+            if (token_idx % lanes_per_block) == lane_in_block:
+                selected_sf[slot] = amax_bf16
+            else:
+                selected_sf[slot] = selected_sf[slot]
+            decode_scale = cutlass.Float32(amax_bf16) * cutlass.Float32(self._data_rcp_limit)
+            scaled_value = value * self._enc_nvfp4(decode_scale)
+            scaled_vec = cute.TensorSSA(
+                vector.insert(
+                    scaled_value.ir_value(),
+                    scaled_vec.ir_value(),
+                    [],
+                    [token_idx],
+                ),
+                (n_tokens,),
+                cutlass.Float32,
+            )
+        self._store_packed_data(data, scaled_vec.to(cutlass.Float4E2M1FN))
+        return data, selected_sf
+
+    @cute.jit
+    def mxfp8_combine_quant_regs_in_thread_impl(
+        self, prequant_reg: cute.Tensor,
+    ) -> Tuple[cute.Tensor, cute.Tensor]:
+        # bf16 in -> e4m3/e5m2 data + per-32 e8m0. amax found on bf16 (packed).
+        vec = self.sf_vec_size
+        n_blocks = cute.size(prequant_reg) // vec
+        data = cute.make_rmem_tensor((cute.size(prequant_reg),), self.data_dtype)
+        sf = cute.make_rmem_tensor((n_blocks,), cutlass.Float8E8M0FNU)
+        in_blocks = cute.zipped_divide(prequant_reg, (vec,))   # ((vec,), (n_blocks,))
+        data_blocks = []
+        sf_values = []
+        for vec_block_idx in cutlass.range_constexpr(n_blocks):
+            block = in_blocks[None, vec_block_idx]
+            # widen the native-bf16 amax to fp32 for the e8m0 round-up math.
+            scale_e8m0, scale_f32 = self._e8m0(cutlass.Float32(self._amax_thread_bf16(block)))
+            sf_values.append(scale_e8m0)
+            data_blocks.append(self._scale_to_mxfp8_data_ssa(block, self._enc_mxfp8(scale_f32)))
+        self._store_packed_blocks(data, data_blocks)
+        sf.store(self._values_to_ssa(sf_values, cutlass.Float8E8M0FNU))
+        return data, sf
+
+    # Mapping: (lane_idx, selected_sf_idx) -> (token_64, hidden_32)
+    # token_idx = lane_idx + selected_sf_idx * 32
+    # hidden_idx = 0
+    @cute.jit
+    def mxfp8_combine_quant_threads_with_the_same_reg_impl(
+        self, prequant_reg: cute.Tensor,
+    ) -> Tuple[cute.Tensor, cute.Tensor]:
+        # UBLK has lane == hidden, so the warp's 32 lanes are 32 consecutive
+        # hidden. A scale block = sf_vec hidden, so the lanes split along hidden
+        # into 32 // sf_vec blocks of sf_vec lanes each (warp = blocks_per_warp *
+        # lanes_per_block, the EP x TP split). Only the sf_vec lanes inside a
+        # block share its CREDUX scale, so they pool the subtile tokens. mxfp8
+        # sf_vec == 32 -> the whole warp is one block, all 32 lanes pool.
+        lanes_per_block = self.sf_vec_size
+        n_tokens = cute.size(prequant_reg)
+        lane_in_block = self.lane_idx % cutlass.Int32(lanes_per_block)
+        data = cute.make_rmem_tensor((n_tokens,), self.data_dtype)
+        selected_sf = cute.make_rmem_tensor((n_tokens // lanes_per_block,), cutlass.Float8E8M0FNU)
+        scaled_vec = cute.full((n_tokens,), cutlass.Float32(0.0), cutlass.Float32)
+        for token_idx in cutlass.range_constexpr(n_tokens):
+            value = cutlass.Float32(prequant_reg[token_idx])
+            scale_e8m0, scale_f32 = self._e8m0(self._amax_lane(value))
+            slot = token_idx // lanes_per_block
+            if (token_idx % lanes_per_block) == lane_in_block:
+                selected_sf[slot] = scale_e8m0
+            else:
+                selected_sf[slot] = selected_sf[slot]
+            scaled_value = value * self._enc_mxfp8(scale_f32)
+            scaled_vec = cute.TensorSSA(
+                vector.insert(
+                    scaled_value.ir_value(),
+                    scaled_vec.ir_value(),
+                    [],
+                    [token_idx],
+                ),
+                (n_tokens,),
+                cutlass.Float32,
+            )
+        self._store_packed_data(data, scaled_vec.to(self.data_dtype))
+        return data, selected_sf
+
+    # -- shared sub-steps -----------------------------------------------------
+
+    @cute.jit
+    def _scale_to_e2m1_ssa(
+        self,
+        block: cute.Tensor,
+        enc: cutlass.Float32,
+    ) -> cute.TensorSSA:
+        block_f32 = block.load().to(cutlass.Float32)
+        enc_vec = cute.full_like(block_f32, enc, cutlass.Float32)
+        return (block_f32 * enc_vec).to(cutlass.Float4E2M1FN)
+
+    @cute.jit
+    def _scale_to_mxfp8_data_ssa(
+        self,
+        block: cute.Tensor,
+        enc: cutlass.Float32,
+    ) -> cute.TensorSSA:
+        block_f32 = block.load().to(cutlass.Float32)
+        enc_vec = cute.full_like(block_f32, enc, cutlass.Float32)
+        return (block_f32 * enc_vec).to(self.data_dtype)
+
+    @cute.jit
+    def _concat_blocks_ssa(self, blocks, dtype: Type[cutlass.Numeric]) -> cute.TensorSSA:
+        values = []
+        for block_idx in cutlass.range_constexpr(len(blocks)):
+            block = blocks[block_idx]
+            for elem_idx in cutlass.range_constexpr(cute.size(block.shape)):
+                values.append(block[elem_idx].ir_value())
+        vec = vector.from_elements(
+            T.vector(len(values), dtype.mlir_type),
+            values,
+        )
+        return cute.TensorSSA(vec, (len(values),), dtype)
+
+    @cute.jit
+    def _values_to_ssa(self, values, dtype: Type[cutlass.Numeric]) -> cute.TensorSSA:
+        vec = vector.from_elements(
+            T.vector(len(values), dtype.mlir_type),
+            [values[i].ir_value() for i in range(len(values))],
+        )
+        return cute.TensorSSA(vec, (len(values),), dtype)
+
+    @cute.jit
+    def _concat_i32_blocks_ssa(self, blocks) -> cute.TensorSSA:
+        values = []
+        for block_idx in cutlass.range_constexpr(len(blocks)):
+            packed_block = blocks[block_idx].bitcast(cutlass.Int32)
+            for elem_idx in cutlass.range_constexpr(cute.size(packed_block.shape)):
+                values.append(packed_block[elem_idx].ir_value())
+        vec = vector.from_elements(
+            T.vector(len(values), cutlass.Int32.mlir_type),
+            values,
+        )
+        return cute.TensorSSA(vec, (len(values),), cutlass.Int32)
+
+    @cute.jit
+    def _store_packed_blocks(self, data: cute.Tensor, blocks) -> None:
+        packed_data = cute.recast_tensor(data, cutlass.Int32)
+        packed_data.store(self._concat_i32_blocks_ssa(blocks))
+
+    @cute.jit
+    def _store_packed_data(self, data: cute.Tensor, data_ssa: cute.TensorSSA) -> None:
+        packed_data = cute.recast_tensor(data, cutlass.Int32)
+        packed_data.store(data_ssa.bitcast(cutlass.Int32))
+
+    @cute.jit
+    def _amax_thread_fp32(self, block: cute.Tensor) -> cutlass.Float32:
+        # max.xorsign.abs reduces |.| in one op per element; the result sign is
+        # the xor of the inputs (junk for an amax), so clear it at the end.
+        def max_abs(lhs: cutlass.Float32, rhs: cutlass.Float32) -> cutlass.Float32:
+            return cutlass.Float32(llvm.inline_asm(
+                T.f32(),
+                [cutlass.Float32(lhs).ir_value(), cutlass.Float32(rhs).ir_value()],
+                "max.xorsign.abs.f32 $0, $1, $2;",
+                "=f,f,f",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            ))
+
+        acc = block[0]
+        for elem_idx in cutlass.range_constexpr(1, cute.size(block)):
+            acc = max_abs(acc, block[elem_idx])
+        mag_bits = cutlass.Int32(
+            llvm.bitcast(T.i32(), cutlass.Float32(acc).ir_value())
+        ) & cutlass.Int32(0x7FFFFFFF)
+        return cutlass.Float32(llvm.bitcast(T.f32(), mag_bits.ir_value()))
+
+    @cute.jit
+    def _amax_thread_bf16(self, block: cute.Tensor) -> cutlass.BFloat16:
+        # Packed bf16x2 abs-max: tree-reduce the pairs, then fold the survivor's
+        # two halves (high shifted into low). max.xorsign.abs leaves a junk sign,
+        # so the low bf16 is masked before being read back. The amax is natively
+        # bf16 -- exactly what the wire format stores.
+        def max_abs(lhs: cutlass.Int32, rhs: cutlass.Int32) -> cutlass.Int32:
+            return cutlass.Int32(llvm.inline_asm(
+                T.i32(),
+                [cutlass.Int32(lhs).ir_value(), cutlass.Int32(rhs).ir_value()],
+                "max.xorsign.abs.bf16x2 $0, $1, $2;",
+                "=r,r,r",
+                has_side_effects=False,
+                is_align_stack=False,
+                asm_dialect=llvm.AsmDialect.AD_ATT,
+            ))
+
+        pairs = cute.recast_tensor(block, cutlass.Int32)   # (vec/2,) bf16x2
+        acc = cutlass.Int32(pairs[0])
+        for pair_idx in cutlass.range_constexpr(1, cute.size(pairs)):
+            acc = max_abs(acc, pairs[pair_idx])
+        acc = max_abs(acc, acc >> cutlass.Int32(16))
+        amax_bits = cute.make_rmem_tensor((1,), cutlass.Int32)
+        amax_bits[0] = acc & cutlass.Int32(0x7FFF)
+        return cute.recast_tensor(amax_bits, cutlass.BFloat16)[0]
+
+    @cute.jit
+    def _amax_lane(self, v: cutlass.Float32) -> cutlass.Float32:
+        if cutlass.const_expr(self.sf_vec_size == 32):
+            return cute.arch.warp_redux_sync(v, "fmax", abs=True)
+        first_half = (self.lane_idx % cutlass.Int32(32)) < cutlass.Int32(16)
+        vsel = cutlass.Float32(0.0)
+        if first_half:
+            vsel = v
+        amax = cute.arch.warp_redux_sync(vsel, "fmax", abs=True)
+        if not first_half:
+            amax = cute.arch.warp_redux_sync(v, "fmax", abs=True)
+        return amax
+
+    @cute.jit
+    def _e8m0(self, amax: cutlass.Float32) -> Tuple[cutlass.Float8E8M0FNU, cutlass.Float32]:
+        candidate = amax * cutlass.Float32(self._data_rcp_limit)
+        scale_f32 = cutlass.Float32(cvt_f32_to_f8_to_f32(candidate, cutlass.Float8E8M0FNU))
+        return scale_f32.to(cutlass.Float8E8M0FNU), scale_f32
+
+    @cute.jit
+    def _enc_nvfp4(self, decode_scale: cutlass.Float32) -> cutlass.Float32:
+        # rcp.approx.ftz with the fc1 cap+mask idiom (amax==0 -> 0, no inf*0 NaN).
+        enc = cute.arch.fmin(cute.arch.rcp_approx(decode_scale), Fp32Max)
+        mask = cute.arch.fmin(decode_scale * cutlass.Float32(1e30), cutlass.Float32(1.0))
+        return enc * mask
+
+    @cute.jit
+    def _enc_mxfp8(self, scale_f32: cutlass.Float32) -> cutlass.Float32:
+        # Skip nan
+        enc = cute.arch.fmin(cute.arch.rcp_approx(scale_f32), Fp32Max)
+        mask = cute.arch.fmin(scale_f32 * cutlass.Float32(1e30), cutlass.Float32(1.0))
+        return enc * mask
+
+
+# =============================================================================
+# Region tag
+# =============================================================================
+
+
+class Region:
+    """Codegen-time region tag for a 16x32 sub-region within a 32x32 tile."""
+
+    Top = 0
+    Bottom = 1
+
+
+# =============================================================================
+# TmemTranspose16x32
+# =============================================================================
+
+
+class _TmemTranspose16x32Core:
+    """Physical implementation of the 16x32 -> 32x16 TMEM in-place transpose.
+
+    The transpose is a fixed sequence of tcgen05 32-bit element atoms; each
+    32-bit slot is opaque to it (an fp32 swiglu-fold value for fc1, or a packed
+    ``(bf16, bf16)`` pair for fc2 -- the physical (lane_idx, elem_idx)
+    distribution is identical either way).  The (thread, reg) -> (tmem_dp,
+    tmem_col) input / output mapping is documented on the ``TmemTranspose16x32``
+    subclass, which is the public entry point.
+
+    Per-thread RMEM coordinate convention:
+
+      - ``lane_idx`` -- warp lane id (= thread index within warp), in [0, 32).
+      - ``elem_idx`` -- per-thread reg index, in [0, 16).
+    """
+
+    _PermR1 = (0, 8, 2, 10, 4, 12, 6, 14, 1, 9, 3, 11, 5, 13, 7, 15)
+    _PermR3 = (0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15)
+    _PermR4 = (0, 8, 2, 10, 4, 12, 6, 14, 1, 9, 3, 11, 5, 13, 7, 15)
+
+    _TmemRowStride = 1 << 16
+    _io_dtype = cutlass.Float32
+
+    @staticmethod
+    def _tmem_layout(num_lanes: int, num_cols: int) -> cute.Layout:
+        return cute.make_layout(
+            (((num_lanes, num_cols), 1),),
+            stride=(((_TmemTranspose16x32Core._TmemRowStride, 1), 0),),
+        )
+
+    @staticmethod
+    def _rmem_copy_view(
+        rmem: cute.Tensor, num_regs: int, offset: int = 0
+    ) -> cute.Tensor:
+        return cute.make_tensor(
+            rmem.iterator + offset,
+            cute.make_layout((((num_regs,), 1),), stride=(((1,), 0),)),
+        )
+
+    @staticmethod
+    def load_subtile_raw_acc(
+        tmem_subtile_tensor: cute.Tensor,
+    ) -> Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor]:
+        """LDTM the entire 32-lane x 64-col raw acc region of one epi
+        subtile into 4 independent (16,) fp32 RMEM tensors.
+
+        Used by the overlap-acc unroll path in
+        ``_run_fc{1,2}_task_tile`` to extract all raw acc data of the
+        first 2 subtiles up front, so that the acc TMEM can be released
+        to the next mma right after the first subtile's 4 LDTMs (instead
+        of waiting for a full subtile body to complete).
+
+        ``tmem_subtile_tensor`` is the (32 lanes, 64 cols) view onto a
+        single epi subtile's acc TMEM region (already offset by
+        ``warp_lane_offset + acc_stage_col_offset + subtile_col_offset``;
+        see ``SwapABSwigluFp4Epilogue._subtile_local_tmem_tensor``).
+
+        Returns a 4-tuple of (16,) fp32 RMEM tensors, each carrying the
+        (lane_idx, elem_idx) input distribution documented on
+        ``TmemTranspose16x32`` (physically identical for fc1 and fc2):
+
+          [0] gate_lo / first-half top   -- subtile cols 0..31, lanes 0..15
+          [1] up_lo   / first-half bot   -- subtile cols 0..31, lanes 16..31
+          [2] raw_top / second-half top  -- subtile cols 32..63, lanes 0..15
+          [3] raw_bot / second-half bot  -- subtile cols 32..63, lanes 16..31
+
+        4 atom calls of ``Ld16x64bOp(Repetition.x16) Float32`` -- the same
+        atom used by the per-subtile entry LDTM.  Each output is in the
+        ``TmemTranspose16x32`` input distribution and can be fed straight
+        into a transpose as ``reg_tensor`` (skip-R1.Load mode).
+        """
+        atom_ld16x64 = cute.make_copy_atom(
+            tcgen05.Ld16x64bOp(tcgen05.Repetition.x16),
+            _TmemTranspose16x32Core._io_dtype,
+        )
+
+        ptr = tmem_subtile_tensor.iterator
+        half_lane_off = 16 * _TmemTranspose16x32Core._TmemRowStride
+
+        # 4 source 16-lane x 32-col views over the (32, 64) subtile region:
+        #   first  half (cols 0..31): top  lanes 0..15  / bot lanes 16..31
+        #   second half (cols 32..63): top lanes 0..15  / bot lanes 16..31
+        # All offsets are Python ints (compile-time const) so cute can
+        # const-fold them and infer the correct (>= 8 B / 2 col) ptr
+        # alignment that the LDTM atom requires.  Using ``cutlass.Int32``
+        # offsets here would wrap them as SSA values that cute treats as
+        # alignment-unknown, tripping the atom's verifier.
+        first_top_view = cute.make_tensor(
+            ptr,
+            _TmemTranspose16x32Core._tmem_layout(16, 32),
+        )
+        first_bot_view = cute.make_tensor(
+            ptr + half_lane_off,
+            _TmemTranspose16x32Core._tmem_layout(16, 32),
+        )
+        second_top_view = cute.make_tensor(
+            ptr + 32,
+            _TmemTranspose16x32Core._tmem_layout(16, 32),
+        )
+        second_bot_view = cute.make_tensor(
+            ptr + 32 + half_lane_off,
+            _TmemTranspose16x32Core._tmem_layout(16, 32),
+        )
+
+        first_top = cute.make_rmem_tensor((16,), _TmemTranspose16x32Core._io_dtype)
+        first_bot = cute.make_rmem_tensor((16,), _TmemTranspose16x32Core._io_dtype)
+        second_top = cute.make_rmem_tensor((16,), _TmemTranspose16x32Core._io_dtype)
+        second_bot = cute.make_rmem_tensor((16,), _TmemTranspose16x32Core._io_dtype)
+
+        cute.copy(
+            atom_ld16x64,
+            first_top_view,
+            _TmemTranspose16x32Core._rmem_copy_view(first_top, 16),
+        )
+        cute.copy(
+            atom_ld16x64,
+            first_bot_view,
+            _TmemTranspose16x32Core._rmem_copy_view(first_bot, 16),
+        )
+        cute.copy(
+            atom_ld16x64,
+            second_top_view,
+            _TmemTranspose16x32Core._rmem_copy_view(second_top, 16),
+        )
+        cute.copy(
+            atom_ld16x64,
+            second_bot_view,
+            _TmemTranspose16x32Core._rmem_copy_view(second_bot, 16),
+        )
+
+        return (first_top, first_bot, second_top, second_bot)
+
+    def __init__(
+        self,
+        tmem_ptr,
+        region: int,
+        reg_tensor: Optional[cute.Tensor] = None,
+    ) -> None:
+        # The whole transpose is built from 32-bit element atoms; _io_dtype
+        # drives _src_regs / output / every LDTM/STTM atom below, so guard the
+        # invariant once here (tautological today, defensive against future
+        # dtype edits).
+        if cutlass.const_expr(self._io_dtype.width != 32):
+            raise TypeError(
+                f"{type(self).__name__} requires a 32-bit _io_dtype (the "
+                f"transpose uses 32-bit element atoms), got {self._io_dtype} "
+                f"(width {self._io_dtype.width})."
+            )
+
+        half_lane_off = 16 * self._TmemRowStride
+        if region == Region.Top:
+            src_ptr = tmem_ptr
+            dst_ptr = tmem_ptr
+        elif region == Region.Bottom:
+            src_ptr = tmem_ptr + half_lane_off
+            dst_ptr = tmem_ptr + 16
+        else:
+            raise ValueError("region must be Region.Top or Region.Bottom")
+
+        self.region = region
+
+        self._tmem_src_full = cute.make_tensor(src_ptr, self._tmem_layout(16, 32))
+        self._tmem_dst_full = cute.make_tensor(dst_ptr, self._tmem_layout(32, 16))
+        self._tmem_dst_top = cute.make_tensor(dst_ptr, self._tmem_layout(16, 16))
+        self._tmem_dst_bot = cute.make_tensor(
+            dst_ptr + half_lane_off, self._tmem_layout(16, 16)
+        )
+
+        self._atom_ld16x64 = cute.make_copy_atom(
+            tcgen05.Ld16x64bOp(tcgen05.Repetition.x16), self._io_dtype,
+        )
+        self._atom_st16x128 = cute.make_copy_atom(
+            tcgen05.St16x128bOp(tcgen05.Repetition.x8), self._io_dtype,
+        )
+        self._atom_st32x32 = cute.make_copy_atom(
+            tcgen05.St32x32bOp(tcgen05.Repetition.x16), self._io_dtype,
+        )
+        self._atom_ld16x256 = cute.make_copy_atom(
+            tcgen05.Ld16x256bOp(tcgen05.Repetition.x2), self._io_dtype,
+        )
+        self._atom_ld16x128 = cute.make_copy_atom(
+            tcgen05.Ld16x128bOp(tcgen05.Repetition.x4), self._io_dtype,
+        )
+
+        self._src_regs = cute.make_rmem_tensor((16,), self._io_dtype)
+        # ``output`` is a bare (16,) RMEM fragment; its (lane_idx, elem_idx)
+        # distribution after all four rounds is the transpose output mapping
+        # documented on ``TmemTranspose16x32``.
+        self.output = cute.make_rmem_tensor((16,), self._io_dtype)
+
+        # skip-R1.Load mode: ``reg_tensor`` must already be in the transpose
+        # input distribution (see ``TmemTranspose16x32`` / produced by
+        # ``load_subtile_raw_acc``); we copy it in lieu of the R1 LDTM.
+        # Weak entry guard (replaces the removed input contract): the transpose
+        # atoms are 32-bit element atoms over exactly 16 regs/lane, so the fed
+        # tensor must be a 32-bit element type (fp32 or packed bf16x2) of size 16.
+        self._reg_tensor = reg_tensor
+        if reg_tensor is not None:
+            if cutlass.const_expr(reg_tensor.element_type.width != 32):
+                raise TypeError(
+                    f"{type(self).__name__} reg_tensor must be a 32-bit element "
+                    f"type (fp32 or packed bf16x2), got element type "
+                    f"{reg_tensor.element_type} (width {reg_tensor.element_type.width})."
+                )
+            if cutlass.const_expr(cute.size(reg_tensor) != 16):
+                raise ValueError(
+                    f"{type(self).__name__} reg_tensor must hold exactly 16 "
+                    f"elements, got {cute.size(reg_tensor)}."
+                )
+            for r in range(16):
+                self._src_regs[r] = reg_tensor[r]
+
+    # -- R1 ------------------------------------------------------------------
+
+    def r1_load(self) -> None:
+        """LDTM src region -> ``_src_regs``.  No-op in skip-R1.Load mode."""
+        if self._reg_tensor is not None:
+            return
+        cute.copy(
+            self._atom_ld16x64,
+            self._tmem_src_full,
+            self._rmem_copy_view(self._src_regs, 16),
+        )
+
+    def r1_perm(self) -> None:
+        for r in range(16):
+            self.output[r] = self._src_regs[self._PermR1[r]]
+
+    def r1_store(self) -> None:
+        cute.copy(
+            self._atom_st16x128,
+            self._rmem_copy_view(self.output, 16),
+            self._tmem_src_full,
+        )
+
+    # -- R2 ------------------------------------------------------------------
+
+    def r2_load(self) -> None:
+        cute.copy(
+            self._atom_ld16x64,
+            self._tmem_src_full,
+            self._rmem_copy_view(self._src_regs, 16),
+        )
+
+    def r2_store(self) -> None:
+        cute.copy(
+            self._atom_st32x32,
+            self._rmem_copy_view(self._src_regs, 16),
+            self._tmem_dst_full,
+        )
+
+    # -- R3 ------------------------------------------------------------------
+
+    def r3_load_top(self) -> None:
+        cute.copy(
+            self._atom_ld16x256,
+            self._tmem_dst_top,
+            self._rmem_copy_view(self._src_regs, 8, offset=0),
+        )
+
+    def r3_load_bot(self) -> None:
+        cute.copy(
+            self._atom_ld16x256,
+            self._tmem_dst_bot,
+            self._rmem_copy_view(self._src_regs, 8, offset=8),
+        )
+
+    def r3_perm(self) -> None:
+        for r in range(16):
+            self.output[r] = self._src_regs[self._PermR3[r]]
+
+    def r3_store(self) -> None:
+        cute.copy(
+            self._atom_st32x32,
+            self._rmem_copy_view(self.output, 16),
+            self._tmem_dst_full,
+        )
+
+    # -- R4 ------------------------------------------------------------------
+
+    def r4_load_top(self) -> None:
+        cute.copy(
+            self._atom_ld16x128,
+            self._tmem_dst_top,
+            self._rmem_copy_view(self._src_regs, 8, offset=0),
+        )
+
+    def r4_load_bot(self) -> None:
+        cute.copy(
+            self._atom_ld16x128,
+            self._tmem_dst_bot,
+            self._rmem_copy_view(self._src_regs, 8, offset=8),
+        )
+
+    def r4_perm(self) -> None:
+        for r in range(16):
+            self.output[r] = self._src_regs[self._PermR4[r]]
+
+    def r4_store(self) -> None:
+        cute.copy(
+            self._atom_st32x32,
+            self._rmem_copy_view(self.output, 16),
+            self._tmem_dst_full,
+        )
+    
+    def from_r1_perm_until_last_store(self) -> cute.Tensor:
+        self.r1_perm()
+        self.r1_store()
+        self.r2_load()
+        self.r2_store()
+        self.r3_load_top()
+        self.r3_load_bot()
+        self.r3_perm()
+        self.r3_store()
+        self.r4_load_top()
+        self.r4_load_bot()
+        self.r4_perm()
+        return self.output
+
+
+class TmemTranspose16x32(_TmemTranspose16x32Core):
+    """Public 16x32 -> 32x16 TMEM in-place transpose.
+
+    The per-thread RMEM ``(lane_idx, elem_idx) -> (tmem_dp, tmem_col)`` mapping
+    is fixed by the underlying atom sequence and is identical for fc1 (each slot
+    is an fp32 swiglu-fold value, ``tmem_col`` = intermediate-output index) and
+    fc2 (each slot is a packed bf16x2, ``tmem_col`` = hidden-pair index).  Only
+    the ``tmem_col`` semantic name differs between the two uses; the physical
+    distribution below is the single source of truth.
+
+    Input distribution -- what each (lane_idx, elem_idx) reg holds on entry
+    (i.e. straight after the 16-dp x 32-col source LDTM, or as fed in via
+    ``reg_tensor`` / ``load_subtile_raw_acc`` for skip-R1.Load mode):
+
+        tmem_dp  = elem_idx * 2 + (lane_idx // 2) % 2          # in [0, 32)
+        tmem_col = (lane_idx % 2) * 8 + lane_idx // 4          # in [0, 16)
+
+    Output distribution -- after all four rounds, the 32-dp x 16-col result has
+    each lane owning one full dp-row of 16 cols:
+
+        tmem_dp  = lane_idx                                    # in [0, 32)
+        tmem_col = elem_idx                                    # in [0, 16)
+    """
+
+
+# =============================================================================
+# TmemTranspose32x32Inplace
+# =============================================================================
+
+
+class TmemTranspose32x32Inplace:
+    """fc1 epi 32x32 in-place TMEM transpose: two ``TmemTranspose16x32``
+    sub-instances (``top`` = lanes 0..15, ``bot`` = lanes 16..31).
+
+    Optional ``reg_tensor_top`` / ``reg_tensor_bot`` enable skip-R1.Load mode
+    for both halves; they must be provided or omitted together.
+    """
+
+    def __init__(
+        self,
+        tmem_ptr,
+        reg_tensor_top: Optional[cute.Tensor] = None,
+        reg_tensor_bot: Optional[cute.Tensor] = None,
+    ) -> None:
+        if (reg_tensor_top is None) != (reg_tensor_bot is None):
+            raise ValueError(
+                "TmemTranspose32x32Inplace: reg_tensor_top and reg_tensor_bot "
+                "must be provided or omitted together (both halves either "
+                "skip-R1.Load or do R1.Load)."
+            )
+        self.top = TmemTranspose16x32(tmem_ptr, Region.Top, reg_tensor=reg_tensor_top)
+        self.bot = TmemTranspose16x32(tmem_ptr, Region.Bottom, reg_tensor=reg_tensor_bot)
+    
+    def from_r1_perm_until_last_store(self) -> Tuple[cute.Tensor, cute.Tensor]:
+        self.bot.r1_perm();   self.top.r1_perm()
+        self.bot.r1_store();  self.top.r1_store()
+
+        self.bot.r2_load();   self.top.r2_load()
+        self.top.r2_store();  self.bot.r2_store()
+
+        self.top.r3_load_top()
+        self.top.r3_load_bot()
+        self.bot.r3_load_top()
+        self.bot.r3_load_bot()
+        self.top.r3_perm()
+        self.bot.r3_perm()
+        self.top.r3_store()
+        self.bot.r3_store()
+
+        self.top.r4_load_top()
+        self.top.r4_load_bot()
+        self.bot.r4_load_top()
+        self.bot.r4_load_bot()
+        self.top.r4_perm()
+        self.bot.r4_perm()
+        return self.top.output, self.bot.output
+
+
+@dataclasses.dataclass(frozen=True)
+class NvFp4OptinalEpiArgs:
+    # MoE domain (experts), nvfp4 only?
+    fc1_alpha: Optional[cute.Tensor]
+    fc2_alpha: Optional[cute.Tensor]
+    fc1_norm_const: Optional[cute.Tensor]
+    # -----------------------------------
+    # MoE domain (token, topk), deepgemm graph only? for transformer graph, we want reduce kernel to perform the score mul.
+    topk_scores: Optional[cute.Tensor]    
+
+
+# TODO: Need to remove `Swiglu` and `Fp4` out of name, later this should be extended to other activations and dtypes.
+class SwapABSwigluFp4Epilogue:
+    """Autonomous epilogue for the swap-AB SwiGLU NVFP4 kernel.
+
+    ``run()`` is the single entry point the kernel calls inside the epi
+    warp body.  The kernel's responsibility is reduced to:
+
+      - allocate / free TMEM and build ``acc_tensor``
+      - construct the AB / acc pipelines
+      - obtain the scheduler consumer
+
+    Everything else (acc consumer state, task-tile loop, overlap rotation,
+    early release, TMA store commit / drain, per-subtile dispatch) lives
+    inside this class.
+    """
+
+    _EpilogueSyncWaitBarId = 1      # Arrive and wait only
+    _EpilogueAsyncBarIdBase = 4     # Some arrive, the others arrive and wait
+    _EpilogueFc1GateUpInterleave = 16
+    _EpilogueTokenTileSize = 64                     # Fundamentally the epi_tile_n
+    _EpilogueFc1IntermediateGateUpTileSize = 128    # Fundamentally epi_tile_m
+    _EpilogueFc1IntermediateDownTileSize = 64       # Fundamentally epi_tile_m // 2
+    _EpilogueFc2HiddenTileSize = 128                # Fundamentally epi_tile_m
+    _EpilogueWarpCnt = 4
+    _TmemColsTotal = 512            # TODO: Remove this hardcode for future arch
+
+    def __init__(
+        self,
+        *,
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        use_2cta_instrs: bool,
+        sf_vec_size: int,
+        fc1_output_dtype: Type[cutlass.Numeric],
+        combine_format: CombineFormat,          # fc2 combine wire: act_dtype (data) + scale_dtype (sf)
+        non_ubulk_fc2_store: bool,              # Whether epilogue warps use STG or UBLK in fc2
+        in_kernel_fc2_reduce: bool,             # Whether epilogue warps reduce fc2 output to peer 
+        token_back_by_dispatch: bool = False,   # Whether epilogue warps store fc2 to local or peer
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        fc1_output_sf_dtype: Type[cutlass.Numeric] = cutlass.Float8E4M3FN,
+        allow_overlap_acc: bool = True,
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,         # [expert, intermediate, hidden]
+        gate_up_clamp: Optional[float] = None,                              # Swiglu style only
+        epi_flag_batch: Optional[Tuple[int, int]] = (1, 1),                 # (fc1, fc2) done-counter publish batch
+    ) -> None:
+        if fc1_output_dtype is not cutlass.Float4E2M1FN:
+            raise NotImplementedError(
+                "SwapABSwigluFp4Epilogue currently assumes fc1 output in "
+                f"sC is NVFP4 Float4E2M1FN; got {fc1_output_dtype}. "
+                "Changing this dtype requires redesigning the fixed 8KB "
+                "shared epilogue scratch layout."
+            )
+        if token_back_by_dispatch and not non_ubulk_fc2_store:
+            raise ValueError(
+                "token_back_by_dispatch=True requires non_ubulk_fc2_store=True; "
+                "bulk fc2 store is incompatible with dispatch-warp token back "
+                "(STG is strictly more efficient for that pipeline)."
+            )
+        if token_back_by_dispatch:
+            in_kernel_fc2_reduce = False
+        self.fc2_use_bulk = not non_ubulk_fc2_store
+        self.reduce_topk_in_kernel = in_kernel_fc2_reduce
+        self.token_back_by_dispatch = token_back_by_dispatch
+        self.combine_format = combine_format
+        self.fc1_output_dtype = fc1_output_dtype
+        self.acc_dtype = acc_dtype
+        self.fc1_output_sf_dtype = fc1_output_sf_dtype
+        self.sf_vec_size = sf_vec_size
+        # Swiglu gate/up clamp limit; None disables clamping.
+        self.gate_up_clamp = gate_up_clamp
+        # Done-counter publish batch granularity
+        _fc1_eb, _fc2_eb = (1, 1) if epi_flag_batch is None else epi_flag_batch
+        self.fc1_epi_flag_batch = max(1, min(32, int(_fc1_eb)))
+        self.fc2_epi_flag_batch = max(1, min(32, int(_fc2_eb)))
+        self.cluster_tile_intermediate_downproj = self._EpilogueFc1IntermediateDownTileSize * cluster_shape_mn[0]
+
+        atom_thr_size = 2 if use_2cta_instrs else 1
+        self.cta_tile_m = self._EpilogueFc2HiddenTileSize
+        self.cta_tile_n = mma_tiler_mnk[1]
+        self.cta_tile_k = mma_tiler_mnk[2]
+        assert(mma_tiler_mnk[0] // atom_thr_size == self.cta_tile_m)
+        assert(self.cta_tile_n % self._EpilogueTokenTileSize == 0)
+        self.static_expert_shape = static_expert_shape
+        self.acc_tmem_cols = self.cta_tile_n
+        self.acc_sf_cols = (max(self.cta_tile_n // 128, 1) * self.cta_tile_k + max(self.cta_tile_m // 128, 1) * self.cta_tile_k) // self.sf_vec_size
+
+        if static_expert_shape is not None and static_expert_shape[2] % (self.cta_tile_m * cluster_shape_mn[0]) == 0:
+            self.fc2_hidden_needs_predicate: bool = False
+        else:
+            self.fc2_hidden_needs_predicate: bool = True
+
+        if static_expert_shape is not None:
+            intermediate_downproj = static_expert_shape[1] // 2
+            self.intermediate_downproj: Optional[int] = intermediate_downproj
+        else:
+            self.intermediate_downproj: Optional[int] = None
+
+        self.subtile_cnt = self.cta_tile_n // self._EpilogueTokenTileSize
+        self.overlapping_accum = allow_overlap_acc and (self.acc_tmem_cols + self.acc_sf_cols > self._TmemColsTotal // 2)
+        self.num_acc_stage = 2
+        self.num_acc_pipeline_stages = 1 if self.overlapping_accum else self.num_acc_stage
+        self.overlapped_tmem_cols = self._EpilogueTokenTileSize if self.overlapping_accum else 0
+        assert(not self.overlapping_accum or self.overlapped_tmem_cols >= self.acc_sf_cols)
+        self.epi_smem_bytes = 8 * 1024
+        if self.fc1_output_dtype.width > 4:
+            raise NotImplementedError("Remember to adjust the smem size when switch to mxfp8 support")
+        self.tmem_acc_layout_py_obj = ((self.cta_tile_m, self.cta_tile_n, self.num_acc_stage), (_TmemTranspose16x32Core._TmemRowStride, 1, self.cta_tile_n - self.overlapped_tmem_cols))
+
+    def get_epi_storage_type(self) -> Type:
+        # This could be extended to take atoms space for the larger sf_vec_size quant.
+        @cute.struct
+        class EpilogueSharedStorage:
+            # 256 byte alignment is for the swizzle start address.
+            epi_smem: cute.struct.Align[cute.struct.MemRange[cutlass.Int8, self.epi_smem_bytes], 256]
+        return EpilogueSharedStorage
+
+    def fc1_staged_smem_layout(
+        self,
+        n_stages: int,
+        without_stage_mode: bool = False
+    ) -> Union[cute.Layout, cute.ComposedLayout]:
+        layout = sm100_utils.make_smem_layout_epi(
+            self.fc1_output_dtype,
+            utils.LayoutEnum.ROW_MAJOR,
+            (self._EpilogueTokenTileSize, self._EpilogueFc1IntermediateDownTileSize),
+            n_stages,
+        )
+        if without_stage_mode:
+            return cute.select(layout, mode=[0, 1])
+        return layout
+
+    @cute.jit
+    def run(
+        self,
+        epi_smem_storage,
+        tmem_ptr: cute.Pointer,
+        acc_pipeline,
+        # ── Sched ────────────────────────────────────────────────────────
+        sched_consumer: MoESchedConsumer,
+        sched_ext: MoESchedExtension,
+        # ── tensors ──────────────────────────────────
+        tma_atom_fc1_output: cute.CopyAtom,
+        fc1_output: cute.Tensor,            # Domain of fake (m, n, l)
+        fc1_output_sf: cute.Tensor,         # Domain of fake (m, n, l)
+        fc2_output: cute.Tensor,            # MoE domain (token, topk, hidden)
+        fc1_done_counter: cute.Tensor,      # 1D tensor
+        tidx: cutlass.Int32,
+        optional_epi_args: NvFp4OptinalEpiArgs = None,      # Epilogue optinal runtime arguments.
+        token_comm_args=None,                               # Only valid when enable token communication
+    ):
+        if cutlass.const_expr(optional_epi_args is None):
+            optional_epi_args = NvFp4OptinalEpiArgs(
+                fc1_alpha=None,
+                fc2_alpha=None,
+                fc1_norm_const=None,
+                topk_scores=None,
+            )
+        tmem_acc = cute.make_tensor(
+            cute.recast_ptr(tmem_ptr, dtype=cutlass.Float32),
+            cute.make_layout(
+                self.tmem_acc_layout_py_obj[0],
+                stride=self.tmem_acc_layout_py_obj[1],
+            ),
+        )
+
+        fc1_epi = SwapABFc1Epilogue(self, tidx, epi_smem_storage, sched_ext, tma_atom_fc1_output, fc1_output, fc1_output_sf, fc1_done_counter, optional_epi_args)
+        fc2_epi = SwapABFc2Epilogue(self, tidx, epi_smem_storage, fc2_output, token_comm_args, optional_epi_args)
+
+        acc_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self.num_acc_pipeline_stages
+        )
+        wait_only_named_barrier = pipeline.NamedBarrier(
+            barrier_id=self._EpilogueSyncWaitBarId,
+            num_threads=32 * self._EpilogueWarpCnt,
+        )
+        is_odd_turn = cutlass.Int32(1)
+        work_tile_info = sched_consumer.consume_work()
+
+        flag_tracker = GpuReleaseFlagBatchTracker(
+            flag_addr=Int64(0),
+            cumulated_flags=cutlass.Int32(0),
+            phase=cutlass.Int32(work_tile_info.phase),
+            tid=tidx % (self._EpilogueWarpCnt * 32),
+        )
+
+        while work_tile_info.is_valid_tile:
+            if cutlass.const_expr(self.overlapping_accum):
+                tmem_stage_idx = acc_consumer_state.phase
+            else:
+                tmem_stage_idx = acc_consumer_state.index
+            tmem_acc_current = tmem_acc[None, None, tmem_stage_idx]
+            if work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1):
+                # The __call__ args should only take the while loop args, leave all loop irrevalent args to the init.
+                fc1_epi(
+                    work_tile_info=work_tile_info,
+                    tmem_acc_tensor=tmem_acc_current,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                    is_odd_turn=is_odd_turn,
+                )
+            else:
+                # The __call__ args should only take the while loop args, leave all loop irrevalent args to the init.
+                fc2_epi(
+                    work_tile_info=work_tile_info,
+                    tmem_acc_tensor=tmem_acc_current,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                    is_odd_turn=is_odd_turn,
+                )
+            iket.range_pop()
+
+            prev_work_tile_info = work_tile_info
+            cur_was_linear1 = prev_work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+
+            acc_consumer_state.advance()
+            if cutlass.const_expr(self.overlapping_accum):
+                is_odd_turn = cutlass.Int32(1) - is_odd_turn
+
+            work_tile_info = sched_consumer.consume_work()
+
+            # Drain fc1 TMA stores and sf stores before publishing the fc1-done counter.
+            if cur_was_linear1:
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+            # _fence_rel_gpu()
+            wait_only_named_barrier.arrive_and_wait()
+
+            # Publish completion for the work tile snapshotted above.
+            if cur_was_linear1:
+                flag_tracker = fc1_epi.signal_fc1_done(
+                    prev_work_tile_info, work_tile_info, flag_tracker
+                )
+            else:
+                flag_tracker = fc2_epi.signal_fc2_done(
+                    prev_work_tile_info, work_tile_info, flag_tracker
+                )
+        # Tail flush
+        flag_tracker.fire()
+
+
+class _ImmutableAfterInit:
+    """Froze at the point calling `_freeze()`"""
+
+    def __setattr__(self, name, value):
+        if self.__dict__.get("_frozen_", False):
+            raise AttributeError(
+                f"{type(self).__name__} is immutable after __init__ "
+                f"(cannot set {name!r})."
+            )
+        object.__setattr__(self, name, value)
+
+    def _freeze(self) -> None:
+        object.__setattr__(self, "_frozen_", True)
+
+
+# Device only object
+class SwapABFc1Epilogue(_ImmutableAfterInit):
+    def __init__(
+        self, 
+        base: SwapABSwigluFp4Epilogue, 
+        tidx: cutlass.Int32, 
+        epi_smem_storage, 
+        sched_ext: MoESchedExtension, 
+        tma_atom_fc1_output: cute.CopyAtom, 
+        fc1_output: cute.Tensor,            # fake (m,n,l) domain
+        fc1_output_sf: cute.Tensor,         # fake (m,n,l) domain
+        fc1_done_counter: cute.Tensor,      # 1D tensor
+        optional_epi_args: NvFp4OptinalEpiArgs,
+    ):
+        self.base = base
+        self.tidx = tidx % (base._EpilogueWarpCnt * 32)
+        self.warp_idx = self.tidx // 32
+        self.lane_idx = self.tidx % 32
+        if cutlass.const_expr(base.fc1_output_dtype.width != 4):
+            raise NotImplementedError("Remember to adjust the swizzle and smem size.")
+        # (token64, intermediate, stage)
+        self.smem_tensor = cute.make_tensor(
+            cute.recast_ptr(
+                epi_smem_storage.epi_smem.data_ptr(),
+                cute.make_swizzle(1, 4, 3),
+                dtype=base.fc1_output_dtype,
+            ),
+            base.fc1_staged_smem_layout(base.subtile_cnt).outer,
+        )
+        self.sched_ext = sched_ext
+        self.fc1_tma_atom = tma_atom_fc1_output
+        self.fc1_output = fc1_output
+        self.fc1_output_sf = fc1_output_sf
+        self.fc1_done_counter = fc1_done_counter
+        self.optional_epi_args = optional_epi_args
+        self._freeze()
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "base"), name)
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        # This object is a loop-invariant Python context wrapper, not a
+        # dynamic value.  Keep it out of scf.while iter_args and reconstruct by
+        # identity across region boundaries.  Any field that becomes a
+        # loop-carried SSA value must be passed explicitly to __call__ instead
+        # of being stored here.
+        return []
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "SwapABFc1Epilogue":
+        assert len(values) == 0
+        return self
+
+    @cute.jit
+    def signal_fc1_done(self, work_tile_info, next_work_tile_info, flag_tracker):
+        # Only in-bound intermediate_downproj tiles signal; OOB -> null slot.
+        if cutlass.const_expr(
+            self.static_expert_shape is None
+            or self.intermediate_downproj % self.cluster_tile_intermediate_downproj != 0
+        ):
+            in_bound = (
+                work_tile_info.tile_m_idx * self._EpilogueFc1IntermediateDownTileSize
+                < self.fc1_output.shape[1]
+            )
+        else:
+            in_bound = True
+        slot = (
+            work_tile_info.cumulative_token_block_count
+            + work_tile_info.tile_n_idx
+        )
+        flag_addr = Int64(0)
+        if in_bound:
+            flag_addr = (self.fc1_done_counter.iterator + slot).toint()            
+        return flag_tracker.accumulate(
+            next_work_tile_info.phase, self.fc1_epi_flag_batch, flag_addr,
+        )
+
+    @cute.jit
+    def __call__(
+        self, 
+        work_tile_info: MoEWorkTileInfo,
+        tmem_acc_tensor: cute.Tensor,       # (cta_tile_m, cta_tile_n)
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn: cutlass.Int32
+    ):
+        # (tokens_this_expert, intermediate_down, 1)
+        real_fc1_output, _ = self.sched_ext.get_gmem_tensor(
+            "c", self.fc1_output, work_tile_info,
+        )
+        # (tokens_this_expert, intermediate_down, 1)
+        real_fc1_output_sf, _ = self.sched_ext.get_gmem_tensor(
+            "sfc", self.fc1_output_sf, work_tile_info,
+        )
+        # subtile-irrevalent hoist out here.
+        if cutlass.const_expr(self.optional_epi_args.fc1_alpha is not None):
+            alpha_val = self.optional_epi_args.fc1_alpha[work_tile_info.expert_idx]
+        else:
+            alpha_val = None
+        if cutlass.const_expr(self.optional_epi_args.fc1_norm_const is not None):
+            norm_const = self.optional_epi_args.fc1_norm_const[work_tile_info.expert_idx]
+        else:
+            norm_const = None
+        # (cta_tile_m, cta_tile_n) -> (epi_tile_m, epi_tile_n, iters)
+        tmem_acc_tensor_tiled_by_epi_tile = cute.flat_divide(tmem_acc_tensor, (self._EpilogueFc1IntermediateGateUpTileSize, self._EpilogueTokenTileSize))[None, None, 0, None]
+
+        acc_pipeline.consumer_wait(acc_consumer_state)
+        iket.range_push("fc1_epi")
+        valid_tokens = work_tile_info.valid_tokens_in_cta_tile
+
+        # Overlap path preloads two subtiles before releasing acc TMEM.
+        unroll_tile_cnt = 2 if cutlass.const_expr(self.overlapping_accum) else 0
+        remain_subtile_cnt = self.subtile_cnt - unroll_tile_cnt
+
+        if cutlass.const_expr(unroll_tile_cnt > 0):
+            subtile_idx_first = (
+                cutlass.Int32(self.subtile_cnt) - is_odd_turn
+            ) % cutlass.Int32(self.subtile_cnt)
+            subtile_idx_second = (
+                cutlass.Int32(self.subtile_cnt + 1) - is_odd_turn
+            ) % cutlass.Int32(self.subtile_cnt)
+
+            # preload_subtile_first: subtile_idx_first's raw PRE-transpose acc, LDTM'd by
+            # all 128 epi threads into 4 reg tensors == the 4 quadrants of the subtile's
+            # (128 tmem_dp x 64 tmem_col) footprint. Only these raw-TMEM offsets are
+            # guaranteed:
+            #   reg[0]/reg[1], reg[2]/reg[3] : top vs bot      -> 16 apart in tmem_dp
+            #   reg[0]/reg[2], reg[1]/reg[3] : 1st vs 2nd half -> 32 apart in tmem_col
+            # (so reg[0..1] = the first 128x32, reg[2..3] = the second 128x32 of the 128x64.)
+            # The per-lane (lane_idx, elem_idx) -> (tmem_dp, tmem_col) layout INSIDE each
+            # reg tensor is opaque -- do not assume it; it only becomes well-defined once
+            # the tmem transpose consumes them.
+            preload_subtile_first : Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor] = _TmemTranspose16x32Core.load_subtile_raw_acc(
+                tmem_acc_tensor_tiled_by_epi_tile[None, None, subtile_idx_first]
+            )
+
+            # Release acc to next MMA unconditionally.
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+            # preload_subtile_second: same 128 tmem_dp x 64 tmem_col footprint, but for
+            # subtile_idx_second (the other token subtile, not the 2nd col-half). Same
+            # quadrant/offset invariants and opaque per-lane layout as above.
+            preload_subtile_second : Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor] = _TmemTranspose16x32Core.load_subtile_raw_acc(
+                tmem_acc_tensor_tiled_by_epi_tile[None, None, subtile_idx_second]
+            )
+
+            # Both unrolled subtiles borrow tmem_subtile_second as workspace.
+            preload_pair = (preload_subtile_first, preload_subtile_second)
+            subtile_idx_pair = (subtile_idx_first, subtile_idx_second)
+            for i in cutlass.range_constexpr(unroll_tile_cnt):
+                if subtile_idx_pair[i] * cutlass.Int32(self._EpilogueTokenTileSize) < valid_tokens:
+                    self.run_subtile(
+                        work_tile_info=work_tile_info,
+                        subtile_idx=subtile_idx_pair[i],
+                        tmem_subtile_tensor=tmem_acc_tensor_tiled_by_epi_tile[None, None, subtile_idx_second],
+                        preload_acc=preload_pair[i],
+                        fc1_output=real_fc1_output,
+                        fc1_output_sf=real_fc1_output_sf,
+                        alpha_val=alpha_val,
+                        norm_const=norm_const,
+                    )
+
+        for i in cutlass.range(remain_subtile_cnt, unroll=1):
+            real_i = i + unroll_tile_cnt
+            if cutlass.const_expr(self.overlapping_accum):
+                subtile_idx = (
+                    cutlass.Int32(real_i + self.subtile_cnt) - is_odd_turn
+                ) % cutlass.Int32(self.subtile_cnt)
+            else:
+                subtile_idx = cutlass.Int32(real_i)
+
+            if subtile_idx * cutlass.Int32(self._EpilogueTokenTileSize) < valid_tokens:
+                self.run_subtile(
+                    work_tile_info=work_tile_info,
+                    subtile_idx=subtile_idx,
+                    tmem_subtile_tensor=tmem_acc_tensor_tiled_by_epi_tile[None, None, subtile_idx],
+                    preload_acc=None,
+                    fc1_output=real_fc1_output,
+                    fc1_output_sf=real_fc1_output_sf,
+                    alpha_val=alpha_val,
+                    norm_const=norm_const,
+                )
+
+        # Non-overlap-path release: at the natural task-tile boundary.
+        if cutlass.const_expr(not self.overlapping_accum):
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+    @cute.jit
+    def run_subtile(
+        self,
+        work_tile_info: MoEWorkTileInfo,
+        subtile_idx: cutlass.Int32,
+        # (intermedaite_gateup_tile, token_subtile), fundamentally (epi_tile_m, epi_tile_n)
+        tmem_subtile_tensor: cute.Tensor,
+        # Rmems preloaded from tmem, contract with downstream tmem trans. Do not assume mapping here.
+        preload_acc: Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor],
+        # (tokens_this_expert, intermediate_down, 1)
+        fc1_output: cute.Tensor,
+        fc1_output_sf: cute.Tensor,
+        alpha_val: Optional[cutlass.Float32],
+        norm_const: Optional[cutlass.Float32],
+    ):
+        if cutlass.const_expr(self.optional_epi_args.topk_scores is not None):
+            # This means we need to perform DeepGEMM computation graph, topk_score at fc1 pre-quant 
+            topk_score_tensor, _ = self.sched_ext.get_gmem_tensor(
+                "topk", self.optional_epi_args.topk_scores, work_tile_info,
+            )      # (tokens_this_expert)
+        else:
+            topk_score_tensor = None
+        
+        # Contract about the transposed acc (assume nvfp4 output):
+        # (epi_tid, val_id) -> (token_idx, intermediate_down_idx)
+        # token_idx = epi_tid % 32 + val_id // 16 * 32
+        # intermediate_down_idx = val_id % 16 + epi_tid // 32 * 16
+        # Each thread holds (intermediate_down_16, token_2):(1, 16)
+
+        # Step -1: preload topk scores.
+        current_two_token_idices = (
+            work_tile_info.tile_n_idx * self.cta_tile_n + subtile_idx * self._EpilogueTokenTileSize + self.lane_idx,
+            work_tile_info.tile_n_idx * self.cta_tile_n + subtile_idx * self._EpilogueTokenTileSize + self.lane_idx + 32
+        )
+        if cutlass.const_expr(topk_score_tensor is not None):
+            topk_scores = (topk_score_tensor[current_two_token_idices[0]], topk_score_tensor[current_two_token_idices[1]])
+        else:
+            topk_scores = None
+        
+        # Step 0: load tmem
+        if cutlass.const_expr(preload_acc is not None):
+            gate_token_0_32, up_token_0_32, gate_token_32_64, up_token_32_64 = preload_acc
+        else:
+            gate_token_0_32 = cute.make_rmem_tensor((16,), cutlass.Float32)
+            up_token_0_32 = cute.make_rmem_tensor((16,), cutlass.Float32)
+            gate_token_32_64 = cute.make_rmem_tensor((16,), cutlass.Float32)
+            up_token_32_64 = cute.make_rmem_tensor((16,), cutlass.Float32)
+            # Although hardcode is not right, but since the whole tmem transpose is too tricky, I have to hardcode...
+            # (epi_tile_m, epi_tile_n) -> (warp_local_epi_tile_m, epi_tile_n)
+            # tmem_subtile_tensor_per_warp = cute.logical_divide(tmem_subtile_tensor, (32, None))[(None, self.warp_idx), None]
+            tmem_subtile_tensor_per_warp = cute.logical_divide(tmem_subtile_tensor, (32, None))[(None, 0), None]
+            # (warp_local_epi_tile_m, epi_tile_n) -> (((16, 32), 1), (2, 2))
+            tmem_subtile_tensor_in_first_load_view = cute.logical_divide(cute.zipped_divide(tmem_subtile_tensor_per_warp, (16, 32)), ((16, 32), 1))
+            atom = cute.make_copy_atom(
+                tcgen05.Ld16x64bOp(tcgen05.Repetition.x16),
+                cutlass.Float32,
+            )
+            cute.copy(
+                atom,
+                wrap_into_copy_standard_layout(
+                    tmem_subtile_tensor_in_first_load_view[None, 0]
+                ),
+                wrap_into_copy_standard_layout(gate_token_0_32),
+            )
+            cute.copy(
+                atom,
+                wrap_into_copy_standard_layout(
+                    tmem_subtile_tensor_in_first_load_view[None, 1]
+                ),
+                wrap_into_copy_standard_layout(up_token_0_32),
+            )
+            cute.copy(
+                atom,
+                wrap_into_copy_standard_layout(
+                    tmem_subtile_tensor_in_first_load_view[None, 2]
+                ),
+                wrap_into_copy_standard_layout(gate_token_32_64),
+            )
+            cute.copy(
+                atom,
+                wrap_into_copy_standard_layout(
+                    tmem_subtile_tensor_in_first_load_view[None, 3]
+                ),
+                wrap_into_copy_standard_layout(up_token_32_64),
+            )
+        
+        # Step 1: perform swiglu on the first part, interleave with the second's 32x32 tmem transpose.
+        token_0_32_pre_quant_pre_trans = self.alpha_swiglu_clamp(gate_token_0_32, up_token_0_32, alpha_val)
+        
+        # gate_token_32_64 / up_token_32_64 are already in the transpose input
+        # distribution (see TmemTranspose16x32 / load_subtile_raw_acc).
+        token_32_64_tmem_trans = TmemTranspose32x32Inplace(
+            tmem_subtile_tensor.iterator,
+            reg_tensor_top=gate_token_32_64,
+            reg_tensor_bot=up_token_32_64,
+        )
+
+        # Transpose output: each lane holds (token_1, intermediate_16); tmem_dp
+        # = lane_idx (token), tmem_col = elem_idx (intermediate output idx).
+        gate_token_32_64_trans_pre_act, up_token_32_64_trans_pre_act = token_32_64_tmem_trans.from_r1_perm_until_last_store()
+
+        token_32_64_pre_quant = self.alpha_swiglu_clamp(
+            gate_token_32_64_trans_pre_act,
+            up_token_32_64_trans_pre_act,
+            alpha_val,
+        )
+
+        token_0_32_tmem_trans = TmemTranspose16x32(
+            tmem_subtile_tensor.iterator,
+            Region.Top,
+            reg_tensor=token_0_32_pre_quant_pre_trans,
+        )
+        token_0_32_pre_quant = token_0_32_tmem_trans.from_r1_perm_until_last_store()
+
+        # Step 2: Quant
+        self.nvfp4_quant(
+            work_tile_info=work_tile_info,
+            two_token=(token_0_32_pre_quant, token_32_64_pre_quant), 
+            topk_scores=topk_scores,
+            norm_const=norm_const,
+            intermediate_output_size=cute.size(fc1_output, 1),
+            fc1_output_sf=fc1_output_sf,
+            subtile_idx=subtile_idx
+        )
+
+        # Step 3: TMASTG
+        # (token_64, intermeidate_64)
+        fc1_smem = self.smem_tensor[None, None, subtile_idx]
+        # (token, intermediate_down, l=1) -> (cta_token, cta_intermediate_down)
+        fc1_gmem_cta_view = cute.flat_divide(
+            fc1_output,
+            (self.cta_tile_n, self.cta_tile_m // 2),
+        )[None, None, work_tile_info.tile_n_idx, work_tile_info.tile_m_idx, 0]
+        # (cta_token, cta_intermediate_down) -> (token_64, intermediate_64)
+        fc1_gmem_subtile_view = cute.flat_divide(fc1_gmem_cta_view, (self._EpilogueTokenTileSize, self._EpilogueFc1IntermediateDownTileSize))[None, None, subtile_idx, 0]
+        tma_smem_src, tma_gmem_dst = cpasync.tma_partition(
+            self.fc1_tma_atom,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(fc1_smem, 0, 2),
+            cute.group_modes(fc1_gmem_subtile_view, 0, 2),
+        )
+
+        subtile_bar_id = subtile_idx + cutlass.Int32(
+            SwapABSwigluFp4Epilogue._EpilogueAsyncBarIdBase
+        )
+        tma_ready_to_read_smem_named_barrier = pipeline.NamedBarrier(
+            barrier_id=subtile_bar_id,
+            num_threads=self._EpilogueWarpCnt * 32,
+        )
+        cute.arch.fence_proxy("async.shared", space="cta")
+        if self.warp_idx == subtile_idx:
+            tma_ready_to_read_smem_named_barrier.arrive_and_wait()
+            with cute.arch.elect_one():
+                # if work_tile_info.tile_m_idx * (self.cta_tile_m // 2) < cute.size(fc1_output, 1):
+                cute.copy(self.fc1_tma_atom, tma_smem_src, tma_gmem_dst)
+        else:
+            tma_ready_to_read_smem_named_barrier.arrive()
+
+
+    @cute.jit
+    def alpha_swiglu_clamp(
+        self, 
+        gate_rmem: cute.Tensor,     # Raw fc1 acc (pre-dequant); even-size 1D fp32 rmem
+        up_rmem: cute.Tensor,       # Raw fc1 acc (pre-dequant); even-size 1D fp32 rmem
+        alpha_val: Optional[cutlass.Float32]
+    ) -> cute.Tensor :
+        # ── Input contract checks (compile-time): fp32, 1D, even-count, rmem ──
+        # Wrapped in const_expr so the DSL evaluates them at trace time and the
+        # raise fires during compilation rather than emitting a runtime branch.
+        for _name, _t in (("gate_rmem", gate_rmem), ("up_rmem", up_rmem)):
+            if cutlass.const_expr(_t.element_type is not cutlass.Float32):
+                raise TypeError(
+                    f"alpha_swiglu_clamp: {_name} must be Float32, got {_t.element_type}"
+                )
+            if cutlass.const_expr(_t.memspace != AddressSpace.rmem):
+                raise ValueError(
+                    f"alpha_swiglu_clamp: {_name} must be a register (rmem) tensor, "
+                    f"got address space {_t.memspace}"
+                )
+            if cutlass.const_expr(cute.rank(_t) != 1):
+                raise ValueError(
+                    f"alpha_swiglu_clamp: {_name} must be 1D, got rank {cute.rank(_t)}"
+                )
+            if cutlass.const_expr(cute.size(_t) % 2 != 0):
+                raise ValueError(
+                    f"alpha_swiglu_clamp: {_name} element count must be even, got {cute.size(_t)}"
+                )
+        if cutlass.const_expr(cute.size(gate_rmem) != cute.size(up_rmem)):
+            raise ValueError(
+                "alpha_swiglu_clamp: gate_rmem and up_rmem must have equal size, got "
+                f"{cute.size(gate_rmem)} vs {cute.size(up_rmem)}"
+            )
+
+        # gate_rmem / up_rmem are the RAW fc1 fp32 accumulator (pre-dequant).
+        # Order follows the NVFP4 -> fp32 -> SwiGLU contract and MUST be:
+        #
+        #   1. dequant:  gate = alpha * gate_raw ; up = alpha * up_raw
+        #      (alpha = expert-wise global scale on the acc; None => alpha == 1.)
+        #   2. clamp the DEQUANTED (real) values, gpt-oss ``_apply_gate`` style:
+        #        gate = min(gate, +limit)           (upper bound only)
+        #        up   = clamp(up, -limit, +limit)   (symmetric)
+        #   3. swiglu:   out = up * gate * sigmoid(gate)
+        #                sigmoid(x) = rcp(1 + exp2(-x * log2e))
+        #
+        # The symmetric up-clamp is a single ``min.xorsign.abs.f32`` (magnitude
+        # min(|up|, limit), sign = sign(up)^sign(limit) = sign(up) since limit>=0);
+        # the gate-clamp is a plain ``min.f32``. ``.xorsign.abs`` has no f32x2 form,
+        # so dequant+clamp run scalar while the swiglu core stays packed f32x2.
+        n = cute.size(gate_rmem)
+        out = cute.make_rmem_tensor((n,), cutlass.Float32)
+        log2_e = 1.4426950408889634
+
+        neg_log2e_pair = (
+            cutlass.Float32(-log2_e),
+            cutlass.Float32(-log2_e),
+        )
+        one_pair = (cutlass.Float32(1.0), cutlass.Float32(1.0))
+        if cutlass.const_expr(self.gate_up_clamp is not None):
+            limit = cutlass.Float32(self.gate_up_clamp)
+
+        for i in cutlass.range_constexpr(0, n, 2):
+            g0 = gate_rmem[i]
+            g1 = gate_rmem[i + 1]
+            u0 = up_rmem[i]
+            u1 = up_rmem[i + 1]
+
+            # 1) dequant raw acc to real values (skip entirely when alpha is None).
+            if cutlass.const_expr(alpha_val is not None):
+                alpha_pair = (alpha_val, alpha_val)
+                g0, g1 = cute.arch.mul_packed_f32x2((g0, g1), alpha_pair)
+                u0, u1 = cute.arch.mul_packed_f32x2((u0, u1), alpha_pair)
+
+            # 2) clamp the real values (skip when no clamp configured).
+            if cutlass.const_expr(self.gate_up_clamp is not None):
+                # gate upper-clamp: min(gate, +limit)
+                g0 = cutlass.Float32(llvm.inline_asm(
+                    cutlass.Float32.mlir_type,
+                    [g0.ir_value(), limit.ir_value()],
+                    "min.f32 $0, $1, $2;", "=f,f,f",
+                    has_side_effects=True, is_align_stack=False,
+                    asm_dialect=llvm.AsmDialect.AD_ATT,
+                ))
+                g1 = cutlass.Float32(llvm.inline_asm(
+                    cutlass.Float32.mlir_type,
+                    [g1.ir_value(), limit.ir_value()],
+                    "min.f32 $0, $1, $2;", "=f,f,f",
+                    has_side_effects=True, is_align_stack=False,
+                    asm_dialect=llvm.AsmDialect.AD_ATT,
+                ))
+                # up symmetric-clamp: clamp(up, -limit, +limit) in one instruction
+                u0 = cutlass.Float32(llvm.inline_asm(
+                    cutlass.Float32.mlir_type,
+                    [u0.ir_value(), limit.ir_value()],
+                    "min.xorsign.abs.f32 $0, $1, $2;", "=f,f,f",
+                    has_side_effects=True, is_align_stack=False,
+                    asm_dialect=llvm.AsmDialect.AD_ATT,
+                ))
+                u1 = cutlass.Float32(llvm.inline_asm(
+                    cutlass.Float32.mlir_type,
+                    [u1.ir_value(), limit.ir_value()],
+                    "min.xorsign.abs.f32 $0, $1, $2;", "=f,f,f",
+                    has_side_effects=True, is_align_stack=False,
+                    asm_dialect=llvm.AsmDialect.AD_ATT,
+                ))
+
+            # 3) swiglu on the dequanted (and clamped) real values:
+            #    out = up * gate * sigmoid(gate)
+            ug = cute.arch.mul_packed_f32x2((u0, u1), (g0, g1))
+            neg_g_log2e = cute.arch.mul_packed_f32x2((g0, g1), neg_log2e_pair)
+            exp_pair = (
+                cute.math.exp2(neg_g_log2e[0], fastmath=True),
+                cute.math.exp2(neg_g_log2e[1], fastmath=True),
+            )
+            one_plus_exp = cute.arch.add_packed_f32x2(exp_pair, one_pair)
+            sigmoid_pair = (
+                cute.arch.rcp_approx(one_plus_exp[0]),
+                cute.arch.rcp_approx(one_plus_exp[1]),
+            )
+            out_pair = cute.arch.mul_packed_f32x2(ug, sigmoid_pair)
+
+            out[i] = out_pair[0]
+            out[i + 1] = out_pair[1]
+
+        return out
+
+    @cute.jit
+    def nvfp4_quant(
+        self,
+        work_tile_info: MoEWorkTileInfo,
+        two_token: Tuple[cute.Tensor, cute.Tensor],     # two rmem tensor, each fp32 @ (token_1, intermediate_16) 
+        topk_scores: Optional[Tuple[cutlass.Float32, cutlass.Float32]],
+        norm_const: Optional[cutlass.Float32],
+        intermediate_output_size: cutlass.Int32,
+        fc1_output_sf: cute.Tensor,                     # MoE domain (token_this_rank, intermediate_down, 1)
+        subtile_idx: cutlass.Int32
+    ):
+        # ``two_token`` are the two post-swiglu, transposed token rmem tensors;
+        # each lane holds one token's ``sf_vec_size`` (=16, one NVFP4 SF block)
+        # intermediate-output values.  half 0 -> token (lane), half 1 -> (lane+32).
+        #
+        # Per token (ported from PostSwigluHalf._gen_sfc_quantize + stg_sfc + r2s):
+        #   1. (Path A) pre-multiply topk weight into the values, if present.
+        #   2. absmax over the (weighted) block.
+        #   3. sfc = absmax * (1/6) * norm_const  -> E4M3 scale factor.
+        #   4. acc_scale = norm_const * rcp(sfc), capped at FP32_MAX, with a
+        #      sfc==0 guard mask; scale the values by acc_scale.
+        #   5. write the E4M3 sfc to fc1_output_sf[token, intermediate_idx, 0]
+        #      (plain scalar store; predicated unless statically in-bound).
+        #   6. cvt the scaled values to NVFP4 and STS.64 into this subtile's
+        #      shared output stage.
+        # norm_const is treated like alpha_val: None => behaves as 1.0 (factors
+        # const-elided, not multiplied by 1.0).
+        n = cute.size(two_token[0])
+        # The core block quant (amax + e4m3 sfc + capped/masked acc_scale + e2m1
+        # cvt) is QuantImpl's job; this method still owns the topk pre-multiply,
+        # the sfc store, and the STS.64 into the shared output stage.
+        quant = QuantImpl("nvfp4", "regs_in_thread")
+
+        intermediate_idx = (
+            work_tile_info.tile_m_idx * (self.cta_tile_m // 2)
+            + self.warp_idx * Nvfp4BlockSize
+        )
+        subtile_token_start = (
+            work_tile_info.tile_n_idx * self.cta_tile_n
+            + subtile_idx * self._EpilogueTokenTileSize
+        )
+        token_idx_pair = (
+            subtile_token_start + self.lane_idx,
+            subtile_token_start + self.lane_idx + 32,
+        )
+
+        # This subtile's (token, intermediate) shared output stage, tiled into
+        # (1, 16) blocks so each thread's 16 NVFP4 cells slice out directly
+        # (zipped_divide + slice; avoids the ambiguous local_tile surface).
+        smem_stage = self.smem_tensor[None, None, subtile_idx]
+        # (token_64, intermediate_down_64) -> ((1, 16), (token_tile_size, warp_cnt))
+        smem_tiled = cute.zipped_divide(smem_stage, (1, Nvfp4BlockSize))
+
+        fp4_copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            cutlass.Float4E2M1FN,
+            num_bits_per_copy=64,
+        )
+
+        for half in cutlass.range_constexpr(2):
+            tok = two_token[half]
+
+            # 1) topk-weight pre-multiply (Path A) into a weighted scratch.
+            weighted = cute.make_rmem_tensor((n,), cutlass.Float32)
+            if cutlass.const_expr(topk_scores is not None):
+                topk_pair = (topk_scores[half], topk_scores[half])
+                for i in cutlass.range_constexpr(0, n, 2):
+                    w0, w1 = cute.arch.mul_packed_f32x2(
+                        (tok[i], tok[i + 1]), topk_pair
+                    )
+                    weighted[i] = w0
+                    weighted[i + 1] = w1
+            else:
+                for i in cutlass.range_constexpr(0, n):
+                    weighted[i] = tok[i]
+
+            # 2) Core block quant: amax + e4m3 sfc + capped/masked acc_scale +
+            #    e2m1 cvt. One 16-wide block -> one e2m1 reg tensor + one sfc.
+            fp4_regs, sfc_regs = quant(weighted, norm_const=norm_const)
+            sfc_e4m3 = sfc_regs[0]
+
+            # 3) scale-factor store (predicate const-elided when statically
+            #    in-bound, mirroring signal_fc1_done's intermediate predicate).
+            if cutlass.const_expr(
+                self.static_expert_shape is None
+                or self.intermediate_downproj % self.cluster_tile_intermediate_downproj != 0
+            ):
+                if intermediate_idx < intermediate_output_size:
+                    fc1_output_sf[token_idx_pair[half], intermediate_idx, 0] = sfc_e4m3
+            else:
+                fc1_output_sf[token_idx_pair[half], intermediate_idx, 0] = sfc_e4m3
+
+            # 4) STS.64 the e2m1 into this subtile's shared output stage.
+            # ((1, 16), (token_tile_size, warp_cnt)) -> (16)
+            smem_thread_row = smem_tiled[(0, None), (self.lane_idx + 32 * half, self.warp_idx)]
+            cute.copy(
+                fp4_copy_atom,
+                cute.coalesce(fp4_regs),
+                cute.coalesce(smem_thread_row),
+            )
+
+
+@dataclasses.dataclass(frozen=True)
+class Fc2ProcessPipeline():
+    tmem_acc_load: Callable
+    f2fp: Callable
+    post_f2fp_reorder: Callable
+    store_function: Callable
+    # Kept as a finer-grained, elem-level reading aid for the store-out layout
+    # (never evaluated); ``store_out_mapping`` is the per-issue form that the
+    # router actually evaluates at runtime to drive metadata / pointer math.
+    fc2_cta_tile_contract: Contract
+    store_out_mapping: Contract            # data plane, per-issue
+    require_tmem_trans: bool
+    # SF plane per-issue mapping; None for the bf16 (unquantized) paths.
+    sf_store_out_mapping: Optional[Contract] = None
+
+
+# Device only object
+class SwapABFc2Epilogue(_ImmutableAfterInit):
+    def __init__(
+        self, 
+        base: SwapABSwigluFp4Epilogue, 
+        tidx: cutlass.Int32, 
+        epi_smem_storage,
+        fc2_output: cute.Tensor,        # MoE domain (token, topk, hidden)
+        token_comm_args: TokenCommArgs, 
+        optional_epi_args: NvFp4OptinalEpiArgs,
+    ):
+        self.base = base
+        self.tidx = tidx % (base._EpilogueWarpCnt * 32)
+        self.warp_idx = self.tidx // 32
+        self.lane_idx = self.tidx % 32
+        self.fc2_output = fc2_output
+        self.token_comm_args = token_comm_args
+        self.optional_epi_args = optional_epi_args
+        if cutlass.const_expr(base.fc2_use_bulk):
+            wire_dtype = base.combine_format.act_dtype
+            fc2_smem_rows = 32
+            if cutlass.const_expr(
+                fc2_smem_rows * base._EpilogueFc2HiddenTileSize
+                * wire_dtype.width // 8 > base.epi_smem_bytes
+            ):
+                raise ValueError("fc2 UBLK data smem exceeds epi_smem budget.")
+            self.smem_tensor = cute.make_tensor(
+                cute.recast_ptr(
+                    epi_smem_storage.epi_smem.data_ptr(),
+                    dtype=wire_dtype,
+                ),
+                cute.make_layout(
+                    (fc2_smem_rows, base._EpilogueFc2HiddenTileSize),
+                    stride=(base._EpilogueFc2HiddenTileSize, 1),
+                ),
+            )
+            self.process_pipeline = make_fc2_ublk_process_pipeline(
+                combine_format=base.combine_format,
+                cta_token_tile_size=base.cta_tile_n,
+                cta_hidden_tile_size=base.cta_tile_m,
+            )
+        else:
+            self.smem_tensor = None
+            if cutlass.const_expr(base.reduce_topk_in_kernel):
+                self.process_pipeline = make_fc2_redg_process_pipeline(
+                    combine_format=base.combine_format,
+                    cta_token_tile_size=base.cta_tile_n,
+                    cta_hidden_tile_size=base.cta_tile_m,
+                )
+            else:
+                self.process_pipeline = make_fc2_stg_process_pipeline(
+                    combine_format=base.combine_format,
+                    cta_token_tile_size=base.cta_tile_n,
+                    cta_hidden_tile_size=base.cta_tile_m,
+                )
+        self._freeze()
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "base"), name)
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        # See SwapABFc1Epilogue.__extract_mlir_values__: this helper carries
+        # only loop-invariant Python context.  It intentionally serializes no
+        # MLIR values, so changing it to store loop-carried state would be a
+        # correctness bug.
+        return []
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "SwapABFc2Epilogue":
+        assert len(values) == 0
+        return self
+
+    @cute.jit
+    def signal_fc2_done(self, work_tile_info, next_work_tile_info, flag_tracker):
+        publish : cutlass.Constexpr = (
+            self.token_back_by_dispatch or self.combine_format.is_quantized
+        )
+        if cutlass.const_expr(publish):
+            flag_addr = (
+                self.token_comm_args.fc2_done_counter.iterator
+                + work_tile_info.expert_idx
+            ).toint()
+        else:
+            flag_addr = Int64(0)
+        no_fire : cutlass.Constexpr = not publish
+        return flag_tracker.accumulate(
+            next_work_tile_info.phase, self.fc2_epi_flag_batch, flag_addr, no_fire
+        )
+
+    @cute.jit
+    def _make_output_router(
+        self,
+        work_tile_info: MoEWorkTileInfo,
+    ) -> "Fc2OutputRouter":
+        task_tile_data_row_start = (
+            work_tile_info.cumulative_data_physical_row
+            + work_tile_info.tile_n_idx * cutlass.Int32(self.cta_tile_n)
+        )
+        hidden_base_this_cta_tile = (
+            work_tile_info.tile_m_idx * cutlass.Int32(self.cta_tile_m)
+        )
+        valid_hidden_this_cta_tile = (
+            cutlass.Int32(self.fc2_output.shape[2]) - hidden_base_this_cta_tile
+        )
+        if valid_hidden_this_cta_tile < 0:
+            valid_hidden_this_cta_tile = 0
+        if valid_hidden_this_cta_tile > self._EpilogueFc2HiddenTileSize:
+            valid_hidden_this_cta_tile = self._EpilogueFc2HiddenTileSize
+
+        metadata_u32 = None
+        peer_rank_ptr_mapper = None
+        data_token_base = task_tile_data_row_start
+        if cutlass.const_expr(
+            self.token_comm_args is not None and not self.token_back_by_dispatch
+        ):
+            metadata_u32 = cute.domain_offset(
+                (task_tile_data_row_start, 0),
+                cute.recast_tensor(
+                    self.token_comm_args.token_src_metadata,
+                    cutlass.Uint32,
+                ),
+            )
+            peer_rank_ptr_mapper = self.token_comm_args.peer_rank_ptr_mapper
+            data_token_base = None
+
+        if cutlass.const_expr(self.combine_format.is_quantized):
+            base_outputs = (self.fc2_output, self.token_comm_args.fc2_output_sf)
+            token_bases = (data_token_base, task_tile_data_row_start)
+            output_mappings = (
+                self.process_pipeline.store_out_mapping,
+                self.process_pipeline.sf_store_out_mapping,
+            )
+        else:
+            base_outputs = self.fc2_output
+            token_bases = data_token_base
+            output_mappings = self.process_pipeline.store_out_mapping
+
+        return Fc2OutputRouter(
+            metadata=metadata_u32,
+            token_bases=token_bases,
+            base_outputs=base_outputs,
+            hidden_base_this_cta_tile=hidden_base_this_cta_tile,
+            peer_rank_ptr_mapper=peer_rank_ptr_mapper,
+            valid_tokens_this_cta_tile=work_tile_info.valid_tokens_in_cta_tile,
+            valid_hidden_this_cta_tile=valid_hidden_this_cta_tile,
+            reduce_topk_in_kernel=self.reduce_topk_in_kernel,
+            output_mappings=output_mappings,
+            epi_tid=self.tidx,
+            combine_format=self.combine_format,
+        ).prefetch()
+
+    @cute.jit
+    def __call__(
+        self, 
+        work_tile_info: MoEWorkTileInfo,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn: cutlass.Int32,
+    ):
+        # subtile-irrelevant hoist: fc2 alpha scales raw fc2 accumulators before f2fp.
+        if cutlass.const_expr(self.optional_epi_args.fc2_alpha is not None):
+            alpha_val = self.optional_epi_args.fc2_alpha[work_tile_info.expert_idx]
+        else:
+            alpha_val = None
+        acc_ready = False
+        if not work_tile_info.peek_ready:
+            acc_ready = True
+            acc_pipeline.consumer_wait(acc_consumer_state)
+        fc2_output_router = self._make_output_router(work_tile_info)
+        # (cta_tile_m, cta_tile_n) -> (epi_tile_m, epi_tile_n, iters)
+        tmem_acc_tensor_tiled_by_epi_tile = cute.flat_divide(tmem_acc_tensor, (self._EpilogueFc2HiddenTileSize, self._EpilogueTokenTileSize))[None, None, 0, None]
+
+        acc_pipeline.consumer_wait(acc_consumer_state, acc_ready)
+        iket.range_push("fc2_epi")
+        valid_tokens = work_tile_info.valid_tokens_in_cta_tile
+
+        # Overlap path preloads two subtiles before releasing acc TMEM.
+        unroll_tile_cnt = 2 if cutlass.const_expr(
+            self.overlapping_accum and self.process_pipeline.require_tmem_trans
+        ) else 0
+        remain_subtile_cnt = self.subtile_cnt - unroll_tile_cnt
+
+        if cutlass.const_expr(unroll_tile_cnt > 0):
+            subtile_idx_first = (
+                cutlass.Int32(self.subtile_cnt) - is_odd_turn
+            ) % cutlass.Int32(self.subtile_cnt)
+            subtile_idx_second = (
+                cutlass.Int32(self.subtile_cnt + 1) - is_odd_turn
+            ) % cutlass.Int32(self.subtile_cnt)
+
+            # preload_subtile_first: subtile_idx_first's raw PRE-transpose acc, LDTM'd by
+            # all 128 epi threads into 4 reg tensors == the 4 quadrants of the subtile's
+            # (128 tmem_dp x 64 tmem_col) footprint. Only these raw-TMEM offsets are
+            # guaranteed:
+            #   reg[0]/reg[1], reg[2]/reg[3] : top vs bot      -> 16 apart in tmem_dp
+            #   reg[0]/reg[2], reg[1]/reg[3] : 1st vs 2nd half -> 32 apart in tmem_col
+            # (so reg[0..1] = the first 128x32, reg[2..3] = the second 128x32 of the 128x64.)
+            # The per-lane (lane_idx, elem_idx) -> (tmem_dp, tmem_col) layout INSIDE each
+            # reg tensor is opaque -- do not assume it; it only becomes well-defined once
+            # the tmem transpose consumes them.
+            preload_subtile_first : Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor] = _TmemTranspose16x32Core.load_subtile_raw_acc(
+                tmem_acc_tensor_tiled_by_epi_tile[None, None, subtile_idx_first]
+            )
+
+            # Release acc to next MMA unconditionally.
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+            # preload_subtile_second: same 128 tmem_dp x 64 tmem_col footprint, but for
+            # subtile_idx_second (the other token subtile, not the 2nd col-half). Same
+            # quadrant/offset invariants and opaque per-lane layout as above.
+            preload_subtile_second : Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor] = _TmemTranspose16x32Core.load_subtile_raw_acc(
+                tmem_acc_tensor_tiled_by_epi_tile[None, None, subtile_idx_second]
+            )
+
+            # Both unrolled subtiles borrow tmem_subtile_second as workspace.
+            preload_pair = (preload_subtile_first, preload_subtile_second)
+            subtile_idx_pair = (subtile_idx_first, subtile_idx_second)
+            for i in cutlass.range_constexpr(unroll_tile_cnt):
+                if subtile_idx_pair[i] * cutlass.Int32(self._EpilogueTokenTileSize) < valid_tokens:
+                    self.run_subtile(
+                        subtile_idx=subtile_idx_pair[i],
+                        tmem_subtile_tensor=tmem_acc_tensor_tiled_by_epi_tile[None, None, subtile_idx_second],
+                        preload_acc=preload_pair[i],
+                        fc2_output_router=fc2_output_router,
+                        alpha_val=alpha_val,
+                        release_after_ldtm=False,
+                        acc_pipeline=acc_pipeline,
+                        acc_consumer_state=acc_consumer_state,
+                    )
+
+
+        if cutlass.const_expr(self.overlapping_accum and unroll_tile_cnt == 0):
+            release_after_ldtm = True
+        else:
+            release_after_ldtm = False
+        for i in cutlass.range(remain_subtile_cnt, unroll=1):
+        # for i in cutlass.range_constexpr(remain_subtile_cnt):
+            real_i = i + unroll_tile_cnt
+            if cutlass.const_expr(self.overlapping_accum):
+                subtile_idx = (
+                    cutlass.Int32(real_i + self.subtile_cnt) - is_odd_turn
+                ) % cutlass.Int32(self.subtile_cnt)
+            else:
+                subtile_idx = cutlass.Int32(real_i)
+
+            if subtile_idx * cutlass.Int32(self._EpilogueTokenTileSize) < valid_tokens:
+                self.run_subtile(
+                    subtile_idx=subtile_idx,
+                    tmem_subtile_tensor=tmem_acc_tensor_tiled_by_epi_tile[None, None, subtile_idx],
+                    preload_acc=None,
+                    fc2_output_router=fc2_output_router,
+                    alpha_val=alpha_val,
+                    release_after_ldtm=release_after_ldtm,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                )
+                release_after_ldtm = False
+
+        # Non-overlap-path release: at the natural task-tile boundary.
+        if cutlass.const_expr(not self.overlapping_accum):
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+    @cute.jit
+    def run_subtile(
+        self,
+        subtile_idx: cutlass.Int32,
+        # (hidden_tile, token_subtile), fundamentally (epi_tile_m, epi_tile_n)
+        tmem_subtile_tensor: cute.Tensor,
+        preload_acc: Optional[Tuple[cute.Tensor, cute.Tensor, cute.Tensor, cute.Tensor]],
+        fc2_output_router: "Fc2OutputRouter",
+        alpha_val: Optional[cutlass.Float32],
+        release_after_ldtm: Union[cutlass.Boolean, bool],
+        acc_pipeline,
+        acc_consumer_state,
+    ):
+        process_pipeline = self.process_pipeline
+        if cutlass.const_expr(preload_acc is None):
+            loaded = process_pipeline.tmem_acc_load(
+                tmem_subtile_tensor=tmem_subtile_tensor,
+                epi=self,
+            )
+            if release_after_ldtm:
+                cute.arch.fence_view_async_tmem_load()
+                acc_pipeline.consumer_release(acc_consumer_state)
+        else:
+            loaded = preload_acc
+
+        casted = process_pipeline.f2fp(
+            *loaded,
+            alpha_val=alpha_val,
+        )
+        # reorder returns a bare RMEM fragment in the store's expected pre-store
+        # distribution; reorder + store are paired 1:1 inside the pipeline.
+        pre_store = process_pipeline.post_f2fp_reorder(
+            casted=casted,
+            tmem_subtile_view=tmem_subtile_tensor,
+        )
+        process_pipeline.store_function(
+            epi=self,
+            subtile=pre_store,
+            subtile_idx=subtile_idx,
+            fc2_output_router=fc2_output_router,
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class Fc2OutputRouter:
+    # (token, 3), 3 -> rank_idx, token_idx, top_k
+    # Later this will be changed to (token, 2), where top_k and rank_idx will be fused into 32bit.
+    # If metadata is None then this is a local write.
+    metadata: Optional[cute.Tensor]
+    # token + possible sf
+    token_bases: Union[Tuple[Optional[cutlass.Int32], cutlass.Int32], Optional[cutlass.Int32]]
+    base_outputs: Union[Tuple[cute.Tensor, cute.Tensor], cute.Tensor]   # (token, topk, hidden)
+    hidden_base_this_cta_tile: Union[cutlass.Int32, int]
+    peer_rank_ptr_mapper: Optional[SymBufferDeviceBase]
+    valid_tokens_this_cta_tile: cutlass.Int32
+    valid_hidden_this_cta_tile: Union[cutlass.Int32, int]
+    reduce_topk_in_kernel: bool
+    # Per-issue (epi_tid, iter_idx) -> (token_cta_tile, hidden_cta_tile). Data
+    # mapping, or (data mapping, sf mapping) when quantized.
+    output_mappings: Union[Tuple[Contract, Contract], Contract]
+    epi_tid: cutlass.Int32
+    combine_format: CombineFormat
+    # After metadata prefetch
+    dst_ptrs: Optional[cute.Tensor] = None      # i64 x (copy_iters_this_thread_cta_tile), fundamentally the pointers.
+    valid: Optional[cute.Tensor] = None         # (copy_iters_this_thread_cta_tile)
+
+    @property
+    def data_output(self) -> cute.Tensor:
+        return self.base_outputs[0] if isinstance(self.base_outputs, tuple) else self.base_outputs
+
+    @property
+    def sf_output(self) -> Optional[cute.Tensor]:
+        # Present iff quantized; (pool_token, 1, hidden // sf_vec) rank-local.
+        return self.base_outputs[1] if isinstance(self.base_outputs, tuple) else None
+
+    @property
+    def data_token_base(self) -> Optional[cutlass.Int32]:
+        return self.token_bases[0] if isinstance(self.token_bases, tuple) else self.token_bases
+
+    @property
+    def sf_token_base(self) -> Optional[cutlass.Int32]:
+        return self.token_bases[1] if isinstance(self.token_bases, tuple) else None
+
+    @property
+    def data_mapping(self) -> Contract:
+        return self.output_mappings[0] if isinstance(self.output_mappings, tuple) else self.output_mappings
+
+    @property
+    def sf_mapping(self) -> Optional[Contract]:
+        return self.output_mappings[1] if isinstance(self.output_mappings, tuple) else None
+
+    def __post_init__(self) -> None:
+        if (self.metadata is None) == (self.data_token_base is None):
+            raise ValueError(
+                "Fc2OutputRouter requires exactly one of metadata or "
+                "a (data) token base."
+            )
+        if (self.metadata is None) != (self.peer_rank_ptr_mapper is None):
+            raise ValueError(
+                "Fc2OutputRouter requires peer_rank_ptr_mapper iff metadata is set."
+            )
+        if self.reduce_topk_in_kernel and self.metadata is None:
+            raise ValueError(
+                "Fc2OutputRouter reduce_topk_in_kernel requires metadata routing."
+            )
+
+    @cute.jit
+    def prefetch(self) -> "Fc2OutputRouter":
+        # Only the metadata (comm) path prefetches a pointer array: its
+        # metadata-derived address has long-latency LDGs worth issuing early.
+        # The local (no-comm) path computes its affine address on demand in
+        # get_dst() -- no array, hence no runtime-indexed local-memory spill.
+        if cutlass.const_expr(self.metadata is None):
+            return self
+        iter_axis = self.data_mapping.domain.names.index("iter_idx")
+        copy_iters: cutlass.Constexpr[int] = self.data_mapping.domain.sizes[iter_axis]
+
+        valid = cute.make_rmem_tensor((copy_iters,), cutlass.Int32)
+        dst_ptrs = cute.make_rmem_tensor((copy_iters,), cutlass.Int64)
+
+        # Compiler should be able to optimize the same token_copy_group's offset add. (Fundamental cse + strength_reduce)
+        # We should check the SASS to ensure this happens.
+        for iter_idx in cutlass.range_constexpr(copy_iters):
+            coord = eval_function_mapping(
+                self.data_mapping,
+                epi_tid=self.epi_tid,
+                iter_idx=iter_idx,
+            )
+            token_in_tile = cutlass.Int32(coord["token_in_cta_tile"])
+            hidden_in_tile = cutlass.Int32(coord["hidden_in_cta_tile"])
+
+            valid[iter_idx] = cutlass.Int32(0)
+            dst_ptrs[iter_idx] = cutlass.Int64(0)
+
+            token_valid = token_in_tile < self.valid_tokens_this_cta_tile
+            hidden_valid = hidden_in_tile < cutlass.Int32(self.valid_hidden_this_cta_tile)
+            if token_valid and hidden_valid:
+                valid[iter_idx] = cutlass.Int32(1)
+                if cutlass.const_expr(self.metadata is None):
+                    dst_tokens = self.data_token_base + token_in_tile
+                    dst_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
+                    # Int64 token coord: dst_tokens*K*H overflows int32 once
+                    # T*K*H exceeds 2^31 (data_output is (token, topk, hidden)).
+                    dst_ptrs[iter_idx] = self.data_output[Int64(dst_tokens), None, dst_hidden].iterator.toint()
+                    
+                else:
+                    md = TokenSrcMetadata.load(
+                        self.metadata.iterator.toint()
+                        + Int64(token_in_tile) * Int64(TokenSrcMetadata.nbytes)
+                    )
+                    dst_rank = md.src_rank
+                    dst_token = md.src_token
+                    dst_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
+                    if cutlass.const_expr(not self.reduce_topk_in_kernel):
+                        dst_topk = md.src_topk
+                    else:
+                        dst_topk = 0
+                    # Int64 token coord: domain_offset on (token, topk, hidden)
+                    # computes dst_token*K*H, which overflows int32 once T*K*H > 2^31.
+                    dst_ptrs[iter_idx] = self.peer_rank_ptr_mapper.ptr_map_to_rank(cute.domain_offset((Int64(dst_token), dst_topk, dst_hidden), self.data_output).iterator, dst_rank, byte_align=32).toint()
+
+        return dataclasses.replace(
+            self,
+            dst_ptrs=dst_ptrs,
+            valid=valid,
+        )
+
+    @cute.jit
+    def get_data_dst(
+        self,
+        iter_idx: Union[int, cutlass.Int32],
+    ) -> Tuple[cute.Pointer, cutlass.Int32]:
+        """Per-issue DATA destination: gmem pointer + validity predicate.
+
+        The router owns ``data_output`` so the caller never re-assembles a
+        pointer from a raw int; it just builds its own copy tensor (STG) or
+        feeds the pointer to inline asm (REDG/UBLK).
+
+        Alignment is unified at 32 B: only STG feeds this pointer to a real
+        ``cute.copy`` (256 b vector store, genuinely 32 B aligned); REDG/UBLK
+        only ``ptrtoint`` it for inline-asm issue, where the hint is inert.
+        """
+        if cutlass.const_expr(self.metadata is None):
+            # no-comm: on-demand affine address (no prefetched array). The
+            # invariant base hoists out of the caller's loop via CSE; a
+            # constexpr iter folds the per-issue offset into the store.
+            coord = eval_function_mapping(
+                self.data_mapping, epi_tid=self.epi_tid, iter_idx=iter_idx,
+            )
+            token_in_tile = cutlass.Int32(coord["token_in_cta_tile"])
+            hidden_in_tile = cutlass.Int32(coord["hidden_in_cta_tile"])
+            pred = cutlass.Int32(0)
+            addr = cutlass.Int64(0)
+            if (
+                token_in_tile < self.valid_tokens_this_cta_tile
+                and hidden_in_tile < cutlass.Int32(self.valid_hidden_this_cta_tile)
+            ):
+                pred = cutlass.Int32(1)
+                dst_tokens = self.data_token_base + token_in_tile
+                dst_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
+                # Int64 token coord: dst_tokens*K*H overflows int32 once T*K*H > 2^31.
+                addr = self.data_output[Int64(dst_tokens), None, dst_hidden].iterator.toint()
+        else:
+            # comm: read the pointer / validity prefetched by prefetch().
+            addr = self.dst_ptrs[iter_idx]
+            pred = self.valid[iter_idx]
+        ptr = cute.make_ptr(
+            self.data_output.element_type,
+            addr,
+            AddressSpace.gmem,
+            assumed_align=32,
+        )
+        return ptr, pred
+
+    @cute.jit
+    def get_sf_dst(
+        self,
+        iter_idx: Union[int, cutlass.Int32],
+    ) -> Tuple[cute.Pointer, cutlass.Int32]:
+        """Per-issue SF destination: rank-local gmem pointer + validity predicate.
+
+        SF never goes to a peer (it is staged locally and pushed token-contiguously
+        by the dispatch / standalone warps), so this is always the affine local
+        address -- no metadata routing, no prefetch. ``sf_output`` is the broadcast
+        plane ``(pool_token, 1, (sf_vec, hidden//sf_vec)):(., ., (0, 1))``, so the
+        logical hidden coordinate folds to its scale block on indexing.
+        """
+        coord = eval_function_mapping(
+            self.sf_mapping, epi_tid=self.epi_tid, iter_idx=iter_idx,
+        )
+        token_in_tile = cutlass.Int32(coord["token_in_cta_tile"])
+        hidden_in_tile = cutlass.Int32(coord["hidden_in_cta_tile"])
+        pred = cutlass.Int32(0)
+        addr = cutlass.Int64(0)
+        if (
+            token_in_tile < self.valid_tokens_this_cta_tile
+            and hidden_in_tile < cutlass.Int32(self.valid_hidden_this_cta_tile)
+        ):
+            pred = cutlass.Int32(1)
+            sf_row = self.sf_token_base + token_in_tile
+            sf_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
+            addr = self.sf_output[Int64(sf_row), None, sf_hidden].iterator.toint()
+        # Per-block scale offsets are element-granular; claim the scale dtype's
+        # natural element alignment (e8m0 1 B / bf16 2 B).
+        sf_ptr = cute.make_ptr(
+            self.sf_output.element_type,
+            addr,
+            AddressSpace.gmem,
+            assumed_align=4,
+        )
+        return sf_ptr, pred
+
+
+
+def make_fc2_stg_cta_store_out_contract(combine_format: CombineFormat, cta_token_tile_size: int, cta_hidden_tile_size: int):
+    assert(cta_hidden_tile_size == 128)
+    assert(cta_token_tile_size % 64 == 0)
+    wire_dtype = combine_format.act_dtype
+    assert wire_dtype.width in (4, 8, 16), "fc2 STG wire dtype must be fp4/fp8/bf16."
+    elems_per_stg = min(256 // wire_dtype.width, 32)
+    stgs_per_hidden32 = 32 // elems_per_stg
+    fundamental_mapping = Contract(
+        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"), (cta_token_tile_size, cta_hidden_tile_size)),
+        mapping=FunctionMapping(lambda epi_tid, elem_idx: {
+            "token_in_cta_tile": epi_tid % 32 + elem_idx // 32 * 32,
+            "hidden_in_cta_tile": elem_idx % 32 + epi_tid // 32 * 32,
+        })
+    )
+    store_out_mapping = Contract(
+        domain=Space(("epi_tid", "iter_idx"), (128, stgs_per_hidden32 * cta_token_tile_size // 32)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"), (cta_token_tile_size, cta_hidden_tile_size)),
+        mapping=FunctionMapping(lambda epi_tid, iter_idx: {
+            "token_in_cta_tile": epi_tid % 32 + iter_idx // stgs_per_hidden32 * 32,
+            "hidden_in_cta_tile": (iter_idx % stgs_per_hidden32) * elems_per_stg + epi_tid // 32 * 32,
+        })
+    )
+    sf_store_out_mapping = None
+    if combine_format.is_quantized:
+        def stg_sf_mapping(epi_tid, iter_idx):
+            lane = epi_tid % 32
+            warp = epi_tid // 32
+            return {
+                "token_in_cta_tile": lane + iter_idx * 32,
+                "hidden_in_cta_tile": warp * 32,
+            }
+        sf_store_out_mapping = Contract(
+            domain=Space(("epi_tid", "iter_idx"), (128, cta_token_tile_size // 32)),
+            codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"), (cta_token_tile_size, cta_hidden_tile_size)),
+            mapping=FunctionMapping(stg_sf_mapping),
+        )
+    return store_out_mapping, sf_store_out_mapping, fundamental_mapping
+
+def make_fc2_redg_cta_store_out_contract(combine_format: CombineFormat, cta_token_tile_size: int, cta_hidden_tile_size: int):
+    assert(cta_hidden_tile_size == 128)
+    assert(cta_token_tile_size % 64 == 0)
+    # In-kernel reduce is bf16-only and never quantized, so there is no SF plane.
+    assert(combine_format.act_dtype.width == 16)
+    assert not combine_format.is_quantized
+    fundamental_mapping = Contract(
+        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"), (cta_token_tile_size, cta_hidden_tile_size)),
+        mapping=FunctionMapping(lambda epi_tid, elem_idx: {
+            "token_in_cta_tile": (
+                ((elem_idx // 4) // 16) * 64
+                + (((elem_idx // 4) % 16) // 8) * 32
+                + (((elem_idx // 4) % 8) // 4) * 16
+                + (((elem_idx // 4) % 4) % 2) * 8
+                + (epi_tid % 32) // 4
+            ),
+            "hidden_in_cta_tile": (
+                (epi_tid // 32) * 32
+                + (epi_tid % 4) * 4
+                + (((elem_idx // 4) % 4) // 2) * 16
+                + elem_idx % 4
+            ),
+        })
+    )
+    # SIMT REDG emits one 8B red.v2.bf16x2 per 4 hidden elements.  Each
+    # 64-token subtile contributes two token rows per lane and 8 hidden
+    # segments per token row.
+    store_out_mapping = Contract(
+        domain=Space(("epi_tid", "iter_idx"), (128, cta_token_tile_size // 64 * 16)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"), (cta_token_tile_size, cta_hidden_tile_size)),
+        mapping=FunctionMapping(lambda epi_tid, iter_idx: {
+            "token_in_cta_tile": (
+                (iter_idx // 16) * 64
+                + ((iter_idx % 16) // 8) * 32
+                + ((iter_idx % 8) // 4) * 16
+                + ((iter_idx % 4) % 2) * 8
+                + (epi_tid % 32) // 4
+            ),
+            "hidden_in_cta_tile": (
+                (epi_tid // 32) * 32
+                + (epi_tid % 4) * 4
+                + ((iter_idx % 4) // 2) * 16
+            ),
+        })
+    )
+    return store_out_mapping, None, fundamental_mapping
+
+def make_fc2_ublk_store_out_contract(combine_format: CombineFormat, cta_token_tile_size: int, cta_hidden_tile_size: int):
+    assert(cta_hidden_tile_size == 128)
+    assert(cta_token_tile_size % 64 == 0)
+    # UBLK pushes whole hidden rows by byte count, so the token/hidden mapping
+    # is element-indexed and dtype-independent (wire dtype only sets copy bytes).
+    assert combine_format.act_dtype.width in (4, 8, 16), "fc2 UBLK wire dtype must be fp4/fp8/bf16."
+    assert(cta_token_tile_size <= 256)
+    max_token_cta_tile = 256
+    fundamental_mapping = Contract(
+        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"), (max_token_cta_tile, cta_hidden_tile_size)),
+        mapping=FunctionMapping(lambda epi_tid, elem_idx: {
+            "token_in_cta_tile": elem_idx // cta_hidden_tile_size * 32 + epi_tid % 8 + epi_tid // 32 * 8 + ((epi_tid % 32) // 8) * 64,
+            "hidden_in_cta_tile": elem_idx % cta_hidden_tile_size,
+        })
+    )
+    store_out_mapping = Contract(
+        domain=Space(("epi_tid", "iter_idx"), (128, 2)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"), (max_token_cta_tile, cta_hidden_tile_size)),
+        mapping=FunctionMapping(lambda epi_tid, iter_idx: {
+            "token_in_cta_tile": iter_idx * 32 + epi_tid % 8 + epi_tid // 32 * 8 + ((epi_tid % 32) // 8) * 64,
+            "hidden_in_cta_tile": 0,
+        })
+    )
+    # SF mapping: each lane owns one hidden across a 64-token subtile, and the
+    # sf_vec lanes of a block share the CREDUX scale -- so they split the block's
+    # tokens. sf_iter flattens (subtile, slot) to keep the whole cta-tile domain.
+    sf_store_out_mapping = None
+    if combine_format.is_quantized:
+        sf_vec = combine_format.scale_block
+        lanes_per_block = sf_vec
+        subtile_tokens = SwapABSwigluFp4Epilogue._EpilogueTokenTileSize
+        iters_per_subtile = subtile_tokens // lanes_per_block
+        n_subtiles = cta_token_tile_size // subtile_tokens
+
+        def ublk_sf_mapping(epi_tid, iter_idx):
+            subtile_idx = iter_idx // iters_per_subtile
+            slot = iter_idx % iters_per_subtile
+            lane = epi_tid % 32
+            warp = epi_tid // 32
+            lane_in_block = lane % lanes_per_block
+            block_in_warp = lane // lanes_per_block
+            return {
+                "token_in_cta_tile": subtile_idx * subtile_tokens + lane_in_block + slot * lanes_per_block,
+                "hidden_in_cta_tile": warp * 32 + block_in_warp * sf_vec,
+            }
+        sf_store_out_mapping = Contract(
+            domain=Space(("epi_tid", "iter_idx"), (128, n_subtiles * iters_per_subtile)),
+            codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"), (max_token_cta_tile, cta_hidden_tile_size)),
+            mapping=FunctionMapping(ublk_sf_mapping),
+        )
+    return store_out_mapping, sf_store_out_mapping, fundamental_mapping
+
+# (...) -> ((atom_v, 1))
+@cute.jit 
+def wrap_into_copy_standard_layout(tensor: cute.Tensor):
+    tensor = cute.coalesce(cute.flatten(tensor))
+    tensor = cute.append_ones(tensor, cute.rank(tensor) + 1)
+    tensor = cute.group_modes(tensor, 0, cute.rank(tensor) - 1)
+    tensor = cute.group_modes(tensor, 0, cute.rank(tensor))
+    return tensor
+
+@cute.jit
+def fc2_f2fp(
+    *tensors,
+    alpha_val: Optional[cutlass.Float32] = None,
+    **_,
+) -> cute.Tensor:
+    reorder_dtype = cutlass.BFloat16
+    total_size = 0
+    for t in tensors:
+        total_size += cute.size(t)
+    converted_acc = cute.make_rmem_tensor((total_size,), reorder_dtype)
+    elems_processed = 0
+    for t in tensors:
+        current_tensor_size = cute.size(t)
+        dst = cute.make_tensor(
+            converted_acc.iterator + elems_processed,
+            cute.make_layout((current_tensor_size,)),
+        )
+        if cutlass.const_expr(alpha_val is None):
+            dst.store(t.load().to(reorder_dtype))
+        else:
+            if cutlass.const_expr(current_tensor_size % 2 != 0):
+                raise ValueError("fc2_f2fp expects even elements for each input tensor.") 
+            scaled = cute.make_rmem_tensor((current_tensor_size,), cutlass.Float32)
+            for i in cutlass.range_constexpr(0, current_tensor_size, 2):
+                # scaled[i] = t[i] * alpha_val
+                s0, s1 = cute.arch.mul_packed_f32x2((t[i], t[i+1]), (alpha_val, alpha_val))
+                scaled[i] = s0
+                scaled[i + 1] = s1
+            dst.store(scaled.load().to(reorder_dtype))
+        elems_processed += current_tensor_size
+    return converted_acc
+
+@cute.jit
+def post_f2fp_reorder_identity(*, casted: cute.Tensor, **_):
+    # UBLK: the f2fp output is already in the pre-store distribution (each lane
+    # owns one hidden element across the 64 subtile tokens); no reorder needed.
+    return casted
+
+@cute.jit
+def fc2_stg_tmem_acc_load(*, tmem_subtile_tensor: cute.Tensor, **_):
+    return _TmemTranspose16x32Core.load_subtile_raw_acc(tmem_subtile_tensor)
+
+@cute.jit
+def fc2_ublk_tmem_acc_load(*, tmem_subtile_tensor: cute.Tensor, epi, **_):
+    # UBLK consumes a warp-local 32-hidden x 64-token slice.  The caller passes
+    # the CTA-level 128-hidden x 64-token subtile view, so select this epi
+    # warp's hidden block before issuing LDTM.x64.
+    tmem_subtile_per_warp = cute.logical_divide(
+        tmem_subtile_tensor,
+        (32, None),
+    )[(None, epi.warp_idx), None]
+    raw_regs = cute.make_rmem_tensor((64,), cutlass.Float32)
+    atom_ld32x32_x64 = cute.make_copy_atom(
+        tcgen05.Ld32x32bOp(tcgen05.Repetition.x64),
+        cutlass.Float32,
+    )
+    cute.copy(
+        atom_ld32x32_x64,
+        wrap_into_copy_standard_layout(tmem_subtile_per_warp),
+        wrap_into_copy_standard_layout(raw_regs),
+    )
+    return (raw_regs,)
+
+@cute.jit
+def fc2_stg_post_f2fp_reorder(
+    *, 
+    casted: cute.Tensor,                # (subtile_cnt,)
+    tmem_subtile_view: cute.Tensor,     # (epi_tile_m, epi_tile_n)
+    **_
+):
+
+    if cutlass.const_expr(cute.size(casted) != 64):
+        raise NotImplementedError("fc2 stg pass expects 64 fp32 regs in total before store reorder.")
+
+    # casted (flat 64) = [h0_top, h0_bot, h1_top, h1_bot], 16 bf16 each.
+    #
+    # gather: interleave (top[i], bot[i]) -> bf16x2 slot i, both halves at once.
+    #   read casted through (t, hidden, half) -> casted[t*16 + hidden + half*32]
+    #   in (t fastest) order -> [top0,bot0,top1,bot1,...] per half = packed bf16x2.
+    # scatter: de-interleave the transposed natural-hidden regs back to the
+    #   STG pre-store order (token = lane + 32*(vid//32), hidden = vid % 32).
+    gather_top_bot_map = ((2, 16, 2), (16, 1, 32))
+    scatter_top_bot_map = ((16, 2, 2), (2, 1, 32))
+    dtype = cutlass.BFloat16
+
+    packed = cute.make_rmem_tensor((64,), dtype)
+    cute.autovec_copy(cute.composition(casted, cute.make_layout((gather_top_bot_map[0],), stride=(gather_top_bot_map[1],))), packed)
+    # Although this works...
+    # packed.store(
+    #     cute.make_tensor(
+    #         casted.iterator,
+    #         cute.make_layout(gather_top_bot_map[0], stride=gather_top_bot_map[1]),
+    #     ).load()
+    # )
+    packed_i32 = cute.recast_tensor(packed, cutlass.Float32)   # (32,): 16 i32 per half
+
+    # Reuse the 32-bit transpose: each i32 slot carries one packed bf16x2 pair.
+    token_0_32_pre_scatter_back = TmemTranspose16x32(
+        tmem_subtile_view.iterator,
+        Region.Top,
+        reg_tensor=cute.composition(packed_i32, (16,)),
+    ).from_r1_perm_until_last_store()
+    token_32_64_pre_scatter_back = TmemTranspose16x32(
+        tmem_subtile_view.iterator + 32,
+        Region.Top,
+        reg_tensor=cute.composition(cute.domain_offset(16, packed_i32), (16,)),
+    ).from_r1_perm_until_last_store()
+    cute.autovec_copy(token_0_32_pre_scatter_back, cute.zipped_divide(packed_i32, (16,))[None, 0])
+    cute.autovec_copy(token_32_64_pre_scatter_back, cute.zipped_divide(packed_i32, (16,))[None, 1])
+    out = cute.make_rmem_tensor((64,), dtype)
+    cute.autovec_copy(cute.composition(packed, cute.make_layout((scatter_top_bot_map[0],), stride=(scatter_top_bot_map[1],))), out)
+    return out
+
+@cute.jit
+def fc2_redg_post_f2fp_reorder(
+    *,
+    casted: cute.Tensor,
+    tmem_subtile_view: cute.Tensor,
+    **_,
+):
+    # (epi_tid, elem_idx) -> (token_64, hidden_128), each thread hold token_2 x hidden_32
+    natural = fc2_stg_post_f2fp_reorder(
+        casted=casted,
+        tmem_subtile_view=tmem_subtile_view,
+    )
+    core_matrix_reorder_sttm_atom = cute.make_copy_atom(
+        tcgen05.St32x32bOp(tcgen05.Repetition.x16),
+        cutlass.Float32,
+    )
+    core_matrix_reorder_ldtm_atom = cute.make_copy_atom(
+        tcgen05.Ld16x256bOp(tcgen05.Repetition.x2),
+        cutlass.Float32,
+    )
+    # ((16, 2), token_32_group)
+    natural_divided_by_token32_16dp = cute.logical_divide(cute.zipped_divide(natural, (32,)), (16, None))
+    out = cute.make_rmem_tensor(natural_divided_by_token32_16dp.shape, casted.dtype)
+    out_as_i32 = cute.recast_tensor(out, cutlass.Float32)
+    # (32, 64)
+    tmem_subtile_warp_local = cute.flat_divide(tmem_subtile_view, (32, cute.size(tmem_subtile_view, 1)))[None, None, 0, 0]
+    # (16, 16, 16dp_group, token_32_groups). Note, this tmem can provide 2x cols since the original is bf16.
+    tmem_subtile_divided_by_token_group_divided_by_16dp = cute.flat_divide(tmem_subtile_warp_local, (16, 16))
+    for i in cutlass.range_constexpr(cute.size(natural_divided_by_token32_16dp, 1)):
+        current_sttm_src = cute.recast_tensor(natural_divided_by_token32_16dp[None, i], cutlass.Float32)
+        cute.copy(core_matrix_reorder_sttm_atom, wrap_into_copy_standard_layout(current_sttm_src), wrap_into_copy_standard_layout(tmem_subtile_divided_by_token_group_divided_by_16dp[None, None, None, i]))
+        cute.copy(core_matrix_reorder_ldtm_atom, wrap_into_copy_standard_layout(tmem_subtile_divided_by_token_group_divided_by_16dp[None, None, 0, i]), wrap_into_copy_standard_layout(out_as_i32[(None, 0), i]))
+        cute.copy(core_matrix_reorder_ldtm_atom, wrap_into_copy_standard_layout(tmem_subtile_divided_by_token_group_divided_by_16dp[None, None, 1, i]), wrap_into_copy_standard_layout(out_as_i32[(None, 1), i]))
+
+    return cute.coalesce(out)
+
+@cute.jit
+def fc2_stg_store_function(
+    *, 
+    epi,
+    subtile: cute.Tensor,       # Always bf16 pre quant tesnor
+    subtile_idx: cutlass.Int32, 
+    fc2_output_router: Fc2OutputRouter,
+    **_
+):
+    if cutlass.const_expr(epi.combine_format.is_quantized):
+        data_subtile, sf_regs = QuantImpl(epi.combine_format, "regs_in_thread")(subtile)
+    else:
+        data_subtile = subtile
+        sf_regs = None
+    stg_width_elems: cutlass.Constexpr[int] = min(32, 256 // data_subtile.element_type.width)
+    stg_bits: cutlass.Constexpr[int] = stg_width_elems * data_subtile.element_type.width
+    copy_atom_vec = cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        cutlass.Int32,
+        num_bits_per_copy=stg_bits,
+    )
+    elems_per_thread: cutlass.Constexpr[int] = cute.size(data_subtile)
+    if cutlass.const_expr(elems_per_thread % stg_width_elems != 0):
+        raise ValueError(
+            "fc2 STG store requires pre-store elems per thread to be divisible "
+            f"by STG issue width, got {elems_per_thread} and {stg_width_elems}."
+        )
+    
+    if cutlass.const_expr(sf_regs is not None):
+        sf_scales_per_stg: cutlass.Constexpr[int] = 32 // epi.combine_format.scale_block
+        token_groups_per_subtile: cutlass.Constexpr[int] = epi._EpilogueTokenTileSize // 32
+        for token_group in cutlass.range_constexpr(token_groups_per_subtile):
+            sf_iter = cutlass.Int32(subtile_idx) * cutlass.Int32(token_groups_per_subtile) + token_group
+            sf_ptr, sf_pred = fc2_output_router.get_sf_dst(sf_iter)
+            if sf_pred != cutlass.Int32(0):
+                sf_dst = cute.make_tensor(sf_ptr, cute.make_layout((sf_scales_per_stg,)))
+                for k in cutlass.range_constexpr(sf_scales_per_stg):
+                    sf_dst[k] = sf_regs[token_group * sf_scales_per_stg + k]
+
+    iters_per_subtile: cutlass.Constexpr[int] = elems_per_thread // stg_width_elems
+    copy_src = cute.zipped_divide(data_subtile, (stg_width_elems,))
+    single_copy_layout = cute.make_layout(((stg_width_elems, 1),), stride=((1, 0),))
+    subtile_iter_base = cutlass.Int32(subtile_idx) * cutlass.Int32(iters_per_subtile)
+    for local_iter in cutlass.range_constexpr(iters_per_subtile):
+        global_iter = subtile_iter_base + cutlass.Int32(local_iter)
+        dst_ptr, pred = fc2_output_router.get_data_dst(global_iter)
+        if pred != cutlass.Int32(0):
+            src_i = cute.make_tensor(copy_src[None, local_iter].iterator, single_copy_layout)
+            dst_i = cute.make_tensor(dst_ptr, single_copy_layout)
+            cute.copy(copy_atom_vec, cute.recast_tensor(src_i, cutlass.Int32), cute.recast_tensor(dst_i, cutlass.Int32))
+
+
+@cute.jit
+def fc2_ublk_store_function_impl(
+    *,
+    epi,
+    subtile: cute.Tensor,       # Always bf16 pre-quant tensor
+    subtile_idx: cutlass.Int32,
+    fc2_output_router: Fc2OutputRouter,
+    **_,
+):
+    smem_tensor = epi.smem_tensor
+    if cutlass.const_expr(smem_tensor is None):
+        raise ValueError("fc2 UBLK store requires epi.smem_tensor.")
+    quantized: cutlass.Constexpr[bool] = epi.combine_format.is_quantized
+    if cutlass.const_expr(quantized):
+        data_subtile, selected_sf = QuantImpl(
+            epi.combine_format, "threads_with_the_same_reg", lane_idx=epi.lane_idx,
+        )(subtile)
+    else:
+        data_subtile = subtile
+        selected_sf = None
+
+    smem_read_write_bar = pipeline.NamedBarrier(
+        barrier_id=SwapABSwigluFp4Epilogue._EpilogueSyncWaitBarId,
+        num_threads=SwapABSwigluFp4Epilogue._EpilogueWarpCnt * 32,
+    )
+    warp_idx = epi.warp_idx
+    lane_idx = epi.lane_idx
+    warp_hidden_base = cutlass.Int32(warp_idx * 32)
+
+    regs_per_thread: cutlass.Constexpr[int] = cute.size(data_subtile)
+    tokens_per_smem_slice: cutlass.Constexpr[int] = cute.size(smem_tensor, mode=[0])
+    if cutlass.const_expr(regs_per_thread % tokens_per_smem_slice != 0):
+        raise ValueError(
+            "fc2 UBLK store requires pre-store regs per thread to be divisible "
+            f"by scratch token rows, got {regs_per_thread} and {tokens_per_smem_slice}."
+        )
+    loop_cnt: cutlass.Constexpr[int] = regs_per_thread // tokens_per_smem_slice
+
+    # SF straight out (no smem): the sf_vec lanes of a block share the CREDUX
+    # result, so each emits its slice -- one scale per slot. The sf mapping owns
+    # the (lane, slot) -> (token, hidden) layout; selected_sf[slot] is this
+    # lane's slot-th scale, aligned to sf_iter = subtile_idx*iters_per_subtile+slot.
+    if cutlass.const_expr(quantized):
+        # A scale block = sf_vec hidden = sf_vec lanes (UBLK), and those lanes
+        # split the subtile's tokens, so each emits subtile_tokens // lanes_per_block.
+        lanes_per_block: cutlass.Constexpr[int] = epi.combine_format.scale_block
+        iters_per_subtile: cutlass.Constexpr[int] = epi._EpilogueTokenTileSize // lanes_per_block
+        for slot in cutlass.range_constexpr(iters_per_subtile):
+            sf_iter = cutlass.Int32(subtile_idx) * cutlass.Int32(iters_per_subtile) + slot
+            sf_ptr, sf_pred = fc2_output_router.get_sf_dst(sf_iter)
+            if sf_pred != cutlass.Int32(0):
+                sf_dst = cute.make_tensor(sf_ptr, cute.make_layout((1,)))
+                sf_dst[0] = selected_sf[slot]
+
+    for token32_group_idx in cutlass.range_constexpr(loop_cnt):
+        if cutlass.const_expr(token32_group_idx > 0):
+            cute.arch.cp_async_bulk_wait_group(0, read=True)
+            smem_read_write_bar.arrive_and_wait()
+
+        # R2S transpose: each lane writes its hidden column's 32 token rows for
+        # this group. (SF already went straight out above; only DATA transposes
+        # through smem here.)
+        for token_i in cutlass.range_constexpr(tokens_per_smem_slice):
+            src_reg = token_i + tokens_per_smem_slice * token32_group_idx
+            smem_tensor[token_i, warp_hidden_base + lane_idx] = data_subtile[src_reg]
+
+        cute.arch.fence_proxy("async.shared", space="cta")
+        smem_read_write_bar.arrive_and_wait()
+
+        # ublk_iter_idx is constexpr so get_dst indexes a constexpr slot (no spill).
+        # Gate / scratch_row specialize the store-out mapping: lane_idx//8 picks the
+        # subtile, warp_idx*8 + lane_idx%8 is the token's row within the 32-group.
+        ublk_iter_idx = token32_group_idx
+        # SF already went straight out above; here only the DATA row is pushed.
+        dst_ptr, pred = fc2_output_router.get_data_dst(ublk_iter_idx)
+        if pred != cutlass.Int32(0) and (lane_idx // cutlass.Int32(8)) == subtile_idx:
+            scratch_row = warp_idx * cutlass.Int32(8) + lane_idx % cutlass.Int32(8)
+            copy_elems = cutlass.Int32(128)
+            if cutlass.const_expr(epi.fc2_hidden_needs_predicate):
+                copy_elems = cutlass.Int32(fc2_output_router.valid_hidden_this_cta_tile)
+            # smem_tensor holds the combine wire dtype, so the bulk byte count
+            # scales with the wire width, not the bf16 compute dtype.
+            copy_bytes = copy_elems * epi.combine_format.act_dtype.width // 8
+
+            src_row = cute.slice_(smem_tensor, (scratch_row, None))
+            if cutlass.const_expr(epi.reduce_topk_in_kernel):
+                _cp_reduce_async_bulk_add_noftz_bf16_s2g(
+                    dst_ptr,
+                    src_row.iterator,
+                    copy_bytes,
+                )
+            else:
+                _cp_async_bulk_s2g(
+                    dst_ptr,
+                    src_row.iterator,
+                    copy_bytes,
+                )
+
+        cute.arch.cp_async_bulk_commit_group()
+
+    # Drain the final bulk op before the fixed scratch tile is reused by the
+    # next subtile / task tile.
+    cute.arch.cp_async_bulk_wait_group(0, read=True)
+    smem_read_write_bar.arrive_and_wait()
+
+@cute.jit
+def fc2_redg_store_function(
+    *,
+    epi,
+    subtile: cute.Tensor,       # Always bf16; in-kernel reduce never quantizes
+    subtile_idx: cutlass.Int32,
+    fc2_output_router: Fc2OutputRouter,
+    **_,
+):
+    redg_width_elems: cutlass.Constexpr[int] = 4
+    elems_per_thread: cutlass.Constexpr[int] = cute.size(subtile)
+    if cutlass.const_expr(elems_per_thread % redg_width_elems != 0):
+        raise ValueError(
+            "fc2 REDG store requires pre-store elems per thread to be divisible "
+            f"by REDG issue width, got {elems_per_thread} and {redg_width_elems}."
+        )
+    iters_per_subtile: cutlass.Constexpr[int] = elems_per_thread // redg_width_elems
+    subtile_iter_base = cutlass.Int32(subtile_idx) * cutlass.Int32(iters_per_subtile)
+    subtile_by_redg_issue = cute.zipped_divide(subtile, (redg_width_elems,))
+
+    for local_iter in cutlass.range_constexpr(iters_per_subtile):
+        global_iter = subtile_iter_base + cutlass.Int32(local_iter)
+        dst_ptr, pred = fc2_output_router.get_data_dst(global_iter)
+        if pred != cutlass.Int32(0):
+            bf16x4 = subtile_by_redg_issue[None, local_iter]
+            packed_bf16x2 = cute.recast_tensor(bf16x4, cutlass.Float32)
+            _red_add_relaxed_sys_v2_bf16x2(
+                dst_ptr,
+                cutlass.Float32(packed_bf16x2[0]),
+                cutlass.Float32(packed_bf16x2[1]),
+            )
+
+def make_fc2_stg_process_pipeline(
+    *,
+    combine_format: CombineFormat,
+    cta_token_tile_size: int,
+    cta_hidden_tile_size: int,
+) -> Fc2ProcessPipeline:
+    store_out_mapping, sf_store_out_mapping, fundamental_mapping = make_fc2_stg_cta_store_out_contract(
+        combine_format,
+        cta_token_tile_size,
+        cta_hidden_tile_size,
+    )
+    return Fc2ProcessPipeline(
+        tmem_acc_load=fc2_stg_tmem_acc_load,
+        f2fp=fc2_f2fp,
+        post_f2fp_reorder=fc2_stg_post_f2fp_reorder,
+        store_function=fc2_stg_store_function,
+        fc2_cta_tile_contract=fundamental_mapping,
+        store_out_mapping=store_out_mapping,
+        sf_store_out_mapping=sf_store_out_mapping,
+        require_tmem_trans=True,
+    )
+
+def make_fc2_redg_process_pipeline(
+    *,
+    combine_format: CombineFormat,
+    cta_token_tile_size: int,
+    cta_hidden_tile_size: int,
+) -> Fc2ProcessPipeline:
+    store_out_mapping, sf_store_out_mapping, fundamental_mapping = make_fc2_redg_cta_store_out_contract(
+        combine_format,
+        cta_token_tile_size,
+        cta_hidden_tile_size,
+    )
+    return Fc2ProcessPipeline(
+        tmem_acc_load=fc2_stg_tmem_acc_load,
+        f2fp=fc2_f2fp,
+        post_f2fp_reorder=fc2_redg_post_f2fp_reorder,
+        store_function=fc2_redg_store_function,
+        fc2_cta_tile_contract=fundamental_mapping,
+        store_out_mapping=store_out_mapping,
+        sf_store_out_mapping=sf_store_out_mapping,
+        require_tmem_trans=True,
+    )
+
+def make_fc2_ublk_process_pipeline(
+    *,
+    combine_format: CombineFormat,
+    cta_token_tile_size: int,
+    cta_hidden_tile_size: int,
+) -> Fc2ProcessPipeline:
+    store_out_mapping, sf_store_out_mapping, fundamental_mapping = make_fc2_ublk_store_out_contract(
+        combine_format,
+        cta_token_tile_size,
+        cta_hidden_tile_size,
+    )
+    return Fc2ProcessPipeline(
+        tmem_acc_load=fc2_ublk_tmem_acc_load,
+        f2fp=fc2_f2fp,
+        post_f2fp_reorder=post_f2fp_reorder_identity,
+        store_function=fc2_ublk_store_function_impl,
+        fc2_cta_tile_contract=fundamental_mapping,
+        store_out_mapping=store_out_mapping,
+        sf_store_out_mapping=sf_store_out_mapping,
+        require_tmem_trans=False,
+    )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/fc1_fc2_fuse_sched.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/fc1_fc2_fuse_sched.py
@@ -1,0 +1,1484 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Fused fc1 + fc2 MegaMoE scheduler."""
+
+from enum import IntEnum
+from typing import List, Literal, Optional, Tuple
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+from cutlass.cutlass_dsl import (
+    Boolean,
+    Int32,
+    Integer,
+    extract_mlir_values,
+    new_from_mlir_values,
+    const_expr,
+    dsl_user_op,
+)
+from cutlass._mlir import ir
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+
+from .moe_persistent_scheduler import (
+    MoEWorkTileInfo,
+    MoESchedulerParamsBase,
+    MoESchedulerBase,
+    WorkTileState,
+    _DEFAULT_SCHED_EXT,
+)
+from .moe_utils import (
+    compute_expert_token_count_from_sizes,
+    compute_expert_token_range,
+    mbarrier_arrive_expect_tx_on_peer,
+    store_i32_to_peer_cluster_smem_async,
+)
+
+
+# =============================================================================
+# Block phase
+# =============================================================================
+
+
+class BlockPhase(IntEnum):
+    """Fused fc1+fc2 work-tile phase. ``None_`` reserved as sentinel for sched
+    invalid tiles (alongside ``WorkTileState.DONE``)."""
+
+    None_ = 0
+    Linear1 = 1
+    Linear2 = 2
+
+
+# =============================================================================
+# Persistent state objects
+# =============================================================================
+
+
+class _FusedFc12SchedState:
+    """Sched warp register-resident state for the (group, phase, expert) state
+    machine.  Field set kept flat so MLIR serialization is one extend per
+    field; nested sub-states would not save anything in this footprint."""
+
+    def __init__(
+        self,
+        current_group_idx: Int32,
+        current_group_first_expert: Int32,
+        current_group_last_expert_exclusive: Int32,
+        current_phase: Int32,
+        current_expert_idx: Int32,
+        current_expert_tile_start: Int32,
+        current_expert_tile_end: Int32,
+        current_group_fc1_subphase_end: Int32,
+        current_group_end: Int32,
+        cumulative_fc1_tiles_at_group_end: Int32,
+        cumulative_fc2_tiles_at_group_end: Int32,
+        # Physical-row / token-block running cumulatives.  Each invariant is
+        # "(...)_cumul reflects the
+        # current expert's *start* offset under that padding granularity":
+        #   current_data_cumul        = sum_{e' < current_expert_idx}
+        #                                   round_up(valid_e', params.token_padding_block)
+        #   current_sf_cumul          = sum_{e' < current_expert_idx}
+        #                                   round_up(valid_e', params.sf_padding_block)
+        #   current_token_block_cumul = sum_{e' < current_expert_idx}
+        #                                   ceil_div(valid_e', cluster_tile_m)
+        # Each ``advance_expert_within_phase`` pushes the *previous* expert's
+        # occupation into these before bumping ``current_expert_idx``.
+        current_data_cumul: Int32,
+        current_sf_cumul: Int32,
+        current_token_block_cumul: Int32,
+        # Group-start checkpoints used by ``switch_to_fc2`` to rewind cumul
+        # state from group-end (fc1 phase's last expert) back to group-start
+        # (fc2 phase will re-walk the same experts).  Captured at
+        # ``advance_group`` time *after* pushing the previous group's tail.
+        group_start_data_cumul: Int32,
+        group_start_sf_cumul: Int32,
+        group_start_token_block_cumul: Int32,
+        current_token_block_count: Int32,
+        current_token_offset: Int32,
+        current_this_expert_token_cnt: Int32,
+        current_work_linear_tile_idx: Int32,
+    ):
+        self.current_group_idx = current_group_idx
+        self.current_group_first_expert = current_group_first_expert
+        self.current_group_last_expert_exclusive = current_group_last_expert_exclusive
+        self.current_phase = current_phase
+        self.current_expert_idx = current_expert_idx
+        self.current_expert_tile_start = current_expert_tile_start
+        self.current_expert_tile_end = current_expert_tile_end
+        self.current_group_fc1_subphase_end = current_group_fc1_subphase_end
+        self.current_group_end = current_group_end
+        self.cumulative_fc1_tiles_at_group_end = cumulative_fc1_tiles_at_group_end
+        self.cumulative_fc2_tiles_at_group_end = cumulative_fc2_tiles_at_group_end
+        self.current_data_cumul = current_data_cumul
+        self.current_sf_cumul = current_sf_cumul
+        self.current_token_block_cumul = current_token_block_cumul
+        self.group_start_data_cumul = group_start_data_cumul
+        self.group_start_sf_cumul = group_start_sf_cumul
+        self.group_start_token_block_cumul = group_start_token_block_cumul
+        self.current_token_block_count = current_token_block_count
+        self.current_token_offset = current_token_offset
+        self.current_this_expert_token_cnt = current_this_expert_token_cnt
+        self.current_work_linear_tile_idx = current_work_linear_tile_idx
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self.current_group_idx))
+        values.extend(extract_mlir_values(self.current_group_first_expert))
+        values.extend(extract_mlir_values(self.current_group_last_expert_exclusive))
+        values.extend(extract_mlir_values(self.current_phase))
+        values.extend(extract_mlir_values(self.current_expert_idx))
+        values.extend(extract_mlir_values(self.current_expert_tile_start))
+        values.extend(extract_mlir_values(self.current_expert_tile_end))
+        values.extend(extract_mlir_values(self.current_group_fc1_subphase_end))
+        values.extend(extract_mlir_values(self.current_group_end))
+        values.extend(extract_mlir_values(self.cumulative_fc1_tiles_at_group_end))
+        values.extend(extract_mlir_values(self.cumulative_fc2_tiles_at_group_end))
+        values.extend(extract_mlir_values(self.current_data_cumul))
+        values.extend(extract_mlir_values(self.current_sf_cumul))
+        values.extend(extract_mlir_values(self.current_token_block_cumul))
+        values.extend(extract_mlir_values(self.group_start_data_cumul))
+        values.extend(extract_mlir_values(self.group_start_sf_cumul))
+        values.extend(extract_mlir_values(self.group_start_token_block_cumul))
+        values.extend(extract_mlir_values(self.current_token_block_count))
+        values.extend(extract_mlir_values(self.current_token_offset))
+        values.extend(extract_mlir_values(self.current_this_expert_token_cnt))
+        values.extend(extract_mlir_values(self.current_work_linear_tile_idx))
+        return values
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "_FusedFc12SchedState":
+        idx = 0
+
+        def _take(obj):
+            nonlocal idx
+            n = len(extract_mlir_values(obj))
+            result = new_from_mlir_values(obj, values[idx : idx + n])
+            idx += n
+            return result
+
+        return _FusedFc12SchedState(
+            current_group_idx=_take(self.current_group_idx),
+            current_group_first_expert=_take(self.current_group_first_expert),
+            current_group_last_expert_exclusive=_take(self.current_group_last_expert_exclusive),
+            current_phase=_take(self.current_phase),
+            current_expert_idx=_take(self.current_expert_idx),
+            current_expert_tile_start=_take(self.current_expert_tile_start),
+            current_expert_tile_end=_take(self.current_expert_tile_end),
+            current_group_fc1_subphase_end=_take(self.current_group_fc1_subphase_end),
+            current_group_end=_take(self.current_group_end),
+            cumulative_fc1_tiles_at_group_end=_take(self.cumulative_fc1_tiles_at_group_end),
+            cumulative_fc2_tiles_at_group_end=_take(self.cumulative_fc2_tiles_at_group_end),
+            current_data_cumul=_take(self.current_data_cumul),
+            current_sf_cumul=_take(self.current_sf_cumul),
+            current_token_block_cumul=_take(self.current_token_block_cumul),
+            group_start_data_cumul=_take(self.group_start_data_cumul),
+            group_start_sf_cumul=_take(self.group_start_sf_cumul),
+            group_start_token_block_cumul=_take(self.group_start_token_block_cumul),
+            current_token_block_count=_take(self.current_token_block_count),
+            current_token_offset=_take(self.current_token_offset),
+            current_this_expert_token_cnt=_take(self.current_this_expert_token_cnt),
+            current_work_linear_tile_idx=_take(self.current_work_linear_tile_idx),
+        )
+
+
+class _DynamicLoadBalanceState:
+    """Atomic-counter load-balance state.  Set on the scheduler only when
+    ``params.load_balance_mode == 'atomic_counter'``.  ``atomic_res`` caches
+    the first pre-init claim so the first advance site does not issue another
+    atom.add.
+    """
+
+    def __init__(
+        self,
+        counter_ptr,
+        broadcast_ptr,
+        is_leader_cta: Boolean,
+        producer_state,
+        consumer_state,
+        atomic_res: Int32,
+    ):
+        self.counter_ptr = counter_ptr
+        self.broadcast_ptr = broadcast_ptr
+        self.is_leader_cta = is_leader_cta
+        self.producer_state = producer_state
+        self.consumer_state = consumer_state
+        self.atomic_res = atomic_res
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self.counter_ptr))
+        values.extend(extract_mlir_values(self.broadcast_ptr))
+        values.extend(extract_mlir_values(self.is_leader_cta))
+        values.extend(extract_mlir_values(self.producer_state))
+        values.extend(extract_mlir_values(self.consumer_state))
+        values.extend(extract_mlir_values(self.atomic_res))
+        return values
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "_DynamicLoadBalanceState":
+        idx = 0
+
+        def _take(obj):
+            nonlocal idx
+            n = len(extract_mlir_values(obj))
+            result = new_from_mlir_values(obj, values[idx : idx + n])
+            idx += n
+            return result
+
+        return _DynamicLoadBalanceState(
+            counter_ptr=_take(self.counter_ptr),
+            broadcast_ptr=_take(self.broadcast_ptr),
+            is_leader_cta=_take(self.is_leader_cta),
+            producer_state=_take(self.producer_state),
+            consumer_state=_take(self.consumer_state),
+            atomic_res=_take(self.atomic_res),
+        )
+
+
+# =============================================================================
+# Scheduler Parameters
+# =============================================================================
+
+
+class MoEFusedFc12SchedulerParams(MoESchedulerParamsBase):
+    """Codegen-time + runtime parameters for the fused fc1+fc2 mega scheduler.
+
+    Inherits ``expert_shape``, ``cta_tile_shape_mnk``, ``cluster_shape_mn``,
+    ``scenario``, ``is_swap_ab``, ``num_sched_stages`` handling from
+    ``MoESchedulerParamsBase``.  ``cta_tile_shape_mnk`` is shared by fc1 / fc2
+    (v1 simplification).
+
+    This params type currently backs the inference fc12 path.  In that path
+    ``expert_shape[1]`` is ``intermediate_gateup`` (gate + up concatenated).
+    Future training/non-swap MegaMoE variants should add their own params
+    contract instead of overloading this one.
+    """
+
+    def __init__(
+        self,
+        scenario: Literal["2Dx3D"],
+        expert_shape: Tuple[int | Int32, int | Int32, int | Int32],
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        group_hint: int,
+        token_padding_block: int,
+        sf_padding_block: int,
+        load_balance_mode: Literal["static", "atomic_counter", "clc"] = "static",
+        load_balance_counter_ptr=None,
+        override_num_stages: Optional[int] = None,
+        is_swap_ab: bool = True,
+        # Exactly one of the next two must be non-None (sizes preferred when
+        # the host can expose a direct view onto ``expert_recv_count_sum``;
+        # prefix_sum required when only a host-precomputed cumsum is
+        # available).  The scheduler picks the data source at codegen time
+        # via ``cutlass.const_expr(self.expert_token_sizes is not None)``;
+        # serialization is type-discriminated below.
+        expert_token_sizes: Optional[cute.Tensor] = None,
+        expert_token_prefix_sum: Optional[cute.Tensor] = None,
+    ):
+        """Create fused fc12 scheduler params."""
+        if scenario != "2Dx3D":
+            raise ValueError(f"fused fc1+fc2 only supports 2Dx3D, got {scenario!r}")
+        if load_balance_mode not in ("static", "atomic_counter", "clc"):
+            raise ValueError(
+                f"load_balance_mode must be one of 'static' / 'atomic_counter' / 'clc', "
+                f"got {load_balance_mode!r}"
+            )
+        if load_balance_mode == "atomic_counter" and load_balance_counter_ptr is None:
+            raise ValueError(
+                "load_balance_counter_ptr must be provided when load_balance_mode == "
+                "'atomic_counter' (GMEM int32 ptr, host-allocated and zero-init per launch)"
+            )
+        if group_hint <= 0:
+            raise ValueError(f"group_hint must be positive, got {group_hint}")
+        if token_padding_block <= 0:
+            raise ValueError(
+                f"token_padding_block must be positive, got {token_padding_block}"
+            )
+        if sf_padding_block <= 0:
+            raise ValueError(
+                f"sf_padding_block must be positive, got {sf_padding_block}"
+            )
+        if (expert_token_sizes is None) == (expert_token_prefix_sum is None):
+            raise ValueError(
+                "Exactly one of expert_token_sizes / expert_token_prefix_sum "
+                "must be provided (got "
+                f"sizes={'set' if expert_token_sizes is not None else 'None'}, "
+                f"prefix_sum={'set' if expert_token_prefix_sum is not None else 'None'})."
+            )
+
+        super().__init__(
+            scenario=scenario,
+            expert_shape=expert_shape,
+            cta_tile_shape_mnk=cta_tile_shape_mnk,
+            cluster_shape_mn=cluster_shape_mn,
+            override_num_stages=override_num_stages,
+            is_swap_ab=is_swap_ab,
+        )
+        self.group_hint = group_hint
+        self.token_padding_block = token_padding_block
+        self.sf_padding_block = sf_padding_block
+        self.load_balance_mode = load_balance_mode
+        self.load_balance_counter_ptr = load_balance_counter_ptr
+        self.expert_token_sizes = expert_token_sizes
+        self.expert_token_prefix_sum = expert_token_prefix_sum
+
+    def get_scheduler_type(self) -> type:
+        return MoEFusedFc12PersistentTileScheduler
+
+    def get_grid_shape(
+        self,
+        max_active_clusters: int,
+    ) -> Tuple[int, int, int]:
+        if self.is_swap_ab:
+            return (
+                self.cluster_shape_mn[1],
+                self.cluster_shape_mn[0],
+                max_active_clusters,
+            )
+        return (
+            self.cluster_shape_mn[0],
+            self.cluster_shape_mn[1],
+            max_active_clusters,
+        )
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        """Type-discriminated serialization (see ``MoEStaticSchedulerParams``).
+
+        Python int fields supplied via ``static_expert_shape`` skip the
+        MLIR carry and remain inlined codegen-time literals; Int32
+        fields (the dynamic ``fc1_weight.shape`` path) flow through as
+        SSA values as usual.
+
+        Exactly one of ``expert_token_sizes`` / ``expert_token_prefix_sum``
+        is non-None (enforced in ``__init__``); whichever it is gets
+        extended.  ``__new_from_mlir_values__`` reads the same prototype
+        ``self`` to decide which side to consume.
+        """
+        values = []
+        if isinstance(self.expert_cnt, Int32):
+            values.extend(extract_mlir_values(self.expert_cnt))
+        if isinstance(self.intermediate, Int32):
+            values.extend(extract_mlir_values(self.intermediate))
+        if isinstance(self.hidden, Int32):
+            values.extend(extract_mlir_values(self.hidden))
+        if self.load_balance_mode == "atomic_counter":
+            values.extend(extract_mlir_values(self.load_balance_counter_ptr))
+        if self.expert_token_sizes is not None:
+            values.extend(extract_mlir_values(self.expert_token_sizes))
+        else:
+            values.extend(extract_mlir_values(self.expert_token_prefix_sum))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "MoEFusedFc12SchedulerParams":
+        # Bypass __init__: stored cta_tile_shape_mnk / cluster_shape_mn are
+        # already in post-swap form, going through __init__ would double-swap.
+        # Mirrors MoEStaticSchedulerParams.__new_from_mlir_values__.
+        result = MoEFusedFc12SchedulerParams.__new__(MoEFusedFc12SchedulerParams)
+        result.scenario = self.scenario
+        result.is_swap_ab = self.is_swap_ab
+        result.cta_tile_shape_mnk = self.cta_tile_shape_mnk
+        result.cluster_shape_mn = self.cluster_shape_mn
+        result.num_sched_stages = self.num_sched_stages
+        result.group_hint = self.group_hint
+        result.token_padding_block = self.token_padding_block
+        result.sf_padding_block = self.sf_padding_block
+        result.load_balance_mode = self.load_balance_mode
+
+        # Type-discriminated rebind: Python int fields copy from
+        # prototype (``self``), Int32 fields consume from ``values``.
+        idx = 0
+        if isinstance(self.expert_cnt, Int32):
+            result.expert_cnt = new_from_mlir_values(
+                self.expert_cnt, [values[idx]]
+            )
+            idx += 1
+        else:
+            result.expert_cnt = self.expert_cnt
+        if isinstance(self.intermediate, Int32):
+            result.intermediate = new_from_mlir_values(
+                self.intermediate, [values[idx]]
+            )
+            idx += 1
+        else:
+            result.intermediate = self.intermediate
+        if isinstance(self.hidden, Int32):
+            result.hidden = new_from_mlir_values(self.hidden, [values[idx]])
+            idx += 1
+        else:
+            result.hidden = self.hidden
+        if self.load_balance_mode == "atomic_counter":
+            ptr_len = len(extract_mlir_values(self.load_balance_counter_ptr))
+            result.load_balance_counter_ptr = new_from_mlir_values(
+                self.load_balance_counter_ptr, values[idx : idx + ptr_len]
+            )
+            idx += ptr_len
+        else:
+            result.load_balance_counter_ptr = None
+        # Sizes / prefix_sum: prototype tells us which side carries the
+        # actual tensor; the other side stays None on the result.
+        if self.expert_token_sizes is not None:
+            t_len = len(extract_mlir_values(self.expert_token_sizes))
+            result.expert_token_sizes = new_from_mlir_values(
+                self.expert_token_sizes, values[idx : idx + t_len]
+            )
+            idx += t_len
+            result.expert_token_prefix_sum = None
+        else:
+            t_len = len(extract_mlir_values(self.expert_token_prefix_sum))
+            result.expert_token_prefix_sum = new_from_mlir_values(
+                self.expert_token_prefix_sum, values[idx : idx + t_len]
+            )
+            idx += t_len
+            result.expert_token_sizes = None
+        assert idx == len(values), (
+            f"Fused fc12 sched params type-discrim mismatch: idx={idx} "
+            f"len(values)={len(values)}"
+        )
+        return result
+
+
+# =============================================================================
+# Scheduler — Fused fc1 + fc2 Persistent (Device-side)
+# =============================================================================
+
+
+class MoEFusedFc12PersistentTileScheduler(MoESchedulerBase):
+    """Mega scheduler for fused fc1+fc2 grouped GEMM under swap-AB.
+
+    Tile space: ``(group, phase, expert, token_block, intermediate_or_hidden_block)``.
+    Within a group: full fc1 sub-segment (all experts in expert order, each expert
+    expanded as ``token_block`` slow / ``intermediate_block`` fast) → full fc2
+    sub-segment (same expert order, each expert expanded short-side-first).
+    """
+
+    def __init__(
+        self,
+        params: MoEFusedFc12SchedulerParams,
+        num_persistent_clusters: Int32,
+        cta_id_in_cluster: cute.Coord,
+        current_work: MoEWorkTileInfo,
+        fused_state: _FusedFc12SchedState,
+        dynamic_state: Optional[_DynamicLoadBalanceState],
+        # Cached scheduler-wide derived constants (computed once in create()
+        # from params.intermediate / params.hidden / params.cluster_tile_n;
+        # avoid recomputing in the hot path of advance / decode).
+        num_fc1_intermediate_blocks: Int32,
+        num_fc2_hidden_blocks: Int32,
+        ext,
+        sched_pipeline,
+        smem_buf_tensor,
+        num_sched_stages: int,
+        cluster_pipeline,
+        producer_state,
+        sched_storage=None,
+    ):
+        # Per-expert token range data source lives on ``params``: either
+        # ``params.expert_token_sizes`` (sizes-mode, e.g. zero-copy view of
+        # ``expert_recv_count_sum``) or ``params.expert_token_prefix_sum``
+        # (cumulative-end, host-precomputed).  See
+        # ``compute_expert_token_range`` / ``compute_expert_token_count_from_sizes``
+        # in ``moe_utils.py`` for the per-mode helpers.
+        self.params = params
+        self.num_persistent_clusters = num_persistent_clusters
+        self.cta_id_in_cluster = cta_id_in_cluster
+        self.current_work = current_work
+        self._fused_state = fused_state
+        self._dynamic_state = dynamic_state
+        self._num_fc1_intermediate_blocks = num_fc1_intermediate_blocks
+        self._num_fc2_hidden_blocks = num_fc2_hidden_blocks
+        self._ext = ext
+        self._pipeline = sched_pipeline
+        self._smem_buf_tensor = smem_buf_tensor
+        self._num_sched_stages = num_sched_stages
+        self._cluster_pipeline = cluster_pipeline
+        self._producer_state = producer_state
+        # Python-only reference to the SMEM scheduler storage struct.  Held
+        # only so that ``internal_init`` can reach
+        # ``sched_storage.cluster_pipeline_mbar`` /
+        # ``sched_storage.cluster_broadcast_slot`` to build the
+        # cluster_pipeline (atomic_counter mode); does NOT serialize.
+        self._sched_storage = sched_storage
+        # Codegen-time Python attribute (NOT MLIR-serialized).  Set to True
+        # by ``internal_init`` to mark "scheduler state has been greedily
+        # advanced one step (atomic_add cached for atomic_counter mode /
+        # current_work decoded for static mode)".  ``gen_next_work``'s
+        # ``cutlass.const_expr(self._first_advance_pending)`` branch reads
+        # this at trace time to elide the corresponding work for the first
+        # call site, then sets it back to False so the second trace site
+        # (while-body) compiles the vanilla path.
+        self._first_advance_pending: bool = False
+
+    @staticmethod
+    def make_storage_struct(
+        params: MoEFusedFc12SchedulerParams,
+        ext=_DEFAULT_SCHED_EXT,
+        **kwargs,
+    ) -> type:
+        if params.load_balance_mode == "clc":
+            raise NotImplementedError(
+                "load_balance_mode='clc' is reserved; CLC path is in"
+                " MoEDynamicPersistentTileScheduler, not the mega scheduler"
+            )
+
+        num_tile_stages = params.num_sched_stages
+        fields_per_stage = ext.WorkTileInfo.TotalFields
+
+        @cute.struct
+        class StaticSchedulerStorage:
+            sched_mbar: cute.struct.MemRange[cutlass.Int64, num_tile_stages * 2]
+            sched_buf: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, fields_per_stage * num_tile_stages],
+                16,
+            ]
+
+        @cute.struct
+        class AtomicCounterSchedulerStorage:
+            sched_mbar: cute.struct.MemRange[cutlass.Int64, num_tile_stages * 2]
+            sched_buf: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, fields_per_stage * num_tile_stages],
+                16,
+            ]
+            cluster_pipeline_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            cluster_broadcast_slot: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, 1], 16,
+            ]
+
+        if params.load_balance_mode == "atomic_counter":
+            return AtomicCounterSchedulerStorage
+        return StaticSchedulerStorage
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: MoEFusedFc12SchedulerParams,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        sched_storage,
+        num_consumer_threads: int,
+        ext=_DEFAULT_SCHED_EXT,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "MoEFusedFc12PersistentTileScheduler":
+        if num_consumer_threads <= 0:
+            raise ValueError(
+                f"num_consumer_threads must be positive, got {num_consumer_threads}"
+            )
+        if params.load_balance_mode == "clc":
+            raise NotImplementedError(
+                "load_balance_mode='clc' is reserved; CLC path is in"
+                " MoEDynamicPersistentTileScheduler, not the mega scheduler"
+            )
+
+        num_stages = params.num_sched_stages
+        fields_per_stage = ext.WorkTileInfo.TotalFields
+
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+
+        bidx, bidy, bidz = block_idx
+
+        # ``params.cluster_shape_mn`` is scheduler-internal.  Under swap-AB,
+        # launch axes map to the opposite internal M/N slots.
+        if const_expr(params.is_swap_ab):
+            cta_id_in_cluster = (
+                Int32(bidy % params.cluster_shape_mn[0]),
+                Int32(bidx % params.cluster_shape_mn[1]),
+                Int32(0),
+            )
+        else:
+            cta_id_in_cluster = (
+                Int32(bidx % params.cluster_shape_mn[0]),
+                Int32(bidy % params.cluster_shape_mn[1]),
+                Int32(0),
+            )
+
+        # State machine sentinel init.  The 0 values for current_group_end /
+        # current_expert_tile_end force gen_next_work's first call to enter
+        # advance_group() and advance_expert_within_phase(), which then fill
+        # the rest of the state from offs.  current_group_idx / current_expert_idx
+        # = -1 so that advance_* increments cleanly to 0 on first call.
+        #
+        # All cumul fields (current_*_cumul / group_start_*_cumul) start at 0;
+        # current_this_expert_token_cnt and current_token_block_count also start
+        # at 0 so that the first advance_expert call inside the first
+        # advance_group call pushes a no-op (round_up(0, ...) = 0) into the
+        # cumul state before reading expert 0's valid count.
+        fused_state = _FusedFc12SchedState(
+            current_group_idx=Int32(-1),
+            current_group_first_expert=Int32(0),
+            current_group_last_expert_exclusive=Int32(0),
+            current_phase=Int32(BlockPhase.Linear1),
+            current_expert_idx=Int32(-1),
+            current_expert_tile_start=Int32(0),
+            current_expert_tile_end=Int32(0),
+            current_group_fc1_subphase_end=Int32(0),
+            current_group_end=Int32(0),
+            cumulative_fc1_tiles_at_group_end=Int32(0),
+            cumulative_fc2_tiles_at_group_end=Int32(0),
+            current_data_cumul=Int32(0),
+            current_sf_cumul=Int32(0),
+            current_token_block_cumul=Int32(0),
+            group_start_data_cumul=Int32(0),
+            group_start_sf_cumul=Int32(0),
+            group_start_token_block_cumul=Int32(0),
+            current_token_block_count=Int32(0),
+            current_token_offset=Int32(0),
+            current_this_expert_token_cnt=Int32(0),
+            current_work_linear_tile_idx=Int32(bidz),
+        )
+
+        # Cached derived constants (scheduler-wide, computed once).
+        #
+        # ``params.intermediate`` carries ``intermediate_gateup`` semantics
+        # (= ``mat_b.shape[2]``, the full gate+up-concat fc1 weight dim;
+        # see ``MoESchedulerParamsBase.__init__`` docstring).  fc1 GEMM-M
+        # under swap-AB IS that gateup axis, so the number of cluster work
+        # tiles along intermediate per ``(expert, token_block)`` is just
+        # ``ceil_div(intermediate_gateup, cluster_tile_n_post_swap)`` --
+        # the same formula ``MoEStaticPersistentTileScheduler._get_cluster_
+        # tile_counts`` uses for its swap-AB 2Dx3D N-axis count.  A prior
+        # ``2 *`` multiplier here was a bug that doubled the per-tile-block
+        # work tile count (assumed ``params.intermediate`` was the half-dim
+        # ``intermediate_downproj``); removed to match the base scheduler.
+        #
+        # ``params.hidden`` is single-semantic (fc2 GEMM-M / fc2 output cols).
+        intermediate_gateup = params.intermediate
+        hidden = params.hidden
+        num_fc1_intermediate_blocks = (
+            intermediate_gateup + params.cluster_tile_n - 1
+        ) // params.cluster_tile_n
+        num_fc2_hidden_blocks = (
+            hidden + params.cluster_tile_n - 1
+        ) // params.cluster_tile_n
+
+        # current_work init must use ext.WorkTileInfo to match the shape that
+        # gen_next_work writes; otherwise MLIR serialization slots would differ.
+        if const_expr(params.is_swap_ab):
+            current_work = ext.WorkTileInfo(
+                expert_idx=Int32(WorkTileState.DONE),
+                tile_m_idx=Int32(0),
+                tile_n_idx=Int32(0),
+                cumulative_data_physical_row=Int32(0),
+                cumulative_sf_physical_row=Int32(0),
+                cumulative_token_block_count=Int32(0),
+                valid_tokens_in_cta_tile=Int32(0),
+                phase_and_peek=Int32(BlockPhase.None_),
+            )
+        else:
+            current_work = ext.WorkTileInfo(
+                expert_idx=Int32(WorkTileState.DONE),
+                tile_m_idx=Int32(0),
+                tile_n_idx=Int32(0),
+                cumulative_data_physical_row=Int32(0),
+                cumulative_sf_physical_row=Int32(0),
+                cumulative_token_block_count=Int32(0),
+                valid_tokens_in_cta_cluster_tile=Int32(0),
+                phase_and_peek=Int32(BlockPhase.None_),
+                fc1_counter_index=Int32(0),
+            )
+
+        sched_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        sched_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_consumer_threads
+        )
+        sched_pipeline = pipeline.PipelineAsync.create(
+            num_stages=num_stages,
+            producer_group=sched_producer_group,
+            consumer_group=sched_consumer_group,
+            barrier_storage=sched_storage.sched_mbar.data_ptr(),
+            defer_sync=True,
+        )
+        smem_buf_tensor = cute.make_tensor(
+            sched_storage.sched_buf.data_ptr(),
+            cute.make_layout(
+                (fields_per_stage, num_stages),
+                stride=(1, fields_per_stage),
+            ),
+        )
+        producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, num_stages
+        )
+
+        # Atomic-counter dynamic load-balance state.  cluster_pipeline is
+        # left as None here and constructed lazily inside ``internal_init``
+        # (it must be created BEFORE ``pipeline_init_arrive`` so all warps
+        # participate in the cluster mbarrier init; ``create`` runs from
+        # the kernel prologue, which already satisfies that).  ``atomic_res``
+        # starts at 0; ``internal_init`` overwrites it with the first claimed
+        # cluster-linear tile id.
+        dynamic_state: Optional[_DynamicLoadBalanceState] = None
+        if const_expr(params.load_balance_mode == "atomic_counter"):
+            is_leader_cta = (
+                cta_id_in_cluster[0] + cta_id_in_cluster[1] + cta_id_in_cluster[2]
+            ) == Int32(0)
+            cluster_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, 1
+            )
+            cluster_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, 1
+            )
+            dynamic_state = _DynamicLoadBalanceState(
+                counter_ptr=params.load_balance_counter_ptr,
+                broadcast_ptr=sched_storage.cluster_broadcast_slot.data_ptr(),
+                is_leader_cta=is_leader_cta,
+                producer_state=cluster_producer_state,
+                consumer_state=cluster_consumer_state,
+                atomic_res=Int32(0),
+            )
+
+        return MoEFusedFc12PersistentTileScheduler(
+            params=params,
+            num_persistent_clusters=num_persistent_clusters,
+            cta_id_in_cluster=cta_id_in_cluster,
+            current_work=current_work,
+            fused_state=fused_state,
+            dynamic_state=dynamic_state,
+            num_fc1_intermediate_blocks=num_fc1_intermediate_blocks,
+            num_fc2_hidden_blocks=num_fc2_hidden_blocks,
+            ext=ext,
+            sched_pipeline=sched_pipeline,
+            smem_buf_tensor=smem_buf_tensor,
+            num_sched_stages=num_stages,
+            cluster_pipeline=None,
+            producer_state=producer_state,
+            sched_storage=sched_storage,
+        )
+
+    # -------------------------------------------------------------------------
+    # internal_init: first-tile pre-init before pipeline_init_arrive
+    # -------------------------------------------------------------------------
+
+    @dsl_user_op
+    @cute.jit
+    def internal_init(
+        self,
+        warp_idx,
+        sched_warp_id: int,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Claim/decode the first work tile during kernel prologue."""
+        if const_expr(self.params.load_balance_mode == "atomic_counter"):
+            cluster_size = (
+                self.params.cluster_shape_mn[0] * self.params.cluster_shape_mn[1]
+            )
+
+            # Cluster-wide broadcast pipeline for the leader CTA's atom.add.
+            self._cluster_pipeline = pipeline.PipelineAsync.create(
+                num_stages=1,
+                producer_group=pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread, 1
+                ),
+                consumer_group=pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread, 32 * cluster_size
+                ),
+                barrier_storage=self._sched_storage.cluster_pipeline_mbar.data_ptr(),
+                defer_sync=True,
+            )
+
+            # Pre-claim and broadcast first dynamic tile id.
+            if warp_idx == sched_warp_id:
+                tidx, _, _ = cute.arch.thread_idx(loc=loc, ip=ip)
+                atomic_res = Int32(0)
+                if (
+                    self._dynamic_state.is_leader_cta
+                    and tidx % 32 == Int32(0)
+                ):
+                    atomic_res = cute.arch.atomic_add(
+                        self._dynamic_state.counter_ptr,
+                        Int32(1),
+                        loc=loc, ip=ip,
+                    )
+                atomic_res = cute.arch.shuffle_sync(
+                    atomic_res,
+                    offset=0,
+                    mask=0xFFFFFFFF,
+                    mask_and_clamp=31,
+                )
+                self._dynamic_state.atomic_res = atomic_res
+                self._dynamic_state = self._dynamic_state  # DSL carry
+            else:
+                self._dynamic_state = self._dynamic_state  # balance scf.if yield
+        elif const_expr(self.params.load_balance_mode == "static"):
+            # Static mode eagerly decodes the first tile.
+            if warp_idx == sched_warp_id:
+                cluster_linear_tile_idx = (
+                    self._advance_work_linear_tile_idx_static(loc=loc, ip=ip)
+                )
+                self._gen_work_from_cluster_idx(
+                    cluster_linear_tile_idx, loc=loc, ip=ip
+                )
+                self._fused_state = self._fused_state  # DSL carry
+                self.current_work = self.current_work
+            else:
+                self._fused_state = self._fused_state  # balance scf.if yield
+                self.current_work = self.current_work
+        else:
+            raise NotImplementedError(
+                "load_balance_mode='clc' is reserved; CLC scheduler is "
+                "MoEDynamicPersistentTileScheduler, not the mega scheduler"
+            )
+
+        # Codegen-time signal: gen_next_work's first trace site sees
+        # this True and emits the first-tile-finalize path; second trace
+        # site (while-body) sees False and emits the vanilla path.
+        self._first_advance_pending = True
+
+    # -------------------------------------------------------------------------
+    # State-machine advance helpers (group → phase → expert)
+    # -------------------------------------------------------------------------
+
+    @dsl_user_op
+    @cute.jit
+    def _advance_work_linear_tile_idx_static(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Int32:
+        """Static stride mode: read current_work_linear_tile_idx, advance by
+        num_persistent_clusters for next iteration, return the read value."""
+        state = self._fused_state
+        cluster_linear_tile_idx = state.current_work_linear_tile_idx
+        state.current_work_linear_tile_idx = (
+            cluster_linear_tile_idx + self.num_persistent_clusters
+        )
+        return cluster_linear_tile_idx
+
+    @dsl_user_op
+    @cute.jit
+    def _advance_work_linear_tile_idx_dynamic(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Int32:
+        """Atomic-counter mode: returns the cluster-linear tile idx broadcast
+        to all CTAs in the cluster.
+
+        Internally const_expr-forks on ``self._first_advance_pending``
+        (codegen-time Python bool):
+
+          - True (first trace site, post-``internal_init``): use the cached
+            ``self._dynamic_state.atomic_res`` ``atom.add`` result; skip
+            issuing a fresh atomic.  The cached value was computed and
+            shuffled across the sched warp by ``internal_init`` BEFORE
+            ``pipeline_init_arrive`` so its memory round trip overlaps with
+            cluster init wait.
+          - False (vanilla, second-and-onward trace sites): leader CTA
+            lane 0 issues a fresh ``atom.global.add.s32`` and shuffles the
+            result across the sched warp.
+
+        Cluster-internal protocol (DSMEM broadcast + cluster_pipeline mbar
+        wait) is identical between the two paths.  Mirrors
+        ``cute_dsl_kernel_library/dsl_kernels/moe/moe_persistent_scheduler.py``
+        ``_fetch_next_cluster_idx`` (lines 838-894).
+        """
+        ds = self._dynamic_state
+        cluster_pipeline = self._cluster_pipeline
+        broadcast_tensor = cute.make_tensor(
+            ds.broadcast_ptr, cute.make_layout((1,))
+        )
+        cluster_size = (
+            self.params.cluster_shape_mn[0] * self.params.cluster_shape_mn[1]
+        )
+
+        # --- Producer side (leader CTA only) ---
+        if ds.is_leader_cta:
+            cluster_pipeline.producer_acquire(ds.producer_state)
+            full_barrier_ptr = cluster_pipeline.sync_object_full.get_barrier(
+                ds.producer_state.index, loc=loc, ip=ip
+            )
+            tidx, _, _ = cute.arch.thread_idx(loc=loc, ip=ip)
+            lane_idx = tidx % Int32(32)
+
+            if cutlass.const_expr(self._first_advance_pending):
+                # First-tile path: consume the cached atomic_res that
+                # internal_init shuffled across the sched warp.
+                atomic_idx = ds.atomic_res
+            else:
+                # Vanilla path: lane 0 atom.add, shuffle to all lanes.
+                atomic_idx = Int32(0)
+                if lane_idx == Int32(0):
+                    atomic_idx = cute.arch.atomic_add(
+                        ds.counter_ptr, Int32(1), loc=loc, ip=ip,
+                    )
+                atomic_idx = cute.arch.shuffle_sync(
+                    atomic_idx,
+                    offset=0,
+                    mask=0xFFFFFFFF,
+                    mask_and_clamp=31,
+                )
+
+            # DSMEM fan-out: lanes [0, cluster_size) each write to one peer
+            # CTA.  Each lane targets a distinct peer (lane_idx == peer rank).
+            if lane_idx < Int32(cluster_size):
+                store_i32_to_peer_cluster_smem_async(
+                    ds.broadcast_ptr,
+                    atomic_idx,
+                    full_barrier_ptr,
+                    lane_idx,
+                    loc=loc, ip=ip,
+                )
+                # Set expect_tx on the peer mbarrier to match the 4-byte
+                # store above; pairs with the consumer_wait below.
+                mbarrier_arrive_expect_tx_on_peer(
+                    full_barrier_ptr,
+                    Int32(4),
+                    lane_idx,
+                    loc=loc, ip=ip,
+                )
+        ds.producer_state.advance()
+
+        # --- Consumer side (all CTAs sched warp threads) ---
+        cluster_pipeline.consumer_wait(ds.consumer_state)
+        cluster_idx = broadcast_tensor[0]
+        cute.arch.fence_acq_rel_cta()
+        cluster_pipeline.sync_object_empty.arrive(
+            ds.consumer_state.index, Int32(0)
+        )
+        ds.consumer_state.advance()
+
+        return cluster_idx
+
+    @dsl_user_op
+    @cute.jit
+    def _advance_expert_within_phase(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Advance to the next expert in the current phase."""
+        state = self._fused_state
+        params = self.params
+        cluster_tile_m = params.cluster_tile_m
+
+        # Push previous expert into cumul state before bumping expert_idx.
+        token_padding = params.token_padding_block
+        sf_padding = params.sf_padding_block
+        prev_valid = state.current_this_expert_token_cnt
+        state.current_data_cumul = state.current_data_cumul + (
+            (prev_valid + Int32(token_padding - 1)) // Int32(token_padding)
+        ) * Int32(token_padding)
+        state.current_sf_cumul = state.current_sf_cumul + (
+            (prev_valid + Int32(sf_padding - 1)) // Int32(sf_padding)
+        ) * Int32(sf_padding)
+        state.current_token_block_cumul = (
+            state.current_token_block_cumul + state.current_token_block_count
+        )
+
+        # Refresh current expert token range.
+        #
+        # Two data-source modes (selected at codegen time by which side of
+        # the params Optional pair is non-None):
+        #   - prefix-sum mode: random-access ``offs[i] - offs[i-1]`` gives
+        #     both offset and count in O(1).
+        #   - sizes mode: ``sizes[i]`` gives only the count; the cumulative
+        #     offset is maintained as a running cumul on
+        #     ``state.current_token_offset`` (push prev_valid before bumping
+        #     expert_idx).  This works because ``_advance_expert_within_phase``
+        #     is always called in monotonically-increasing expert order
+        #     (every group advance walks through residual experts of the
+        #     finishing group first, so no random jumps).
+        state.current_expert_idx = state.current_expert_idx + Int32(1)
+        if cutlass.const_expr(self.params.expert_token_sizes is not None):
+            state.current_token_offset = (
+                state.current_token_offset + prev_valid
+            )
+            this_expert_token_cnt = compute_expert_token_count_from_sizes(
+                self.params.expert_token_sizes,
+                state.current_expert_idx,
+                loc=loc,
+                ip=ip,
+            )
+        else:
+            token_offset, this_expert_token_cnt = compute_expert_token_range(
+                self.params.expert_token_prefix_sum,
+                state.current_expert_idx,
+                loc=loc,
+                ip=ip,
+            )
+            state.current_token_offset = token_offset
+        state.current_this_expert_token_cnt = this_expert_token_cnt
+        state.current_token_block_count = (
+            this_expert_token_cnt + Int32(cluster_tile_m) - 1
+        ) // Int32(cluster_tile_m)
+
+        # --- Step 3: slide expert_tile_start / expert_tile_end.
+        state.current_expert_tile_start = state.current_expert_tile_end
+        # Prebind due to DSL AST.
+        tiles_in_expert = Int32(0)
+        if state.current_phase == Int32(BlockPhase.Linear1):
+            tiles_in_expert = (
+                state.current_token_block_count * self._num_fc1_intermediate_blocks
+            )
+        else:
+            tiles_in_expert = (
+                state.current_token_block_count * self._num_fc2_hidden_blocks
+            )
+        state.current_expert_tile_end = (
+            state.current_expert_tile_start + tiles_in_expert
+        )
+
+    @dsl_user_op
+    @cute.jit
+    def _switch_to_fc2(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Switch current group from Linear1 to Linear2."""
+        state = self._fused_state
+        state.current_phase = Int32(BlockPhase.Linear2)
+        state.current_expert_idx = state.current_group_first_expert - Int32(1)
+        state.current_expert_tile_end = state.current_group_fc1_subphase_end
+        # Zero previous-expert cache before rewinding to group start.
+        state.current_this_expert_token_cnt = Int32(0)
+        state.current_token_block_count = Int32(0)
+        state.current_data_cumul = state.group_start_data_cumul
+        state.current_sf_cumul = state.group_start_sf_cumul
+        state.current_token_block_cumul = state.group_start_token_block_cumul
+        self._advance_expert_within_phase(loc=loc, ip=ip)
+
+    @dsl_user_op
+    @cute.jit
+    def _advance_group(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Open the next group and prime its first Linear1 expert."""
+        state = self._fused_state
+        params = self.params
+        cluster_tile_m = params.cluster_tile_m
+
+        # Push residual experts from the just-finished group into cumul state.
+        residual_expert_idx = state.current_expert_idx
+        residual_group_last_expert_exclusive = state.current_group_last_expert_exclusive
+        while residual_expert_idx + Int32(1) < residual_group_last_expert_exclusive:
+            self._advance_expert_within_phase(loc=loc, ip=ip)
+            self._fused_state = self._fused_state
+            state = self._fused_state
+            residual_expert_idx = state.current_expert_idx
+            residual_group_last_expert_exclusive = (
+                state.current_group_last_expert_exclusive
+            )
+        state = self._fused_state
+
+        # Final push; cumul now reflects the next group's first expert start.
+        token_padding = params.token_padding_block
+        sf_padding = params.sf_padding_block
+        prev_valid = state.current_this_expert_token_cnt
+        state.current_data_cumul = state.current_data_cumul + (
+            (prev_valid + Int32(token_padding - 1)) // Int32(token_padding)
+        ) * Int32(token_padding)
+        state.current_sf_cumul = state.current_sf_cumul + (
+            (prev_valid + Int32(sf_padding - 1)) // Int32(sf_padding)
+        ) * Int32(sf_padding)
+        state.current_token_block_cumul = (
+            state.current_token_block_cumul + state.current_token_block_count
+        )
+
+        # --- Step 3: snapshot new group_start cumul checkpoint.
+        state.group_start_data_cumul = state.current_data_cumul
+        state.group_start_sf_cumul = state.current_sf_cumul
+        state.group_start_token_block_cumul = state.current_token_block_cumul
+
+        # --- Step 4: roll group state forward.
+        base_fc1 = state.cumulative_fc1_tiles_at_group_end
+        base_fc2 = state.cumulative_fc2_tiles_at_group_end
+
+        state.current_group_idx = state.current_group_idx + Int32(1)
+        state.current_group_first_expert = state.current_group_last_expert_exclusive
+
+        # Greedy walk: accumulate per-expert fc1+fc2 tile counts until fc1
+        # cumulative crosses (base + group_hint), or experts exhausted.
+        threshold = base_fc1 + Int32(params.group_hint)
+        cumulative_fc1 = base_fc1
+        cumulative_fc2 = base_fc2
+        expert_cursor = state.current_group_first_expert
+
+        while expert_cursor < self.expert_cnt and cumulative_fc1 < threshold:
+            # Only the per-expert token count drives the group greedy walk
+            # (the offset is not consumed here), so the sizes-mode branch
+            # is the simpler one.
+            if cutlass.const_expr(self.params.expert_token_sizes is not None):
+                token_count_e = compute_expert_token_count_from_sizes(
+                    self.params.expert_token_sizes,
+                    expert_cursor,
+                    loc=loc,
+                    ip=ip,
+                )
+            else:
+                _, token_count_e = compute_expert_token_range(
+                    self.params.expert_token_prefix_sum,
+                    expert_cursor,
+                    loc=loc,
+                    ip=ip,
+                )
+            token_block_count_e = (
+                token_count_e + Int32(cluster_tile_m) - 1
+            ) // Int32(cluster_tile_m)
+            cumulative_fc1 = (
+                cumulative_fc1
+                + token_block_count_e * self._num_fc1_intermediate_blocks
+            )
+            cumulative_fc2 = (
+                cumulative_fc2 + token_block_count_e * self._num_fc2_hidden_blocks
+            )
+            expert_cursor = expert_cursor + Int32(1)
+
+        state.current_group_last_expert_exclusive = expert_cursor
+        state.cumulative_fc1_tiles_at_group_end = cumulative_fc1
+        state.cumulative_fc2_tiles_at_group_end = cumulative_fc2
+
+        group_total_fc1_tiles = cumulative_fc1 - base_fc1
+        group_total_fc2_tiles = cumulative_fc2 - base_fc2
+
+        # Previous group's end = this group's start in tile space.
+        group_start_tile = state.current_group_end
+        state.current_group_fc1_subphase_end = (
+            group_start_tile + group_total_fc1_tiles
+        )
+        state.current_group_end = (
+            state.current_group_fc1_subphase_end + group_total_fc2_tiles
+        )
+
+        # No-op push barrier before priming the group's first expert.
+        state.current_phase = Int32(BlockPhase.Linear1)
+        state.current_expert_idx = state.current_group_first_expert - Int32(1)
+        state.current_expert_tile_end = group_start_tile
+        state.current_this_expert_token_cnt = Int32(0)
+        state.current_token_block_count = Int32(0)
+        self._advance_expert_within_phase(loc=loc, ip=ip)
+
+    # -------------------------------------------------------------------------
+    # Fast-path decode
+    # -------------------------------------------------------------------------
+
+    @dsl_user_op
+    @cute.jit
+    def _decode_inside_expert(
+        self,
+        cluster_linear_tile_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> MoEWorkTileInfo:
+        """Decode one cluster-linear tile using the current scheduler state."""
+        state = self._fused_state
+        params = self.params
+        cta_tile_m = params.cta_tile_shape_mnk[0]
+
+        local_id = cluster_linear_tile_idx - state.current_expert_tile_start
+
+        # Prebind due to DSL AST.
+        cluster_token_block_idx = Int32(0)
+        cluster_intermediate_or_hidden_block_idx = Int32(0)
+
+        is_fc1 = state.current_phase == Int32(BlockPhase.Linear1)
+        if is_fc1:
+            num_fc1_intermediate_blocks = self._num_fc1_intermediate_blocks
+            cluster_token_block_idx = local_id // num_fc1_intermediate_blocks
+            cluster_intermediate_or_hidden_block_idx = (
+                local_id - cluster_token_block_idx * num_fc1_intermediate_blocks
+            )
+        else:
+            num_fc2_hidden_blocks = self._num_fc2_hidden_blocks
+            # Keep token-block as the slow axis in both phases.
+            cluster_token_block_idx = local_id // num_fc2_hidden_blocks
+            cluster_intermediate_or_hidden_block_idx = (
+                local_id - cluster_token_block_idx * num_fc2_hidden_blocks
+            )
+
+        # Cluster → CTA granularity (mirrors MoESchedulerBase._get_work_tile_for_linear_idx)
+        cta_token_block_idx = (
+            cluster_token_block_idx * params.cluster_shape_mn[0]
+            + self.cta_id_in_cluster[0]
+        )
+        cta_intermediate_or_hidden_block_idx = (
+            cluster_intermediate_or_hidden_block_idx * params.cluster_shape_mn[1]
+            + self.cta_id_in_cluster[1]
+        )
+
+        # valid_tokens_in_cta_tile: clip cta_tile_m tokens at the current expert
+        # right boundary.
+        token_idx_start_in_expert = cta_token_block_idx * Int32(cta_tile_m)
+        remaining_in_expert = (
+            state.current_this_expert_token_cnt - token_idx_start_in_expert
+        )
+        remaining_in_expert = cutlass.max(remaining_in_expert, Int32(0))
+        valid_tokens_in_cta_tile = cutlass.min(remaining_in_expert, Int32(cta_tile_m))
+
+        # Swap scheduler-internal M/N back to GEMM-domain M/N on output.
+        if const_expr(params.is_swap_ab):
+            tile_m_idx = cta_intermediate_or_hidden_block_idx
+            tile_n_idx = cta_token_block_idx
+        else:
+            tile_m_idx = cta_token_block_idx
+            tile_n_idx = cta_intermediate_or_hidden_block_idx
+
+        # ext.enrich_work_tile_info may OR the peek bit into phase_and_peek.
+        if const_expr(params.is_swap_ab):
+            return self._ext.WorkTileInfo(
+                expert_idx=state.current_expert_idx,
+                tile_m_idx=tile_m_idx,
+                tile_n_idx=tile_n_idx,
+                cumulative_data_physical_row=state.current_data_cumul,
+                cumulative_sf_physical_row=state.current_sf_cumul,
+                cumulative_token_block_count=state.current_token_block_cumul,
+                valid_tokens_in_cta_tile=valid_tokens_in_cta_tile,
+                phase_and_peek=state.current_phase,
+            )
+        else:
+            fc1_counter_index = cluster_token_block_idx
+            cluster_tile_m = params.cluster_shape_mn[0] * cta_tile_m
+            cluster_start = cluster_token_block_idx * Int32(cluster_tile_m)
+            remaining_cluster = cutlass.max(
+                state.current_this_expert_token_cnt - cluster_start, Int32(0)
+            )
+            valid_tokens_in_cluster_tile = cutlass.min(remaining_cluster, Int32(cluster_tile_m))
+            # Pack: high 16b = per-CTA tile count, low 16b = cluster-level count.
+            valid_tokens_in_cta_cluster_tile = (
+                (valid_tokens_in_cta_tile << Int32(16)) | valid_tokens_in_cluster_tile
+            )
+            return self._ext.WorkTileInfo(
+                expert_idx=state.current_expert_idx,
+                tile_m_idx=tile_m_idx,
+                tile_n_idx=tile_n_idx,
+                cumulative_data_physical_row=state.current_data_cumul,
+                cumulative_sf_physical_row=state.current_sf_cumul,
+                cumulative_token_block_count=state.current_token_block_cumul,
+                valid_tokens_in_cta_cluster_tile=valid_tokens_in_cta_cluster_tile,
+                phase_and_peek=state.current_phase,
+                fc1_counter_index=fc1_counter_index,
+            )
+
+    @dsl_user_op
+    @cute.jit
+    def _gen_work_from_cluster_idx(
+        self,
+        cluster_linear_tile_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Decode and publish current work from one cluster-linear tile id."""
+        state = self._fused_state
+
+        # Sentinel-by-default work tile; conditionally overwritten by decode.
+        if const_expr(self.params.is_swap_ab):
+            base_work = self._ext.WorkTileInfo(
+                expert_idx=Int32(WorkTileState.DONE),
+                tile_m_idx=Int32(0),
+                tile_n_idx=Int32(0),
+                cumulative_data_physical_row=Int32(0),
+                cumulative_sf_physical_row=Int32(0),
+                cumulative_token_block_count=Int32(0),
+                valid_tokens_in_cta_tile=Int32(0),
+                phase_and_peek=Int32(BlockPhase.None_),
+            )
+        else:
+            base_work = self._ext.WorkTileInfo(
+                expert_idx=Int32(WorkTileState.DONE),
+                tile_m_idx=Int32(0),
+                tile_n_idx=Int32(0),
+                cumulative_data_physical_row=Int32(0),
+                cumulative_sf_physical_row=Int32(0),
+                cumulative_token_block_count=Int32(0),
+                valid_tokens_in_cta_cluster_tile=Int32(0),
+                phase_and_peek=Int32(BlockPhase.None_),
+                fc1_counter_index=Int32(0),
+            )
+
+        # DSL carry for mutated self and while-condition fields.
+        outer_group_end = state.current_group_end
+        outer_group_last_expert_exclusive = state.current_group_last_expert_exclusive
+        while (
+            cluster_linear_tile_idx >= outer_group_end
+            and outer_group_last_expert_exclusive < self.expert_cnt
+        ):
+            self._advance_group(loc=loc, ip=ip)
+            self._fused_state = self._fused_state  # DSL carry
+            state = (
+                self._fused_state
+            )  # re-bind alias inside body so refresh below sees new SSA
+            outer_group_end = state.current_group_end
+            outer_group_last_expert_exclusive = (
+                state.current_group_last_expert_exclusive
+            )
+        state = self._fused_state  # re-bind alias to the post-while yielded SSA
+
+        is_valid = cluster_linear_tile_idx < state.current_group_end
+        if is_valid:
+            # fc1 → fc2 phase transition inside current group, if crossed.
+            if (
+                state.current_phase == Int32(BlockPhase.Linear1)
+                and cluster_linear_tile_idx >= state.current_group_fc1_subphase_end
+            ):
+                self._switch_to_fc2(loc=loc, ip=ip)
+                self._fused_state = (
+                    self._fused_state
+                )  # DSL carry
+            else:
+                self._fused_state = self._fused_state  # balanced else-side rebind
+            state = self._fused_state  # re-bind alias
+
+            # non-PyIR: carry loop-condition fields as locals.
+            inner_expert_tile_end = state.current_expert_tile_end
+            while cluster_linear_tile_idx >= inner_expert_tile_end:
+                self._advance_expert_within_phase(loc=loc, ip=ip)
+                self._fused_state = self._fused_state  # DSL carry
+                state = self._fused_state  # re-bind alias inside body
+                inner_expert_tile_end = state.current_expert_tile_end
+            state = self._fused_state  # re-bind alias
+
+            base_work = self._decode_inside_expert(
+                cluster_linear_tile_idx, loc=loc, ip=ip
+            )
+        else:
+            # Balance scf.if yield for self.
+            self._fused_state = self._fused_state
+
+        self.current_work = self._ext.enrich_work_tile_info(base_work)
+
+    @dsl_user_op
+    @cute.jit
+    def gen_next_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Produce the next work tile for this cluster's persistent loop.
+
+        Codegen-time fork on ``self._first_advance_pending`` (Python bool,
+        set True by ``internal_init``):
+
+          - First trace site (kernel main loop's first
+            ``scheduler.gen_next_work()``): static mode is a noop
+            (``self.current_work`` was decoded by ``internal_init``);
+            atomic mode runs the full ``_advance_work_linear_tile_idx_dynamic
+            + _gen_work_from_cluster_idx`` pipeline, with
+            ``_advance_work_linear_tile_idx_dynamic`` itself reading
+            ``_first_advance_pending`` to consume the cached
+            ``ds.atomic_res`` (set by ``internal_init`` BEFORE
+            ``pipeline_init_arrive``) instead of issuing a fresh
+            ``atom.add``.  At the tail, ``_first_advance_pending`` flips
+            to False so subsequent trace sites pick the vanilla path.
+
+          - Second trace site (inside-while-body call): vanilla
+            ``_advance_work_linear_tile_idx_*`` + ``_gen_work_from_cluster_idx``
+            for both modes.
+
+        First trace site consumes pre-init work; later trace sites advance normally.
+        """
+        iket.range_push("produce_tile_id")
+        # static mode first call short-circuits: internal_init already wrote
+        # the first work tile to self.current_work, so just leave it alone.
+        # All other (mode, call-site) combinations run the full advance +
+        # decode pipeline.  ``_advance_work_linear_tile_idx_dynamic`` itself
+        # const_expr-forks on _first_advance_pending to consume the cached
+        # atomic_res on its own first trace site.
+        if cutlass.const_expr(
+            self._first_advance_pending
+            and self.params.load_balance_mode == "static"
+        ):
+            pass
+        else:
+            if const_expr(self.params.load_balance_mode == "atomic_counter"):
+                cluster_linear_tile_idx = (
+                    self._advance_work_linear_tile_idx_dynamic(loc=loc, ip=ip)
+                )
+            elif const_expr(self.params.load_balance_mode == "static"):
+                cluster_linear_tile_idx = (
+                    self._advance_work_linear_tile_idx_static(loc=loc, ip=ip)
+                )
+            else:  # "clc"
+                raise NotImplementedError(
+                    "load_balance_mode='clc' is reserved; CLC scheduler is "
+                    "MoEDynamicPersistentTileScheduler, not the mega scheduler"
+                )
+            self._gen_work_from_cluster_idx(
+                cluster_linear_tile_idx, loc=loc, ip=ip
+            )
+
+        # Codegen-time flip after the first trace site so subsequent traces
+        # (the while-body call) pick the vanilla path.  This Python
+        # attribute write is observed at trace time by the next jit
+        # invocation of gen_next_work / _advance_work_linear_tile_idx_dynamic.
+        if cutlass.const_expr(self._first_advance_pending):
+            self._first_advance_pending = False
+        iket.range_pop()
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self.params))
+        values.extend(extract_mlir_values(self.num_persistent_clusters))
+        values.extend(extract_mlir_values(self.cta_id_in_cluster))
+        values.extend(extract_mlir_values(self.current_work))
+        values.extend(extract_mlir_values(self._fused_state))
+        values.extend(extract_mlir_values(self._num_fc1_intermediate_blocks))
+        values.extend(extract_mlir_values(self._num_fc2_hidden_blocks))
+        if self.params.load_balance_mode == "atomic_counter":
+            values.extend(extract_mlir_values(self._dynamic_state))
+        values.extend(extract_mlir_values(self._producer_state))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "MoEFusedFc12PersistentTileScheduler":
+        idx = 0
+
+        def _take(obj):
+            nonlocal idx
+            n = len(extract_mlir_values(obj))
+            result = new_from_mlir_values(obj, values[idx : idx + n])
+            idx += n
+            return result
+
+        new_params = _take(self.params)
+        new_num_persistent_clusters = _take(self.num_persistent_clusters)
+        new_cta_id_in_cluster = _take(self.cta_id_in_cluster)
+        new_current_work = _take(self.current_work)
+        new_fused_state = _take(self._fused_state)
+        new_num_fc1_intermediate_blocks = _take(self._num_fc1_intermediate_blocks)
+        new_num_fc2_hidden_blocks = _take(self._num_fc2_hidden_blocks)
+        new_dynamic_state = (
+            _take(self._dynamic_state)
+            if self.params.load_balance_mode == "atomic_counter"
+            else None
+        )
+        new_producer_state = _take(self._producer_state)
+
+        result = MoEFusedFc12PersistentTileScheduler.__new__(
+            MoEFusedFc12PersistentTileScheduler
+        )
+        result.params = new_params
+        result.num_persistent_clusters = new_num_persistent_clusters
+        result.cta_id_in_cluster = new_cta_id_in_cluster
+        result.current_work = new_current_work
+        result._fused_state = new_fused_state
+        result._num_fc1_intermediate_blocks = new_num_fc1_intermediate_blocks
+        result._num_fc2_hidden_blocks = new_num_fc2_hidden_blocks
+        result._dynamic_state = new_dynamic_state
+        result._ext = self._ext
+        result._pipeline = self._pipeline
+        result._smem_buf_tensor = self._smem_buf_tensor
+        result._num_sched_stages = self._num_sched_stages
+        result._cluster_pipeline = self._cluster_pipeline
+        result._producer_state = new_producer_state
+        # Python-only attrs: copy from prototype, not MLIR values.
+        result._sched_storage = self._sched_storage
+        result._first_advance_pending = self._first_advance_pending
+        return result

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/kernel_fc12.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/kernel_fc12.py
@@ -1,0 +1,2303 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Fused fc1+fc2 swap-AB SwiGLU NVFP4 kernel for SM100."""
+
+from typing import Literal, Optional, Tuple, Type
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+
+from .epilogue_refactor import (
+    NvFp4OptinalEpiArgs,
+    SwapABSwigluFp4Epilogue,
+)
+from .fc1_fc2_fuse_sched import (
+    BlockPhase,
+    MoEFusedFc12SchedulerParams,
+)
+from .custom_ext import SwapABSwigluFp4Fc12SchedExtension
+from common.megamoe_constants import (
+    Nvfp4BlockSize,
+    SupportedMmaTileM,
+    SupportedMmaTileN,
+)
+from .moe_utils import spin_wait
+from . import dynamic_mainloop
+from src.token_comm import CombineFormat
+
+
+# token_comm_args is an opaque subclass-owned bundle.  The base only forwards it
+# to hook methods; ``None`` keeps the lean fc1+fc2 path free of token-comm IR.
+
+
+# =============================================================================
+# Sm100SwapABSwigluFp4Fc12Kernel
+# =============================================================================
+
+
+class Sm100SwapABSwigluFp4Fc12Kernel:
+    """Fused fc1+fc2 swap-AB SwiGLU NVFP4 grouped GEMM for MoE on SM100.
+
+    This class owns the local fc1/fc2 GEMM pipeline and exposes token-comm
+    hooks for the MegaMoE subclass.
+    """
+
+    # SMEM budget for all "non-problem-tensor" buffers (mbarriers, sched
+    # work-tile buffer, TMEM allocator state).  Reserved at host side in
+    # ``_compute_stages``.  Bump if ``SharedStorage`` over-allocates SMEM.
+    _SmemMiscBudget = 1024
+
+    def __init__(
+        self,
+        # Geometry.
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mnk: Tuple[int, int, int],
+        use_2cta_instrs: bool,
+        # Fused fc1+fc2 scheduler knobs.
+        group_hint: int,
+        token_padding_block: int,
+        sf_padding_block: int,
+        load_balance_mode: Literal["static", "atomic_counter"] = "static",
+        # Optional scheduler/codegen knobs.
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,
+        force_static_sched: bool = True,
+        clc_bundle_size: Optional[int] = None,
+        num_sched_stages: Optional[int] = None,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        sf_vec_size: int = 16,
+        scenario: Literal["2Dx3D"] = "2Dx3D",
+        *,
+        fc2_output_dtype: Type[cutlass.Numeric],
+        non_ubulk_fc2_store: bool = True,
+        in_kernel_fc2_reduce: bool = False,
+        token_back_by_dispatch: bool = False,
+        apply_topk_in_fc1: bool = True,
+        gate_up_clamp: Optional[float] = None,
+        epi_flag_batch: Optional[Tuple[int, int]] = (1, 1),
+    ) -> None:
+        if not force_static_sched:
+            raise NotImplementedError(
+                "v1 only implements force_static_sched=True (lean 7-warp). "
+                "Dynamic CLC (force_static_sched=False) is not wired here."
+            )
+        if sf_vec_size != Nvfp4BlockSize:
+            raise NotImplementedError(
+                f"v1 only supports sf_vec_size={Nvfp4BlockSize} (NVFP4); "
+                f"got {sf_vec_size}."
+            )
+        if scenario != "2Dx3D":
+            raise NotImplementedError(
+                f"v1 fused fc12 only supports scenario='2Dx3D' (forward); "
+                f"got {scenario!r}."
+            )
+        if load_balance_mode not in ("static", "atomic_counter"):
+            raise ValueError(
+                f"load_balance_mode must be 'static' or 'atomic_counter'; "
+                f"got {load_balance_mode!r}."
+            )
+
+        self.acc_dtype = acc_dtype
+        self.mma_tiler_mnk = mma_tiler_mnk
+        self.cluster_shape_mn = (cluster_shape_mnk[0], cluster_shape_mnk[1])
+        self.use_2cta_instrs = use_2cta_instrs
+        self.force_static_sched = force_static_sched
+        self.static_expert_shape = static_expert_shape
+        self.clc_bundle_size = clc_bundle_size
+        self.num_sched_stages = num_sched_stages
+
+        # Fused fc12 sched-side knobs
+        self.group_hint = group_hint
+        self.token_padding_block = token_padding_block
+        self.sf_padding_block = sf_padding_block
+        self.load_balance_mode = load_balance_mode
+
+        self.sf_vec_size = sf_vec_size
+        self.scenario = scenario
+        self.arch = "sm_100"
+
+        self.fc2_output_dtype = fc2_output_dtype
+        self.non_ubulk_fc2_store = non_ubulk_fc2_store
+        self.in_kernel_fc2_reduce = in_kernel_fc2_reduce
+        self.token_back_by_dispatch = token_back_by_dispatch
+        self.apply_topk_in_fc1 = apply_topk_in_fc1
+        self.gate_up_clamp = gate_up_clamp
+        self.epi_flag_batch = epi_flag_batch
+
+        self._validate_mma_tiler_and_cluster_shape()
+        self.mma_tiler = mma_tiler_mnk
+
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        # Subclasses set this before __call__ reaches _setup_attributes.
+        self.enable_token_comm: bool = False
+
+        # Lean warp specialization; token-comm subclasses override it in setup.
+        self.occupancy = 1
+        self.epilogue_warp_id = (0, 1, 2, 3)
+        self.mma_warp_id = 4
+        self.tma_a_warp_id = 5
+        self.tma_b_warp_id = 6
+        self.sched_warp_id = 7
+        # Installed by token-comm subclasses.
+        self.dispatch_warp_id: Optional[Tuple[int, int, int, int]] = None
+        self.token_back_warp_id: Optional[Tuple[int, int, int, int]] = None
+        self.token_back_standalone: bool = False
+        self.threads_per_cta = 32 * len(
+            (
+                self.mma_warp_id,
+                self.tma_a_warp_id,
+                self.tma_b_warp_id,
+                self.sched_warp_id,
+                *self.epilogue_warp_id,
+            )
+        )
+
+        # Barrier 1 is reused by ordered epilogue rendezvous; IDs 2-7 are
+        # reserved for TMEM allocation/deallocation and subtile sync.
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+        self.tmem_dealloc_sync_bar_id = 3
+        self.epi_subtile_bar_ids = (4, 5, 6, 7)
+
+        # MegaMoE-only register policy.  Lean/base fc12 keeps its original
+        # register allocation because setmaxnreg emission is gated by
+        # ``self.enable_token_comm`` inside the device kernel.
+        self.epi_reg_cnt = 256
+        self.task_reg_cnt = 72
+
+        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
+
+    def name(self) -> str:
+        """Canonical encoding of the codegen-affecting constexpr -- the compiled-
+        kernel cache key. ``local_rank`` excluded (deployment detail); only
+        ``force_static_sched`` / ``clc_bundle_size`` / ``num_sched_stages`` /
+        ``scenario`` are dropped -- every other constexpr is kept."""
+        m, n, k = self.mma_tiler_mnk
+        cm, cn = self.cluster_shape_mn
+        exp = "x".join(map(str, self.static_expert_shape)) if self.static_expert_shape else "dyn"
+        epiflag = "x".join(map(str, self.epi_flag_batch)) if self.epi_flag_batch else "none"
+        cta = "2_cta" if self.use_2cta_instrs else "1_cta"
+        fc2store = "fc2store_stg" if self.non_ubulk_fc2_store else "fc2store_ublk"
+        inkred = "inkernel_redg" if self.in_kernel_fc2_reduce else "no_inkernel_redg"
+        apply_topk = "apply_topk_fc1_pre_quant" if self.apply_topk_in_fc1 else "apply_topk_after_fc2"
+        # token-back is a token-communication concept -- it lives in the MegaMoE
+        # subclass name(), not the lean base.
+        return (
+            "moe_fc12_fuse_nvfp4"
+            f"_mmatiler_{m}x{n}x{k}_cluster_{cm}x{cn}_{cta}_sched_{self.load_balance_mode}"
+            f"_expert_shape_{exp}_grouphint_{self.group_hint}"
+            f"_padding_{self.token_padding_block}x{self.sf_padding_block}"
+            f"_{fc2store}_{inkred}_{apply_topk}"
+            f"_fc2out{self.fc2_output_dtype.__name__}_sfvec{self.sf_vec_size}"
+            f"_acc{self.acc_dtype.__name__}_clamp{self.gate_up_clamp}_epiflag{epiflag}"
+        )
+
+    def _validate_mma_tiler_and_cluster_shape(self) -> None:
+        """Validate user-provided geometry against v1 fused-fc12 constraints.
+
+        ``mma_tiler_n`` is restricted to {128, 256}.  Short-N is handled by
+        the swap-AB scheduler via subtile-level early-exit.
+        """
+        m, n, k = self.mma_tiler_mnk
+        cm, cn = self.cluster_shape_mn
+
+        if m not in SupportedMmaTileM:
+            raise ValueError(
+                f"mma_tiler M ({m}) must be one of {SupportedMmaTileM}"
+            )
+
+        per_cta_m = m // (2 if self.use_2cta_instrs else 1)
+        if per_cta_m != 128:
+            raise ValueError(
+                f"per-CTA mma_tiler M must be 128, got {per_cta_m} "
+                f"(mma_tiler_m={m}, use_2cta_instrs={self.use_2cta_instrs})"
+            )
+
+        if n not in SupportedMmaTileN:
+            raise ValueError(
+                f"mma_tiler N ({n}) must be one of {SupportedMmaTileN} in fused fc12 "
+                f"(N=64 SFB hack is dropped; swap-AB sched handles short-N "
+                f"via subtile early-exit)."
+            )
+
+        sf_k_granularity = self.sf_vec_size * 4
+        if k % sf_k_granularity != 0:
+            raise ValueError(
+                f"mma_tiler K ({k}) must be a multiple of "
+                f"sf_vec_size * 4 = {sf_k_granularity}"
+            )
+
+        if cm % (2 if self.use_2cta_instrs else 1) != 0:
+            raise ValueError(
+                f"cluster_shape M ({cm}) must be even when use_2cta_instrs=True"
+            )
+
+        is_pow2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        if cm * cn > 16 or not is_pow2(cm) or not is_pow2(cn) or cm > 4 or cn > 4:
+            raise ValueError(
+                f"Invalid cluster_shape ({cm}, {cn}): each dim must be "
+                f"a power of 2 and <= 4, product must be <= 16"
+            )
+
+        # v1 swap-AB requires cluster_n == 1.
+        if cn != 1:
+            raise NotImplementedError(
+                f"v1 fused fc12 requires cluster_n == 1 (got {cn}).  "
+                f"cluster_n > 1 needs sentinel-style acc/ab pipeline release."
+            )
+
+    def _create_tiled_mmas(self) -> Tuple[cute.TiledMma, cute.TiledMma]:
+        """Return ``(tiled_mma, tiled_mma_sfb)``.
+
+        Both phases share the same MMA configuration because ``mma_tiler_mnk``
+        is shared.  Phase selection is
+        purely a matter of which TMA load fills SMEM / which acc TMEM stage
+        the MMA writes -- the tiled MMA atoms themselves are phase-invariant.
+
+        SFB always uses ``CtaGroup.ONE``: SFB is not multicast across the
+        2-CTA pair under ``use_2cta_instrs``.
+        """
+        common = (
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+        )
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            *common, self.cta_group, self.mma_inst_shape_mn,
+        )
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            *common, tcgen05.CtaGroup.ONE, self.mma_inst_shape_mn_sfb,
+        )
+        return tiled_mma, tiled_mma_sfb
+
+    def _setup_attributes(self) -> None:
+        """Set up MMA / cluster / tile shapes, SMEM layouts, stage counts.
+
+        The fc12 path shares ``mma_tiler_mnk`` and SMEM layouts across phases.
+        Warp topology / ``threads_per_cta`` are fixed in ``__init__`` (the
+        lean default here, the 12-warp MegaMoE layout in the token-comm
+        subclass), so this method does not touch them.
+        """
+        self.mma_inst_shape_mn = (self.mma_tiler[0], self.mma_tiler[1])
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma, tiled_mma_sfb = self._create_tiled_mmas()
+
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        assert self.mma_tiler[2] % mma_inst_shape_k == 0, (
+            f"mma_tiler K ({self.mma_tiler[2]}) must be a multiple of "
+            f"MMA instruction K ({mma_inst_shape_k})"
+        )
+
+        # SFB-specific tiler: rounded-up MN; same K as main tiler.
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Multicast CTA counts
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+
+        # Epilogue is autonomous: it owns all epi-side decisions (overlap,
+        # acc stages, subtile dispatch, TMA commit/drain, piggyback red.add).
+        # We pass kernel-level params + ``allow_overlap_acc`` hint and read
+        # the decisions back via @property below.
+        #
+        # ``fc1_output_dtype`` here is the fc1 NVFP4 output dtype (the
+        # dtype that lives in sC).  fc2 output dtype is hard-coded as
+        # ``BFloat16`` inside the epilogue's ``Fc2UnpackPermuteStg`` and
+        # does not flow through this knob.
+        # combine_format is comm-side state: the MegaMoE subclass injects
+        # ``self.combine_format`` before super().__init__, so it is already on
+        # ``self`` here; the standalone base defaults to the bf16 (no-quant)
+        # combine. Only hooks / token_comm_args otherwise cross into this base.
+        if not hasattr(self, "combine_format"):
+            self.combine_format = CombineFormat.parse("bf16")
+        self.epilogue = SwapABSwigluFp4Epilogue(
+            mma_tiler_mnk=self.mma_tiler,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_2cta_instrs=self.use_2cta_instrs,
+            sf_vec_size=self.sf_vec_size,
+            fc1_output_dtype=self.fc1_output_dtype,
+            combine_format=self.combine_format,
+            non_ubulk_fc2_store=self.non_ubulk_fc2_store,
+            in_kernel_fc2_reduce=self.in_kernel_fc2_reduce,
+            token_back_by_dispatch=self.token_back_by_dispatch,
+            epi_flag_batch=self.epi_flag_batch,
+            acc_dtype=self.acc_dtype,
+            allow_overlap_acc=True,
+            static_expert_shape=self.static_expert_shape,
+            gate_up_clamp=self.gate_up_clamp,
+        )
+
+        if self.num_sched_stages is None:
+            self.num_sched_stages = 2
+
+        # Refactored epilogue owns its fixed 8KB shared scratch.
+        c_bytes_total = self.epilogue.epi_smem_bytes
+
+        (
+            self.num_acc_stage,
+            self.num_ab_stage,
+            self.num_sched_stages,
+        ) = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.sf_dtype,
+            self.sf_vec_size,
+            c_bytes_total,
+            self.smem_capacity,
+            self.occupancy,
+            self.num_sched_stages,
+            self._smem_misc_budget_bytes(),
+        )
+        # print(
+        #     f"[fc12 stages] num_ab_stage={self.num_ab_stage} "
+        #     f"num_acc_stage={self.num_acc_stage} "
+        #     f"misc_budget={self._smem_misc_budget_bytes()} "
+        #     f"c_bytes_total={c_bytes_total} smem_cap={self.smem_capacity} "
+        #     f"token_back_standalone={self.token_back_standalone}"
+        # )
+
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        # Read epilogue's autonomous decisions.
+        self.overlapping_accum = self.epilogue.overlapping_accum
+        self.num_acc_pipeline_stages = self.epilogue.num_acc_pipeline_stages
+        self.num_acc_stage = self.epilogue.num_acc_stage
+        self.num_sfa_tmem_cols = (
+            max(self.epilogue.cta_tile_m // 128, 1)
+            * self.epilogue.cta_tile_k
+            // self.epilogue.sf_vec_size
+        )
+        self.num_sf_tmem_cols = self.epilogue.acc_sf_cols
+        self.num_accumulator_tmem_cols = (
+            self.epilogue.cta_tile_n * self.num_acc_stage
+            - (self.num_sf_tmem_cols if self.overlapping_accum else 0)
+        )
+
+        # TMA load bytes per stage (A + B + SFA + SFB).
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (
+            a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size
+        ) * atom_thr_size
+
+    def _smem_misc_budget_bytes(self) -> int:
+        """SMEM bytes reserved for everything outside the AB / SF stage
+        buffers and the ``sC`` epilogue staging.
+
+        Hook for subclasses that need additional SMEM regions outside
+        the base's main ``SharedStorage`` (e.g. MegaMoE dispatch warps
+        allocate their own pull_buffer / pull_mbar / smem_expert_count
+        via ``token_comm_extra_smem_storage_class``).  Subclass
+        overrides add their region size to the returned value so
+        ``_compute_stages`` properly subtracts it from the AB-stage
+        SMEM budget.  Base default returns the 1024-byte
+        miscellaneous reservation (mbarriers, sched work-tile buffer,
+        TMEM allocator state).
+        """
+        return self._SmemMiscBudget
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_bytes_total: int,
+        smem_capacity: int,
+        occupancy: int,
+        num_sched_stages: int,
+        misc_budget: int,
+    ) -> Tuple[int, int, int]:
+        """Compute stage counts for ACC, AB+SF, and scheduler.
+
+        ``misc_budget`` is the byte count consumed by everything
+        outside ``ab_bytes_per_stage * num_ab_stage + c_bytes_total``
+        (mbarriers / sched work-tile buffer / TMEM allocator state in
+        the lean path; plus the dispatch warps' pull_buffer / mbar /
+        per-CTA expert histogram under MegaMoE).  Provided by the
+        ``_smem_misc_budget_bytes`` hook so subclasses can extend the
+        reservation without touching this helper.
+        """
+        num_acc_stage = 2
+
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma, mma_tiler_mnk, a_dtype, 1,
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma, mma_tiler_mnk, b_dtype, 1,
+        )
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma, mma_tiler_mnk, sf_vec_size, 1,
+        )
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma, mma_tiler_mnk, sf_vec_size, 1,
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+
+        fixed_overhead = misc_budget + c_bytes_total
+
+        num_ab_stage = (
+            smem_capacity // occupancy - fixed_overhead
+        ) // ab_bytes_per_stage
+        return num_acc_stage, num_ab_stage, num_sched_stages
+
+    def get_workspace_size_in_bytes(
+        self,
+        fc1_activation_tensor,
+        fc1_weight_tensor,
+    ) -> int:
+        """Compute opaque workspace size for one fused fc1+fc2 launch."""
+        sf_padding_block = self.sf_padding_block
+        sf_vec_size = self.sf_vec_size
+
+        mma_tiler_n = self.mma_tiler_mnk[1]
+
+        data_total_rows, _hidden = fc1_activation_tensor.shape
+        experts, _hidden_w, intermediate_gateup = fc1_weight_tensor.shape
+        intermediate_downproj = intermediate_gateup // 2
+
+        # Conservative upper bound for sf_total_rows.
+        sf_total_rows_upper = data_total_rows + experts * sf_padding_block
+
+        # fc1_output: NVFP4 packs 2 elements per byte.  intermediate_downproj
+        # is always even (intermediate_gateup is a multiple of 32), so
+        # the division is exact.
+        fc1_output_bytes = data_total_rows * (intermediate_downproj // 2)
+
+        # fc1_output_sf: SF atom layout rounds inner SF-block axis to 4.
+        sf_block_cols = (
+            (intermediate_downproj // sf_vec_size) + 3
+        ) // 4 * 4
+        fc1_output_sf_bytes = sf_total_rows_upper * sf_block_cols
+
+        # fc1_done_counter: one Int32 per global token block, plus expert slack.
+        counter_slots_upper = (
+            (data_total_rows + mma_tiler_n - 1) // mma_tiler_n
+            + experts
+        )
+        fc1_done_counter_bytes = counter_slots_upper * 4
+
+        # load_balance_counter: Int32 scalar.
+        if self.load_balance_mode == "atomic_counter":
+            load_balance_counter_bytes = 4
+        else:
+            load_balance_counter_bytes = 0
+
+        total = (
+            fc1_output_bytes
+            + fc1_output_sf_bytes
+            + fc1_done_counter_bytes
+            + load_balance_counter_bytes
+        )
+
+        # 128B align (TMA tensor base address alignment requirement).
+        alignment = 128
+        total = ((total + alignment - 1) // alignment) * alignment
+        return total
+
+    # =============================================================================
+    # MegaMoE hooks (overridden by subclasses)
+    # =============================================================================
+    #
+    # The base class never emits any MegaMoE-specific PTX -- all hooks below are
+    # plain ``pass`` defaults, plus ``token_comm_extra_smem_storage_class`` which
+    # returns ``None``.  Subclasses that fuse dispatch / combine override these
+    # methods to (a) declare their extra SMEM struct, (b) acquire/peek the
+    # dispatch->fc1 release counter, (c) emit the dispatch warps' work body,
+    # (d) wire the kernel-tail rendezvous + cross-rank NVLink barrier.  No
+    # MegaMoE workspace name (l1_*, %smid, NVLink slot id, ...) ever leaks
+    # into the base; every such decision is the subclass's to make.
+    #
+    # Hooks are called from ``fc1fc2_kernel_impl`` and run inside ``@cute.kernel``
+    # tracing, so they may issue PTX / TMA / NamedBarrier / spin_wait freely.
+    # ``token_comm_args`` is forwarded as-is (the base never reads its fields).
+
+    def token_comm_extra_smem_storage_class(self) -> Optional[type]:
+        """Return an ``@cute.struct`` class for the subclass's extra SMEM
+        region (= ``token_comm_storage``), or ``None`` if no extra SMEM is
+        needed.  The base inner kernel allocates the returned struct
+        adjacent to the main ``SharedStorage`` and forwards the resulting
+        handle to ``token_comm_hook_dispatch_warp_body`` (the only hook
+        that consumes it in the current design)."""
+        return None
+
+    def token_comm_hook_fc1_ready_counter_ptr(self, token_comm_args):
+        """Return the pointer the sched-warp peek (inside
+        ``SwapABSwigluFp4Fc12SchedExtension``) should watch as the
+        dispatch->fc1 release counter, or ``None`` to disable the fc1
+        phase peek entirely.  Called once at ext construction time."""
+        return None
+
+    @cute.jit
+    def token_comm_hook_sched_warp_pre_init_wait(self, token_comm_args):
+        """Emitted on the sched warp BEFORE the late ``internal_init`` call.
+        Default: no-op (lean path: there is nothing to wait for).
+        MegaMoE: arrive_and_wait on the dispatch->sched NamedBarrier so the
+        sched warp does not read ``expert_recv_count_sum`` (= sizes view)
+        until this CTA's dispatch warps have walked through the cross-rank
+        NVLink slot=0 acquire fence inside ``_dispatch_barrier``."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_fc1_tma_b_predispatch_spin(
+        self, token_comm_args, work_tile_info,
+    ):
+        """Emitted on the TMA-B warp at the head of each fc1-phase task tile,
+        before its K-loop.  Default: no-op.  MegaMoE: blocking spin on the
+        dispatch->fc1 release counter at ``cumulative_token_block_count +
+        tile_n_idx`` until it reaches ``work_tile_info.valid_tokens_in_cta_tile``,
+        unless ``work_tile_info.peek_ready`` already saturated it.  Skipping
+        this in the lean path is correct because in the lean path the
+        per-tile input is already resident in GMEM at launch time."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_dispatch_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        """Subclass dispatch warp body; no-op in the lean kernel."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_token_back_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        """Subclass standalone token-back warp body; no-op in the lean kernel."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_kernel_tail(
+        self,
+        token_comm_args,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        """Subclass kernel-tail hook; no-op in the lean kernel."""
+        pass
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """SMEM → TMEM tiled copy + partition for SFA / SFB."""
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t, tCsSF_compact_s2t_
+        )
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    @cute.jit
+    def __call__(
+        self,
+        # ── fc1 (Linear1) problem tensors ────────────────────────────────
+        activation: cute.Tensor,           # (token_sum_padded, hidden) NVFP4
+        fc1_weight: cute.Tensor,           # (experts, hidden, intermediate_gateup) NVFP4
+        activation_sf: cute.Tensor,         # (token_sum_padded_sf, hidden / sf_vec_size) FP8
+        fc1_weight_sf: cute.Tensor,         # (experts, intermediate_gateup_padded * hidden / sf_vec_size) FP8
+        # ── fc1 workspace consumed as fc2 GEMM-B ─────────────────────────
+        fc1_output: cute.Tensor,         # (token_sum_padded, intermediate_downproj) NVFP4
+        fc1_output_sf: cute.Tensor,      # (token_sum_padded_sf, intermediate_downproj / sf_vec_size) FP8
+        # ── fc2 (Linear2) problem tensors ────────────────────────────────
+        fc2_weight: cute.Tensor,          # (experts, intermediate_downproj, hidden) NVFP4
+        fc2_weight_sf: cute.Tensor,        # (experts, hidden_padded * intermediate_downproj / sf_vec_size) FP8
+        # MoE-domain ``(token_max, topk, hidden)`` output.
+        fc2_output: cute.Tensor,
+        # ── topk weights (Path A) ────────────────────────────────────────
+        topk_scores: cute.Tensor,     # (token_sum_padded,) Float32
+        # ── Cross-phase workspace ────────────────────────────────────────
+        fc1_done_counter: cute.Tensor,  # (max_token_block_per_rank,) Int32
+        # ── Sched / runtime ──────────────────────────────────────────────
+        # Exactly one of ``offs`` or ``expert_token_sizes`` must be provided.
+        offs: Optional[cute.Tensor] = None,  # (experts,) Int32 cumulative end offsets
+        max_active_clusters: cutlass.Constexpr = None,
+        stream: cuda.CUstream = None,
+        # ── Optional epi-side scaling ────────────────────────────────────
+        fc1_alpha: Optional[cute.Tensor] = None,
+        fc2_alpha: Optional[cute.Tensor] = None,
+        fc1_norm_const: Optional[cute.Tensor] = None,
+        # ── Optional dynamic load-balance counter ────────────────────────
+        load_balance_counter: Optional[cute.Tensor] = None,
+        # ── Sizes-mode per-expert token count (MegaMoE path) ─────────────
+        # (experts,) Int32 raw token counts (NOT cumulative).
+        expert_token_sizes: Optional[cute.Tensor] = None,
+        # ── MegaMoE bundle (Optional) ────────────────────────────────────
+        # Opaque subclass bundle; None for the lean path.
+        token_comm_args=None,
+    ) -> None:
+        """Launch the fused fc1+fc2 swap-AB SwiGLU NVFP4 kernel."""
+
+        # Bind data-tensor shapes to codegen-time expert dims when requested.
+        # Strides, token rows, and SF tensors stay runtime-dynamic because they
+        # encode host padding/swizzle choices.
+        if cutlass.const_expr(self.static_expert_shape is not None):
+            (
+                experts_static,
+                intermediate_gateup_static,
+                hidden_static,
+            ) = self.static_expert_shape
+            intermediate_downproj_static = intermediate_gateup_static // 2
+
+            fc1_weight = cute.make_tensor(
+                fc1_weight.iterator,
+                cute.make_layout(
+                    (experts_static, hidden_static, intermediate_gateup_static),
+                    stride=fc1_weight.stride,
+                ),
+            )
+            fc2_weight = cute.make_tensor(
+                fc2_weight.iterator,
+                cute.make_layout(
+                    (experts_static, intermediate_downproj_static, hidden_static),
+                    stride=fc2_weight.stride,
+                ),
+            )
+            activation = cute.make_tensor(
+                activation.iterator,
+                cute.make_layout(
+                    (activation.shape[0], hidden_static),
+                    stride=activation.stride,
+                ),
+            )
+            fc1_output = cute.make_tensor(
+                fc1_output.iterator,
+                cute.make_layout(
+                    (fc1_output.shape[0], intermediate_downproj_static),
+                    stride=fc1_output.stride,
+                ),
+            )
+            # fc2_output is MoE-domain ``(token_max, topk, hidden)``; bind
+            # the hidden dim to its codegen-time const but keep ``topk``
+            # caller-supplied (lean = 1 const, MegaMoE = num_topk const,
+            # both already folded by the caller) and ``token_max`` runtime.
+            fc2_output = cute.make_tensor(
+                fc2_output.iterator,
+                cute.make_layout(
+                    (fc2_output.shape[0], fc2_output.shape[1], hidden_static),
+                    stride=fc2_output.stride,
+                ),
+            )
+
+        # ── GEMM-domain fake-MNKL transform (swap-AB) for fc1 phase ──
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int32(0)
+
+        def round_up(value, multiple):
+            return ((value + multiple - 1) // multiple) * multiple
+
+        def is_constexpr_int(*values) -> bool:
+            return all(isinstance(value, int) for value in values)
+
+        # A_gemm (fc1 weights): (experts, hidden, intermediate_gateup)
+        # -> (M=intermediate_gateup, K=hidden, L=experts).
+        experts, hidden_b, intermediate_gateup = fc1_weight.shape
+        fc1_weight_gemm = cute.make_tensor(
+            fc1_weight.iterator,
+            cute.make_layout(
+                (cutlass.Int32(intermediate_gateup), cutlass.Int32(hidden_b), cutlass.Int32(experts)),
+                stride=(fc1_weight.stride[2], fc1_weight.stride[1], fc1_weight.stride[0]),
+            ),
+        )
+
+        # B_gemm (fc1 activations): (tokens_sum, hidden) -> (N, K, L=1).
+        tokens_sum, hidden = activation.shape
+        activation_gemm = cute.make_tensor(
+            activation.iterator,
+            cute.make_layout(
+                (tokens_sum, cutlass.Int32(hidden), c1),
+                stride=(activation.stride[0], activation.stride[1], 0),
+            ),
+        )
+
+        # C_gemm is a user-view output tensor; epilogue owns its store path.
+        intermediate_downproj = fc1_output.shape[1]
+        fc1_output_gemm = cute.make_tensor(
+            fc1_output.iterator,
+            cute.make_layout(
+                (tokens_sum, cutlass.Int32(intermediate_downproj), c1),
+                stride=(fc1_output.stride[0], fc1_output.stride[1], 0),
+            ),
+        )
+
+        # SFA / SFB scale tensors (atom-tiled) — fc1 phase.
+        #   SFA (mma M-side) = fc1_weight_sf (weight scales)
+        #   SFB (mma N-side) = activation_sf (activation scales)
+        tokens_sum_padded = activation_sf.shape[0]
+        hidden_padded = activation_sf.shape[1] * self.sf_vec_size
+        activation_sf_gemm = cute.make_tensor(
+            activation_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded, cutlass.Int32(hidden_padded), c1), self.sf_vec_size
+            ),
+        )
+        intermediate_gateup_padded = round_up(
+            intermediate_gateup, self.sf_vec_size * 4,
+        )
+        expected_fc1_weight_sf_cols = (
+            intermediate_gateup_padded * hidden_padded // self.sf_vec_size
+        )
+        if cutlass.const_expr(
+            is_constexpr_int(fc1_weight_sf.shape[1], expected_fc1_weight_sf_cols)
+        ):
+            if cutlass.const_expr(fc1_weight_sf.shape[1] != expected_fc1_weight_sf_cols):
+                raise ValueError(
+                    f"fc1_weight_sf.shape[1] ({fc1_weight_sf.shape[1]}) does not "
+                    f"match intermediate_padded({intermediate_gateup_padded}) * "
+                    f"hidden_padded({hidden_padded}) / sf_vec_size({self.sf_vec_size}) "
+                    f"= {expected_fc1_weight_sf_cols}."
+                )
+        fc1_weight_sf_gemm = cute.make_tensor(
+            fc1_weight_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (cutlass.Int32(intermediate_gateup_padded), cutlass.Int32(hidden_padded), cutlass.Int32(experts)),
+                self.sf_vec_size,
+            ),
+        )
+
+        # ── GEMM-domain transform for fc2 phase ──
+        #
+        # fc2 roles: M=hidden, N=tokens_sum, K=intermediate_downproj.
+
+        # A_gemm (fc2 weights): (experts, intermediate_downproj, hidden)
+        # -> (M=hidden, K=intermediate_downproj, L=experts).
+        experts2, intermediate_downproj_b2, hidden_b2 = fc2_weight.shape
+        fc2_weight_gemm = cute.make_tensor(
+            fc2_weight.iterator,
+            cute.make_layout(
+                (cutlass.Int32(hidden_b2), cutlass.Int32(intermediate_downproj_b2), cutlass.Int32(experts2)),
+                stride=(fc2_weight.stride[2], fc2_weight.stride[1], fc2_weight.stride[0]),
+            ),
+        )
+
+        # fc2 phase B operand = fc1 output reused (no new view needed:
+        # ``fc1_output_gemm`` was built from ``fc1_output.iterator`` with the same
+        # (tokens_sum, intermediate_downproj, fake-L=1) layout that fc2's
+        # GEMM-B view wants; reuse it directly when wiring fc2 TMA-B atom).
+
+        # fc2_output is MoE-domain ``(token_max, topk, hidden)`` already;
+        # we do NOT build a GEMM-domain wrapper for it.  The epilogue builds
+        # a full CTA-token-tile return view from ``token_comm_args`` and
+        # resolves per-token destinations inside the fc2 store path.  No
+        # sched ext ``"c"`` path in this kernel anymore.
+
+        # SFA / SFB for fc2:
+        #   SFA (mma M-side) = fc2_weight_sf (fc2 weight scales)
+        #   SFB (mma N-side) = fc1_output_sf (post-SwiGLU NVFP4 SFs from fc1)
+        # fc2 output has no SF; no SFC built.
+        tokens_sum_padded_sf = fc1_output_sf.shape[0]
+        intermediate_downproj_padded = fc1_output_sf.shape[1] * self.sf_vec_size
+        fc1_output_sf_gemm_for_fc2_load = cute.make_tensor(
+            fc1_output_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded_sf, cutlass.Int32(intermediate_downproj_padded), c1),
+                self.sf_vec_size,
+            ),
+        )
+        hidden_padded_fc2 = round_up(hidden_b2, 128)
+        intermediate_downproj_padded = round_up(
+            intermediate_downproj_b2, self.sf_vec_size * 4,
+        )
+        expected_fc2_weight_sf_cols = (
+            hidden_padded_fc2 * intermediate_downproj_padded // self.sf_vec_size
+        )
+        if cutlass.const_expr(
+            is_constexpr_int(fc2_weight_sf.shape[1], expected_fc2_weight_sf_cols)
+        ):
+            if cutlass.const_expr(fc2_weight_sf.shape[1] != expected_fc2_weight_sf_cols):
+                raise ValueError(
+                    f"fc2_weight_sf.shape[1] ({fc2_weight_sf.shape[1]}) does not "
+                    f"match hidden_padded({hidden_padded_fc2}) * "
+                    f"intermediate_padded({intermediate_downproj_padded}) / "
+                    f"sf_vec_size({self.sf_vec_size}) = {expected_fc2_weight_sf_cols}."
+                )
+        fc2_weight_sf_gemm = cute.make_tensor(
+            fc2_weight_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (cutlass.Int32(hidden_padded_fc2), cutlass.Int32(intermediate_downproj_padded), cutlass.Int32(experts2)),
+                self.sf_vec_size,
+            ),
+        )
+
+        expert_cnt = experts
+        # ``intermediate_gateup`` (= fc1_weight.shape[2]) is what we pass to the
+        # scheduler via ``expert_shape``; see ``MoESchedulerParamsBase``
+        # docstring for the precise contract.
+        hidden_dim = hidden
+
+        # ── Infer dtypes and major modes ──
+        # Phases share dtypes by construction (fc1_weight and fc2_weight are
+        # both NVFP4; activation and fc1_output are both NVFP4; scales are
+        # all FP8).  ``self.fc1_output_dtype`` selects the fc1 NVFP4 output
+        # that lives in sC; passed to the epilogue ctor as ``fc1_output_dtype``.
+        self.a_dtype: Type[cutlass.Numeric] = fc1_weight_gemm.element_type
+        self.b_dtype: Type[cutlass.Numeric] = activation_gemm.element_type
+        self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = fc1_weight_sf_gemm.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(fc1_weight_gemm).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(activation_gemm).mma_major_mode()
+
+        self._setup_attributes()
+        tiled_mma, tiled_mma_sfb = self._create_tiled_mmas()
+
+        # ── fc1 TMA atoms ──
+
+        # TMA load A1 (= fc1 weights)
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_fc1_weight, tma_tensor_fc1_weight = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            fc1_weight_gemm,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load B1 (= fc1 activations)
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_activation, tma_tensor_activation = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            activation_gemm,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load SFA1 (= fc1_weight_sf, fc1 weight SFs)
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_fc1_weight_sf, tma_tensor_fc1_weight_sf = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            fc1_weight_sf_gemm,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Uint16,
+        )
+
+        # TMA load SFB1 (= activation_sf, fc1 activation SFs)
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_activation_sf, tma_tensor_activation_sf = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            activation_sf_gemm,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint16,
+        )
+
+        # TMA store for fc1 NVFP4 output (via SMEM-staged bulk store).
+        # Per-subtile issue lives in
+        # ``self.epilogue.tma_store_fc1_output``; commit / drain lives
+        # inside the epilogue's ``run`` loop body.
+        fc1_output_tma_op = cpasync.CopyBulkTensorTileS2GOp()
+        fc1_output_smem_layout = self.epilogue.fc1_staged_smem_layout(
+            1,
+            without_stage_mode=True,
+        )
+        fc1_output_epi_tile = (
+            self.epilogue._EpilogueTokenTileSize,
+            self.epilogue._EpilogueFc1IntermediateDownTileSize,
+        )
+        tma_atom_fc1_output, tma_tensor_fc1_output = cpasync.make_tiled_tma_atom(
+            fc1_output_tma_op,
+            fc1_output_gemm,
+            fc1_output_smem_layout,
+            fc1_output_epi_tile,
+        )
+
+        # fc1 SFC GMEM tensor (= fc1_output_sf user view).  No TMA atom; it is
+        # per-thread STG.
+        fc1_output_sf_gemm = cute.make_tensor(
+            fc1_output_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded, intermediate_downproj, c1),
+                self.sf_vec_size,
+            ),
+        )
+
+        # ── fc2 TMA atoms: same SMEM layouts, phase-specific descriptors. ──
+
+        tma_atom_fc2_weight, tma_tensor_fc2_weight = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            fc2_weight_gemm,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        tma_atom_fc1_output_as_fc2_input, tma_tensor_fc1_output_as_fc2_input = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            fc1_output_gemm,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+        tma_atom_fc2_weight_sf, tma_tensor_fc2_weight_sf = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            fc2_weight_sf_gemm,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Uint16,
+        )
+        tma_atom_fc1_output_sf_as_fc2_input, tma_tensor_fc1_output_sf_as_fc2_input = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            fc1_output_sf_gemm_for_fc2_load,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint16,
+        )
+
+        # ── Scheduler params + grid + launch ──
+        #
+        # ``expert_cnt`` / ``intermediate_gateup`` / ``hidden_dim`` are
+        # extracted from the (possibly rewritten) tensor shapes above:
+        #   - static path (``static_expert_shape`` bound): they are
+        #     codegen-time Python int constants; the new base
+        #     ``MoESchedulerParamsBase.__init__`` preserves the Python
+        #     int type and ``__extract_mlir_values__`` skips them, so
+        #     they remain inlined literals across the scheduler's scf
+        #     region boundaries (no demotion to iter_arg / kernel-arg).
+        #   - dynamic path: they are runtime Int32 from tensor metadata.
+        #
+        # ``expert_shape[1]`` carries ``intermediate_gateup`` semantics
+        # (= fc1_weight.shape[2]) per the ``MoESchedulerParamsBase.__init__``
+        # contract.  The fused fc12 scheduler reads it as fc1 GEMM-M
+        # (under swap-AB) and derives ``num_fc1_intermediate_blocks``
+        # from it.
+        # atomic_counter mode requires a host-allocated GMEM Int32 scalar
+        # whose pointer lives in scheduler params; static mode passes
+        # None (params validate this).  Caller's contract from __call__:
+        # ``load_balance_counter`` is required iff ``load_balance_mode ==
+        # 'atomic_counter'``; otherwise may be None.
+        if cutlass.const_expr(self.load_balance_mode == "atomic_counter"):
+            if cutlass.const_expr(load_balance_counter is None):
+                raise ValueError(
+                    "load_balance_counter must be provided when "
+                    "load_balance_mode == 'atomic_counter'"
+                )
+            load_balance_counter_ptr = load_balance_counter.iterator
+        else:
+            load_balance_counter_ptr = None
+
+        # Pick the scheduler data source.  Exactly one of ``offs`` /
+        # ``expert_token_sizes`` is non-None (caller's contract; also
+        # re-checked by ``MoEFusedFc12SchedulerParams`` below).  The
+        # lean fc1+fc2 path goes through ``offs`` (cumulative-end, host
+        # precomputed); the MegaMoE subclass goes through
+        # ``expert_token_sizes`` (zero-copy ``i32 stride=(2,)`` view onto
+        # ``expert_recv_count_sum`` so the sched warp can walk per-expert
+        # token counts produced earlier in the same launch by the
+        # dispatch warps).  Routing happens at codegen time via the
+        # const-expr discrimination inside the scheduler.
+        if cutlass.const_expr((offs is None) == (expert_token_sizes is None)):
+            raise ValueError(
+                "Exactly one of `offs` / `expert_token_sizes` must be "
+                "provided; got "
+                f"offs={'set' if offs is not None else 'None'}, "
+                f"expert_token_sizes="
+                f"{'set' if expert_token_sizes is not None else 'None'}."
+            )
+        sched_params = MoEFusedFc12SchedulerParams(
+            scenario=self.scenario,
+            expert_shape=(expert_cnt, intermediate_gateup, hidden_dim),
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            group_hint=self.group_hint,
+            token_padding_block=self.token_padding_block,
+            sf_padding_block=self.sf_padding_block,
+            load_balance_mode=self.load_balance_mode,
+            load_balance_counter_ptr=load_balance_counter_ptr,
+            override_num_stages=self.num_sched_stages,
+            is_swap_ab=True,
+            expert_token_prefix_sum=offs,
+            expert_token_sizes=expert_token_sizes,
+        )
+        grid = sched_params.get_grid_shape(max_active_clusters)
+
+        # ``token_comm_args`` is the MegaMoE-only bundle (Optional, accepted
+        # via the public ``__call__`` kwarg above).  When None (lean base
+        # usage), every MegaMoE-specific code branch inside the device
+        # kernel is gated by ``cutlass.const_expr(token_comm_args is not
+        # None)`` and vanishes at codegen time.
+
+        self.fc1fc2_kernel_impl(
+            tiled_mma,
+            tiled_mma_sfb,
+            # fc1 TMA atoms / tensors
+            tma_atom_fc1_weight,
+            tma_tensor_fc1_weight,
+            tma_atom_activation,
+            tma_tensor_activation,
+            tma_atom_fc1_weight_sf,
+            tma_tensor_fc1_weight_sf,
+            tma_atom_activation_sf,
+            tma_tensor_activation_sf,
+            tma_atom_fc1_output,
+            tma_tensor_fc1_output,
+            # fc2 TMA atoms / tensors
+            tma_atom_fc2_weight,
+            tma_tensor_fc2_weight,
+            tma_atom_fc1_output_as_fc2_input,
+            tma_tensor_fc1_output_as_fc2_input,
+            tma_atom_fc2_weight_sf,
+            tma_tensor_fc2_weight_sf,
+            tma_atom_fc1_output_sf_as_fc2_input,
+            tma_tensor_fc1_output_sf_as_fc2_input,
+            # GEMM-domain tensors (fc1)
+            fc1_weight_gemm,
+            activation_gemm,
+            fc1_output_gemm,
+            fc1_weight_sf_gemm,
+            activation_sf_gemm,
+            fc1_output_sf_gemm,
+            # GEMM-domain tensors (fc2; fc2's GEMM-B view = fc1_output_gemm
+            # reused, so it is NOT re-passed here).  ``fc2_output`` stays
+            # in MoE-domain ``(token_max, topk, hidden)`` -- the inner
+            # kernel forwards it directly to the epilogue return tile.
+            fc2_weight_gemm,
+            fc2_output,
+            fc2_weight_sf_gemm,
+            fc1_output_sf_gemm_for_fc2_load,
+            # topk + cross-phase sync workspace
+            topk_scores,
+            fc1_done_counter,
+            # Optional epilogue runtime args
+            fc1_alpha,
+            fc2_alpha,
+            fc1_norm_const,
+            # Scheduling (``offs`` now lives inside ``sched_params`` as
+            # ``expert_token_prefix_sum``; the inner kernel reads it via
+            # ``self.params`` and no longer needs a separate copy).
+            sched_params,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            # SMEM layouts
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            # MegaMoE bundle (None under the lean path).
+            token_comm_args,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=self.occupancy,
+        )
+
+    @cute.kernel
+    def fc1fc2_kernel_impl(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        # fc1 TMA atoms / tensors
+        tma_atom_fc1_weight: cute.CopyAtom,
+        tma_tensor_fc1_weight: cute.Tensor,
+        tma_atom_activation: cute.CopyAtom,
+        tma_tensor_activation: cute.Tensor,
+        tma_atom_fc1_weight_sf: cute.CopyAtom,
+        tma_tensor_fc1_weight_sf: cute.Tensor,
+        tma_atom_activation_sf: cute.CopyAtom,
+        tma_tensor_activation_sf: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        tma_tensor_fc1_output: cute.Tensor,
+        # fc2 TMA atoms / tensors
+        tma_atom_fc2_weight: cute.CopyAtom,
+        tma_tensor_fc2_weight: cute.Tensor,
+        tma_atom_fc1_output_as_fc2_input: cute.CopyAtom,
+        tma_tensor_fc1_output_as_fc2_input: cute.Tensor,
+        tma_atom_fc2_weight_sf: cute.CopyAtom,
+        tma_tensor_fc2_weight_sf: cute.Tensor,
+        tma_atom_fc1_output_sf_as_fc2_input: cute.CopyAtom,
+        tma_tensor_fc1_output_sf_as_fc2_input: cute.Tensor,
+        # GEMM-domain tensors (fc1)
+        fc1_weight_gemm: cute.Tensor,
+        activation_gemm: cute.Tensor,
+        fc1_output_gemm: cute.Tensor,
+        fc1_weight_sf_gemm: cute.Tensor,
+        activation_sf_gemm: cute.Tensor,
+        fc1_output_sf_gemm: cute.Tensor,
+        # GEMM-domain tensors (fc2; fc2's GEMM-B view = ``fc1_output_gemm``
+        # reused, so it is NOT in this list -- see the caller).
+        # ``fc2_output`` is MoE-domain ``(token_max, topk, hidden)`` --
+        # no GEMM-domain wrapper is built; the epilogue return tile consumes
+        # the MoE-domain shape directly.
+        fc2_weight_gemm: cute.Tensor,
+        fc2_output: cute.Tensor,
+        fc2_weight_sf_gemm: cute.Tensor,
+        fc1_output_sf_gemm_for_fc2_load: cute.Tensor,
+        # topk + cross-phase sync workspace
+        topk_scores: cute.Tensor,
+        fc1_done_counter: cute.Tensor,
+        # Optional epilogue runtime args
+        fc1_alpha: Optional[cute.Tensor],
+        fc2_alpha: Optional[cute.Tensor],
+        fc1_norm_const: Optional[cute.Tensor],
+        # Scheduling (the per-expert token range tensor is carried inside
+        # ``sched_params`` as ``expert_token_prefix_sum`` or
+        # ``expert_token_sizes`` -- never passed separately).
+        sched_params: MoEFusedFc12SchedulerParams,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        # SMEM layouts
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        # MegaMoE-only bundle (None for the lean fc1+fc2 path).  All
+        # MegaMoE-specific code (dispatch warps emit, fc1 spin on
+        # ``l1_arrival_count``, combine STG redirect, kernel-tail NVLink
+        # barrier) is gated by ``cutlass.const_expr(token_comm_args is not
+        # None)`` so when None those branches vanish at codegen time.
+        token_comm_args=None,
+    ):
+        """Device kernel for fused fc1+fc2 swap-AB SwiGLU NVFP4 grouped GEMM.
+
+        Lean (``force_static_sched=True``) path: 7-warp specialization with
+        no empty / drain_aux warps and no expert-wise TMA desc rewriting
+        (every desc is tile-invariant under swap-AB).
+
+        Epilogue is fully owned by ``self.epilogue.run(...)`` -- the four epi
+        warps make a single call that drives the entire 2-phase task-tile
+        loop (acc consumer state, subtile dispatch, TMA commit/drain, and
+        the piggyback ``red.release.gpu.add.s32`` to ``fc1_done_counter``).
+        """
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, None, 0))
+        sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, None, 0))
+
+        # fc2 waits for all fc1 intermediate CTAs in the same token block.
+        ext_fc2_spin_threshold = (
+            fc1_weight_gemm.shape[0] + self.cta_tile_shape_mnk[0] - 1
+        ) // self.cta_tile_shape_mnk[0]
+
+        # The ``token_comm_hook_fc1_ready_counter_ptr`` hook lets a MegaMoE
+        # subclass plug in the dispatch->fc1 release counter pointer so the
+        # ext's sched-warp peek can cover the fc1 phase as well.  Base
+        # returns None, leaving the lean fc1+fc2 path with only the
+        # fc1->fc2 peek active.
+        ext = SwapABSwigluFp4Fc12SchedExtension(
+            sf_vec_size=self.sf_vec_size,
+            fc1_done_counter_ptr=fc1_done_counter.iterator,
+            fc2_spin_threshold=ext_fc2_spin_threshold,
+            fc1_ready_counter_ptr=self.token_comm_hook_fc1_ready_counter_ptr(
+                token_comm_args
+            ),
+        )
+
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        bidx, _, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+
+        # SharedStorage.
+        SchedCls = sched_params.get_scheduler_type()
+        SchedStorage = SchedCls.make_storage_struct(
+            sched_params, ext, num_drain_warps=0
+        )
+
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.num_acc_pipeline_stages * 2
+            ]
+            sched_storage: SchedStorage
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        # MegaMoE-only ``token_comm_storage``: standalone SMEM region whose
+        # struct shape is owned by the subclass (e.g. dispatch pull_buffer
+        # / per-warp mbarriers / per-expert SMEM histogram).  Kept disjoint
+        # from the base ``SharedStorage`` so the lean path neither allocates
+        # nor names it.  None when the subclass returns None (base default);
+        # any subclass that needs SMEM returns its own ``@cute.struct``
+        # class from ``token_comm_extra_smem_storage_class`` and consumes
+        # the handle inside ``token_comm_hook_dispatch_warp_body``.
+        TokenCommStorageCls = self.token_comm_extra_smem_storage_class()
+        if cutlass.const_expr(TokenCommStorageCls is not None):
+            token_comm_storage = smem.allocate(TokenCommStorageCls)
+        else:
+            token_comm_storage = None
+
+        epi_smem_storage = smem.allocate(self.epilogue.get_epi_storage_type())
+
+        # ── Pipelines: two TMA producer warps share the AB pipeline. ──
+
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, 2
+        )
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes // 2,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = (
+            len(self.epilogue_warp_id) * 32 * (2 if use_2cta_instrs else 1)
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_pipeline_stages,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # TMEM allocator
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+        )
+
+        # Sched
+        num_sched_consumer_threads = 32 * len(
+            (
+                self.tma_a_warp_id,
+                self.tma_b_warp_id,
+                self.mma_warp_id,
+                *self.epilogue_warp_id,
+            )
+        )
+        scheduler = SchedCls.create(
+            sched_params,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            sched_storage=storage.sched_storage,
+            num_consumer_threads=num_sched_consumer_threads,
+            ext=ext,
+        )
+        sched_consumer = scheduler.make_consumer()
+
+        # Early-init iff ``internal_init`` does NOT depend on sizes.  Sizes
+        # under MegaMoE come from ``expert_recv_count_sum`` filled by the
+        # dispatch warps; if static load-balance mode + token_comm are
+        # both active, ``internal_init`` walks the per-expert sizes during
+        # the first-tile decode and MUST run AFTER the dispatch_barrier
+        # completes (i.e. after the sched warp drains NamedBarrier 9 in
+        # the per-warp split below).  The other three combos can keep the
+        # existing "atomic overlaps cluster barrier" timing.
+        early_internal_init = (
+            (self.load_balance_mode == "atomic_counter")
+            or (not self.enable_token_comm)
+        )
+
+        # Issue the first scheduler claim before cluster init wait so the
+        # atomic/offets latency overlaps with pipeline setup.
+        if cutlass.const_expr(early_internal_init):
+            scheduler.internal_init(
+                warp_idx=warp_idx,
+                sched_warp_id=self.sched_warp_id,
+            )
+
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        # ── SMEM tensors A / B / SFA / SFB (shared by fc1 / fc2) ──
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+        sSFA = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfa_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sSFB = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfb_smem_layout_staged,
+            byte_alignment=128,
+        )
+
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+
+        # tCtAcc_fake layout: (MMA, MMA_M, MMA_N, STAGE).
+        tCtAcc_fake = tiled_mma.make_fragment_C(
+            cute.append(acc_shape, self.num_acc_stage)
+        )
+        if cutlass.const_expr(self.overlapping_accum):
+            acc_stage_stride = (
+                self.epilogue.cta_tile_n - self.epilogue.overlapped_tmem_cols
+            )
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        acc_stage_stride * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+
+        # Cluster wait before TMEM alloc.
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        mma_tiler_k = self.mma_tiler[2]
+        # ``fc1_weight_gemm.shape[1]`` / ``fc2_weight_gemm.shape[1]``
+        # both resolve to ``hidden`` / ``intermediate_downproj``.  Under
+        # ``static_expert_shape`` they are codegen-time Python ints
+        # (rewritten on ``fc1_weight`` / ``fc2_weight`` at ``__call__``
+        # entry); otherwise they are runtime Int32 from tensor metadata.
+        # The arithmetic below folds to an immediate in the static path.
+        k_tile_cnt_fc1 = (fc1_weight_gemm.shape[1] + mma_tiler_k - 1) // mma_tiler_k
+        k_tile_cnt_fc2 = (fc2_weight_gemm.shape[1] + mma_tiler_k - 1) // mma_tiler_k
+
+        # ════════════════════════════════════════════════════════════════════
+        # Scheduler warp (warp 7)
+        # ════════════════════════════════════════════════════════════════════
+        if warp_idx == self.sched_warp_id:
+            if cutlass.const_expr(self.enable_token_comm):
+                cute.arch.warpgroup_reg_dealloc(self.task_reg_cnt)
+
+            # MegaMoE subclass uses this hook to wait for this CTA's
+            # dispatch warps to finish ``_dispatch_barrier`` -- only then
+            # is ``expert_recv_count_sum`` (and therefore the sizes view
+            # the scheduler reads in static mode, plus everything
+            # dispatch_pull writes per token) visible.  Base no-op:
+            # nothing to wait for in the lean path.
+            self.token_comm_hook_sched_warp_pre_init_wait(token_comm_args)
+            # Late init (only token_comm + static lands here -- the other
+            # three combos finished ``internal_init`` before
+            # pipeline_init_arrive above and ``early_internal_init`` is
+            # True for them).
+            if cutlass.const_expr(not early_internal_init):
+                scheduler.internal_init(
+                    warp_idx=warp_idx,
+                    sched_warp_id=self.sched_warp_id,
+                )
+            scheduler.gen_next_work()
+            while scheduler.current_work.is_valid_tile:
+                ext.prefetch_for_expert(scheduler.current_work.expert_idx)
+                scheduler.publish_work()
+                scheduler.gen_next_work()
+            # Sentinel publish (current_work is already invalid here).
+            scheduler.publish_work()
+            scheduler.produce_tail()
+
+        # ════════════════════════════════════════════════════════════════════
+        # TMA load warps (warps 5 / 6)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # TMA-A loads weights/SFA; TMA-B loads activations/SFB and waits for
+        # fc1 workspace readiness in fc2 phase.  Both feed the same AB pipeline.
+
+
+        # ── TMA-A warp (warp 5) ─────────────────────────────────────────────
+        if warp_idx == self.tma_a_warp_id:
+            if cutlass.const_expr(self.enable_token_comm):
+                cute.arch.warpgroup_reg_dealloc(self.task_reg_cnt)
+
+            a_full_mcast_mask = None
+            sfa_full_mcast_mask = None
+            if cutlass.const_expr(self.is_a_mcast or use_2cta_instrs):
+                a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+                sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+
+            a_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+            )
+            sfa_cta_layout = a_cta_layout
+
+            thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+
+                if is_phase_linear1:
+                    # ── fc1 phase A-side ─────────────────────────────────
+                    iket.range_push("tma_weight_fc1")
+                    k_tile_cnt = k_tile_cnt_fc1
+                    real_a, desc_ptr_a = ext.get_gmem_tensor(
+                        "a", tma_tensor_fc1_weight, work_tile_info,
+                    )
+                    real_sfa, desc_ptr_sfa = ext.get_gmem_tensor(
+                        "sfa", tma_tensor_fc1_weight_sf, work_tile_info,
+                    )
+
+                    gA_mkl = cute.local_tile(
+                        real_a,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    gSFA_mkl = cute.local_tile(
+                        real_sfa,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    tCgA = thr_mma.partition_A(gA_mkl)
+                    tCgSFA = thr_mma.partition_A(gSFA_mkl)
+
+                    tAsA, tAgA = cpasync.tma_partition(
+                        tma_atom_fc1_weight,
+                        block_in_cluster_coord_vmnk[2],
+                        a_cta_layout,
+                        cute.group_modes(sA, 0, 3),
+                        cute.group_modes(tCgA, 0, 3),
+                    )
+                    tAsSFA, tAgSFA = cpasync.tma_partition(
+                        tma_atom_fc1_weight_sf,
+                        block_in_cluster_coord_vmnk[2],
+                        sfa_cta_layout,
+                        cute.group_modes(sSFA, 0, 3),
+                        cute.group_modes(tCgSFA, 0, 3),
+                    )
+                    tAsSFA = cute.filter_zeros(tAsSFA)
+                    tAgSFA = cute.filter_zeros(tAgSFA)
+
+                    mma_tile_m = work_tile_info.tile_m_idx // cute.size(
+                        tiled_mma.thr_id.shape
+                    )
+                    tAgA_slice = tAgA[(None, mma_tile_m, None, 0)]
+                    tAgSFA_slice = tAgSFA[(None, mma_tile_m, None, 0)]
+
+                    ab_producer.reset()
+                    peek_ab_empty_status = ab_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = ab_producer.acquire_and_advance(
+                            peek_ab_empty_status
+                        )
+                        peek_ab_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_ab_empty_status = ab_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc1_weight,
+                            tAgA_slice[(None, handle.count)],
+                            tAsA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_a,
+                            mcast_mask=a_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc1_weight_sf,
+                            tAgSFA_slice[(None, handle.count)],
+                            tAsSFA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfa,
+                            mcast_mask=sfa_full_mcast_mask,
+                        )
+                else:
+                    # ── fc2 phase A-side (no readiness gate) ─────────────
+                    iket.range_push("tma_weight_fc2")
+                    k_tile_cnt = k_tile_cnt_fc2
+                    real_a, desc_ptr_a = ext.get_gmem_tensor(
+                        "a", tma_tensor_fc2_weight, work_tile_info,
+                    )
+                    real_sfa, desc_ptr_sfa = ext.get_gmem_tensor(
+                        "sfa", tma_tensor_fc2_weight_sf, work_tile_info,
+                    )
+
+                    gA_mkl = cute.local_tile(
+                        real_a,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    gSFA_mkl = cute.local_tile(
+                        real_sfa,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    tCgA = thr_mma.partition_A(gA_mkl)
+                    tCgSFA = thr_mma.partition_A(gSFA_mkl)
+
+                    tAsA, tAgA = cpasync.tma_partition(
+                        tma_atom_fc2_weight,
+                        block_in_cluster_coord_vmnk[2],
+                        a_cta_layout,
+                        cute.group_modes(sA, 0, 3),
+                        cute.group_modes(tCgA, 0, 3),
+                    )
+                    tAsSFA, tAgSFA = cpasync.tma_partition(
+                        tma_atom_fc2_weight_sf,
+                        block_in_cluster_coord_vmnk[2],
+                        sfa_cta_layout,
+                        cute.group_modes(sSFA, 0, 3),
+                        cute.group_modes(tCgSFA, 0, 3),
+                    )
+                    tAsSFA = cute.filter_zeros(tAsSFA)
+                    tAgSFA = cute.filter_zeros(tAgSFA)
+
+                    mma_tile_m = work_tile_info.tile_m_idx // cute.size(
+                        tiled_mma.thr_id.shape
+                    )
+                    tAgA_slice = tAgA[(None, mma_tile_m, None, 0)]
+                    tAgSFA_slice = tAgSFA[(None, mma_tile_m, None, 0)]
+
+                    ab_producer.reset()
+                    peek_ab_empty_status = ab_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = ab_producer.acquire_and_advance(
+                            peek_ab_empty_status
+                        )
+                        peek_ab_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_ab_empty_status = ab_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc2_weight,
+                            tAgA_slice[(None, handle.count)],
+                            tAsA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_a,
+                            mcast_mask=a_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc2_weight_sf,
+                            tAgSFA_slice[(None, handle.count)],
+                            tAsSFA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfa,
+                            mcast_mask=sfa_full_mcast_mask,
+                        )
+
+                iket.range_pop()
+                work_tile_info = sched_consumer.consume_work()
+
+            ab_producer.tail()
+
+        # ── TMA-B warp (warp 6) ─────────────────────────────────────────────
+        if warp_idx == self.tma_b_warp_id:
+            if cutlass.const_expr(self.enable_token_comm):
+                cute.arch.warpgroup_reg_dealloc(self.task_reg_cnt)
+
+            b_full_mcast_mask = None
+            sfb_full_mcast_mask = None
+            if cutlass.const_expr(self.is_b_mcast or use_2cta_instrs):
+                b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+                )
+                sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_sfb_vmnk,
+                    block_in_cluster_coord_sfb_vmnk,
+                    mcast_mode=1,
+                )
+
+            b_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+            )
+            sfb_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+            )
+
+            thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+            thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+
+            # fc2-spin saturation threshold (work-tile-invariant -- the
+            # per-(expert, token_block) per-CTA-event count along the
+            # ``intermediate_gateup`` axis is a global constant under v1
+            # mma_tiler, depending only on the geometry).
+            #
+            # ``fc1_weight_gemm.shape[0]`` resolves to ``intermediate_gateup``,
+            # which is a codegen-time Python int under ``static_expert_shape``
+            # (rewritten on ``fc1_weight`` at ``__call__`` entry) or a
+            # runtime Int32 from tensor metadata otherwise.  ``//
+            # cta_tile_shape_mnk[0]`` then folds to an immediate in the
+            # static path (divisor is always a Python int constant); in
+            # the dynamic path it's still loop-invariant and hoisted here
+            # so the work-tile loop body just reads a register.
+            #
+            # fc2 waits for all fc1 intermediate CTAs in the same token block.
+            fc2_spin_threshold = (
+                fc1_weight_gemm.shape[0] + self.cta_tile_shape_mnk[0] - 1
+            ) // self.cta_tile_shape_mnk[0]
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+
+                if is_phase_linear1:
+                    # ── fc1 phase B-side (activation + activation_sf) ────
+                    iket.range_push("tma_token_fc1")
+
+                    # MegaMoE subclass uses this hook to spin on the
+                    # dispatch->fc1 release counter for this task tile
+                    # before issuing the TMA loads.  Base no-op: in the
+                    # lean path the activation tensor is fully resident
+                    # in GMEM by launch time, no per-tile wait required.
+                    self.token_comm_hook_fc1_tma_b_predispatch_spin(
+                        token_comm_args, work_tile_info,
+                    )
+
+                    k_tile_cnt = k_tile_cnt_fc1
+                    real_b, desc_ptr_b = ext.get_gmem_tensor(
+                        "b", tma_tensor_activation, work_tile_info,
+                    )
+                    real_sfb, desc_ptr_sfb = ext.get_gmem_tensor(
+                        "sfb", tma_tensor_activation_sf, work_tile_info,
+                    )
+
+                    # Non-leader CTA's TMA-B GMEM read must align with MMA's
+                    # dynamic N split under 2cta (see compute_non_leader_cta_load_shift).
+                    if cutlass.const_expr(self.use_2cta_instrs):
+                        if not is_leader_cta:
+                            load_shift = dynamic_mainloop.compute_non_leader_cta_load_shift(
+                                valid_tokens_in_tile=work_tile_info.valid_tokens_in_cta_tile,
+                                mma_tiler_n=self.mma_tiler[1],
+                            )
+                            real_b = cute.domain_offset(
+                                (load_shift, 0, 0), real_b
+                            )
+
+                    gB_nkl = cute.local_tile(
+                        real_b,
+                        cute.slice_(self.mma_tiler, (0, None, None)),
+                        (None, None, None),
+                    )
+                    gSFB_nkl = cute.local_tile(
+                        real_sfb,
+                        cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+                        (None, None, None),
+                    )
+                    tCgB = thr_mma.partition_B(gB_nkl)
+                    tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                    tBsB, tBgB = cpasync.tma_partition(
+                        tma_atom_activation,
+                        block_in_cluster_coord_vmnk[1],
+                        b_cta_layout,
+                        cute.group_modes(sB, 0, 3),
+                        cute.group_modes(tCgB, 0, 3),
+                    )
+                    tBsSFB, tBgSFB = cpasync.tma_partition(
+                        tma_atom_activation_sf,
+                        block_in_cluster_coord_sfb_vmnk[1],
+                        sfb_cta_layout,
+                        cute.group_modes(sSFB, 0, 3),
+                        cute.group_modes(tCgSFB, 0, 3),
+                    )
+                    tBsSFB = cute.filter_zeros(tBsSFB)
+                    tBgSFB = cute.filter_zeros(tBgSFB)
+
+                    tBgB_slice = tBgB[(None, work_tile_info.tile_n_idx, None, 0)]
+                    # Apply SFB slicing hack when mma_tiler_n == 64.
+                    sfb_tile_n_idx = work_tile_info.tile_n_idx
+                    if cutlass.const_expr(self.mma_tiler[1] == 64):
+                        sfb_tile_n_idx = work_tile_info.tile_n_idx // cutlass.Int32(2)
+                    tBgSFB_slice = tBgSFB[
+                        (None, sfb_tile_n_idx, None, 0)
+                    ]
+
+                    ab_producer.reset()
+                    peek_ab_empty_status = ab_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = ab_producer.acquire_and_advance(
+                            peek_ab_empty_status
+                        )
+                        peek_ab_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_ab_empty_status = ab_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_activation,
+                            tBgB_slice[(None, handle.count)],
+                            tBsB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_b,
+                            mcast_mask=b_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_activation_sf,
+                            tBgSFB_slice[(None, handle.count)],
+                            tBsSFB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfb,
+                            mcast_mask=sfb_full_mcast_mask,
+                        )
+                else:
+                    # ── fc2 phase B-side ─────────────────────────────────
+                    #
+                    # Step 1: coarse-grain spin on ``fc1_done_counter[slot]``
+                    # until saturation, via the shared
+                    # ``moe_utils.spin_wait`` helper.
+                    #
+                    #   - Slot index = ``cumulative_token_block_count +
+                    #     tile_n_idx``.  counter is indexed by global
+                    #     token-block index along the GEMM-N axis (=
+                    #     token axis under swap-AB); matches fc1 epi's
+                    #     piggyback ``red.release.gpu.add.s32 1`` call
+                    #     site at ``epilogue.py``.
+                    #
+                    #   - Saturation threshold = per-CTA-event total
+                    #     along intermediate for the current
+                    #     ``(expert, token_block)``.  Compute as
+                    #     ``intermediate_gateup // cta_tile_m`` (=
+                    #     ``fc1_weight_gemm.shape[0] //
+                    #     self.cta_tile_shape_mnk[0]``).
+                    #     Equivalent rewrite under SwiGLU half:
+                    iket.range_push("tma_token_fc2")
+                    counter_slot = (
+                        work_tile_info.cumulative_token_block_count
+                        + work_tile_info.tile_n_idx
+                    )
+                    counter_ptr = fc1_done_counter.iterator + counter_slot
+                    # If sched-warp peek saw saturation, the monotonic counter
+                    # lets TMA-B skip its own spin.
+                    if not work_tile_info.peek_ready:
+                        iket.range_push("tma_token_fc2_wait")
+                        spin_wait(
+                            counter_ptr,
+                            lambda v: v >= fc2_spin_threshold,
+                            fail_sleep_cycles=500,
+                        )
+                        iket.range_pop()
+
+                    # fc1 workspace is fc2 GEMM-B/SFB for this token block.
+                    k_tile_cnt = k_tile_cnt_fc2
+                    real_b, desc_ptr_b = ext.get_gmem_tensor(
+                        "b",
+                        tma_tensor_fc1_output_as_fc2_input,
+                        work_tile_info,
+                    )
+                    real_sfb, desc_ptr_sfb = ext.get_gmem_tensor(
+                        "sfb",
+                        tma_tensor_fc1_output_sf_as_fc2_input,
+                        work_tile_info,
+                    )
+
+                    # Non-leader CTA's TMA-B GMEM read must align with MMA's
+                    # dynamic N split under 2cta (see compute_non_leader_cta_load_shift).
+                    if cutlass.const_expr(self.use_2cta_instrs):
+                        if not is_leader_cta:
+                            load_shift = dynamic_mainloop.compute_non_leader_cta_load_shift(
+                                valid_tokens_in_tile=work_tile_info.valid_tokens_in_cta_tile,
+                                mma_tiler_n=self.mma_tiler[1],
+                            )
+                            real_b = cute.domain_offset(
+                                (load_shift, 0, 0), real_b
+                            )
+
+                    gB_nkl = cute.local_tile(
+                        real_b,
+                        cute.slice_(self.mma_tiler, (0, None, None)),
+                        (None, None, None),
+                    )
+                    gSFB_nkl = cute.local_tile(
+                        real_sfb,
+                        cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+                        (None, None, None),
+                    )
+                    tCgB = thr_mma.partition_B(gB_nkl)
+                    tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                    tBsB, tBgB = cpasync.tma_partition(
+                        tma_atom_fc1_output_as_fc2_input,
+                        block_in_cluster_coord_vmnk[1],
+                        b_cta_layout,
+                        cute.group_modes(sB, 0, 3),
+                        cute.group_modes(tCgB, 0, 3),
+                    )
+                    tBsSFB, tBgSFB = cpasync.tma_partition(
+                        tma_atom_fc1_output_sf_as_fc2_input,
+                        block_in_cluster_coord_sfb_vmnk[1],
+                        sfb_cta_layout,
+                        cute.group_modes(sSFB, 0, 3),
+                        cute.group_modes(tCgSFB, 0, 3),
+                    )
+                    tBsSFB = cute.filter_zeros(tBsSFB)
+                    tBgSFB = cute.filter_zeros(tBgSFB)
+
+                    tBgB_slice = tBgB[
+                        (None, work_tile_info.tile_n_idx, None, 0)
+                    ]
+                    # Apply SFB slicing hack when mma_tiler_n == 64.
+                    sfb_tile_n_idx = work_tile_info.tile_n_idx
+                    if cutlass.const_expr(self.mma_tiler[1] == 64):
+                        sfb_tile_n_idx = work_tile_info.tile_n_idx // cutlass.Int32(2)
+                    tBgSFB_slice = tBgSFB[
+                        (None, sfb_tile_n_idx, None, 0)
+                    ]
+
+                    # Step 3: K-loop with 2x cute.copy per tile (B +
+                    # SFB).  Same cadence as the fc1 phase above; we
+                    # share the AB pipeline producer with tma_a_warp
+                    # under the cooperative-producer wiring (see
+                    # pipeline create call above).
+                    ab_producer.reset()
+                    peek_ab_empty_status = ab_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = ab_producer.acquire_and_advance(
+                            peek_ab_empty_status
+                        )
+                        peek_ab_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_ab_empty_status = ab_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc1_output_as_fc2_input,
+                            tBgB_slice[(None, handle.count)],
+                            tBsB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_b,
+                            mcast_mask=b_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc1_output_sf_as_fc2_input,
+                            tBgSFB_slice[(None, handle.count)],
+                            tBsSFB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfb,
+                            mcast_mask=sfb_full_mcast_mask,
+                        )
+                iket.range_pop()
+                work_tile_info = sched_consumer.consume_work()
+
+            ab_producer.tail()
+
+        # ════════════════════════════════════════════════════════════════════
+        # MMA warp (warp 4)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # Both phases share tiled_mma and TMEM; only K-tile count differs.
+        if warp_idx == self.mma_warp_id:
+            if cutlass.const_expr(self.enable_token_comm):
+                cute.arch.warpgroup_reg_dealloc(self.task_reg_cnt)
+
+            tCrA = tiled_mma.make_fragment_A(sA)
+            tCrB = tiled_mma.make_fragment_B(sB)
+
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # SFA TMEM tensor (placed after the acc cols).
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # SFB TMEM tensor (after acc + SFA cols).
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_pipeline_stages
+            )
+
+            # K-tile counts ``k_tile_cnt_fc1`` / ``k_tile_cnt_fc2`` come
+            # from the enclosing scope (computed once before the TMA warps).
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+                # Prebind k_tile_cnt due to DSL AST.
+                k_tile_cnt = cutlass.Int32(0)
+                if is_phase_linear1:
+                    k_tile_cnt = k_tile_cnt_fc1
+                    iket.range_push("mma_fc1")
+                else:
+                    k_tile_cnt = k_tile_cnt_fc2
+                    iket.range_push("mma_fc2")
+
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+
+                if is_leader_cta:
+                    tCtAcc = tCtAcc_base[(None, None, None, acc_stage_index)]
+
+                    ab_consumer.reset()
+                    peek_ab_full_status = cutlass.Boolean(1)
+                    iket.range_push("mma_acquire")
+                    peek_ab_full_status = ab_consumer.try_wait()
+                    acc_pipeline.producer_acquire(acc_producer_state)
+                    iket.range_pop()
+
+                    # Apply TMEM pointer offset hack when mma_tiler_n == 64.
+                    tCtSFB_mma = tCtSFB
+                    if cutlass.const_expr(self.mma_tiler[1] == 64):
+                        sfb_shift = cutlass.Int32(
+                            (work_tile_info.tile_n_idx % cutlass.Int32(2)) * cutlass.Int32(2)
+                        )
+                        shifted_sfb_ptr = cute.recast_ptr(
+                            acc_tmem_ptr
+                            + self.num_accumulator_tmem_cols
+                            + self.num_sfa_tmem_cols
+                            + sfb_shift,
+                            dtype=self.sf_dtype,
+                        )
+                        tCtSFB_mma = cute.make_tensor(shifted_sfb_ptr, tCtSFB_layout)
+
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = ab_consumer.wait_and_advance(peek_ab_full_status)
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        if k_tile + 1 < k_tile_cnt:
+                            peek_ab_full_status = ab_consumer.try_wait()
+
+                        s2t_stage_coord = (None, None, None, None, handle.index)
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[s2t_stage_coord],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[s2t_stage_coord],
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                        tile_crd = (None, None, None, handle.index)
+                        dynamic_mainloop.issue_dynamic_block_scaled_mma_tile(
+                            acc_tensor=tCtAcc,
+                            a_frag_tile=tCrA[tile_crd],
+                            b_frag_tile=tCrB[tile_crd],
+                            sfa_tensor=tCtSFA,
+                            sfb_tensor=tCtSFB_mma,
+                            k_tile_idx=k_tile,
+                            valid_tokens_in_tile=work_tile_info.valid_tokens_in_cta_tile,
+                            mma_tiler_mnk=self.mma_tiler_mnk,
+                        )
+                        handle.release()
+
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                iket.range_pop()
+
+                work_tile_info = sched_consumer.consume_work()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        # ════════════════════════════════════════════════════════════════════
+        # Epilogue warps (warps 0-3)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # Fully delegated to ``self.epilogue.run(...)`` -- the epilogue owns
+        # the entire 2-phase task-tile loop including:
+        #   - acc_consumer_state (allocation + advance + phase tracking)
+        #   - per-task-tile subtile loop (with valid_tokens early-exit)
+        #   - rotated-leader TMA store cmd issue (fc1 phase)
+        #   - STG.256 GMEM writes (fc2 phase)
+        #   - per-task-tile TMA commit + drain + epilog_sync_bar sync
+        #   - piggyback ``red.release.gpu.add.s32`` to ``fc1_done_counter``
+        #     after each fc1 task tile (release side of fc1->fc2 protocol)
+        if warp_idx < self.mma_warp_id:
+            if cutlass.const_expr(self.enable_token_comm):
+                cute.arch.warpgroup_reg_alloc(self.epi_reg_cnt)
+
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+
+            optional_epi_args = NvFp4OptinalEpiArgs(
+                fc1_alpha=fc1_alpha,
+                fc2_alpha=fc2_alpha,
+                fc1_norm_const=fc1_norm_const,
+                topk_scores=(
+                    topk_scores
+                    if cutlass.const_expr(self.apply_topk_in_fc1)
+                    else None
+                ),
+            )
+
+            self.epilogue.run(
+                epi_smem_storage=epi_smem_storage,
+                tmem_ptr=acc_tmem_ptr,
+                acc_pipeline=acc_pipeline,
+                sched_consumer=sched_consumer,
+                sched_ext=ext,
+                tma_atom_fc1_output=tma_atom_fc1_output,
+                fc1_output=tma_tensor_fc1_output,
+                fc1_output_sf=fc1_output_sf_gemm,
+                fc2_output=fc2_output,
+                fc1_done_counter=fc1_done_counter,
+                tidx=tidx,
+                optional_epi_args=optional_epi_args,
+                token_comm_args=token_comm_args,
+            )
+            cute.arch.fence_acq_rel_sys()
+            tmem.relinquish_alloc_permit()
+            tmem.free(tmem.retrieve_ptr(self.acc_dtype), self.num_tmem_alloc_cols)
+
+
+        # ════════════════════════════════════════════════════════════════════
+        # Dispatch warps hook (warp 8-11; MegaMoE-only)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # ``enable_token_comm=False`` means warps 8-11 don't exist at all
+        # (threads_per_cta = 256 in lean mode), so the hook call is
+        # entirely const_expr-eliminated.  When ``enable_token_comm=True``
+        # the subclass implements the full dispatch chain inside this
+        # hook (prep -> cross-rank barrier -> per-token pull -> release
+        # to fc1 -> arrive on dispatch-to-sched NamedBarrier).
+        if cutlass.const_expr(self.enable_token_comm):
+            if warp_idx >= self.dispatch_warp_id[0]:
+                cute.arch.warpgroup_reg_dealloc(self.task_reg_cnt)
+
+                lane_idx_for_dispatch = cute.arch.lane_idx()
+                if cutlass.const_expr(self.token_back_standalone):
+                    if warp_idx < self.token_back_warp_id[0]:
+                        self.token_comm_hook_dispatch_warp_body(
+                            token_comm_args,
+                            token_comm_storage,
+                            warp_idx=warp_idx,
+                            lane_idx=lane_idx_for_dispatch,
+                            tidx=tidx,
+                        )
+                    else:
+                        self.token_comm_hook_token_back_warp_body(
+                            token_comm_args,
+                            token_comm_storage,
+                            warp_idx=warp_idx,
+                            lane_idx=lane_idx_for_dispatch,
+                            tidx=tidx,
+                        )
+                else:
+                    self.token_comm_hook_dispatch_warp_body(
+                        token_comm_args,
+                        token_comm_storage,
+                        warp_idx=warp_idx,
+                        lane_idx=lane_idx_for_dispatch,
+                        tidx=tidx,
+                    )
+
+        # ════════════════════════════════════════════════════════════════════
+        # Kernel tail hook (MegaMoE-only path; lean base = no-op)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # All 12 warps fall through to this point in MegaMoE mode (warp
+        # 8-11 already exited the dispatch warp body hook above; warps
+        # 0-7 just finished GEMM / epi work).  The subclass hook owns
+        # the kernel-tail rendezvous (12-warp NamedBarrier) and the
+        # cross-rank NVLink release.  Base no-op: lean path has no peer
+        # ranks and no kernel-tail concept.
+        lane_idx = cute.arch.lane_idx()
+        self.token_comm_hook_kernel_tail(
+            token_comm_args,
+            warp_idx=warp_idx,
+            lane_idx=lane_idx,
+            tidx=tidx,
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/mega_reference.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/mega_reference.py
@@ -1,0 +1,2600 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""CuTeDSL-backed MoE reference for the multi-rank MegaMoE kernel.
+
+Eyeball-reviewable ground truth for ``mega_runner.py``.  The reference
+does **not** model any dispatch wire-format / pool-layout detail: it
+takes already-NVFP4 inputs plus a routing table ``topk_idx`` and
+computes ``combine_output[r, t, k] = fc12(input[r, t], expert[topk_idx[r, t, k]])``
+for every ``(rank, token, topk_slot)``.  As long as the kernel's final
+``combine_output`` matches this, the kernel is correct regardless of
+its internal pool / SF / metadata layout choices.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional, Tuple, Type, Union, Any
+
+import torch
+import cutlass
+
+from common.megamoe_constants import Nvfp4BlockSize, Nvfp4E2M1RcpLimit
+from common.host_utils import mxfp8_quantize_per_block_32
+from moe_nvfp4_swapab.runner_common import (
+    nvfp4_quantize_per_block_16,
+    swiglu_fold_interleave,
+    to_blocked,
+    unpack_fp4_to_f32,
+    dequant_block_scale_to_fp32,
+    _pack_f32_to_fp4,
+    _rcp_approx_ftz_f32_cuda,
+)
+from src.token_comm import CombineFormat
+
+
+@dataclass(frozen=True)
+class MegaMoEReference:
+    """Reference outputs for MegaMoE validation.
+
+    ``combine_output`` always has shape ``(rank, token, topk, hidden)`` and
+    stores the per-topk fc2 terms.  ``combine_reduced_output`` stores the
+    graph-specific canonical ``(rank, token, hidden)`` reduce reference.
+    """
+
+    combine_output: torch.Tensor
+    combine_reduced_output: torch.Tensor
+
+
+def _check_cuda_inputs(named_tensors: Tuple[Tuple[str, torch.Tensor], ...]) -> None:
+    for name, tensor in named_tensors:
+        if not tensor.is_cuda:
+            raise RuntimeError(
+                f"CuTeDSL MegaMoE reference requires CUDA tensors; "
+                f"{name} is on {tensor.device}."
+            )
+
+
+def _byte_gather_rank_token(
+    tensor: torch.Tensor,
+    source_ranks: torch.Tensor,
+    source_tokens: torch.Tensor,
+) -> torch.Tensor:
+    """Gather ``tensor[rank, token]`` through uint8 storage for sub-byte dtypes."""
+    gathered = tensor.view(torch.uint8)[source_ranks, source_tokens]
+    return gathered.view(tensor.dtype)
+
+
+def _byte_select_expert(
+    tensor: torch.Tensor,
+    target_rank: int,
+    local_expert: int,
+) -> torch.Tensor:
+    """Select one expert through uint8 storage while preserving tensor strides."""
+    selected = tensor.view(torch.uint8)[target_rank, local_expert]
+    return selected.view(tensor.dtype)
+
+
+def reference_expert_fc12(
+    *,
+    ref_scaled_mm,
+    quantize_fn,
+    act_packed: torch.Tensor,
+    act_sf: torch.Tensor,
+    fc1_weight_packed: torch.Tensor,
+    fc1_weight_sf: torch.Tensor,
+    fc2_weight_packed: torch.Tensor,
+    fc2_weight_sf: torch.Tensor,
+    intermediate: int,
+    hidden: int,
+    fc1_alpha: float,
+    fc2_alpha: float,
+    fc1_norm_const: float,
+    gate_up_interleave: int,
+    gate_up_clamp: Optional[float],
+    topk_weights: Optional[torch.Tensor],
+    ref_compute_graph: Literal["transformers", "deepgemm"],
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Single-expert fused fc1+fc2 reference shared by the single-rank tester
+    and the multi-rank MegaMoE reference.
+
+    Both GEMMs run on the bit-exact blockscaled launcher (``ref_scaled_mm``)
+    straight off the packed fp4/fp8 operands -- no host dequant; the launcher's
+    K-major ``b`` and raw SF formats are identical for the per-expert single-rank
+    and gathered multi-rank tensors.  Returns the fc2 fp32 output (``deepgemm``:
+    topk pre-multiplied into SwiGLU; ``transformers``: left unweighted for the
+    caller to apply), plus the fc1 NVFP4 hand-off ``(fc1_q, fc1_sf)`` used by the
+    fc1-phase ablation.
+    """
+    intermediate_downproj = intermediate // 2
+    fc1_fp32 = ref_scaled_mm(
+        a=act_packed, sfa=act_sf,
+        b=fc1_weight_packed, sfb=fc1_weight_sf,
+        n=intermediate, k=hidden,
+    )
+    fc1_fp32 = fc1_fp32 * fc1_alpha
+
+    swiglu = swiglu_fold_interleave(
+        fc1_fp32, gate_up_interleave, gate_up_clamp=gate_up_clamp,
+    )
+    if ref_compute_graph == "deepgemm":
+        swiglu = swiglu * topk_weights.unsqueeze(-1)
+
+    fc1_q, fc1_sf_out = quantize_fn(swiglu, fc1_norm_const)
+
+    fc2_fp32 = ref_scaled_mm(
+        a=fc1_q, sfa=fc1_sf_out,
+        b=fc2_weight_packed, sfb=fc2_weight_sf,
+        n=hidden, k=intermediate_downproj,
+    )
+    fc2_fp32 = fc2_fp32 * fc2_alpha
+    return fc2_fp32, fc1_q, fc1_sf_out, fc1_fp32
+
+
+# Per-term quantization SNR floor (dB) for each quantized combine format. The
+# theoretical block-scaled-float round-trip SNR is ~14.5 + 6*mantissa_bits:
+# e2m1 (m=1) -> ~20.5, e5m2 (m=2) -> ~26.5, e4m3 (m=3) -> ~32.5 (e8m0's
+# power-of-2 scale loses ~1 dB -> ~31.5 / ~25.5 respectively). These are
+# nearly distribution-independent (within ~0.5 dB), so the floors sit ~1.5 dB
+# below target -- tight enough to catch a degraded quantizer, loose enough
+# for bf16-amax scale rounding and real-data drift.
+_combine_snr_floor_db = {
+    "16e2m1xbf16": 19.0,
+    "32e4m3xe8m0": 30.0,
+    "32e5m2xe8m0": 24.0,
+}
+
+
+def combine_roundtrip_to_fp32(
+    terms_fp32: torch.Tensor,           # (..., hidden) fp32 per-(token, topk) fc2 terms
+    combine_format: CombineFormat,
+) -> torch.Tensor:
+    """Round-trip the fc2 terms through the combine wire format.
+
+    Quantize then dequantize each block exactly as the device combine encoder +
+    topk_reduce do, returning the fp32 values topk_reduce reduces over. The bf16
+    baseline is identity (terms are already bf16). The fp4 path stores a per-16
+    bf16 amax (decode scale = amax / 6) and packs e2m1 with the shared
+    nearest-fp4 LUT; the mxfp8 path reuses the standard per-32 e8m0 quantizer.
+    Decode mirrors topk_reduce: plain ``unpack * stored_scale``.
+    """
+    if not combine_format.is_quantized:
+        return terms_fp32
+
+    block = combine_format.scale_block
+    *lead, hidden = terms_fp32.shape
+    if hidden % block != 0:
+        raise ValueError(
+            f"hidden ({hidden}) must be a multiple of scale_block ({block})."
+        )
+
+    if combine_format.act_dtype is cutlass.Float4E2M1FN:
+        blocked = terms_fp32.reshape(*lead, hidden // block, block)
+        amax = blocked.abs().amax(dim=-1)
+        # amax of a bf16 set is itself a bf16 value, so storing it as bf16 is
+        # lossless; decode scale = amax / 6 (matches topk_reduce's * RcpLimit).
+        decode_scale = amax.to(torch.bfloat16).float() * Nvfp4E2M1RcpLimit
+        # Encode with the reciprocal of the *stored* scale (round-trip idiom);
+        # rcp.approx.ftz matches the device encoder. amax==0 -> 0 (codes stay 0).
+        enc_scale = _rcp_approx_ftz_f32_cuda(decode_scale.contiguous())
+        enc_scale = torch.where(
+            decode_scale > 0, enc_scale, torch.zeros_like(enc_scale)
+        )
+        codes = _pack_f32_to_fp4(blocked * enc_scale.unsqueeze(-1))
+        deq = unpack_fp4_to_f32(codes) * decode_scale.unsqueeze(-1)
+        return deq.reshape(*lead, hidden)
+
+    # mxfp8-family combine (e4m3 or e5m2): standard per-32 e8m0 round-trip.
+    torch_act_dtype = {
+        cutlass.Float8E4M3FN: torch.float8_e4m3fn,
+        cutlass.Float8E5M2: torch.float8_e5m2,
+    }[combine_format.act_dtype]
+    flat = terms_fp32.reshape(-1, hidden)
+    codes, scale_e8m0 = mxfp8_quantize_per_block_32(flat, torch_act_dtype)
+    deq = dequant_block_scale_to_fp32(codes, scale_e8m0, block)
+    return deq.reshape(*lead, hidden)
+
+
+def compute_megamoe_reference(
+    # NVFP4 tensors below carry STORAGE shape: a logical dim of size N is
+    # stored as a packed dim of size N // 2 (one byte holds two fp4 values).
+    # ``unpack_fp4_to_f32`` reverses the packing by doubling the packed dim.
+    input_activation: torch.Tensor,        # storage (num_ranks, num_tokens_per_rank, hidden//2)
+    input_activation_sf: torch.Tensor,     # (num_ranks, num_tokens_per_rank, hidden//Nvfp4BlockSize) fp8 plain K-major
+    input_topk_idx: torch.Tensor,          # (num_ranks, num_tokens_per_rank, num_topk) int64
+    input_topk_weights: torch.Tensor,      # (num_ranks, num_tokens_per_rank, num_topk) fp32
+    fc1_weight: torch.Tensor,              # storage (num_ranks, num_experts_per_rank, hidden//2, intermediate); hidden is the packed dim
+    fc1_weight_sf: torch.Tensor,           # (num_ranks, num_experts_per_rank, intermediate, hidden//Nvfp4BlockSize) fp8 plain
+    fc2_weight: torch.Tensor,              # storage (num_ranks, num_experts_per_rank, intermediate//4, hidden); intermediate//2 is the packed dim
+    fc2_weight_sf: torch.Tensor,           # (num_ranks, num_experts_per_rank, hidden, (intermediate//2)//Nvfp4BlockSize) fp8 plain
+    fc1_alpha: torch.Tensor,                # (num_ranks, num_experts_per_rank) fp32
+    fc2_alpha: torch.Tensor,                # (num_ranks, num_experts_per_rank) fp32
+    fc1_norm_const: torch.Tensor,           # (num_ranks, num_experts_per_rank) fp32
+    ref_compute_graph: Literal["transformers", "deepgemm"],
+    combine_format: CombineFormat,
+    gate_up_clamp: Optional[float] = None,
+) -> MegaMoEReference:
+    """Return per-topk combine terms plus optional reduced reference.
+
+    Two routing-weight application points are supported.  ``deepgemm``
+    pre-multiplies the per-token weight into the SwiGLU output BEFORE the
+    fc1-output NVFP4 quant; this matches the MegaMoE form-B path.  In
+    ``transformers`` mode ``combine_output`` intentionally stays unweighted;
+    Mega form A applies topk scores in the standalone topk_reduce kernel.  Both
+    compute graphs return ``combine_reduced_output`` so callers can validate the
+    reduced form without re-implementing graph-specific reduce semantics.
+
+    The structure (per-expert gather -> packed blockscaled fc1 -> swiglu +
+    fc1-out NVFP4 round-trip -> packed blockscaled fc2 -> scatter back) mirrors
+    the kernel's own data path so kernel-vs-reference disagreement is bounded by
+    NVFP4 quantize RTNE at fc1-out and blockscaled GEMM accumulation noise.
+    """
+    if ref_compute_graph not in ("transformers", "deepgemm"):
+        raise ValueError(
+            f"ref_compute_graph must be 'transformers' or 'deepgemm', "
+            f"got {ref_compute_graph!r}."
+        )
+    _check_cuda_inputs(
+        (
+            ("input_activation", input_activation),
+            ("input_activation_sf", input_activation_sf),
+            ("input_topk_idx", input_topk_idx),
+            ("input_topk_weights", input_topk_weights),
+            ("fc1_weight", fc1_weight),
+            ("fc1_weight_sf", fc1_weight_sf),
+            ("fc2_weight", fc2_weight),
+            ("fc2_weight_sf", fc2_weight_sf),
+            ("fc1_alpha", fc1_alpha),
+            ("fc2_alpha", fc2_alpha),
+            ("fc1_norm_const", fc1_norm_const),
+        )
+    )
+    vec_size = 16 if input_activation_sf.dtype == torch.float8_e4m3fn else 32
+    ref_scaled_mm = _BlockScaledGemmReferenceLauncher(
+        sf_vec_size=vec_size,
+        mma_tiler_mn=(128, 128),
+        cluster_shape_mn=(1, 1),
+    )
+
+    num_ranks, num_tokens_per_rank, num_topk = input_topk_idx.shape
+    num_experts_per_rank = fc1_weight.shape[1]
+    num_total_experts = num_ranks * num_experts_per_rank
+
+    # hidden is the un-packed dim of fc2_weight (= shape[-1]); cross-check
+    # against the packed input + fc1_weight dims to catch shape mismatches
+    # early (helpful when the runner-side reshape forgets a //2).
+    hidden = fc2_weight.shape[-1]
+    intermediate = fc1_weight.shape[-1]
+    intermediate_downproj = intermediate // 2
+
+    if fc1_weight.shape[0] != num_ranks or fc2_weight.shape[0] != num_ranks:
+        raise ValueError(
+            f"fc1_weight / fc2_weight must have leading dim num_ranks={num_ranks}, "
+            f"got {tuple(fc1_weight.shape)}, {tuple(fc2_weight.shape)}."
+        )
+    if input_activation.shape[-1] * 2 != hidden:
+        raise ValueError(
+            f"input_activation packed last dim ({input_activation.shape[-1]}) * 2 "
+            f"!= hidden ({hidden})."
+        )
+    if fc1_weight.shape[2] * 2 != hidden:
+        raise ValueError(
+            f"fc1_weight packed dim ({fc1_weight.shape[2]}) * 2 != hidden ({hidden})."
+        )
+    if fc2_weight.shape[2] * 2 != intermediate_downproj:
+        raise ValueError(
+            f"fc2_weight packed dim ({fc2_weight.shape[2]}) * 2 != "
+            f"intermediate_downproj ({intermediate_downproj}); fc2's K is "
+            f"intermediate//2 (post-SwiGLU-fold)."
+        )
+
+    combine_ref = torch.zeros(
+        (num_ranks, num_tokens_per_rank, num_topk, hidden),
+        dtype=torch.bfloat16,
+        device=input_activation.device,
+    )
+
+    # Per-expert GEMM chain.  Compute a fresh boolean routing mask per expert:
+    # the clearer loop is worth the extra mask sweep for this ground truth.
+    for global_expert in range(num_total_experts):
+        target_rank = global_expert // num_experts_per_rank
+        local_expert = global_expert % num_experts_per_rank
+
+        routing_mask = input_topk_idx == global_expert
+        if not routing_mask.any():
+            continue
+        routed = routing_mask.nonzero(as_tuple=False)
+        source_ranks = routed[:, 0]
+        source_tokens = routed[:, 1]
+        source_topk_slots = routed[:, 2]
+
+        gathered_act = _byte_gather_rank_token(
+            input_activation, source_ranks, source_tokens
+        )
+        gathered_act_sf = _byte_gather_rank_token(
+            input_activation_sf, source_ranks, source_tokens
+        )
+        gathered_topk_weights = input_topk_weights[
+            source_ranks, source_tokens, source_topk_slots
+        ]
+
+        # Packed NVFP4 blockscaled fc1 -> SwiGLU(+clamp) -> NVFP4 round-trip ->
+        # blockscaled fc2, all via the shared bit-exact per-expert core.  The
+        # NVFP4 round-trip on the fc1 output is the only step that introduces
+        # kernel-vs-ref disagreement above fp32 accumulation noise (RTNE may
+        # flip when a value sits within ~half an fp4 step of a bin boundary).
+        # ``transformers`` keeps the per-topk fc2 term unweighted so the
+        # standalone topk_reduce kernel can match the device graph.
+        fc2_output_fp32, _fc1_q, _fc1_sf, _fc1_gateup = reference_expert_fc12(
+            ref_scaled_mm=ref_scaled_mm,
+            quantize_fn=nvfp4_quantize_per_block_16,
+            act_packed=gathered_act,
+            act_sf=gathered_act_sf,
+            fc1_weight_packed=_byte_select_expert(fc1_weight, target_rank, local_expert),
+            fc1_weight_sf=_byte_select_expert(fc1_weight_sf, target_rank, local_expert),
+            fc2_weight_packed=_byte_select_expert(fc2_weight, target_rank, local_expert),
+            fc2_weight_sf=_byte_select_expert(fc2_weight_sf, target_rank, local_expert),
+            intermediate=intermediate,
+            hidden=hidden,
+            fc1_alpha=float(fc1_alpha[target_rank, local_expert].item()),
+            fc2_alpha=float(fc2_alpha[target_rank, local_expert].item()),
+            fc1_norm_const=float(fc1_norm_const[target_rank, local_expert].item()),
+            gate_up_interleave=16,
+            gate_up_clamp=gate_up_clamp,
+            topk_weights=gathered_topk_weights,
+            ref_compute_graph=ref_compute_graph,
+        )
+
+        combine_ref[source_ranks, source_tokens, source_topk_slots, :] = (
+            fc2_output_fp32.to(torch.bfloat16)
+        )
+
+    reduced_fp32 = torch.zeros(
+        (num_ranks, num_tokens_per_rank, hidden),
+        dtype=torch.float32,
+        device=input_activation.device,
+    )
+    terms_fp32 = combine_ref.to(torch.float32)
+    ideal_terms = terms_fp32
+    terms_fp32 = combine_roundtrip_to_fp32(terms_fp32, combine_format)
+    if combine_format.is_quantized:
+        # Self-guard: per-term quantization SNR must clear the format floor.
+        # A correct round-trip sits well above it; a broken quantizer craters.
+        signal = ideal_terms.pow(2).mean()
+        noise = (terms_fp32 - ideal_terms).pow(2).mean()
+        snr_db = (
+            float("inf") if noise.item() == 0
+            else 10.0 * torch.log10(signal / noise).item()
+        )
+        floor_db = _combine_snr_floor_db.get(combine_format.name)
+        if floor_db is None:
+            raise KeyError(f"no combine SNR floor configured for {combine_format}.")
+        if snr_db < floor_db:
+            raise AssertionError(
+                f"combine {combine_format} round-trip SNR {snr_db:.1f} dB < "
+                f"floor {floor_db:.1f} dB; the host quantizer is likely broken."
+            )
+    if ref_compute_graph == "transformers":
+        for k in range(num_topk):
+            reduced_fp32 = torch.addcmul(
+                reduced_fp32,
+                terms_fp32[:, :, k, :],
+                input_topk_weights[:, :, k].unsqueeze(-1),
+            )
+        reduced_ref = reduced_fp32.to(torch.bfloat16)
+    else:
+        for k in range(num_topk):
+            reduced_fp32 = reduced_fp32 + terms_fp32[:, :, k, :]
+        reduced_ref = reduced_fp32.to(torch.bfloat16)
+
+    return MegaMoEReference(
+        combine_output=combine_ref,
+        combine_reduced_output=reduced_ref,
+    )
+
+
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.torch as cutlass_torch
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.nvgpu import OperandMajorMode, cpasync, tcgen05
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+
+
+class Sm100BlockScaledPersistentDenseGemmKernel:
+    """See CuTeDSL Example"""
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ):
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler = (*mma_tiler_mn, 1)
+
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        self.occupancy = 1
+        # Set specialized warp ids
+        self.epilog_warp_id = (
+            0,
+            1,
+            2,
+            3,
+        )
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.threads_per_warp = 32
+        self.threads_per_cta = self.threads_per_warp * len(
+            (self.mma_warp_id, self.tma_warp_id, *self.epilog_warp_id)
+        )
+        # Set barrier id for epilogue sync and tmem ptr sync
+        self.epilog_sync_barrier = pipeline.NamedBarrier(
+            barrier_id=1,
+            num_threads=self.threads_per_warp * len(self.epilog_warp_id),
+        )
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=self.threads_per_warp
+            * len((self.mma_warp_id, *self.epilog_warp_id)),
+        )
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
+
+    def _setup_attributes(self):
+        """Set up configurations that are dependent on GEMM inputs
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B/SFA/SFB
+        - Computing epilogue subtile
+        - Setting up A/B/SFA/SFB/C stage counts in shared memory
+        - Computing A/B/SFA/SFB/C shared memory layout
+        """
+        # Compute mma instruction shapes
+        # (MMA_Tile_Shape_M, MMA_Tile_Shape_N, MMA_Inst_Shape_K)
+        self.mma_inst_shape_mn = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+        )
+        # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+
+        # Compute mma/cluster/tile shapes
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            mma_inst_shape_k * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+
+        # Compute epilogue subtile
+        self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.c_layout,
+            self.c_dtype,
+        )
+        self.epi_tile_n = cute.size(self.epi_tile[1])
+
+        # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.smem_alloc_a_dtype,
+            self.smem_alloc_b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
+        )
+
+        # Compute A/B/SFA/SFB/C shared memory layout
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.smem_alloc_a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.smem_alloc_b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+        # Overlap and double buffer accumulator when num_acc_stage == 1 for cta_tile_n = 256 case
+        self.overlapping_accum = self.num_acc_stage == 1
+
+        # Compute number of TMEM columns for SFA/SFB/Accumulator
+        sf_atom_mn = 32
+        self.num_sfa_tmem_cols = (
+            self.cta_tile_shape_mnk[0] // sf_atom_mn
+        ) * mma_inst_tile_k
+        self.num_sfb_tmem_cols = (
+            self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn
+        ) * mma_inst_tile_k
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = (
+            self.cta_tile_shape_mnk[1] * self.num_acc_stage
+            if not self.overlapping_accum
+            else self.cta_tile_shape_mnk[1] * 2 - self.num_sf_tmem_cols
+        )
+
+        # Only when overlapping_accum is enabled, we need to release accumulator buffer early in epilogue
+        self.iter_acc_early_release_in_epilogue = (
+            self.num_sf_tmem_cols // self.epi_tile_n
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_tensor: cute.Tensor,
+        b_tensor: cute.Tensor,
+        sfa_tensor: cute.Tensor,
+        sfb_tensor: cute.Tensor,
+        c_tensor: cute.Tensor,
+        layouts: cutlass.Constexpr[
+            Tuple[OperandMajorMode, OperandMajorMode, utils.LayoutEnum]
+        ],
+        problem_mnkl: Tuple[int, int, int, int],
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Execute the GEMM operation in steps:
+        - Setup static attributes before smem/grid/tma computation
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size with regard to hardware constraints
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        :param a_tensor: Input tensor A
+        :type a_tensor: cute.Tensor
+        :param b_tensor: Input tensor B
+        :type b_tensor: cute.Tensor
+        :param sfa_tensor: Scale factor tensor A
+        :type sfa_tensor: cute.Tensor
+        :param sfb_tensor: Scale factor tensor B
+        :type sfb_tensor: cute.Tensor
+        :param c_tensor: Output tensor C
+        :type c_tensor: cute.Tensor
+        :param max_active_clusters: Maximum number of active clusters
+        :type max_active_clusters: cutlass.Constexpr
+        :param stream: CUDA stream for asynchronous execution
+        :type stream: cuda.CUstream
+        :param epilogue_op: Optional elementwise lambda function to apply to the output tensor
+        :type epilogue_op: cutlass.Constexpr
+        :raises TypeError: If input data types are incompatible with the MMA instruction.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        a_ptr = a_tensor.iterator
+        b_ptr = b_tensor.iterator
+        sfa_ptr = sfa_tensor.iterator
+        sfb_ptr = sfb_tensor.iterator
+        c_ptr = c_tensor.iterator
+        self.a_dtype: Type[cutlass.Numeric] = a_ptr.value_type
+        self.b_dtype: Type[cutlass.Numeric] = b_ptr.value_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa_ptr.value_type
+        self.c_dtype: Type[cutlass.Numeric] = c_ptr.value_type
+        self.mxf8f6f4 = self.needs_unpack_tma(self.a_dtype, self.b_dtype)
+        self.smem_alloc_a_dtype = (
+            cutlass.Int8 if (self.mxf8f6f4 and self.a_dtype.width < 8) else self.a_dtype
+        )
+        self.smem_alloc_b_dtype = (
+            cutlass.Int8 if (self.mxf8f6f4 and self.b_dtype.width < 8) else self.b_dtype
+        )
+        m, n, k, l = problem_mnkl
+        self.a_major_mode, self.b_major_mode, self.c_layout = layouts
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        a_layout = cute.make_ordered_layout((m, cute.assume(k, 32), l), order=(0, 1, 2))
+        if cutlass.const_expr(self.a_major_mode == OperandMajorMode.K):
+            a_layout = cute.make_ordered_layout(
+                (cute.assume(m, 32), k, l), order=(1, 0, 2)
+            )
+        b_layout = cute.make_ordered_layout((n, cute.assume(k, 32), l), order=(0, 1, 2))
+        if cutlass.const_expr(self.b_major_mode == OperandMajorMode.K):
+            b_layout = cute.make_ordered_layout(
+                (cute.assume(n, 32), k, l), order=(1, 0, 2)
+            )
+        c_layout = cute.make_ordered_layout((cute.assume(m, 32), n, l), order=(0, 1, 2))
+        if cutlass.const_expr(self.c_layout == utils.LayoutEnum.ROW_MAJOR):
+            c_layout = cute.make_ordered_layout(
+                (m, cute.assume(n, 32), l), order=(1, 0, 2)
+            )
+        a_tensor = cute.make_tensor(a_ptr, a_layout)
+        b_tensor = cute.make_tensor(b_ptr, b_layout)
+        c_tensor = cute.make_tensor(c_ptr, c_layout)
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            a_tensor.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa_ptr, sfa_layout)
+
+        # ((Atom_N, Rest_N),(Atom_K, Rest_K),RestL)
+        sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b_tensor.shape, self.sf_vec_size
+        )
+        sfb_tensor = cute.make_tensor(sfb_ptr, sfb_layout)
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        # For 2CTA blockscaled kernels, SFB needs to be replicated across peer CTAs. # {$nv-internal-release}
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a_tensor,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=self.smem_alloc_a_dtype
+            if (self.mxf8f6f4 and self.a_dtype.width < 8)
+            else None,
+        )
+
+        # Setup TMA load for B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b_tensor,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=self.smem_alloc_b_dtype
+            if (self.mxf8f6f4 and self.b_dtype.width < 8)
+            else None,
+        )
+
+        # Setup TMA load for SFA
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa_tensor,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        # Setup TMA load for SFB
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb_tensor,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        # {$nv-internal-release begin}
+        # This modifies the layout to handle overlapping 256x(# of scale factors for a single column of B (nNSF)) logical blocks for SFB when cta_tile_shape_n=192
+        # {$nv-internal-release end}
+        if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+            x = tma_tensor_sfb.stride[0][1]
+            y = cute.ceil_div(tma_tensor_sfb.shape[0][1], 4)
+
+            new_shape = (
+                (tma_tensor_sfb.shape[0][0], ((2, 2), y)),
+                tma_tensor_sfb.shape[1],
+                tma_tensor_sfb.shape[2],
+            )
+            # Use right multiplication for ScaledBasis (3 * x instead of x * 3)
+            x_times_3 = 3 * x
+            new_stride = (
+                (tma_tensor_sfb.stride[0][0], ((x, x), x_times_3)),
+                tma_tensor_sfb.stride[1],
+                tma_tensor_sfb.stride[2],
+            )
+            tma_tensor_sfb_new_layout = cute.make_layout(new_shape, stride=new_stride)
+            tma_tensor_sfb = cute.make_tensor(
+                tma_tensor_sfb.iterator, tma_tensor_sfb_new_layout
+            )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (
+            a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size
+        ) * atom_thr_size
+
+        # Setup TMA store for C
+        epi_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            c_tensor,
+            epi_smem_layout,
+            self.epi_tile,
+        )
+
+        # Compute grid size
+        self.tile_sched_params, grid = self._compute_grid(
+            c_tensor,
+            self.cta_tile_shape_mnk,
+            self.cluster_shape_mn,
+            max_active_clusters,
+        )
+
+        self.buffer_align_bytes = 1024
+
+        # Define shared storage for kernel
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            tmem_dealloc_mbar: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            # (EPI_TILE_M, EPI_TILE_N, STAGE)
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    cute.cosize(self.c_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.smem_alloc_a_dtype,
+                    cute.cosize(self.a_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.smem_alloc_b_dtype,
+                    cute.cosize(self.b_smem_layout_staged.outer),
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # Launch the kernel synchronously
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            tma_atom_c,
+            tma_tensor_c,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+        return
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+        """
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        # Coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # Initialize mainloop ab_pipeline (barrier) and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_pipeline = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # Initialize acc_pipeline (barrier) and states
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = (
+            self.threads_per_warp
+            * len(self.epilog_warp_id)
+            * (2 if use_2cta_instrs else 1)
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epilog_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar.ptr,
+        )
+
+        # Cluster arrive after barrier init
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        #
+        # Setup smem tensor A/B/SFA/SFB/C
+        #
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        sC = storage.sC.get_tensor(
+            c_smem_layout_staged.outer, swizzle=c_smem_layout_staged.inner
+        )
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        #
+        # Compute multicast mask for A/B/SFA/SFB buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1
+            )
+
+        #
+        # Local_tile partition global tensors
+        #
+        # (bM, bK, RestM, RestK, RestL)
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        # (bM, bK, RestM, RestK, RestL)
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+            (None, None, None),
+        )
+        # (bM, bN, RestM, RestN, RestL)
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        #
+        # Partition global tensor for TiledMMA_A/B/C
+        #
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgSFA = thr_mma.partition_A(gSFA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+        # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        #
+        # Partition global/shared tensor for TMA load A/B
+        #
+        # TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        #  TMA load scaled factor A partition_S/D
+        sfa_cta_layout = a_cta_layout
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsSFA, tAgSFA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfa,
+            block_in_cluster_coord_vmnk[2],
+            sfa_cta_layout,
+            cute.group_modes(sSFA, 0, 3),
+            cute.group_modes(tCgSFA, 0, 3),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # TMA load scaled factor B partition_S/D
+        sfb_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsSFB, tBgSFB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfb,
+            block_in_cluster_coord_sfb_vmnk[1],
+            sfb_cta_layout,
+            cute.group_modes(sSFB, 0, 3),
+            cute.group_modes(tCgSFB, 0, 3),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+
+        #
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/C
+        #
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        if cutlass.const_expr(self.overlapping_accum):
+            num_acc_stage_overlapped = 2
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, num_acc_stage_overlapped)
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        else:
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, self.num_acc_stage)
+            )
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        #
+        # Specialized TMA load warp
+        #
+        if warp_idx == self.tma_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_ab_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((atom_v, rest_v), RestK)
+                tAgA_slice = tAgA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+                # ((atom_v, rest_v), RestK)
+                tBgB_slice = tBgB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                # ((atom_v, rest_v), RestK)
+                tAgSFA_slice = tAgSFA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+
+                # Apply SFB slicing hack when cta_tile_shape_n=64 # {$nv-internal-release}
+                slice_n = mma_tile_coord_mnl[1]
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_mnl[1] // 2
+                # ((atom_v, rest_v), RestK)
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, mma_tile_coord_mnl[2])]
+
+                # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt
+                ab_producer_state.reset_count()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if ab_producer_state.count < k_tile_cnt:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(
+                        ab_producer_state
+                    )
+                #
+                # Tma load loop
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Conditionally wait for AB buffer empty
+                    ab_pipeline.producer_acquire(
+                        ab_producer_state, peek_ab_empty_status
+                    )
+
+                    # TMA load A/B/SFA/SFB
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, ab_producer_state.count)],
+                        tAsA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, ab_producer_state.count)],
+                        tBsB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_slice[(None, ab_producer_state.count)],
+                        tAsSFA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_slice[(None, ab_producer_state.count)],
+                        tBsSFB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfb_full_mcast_mask,
+                    )
+
+                    # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt + k_tile + 1
+                    ab_producer_state.advance()
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if ab_producer_state.count < k_tile_cnt:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(
+                            ab_producer_state
+                        )
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait A/B buffer empty
+            #
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator/SFA/SFB tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # Make accumulator tmem tensor
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # Make SFA tmem tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_M, MMA_K)
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # Make SFB tmem tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_N, MMA_K)
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+            #
+            # Partition for S2T copy of SFA/SFB
+            #
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_ab_stage
+            )
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                # Get accumulator stage index
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+
+                # Set tensor memory buffer for current tile
+                # (MMA, MMA_M, MMA_N)
+                tCtAcc = tCtAcc_base[(None, None, None, acc_stage_index)]
+
+                # Peek (try_wait) AB buffer full for k_tile = 0
+                ab_consumer_state.reset_count()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(
+                        ab_consumer_state
+                    )
+
+                #
+                # Wait for accumulator buffer empty
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_acquire(acc_producer_state)
+
+                # Apply TMEM pointer offset hack when cta_tile_shape_n=192 or cta_tile_shape_n=64 # {$nv-internal-release}
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] in {64, 192}):
+                    # If this is an ODD tile, shift the TMEM start address for cta_tile_shape_n=192 case by two words (ignores first 64 columns of SFB)
+                    offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr
+                        + self.num_accumulator_tmem_cols
+                        + self.num_sfa_tmem_cols
+                        + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                #
+                # Reset the ACCUMULATE field for each tile
+                #
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                #
+                # Mma mainloop
+                #
+                for k_tile in range(k_tile_cnt):
+                    if is_leader_cta:
+                        # Conditionally wait for AB buffer full
+                        ab_pipeline.consumer_wait(
+                            ab_consumer_state, peek_ab_full_status
+                        )
+
+                        #  Copy SFA/SFB from smem to tmem
+                        s2t_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            ab_consumer_state.index,
+                        )
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t_staged,
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t_staged,
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                        tile_crd = (None, None, None, ab_consumer_state.index)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc,
+                            [tCrA[tile_crd], tCtSFA],
+                            [tCrB[tile_crd], tCtSFB_mma],
+                            tCtAcc,
+                        )
+
+                        # Async arrive AB buffer empty
+                        ab_pipeline.consumer_release(ab_consumer_state)
+
+                    # Peek (try_wait) AB buffer full for k_tile = k_tile + 1
+                    ab_consumer_state.advance()
+                    peek_ab_full_status = cutlass.Boolean(1)
+                    if ab_consumer_state.count < k_tile_cnt:
+                        if is_leader_cta:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(
+                                ab_consumer_state
+                            )
+
+                #
+                # Async arrive accumulator buffer full
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+        #
+        # Specialized epilogue warps
+        #
+        if warp_idx < self.mma_warp_id:
+            #
+            # Alloc tensor memory buffer
+            #
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Partition for epilogue
+            #
+            epi_tidx = tidx
+            (
+                tiled_copy_t2r,
+                tTR_tAcc_base,
+                tTR_rAcc,
+            ) = self.epilog_tmem_copy_and_partition(
+                epi_tidx, tCtAcc_base, tCgC, epi_tile, use_2cta_instrs
+            )
+
+            tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.c_dtype)
+            tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                tiled_copy_t2r, tTR_rC, epi_tidx, sC
+            )
+            (
+                tma_atom_c,
+                bSG_sC,
+                bSG_gC_partitioned,
+            ) = self.epilog_gmem_copy_and_partition(
+                epi_tidx, tma_atom_c, tCgC, epi_tile, sC
+            )
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+
+            # Threads/warps participating in tma store pipeline
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                self.threads_per_warp * len(self.epilog_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage,
+                producer_group=c_producer_group,
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((ATOM_V, REST_V), EPI_M, EPI_N)
+                bSG_gC = bSG_gC_partitioned[
+                    (
+                        None,
+                        None,
+                        None,
+                        *mma_tile_coord_mnl,
+                    )
+                ]
+
+                # Get accumulator stage index
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_consumer_state.phase
+                    reverse_subtile = True if acc_stage_index == 0 else False
+                else:
+                    acc_stage_index = acc_consumer_state.index
+
+                # Set tensor memory buffer for current tile
+                # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                tTR_tAcc = tTR_tAcc_base[
+                    (None, None, None, None, None, acc_stage_index)
+                ]
+
+                #
+                # Wait for accumulator buffer full
+                #
+                acc_pipeline.consumer_wait(acc_consumer_state)
+
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+                #
+                # Store accumulator to global memory in subtiles
+                #
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+                for subtile_idx in cutlass.range(subtile_cnt):
+                    real_subtile_idx = subtile_idx
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if reverse_subtile:
+                            # Subtile always iterates on N dimension as we only have 4x1DP tmem load pattern for cta_tile_m = 128 cases. # {$nv-internal-release}
+                            real_subtile_idx = (
+                                self.cta_tile_shape_mnk[1] // self.epi_tile_n
+                                - 1
+                                - subtile_idx
+                            )
+                    #
+                    # Load accumulator from tensor memory buffer to register
+                    #
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                    #
+                    # Async arrive accumulator buffer empty ealier when overlapping_accum is enabled
+                    #
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if subtile_idx == self.iter_acc_early_release_in_epilogue:
+                            # Fence for TMEM load
+                            cute.arch.fence_view_async_tmem_load()
+                            acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_consumer_state.advance()
+
+                    #
+                    # Convert to C type
+                    #
+                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+                    acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                    tRS_rC.store(acc_vec)
+
+                    #
+                    # Store C to shared memory
+                    #
+                    c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
+                    cute.copy(
+                        tiled_copy_r2s,
+                        tRS_rC,
+                        tRS_sC[(None, None, None, c_buffer)],
+                    )
+                    # Fence and barrier to make sure shared memory store is visible to TMA store
+                    cute.arch.fence_proxy(
+                        "async.shared",
+                        space="cta",
+                    )
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                    #
+                    # TMA store C to global memory
+                    #
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sC[(None, c_buffer)],
+                            bSG_gC[(None, real_subtile_idx)],
+                        )
+                        # Fence and barrier to make sure shared memory store is visible to TMA store
+                        c_pipeline.producer_commit()
+                        c_pipeline.producer_acquire()
+                    self.epilog_sync_barrier.arrive_and_wait()
+
+                #
+                # Async arrive accumulator buffer empty
+                #
+                if cutlass.const_expr(not self.overlapping_accum):
+                    acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            tmem.relinquish_alloc_permit()
+            self.epilog_sync_barrier.arrive_and_wait()
+            tmem.free(acc_tmem_ptr)
+            #
+            # Wait for C store complete
+            #
+            c_pipeline.producer_tail()
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for smem to tmem load for scale factor tensor, then use it to partition smem memory (source) and tensor memory (destination).
+
+        :param sSF: The scale factor tensor in smem
+        :type sSF: cute.Tensor
+        :param tSF: The scale factor tensor in tmem
+        :type tSF: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t) where:
+            - tiled_copy_s2t: The tiled copy operation for smem to tmem load for scale factor tensor(s2t)
+            - tCsSF_compact_s2t: The partitioned scale factor tensor in smem
+            - tSF_compact_s2t: The partitioned scale factor tensor in tmem
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # (MMA, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        # (MMA, MMA_MN, MMA_K)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        # Make S2T CopyAtom and tiledCopy
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t, tCsSF_compact_s2t_
+        )
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    def epilog_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tAcc: cute.Tensor,
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for tensor memory load, then use it to partition tensor memory (source) and register array (destination).
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param tAcc: The accumulator tensor to be copied and partitioned
+        :type tAcc: cute.Tensor
+        :param gC_mnl: The global tensor C
+        :type gC_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param use_2cta_instrs: Whether use_2cta_instrs is enabled
+        :type use_2cta_instrs: bool
+
+        :return: A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc) where:
+            - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+            - tTR_tAcc: The partitioned accumulator tensor
+            - tTR_rAcc: The accumulated tensor in register used to hold t2r results
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # Make tiledCopy for tensor memory load
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.c_layout,
+            self.c_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, STAGE)
+        tAcc_epi = cute.flat_divide(
+            tAcc[((None, None), 0, 0, None)],
+            epi_tile,
+        )
+        # (EPI_TILE_M, EPI_TILE_N)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(
+            copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)]
+        )
+
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_M, STAGE)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_mnl_epi = cute.flat_divide(
+            gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile
+        )
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        # (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_rmem_tensor(
+            tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
+        )
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def epilog_smem_copy_and_partition(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tidx: cutlass.Int32,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory store, then use it to partition register array (source) and shared memory (destination).
+
+        :param tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+        :type tiled_copy_t2r: cute.TiledCopy
+        :param tTR_rC: The partitioned accumulator tensor
+        :type tTR_rC: cute.Tensor
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+        :type sepi: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_r2s, tRS_rC, tRS_sC) where:
+            - tiled_copy_r2s: The tiled copy operation for register to smem copy(r2s)
+            - tRS_rC: The partitioned tensor C (register source)
+            - tRS_sC: The partitioned tensor C (smem destination)
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        copy_atom_r2s = sm100_utils.get_smem_store_op(
+            self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r
+        )
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, PIPE_D)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sC = thr_copy_r2s.partition_D(sC)
+        # (R2S, R2S_M, R2S_N)
+        tRS_rC = tiled_copy_r2s.retile(tTR_rC)
+        return tiled_copy_r2s, tRS_rC, tRS_sC
+
+    def epilog_gmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        atom: Union[cute.CopyAtom, cute.TiledCopy],
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """Make tiledCopy for global memory store, then use it to:
+        partition shared memory (source) and global memory (destination) for TMA store version.
+
+        :param tidx: The thread index in epilogue warp groups
+        :type tidx: cutlass.Int32
+        :param atom: The copy_atom_c to be used for TMA store version, or tiled_copy_t2r for none TMA store version
+        :type atom: cute.CopyAtom or cute.TiledCopy
+        :param gC_mnl: The global tensor C
+        :type gC_mnl: cute.Tensor
+        :param epi_tile: The epilogue tiler
+        :type epi_tile: cute.Tile
+        :param sC: The shared memory tensor to be copied and partitioned
+        :type sC: cute.Tensor
+
+        :return: A tuple containing (tma_atom_c, bSG_sC, bSG_gC) where:
+            - tma_atom_c: The TMA copy atom
+            - bSG_sC: The partitioned shared memory tensor C
+            - bSG_gC: The partitioned global tensor C
+        :rtype: Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]
+        """
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_epi = cute.flat_divide(
+            gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile
+        )
+
+        tma_atom_c = atom
+        sC_for_tma_partition = cute.group_modes(sC, 0, 2)
+        gC_for_tma_partition = cute.group_modes(gC_epi, 0, 2)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N, RestM, RestN, RestL)
+        bSG_sC, bSG_gC = cpasync.tma_partition(
+            tma_atom_c,
+            0,
+            cute.make_layout(1),
+            sC_for_tma_partition,
+            gC_for_tma_partition,
+        )
+        return tma_atom_c, bSG_sC, bSG_gC
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        smem_capacity: int,
+        occupancy: int,
+    ) -> Tuple[int, int, int]:
+        """Computes the number of stages for A/B/C operands based on heuristics.
+
+        :param tiled_mma: The tiled MMA object defining the core computation.
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler_mnk: The shape (M, N, K) of the MMA tiler.
+        :type mma_tiler_mnk: tuple[int, int, int]
+        :param a_dtype: Data type of operand A.
+        :type a_dtype: type[cutlass.Numeric]
+        :param b_dtype: Data type of operand B.
+        :type b_dtype: type[cutlass.Numeric]
+        :param epi_tile: The epilogue tile shape.
+        :type epi_tile: cute.Tile
+        :param c_dtype: Data type of operand C (output).
+        :type c_dtype: type[cutlass.Numeric]
+        :param c_layout: Layout enum of operand C.
+        :type c_layout: utils.LayoutEnum
+        :param sf_dtype: Data type of Scale factor.
+        :type sf_dtype: type[cutlass.Numeric]
+        :param sf_vec_size: Scale factor vector size.
+        :type sf_vec_size: int
+        :param smem_capacity: Total available shared memory capacity in bytes.
+        :type smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+
+        :return: A tuple containing the computed number of stages for:
+                 (ACC stages, A/B operand stages, C stages)
+        :rtype: tuple[int, int, int]
+        """
+        # ACC stages
+        num_acc_stage = 1 if mma_tiler_mnk[1] == 256 else 2
+
+        # Default C stages
+        num_c_stage = 2
+
+        # Calculate smem layout and size for one stage of A, B, SFA, SFB and C
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            mma_tiler_mnk,
+            a_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            mma_tiler_mnk,
+            b_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+        mbar_helpers_bytes = 1024
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+        c_bytes = c_bytes_per_stage * num_c_stage
+
+        # Calculate A/B/SFA/SFB stages:
+        # Start with total smem per CTA (capacity / occupancy)
+        # Subtract reserved bytes and initial C stages bytes
+        # Divide remaining by bytes needed per A/B/SFA/SFB stage
+        num_ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+        ) // ab_bytes_per_stage
+
+        # Refine epilogue stages:
+        # Calculate remaining smem after allocating for A/B/SFA/SFB stages and reserved bytes
+        # Add remaining unused smem to epilogue
+        num_c_stage += (
+            smem_capacity
+            - occupancy * ab_bytes_per_stage * num_ab_stage
+            - occupancy * (mbar_helpers_bytes + c_bytes)
+        ) // (occupancy * c_bytes_per_stage)
+
+        return num_acc_stage, num_ab_stage, num_c_stage
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        max_active_clusters: cutlass.Constexpr,
+        swizzle_size: int = 1,
+        raster_order: Literal["m", "n"] = "m",
+    ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
+        """Use persistent tile scheduler to compute the grid size for the output tensor C.
+
+        :param c: The output tensor C
+        :type c: cute.Tensor
+        :param cta_tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type cta_tile_shape_mnk: tuple[int, int, int]
+        :param cluster_shape_mn: Shape of each cluster in M, N dimensions.
+        :type cluster_shape_mn: tuple[int, int]
+        :param max_active_clusters: Maximum number of active clusters.
+        :type max_active_clusters: cutlass.Constexpr
+        :param swizzle_size: Swizzling size in the unit of cluster for improving L2 cache hit rate, defaults to 1
+        :type swizzle_size: int
+        :param raster_order: Rasterization order of clusters ('m' or 'n'), defaults to 'm'
+        :type raster_order: Literal["m", "n"]
+
+        :return: A tuple containing:
+            - tile_sched_params: Parameters for the persistent tile scheduler.
+            - grid: Grid shape for kernel launch.
+        :rtype: Tuple[utils.PersistentTileSchedulerParams, tuple[int, int, int]]
+        """
+        c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        # Convert raster_order ("m" or "n") to raster_along_m (True or False)
+        raster_along_m = raster_order == "m"
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl, swizzle_size, raster_along_m
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+
+        return tile_sched_params, grid
+
+    @staticmethod
+    def needs_unpack_tma(
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Decide whether TMA must use the UNPACK_U8 variant (U4_UNPACK_U8 /
+        U6_UNPACK_U8) for narrow-precision operands.
+
+        Unpack is required when:
+          * Operand widths differ (mxf8f6f4 mixed-precision) — A and B must
+            share a uniform byte-per-element SMEM layout, so the narrower
+            operand is unpacked into 1B/elem containers in SMEM.
+          * Either operand is 6-bit — there is no packed U6 TMA format,
+            only U6_UNPACK_U8 exists.
+
+        Otherwise (same-width and no 6-bit operand, e.g. f4xf4 / f8xf8 /
+        f8E4M3xf8E5M2) TMA can use the natural packed format (U4 for 4-bit,
+        U8 for 8-bit).
+
+        :param a_dtype: Element data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: Element data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
+        :return: True if UNPACK_U8 TMA format must be used, False otherwise
+        :rtype: bool
+        """
+        if a_dtype.width != b_dtype.width:
+            return True
+        if a_dtype.width == 6 or b_dtype.width == 6:
+            return True
+        return False
+
+    @staticmethod
+    def is_valid_dtypes_and_scale_factor_vec_size(
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Check if the dtypes and sf_vec_size are valid combinations
+
+        :param a_dtype: The data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: The data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
+        :param sf_dtype: The data type of the scale factor
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param sf_vec_size: The vector size of the scale factor
+        :type sf_vec_size: int
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+
+        :return: True if the dtypes and sf_vec_size are valid, False otherwise
+        :rtype: bool
+        """
+        supported_ab_dtypes = {
+            cutlass.Float4E2M1FN,
+            cutlass.Float6E2M3FN,
+            cutlass.Float6E3M2FN,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }
+
+        # Check A/B element types
+        if a_dtype not in supported_ab_dtypes or b_dtype not in supported_ab_dtypes:
+            return False
+
+        # Check SF element type
+        if sf_dtype not in {cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN}:
+            return False
+
+        # sf_vec_size rules:
+        #   * 16 is only supported for Float4E2M1FN x Float4E2M1FN (NVF4 / MXF4 fp4-pair)
+        #   * 32 is required for every other A/B combination (MXF8, mxf8f6f4 mixed, MXF4-pair with MX scaling)
+        # SF dtype pairing with sf_vec_size:
+        #   * sf_vec_size == 16 requires sf_dtype in {Float8E4M3FN (NVF4), Float8E8M0FNU (MXF4)}
+        #   * sf_vec_size == 32 requires sf_dtype == Float8E8M0FNU (MX scaling)
+        both_fp4 = a_dtype is cutlass.Float4E2M1FN and b_dtype is cutlass.Float4E2M1FN
+        if sf_vec_size == 16:
+            if not both_fp4:
+                return False
+        elif sf_vec_size == 32:
+            if sf_dtype is not cutlass.Float8E8M0FNU:
+                return False
+        else:
+            return False
+
+        # Check valid c_dtype
+        if c_dtype not in {
+            cutlass.Float32,
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }:
+            return False
+
+        return True
+
+    @staticmethod
+    def is_valid_layouts(
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: Literal["m", "k"],
+        b_major: Literal["n", "k"],
+        c_major: Literal["m", "n"],
+    ) -> bool:
+        """
+        Check if layouts and dtypes are valid combinations
+
+        :param a_dtype: The data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: The data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major dimension of the A tensor
+        :type a_major: Literal["m", "k"]
+        :param b_major: The major dimension of the B tensor
+        :type b_major: Literal["n", "k"]
+        :param c_major: The major dimension of the C tensor
+        :type c_major: Literal["m", "n"]
+
+        :return: True if the layouts are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        # FP4 operands can only be k-major (checked per operand)
+        if a_dtype is cutlass.Float4E2M1FN and a_major != "k":
+            is_valid = False
+        if b_dtype is cutlass.Float4E2M1FN and b_major != "k":
+            is_valid = False
+        # {$nv-internal-release begin}
+        # TODO: Currently we don't support m major output for Float4E2M1FN
+        if c_dtype is cutlass.Float4E2M1FN and c_major == "m":
+            is_valid = False
+        # {$nv-internal-release end}
+
+        return is_valid
+
+    @staticmethod
+    def is_valid_mma_tiler_and_cluster_shape(
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ) -> bool:
+        """
+        Check if the mma tiler and cluster shape are valid
+
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
+        :type cluster_shape_mn: Tuple[int, int]
+
+        :return: True if the mma tiler and cluster shape are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+        # Skip invalid mma tile shape
+        if mma_tiler_mn[0] not in [128, 256]:
+            is_valid = False
+        if mma_tiler_mn[1] not in [64, 128, 192, 256]:
+            is_valid = False
+        # Skip illegal cluster shape
+        if cluster_shape_mn[0] % (2 if mma_tiler_mn[0] == 256 else 1) != 0:
+            is_valid = False
+        # Skip invalid cluster shape
+        is_power_of_2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        if (
+            cluster_shape_mn[0] * cluster_shape_mn[1] > 16
+            or cluster_shape_mn[0] <= 0
+            or cluster_shape_mn[1] <= 0
+            # Special cluster shape check for scale factor multicasts.
+            # Due to limited size of scale factors, we can't multicast among more than 4 CTAs.
+            or cluster_shape_mn[0] > 4
+            or cluster_shape_mn[1] > 4
+            or not is_power_of_2(cluster_shape_mn[0])
+            or not is_power_of_2(cluster_shape_mn[1])
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_tensor_alignment(
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: Literal["m", "k"],
+        b_major: Literal["n", "k"],
+        c_major: Literal["m", "n"],
+        mma_tiler_mn: Tuple[int, int],
+    ) -> bool:
+        """
+        Check if the tensor alignment is valid
+
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param a_dtype: The data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: The data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major axis of the A tensor
+        :type a_major: Literal["m", "k"]
+        :param b_major: The major axis of the B tensor
+        :type b_major: Literal["n", "k"]
+        :param c_major: The major axis of the C tensor
+        :type c_major: Literal["m", "n"]
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler,
+            needed to verify per-CTA UNPACK alignment under 2CTA MMA.
+        :type mma_tiler_mn: Tuple[int, int]
+
+        :return: True if the problem shape is valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            # TMA requires the contiguous inner dimension to be a multiple of
+            # 16 B (= 128 bits). Work in bits so non-byte-aligned widths
+            # (e.g. 6-bit) are handled correctly: 16 * 8 // dtype.width is
+            # wrong when dtype.width does not divide 128 (it returns 21 for
+            # 6-bit instead of the real requirement K*6 % 128 == 0).
+            return (num_major_elements * dtype.width) % (16 * 8) == 0
+
+        def check_contigous_128_alignment(dtype, is_mode0_major, tensor_shape):
+            # we only need to check alignment for subbyte dtype
+            if dtype.width >= 8:
+                return True
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 128
+            return num_major_elements % num_contiguous_elements == 0
+
+        if (
+            not check_contigous_16B_alignment(a_dtype, a_major == "m", (m, k, l))
+            or not check_contigous_16B_alignment(b_dtype, b_major == "n", (n, k, l))
+            or not check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        ):
+            is_valid = False
+        # When an operand is loaded via the UNPACK TMA variant
+        # (U4_UNPACK_U8 or U6_UNPACK_U8), its inner tensor dimension in bytes
+        # must be a multiple of 64B (4-bit) or 96B (6-bit); both work out to
+        # a multiple of 128 elements along the contiguous dim. The check only
+        # applies to sub-byte operands and only when the pair triggers UNPACK.
+        if Sm100BlockScaledPersistentDenseGemmKernel.needs_unpack_tma(
+            a_dtype, b_dtype
+        ) and (
+            not check_contigous_128_alignment(a_dtype, a_major == "m", (m, k, l))
+            or not check_contigous_128_alignment(b_dtype, b_major == "n", (n, k, l))
+        ):
+            is_valid = False
+        # Additional UNPACK constraint for any sub-byte operand on its contig
+        # axis: when a sub-byte A is m-major (contig=M) or a sub-byte B is
+        # n-major (contig=N), the MMA tile's contig dim (after 2CTA M-split,
+        # which splits M for both A and B on the non-multicast atom path)
+        # must be a multiple of 128 elements to satisfy the 64B (fp4) /
+        # 96B (fp6) inner-dim requirement of U4_/U6_UNPACK_U8. Observed
+        # failures: (128,192)/(1,1)/m-n-m (1CTA) and (256,128)/(2,2)/m-n-m
+        # (2CTA) trigger CUDA illegal instruction for fp6 when mma_tiler_N
+        # (or N/2 after 2CTA split) is not a 128-multiple; the same rule
+        # applies to any other sub-byte operand on its non-K contig axis.
+        use_2cta_instrs = mma_tiler_mn[0] == 256
+        cta_div = 2 if use_2cta_instrs else 1
+        if (
+            Sm100BlockScaledPersistentDenseGemmKernel.needs_unpack_tma(a_dtype, b_dtype)
+            and a_major == "m"
+            and a_dtype.width < 8
+            and (mma_tiler_mn[0] // cta_div) % 128 != 0
+        ):
+            is_valid = False
+        if (
+            Sm100BlockScaledPersistentDenseGemmKernel.needs_unpack_tma(a_dtype, b_dtype)
+            and b_major == "n"
+            and b_dtype.width < 8
+            and (mma_tiler_mn[1] // cta_div) % 128 != 0
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def can_implement(
+        mnkl: Tuple[int, int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: Literal["m", "k"],
+        b_major: Literal["n", "k"],
+        c_major: Literal["m", "n"],
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ) -> bool:
+        """
+        Check if the gemm can be implemented
+
+        :param mnkl: The problem size as a tuple (M, N, K, L).
+        :type mnkl: Tuple[int, int, int, int]
+        :param a_dtype: The data type of the A operand
+        :type a_dtype: Type[cutlass.Numeric]
+        :param b_dtype: The data type of the B operand
+        :type b_dtype: Type[cutlass.Numeric]
+        :param sf_dtype: The data type of the scale factor tensor
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param a_major: The major axis of the A tensor
+        :type a_major: Literal["m", "k"]
+        :param b_major: The major axis of the B tensor
+        :type b_major: Literal["n", "k"]
+        :param c_major: The major axis of the C tensor
+        :type c_major: Literal["m", "n"]
+        :param sf_vec_size: The vector size
+        :type sf_vec_size: int
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
+        :type cluster_shape_mn: Tuple[int, int]
+        :return: True if the gemm can be implemented, False otherwise
+        :rtype: bool
+        """
+        # Unpack parameters
+        m, n, k, l = mnkl
+        can_implement = True
+        # Skip unsupported types
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_dtypes_and_scale_factor_vec_size(
+            a_dtype, b_dtype, sf_dtype, sf_vec_size, c_dtype
+        ):
+            can_implement = False
+        # Skip unsupported layouts
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_layouts(
+            a_dtype, b_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+        # Skip invalid mma tile shape and cluster shape
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_mma_tiler_and_cluster_shape(
+            mma_tiler_mn, cluster_shape_mn
+        ):
+            can_implement = False
+        # Skip illegal problem shape for load/store alignment
+        if not Sm100BlockScaledPersistentDenseGemmKernel.is_valid_tensor_alignment(
+            m,
+            n,
+            k,
+            l,
+            a_dtype,
+            b_dtype,
+            c_dtype,
+            a_major,
+            b_major,
+            c_major,
+            mma_tiler_mn,
+        ):
+            can_implement = False
+        return can_implement
+
+
+def _to_cute_tensor(tensor: torch.Tensor, assumed_align: int = 32) -> cute.Tensor:
+    cute_tensor = cutlass_torch.from_dlpack(tensor, assumed_align=assumed_align)
+    if tensor.dim() <= 1:
+        return cute_tensor
+    leading_dim = cutlass_torch.get_leading_dim(tensor)
+    return cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+
+
+class _BlockScaledGemmReferenceLauncher:
+    """Host-side wrapper for the dense blockscaled GEMM reference calls."""
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ):
+        self.sf_vec_size = sf_vec_size
+        self.mma_tiler_mn = mma_tiler_mn
+        self.cluster_shape_mn = cluster_shape_mn
+        self.layouts = (
+            OperandMajorMode.K,
+            OperandMajorMode.K,
+            utils.LayoutEnum.ROW_MAJOR,
+        )
+        cluster_size = cluster_shape_mn[0] * cluster_shape_mn[1]
+        self.max_active_clusters = utils.HardwareInfo().get_max_active_clusters(
+            cluster_size
+        )
+        self.gemm = Sm100BlockScaledPersistentDenseGemmKernel(
+            self.sf_vec_size,
+            self.mma_tiler_mn,
+            self.cluster_shape_mn,
+        )
+        self._compiled: dict[Tuple[Any, ...], Any] = {}
+
+    def __call__(
+        self,
+        *,
+        a: torch.Tensor,
+        sfa: torch.Tensor,
+        b: torch.Tensor,
+        sfb: torch.Tensor,
+        n: int,
+        k: int,
+    ) -> torch.Tensor:
+        """Run C[M,N] = blockscaled(A[M,K], B[N,K]) and return fp32 C."""
+        if a.dim() != 2 or b.dim() != 2 or sfa.dim() != 2 or sfb.dim() != 2:
+            raise ValueError(
+                "blockscaled reference GEMM expects 2D A/B/SFA/SFB tensors; "
+                f"got A={a.dim()}D B={b.dim()}D SFA={sfa.dim()}D SFB={sfb.dim()}D."
+            )
+        m = a.shape[0]
+        # Accept both fp4 (2 elems/byte -> inner == K//2) and fp8 (1 elem/byte
+        # -> inner == K) operands; the underlying blockscaled GEMM supports
+        # nvfp4 / mxfp4 / mxfp8 by design, the inner-dim is the only difference.
+        if a.shape[1] != k and a.shape[1] * 2 != k:
+            raise ValueError(
+                f"A inner dim ({a.shape[1]}) must equal logical K ({k}) for "
+                f"1-elem/byte (fp8) operands or K//2 for 2-elem/byte (fp4)."
+            )
+        expected_sf_cols = (k + self.sf_vec_size - 1) // self.sf_vec_size
+        if sfa.shape != (m, expected_sf_cols):
+            raise ValueError(
+                f"SFA must have raw shape {(m, expected_sf_cols)}, got {tuple(sfa.shape)}."
+            )
+        if sfb.shape != (n, expected_sf_cols):
+            raise ValueError(
+                f"SFB must have raw shape {(n, expected_sf_cols)}, got {tuple(sfb.shape)}."
+            )
+
+        a_3d = a.unsqueeze(-1)
+        b_3d = b.unsqueeze(-1)
+        c_3d = torch.empty((m, n, 1), dtype=torch.float32, device=a.device)
+        sfa_blocked = to_blocked(sfa).contiguous()
+        sfb_blocked = to_blocked(sfb).contiguous()
+
+        a_cute = _to_cute_tensor(a_3d)
+        b_cute = _to_cute_tensor(b_3d)
+        c_cute = _to_cute_tensor(c_3d)
+        sfa_cute = _to_cute_tensor(sfa_blocked, assumed_align=32)
+        sfb_cute = _to_cute_tensor(sfb_blocked, assumed_align=32)
+
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+        key = (a.dtype, b.dtype, sfa.dtype, sfb.dtype, c_3d.dtype)
+        compiled = self._compiled.get(key)
+        if compiled is None:
+            compiled = cute.compile(
+                self.gemm,
+                a_cute,
+                b_cute,
+                sfa_cute,
+                sfb_cute,
+                c_cute,
+                self.layouts,
+                (
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                ),
+                self.max_active_clusters,
+                stream,
+            )
+            self._compiled[key] = compiled
+        
+        compiled(
+            a_cute,
+            b_cute,
+            sfa_cute,
+            sfb_cute,
+            c_cute,
+            (m, n, k, 1),
+            stream,
+        )
+        torch.cuda.current_stream().synchronize()
+        return c_3d.squeeze(-1)
+
+
+
+__all__ = ["MegaMoEReference", "compute_megamoe_reference", "Nvfp4BlockSize"]

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/mega_runner.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/mega_runner.py
@@ -1,0 +1,2754 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Multi-rank MegaMoE host driver (NVFP4 dispatch + fc1+fc2 + combine).
+
+Parallel sibling of ``runner_fc12.py``.  ``runner_fc12.py`` is the
+single-rank fused fc1+fc2 perf testbed (no cross-rank comm); this
+runner adds dispatch and combine on top of the same fc1+fc2 math and
+runs them all in one kernel.  Ground truth is the eyeball-reviewable
+``compute_megamoe_reference`` in ``mega_reference.py``; everything in
+this file is glue.
+
+Design choices worth knowing:
+
+  * Inputs are generated deterministically across ranks from a shared
+    seed (numpy rng + ``torch.from_numpy(...).cuda()``).  Every rank
+    reproduces the full ``(num_ranks, num_tokens_per_rank, *)`` view
+    and the ``(num_ranks, num_experts_per_rank, ...)`` weight bank in
+    lock-step -- zero NCCL/NVSHMEM traffic during input gen.
+
+  * The reference is computed against the full global view on every
+    rank; each rank picks its own ``(T, K, hidden)`` slice for validate.
+    ``num_ranks`` times the reference work but immune to host-side
+    comm bugs.
+
+  * Workspace partitioning is the kernel's business.  Host asks for
+    ``(local_ws_bytes, shared_ws_bytes)`` and hands back two opaque
+    byte buffers; kernel does its own region split internally.
+
+Kernel-client contract assumed below (lives in ``megamoe_kernel.py``)::
+
+    class MegaMoEKernel:
+        def __init__(self, problem_const, impl_options): ...
+        def get_workspace_sizes(self, ...) -> Tuple[int, int]:
+            \"\"\"(local_ws_bytes, shared_ws_bytes)\"\"\"
+        def __call__(self,
+            activation, activation_sf,           # NVFP4 + fp8 plain SF
+            topk_idx, topk_weights,
+            fc1_weight, fc1_weight_sf,
+            fc2_weight, fc2_weight_sf,
+            output_activation,                   # (T, hidden) final output
+            local_workspace, shared_workspace,   # opaque uint8
+            # ``peer_rank_ptr_mapper_host`` carries runtime peer offsets;
+            # kernel.__call__ packs it into SymBuffer{world_size}.
+            stream): ...
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from typing import List, Literal, Optional, Tuple
+
+from itertools import permutations
+import numpy as np
+import torch
+import triton
+import triton.language as tl
+
+
+_FORM_B_PERM_K_LIMIT = 4   # K! perms: K<=4 -> <=24, manageable
+
+
+@triton.jit
+def _form_b_all_perms_kernel(
+    src_ptr,    # (T, K, H) bf16, contiguous
+    dst_ptr,    # (T, H, n_perms) bf16, contiguous
+    perms_ptr,  # (n_perms, K) int32
+    T,
+    K,
+    H,
+    BLOCK_H: tl.constexpr,
+    K_const: tl.constexpr,
+    n_perms_const: tl.constexpr,
+):
+    """Enumerate every K-axis permutation's bf16 sequential-add result.
+
+    Triton's ``tl.bfloat16`` add lowers to PTX ``add.bf16x2`` on sm_90+,
+    which is the same round-to-nearest bf16 op the hardware atomic-add
+    path uses internally -- so this kernel's candidates are
+    bit-comparable to ``red.global.add.noftz.v2.bf16x2`` observable
+    outputs (modulo the atomic-add ordering, which is exactly what we
+    enumerate).
+    """
+    t = tl.program_id(0)
+    h_off = tl.program_id(1) * BLOCK_H + tl.arange(0, BLOCK_H)
+    mask = h_off < H
+    for p in tl.static_range(n_perms_const):
+        acc = tl.zeros((BLOCK_H,), dtype=tl.bfloat16)
+        for k_pos in tl.static_range(K_const):
+            k = tl.load(perms_ptr + p * K_const + k_pos)
+            v = tl.load(
+                src_ptr + t * K * H + k * H + h_off,
+                mask=mask, other=0,
+            ).to(tl.bfloat16)
+            acc = acc + v
+        tl.store(
+            dst_ptr + t * H * n_perms_const + h_off * n_perms_const + p,
+            acc, mask=mask,
+        )
+
+
+def _form_b_enumerate_perms(ref_K_terms: torch.Tensor) -> torch.Tensor:
+    """Return ``(T, H, K!)`` bf16 tensor of every K-axis permutation's
+    bf16 sequential-add candidate result.  Hard-rejects ``K > 4`` (K!
+    grows factorially; K=4 -> 24 perms is the practical ceiling for
+    full ordering enumeration).
+    """
+    assert ref_K_terms.dtype == torch.bfloat16 and ref_K_terms.is_cuda
+    T, K, H = ref_K_terms.shape
+    if K > _FORM_B_PERM_K_LIMIT:
+        raise ValueError(
+            f"_form_b_enumerate_perms: K={K} > {_FORM_B_PERM_K_LIMIT}; "
+            f"K! enumeration is intractable beyond K=4."
+        )
+    perms = list(permutations(range(K)))
+    n_perms = len(perms)
+    perms_t = torch.tensor(perms, dtype=torch.int32, device=ref_K_terms.device)
+    src = ref_K_terms.contiguous()
+    dst = torch.empty(
+        (T, H, n_perms), dtype=torch.bfloat16, device=ref_K_terms.device,
+    )
+    BLOCK_H = 256
+    grid = (T, triton.cdiv(H, BLOCK_H))
+    _form_b_all_perms_kernel[grid](
+        src, dst, perms_t, T, K, H,
+        BLOCK_H=BLOCK_H, K_const=K, n_perms_const=n_perms,
+    )
+    return dst
+
+
+def _quantile_compat(x: torch.Tensor, qs: List[float]) -> List[float]:
+    """torch.quantile-equivalent that handles >16M tensors via numpy.
+
+    ``torch.quantile`` errors out with "input tensor is too large" past
+    ~2^24 elements (CPU sort backed); ``np.quantile`` is partition-based
+    and has no such cap.  Both paths return the same fp64 quantiles.
+    """
+    if x.numel() <= 16_777_216:
+        return torch.quantile(
+            x, torch.tensor(qs, dtype=x.dtype, device=x.device),
+        ).cpu().tolist()
+    return np.quantile(x.cpu().numpy(), np.asarray(qs)).tolist()
+
+
+def _form_b_bitwise_match(
+    actual_reduced: torch.Tensor,  # (T, H) bf16 or fp32 (bit cast via .to(bf16))
+    ref_K_terms: torch.Tensor,     # (T, K, H) bf16
+) -> Tuple[torch.Tensor, int]:
+    """For each (t, h) cell, return True iff ``actual_reduced[t, h]`` is
+    bit-exactly equal to SOME of the K! bf16-sequential-add permutations
+    of ``ref_K_terms[t, :, h]``.
+
+    Used by reduce modes (``fc2_transpose_redg`` / ``fc2_ublkredg``) to validate the device-side
+    ``red.global.add.noftz.v2.bf16x2`` flow is algorithmically correct
+    (modulo non-deterministic atomic-add ordering): every K! permutation
+    is a legal observable outcome of K concurrent atomic adds, so actual
+    hitting ANY of them proves the only discrepancy from a host fp32 ref
+    is ordering, not a real bug.  100% match additionally confirms the
+    hardware atomic-add rounds per-step (bf16+bf16->bf16) rather than
+    keeping a wider intermediate -- because if it kept fp32 accum, the
+    observable result set would NOT be exhausted by bf16-sequential
+    candidates.
+
+    Returns ``(match_mask: (T, H) bool, n_perms: int)``.
+    """
+    candidates = _form_b_enumerate_perms(ref_K_terms)  # (T, H, K!)
+    n_perms = candidates.shape[-1]
+    actual_bf16 = actual_reduced.to(torch.bfloat16)
+    match_mask = (candidates == actual_bf16.unsqueeze(-1)).any(dim=-1)
+    return match_mask, n_perms
+
+
+@triton.jit
+def _bf16_seq_sum_k_kernel(
+    src_ptr,    # (T, K, H) bf16 contiguous
+    dst_ptr,    # (T, H)    bf16 contiguous
+    T: tl.constexpr,
+    K: tl.constexpr,
+    H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """Per-(token, hidden-block) sequential bf16 add over the K axis.
+
+    Mirrors the device-side ``red.global.add.noftz.v2.bf16x2`` precision
+    (= bf16 round-to-nearest per add) so the form-B validate comparison
+    captures only the atomic-ordering difference, not the host-vs-device
+    accumulator precision gap (host fp32 sum would over-estimate ref).
+    """
+    t = tl.program_id(0)
+    h_off = tl.program_id(1) * BLOCK_H + tl.arange(0, BLOCK_H)
+    mask = h_off < H
+    acc = tl.zeros((BLOCK_H,), dtype=tl.bfloat16)
+    for k in tl.static_range(K):
+        v = tl.load(
+            src_ptr + t * K * H + k * H + h_off, mask=mask, other=0
+        ).to(tl.bfloat16)
+        acc = acc + v
+    tl.store(dst_ptr + t * H + h_off, acc, mask=mask)
+
+
+def _bf16_seq_sum_k(src: torch.Tensor) -> torch.Tensor:
+    """Triton-backed ``sum(dim=1)`` over (T, K, H) bf16, accumulating in
+    bf16 to match device-side atomic-add precision (see kernel docstring).
+    """
+    assert src.dtype == torch.bfloat16 and src.is_cuda
+    T, K, H = src.shape
+    src = src.contiguous()
+    dst = torch.empty((T, H), dtype=torch.bfloat16, device=src.device)
+    BLOCK_H = 256
+    grid = (T, triton.cdiv(H, BLOCK_H))
+    _bf16_seq_sum_k_kernel[grid](src, dst, T, K, H, BLOCK_H=BLOCK_H)
+    return dst
+
+# Ensure absolute package imports work when run as a script.
+_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+_PARENT_DIR = os.path.dirname(_PKG_DIR)
+if _PARENT_DIR not in sys.path:
+    sys.path.insert(0, _PARENT_DIR)
+
+import cutlass
+
+from moe_nvfp4_swapab.epilogue_refactor import (
+    SwapABSwigluFp4Epilogue as _SwapABEpilogue,
+)
+from moe_nvfp4_swapab.mega_reference import compute_megamoe_reference
+from src.token_comm import CombineFormat
+from common.megamoe_constants import Nvfp4BlockSize
+from moe_nvfp4_swapab.runner_common import (
+    _DataDtype,
+    _Fp4DecodeTable,
+    _ScaleDtype,
+    _stack_byte_reinterpretable_tensors,
+    ceil_div,
+    make_nvfp4_tensor_from_torch_rng as _make_nvfp4_tensor_from_torch_rng,
+    make_raw_scale_tensor_from_torch_rng as _make_raw_scale_tensor_from_torch_rng,
+    round_up,
+    to_blocked,
+)
+from moe_nvfp4_swapab.runner_fc12 import (
+    ImplDesc,
+    MiscDesc,
+)
+
+_SwapABEpilogueTokenTile = _SwapABEpilogue._EpilogueTokenTileSize
+_SwapABEpilogueIntermediateAlignment = (
+    2 * _SwapABEpilogue._EpilogueFc1GateUpInterleave
+)
+
+
+# =============================================================================
+# Problem descriptor
+# =============================================================================
+
+
+@dataclass
+class TokenCommProblemDesc:
+    """Multi-rank, pre-dispatch problem configuration.
+
+    Each rank holds ``num_tokens_per_rank`` input-token slots and the
+    routing layer picks ``num_topk`` experts out of ``num_total_experts``.
+    Per-rank locality (``num_experts_per_rank = num_total_experts //
+    world_size``) is implicit.
+
+    ``num_tokens_per_rank``: input-token slot count per rank, equal across
+    all EP ranks.  This is the dispatch-protocol assumption -- the
+    per-rank ``input_token_buffer`` has a fixed shape so peer TMA loads
+    can use a static descriptor.  In real EP deployments the per-rank
+    slot count comes from ``global_batch / DP_size`` (times seq_len if
+    no sequence-parallel), which is also equal across EP ranks under
+    balanced DP.  Variable-length sequences / drop-token routing are
+    handled by setting individual slots' ``topk_idx`` to -1 (masked
+    routing) rather than by ragged buffer shapes -- v1 doesn't yet wire
+    masked routing through but the buffer layout already accommodates it.
+
+    Contrast ``runner_fc12.ProblemDesc``: that describes the post-dispatch
+    world (already-grouped tokens per local expert), and its
+    ``balance_route`` flag controls expert-side balance of an
+    already-routed stream.  Here, ``route_distribution`` controls how
+    the routing table is *generated* in the first place.
+
+    v1 layout / dtype locks (inherited from ``runner_fc12``): NVFP4 data,
+    fp8 plain K-major SF on inputs (no atom swizzle at the user boundary
+    -- the kernel's dispatch warps swizzle SF internally before fc1 reads
+    them), bf16/fp16 ``fc2_output_dtype``.
+
+    TODO: expose ``activation_global_scale`` / ``fc1_weight_global_scale``
+    / ``fc2_weight_global_scale`` / ``norm_const`` as fields once they're
+    randomized; v1 pins to 1.0 matching ``runner_fc12.py``.
+    """
+
+    world_size: int = 0
+    num_tokens_per_rank: int = 0
+    num_topk: int = 0
+    num_total_experts: int = 0
+    hidden: int = 0
+    intermediate: int = 0
+    fc2_output_dtype: torch.dtype = torch.bfloat16
+    # Cross-rank combine wire format (drives the host ref's quant round-trip and,
+    # once wired, the kernel's fc2 encoder). Default is the bf16 no-quant baseline.
+    combine_format: CombineFormat = CombineFormat.parse("bf16")
+    # ``balanced``: locally uniform random block assignment, with exact
+    # per-expert balance on each full E-token block and randomized tails.
+    # ``power_law``: Zipf-rank-frequency, matches the empirical
+    # token-to-expert distribution shape reported by the TRT team.
+    route_distribution: Literal["balanced", "power_law"] = "balanced"
+    # Only consulted when route_distribution == "power_law".  1.0 = classic
+    # Zipf (top ~10% experts absorb ~50% tokens); larger = more skewed; 0
+    # degenerates to uniform.
+    power_law_exponent: float = 1.0
+    # DeepSeek-V4 ``config.swiglu_limit``: asymmetric clamp on the real
+    # (post-fc1_alpha) gate/up pre-activations before SiLU
+    # (``gate=clamp(gate,max=limit)``, ``up=clamp(up,-limit,+limit)``).  Part
+    # of the model math, so it lives in the problem desc and drives both the
+    # reference and the kernel build.  None disables the clamp.
+    gate_up_clamp: Optional[float] = None
+
+    @property
+    def num_experts_per_rank(self) -> int:
+        return self.num_total_experts // self.world_size
+
+    def __post_init__(self) -> None:
+        if self.world_size <= 0:
+            raise ValueError(f"world_size must be positive, got {self.world_size}.")
+        if self.num_tokens_per_rank <= 0:
+            raise ValueError(
+                f"num_tokens_per_rank must be positive, got {self.num_tokens_per_rank}."
+            )
+        if self.num_topk <= 0:
+            raise ValueError(f"num_topk must be positive, got {self.num_topk}.")
+        if self.num_total_experts <= 0:
+            raise ValueError(
+                f"num_total_experts must be positive, got {self.num_total_experts}."
+            )
+        if self.num_total_experts % self.world_size != 0:
+            raise ValueError(
+                f"num_total_experts ({self.num_total_experts}) must be divisible "
+                f"by world_size ({self.world_size})."
+            )
+        if self.num_topk > self.num_total_experts:
+            raise ValueError(
+                f"num_topk ({self.num_topk}) > num_total_experts "
+                f"({self.num_total_experts}); each token's K slots must select "
+                f"distinct experts."
+            )
+        if self.hidden <= 0 or self.hidden % (2 * Nvfp4BlockSize) != 0:
+            raise ValueError(
+                f"hidden ({self.hidden}) must be a positive multiple of "
+                f"{2 * Nvfp4BlockSize} (NVFP4 data leg: 4-bit packed yields "
+                f"hidden/2 bytes/row; TMA leading-row 16-byte align requires "
+                f"hidden % 32 == 0).  The SF leg's stricter %64 alignment "
+                f"is NOT enforced at the hidden level: callers may keep "
+                f"hidden at %32 granularity and zero-pad activation_sf "
+                f"along K_sf to the next multiple of 4 FP8 SFs."
+            )
+        if self.intermediate <= 0:
+            raise ValueError(f"intermediate must be positive, got {self.intermediate}.")
+        if self.intermediate % _SwapABEpilogueIntermediateAlignment != 0:
+            raise ValueError(
+                f"intermediate ({self.intermediate}) must be a positive multiple of "
+                f"{_SwapABEpilogueIntermediateAlignment} for the current "
+                "swapAB epilogue."
+            )
+        if (self.intermediate // 2) % Nvfp4BlockSize != 0:
+            raise ValueError(
+                f"intermediate/2 ({self.intermediate // 2}) must be a multiple of "
+                f"sf_vec_size ({Nvfp4BlockSize})."
+            )
+        if self.fc2_output_dtype not in (torch.bfloat16, torch.float16):
+            raise ValueError(
+                f"fc2_output_dtype must be torch.bfloat16 or torch.float16, "
+                f"got {self.fc2_output_dtype}."
+            )
+        if self.route_distribution not in ("balanced", "power_law"):
+            raise ValueError(
+                f"route_distribution must be 'balanced' or 'power_law', "
+                f"got {self.route_distribution!r}."
+            )
+        if self.power_law_exponent < 0.0:
+            raise ValueError(
+                f"power_law_exponent must be non-negative, got "
+                f"{self.power_law_exponent}."
+            )
+        if self.gate_up_clamp is not None and self.gate_up_clamp < 0.0:
+            raise ValueError(
+                f"gate_up_clamp must be None or non-negative, got "
+                f"{self.gate_up_clamp}."
+            )
+
+    def __str__(self) -> str:
+        dtype_name = lambda t: str(t).split(".")[-1]
+        route_str = self.route_distribution
+        if self.route_distribution == "power_law":
+            route_str = f"power_law(exponent={self.power_law_exponent:.3g})"
+        clamp_str = (
+            "off" if self.gate_up_clamp is None
+            else f"{self.gate_up_clamp:.4g}"
+        )
+        return (
+            f"TokenCommProblemDesc: world={self.world_size} "
+            f"tokens_per_rank={self.num_tokens_per_rank} topk={self.num_topk} "
+            f"experts(total={self.num_total_experts}, "
+            f"per_rank={self.num_experts_per_rank}) | "
+            f"hidden={self.hidden} intermediate={self.intermediate} | "
+            f"fc2_output_dtype={dtype_name(self.fc2_output_dtype)} | "
+            f"combine={self.combine_format} | "
+            f"route={route_str} | swiglu_clamp={clamp_str}"
+        )
+
+
+# =============================================================================
+# Routing-table generators (vectorized, deterministic)
+# =============================================================================
+
+
+def _generate_topk_idx_balanced(
+    num_ranks: int,
+    num_tokens_per_rank: int,
+    num_topk: int,
+    num_total_experts: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Locally uniform random routing over E-token blocks.
+
+    Each source rank is partitioned into padded blocks of ``num_total_experts``
+    consecutive tokens.  Within every block, each top-k column traverses a
+    random permutation of all experts exactly once, shifted by a distinct
+    per-column offset.  This makes every token's K experts distinct while
+    keeping the source-rank-to-expert and source-rank-to-target-rank traffic
+    balanced in each local block.
+
+    Properties:
+      - The K experts per token are pairwise distinct.
+      - Every full block contributes exactly ``num_topk`` tokens to every
+        expert from each source rank.
+      - Non-divisible token counts are handled by generating one padded block
+        and truncating it, so tail imbalance is random instead of structural.
+    """
+    assert num_topk <= num_total_experts, (
+        f"num_topk ({num_topk}) > num_total_experts ({num_total_experts})"
+    )
+    num_padded_tokens_per_rank = (
+        (num_tokens_per_rank + num_total_experts - 1)
+        // num_total_experts
+        * num_total_experts
+    )
+    num_blocks = num_padded_tokens_per_rank // num_total_experts
+
+    expert_permutations = rng.random(
+        (num_ranks, num_blocks, num_total_experts)
+    ).argsort(axis=-1)
+    topk_offsets = rng.random(
+        (num_ranks, num_blocks, num_total_experts)
+    ).argsort(axis=-1)[..., :num_topk]
+
+    token_offsets = np.arange(num_total_experts)[None, None, :, None]
+    expert_indices = (
+        token_offsets + topk_offsets[:, :, None, :]
+    ) % num_total_experts
+    topk_blocks = np.take_along_axis(
+        expert_permutations[..., None], expert_indices, axis=2,
+    )
+    return topk_blocks.reshape(
+        num_ranks, num_padded_tokens_per_rank, num_topk,
+    )[:, :num_tokens_per_rank, :].astype(np.int64)
+
+
+def _generate_topk_idx_power_law(
+    num_ranks: int,
+    num_tokens_per_rank: int,
+    num_topk: int,
+    num_total_experts: int,
+    exponent: float,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Power-law (Zipf-rank-frequency) routing.
+
+    Matches the token-to-expert distribution shape observed by the TRT
+    team: the expert with popularity rank ``r`` (1-indexed) receives
+    probability proportional to ``1 / r ** exponent``.  ``exponent = 1.0``
+    is the classic Zipf law (top ~10% experts absorb ~50% of tokens);
+    larger exponents skew further; ``exponent = 0`` degenerates to uniform.
+
+    A random permutation of expert ids carries the popularity rank, so
+    "which experts are hot" varies with the seed instead of always
+    being ``expert_id 0..N``.
+
+    Vectorized via Gumbel-top-K: ``argpartition(log p + Gumbel)`` over
+    the expert axis is statistically equivalent to
+    ``rng.choice(p=p, replace=False)`` but runs as one numpy op instead
+    of ``num_ranks * num_tokens_per_rank`` Python iterations.
+    """
+    assert num_topk <= num_total_experts, (
+        f"num_topk ({num_topk}) > num_total_experts ({num_total_experts})"
+    )
+    popularity_rank_to_expert = rng.permutation(num_total_experts)
+    rank_freq = 1.0 / (np.arange(num_total_experts) + 1).astype(np.float64) ** exponent
+    probs = np.empty(num_total_experts, dtype=np.float64)
+    probs[popularity_rank_to_expert] = rank_freq / rank_freq.sum()
+
+    log_probs = np.log(np.maximum(probs, 1e-30))
+    num_token_slots = num_ranks * num_tokens_per_rank
+    uniform_noise = rng.random(size=(num_token_slots, num_total_experts))
+    gumbel_noise = -np.log(-np.log(np.maximum(uniform_noise, 1e-30)) + 1e-30)
+    scores = log_probs[None, :] + gumbel_noise
+    # ``argpartition`` returns the top-K indices in unspecified order; routing
+    # correctness doesn't depend on intra-token order, so this is fine.
+    topk_flat = np.argpartition(-scores, kth=num_topk - 1, axis=-1)[:, :num_topk]
+    return topk_flat.reshape(num_ranks, num_tokens_per_rank, num_topk).astype(np.int64)
+
+
+def _get_remote_rank_comm_matrices(
+    topk_idx: np.ndarray,
+    world_size: int,
+    num_total_experts: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return remote dispatch and fc2-return routed-token count matrices.
+
+    Unit is routed token after topk expansion: one original token with K
+    selected experts contributes K routed-token counts.  ``dispatch[src, dst]``
+    counts routed tokens whose expert is owned by ``dst`` and whose source
+    token lives on ``src``.  ``fc2_return`` is the reverse direction for the
+    same routed tokens, so it is the transpose of dispatch at count
+    granularity.  Local entries are zeroed because they do not contribute
+    inter-rank traffic.
+    """
+    if num_total_experts % world_size != 0:
+        raise ValueError(
+            f"num_total_experts ({num_total_experts}) must be divisible by "
+            f"world_size ({world_size})."
+        )
+    if topk_idx.ndim != 3 or topk_idx.shape[0] != world_size:
+        raise ValueError(
+            f"topk_idx must have shape (world_size, tokens_per_rank, topk), "
+            f"got {topk_idx.shape} for world_size={world_size}."
+        )
+
+    num_experts_per_rank = num_total_experts // world_size
+    valid = topk_idx >= 0
+    src_ranks = np.broadcast_to(
+        np.arange(world_size, dtype=np.int64)[:, None, None],
+        topk_idx.shape,
+    )[valid]
+    dst_ranks = (topk_idx[valid] // num_experts_per_rank).astype(np.int64)
+
+    dispatch = np.zeros((world_size, world_size), dtype=np.int64)
+    np.add.at(dispatch, (src_ranks, dst_ranks), 1)
+    np.fill_diagonal(dispatch, 0)
+    return dispatch, dispatch.T.copy()
+
+
+def _print_remote_rank_comm_matrices(
+    topk_idx: np.ndarray,
+    world_size: int,
+    num_total_experts: int,
+) -> None:
+    """Print remote rank-to-rank routed-token counts for route inspection."""
+    dispatch, fc2_return = _get_remote_rank_comm_matrices(
+        topk_idx, world_size, num_total_experts,
+    )
+
+    def _print_matrix(title: str, matrix: np.ndarray) -> None:
+        col_width = 12
+        print(f"{title} [unit: routed tokens after topk count]")
+        src_dst_label = "src\\dst"
+        header = f"{src_dst_label:>8}" + "".join(
+            f"{f'dst{dst}':>{col_width}}" for dst in range(world_size)
+        )
+        print(header)
+        for src in range(world_size):
+            row = "".join(
+                f"{int(matrix[src, dst]):>{col_width}}" for dst in range(world_size)
+            )
+            print(f"{f'src{src}':>8}{row}")
+        print(
+            f"  row_sums_routed_tokens={matrix.sum(axis=1).astype(np.int64).tolist()} "
+            f"col_sums_routed_tokens={matrix.sum(axis=0).astype(np.int64).tolist()} "
+            f"total_remote_routed_tokens={int(matrix.sum())}"
+        )
+
+    print(
+        "---- remote rank traffic from topk_idx "
+        "[unit: routed tokens after topk count] ----"
+    )
+    _print_matrix("dispatch input tokens: source rank -> expert-owner rank", dispatch)
+    _print_matrix("fc2 return tokens: expert-owner rank -> source rank", fc2_return)
+
+
+def _generate_topk_weights(
+    num_ranks: int,
+    num_tokens_per_rank: int,
+    num_topk: int,
+    rng: torch.Generator,
+) -> torch.Tensor:
+    """Per-(rank, token, slot) routing weight uniformly in ``[0.5, 1.5]``.
+
+    NOT a faithful softmax output (those sum to 1 along the K axis); this
+    is just a moderate-magnitude positive value picked to keep
+    ``swiglu * topk_weight`` within fp8 SF range.  Reference and kernel
+    see the same tensor so the absolute scale doesn't affect correctness,
+    only the local numerical regime.
+    """
+    return torch.rand(
+        (num_ranks, num_tokens_per_rank, num_topk),
+        dtype=torch.float32, device="cuda", generator=rng,
+    ) + 0.5
+
+
+# =============================================================================
+# NVFP4 / SF tensor builders (host-side numpy rng -> cuda)
+# =============================================================================
+
+
+# =============================================================================
+# Symmetric-heap allocation
+# =============================================================================
+
+
+# MEGA_NO_DIST=1: opt out of torch.distributed + NVSHMEM init so the
+# runner can be launched as plain ``python mega_runner.py`` (e.g. under
+# compute-sanitizer).  Single-rank only; sym tensors degrade to plain
+# CUDA ``torch.zeros`` and the SymBuffer offsets list is hard-coded to
+# ``(0,) * world_size``.
+_NO_DIST: bool = bool(int(os.environ.get("MEGA_NO_DIST", "0")))
+
+
+def _sym_zeros(shape: Tuple[int, ...], dtype: torch.dtype) -> torch.Tensor:
+    """Zero-initialised symmetric-heap tensor.
+
+    Restricted to dtypes nvshmem4py natively supports (``uint8``, ``int32``,
+    ``int64``, ``float32``, ``bfloat16``, ``float16``).  NVFP4 / fp8 go
+    through the byte-buf reinterpret helpers below.
+
+    Caller is responsible for freeing via ``nvshmem.core.free_tensor``
+    before ``nvshmem.core.finalize()``.
+    """
+    if _NO_DIST:
+        return torch.zeros(shape, dtype=dtype, device="cuda")
+    import nvshmem.core
+    tensor = nvshmem.core.tensor(shape, dtype=dtype)
+    tensor.zero_()
+    return tensor
+
+
+def _sym_zeros_byte_view(
+    logical_shape: Tuple[int, ...], target_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Sym-heap allocation for dtypes nvshmem4py doesn't natively support
+    (NVFP4 / fp8): allocate uint8 byte buffer, ``.view(target_dtype)``.
+
+    NVFP4 halves the last logical dim (2 fp4 elements packed per byte);
+    fp8 keeps shape as-is.  Returns a tensor whose ``.shape`` is the
+    storage shape -- callers that want a different packed dim should
+    permute after this returns.
+    """
+    if target_dtype == _DataDtype:
+        if not logical_shape or logical_shape[-1] % 2 != 0:
+            raise ValueError(
+                f"NVFP4 sym view needs non-empty logical_shape with even last dim, "
+                f"got {logical_shape}."
+            )
+        storage_shape = (*logical_shape[:-1], logical_shape[-1] // 2)
+    elif target_dtype == _ScaleDtype:
+        storage_shape = tuple(logical_shape)
+    else:
+        raise ValueError(
+            f"_sym_zeros_byte_view: dtype must be {_DataDtype} or {_ScaleDtype}, "
+            f"got {target_dtype}."
+        )
+    total_bytes = 1
+    for dim_size in storage_shape:
+        total_bytes *= dim_size
+    return _sym_zeros((total_bytes,), torch.uint8).view(target_dtype).reshape(storage_shape)
+
+
+def _compute_peer_offsets(
+    sym_tensor: torch.Tensor, world_size: int
+) -> Tuple[int, Tuple[int, ...]]:
+    """Host-side peer-delta table for one sym-heap allocation.
+
+    Returns ``(local_base, peer_offsets_list)`` where:
+      * ``local_base`` = ``int(sym_tensor.data_ptr())`` -- the local
+        rank's symmetric-heap base byte address.
+      * ``peer_offsets_list[r] = peer_r_base - local_base`` in bytes,
+        as a length-``world_size`` ``Tuple[int, ...]``.  Per NVSHMEM
+        convention, ``peer_offsets_list[local_rank] == 0``.
+
+    NVSHMEM keeps every rank's symmetric heap laid out identically (same
+    allocation order -> same offsets), so this single per-peer constant
+    works for every sub-allocation in the heap.  These ints are passed
+    through ``SymBufferHost`` as runtime launch args; kernel.__call__
+    packs them into ``SymBuffer{world_size}`` before entering device
+    code.  The offsets land in the kernel parameter bank, and a
+    runtime-indexed peer lookup lowers to a single ``ld.param.b64`` (=
+    ``LDC.U64``) with no GMEM traffic at all.
+
+    The legacy version returned a ``(world_size,) int64`` device tensor
+    to obtain an ``LDC.E.64`` indexed load via an extra GMEM step; the
+    byval ``SymBuffer`` removes that indirection entirely (one LDC
+    against the param bank, zero GMEM).
+    """
+    if _NO_DIST:
+        local_base = int(sym_tensor.data_ptr())
+        return local_base, tuple(0 for _ in range(world_size))
+    import nvshmem.core
+    local_base = int(sym_tensor.data_ptr())
+    peer_offsets_list = tuple(
+        int(nvshmem.core.get_peer_tensor(sym_tensor, peer).data_ptr())
+        - local_base
+        for peer in range(world_size)
+    )
+    return local_base, peer_offsets_list
+
+
+# =============================================================================
+# Tester
+# =============================================================================
+
+
+class MegaMoETester:
+    """Multi-rank MegaMoE host driver.
+
+    Lifecycle:
+
+      1. ``generate_inputs``: deterministically reproduce the global view
+         on EVERY rank from ``misc.seed``; slice own-rank into the sym
+         heap.  Weights stay on regular cuda (no cross-rank access).
+      2. ``compute_reference``: run ``compute_megamoe_reference`` on the
+         global view; slice own ``(T, K, hidden)`` into ``combine_output_ref``.
+      3. ``allocate_workspaces``: ``kernel.get_workspace_sizes()`` ->
+         allocate local (cuda) + shared (sym) byte buffers; derive the
+         ``(symmetric_base, peer_offsets_list)`` host-side ints used to
+         build the kernel-side ``SymBuffer`` (covers every sym sub-region).
+      4. ``run_kernel``: placeholder until the kernel side is wired.
+      5. ``validate``: bf16-grade compare own-rank ``combine_output``
+         against ``combine_output_ref``.
+
+    None of steps 1-3 emit NCCL/NVSHMEM traffic; only step 4 (kernel
+    launch) and step 5's compare touch sym memory.
+    """
+
+    def __init__(
+        self,
+        problem: TokenCommProblemDesc,
+        impl: ImplDesc,
+        misc: MiscDesc,
+        *,
+        rank: int,
+    ) -> None:
+        self.problem = problem
+        self.impl = impl
+        self.misc = misc
+        self.rank = rank
+        if impl.fc2_reduces_topk and misc.ref_compute_graph != "deepgemm":
+            raise ValueError(
+                "in-kernel fc2 reduce requires ref_compute_graph='deepgemm'; "
+                f"got {misc.ref_compute_graph!r}.  The REDG path can only "
+                "atomic-add terms whose topk score was already absorbed before "
+                "fc2."
+            )
+        # Single source of truth for world size; ``local_rank`` was only
+        # needed for the upstream ``torch.cuda.set_device`` inside the
+        # NCCL+NVSHMEM bootstrap, the tester itself doesn't reference it.
+        self.world_size = problem.world_size
+
+        torch.manual_seed(misc.seed)
+        np.random.seed(misc.seed)
+        self._np_rng: np.random.Generator = np.random.default_rng(misc.seed)
+        self._torch_cuda_rng = torch.Generator(device="cuda")
+        self._torch_cuda_rng.manual_seed(misc.seed)
+
+        # Own-rank inputs on the symmetric heap (peer-pulled by dispatch).
+        self.my_activation: Optional[torch.Tensor] = None
+        self.my_activation_sf: Optional[torch.Tensor] = None
+        self.my_topk_idx: Optional[torch.Tensor] = None
+        self.my_topk_weights: Optional[torch.Tensor] = None
+
+        # Own-rank weights on regular cuda (no cross-rank access).
+        self.my_fc1_weight: Optional[torch.Tensor] = None
+        self.my_fc1_weight_sf: Optional[torch.Tensor] = None
+        self.my_fc2_weight: Optional[torch.Tensor] = None
+        self.my_fc2_weight_sf: Optional[torch.Tensor] = None
+
+        # Full global view (regular cuda) -- kept so ``compute_reference``
+        # can feed it without re-rolling the rng.
+        self._global_activation: Optional[torch.Tensor] = None
+        self._global_activation_sf: Optional[torch.Tensor] = None
+        self._global_topk_idx: Optional[torch.Tensor] = None
+        self._global_topk_weights: Optional[torch.Tensor] = None
+        self._global_fc1_weight: Optional[torch.Tensor] = None
+        self._global_fc1_weight_sf: Optional[torch.Tensor] = None
+        self._global_fc2_weight: Optional[torch.Tensor] = None
+        self._global_fc2_weight_sf: Optional[torch.Tensor] = None
+        self._global_fc1_alpha: Optional[torch.Tensor] = None
+        self._global_fc2_alpha: Optional[torch.Tensor] = None
+        self._global_fc1_norm_const: Optional[torch.Tensor] = None
+
+        # Public 2D (T, hidden) combined output the kernel produces.  
+        self.output_activation: Optional[torch.Tensor] = None
+        self.combine_output_ref: Optional[torch.Tensor] = None
+        self.combine_reduced_output_ref: Optional[torch.Tensor] = None
+
+        self.local_workspace: Optional[torch.Tensor] = None
+        self.shared_workspace: Optional[torch.Tensor] = None
+        # Host-side SymBuffer payload.  It is passed as a runtime arg via
+        # SymBufferHost and packed into SymBuffer{world_size} in
+        # kernel.__call__.  No GMEM tensor is allocated for these offsets.
+        self.symmetric_base: Optional[int] = None
+        self.peer_offsets_list: Optional[Tuple[int, ...]] = None
+
+        self._kernel = None
+        self._compiled_kernel = None
+        self._use_torch_profiler = False
+        self._perf_warmup = 1
+        self._perf_iters = 1
+
+        # v1 pinned expert-wise epilogue args.
+        self.my_fc1_alpha: Optional[torch.Tensor] = None
+        self.my_fc2_alpha: Optional[torch.Tensor] = None
+        self.my_fc1_norm_const: Optional[torch.Tensor] = None
+
+    def set_torch_profiler_enabled(self, enabled: bool) -> None:
+        """Enable optional torch profiler timing for the target kernel launch."""
+        self._use_torch_profiler = enabled
+
+    def set_perf_iters(self, warmup: int, iters: int) -> None:
+        """Configure steady-state timing: `warmup` untimed launches then
+        `iters` back-to-back timed launches (torch-profiler path only)."""
+        self._perf_warmup = max(0, int(warmup))
+        self._perf_iters = max(1, int(iters))
+
+    def _check_cuda_rng_consistency(self) -> None:
+        """Weakly verify CUDA RNG streams stayed aligned across ranks."""
+        if not (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+        ):
+            return
+
+        random_parts = torch.randint(
+            0, 1 << 31, (2, 16),
+            dtype=torch.int64, device="cuda", generator=self._torch_cuda_rng,
+        )
+        sentinel = (random_parts[0] << 31) ^ random_parts[1]
+        gathered = [torch.empty_like(sentinel) for _ in range(self.world_size)]
+        torch.distributed.all_gather(gathered, sentinel)
+
+        reference = gathered[0]
+        mismatched_ranks = [
+            rank for rank, value in enumerate(gathered)
+            if not torch.equal(value, reference)
+        ]
+        if mismatched_ranks:
+            raise RuntimeError(
+                f"CUDA RNG state mismatch across ranks after generate_inputs; "
+                f"mismatched ranks: {mismatched_ranks}."
+            )
+
+    # ------------------------------------------------------------------
+    # Step 1: deterministic input + weight generation
+    # ------------------------------------------------------------------
+
+    def generate_inputs(self) -> None:
+        problem = self.problem
+        rng = self._np_rng
+        num_ranks = problem.world_size
+        num_tokens_per_rank = problem.num_tokens_per_rank
+        num_topk = problem.num_topk
+        hidden = problem.hidden
+        intermediate = problem.intermediate
+        intermediate_downproj = intermediate // 2
+        num_experts_per_rank = problem.num_experts_per_rank
+        scale_blocksize = Nvfp4BlockSize
+        hidden_sf_cols = ceil_div(hidden, scale_blocksize)
+        intermediate_downproj_sf_cols = ceil_div(intermediate_downproj, scale_blocksize)
+
+        # ---- Activation (NVFP4 packed in hidden) + plain K-major SF.
+        # SF lives in the user-facing plain layout -- the kernel's dispatch
+        # warps re-stage it into the SFB atom layout inside l1_sf_buffer
+        # before fc1 reads it; the boundary stays plain so the host
+        # reference can dequant directly.
+        self._global_activation = _make_nvfp4_tensor_from_torch_rng(
+            self._torch_cuda_rng, (num_ranks, num_tokens_per_rank, hidden),
+            packed_dim=-1, perf_run=self.misc.perf_run,
+        )
+        self._global_activation_sf = _make_raw_scale_tensor_from_torch_rng(
+            self._torch_cuda_rng,
+            num_ranks * num_tokens_per_rank, hidden, blocksize=scale_blocksize,
+            strict=True
+        ).reshape(num_ranks, num_tokens_per_rank, hidden_sf_cols)
+
+        # ---- Routing table.
+        if problem.route_distribution == "balanced":
+            topk_idx_np = _generate_topk_idx_balanced(
+                num_ranks, num_tokens_per_rank, num_topk,
+                problem.num_total_experts, rng,
+            )
+        else:
+            topk_idx_np = _generate_topk_idx_power_law(
+                num_ranks, num_tokens_per_rank, num_topk,
+                problem.num_total_experts, problem.power_law_exponent, rng,
+            )
+        topk_weights = _generate_topk_weights(
+            num_ranks, num_tokens_per_rank, num_topk, self._torch_cuda_rng,
+        )
+        if self.rank == 0:
+            _print_remote_rank_comm_matrices(
+                topk_idx_np, num_ranks, problem.num_total_experts,
+            )
+        self._global_topk_idx = torch.from_numpy(topk_idx_np).cuda()
+        self._global_topk_weights = topk_weights
+
+        # ---- Weights.  fc1 packs along hidden (K of fc1); fc2 packs along
+        # intermediate_downproj (K of fc2).
+        self._global_fc1_weight = _make_nvfp4_tensor_from_torch_rng(
+            self._torch_cuda_rng,
+            (num_ranks, num_experts_per_rank, hidden, intermediate),
+            packed_dim=2, perf_run=self.misc.perf_run,
+        )
+        self._global_fc1_weight_sf = _make_raw_scale_tensor_from_torch_rng(
+            self._torch_cuda_rng,
+            num_ranks * num_experts_per_rank * intermediate,
+            hidden, blocksize=scale_blocksize, strict=True
+        ).reshape(num_ranks, num_experts_per_rank, intermediate, hidden_sf_cols)
+
+        self._global_fc2_weight = _make_nvfp4_tensor_from_torch_rng(
+            self._torch_cuda_rng,
+            (num_ranks, num_experts_per_rank, intermediate_downproj, hidden),
+            packed_dim=2, perf_run=self.misc.perf_run,
+        )
+        self._global_fc2_weight_sf = _make_raw_scale_tensor_from_torch_rng(
+            self._torch_cuda_rng,
+            num_ranks * num_experts_per_rank * hidden,
+            intermediate_downproj, blocksize=scale_blocksize,
+            strict=True
+        ).reshape(
+            num_ranks, num_experts_per_rank, hidden, intermediate_downproj_sf_cols,
+        )
+        epi_arg_shape = (num_ranks, num_experts_per_rank)
+        self._global_fc1_alpha = torch.randint(
+            1, 5, epi_arg_shape, generator=self._torch_cuda_rng, device="cuda",
+        ).to(torch.float32) * 0.5
+        self._global_fc2_alpha = torch.randint(
+            1, 5, epi_arg_shape, generator=self._torch_cuda_rng, device="cuda",
+        ).to(torch.float32) * 0.5
+        self._global_fc1_norm_const = torch.randint(
+            2, 5, epi_arg_shape, generator=self._torch_cuda_rng, device="cuda",
+        ).to(torch.float32) * 0.5
+
+        # ---- Atom-swizzle the weight SFs.  fc1_weight / fc2_weight are
+        # consumed by the base kernel directly (NOT routed through dispatch
+        # like the activation SF), so the host has to feed them in the
+        # 32x4x4 atom-swizzled, flat 2D ``(experts, flat_atom_size)`` layout
+        # that ``tile_atom_to_shape_SF`` and the TMA SFA descriptor expect.
+        # Mirrors the lean ``runner_fc12``'s ``assemble_raw_scales_stacked_expert``
+        # pipeline.  Plain ``_global_fc1/2_weight_sf`` are kept untouched for
+        # ``compute_megamoe_reference`` (which dequantizes from the raw plain
+        # layout).
+        fc1_sf_swizzled = [
+            to_blocked(self._global_fc1_weight_sf[r, e])
+            for r in range(num_ranks)
+            for e in range(num_experts_per_rank)
+        ]
+        fc1_flat_sf_size = fc1_sf_swizzled[0].numel()
+        self._global_fc1_weight_sf_swizzled = (
+            _stack_byte_reinterpretable_tensors(fc1_sf_swizzled, dim=0)
+            .view(num_ranks, num_experts_per_rank, fc1_flat_sf_size)
+        )
+
+        fc2_sf_swizzled = [
+            to_blocked(self._global_fc2_weight_sf[r, e])
+            for r in range(num_ranks)
+            for e in range(num_experts_per_rank)
+        ]
+        fc2_flat_sf_size = fc2_sf_swizzled[0].numel()
+        self._global_fc2_weight_sf_swizzled = (
+            _stack_byte_reinterpretable_tensors(fc2_sf_swizzled, dim=0)
+            .view(num_ranks, num_experts_per_rank, fc2_flat_sf_size)
+        )
+
+        # ---- Stage own-rank inputs into the symmetric heap.
+        own_activation = self._global_activation[self.rank]
+        own_activation_sf = self._global_activation_sf[self.rank]
+        own_topk_idx = self._global_topk_idx[self.rank]
+        own_topk_weights = self._global_topk_weights[self.rank]
+
+        # NVFP4 / fp8 go through uint8 byte-buf views (nvshmem4py doesn't
+        # natively support these dtypes); copy via uint8 to dodge any
+        # NVFP4-to-NVFP4 assignment quirks between allocators.
+        self.my_activation = _sym_zeros_byte_view(
+            (num_tokens_per_rank, hidden), _DataDtype,
+        )
+        self.my_activation.view(torch.uint8).copy_(own_activation.view(torch.uint8))
+
+        # SF leg caller contract: the K_sf axis (= ``ceil(hidden, 16)``)
+        # must be a multiple of 4 fp8 SFs so dispatch_pull's LDG.32 byte
+        # stride (= ``sf_uint32_per_token * 4 bytes/token``) matches the
+        # host row stride.  Pad-to-multiple-of-4 + zero-fill on the host
+        # side; the kernel never reads past ``ceil(hidden/16)`` valid SFs
+        # because the trailing K_sf elements are paired with NVFP4 data
+        # entries that fall in TMA's OOB-fill-0 region.
+        #
+        # ``_sym_zeros_byte_view`` already zero-inits the symmetric heap
+        # allocation, so we only need to copy the first ``hidden_sf_cols``
+        # uint8 columns; the trailing padded columns remain at zero.  Use
+        # the uint8 byte view to dodge fp8 dtype's spotty support for
+        # tensor-indexing assignment across torch versions.
+        hidden_sf_cols_padded = round_up(hidden_sf_cols, 4)
+        self.my_activation_sf = _sym_zeros_byte_view(
+            (num_tokens_per_rank, hidden_sf_cols_padded), _ScaleDtype,
+        )
+        self.my_activation_sf.view(torch.uint8)[:, :hidden_sf_cols].copy_(
+            own_activation_sf.view(torch.uint8)
+        )
+
+        self.my_topk_idx = _sym_zeros(tuple(own_topk_idx.shape), torch.int64)
+        self.my_topk_idx.copy_(own_topk_idx)
+
+        self.my_topk_weights = _sym_zeros(tuple(own_topk_weights.shape), torch.float32)
+        self.my_topk_weights.copy_(own_topk_weights)
+
+        # ---- Own-rank weights stay on regular cuda.  DO NOT ``.contiguous()``:
+        # ``_make_nvfp4_tensor_from_torch_rng`` uses an internal permute to put
+        # the packed dim mid-tensor; ``.contiguous()`` would re-pack to
+        # row-major and break the K-as-stride-1 invariant the dequant +
+        # GEMM path depends on.  Leading-dim slicing keeps the existing
+        # stride pattern.
+        self.my_fc1_weight = self._global_fc1_weight[self.rank]
+        # Kernel consumes atom-swizzled (E, flat_atom_size); reference path
+        # (``compute_megamoe_reference``) still uses the plain
+        # ``_global_fc1_weight_sf`` directly to dequantize.
+        self.my_fc1_weight_sf = self._global_fc1_weight_sf_swizzled[self.rank]
+        self.my_fc2_weight = self._global_fc2_weight[self.rank]
+        self.my_fc2_weight_sf = self._global_fc2_weight_sf_swizzled[self.rank]
+        self.my_fc1_alpha = self._global_fc1_alpha[self.rank]
+        self.my_fc2_alpha = self._global_fc2_alpha[self.rank]
+        self.my_fc1_norm_const = self._global_fc1_norm_const[self.rank]
+
+        # ---- Public 2D (T, hidden) combined output.  The kernel owns the
+        # per-topk (T, K, H) combine staging internally; the caller only
+        # provides/consumes the final reduced result.  Placement depends on the
+        # reduce mode:
+        #   * in_kernel_reduce: this IS the cross-rank ``red.global.add.v2.bf16x2``
+        #     target, so it MUST live on the sym heap; ``_sym_zeros`` also gives
+        #     the atomic-add-accumulate caller contract (start from zero).
+        #   * separate_kernel_reduce: peers write the internal staging instead;
+        #     this only receives the local tail reduce, so allocate it locally
+        #     (avoids any symmetric-heap caching ambiguity, matches deployment).
+        if self.impl.fc2_reduces_topk:
+            self.output_activation = _sym_zeros(
+                (num_tokens_per_rank, hidden),
+                problem.fc2_output_dtype,
+            )
+        else:
+            if problem.fc2_output_dtype != torch.bfloat16:
+                raise ValueError(
+                    "separate_kernel_reduce currently expects BF16 output, "
+                    f"got {problem.fc2_output_dtype}."
+                )
+            self.output_activation = torch.empty(
+                (num_tokens_per_rank, hidden),
+                dtype=problem.fc2_output_dtype,
+                device="cuda",
+            )
+
+        torch.cuda.synchronize()
+        self._check_cuda_rng_consistency()
+
+    # ------------------------------------------------------------------
+    # Step 2: reference
+    # ------------------------------------------------------------------
+
+    def compute_reference(self) -> None:
+        if self.misc.skip_ref_check:
+            return
+        if self._global_activation is None:
+            raise RuntimeError("compute_reference requires generate_inputs first.")
+
+        reference = compute_megamoe_reference(
+            input_activation=self._global_activation,
+            input_activation_sf=self._global_activation_sf,
+            input_topk_idx=self._global_topk_idx,
+            input_topk_weights=self._global_topk_weights,
+            fc1_weight=self._global_fc1_weight,
+            fc1_weight_sf=self._global_fc1_weight_sf,
+            fc2_weight=self._global_fc2_weight,
+            fc2_weight_sf=self._global_fc2_weight_sf,
+            fc1_alpha=self._global_fc1_alpha,
+            fc2_alpha=self._global_fc2_alpha,
+            fc1_norm_const=self._global_fc1_norm_const,
+            ref_compute_graph=self.misc.ref_compute_graph,
+            combine_format=self.problem.combine_format,
+            gate_up_clamp=self.problem.gate_up_clamp,
+        )
+        self.combine_output_ref = reference.combine_output[self.rank].contiguous()
+        self.combine_reduced_output_ref = (
+            reference.combine_reduced_output[self.rank].contiguous()
+        )
+
+    # ------------------------------------------------------------------
+    # Step 3: workspace allocation
+    # ------------------------------------------------------------------
+
+    def allocate_workspaces(self) -> None:
+        """Allocate the two opaque byte buffers the kernel partitions internally.
+
+        ``local_workspace`` lives in plain CUDA device memory (no peer
+        access; counter / fc1_output / pool slots etc. are all local).
+        ``shared_workspace`` lives on the NVSHMEM symmetric heap so the
+        dispatch warps' ``peer_rank_ptr_mapper.map`` writes can reach peer ranks.
+        ``(symmetric_base, peer_offsets_list)`` is computed once from the
+        symmetric workspace's base address -- NVSHMEM guarantees the same
+        delta works for every sub-allocation in the heap, so the same
+        table also covers ``my_activation`` / ``my_activation_sf`` /
+        ``my_topk_weights`` / ``combine_output``.  ``run_kernel`` passes
+        these ints through ``SymBufferHost`` so kernel.__call__ can pack
+        them into SymBuffer{world_size}.
+
+        Caller invariant: ``self._kernel`` must already be instantiated
+        (``run_kernel`` is responsible for that step before invoking us).
+        """
+        if self._kernel is None:
+            raise RuntimeError(
+                "allocate_workspaces called before self._kernel was "
+                "instantiated; run_kernel must create the kernel first."
+            )
+
+        local_ws_bytes, shared_ws_bytes = self._kernel.get_workspace_sizes()
+
+        self.local_workspace = torch.zeros(
+            (local_ws_bytes,), dtype=torch.uint8, device="cuda",
+        )
+        self.shared_workspace = _sym_zeros((shared_ws_bytes,), torch.uint8)
+        self.symmetric_base, self.peer_offsets_list = _compute_peer_offsets(
+            self.shared_workspace, self.world_size,
+        )
+
+    # ------------------------------------------------------------------
+    # Step 4: kernel launch
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _profiler_event_cuda_time_us(event) -> float:
+        """Return CUDA/device time in microseconds from a torch profiler event."""
+        for attr_name in ("device_time_total", "cuda_time_total"):
+            value = getattr(event, attr_name, None)
+            if value is not None:
+                return float(value)
+        return 0.0
+
+    def _report_torch_profiler_kernel_time(self, prof, num_iters: int = 1) -> None:
+        """Gather and print per-rank ``kernel_cutlass*`` CUDA times.
+
+        ``prof.events()`` aggregates the CUDA time over all occurrences of
+        each event, so when the timed region launched the pipeline
+        ``num_iters`` times the sums are divided down to a per-launch time.
+        ``mega`` and ``topk_reduce`` are reported separately.
+        """
+        mega_time_us = 0.0
+        topk_time_us = 0.0
+        matched_event_names = []
+        for event in prof.events():
+            event_name = getattr(event, "key", "")
+            if not event_name.startswith("kernel_cutlass"):
+                continue
+            event_time_us = self._profiler_event_cuda_time_us(event)
+            matched_event_names.append(event_name)
+            if event_name.startswith("kernel_cutlass__reduce_"):
+                topk_time_us += event_time_us
+            else:
+                mega_time_us += event_time_us
+
+        if not matched_event_names:
+            mega_time_us = float("nan")
+            topk_time_us = float("nan")
+        else:
+            # Aggregate sums cover ``num_iters`` back-to-back launches in the
+            # timed region; divide down to a per-launch (steady-state) time.
+            mega_time_us /= max(1, num_iters)
+            topk_time_us /= max(1, num_iters)
+            if mega_time_us == 0.0:
+                mega_time_us = float("nan")
+            if topk_time_us == 0.0:
+                topk_time_us = float("nan")
+        finite_parts = [
+            time_us
+            for time_us in (mega_time_us, topk_time_us)
+            if np.isfinite(time_us)
+        ]
+        total_time_us = sum(finite_parts) if finite_parts else float("nan")
+
+        dist_active = (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+        )
+        if dist_active:
+            local_times = torch.tensor(
+                [mega_time_us, topk_time_us, total_time_us],
+                dtype=torch.float64,
+                device="cuda",
+            )
+            gathered_times = [
+                torch.empty_like(local_times) for _ in range(self.world_size)
+            ]
+            torch.distributed.all_gather(gathered_times, local_times)
+            rank_times_us = [
+                [float(value) for value in rank_time.tolist()]
+                for rank_time in gathered_times
+            ]
+        else:
+            rank_times_us = [[mega_time_us, topk_time_us, total_time_us]]
+
+        if self.rank == 0:
+            mega_values = [rank_times[0] for rank_times in rank_times_us]
+            finite_mega = [
+                (rank, time_us)
+                for rank, time_us in enumerate(mega_values)
+                if np.isfinite(time_us)
+            ]
+            if finite_mega:
+                min_rank, min_mega_us = min(finite_mega, key=lambda x: x[1])
+                min_topk_us = rank_times_us[min_rank][1]
+                min_total_us = rank_times_us[min_rank][2]
+            else:
+                min_rank = -1
+                min_mega_us = float("nan")
+                min_topk_us = float("nan")
+                min_total_us = float("nan")
+
+            def _fmt(time_us: float) -> str:
+                return f"{time_us:.2f} us" if np.isfinite(time_us) else "n/a"
+
+            print("---- torch profiler target pipeline CUDA time ----")
+            print(
+                f"  min_rank_by_mega=rank {min_rank}: "
+                f"mega={_fmt(min_mega_us)} "
+                f"topk_reduce={_fmt(min_topk_us)} "
+                f"total={_fmt(min_total_us)}"
+            )
+            print("  mega:")
+            for rank, times in enumerate(rank_times_us):
+                print(f"    rank_{rank}: {_fmt(times[0])}")
+            has_any_topk = any(np.isfinite(times[1]) for times in rank_times_us)
+            if has_any_topk:
+                print("  topk:")
+                for rank, times in enumerate(rank_times_us):
+                    print(f"    rank_{rank}: {_fmt(times[1])}")
+            if not matched_event_names:
+                print("  warning: no kernel_cutlass* events matched")
+
+    def _launch_target_kernels_with_optional_torch_profiler(
+        self,
+        runtime_kwargs,
+    ) -> None:
+        """Launch the target kernel pipeline, optionally under torch profiler.
+
+        The compiled kernel now owns the separate-kernel-reduce tail internally
+        (launched on the same stream inside ``__call__``), so this is a single
+        compiled-kernel call; the reduce still shows up as its own
+        ``kernel_cutlass_topk_reduce_*`` device event in the profiler.
+        """
+        if self._compiled_kernel is None:
+            raise RuntimeError("compiled kernel is not available")
+
+        def _launch() -> None:
+            self._compiled_kernel(**runtime_kwargs)
+
+        if not self._use_torch_profiler:
+            _launch()
+            torch.cuda.synchronize()
+            return
+
+        for _ in range(self._perf_warmup):
+            self._compiled_kernel(**runtime_kwargs)
+        torch.cuda.synchronize()
+
+        # Timed: `_perf_iters` back-to-back launches, no host sync between them.
+        n_iters = max(1, self._perf_iters)
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+        ) as prof:
+            for _ in range(n_iters):
+                _launch()
+            torch.cuda.synchronize()
+        self._report_torch_profiler_kernel_time(prof, num_iters=n_iters)
+
+    def run_kernel(self) -> None:
+        """Compile + launch ``Sm100MegaMoEKernel`` on the current cuda stream.
+
+        Steps (lazy-imported so the harness paths -- ``generate_inputs`` +
+        ``compute_reference`` -- can still be exercised on machines without
+        a working cute install):
+
+          1. Instantiate the kernel with the static expert shape derived
+             from ``ProblemDesc`` and the impl-side tile config.
+          2. Allocate the opaque local + shared workspaces via
+             ``self.allocate_workspaces()``.
+          3. Convert every host-side torch tensor into a cute.Tensor with
+             ``cutlass.torch.from_dlpack`` + ``mark_layout_dynamic``.
+          4. ``cute.compile`` once.
+          5. Launch on the current cuda stream.
+        """
+        if (
+            self.my_activation is None
+            or self.my_activation_sf is None
+            or self.my_topk_idx is None
+            or self.my_topk_weights is None
+            or self.my_fc1_weight is None
+            or self.my_fc1_weight_sf is None
+            or self.my_fc2_weight is None
+            or self.my_fc2_weight_sf is None
+            or self.my_fc1_alpha is None
+            or self.my_fc2_alpha is None
+            or self.my_fc1_norm_const is None
+            or self.output_activation is None
+        ):
+            raise RuntimeError("run_kernel requires generate_inputs first.")
+
+        # SF leg caller contract guard: the host-supplied
+        # ``activation_sf`` row stride must already be padded to a
+        # multiple of 4 fp8 SFs so dispatch_pull's LDG.32 byte stride
+        # (= ``sf_uint32_per_token * 4 bytes/token``) matches.  Catch
+        # any future caller drift here rather than relying on a silent
+        # cross-token-row misalignment manifesting as a numeric mismatch.
+        if self.my_activation_sf.shape[-1] % 4 != 0:
+            raise ValueError(
+                f"activation_sf.shape[-1] ({self.my_activation_sf.shape[-1]}) "
+                f"must be a multiple of 4 (4 FP8 SFs per uint32 dispatch "
+                f"LDG.32 wire format).  Caller must pad K_sf along the "
+                f"hidden axis with zero bytes before staging onto the "
+                f"symmetric heap."
+            )
+
+        import cuda.bindings.driver as cuda
+        import cutlass.cute as cute
+        import cutlass.torch as cutlass_torch
+        import cutlass.utils as utils
+
+        from common.megamoe_constants import SfPaddingBlock
+        from moe_nvfp4_swapab.megamoe_kernel import Sm100MegaMoEKernel
+        from src.sym_buffer import SymBufferHost
+
+        # -- 1. Kernel instance --
+        # MegaMoE currently requires ``static_expert_shape != None`` (see
+        # the subclass docstring): the dispatch SMEM sizing + the pool
+        # capacity formulas need ``num_experts_per_rank`` /
+        # ``intermediate_gateup`` / ``hidden`` as codegen-time constants.
+        static_expert_shape = (
+            self.problem.num_experts_per_rank,
+            self.problem.intermediate,
+            self.problem.hidden,
+        )
+
+        cluster_size = (
+            self.impl.cluster_shape_mnk[0] * self.impl.cluster_shape_mnk[1]
+        )
+        max_active_clusters = utils.HardwareInfo().get_max_active_clusters(
+            cluster_size
+        )
+        group_hint = self.impl.group_hint
+        if group_hint is None:
+            group_hint = max_active_clusters
+
+        self._kernel = Sm100MegaMoEKernel(
+            mma_tiler_mnk=self.impl.mma_tiler_mnk,
+            cluster_shape_mnk=self.impl.cluster_shape_mnk,
+            use_2cta_instrs=self.impl.use_2cta_instrs,
+            group_hint=group_hint,
+            token_padding_block=_SwapABEpilogueTokenTile,
+            sf_padding_block=SfPaddingBlock,
+            load_balance_mode=self.impl.load_balance_mode,
+            static_expert_shape=static_expert_shape,
+            force_static_sched=self.impl.force_static_sched,
+            clc_bundle_size=self.impl.clc_bundle_size,
+            num_sched_stages=self.impl.num_sched_stages,
+            world_size=self.world_size,
+            num_topk=self.problem.num_topk,
+            max_tokens_per_rank=self.problem.num_tokens_per_rank,
+            hidden=self.problem.hidden,
+            fc2_output_dtype=cutlass.BFloat16,
+            combine_format=self.problem.combine_format,
+            non_ubulk_fc2_store=self.impl.non_ubulk_fc2_store,
+            in_kernel_fc2_reduce=self.impl.in_kernel_fc2_reduce,
+            token_back_mode=self.impl.token_back_mode,
+            apply_topk_in_fc1=self.misc.ref_compute_graph == "deepgemm",
+            gate_up_clamp=self.problem.gate_up_clamp,
+            flag_batch=self.impl.flag_batch,
+            epi_flag_batch=self.impl.epi_flag_batch,
+        )
+
+        # -- 2. Workspaces (local cuda + sym-heap) --
+        self.allocate_workspaces()
+
+        # -- 3. Torch -> cute --
+        # Same align defaults as runner_fc12: 16 B for general tensors,
+        # 4 B for the i32 / fp32 counter / sized buffers.
+        def _to_cute(tensor: torch.Tensor, assumed_align: int = 16, force_static_layout = False):
+            cute_tensor = cutlass_torch.from_dlpack(
+                tensor, assumed_align=assumed_align,
+            )
+            if force_static_layout:
+                return cute_tensor
+            leading_dim = cutlass_torch.get_leading_dim(tensor)
+            return cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+
+        activation_cute = _to_cute(self.my_activation)
+        activation_sf_cute = _to_cute(self.my_activation_sf)
+        topk_idx_cute = _to_cute(self.my_topk_idx)
+        topk_weights_cute = _to_cute(self.my_topk_weights)
+        fc1_weight_cute = _to_cute(self.my_fc1_weight)
+        fc1_weight_sf_cute = _to_cute(self.my_fc1_weight_sf)
+        fc2_weight_cute = _to_cute(self.my_fc2_weight)
+        fc2_weight_sf_cute = _to_cute(self.my_fc2_weight_sf)
+        fc1_alpha_cute = _to_cute(self.my_fc1_alpha, assumed_align=4)
+        fc2_alpha_cute = _to_cute(self.my_fc2_alpha, assumed_align=4)
+        fc1_norm_const_cute = _to_cute(self.my_fc1_norm_const, assumed_align=4)
+        output_activation_cute = _to_cute(self.output_activation)
+
+        # Opaque byte workspaces -> raw uint8 gmem base pointers (no tensor). The
+        # kernel addresses them by base + Int64 byte offset; a tensor's shape would
+        # be ignored AND overflow cute's 32-bit memref shape field once the
+        # internalized combine staging pushes shared_workspace past 2 GiB.
+        from cutlass.cute.typing import AddressSpace as _AddressSpace
+
+        def _to_cute_ptr(tensor: torch.Tensor, assumed_align: int = 16):
+            return cute.runtime.make_ptr(
+                cutlass.Uint8, tensor.data_ptr(), _AddressSpace.gmem,
+                assumed_align=assumed_align,
+            )
+
+        local_workspace_cute = _to_cute_ptr(self.local_workspace)
+        shared_workspace_cute = _to_cute_ptr(self.shared_workspace)
+
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+        # -- 4. cute.compile --
+        # Runtime payload for the peer pointer mapper.  The generated host
+        # wrapper packs these scalar args into ``SymBuffer{world_size}``
+        # before launching the device kernel.
+        peer_rank_ptr_mapper_host = SymBufferHost(
+            base_addr=self.symmetric_base,
+            offsets=tuple(self.peer_offsets_list),
+            rank_idx=self.rank,
+            num_max_ranks=self.world_size,
+        )
+
+        runtime_kwargs = dict(
+            activation=activation_cute,
+            activation_sf=activation_sf_cute,
+            topk_idx=topk_idx_cute,
+            topk_weights=topk_weights_cute,
+            fc1_weight=fc1_weight_cute,
+            fc1_weight_sf=fc1_weight_sf_cute,
+            fc2_weight=fc2_weight_cute,
+            fc2_weight_sf=fc2_weight_sf_cute,
+            fc1_alpha=fc1_alpha_cute,
+            fc2_alpha=fc2_alpha_cute,
+            fc1_norm_const=fc1_norm_const_cute,
+            output_activation=output_activation_cute,
+            local_workspace=local_workspace_cute,
+            shared_workspace=shared_workspace_cute,
+            peer_rank_ptr_mapper_host=peer_rank_ptr_mapper_host,
+            stream=stream,
+        )
+        compile_kwargs = dict(runtime_kwargs)
+        compile_kwargs["max_active_clusters"] = max_active_clusters
+        if self.misc.enable_iket:
+            compile_kwargs["options"] = "iket"
+
+        self._compiled_kernel = cute.compile(self._kernel, **compile_kwargs)
+
+        # The separate-kernel-reduce tail is now launched inside the kernel's
+        # ``__call__`` (same stream, right after the mega kernel), so the runner
+        # no longer compiles or chains a standalone reduce.
+
+        # -- 5. Launch --
+        #
+        # ``profile_friendly`` mode wraps the launch in 4 markers:
+        #
+        #   (a) ``torch.cuda.synchronize()`` BEFORE the launch -- drains
+        #       every setup-side GPU op off the stream so the capture
+        #       launch sits alone in the post-sync timeline.
+        #
+        #   (b) Cross-rank ``dist.barrier()`` BEFORE cudaProfilerStart --
+        #       aligns every rank to the same wall-clock moment before
+        #       opening the capture window.  Without this, a rank that
+        #       finishes setup early opens cudaProfilerStart, launches
+        #       its mega kernel, and then spin-waits inside the kernel's
+        #       NVSHMEM cross-rank ops for slower ranks to reach the
+        #       same launch point; that spin time gets baked into the
+        #       captured kernel duration and pollutes per-rank timing.
+        #       The NCCL barrier kernel itself runs OUTSIDE the
+        #       cudaProfilerStart/Stop window, so even though nsys
+        #       observes it, the ``--capture-range=cudaProfilerApi`` flag
+        #       keeps it out of the .nsys-rep timeline.
+        #
+        #   (c) ``cudaProfilerStart`` / ``cudaProfilerStop`` around the
+        #       launch -- driver-level markers honoured by
+        #       ``nsys --capture-range=cudaProfilerApi --capture-range-end=stop``
+        #       and ``ncu --capture-range=cudaProfilerApi``.
+        #
+        #   (d) Cross-rank ``dist.barrier()`` AFTER cudaProfilerStop --
+        #       ensures every rank has closed its capture window before
+        #       advancing into the post-launch path (``free_tensor`` /
+        #       ``nvshmem.finalize`` / etc.).  Without this, a fast rank
+        #       can start freeing its sym tensors while a slower rank's
+        #       mega kernel is still touching the sym heap, which races
+        #       the symmetric-memory teardown and is the leading suspect
+        #       behind multi-rank ``nsys`` runs hanging post-capture.
+        #
+        # ``_NO_DIST=1`` / uninitialised ``torch.distributed`` paths skip
+        # both barriers silently so single-rank smoke runs and the
+        # ``MEGA_NO_DIST=1`` debugger path are unaffected.
+        #
+        # Outside ``profile_friendly`` mode the launch path is unchanged.
+        if self.misc.profile_friendly:
+            import nvtx
+
+            torch.cuda.synchronize()
+            _dist_active = (
+                torch.distributed.is_available()
+                and torch.distributed.is_initialized()
+            )
+            if _dist_active:
+                torch.distributed.barrier()
+                torch.cuda.synchronize()
+            with nvtx.annotate("cute_dsl_prof"):
+                self._launch_target_kernels_with_optional_torch_profiler(
+                    runtime_kwargs,
+                )
+            if _dist_active:
+                torch.distributed.barrier()
+                torch.cuda.synchronize()
+        else:
+            self._launch_target_kernels_with_optional_torch_profiler(
+                runtime_kwargs,
+            )
+
+    # ------------------------------------------------------------------
+    # Step 5: validation
+    # ------------------------------------------------------------------
+
+    def validate(self) -> None:
+        """Compare the rank's final ``(token, hidden)`` combine output
+        against the reference.
+
+        The final downstream consumer of MegaMoE is a per-token, all-topk-
+        aggregated activation tensor of shape ``(num_tokens_per_rank,
+        hidden)`` -- i.e. ``sum_k combine_output[t, k, :]``.  The runner
+        validates against that final form regardless of which side did
+        the topk reduce:
+
+          * non-reduce modes (form A, default): the
+            kernel writes one fc2 cell per ``(src_token, src_topk)``
+            into a ``(T, K, H)`` combine_output; a standalone CuTeDSL
+            kernel applies topk weights, accumulates K in FP32, and
+            stores BF16 ``(T, H)``.  The host K-axis sum is only used to
+            build the validation reference, with the same final BF16 cast.
+
+          * reduce modes (form B): the kernel emits
+            a ``(T, 1, H)`` already-K-reduced output via cross-rank
+            ``red.global.add.v2.bf16x2`` atomic adds.  The runner squeezes
+            the singleton K axis and reduces the reference's K axis on
+            host to match.
+
+        bf16 tolerance: ``5e-2`` atol / rtol, identical to the runner's
+        existing acceptance band; the K-axis sum adds at most ~K worth
+        of bf16 round-off, which is well below this band for the v1
+        configurations.  Form B (device-side reduce) is slightly noisier
+        in principle because atomic-add ordering is non-deterministic,
+        but the same atol covers it -- bf16 quantisation dwarfs the
+        ordering-driven rounding drift.
+        """
+        if self.misc.skip_ref_check:
+            return
+        if self.output_activation is None:
+            raise RuntimeError("validate requires run_kernel first.")
+        if self.combine_output_ref is None:
+            raise RuntimeError("validate requires compute_reference first.")
+        if self.combine_reduced_output_ref is None:
+            raise RuntimeError("validate requires reduced reference output.")
+
+        atol = 5e-2
+        rtol = 5e-2
+
+        if self.misc.ref_compute_graph == "transformers" and self.impl.fc2_reduces_topk:
+            raise NotImplementedError(
+                "transformers ref graph requires topk weighting during the "
+                "host/combine reduce; in-kernel fc2 reduce has already "
+                "collapsed the topk axis."
+            )
+
+        # Both modes now expose the same 2D (T, hidden) ``output_activation``.
+        actual_reduced = self.output_activation.to(torch.float32)
+        if self.impl.fc2_reduces_topk:
+            # in_kernel_reduce: K already collapsed on device; the reference is
+            # the host bf16 sequential K-sum of the per-topk reference cells.
+            ref_reduced = _bf16_seq_sum_k(
+                self.combine_output_ref
+            ).to(torch.float32)
+        else:
+            ref_reduced = self.combine_reduced_output_ref.to(torch.float32)
+
+        diff = (actual_reduced - ref_reduced).abs()
+
+        if self.rank == 0 and os.environ.get("MEGA_PEEK_WORKSPACE", "0") == "1":
+            self._peek_workspace(actual_reduced, ref_reduced, diff)
+
+        # Form B branching:
+        #   K <= _FORM_B_PERM_K_LIMIT: exhaustive K! ordering bitwise check
+        #     -- every K concurrent atomic adds can be observed in any of K!
+        #     serial orders; if every cell hits SOME order's bf16-seq-sum,
+        #     the redg path is algorithmically correct (= not a bug).
+        #   K > _FORM_B_PERM_K_LIMIT: K! is intractable; switch to a
+        #     percentile observatory on abs/rel diff and accept under a
+        #     conservative threshold (real algorithmic bugs typically
+        #     manifest as O(1) rel diff -- way above the threshold).
+        if self.impl.fc2_reduces_topk:
+            K = self.combine_output_ref.shape[1]
+            if K <= _FORM_B_PERM_K_LIMIT:
+                match_mask, n_perms = _form_b_bitwise_match(
+                    actual_reduced, self.combine_output_ref,
+                )
+                n_matched = int(match_mask.sum().item())
+                n_total = match_mask.numel()
+                pct = 100.0 * n_matched / max(n_total, 1)
+                if self.rank == 0:
+                    print(
+                        f"---- form-B bitwise-ordering check "
+                        f"(K={K}, perms={n_perms}): "
+                        f"{n_matched}/{n_total} cells matched "
+                        f"({pct:.2f}%) ----"
+                    )
+                # Cross-rank agreement MUST be a collective every rank
+                # reaches: a passing rank returning early while a failing rank
+                # falls through to a later all_gather desyncs NCCL and hangs.
+                # Gather the per-rank pass flag here so all ranks branch
+                # identically (all return, or all raise).
+                local_bitwise_pass = n_matched == n_total
+                rank_bitwise_passes = [local_bitwise_pass]
+                if (
+                    torch.distributed.is_available()
+                    and torch.distributed.is_initialized()
+                ):
+                    pass_tensor = torch.tensor(
+                        [int(local_bitwise_pass)],
+                        device=actual_reduced.device,
+                        dtype=torch.int32,
+                    )
+                    gathered_passes = [
+                        torch.empty_like(pass_tensor)
+                        for _ in range(self.world_size)
+                    ]
+                    torch.distributed.all_gather(gathered_passes, pass_tensor)
+                    rank_bitwise_passes = [
+                        bool(t.item()) for t in gathered_passes
+                    ]
+                if all(rank_bitwise_passes):
+                    if self.rank == 0:
+                        print(
+                            f"Validation PASSED on all ranks "
+                            f"(form B bitwise: 100% cells match some "
+                            f"K!={n_perms} ordering)"
+                        )
+                    return
+                if not local_bitwise_pass:
+                    bad = (~match_mask).nonzero(as_tuple=False)
+                    n_local_bad = int(bad.shape[0])
+                    sample = bad[:min(8, n_local_bad)].cpu().tolist()
+                    print(
+                        f"[rank {self.rank}] form-B bitwise miss: "
+                        f"{n_local_bad} cell(s); sample "
+                        f"(token, hidden)={sample}"
+                    )
+                    sys.stdout.flush()
+                failed_ranks = [
+                    r for r, ok in enumerate(rank_bitwise_passes) if not ok
+                ]
+                n_bad = int((diff > atol).sum().item())
+                raise AssertionError(
+                    f"[rank {self.rank}] form-B bitwise check failed on ranks "
+                    f"{failed_ranks}; this rank matched {n_matched}/{n_total} "
+                    f"cells to some K!={n_perms} ordering "
+                    f"(max_diff={diff.max().item():.4g} "
+                    f"mean_diff={diff.mean().item():.4g} n_bad={n_bad})."
+                )
+            else:
+                # K > _FORM_B_PERM_K_LIMIT: K! enumeration intractable.
+                # Two-tier validation:
+                #   Tier 1 -- bulk noise floor sanity: rel_diff p90 must be
+                #     under P90_REL_THRESHOLD (a small generous bound that
+                #     real algo bugs would blow through; cancellation +
+                #     bf16 ULP noise of mainstream cells stays well below).
+                #   Tier 2 -- per-cell Wilkinson bf16 K-axis-accum bound on
+                #     the top-N rel_diff outliers: every K! ordering's
+                #     bf16-seq-sum result is provably within
+                #     ``SAFETY * K * sum(|ref_K_terms|) / 256`` of the
+                #     fp32 exact sum (Wilkinson 1963 round-off analysis).
+                #     ``abs_diff <= bound`` <=> ``actual`` may come from
+                #     SOME ordering -> no algo bug.
+                P90_REL_THRESHOLD = 0.10
+                N_VERIFY = 500
+                # Wilkinson 1963 tight upper bound on bf16 K-axis
+                # sequential round-off; no slack.  Cell PASS <=>
+                # ``actual`` is mathematically reachable by SOME K!
+                # ordering's bf16-seq-sum of ``ref_K_terms``.  Any
+                # excess <=> bug.
+                SAFETY = 1.0
+
+                abs_diff = (actual_reduced - ref_reduced).abs()
+                rel_diff = abs_diff / ref_reduced.abs().clamp(min=1.0)
+                qs = [0.5, 0.9, 0.99, 0.999, 1.0]
+                abs_q = _quantile_compat(abs_diff.flatten(), qs)
+                rel_q = _quantile_compat(rel_diff.flatten(), qs)
+                if self.rank == 0:
+                    print(
+                        f"---- form-B percentile observatory "
+                        f"(K={K} > _FORM_B_PERM_K_LIMIT="
+                        f"{_FORM_B_PERM_K_LIMIT}; bitwise enumeration "
+                        f"skipped) ----"
+                    )
+                    print(
+                        f"  abs diff: p50={abs_q[0]:.4g} p90={abs_q[1]:.4g} "
+                        f"p99={abs_q[2]:.4g} p99.9={abs_q[3]:.4g} "
+                        f"max={abs_q[4]:.4g}"
+                    )
+                    print(
+                        f"  rel diff: p50={rel_q[0]:.4g} p90={rel_q[1]:.4g} "
+                        f"p99={rel_q[2]:.4g} p99.9={rel_q[3]:.4g} "
+                        f"max={rel_q[4]:.4g}"
+                    )
+                # Tier 1: bulk p90 rel sanity (catches systematic biases
+                # that affect the majority of cells -- a real algo bug
+                # would push the median up, not just the tail).
+                if rel_q[1] > P90_REL_THRESHOLD:
+                    raise AssertionError(
+                        f"[rank {self.rank}] form-B bulk noise floor "
+                        f"violated: p90_rel={rel_q[1]:.4g} > "
+                        f"{P90_REL_THRESHOLD}.  The majority of cells "
+                        f"have unexpectedly large drift; this is "
+                        f"systematic, not tail outliers."
+                    )
+                # Tier 2: per-cell Wilkinson bound on top-N rel_diff cells.
+                # rel_diff is the right "suspicion" metric for outliers
+                # because small-ref + bf16-noise blows up there; abs_diff
+                # alone misses them (they have small abs but huge rel).
+                n_cells_total = rel_diff.numel()
+                n_verify = min(N_VERIFY, n_cells_total)
+                flat_rel = rel_diff.flatten()
+                top_indices = torch.topk(flat_rel, n_verify).indices
+                H = ref_reduced.shape[1]
+                suspect_t = (top_indices // H).cpu()
+                suspect_h = (top_indices % H).cpu()
+                # Gather per-cell K terms (n_verify, K) then sum of |x|.
+                # combine_output_ref is (T, K, H) bf16; advanced index
+                # combines suspect_t and suspect_h elementwise.
+                cells_ref_K = self.combine_output_ref[
+                    suspect_t, :, suspect_h
+                ].to(torch.float32)
+                cells_abs_sum = cells_ref_K.abs().sum(dim=1)
+                bound = SAFETY * K * cells_abs_sum / 256.0
+                suspect_abs_diff = abs_diff.flatten()[top_indices].cpu()
+                bound_cpu = bound.cpu()
+                excess = (suspect_abs_diff - bound_cpu).clamp(min=0)
+                n_violators = int((excess > 0).sum().item())
+                if n_violators > 0:
+                    worst_idx = int(excess.argmax().item())
+                    worst_t = int(suspect_t[worst_idx].item())
+                    worst_h = int(suspect_h[worst_idx].item())
+                    raise AssertionError(
+                        f"[rank {self.rank}] form-B Wilkinson bf16-accum "
+                        f"bound violated on {n_violators}/{n_verify} "
+                        f"top-rel-diff suspect cells (SAFETY={SAFETY}x).  "
+                        f"Worst: token={worst_t}, hidden={worst_h}, "
+                        f"abs_diff="
+                        f"{suspect_abs_diff[worst_idx].item():.4g}, "
+                        f"bound={bound_cpu[worst_idx].item():.4g}, "
+                        f"excess={excess[worst_idx].item():.4g}, "
+                        f"ref="
+                        f"{ref_reduced[worst_t, worst_h].item():.4g}, "
+                        f"actual="
+                        f"{actual_reduced[worst_t, worst_h].item():.4g}, "
+                        f"sum_|ref_K_terms|="
+                        f"{cells_abs_sum[worst_idx].item():.4g}.  "
+                        f"See percentiles above."
+                    )
+                if self.rank == 0:
+                    print(
+                        f"Validation PASSED on all ranks (form B: "
+                        f"p90_rel={rel_q[1]:.3g} <= {P90_REL_THRESHOLD}; "
+                        f"top-{n_verify} rel-diff cells all within "
+                        f"{SAFETY}x Wilkinson bf16-K-accum bound)"
+                    )
+                return
+
+        bitwise_mismatch_count = None
+        if self.impl.fc2_reduces_topk:
+            local_pass = torch.allclose(
+                actual_reduced, ref_reduced, atol=atol, rtol=rtol,
+            )
+        else:
+            bitwise_mismatch_count = int((diff != 0).sum().item())
+            local_pass = bitwise_mismatch_count == 0
+        local_max_diff = diff.max().detach().reshape(1)
+        rank_max_diffs = [float(local_max_diff.item())]
+        rank_passes = [local_pass]
+        _dist_active = (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+        )
+        if _dist_active:
+            gathered_diffs = [
+                torch.empty_like(local_max_diff) for _ in range(self.world_size)
+            ]
+            pass_tensor = torch.tensor(
+                [int(local_pass)], device=diff.device, dtype=torch.int32
+            )
+            gathered_passes = [
+                torch.empty_like(pass_tensor) for _ in range(self.world_size)
+            ]
+            torch.distributed.all_gather(gathered_diffs, local_max_diff)
+            torch.distributed.all_gather(gathered_passes, pass_tensor)
+            rank_max_diffs = [float(rank_diff.item()) for rank_diff in gathered_diffs]
+            rank_passes = [bool(rank_pass.item()) for rank_pass in gathered_passes]
+
+        if not local_pass:
+            print(self.output_activation)
+            print(self.combine_output_ref)
+            num_bad = (
+                bitwise_mismatch_count
+                if bitwise_mismatch_count is not None
+                else int((diff > atol).sum().item())
+            )
+            reduce_label = (
+                "form-B in-kernel fc2 reduce"
+                if self.impl.fc2_reduces_topk
+                else "CuTeDSL form-A topk reduce"
+            )
+            raise AssertionError(
+                f"[rank {self.rank}] combine_output mismatch after "
+                f"{reduce_label}: "
+                f"max_diff={diff.max().item():.4g} "
+                f"mean_diff={diff.mean().item():.4g} "
+                f"n_bad={num_bad}/{actual_reduced.numel()} "
+                f"({100 * num_bad / max(actual_reduced.numel(), 1):.2f}%)"
+            )
+
+        if self.rank == 0 and all(rank_passes):
+            diff_summary = ", ".join(
+                f"rank {rank}: max_diff={max_diff:.4g}"
+                for rank, max_diff in enumerate(rank_max_diffs)
+            )
+            print(
+                f"Validation PASSED on all ranks "
+                f"({diff_summary})"
+            )
+
+    # ------------------------------------------------------------------
+    # Workspace peek (MEGA_PEEK_WORKSPACE=1)
+    # ------------------------------------------------------------------
+
+    def _peek_workspace(
+        self,
+        actual_reduced: torch.Tensor,
+        ref_reduced: torch.Tensor,
+        diff: torch.Tensor,
+    ) -> None:
+        """Dump intermediate workspace regions on a failing rank-0 run.
+
+        Read-only peek into the local + shared workspace partitioned by
+        the kernel, mostly meant to localise a combine mismatch to one
+        of: (a) dispatch (routing / metadata), (b) fc1 (acc / SwiGLU
+        cast), or (c) fc2 epi (STG indexing / peer_rank_ptr_mapper.map peer
+        redirect).
+
+        Gated by ``MEGA_PEEK_WORKSPACE=1`` so it never fires on perf or
+        clean validate runs.  All slicing assumes ``_kernel`` has cached
+        the region specs (it does, after ``run_kernel``).
+        """
+        from moe_nvfp4_swapab.megamoe_kernel import _layout_regions
+
+        local_specs = self._kernel._local_region_specs
+        shared_specs = self._kernel._shared_region_specs
+        local_offsets, _ = _layout_regions(local_specs)
+        shared_offsets, _ = _layout_regions(shared_specs)
+        local_by_name = self._kernel._local_region_by_name
+        shared_by_name = self._kernel._shared_region_by_name
+
+        def _region(ws, by_name, offsets, name, torch_dtype):
+            spec = by_name[name]
+            off = offsets[name]
+            return ws[off:off + spec.nbytes].view(torch_dtype)
+
+        # ---- 1. expert routing counters (low32=tokens, high32=publishers*ranks).
+        ercs = _region(
+            self.shared_workspace, shared_by_name, shared_offsets,
+            "expert_recv_count_sum", torch.int64,
+        )
+        print("---- expert_recv_count_sum ----")
+        for i in range(ercs.shape[0]):
+            v = int(ercs[i].item()) & 0xFFFFFFFFFFFFFFFF
+            print(
+                f"  expert[{i}]: tokens={v & 0xFFFFFFFF} "
+                f"publishers*ranks={(v >> 32) & 0xFFFFFFFF}"
+            )
+
+        # ---- 2. token_src_metadata: (pool_slot) -> (src_rank, src_token, src_topk).
+        mbuf = _region(
+            self.local_workspace, local_by_name, local_offsets,
+            "token_src_metadata", torch.int32,
+        )
+        md_u32 = mbuf.reshape(-1, 3)
+        n_slots = md_u32.shape[0]
+        sample_rows = sorted(set(
+            list(range(min(8, n_slots)))
+            + [n_slots // 2 - 1, n_slots // 2, n_slots // 2 + 1]
+            + list(range(max(0, n_slots - 4), n_slots))
+        ))
+        print(
+            f"---- token_src_metadata (pool_slot -> (src_rank, src_token, src_topk)) "
+            f"n_slots={n_slots} ----"
+        )
+        for s in sample_rows:
+            r = md_u32[s].cpu().tolist()
+            print(
+                f"  slot[{s}]: src_rank={r[0]} src_token={r[1]} src_topk={r[2]}"
+            )
+
+        # ---- 2a. duplicate (src_rank, src_token, src_topk) detection.
+        #
+        # In a well-formed dispatch every valid pool slot maps to a unique
+        # ``(src_rank, src_token, src_topk)`` triple (= one cell of
+        # ``combine_output``).  If two pool slots share a triple, both will
+        # fire their fc2 STG onto the same ``combine_output[src_token,
+        # src_topk, :]`` row -- exactly the race-condition shape we saw
+        # (non-determinism + all bad cells concentrated on one src_topk
+        # slot).  This pass enumerates the offending triples and the pool
+        # slots that map to each, so the bug can be localised to a
+        # specific expert / advertise-card slot range.
+        #
+        # Padding slots (where dispatch never wrote metadata) sit at the
+        # default ``(0, 0, 0)`` triple; they show up as one big
+        # multi-collision cluster.  We separate them out and report the
+        # padding-slot count plus the count of OTHER collision triples.
+        md_cpu = md_u32.cpu()
+        # Build a single int64 key per slot so we can rely on torch.unique.
+        # Key bit layout: bits 0..15 = src_topk, bits 16..47 = src_token,
+        # bits 48..63 = src_rank.  src_token can in principle exceed 16
+        # bits (e.g. 1M-token bench config), so we use a 32-bit field for
+        # safety -- the 64-bit key still fits.
+        key = (
+            md_cpu[:, 0].to(torch.int64) << 48
+            | (md_cpu[:, 1].to(torch.int64) & 0xFFFFFFFF) << 16
+            | (md_cpu[:, 2].to(torch.int64) & 0xFFFF)
+        )
+        unique_keys, inverse, counts = torch.unique(
+            key, return_inverse=True, return_counts=True
+        )
+        coll_mask = counts > 1
+        n_collisions = int(coll_mask.sum().item())
+        print(
+            f"---- duplicate metadata triples (n_collision_triples="
+            f"{n_collisions}) ----"
+        )
+        if n_collisions == 0:
+            print("  (no duplicates -- metadata is 1:1 with combine_output cells)")
+        else:
+            coll_keys = unique_keys[coll_mask]
+            coll_counts = counts[coll_mask]
+            # Rank collision triples by replication count (worst first).
+            sort_idx = torch.argsort(coll_counts, descending=True)
+            shown = 0
+            shown_limit = 8
+            for i in sort_idx.tolist():
+                k = int(coll_keys[i].item())
+                c = int(coll_counts[i].item())
+                src_rank = (k >> 48) & 0xFFFF
+                src_token = (k >> 16) & 0xFFFFFFFF
+                src_topk = k & 0xFFFF
+                # Find which pool_slots map here.
+                slot_ids = (key == k).nonzero(as_tuple=False).squeeze(-1)
+                slot_sample = slot_ids[:min(8, slot_ids.numel())].tolist()
+                tag = ""
+                if src_rank == 0 and src_token == 0 and src_topk == 0:
+                    tag = "  [LIKELY PADDING / UNWRITTEN]"
+                print(
+                    f"  (src_rank={src_rank}, src_token={src_token}, "
+                    f"src_topk={src_topk}) x {c}{tag}"
+                )
+                print(
+                    f"    first {len(slot_sample)} slot ids: {slot_sample}"
+                )
+                shown += 1
+                if shown >= shown_limit:
+                    remaining = n_collisions - shown
+                    if remaining > 0:
+                        print(
+                            f"  ... ({remaining} more collision triples elided)"
+                        )
+                    break
+
+        # ---- 2b. expected-vs-actual (src_token, src_topk) reverse check.
+        #
+        # Single-rank only: every ``(src_token, src_topk)`` in
+        # ``[0, T) x [0, K)`` routes to this rank and should appear in
+        # ``token_src_metadata`` exactly once.  Multi-rank would need
+        # filtering by ``my_topk_idx`` (rank ownership of each (t, k));
+        # left as future work.
+        #
+        # ``missing`` = pairs that should have been stamped but weren't
+        # (= dispatch dropped the metadata STG, leaving the slot at the
+        # default ``(0, 0, 0)``).  ``extras`` = pairs stamped that
+        # shouldn't exist in routing (= dispatch wrote garbage).  Both
+        # are direct evidence of a dispatch bug.
+        #
+        # Histogram by ``src_topk`` is the high-signal bit: if missing
+        # concentrates on a single src_topk, it pairs 1:1 with the
+        # worst-diff topk slot downstream.
+        #
+        # Valid-slot identification: use ``fc1_output`` non-zero row mask
+        # rather than ``(md != (0,0,0))``, because the legitimate routing
+        # pair ``(src_token=0, src_topk=0)`` would otherwise collide with
+        # the padding default and be mis-flagged as missing.  fc1_output
+        # is written iff the slot carries a valid token instance, so
+        # ``fc1_output non-zero`` is the correct "this slot is in use"
+        # discriminator.  Recomputed inline rather than threaded from the
+        # later fc1_output block to keep the two passes independent.
+        fc1_spec_rc = local_by_name["fc1_output"]
+        fc1_off_rc = local_offsets["fc1_output"]
+        fc1_raw_rc = self.local_workspace[
+            fc1_off_rc:fc1_off_rc + fc1_spec_rc.nbytes
+        ].view(torch.uint8)
+        row_bytes_rc = (
+            fc1_spec_rc.shape[1] // 2 if len(fc1_spec_rc.shape) >= 2 else 0
+        )
+        rc_ready = (
+            row_bytes_rc > 0
+            and fc1_raw_rc.numel() % row_bytes_rc == 0
+        )
+        if rc_ready:
+            fc1_2d_rc = fc1_raw_rc.view(-1, row_bytes_rc).cpu()
+            valid_slot_mask = (fc1_2d_rc != 0).any(dim=1)
+            T = self.problem.num_tokens_per_rank
+            K = self.problem.num_topk
+            # Multi-rank: also need src_rank to disambiguate (same
+            # (t, k) on different source ranks lives in different
+            # pool slots on the receiver).  Single-rank degenerates to
+            # the previous behaviour (src_rank == 0 everywhere).
+            seen_triples = set(
+                map(tuple, md_cpu[valid_slot_mask, :].tolist())
+            )
+            # Expected universe: every (src_rank, src_token, src_topk)
+            # whose routed expert lands on THIS rank.  Per-rank
+            # routing is built by replaying ``_generate_topk_idx_*``;
+            # to avoid recomputing it the harness keeps the global
+            # tensor in ``self._global_topk_idx`` (shape
+            # ``(num_ranks, T, K)``).  Filter by
+            # ``expert // num_experts_per_rank == self.rank``.
+            num_experts_per_rank = (
+                self.problem.num_total_experts // self.world_size
+            )
+            expected_triples = set()
+            if (
+                hasattr(self, "_global_topk_idx")
+                and self._global_topk_idx is not None
+            ):
+                gti = self._global_topk_idx.cpu()  # (R, T, K)
+                for sr in range(self.world_size):
+                    for t in range(T):
+                        for k in range(K):
+                            e = int(gti[sr, t, k].item())
+                            if e // num_experts_per_rank == self.rank:
+                                expected_triples.add((sr, t, k))
+            expected_pairs = expected_triples  # alias kept for parity
+            seen_pairs = seen_triples
+            missing = expected_pairs - seen_pairs
+            extras = seen_pairs - expected_pairs
+            print(
+                f"---- expected-vs-actual (src_rank, src_token, src_topk) "
+                f"reverse check (world={self.world_size}, T={T}, K={K}, "
+                f"expected={len(expected_triples)}, observed_unique="
+                f"{len(seen_pairs)}) ----"
+            )
+            print(f"  missing (expected but never stamped): {len(missing)}")
+            print(f"  extras  (stamped but not in routing): {len(extras)}")
+            if missing:
+                topk_hist = [0] * K
+                rank_hist = [0] * self.world_size
+                for sr, _, k in missing:
+                    if 0 <= k < K:
+                        topk_hist[k] += 1
+                    if 0 <= sr < self.world_size:
+                        rank_hist[sr] += 1
+                print(
+                    f"  missing by src_topk: "
+                    f"{ {k: c for k, c in enumerate(topk_hist) if c} }"
+                )
+                print(
+                    f"  missing by src_rank: "
+                    f"{ {r: c for r, c in enumerate(rank_hist) if c} }"
+                )
+                sample = sorted(missing)[:16]
+                print(f"  first 16 missing (src_rank, src_token, src_topk): {sample}")
+            if extras:
+                topk_hist = [0] * K
+                rank_hist = [0] * self.world_size
+                for sr, _, k in extras:
+                    if 0 <= k < K:
+                        topk_hist[k] += 1
+                    if 0 <= sr < self.world_size:
+                        rank_hist[sr] += 1
+                print(
+                    f"  extras by src_topk: "
+                    f"{ {k: c for k, c in enumerate(topk_hist) if c} }"
+                )
+                print(
+                    f"  extras by src_rank: "
+                    f"{ {r: c for r, c in enumerate(rank_hist) if c} }"
+                )
+                sample = sorted(extras)[:16]
+                print(f"  first 16 extras (src_rank, src_token, src_topk): {sample}")
+        else:
+            print(
+                f"---- expected-vs-actual reverse check skipped "
+                f"(fc1_output peek unavailable) ----"
+            )
+
+        # ---- 3. fc1_output non-zero row mask (per pool_slot) + hash.
+        #
+        # The hash (sum modulo a large prime over the raw bytes) is a
+        # quick fingerprint to compare ``fc1_output`` across two runs
+        # of the same cmd: if the hash differs the race is on the
+        # write side of fc1_output (dispatch pull -> fc1 GEMM / fc1
+        # epi); if the hash matches but ``combine_output`` still
+        # differs the race is on the read / fc2 phase side.
+        fc1_spec = local_by_name["fc1_output"]
+        fc1_off = local_offsets["fc1_output"]
+        fc1_raw = self.local_workspace[
+            fc1_off:fc1_off + fc1_spec.nbytes
+        ].view(torch.uint8)
+        row_bytes = fc1_spec.shape[1] // 2 if len(fc1_spec.shape) >= 2 else 0
+        if row_bytes > 0 and fc1_raw.numel() % row_bytes == 0:
+            fc1_2d = fc1_raw.view(-1, row_bytes).cpu()
+            nz = (fc1_2d != 0).any(dim=1)
+            zero_rows = (~nz).nonzero(as_tuple=False).squeeze(-1).tolist()
+            # Cheap byte fingerprint: sum over uint32 view modulo a
+            # 31-bit prime.  Stable across runs iff the underlying
+            # bytes are identical -- collisions are vanishingly rare
+            # for the workspaces we look at.
+            fc1_u32 = fc1_raw.view(torch.int32).cpu().to(torch.int64)
+            fc1_hash = int((fc1_u32 & 0xFFFFFFFF).sum().item()) % 0x7FFFFFFF
+            print(
+                f"---- fc1_output zero-row mask "
+                f"shape={tuple(fc1_2d.shape)} all_zero_rows={len(zero_rows)}/{fc1_2d.shape[0]} "
+                f"hash=0x{fc1_hash:08x} ----"
+            )
+            if zero_rows:
+                print(
+                    f"  first 16 zero rows: {zero_rows[:16]}"
+                )
+                print(
+                    f"  last 16 zero rows : {zero_rows[-16:]}"
+                )
+
+            # ---- 3b. fc1_output * SF dequant sample (head/tail rows).
+            #
+            # cute SF layout (``tile_atom_to_shape_SF((M, K, L=1), vec)``):
+            #   shape  ((32, 4, M_rest), (vec, 4, K_rest))
+            #   stride ((16, 4, 512*K_rest), (0, 1, 512))
+            # Per-byte offset for logical (m, k_element):
+            #   m_inner=(m%32)*16 + ((m//32)%4)*4 + (m//128)*512*K_atoms
+            #   k     =(k%vec=collapsed) + ((k//vec)%4)*1 + (k//(vec*4))*512
+            sf_vec_size = Nvfp4BlockSize
+            intermediate_downproj_int = fc1_spec.shape[1]
+            K_sf_blocks_total = intermediate_downproj_int // sf_vec_size
+            K_atoms = (K_sf_blocks_total + 3) // 4
+            sf_spec = local_by_name["fc1_output_sf"]
+            sf_off = local_offsets["fc1_output_sf"]
+            sf_raw = self.local_workspace[
+                sf_off:sf_off + sf_spec.nbytes
+            ].view(torch.uint8).cpu()
+
+            def _sf_byte_offset(m: int, sf_block: int) -> int:
+                return (
+                    (m % 32) * 16
+                    + ((m // 32) % 4) * 4
+                    + (m // 128) * (512 * K_atoms)
+                    + (sf_block % 4)
+                    + (sf_block // 4) * 512
+                )
+
+            n_show_rows = 4
+            n_show_cells = 16
+            n_rows_total = fc1_2d.shape[0]
+            sample_row_ids = list(range(min(n_show_rows, n_rows_total))) + [
+                r for r in range(
+                    max(0, n_rows_total - n_show_rows), n_rows_total,
+                )
+                if r >= n_show_rows  # avoid duplicates when rows < 2*n_show
+            ]
+            print(
+                f"---- fc1_output * SF dequant sample "
+                f"(rows {sample_row_ids}; SF per {sf_vec_size}-element block) ----"
+            )
+            for r in sample_row_ids:
+                # fp4 values for this row.
+                row_bytes_t = fc1_2d[r]  # uint8, len=row_bytes
+                lo = (row_bytes_t & 0x0F).to(torch.int64)
+                hi = ((row_bytes_t >> 4) & 0x0F).to(torch.int64)
+                fp4_idx = torch.stack([lo, hi], dim=-1).reshape(-1)
+                fp4_vals = _Fp4DecodeTable[fp4_idx]
+                # SF bytes for this row (one byte per sf_block).
+                sf_byte_idxs = torch.tensor(
+                    [
+                        _sf_byte_offset(r, sb)
+                        for sb in range(K_sf_blocks_total)
+                    ],
+                    dtype=torch.int64,
+                )
+                sf_bytes = sf_raw[sf_byte_idxs]
+                sf_fp32 = sf_bytes.view(torch.float8_e4m3fn).to(torch.float32)
+                # Apply per-block SF.
+                dequant = (
+                    fp4_vals.reshape(K_sf_blocks_total, sf_vec_size)
+                    * sf_fp32.unsqueeze(-1)
+                ).reshape(-1)
+
+                n_cells_actual = min(n_show_cells, dequant.numel())
+                head_cells = [
+                    f"{v:+.2f}" for v in dequant[:n_cells_actual].tolist()
+                ]
+                sf_show = [f"{s:+.3f}" for s in sf_fp32.tolist()]
+                print(
+                    f"  row[{r}]: dequant min={dequant.min().item():+.3f} "
+                    f"max={dequant.max().item():+.3f} "
+                    f"mean={dequant.mean().item():+.3f} "
+                    f"nnz={int((fp4_vals != 0).sum().item())}"
+                    f"/{fp4_vals.numel()} | "
+                    f"first {n_cells_actual}: {head_cells} | "
+                    f"SF: {sf_show}"
+                )
+
+            # ---- 3c. fc1_output * SF percentiles over valid rows only.
+            # ``nz`` already marks valid pool rows (= any non-zero byte
+            # in the row); padding rows are TMA-OOB-fill-0 so they are
+            # zero and dominate the global distribution if not filtered.
+            valid_row_ids = nz.nonzero(as_tuple=False).squeeze(-1).tolist()
+            n_valid = len(valid_row_ids)
+            if n_valid > 0:
+                # Bulk dequant whole pool's fp4 first, then index valid
+                # rows + SF gather.  fc1_2d is (n_rows, row_bytes) uint8
+                # already on CPU.
+                full_lo = (fc1_2d & 0x0F).to(torch.int64)
+                full_hi = ((fc1_2d >> 4) & 0x0F).to(torch.int64)
+                full_fp4_idx = torch.stack(
+                    [full_lo, full_hi], dim=-1,
+                ).reshape(fc1_2d.shape[0], -1)
+                full_fp4_vals = _Fp4DecodeTable[full_fp4_idx]
+                # Per-(valid_row, sf_block) SF byte offsets, gathered
+                # into one tensor then sliced back.
+                sf_offsets_all = torch.tensor(
+                    [
+                        _sf_byte_offset(r, sb)
+                        for r in valid_row_ids
+                        for sb in range(K_sf_blocks_total)
+                    ],
+                    dtype=torch.int64,
+                )
+                sf_bytes_all = sf_raw[sf_offsets_all].view(
+                    n_valid, K_sf_blocks_total,
+                )
+                sf_fp32_all = (
+                    sf_bytes_all.view(torch.float8_e4m3fn).to(torch.float32)
+                )
+                valid_fp4 = full_fp4_vals[valid_row_ids]
+                dequant_all = (
+                    valid_fp4.reshape(
+                        n_valid, K_sf_blocks_total, sf_vec_size,
+                    )
+                    * sf_fp32_all.unsqueeze(-1)
+                ).reshape(n_valid, -1)
+                all_vals = dequant_all.flatten()
+                abs_vals = all_vals.abs()
+                qs = [0.5, 0.9, 0.99, 0.999, 1.0]
+                abs_q = _quantile_compat(abs_vals, qs)
+                sf_q = _quantile_compat(sf_fp32_all.flatten(), qs)
+                print(
+                    f"---- fc1_output * SF percentiles "
+                    f"(valid_rows={n_valid}, cells={all_vals.numel()}) ----"
+                )
+                print(
+                    f"  |val|:   p50={abs_q[0]:.4g} p90={abs_q[1]:.4g} "
+                    f"p99={abs_q[2]:.4g} p99.9={abs_q[3]:.4g} "
+                    f"max={abs_q[4]:.4g}"
+                )
+                print(
+                    f"  SF:      p50={sf_q[0]:.4g} p90={sf_q[1]:.4g} "
+                    f"p99={sf_q[2]:.4g} p99.9={sf_q[3]:.4g} "
+                    f"max={sf_q[4]:.4g}"
+                )
+                print(
+                    f"  signed:  mean={all_vals.mean().item():+.4g} "
+                    f"std={all_vals.std().item():.4g} "
+                    f"nnz%={100 * (all_vals != 0).float().mean().item():.2f}"
+                )
+        else:
+            print(
+                f"---- fc1_output peek skipped (spec.shape={fc1_spec.shape}, "
+                f"raw nbytes={fc1_raw.numel()}) ----"
+            )
+
+        # ---- 3a. fc1_output_sf and l1_sf_buffer hash for cross-run diffing.
+        #
+        # Same purpose as the fc1_output hash above: stable byte hash
+        # across runs => buffer content is deterministic; varying hash
+        # => race on the write side of that buffer.  l1_sf_buffer is
+        # the dispatch-pull-written input SF for the fc1 phase;
+        # fc1_output_sf is fc1 epi's per-thread STG output SF for the
+        # fc2 phase.  Pairing the three hashes (fc1_output above +
+        # these two) lets us localise a race to one of the three
+        # write stages.
+        for buf_name in ("fc1_output_sf", "l1_sf_buffer"):
+            spec = local_by_name[buf_name]
+            off = local_offsets[buf_name]
+            raw = self.local_workspace[off:off + spec.nbytes].view(torch.uint8)
+            u32 = raw.view(torch.int32).cpu().to(torch.int64)
+            buf_hash = int((u32 & 0xFFFFFFFF).sum().item()) % 0x7FFFFFFF
+            print(
+                f"---- {buf_name} hash=0x{buf_hash:08x} "
+                f"(spec.shape={spec.shape}, nbytes={raw.numel()}) ----"
+            )
+
+        # ---- 3a2. routing dump for the tokens that show a non-zero
+        # ``diff_sum`` (= K-reduced abs diff on the host-side reduce
+        # path).  In power_law a subset of tokens is suspected to be
+        # deterministic-error tokens (token 0 + a handful of others);
+        # dumping each such token's 11 routing experts lets us check
+        # whether they share a structural property (e.g. all hit one
+        # specific heavy-tail expert, or all hit a particular task-tile
+        # boundary).
+        if hasattr(self, "_global_topk_idx") and self._global_topk_idx is not None:
+            host_diff_per_token = diff.sum(dim=-1).cpu()  # (T,)
+            bad_token_ids = (
+                (host_diff_per_token > 0).nonzero(as_tuple=False)
+                .squeeze(-1).tolist()
+            )
+            n_bad_tokens = len(bad_token_ids)
+            topk_idx_cpu = self._global_topk_idx[self.rank].cpu()
+            topk_w_cpu = (
+                self._global_topk_weights[self.rank].cpu()
+                if hasattr(self, "_global_topk_weights")
+                and self._global_topk_weights is not None
+                else None
+            )
+            # Per-LOCAL-expert recv count (``ercs`` only covers this
+            # rank's ``num_experts_per_rank`` experts; global expert
+            # ids that route to OTHER ranks have no entry here).
+            n_local_e = ercs.shape[0]
+            num_experts_per_rank = (
+                self.problem.num_total_experts // self.world_size
+            )
+            expert_recv_local = [
+                int(ercs[i].item()) & 0xFFFFFFFF
+                for i in range(n_local_e)
+            ]
+
+            def _recv_for(e_global):
+                owner = e_global // num_experts_per_rank
+                if owner == self.rank:
+                    local = e_global - owner * num_experts_per_rank
+                    if 0 <= local < n_local_e:
+                        return str(expert_recv_local[local])
+                return f"@r{owner}"  # remote-rank expert: count not visible here
+
+            dump_limit = 8
+            print(
+                f"---- routing for tokens with diff_sum > 0 "
+                f"(count={n_bad_tokens}, showing first {min(dump_limit, n_bad_tokens)}) ----"
+            )
+            for t in bad_token_ids[:dump_limit]:
+                t_routes = topk_idx_cpu[t].tolist()
+                ds = float(host_diff_per_token[t].item())
+                pieces = []
+                for k_idx, e in enumerate(t_routes):
+                    e_int = int(e)
+                    wt = (
+                        f"w={topk_w_cpu[t, k_idx].item():.3g}"
+                        if topk_w_cpu is not None
+                        else ""
+                    )
+                    pieces.append(
+                        f"k{k_idx}=e{e_int}(recv={_recv_for(e_int)},{wt})"
+                    )
+                print(
+                    f"  token[{t}] diff_sum={ds:.4g}  " + " ".join(pieces)
+                )
+
+        # ---- 4. worst-diff tokens (on UNREDUCED (T, K, H) abs diff).
+        #
+        # ``diff`` is ``|actual_reduced - ref_reduced|`` over the
+        # K-axis-reduced view -- topk reduction can cancel
+        # opposite-sign errors and undercount real per-cell errors.
+        # The peek instead works on the raw ``|actual - ref|`` cell
+        # tensor of shape ``(T, K, H)`` so every cell-level error is
+        # visible.
+        # separate_kernel_reduce: the per-topk (T, K, H) staging is internal to
+        #   the kernel, so read it back from the shared-workspace
+        #   ``combine_quant`` region for a raw per-cell diff (bf16 combine only).
+        # in_kernel_reduce: device output is already (T, H) (K reduced on
+        #   device); the per-(K, H) cell diff is meaningless, so reduce ref's K
+        #   axis on host and diff in (T, H).
+        if self.impl.fc2_reduces_topk:
+            actual_full = self.output_activation.to(torch.float32)
+            ref_full = self.combine_output_ref.to(torch.float32).sum(dim=1)
+            unreduced_diff = (actual_full - ref_full).abs()  # (T, H)
+            per_token_diff_sum = unreduced_diff.sum(dim=-1)  # (T,)
+        else:
+            combine_quant_raw = _region(
+                self.shared_workspace, shared_by_name, shared_offsets,
+                "combine_quant", self.problem.fc2_output_dtype,
+            )
+            actual_full = (
+                combine_quant_raw.reshape(self.combine_output_ref.shape)
+                .to(torch.float32)
+            )
+            ref_full = self.combine_output_ref.to(torch.float32)
+            unreduced_diff = (actual_full - ref_full).abs()  # (T, K, H)
+            per_token_diff_sum = unreduced_diff.sum(dim=(1, 2))  # (T,)
+        n_worst_tokens = min(8, per_token_diff_sum.numel())
+        worst_tokens = torch.topk(per_token_diff_sum, k=n_worst_tokens)
+        bad_tokens = worst_tokens.indices.cpu().tolist()
+        bad_diff_sums = worst_tokens.values.cpu().tolist()
+
+        n_worst_cells_per_token = 6
+        H = unreduced_diff.shape[-1]
+        if self.impl.fc2_reduces_topk:
+            print(
+                "---- worst-diff tokens (top "
+                f"{n_worst_tokens} by sum over hidden; per token: "
+                f"top {n_worst_cells_per_token} hidden cells; K already "
+                "reduced on device) ----"
+            )
+            for t, ds in zip(bad_tokens, bad_diff_sums):
+                token_diff = unreduced_diff[t]  # (H,)
+                n_cells = min(n_worst_cells_per_token, token_diff.numel())
+                top_cells = torch.topk(token_diff, k=n_cells)
+                cell_idxs = top_cells.indices.cpu().tolist()
+                print(
+                    f"  token[{t}]: diff_sum={ds:.4g}  "
+                    f"max_cell_diff={token_diff.max().item():.4g}"
+                )
+                for h in cell_idxs:
+                    a = float(actual_full[t, h].item())
+                    r = float(ref_full[t, h].item())
+                    d = float(token_diff[h].item())
+                    print(
+                        f"    (hidden={h}): "
+                        f"actual={a:.4g}  ref={r:.4g}  diff={d:.4g}"
+                    )
+        else:
+            print(
+                "---- worst-diff tokens (top "
+                f"{n_worst_tokens} by sum over (topk, hidden); per token: "
+                f"top {n_worst_cells_per_token} (topk, hidden) cells) ----"
+            )
+            for t, ds in zip(bad_tokens, bad_diff_sums):
+                token_diff = unreduced_diff[t]  # (K, H)
+                flat = token_diff.flatten()
+                n_cells = min(n_worst_cells_per_token, flat.numel())
+                top_cells = torch.topk(flat, k=n_cells)
+                cell_idxs = top_cells.indices.cpu().tolist()
+                print(
+                    f"  token[{t}]: diff_sum={ds:.4g}  "
+                    f"max_cell_diff={token_diff.max().item():.4g}"
+                )
+                for ci in cell_idxs:
+                    k = ci // H
+                    h = ci % H
+                    a = float(actual_full[t, k, h].item())
+                    r = float(ref_full[t, k, h].item())
+                    d = float(token_diff[k, h].item())
+                    print(
+                        f"    (topk={k}, hidden={h}): "
+                        f"actual={a:.4g}  ref={r:.4g}  diff={d:.4g}"
+                    )
+
+    # ------------------------------------------------------------------
+    # Top-level orchestration
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        if self.rank == 0:
+            print(self.problem)
+            print(self.impl)
+            print(self.misc)
+            print(
+                f"MegaMoETester: torch_profiler="
+                f"{'on' if self._use_torch_profiler else 'off'}"
+            )
+
+        self.generate_inputs()
+
+        if self.rank == 0:
+            for name, tensor in (
+                ("my_activation", self.my_activation),
+                ("my_activation_sf", self.my_activation_sf),
+                ("my_topk_idx", self.my_topk_idx),
+                ("my_fc1_weight", self.my_fc1_weight),
+                ("output_activation", self.output_activation),
+            ):
+                if tensor is None:
+                    print(f"[rank {self.rank}] {name:18s} not allocated")
+                    continue
+                print(
+                    f"[rank {self.rank}] {name:18s} "
+                    f"shape={tuple(tensor.shape)} dtype={tensor.dtype}"
+                )
+
+        skip_ref = self.misc.skip_ref_check or self.misc.profile_friendly
+        if not skip_ref:
+            self.compute_reference()
+
+        # Once the kernel is wired, this is also the place ``allocate_workspaces``
+        # gets called (depends on self._kernel being instantiated inside run_kernel).
+        self.run_kernel()
+
+        if not skip_ref:
+            self.validate()
+
+        if self.rank == 0:
+            print("DONE")
+
+
+# =============================================================================
+# CLI
+# =============================================================================
+
+
+def _parse_tuple(argument: str) -> Tuple[int, ...]:
+    return tuple(int(value) for value in argument.split(","))
+
+
+def _parse_output_dtype(argument: str) -> torch.dtype:
+    mapping = {
+        "bf16": torch.bfloat16, "bfloat16": torch.bfloat16,
+        "fp16": torch.float16, "float16": torch.float16, "half": torch.float16,
+    }
+    if argument not in mapping:
+        raise argparse.ArgumentTypeError(
+            f"fc2_output_dtype must be one of {sorted(mapping.keys())}, got {argument!r}"
+        )
+    return mapping[argument]
+
+
+def _parse_combine_format(argument: str) -> CombineFormat:
+    try:
+        return CombineFormat.parse(argument)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc))
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="MegaMoE NVFP4 multi-rank fused dispatch+fc12+combine runner",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--num_tokens_per_rank", type=int, default=128)
+    parser.add_argument("--num_topk", type=int, default=4)
+    parser.add_argument("--num_total_experts", type=int, default=32)
+    parser.add_argument("--hidden", type=int, default=2048)
+    parser.add_argument("--intermediate", type=int, default=1024)
+    parser.add_argument(
+        "--fc2_output_dtype", type=_parse_output_dtype, default=torch.bfloat16,
+    )
+    parser.add_argument(
+        "--combine_format", type=_parse_combine_format,
+        default=CombineFormat.parse("bf16"),
+        help="Cross-rank combine wire format: 'bf16' (no-quant baseline), "
+             "'16e2m1xbf16' (fp4 + per-16 bf16 amax), or '32e4m3xe8m0' (MXFP8).",
+    )
+    parser.add_argument(
+        "--route_distribution", type=str, default="balanced",
+        choices=["balanced", "power_law"],
+    )
+    parser.add_argument(
+        "--power_law_exponent", type=float, default=1.0,
+        help="Zipf exponent for --route_distribution power_law; 1.0 = classic "
+             "Zipf, larger = more skewed, 0 = uniform.",
+    )
+    parser.add_argument(
+        "--gate_up_clamp", type=float, default=None,
+        help="DeepSeek-V4 swiglu_limit: asymmetric clamp on the real gate/up "
+             "pre-activations (gate<=limit, |up|<=limit) before SiLU. "
+             "Omitted/None disables the clamp; must be non-negative.",
+    )
+
+    parser.add_argument("--mma_tiler_mnk", type=str, default="128,128,256")
+    parser.add_argument("--cluster_shape_mnk", type=str, default="1,1,1")
+    parser.add_argument("--use_2cta_instrs", action="store_true", default=False)
+    parser.add_argument("--enable_static_expert_shape", action="store_true", default=False)
+    parser.add_argument("--dynamic_sched", action="store_true", default=False)
+    parser.add_argument("--clc_bundle_size", type=int, default=None)
+    parser.add_argument("--num_sched_stages", type=int, default=None)
+    parser.add_argument(
+        "--load_balance_mode", type=str, default="static",
+        choices=["static", "atomic_counter"],
+    )
+    parser.add_argument("--group_hint", type=int, default=None)
+    parser.add_argument("--flag_batch", type=int, default=4)
+    parser.add_argument(
+        "--epi_flag_batch", type=str, default="1,1",
+        help="(fc1,fc2) done-counter publish batch in comma form",
+    )
+    parser.add_argument(
+        "--use_bulk_fc2_store",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--in_kernel_fc2_reduce",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--token_back_mode",
+        type=str,
+        default="epi_warps",
+        choices=["epi_warps", "standalone_warps", "reuse_dispatch_warps"],
+        help="Where the cross-rank fc2 push-back runs: epi_warps (epilogue "
+             "STG redirect, default), standalone_warps (dedicated warps "
+             "12-15), or reuse_dispatch_warps (dispatch warps 8-11).",
+    )
+    parser.add_argument("--perf_run", action="store_true", default=False)
+    parser.add_argument("--skip_ref_check", action="store_true", default=False)
+    parser.add_argument("--profile_friendly", action="store_true", default=False)
+    parser.add_argument("--use_torch_profiler", action="store_true", default=False)
+    # Default to 0,1 to avoid testing time.
+    parser.add_argument("--perf_warmup", type=int, default=0)
+    parser.add_argument("--perf_iters", type=int, default=1)
+    parser.add_argument("--enable_debug_checks", action="store_true", default=False)
+    parser.add_argument(
+        "--ref_compute_graph", type=str, default="deepgemm",
+        choices=["transformers", "deepgemm"],
+    )
+    parser.add_argument("--enable_iket", action="store_true", default=False)
+    parser.add_argument("--seed", type=int, default=1234)
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Bootstrap NCCL + NVSHMEM, build the tester, run one pass.
+
+    Launcher::
+
+        torchrun --nproc_per_node=4 -m moe_nvfp4_swapab.mega_runner \\
+            --num_total_experts 32 --route_distribution balanced
+    """
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if _NO_DIST:
+        # MEGA_NO_DIST=1: bypass torch.distributed + NVSHMEM init so the
+        # script can be launched as plain ``python mega_runner.py`` under
+        # compute-sanitizer / debugger.  Single-rank only.
+        torch.cuda.set_device(0)
+        rank = 0
+        world_size = 1
+    else:
+        from src.bootstrap import init_dist_and_nvshmem
+        _local_rank, rank, world_size, _ = init_dist_and_nvshmem()
+
+    problem = TokenCommProblemDesc(
+        world_size=world_size,
+        num_tokens_per_rank=args.num_tokens_per_rank,
+        num_topk=args.num_topk,
+        num_total_experts=args.num_total_experts,
+        hidden=args.hidden,
+        intermediate=args.intermediate,
+        fc2_output_dtype=args.fc2_output_dtype,
+        combine_format=args.combine_format,
+        route_distribution=args.route_distribution,
+        power_law_exponent=args.power_law_exponent,
+        gate_up_clamp=args.gate_up_clamp,
+    )
+
+    if problem.num_topk > 32:
+        raise ValueError(
+            f"num_topk ({problem.num_topk}) > 32 is unsupported by the current. Shit inherited from DeepGEMM."
+        )
+
+    impl = ImplDesc(
+        mma_tiler_mnk=_parse_tuple(args.mma_tiler_mnk),
+        cluster_shape_mnk=_parse_tuple(args.cluster_shape_mnk),
+        use_2cta_instrs=args.use_2cta_instrs,
+        enable_static_expert_shape=args.enable_static_expert_shape,
+        force_static_sched=not args.dynamic_sched,
+        clc_bundle_size=args.clc_bundle_size,
+        num_sched_stages=args.num_sched_stages,
+        load_balance_mode=args.load_balance_mode,
+        group_hint=args.group_hint,
+        non_ubulk_fc2_store=not args.use_bulk_fc2_store,
+        in_kernel_fc2_reduce=args.in_kernel_fc2_reduce,
+        token_back_mode=args.token_back_mode,
+        flag_batch=args.flag_batch,
+        epi_flag_batch=_parse_tuple(args.epi_flag_batch),
+    )
+
+    misc = MiscDesc(
+        perf_run=args.perf_run,
+        skip_ref_check=args.skip_ref_check,
+        # MiscDesc field kept as ``run_target_kernel_only`` to keep
+        # runner_fc12.py's reads working unmodified.  ``profile_friendly``
+        # is the @property alias defined alongside the field; both spellings
+        # read the same boolean.
+        run_target_kernel_only=args.profile_friendly,
+        enable_debug_checks=args.enable_debug_checks,
+        ref_compute_graph=args.ref_compute_graph,
+        enable_iket=args.enable_iket,
+        seed=args.seed,
+    )
+
+    tester = MegaMoETester(problem, impl, misc, rank=rank)
+    tester.set_torch_profiler_enabled(args.use_torch_profiler)
+    tester.set_perf_iters(args.perf_warmup, args.perf_iters)
+
+    return_code = 0
+    try:
+        tester.run()
+    except NotImplementedError as exc:
+        # Expected until the MegaMoE kernel side is wired; the host
+        # orchestration above is the part being smoke-tested for now.
+        if rank == 0:
+            print(f"[mega_runner] kernel launch skipped: {exc}")
+
+    if not _NO_DIST:
+        # nvshmem_free/finalize are collective barriers; an unsynchronized or
+        # GC-driven teardown deadlocks once per-rank free order diverges.  So
+        # just barrier-align, then os._exit and let the driver reclaim the heap
+        # on exit.  os._exit skips finalizers/GC, hence the manual flush.
+        torch.cuda.synchronize()
+        if torch.distributed.is_initialized():
+            torch.distributed.barrier()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(return_code)
+    return return_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/megamoe_kernel.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/megamoe_kernel.py
@@ -1,0 +1,1510 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""MegaMoE fused dispatch + fc1 + fc2 + combine kernel.
+
+The base class owns the local fc1/fc2 GEMM pipeline.  This subclass owns the
+token-communication hooks, workspace partitioning, and the MegaMoE argument
+bundle.  ``static_expert_shape`` is required because dispatch storage and pool
+sizes are codegen-time quantities.
+
+Shared / local workspace split:
+
+  SHARED  : src_token_topk_idx, expert_recv_count, expert_recv_count_sum,
+            nvlink_barrier_signal
+  LOCAL   : expert_send_count, grid_sync_counter, l1_token_buffer,
+            l1_sf_buffer, l1_topk_weights_buffer, l1_arrival_count,
+            token_src_metadata, fc1_output, fc1_output_sf,
+            fc1_done_counter, (optionally) load_balance_counter
+
+User tensors are not in the opaque workspaces. ``activation``,
+``activation_sf``, ``topk_weights``, and ``combine_output`` must be reachable
+through the symmetric-heap peer mapper; ``topk_idx`` and weights are local.
+
+Dispatch/pool alignment constraints are unified at construction time:
+``token_padding_block`` (base) and ``block_m`` (dispatch) become the
+same constant, similarly for ``sf_padding_block`` / ``sf_block_m``;
+C3 reduces to a divisibility check that ``cluster_tile_tokens`` is a
+multiple of ``token_padding_block``.
+"""
+
+# NOTE: ``from __future__ import annotations`` is intentionally NOT used here.
+# PEP 563 string-ifies class-body annotations, which breaks ``@cute.struct``'s
+# element-type introspection (it reads ``__annotations__`` and demands the
+# values be live ``cute.struct.MemRange[...] / struct / array / base_dsl
+# scalar`` objects, not their string forms).  The lean fc1+fc2 base
+# (``kernel_fc12.py``) and the dispatch standalone (``src/dispatch_kernel.py``)
+# both already follow this convention.  Self-references (the single
+# ``"TokenCommArgs"`` forward ref on ``__new_from_mlir_values__``) stay
+# quoted explicitly.
+
+import dataclasses
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import AddressSpace
+from cutlass.cutlass_dsl import Int64
+
+from .kernel_fc12 import Sm100SwapABSwigluFp4Fc12Kernel
+from .topk_reduce import TopkReduce
+from src.token_comm import (
+    CombineFormat,
+    TokenCommArgs as ExtractedTokenCommArgs,
+    TokenInPullTokenBackPush,
+    TokenSrcMetadata,
+)
+
+
+# =============================================================================
+# Module-level constants.
+# =============================================================================
+
+# NamedBarrier IDs.  Base reserves 1-7; this subclass uses 8 and 9.
+_KernelTailNamedBarrierId = 8        # 12-warp rendezvous (384 threads)
+_DispatchToSchedNamedBarrierId = 9   # 4 dispatch + 1 sched (160 threads)
+
+# Dispatch warp count.
+_DispatchWarpCount = 4
+
+# Stable symbol prefix for the AOT object handoff (dump_to_object / load_module).
+# One function per .o, each in its own engine, so a fixed prefix never collides.
+_aot_symbol_prefix = "megamoe_aot"
+
+# Per-pool-slot provenance record consumed by combine STG redirect (S3) and
+# token-back; one i64 = {src_rank, src_token, src_topk} (see TokenSrcMetadata).
+_TokenMetadataBytes = TokenSrcMetadata.nbytes
+
+# NVLink signal slots used by the DeepGEMM-style phase/sign barrier.
+# A separate local counter selects phase/sign; the signal slots are not reset
+# by tail cleanup.
+_NvlinkSlotCount = 2
+
+# Grid-sync counter slot count.  ``software_grid_sync`` phase-flips bit 31
+# so a single slot suffices; 2 slots keeps the layout 8-byte aligned.
+_GridSyncSlotCount = 2
+
+
+# =============================================================================
+# Region spec + layout helpers
+# =============================================================================
+
+
+@dataclasses.dataclass(frozen=True)
+class _RegionSpec:
+    """One region in either the local or shared workspace.
+
+    Byte size = ``ceil(numel * cute_dtype.width / 8)``.  ``align`` is
+    the region's start-byte alignment (TMA store / load destinations
+    want 128 B; counters / metadata want 16 B).
+    """
+
+    name: str
+    cute_dtype: Any
+    shape: Tuple[int, ...]
+    align: int
+
+    @property
+    def numel(self) -> int:
+        n = 1
+        for d in self.shape:
+            n *= d
+        return n
+
+    @property
+    def stride_row_major(self) -> Tuple[int, ...]:
+        """Row-major stride matching ``shape`` (rightmost dim contiguous)."""
+        if len(self.shape) == 0:
+            return ()
+        out: List[int] = [1]
+        for d in reversed(self.shape[1:]):
+            out.append(out[-1] * d)
+        out.reverse()
+        return tuple(out)
+
+    @property
+    def nbytes(self) -> int:
+        bits = self.numel * int(self.cute_dtype.width)
+        return (bits + 7) // 8
+
+
+def _round_up(x: int, m: int) -> int:
+    return ((x + m - 1) // m) * m
+
+
+def _layout_regions(
+    regions: List[_RegionSpec],
+) -> Tuple[Dict[str, int], int]:
+    """Place ``regions`` sequentially honouring each region's ``align``.
+    Returns ``(name -> byte_offset)`` and the total byte count (rounded
+    up to 16 B for downstream safety).
+
+    Drives both ``get_workspace_sizes()`` (total only) and the
+    ``__call__`` partition (offsets) -- keeping the host allocation
+    and the device view construction in sync without any explicit
+    handshake.
+    """
+    offsets: Dict[str, int] = {}
+    cursor = 0
+    for r in regions:
+        cursor = _round_up(cursor, r.align)
+        offsets[r.name] = cursor
+        cursor += r.nbytes
+    total = _round_up(cursor, 16)
+    return offsets, total
+
+
+# =============================================================================
+# Sm100MegaMoEKernel
+# =============================================================================
+
+
+class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
+    """MegaMoE-complete fused dispatch + fc1 + fc2 + combine kernel."""
+
+    def __init__(
+        self,
+        # Base-class kwargs (forwarded 1:1 to ``super().__init__``).
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mnk: Tuple[int, int, int],
+        use_2cta_instrs: bool,
+        group_hint: int,
+        token_padding_block: int,
+        sf_padding_block: int,
+        load_balance_mode: str = "static",
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,
+        force_static_sched: bool = True,
+        clc_bundle_size: Optional[int] = None,
+        num_sched_stages: Optional[int] = None,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        sf_vec_size: int = 16,
+        scenario: str = "2Dx3D",
+        # MegaMoE-specific independent constants.
+        *,
+        world_size: int,
+        num_topk: int,
+        max_tokens_per_rank: int,
+        hidden: int,
+        fc2_output_dtype: Type[cutlass.Numeric],
+        combine_format: CombineFormat = CombineFormat.parse("bf16"),
+        non_ubulk_fc2_store: bool = True,
+        in_kernel_fc2_reduce: bool = False,
+        token_back_mode: Literal[
+            "epi_warps", "standalone_warps", "reuse_dispatch_warps"
+        ] = "epi_warps",
+        apply_topk_in_fc1: bool = True,
+        gate_up_clamp: Optional[float] = None,
+        epi_flag_batch: Optional[Tuple[int, int]] = (1, 1),
+        flag_batch: int = 1,
+    ) -> None:
+        # The combine wire format drives the fc2 epilogue encoder, token_comm
+        # push, and the combine_quant/combine_sf workspace sizing. The dataflow
+        # (workspace carve, views, arg threading, topk_reduce receiver) is wired
+        # for every format; only the epilogue *encode* is still bf16-only, so the
+        # quantized guard sits at the launch (see __call__), letting the workspace
+        # anchor size + partition for quantized formats here.
+        self.combine_format = combine_format
+        if in_kernel_fc2_reduce and combine_format.is_quantized:
+            raise ValueError(
+                f"in_kernel_fc2_reduce requires a non-quantized (bf16) combine "
+                f"format; got {combine_format}."
+            )
+        if in_kernel_fc2_reduce and not apply_topk_in_fc1:
+            raise ValueError(
+                "in_kernel_fc2_reduce requires apply_topk_in_fc1=True; "
+                "the REDG path can only atomic-add terms whose topk score "
+                "was already absorbed before fc2."
+            )
+        if (
+            combine_format.act_dtype is cutlass.Float4E2M1FN
+            and not non_ubulk_fc2_store
+        ):
+            raise ValueError(
+                f"{combine_format} combine requires non_ubulk_fc2_store=True "
+                "(the UBLK fc2 store path cannot scalar-dereference FP4)."
+            )
+        if static_expert_shape is None:
+            raise NotImplementedError(
+                "Sm100MegaMoEKernel currently requires "
+                "static_expert_shape != None (dynamic-shape MegaMoE is "
+                "not wired)."
+            )
+        # Keep the explicit ``hidden`` kwarg in lockstep with static shape;
+        # dispatch SMEM sizing reads it before tensor layouts are rewritten.
+        if hidden != static_expert_shape[2]:
+            raise ValueError(
+                f"hidden ({hidden}) must equal "
+                f"static_expert_shape[2] ({static_expert_shape[2]})."
+            )
+
+        # token_back_mode selects where the cross-rank fc2 push-back runs:
+        #   epi_warps            -> epilogue warps STG directly to the peer
+        #   standalone_warps     -> dedicated warp group 12-15, concurrent
+        #                           with dispatch_pull
+        #   reuse_dispatch_warps -> dispatch warps 8-11 push after dispatch_pull
+        # The two non-epi modes both stage fc2 to a local workspace first, i.e.
+        # token_back_by_dispatch=True; epi_warps keeps the epilogue STG redirect.
+        if token_back_mode not in (
+            "epi_warps", "standalone_warps", "reuse_dispatch_warps"
+        ):
+            raise ValueError(
+                f"token_back_mode must be 'epi_warps', 'standalone_warps', "
+                f"or 'reuse_dispatch_warps'; got {token_back_mode!r}."
+            )
+        token_back_by_dispatch = token_back_mode != "epi_warps"
+
+        super().__init__(
+            mma_tiler_mnk=mma_tiler_mnk,
+            cluster_shape_mnk=cluster_shape_mnk,
+            use_2cta_instrs=use_2cta_instrs,
+            group_hint=group_hint,
+            token_padding_block=token_padding_block,
+            sf_padding_block=sf_padding_block,
+            load_balance_mode=load_balance_mode,
+            static_expert_shape=static_expert_shape,
+            force_static_sched=force_static_sched,
+            clc_bundle_size=clc_bundle_size,
+            num_sched_stages=num_sched_stages,
+            acc_dtype=acc_dtype,
+            sf_vec_size=sf_vec_size,
+            scenario=scenario,
+            fc2_output_dtype=fc2_output_dtype,
+            non_ubulk_fc2_store=non_ubulk_fc2_store,
+            in_kernel_fc2_reduce=in_kernel_fc2_reduce,
+            token_back_by_dispatch=token_back_by_dispatch,
+            apply_topk_in_fc1=apply_topk_in_fc1,
+            gate_up_clamp=gate_up_clamp,
+            epi_flag_batch=epi_flag_batch,
+        )
+
+        self.enable_token_comm = True
+        self.dispatch_warp_id = (8, 9, 10, 11)
+        # Standalone token-back: a dedicated 4-warp group (12-15) doing
+        # token_back_by_push concurrently with dispatch_pull, selected by the
+        # user-facing token_back_mode knob ("standalone_warps").
+        self.token_back_mode = token_back_mode
+        self.token_back_standalone = token_back_mode == "standalone_warps"
+        self.token_back_warp_id = (12, 13, 14, 15) if self.token_back_standalone else None
+        num_token_back_warps = (
+            len(self.token_back_warp_id) if self.token_back_standalone else 0
+        )
+        self.threads_per_cta = 32 * (
+            len(self.epilogue_warp_id)
+            + 1  # mma
+            + 1  # tma_a
+            + 1  # tma_b
+            + 1  # sched
+            + len(self.dispatch_warp_id)
+            + num_token_back_warps
+        )
+
+        # Independent MegaMoE-specific constants. 
+        self.world_size = world_size
+        self.num_topk = num_topk
+        self.max_tokens_per_rank = max_tokens_per_rank
+        self.hidden = hidden
+        self.flag_batch = flag_batch        # stored so name() can encode it
+
+        # static_expert_shape = (num_experts_per_rank, intermediate_gateup, hidden).
+        self.num_experts_per_rank = static_expert_shape[0]
+        self.intermediate_gateup = static_expert_shape[1]
+        self.intermediate_downproj = self.intermediate_gateup // 2
+
+        # NVFP4: 4 bits/elem -> 2 elements per byte.
+        self.hidden_bytes = self.hidden // 2
+        # Dispatch pulls SF in uint32 units; host activation_sf rows must pad
+        # to this ceiling with zero-filled bytes.
+        sf_atom_k_elements = 4 * self.sf_vec_size
+        self.sf_uint32_per_token = (
+            (self.hidden + sf_atom_k_elements - 1) // sf_atom_k_elements
+        )
+        # Cross-rank totals: per-rank count * world_size.
+        self.num_total_experts = world_size * self.num_experts_per_rank
+
+        # Per-(token, topk) SF block padded to a 16 B multiple so the token-back
+        # cp.async.bulk push moves one aligned block per shot; only the first
+        # hidden//scale_block entries of each block are valid (the rest is the
+        # alignment gap).  ``None`` for the bf16 baseline (no SF plane).
+        self.sf_block_pad = (
+            _round_up(
+                self.hidden // self.combine_format.scale_block,
+                16 // (int(self.combine_format.scale_dtype.width) // 8),
+            )
+            if self.combine_format.is_quantized
+            else None
+        )
+
+        # Per-task-tile release-counter granularity used by dispatch_pull.
+        self.cluster_tile_tokens = mma_tiler_mnk[1] * cluster_shape_mnk[1]
+
+        # One dispatch task tile must map to contiguous pool blocks.
+        if self.cluster_tile_tokens % self.token_padding_block != 0:
+            raise ValueError(
+                f"C3 violated: cluster_tile_tokens "
+                f"({self.cluster_tile_tokens}) must be a multiple of "
+                f"token_padding_block ({self.token_padding_block}); "
+                f"otherwise pool row offsets and release counter slots "
+                f"will not align."
+            )
+
+        # Cache region sizing inputs used by workspace layout and __call__.
+        (
+            self.pool_token_capacity,
+            self.pool_sf_capacity,
+            self.pool_task_tile_capacity,
+        ) = self._pool_shapes()
+        # Cohabit warps in this CTA outside the dispatch group:
+        # epilogue + mma + tma_a + tma_b + sched.
+        num_other_warps = (
+            len(self.epilogue_warp_id) + 1 + 1 + 1 + 1
+        )
+        # fc2 epi publishes once per CTA per work tile; edge hidden tiles
+        # still publish (no in-bound gating), so ceil_div on the hidden axis.
+        cluster_fc2_tile_hidden = (
+            self.mma_tiler[0] * self.cluster_shape_mn[0]
+            // (2 if self.use_2cta_instrs else 1)
+        )
+        fc2_publishes_per_token_cluster_tile = (
+            (self.hidden + cluster_fc2_tile_hidden - 1)
+            // cluster_fc2_tile_hidden
+        ) * self.cluster_shape_mn[0]
+
+        # Token-back warps run when they push the DATA plane (dispatch modes) OR
+        # the SF plane (any quantized combine, including the epi_warps data path
+        # where the epilogue STGs the data straight to the peer but SF still
+        # needs the staged token-contiguous push).
+        self.token_back_enabled = (
+            self.token_back_by_dispatch or self.combine_format.is_quantized
+        )
+        # Homomorphic to the fc1+fc2 scheduler: atomic_counter token-back only
+        # nets a win with enough tokens, the same condition that selects the
+        # atomic_counter fc1+fc2 scheduler.  Static when token-back is off.
+        self.token_back_schedule_mode = (
+            self.load_balance_mode if self.token_back_enabled else "static"
+        )
+
+        self.token_comm = TokenInPullTokenBackPush(
+            world_size=self.world_size,
+            num_topk=self.num_topk,
+            num_experts_per_rank=self.num_experts_per_rank,
+            num_total_experts=self.num_total_experts,
+            hidden=self.hidden,
+            fc1_token_dtype=cutlass.Float4E2M1FN,
+            combine_format=self.combine_format,
+            token_back_by_dispatch=self.token_back_by_dispatch,
+            fc2_publishes_per_token_cluster_tile=fc2_publishes_per_token_cluster_tile,
+            token_back_reduce_topk=(
+                self.token_back_by_dispatch and self.in_kernel_fc2_reduce
+            ),
+            token_back_standalone=self.token_back_standalone,
+            sf_uint32_per_token=self.sf_uint32_per_token,
+            token_padding_block=self.token_padding_block,
+            sf_padding_block=self.sf_padding_block,
+            cluster_tile_tokens=self.cluster_tile_tokens,
+            cluster_shape_mn=self.cluster_shape_mn,
+            dispatch_warp_start=self.dispatch_warp_id[0],
+            num_other_warps=num_other_warps,
+            flag_batch=flag_batch,
+            is_swap_ab=True,
+            token_back_schedule_mode=self.token_back_schedule_mode,
+        )
+
+        # Region layout (same call drives both get_workspace_sizes() and
+        # the __call__ partition).
+        self._local_region_specs = self._build_local_region_specs()
+        self._shared_region_specs = self._build_shared_region_specs()
+        self._local_offsets, self._local_total = _layout_regions(
+            self._local_region_specs
+        )
+        self._shared_offsets, self._shared_total = _layout_regions(
+            self._shared_region_specs
+        )
+        self._local_region_by_name: Dict[str, _RegionSpec] = {
+            r.name: r for r in self._local_region_specs
+        }
+        self._shared_region_by_name: Dict[str, _RegionSpec] = {
+            r.name: r for r in self._shared_region_specs
+        }
+
+        # Counter-prefix byte extents: the accumulating counters are front-placed
+        # (see _build_*_region_specs), so the leading bytes up to the first data
+        # region cover exactly the per-launch zero set. ``tail_reset_counters``
+        # bulk-zeros these each launch; only the first launch needs a caller-zeroed
+        # workspace. 128B-aligned offsets => multiples of 4 (Int32 zeroing exact).
+        local_leading = self._local_offsets["l1_token_buffer"]      # first data region
+        shared_leading = self._shared_offsets["src_token_topk_idx"]  # first data region
+        self.require_zero_workspace_leading_bytes: Tuple[int, int] = (
+            local_leading, shared_leading,
+        )
+        self.local_zero_i32_count = local_leading // 4
+        self.shared_zero_i32_count = shared_leading // 4
+
+    # =========================================================================
+    # SMEM budget hook (base override)
+    # =========================================================================
+
+    def _dispatch_smem_bytes(self) -> int:
+        """SMEM bytes for dispatch pull mbarriers, expert scratch, and token buffer."""
+        pull_mbar_bytes = _DispatchWarpCount * 8
+        expert_count_bytes = self.num_total_experts * 4
+        pull_buffer_bytes = _DispatchWarpCount * self.hidden_bytes
+        total = (
+            _round_up(pull_mbar_bytes, 16)
+            + _round_up(expert_count_bytes, 16)
+            + _round_up(pull_buffer_bytes, 128)
+        )
+        if self.token_back_standalone:
+            total += (
+                _round_up(_DispatchWarpCount * 8, 16)
+                + _round_up(
+                    _DispatchWarpCount * self.token_comm.tb_chunk_bytes, 128
+                )
+            )
+        return total
+
+    def _smem_misc_budget_bytes(self) -> int:
+        """Base misc reservation plus dispatch-warp SMEM."""
+        return super()._smem_misc_budget_bytes() + self._dispatch_smem_bytes()
+
+    # =========================================================================
+    # Pool sizing (first-principles)
+    # =========================================================================
+
+    def _pool_shapes(self) -> Tuple[int, int, int]:
+        """Worst-case pool sizes.
+
+        ``pool_token_capacity``: every received token from any peer can
+        replicate to ``min(num_topk, num_experts_per_rank)`` local
+        experts; worst case is ``world_size * max_tokens_per_rank``
+        tokens received, each replicated up to that bound.  Each of
+        the ``num_experts_per_rank`` experts wastes up to
+        ``token_padding_block - 1`` rows at its tail; round the whole
+        sum up to the pool-layout granularity ``token_padding_block``.
+
+        ``pool_sf_capacity``: same number of expert blocks as the data
+        pool, each padded to ``sf_padding_block`` rows (UTCCP 4x32
+        swizzle that the SF TMA load expects).
+
+        ``pool_task_tile_capacity``: ``ceil(pool_token_capacity,
+        cluster_tile_tokens)``.  C3 makes ``cluster_tile_tokens`` a
+        multiple of ``token_padding_block`` so this stays exact.
+        """
+        world_size = self.world_size
+        max_tokens_per_rank = self.max_tokens_per_rank
+        num_topk = self.num_topk
+        num_experts_per_rank = self.num_experts_per_rank
+        token_padding_block = self.token_padding_block
+        sf_padding_block = self.sf_padding_block
+        cluster_tile_tokens = self.cluster_tile_tokens
+
+        max_recv = world_size * max_tokens_per_rank
+        max_per_token = min(num_topk, num_experts_per_rank)
+        raw = (
+            max_recv * max_per_token
+            + num_experts_per_rank * (token_padding_block - 1)
+        )
+        pool_token_capacity = _round_up(raw, token_padding_block)
+        pool_sf_capacity = (
+            (pool_token_capacity // token_padding_block) * sf_padding_block
+        )
+        # Upper bound for sum_e ceil(valid_e, cluster_tile_tokens).  The
+        # per-expert slack covers each expert's final partial task tile.
+        pool_task_tile_capacity = (
+            (pool_token_capacity + cluster_tile_tokens - 1) // cluster_tile_tokens
+            + num_experts_per_rank
+        )
+        return (
+            pool_token_capacity,
+            pool_sf_capacity,
+            pool_task_tile_capacity,
+        )
+
+    # =========================================================================
+    # Region tables
+    # =========================================================================
+
+    def _build_local_region_specs(self) -> List[_RegionSpec]:
+        """Local-only regions (no peer access via ``peer_rank_ptr_mapper.map`` in
+        ``src/dispatch_kernel.py``).
+        """
+        pool_token_capacity = self.pool_token_capacity
+        pool_sf_capacity = self.pool_sf_capacity
+        pool_task_tile_capacity = self.pool_task_tile_capacity
+        num_experts_per_rank = self.num_experts_per_rank
+        num_total_experts = self.num_total_experts
+        hidden_bytes = self.hidden_bytes
+        sf_uint32_per_token = self.sf_uint32_per_token
+        intermediate_downproj = self.intermediate_downproj
+        mma_tiler_n = self.mma_tiler_mnk[1]
+        sf_vec_size = self.sf_vec_size
+        sf_padding_block = self.sf_padding_block
+
+        # fc1_output_sf / fc1_done_counter sizing mirrors base
+        # ``get_workspace_size_in_bytes`` (kernel_fc12.py ~lines 525-543).
+        sf_total_rows_upper = (
+            pool_token_capacity + num_experts_per_rank * sf_padding_block
+        )
+        sf_block_cols = (
+            (((intermediate_downproj // sf_vec_size) + 3) // 4) * 4
+        )
+        fc1_done_slots = (
+            (pool_token_capacity + mma_tiler_n - 1) // mma_tiler_n
+            + num_experts_per_rank
+        )
+
+        # === Accumulating-counter prefix ===========================================
+        # Front-placed so the per-launch reset is a single bulk zero of
+        # ``[0:local_leading]`` (the bytes up to the first data region). These hold
+        # spin thresholds / write cursors / phase-flip counters that the kernel
+        # accumulates across the launch and that MUST start at 0 each launch; the
+        # kernel tail (``tail_reset_counters``) bulk-zeros this prefix, so only the
+        # FIRST launch relies on a caller-zeroed workspace.
+        specs: List[_RegionSpec] = [
+            _RegionSpec(
+                "l1_arrival_count",
+                cutlass.Int32,
+                (pool_task_tile_capacity,),
+                16,
+            ),
+            _RegionSpec(
+                "expert_send_count",
+                cutlass.Int64,
+                (num_total_experts,),
+                16,
+            ),
+            _RegionSpec(
+                "grid_sync_counter",
+                cutlass.Int32,
+                (_GridSyncSlotCount,),
+                16,
+            ),
+            _RegionSpec(
+                "fc1_done_counter",
+                cutlass.Int32,
+                (fc1_done_slots,),
+                16,
+            ),
+        ]
+        if self.token_back_enabled:
+            # Per-expert fc2 completion gate consumed by the token-back push
+            # (DATA and/or SF).  Published by the fc2 epilogue for every enabled
+            # token-back path, including the epi_warps SF-only push.
+            specs.append(
+                _RegionSpec(
+                    "fc2_done_counter",
+                    cutlass.Int32,
+                    (num_experts_per_rank,),
+                    16,
+                )
+            )
+            if self.token_back_schedule_mode == "atomic_counter":
+                specs.append(
+                    _RegionSpec(
+                        "token_back_schedule_counter",
+                        cutlass.Int32,
+                        (1,),
+                        16,
+                    )
+                )
+        if self.load_balance_mode == "atomic_counter":
+            specs.append(
+                _RegionSpec(
+                    "load_balance_counter",
+                    cutlass.Int32,
+                    (1,),
+                    16,
+                )
+            )
+
+        # === Data buffers (overwritten each launch; NOT zeroed) ====================
+        # ``l1_token_buffer`` MUST be the first data region: ``__init__`` derives
+        # ``local_leading`` from its offset (= end of the counter prefix).
+        specs += [
+            # L1 input pool (dispatch_pull writes -> fc1 reads), Uint8 bytes; the
+            # NVFP4 view at the same offset is built inside ``__call__``.
+            _RegionSpec(
+                "l1_token_buffer",
+                cutlass.Uint8,
+                (pool_token_capacity, hidden_bytes),
+                128,
+            ),
+            # Persisted across launches (deliberately OUT of the zero prefix): the
+            # sense-reversing nvlink barrier rides this phase counter across launch
+            # boundaries (non-ncu back-to-back), and ncu kernel replay restores it
+            # via its local-memory snapshot. Only the FIRST launch relies on the
+            # caller-zeroed workspace.
+            _RegionSpec(
+                "nvlink_barrier_counter",
+                cutlass.Int32,
+                (1,),
+                16,
+            ),
+            # Int32 atom-flat SF buffer (dispatch_pull 32b read/write; FP8 view at
+            # the same offset). Count = pool_sf_capacity * sf_uint32_per_token.
+            _RegionSpec(
+                "l1_sf_buffer",
+                cutlass.Int32,
+                (pool_sf_capacity * sf_uint32_per_token,),
+                16,
+            ),
+            _RegionSpec(
+                "l1_topk_weights_buffer",
+                cutlass.Float32,
+                (pool_token_capacity,),
+                16,
+            ),
+            _RegionSpec(
+                "token_src_metadata",
+                cutlass.Uint8,
+                (pool_token_capacity, _TokenMetadataBytes),
+                16,
+            ),
+            _RegionSpec(
+                "fc1_output",
+                cutlass.Float4E2M1FN,
+                (pool_token_capacity, intermediate_downproj),
+                128,
+            ),
+            _RegionSpec(
+                "fc1_output_sf",
+                cutlass.Float8E4M3FN,
+                (sf_total_rows_upper, sf_block_cols),
+                128,
+            ),
+        ]
+        if self.token_back_by_dispatch:
+            # Local fc2 DATA staging (token_back_by_dispatch modes only); the
+            # wire-format dtype sizes the plane.
+            specs.append(
+                _RegionSpec(
+                    "fc2_output_workspace",
+                    self.combine_format.act_dtype,
+                    (pool_token_capacity, 1, self.hidden),
+                    128,
+                )
+            )
+        # The per-block SF plane is ALWAYS staged locally (then pushed
+        # token-contiguously by the dispatch / standalone warps), independent of
+        # whether the DATA path goes local or straight to a peer: writing SF
+        # per-token to a peer would scatter one warp's 32 lanes across up to 32
+        # ranks and explode the NVLink request count. So it is allocated for
+        # every quantized format, not only the dispatch data path.
+        if self.combine_format.is_quantized:
+            # Flat padded capacity (pool_token * sf_block_pad scale entries); the
+            # (pool_token, 1, hidden//scale_block) logical shape + 16 B-aligned
+            # per-block stride is assembled where the view is built in __call__.
+            specs.append(
+                _RegionSpec(
+                    "fc2_output_sf",
+                    self.combine_format.scale_dtype,
+                    (pool_token_capacity * self.sf_block_pad,),
+                    128,
+                )
+            )
+
+        return specs
+
+    def _build_shared_region_specs(self) -> List[_RegionSpec]:
+        """Shared (peer-mapped) regions -- every entry is reached from
+        some ``peer_rank_ptr_mapper.map(local_ptr, peer_rank, byte_off)``
+        call site inside ``src/dispatch_kernel.py``:
+
+          * ``src_token_topk_idx`` -- ``_dispatch_prep`` round 3
+          * ``expert_recv_count`` / ``expert_recv_count_sum``
+            -- ``_dispatch_barrier`` step 2 (b64 store + sys-atomic-add)
+          * ``nvlink_barrier_signal``
+            -- ``_nvlink_barrier_3stage`` stage B (two reusable phase slots)
+        """
+        world_size = self.world_size
+        num_topk = self.num_topk
+        max_tokens_per_rank = self.max_tokens_per_rank
+        num_experts_per_rank = self.num_experts_per_rank
+
+        # ``MAX_SLOT`` in ``_dispatch_prep`` round 3: every (token, topk)
+        # edge any peer might publish for this rank's local experts.
+        max_slot = max_tokens_per_rank * num_topk
+
+        # Accumulating counters first (zero-prefix -> tail bulk-zeros
+        # ``[0:shared_leading]``); then the data/signal regions that must persist
+        # across launches (``src_token_topk_idx`` overwritten each launch;
+        # ``nvlink_barrier_signal`` is phase-flip and must NOT be zeroed).
+        # ``src_token_topk_idx`` MUST be the first non-counter region: ``__init__``
+        # derives ``shared_leading`` from its offset (= end of the counter prefix).
+        specs: List[_RegionSpec] = [
+            _RegionSpec(
+                "expert_recv_count",
+                cutlass.Int64,
+                (world_size, num_experts_per_rank),
+                16,
+            ),
+            _RegionSpec(
+                "expert_recv_count_sum",
+                cutlass.Int64,
+                (num_experts_per_rank,),
+                16,
+            ),
+            _RegionSpec(
+                "src_token_topk_idx",
+                cutlass.Int32,
+                (num_experts_per_rank, world_size, max_slot),
+                16,
+            ),
+            _RegionSpec(
+                "nvlink_barrier_signal",
+                cutlass.Int32,
+                (_NvlinkSlotCount,),
+                16,
+            ),
+        ]
+        # separate-kernel-reduce only: the per-topk fc2 combine staging buffer is
+        # internalized here instead of being a caller tensor, so the public output
+        # is the 2D (T, hidden) reduce result.  It is the cross-rank combine STG
+        # target, hence must live on the symmetric heap (= this shared workspace);
+        # appended after the data regions so it stays out of the per-launch zero
+        # prefix (only the first launch relies on the caller-zeroed workspace).
+        if not self.in_kernel_fc2_reduce:
+            # combine_quant: the cross-rank combine data plane, one cell per
+            # (token, topk). dtype follows the wire format -- the bf16 baseline is
+            # byte-identical to the old ``combine_partial``; fp4/e4m3 shrink it.
+            specs.append(
+                _RegionSpec(
+                    "combine_quant",
+                    self.combine_format.act_dtype,
+                    (max_tokens_per_rank, num_topk, self.hidden),
+                    128,
+                )
+            )
+            # combine_sf: per-block scale plane; only quantized formats carry one.
+            if self.combine_format.is_quantized:
+                # Flat padded capacity (max_tokens * num_topk * sf_block_pad scale
+                # entries); the (max_tokens, num_topk, hidden//scale_block) logical
+                # shape + 16 B-aligned per-block stride is assembled where the view
+                # is built in __call__.
+                specs.append(
+                    _RegionSpec(
+                        "combine_sf",
+                        self.combine_format.scale_dtype,
+                        (max_tokens_per_rank * num_topk * self.sf_block_pad,),
+                        128,
+                    )
+                )
+        return specs
+
+    # =========================================================================
+    # Public: workspace size query
+    # =========================================================================
+
+    def get_workspace_sizes(self) -> Tuple[int, int]:
+        """Return ``(local_ws_bytes, shared_ws_bytes)`` -- the byte
+        budgets for the two opaque workspaces the host must allocate.
+        Both totals are invariant across launches; per-launch ``T``
+        may be <= ``max_tokens_per_rank``.
+        """
+        return self._local_total, self._shared_total
+
+    # =========================================================================
+    # Workspace partition helpers
+    # =========================================================================
+
+    @staticmethod
+    def _make_typed_view(
+        byte_base: cute.Pointer,
+        byte_offset: int,
+        cute_dtype: Any,
+        shape: Tuple[int, ...],
+        stride: Optional[Tuple[int, ...]],
+        assumed_align: int,
+    ) -> cute.Tensor:
+        """Build a typed cute view at ``byte_offset`` of the opaque workspace.
+
+        The workspace is a raw ``cute.Pointer`` (uint8 gmem base), not a tensor:
+        the kernel only ever needs the base address + its own byte-offset table, so
+        a tensor's shape would be both ignored AND, for >2 GiB workspaces (the
+        internalized combine staging), overflow cute's 32-bit memref shape field.
+        """
+        # Large MegaMoE problems place later regions above the 2 GiB / 4 GiB
+        # boundary; keep the base adjustment in 64-bit pointer arithmetic so region
+        # starts (fc1_output_sf / counters) do not wrap before the typed view.
+        byte_ptr = byte_base + Int64(byte_offset)
+        typed_iter = cute.make_ptr(
+            cute_dtype,
+            byte_ptr.toint(),
+            AddressSpace.gmem,
+            assumed_align=assumed_align,
+        )
+        return cute.make_tensor(typed_iter, cute.make_layout(shape, stride=stride))
+
+    def _view_local(
+        self,
+        local_workspace: cute.Pointer,
+        name: str,
+        *,
+        cute_dtype: Optional[Any] = None,
+        shape: Optional[Tuple[int, ...]] = None,
+        stride: Optional[Tuple[int, ...]] = None,
+    ) -> cute.Tensor:
+        """Partition a region of the local workspace.  With no overrides,
+        uses the region's declared dtype + shape + row-major stride;
+        overrides let dual-view callers build alternate-dtype views at
+        the same byte offset.
+        """
+        return self._partition_region(
+            local_workspace,
+            self._local_offsets,
+            self._local_region_by_name[name],
+            cute_dtype=cute_dtype,
+            shape=shape,
+            stride=stride,
+        )
+
+    def _view_shared(
+        self,
+        shared_workspace: cute.Pointer,
+        name: str,
+        *,
+        cute_dtype: Optional[Any] = None,
+        shape: Optional[Tuple[int, ...]] = None,
+        stride: Optional[Tuple[int, ...]] = None,
+    ) -> cute.Tensor:
+        return self._partition_region(
+            shared_workspace,
+            self._shared_offsets,
+            self._shared_region_by_name[name],
+            cute_dtype=cute_dtype,
+            shape=shape,
+            stride=stride,
+        )
+
+    def _partition_region(
+        self,
+        byte_workspace: cute.Pointer,
+        offsets: Dict[str, int],
+        spec: _RegionSpec,
+        *,
+        cute_dtype: Optional[Any],
+        shape: Optional[Tuple[int, ...]],
+        stride: Optional[Tuple[int, ...]],
+    ) -> cute.Tensor:
+        dt = cute_dtype if cute_dtype is not None else spec.cute_dtype
+        sh = shape if shape is not None else spec.shape
+        st = stride
+        if st is None:
+            if cute_dtype is None and shape is None:
+                st = spec.stride_row_major
+            else:
+                # Derive row-major from the (possibly overridden) shape.
+                out: List[int] = [1]
+                for d in reversed(list(sh)[1:]):
+                    out.append(out[-1] * d)
+                out.reverse()
+                st = tuple(out)
+        return self._make_typed_view(
+            byte_workspace, offsets[spec.name], dt, sh, st, spec.align,
+        )
+
+    # =========================================================================
+    # __call__
+    # =========================================================================
+
+    def name(self) -> str:
+        """Full compiled-kernel cache key. Self-contained on purpose (no shared
+        helper): mirrors the base fc12 fields and appends the MegaMoE-specific
+        ones -- keep the shared part in sync with the base ``name()``.
+        ``local_rank`` excluded (deployment detail); same dropped set as base."""
+        m, n, k = self.mma_tiler_mnk
+        cm, cn = self.cluster_shape_mn
+        exp = "x".join(map(str, self.static_expert_shape)) if self.static_expert_shape else "dyn"
+        epiflag = "x".join(map(str, self.epi_flag_batch)) if self.epi_flag_batch else "none"
+        cta = "2_cta" if self.use_2cta_instrs else "1_cta"
+        fc2store = "fc2store_stg" if self.non_ubulk_fc2_store else "fc2store_ublk"
+        inkred = "inkernel_redg" if self.in_kernel_fc2_reduce else "no_inkernel_redg"
+        apply_topk = "apply_topk_fc1_pre_quant" if self.apply_topk_in_fc1 else "apply_topk_after_fc2"
+        token_back = {
+            "epi_warps": "epiwarps",
+            "standalone_warps": "standalone",
+            "reuse_dispatch_warps": "reuse_dispatch",
+        }.get(self.token_back_mode, self.token_back_mode)
+        return (
+            "megamoe_nvfp4"
+            f"_mmatiler_{m}x{n}x{k}_cluster_{cm}x{cn}_{cta}_sched_{self.load_balance_mode}"
+            f"_expert_shape_{exp}_grouphint_{self.group_hint}"
+            f"_padding_{self.token_padding_block}x{self.sf_padding_block}"
+            f"_{fc2store}_{inkred}_token_back_by_{token_back}_{apply_topk}"
+            f"_fc2out{self.fc2_output_dtype.__name__}_combine{self.combine_format}_sfvec{self.sf_vec_size}"
+            f"_acc{self.acc_dtype.__name__}_clamp{self.gate_up_clamp}_epiflag{epiflag}"
+            # MegaMoE-specific constexpr:
+            f"_ep_{self.world_size}_topk_{self.num_topk}_maxtoken_{self.max_tokens_per_rank}"
+            f"_flagbatch_{self.flag_batch}"
+        )
+
+    # -- AOT compile / load (TVM-FFI calling convention) ----------------------
+
+    def aot_compile(self, out_path: Optional[str] = None, max_active_clusters: Optional[int] = None):
+        """Compile against fake (metadata-only) inputs. ``out_path=None`` returns the
+        in-memory compiled callable (serial path); a path serializes the callable to a
+        ``.o`` and returns it (parallel path: the object isn't picklable, so it crosses
+        processes as a file). ``max_active_clusters`` (the persistent-scheduler occupancy
+        const) is queried from the device when ``None``; the parallel path passes a
+        precomputed value so the spawn worker needs no occupancy-probe compile.
+
+        ``cute.compile[EnableTVMFFI(True)]`` -> the callable takes plain framework
+        tensors (no per-call from_dlpack) plus an explicit stream. The fake tensors
+        define the runtime ABI, so each must mirror what the caller stages
+        (generate_inputs / to_kernel_inputs): per-rank EP slice, SF column padding, and
+        to_cute's mark_layout_dynamic (stride-1 dim stays static, every other dim is a
+        runtime SymInt). Static extents are this kernel's constexpr; the dynamic
+        token/expert counts are placeholders. ``stride_order`` follows
+        make_data_tensor's ``memory_order`` (0 == innermost)."""
+        import math
+
+        import cutlass.utils as cutlass_utils
+        from cutlass.cutlass_dsl import Int32
+        from cutlass.cute.runtime import (
+            make_fake_compact_tensor,
+            make_fake_stream,
+            make_ptr,
+        )
+        from cutlass.cute.typing import sym_int64
+
+        from src.sym_buffer import SymBufferHost
+
+        def round_up(value: int, multiple: int) -> int:
+            return ((value + multiple - 1) // multiple) * multiple
+
+        tokens = self.max_tokens_per_rank
+        hidden = self.hidden
+        topk = self.num_topk
+        experts = self.num_experts_per_rank
+        fc1_n = self.intermediate_gateup
+        intermediate = self.intermediate_downproj
+        sf_vec = self.sf_vec_size
+        activation_sf_cols = self.sf_uint32_per_token * 4          # _stage_activation_sf padding
+        fc1_sf_cols = round_up(fc1_n, 128) * round_up(hidden // sf_vec, 4)
+        fc2_sf_cols = round_up(hidden, 128) * round_up(intermediate // sf_vec, 4)
+        data_dtype = cutlass.Float4E2M1FN
+        scale_dtype = cutlass.Float8E4M3FN
+        float32 = cutlass.Float32
+
+        def fake_tensor(dtype, shape, stride_order, dynamic_dims, alignment):
+            # dynamic_dims -> runtime SymInt(div=gcd(extent,128)); the stride-1
+            # (contiguous) dim stays static -- mirrors to_cute's mark_layout_dynamic.
+            extents = tuple(
+                sym_int64(divisibility=math.gcd(int(extent), 128))
+                if axis in dynamic_dims else int(extent)
+                for axis, extent in enumerate(shape)
+            )
+            return make_fake_compact_tensor(
+                dtype, extents, stride_order=stride_order, assumed_align=alignment,
+            )
+
+        # alignment mirrors to_cute's proven-safe values (16 / element_size / 4).
+        fake = dict(
+            activation=fake_tensor(data_dtype, (tokens, hidden), (1, 0), {0}, 16),
+            activation_sf=fake_tensor(scale_dtype, (tokens, activation_sf_cols), (1, 0), {0}, 16),
+            topk_idx=fake_tensor(Int64, (tokens, topk), (1, 0), {0}, 8),
+            topk_weights=fake_tensor(float32, (tokens, topk), (1, 0), {0}, 16),
+            fc1_weight=fake_tensor(data_dtype, (experts, hidden, fc1_n), (2, 0, 1), {0, 2}, 16),
+            fc1_weight_sf=fake_tensor(scale_dtype, (experts, fc1_sf_cols), (1, 0), {0}, 16),
+            fc2_weight=fake_tensor(data_dtype, (experts, intermediate, hidden), (2, 0, 1), {0, 2}, 16),
+            fc2_weight_sf=fake_tensor(scale_dtype, (experts, fc2_sf_cols), (1, 0), {0}, 16),
+            fc1_alpha=fake_tensor(float32, (experts,), (0,), set(), 4),
+            fc2_alpha=fake_tensor(float32, (experts,), (0,), set(), 4),
+            fc1_norm_const=fake_tensor(float32, (experts,), (0,), set(), 4),
+            output_activation=fake_tensor(self.fc2_output_dtype, (tokens, hidden), (1, 0), {0}, 16),
+            # Opaque byte workspaces: a bare base pointer (no shape), like to_cute_ptr.
+            local_workspace=make_ptr(cutlass.Uint8, 0, AddressSpace.gmem, assumed_align=16),
+            shared_workspace=make_ptr(cutlass.Uint8, 0, AddressSpace.gmem, assumed_align=16),
+            # Field values are placeholders (marshalled as runtime scalars); only
+            # num_max_ranks is constexpr, so it must be exact.
+            peer_rank_ptr_mapper_host=SymBufferHost(
+                base_addr=Int64(0),
+                offsets=tuple(Int64(0) for _ in range(self.world_size)),
+                rank_idx=Int32(0),          # placeholder; rank_idx is a runtime i32 (real PE id supplied at launch)
+                num_max_ranks=self.world_size,
+            ),
+            max_active_clusters=(
+                max_active_clusters if max_active_clusters is not None
+                else int(cutlass_utils.HardwareInfo().get_max_active_clusters(
+                    self.cluster_shape_mn[0] * self.cluster_shape_mn[1]
+                ))
+            ),
+            stream=make_fake_stream(),       # explicit stream arg -> caller keeps launch control
+        )
+
+        compiled = cute.compile[cute.EnableTVMFFI(True)](self, **fake)
+        if out_path is None:
+            return compiled
+        # The TVM-FFI compiled object has its own export_to_c that renames the
+        # __tvm_ffi_<internal> symbol to __tvm_ffi_<function_name> -- the entry
+        # load_module(..., enable_tvm_ffi=True)[prefix] looks up. (dump_to_object
+        # is the non-tvm path; its generic prefix-rename misnames that symbol.)
+        compiled.export_to_c(
+            out_path, function_name=_aot_symbol_prefix, export_only_tvm_ffi_symbols=True,
+        )
+        return out_path
+
+    @staticmethod
+    def load_compiled(path: str):
+        """Load a ``.o`` from ``aot_compile`` into a callable with the same TVM-FFI
+        ABI. JITLink only (no ptxas); ``enable_tvm_ffi`` resolves the ``__tvm_ffi_*``
+        entry."""
+        from cutlass.cute.runtime import load_module
+
+        return load_module(path, enable_tvm_ffi=True)[_aot_symbol_prefix]
+
+    @cute.jit
+    def __call__(
+        self,
+        # User-domain inputs (peer-mapped on the symmetric heap).
+        activation: cute.Tensor,           # (T, hidden) NVFP4
+        activation_sf: cute.Tensor,        # (T, round_up(hidden, sf_atom_block_k)) FP8
+        topk_idx: cute.Tensor,             # (T, num_topk) Int64
+        topk_weights: cute.Tensor,         # (T, num_topk) Float32
+        # Per-rank model weights (local-only; not in workspace).
+        fc1_weight: cute.Tensor,
+        fc1_weight_sf: cute.Tensor,
+        fc2_weight: cute.Tensor,
+        fc2_weight_sf: cute.Tensor,
+        fc1_alpha: cute.Tensor,
+        fc2_alpha: cute.Tensor,
+        fc1_norm_const: cute.Tensor,
+        # Final combined output the caller consumes: 2D (T, hidden).  Under
+        # in_kernel_reduce it is the cross-rank REDG target (symmetric heap);
+        # under separate_kernel_reduce it is the local tail-reduce destination
+        # while the per-topk staging lives in the internal ``combine_quant``.
+        output_activation: cute.Tensor,    # (T, hidden) BF16
+        # Opaque workspaces.
+        local_workspace: cute.Pointer,     # uint8 gmem base of (local_ws_bytes,)
+        shared_workspace: cute.Pointer,    # uint8 gmem base of (shared_ws_bytes,)
+        # Runtime host payload; packed into ``SymBuffer{world_size}``
+        # before entering the device kernel.
+        peer_rank_ptr_mapper_host,
+        # Codegen / runtime.
+        max_active_clusters: cutlass.Constexpr,
+        stream,
+    ) -> None:
+        """Launch the MegaMoE-complete fused kernel.
+
+        Pointer-mapping contract:
+          * ``activation`` / ``activation_sf`` / ``topk_weights`` MUST
+            point into memory reachable via ``peer_rank_ptr_mapper.map(...)``
+            (typically NVSHMEM symmetric heap).  Single-rank degenerate
+            runs (``peer_rank_ptr_mapper.offsets[local_rank] == 0`` by NVSHMEM
+            convention) are allowed.
+          * ``topk_idx`` is read on the local rank only; placement is
+            unconstrained (cuda local or sym heap).
+          * ``fc1_weight`` / ``fc1_weight_sf`` / ``fc2_weight`` /
+            ``fc2_weight_sf`` are local-only.
+          * ``output_activation`` is the 2D (T, hidden) result.  Under
+            ``in_kernel_reduce`` it is the per-rank cross-rank combine STG
+            target and MUST be reachable via the peer mapper (sym heap, or
+            local in the single-rank degenerate case).  Under
+            ``separate_kernel_reduce`` the cross-rank target is the internal
+            ``combine_quant`` staging region and ``output_activation`` only
+            receives the local tail reduce, so it may be plain local memory.
+
+        Workspace zero-init contract: caller is currently expected to
+        zero ``shared_workspace`` before launch (the dispatch
+        primitives' counters / signals rely on a clean state).  This
+        contract may be tightened later to have the kernel take
+        ownership of the reset.
+        """
+        # ``max_active_clusters`` and ``cluster_size`` are both Python ints
+        # at trace time, so the product folds to a Python int that flows
+        # cleanly to every dispatch primitive's ``num_sms: Constexpr[int]``
+        # slot.
+        cluster_size = self.cluster_shape_mn[0] * self.cluster_shape_mn[1]
+        sm_count = max_active_clusters * cluster_size
+        peer_rank_ptr_mapper = peer_rank_ptr_mapper_host.make_device_obj()
+
+        pool_token_capacity = self.pool_token_capacity
+        pool_sf_capacity = self.pool_sf_capacity
+        hidden = self.hidden
+        sf_per_token_fp8 = self.sf_uint32_per_token * 4  # 4 FP8 SFs per Int32
+
+        # L1 token buffer: Uint8 view (dispatch_pull byte arith) + NVFP4
+        # view (fc1 GEMM mainloop).  Same byte offset.
+        l1_token_buffer_u8 = self._view_local(
+            local_workspace, "l1_token_buffer",
+        )
+        l1_token_buffer_nvfp4 = self._make_typed_view(
+            local_workspace,
+            self._local_offsets["l1_token_buffer"],
+            cutlass.Float4E2M1FN,
+            (pool_token_capacity, hidden),
+            (hidden, 1),
+            self._local_region_by_name["l1_token_buffer"].align,
+        )
+
+        # L1 SF buffer: Int32 view (dispatch_pull's [j, t] 2D indexing) +
+        # FP8 view (base.activation_sf re-views via tile_atom_to_shape_SF
+        # off the iterator, so the stride here is informational only).
+        l1_sf_buffer_i32 = self._view_local(
+            local_workspace, "l1_sf_buffer",
+        )
+        l1_sf_buffer_fp8 = self._make_typed_view(
+            local_workspace,
+            self._local_offsets["l1_sf_buffer"],
+            cutlass.Float8E4M3FN,
+            (pool_sf_capacity, sf_per_token_fp8),
+            (sf_per_token_fp8, 1),
+            self._local_region_by_name["l1_sf_buffer"].align,
+        )
+
+        l1_topk_weights_buffer = self._view_local(
+            local_workspace, "l1_topk_weights_buffer",
+        )
+        l1_arrival_count = self._view_local(
+            local_workspace, "l1_arrival_count",
+        )
+        # token_src_metadata storage = (pool_token_capacity, 12) Uint8;
+        # dispatch_pull writes three Uint32 fields per pool token row via
+        # byte-stepped pointer arithmetic on this Uint8 view (so its
+        # element-width-1 ``+ pool_token_idx * 12`` matches a 12-byte row
+        # stride).  The fc2 epilogue's metadata-LDG path wants a logical
+        # ``(N, 3) Uint32`` view of the same bytes -- it does that recast
+        # itself inside ``_run_fc2_task_tile`` to keep the dispatch-side
+        # Uint8 ABI intact (dispatch_kernel.py is a standalone module
+        # whose API the fused kernel does not mutate).
+        token_src_metadata = self._view_local(
+            local_workspace, "token_src_metadata",
+        )
+        expert_send_count = self._view_local(
+            local_workspace, "expert_send_count",
+        )
+        grid_sync_counter = self._view_local(
+            local_workspace, "grid_sync_counter",
+        )
+        nvlink_barrier_counter = self._view_local(
+            local_workspace, "nvlink_barrier_counter",
+        )
+        fc1_output = self._view_local(local_workspace, "fc1_output")
+        fc1_output_sf = self._view_local(local_workspace, "fc1_output_sf")
+        fc1_done_counter = self._view_local(
+            local_workspace, "fc1_done_counter",
+        )
+
+        load_balance_counter: Optional[cute.Tensor] = None
+        if cutlass.const_expr(self.load_balance_mode == "atomic_counter"):
+            load_balance_counter = self._view_local(
+                local_workspace, "load_balance_counter",
+            )
+
+        # Shared regions.
+        src_token_topk_idx = self._view_shared(
+            shared_workspace, "src_token_topk_idx",
+        )
+        expert_recv_count = self._view_shared(
+            shared_workspace, "expert_recv_count",
+        )
+        expert_recv_count_sum = self._view_shared(
+            shared_workspace, "expert_recv_count_sum",
+        )
+        nvlink_barrier_signal = self._view_shared(
+            shared_workspace, "nvlink_barrier_signal",
+        )
+
+        # i32 stride=(2,) view onto the i64 ``expert_recv_count_sum``
+        # buffer -- low32 bits hold per-expert total token count after
+        # _dispatch_barrier; zero-copy alias for sizes-mode scheduling.
+        expert_token_sizes = self._view_shared(
+            shared_workspace,
+            "expert_recv_count_sum",
+            cute_dtype=cutlass.Int32,
+            shape=(self.num_experts_per_rank,),
+            stride=(2,),
+        )
+
+        # MoE-domain ``(token_max, topk, hidden)`` cross-rank combine STG target.
+        #   * in_kernel_reduce: REDG collapses topk on the fly, so this is a
+        #     ``(T, 1, hidden)`` view of the caller's 2D ``output_activation``
+        #     (the epilogue's topk index is a constexpr 0 in this mode).
+        #   * separate_kernel_reduce: peers write one cell per (token, topk) into
+        #     the internal ``combine_quant`` staging; the tail reduce below
+        #     collapses topk into ``output_activation``.
+        if cutlass.const_expr(self.in_kernel_fc2_reduce):
+            combine_target = cute.make_tensor(
+                output_activation.iterator,
+                cute.make_layout(
+                    (self.max_tokens_per_rank, 1, self.hidden),
+                    stride=(self.hidden, self.hidden, 1),
+                ),
+            )
+        else:
+            combine_target = self._view_shared(shared_workspace, "combine_quant")
+
+        # Per-block scale plane parallel to combine_quant; quantized formats only
+        # (bf16 carries no SF, and in_kernel_reduce is bf16-by-construction).
+        sf_blocks = (
+            self.hidden // self.combine_format.scale_block
+            if self.combine_format.is_quantized else 0
+        )
+        if cutlass.const_expr(
+            self.combine_format.is_quantized and not self.in_kernel_fc2_reduce
+        ):
+            # Assemble the (token, topk, valid_blocks) logical view + 16 B-aligned
+            # per-block stride over the flat combine_sf capacity.
+            combine_sf = self._view_shared(
+                shared_workspace, "combine_sf",
+                shape=(self.max_tokens_per_rank, self.num_topk, sf_blocks),
+                stride=(self.num_topk * self.sf_block_pad, self.sf_block_pad, 1),
+            )
+        else:
+            combine_sf = None
+
+        if cutlass.const_expr(self.combine_format.is_quantized):
+            # Same: logical (pool_token, 1, valid_blocks) + padded per-block stride
+            # over the flat fc2_output_sf capacity.
+            fc2_output_sf_phys = self._view_local(
+                local_workspace, "fc2_output_sf",
+                shape=(self.pool_token_capacity, 1, sf_blocks),
+                stride=(self.sf_block_pad, self.sf_block_pad, 1),
+            )
+            sf_vec = self.combine_format.scale_block
+            sf_layout = fc2_output_sf_phys.layout
+            fc2_output_sf = cute.make_tensor(
+                fc2_output_sf_phys.iterator,
+                cute.make_layout(
+                    (sf_layout.shape[0], sf_layout.shape[1], (sf_vec, sf_layout.shape[2])),
+                    stride=(sf_layout.stride[0], sf_layout.stride[1], (0, sf_layout.stride[2])),
+                ),
+            )
+        else:
+            fc2_output_sf = None
+
+        if cutlass.const_expr(self.token_back_by_dispatch):
+            fc2_output_workspace_native = self._view_local(
+                local_workspace, "fc2_output_workspace",
+            )
+            # Byte count = elements * dtype.width // 8 (multiply before divide so
+            # the 4-bit fp4 data plane is not truncated to zero bytes/element).
+            fc2_output_workspace_u8 = self._make_typed_view(
+                local_workspace,
+                self._local_offsets["fc2_output_workspace"],
+                cutlass.Uint8,
+                ((pool_token_capacity * self.hidden
+                  * int(self.combine_format.act_dtype.width)) // 8,),
+                None,
+                self._local_region_by_name["fc2_output_workspace"].align,
+            )
+            combine_output_u8 = cute.recast_tensor(
+                combine_target, cutlass.Uint8,
+            )
+        else:
+            fc2_output_workspace_native = None
+            fc2_output_workspace_u8 = None
+            combine_output_u8 = combine_target
+
+        # fc2 completion gate: present whenever token-back runs (DATA and/or SF
+        # push), so the epi_warps SF-only push gates per expert just like the
+        # dispatch DATA path.
+        if cutlass.const_expr(self.token_back_enabled):
+            fc2_done_counter = self._view_local(
+                local_workspace, "fc2_done_counter",
+            )
+        else:
+            fc2_done_counter = None
+
+        if cutlass.const_expr(self.token_back_schedule_mode == "atomic_counter"):
+            token_back_schedule_counter = self._view_local(
+                local_workspace, "token_back_schedule_counter",
+            ).iterator
+        else:
+            token_back_schedule_counter = None
+
+        # Int32 views over each workspace's front counter prefix; the kernel tail
+        # bulk-zeros them every launch (tail_reset_counters).
+        local_zero_prefix = self._make_typed_view(
+            local_workspace, 0, cutlass.Int32, (self.local_zero_i32_count,), (1,), 16,
+        )
+        shared_zero_prefix = self._make_typed_view(
+            shared_workspace, 0, cutlass.Int32, (self.shared_zero_i32_count,), (1,), 16,
+        )
+        token_comm_args = ExtractedTokenCommArgs(
+            input_token_buffer=activation,
+            input_sf_buffer=activation_sf,
+            topk_idx=topk_idx,
+            input_topk_weights_buffer=topk_weights,
+            expert_send_count=expert_send_count,
+            expert_recv_count=expert_recv_count,
+            expert_recv_count_sum=expert_recv_count_sum,
+            src_token_topk_idx=src_token_topk_idx,
+            fc1_input_token_buffer=l1_token_buffer_u8,
+            fc1_input_sf_buffer=l1_sf_buffer_i32,
+            fc1_input_topk_weights_buffer=l1_topk_weights_buffer,
+            fc1_ready_counter=l1_arrival_count,
+            token_src_metadata=token_src_metadata,
+            combine_output=combine_output_u8,
+            combine_sf=combine_sf,
+            fc2_output_workspace=fc2_output_workspace_u8,
+            fc2_output_sf=fc2_output_sf,
+            fc2_done_counter=fc2_done_counter,
+            token_back_schedule_counter=token_back_schedule_counter,
+            nvlink_barrier_signal=nvlink_barrier_signal,
+            nvlink_barrier_counter=nvlink_barrier_counter,
+            grid_sync_counter=grid_sync_counter,
+            local_zero_prefix=local_zero_prefix,
+            shared_zero_prefix=shared_zero_prefix,
+            peer_rank_ptr_mapper=peer_rank_ptr_mapper,
+            world_size=self.world_size,
+            local_rank=peer_rank_ptr_mapper_host.rank_idx,
+            num_total_experts=self.num_total_experts,
+            num_experts_per_rank=self.num_experts_per_rank,
+            num_topk=self.num_topk,
+            hidden_bytes=self.hidden_bytes,
+            sf_uint32_per_token=self.sf_uint32_per_token,
+            token_padding_block=self.token_padding_block,
+            sf_padding_block=self.sf_padding_block,
+            sm_count=sm_count,
+        )
+
+        # C1 / C2 are tautological (token_padding_block == "block_m";
+        # sf_padding_block == "sf_block_m") so the pool layout and the
+        # sched cumulative-row offsets align by construction.
+        #
+        # ``combine_target`` is MoE-domain storage. separate_kernel_reduce uses
+        # ``(max_tokens_per_rank, num_topk, hidden)`` (internal staging) and a
+        # tail reduce; in_kernel_reduce uses ``(max_tokens_per_rank, 1, hidden)``
+        # and reduces in kernel.  The epilogue return tile maps local pool rows
+        # back to the source rank's token row through ``token_comm_args``.
+        if cutlass.const_expr(self.token_back_by_dispatch):
+            fc2_output_target = fc2_output_workspace_native
+        else:
+            fc2_output_target = combine_target
+
+        # Quantized combine loop is closed: the fc2 epilogue encodes the data
+        # plane (STG-to-peer in epi_warps, or local staging in the dispatch
+        # modes) and writes per-block scales to the rank-local SF plane
+        # (fc2_output_sf); the token-back warps push that SF plane
+        # token-contiguously to the peers' combine_sf (and the data plane too in
+        # the dispatch modes); TopkReduce below dequantizes and reduces.
+        super().__call__(
+            activation=l1_token_buffer_nvfp4,
+            fc1_weight=fc1_weight,
+            activation_sf=l1_sf_buffer_fp8,
+            fc1_weight_sf=fc1_weight_sf,
+            fc1_output=fc1_output,
+            fc1_output_sf=fc1_output_sf,
+            fc2_weight=fc2_weight,
+            fc2_weight_sf=fc2_weight_sf,
+            fc2_output=fc2_output_target,
+            topk_scores=l1_topk_weights_buffer,
+            fc1_done_counter=fc1_done_counter,
+            fc1_alpha=fc1_alpha,
+            fc2_alpha=fc2_alpha,
+            fc1_norm_const=fc1_norm_const,
+            offs=None,
+            max_active_clusters=max_active_clusters,
+            stream=stream,
+            load_balance_counter=load_balance_counter,
+            expert_token_sizes=expert_token_sizes,
+            token_comm_args=token_comm_args,
+        )
+
+        # separate_kernel_reduce: collapse the per-topk ``combine_quant`` staging
+        # into the public 2D output via the shared TopkReduce launcher (sized from
+        # codegen-time hidden / num_topk / combine_format -- it dequantizes per
+        # format and reduces over topk). Same stream, so it is ordered strictly
+        # after the cross-rank combine writes landed (the mega kernel's nvlink
+        # barrier guarantees all peer combine STGs to this rank completed before it
+        # exits). Weighting follows the compute graph: deepgemm (apply_topk_in_fc1)
+        # folded the routing weight into fc1 -> plain K-sum; transformers applies
+        # topk_weights here.
+        if cutlass.const_expr(not self.in_kernel_fc2_reduce):
+            score = (
+                topk_weights if cutlass.const_expr(not self.apply_topk_in_fc1)
+                else None
+            )
+            TopkReduce(self.hidden, self.num_topk, self.combine_format)(
+                combine_target, combine_sf, output_activation, score, stream,
+            )
+
+    # =========================================================================
+    # TokenComm delegation surface consumed by the fc1/fc2 base kernel
+    # =========================================================================
+
+    def token_comm_extra_smem_storage_class(self) -> type:
+        return self.token_comm.extra_smem_storage_class()
+
+    def token_comm_hook_fc1_ready_counter_ptr(self, token_comm_args):
+        return self.token_comm.fc1_ready_counter_ptr(token_comm_args)
+
+    @cute.jit
+    def token_comm_hook_sched_warp_pre_init_wait(self, token_comm_args):
+        self.token_comm.sched_warp_pre_init_wait(token_comm_args)
+
+    @cute.jit
+    def token_comm_hook_fc1_tma_b_predispatch_spin(
+        self, token_comm_args, work_tile_info,
+    ):
+        self.token_comm.fc1_tma_b_predispatch_spin(
+            token_comm_args, work_tile_info,
+        )
+
+    @cute.jit
+    def token_comm_hook_dispatch_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        self.token_comm.dispatch_warp_body(
+            token_comm_args,
+            token_comm_storage,
+            warp_idx=warp_idx,
+            lane_idx=lane_idx,
+            tidx=tidx,
+        )
+
+    @cute.jit
+    def token_comm_hook_token_back_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        self.token_comm.token_back_warp_body(
+            token_comm_args,
+            token_comm_storage,
+            warp_idx=warp_idx,
+            lane_idx=lane_idx,
+            tidx=tidx,
+        )
+
+    @cute.jit
+    def token_comm_hook_tail_reset_shared_counters(
+        self,
+        token_comm_args,
+        *,
+        cta_linear_id,
+        local_warp_idx,
+        lane_idx,
+    ):
+        self.token_comm.tail_reset_counters(
+            token_comm_args,
+            token_comm_args.shared_zero_prefix,
+            cta_linear_id=cta_linear_id,
+            local_warp_idx=local_warp_idx,
+            lane_idx=lane_idx,
+        )
+
+    @cute.jit
+    def token_comm_hook_kernel_tail(
+        self,
+        token_comm_args,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        self.token_comm.kernel_tail(
+            token_comm_args,
+            warp_idx=warp_idx,
+            lane_idx=lane_idx,
+            tidx=tidx,
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/moe_persistent_scheduler.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/moe_persistent_scheduler.py
@@ -1,0 +1,2124 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Shared MoE persistent scheduler utilities."""
+
+from abc import ABC, abstractmethod
+from enum import IntEnum
+from typing import List, Optional, Tuple, Literal
+
+import cutlass
+import cutlass.cute as cute
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+from cutlass.cutlass_dsl import (
+    Boolean,
+    Int32,
+    Integer,
+    extract_mlir_values,
+    new_from_mlir_values,
+    const_expr,
+    dsl_user_op,
+)
+from cutlass._mlir import ir
+import cutlass.pipeline as pipeline
+
+# =============================================================================
+# Work Tile State
+# =============================================================================
+
+
+class WorkTileState(IntEnum):
+    """State encoding for MoEWorkTileInfo via expert_idx sentinel values."""
+
+    DONE = -1  # Fully finished (all tiles processed + CLC exhausted, or HW eviction)
+    DRAINING = -2  # Task tiles finished, CLC grid not yet exhausted
+
+
+# =============================================================================
+# Work Tile Info
+# =============================================================================
+
+
+class MoEWorkTileInfo:
+    """CTA-level scheduler tile plus expert_idx sentinel state."""
+
+    BaseFields = 4
+    BaseBytes = 16  # 4 * sizeof(Int32)
+    TotalFields = BaseFields  # Subclasses override with BaseFields + extra
+
+    def __init__(
+        self,
+        expert_idx: Int32,  # >=0 valid, or WorkTileState sentinel
+        tile_m_idx: Int32,
+        tile_n_idx: Int32,
+        k_tile_cnt: Int32,
+    ):
+        self.expert_idx = expert_idx
+        self.tile_m_idx = tile_m_idx
+        self.tile_n_idx = tile_n_idx
+        self.k_tile_cnt = k_tile_cnt
+
+    @property
+    def is_valid_tile(self) -> Boolean:
+        """Check if this is a valid work tile (expert_idx >= 0)."""
+        return self.expert_idx >= Int32(0)
+
+    @property
+    def is_draining(self) -> Boolean:
+        """Check if this is a drain sentinel (CLC grid not yet exhausted)."""
+        return self.expert_idx == Int32(WorkTileState.DRAINING)
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = extract_mlir_values(self.expert_idx)
+        values.extend(extract_mlir_values(self.tile_m_idx))
+        values.extend(extract_mlir_values(self.tile_n_idx))
+        values.extend(extract_mlir_values(self.k_tile_cnt))
+        return values
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "MoEWorkTileInfo":
+        assert len(values) == 4
+        return MoEWorkTileInfo(
+            expert_idx=new_from_mlir_values(self.expert_idx, [values[0]]),
+            tile_m_idx=new_from_mlir_values(self.tile_m_idx, [values[1]]),
+            tile_n_idx=new_from_mlir_values(self.tile_n_idx, [values[2]]),
+            k_tile_cnt=new_from_mlir_values(self.k_tile_cnt, [values[3]]),
+        )
+
+    # =========================================================================
+    # Serialization layer (subclasses override to_rmem / from_rmem for extra fields)
+    # =========================================================================
+
+    def to_rmem(self) -> cute.Tensor:
+        """Pack fields into an rmem tensor for vectorized smem copy.
+        Subclasses override to include extra fields."""
+        rmem = cute.make_rmem_tensor((self.BaseFields,), Int32)
+        rmem[0] = self.expert_idx
+        rmem[1] = self.tile_m_idx
+        rmem[2] = self.tile_n_idx
+        rmem[3] = self.k_tile_cnt
+        return rmem
+
+    @classmethod
+    def from_rmem(cls, rmem: cute.Tensor) -> "MoEWorkTileInfo":
+        """Unpack from rmem tensor. Subclasses override to read extra fields."""
+        return cls(
+            expert_idx=rmem[0],  # type: ignore[arg-type]
+            tile_m_idx=rmem[1],  # type: ignore[arg-type]
+            tile_n_idx=rmem[2],  # type: ignore[arg-type]
+            k_tile_cnt=rmem[3],  # type: ignore[arg-type]
+        )
+
+    # =========================================================================
+    # Communication layer (handles pipeline + smem transfer)
+    # =========================================================================
+
+    @dsl_user_op
+    @cute.jit
+    def write_to_smem(
+        self,
+        smem_buf_tensor: cute.Tensor,
+        dependency,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Write work tile to smem with full pipeline management.
+        dependency = (pipeline, producer_state)."""
+        pipe, state = dependency
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), cutlass.Int32, num_bits_per_copy=128
+        )
+        pipe.producer_acquire(state)
+        rmem = self.to_rmem()
+        cute.copy(copy_atom, rmem, smem_buf_tensor[(None, state.index)])
+        cute.arch.fence_proxy("async.shared", space="cta")
+        pipe.producer_commit(state)
+        state.advance()
+
+    @classmethod
+    @dsl_user_op
+    @cute.jit
+    def read_from_smem(
+        cls,
+        smem_buf_tensor: cute.Tensor,
+        dependency,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "MoEWorkTileInfo":
+        """Read work tile from smem with full pipeline management.
+        dependency = (pipeline, consumer_state)."""
+        pipe, state = dependency
+        copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), cutlass.Int32, num_bits_per_copy=128
+        )
+        pipe.consumer_wait(state)
+        rmem = cute.make_rmem_tensor((cls.TotalFields,), Int32)
+        cute.copy(copy_atom, smem_buf_tensor[(None, state.index)], rmem)
+        work = cls.from_rmem(rmem)
+        cute.arch.fence_acq_rel_cta()
+        pipe.consumer_release(state)
+        state.advance()
+        return work
+
+
+# =============================================================================
+# Scheduler Extension — Base
+# =============================================================================
+
+
+class MoESchedExtension:
+    """
+    Base class for MoE scheduler extensions.
+
+    Bridges the scheduler with tensor-level domain conversion and TMA
+    descriptor management. Each kernel type (grouped_mm, scaled_grouped_mm,
+    etc.) provides its own subclass with:
+
+    - WorkTileInfo subclass with extra precomputed fields (token_offset, etc.)
+    - enrich_work_tile_info(): called by scheduler to populate extra fields
+    - get_gmem_tensor(): called by consumer warps for domain conversion
+    - prefetch_for_expert(): called by scheduler warp for TMA desc prefetch
+
+    This base class provides identity/no-op defaults so the scheduler can
+    always call through self._ext without None checks.
+    """
+
+    WorkTileInfo = MoEWorkTileInfo
+
+    def __init__(self, workspace=None):
+        self.workspace = workspace
+
+    def enrich_work_tile_info(self, base_work: MoEWorkTileInfo) -> MoEWorkTileInfo:
+        """Enrich base work tile with domain-specific extra fields.
+
+        Default: identity (returns base_work unchanged).
+        Subclasses override to compute and attach extra fields such as
+        token_offset, tokens_i, padded_token_offset, padded_tokens_i.
+        Must handle invalid tiles (return enriched type with dummy extras).
+        """
+        return base_work
+
+    def get_gmem_tensor(self, tensor_name, gmem_tensor_in_moe_view, work_tile_info):
+        """Convert MoE-view tensor to per-expert tensor for domain conversion.
+
+        Subclasses must override. Reads precomputed extra fields directly
+        from work_tile_info instead of recomputing from offs.
+        """
+        raise NotImplementedError(
+            "Subclass must implement get_gmem_tensor for domain conversion"
+        )
+
+    def prefetch_for_expert(self, expert_idx: Int32) -> None:
+        """Prefetch expert-wise TMA descriptors. Default: no-op."""
+        pass
+
+
+_DEFAULT_SCHED_EXT = MoESchedExtension()
+
+
+# =============================================================================
+# Scheduler Parameters — Base
+# =============================================================================
+
+
+class MoESchedulerParamsBase(ABC):
+    """
+    Abstract base class for MoE tile scheduler parameters.
+
+    Uses unified semantics for both scenarios:
+    - expert_shape: (expert_cnt, intermediate, hidden)
+
+    For 2Dx3D: GEMM is (M=tokens_i, N=intermediate, K=hidden) per expert
+    For 2Dx2D: GEMM is (M=hidden, N=intermediate, K=tokens_i) per expert
+
+    ``intermediate`` is the scheduler's per-expert full axis.  Concrete
+    kernels may give that axis a narrower meaning.  For example, the current
+    fused fc12 swap-AB inference kernel binds it to ``intermediate_gateup``
+    (gate + up concatenated); a future non-swap or training kernel should
+    document its own interpretation at its params layer instead of changing
+    this shared base contract.
+
+    Tile hierarchy:
+    - cta_tile_shape_mnk: Single CTA tile shape (tile_m, tile_n, tile_k)
+    - cluster_shape_mn: CTAs per cluster (cluster_m, cluster_n)
+    - cluster_tile_shape_mn: Cluster tile shape = cta_tile_shape * cluster_shape
+
+    This class is used both on host (for grid shape calculation) and on device
+    (stored in scheduler). Codegen-time constants (scenario, cta_tile_shape_mnk,
+    cluster_shape_mn, num_sched_stages, is_swap_ab) are NOT serialized to MLIR
+    values.
+
+    Coordinate convention:
+        The scheduler body uses an internal M-slot for the axis grouped by
+        ``offs`` and an internal N-slot for the per-expert full axis.  Callers
+        still pass tile and cluster shapes in GEMM-domain order.  When
+        ``is_swap_ab`` is true, the constructor swaps M/N once on entry and
+        concrete decoders swap tile indices back on exit, so consumers always
+        see GEMM-domain ``tile_m_idx`` / ``tile_n_idx``.
+    """
+
+    DEFAULT_NUM_SCHED_STAGES = 2
+
+    def __init__(
+        self,
+        scenario: Literal["2Dx3D", "2Dx2D"],
+        expert_shape: Tuple[
+            int | Int32, int | Int32, int | Int32
+        ],  # (expert_cnt, intermediate, hidden)
+        cta_tile_shape_mnk: Tuple[int, int, int],  # (tile_m, tile_n, tile_k)
+        cluster_shape_mn: Tuple[int, int],  # (cluster_m, cluster_n)
+        override_num_stages: Optional[int] = None,
+        is_swap_ab: bool = False,
+    ):
+        if is_swap_ab and scenario == "2Dx2D":
+            # Weight-grad path is an entirely different problem shape and is
+            # not in v1 scope for swap-AB.  Reject loudly rather than silently
+            # producing nonsense work tiles.
+            raise ValueError(
+                "is_swap_ab=True is incompatible with scenario='2Dx2D' "
+                "(weight-grad path); v1 only supports forward 2Dx3D swap-AB."
+            )
+
+        self.scenario = scenario
+        self.is_swap_ab = is_swap_ab
+        e, i, h = expert_shape
+        # Preserve Python ints as codegen-time constants; Int32 stays runtime.
+        self.expert_cnt = e
+        self.intermediate = i
+        self.hidden = h
+
+        # When is_swap_ab is True, the user supplies tuples in GEMM-domain
+        # (M, N, K) order but the scheduler body uses "grouped-axis-as-M"
+        # internally; swap once here so the rest of the body stays oblivious.
+        if is_swap_ab:
+            cta_tile_shape_mnk = (
+                cta_tile_shape_mnk[1],
+                cta_tile_shape_mnk[0],
+                cta_tile_shape_mnk[2],
+            )
+            cluster_shape_mn = (cluster_shape_mn[1], cluster_shape_mn[0])
+        self.cta_tile_shape_mnk = cta_tile_shape_mnk
+        self.cluster_shape_mn = cluster_shape_mn
+
+        self.num_sched_stages = (
+            override_num_stages
+            if override_num_stages is not None
+            else self.DEFAULT_NUM_SCHED_STAGES
+        )
+        if self.num_sched_stages <= 0:
+            raise ValueError(
+                f"num_sched_stages must be positive, got {self.num_sched_stages}"
+            )
+
+    @property
+    def cluster_tile_m(self) -> int:
+        """Cluster tile size along M = cta_tile_m * cluster_m."""
+        return self.cta_tile_shape_mnk[0] * self.cluster_shape_mn[0]
+
+    @property
+    def cluster_tile_n(self) -> int:
+        """Cluster tile size along N = cta_tile_n * cluster_n."""
+        return self.cta_tile_shape_mnk[1] * self.cluster_shape_mn[1]
+
+    @property
+    def cta_tile_k(self) -> int:
+        """CTA tile size along K (same as cluster since cluster_k = 1)."""
+        return self.cta_tile_shape_mnk[2]
+
+    @abstractmethod
+    def get_scheduler_type(self) -> type:
+        """Return the concrete scheduler class bound to this params type."""
+        ...
+
+    @abstractmethod
+    def get_grid_shape(
+        self,
+        max_active_clusters: int,
+    ) -> Tuple[int, int, int]:
+        """Compute grid shape for kernel launch."""
+        ...
+
+
+# =============================================================================
+# Scheduler Parameters — Static
+# =============================================================================
+
+
+class MoEStaticSchedulerParams(MoESchedulerParamsBase):
+    """
+    Static scheduler parameters. Grid shape is determined by max_active_clusters.
+    """
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        """Type-discriminated serialization.
+
+        Only ``Int32`` (runtime SSA) fields contribute MLIR values to
+        the carry; Python int fields (codegen-time constants supplied
+        via ``static_expert_shape``) are skipped so they remain inlined
+        literals across scf region boundaries.
+        """
+        values = []
+        if isinstance(self.expert_cnt, Int32):
+            values.extend(extract_mlir_values(self.expert_cnt))
+        if isinstance(self.intermediate, Int32):
+            values.extend(extract_mlir_values(self.intermediate))
+        if isinstance(self.hidden, Int32):
+            values.extend(extract_mlir_values(self.hidden))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "MoEStaticSchedulerParams":
+        # Bypass __init__ here: the stored cta_tile_shape_mnk / cluster_shape_mn
+        # are already in post-swap (scheduler-internal) form, so going back
+        # through the constructor would double-swap when is_swap_ab=True.
+        # This mirrors MoEDynamicSchedulerParams.__new_from_mlir_values__.
+        result = MoEStaticSchedulerParams.__new__(MoEStaticSchedulerParams)
+        result.scenario = self.scenario
+        result.is_swap_ab = self.is_swap_ab
+        result.cta_tile_shape_mnk = self.cta_tile_shape_mnk
+        result.cluster_shape_mn = self.cluster_shape_mn
+        result.num_sched_stages = self.num_sched_stages
+        # Type-discriminated rebind: Python int fields copy from
+        # prototype (``self``), Int32 fields consume from ``values``.
+        idx = 0
+        if isinstance(self.expert_cnt, Int32):
+            result.expert_cnt = new_from_mlir_values(
+                self.expert_cnt, [values[idx]]
+            )
+            idx += 1
+        else:
+            result.expert_cnt = self.expert_cnt
+        if isinstance(self.intermediate, Int32):
+            result.intermediate = new_from_mlir_values(
+                self.intermediate, [values[idx]]
+            )
+            idx += 1
+        else:
+            result.intermediate = self.intermediate
+        if isinstance(self.hidden, Int32):
+            result.hidden = new_from_mlir_values(self.hidden, [values[idx]])
+            idx += 1
+        else:
+            result.hidden = self.hidden
+        assert idx == len(values), (
+            f"Static sched params type-discrim mismatch: idx={idx} "
+            f"len(values)={len(values)}"
+        )
+        return result
+
+    def get_scheduler_type(self) -> type:
+        return MoEStaticPersistentTileScheduler
+
+    def get_grid_shape(
+        self,
+        max_active_clusters: int,
+    ) -> Tuple[int, int, int]:
+        """
+        Compute grid shape for kernel launch.
+
+        Since host doesn't know token distribution across experts,
+        we launch max_active_clusters and let device-side scheduler
+        determine which tiles are valid.
+
+        Output orientation is launch (= mma / user) view: the returned
+        ``(cluster_m, cluster_n, ...)`` matches the cluster shape the
+        kernel uses at launch time.  Under ``is_swap_ab`` the internally
+        stored ``self.cluster_shape_mn`` is post-swap, so we flip back
+        here.
+        """
+        if self.is_swap_ab:
+            return (
+                self.cluster_shape_mn[1],
+                self.cluster_shape_mn[0],
+                max_active_clusters,
+            )
+        return (
+            self.cluster_shape_mn[0],
+            self.cluster_shape_mn[1],
+            max_active_clusters,
+        )
+
+
+# =============================================================================
+# Scheduler Parameters — Dynamic (CLC-based)
+# =============================================================================
+
+
+class MoEDynamicSchedulerParams(MoESchedulerParamsBase):
+    """
+    Dynamic scheduler parameters for CLC-based scheduling.
+
+    Each CLC tile_id maps to work_id_bundle_scale (S) consecutive work tiles.
+    S is a static codegen-time constant specified via clc_bundle_size; only
+    static bundling is supported so that drain tolerance (S * num_sched_stages *
+    per_tile_cycles) is fully static and predictable. Users targeting different
+    EP degrees should instance separate kernels.
+
+    - clc_bundle_size (Optional[int]): S as a Python int literal. None or 1
+      means no bundling. Must be 1 for 2Dx2D (WGrad) where grid is exact.
+    """
+
+    def __init__(
+        self,
+        scenario: Literal["2Dx3D", "2Dx2D"],
+        expert_shape: Tuple[int | Int32, int | Int32, int | Int32],
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        tokens_sum,
+        clc_bundle_size: Optional[int] = None,
+        override_num_stages: Optional[int] = None,
+        is_swap_ab: bool = False,
+    ):
+        super().__init__(
+            scenario,
+            expert_shape,
+            cta_tile_shape_mnk,
+            cluster_shape_mn,
+            override_num_stages,
+            is_swap_ab=is_swap_ab,
+        )
+        self.tokens_sum = tokens_sum
+
+        # Derive work_id_bundle_scale (S) — static int only.
+        if scenario == "2Dx2D":
+            if clc_bundle_size is not None and clc_bundle_size != 1:
+                raise ValueError(
+                    f"2Dx2D (WGrad) does not accept clc_bundle_size != 1, "
+                    f"got {clc_bundle_size}. 2Dx2D grid exactly matches the "
+                    f"output space, no bundling is meaningful."
+                )
+            # 2Dx2D dyn runs the lean codegen path on the kernel side (no
+            # drain machinery, no 12-warp symmetric layout). Sweeping
+            # num_sched_stages gives no meaningful behavior change there
+            # (drain tolerance is 0 anyway), and accepting non-default
+            # values would create silent confusion vs. the kernel's
+            # belt-and-suspenders reject. Keep it pinned to default.
+            if override_num_stages is not None and override_num_stages != 2:
+                raise ValueError(
+                    f"2Dx2D scheduler runs the lean codegen path; "
+                    f"override_num_stages must be None or 2, "
+                    f"got {override_num_stages}."
+                )
+            self.work_id_bundle_scale = 1
+        elif clc_bundle_size is not None:
+            if clc_bundle_size < 1:
+                raise ValueError(f"clc_bundle_size must be >= 1, got {clc_bundle_size}")
+            self.work_id_bundle_scale = int(clc_bundle_size)
+        else:
+            self.work_id_bundle_scale = 1
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        """Type-discriminated serialization (see ``MoEStaticSchedulerParams``)."""
+        values = []
+        if isinstance(self.expert_cnt, Int32):
+            values.extend(extract_mlir_values(self.expert_cnt))
+        if isinstance(self.intermediate, Int32):
+            values.extend(extract_mlir_values(self.intermediate))
+        if isinstance(self.hidden, Int32):
+            values.extend(extract_mlir_values(self.hidden))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "MoEDynamicSchedulerParams":
+        result = MoEDynamicSchedulerParams.__new__(MoEDynamicSchedulerParams)
+        result.scenario = self.scenario
+        result.is_swap_ab = self.is_swap_ab
+        result.cta_tile_shape_mnk = self.cta_tile_shape_mnk
+        result.cluster_shape_mn = self.cluster_shape_mn
+        result.num_sched_stages = self.num_sched_stages
+        result.tokens_sum = self.tokens_sum
+        result.work_id_bundle_scale = self.work_id_bundle_scale
+        # Type-discriminated rebind (see ``MoEStaticSchedulerParams``).
+        idx = 0
+        if isinstance(self.expert_cnt, Int32):
+            result.expert_cnt = new_from_mlir_values(
+                self.expert_cnt, [values[idx]]
+            )
+            idx += 1
+        else:
+            result.expert_cnt = self.expert_cnt
+        if isinstance(self.intermediate, Int32):
+            result.intermediate = new_from_mlir_values(
+                self.intermediate, [values[idx]]
+            )
+            idx += 1
+        else:
+            result.intermediate = self.intermediate
+        if isinstance(self.hidden, Int32):
+            result.hidden = new_from_mlir_values(self.hidden, [values[idx]])
+            idx += 1
+        else:
+            result.hidden = self.hidden
+        assert idx == len(values), (
+            f"Dyn sched params type-discrim mismatch: idx={idx} "
+            f"len(values)={len(values)}"
+        )
+        return result
+
+    def get_scheduler_type(self) -> type:
+        return MoEDynamicPersistentTileScheduler
+
+    @dsl_user_op
+    @cute.jit
+    def get_grid_shape(
+        self,
+        max_active_clusters,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ):
+        """
+        Compute grid shape for CLC-based dynamic scheduling.
+
+        Both 2Dx2D and 2Dx3D produce a linearized cluster index space
+        (grid_z_lin) along the Z axis, then pick one of two grid layouts
+        based on whether grid_z_lin fits the Y/Z hardware limit (65535):
+
+        - Layout A (grid_z_lin <= 65535):  (cm,              cn, grid_z_lin)
+        - Layout B (grid_z_lin >  65535):  (cm * grid_z_lin, cn, 1)
+
+        Device-side decoding is unified across layouts via:
+            cta_id_in_cluster[0] = bidx % cm
+            cluster_linear_idx   = (bidx // cm) + bidz
+        (cm is a static power of 2, so `%` becomes mask and `//` becomes shift.)
+
+        2Dx2D: grid_z_lin = expert_cnt * m_cnt * n_cnt   (S = 1, exact)
+        2Dx3D: grid_z_lin = ceil(possible_max / S)
+        """
+        GRID_YZ_MAX = 65535
+        # ``cm`` / ``cn`` here are the launch-view (= mma / user-view)
+        # cluster sizes, used to lay out grid.x / grid.y so that the kernel
+        # ``cluster=(...)`` argument lines up with the launch grid axes.
+        # Internally ``self.cluster_shape_mn`` is post-swap under
+        # ``is_swap_ab``, so we read it via flipped indices.
+        if const_expr(self.is_swap_ab):
+            cm = self.cluster_shape_mn[1]
+            cn = self.cluster_shape_mn[0]
+        else:
+            cm = self.cluster_shape_mn[0]
+            cn = self.cluster_shape_mn[1]
+        cluster_tile_m = self.cluster_tile_m
+        cluster_tile_n = self.cluster_tile_n
+
+        if const_expr(self.scenario == "2Dx2D"):
+            m_cnt = (self.hidden + cluster_tile_m - 1) // cluster_tile_m
+            n_cnt = (self.intermediate + cluster_tile_n - 1) // cluster_tile_n
+            grid_z_lin = self.expert_cnt * m_cnt * n_cnt
+        else:  # 2Dx3D
+            S = self.work_id_bundle_scale
+            n_tiles = (self.intermediate + cluster_tile_n - 1) // cluster_tile_n
+            possible_max = (
+                (self.tokens_sum + cluster_tile_m - 1) // cluster_tile_m
+                + self.expert_cnt
+                - 1
+            ) * n_tiles
+            grid_z_lin = (possible_max + S - 1) // S
+
+        grid_x = Int32(0)
+        grid_z = Int32(0)
+        # Runtime two-way layout pick; device decoder formula is uniform.
+        if grid_z_lin > Int32(GRID_YZ_MAX):
+            grid_x = cm * grid_z_lin
+            grid_z = Int32(1)
+            # Diagnostic only: CUDA launch will fail on its own if grid.x
+            # actually exceeds INT32_MAX. We cannot host-assert inside an
+            # @dsl_user_op (MLIR context), so just surface the situation.
+            if grid_x < Int32(0):  # sign-bit set -> overflow
+                cute.printf(
+                    "[MoE scheduler] grid.x overflow: cm=%d * grid_z_lin=%d "
+                    "exceeds INT32_MAX; kernel launch will fail. "
+                    "Consider splitting the workload.\n",
+                    Int32(cm),
+                    grid_z_lin,
+                )
+        else:
+            grid_x = Int32(cm)
+            grid_z = grid_z_lin
+
+        return (grid_x, cn, grid_z)
+
+
+# =============================================================================
+# Scheduler — Base (Device-side)
+# =============================================================================
+
+
+class MoESchedulerBase(ABC):
+    """
+    Abstract base class for MoE persistent tile schedulers.
+
+    Provides shared tile iteration helpers that convert linear cluster indices
+    to (expert_idx, tile_m_idx, tile_n_idx, k_tile_cnt). Subclasses implement
+    gen_next_work() to define how linear indices are produced (static striding,
+    CLC try_cancel, etc.).
+
+    Required members (set by concrete __init__ / create()):
+        params: MoESchedulerParamsBase
+        offs: cute.Tensor           — (experts,) cumsum of token counts
+        _ext: MoESchedExtension     — extension (Python ref, not MLIR-serialized)
+        cta_id_in_cluster: cute.Coord
+        current_expert_idx: Int32
+        expert_tile_start: Int32
+        expert_tile_end: Int32
+        current_work: MoEWorkTileInfo (or subclass defined by _ext.WorkTileInfo)
+
+    SMEM communication members (set by concrete create()):
+        _pipeline                   — PipelineAsync for work tile broadcast
+        _smem_buf_tensor            — SMEM tensor for work tile stages
+        _num_sched_stages: int      — number of pipeline stages
+        _producer_state             — pipeline producer state (MLIR-serialized)
+    """
+
+    # =========================================================================
+    # Abstract interface
+    # =========================================================================
+
+    @abstractmethod
+    def gen_next_work(self) -> None:
+        """Advance internal state to the next work tile. Sets self.current_work."""
+        ...
+
+    # =========================================================================
+    # SMEM communication (shared by all scheduler subclasses)
+    # =========================================================================
+
+    @dsl_user_op
+    @cute.jit
+    def publish_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Write current_work to SMEM and advance the producer pipeline."""
+        self.current_work.write_to_smem(
+            self._smem_buf_tensor,
+            (self._pipeline, self._producer_state),
+            loc=loc,
+            ip=ip,
+        )
+
+    @dsl_user_op
+    @cute.jit
+    def produce_tail(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Ensure all published stages are fully consumed, then release resources."""
+        self._pipeline.producer_tail(self._producer_state)
+
+    def make_consumer(self) -> "MoESchedConsumer":
+        """Create a consumer handle for non-scheduler warps."""
+        return MoESchedConsumer(
+            self._pipeline,
+            self._smem_buf_tensor,
+            self._num_sched_stages,
+            work_tile_cls=self._ext.WorkTileInfo,
+        )
+
+    # =========================================================================
+    # Convenience accessors for params
+    # =========================================================================
+
+    @property
+    def scenario(self) -> Literal["2Dx3D", "2Dx2D"]:
+        return self.params.scenario
+
+    @property
+    def expert_cnt(self) -> Int32:
+        return self.params.expert_cnt
+
+    @property
+    def intermediate(self) -> Int32:
+        return self.params.intermediate
+
+    @property
+    def hidden(self) -> Int32:
+        return self.params.hidden
+
+    @property
+    def cta_tile_shape_mnk(self) -> Tuple[int, int, int]:
+        return self.params.cta_tile_shape_mnk
+
+    @property
+    def cluster_shape_mn(self) -> Tuple[int, int]:
+        """Cluster shape used to size cta_id_in_cluster."""
+        return self.params.cluster_shape_mn
+
+    @property
+    def cluster_tile_m(self) -> int:
+        """Tile-partitioning granularity along M."""
+        return self.params.cluster_tile_m
+
+    @property
+    def cluster_tile_n(self) -> int:
+        """Tile-partitioning granularity along N."""
+        return self.params.cluster_tile_n
+
+    @property
+    def cta_tile_k(self) -> int:
+        return self.params.cta_tile_k
+
+    # =========================================================================
+    # Shared tile iteration helpers
+    # =========================================================================
+
+    @dsl_user_op
+    @cute.jit
+    def _get_work_tile_for_linear_idx(
+        self,
+        cluster_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> MoEWorkTileInfo:
+        """
+        Convert a linear cluster index to MoEWorkTileInfo.
+
+        Uses cached expert tracking state for O(1) fast path when staying
+        within the same expert. Advances expert state when needed.
+
+        Returns an invalid tile (expert_idx = -1) if cluster_linear_idx is out of range.
+        """
+        self._advance_expert_to_contain(cluster_linear_idx, loc=loc, ip=ip)
+
+        is_valid = self.current_expert_idx < self.expert_cnt
+
+        work_tile_info = MoEWorkTileInfo(
+            expert_idx=Int32(WorkTileState.DONE),
+            tile_m_idx=Int32(0),
+            tile_n_idx=Int32(0),
+            k_tile_cnt=Int32(0),
+        )
+
+        if is_valid:
+            local_idx = cluster_linear_idx - self.expert_tile_start
+            cluster_tile_m_idx, cluster_tile_n_idx = self._decompose_local_idx(
+                local_idx, self.current_expert_idx, loc=loc, ip=ip
+            )
+
+            cta_tile_m_idx = (
+                cluster_tile_m_idx * self.cluster_shape_mn[0]
+                + self.cta_id_in_cluster[0]  # type: ignore[index]
+            )
+            cta_tile_n_idx = (
+                cluster_tile_n_idx * self.cluster_shape_mn[1]
+                + self.cta_id_in_cluster[1]  # type: ignore[index]
+            )
+
+            k_tile_cnt = self._compute_k_tile_cnt(
+                self.current_expert_idx, loc=loc, ip=ip
+            )
+
+            # Swap-AB: re-express the tile indices in GEMM-domain (M, N) on
+            # the way out — see MoESchedulerParamsBase docstring.  The body
+            # above produced "scheduler-internal M-slot / N-slot" indices
+            # (M = grouped axis, N = full axis); when is_swap_ab is True the
+            # GEMM-domain mapping is flipped.  Codegen-time const_expr makes
+            # this a zero-cost branch.
+            if const_expr(self.params.is_swap_ab):
+                cta_tile_m_idx, cta_tile_n_idx = cta_tile_n_idx, cta_tile_m_idx
+
+            work_tile_info = MoEWorkTileInfo(
+                expert_idx=self.current_expert_idx,
+                tile_m_idx=cta_tile_m_idx,
+                tile_n_idx=cta_tile_n_idx,
+                k_tile_cnt=k_tile_cnt,
+            )
+        return work_tile_info
+
+    @dsl_user_op
+    @cute.jit
+    def _advance_expert_to_contain(
+        self,
+        cluster_linear_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """
+        Advance expert tracking state until current expert contains cluster_linear_idx,
+        or we run out of experts.
+
+        Fast path: If already in correct expert, no work needed.
+        """
+        if self.expert_tile_end == Int32(0):
+            tiles_for_expert_0 = self._compute_tiles_for_expert(
+                Int32(0), loc=loc, ip=ip
+            )
+            self.expert_tile_end = tiles_for_expert_0
+
+        while (
+            cluster_linear_idx >= self.expert_tile_end
+            and self.current_expert_idx < self.expert_cnt
+        ):
+            self.current_expert_idx = self.current_expert_idx + 1
+            self.expert_tile_start = self.expert_tile_end
+
+            if self.current_expert_idx < self.expert_cnt:
+                tiles_for_expert = self._compute_tiles_for_expert(
+                    self.current_expert_idx, loc=loc, ip=ip
+                )
+                self.expert_tile_end = self.expert_tile_end + tiles_for_expert
+
+    @dsl_user_op
+    @cute.jit
+    def _compute_tiles_for_expert(
+        self,
+        expert_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Int32:
+        """Compute total cluster tiles for a given expert.
+
+        Uses self.cluster_tile_m / self.cluster_tile_n — see the properties'
+        docstrings for the preferred vs actual distinction (relevant once
+        mix CGA lands).
+        """
+        if const_expr(self.scenario == "2Dx2D"):
+            cluster_tile_m_cnt = (
+                self.hidden + self.cluster_tile_m - 1
+            ) // self.cluster_tile_m
+            cluster_tile_n_cnt = (
+                self.intermediate + self.cluster_tile_n - 1
+            ) // self.cluster_tile_n
+            return cluster_tile_m_cnt * cluster_tile_n_cnt
+        else:  # 2Dx3D
+            tokens_i = self.offs[expert_idx]
+            if expert_idx > 0:
+                tokens_i = tokens_i - self.offs[expert_idx - 1]  # type: ignore[operator]
+            cluster_tile_m_cnt = (
+                tokens_i + self.cluster_tile_m - 1  # type: ignore[operator]
+            ) // self.cluster_tile_m
+            cluster_tile_n_cnt = (
+                self.intermediate + self.cluster_tile_n - 1
+            ) // self.cluster_tile_n
+            return cluster_tile_m_cnt * cluster_tile_n_cnt
+
+    @dsl_user_op
+    @cute.jit
+    def _decompose_local_idx(
+        self,
+        local_idx: Int32,
+        expert_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Int32, Int32]:
+        """
+        Decompose local cluster tile index within expert to (cluster_tile_m_idx, cluster_tile_n_idx).
+
+        Uses short-side-first raster; outputs preferred-granularity indices.
+        """
+        cluster_tile_m_cnt, cluster_tile_n_cnt = self._get_cluster_tile_counts(
+            expert_idx, loc=loc, ip=ip
+        )
+        cluster_tile_m_idx = -1
+        cluster_tile_n_idx = -1
+
+        if cluster_tile_m_cnt <= cluster_tile_n_cnt:
+            cluster_tile_m_idx = local_idx % cluster_tile_m_cnt
+            cluster_tile_n_idx = local_idx // cluster_tile_m_cnt
+        else:
+            cluster_tile_n_idx = local_idx % cluster_tile_n_cnt
+            cluster_tile_m_idx = local_idx // cluster_tile_n_cnt
+
+        return (cluster_tile_m_idx, cluster_tile_n_idx)
+
+    @dsl_user_op
+    @cute.jit
+    def _get_cluster_tile_counts(
+        self,
+        expert_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Tuple[Int32, Int32]:
+        """Get (cluster_tile_m_cnt, cluster_tile_n_cnt) for a given expert.
+
+        Uses self.cluster_tile_m / self.cluster_tile_n — see their docstrings
+        for the preferred vs actual distinction.
+        """
+        if const_expr(self.scenario == "2Dx2D"):
+            cluster_tile_m_cnt = (
+                self.hidden + self.cluster_tile_m - 1
+            ) // self.cluster_tile_m
+            cluster_tile_n_cnt = (
+                self.intermediate + self.cluster_tile_n - 1
+            ) // self.cluster_tile_n
+        else:  # 2Dx3D
+            tokens_i = self.offs[expert_idx]
+            if expert_idx > 0:
+                tokens_i = tokens_i - self.offs[expert_idx - 1]  # type: ignore[operator]
+            cluster_tile_m_cnt = (
+                tokens_i + self.cluster_tile_m - 1  # type: ignore[operator]
+            ) // self.cluster_tile_m
+            cluster_tile_n_cnt = (
+                self.intermediate + self.cluster_tile_n - 1
+            ) // self.cluster_tile_n
+        return (cluster_tile_m_cnt, cluster_tile_n_cnt)
+
+    @dsl_user_op
+    @cute.jit
+    def _compute_k_tile_cnt(
+        self,
+        expert_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> Int32:
+        """
+        Compute the number of K tiles for this expert.
+
+        2Dx3D: K = hidden (fixed) -> k_tile_cnt = ceil(hidden / cta_tile_k)
+        2Dx2D: K = tokens_i (variable) -> k_tile_cnt = ceil(tokens_i / cta_tile_k)
+        """
+        if const_expr(self.scenario == "2Dx3D"):
+            return (self.hidden + self.cta_tile_k - 1) // self.cta_tile_k
+        else:  # 2Dx2D
+            tokens_i = self.offs[expert_idx]
+            if expert_idx > cutlass.Int32(0):
+                tokens_i = tokens_i - self.offs[expert_idx - 1]  # type: ignore[operator]
+            return (tokens_i + self.cta_tile_k - 1) // self.cta_tile_k  # type: ignore[return-value, operator]
+
+
+# =============================================================================
+# Scheduler Consumer Handle
+# =============================================================================
+
+
+class MoESchedConsumer:
+    """
+    Consumer handle for non-scheduler warps to read work tiles from SMEM.
+
+    Each consumer warp creates its own instance (via scheduler.make_consumer())
+    inside its warp_idx branch, giving each warp independent pipeline state.
+
+    The work_tile_cls parameter determines which WorkTileInfo subclass is used
+    for deserialization, enabling polymorphic extra fields defined by the
+    MoESchedExtension.
+    """
+
+    def __init__(
+        self,
+        sched_pipeline,
+        smem_buf_tensor: cute.Tensor,
+        num_stages: int,
+        work_tile_cls=MoEWorkTileInfo,
+    ):
+        self._pipeline = sched_pipeline
+        self._smem_buf_tensor = smem_buf_tensor
+        self._work_tile_cls = work_tile_cls
+        self._consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, num_stages
+        )
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self._consumer_state))
+        return values
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "MoESchedConsumer":
+        cs_len = len(extract_mlir_values(self._consumer_state))
+        new_cs = new_from_mlir_values(self._consumer_state, values[:cs_len])
+        new_obj = MoESchedConsumer.__new__(MoESchedConsumer)
+        new_obj._pipeline = self._pipeline
+        new_obj._smem_buf_tensor = self._smem_buf_tensor
+        new_obj._work_tile_cls = self._work_tile_cls
+        new_obj._consumer_state = new_cs
+        return new_obj
+
+    @dsl_user_op
+    @cute.jit
+    def consume_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> MoEWorkTileInfo:
+        """Read the next work tile from SMEM. Blocks until data is available."""
+        return self._work_tile_cls.read_from_smem(
+            self._smem_buf_tensor,
+            (self._pipeline, self._consumer_state),
+            loc=loc,
+            ip=ip,
+        )
+
+
+# =============================================================================
+# Scheduler — Static (Device-side)
+# =============================================================================
+
+
+class MoEStaticPersistentTileScheduler(MoESchedulerBase):
+    """
+    Static persistent tile scheduler for MoE grouped GEMM.
+
+    Uses deterministic strided scheduling: each CGA starts at bidz and
+    advances by num_persistent_clusters each iteration.
+
+    Usage:
+        # Before warp specialization (all warps):
+        sched = MoEStaticPersistentTileScheduler.create(
+            params, offs, block_idx, grid_dim, sched_storage,
+            num_consumer_threads, ext=ext,
+        )
+
+        # Scheduler warp:
+        sched.gen_next_work()
+        while sched.current_work.is_valid_tile:
+            ext.prefetch_for_expert(sched.current_work.expert_idx)
+            sched.publish_work()
+            sched.gen_next_work()
+        sched.publish_work()   # sentinel
+        sched.produce_tail()
+
+        # Consumer warp:
+        consumer = sched.make_consumer()
+        work = consumer.consume_work()   # returns ext.WorkTileInfo
+        while work.is_valid_tile:
+            # ... do work using work.token_offset, work.tokens_i, etc. ...
+            work = consumer.consume_work()
+    """
+
+    def __init__(
+        self,
+        params: MoEStaticSchedulerParams,
+        offs: cute.Tensor,
+        num_persistent_clusters: Int32,
+        current_work_linear_idx: Int32,
+        cta_id_in_cluster: cute.Coord,
+        current_expert_idx: Int32,
+        expert_tile_start: Int32,
+        expert_tile_end: Int32,
+        current_work: MoEWorkTileInfo,
+        # Extension (Python object, not MLIR-serialized)
+        ext,
+        # SMEM communication state (Python objects, not MLIR-serialized)
+        sched_pipeline,
+        smem_buf_tensor,
+        num_sched_stages: int,
+        # Pipeline producer state (MLIR-serialized)
+        producer_state,
+    ):
+        self.params = params
+        self.offs = offs
+        self.num_persistent_clusters = num_persistent_clusters
+        self._current_work_linear_idx = current_work_linear_idx
+        self.cta_id_in_cluster = cta_id_in_cluster
+        self.current_expert_idx = current_expert_idx
+        self.expert_tile_start = expert_tile_start
+        self.expert_tile_end = expert_tile_end
+        self.current_work = current_work
+        self._ext = ext
+        self._pipeline = sched_pipeline
+        self._smem_buf_tensor = smem_buf_tensor
+        self._num_sched_stages = num_sched_stages
+        self._producer_state = producer_state
+
+    # =========================================================================
+    # SMEM storage definition
+    # =========================================================================
+
+    @staticmethod
+    def make_storage_struct(
+        params: MoESchedulerParamsBase, ext=_DEFAULT_SCHED_EXT, **kwargs
+    ):
+        """Construct the SMEM storage struct for scheduler communication.
+
+        :param params: Scheduler parameters (reads num_sched_stages from params)
+        :param ext: MoESchedExtension instance. The storage is sized for
+            ext.WorkTileInfo.TotalFields per stage, enabling extra precomputed
+            fields (e.g., token_offset, tokens_i) to be piggybacked onto the
+            work tile through the SMEM pipeline.
+        :param kwargs: Ignored (compatibility with dynamic scheduler's extra params).
+        :return: A cute.struct type for embedding in kernel's SharedStorage
+        """
+        num_tile_stages = params.num_sched_stages
+        fields_per_stage = ext.WorkTileInfo.TotalFields
+
+        @cute.struct
+        class SchedulerStorage:
+            sched_mbar: cute.struct.MemRange[cutlass.Int64, num_tile_stages * 2]
+            sched_buf: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, fields_per_stage * num_tile_stages],
+                16,
+            ]
+
+        return SchedulerStorage
+
+    # =========================================================================
+    # MLIR value serialization
+    # =========================================================================
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self.params))
+        values.extend(extract_mlir_values(self.offs))
+        values.extend(extract_mlir_values(self.num_persistent_clusters))
+        values.extend(extract_mlir_values(self._current_work_linear_idx))
+        values.extend(extract_mlir_values(self.cta_id_in_cluster))
+        values.extend(extract_mlir_values(self.current_expert_idx))
+        values.extend(extract_mlir_values(self.expert_tile_start))
+        values.extend(extract_mlir_values(self.expert_tile_end))
+        values.extend(extract_mlir_values(self.current_work))
+        values.extend(extract_mlir_values(self._producer_state))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "MoEStaticPersistentTileScheduler":
+        idx = 0
+
+        new_params = new_from_mlir_values(self.params, values[idx : idx + 3])
+        idx += 3
+
+        offs_len = len(extract_mlir_values(self.offs))
+        new_offs = new_from_mlir_values(self.offs, values[idx : idx + offs_len])
+        idx += offs_len
+
+        new_num_persistent_clusters = new_from_mlir_values(
+            self.num_persistent_clusters, [values[idx]]
+        )
+        idx += 1
+        new_current_work_linear_idx = new_from_mlir_values(
+            self._current_work_linear_idx, [values[idx]]
+        )
+        idx += 1
+
+        new_cta_id_in_cluster = new_from_mlir_values(
+            self.cta_id_in_cluster, values[idx : idx + 3]
+        )
+        idx += 3
+
+        new_current_expert_idx = new_from_mlir_values(
+            self.current_expert_idx, [values[idx]]
+        )
+        idx += 1
+        new_expert_tile_start = new_from_mlir_values(
+            self.expert_tile_start, [values[idx]]
+        )
+        idx += 1
+        new_expert_tile_end = new_from_mlir_values(self.expert_tile_end, [values[idx]])
+        idx += 1
+
+        work_len = len(extract_mlir_values(self.current_work))
+        new_current_work = new_from_mlir_values(
+            self.current_work, values[idx : idx + work_len]
+        )
+        idx += work_len
+
+        ps_len = len(extract_mlir_values(self._producer_state))
+        new_producer_state = new_from_mlir_values(
+            self._producer_state, values[idx : idx + ps_len]
+        )
+        idx += ps_len
+
+        result = MoEStaticPersistentTileScheduler.__new__(
+            MoEStaticPersistentTileScheduler
+        )
+        result.params = new_params
+        result.offs = new_offs
+        result.num_persistent_clusters = new_num_persistent_clusters
+        result._current_work_linear_idx = new_current_work_linear_idx
+        result.cta_id_in_cluster = new_cta_id_in_cluster
+        result.current_expert_idx = new_current_expert_idx
+        result.expert_tile_start = new_expert_tile_start
+        result.expert_tile_end = new_expert_tile_end
+        result.current_work = new_current_work
+        result._ext = self._ext
+        result._pipeline = self._pipeline
+        result._smem_buf_tensor = self._smem_buf_tensor
+        result._num_sched_stages = self._num_sched_stages
+        result._producer_state = new_producer_state
+        return result
+
+    # =========================================================================
+    # Factory method
+    # =========================================================================
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: MoEStaticSchedulerParams,
+        offs: cute.Tensor,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        sched_storage,
+        num_consumer_threads: int,
+        ext=_DEFAULT_SCHED_EXT,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "MoEStaticPersistentTileScheduler":
+        """
+        Create a MoE static persistent tile scheduler.
+
+        :param params: Scheduler parameters (from host)
+        :param offs: Cumsum tensor of token counts per expert, shape (experts,)
+        :param block_idx: CUDA block index
+        :param grid_dim: CUDA grid dimensions
+        :param sched_storage: SchedulerStorage instance (from make_storage_struct)
+        :param num_consumer_threads: Total consumer threads for sched pipeline
+        :param ext: MoESchedExtension instance for work tile enrichment and
+            polymorphic WorkTileInfo sizing
+        :raises ValueError: If num_consumer_threads <= 0
+        """
+        if num_consumer_threads <= 0:
+            raise ValueError(
+                f"num_consumer_threads must be positive, got {num_consumer_threads}"
+            )
+
+        num_stages = params.num_sched_stages
+        fields_per_stage = ext.WorkTileInfo.TotalFields
+
+        num_persistent_clusters = cute.size(grid_dim, loc=loc, ip=ip) // cute.size(
+            params.cluster_shape_mn, loc=loc, ip=ip
+        )
+
+        bidx, bidy, bidz = block_idx
+        current_work_linear_idx = Int32(bidz)
+
+        # ``cta_id_in_cluster`` carries the scheduler-internal (M-slot,
+        # N-slot) cluster-CTA position.  Under ``is_swap_ab`` the launch
+        # axes (which bidx / bidy are indexed in) are swapped relative to
+        # scheduler-internal axes — launch X maps to N-slot (full axis),
+        # launch Y maps to M-slot (grouped axis) — so we feed the right
+        # bid into each modulo.  ``params.cluster_shape_mn[0/1]`` itself
+        # is always the internal (M-slot, N-slot) sizes; only the bid
+        # source is flipped.
+        if const_expr(params.is_swap_ab):
+            cta_id_in_cluster = (
+                Int32(bidy % params.cluster_shape_mn[0]),
+                Int32(bidx % params.cluster_shape_mn[1]),
+                Int32(0),
+            )
+        else:
+            cta_id_in_cluster = (
+                Int32(bidx % params.cluster_shape_mn[0]),
+                Int32(bidy % params.cluster_shape_mn[1]),
+                Int32(0),
+            )
+
+        current_expert_idx = Int32(0)
+        expert_tile_start = Int32(0)
+        expert_tile_end = Int32(0)
+
+        base_sentinel = MoEWorkTileInfo(
+            expert_idx=Int32(WorkTileState.DONE),
+            tile_m_idx=Int32(0),
+            tile_n_idx=Int32(0),
+            k_tile_cnt=Int32(0),
+        )
+        current_work = ext.enrich_work_tile_info(base_sentinel)
+
+        sched_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        sched_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_consumer_threads
+        )
+        sched_pipeline = pipeline.PipelineAsync.create(
+            num_stages=num_stages,
+            producer_group=sched_producer_group,
+            consumer_group=sched_consumer_group,
+            barrier_storage=sched_storage.sched_mbar.data_ptr(),
+            defer_sync=True,
+        )
+        smem_buf_tensor = cute.make_tensor(
+            sched_storage.sched_buf.data_ptr(),
+            cute.make_layout(
+                (fields_per_stage, num_stages),
+                stride=(1, fields_per_stage),
+            ),
+        )
+        producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, num_stages
+        )
+
+        return MoEStaticPersistentTileScheduler(
+            params=params,
+            offs=offs,
+            num_persistent_clusters=num_persistent_clusters,
+            current_work_linear_idx=current_work_linear_idx,
+            cta_id_in_cluster=cta_id_in_cluster,
+            current_expert_idx=current_expert_idx,
+            expert_tile_start=expert_tile_start,
+            expert_tile_end=expert_tile_end,
+            current_work=current_work,
+            ext=ext,
+            sched_pipeline=sched_pipeline,
+            smem_buf_tensor=smem_buf_tensor,
+            num_sched_stages=num_stages,
+            producer_state=producer_state,
+        )
+
+    # =========================================================================
+    # Tile iteration
+    # =========================================================================
+
+    @dsl_user_op
+    @cute.jit
+    def gen_next_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Compute work tile for current linear index, then advance the index.
+
+        When an extension is set, the base MoEWorkTileInfo is enriched with
+        domain-specific extra fields via ext.enrich_work_tile_info().
+        """
+        base_work = self._get_work_tile_for_linear_idx(
+            self._current_work_linear_idx, loc=loc, ip=ip
+        )
+        self._current_work_linear_idx += self.num_persistent_clusters
+        self.current_work = self._ext.enrich_work_tile_info(base_work)
+
+
+# =============================================================================
+# CLC Dynamic Scheduling State
+# =============================================================================
+
+
+class _ClcDynamicState:
+    """Encapsulates all CLC dynamic scheduling state. MLIR-serializable.
+
+    Groups the sub-iterator, CLC response cache, pipeline states, and CLC
+    SMEM pointer into one object so the scheduler holds a single _clc_state
+    member instead of many scattered fields.
+
+    CLC coordinate semantics (unified across 2Dx2D and 2Dx3D after the
+    WGrad linearization):
+        {$nv-internal-release begin}
+        These store the **cluster origin** coordinates from the CLC response,
+        i.e., the grid position of the first CTA of the canceled cluster.
+        This matches the CLC hardware behavior: UGETNEXTWORKID returns
+        "the first CTA of the CGA" coordinates (see ISA spec).
+        {$nv-internal-release end}
+
+        Grid layouts produced by MoEDynamicSchedulerParams.get_grid_shape:
+            Layout A (grid_z_lin <= 65535):  (cm,              cn, grid_z_lin)
+            Layout B (grid_z_lin >  65535):  (cm * grid_z_lin, cn, 1)
+
+        clc_l stores cluster_linear_idx (preferred-cluster granularity).
+        clc_m / clc_n are always 0 in this encoding: the grid dimensions
+        xy are aligned to the (preferred) cluster shape so every cluster's
+        origin in those axes is 0 modulo cm / cn, and the linearized index
+        already absorbs layout A vs B through bidz or bidx.
+
+        Per-CTA tile recovery:
+            cta_id_in_cluster[0] = bidx % cm       (mask)
+            cta_id_in_cluster[1] = bidy % cn       (mask)
+            cluster_linear_idx   = (bidx // cm) + bidz   (shift + add)
+        Then _get_work_tile_for_linear_idx + _decompose_local_idx finish
+        the decomposition to (expert_idx, tile_m, tile_n).
+
+        Initial bootstrap (see MoEDynamicPersistentTileScheduler.create):
+        clc_l is computed from block_idx using the same unified formula,
+        equivalent to a "CLC response #0" that the hardware would have
+        emitted for this CGA.
+
+    Note on mix CGA (future):
+        The "preferred cluster granularity" used to compute cluster_linear_idx
+        must remain static across both preferred and fallback branches.
+        Currently preferred == actual (single-cluster configurations only).
+    """
+
+    def __init__(
+        self,
+        bundle_remaining: Int32,
+        bundle_idx: Int32,
+        clc_m: Int32,
+        clc_n: Int32,
+        clc_l: Int32,
+        clc_is_valid: Boolean,
+        clc_producer_state,
+        clc_consumer_state,
+        is_leader_cta: Boolean,
+        clc_response_ptr,
+    ):
+        self.bundle_remaining = bundle_remaining
+        self.bundle_idx = bundle_idx
+        self.clc_m = clc_m
+        self.clc_n = clc_n
+        self.clc_l = clc_l
+        self.clc_is_valid = clc_is_valid
+        self.clc_producer_state = clc_producer_state
+        self.clc_consumer_state = clc_consumer_state
+        self.is_leader_cta = is_leader_cta
+        self.clc_response_ptr = clc_response_ptr
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self.bundle_remaining))
+        values.extend(extract_mlir_values(self.bundle_idx))
+        values.extend(extract_mlir_values(self.clc_m))
+        values.extend(extract_mlir_values(self.clc_n))
+        values.extend(extract_mlir_values(self.clc_l))
+        values.extend(extract_mlir_values(self.clc_is_valid))
+        values.extend(extract_mlir_values(self.clc_producer_state))
+        values.extend(extract_mlir_values(self.clc_consumer_state))
+        values.extend(extract_mlir_values(self.is_leader_cta))
+        values.extend(extract_mlir_values(self.clc_response_ptr))
+        return values
+
+    def __new_from_mlir_values__(self, values: List[ir.Value]) -> "_ClcDynamicState":
+        idx = 0
+
+        def _take(obj):
+            nonlocal idx
+            n = len(extract_mlir_values(obj))
+            result = new_from_mlir_values(obj, values[idx : idx + n])
+            idx += n
+            return result
+
+        return _ClcDynamicState(
+            bundle_remaining=_take(self.bundle_remaining),
+            bundle_idx=_take(self.bundle_idx),
+            clc_m=_take(self.clc_m),
+            clc_n=_take(self.clc_n),
+            clc_l=_take(self.clc_l),
+            clc_is_valid=_take(self.clc_is_valid),
+            clc_producer_state=_take(self.clc_producer_state),
+            clc_consumer_state=_take(self.clc_consumer_state),
+            is_leader_cta=_take(self.is_leader_cta),
+            clc_response_ptr=_take(self.clc_response_ptr),
+        )
+
+
+# =============================================================================
+# Scheduler — Dynamic (CLC-based, Device-side)
+# =============================================================================
+
+
+class MoEDynamicPersistentTileScheduler(MoESchedulerBase):
+    """
+    CLC-based dynamic persistent tile scheduler for MoE grouped GEMM.
+
+    Unified across both scenarios via a single cluster_linear_idx space:
+    - 2Dx2D (WGrad): grid_z_lin = expert_cnt * m_cnt * n_cnt (S forced to 1),
+      grid is exact; no drain actually triggers. Short-side-first raster is
+      inherited from the shared _decompose_local_idx helper.
+    - 2Dx3D (Forward/DGrad): grid_z_lin = ceil(possible_max / S) (S may be > 1
+      for EP-like workloads), grid can exceed actual work; drain consumes the
+      tail.
+
+    Grid is placed as either layout A (cm, cn, grid_z_lin) or layout B
+    (cm * grid_z_lin, cn, 1) depending on whether grid_z_lin exceeds 65535
+    (see MoEDynamicSchedulerParams.get_grid_shape). The device-side decoder
+    is one formula for both layouts (see _ClcDynamicState docstring).
+
+    Sub-iterator pattern: each CLC try_cancel returns one tile_id. The
+    scheduler expands it into work_id_bundle_scale (S) consecutive work tiles
+    before issuing the next try_cancel.
+
+    Usage:
+        # Before warp specialization (all warps):
+        sched = MoEDynamicPersistentTileScheduler.create(
+            params, offs, block_idx, grid_dim, sched_storage,
+            num_consumer_threads, ext=ext,
+        )
+
+        # Scheduler warp:
+        sched.gen_next_work()
+        while sched.current_work.is_valid_tile:
+            ext.prefetch_for_expert(sched.current_work.expert_idx)
+            sched.publish_work()
+            sched.gen_next_work()
+        sched.publish_work()   # sentinel
+        sched.produce_tail()
+
+        # Consumer warp:
+        consumer = sched.make_consumer()
+        work = consumer.consume_work()
+        while work.is_valid_tile:
+            # ... do work using work.token_offset, work.tokens_i, etc. ...
+            work = consumer.consume_work()
+    """
+
+    def __init__(
+        self,
+        params: MoEDynamicSchedulerParams,
+        offs: cute.Tensor,
+        cta_id_in_cluster: cute.Coord,
+        current_expert_idx: Int32,
+        expert_tile_start: Int32,
+        expert_tile_end: Int32,
+        current_work: MoEWorkTileInfo,
+        clc_state: _ClcDynamicState,
+        # Python objects (not MLIR-serialized)
+        ext,
+        clc_pipeline,
+        sched_pipeline,
+        smem_buf_tensor,
+        num_sched_stages: int,
+        # MLIR-serialized
+        producer_state,
+    ):
+        self.params = params
+        self.offs = offs
+        self.cta_id_in_cluster = cta_id_in_cluster
+        self.current_expert_idx = current_expert_idx
+        self.expert_tile_start = expert_tile_start
+        self.expert_tile_end = expert_tile_end
+        self.current_work = current_work
+        self._clc_state = clc_state
+        self._ext = ext
+        self._clc_pipeline = clc_pipeline
+        self._pipeline = sched_pipeline
+        self._smem_buf_tensor = smem_buf_tensor
+        self._num_sched_stages = num_sched_stages
+        self._producer_state = producer_state
+
+    # =========================================================================
+    # SMEM storage definition
+    # =========================================================================
+
+    @staticmethod
+    def make_storage_struct(
+        params: MoEDynamicSchedulerParams,
+        ext=_DEFAULT_SCHED_EXT,
+        num_drain_warps: int = 0,
+    ):
+        """Construct SMEM storage for dynamic scheduler communication.
+
+        :param params: Scheduler parameters
+        :param ext: MoESchedExtension for WorkTileInfo sizing
+        :param num_drain_warps: Number of warps that participate in CLC drain.
+            Each warp gets 1 mbar (2 Int64) + 1 response slot (4 Int32).
+        :return: A cute.struct type for embedding in kernel's SharedStorage
+        """
+        num_tile_stages = params.num_sched_stages
+        fields_per_stage = ext.WorkTileInfo.TotalFields
+        num_drain_mbar = num_drain_warps * 2
+        num_drain_response = num_drain_warps * 4
+
+        @cute.struct
+        class SchedulerStorage:
+            sched_mbar: cute.struct.MemRange[cutlass.Int64, num_tile_stages * 2]
+            sched_buf: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, fields_per_stage * num_tile_stages],
+                16,
+            ]
+            clc_mbar: cute.struct.MemRange[cutlass.Int64, 2]
+            clc_response: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, 4],
+                16,
+            ]
+            drain_mbar: cute.struct.MemRange[cutlass.Int64, num_drain_mbar]
+            drain_response: cute.struct.Align[
+                cute.struct.MemRange[cutlass.Int32, num_drain_response],
+                16,
+            ]
+
+        return SchedulerStorage
+
+    # =========================================================================
+    # MLIR value serialization
+    # =========================================================================
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values = []
+        values.extend(extract_mlir_values(self.params))
+        values.extend(extract_mlir_values(self.offs))
+        values.extend(extract_mlir_values(self.cta_id_in_cluster))
+        values.extend(extract_mlir_values(self.current_expert_idx))
+        values.extend(extract_mlir_values(self.expert_tile_start))
+        values.extend(extract_mlir_values(self.expert_tile_end))
+        values.extend(extract_mlir_values(self.current_work))
+        values.extend(extract_mlir_values(self._clc_state))
+        values.extend(extract_mlir_values(self._producer_state))
+        return values
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "MoEDynamicPersistentTileScheduler":
+        idx = 0
+
+        def _take(obj):
+            nonlocal idx
+            n = len(extract_mlir_values(obj))
+            result = new_from_mlir_values(obj, values[idx : idx + n])
+            idx += n
+            return result
+
+        result = MoEDynamicPersistentTileScheduler.__new__(
+            MoEDynamicPersistentTileScheduler
+        )
+        result.params = _take(self.params)
+        result.offs = _take(self.offs)
+        result.cta_id_in_cluster = _take(self.cta_id_in_cluster)
+        result.current_expert_idx = _take(self.current_expert_idx)
+        result.expert_tile_start = _take(self.expert_tile_start)
+        result.expert_tile_end = _take(self.expert_tile_end)
+        result.current_work = _take(self.current_work)
+        result._clc_state = _take(self._clc_state)
+        result._producer_state = _take(self._producer_state)
+        result._ext = self._ext
+        result._clc_pipeline = self._clc_pipeline
+        result._pipeline = self._pipeline
+        result._smem_buf_tensor = self._smem_buf_tensor
+        result._num_sched_stages = self._num_sched_stages
+        return result
+
+    # =========================================================================
+    # Factory method
+    # =========================================================================
+
+    @staticmethod
+    @dsl_user_op
+    def create(
+        params: MoEDynamicSchedulerParams,
+        offs: cute.Tensor,
+        block_idx: Tuple[Integer, Integer, Integer],
+        grid_dim: Tuple[Integer, Integer, Integer],
+        sched_storage,
+        num_consumer_threads: int,
+        ext=_DEFAULT_SCHED_EXT,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> "MoEDynamicPersistentTileScheduler":
+        """
+        Create a CLC-based dynamic persistent tile scheduler.
+
+        :param params: Dynamic scheduler parameters (includes work_id_bundle_scale)
+        :param offs: Cumsum tensor of token counts per expert, shape (experts,)
+        :param block_idx: CUDA block index
+        :param grid_dim: CUDA grid dimensions
+        :param sched_storage: SchedulerStorage from make_storage_struct
+        :param num_consumer_threads: Total consumer threads for sched pipeline
+        :param ext: MoESchedExtension for work tile enrichment
+        """
+        if num_consumer_threads <= 0:
+            raise ValueError(
+                f"num_consumer_threads must be positive, got {num_consumer_threads}"
+            )
+
+        num_stages = params.num_sched_stages
+        fields_per_stage = ext.WorkTileInfo.TotalFields
+        S = params.work_id_bundle_scale
+
+        # ``cm`` / ``cn`` here are launch-view (= mma / user-view) cluster
+        # sizes — used for the bidx-based clc_l decoder and the cta_layout
+        # the CLC pipeline runs on (both must agree with the launch grid /
+        # cluster orientation).  Internal ``params.cluster_shape_mn`` is
+        # post-swap under ``is_swap_ab``, so we read flipped indices.
+        if const_expr(params.is_swap_ab):
+            cm = params.cluster_shape_mn[1]  # codegen-time static power-of-2
+            cn = params.cluster_shape_mn[0]
+        else:
+            cm = params.cluster_shape_mn[0]
+            cn = params.cluster_shape_mn[1]
+        bidx, bidy, bidz = block_idx
+
+        # ``cta_id_in_cluster`` is in scheduler-internal (M-slot, N-slot)
+        # coordinates.  Under ``is_swap_ab`` launch X maps to N-slot and
+        # launch Y maps to M-slot, so the bid feeding each modulo is
+        # flipped (the modulo divisor itself stays internal).
+        if const_expr(params.is_swap_ab):
+            cta_id_in_cluster = (
+                Int32(bidy % params.cluster_shape_mn[0]),
+                Int32(bidx % params.cluster_shape_mn[1]),
+                Int32(0),
+            )
+        else:
+            cta_id_in_cluster = (
+                Int32(bidx % params.cluster_shape_mn[0]),
+                Int32(bidy % params.cluster_shape_mn[1]),
+                Int32(0),
+            )
+
+        current_expert_idx = Int32(0)
+        expert_tile_start = Int32(0)
+        expert_tile_end = Int32(0)
+
+        is_leader_cta = (
+            cta_id_in_cluster[0] + cta_id_in_cluster[1] + cta_id_in_cluster[2]
+        ) == Int32(0)
+
+        cluster_size = cm * cn
+
+        clc_pipeline = pipeline.PipelineClcFetchAsync.create(
+            barrier_storage=sched_storage.clc_mbar.data_ptr(),
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread),
+            consumer_group=pipeline.CooperativeGroup(
+                pipeline.Agent.Thread, 32 * cluster_size
+            ),
+            tx_count=16,
+            cta_layout_vmnk=cute.make_layout((1, cm, cn, 1)),
+            defer_sync=True,
+        )
+
+        clc_producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.ProducerConsumer, 1
+        )
+        clc_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, 1
+        )
+
+        # Bootstrap CLC state from block_idx under the unified grid layout
+        # (see MoEDynamicSchedulerParams.get_grid_shape docstring):
+        #   cluster_linear_idx = (bidx // cm) + bidz
+        # This holds for both layouts:
+        #   Layout A (bidx < cm, bidz < grid_z_lin): bidx // cm == 0 → clc_l = bidz
+        #   Layout B (bidz == 0, bidx < cm * grid_z_lin): clc_l = bidx // cm
+        # Since the grid dimensions xy are aligned to the preferred cluster
+        # shape, clc_m / clc_n are always 0 in this unified encoding.
+        clc_l_initial = Int32(bidx) // Int32(cm) + Int32(bidz)
+        clc_state = _ClcDynamicState(
+            bundle_remaining=Int32(S),
+            bundle_idx=Int32(0),
+            clc_m=Int32(0),
+            clc_n=Int32(0),
+            clc_l=clc_l_initial,
+            clc_is_valid=Boolean(True),
+            clc_producer_state=clc_producer_state,
+            clc_consumer_state=clc_consumer_state,
+            is_leader_cta=is_leader_cta,
+            clc_response_ptr=sched_storage.clc_response.data_ptr(),
+        )
+
+        # Sched pipeline for work tile broadcast (same as static)
+        sched_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread, 32)
+        sched_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_consumer_threads
+        )
+        sched_pipeline = pipeline.PipelineAsync.create(
+            num_stages=num_stages,
+            producer_group=sched_producer_group,
+            consumer_group=sched_consumer_group,
+            barrier_storage=sched_storage.sched_mbar.data_ptr(),
+            defer_sync=True,
+        )
+        smem_buf_tensor = cute.make_tensor(
+            sched_storage.sched_buf.data_ptr(),
+            cute.make_layout(
+                (fields_per_stage, num_stages),
+                stride=(1, fields_per_stage),
+            ),
+        )
+        producer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Producer, num_stages
+        )
+
+        # Initial work from block_idx (treated as CLC response #0)
+        base_sentinel = MoEWorkTileInfo(
+            expert_idx=Int32(WorkTileState.DONE),
+            tile_m_idx=Int32(0),
+            tile_n_idx=Int32(0),
+            k_tile_cnt=Int32(0),
+        )
+        current_work = ext.enrich_work_tile_info(base_sentinel)
+
+        return MoEDynamicPersistentTileScheduler(
+            params=params,
+            offs=offs,
+            cta_id_in_cluster=cta_id_in_cluster,
+            current_expert_idx=current_expert_idx,
+            expert_tile_start=expert_tile_start,
+            expert_tile_end=expert_tile_end,
+            current_work=current_work,
+            clc_state=clc_state,
+            ext=ext,
+            clc_pipeline=clc_pipeline,
+            sched_pipeline=sched_pipeline,
+            smem_buf_tensor=smem_buf_tensor,
+            num_sched_stages=num_stages,
+            producer_state=producer_state,
+        )
+
+    # =========================================================================
+    # Pipeline tail — close the cluster-exit race on the CLC broadcast pipeline
+    # =========================================================================
+
+    @dsl_user_op
+    @cute.jit
+    def produce_tail(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Tail both pipelines before the sched warp retires.
+
+        Two producer-side pipelines must be drained on the leader CTA before
+        kernel exit:
+
+        1. ``sched_pipeline`` (parent class produce_tail):
+           waits for all consumer warps **within this CTA** to release the
+           last published work tile.
+
+        2. ``clc_pipeline`` (added here, leader CTA only):
+           closes a cluster-exit race that bites whenever the kernel layout
+           on the leader CTA is lean enough that the leader retires before
+           the slowest cluster CTA has landed its last consumer_release.
+
+           ``PipelineClcFetchAsync`` builds ``sync_object_empty`` with
+           ``consumer_mask = 0`` — every CTA in the cluster routes its
+           ``consumer_release`` to **CTA rank 0's** mbarrier (the leader).
+           If the leader retires while a remote CTA is still in flight to
+           that mbarrier, hardware raises
+           ``CUDA_EXCEPTION_17 / Cluster target block not present``.
+
+           Calling ``producer_tail`` on the leader CTA forces it to wait for
+           ``num_stages × cluster_size`` arrives on its empty barrier before
+           returning, which guarantees every cluster CTA has visibly
+           released the last broadcast stage. Non-leader CTAs MUST NOT call
+           into ``_clc_pipeline.producer_tail`` — they are not producers and
+           their own ``sync_object_empty`` is never arrived on (deadlock).
+
+        Leader-CTA tail waits for all cluster CTAs to release the broadcast
+        pipeline before retirement.  Non-leaders must not producer-tail.
+        """
+        super().produce_tail(loc=loc, ip=ip)
+
+        cs = self._clc_state
+        if self._clc_state.is_leader_cta:
+            self._clc_pipeline.producer_tail(
+                self._clc_state.clc_producer_state, loc=loc, ip=ip
+            )
+        else:
+            self._clc_state = cs
+
+    # =========================================================================
+    # Tile iteration — CLC + sub-iterator
+    # =========================================================================
+
+    @dsl_user_op
+    @cute.jit
+    def gen_next_work(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Advance to the next work tile using CLC sub-iterator.
+
+        When bundle_remaining reaches 0, issues a CLC try_cancel to get the
+        next tile_id and resets the bundle. Then maps the current bundle
+        position to a work tile via _map_clc_to_work.
+        """
+        cs = self._clc_state
+        if self._clc_state.bundle_remaining <= Int32(0):
+            self._clc_try_cancel(loc=loc, ip=ip)
+        else:
+            self._clc_state = cs
+
+        base_work = MoEWorkTileInfo(
+            expert_idx=Int32(WorkTileState.DONE),
+            tile_m_idx=Int32(0),
+            tile_n_idx=Int32(0),
+            k_tile_cnt=Int32(0),
+        )
+        if self._clc_state.clc_is_valid:
+            base_work = self._map_clc_to_work(
+                self._clc_state.bundle_idx, loc=loc, ip=ip
+            )
+            self._clc_state.bundle_idx = self._clc_state.bundle_idx + Int32(1)
+            self._clc_state.bundle_remaining = self._clc_state.bundle_remaining - Int32(
+                1
+            )
+            if not base_work.is_valid_tile:
+                base_work = MoEWorkTileInfo(
+                    expert_idx=Int32(WorkTileState.DRAINING),
+                    tile_m_idx=Int32(0),
+                    tile_n_idx=Int32(0),
+                    k_tile_cnt=Int32(0),
+                )
+
+        self.current_work = self._ext.enrich_work_tile_info(base_work)
+
+    @dsl_user_op
+    @cute.jit
+    def _clc_try_cancel(
+        self,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Issue CLC try_cancel and update clc_state with the response.
+
+        Leader CTA: producer_acquire → elect_one → issue_clc_query (multicast)
+        All CTAs: consumer_wait → parse response → consumer_release
+        """
+
+        if self._clc_state.is_leader_cta:
+            self._clc_pipeline.producer_acquire(self._clc_state.clc_producer_state)
+            mbar_ptr = self._clc_pipeline.producer_get_barrier(
+                self._clc_state.clc_producer_state
+            )
+            with cute.arch.elect_one():
+                cute.arch.issue_clc_query(
+                    mbar_ptr, self._clc_state.clc_response_ptr, loc=loc, ip=ip
+                )
+        self._clc_state.clc_producer_state.advance()
+
+        self._clc_pipeline.consumer_wait(self._clc_state.clc_consumer_state)
+        m_idx, n_idx, l_idx, is_valid = cute.arch.clc_response(
+            self._clc_state.clc_response_ptr, loc=loc, ip=ip
+        )
+        cute.arch.fence_acq_rel_cta()
+        self._clc_pipeline.consumer_release(self._clc_state.clc_consumer_state)
+        self._clc_state.clc_consumer_state.advance()
+
+        # Normalize CLC response to unified cluster_linear_idx. The grid is
+        # laid out in one of two ways (see MoEDynamicSchedulerParams.get_grid_shape):
+        #   Layout A: (cm, cn, grid_z_lin)            → m_idx == 0, l_idx carries the idx
+        #   Layout B: (cm * grid_z_lin, cn, 1)        → l_idx == 0, m_idx carries the idx
+        # Either way, (m_idx // cm) + l_idx is the cluster_linear_idx.
+        # ``cm`` here is launch-view (= user-view) cluster X size — under
+        # ``is_swap_ab`` the internal ``cluster_shape_mn`` is post-swap, so
+        # we read ``cluster_shape_mn[1]`` (= post-swap N = user-view M).
+        if const_expr(self.params.is_swap_ab):
+            cm = self.params.cluster_shape_mn[1]
+        else:
+            cm = self.params.cluster_shape_mn[0]
+        self._clc_state.clc_m = Int32(0)
+        self._clc_state.clc_n = Int32(0)
+        self._clc_state.clc_l = (m_idx // Int32(cm)) + l_idx
+        self._clc_state.clc_is_valid = is_valid != Int32(0)
+        self._clc_state.bundle_remaining = Int32(self.params.work_id_bundle_scale)
+        self._clc_state.bundle_idx = Int32(0)
+
+    @dsl_user_op
+    @cute.jit
+    def _map_clc_to_work(
+        self,
+        bundle_idx: Int32,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> MoEWorkTileInfo:
+        """Map CLC response + bundle index to a work tile.
+
+        After the 2Dx2D linearization, both scenarios share one formula:
+        clc_l carries a cluster_linear_idx (preferred-cluster granularity),
+        and the bundle expands it to S consecutive work tiles. The work
+        tile is recovered via shared helpers (_advance_expert_to_contain,
+        _decompose_local_idx) which take care of expert boundaries and
+        short-side-first raster.
+
+        For 2Dx2D, S is always 1, so bundle_idx is always 0; the formula
+        degenerates correctly.
+        """
+        linear_idx = (
+            self._clc_state.clc_l * self.params.work_id_bundle_scale + bundle_idx
+        )
+        return self._get_work_tile_for_linear_idx(linear_idx, loc=loc, ip=ip)
+
+    # =========================================================================
+    # Drain — exhaust remaining CLC grid entries
+    # =========================================================================
+
+    _DRAIN_BATCH_SIZE = 4
+
+    @staticmethod
+    @dsl_user_op
+    @cute.jit
+    def drain_empty_tiles(
+        sched_storage,
+        warp_drain_idx,
+        *,
+        loc: Optional[ir.Location] = None,
+        ip: Optional[ir.InsertionPoint] = None,
+    ) -> None:
+        """Drain remaining CLC grid entries for one warp.
+
+        Each drain warp independently fires batches of CLC try_cancel queries
+        until the grid is exhausted. Multiple drain warps run concurrently to
+        saturate CLC issue bandwidth.
+
+        :param sched_storage: SchedulerStorage from make_storage_struct
+            (contains drain_mbar and drain_response fields)
+        :param warp_drain_idx: Slot index for this drain warp (0-based).
+            May be either a Python int (compile-time constant, used by the
+            sched warp at slot 0) or a runtime Int32 (used by the dedicated
+            drain_aux warps which all share a single kernel-side branch).
+            Selects the SMEM slot (mbar + response). For IKET observability,
+            constexpr 0 lights up `sched_drain`; runtime values fall back to
+            a single `helper_drain` range that lumps drain_aux warps together.
+        """
+        batch_size = MoEDynamicPersistentTileScheduler._DRAIN_BATCH_SIZE
+        tx_count = batch_size * 16
+
+        # Promote the (potentially runtime) warp_drain_idx to a cute IntValue
+        # with a divisibility annotation. tuple_mul then propagates divby
+        # through `* 2` / `* 4`, which is what makes the resulting smem
+        # pointer's alignment provable to the cute.copy verifier in
+        # `cute.arch.clc_response` (which does an i128 load and requires
+        # 16-byte source alignment).
+        #
+        # For Python int input (sched warp passes 0), `cute.assume` short
+        # circuits and returns the int unchanged: zero IR cost.
+        idx = cute.assume(warp_drain_idx, divby=1)
+        warp_mbar_ptr = sched_storage.drain_mbar.data_ptr() + idx * 2
+        warp_resp_ptr = sched_storage.drain_response.data_ptr() + idx * 4
+
+        with cute.arch.elect_one():
+            cute.arch.mbarrier_init(warp_mbar_ptr, 1)
+        cute.arch.mbarrier_init_fence()
+
+        if cutlass.const_expr(isinstance(warp_drain_idx, int)):
+            iket.range_push("sched_drain")
+        else:
+            iket.range_push("helper_drain")
+
+        phase = Int32(0)
+        is_valid = Boolean(True)
+        while is_valid:
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive_and_expect_tx(
+                    warp_mbar_ptr, tx_count, loc=loc, ip=ip
+                )
+                for _ in cutlass.range(0, batch_size, 1, unroll=1):
+                    cute.arch.issue_clc_query(
+                        warp_mbar_ptr,
+                        warp_resp_ptr,
+                        multicast=False,
+                        loc=loc,
+                        ip=ip,
+                    )
+            cute.arch.mbarrier_wait(warp_mbar_ptr, phase, loc=loc, ip=ip)
+            _, _, _, is_valid_i32 = cute.arch.clc_response(
+                warp_resp_ptr, loc=loc, ip=ip
+            )
+            is_valid = is_valid_i32 != Int32(0)
+            phase = phase ^ Int32(1)
+
+        iket.range_pop()

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/moe_utils.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/moe_utils.py
@@ -1,0 +1,1199 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Shared MoE scheduler utilities and online TMA descriptor helpers."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Literal, Optional, Tuple, Type, Union
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import AddressSpace, Numeric, Pointer
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cute.arch import nvvm_wrappers
+from cutlass.cutlass_dsl import dsl_user_op, Boolean, Int32, Float32, T
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass._mlir.dialects import cute as _cute_ir
+from cutlass._mlir.dialects import vector, arith
+from cutlass._mlir.dialects import cute_nvgpu as _cute_nvgpu_ir
+from dataclasses import dataclass
+
+from cutlass.utils.blockscaled_layout import tile_atom_to_shape_SF
+
+TensormapDescBytes = 128
+TensormapDescBytes = 64  # {$nv-internal-release}
+
+
+# =============================================================================
+# Pointer Utilities
+# =============================================================================
+
+
+@dsl_user_op
+def _nanosleep(
+    sleep_time: int,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Compatibility wrapper for wheels without ``cute.arch.nanosleep``."""
+    if cutlass.const_expr(hasattr(cute.arch, "nanosleep")):
+        cute.arch.nanosleep(sleep_time=sleep_time, loc=loc, ip=ip)
+    else:
+        llvm.inline_asm(
+            res=None,
+            operands_=[Int32(sleep_time).ir_value(loc=loc, ip=ip)],
+            asm_string="nanosleep.u32 $0;",
+            constraints="r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+
+
+@dsl_user_op
+@cute.jit
+def spin_wait(
+    ptr: Pointer,
+    condition: Callable[[Int32], bool],
+    fail_sleep_cycles: int = 100,
+    peek_only: bool = False,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Boolean:
+    """Spin until condition is true, or do one condition check with peek_only."""
+    # The first load must be acquire to build the mem order.
+    current = cute.arch.load(ptr, ptr.dtype, sem="acquire", scope="gpu")
+    if cutlass.const_expr(peek_only):
+        # One-shot peek: forward the condition Boolean to the caller.
+        return Boolean(condition(current))
+    while not condition(current):
+        # Load with L1 cache bypass (ld.global.cg)
+        if cutlass.const_expr(fail_sleep_cycles > 0):
+            _nanosleep(fail_sleep_cycles, loc=loc, ip=ip)
+        current = cute.arch.load(ptr, ptr.dtype, sem="acquire", scope="gpu")
+    # Spin-path: condition was satisfied; uniformize return type with the
+    # peek path so callers always see a Boolean.
+    return Boolean(True)
+
+
+# =============================================================================
+# Cluster-DSMEM helpers (for atomic_counter dynamic scheduler)
+# =============================================================================
+#
+# Ported from cute_dsl_kernel_library/dsl_kernels/moe/moe_persistent_scheduler.py
+# (lines 79-145).  Used by the fused fc1+fc2 mega scheduler when
+# load_balance_mode == 'atomic_counter' to
+# implement the leader-CTA atom.add + DSMEM broadcast cluster-tile-idx
+# fetch protocol.  ``atom.add`` itself uses cute.arch.atomic_add (the
+# upstream cute_dsl wrapper) instead of a hand-rolled helper.
+
+
+@dsl_user_op
+def store_i32_to_peer_cluster_smem_async(
+    smem_ptr,
+    value: Int32,
+    mbar_ptr,
+    cta_rank_in_cluster,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Store one int32 to a peer CTA's SMEM via st.async.shared::cluster.
+
+    Uses ``mapa.shared::cluster`` to translate ``smem_ptr`` / ``mbar_ptr``
+    (this CTA's SMEM addresses) into the peer CTA's address space, then
+    issues ``st.async.shared::cluster.mbarrier::complete_tx::bytes.u32``
+    which both writes the int32 AND signals completion on the peer
+    mbarrier.  The peer mbarrier's expect_tx must be set up beforehand
+    (see ``mbarrier_arrive_expect_tx_on_peer``).
+    """
+    smem_addr = llvm.ptrtoint(T.i32(), smem_ptr.llvm_ptr, loc=loc, ip=ip)
+    mbar_addr = llvm.ptrtoint(T.i32(), mbar_ptr.llvm_ptr, loc=loc, ip=ip)
+    llvm.inline_asm(
+        res=None,
+        operands_=[
+            smem_addr,
+            value.ir_value(loc=loc, ip=ip),
+            mbar_addr,
+            Int32(cta_rank_in_cluster).ir_value(loc=loc, ip=ip),
+        ],
+        asm_string="""{{
+            .reg .u32 remote_addr;
+            .reg .u32 remote_mbar;
+            mapa.shared::cluster.u32 remote_addr, $0, $3;
+            mapa.shared::cluster.u32 remote_mbar, $2, $3;
+            st.async.shared::cluster.mbarrier::complete_tx::bytes.u32 [remote_addr], $1, [remote_mbar];
+        }}""",
+        constraints="r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def mbarrier_arrive_expect_tx_on_peer(
+    mbar_ptr,
+    tx_count: Int32,
+    cta_rank_in_cluster,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Set expect_tx on a peer CTA's mbarrier via inline PTX.
+
+    Pairs with ``store_i32_to_peer_cluster_smem_async``: this side
+    declares "I expect ``tx_count`` bytes via st.async on this peer
+    mbarrier"; the store side then completes the transaction.
+    """
+    mbar_addr = llvm.ptrtoint(T.i32(), mbar_ptr.llvm_ptr, loc=loc, ip=ip)
+    llvm.inline_asm(
+        res=None,
+        operands_=[
+            mbar_addr,
+            Int32(cta_rank_in_cluster).ir_value(loc=loc, ip=ip),
+            tx_count.ir_value(loc=loc, ip=ip),
+        ],
+        asm_string="""{{
+            .reg .u32 remote_mbar;
+            mapa.shared::cluster.u32 remote_mbar, $0, $1;
+            mbarrier.arrive.expect_tx.shared::cluster.b64 _, [remote_mbar], $2;
+        }}""",
+        constraints="r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def gmem_ptr_to_generic(
+    gmem_ptr: Pointer,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Pointer:
+    if gmem_ptr.memspace != AddressSpace.gmem:
+        raise ValueError(
+            f"gmem_ptr_to_generic requires pointer in gmem address space, "
+            f"got {gmem_ptr.memspace}"
+        )
+    # Get LLVM pointer and cast to generic address space
+    llvm_ptr = gmem_ptr.to_llvm_ptr(loc=loc, ip=ip)  # type: ignore[attr-defined]
+    generic_llvm_ptr = llvm.addrspacecast(
+        llvm.PointerType.get(AddressSpace.generic), llvm_ptr, loc=loc, ip=ip
+    )
+    # Create a new cute.Pointer with generic address space, preserving alignment
+    return cute.make_ptr(
+        gmem_ptr.dtype,
+        generic_llvm_ptr,
+        AddressSpace.generic,
+        assumed_align=gmem_ptr.alignment,  # type: ignore[attr-defined]
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def generic_ptr_to_gmem(
+    generic_ptr: Pointer,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Pointer:
+    if generic_ptr.memspace != AddressSpace.generic:
+        raise ValueError(
+            f"generic_ptr_to_gmem requires pointer in generic address space, "
+            f"got {generic_ptr.memspace}"
+        )
+    # Get LLVM pointer and cast to gmem address space
+    llvm_ptr = generic_ptr.to_llvm_ptr(loc=loc, ip=ip)  # type: ignore[attr-defined]
+    gmem_llvm_ptr = llvm.addrspacecast(
+        llvm.PointerType.get(AddressSpace.gmem), llvm_ptr, loc=loc, ip=ip
+    )
+    # Create a new cute.Pointer with gmem address space, preserving alignment
+    return cute.make_ptr(
+        generic_ptr.dtype,
+        gmem_llvm_ptr,
+        AddressSpace.gmem,
+        assumed_align=generic_ptr.alignment,  # type: ignore[attr-defined]
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def prefetch_tma_descriptor(
+    tma_desc_ptr: Pointer,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """
+    Prefetch a TMA descriptor from global memory.
+
+    This function prefetches the TMA descriptor pointed to by tma_desc_ptr
+    into the TMA descriptor cache. The pointer must be in generic or global
+    address space. If a gmem pointer is passed, it will be automatically
+    converted to generic address space.
+
+    :param tma_desc_ptr: Pointer to the TMA descriptor in global or generic memory
+    :type tma_desc_ptr: Pointer
+    :raises ValueError: If pointer is not in generic or global address space
+    """
+    if tma_desc_ptr.memspace not in (AddressSpace.gmem, AddressSpace.generic):
+        raise ValueError(
+            f"prefetch_tma_descriptor requires pointer in gmem or generic address space, "
+            f"got {tma_desc_ptr.memspace}"
+        )
+    # Convert gmem pointer to generic if needed
+    if tma_desc_ptr.memspace == AddressSpace.gmem:
+        tma_desc_ptr = gmem_ptr_to_generic(tma_desc_ptr, loc=loc, ip=ip)
+    # Convert cute.Pointer to LLVM pointer for prefetch
+    llvm_ptr = tma_desc_ptr.to_llvm_ptr(loc=loc, ip=ip)  # type: ignore[attr-defined]
+    nvvm_wrappers.prefetch(llvm_ptr, tensormap=True, loc=loc, ip=ip)
+
+
+def ptr_offset_bytes(ptr: Pointer, byte_offset: int) -> Pointer:
+    """Offset a pointer by a given number of bytes."""
+    element_offset = byte_offset * 8 // ptr.dtype.width
+    return ptr + element_offset
+
+
+@dsl_user_op
+def tensormap_ptr_for_copy(
+    raw_ptr: Pointer,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Pointer:
+    """
+    Convert a raw TMA descriptor gmem pointer to the type expected by cute.copy.
+
+    cute.copy requires the tma_desc_ptr to be in generic address space and
+    recast to TmaDescriptorTiledType. This utility performs both conversions.
+
+    :param raw_ptr: Raw pointer to TMA descriptor in gmem
+    :type raw_ptr: Pointer
+    :return: Pointer compatible with cute.copy's tma_desc_ptr parameter
+    :rtype: Pointer
+    """
+    generic_ptr = gmem_ptr_to_generic(raw_ptr, loc=loc, ip=ip)
+    tma_desc_ptr_ty = _cute_ir.PtrType.get(
+        _cute_nvgpu_ir.TmaDescriptorTiledType.get(),
+        generic_ptr.memspace,
+        generic_ptr.alignment,
+    )
+    return _cute_ir.recast_iter(tma_desc_ptr_ty, generic_ptr.value)
+
+
+# =============================================================================
+# MoE Utilities
+# =============================================================================
+
+
+@dsl_user_op
+@cute.jit
+def compute_expert_token_range(
+    offs: cute.Tensor,
+    expert_idx: Int32,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Tuple[Int32, Int32]:
+    """
+    Compute token offset and count for a given expert from the cumsum offs tensor.
+
+    :param offs: Cumulative sum tensor of token counts per expert, shape (experts,)
+    :param expert_idx: Index of the expert
+    :return: (token_offset, tokens_i) where token_offset is the start position
+             and tokens_i is the number of tokens for this expert
+    """
+    token_offset = Int32(0)
+    if expert_idx > Int32(0):
+        token_offset = offs[expert_idx - 1]  # type: ignore[assignment]
+    tokens_i = offs[expert_idx] - token_offset
+    return token_offset, tokens_i
+
+
+@dsl_user_op
+@cute.jit
+def compute_expert_token_count_from_sizes(
+    sizes: cute.Tensor,
+    expert_idx: Int32,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> Int32:
+    """
+    Read per-expert token count from a raw sizes tensor.
+
+    This is the sizes-mode counterpart of ``compute_expert_token_range``: it
+    returns *only* the count for ``expert_idx``; the cumulative token offset
+    is the caller's responsibility (typically maintained as a running cumul in
+    scheduler register state, updated when ``expert_idx`` advances).  Used by
+    the MegaMoE-fused fc12 scheduler when sizes are exposed as a direct view
+    of ``expert_recv_count_sum`` (e.g. via ``i32 stride=(2,)`` over an i64
+    tensor) and no cumulative sum kernel was run on the host.
+    """
+    return sizes[expert_idx]
+
+
+@dsl_user_op
+def rewrite_tensor_shape(
+    tensor: cute.Tensor,
+    new_shape: Tuple,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> cute.Tensor:
+    """
+    Rewrite tensor shape while keeping the same stride and iterator.
+
+    This is primarily for debug friendliness - shows the actual expert's shape
+    instead of the fake global shape. No runtime overhead as it becomes
+    dead code in non-debug builds.
+
+    :param tensor: Source tensor whose stride and iterator to preserve
+    :param new_shape: New shape to apply
+    :return: New tensor with the given shape but original stride and iterator
+    """
+    new_layout = cute.make_layout(new_shape, stride=tensor.stride, loc=loc, ip=ip)
+    return cute.make_tensor(tensor.iterator, new_layout, loc=loc, ip=ip)
+
+
+# =============================================================================
+# TMA Descriptor Workspace Helper
+# =============================================================================
+
+
+class TensormapWorkspace:
+    """
+    Helper for linear workspace layout of TMA descriptors.
+
+    Manages address calculation for a workspace buffer containing TMA descriptors
+    organized as: for each executor (e.g., expert or group), a fixed set of
+    named descriptor slots.
+
+    Layout: [slot_0_exec_0, slot_1_exec_0, ..., slot_0_exec_1, slot_1_exec_1, ...]
+
+    Example:
+        # 2Dx3D MoE: only C is expert-wise
+        workspace = TensormapWorkspace(workspace_ptr, ["c"])
+
+        # 2Dx2D MoE: A and B are expert-wise
+        workspace = TensormapWorkspace(workspace_ptr, ["a", "b"])
+
+        # General grouped GEMM: all three tensors
+        workspace = TensormapWorkspace(workspace_ptr, ["a", "b", "c"])
+    """
+
+    def __init__(self, workspace_ptr: Pointer, slot_names: list):
+        """
+        :param workspace_ptr: Pointer to the beginning of the workspace buffer
+        :param slot_names: Ordered list of tensor names, defining the slot layout
+                           per executor. e.g., ["a", "b", "c"]
+        """
+        self.workspace_ptr = workspace_ptr
+        self._name_to_slot = {name: i for i, name in enumerate(slot_names)}
+        self._slots_per_executor = len(slot_names)
+
+    @cute.jit
+    def get_ptr(self, tensor_name: str, executor_idx: Int32) -> Pointer:
+        """
+        Get the workspace pointer for a specific TMA descriptor.
+
+        :param tensor_name: Name of the tensor (must be one of the slot_names)
+        :param executor_idx: Index of the executor (e.g., group_idx or expert_idx)
+        :return: Aligned pointer to the TMA descriptor in workspace
+        """
+        if cutlass.const_expr(tensor_name not in self._name_to_slot):
+            raise ValueError(
+                f"Invalid tensor_name '{tensor_name}', "
+                f"expected one of {list(self._name_to_slot.keys())}"
+            )
+        slot = self._name_to_slot[tensor_name]
+        byte_offset = (
+            executor_idx * self._slots_per_executor + slot
+        ) * TensormapDescBytes
+        return ptr_offset_bytes(self.workspace_ptr, byte_offset).align(
+            TensormapDescBytes
+        )
+
+    @staticmethod
+    def size_bytes(num_slots: int, num_executors: int) -> int:
+        """
+        Calculate workspace size in bytes.
+
+        :param num_slots: Number of descriptor slots per executor
+        :param num_executors: Total number of executors (e.g., expert_cnt or group_cnt)
+        :return: Total workspace size in bytes
+        """
+        return num_slots * num_executors * TensormapDescBytes
+
+
+# =============================================================================
+# Online TMA Descriptor Creator (Abstract Base Class)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class OnlineTensormapDescCreator(ABC):
+    """
+    Abstract base class for building TMA descriptors online (at kernel runtime).
+
+    Subclasses store all needed parameters (both codegen-time configs and runtime
+    values) as explicit instance attributes in __init__. No dict-based APIs.
+
+    Subclasses must implement exactly 2 abstract methods:
+    - construct_and_write: Build TMA descriptor(s) for one executor and write to workspace
+    - get_desc_ptr: Return raw gmem pointer to a specific descriptor in workspace
+
+    To convert the raw pointer for use with cute.copy, callers should use the
+    standalone tensormap_ptr_for_copy() utility.
+    """
+
+    @abstractmethod
+    def construct_and_write(self, executor_idx: Int32, dependency: Any = None) -> None:
+        """
+        Build TMA descriptor(s) for one executor and write to workspace.
+
+        :param executor_idx: Index of the executor (e.g., group_idx or expert_idx).
+            Semantics may vary by subclass when ``dependency`` is provided.
+        :param dependency: Optional pipeline consumer for inter-warp-group
+            synchronization. When provided, the subclass decides when to wait
+            (via ``dependency.wait_and_advance()``) and release. The subclass
+            also decides how to interpret ``executor_idx`` in this mode.
+        """
+        ...
+
+    @abstractmethod
+    def get_desc_ptr(self, tensor_name: str, executor_idx: Int32) -> Pointer:
+        """
+        Get the raw gmem pointer to a specific TMA descriptor in workspace.
+
+        :param tensor_name: Name identifying which tensor's descriptor
+        :param executor_idx: Index of the executor (e.g., group_idx or expert_idx)
+        :return: Raw pointer (gmem) to the TMA descriptor
+        """
+        ...
+
+
+# {$nv-internal-release begin}
+
+# Internal example to show the general grouped gemm online desc construction.
+# =============================================================================
+# General Grouped GEMM TMA Descriptor Constructor
+# =============================================================================
+
+
+class GeneralGroupedGemmTensormapConstructor(OnlineTensormapDescCreator):
+    """
+    TMA descriptor constructor for general Grouped GEMM with pre-initialized descriptors.
+
+    This class creates TMA descriptors for A, B, C tensors and writes them
+    to a workspace buffer. Each group has its own set of descriptors.
+
+    Uses cute.nvgpu.make_tiled_tma_atom_A/B for A and B tensors to ensure
+    correct MMA projections.
+
+    All parameters are stored as explicit instance attributes (no dicts).
+
+    Workspace layout per group: [A(64B), B(64B), C(64B)]
+
+    :param a_dtype: Data type for tensor A
+    :param b_dtype: Data type for tensor B
+    :param c_dtype: Data type for tensor C
+    :param a_smem_layout: SMEM layout for A TMA
+    :param b_smem_layout: SMEM layout for B TMA
+    :param epi_smem_layout: SMEM layout for epilogue (C) TMA
+    :param a_tma_op: TMA operation for A (G2S or G2S multicast)
+    :param b_tma_op: TMA operation for B (G2S or G2S multicast)
+    :param tiled_mma: TiledMma for correct MMA projections
+    :param mma_tiler: MMA tiler shape (M, N, K)
+    :param cluster_layout_vmnk_shape: Cluster layout shape for multicast
+    :param epi_tile: Epilogue tile shape
+    :param ptrs_abc: Tensor[num_groups, 3] (i64) - pointers to A, B, C
+    :param problem_sizes_mnkl: Tensor[num_groups, 4] (i32) - M, N, K, L per group
+    :param strides_abc: Tensor[num_groups, 3, 2] (i32) - strides for A, B, C
+    :param group_cnt: Number of groups
+    :param workspace_ptr: Pointer to workspace for TMA descriptors
+    """
+
+    def __init__(
+        self,
+        # Codegen-time configs
+        a_dtype: Type[Numeric],
+        b_dtype: Type[Numeric],
+        c_dtype: Type[Numeric],
+        a_smem_layout: cute.Layout,
+        b_smem_layout: cute.Layout,
+        epi_smem_layout: cute.Layout,
+        a_tma_op: cute.CopyAtom,
+        b_tma_op: cute.CopyAtom,
+        tiled_mma: cute.TiledMma,
+        mma_tiler: cute.Tile,
+        cluster_layout_vmnk_shape: cute.Layout,
+        epi_tile: cute.Tile,
+        # Runtime params
+        ptrs_abc: cute.Tensor,
+        problem_sizes_mnkl: cute.Tensor,
+        strides_abc: cute.Tensor,
+        group_cnt: Int32,
+        workspace_ptr: Pointer,
+    ) -> None:
+        super().__init__()
+        # Codegen-time configs
+        self.a_dtype = a_dtype
+        self.b_dtype = b_dtype
+        self.c_dtype = c_dtype
+        self.a_smem_layout = a_smem_layout
+        self.b_smem_layout = b_smem_layout
+        self.epi_smem_layout = epi_smem_layout
+        self.a_tma_op = a_tma_op
+        self.b_tma_op = b_tma_op
+        self.tiled_mma = tiled_mma
+        self.mma_tiler = mma_tiler
+        self.cluster_layout_vmnk_shape = cluster_layout_vmnk_shape
+        self.epi_tile = epi_tile
+        # Runtime params
+        self.ptrs_abc = ptrs_abc
+        self.problem_sizes_mnkl = problem_sizes_mnkl
+        self.strides_abc = strides_abc
+        self.group_cnt = group_cnt
+        self.workspace = TensormapWorkspace(workspace_ptr, ["a", "b", "c"])
+
+    @cute.jit
+    def get_desc_ptr(self, tensor_name: str, executor_idx: Int32) -> Pointer:
+        return self.workspace.get_ptr(tensor_name, executor_idx)
+
+    @cute.jit
+    def construct_and_write(self, executor_idx: Int32, dependency: Any = None) -> None:
+        """
+        Build TMA descriptors for A, B, C of one group and write to workspace.
+        """
+        group_idx = executor_idx
+
+        if group_idx < self.group_cnt:
+            # Read pointers
+            ptr_a = self.ptrs_abc[group_idx, 0]
+            ptr_b = self.ptrs_abc[group_idx, 1]
+            ptr_c = self.ptrs_abc[group_idx, 2]
+
+            # Read problem sizes
+            M = self.problem_sizes_mnkl[group_idx, 0]
+            N = self.problem_sizes_mnkl[group_idx, 1]
+            K = self.problem_sizes_mnkl[group_idx, 2]
+
+            # Read strides
+            stride_a_0 = self.strides_abc[group_idx, 0, 0]
+            stride_a_1 = self.strides_abc[group_idx, 0, 1]
+            stride_b_0 = self.strides_abc[group_idx, 1, 0]
+            stride_b_1 = self.strides_abc[group_idx, 1, 1]
+            stride_c_0 = self.strides_abc[group_idx, 2, 0]
+            stride_c_1 = self.strides_abc[group_idx, 2, 1]
+
+            # Construct tensors with shape (mode0, mode1, L=1)
+            c1 = cutlass.Int32(1)
+            c0 = cutlass.Int32(0)
+
+            # Tensor A: (M, K, 1)
+            a_ptr = cute.make_ptr(self.a_dtype, ptr_a, AddressSpace.gmem)
+            a_layout = cute.make_layout((M, K, c1), stride=(stride_a_0, stride_a_1, c0))
+            a_tensor = cute.make_tensor(a_ptr, a_layout)
+
+            # Tensor B: (N, K, 1)
+            b_ptr = cute.make_ptr(self.b_dtype, ptr_b, AddressSpace.gmem)
+            b_layout = cute.make_layout((N, K, c1), stride=(stride_b_0, stride_b_1, c0))
+            b_tensor = cute.make_tensor(b_ptr, b_layout)
+
+            # Tensor C: (M, N, 1)
+            c_ptr = cute.make_ptr(self.c_dtype, ptr_c, AddressSpace.gmem)
+            c_layout = cute.make_layout((M, N, c1), stride=(stride_c_0, stride_c_1, c0))
+            c_tensor = cute.make_tensor(c_ptr, c_layout)
+
+            # Create TMA atom for A using make_tiled_tma_atom_A
+            tma_atom_a, _ = cute.nvgpu.make_tiled_tma_atom_A(
+                self.a_tma_op,
+                a_tensor,
+                self.a_smem_layout,
+                self.mma_tiler,
+                self.tiled_mma,
+                self.cluster_layout_vmnk_shape,
+            )
+            cpasync.copy_tensormap(tma_atom_a, self.get_desc_ptr("a", group_idx))
+
+            # Create TMA atom for B using make_tiled_tma_atom_B
+            tma_atom_b, _ = cute.nvgpu.make_tiled_tma_atom_B(
+                self.b_tma_op,
+                b_tensor,
+                self.b_smem_layout,
+                self.mma_tiler,
+                self.tiled_mma,
+                self.cluster_layout_vmnk_shape,
+            )
+            cpasync.copy_tensormap(tma_atom_b, self.get_desc_ptr("b", group_idx))
+
+            # Create TMA atom for C (S2G) using generic make_tiled_tma_atom
+            tma_atom_c, _ = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                c_tensor,
+                self.epi_smem_layout,
+                self.epi_tile,
+            )
+            cpasync.copy_tensormap(tma_atom_c, self.get_desc_ptr("c", group_idx))
+
+
+# {$nv-internal-release end}
+
+# =============================================================================
+# MoE Grouped GEMM Tensormap Constructor
+# =============================================================================
+
+
+class MoEGroupedGemmTensormapConstructor(OnlineTensormapDescCreator):
+    """
+    Tensormap descriptor constructor for MoE Grouped GEMM (expert-wise descriptors only).
+
+    Non-expert-wise descriptors are passed directly at kernel launch.
+    This class only handles:
+    - 2Dx3D: C descriptors (expert-wise, to avoid write conflicts)
+    - 2Dx2D: A and B descriptors (expert-wise, tokens is reduction axis)
+
+    All parameters are stored as explicit instance attributes (no dicts).
+
+    Workspace layout:
+    - 2Dx3D: [C_0, C_1, ..., C_{n-1}]
+    - 2Dx2D: [A_0, A_1, ..., A_{n-1}, B_0, B_1, ..., B_{n-1}]
+    """
+
+    def __init__(
+        self,
+        scenario: Literal["2Dx3D", "2Dx2D"],
+        # Codegen-time configs
+        a_dtype: Type[Numeric],
+        b_dtype: Type[Numeric],
+        c_dtype: Type[Numeric],
+        a_smem_layout: cute.Layout,
+        b_smem_layout: cute.Layout,
+        epi_smem_layout: cute.Layout,
+        a_tma_op: cute.CopyAtom,
+        b_tma_op: cute.CopyAtom,
+        c_tma_op: cute.CopyAtom,
+        tiled_mma: cute.TiledMma,
+        mma_tiler: cute.Tile,
+        cluster_layout_vmnk_shape: cute.Layout,
+        epi_tile: cute.Tile,
+        # Runtime params
+        a_tensor: cute.Tensor,  # fake GEMM domain A
+        b_tensor: cute.Tensor,  # fake GEMM domain B
+        c_tensor: cute.Tensor,  # fake GEMM domain C
+        offs: cute.Tensor,  # (experts,) cumsum
+        workspace_ptr: Pointer,
+    ) -> None:
+        super().__init__()
+        self.scenario = scenario
+        # Codegen-time configs
+        self.a_dtype = a_dtype
+        self.b_dtype = b_dtype
+        self.c_dtype = c_dtype
+        self.a_smem_layout = a_smem_layout
+        self.b_smem_layout = b_smem_layout
+        self.epi_smem_layout = epi_smem_layout
+        self.a_tma_op = a_tma_op
+        self.b_tma_op = b_tma_op
+        self.c_tma_op = c_tma_op
+        self.tiled_mma = tiled_mma
+        self.mma_tiler = mma_tiler
+        self.cluster_layout_vmnk_shape = cluster_layout_vmnk_shape
+        self.epi_tile = epi_tile
+        # Runtime params
+        self.a_tensor = a_tensor
+        self.b_tensor = b_tensor
+        self.c_tensor = c_tensor
+        self.offs = offs
+        # Workspace with scenario-specific slot layout
+        if scenario == "2Dx3D":
+            self.workspace = TensormapWorkspace(workspace_ptr, ["c"])
+        else:
+            self.workspace = TensormapWorkspace(workspace_ptr, ["a", "b"])
+
+    @staticmethod
+    def get_workspace_size(scenario: Literal["2Dx3D", "2Dx2D"], expert_cnt: int) -> int:
+        """Calculate workspace size in bytes for tensormap descriptors."""
+        if scenario == "2Dx3D":
+            return TensormapWorkspace.size_bytes(1, expert_cnt)  # only C
+        else:
+            return TensormapWorkspace.size_bytes(2, expert_cnt)  # A and B
+
+    @cute.jit
+    def get_desc_ptr(self, tensor_name: str, executor_idx: Int32) -> Pointer:
+        return self.workspace.get_ptr(tensor_name, executor_idx)
+
+    @cute.jit
+    def construct_and_write(self, executor_idx: Int32, dependency: Any = None) -> None:
+        """
+        Create expert-wise tensormap descriptors for the given expert.
+
+        - 2Dx3D: Creates C descriptor for this expert
+        - 2Dx2D: Creates A and B descriptors for this expert
+        """
+        if cutlass.const_expr(self.scenario == "2Dx3D"):
+            self._construct_c_desc_2dx3d(executor_idx)
+        else:  # 2Dx2D
+            self._construct_ab_descs_2dx2d(executor_idx)
+
+    @cute.jit
+    def _construct_c_desc_2dx3d(self, expert_idx: Int32) -> None:
+        """
+        2Dx3D: Create expert-wise C descriptor.
+        C tensor: (fake_m, n, 1) = (tokens_sum, intermediate, 1)
+        Slice fake_m -> (tokens_i, intermediate, 1) per expert.
+        """
+        token_offset, tokens_i = compute_expert_token_range(self.offs, expert_idx)
+
+        c_ptr = self.c_tensor.iterator
+        c_stride = self.c_tensor.stride
+        intermediate = self.c_tensor.shape[1]  # type: ignore[index]
+
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int32(0)
+
+        c_ptr_i = c_ptr + token_offset * c_stride[0]  # type: ignore[index]
+        c_layout_i = cute.make_layout(
+            (tokens_i, intermediate, c1),
+            stride=(c_stride[0], c_stride[1], c0),  # type: ignore[index]
+        )
+        c_tensor_i = cute.make_tensor(c_ptr_i, c_layout_i)
+
+        tma_atom_c, _ = cpasync.make_tiled_tma_atom(
+            self.c_tma_op,
+            c_tensor_i,
+            self.epi_smem_layout,
+            self.epi_tile,
+        )
+        cpasync.copy_tensormap(tma_atom_c, self.get_desc_ptr("c", expert_idx))
+
+    @cute.jit
+    def _construct_ab_descs_2dx2d(self, expert_idx: Int32) -> None:
+        """
+        2Dx2D: Create expert-wise A and B descriptors.
+        A: (m, fake_k, 1) -> slice to (m, tokens_i, 1)
+        B: (n, fake_k, 1) -> slice to (n, tokens_i, 1)
+        """
+        token_offset, tokens_i = compute_expert_token_range(self.offs, expert_idx)
+
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int32(0)
+
+        # A tensor: (m, fake_k, 1) -> (m, tokens_i, 1)
+        a_ptr = self.a_tensor.iterator
+        a_stride = self.a_tensor.stride
+        a_m = self.a_tensor.shape[0]  # type: ignore[index]
+
+        a_ptr_i = a_ptr + token_offset * a_stride[1]  # type: ignore[index]
+        a_layout_i = cute.make_layout(
+            (a_m, tokens_i, c1),
+            stride=(a_stride[0], a_stride[1], c0),  # type: ignore[index]
+        )
+        a_tensor_i = cute.make_tensor(a_ptr_i, a_layout_i)
+
+        tma_atom_a, _ = cute.nvgpu.make_tiled_tma_atom_A(
+            self.a_tma_op,
+            a_tensor_i,
+            self.a_smem_layout,
+            self.mma_tiler,
+            self.tiled_mma,
+            self.cluster_layout_vmnk_shape,
+        )
+        cpasync.copy_tensormap(tma_atom_a, self.get_desc_ptr("a", expert_idx))
+
+        # B tensor: (n, fake_k, 1) -> (n, tokens_i, 1)
+        b_ptr = self.b_tensor.iterator
+        b_stride = self.b_tensor.stride
+        b_n = self.b_tensor.shape[0]  # type: ignore[index]
+
+        b_ptr_i = b_ptr + token_offset * b_stride[1]  # type: ignore[index]
+        b_layout_i = cute.make_layout(
+            (b_n, tokens_i, c1),
+            stride=(b_stride[0], b_stride[1], c0),  # type: ignore[index]
+        )
+        b_tensor_i = cute.make_tensor(b_ptr_i, b_layout_i)
+
+        tma_atom_b, _ = cute.nvgpu.make_tiled_tma_atom_B(
+            self.b_tma_op,
+            b_tensor_i,
+            self.b_smem_layout,
+            self.mma_tiler,
+            self.tiled_mma,
+            self.cluster_layout_vmnk_shape,
+        )
+        cpasync.copy_tensormap(tma_atom_b, self.get_desc_ptr("b", expert_idx))
+
+
+# =============================================================================
+# MoE Scaled Grouped GEMM Tensormap Constructor
+# =============================================================================
+
+
+class MoEScaledGroupedGemmTensormapConstructor(OnlineTensormapDescCreator):
+    """
+    Tensormap descriptor constructor for MoE Scaled Grouped GEMM (block-scaled).
+
+    .. py:attribute:: ChunkSize
+        :value: 128
+
+        Number of experts processed per chunk in the desc_init_kernel.
+        Must match the warp-group width (4 warps × 32 threads).
+
+    Extends MoEGroupedGemmTensormapConstructor with SFA/SFB descriptor support.
+
+    Expert-wise descriptors only — non-expert-wise descriptors are passed
+    directly at kernel launch.
+
+    Workspace layout:
+    - 2Dx3D: [C_0, C_1, ..., C_{n-1}]  (1 slot per expert)
+    - 2Dx2D: [A_0, B_0, SFA_0, SFB_0, A_1, B_1, SFA_1, SFB_1, ...]  (4 slots per expert)
+
+    :param scenario: "2Dx3D" or "2Dx2D"
+    :param sf_vec_size: Scale factor vector size (32 for MXFP8/MXFP4, 16 for NVFP4)
+    :param a_dtype: Data type for tensor A
+    :param b_dtype: Data type for tensor B
+    :param c_dtype: Data type for tensor C
+    :param sf_dtype: Data type for scale factors (SFA/SFB)
+    :param a_smem_layout: SMEM layout for A TMA
+    :param b_smem_layout: SMEM layout for B TMA
+    :param epi_smem_layout: SMEM layout for epilogue (C) TMA
+    :param sfa_smem_layout: SMEM layout for SFA TMA
+    :param sfb_smem_layout: SMEM layout for SFB TMA
+    :param a_tma_op: TMA operation for A
+    :param b_tma_op: TMA operation for B
+    :param c_tma_op: TMA operation for C (S2G store or reduce)
+    :param sfa_tma_op: TMA operation for SFA
+    :param sfb_tma_op: TMA operation for SFB
+    :param tiled_mma: TiledMma for A/B/SFA/C TMA atom construction
+    :param tiled_mma_sfb: TiledMma for SFB (separate due to 2CTA replication)
+    :param mma_tiler: MMA tiler shape (M, N, K)
+    :param mma_tiler_sfb: MMA tiler shape for SFB
+    :param cluster_layout_vmnk_shape: Cluster layout shape for A/B/SFA multicast
+    :param cluster_layout_sfb_vmnk_shape: Cluster layout shape for SFB multicast
+    :param epi_tile: Epilogue tile shape
+    :param a_tensor: Fake GEMM domain A tensor
+    :param b_tensor: Fake GEMM domain B tensor
+    :param c_tensor: Fake GEMM domain C tensor
+    :param sfa_tensor: Fake GEMM domain SFA tensor (atom-tiled layout)
+    :param sfb_tensor: Fake GEMM domain SFB tensor (atom-tiled layout)
+    :param offs: (experts,) cumsum offsets in data domain
+    :param offs_padded: (experts,) cumsum offsets in padded scale domain
+    :param workspace_ptr: Pointer to workspace for TMA descriptors
+    :param expert_cnt: Total number of experts
+    """
+
+    ChunkSize = 128
+
+    def __init__(
+        self,
+        scenario: Literal["2Dx3D", "2Dx2D"],
+        sf_vec_size: int,
+        # Codegen-time configs: dtypes
+        a_dtype: Type[Numeric],
+        b_dtype: Type[Numeric],
+        c_dtype: Type[Numeric],
+        sf_dtype: Type[Numeric],
+        # Codegen-time configs: SMEM layouts
+        a_smem_layout: cute.Layout,
+        b_smem_layout: cute.Layout,
+        epi_smem_layout: cute.Layout,
+        sfa_smem_layout: cute.Layout,
+        sfb_smem_layout: cute.Layout,
+        # Codegen-time configs: TMA ops
+        a_tma_op: cute.CopyAtom,
+        b_tma_op: cute.CopyAtom,
+        c_tma_op: cute.CopyAtom,
+        sfa_tma_op: cute.CopyAtom,
+        sfb_tma_op: cute.CopyAtom,
+        # Codegen-time configs: MMA / cluster / tile
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        mma_tiler: cute.Tile,
+        mma_tiler_sfb: cute.Tile,
+        cluster_layout_vmnk_shape: cute.Layout,
+        cluster_layout_sfb_vmnk_shape: cute.Layout,
+        epi_tile: cute.Tile,
+        # Runtime params
+        a_tensor: cute.Tensor,
+        b_tensor: cute.Tensor,
+        c_tensor: cute.Tensor,
+        sfa_tensor: cute.Tensor,
+        sfb_tensor: cute.Tensor,
+        offs: cute.Tensor,
+        offs_padded: cute.Tensor,
+        workspace_ptr: Pointer,
+        expert_cnt: Optional[Union[Int32, int]] = None,
+    ) -> None:
+        super().__init__()
+        self.scenario = scenario
+        self.sf_vec_size = sf_vec_size
+        # Dtypes
+        self.a_dtype = a_dtype
+        self.b_dtype = b_dtype
+        self.c_dtype = c_dtype
+        self.sf_dtype = sf_dtype
+        # SMEM layouts
+        self.a_smem_layout = a_smem_layout
+        self.b_smem_layout = b_smem_layout
+        self.epi_smem_layout = epi_smem_layout
+        self.sfa_smem_layout = sfa_smem_layout
+        self.sfb_smem_layout = sfb_smem_layout
+        # TMA ops
+        self.a_tma_op = a_tma_op
+        self.b_tma_op = b_tma_op
+        self.c_tma_op = c_tma_op
+        self.sfa_tma_op = sfa_tma_op
+        self.sfb_tma_op = sfb_tma_op
+        # MMA / cluster / tile
+        self.tiled_mma = tiled_mma
+        self.tiled_mma_sfb = tiled_mma_sfb
+        self.mma_tiler = mma_tiler
+        self.mma_tiler_sfb = mma_tiler_sfb
+        self.cluster_layout_vmnk_shape = cluster_layout_vmnk_shape
+        self.cluster_layout_sfb_vmnk_shape = cluster_layout_sfb_vmnk_shape
+        self.epi_tile = epi_tile
+        # Runtime params
+        self.a_tensor = a_tensor
+        self.b_tensor = b_tensor
+        self.c_tensor = c_tensor
+        self.sfa_tensor = sfa_tensor
+        self.sfb_tensor = sfb_tensor
+        self.offs = offs
+        self.offs_padded = offs_padded
+        self.expert_cnt = expert_cnt
+        # Workspace with scenario-specific slot layout
+        if scenario == "2Dx3D":
+            self.workspace = TensormapWorkspace(workspace_ptr, ["c"])
+        else:
+            self.workspace = TensormapWorkspace(workspace_ptr, ["a", "b", "sfa", "sfb"])
+
+    @staticmethod
+    def get_workspace_size(scenario: Literal["2Dx3D", "2Dx2D"], expert_cnt: int) -> int:
+        """Calculate workspace size in bytes for tensormap descriptors."""
+        if scenario == "2Dx3D":
+            return TensormapWorkspace.size_bytes(1, expert_cnt)  # C only
+        else:
+            return TensormapWorkspace.size_bytes(4, expert_cnt)  # A, B, SFA, SFB
+
+    @cute.jit
+    def get_desc_ptr(self, tensor_name: str, executor_idx: Int32) -> Pointer:
+        return self.workspace.get_ptr(tensor_name, executor_idx)
+
+    @cute.jit
+    def construct_and_write(self, lane_in_group: Int32, dependency: Any = None) -> None:
+        """Create expert-wise tensormap descriptors for all experts."""
+        consumer, smem_offs_padded = dependency
+        assert self.expert_cnt is not None
+        num_chunks = (self.expert_cnt + self.ChunkSize - 1) // self.ChunkSize
+
+        chunk_idx = cutlass.Int32(0)
+        while chunk_idx < num_chunks:
+            expert_idx = chunk_idx * self.ChunkSize + lane_in_group
+            in_bounds = expert_idx < self.expert_cnt
+
+            # Phase 1: descriptors independent of offs_padded.
+            if in_bounds:
+                if cutlass.const_expr(self.scenario == "2Dx2D"):
+                    self._construct_ab_descs_2dx2d(expert_idx)
+                else:
+                    self._construct_c_desc_2dx3d(expert_idx)
+
+            # All threads participate in barrier (fixed arrive count)
+            handle = consumer.wait_and_advance()
+
+            # Phase 2: SF descriptors read padded offsets from SMEM.
+            if in_bounds:
+                if cutlass.const_expr(self.scenario == "2Dx2D"):
+                    # smem_offs_padded layout: [carry, chunk[0], ..., chunk[127]]
+                    # padded_offset = smem[lane]     (prev expert's cumulative)
+                    # padded_end    = smem[lane + 1] (this expert's cumulative)
+                    padded_offset = smem_offs_padded[lane_in_group]
+                    padded_size_i = smem_offs_padded[lane_in_group + 1] - padded_offset
+                    self._construct_sf_descs_2dx2d_direct(
+                        expert_idx, padded_offset, padded_size_i
+                    )
+
+            # All threads release (fixed arrive count)
+            handle.release()
+
+            chunk_idx += 1
+
+    # -----------------------------------------------------------------
+    # 2Dx3D: C descriptor (same as MoEGroupedGemmTensormapConstructor)
+    # -----------------------------------------------------------------
+
+    @cute.jit
+    def _construct_c_desc_2dx3d(self, expert_idx: Int32) -> None:
+        """
+        2Dx3D: Create expert-wise C descriptor.
+        C: (fake_m, n, 1) -> slice to (tokens_i, n, 1) per expert.
+        """
+        token_offset, tokens_i = compute_expert_token_range(self.offs, expert_idx)
+        c1 = cutlass.Int32(1)
+
+        c_i = cute.domain_offset((token_offset, 0, 0), self.c_tensor)
+        c_i = rewrite_tensor_shape(c_i, (tokens_i, self.c_tensor.shape[1], c1))  # type: ignore[index]
+
+        tma_atom_c, _ = cpasync.make_tiled_tma_atom(
+            self.c_tma_op,
+            c_i,
+            self.epi_smem_layout,
+            self.epi_tile,
+        )
+        cpasync.copy_tensormap(tma_atom_c, self.get_desc_ptr("c", expert_idx))
+
+    # -----------------------------------------------------------------
+    # 2Dx2D: A, B descriptors (same as MoEGroupedGemmTensormapConstructor)
+    # -----------------------------------------------------------------
+
+    @cute.jit
+    def _construct_ab_descs_2dx2d(self, expert_idx: Int32) -> None:
+        """
+        2Dx2D: Create expert-wise A and B descriptors.
+        A: (m, fake_k, 1) -> slice to (m, tokens_i, 1)
+        B: (n, fake_k, 1) -> slice to (n, tokens_i, 1)
+        """
+        token_offset, tokens_i = compute_expert_token_range(self.offs, expert_idx)
+        c1 = cutlass.Int32(1)
+
+        # A: (m, fake_k, 1) -> domain_offset + rewrite shape
+        a_i = cute.domain_offset((0, token_offset, 0), self.a_tensor)
+        a_i = rewrite_tensor_shape(a_i, (self.a_tensor.shape[0], tokens_i, c1))  # type: ignore[index]
+
+        tma_atom_a, _ = cute.nvgpu.make_tiled_tma_atom_A(
+            self.a_tma_op,
+            a_i,
+            self.a_smem_layout,
+            self.mma_tiler,
+            self.tiled_mma,
+            self.cluster_layout_vmnk_shape,
+        )
+        cpasync.copy_tensormap(tma_atom_a, self.get_desc_ptr("a", expert_idx))
+
+        # B: (n, fake_k, 1) -> domain_offset + rewrite shape
+        b_i = cute.domain_offset((0, token_offset, 0), self.b_tensor)
+        b_i = rewrite_tensor_shape(b_i, (self.b_tensor.shape[0], tokens_i, c1))  # type: ignore[index]
+
+        tma_atom_b, _ = cute.nvgpu.make_tiled_tma_atom_B(
+            self.b_tma_op,
+            b_i,
+            self.b_smem_layout,
+            self.mma_tiler,
+            self.tiled_mma,
+            self.cluster_layout_vmnk_shape,
+        )
+        cpasync.copy_tensormap(tma_atom_b, self.get_desc_ptr("b", expert_idx))
+
+    # -----------------------------------------------------------------
+    # 2Dx2D: SFA, SFB descriptors (new for block-scaled)
+    # -----------------------------------------------------------------
+
+    @cute.jit
+    def _construct_sf_descs_2dx2d_direct(
+        self,
+        expert_idx: Int32,
+        padded_offset: Int32,
+        padded_size_i: Int32,
+    ) -> None:
+        """
+        2Dx2D: Create expert-wise SFA and SFB descriptors with pre-computed
+        padded offset and size.
+
+        This variant allows the caller to supply padded offsets from SMEM
+        (in desc_init_kernel) instead of reading from ``self.offs_padded`` in GMEM.
+        """
+        c1 = cutlass.Int32(1)
+
+        a_chunks_to_move = (
+            padded_offset
+            // self.sf_vec_size
+            * cute.size(self.sfa_tensor, mode=[0])
+            // 128
+        )
+        a_elems_to_move = (
+            cute.size(self.sfa_tensor, mode=[0]) * padded_offset // self.sf_vec_size
+        )
+        b_chunks_to_move = (
+            padded_offset
+            // self.sf_vec_size
+            * cute.size(self.sfb_tensor, mode=[0])
+            // 128
+        )
+        b_elems_to_move = (
+            cute.size(self.sfb_tensor, mode=[0]) * padded_offset // self.sf_vec_size
+        )
+
+        per_expert_sfa_shape = (self.sfa_tensor.shape[0], padded_size_i, c1)  # type: ignore[index]
+        sfa_layout_i = tile_atom_to_shape_SF(per_expert_sfa_shape, self.sf_vec_size)
+        sfa_i = cute.make_tensor(
+            self.sfa_tensor.iterator + a_elems_to_move, sfa_layout_i
+        )
+
+        tma_atom_sfa, _ = cute.nvgpu.make_tiled_tma_atom_A(
+            self.sfa_tma_op,
+            sfa_i,
+            self.sfa_smem_layout,
+            self.mma_tiler,
+            self.tiled_mma,
+            self.cluster_layout_vmnk_shape,
+            internal_type=cutlass.Uint64,
+        )
+        cpasync.copy_tensormap(tma_atom_sfa, self.get_desc_ptr("sfa", expert_idx))
+
+        per_expert_sfb_shape = (self.sfb_tensor.shape[0], padded_size_i, c1)  # type: ignore[index]
+        sfb_layout_i = tile_atom_to_shape_SF(per_expert_sfb_shape, self.sf_vec_size)
+        sfb_i = cute.make_tensor(
+            self.sfb_tensor.iterator + b_elems_to_move, sfb_layout_i
+        )
+
+        tma_atom_sfb, _ = cute.nvgpu.make_tiled_tma_atom_B(
+            self.sfb_tma_op,
+            sfb_i,
+            self.sfb_smem_layout,
+            self.mma_tiler_sfb,
+            self.tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk_shape,
+            internal_type=cutlass.Uint64,
+        )
+        cpasync.copy_tensormap(tma_atom_sfb, self.get_desc_ptr("sfb", expert_idx))

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/run_functional_tests.sh
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/run_functional_tests.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Functional test harness for the local fused fc1+fc2 MoE NVFP4 swap-AB runner.
+# It resolves runner_fc12.py relative to this script, so CWD is irrelevant.
+#
+# Coverage dimensions mixed across the list below:
+#   static/dynamic expert shapes, static/atomic_counter scheduling, 1CTA/2CTA,
+#   cluster_m, balanced/dirichlet routing, partial-K/SF-padding boundaries, and
+#   the fc2 transpose/UBLK store modes supported by the local runner.
+#
+# Usage:
+#   bash <abs path>/run_functional_tests.sh
+#   PYTHON=python3.11 bash .../run_functional_tests.sh
+#   bash .../run_functional_tests.sh --fail-fast
+#   bash .../run_functional_tests.sh --list
+#   bash .../run_functional_tests.sh --help
+#
+# Selective execution (positional args; substring match against test names,
+# OR-combined across multiple selectors):
+#   bash .../run_functional_tests.sh A1                    # run A1_static_dynShape only
+#   bash .../run_functional_tests.sh A1 A3 E15             # run those three
+#   bash .../run_functional_tests.sh atomic                # run anything with "atomic"
+#   bash .../run_functional_tests.sh dirichlet --fail-fast # combine with flags
+#
+# Exit code: number of failed tests (0 = all pass).  Per-test runner stdout /
+# stderr is passed through verbatim; the [CMD] line printed before each test
+# is the exact command to copy-paste for standalone debugging.
+
+export PATH=/usr/bin:$PATH 
+export LD=/usr/bin/ld 
+export CC=/usr/bin/gcc 
+export CXX=/usr/bin/g++ 
+export CUDAHOSTCXX=/usr/bin/g++
+export TRITON_CC=/usr/bin/gcc
+export CFLAGS="-B/usr/bin"
+export CXXFLAGS="-B/usr/bin"
+export LDFLAGS="-B/usr/bin -fuse-ld=bfd"
+
+set -u  # fail on undefined vars; do NOT set -e (we want to continue on failures)
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+RUNNER="${SCRIPT_DIR}/runner_fc12.py"
+PYTHON="${PYTHON:-python}"
+
+if [ ! -f "$RUNNER" ]; then
+    echo "ERROR: runner_fc12.py not found at ${RUNNER}" >&2
+    exit 2
+fi
+
+FAIL_FAST=0
+LIST_ONLY=0
+declare -a SELECTORS=()
+for arg in "$@"; do
+    case "$arg" in
+        --fail-fast)
+            FAIL_FAST=1
+            ;;
+        --list)
+            LIST_ONLY=1
+            ;;
+        -h|--help)
+            sed -n '2,/^# Exit code/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown flag: $arg (use --help)" >&2
+            exit 2
+            ;;
+        *)
+            # Positional arg: test name selector (substring match).  Multiple
+            # selectors are OR-combined; empty list means "run all".
+            SELECTORS+=("$arg")
+            ;;
+    esac
+done
+
+# Returns 0 (true) if the test name matches any selector, OR if the selector
+# list is empty (default = run all).
+test_matches_selectors() {
+    local name="$1"
+    if [ "${#SELECTORS[@]}" -eq 0 ]; then
+        return 0
+    fi
+    local sel
+    for sel in "${SELECTORS[@]}"; do
+        if [[ "$name" == *"$sel"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Each entry: "name | space-separated runner CLI args".
+declare -a TESTS=(
+    "A1_static_dynShape_transformers | --tokens_after_topk 1500 --experts 3  --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode static --ref_compute_graph transformers"
+    "A2_static_statShape             | --tokens_after_topk 1500 --experts 5  --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode static --enable_static_expert_shape"
+    "A3_atomic_dynShape              | --tokens_after_topk 1500 --experts 7  --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode atomic_counter"
+    "A4_atomic_statShape_ublkcp      | --tokens_after_topk 1500 --experts 11 --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode atomic_counter --enable_static_expert_shape --use_bulk_fc2_store"
+
+    "B5_cluster_m2_static_ublkcp     | --tokens_after_topk 2400 --experts 13 --hidden 1792 --intermediate 1536 --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode static --enable_static_expert_shape --use_bulk_fc2_store"
+    "B6_cluster_m2_atomic_transformers | --tokens_after_topk 2400 --experts 17 --hidden 1792 --intermediate 1536 --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode atomic_counter --ref_compute_graph transformers"
+    "B7_cluster_m4_atomic_statShape  | --tokens_after_topk 4500 --experts 19 --hidden 1792 --intermediate 1536 --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 4,1,1 --use_2cta_instrs --balance_route --load_balance_mode atomic_counter --enable_static_expert_shape"
+
+    "C8_dirichlet_static             | --tokens_after_topk 3000 --experts 23 --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --load_balance_mode static"
+    "C9_dirichlet_atomic_transformers | --tokens_after_topk 3000 --experts 29 --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --load_balance_mode atomic_counter --ref_compute_graph transformers"
+    "C10_dirichlet_atomic_cluster_m2 | --tokens_after_topk 9000 --experts 31 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --load_balance_mode atomic_counter --enable_static_expert_shape"
+
+    "D11_large_static_balanced       | --tokens_after_topk 17000 --experts 8  --hidden 7168 --intermediate 4608 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode static"
+    "D12_large_atomic_balanced       | --tokens_after_topk 17000 --experts 8  --hidden 7168 --intermediate 4608 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode atomic_counter"
+    "D13_large_atomic_dirichlet_c4   | --tokens_after_topk 24000 --experts 37 --hidden 6912 --intermediate 4608 --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 4,1,1 --use_2cta_instrs --load_balance_mode atomic_counter --enable_static_expert_shape"
+
+    "E14_fc1_partial_k_hidden        | --tokens_after_topk 3000 --experts 41 --hidden 1312 --intermediate 1536 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode atomic_counter"
+    "E15_fc2_partial_k_single_tile_transformers | --tokens_after_topk 2000 --experts 43 --hidden 1280 --intermediate 192  --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode atomic_counter --ref_compute_graph transformers"
+    "E16_tiny_double_partial_k       | --tokens_after_topk 240  --experts 47 --hidden 224  --intermediate 448  --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode atomic_counter"
+    "E17_imbalanced_dirichlet_tiny   | --tokens_after_topk 240  --experts 53 --hidden 224  --intermediate 448  --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --load_balance_mode static"
+    "E18_atomic_many_experts         | --tokens_after_topk 4500 --experts 32 --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,128,256 --cluster_shape_mnk 1,1,1 --load_balance_mode atomic_counter"
+
+    "F19_T256_dirichlet_atomic_clamp | --tokens_after_topk 4500 --experts 59 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --load_balance_mode atomic_counter --gate_up_clamp 10"
+    "F20_T256_balanced_static_stat   | --tokens_after_topk 4500 --experts 61 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode static --enable_static_expert_shape"
+    "F21_T256_balanced_ublk_clamp3_transformers | --tokens_after_topk 4500 --experts 89 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode static --enable_static_expert_shape --use_bulk_fc2_store --gate_up_clamp 3 --ref_compute_graph transformers"
+
+    # ── Group G: tile_n=64 ──
+    "G22_N64_1cta_balanced_static_transformers | --tokens_after_topk 1500 --experts 67 --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,64,256 --cluster_shape_mnk 1,1,1 --balance_route --load_balance_mode static --ref_compute_graph transformers"
+    "G23_N64_1cta_dirichlet_atomic   | --tokens_after_topk 3000 --experts 71 --hidden 1280 --intermediate 1536 --mma_tiler_mnk 128,64,256 --cluster_shape_mnk 1,1,1 --load_balance_mode atomic_counter"
+    "G24_N64_2cta_balanced_statShape | --tokens_after_topk 2400 --experts 73 --hidden 1792 --intermediate 1536 --mma_tiler_mnk 256,64,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --balance_route --load_balance_mode static --enable_static_expert_shape"
+    "G25_N64_2cta_dirichlet_atomic   | --tokens_after_topk 4500 --experts 79 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,64,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --load_balance_mode atomic_counter"
+    "G26_N64_cluster_m4_atomic       | --tokens_after_topk 9000 --experts 83 --hidden 2304 --intermediate 2560 --mma_tiler_mnk 256,64,256 --cluster_shape_mnk 4,1,1 --use_2cta_instrs --load_balance_mode atomic_counter"
+)
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+declare -a FAIL_NAMES=()
+TOTAL=${#TESTS[@]}
+START_TIME=$SECONDS
+
+# --list mode: print all test names (with selector filter applied) and exit.
+if [ "$LIST_ONLY" -eq 1 ]; then
+    for entry in "${TESTS[@]}"; do
+        name="${entry%%|*}"
+        name="${name%"${name##*[![:space:]]}"}"
+        if test_matches_selectors "$name"; then
+            echo "$name"
+        fi
+    done
+    exit 0
+fi
+
+for entry in "${TESTS[@]}"; do
+    # Split on first '|'; trim trailing/leading whitespace on both halves.
+    name="${entry%%|*}"
+    name="${name%"${name##*[![:space:]]}"}"   # rstrip
+    args="${entry#*|}"
+    args="${args#"${args%%[![:space:]]*}"}"   # lstrip
+
+    if ! test_matches_selectors "$name"; then
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        continue
+    fi
+
+    echo
+    echo "==========================================================================="
+    echo "[TEST] $name"
+    echo "[CMD]  $PYTHON $RUNNER $args"
+    echo "==========================================================================="
+
+    test_start=$SECONDS
+    # shellcheck disable=SC2086  # intentional word-splitting on $args
+    "$PYTHON" "$RUNNER" $args
+    rc=$?
+    elapsed=$((SECONDS - test_start))
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[RESULT] PASS  (${elapsed}s) $name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "[RESULT] FAIL  (rc=${rc}, ${elapsed}s) $name"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAIL_NAMES+=("$name")
+        if [ "$FAIL_FAST" -eq 1 ]; then
+            echo "[--fail-fast] aborting after first failure"
+            break
+        fi
+    fi
+done
+
+TOTAL_ELAPSED=$((SECONDS - START_TIME))
+RAN_COUNT=$((PASS_COUNT + FAIL_COUNT))
+echo
+echo "==========================================================================="
+if [ "${#SELECTORS[@]}" -gt 0 ]; then
+    echo "SUMMARY: ${PASS_COUNT}/${RAN_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped (selectors: ${SELECTORS[*]}; wallclock ${TOTAL_ELAPSED}s)"
+else
+    echo "SUMMARY: ${PASS_COUNT}/${TOTAL} passed, ${FAIL_COUNT} failed (wallclock ${TOTAL_ELAPSED}s)"
+fi
+echo "==========================================================================="
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "Failed tests:"
+    for name in "${FAIL_NAMES[@]}"; do
+        echo "  - $name"
+    done
+fi
+if [ "${#SELECTORS[@]}" -gt 0 ] && [ "$RAN_COUNT" -eq 0 ]; then
+    echo "WARNING: selectors matched 0 tests (use --list to see all available test names)"
+fi
+
+exit "$FAIL_COUNT"

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/run_mega_tests.sh
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/run_mega_tests.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+# Functional test harness for the distributed MegaMoE fused dispatch + fc1/fc2
+# + combine runner.  M01 runs single-rank with MEGA_NO_DIST=1; other cases run
+# through torchrun using MEGA_NPROC/MEGA_NNODES overrides when present.
+#
+# Coverage dimensions mixed across the list below:
+#   balanced/power_law routing, static/atomic_counter scheduling, topk range,
+#   1CTA/2CTA, cluster_m, transpose/UBLK fc2 output modes, SF padding
+#   boundaries for hidden/intermediate shapes, and token-back mode
+#   (epi_warps / standalone_warps / reuse_dispatch_warps).
+#
+# Test entry format (pipe-separated, optional 4th env field):
+#   "name | mode | args [ | ENV=val ENV2=val2 ]"
+# The 4th field, when present, is exported (via ``env``) only for that test's
+# launch, e.g. the developer-only MEGA_TOKEN_BACK_ATOMIC_BATCH knob.
+#
+# Usage:
+#   bash <abs path>/run_mega_tests.sh
+#   PYTHON=python3.11 bash .../run_mega_tests.sh
+#   MEGA_NPROC=4 bash .../run_mega_tests.sh
+#   bash .../run_mega_tests.sh --fail-fast
+#   bash .../run_mega_tests.sh --list
+#   bash .../run_mega_tests.sh --help
+#
+# Selective execution (positional args; substring match against test names,
+# OR-combined across multiple selectors):
+#   bash .../run_mega_tests.sh M01
+#   bash .../run_mega_tests.sh M01 M03 M19
+#   bash .../run_mega_tests.sh balanced --fail-fast
+#
+# Exit code: number of failed tests (0 = all pass).
+
+export PATH=/usr/bin:$PATH
+export LD=/usr/bin/ld
+export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
+export CUDAHOSTCXX=/usr/bin/g++
+export TRITON_CC=/usr/bin/gcc
+export CFLAGS="-B/usr/bin"
+export CXXFLAGS="-B/usr/bin"
+export LDFLAGS="-B/usr/bin -fuse-ld=bfd"
+
+set -u  # fail on undefined vars; do NOT set -e (continue on failures)
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+RUNNER="${SCRIPT_DIR}/mega_runner.py"
+PYTHON="${PYTHON:-python}"
+
+if [ ! -f "$RUNNER" ]; then
+    echo "ERROR: mega_runner.py not found at ${RUNNER}" >&2
+    exit 2
+fi
+
+# Resolve the multi-rank world size.  Order of precedence:
+#   1. MEGA_NPROC env override
+#   2. CUDA_VISIBLE_DEVICES list length
+#   3. nvidia-smi visible GPU count
+#   4. fallback to 2
+if [ -n "${MEGA_NPROC:-}" ]; then
+    NPROC="$MEGA_NPROC"
+elif [ -n "${CUDA_VISIBLE_DEVICES:-}" ] && [ "$CUDA_VISIBLE_DEVICES" != "NoDevFiles" ]; then
+    IFS=',' read -r -a _VISIBLE_DEVICES <<< "$CUDA_VISIBLE_DEVICES"
+    NPROC="${#_VISIBLE_DEVICES[@]}"
+elif command -v nvidia-smi >/dev/null 2>&1; then
+    NPROC=$(nvidia-smi --list-gpus 2>/dev/null | wc -l | tr -d '[:space:]')
+    if [ -z "$NPROC" ] || [ "$NPROC" -le 0 ]; then
+        NPROC=2
+    fi
+else
+    NPROC=2
+fi
+
+MEGA_NNODES="${MEGA_NNODES:-1}"
+MEGA_NODE_RANK="${MEGA_NODE_RANK:-0}"
+MEGA_MASTER_ADDR="${MEGA_MASTER_ADDR:-localhost}"
+MEGA_MASTER_PORT="${MEGA_MASTER_PORT:-29500}"
+WORLD_SIZE=$((NPROC * MEGA_NNODES))
+
+FAIL_FAST=0
+LIST_ONLY=0
+declare -a SELECTORS=()
+for arg in "$@"; do
+    case "$arg" in
+        --fail-fast)
+            FAIL_FAST=1
+            ;;
+        --list)
+            LIST_ONLY=1
+            ;;
+        -h|--help)
+            sed -n '2,/^# Exit code/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown flag: $arg (use --help)" >&2
+            exit 2
+            ;;
+        *)
+            SELECTORS+=("$arg")
+            ;;
+    esac
+done
+
+test_matches_selectors() {
+    local name="$1"
+    if [ "${#SELECTORS[@]}" -eq 0 ]; then
+        return 0
+    fi
+    local sel
+    for sel in "${SELECTORS[@]}"; do
+        if [[ "$name" == *"$sel"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Strip leading/trailing whitespace from $1 (no external processes).
+trim() {
+    local s="$1"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+declare -a TESTS=(
+    "M01_single_balanced_topk2       | single | --num_tokens_per_rank 192  --num_topk 2  --num_total_experts 8   --hidden 1024 --intermediate 2048 --enable_static_expert_shape --use_bulk_fc2_store --ref_compute_graph transformers"
+
+    "M02_mr_balanced_topk2_tiny      | multi  | --num_tokens_per_rank 96   --num_topk 2  --num_total_experts 8   --hidden 1152 --intermediate 1088 --enable_static_expert_shape --use_bulk_fc2_store --in_kernel_fc2_reduce"
+    "M03_mr_balanced_topk3_dual_sa   | multi  | --num_tokens_per_rank 256  --num_topk 3  --num_total_experts 24  --hidden 1568 --intermediate 2112 --enable_static_expert_shape --load_balance_mode atomic_counter --token_back_mode standalone_warps --combine_format 16e2m1xbf16"
+    "M04_mr_balanced_topk5           | multi  | --num_tokens_per_rank 384  --num_topk 5  --num_total_experts 40  --hidden 1664 --intermediate 2176 --enable_static_expert_shape --use_bulk_fc2_store --in_kernel_fc2_reduce"
+    "M05_mr_balanced_topk7           | multi  | --num_tokens_per_rank 448  --num_topk 7  --num_total_experts 56  --hidden 2048 --intermediate 2368 --enable_static_expert_shape --use_bulk_fc2_store --combine_format 32e4m3xe8m0"
+    "M06_mr_balanced_topk11_redg_ru  | multi  | --num_tokens_per_rank 880  --num_topk 11 --num_total_experts 88  --hidden 1920 --intermediate 3136 --enable_static_expert_shape --in_kernel_fc2_reduce --token_back_mode reuse_dispatch_warps"
+
+    "M07_mr_power_law_topk3_dual_sa  | multi  | --num_tokens_per_rank 320  --num_topk 3  --num_total_experts 24  --hidden 1632 --intermediate 1728 --enable_static_expert_shape --route_distribution power_law --token_back_mode standalone_warps --combine_format bf16"
+    "M08_mr_power_law_topk7_dual_ru  | multi  | --num_tokens_per_rank 640  --num_topk 7  --num_total_experts 56  --hidden 1440 --intermediate 1920 --enable_static_expert_shape --route_distribution power_law --load_balance_mode atomic_counter --ref_compute_graph transformers --token_back_mode reuse_dispatch_warps --combine_format 32e4m3xe8m0"
+    "M09_mr_power_law_topk13_clamp   | multi  | --num_tokens_per_rank 832  --num_topk 13 --num_total_experts 104 --hidden 2560 --intermediate 4160 --enable_static_expert_shape --route_distribution power_law --use_bulk_fc2_store --in_kernel_fc2_reduce --gate_up_clamp 10"
+
+    "M10_mr_large_topk5              | multi  | --num_tokens_per_rank 768  --num_topk 5  --num_total_experts 40  --hidden 2304 --intermediate 3392 --enable_static_expert_shape --use_bulk_fc2_store --in_kernel_fc2_reduce"
+    "M11_mr_large_topk11_aligned_clamp_ru | multi | --num_tokens_per_rank 1792 --num_topk 11 --num_total_experts 88  --hidden 2944 --intermediate 4096 --enable_static_expert_shape --load_balance_mode atomic_counter --gate_up_clamp 10 --token_back_mode reuse_dispatch_warps --combine_format 16e2m1xbf16"
+
+    "M12_mr_T256_clm2_balanced_topk4_redg_sa | multi  | --num_tokens_per_rank 704  --num_topk 4  --num_total_experts 40  --hidden 2080 --intermediate 3136 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --in_kernel_fc2_reduce --token_back_mode standalone_warps"
+    "M13_mr_T256_clm2_pl_topk7_dual_ru | multi  | --num_tokens_per_rank 896  --num_topk 7  --num_total_experts 56  --hidden 2272 --intermediate 2624 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --route_distribution power_law --token_back_mode reuse_dispatch_warps --combine_format 32e4m3xe8m0"
+    "M14_mr_T256_clm2_balanced_topk13_sa | multi  | --num_tokens_per_rank 1280 --num_topk 13 --num_total_experts 104 --hidden 2816 --intermediate 4288 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --load_balance_mode atomic_counter --ref_compute_graph transformers --gate_up_clamp 10 --token_back_mode standalone_warps --combine_format 16e2m1xbf16"
+    "M15_mr_T256_clm4_topk11_aligned | multi  | --num_tokens_per_rank 2048 --num_topk 11 --num_total_experts 88  --hidden 2176 --intermediate 3712 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 4,1,1 --use_2cta_instrs --use_bulk_fc2_store --gate_up_clamp 9"
+    "M16_mr_T256_clm4_pl_topk4_redg_sa | multi  | --num_tokens_per_rank 1024 --num_topk 4  --num_total_experts 40  --hidden 2432 --intermediate 3776 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 4,1,1 --use_2cta_instrs --route_distribution power_law --in_kernel_fc2_reduce --load_balance_mode atomic_counter --gate_up_clamp 8 --token_back_mode standalone_warps"
+
+    "M17_mr_atomic_balanced_topk3    | multi  | --num_tokens_per_rank 128  --num_topk 3  --num_total_experts 24  --hidden 1280 --intermediate 2432 --enable_static_expert_shape --load_balance_mode atomic_counter --use_bulk_fc2_store --in_kernel_fc2_reduce"
+    "M18_mr_atomic_pl_topk7_dual_redg_ru | multi  | --num_tokens_per_rank 512  --num_topk 7  --num_total_experts 56  --hidden 1856 --intermediate 1856 --enable_static_expert_shape --load_balance_mode atomic_counter --route_distribution power_law --in_kernel_fc2_reduce --token_back_mode reuse_dispatch_warps"
+    "M19_mr_atomic_T256_clm2_topk5_ru | multi  | --num_tokens_per_rank 1152 --num_topk 5  --num_total_experts 40  --hidden 2688 --intermediate 3648 --enable_static_expert_shape --load_balance_mode atomic_counter --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --gate_up_clamp 10 --token_back_mode reuse_dispatch_warps"
+
+    "M20_mr_balanced_wide_intermed   | multi  | --num_tokens_per_rank 64   --num_topk 3  --num_total_experts 24  --hidden 1792 --intermediate 4928 --enable_static_expert_shape --load_balance_mode atomic_counter --use_bulk_fc2_store --ref_compute_graph transformers --gate_up_clamp 11 --combine_format 32e4m3xe8m0"
+
+    # ── M21..M23: tile_n=64 ──
+    "M21_mr_N64_1cta_balanced_topk3_sa    | multi  | --num_tokens_per_rank 288 --num_topk 3 --num_total_experts 48 --hidden 1408 --intermediate 2240 --enable_static_expert_shape --mma_tiler_mnk 128,64,256 --cluster_shape_mnk 1,1,1 --ref_compute_graph transformers --token_back_mode standalone_warps --combine_format 16e2m1xbf16"
+    "M22_mr_N64_T256_clm2_pl_topk4_redg_sa | multi  | --num_tokens_per_rank 480 --num_topk 4 --num_total_experts 96 --hidden 1472 --intermediate 2752 --enable_static_expert_shape --mma_tiler_mnk 256,64,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --route_distribution power_law --in_kernel_fc2_reduce --token_back_mode standalone_warps"
+    "M23_mr_N64_T256_clm4_pl_atomic_topk7_ru | multi  | --num_tokens_per_rank 672 --num_topk 7 --num_total_experts 72 --hidden 1728 --intermediate 3520 --enable_static_expert_shape --mma_tiler_mnk 256,64,256 --cluster_shape_mnk 4,1,1 --use_2cta_instrs --route_distribution power_law --load_balance_mode atomic_counter --ref_compute_graph transformers --gate_up_clamp 6 --token_back_mode reuse_dispatch_warps --combine_format 32e4m3xe8m0"
+    
+    # -- Token-back modes (standalone/reuse) + in_kernel_reduce + flag > 1.
+    # M24 keeps the default atomic batch (1); M25-M27 exercise the
+    # developer-only MEGA_TOKEN_BACK_ATOMIC_BATCH env at 2/3 (only meaningful
+    # under a non-epi token_back_mode + atomic_counter scheduling).
+    "M24_mr_tbstandalone_reduce_flag8_powerlaw | multi  | --num_tokens_per_rank 3344 --num_topk 5 --num_total_experts 72 --hidden 6176 --intermediate 6080 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --route_distribution power_law --load_balance_mode atomic_counter --flag_batch 8 --epi_flag_batch 2,4 --token_back_mode standalone_warps --in_kernel_fc2_reduce"
+
+    "M25_mr_tbreuse_reduce_atomic2_powerlaw    | multi  | --num_tokens_per_rank 1024 --num_topk 5 --num_total_experts 72 --hidden 6176 --intermediate 6080 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --route_distribution power_law --load_balance_mode atomic_counter --flag_batch 8 --epi_flag_batch 2,4 --token_back_mode reuse_dispatch_warps --in_kernel_fc2_reduce | MEGA_TOKEN_BACK_ATOMIC_BATCH=2"
+    "M26_mr_tbstandalone_atomic3_powerlaw      | multi  | --num_tokens_per_rank 1024 --num_topk 5 --num_total_experts 72 --hidden 6176 --intermediate 6080 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --route_distribution power_law --load_balance_mode atomic_counter --flag_batch 8 --epi_flag_batch 2,4 --token_back_mode standalone_warps --combine_format 16e2m1xbf16 | MEGA_TOKEN_BACK_ATOMIC_BATCH=3"
+    "M27_mr_tbreuse_reduce_atomic2_pl_small     | multi  | --num_tokens_per_rank 768  --num_topk 5 --num_total_experts 72 --hidden 6176 --intermediate 6080 --enable_static_expert_shape --mma_tiler_mnk 256,256,256 --cluster_shape_mnk 2,1,1 --use_2cta_instrs --route_distribution power_law --load_balance_mode atomic_counter --flag_batch 8 --epi_flag_batch 2,4 --token_back_mode reuse_dispatch_warps --in_kernel_fc2_reduce | MEGA_TOKEN_BACK_ATOMIC_BATCH=2"
+)
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+declare -a FAIL_NAMES=()
+TOTAL=${#TESTS[@]}
+START_TIME=$SECONDS
+
+if [ "$LIST_ONLY" -eq 1 ]; then
+    for entry in "${TESTS[@]}"; do
+        name="${entry%%|*}"
+        name="${name%"${name##*[![:space:]]}"}"
+        if test_matches_selectors "$name"; then
+            echo "$name"
+        fi
+    done
+    exit 0
+fi
+
+echo "==========================================================================="
+echo "MegaMoE functional tests"
+echo "  RUNNER : ${RUNNER}"
+echo "  PYTHON : ${PYTHON}"
+echo "  NPROC  : ${NPROC}"
+echo "  NNODES : ${MEGA_NNODES}"
+echo "  WORLD  : ${WORLD_SIZE}"
+if [ "$MEGA_NNODES" -gt 1 ]; then
+    echo "  NODE   : rank ${MEGA_NODE_RANK}, master ${MEGA_MASTER_ADDR}:${MEGA_MASTER_PORT}"
+fi
+echo "  TOTAL  : ${TOTAL} tests"
+if [ "${#SELECTORS[@]}" -gt 0 ]; then
+    echo "  FILTER : ${SELECTORS[*]}"
+fi
+echo "==========================================================================="
+
+for entry in "${TESTS[@]}"; do
+    # Parse "name | mode | args [ | env ]".  Strip whitespace around each
+    # segment.  args carry no '|', so a 4-var IFS split is unambiguous; the
+    # optional 4th field holds per-test env assignments.
+    IFS='|' read -r name mode args test_env <<< "$entry"
+    name="$(trim "$name")"
+    mode="$(trim "$mode")"
+    args="$(trim "$args")"
+    test_env="$(trim "$test_env")"
+
+    if ! test_matches_selectors "$name"; then
+        SKIP_COUNT=$((SKIP_COUNT + 1))
+        continue
+    fi
+
+    echo
+    echo "==========================================================================="
+    echo "[TEST] $name"
+    case "$mode" in
+        single)
+            echo "[CMD]  env $test_env MEGA_NO_DIST=1 $PYTHON $RUNNER $args"
+            ;;
+        multi)
+            if [ "$MEGA_NNODES" -gt 1 ]; then
+                echo "[CMD]  env $test_env torchrun --nnodes=$MEGA_NNODES --node_rank=$MEGA_NODE_RANK --nproc_per_node=$NPROC --master_addr=$MEGA_MASTER_ADDR --master_port=$MEGA_MASTER_PORT $RUNNER $args"
+            else
+                echo "[CMD]  env $test_env torchrun --nproc_per_node=$NPROC $RUNNER $args"
+            fi
+            ;;
+        *)
+            echo "[ERROR] unknown launch mode '$mode' for test '$name'; skipping" >&2
+            FAIL_COUNT=$((FAIL_COUNT + 1))
+            FAIL_NAMES+=("$name (bad-mode)")
+            continue
+            ;;
+    esac
+    echo "==========================================================================="
+
+    test_start=$SECONDS
+    # shellcheck disable=SC2086  # intentional word-splitting on $args / $test_env
+    case "$mode" in
+        single)
+            env $test_env MEGA_NO_DIST=1 "$PYTHON" "$RUNNER" $args
+            rc=$?
+            ;;
+        multi)
+            if [ "$MEGA_NNODES" -gt 1 ]; then
+                env $test_env torchrun \
+                    --nnodes="$MEGA_NNODES" --node_rank="$MEGA_NODE_RANK" \
+                    --nproc_per_node="$NPROC" \
+                    --master_addr="$MEGA_MASTER_ADDR" --master_port="$MEGA_MASTER_PORT" \
+                    "$RUNNER" $args
+            else
+                env $test_env torchrun --nproc_per_node="$NPROC" "$RUNNER" $args
+            fi
+            rc=$?
+            ;;
+    esac
+    elapsed=$((SECONDS - test_start))
+
+    if [ "$rc" -eq 0 ]; then
+        echo "[RESULT] PASS  (${elapsed}s) $name"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "[RESULT] FAIL  (rc=${rc}, ${elapsed}s) $name"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        FAIL_NAMES+=("$name")
+        if [ "$FAIL_FAST" -eq 1 ]; then
+            echo "[--fail-fast] aborting after first failure"
+            break
+        fi
+    fi
+done
+
+TOTAL_ELAPSED=$((SECONDS - START_TIME))
+RAN_COUNT=$((PASS_COUNT + FAIL_COUNT))
+echo
+echo "==========================================================================="
+if [ "${#SELECTORS[@]}" -gt 0 ]; then
+    echo "SUMMARY: ${PASS_COUNT}/${RAN_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped (selectors: ${SELECTORS[*]}; wallclock ${TOTAL_ELAPSED}s)"
+else
+    echo "SUMMARY: ${PASS_COUNT}/${TOTAL} passed, ${FAIL_COUNT} failed (wallclock ${TOTAL_ELAPSED}s)"
+fi
+echo "==========================================================================="
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo "Failed tests:"
+    for name in "${FAIL_NAMES[@]}"; do
+        echo "  - $name"
+    done
+fi
+if [ "${#SELECTORS[@]}" -gt 0 ] && [ "$RAN_COUNT" -eq 0 ]; then
+    echo "WARNING: selectors matched 0 tests (use --list to see all available test names)"
+fi
+
+exit "$FAIL_COUNT"

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/runner_common.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/runner_common.py
@@ -1,0 +1,672 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Host-side helpers shared by the lean and distributed MegaMoE runners."""
+
+from __future__ import annotations
+
+import functools
+from typing import List, Optional, Tuple
+
+import torch
+
+from common.megamoe_constants import (
+    Fp8E5M2Max,
+    Fp8E4M3FNMax,
+    Nvfp4E2M1Max,
+    Nvfp4BlockSize,
+    Mxfp8BlockSize,
+    SfPaddingBlock,
+    TmaLeadingDimByteAlign,
+    Nvfp4E2M1RcpLimit,
+    Fp8E4M3RcpLimit,
+    Fp8E5M2RcpLimit,
+)
+
+### TO BE REMOVED
+DataDtype: torch.dtype = torch.float4_e2m1fn_x2
+ScaleDtype: torch.dtype = torch.float8_e4m3fn
+
+# Backward-compatible aliases used by existing runners.
+_DataDtype = DataDtype
+_ScaleDtype = ScaleDtype
+
+
+Nvfp4DataDtype: torch.dtype = torch.float4_e2m1fn_x2
+Nvfp4ScaleDtype: torch.dtype = torch.float8_e4m3fn
+Mxfp8DataDtype_e4m3: torch.dtype = torch.float8_e4m3fn
+Mxfp8DataDtype_e5m2: torch.dtype = torch.float8_e5m2
+Mxfp8ScaleDtype: torch.dtype = torch.float8_e8m0fnu
+
+
+def ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def round_up(a: int, b: int) -> int:
+    return ceil_div(a, b) * b
+
+
+from common.host_utils import kind_data_dtype, kind_scale_dtype, kind_sf_vec_size
+
+
+def kind_data_max(kind: str) -> float:
+    if kind == "nvfp4":
+        return Nvfp4E2M1Max
+    if kind == "mxfp8_e4m3":
+        return Fp8E4M3FNMax
+    if kind == "mxfp8_e5m2":
+        return Fp8E5M2Max
+    raise ValueError(f"Unknown kind: {kind!r}")
+
+
+def leading_dim_bytes(leading_elems: int, dtype: torch.dtype) -> int:
+    """Bytes occupied by one stride-1 row of ``leading_elems`` elements."""
+    if dtype == Nvfp4DataDtype:
+        if leading_elems % 2 != 0:
+            raise ValueError(
+                f"NVFP4 leading-dim element count ({leading_elems}) must be even "
+                f"(2 fp4 packed per byte)."
+            )
+        return leading_elems // 2
+    if dtype in (torch.bfloat16, torch.float16):
+        return leading_elems * 2
+    if dtype == torch.float32:
+        return leading_elems * 4
+    if dtype in (Nvfp4ScaleDtype,
+                 Mxfp8DataDtype_e4m3,
+                 Mxfp8DataDtype_e5m2,
+                 Mxfp8ScaleDtype):
+        return leading_elems
+    raise ValueError(f"leading_dim_bytes: unsupported dtype {dtype!r}.")
+
+
+def check_tma_leading_dim_align(
+    tensor_name: str, leading_elems: int, dtype: torch.dtype
+) -> None:
+    """Reject a tensor whose stride-1 row is not TMA aligned."""
+    leading_bytes = leading_dim_bytes(leading_elems, dtype)
+    if leading_bytes % TmaLeadingDimByteAlign != 0:
+        raise ValueError(
+            f"{tensor_name}: leading-dim byte size = {leading_bytes} "
+            f"(= {leading_elems} elements of {dtype}) is not a multiple of "
+            f"{TmaLeadingDimByteAlign} bytes; TMA descriptor requires "
+            f"{TmaLeadingDimByteAlign}-byte alignment for the stride-1 row."
+        )
+
+
+def offs_to_group_sizes(offs: torch.Tensor) -> List[int]:
+    """Convert cumulative-end offsets to per-expert valid token counts."""
+    offs_cpu = offs.cpu().tolist()
+    prev = 0
+    sizes: List[int] = []
+    for end in offs_cpu:
+        sizes.append(int(end) - prev)
+        prev = int(end)
+    return sizes
+
+
+_Fp4DecodeTable: torch.Tensor = torch.tensor(
+    [
+        0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+        -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def fp4_packed_dim(tensor: torch.Tensor) -> int:
+    """Return the packed stride-1 dimension in a ``float4_e2m1fn_x2`` tensor."""
+    positive_strides = [
+        (abs(stride), idx) for idx, stride in enumerate(tensor.stride()) if stride > 0
+    ]
+    if not positive_strides:
+        return tensor.dim() - 1
+    return min(positive_strides)[1]
+
+
+def unpack_fp4_to_f32(packed: torch.Tensor) -> torch.Tensor:
+    """Unpack a ``float4_e2m1fn_x2`` tensor into fp32 along the packed dim."""
+    packed_dim = fp4_packed_dim(packed)
+    raw = packed.view(torch.uint8)
+
+    if packed_dim != raw.dim() - 1:
+        perm = list(range(raw.dim()))
+        perm[packed_dim], perm[-1] = perm[-1], perm[packed_dim]
+        raw = raw.permute(perm).contiguous()
+    else:
+        perm = None
+
+    lo = (raw & 0x0F).to(torch.int64)
+    hi = (raw >> 4).to(torch.int64)
+    lut = _Fp4DecodeTable.to(raw.device)
+
+    unpacked_shape = list(raw.shape)
+    unpacked_shape[-1] *= 2
+    unpacked = torch.empty(unpacked_shape, dtype=torch.float32, device=raw.device)
+    unpacked[..., ::2] = lut[lo]
+    unpacked[..., 1::2] = lut[hi]
+
+    if perm is not None:
+        unpacked = unpacked.permute(perm)
+    return unpacked
+
+
+def slice_tensor_logical_dim(
+    tensor: torch.Tensor, dim: int, start: int, end: int
+) -> torch.Tensor:
+    """Slice along a logical dimension, compensating for FP4 packing."""
+    if tensor.dtype == Nvfp4DataDtype and dim == fp4_packed_dim(tensor):
+        if start % 2 != 0 or end % 2 != 0:
+            raise ValueError(
+                f"FP4 packed slicing requires even indices, got start={start}, end={end}."
+            )
+        start = start // 2
+        end = end // 2
+    return tensor.narrow(dim, start, end - start)
+
+
+def dequant_block_scale_to_fp32(
+    data: torch.Tensor,
+    raw_scale: torch.Tensor,
+    blocksize: int,
+    global_scale: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Dequantize one 2D NVFP4 tensor using raw block scales."""
+    data_fp32 = unpack_fp4_to_f32(data) if data.dtype == Nvfp4DataDtype else data.to(torch.float32)
+    if data_fp32.dim() != 2 or raw_scale.dim() != 2:
+        raise ValueError(
+            f"Expected 2D tensors, got data={data_fp32.dim()}D raw_scale={raw_scale.dim()}D."
+        )
+
+    expected = (data_fp32.shape[0], ceil_div(data_fp32.shape[1], blocksize))
+    if tuple(raw_scale.shape) != expected:
+        raise ValueError(
+            f"Raw scale shape mismatch: expected {expected}, got {tuple(raw_scale.shape)}."
+        )
+
+    expanded = raw_scale.to(torch.float32).repeat_interleave(blocksize, dim=-1)[
+        :, : data_fp32.shape[1]
+    ]
+    result = data_fp32 * expanded
+    if global_scale is not None:
+        result = result * global_scale.to(torch.float32).reshape(1, 1)
+    return result
+
+
+def transpose_rhs_for_block_dequant(data: torch.Tensor) -> torch.Tensor:
+    """Convert a ``(K, N)`` RHS slice into ``(N, K)`` for K-block dequant."""
+    if data.dim() != 2:
+        raise ValueError(f"Expected 2D RHS tensor, got {data.dim()}D.")
+    if data.dtype == Nvfp4DataDtype:
+        return unpack_fp4_to_f32(data).transpose(0, 1)
+    return data.transpose(0, 1)
+
+
+def from_blocked(flat: torch.Tensor, raw_rows: int, raw_cols: int) -> torch.Tensor:
+    """Inverse of :func:`to_blocked` for the 32x4x4 FP8 scale layout."""
+    if flat.dim() != 1:
+        raise ValueError(f"Expected 1D flat tensor, got {flat.dim()}D.")
+    if raw_rows == 0 or raw_cols == 0:
+        return flat.new_empty((raw_rows, raw_cols))
+
+    row_blocks = ceil_div(raw_rows, SfPaddingBlock)
+    col_blocks = ceil_div(raw_cols, 4)
+    padded_rows = row_blocks * SfPaddingBlock
+    padded_cols = col_blocks * 4
+    expected = padded_rows * padded_cols
+    if flat.numel() != expected:
+        raise ValueError(
+            f"from_blocked: flat size {flat.numel()} != expected "
+            f"{expected} for raw ({raw_rows}, {raw_cols}) padded to "
+            f"({padded_rows}, {padded_cols})."
+        )
+
+    rearranged = flat.reshape(-1, 32, 16).reshape(-1, 32, 4, 4)
+    blocks = rearranged.transpose(1, 2).reshape(-1, SfPaddingBlock, 4)
+    blocks = blocks.reshape(row_blocks, col_blocks, SfPaddingBlock, 4)
+    padded = blocks.permute(0, 2, 1, 3).reshape(padded_rows, padded_cols)
+    return padded[:raw_rows, :raw_cols].contiguous()
+
+
+def to_blocked(scale_2d: torch.Tensor) -> torch.Tensor:
+    """Pad and apply the 32x4x4 FP8 scale swizzle to one raw scale tensor."""
+    if scale_2d.dim() != 2:
+        raise ValueError(f"Expected 2D scale tensor, got {scale_2d.dim()}D.")
+    rows, cols = scale_2d.shape
+    if rows == 0 or cols == 0:
+        return scale_2d.new_empty((0,))
+
+    row_blocks = ceil_div(rows, SfPaddingBlock)
+    col_blocks = ceil_div(cols, 4)
+    padded_rows = row_blocks * SfPaddingBlock
+    padded_cols = col_blocks * 4
+
+    padded = scale_2d
+    if (rows, cols) != (padded_rows, padded_cols):
+        padded = torch.zeros(
+            (padded_rows, padded_cols), dtype=scale_2d.dtype, device=scale_2d.device
+        )
+        padded[:rows, :cols] = scale_2d
+
+    blocks = padded.view(row_blocks, SfPaddingBlock, col_blocks, 4).permute(0, 2, 1, 3)
+    rearranged = blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16)
+    return rearranged.flatten()
+
+
+def _cat_byte_reinterpretable_tensors(
+    tensors: List[torch.Tensor], dim: int = 0
+) -> torch.Tensor:
+    """Concatenate byte-backed float tensors via uint8 view."""
+    if not tensors:
+        raise ValueError("Expected at least one tensor to concatenate.")
+    first = tensors[0]
+    if first.is_floating_point() and first.element_size() == 1:
+        concatenated = torch.cat([t.view(torch.uint8) for t in tensors], dim=dim)
+        return concatenated.view(first.dtype)
+    return torch.cat(tensors, dim=dim)
+
+
+def _stack_byte_reinterpretable_tensors(
+    tensors: List[torch.Tensor], dim: int = 0
+) -> torch.Tensor:
+    """Stack byte-backed float tensors via uint8 view."""
+    if not tensors:
+        raise ValueError("Expected at least one tensor to stack.")
+    first = tensors[0]
+    if first.is_floating_point() and first.element_size() == 1:
+        stacked = torch.stack([t.view(torch.uint8) for t in tensors], dim=dim)
+        return stacked.view(first.dtype)
+    return torch.stack(tensors, dim=dim)
+
+
+def assemble_raw_scales_grouped_token(raw_scales: List[torch.Tensor]) -> torch.Tensor:
+    """Concatenate per-expert raw SF tensors grouped along the token axis."""
+    flat_parts = [to_blocked(s) for s in raw_scales]
+    all_flat = _cat_byte_reinterpretable_tensors(flat_parts, dim=0)
+    total_rows = sum(round_up(s.shape[0], SfPaddingBlock) for s in raw_scales)
+    return all_flat.reshape(total_rows, -1)
+
+
+def assemble_raw_scales_stacked_expert(raw_scales: List[torch.Tensor]) -> torch.Tensor:
+    """Stack per-expert raw SF tensors after applying the 32x4x4 swizzle."""
+    flat_parts = [to_blocked(s) for s in raw_scales]
+    return _stack_byte_reinterpretable_tensors(flat_parts, dim=0)
+
+
+def _create_raw_scale_tensor(
+    non_k_size: int,
+    k_size: int,
+    blocksize: int,
+    scale_dtype: torch.dtype,
+    device: str = "cuda",
+    strict: bool = False,
+) -> torch.Tensor:
+    """Create one 2-D raw block-scale tensor with dtype-specific scale values."""
+    scale_cols = ceil_div(k_size, blocksize)
+
+    if scale_dtype == torch.float8_e4m3fn:
+        scale_values = torch.tensor(
+            [0.75, 1.0, 1.25, 1.5] if strict else [1.0, 2.0],
+            dtype=torch.float32,
+            device=device,
+        )
+    elif scale_dtype == torch.float8_e8m0fnu:
+        scale_values = torch.tensor(
+            [0.25, 0.5, 1.0, 2.0] if strict else [1.0, 2.0],
+            dtype=torch.float32,
+            device=device,
+        )
+    else:
+        raise ValueError(f"Unsupported scale_dtype: {scale_dtype}")
+
+    indices = torch.randint(
+        0,
+        scale_values.numel(),
+        (non_k_size, scale_cols),
+        device=device,
+    )
+    scales = scale_values[indices]
+    return scales.to(scale_dtype).reshape(non_k_size, scale_cols)
+
+def make_nvfp4_tensor_from_torch_rng(
+    rng: torch.Generator,
+    logical_shape: Tuple[int, ...],
+    packed_dim: int,
+    *,
+    perf_run: bool,
+    device: str = "cuda",
+) -> torch.Tensor:
+    """Build a deterministic ``float4_e2m1fn_x2`` tensor from an explicit RNG."""
+    ndim = len(logical_shape)
+    packed_dim = packed_dim % ndim
+    if logical_shape[packed_dim] % 2 != 0:
+        raise ValueError(
+            f"packed_dim {packed_dim} size ({logical_shape[packed_dim]}) "
+            f"must be even (2 fp4 packed per byte)."
+        )
+
+    if perf_run:
+        total_elements = 1
+        for dim_size in logical_shape:
+            total_elements *= dim_size
+        flat_bytes = torch.randint(
+            0, 256, (total_elements // 2,),
+            dtype=torch.uint8, device=device, generator=rng,
+        )
+    else:
+        random_u8 = torch.randint(
+            0, 100, logical_shape,
+            dtype=torch.uint8, device=device, generator=rng,
+        )
+        nibbles = torch.zeros_like(random_u8)
+        nibbles[(random_u8 >= 80) & (random_u8 < 90)] = 0x2
+        nibbles[random_u8 >= 90] = 0xA
+
+        need_perm = packed_dim != ndim - 1
+        if need_perm:
+            perm_to_last = list(range(ndim))
+            perm_to_last[packed_dim], perm_to_last[-1] = (
+                perm_to_last[-1], perm_to_last[packed_dim],
+            )
+            nibbles = nibbles.permute(perm_to_last).contiguous()
+        even, odd = nibbles[..., 0::2], nibbles[..., 1::2]
+        flat_bytes = ((odd << 4) | even).contiguous().reshape(-1)
+
+    storage_shape = list(logical_shape)
+    need_perm = packed_dim != ndim - 1
+    if need_perm:
+        storage_shape[packed_dim], storage_shape[-1] = (
+            storage_shape[-1], storage_shape[packed_dim],
+        )
+    storage_shape[-1] //= 2
+    tensor = flat_bytes.view(Nvfp4DataDtype).reshape(storage_shape)
+    if need_perm:
+        permute_back = list(range(ndim))
+        permute_back[packed_dim], permute_back[-1] = (
+            permute_back[-1], permute_back[packed_dim],
+        )
+        tensor = tensor.permute(permute_back)
+    return tensor
+
+
+def make_raw_scale_tensor_from_torch_rng(
+    rng: torch.Generator,
+    non_k_size: int,
+    k_size: int,
+    blocksize: int,
+    *,
+    device: str = "cuda",
+    strict: bool = False,
+) -> torch.Tensor:
+    """Create deterministic raw FP8 block scales from an explicit RNG."""
+    num_scale_cols = ceil_div(k_size, blocksize)
+
+    if ScaleDtype == torch.float8_e4m3fn:
+        scale_values = torch.tensor(
+            [0.75, 1.0, 1.25, 1.5] if strict else [1.0, 2.0],
+            dtype=torch.float32,
+            device=device,
+        )
+    elif ScaleDtype == torch.float8_e8m0fnu:
+        scale_values = torch.tensor(
+            [0.25, 0.5, 1.0, 2.0] if strict else [1.0, 2.0],
+            dtype=torch.float32,
+            device=device,
+        )
+    else:
+        raise ValueError(f"Unsupported ScaleDtype: {ScaleDtype}")
+
+    indices = torch.randint(
+        0,
+        scale_values.numel(),
+        (non_k_size, num_scale_cols),
+        device=device,
+        generator=rng,
+    )
+    scales_fp32 = scale_values[indices]
+    return scales_fp32.to(ScaleDtype).reshape(non_k_size, num_scale_cols)
+
+
+def swiglu_fold_interleave(
+    c_fp32: torch.Tensor,
+    gate_up_interleave: int,
+    gate_up_clamp: Optional[float] = None,
+) -> torch.Tensor:
+    """Apply the gate/up SwiGLU fold over a ``gate_up_interleave``-column
+    interleaved layout (16 for NVFP4, 32 for MXFP8).
+
+    ``gate_up_clamp`` mirrors DeepSeek-V4's ``config.swiglu_limit``
+    (``DeepseekV4Experts.forward``): an asymmetric clamp on the real
+    (already-dequanted) gate/up pre-activations, ``gate = clamp(gate, max=limit)``
+    and ``up = clamp(up, -limit, +limit)``, applied before SiLU.  ``None``
+    disables it.  The caller must pass the post-``fc1_alpha`` tensor so the
+    clamp acts on real values, matching the kernel.
+    """
+    M, intermediate = c_fp32.shape
+    if intermediate % (2 * gate_up_interleave) != 0:
+        raise ValueError(
+            f"intermediate ({intermediate}) must be a multiple of "
+            f"{2 * gate_up_interleave} for {gate_up_interleave}-granularity "
+            f"gate/up interleave."
+        )
+    n_pairs = intermediate // (2 * gate_up_interleave)
+    reshaped = c_fp32.view(M, n_pairs, 2, gate_up_interleave)
+    gate = reshaped[:, :, 0, :]
+    up = reshaped[:, :, 1, :]
+    if gate_up_clamp is not None:
+        limit = float(gate_up_clamp)
+        gate = gate.clamp(max=limit)
+        up = up.clamp(min=-limit, max=limit)
+    out = _swiglu_pair_hw_match_cuda(gate, up)
+    return out.reshape(M, intermediate // 2)
+
+
+def swiglu_fold_interleave_16(
+    c_fp32: torch.Tensor,
+    gate_up_clamp: Optional[float] = None,
+) -> torch.Tensor:
+    """NVFP4 16-column interleave wrapper (kept for existing callers)."""
+    return swiglu_fold_interleave(c_fp32, 16, gate_up_clamp=gate_up_clamp)
+
+
+@functools.lru_cache(None)
+def _get_pack_fp4_triton_kernel():
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _pack_fp4_kernel(x_ptr, out_ptr, n_pairs, BLOCK: tl.constexpr):
+        # int64 offsets: the combine round-trip packs the whole (world*tok, topk,
+        # hidden) terms (billions of elements at ep4 / 32768), so ``2 * offsets``
+        # overflows int32 and wraps to a negative address (illegal access).
+        offsets = tl.program_id(0).to(tl.int64) * BLOCK + tl.arange(0, BLOCK)
+        mask = offsets < n_pairs
+        # Even element -> low nibble, odd -> high (matches unpack_fp4_to_f32).
+        # cvt.rn.satfinite.e2m1x2.f32 stores src $1 in the HIGH nibble and $2 in
+        # the LOW nibble, so pass (odd, even).
+        even = tl.load(x_ptr + 2 * offsets, mask=mask, other=0.0)
+        odd = tl.load(x_ptr + 2 * offsets + 1, mask=mask, other=0.0)
+        packed = tl.inline_asm_elementwise(
+            """
+            {
+                .reg .b8 r;
+                cvt.rn.satfinite.e2m1x2.f32 r, $1, $2;
+                mov.b32 $0, {r, r, r, r};
+            }
+            """,
+            constraints="=r,f,f",
+            args=[odd, even],
+            dtype=tl.uint8,
+            is_pure=True,
+            pack=1,
+        )
+        tl.store(out_ptr + offsets, packed, mask=mask)
+
+    return triton, _pack_fp4_kernel
+
+
+def _pack_f32_to_fp4(fp32: torch.Tensor) -> torch.Tensor:
+    """Round fp32 to FP4 E2M1 (HW ``cvt.rn.satfinite.e2m1x2.f32``, RTNE, bit-exact
+    with the device encoder) and nibble-pack into ``float4_e2m1fn_x2``.
+
+    O(N): replaces the per-element 16-way LUT argmin, whose ``(N, 16)`` distance
+    broadcast allocated ``N * 16`` fp32 (hundreds of GB at large token counts,
+    e.g. ep4 / 32768).  Even element -> low nibble, odd -> high (matches
+    ``unpack_fp4_to_f32``; the decode table is standard E2M1).
+    """
+    if not fp32.is_cuda or fp32.dtype != torch.float32:
+        raise ValueError(
+            f"_pack_f32_to_fp4 expects a CUDA float32 tensor; got "
+            f"device={fp32.device}, dtype={fp32.dtype}."
+        )
+    *lead, last = fp32.shape
+    if last % 2 != 0:
+        raise ValueError(f"FP4 pack needs an even trailing dim, got {last}.")
+    flat = fp32.reshape(-1).contiguous()
+    n_pairs = flat.numel() // 2
+    out = torch.empty(n_pairs, dtype=torch.uint8, device=fp32.device)
+    if n_pairs > 0:
+        triton, kernel = _get_pack_fp4_triton_kernel()
+        block = 1024
+        grid = (triton.cdiv(n_pairs, block),)
+        kernel[grid](flat, out, n_pairs, BLOCK=block)
+    return out.view(*lead, last // 2).view(Nvfp4DataDtype)
+
+
+@functools.lru_cache(None)
+def _get_rcp_approx_triton_kernel():
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _rcp_approx_kernel(x_ptr, y_ptr, n_elements, BLOCK: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = offsets < n_elements
+        x = tl.load(x_ptr + offsets, mask=mask, other=1.0)
+        y = tl.inline_asm_elementwise(
+            "rcp.approx.ftz.f32 $0, $1;",
+            "=r, r",
+            [x],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+        tl.store(y_ptr + offsets, y, mask=mask)
+
+    return triton, _rcp_approx_kernel
+
+
+def _rcp_approx_ftz_f32_cuda(x: torch.Tensor) -> torch.Tensor:
+    """Bit-match kernel-side ``cute.arch.rcp_approx`` for CUDA fp32 tensors."""
+    if not x.is_cuda or x.dtype != torch.float32:
+        raise ValueError(
+            "_rcp_approx_ftz_f32_cuda expects a CUDA float32 tensor; "
+            f"got device={x.device}, dtype={x.dtype}."
+        )
+    x_contig = x.contiguous()
+    y = torch.empty_like(x_contig)
+    n_elements = x_contig.numel()
+    if n_elements == 0:
+        return y.view_as(x)
+
+    triton, kernel = _get_rcp_approx_triton_kernel()
+    block = 1024
+    grid = (triton.cdiv(n_elements, block),)
+    kernel[grid](x_contig, y, n_elements, BLOCK=block)
+    return y.view_as(x)
+
+
+@functools.lru_cache(None)
+def _get_swiglu_pair_hw_match_triton_kernel():
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _swiglu_pair_kernel(gate_ptr, up_ptr, out_ptr, n_elements, BLOCK: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+        mask = offsets < n_elements
+        gate = tl.load(gate_ptr + offsets, mask=mask, other=0.0)
+        up = tl.load(up_ptr + offsets, mask=mask, other=0.0)
+        ug = up * gate
+        neg_g_l2e = gate * (-1.4426950408889634)
+        exp_neg = tl.inline_asm_elementwise(
+            "ex2.approx.f32 $0, $1;",
+            "=r, r",
+            [neg_g_l2e],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+        one_plus = exp_neg + 1.0
+        sigmoid = tl.inline_asm_elementwise(
+            "rcp.approx.ftz.f32 $0, $1;",
+            "=r, r",
+            [one_plus],
+            dtype=tl.float32,
+            is_pure=True,
+            pack=1,
+        )
+        out = ug * sigmoid
+        tl.store(out_ptr + offsets, out, mask=mask)
+
+    return triton, _swiglu_pair_kernel
+
+
+def _swiglu_pair_hw_match_cuda(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+    """Compute SwiGLU matching the kernel-side PTX op sequence."""
+    if not gate.is_cuda or not up.is_cuda:
+        return up * (gate * torch.sigmoid(gate))
+    if gate.dtype != torch.float32 or up.dtype != torch.float32:
+        return _swiglu_pair_hw_match_cuda(
+            gate.to(torch.float32), up.to(torch.float32)
+        ).to(gate.dtype)
+    if gate.shape != up.shape:
+        raise ValueError(
+            f"_swiglu_pair_hw_match_cuda: gate.shape {tuple(gate.shape)} "
+            f"!= up.shape {tuple(up.shape)}."
+        )
+    if gate.numel() == 0:
+        return torch.empty_like(gate)
+
+    gate_c = gate.contiguous()
+    up_c = up.contiguous()
+    out = torch.empty_like(gate_c)
+    n_elements = gate_c.numel()
+
+    triton, kernel = _get_swiglu_pair_hw_match_triton_kernel()
+    block = 1024
+    grid = (triton.cdiv(n_elements, block),)
+    kernel[grid](gate_c, up_c, out, n_elements, BLOCK=block)
+    return out.view_as(gate)
+
+
+def nvfp4_quantize_per_block_16(
+    c_swiglu: torch.Tensor,
+    norm_const: float,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """NVFP4-quantize the SwiGLU output along its trailing dim."""
+    M, N = c_swiglu.shape
+    if N % Nvfp4BlockSize != 0:
+        raise ValueError(
+            f"Trailing dim ({N}) must be a multiple of sf_vec_size ({Nvfp4BlockSize})."
+        )
+    n_blocks = N // Nvfp4BlockSize
+
+    blocked = c_swiglu.view(M, n_blocks, Nvfp4BlockSize)
+    absmax = blocked.abs().amax(dim=-1)
+    sfc_fp32 = absmax * Nvfp4E2M1RcpLimit * norm_const
+    sfc_fp32_clamped = torch.clamp(sfc_fp32, min=-Fp8E4M3FNMax, max=Fp8E4M3FNMax)
+    sfc_fp8 = sfc_fp32_clamped.to(Nvfp4ScaleDtype)
+    sfc_fp32_rt = sfc_fp8.to(torch.float32)
+
+    fp32_max = torch.finfo(torch.float32).max
+    acc_scale = float(norm_const) * _rcp_approx_ftz_f32_cuda(sfc_fp32_rt)
+    acc_scale = torch.nan_to_num(acc_scale, nan=fp32_max, posinf=fp32_max, neginf=fp32_max)
+    acc_scale = torch.clamp(acc_scale, max=fp32_max)
+    acc_scale = torch.where(
+        sfc_fp32_rt > 0, acc_scale, torch.zeros_like(acc_scale)
+    )
+
+    scaled = c_swiglu * acc_scale.unsqueeze(-1).expand_as(blocked).reshape(M, N)
+    c_fp4 = _pack_f32_to_fp4(scaled)
+    return c_fp4, sfc_fp8

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/runner_fc12.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/runner_fc12.py
@@ -1,0 +1,414 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Host driver for the MegaMoE NVFP4 swap-AB fused fc1+fc2 kernel."""
+
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import List, Literal, Optional, Tuple
+
+import numpy as np
+import torch
+
+# Ensure absolute package imports work when this file is run as a script.
+_PKG_DIR = os.path.dirname(os.path.abspath(__file__))
+_PARENT_DIR = os.path.dirname(_PKG_DIR)
+if _PARENT_DIR not in sys.path:
+    sys.path.insert(0, _PARENT_DIR)
+
+# Re-export the shared descriptors so legacy importers (e.g. mega_runner.py)
+# continue to find them at ``moe_nvfp4_swapab.runner_fc12``.
+from moe_nvfp4_swapab.runner_fc12_common import (
+    ProblemDesc,
+    ImplDesc,
+    MiscDesc,
+    Fc12TesterBase,
+    add_common_fc12_arguments,
+    parse_tuple,
+)
+from moe_nvfp4_swapab.epilogue_refactor import SwapABSwigluFp4Epilogue
+from moe_nvfp4_swapab.runner_common import (
+    Nvfp4DataDtype,
+    dequant_block_scale_to_fp32,
+    from_blocked,
+    nvfp4_quantize_per_block_16,
+)
+from common.host_utils import (
+    kind_data_dtype,
+    kind_sf_vec_size,
+)
+
+
+# =============================================================================
+# NVFP4 tester
+# =============================================================================
+
+
+class SwapABSwigluFp4Fc12Tester(Fc12TesterBase):
+    """NVFP4 host-side input/reference/launch/validation driver."""
+
+    @property
+    def _epilogue_token_tile(self) -> int:
+        # Sourced from the NVFP4 epilogue class (C.8), not a runner hardcode.
+        return SwapABSwigluFp4Epilogue._EpilogueTokenTileSize
+
+    # ------------------------------------------------------------------
+    # FP4 tensor creation
+    # ------------------------------------------------------------------
+
+    def _create_fp4_tensor(
+        self, logical_shape: Tuple[int, ...], packed_dim: int = -1
+    ) -> torch.Tensor:
+        """Create a ``float4_e2m1fn_x2`` tensor.
+
+        Two modes (selected by ``misc.perf_run``):
+          - correctness: sparse nibbles from {0x0, 0x2, 0xA} (= {0, +1, -1}),
+            80 % zeros / 10 % +1 / 10 % -1.  Keeps GEMM absmax low enough
+            that SwiGLU output stays below fp8e4m3fn SF saturation (= 448).
+          - perf: random uint8 bytes (FP4 has no NaN; every byte is a valid
+            packed pair).  Used for timing.
+
+        ``packed_dim`` is the logical dim that becomes stride-1 (i.e. halved
+        in the byte buffer).  The size along that dim must be even.
+        """
+        ndim = len(logical_shape)
+        packed_dim = packed_dim % ndim
+        if logical_shape[packed_dim] % 2 != 0:
+            raise ValueError(
+                f"packed_dim {packed_dim} size ({logical_shape[packed_dim]}) must be even."
+            )
+
+        if self.misc.perf_run:
+            elem_cnt = 1
+            for s in logical_shape:
+                elem_cnt *= s
+            byte_cnt = elem_cnt // 2
+            flat = torch.randint(0, 256, (byte_cnt,), dtype=torch.uint8, device="cuda")
+
+            shape_reordered = list(logical_shape)
+            need_perm = packed_dim != ndim - 1
+            if need_perm:
+                shape_reordered[packed_dim], shape_reordered[-1] = (
+                    shape_reordered[-1],
+                    shape_reordered[packed_dim],
+                )
+            shape_reordered[-1] //= 2
+            tensor = flat.view(Nvfp4DataDtype).reshape(shape_reordered)
+            if need_perm:
+                perm = list(range(ndim))
+                perm[packed_dim], perm[-1] = perm[-1], perm[packed_dim]
+                tensor = tensor.permute(perm)
+            return tensor
+
+        # -- Correctness mode --
+        rand_u8 = torch.randint(0, 100, logical_shape, dtype=torch.uint8, device="cuda")
+        nibbles = torch.zeros_like(rand_u8)         # default 0 (nibble 0x0)
+        nibbles.masked_fill_((rand_u8 >= 80) & (rand_u8 < 90), 0x2)   # 10 %: +1
+        nibbles.masked_fill_(rand_u8 >= 90, 0xA)                      # 10 %: -1
+
+        need_perm = packed_dim != ndim - 1
+        if need_perm:
+            perm_to_last = list(range(ndim))
+            perm_to_last[packed_dim], perm_to_last[-1] = (
+                perm_to_last[-1],
+                perm_to_last[packed_dim],
+            )
+            nibbles = nibbles.permute(perm_to_last).contiguous()
+
+        even = nibbles[..., ::2]
+        odd = nibbles[..., 1::2]
+        packed_uint8 = (odd << 4) | even
+        tensor = packed_uint8.view(Nvfp4DataDtype)
+
+        if need_perm:
+            inv_perm = list(range(ndim))
+            inv_perm[packed_dim], inv_perm[-1] = inv_perm[-1], inv_perm[packed_dim]
+            tensor = tensor.permute(inv_perm)
+        return tensor
+
+    # ------------------------------------------------------------------
+    # Kind hooks: input / output tensor creation
+    # ------------------------------------------------------------------
+
+    def _fc2_output_shape(self, data_total_rows: int) -> Tuple[int, ...]:
+        # MoE-domain layout ``(token_max, topk, hidden)``: lean fc1+fc2
+        # collapses topk=1 (codegen-time const), storage is row-major and
+        # therefore byte-equivalent to the legacy ``(M, H)`` form -- the
+        # second axis only carries kernel-side stride metadata used by the
+        # fc2 return tile to address one output cell per pool token row
+        # (topk index always 0 in lean mode).  Validation / display paths
+        # squeeze axis 1 to recover ``(M, H)`` for comparison.
+        return (data_total_rows, 1, self.problem.hidden)
+
+    def _create_input_data_tensors(self, data_total_rows: int) -> None:
+        problem = self.problem
+        hidden = problem.hidden
+        intermediate = problem.intermediate
+        experts = problem.experts
+        data_dtype = kind_data_dtype(problem.kind)
+
+        # -- activation --
+        if data_total_rows > 0:
+            self.activation = self._create_fp4_tensor(
+                (data_total_rows, hidden), packed_dim=-1
+            )
+        else:
+            self.activation = torch.empty(
+                (0, hidden // 2), dtype=torch.uint8, device="cuda",
+            ).view(data_dtype)
+
+        # -- fc1_weight --
+        self.fc1_weight = self._create_fp4_tensor(
+            (experts, hidden, intermediate), packed_dim=1
+        )
+
+        # -- fc2_weight --
+        self.fc2_weight = self._create_fp4_tensor(
+            (experts, intermediate // 2, hidden), packed_dim=1
+        )
+
+        # -- per-expert fc1/fc2 alpha (always random for the NVFP4 tester,
+        #    mirroring mega_runner): real-value rescale folded into the
+        #    epilogue, fed to both the kernel runtime and the reference core.
+        self.fc1_alpha = (
+            torch.randint(1, 5, (experts,), device="cuda").to(torch.float32) * 0.5
+        )
+        self.fc2_alpha = (
+            torch.randint(1, 5, (experts,), device="cuda").to(torch.float32) * 0.5
+        )
+
+    def _alloc_fc2_output(self, data_total_rows: int) -> None:
+        # 0xFF byte fill: bf16 0xFFFF = NaN, fp16 0xFFFF = NaN -- kernel
+        # output overwriting valid rows is easy to distinguish from "kernel
+        # never touched this row".  Storage shape carries the lean
+        # ``topk=1`` axis demanded by the MoE-domain fc2 return tile contract;
+        # byte layout is identical to the legacy 2D form.
+        problem = self.problem
+        hidden = problem.hidden
+        fc2_output_bytes = torch.full(
+            (data_total_rows, hidden * problem.fc2_output_dtype.itemsize),
+            0xFF,
+            dtype=torch.uint8, device="cuda",
+        )
+        self.fc2_output = fc2_output_bytes.view(problem.fc2_output_dtype).reshape(
+            data_total_rows, 1, hidden
+        )
+
+    # ------------------------------------------------------------------
+    # Kind hooks: reference compute
+    # ------------------------------------------------------------------
+
+    def _quantize_fc1(
+        self, swiglu: torch.Tensor, norm_const_val: float
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return nvfp4_quantize_per_block_16(swiglu, norm_const_val)
+
+    def _apply_topk_post_fc2(
+        self, fc2_fp32: torch.Tensor, topk_slice: torch.Tensor
+    ) -> torch.Tensor:
+        # HF transformers semantics: topk weight applied AFTER fc2 GEMM.
+        if self.misc.ref_compute_graph == "transformers":
+            return fc2_fp32 * topk_slice.unsqueeze(-1)
+        return fc2_fp32
+
+    # ------------------------------------------------------------------
+    # Kind hooks: kernel + validation
+    # ------------------------------------------------------------------
+
+    def _instantiate_kernel(self, common_kwargs: dict):
+        import cutlass
+        from moe_nvfp4_swapab.kernel_fc12 import Sm100SwapABSwigluFp4Fc12Kernel
+
+        return Sm100SwapABSwigluFp4Fc12Kernel(
+            **common_kwargs,
+            fc2_output_dtype=cutlass.BFloat16,
+            non_ubulk_fc2_store=self.impl.non_ubulk_fc2_store,
+            in_kernel_fc2_reduce=self.impl.in_kernel_fc2_reduce,
+            apply_topk_in_fc1=self.misc.ref_compute_graph == "deepgemm",
+            gate_up_clamp=self.problem.gate_up_clamp,
+            epi_flag_batch=self.impl.epi_flag_batch,
+        )
+
+    def _fc2_tolerance(self) -> Tuple[float, float]:
+        return 5e-2, 5e-2
+
+    def _validate_fc1_phase(self) -> None:
+        """fc1 NVFP4 hand-off ablation: dequant kernel vs ref and compare values.
+
+        The kernel's fc1 nibble *byte packing* need not match the host
+        ``nvfp4_quantize`` packing, so a raw byte compare is meaningless; instead
+        dequantize both sides (``from_blocked`` un-swizzles the kernel SF) and
+        compare fp32 values.  With a bit-exact reference (fc1 also runs the real
+        blockscaled GEMM) any remaining diff is just fp4 RTNE near bin
+        boundaries, so this should be tiny.
+        """
+        if (
+            self._ws_fc1_output_torch is None
+            or self._ws_fc1_output_sf_torch is None
+            or not self._ref_fc1_q_per_expert
+        ):
+            print("[fc1 phase ablation] skipped (workspace or ref not populated)")
+            return
+
+        intermediate_downproj = self.problem.intermediate // 2
+        sf_vec_size = kind_sf_vec_size(self.problem.kind)
+        K_sf = intermediate_downproj // sf_vec_size  # raw SF cols per token
+
+        valid_tokens = self.valid_tokens_per_expert
+        data_offsets = self.data_physical_offsets
+        sf_offsets = self.sf_physical_offsets
+
+        print("=" * 60)
+        print("[fc1 phase ablation] kernel vs ref fc1 hand-off (dequant fp32)")
+        print(
+            f"{'expert':>6} {'v_e':>6} {'max_diff':>12} "
+            f"{'mean_diff':>12} {'n_bad@5e-2':>12} {'%bad':>8}"
+        )
+
+        total_n = 0
+        total_bad = 0
+        overall_max = 0.0
+        for e in range(self.problem.experts):
+            v_e = valid_tokens[e]
+            if v_e == 0:
+                continue
+            ref_q = self._ref_fc1_q_per_expert[e]
+            ref_sf = self._ref_fc1_raw_sf_per_expert[e]
+            if ref_q is None or ref_sf is None:
+                continue
+            d_start = data_offsets[e]
+            sf_start = sf_offsets[e]
+            sf_end = sf_offsets[e + 1]
+
+            kernel_q = self._ws_fc1_output_torch[d_start : d_start + v_e]
+            kernel_sf_raw = from_blocked(
+                self._ws_fc1_output_sf_torch[sf_start:sf_end]
+                .contiguous().view(-1),
+                v_e, K_sf,
+            )
+            kernel_fp32 = dequant_block_scale_to_fp32(
+                kernel_q, kernel_sf_raw, sf_vec_size, None
+            )
+            ref_fp32 = dequant_block_scale_to_fp32(
+                ref_q, ref_sf, sf_vec_size, None
+            )
+
+            diff = (kernel_fp32 - ref_fp32).abs()
+            max_d = diff.max().item()
+            mean_d = diff.mean().item()
+            n = diff.numel()
+            n_bad = int((diff > 5e-2).sum().item())
+            total_n += n
+            total_bad += n_bad
+            overall_max = max(overall_max, max_d)
+            print(
+                f"{e:>6d} {v_e:>6d} {max_d:>12.4g} {mean_d:>12.4g} "
+                f"{n_bad:>12d} {n_bad / max(n, 1) * 100:>7.3f}%"
+            )
+
+        print(
+            f"{'TOTAL':>6} {'':>6} {overall_max:>12.4g} {'':>12} "
+            f"{total_bad:>12d} {total_bad / max(total_n, 1) * 100:>7.3f}%"
+        )
+        print("=" * 60)
+
+
+# =============================================================================
+# CLI entry point
+# =============================================================================
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """argparse setup for the NVFP4 fused fc12 path."""
+    parser = argparse.ArgumentParser(
+        description="MoE NVFP4 Swap-AB fused fc1+fc2 SwiGLU (host-ready harness)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    add_common_fc12_arguments(parser)
+
+    parser.add_argument(
+        "--flag_batch", type=int, default=1,
+        help="dispatch_pull release-flag batch size; 1 == per-token "
+        "baseline, larger amortizes the device fence over more tokens.",
+    )
+    parser.add_argument(
+        "--epi_flag_batch", type=str, default="1,1",
+        help="(fc1,fc2) done-counter publish batch in comma form like "
+             "--mma_tiler_mnk (warp-cooperative, each in 1..32). E.g. 1,4.",
+    )
+    parser.add_argument(
+        "--gate_up_clamp", type=float, default=None,
+        help="DeepSeek-V4 swiglu_limit: asymmetric clamp on the real gate/up "
+             "pre-activations (gate<=limit, |up|<=limit) before SiLU. "
+             "Omitted/None disables it; must be non-negative.",
+    )
+    parser.add_argument(
+        "--use_bulk_fc2_store",
+        action="store_true",
+        default=False,
+        help="Use bulk (cp.async.bulk) fc2 store path instead of STG.256.",
+    )
+    parser.add_argument(
+        "--in_kernel_fc2_reduce",
+        action="store_true",
+        default=False,
+        help="Reduce topk in-kernel via fc2 atomic add "
+             "(lean runner forbids this).",
+    )
+
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    problem = ProblemDesc(
+        tokens_after_topk=args.tokens_after_topk,
+        experts=args.experts,
+        balance_route=args.balance_route,
+        hidden=args.hidden,
+        intermediate=args.intermediate,
+        simulate_ep=args.simulate_ep,
+        fc2_output_dtype=args.fc2_output_dtype,
+        gate_up_clamp=args.gate_up_clamp,
+        kind="nvfp4",
+    )
+
+    impl = ImplDesc(
+        mma_tiler_mnk=parse_tuple(args.mma_tiler_mnk),
+        cluster_shape_mnk=parse_tuple(args.cluster_shape_mnk),
+        use_2cta_instrs=args.use_2cta_instrs,
+        enable_static_expert_shape=args.enable_static_expert_shape,
+        force_static_sched=not args.dynamic_sched,
+        clc_bundle_size=args.clc_bundle_size,
+        num_sched_stages=args.num_sched_stages,
+        load_balance_mode=args.load_balance_mode,
+        group_hint=args.group_hint,
+        non_ubulk_fc2_store=not args.use_bulk_fc2_store,
+        in_kernel_fc2_reduce=args.in_kernel_fc2_reduce,
+        flag_batch=args.flag_batch,
+        epi_flag_batch=parse_tuple(args.epi_flag_batch),
+    )
+
+    misc = MiscDesc(
+        perf_run=args.perf_run,
+        skip_ref_check=args.skip_ref_check,
+        run_target_kernel_only=args.run_target_kernel_only,
+        enable_debug_checks=args.enable_debug_checks,
+        ref_compute_graph=args.ref_compute_graph,
+        enable_iket=args.enable_iket,
+        seed=args.seed,
+        verbose=args.verbose,
+    )
+
+    tester = SwapABSwigluFp4Fc12Tester(problem, impl, misc)
+    tester.run()
+
+
+if __name__ == "__main__":
+    main()
+    exit(0)

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/runner_fc12_common.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/runner_fc12_common.py
@@ -1,0 +1,1864 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Shared host-driver scaffolding for the MegaMoE fused fc1+fc2 runners.
+
+This module holds everything the NVFP4 (``moe_nvfp4_swapab/runner_fc12.py``)
+and MXFP8 (``moe_mxfp8_glu/runner_fc12.py``) fused-fc12 runners have in common:
+
+  * The three configuration descriptors (:class:`ProblemDesc`,
+    :class:`ImplDesc`, :class:`MiscDesc`).  They are quantization-kind
+    *parameterized* (each carries a ``kind`` and the descriptors validate
+    against it), not kind-specific, so both runners reuse them verbatim.
+
+  * :class:`Fc12TesterBase` -- the host-side input/reference/launch/
+    validation driver.  All kind-agnostic logic (offs generation, physical
+    offsets, raw-scale assembly, workspace partition, kernel launch
+    plumbing, determinism check, scheduler-layout preview, top-level
+    ``run`` orchestration) lives here.  The handful of genuinely
+    kind-entangled steps are expressed as overridable hooks that the two
+    concrete subclasses implement:
+
+      - :meth:`_create_input_data_tensors` -- activation / fc1 / fc2 weights
+      - :meth:`_alloc_fc2_output`          -- fc2 output buffer (3D vs 2D)
+      - :meth:`_quantize_fc1`              -- post-SwiGLU quantize (nvfp4 vs mxfp8)
+      - :meth:`_apply_topk_post_fc2`       -- transformers topk post-multiply
+      - :meth:`_instantiate_kernel`        -- pick / construct the kernel class
+      - :meth:`_validate_fc1_phase`        -- fc1 workspace readback diagnostics
+      - :meth:`_fc2_tolerance`             -- (atol, rtol) for the fc2 compare
+
+  * Shared argparse helpers (:func:`add_common_fc12_arguments`,
+    :func:`parse_tuple`, :func:`parse_output_dtype`).
+"""
+
+
+import argparse
+from dataclasses import dataclass
+from typing import List, Literal, Optional, Tuple
+
+import numpy as np
+import torch
+import cutlass
+from cutlass.utils import HardwareInfo
+
+from moe_nvfp4_swapab.epilogue import (
+    EpilogueTokenTile,
+    Fc1GateUpInterleave as Nvfp4Fc1GateUpInterleave,
+)
+from moe_mxfp8_glu.epilogue_mxfp8 import (
+    Fc1GateUpInterleave as Mxfp8Fc1GateUpInterleave,
+)
+from common.megamoe_constants import (
+    Nvfp4BlockSize,
+    Mxfp8BlockSize,
+    SfPaddingBlock,
+    SupportedMmaTileM,
+    SupportedMmaTileN,
+)
+from moe_nvfp4_swapab.simulate_fc1_fc2_sched import FusedFc12Simulator
+
+from moe_nvfp4_swapab.runner_common import (
+    Nvfp4DataDtype,
+    _create_raw_scale_tensor,
+    assemble_raw_scales_grouped_token,
+    assemble_raw_scales_stacked_expert,
+    ceil_div,
+    offs_to_group_sizes,
+    round_up,
+    slice_tensor_logical_dim,
+)
+from common.host_utils import (
+    kind_data_dtype,
+    kind_scale_dtype,
+    kind_sf_vec_size,
+    compare_and_report_mismatches,
+)
+
+
+# =============================================================================
+# Configuration descriptors (shared, kind-parameterized)
+# =============================================================================
+
+
+@dataclass
+class ProblemDesc:
+    """Problem-side configuration and host-visible layout locks."""
+
+    tokens_after_topk: int = 0
+    experts: int = 0
+    balance_route: bool = True
+    hidden: int = 0
+    intermediate: int = 0
+    simulate_ep: Optional[int] = None
+    fc2_output_dtype: torch.dtype = torch.bfloat16
+    # DeepSeek-V4 swiglu_limit: asymmetric clamp on the real gate/up
+    # pre-activations before SiLU.  NVFP4-only knob; ``None`` disables it (and
+    # other kinds leave it None).
+    gate_up_clamp: Optional[float] = None
+
+    scenario: Literal["2Dx3D"] = "2Dx3D"
+    kind: Literal["nvfp4", "mxfp8_e4m3", "mxfp8_e5m2"] = "nvfp4"
+    acc_dtype: torch.dtype = torch.float32
+    fc1_activation_layout: Literal["k_major"] = "k_major"
+    fc1_weight_layout: Literal["k_major"] = "k_major"
+    fc2_weight_layout: Literal["k_major", "n_major"] = "k_major"
+    fc2_output_layout: Literal["n_major"] = "n_major"
+
+    def __post_init__(self) -> None:
+        if self.tokens_after_topk < 0:
+            raise ValueError(
+                f"tokens_after_topk must be non-negative, got {self.tokens_after_topk}."
+            )
+        if self.experts <= 0:
+            raise ValueError(f"experts must be positive, got {self.experts}.")
+        if self.hidden <= 0 or self.hidden % Nvfp4BlockSize != 0:
+            raise ValueError(
+                f"hidden ({self.hidden}) must be a positive multiple of {Nvfp4BlockSize}."
+            )
+        _interleave = Nvfp4Fc1GateUpInterleave if self.kind == "nvfp4" else Mxfp8Fc1GateUpInterleave
+        if self.intermediate <= 0 or self.intermediate % (2 * _interleave) != 0:
+            raise ValueError(
+                f"intermediate ({self.intermediate}) must be a positive multiple of "
+                f"{2 * _interleave} (gate/up interleave granularity for kind={self.kind!r})."
+            )
+        _sf_vec = Nvfp4BlockSize if self.kind == "nvfp4" else Mxfp8BlockSize
+        if (self.intermediate // 2) % _sf_vec != 0:
+            raise ValueError(
+                f"intermediate/2 ({self.intermediate // 2}) must be a multiple of "
+                f"sf_vec_size ({_sf_vec}) for fc2's per-block SF coverage."
+            )
+        if self.simulate_ep is not None and self.simulate_ep <= 0:
+            raise ValueError(f"simulate_ep must be positive, got {self.simulate_ep}.")
+        if self.gate_up_clamp is not None and self.gate_up_clamp < 0.0:
+            raise ValueError(
+                f"gate_up_clamp must be None or non-negative, got "
+                f"{self.gate_up_clamp}."
+            )
+
+        # -- Locked-domain fields --
+        # Run BEFORE the TMA alignment block: the alignment derivation reads
+        # the layout fields to pick which dim is the stride-1 (leading) row,
+        # so an unsupported layout would otherwise surface as a confusing
+        # KeyError instead of a clear "layout is locked" message.
+        if self.scenario != "2Dx3D":
+            raise ValueError(
+                f"Only scenario='2Dx3D' is supported in v1, got {self.scenario!r}."
+            )
+        if self.kind not in ("nvfp4", "mxfp8_e4m3", "mxfp8_e5m2"):
+            raise ValueError(
+                f"kind must be one of 'nvfp4', 'mxfp8_e4m3', 'mxfp8_e5m2'; "
+                f"got {self.kind!r}."
+            )
+        if self.fc2_output_dtype not in (torch.bfloat16, torch.float16):
+            raise ValueError(
+                f"fc2_output_dtype must be torch.bfloat16 or torch.float16, "
+                f"got {self.fc2_output_dtype}."
+            )
+        if self.acc_dtype != torch.float32:
+            raise ValueError(
+                f"acc_dtype is locked to torch.float32 in v1, got {self.acc_dtype}."
+            )
+        if self.fc1_activation_layout != "k_major":
+            raise ValueError(
+                f"fc1_activation_layout is locked to 'k_major' in v1, got "
+                f"{self.fc1_activation_layout!r}."
+            )
+        if self.fc1_weight_layout != "k_major":
+            raise ValueError(
+                f"fc1_weight_layout is locked to 'k_major' in v1, got "
+                f"{self.fc1_weight_layout!r}."
+            )
+        if self.fc2_weight_layout != "k_major":
+            raise ValueError(
+                f"fc2_weight_layout='n_major' is reserved for MXFP8 and not "
+                f"supported in v1; got {self.fc2_weight_layout!r}."
+            )
+        if self.fc2_output_layout != "n_major":
+            raise ValueError(
+                f"fc2_output_layout is locked to 'n_major' in v1, got "
+                f"{self.fc2_output_layout!r}."
+            )
+
+        # -- TMA leading-dim 16-byte alignment --
+        # Each host-exposed tensor's stride-1 row is selected by the
+        # corresponding layout field above; the leading-dim element count
+        # is then picked from ProblemDesc dims via the per-tensor mapping
+        # tables below.  Each table covers all currently-typed layout
+        # choices (the v1-locked guards above narrow them to the ones
+        # actually supported, but the tables stay forward-compat for when
+        # the locks are relaxed).  Bytes per leading row are derived from
+        # the dtype by ``check_tma_leading_dim_align`` (NVFP4 = 0.5B/elem,
+        # bf16/fp16 = 2B, fp32 = 4B, fp8 = 1B).
+        #
+        # ``fc1_output`` is the kernel-internal staging buffer (post-fc1
+        # NVFP4 + per-block SF, consumed as fc2's B operand).  Its layout
+        # is fixed by the kernel (k_major over (tokens, intermediate/2))
+        # and not exposed via ProblemDesc, but its leading-dim alignment
+        # still has to hold or fc2's TMA load reads garbage -- check
+        # explicitly here with the kernel-fixed layout inlined.
+        from moe_nvfp4_swapab.runner_common import (
+            check_tma_leading_dim_align as _check_tma_leading_dim_align,
+        )
+        _check_tma_leading_dim_align(
+            "activation",
+            {"k_major": self.hidden}[self.fc1_activation_layout],
+            Nvfp4DataDtype,
+        )
+        _check_tma_leading_dim_align(
+            "fc1_weight",
+            {"k_major": self.hidden}[self.fc1_weight_layout],
+            Nvfp4DataDtype,
+        )
+        _check_tma_leading_dim_align(
+            "fc2_weight",
+            {"k_major": self.intermediate // 2, "n_major": self.hidden}[
+                self.fc2_weight_layout
+            ],
+            Nvfp4DataDtype,
+        )
+        _check_tma_leading_dim_align(
+            "fc1_output (kernel-internal, fixed k_major)",
+            self.intermediate // 2,
+            Nvfp4DataDtype,
+        )
+        _check_tma_leading_dim_align(
+            "fc2_output",
+            {"n_major": self.hidden}[self.fc2_output_layout],
+            self.fc2_output_dtype,
+        )
+
+    def __str__(self) -> str:
+        d = lambda t: str(t).split(".")[-1]
+        route = "balanced" if self.balance_route else "random"
+        ep_str = f" ep={self.simulate_ep}" if self.simulate_ep is not None else ""
+        return (
+            f"ProblemDesc: {self.scenario} | kind={self.kind} | "
+            f"tokens_after_topk={self.tokens_after_topk} experts={self.experts} "
+            f"route={route} | "
+            f"hidden={self.hidden} intermediate={self.intermediate} | "
+            f"fc2_output_dtype={d(self.fc2_output_dtype)} "
+            f"layouts=(act={self.fc1_activation_layout},"
+            f"fc1w={self.fc1_weight_layout},"
+            f"fc2w={self.fc2_weight_layout},"
+            f"fc2out={self.fc2_output_layout}) "
+            f"acc={d(self.acc_dtype)}{ep_str}"
+        )
+
+
+@dataclass
+class ImplDesc:
+    """Kernel-instantiation-side configuration.
+
+    Defaults: mma_tiler ``(M=128, N=128, K=256)``, single-cluster, single-CTA
+    MMA, static sched, static load balance.
+
+    Fused fc12 fields:
+      - ``load_balance_mode``: chooses the persistent scheduler's load-balance
+        strategy.  ``"static"`` is the v1 default (stride mode);
+        ``"atomic_counter"`` is the dynamic alternative.
+      - ``group_hint``: per-group fc1 tile threshold that drives expert
+        packing.  ``None`` means the runner fills in
+        ``HardwareInfo().get_max_active_clusters(cluster_size)`` at kernel
+        launch time.
+      - ``enable_static_expert_shape``: when True, ``run_kernel`` constructs
+        the kernel with
+        ``static_expert_shape = (experts, intermediate_gateup, hidden)``
+        Python int triple read from ``ProblemDesc``, so the scheduler sees
+        codegen-const dims (lets div/mod over ``intermediate_gateup`` /
+        ``hidden`` fold to magic-mul).  When False the kernel reads those
+        three dims from the per-launch tensors at runtime (dynamic Int32).
+        Either path is correct; ``True`` typically gives a small perf win
+        at the cost of one extra ``cute.compile`` per problem shape.
+    """
+
+    mma_tiler_mnk: Tuple[int, int, int] = (128, 128, 256)
+    cluster_shape_mnk: Tuple[int, int, int] = (1, 1, 1)
+    use_2cta_instrs: bool = False
+    enable_static_expert_shape: bool = False
+    force_static_sched: bool = True
+    clc_bundle_size: Optional[int] = None
+    num_sched_stages: Optional[int] = None
+    load_balance_mode: Literal["static", "atomic_counter"] = "static"
+    group_hint: Optional[int] = None
+    non_ubulk_fc2_store: bool = True
+    in_kernel_fc2_reduce: bool = False
+    token_back_mode: Literal[
+        "epi_warps", "standalone_warps", "reuse_dispatch_warps"
+    ] = "epi_warps"
+    flag_batch: int = 4
+    epi_flag_batch: Optional[Tuple[int, int]] = (1, 1)
+
+    def __post_init__(self) -> None:
+        m, n, _k = self.mma_tiler_mnk
+        cm, cn, cl = self.cluster_shape_mnk
+
+        if m not in SupportedMmaTileM:
+            raise ValueError(f"mma_tiler_m must be one of {SupportedMmaTileM}, got {m}.")
+        if n not in SupportedMmaTileN:
+            raise ValueError(f"mma_tiler_n must be one of {SupportedMmaTileN}, got {n}.")
+        if cl != 1:
+            raise ValueError(f"cluster_l must be 1, got {cl}.")
+        if cn != 1:
+            raise ValueError(
+                f"cluster_n must be 1 in v1, got {cn}."
+            )
+        if cm < 1 or cm > 16 or cm * cn > 16:
+            raise ValueError(
+                f"cluster_m must be in [1, 16] and cluster_m*cluster_n <=16, "
+                f"got cluster=({cm},{cn})."
+            )
+        if self.use_2cta_instrs != (m == 256):
+            raise ValueError(
+                f"use_2cta_instrs ({self.use_2cta_instrs}) must equal "
+                f"(mma_tiler_m == 256), got mma_tiler_m={m}."
+            )
+        if self.load_balance_mode not in ("static", "atomic_counter"):
+            raise ValueError(
+                f"load_balance_mode must be 'static' or 'atomic_counter' "
+                f"(the 'clc' mode is handled by a separate scheduler class "
+                f"and is not wired through the fused fc12 kernel); "
+                f"got {self.load_balance_mode!r}."
+            )
+        if self.token_back_mode not in (
+            "epi_warps", "standalone_warps", "reuse_dispatch_warps"
+        ):
+            raise ValueError(
+                f"token_back_mode must be 'epi_warps', 'standalone_warps', "
+                f"or 'reuse_dispatch_warps'; got {self.token_back_mode!r}."
+            )
+        if self.group_hint is not None and self.group_hint <= 0:
+            raise ValueError(f"group_hint must be positive when set, got {self.group_hint}.")
+        if self.flag_batch < 1:
+            raise ValueError(f"flag_batch must be >= 1, got {self.flag_batch}.")
+        # epi done-counter batch is a ``(fc1, fc2)`` pair, published
+        # warp-cooperatively (one lane per pending tile), so a single warp-wide
+        # flush caps each at 32.
+        eb = self.epi_flag_batch if self.epi_flag_batch is not None else (1, 1)
+        if len(eb) != 2:
+            raise ValueError(
+                f"epi_flag_batch must be a (fc1, fc2) pair, got "
+                f"{self.epi_flag_batch}."
+            )
+        for _leg, _val in (("fc1", eb[0]), ("fc2", eb[1])):
+            if _val < 1 or _val > 32:
+                raise ValueError(
+                    f"epi_flag_batch[{_leg}] must be in [1, 32], got {_val}."
+                )
+
+    @property
+    def fc2_reduces_topk(self) -> bool:
+        return self.in_kernel_fc2_reduce
+
+    @property
+    def token_back_by_dispatch(self) -> bool:
+        """True when fc2 is staged to a local workspace and pushed back by
+        dispatch-area warps (standalone or reused), i.e. any non-epi mode."""
+        return self.token_back_mode != "epi_warps"
+
+    def __str__(self) -> str:
+        tile = ",".join(map(str, self.mma_tiler_mnk))
+        cluster = ",".join(map(str, self.cluster_shape_mnk))
+        static_shape = (
+            "static" if self.enable_static_expert_shape else "dynamic"
+        )
+        sched = "static" if self.force_static_sched else "dynamic_clc"
+        bundle = self.clc_bundle_size if self.clc_bundle_size is not None else "default"
+        stages = (
+            self.num_sched_stages if self.num_sched_stages is not None else "default"
+        )
+        group_hint_str = (
+            str(self.group_hint) if self.group_hint is not None else "max_active_clusters"
+        )
+        return (
+            f"ImplDesc: tile={tile} cluster={cluster} 2cta={self.use_2cta_instrs} | "
+            f"expert_shape={static_shape} sched={sched} bundle={bundle} stages={stages} | "
+            f"load_balance={self.load_balance_mode} group_hint={group_hint_str} | "
+            f"non_ubulk_fc2_store={self.non_ubulk_fc2_store} "
+            f"in_kernel_fc2_reduce={self.in_kernel_fc2_reduce} "
+            f"token_back_mode={self.token_back_mode}"
+        )
+
+
+@dataclass
+class MiscDesc:
+    """Misc run-time switches for the fused fc12 runner.
+
+    ``ref_compute_graph`` selects which reference compute graph to use:
+
+      - ``"transformers"``: HuggingFace transformers semantics --
+        ``out = (down_proj @ swiglu) * topk_score`` with topk_score
+        applied AFTER fc2 GEMM in fp32, then cast to bf16/fp16.
+
+      - ``"deepgemm"``:  DeepGEMM mega-MoE semantics (Path A) --
+        ``out = down_proj @ (swiglu * topk_score)`` with topk_score
+        pre-multiplied into swiglu in fp32 BEFORE NVFP4 quantize, so
+        per-block SF absorbs the per-token scaling.  This is what the
+        kernel does when its PostSwigluHalf path is enabled (the path
+        adopted to avoid an fc2-side warp shuffle for weight broadcast).
+
+    The two paths are NOT bit-exact (NVFP4 round-to-nearest at fp4 ULP
+    differs slightly when the inputs differ), but in NVFP4 the additional
+    error introduced by Path A is on the order of fp8 SF rounding (~0.4%)
+    -- much smaller than NVFP4's inherent ~6% quant error.
+
+    Default ``"deepgemm"`` matches the kernel path; switch to
+    ``"transformers"`` to compare against the ground-truth reference
+    semantics (expect tolerance to absorb the small extra mismatch).
+    """
+
+    perf_run: bool = False
+    skip_ref_check: bool = False
+    run_target_kernel_only: bool = False
+    enable_debug_checks: bool = False
+    ref_compute_graph: Literal["transformers", "deepgemm"] = "deepgemm"
+    seed: int = 1234
+    # Preserve iket.* ops through lowering; runtime backend is selected outside
+    # this runner via DKG_IKET_INSTRUMENTATION_METHOD.
+    enable_iket: bool = False
+    verbose: bool = False
+
+    @property
+    def profile_friendly(self) -> bool:
+        """Alias for ``run_target_kernel_only``."""
+        return self.run_target_kernel_only
+
+    def __post_init__(self) -> None:
+        if self.ref_compute_graph not in ("transformers", "deepgemm"):
+            raise ValueError(
+                f"ref_compute_graph must be 'transformers' or 'deepgemm', "
+                f"got {self.ref_compute_graph!r}."
+            )
+
+    def __str__(self) -> str:
+        return (
+            f"MiscDesc: perf={self.perf_run} skip_ref={self.skip_ref_check} "
+            f"target_only={self.run_target_kernel_only} "
+            f"debug_checks={'on' if self.enable_debug_checks else 'off'} "
+            f"ref_graph={self.ref_compute_graph} "
+            f"iket={'on' if self.enable_iket else 'off'} seed={self.seed}"
+        )
+
+
+# =============================================================================
+# Tester base (kind-agnostic host driver)
+# =============================================================================
+
+
+class Fc12TesterBase:
+    """Host-side input/reference/launch/validation driver (kind-agnostic).
+
+    Concrete subclasses (``SwapABSwigluFp4Fc12Tester`` for NVFP4,
+    ``SwigluMxfp8Fc12Tester`` for MXFP8) implement the small set of
+    kind-entangled hooks documented at the bottom of this class.
+    """
+
+    def __init__(
+        self,
+        problem: ProblemDesc,
+        impl: ImplDesc,
+        misc: MiscDesc,
+    ) -> None:
+        if impl.fc2_reduces_topk:
+            raise ValueError(
+                "in_kernel_fc2_reduce=True requires MegaMoE token_comm "
+                "metadata; lean runner has no topk combine semantics."
+            )
+
+        self.problem = problem
+        self.impl = impl
+        self.misc = misc
+
+        torch.manual_seed(misc.seed)
+        np.random.seed(misc.seed)
+        self._np_rng: np.random.Generator = np.random.default_rng(misc.seed)
+
+        # Dirichlet concentration parameter (only consulted when
+        # ``balance_route`` is False).
+        self.dirichlet_alpha: float = 0.5
+
+        # -- State populated by generate_inputs / compute_reference --
+        self.offs: Optional[torch.Tensor] = None
+        self.valid_tokens_per_expert: Optional[List[int]] = None
+        self.data_physical_offsets: Optional[List[int]] = None
+        self.sf_physical_offsets: Optional[List[int]] = None
+
+        self.activation: Optional[torch.Tensor] = None
+        self.fc1_weight: Optional[torch.Tensor] = None
+        self.fc2_weight: Optional[torch.Tensor] = None
+        self.activation_sf: Optional[torch.Tensor] = None
+        self.fc1_weight_sf: Optional[torch.Tensor] = None
+        self.fc2_weight_sf: Optional[torch.Tensor] = None
+        self.raw_activation_sf_list: Optional[List[torch.Tensor]] = None
+        self.raw_fc1_weight_sf_list: Optional[List[torch.Tensor]] = None
+        self.raw_fc2_weight_sf_list: Optional[List[torch.Tensor]] = None
+        self.activation_global_scale: Optional[torch.Tensor] = None
+        self.fc1_weight_global_scale: Optional[torch.Tensor] = None
+        self.fc2_weight_global_scale: Optional[torch.Tensor] = None
+        self.norm_const: Optional[torch.Tensor] = None
+        # Optional per-expert fc1/fc2 alpha (real-value rescale folded into the
+        # epilogue).  ``None`` => no alpha (kernel + reference both treat as 1.0);
+        # the NVFP4 tester fills them, mxfp8 leaves them None.
+        self.fc1_alpha: Optional[torch.Tensor] = None
+        self.fc2_alpha: Optional[torch.Tensor] = None
+        self.topk_scores: Optional[torch.Tensor] = None
+        self.fc2_output: Optional[torch.Tensor] = None
+        self.workspace: Optional[torch.Tensor] = None
+
+        self.fc2_output_ref: Optional[torch.Tensor] = None
+
+        # Compiled-kernel cache (run_kernel populates on first invocation).
+        self._compiled_kernel = None
+
+        # -- Per-phase debug ablation state (compute_reference + run_kernel
+        # populate; _validate_fc1_phase / _check_kernel_determinism consume) --
+        #
+        # Indexed by expert idx; ``None`` slot for 0-token experts (which
+        # ``compute_reference`` skips and the kernel never writes for).  All
+        # tensors live on the same CUDA device as the launch outputs so
+        # diff arithmetic stays GPU-side.
+        self._ref_fc1_q_per_expert: List[Optional[torch.Tensor]] = []
+        self._ref_fc1_raw_sf_per_expert: List[Optional[torch.Tensor]] = []
+        self._ref_fc1_gateup_per_expert: List[Optional[torch.Tensor]] = []
+
+        # Workspace + launch handles re-used by the kernel-determinism
+        # re-launch (``_check_kernel_determinism``) and by the per-expert
+        # fc1 readback (``_validate_fc1_phase``).  ``run_kernel`` writes
+        # them at the end of the first launch path.
+        self._ws_fc1_output_torch: Optional[torch.Tensor] = None
+        self._ws_fc1_output_sf_torch: Optional[torch.Tensor] = None
+        self._launch_runtime_kwargs: Optional[dict] = None
+
+    # ------------------------------------------------------------------
+    # Offs generation (per-expert VALID token counts; not padded)
+    # ------------------------------------------------------------------
+
+    def _generate_offs(self) -> torch.Tensor:
+        """Build a cumulative-end ``offs`` tensor where each value is a *valid*
+        token count cumsum.
+
+        Per-expert valid count can be any non-negative integer (Dirichlet
+        path produces zero-token experts in skewed routing scenarios).  No
+        per-expert 128 / 64 alignment constraint is imposed at the offs
+        level -padding policy is enforced separately by ``generate_inputs``
+        when laying out physical buffers.
+
+        ``simulate_ep`` divides the effective valid token budget to mimic
+        EP fan-out.
+        """
+        ep = self.problem.simulate_ep
+        if ep is not None and ep > 1:
+            total = ceil_div(self.problem.tokens_after_topk, ep)
+        else:
+            total = self.problem.tokens_after_topk
+
+        experts = self.problem.experts
+        if total < 0:
+            raise ValueError(f"Effective valid token total ({total}) must be non-negative.")
+
+        if total == 0:
+            return torch.zeros((experts,), dtype=torch.int32, device="cuda")
+
+        if self.problem.balance_route:
+            base, remainder = divmod(total, experts)
+            counts = [base + (1 if i < remainder else 0) for i in range(experts)]
+        else:
+            proportions = self._np_rng.dirichlet([self.dirichlet_alpha] * experts)
+            raw = np.floor(proportions * total).astype(int)
+            deficit = total - int(raw.sum())
+            # Greedy fill of the deficit (token slot allocator).
+            while deficit > 0:
+                idx = int(np.argmin(raw / (proportions * total + 1e-12)))
+                raw[idx] += 1
+                deficit -= 1
+            while deficit < 0:
+                ratios = np.where(
+                    raw > 0,
+                    raw / (proportions * total + 1e-12),
+                    -np.inf,
+                )
+                idx = int(np.argmax(ratios))
+                raw[idx] -= 1
+                deficit += 1
+            counts = raw.tolist()
+
+        assert sum(counts) == total, (
+            f"Internal: valid-count allocation mismatch ({sum(counts)} != {total})"
+        )
+
+        cum = 0
+        offsets: List[int] = []
+        for c in counts:
+            cum += int(c)
+            offsets.append(cum)
+        return torch.tensor(offsets, dtype=torch.int32, device="cuda")
+
+    # ------------------------------------------------------------------
+    # Raw scale generation
+    # ------------------------------------------------------------------
+
+    def _generate_raw_scales(
+        self, valid_tokens_per_expert: List[int]
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor], List[torch.Tensor]]:
+        """Build per-expert raw (un-swizzled) SF tensors for the three SF sides.
+
+        - ``raw_activation_sf``: per expert ``(valid_tokens_e, hidden / blocksize)``
+        - ``raw_fc1_weight_sf``: per expert ``(intermediate, hidden / blocksize)``
+                                  (identical shape across experts)
+        - ``raw_fc2_weight_sf``: per expert ``(hidden, (intermediate/2) / blocksize)``
+                                  (identical shape across experts)
+        """
+        hidden = self.problem.hidden
+        intermediate = self.problem.intermediate
+        experts = self.problem.experts
+
+        sf_vec_size = kind_sf_vec_size(self.problem.kind)
+        scale_dtype = kind_scale_dtype(self.problem.kind)
+
+        raw_activation_sf = [
+            _create_raw_scale_tensor(
+                non_k_size=v,
+                k_size=hidden,
+                blocksize=sf_vec_size,
+                scale_dtype=scale_dtype,
+            )
+            for v in valid_tokens_per_expert
+        ]
+        raw_fc1_weight_sf = [
+            _create_raw_scale_tensor(
+                non_k_size=intermediate,
+                k_size=hidden,
+                blocksize=sf_vec_size,
+                scale_dtype=scale_dtype,
+            )
+            for _ in range(experts)
+        ]
+        raw_fc2_weight_sf = [
+            _create_raw_scale_tensor(
+                non_k_size=hidden,
+                k_size=intermediate // 2,
+                blocksize=sf_vec_size,
+                scale_dtype=scale_dtype,
+            )
+            for _ in range(experts)
+        ]
+        return raw_activation_sf, raw_fc1_weight_sf, raw_fc2_weight_sf
+
+    # ------------------------------------------------------------------
+    # Input construction
+    # ------------------------------------------------------------------
+
+    @property
+    def _epilogue_token_tile(self) -> int:
+        """Per-expert token-padding granularity, owned by the impl epilogue.
+
+        Subclasses override to read their own epilogue class constant instead of
+        a runner-side hardcode; the base default keeps the shared value so
+        kinds that don't override are unchanged.
+        """
+        return EpilogueTokenTile
+
+    def _compute_physical_offsets(
+        self, valid_tokens_per_expert: List[int]
+    ) -> Tuple[List[int], List[int]]:
+        """Return ``(data_physical_offsets, sf_physical_offsets)``.
+
+        Each is a length-``(experts+1)`` list; entry ``e`` is the physical
+        starting row of expert ``e`` in the corresponding tensor.  The last
+        entry is the total physical row count.
+        """
+        data_offsets: List[int] = [0]
+        sf_offsets: List[int] = [0]
+        for v in valid_tokens_per_expert:
+            data_offsets.append(data_offsets[-1] + round_up(v, self._epilogue_token_tile))
+            sf_offsets.append(sf_offsets[-1] + round_up(v, SfPaddingBlock))
+        return data_offsets, sf_offsets
+
+    def _generate_inputs_skeleton(
+        self,
+        valid_tokens_per_expert: List[int],
+        data_total_rows: int,
+        sf_total_rows: int,
+    ) -> None:
+        """Allocate tensors with correct shape / stride / dtype but no data init.
+
+        Only ``offs`` carries real values; every other buffer is
+        ``torch.empty`` -zero CUDA kernel launches.  Intended for simulator
+        runs where only the target kernel should execute.
+        """
+        problem = self.problem
+        hidden = problem.hidden
+        intermediate = problem.intermediate
+        experts = problem.experts
+
+        # -- activation: (data_total_rows, hidden) fp4, hidden stride-1 --
+        data_dtype   = kind_data_dtype(problem.kind)
+        scale_dtype  = kind_scale_dtype(problem.kind)
+        sf_vec_size  = kind_sf_vec_size(problem.kind)
+
+        if problem.kind == "nvfp4":
+            self.activation = torch.empty(
+                (data_total_rows, hidden // 2), dtype=torch.uint8, device="cuda",
+            ).view(data_dtype)
+            self.fc1_weight = (
+                torch.empty((experts, intermediate, hidden // 2), dtype=torch.uint8, device="cuda")
+                .view(data_dtype).permute(0, 2, 1)
+            )
+            self.fc2_weight = (
+                torch.empty((experts, hidden, (intermediate // 2) // 2), dtype=torch.uint8, device="cuda")
+                .view(data_dtype).permute(0, 2, 1)
+            )
+        else:
+            self.activation = torch.empty((data_total_rows, hidden), dtype=data_dtype, device="cuda")
+            # fc1_weight: (experts, intermediate, hidden) → permute → (experts, hidden, intermediate), hidden stride-1
+            self.fc1_weight = torch.empty((experts, intermediate, hidden), dtype=data_dtype, device="cuda").permute(0, 2, 1)
+            # fc2_weight: (experts, hidden, inter//2) → permute → (experts, inter//2, hidden), inter//2 stride-1
+            self.fc2_weight = torch.empty((experts, hidden, intermediate // 2), dtype=data_dtype, device="cuda").permute(0, 2, 1)
+
+        # -- SFs (atom-layout 2D buffers, byte-allocated) --
+        sfa_cols = round_up(ceil_div(hidden, sf_vec_size), 4)
+        self.activation_sf = torch.empty(
+            (sf_total_rows, sfa_cols), dtype=torch.uint8, device="cuda",
+        ).view(scale_dtype)
+
+        sfb_per_expert = round_up(intermediate, SfPaddingBlock) * round_up(
+            ceil_div(hidden, sf_vec_size), 4
+        )
+        self.fc1_weight_sf = torch.empty(
+            (experts, sfb_per_expert), dtype=torch.uint8, device="cuda",
+        ).view(scale_dtype)
+
+        sfb2_per_expert = round_up(hidden, SfPaddingBlock) * round_up(
+            ceil_div(intermediate // 2, sf_vec_size), 4
+        )
+        self.fc2_weight_sf = torch.empty(
+            (experts, sfb2_per_expert), dtype=torch.uint8, device="cuda",
+        ).view(scale_dtype)
+
+        # -- global scales / norm_const --
+        self.activation_global_scale = torch.empty((experts,), dtype=torch.float32, device="cuda")
+        self.fc1_weight_global_scale = torch.empty((experts,), dtype=torch.float32, device="cuda")
+        self.fc2_weight_global_scale = torch.empty((experts,), dtype=torch.float32, device="cuda")
+        self.norm_const = torch.empty((1,), dtype=torch.float32, device="cuda")
+
+        # -- topk_scores --
+        self.topk_scores = torch.empty(
+            (data_total_rows,), dtype=torch.float32, device="cuda",
+        )
+
+        # -- fc2_output --
+        self._alloc_fc2_output_skeleton(data_total_rows)
+
+        # -- Workspace --
+        # Allocate a 1 MiB placeholder buffer so callers see a non-None
+        # ``self.workspace`` even on the short-circuit path.  ``run_kernel``
+        # queries the kernel for the precise required size and reallocates
+        # if this is too small (then zero-inits).
+        self.workspace = torch.zeros((1 << 20,), dtype=torch.uint8, device="cpu").to(
+            "cuda"
+        )
+
+        self.raw_activation_sf_list = None
+        self.raw_fc1_weight_sf_list = None
+        self.raw_fc2_weight_sf_list = None
+
+    def _alloc_fc2_output_skeleton(self, data_total_rows: int) -> None:
+        """Allocate an un-initialized ``fc2_output`` for the skeleton path.
+
+        Shape differs by kind (NVFP4 carries a lean ``topk=1`` axis), so
+        defer to the same ``_alloc_fc2_output`` shape contract subclasses
+        use, but with ``torch.empty`` instead of a 0xFF sentinel fill.
+        """
+        problem = self.problem
+        self.fc2_output = torch.empty(
+            self._fc2_output_shape(data_total_rows),
+            dtype=problem.fc2_output_dtype, device="cuda",
+        )
+
+    def generate_inputs(self) -> None:
+        """Build offs and all input / output tensors.
+
+        Memory layout summary:
+
+          ``activation``    physical rows = ``sum_e round_up(valid_e, 64)``
+          ``fc2_output``    physical rows = same as ``activation``
+          ``topk_scores``   physical rows = same as ``activation``
+          ``activation_sf`` physical rows = ``sum_e round_up(valid_e, 128)``
+
+        Padding rows for each expert sit after that expert's valid rows but
+        before the next expert's valid rows.  The kernel must (a) not depend
+        on the contents of padding rows, and (b) not write outputs into
+        padding rows -both invariants are achieved by epilogue subtile-level
+        early exit driven by ``valid_tokens_in_tile``.
+
+        For correctness sentinel detection, ``fc2_output`` and ``activation``
+        are filled with 0xFF before the kernel runs; padding rows are left
+        at 0xFF after the kernel writes valid rows.
+
+        Kind-specific data tensor creation is delegated to
+        :meth:`_create_input_data_tensors` and :meth:`_alloc_fc2_output`.
+        """
+        # -- 1. offs (valid cumsum) --
+        self.offs = self._generate_offs()
+        valid_tokens = offs_to_group_sizes(self.offs)
+        self.valid_tokens_per_expert = valid_tokens
+
+        # -- 2. Physical offsets (data side 64-padded, SF side 128-padded) --
+        data_offsets, sf_offsets = self._compute_physical_offsets(valid_tokens)
+        self.data_physical_offsets = data_offsets
+        self.sf_physical_offsets = sf_offsets
+        data_total_rows = data_offsets[-1]
+        sf_total_rows = sf_offsets[-1]
+
+        # Short-circuit on two paths that don't need fully-initialized data:
+        #   - ``run_target_kernel_only``: perf simulator runs the kernel
+        #     against undefined inputs to measure kernel-only latency.
+        #   - ``data_total_rows == 0``: a high-EP rank with no routed tokens
+        #     this step; SF assemble's ``reshape(0, -1)`` is ambiguous when
+        #     all experts contribute 0 rows, so dodge it via skeleton.
+        if self.misc.run_target_kernel_only or data_total_rows == 0:
+            self._generate_inputs_skeleton(
+                valid_tokens, data_total_rows, sf_total_rows
+            )
+            return
+
+        # -- 3-5. activation / fc1_weight / fc2_weight (kind-specific) --
+        self._create_input_data_tensors(data_total_rows)
+
+        # -- 6. Raw scales + atom-layout assemble --
+        (
+            self.raw_activation_sf_list,
+            self.raw_fc1_weight_sf_list,
+            self.raw_fc2_weight_sf_list,
+        ) = self._generate_raw_scales(valid_tokens)
+        self.activation_sf = assemble_raw_scales_grouped_token(self.raw_activation_sf_list)
+        self.fc1_weight_sf = assemble_raw_scales_stacked_expert(self.raw_fc1_weight_sf_list)
+        self.fc2_weight_sf = assemble_raw_scales_stacked_expert(self.raw_fc2_weight_sf_list)
+
+        # -- 7-8. Global scales + norm_const (v1 pinned to 1.0) --
+        self._init_global_scales_and_norm()
+
+        # -- 9. topk_scores --
+        self._init_topk_scores(data_total_rows)
+
+        # -- 10. fc2_output (kind-specific shape, 0xFF sentinel fill) --
+        self._alloc_fc2_output(data_total_rows)
+
+        # -- 11. Workspace placeholder --
+        self._alloc_workspace_placeholder()
+
+        torch.cuda.synchronize()
+
+    def _init_global_scales_and_norm(self) -> None:
+        """Per-expert tensor-wise global scales + NVFP4 norm const, pinned 1.0.
+
+        Holding all three global scales at 1.0 makes the ``alpha =
+        global_scale_a * global_scale_b`` factor a no-op, so a kernel that
+        ignores them validates correctly.  When wired through, randomize
+        these.
+        """
+        experts = self.problem.experts
+        self.activation_global_scale = torch.ones((experts,), dtype=torch.float32, device="cuda")
+        self.fc1_weight_global_scale = torch.ones((experts,), dtype=torch.float32, device="cuda")
+        self.fc2_weight_global_scale = torch.ones((experts,), dtype=torch.float32, device="cuda")
+        self.norm_const = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+
+    def _init_topk_scores(self, data_total_rows: int) -> None:
+        """``(data_total_rows,)`` fp32 topk scores.
+
+        Valid rows get random values in [0.5, 1.5] (typical routing weight
+        range); padding rows are explicitly zeroed so the kernel -if it
+        accidentally writes a padding row -produces a deterministic 0
+        that's easy to inspect.
+        """
+        valid_tokens = self.valid_tokens_per_expert
+        data_offsets = self.data_physical_offsets
+        self.topk_scores = torch.zeros(
+            (data_total_rows,), dtype=torch.float32, device="cuda",
+        )
+        for e in range(self.problem.experts):
+            v_e = valid_tokens[e]
+            if v_e == 0:
+                continue
+            phys = data_offsets[e]
+            self.topk_scores[phys : phys + v_e] = (
+                torch.rand((v_e,), dtype=torch.float32, device="cuda") + 0.5
+            )
+
+    def _alloc_workspace_placeholder(self) -> None:
+        """Ensure ``self.workspace`` is non-None before kernel launch.
+
+        ``run_kernel`` queries the precise required size via the kernel's
+        ``get_workspace_size_in_bytes`` and reallocates if needed; this
+        placeholder just guarantees any code path touching ``self.workspace``
+        before the launch sees a real buffer.
+        """
+        if self.workspace is None:
+            self.workspace = torch.zeros(
+                (1 << 20,), dtype=torch.uint8, device="cpu"
+            ).to("cuda")
+
+    # ------------------------------------------------------------------
+    # Reference (per-expert manual path)
+    # ------------------------------------------------------------------
+
+    def compute_reference(self) -> None:
+        """Per-expert manual PyTorch reference for fused fc1+fc2.
+
+        Reference strategy: ``use_quantized_fc1`` -- fc1's quantized output
+        is dequantized and fed to fc2, mirroring what the kernel sees at the
+        in-buffer hand-off point.  This keeps the reference bit-accurate to
+        the kernel's data path (modulo fp32 vs tcgen05 MMA rounding inside
+        the GEMMs themselves).
+
+        Per expert ``e`` with ``v_e`` valid tokens (skipping ``v_e == 0``):
+
+          1. dequant activation slice -> ``act_fp32``  (v_e, hidden)
+          2. dequant fc1 weight        -> ``w1_fp32``   (hidden, intermediate)
+          3. ``fc1_fp32 = act_fp32 @ w1_fp32``
+          4. SwiGLU fold over gate/up interleave        (v_e, intermediate/2)
+          4.5. (kind hook) topk pre-multiply into swiglu  [NVFP4 Path A only]
+          5. quantize swiglu  -> ``(fc1_q, fc1_sf)``    [kind hook]
+          6. dequant fc1's quantized output             (v_e, intermediate/2)
+          7. dequant fc2 weight        -> ``w2_fp32``   (intermediate/2, hidden)
+          8. ``fc2_fp32 = fc1_dq @ w2_fp32``            (v_e, hidden)
+          9. (kind hook) topk post-multiply             [NVFP4 transformers only]
+         10. cast to fc2_output_dtype and store into ``fc2_output_ref``
+
+        Padding rows (per-expert ``round_up(v_e, 64) - v_e`` extras) remain
+        at the buffer's initial fill (0); ``validate`` skips them.
+        """
+        if self.activation is None or self.offs is None:
+            raise RuntimeError("compute_reference requires generate_inputs first.")
+        if self.misc.skip_ref_check:
+            return
+
+        from moe_nvfp4_swapab.mega_reference import (
+            _BlockScaledGemmReferenceLauncher,
+            reference_expert_fc12,
+        )
+
+        problem = self.problem
+        valid_tokens = self.valid_tokens_per_expert
+        data_offsets = self.data_physical_offsets
+        data_total_rows = data_offsets[-1]
+        norm_const_val = float(self.norm_const[0].item())
+        sf_vec_size = kind_sf_vec_size(problem.kind)
+        gate_up_interleave = (
+            Nvfp4Fc1GateUpInterleave if problem.kind == "nvfp4"
+            else Mxfp8Fc1GateUpInterleave
+        )
+        # ``gate_up_clamp`` lives on the NVFP4 ProblemDesc only (None elsewhere).
+        gate_up_clamp = getattr(problem, "gate_up_clamp", None)
+
+        # Bit-exact blockscaled GEMM launcher, shared across this expert sweep
+        # (compiles per dtype-key on first use, cached internally).
+        ref_scaled_mm = _BlockScaledGemmReferenceLauncher(
+            sf_vec_size=sf_vec_size,
+            mma_tiler_mn=(128, 128),
+            cluster_shape_mn=(1, 1),
+        )
+
+        # -- fc2_output_ref allocation --
+        # Allocate via uint8 bytes then reinterpret to bf16/fp16, mirroring
+        # the same trick used for ``self.fc2_output`` (some pytorch versions
+        # lack a direct ``torch.empty(dtype=bfloat16, ...)`` path on some
+        # backends; bytes + view is bulletproof).
+        ref_bytes = torch.zeros(
+            (data_total_rows, problem.hidden * problem.fc2_output_dtype.itemsize),
+            dtype=torch.uint8, device="cuda",
+        )
+        self.fc2_output_ref = ref_bytes.view(problem.fc2_output_dtype).reshape(
+            data_total_rows, problem.hidden
+        )
+
+        # Per-expert fc1 NVFP4 hand-off snapshots for the fc1-phase ablation
+        # (reset each call so a unit-test loop doesn't leak stale entries).
+        self._ref_fc1_q_per_expert = [None] * problem.experts
+        self._ref_fc1_raw_sf_per_expert = [None] * problem.experts
+        self._ref_fc1_gateup_per_expert = [None] * problem.experts
+
+        for expert_idx in range(problem.experts):
+            v_e = valid_tokens[expert_idx]
+            if v_e == 0:
+                continue
+
+            d_start = data_offsets[expert_idx]
+            topk_slice = self.topk_scores[d_start : d_start + v_e]
+
+            act_slice = slice_tensor_logical_dim(
+                self.activation, dim=0, start=d_start, end=d_start + v_e
+            )
+
+            # Shared bit-exact core: packed fc1 GEMM -> SwiGLU(+clamp) ->
+            # (deepgemm: topk pre-mult) -> NVFP4 round-trip -> packed fc2 GEMM.
+            # ``_quantize_fc1`` is the per-kind quantizer hook; global scales are
+            # pinned to 1.0 in v1 so alpha/norm fold them away (no host dequant).
+            fc2_fp32, fc1_q, fc1_sf, fc1_gateup = reference_expert_fc12(
+                ref_scaled_mm=ref_scaled_mm,
+                quantize_fn=self._quantize_fc1,
+                act_packed=act_slice,
+                act_sf=self.raw_activation_sf_list[expert_idx],
+                fc1_weight_packed=self.fc1_weight[expert_idx],
+                fc1_weight_sf=self.raw_fc1_weight_sf_list[expert_idx],
+                fc2_weight_packed=self.fc2_weight[expert_idx],
+                fc2_weight_sf=self.raw_fc2_weight_sf_list[expert_idx],
+                intermediate=problem.intermediate,
+                hidden=problem.hidden,
+                fc1_alpha=(
+                    float(self.fc1_alpha[expert_idx].item())
+                    if self.fc1_alpha is not None else 1.0
+                ),
+                fc2_alpha=(
+                    float(self.fc2_alpha[expert_idx].item())
+                    if self.fc2_alpha is not None else 1.0
+                ),
+                fc1_norm_const=norm_const_val,
+                gate_up_interleave=gate_up_interleave,
+                gate_up_clamp=gate_up_clamp,
+                topk_weights=topk_slice,
+                ref_compute_graph=self.misc.ref_compute_graph,
+            )
+
+            # ``transformers`` applies the topk weight after fc2 (kind hook;
+            # ``deepgemm`` already pre-multiplied it into SwiGLU inside the core).
+            fc2_fp32 = self._apply_topk_post_fc2(fc2_fp32, topk_slice)
+            self.fc2_output_ref[d_start : d_start + v_e] = fc2_fp32.to(
+                problem.fc2_output_dtype
+            )
+
+            # fc1 hand-off snapshots for the fc1-phase ablation and generate_c check.
+            self._ref_fc1_q_per_expert[expert_idx] = fc1_q
+            self._ref_fc1_raw_sf_per_expert[expert_idx] = fc1_sf
+            self._ref_fc1_gateup_per_expert[expert_idx] = fc1_gateup
+
+    # ------------------------------------------------------------------
+    # Workspace partition helper
+    # ------------------------------------------------------------------
+
+    def _partition_workspace(
+        self,
+        mma_tiler_n: int,
+    ) -> Tuple[
+        torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]
+    ]:
+        """Slice the opaque byte ``self.workspace`` into per-section views.
+
+        The layout MUST match the kernel's ``get_workspace_size_in_bytes``
+        allocation order (the kernel doesn't see this partition explicitly
+        -- each section is forwarded as a separate cute.Tensor argument,
+        but the underlying bytes share the same host-allocated buffer):
+
+          0:                                 fc1_output (packed)
+          fc1_output_end:                    fc1_output_sf (atom-tiled)
+          fc1_output_sf_end:                 fc1_done_counter (Int32 1D)
+          fc1_done_counter_end:              load_balance_counter (Int32 scalar,
+                                             atomic_counter mode only)
+
+        Returns ``(fc1_output_torch, fc1_output_sf_torch,
+        fc1_done_counter_torch, load_balance_counter_torch_or_None)``
+        as ``torch.Tensor`` views over ``self.workspace``.  Callers should
+        further wrap each into a ``cute.Tensor`` via
+        ``cutlass_torch.from_dlpack`` before passing to the kernel.
+
+        ``mma_tiler_n`` is the token-axis CTA tile size under swap-AB
+        (= ``mma_tiler_mnk[1]``).  Drives the fc1_done counter sizing
+        because the counter is indexed along the token axis: slot =
+        ``cumulative_token_block_count + tile_n_idx``, and each
+        token-block covers ``mma_tiler_n`` consecutive tokens.
+        """
+        problem = self.problem
+        experts = problem.experts
+        intermediate = problem.intermediate  # intermediate_gateup
+        intermediate_downproj = intermediate // 2
+        data_total_rows = int(self.data_physical_offsets[-1])
+
+        # Kind-specific workspace layout to match kernel's get_workspace_size_in_bytes.
+        is_nvfp4 = (self.problem.kind == "nvfp4")
+        data_dtype    = kind_data_dtype(self.problem.kind)
+        scale_dtype   = kind_scale_dtype(self.problem.kind)
+        sf_vec_size   = kind_sf_vec_size(self.problem.kind)
+        # For FP4: 4-bit = 2 per byte. For FP8: 8-bit = 1 per byte.
+        elem_bits = 4 if is_nvfp4 else 8
+
+        sf_total_rows_upper = data_total_rows + experts * SfPaddingBlock
+        sf_block_cols = (
+            (intermediate_downproj // sf_vec_size) + 3
+        ) // 4 * 4
+        counter_slots_upper = (
+            (data_total_rows + mma_tiler_n - 1) // mma_tiler_n
+            + experts
+        )
+
+        fc1_output_byte_count = data_total_rows * intermediate_downproj * elem_bits // 8
+        fc1_output_sf_byte_count = sf_total_rows_upper * sf_block_cols
+        fc1_done_counter_byte_count = counter_slots_upper * 4
+
+        ws = self.workspace
+        offset = 0
+
+        # -- fc1_output --
+        if is_nvfp4:
+            fc1_output_torch = (
+                ws[offset : offset + fc1_output_byte_count]
+                .view(torch.uint8)
+                .view(data_dtype)
+                .reshape(data_total_rows, intermediate_downproj // 2)
+            )
+        else:
+            fc1_output_torch = (
+                ws[offset : offset + fc1_output_byte_count]
+                .view(torch.uint8)
+                .view(data_dtype)
+                .reshape(data_total_rows, intermediate_downproj)
+            )
+        offset += fc1_output_byte_count
+
+        # -- fc1_output_sf --
+        fc1_output_sf_torch = (
+            ws[offset : offset + fc1_output_sf_byte_count]
+            .view(torch.uint8)
+            .view(scale_dtype)
+            .reshape(sf_total_rows_upper, sf_block_cols)
+        )
+        offset += fc1_output_sf_byte_count
+
+        # -- fc1_done_counter: Int32 1D, zero-init (host responsibility,
+        # done by ``self.workspace.zero_()`` in run_kernel above).
+        fc1_done_counter_torch = (
+            ws[offset : offset + fc1_done_counter_byte_count]
+            .view(torch.int32)
+        )
+        offset += fc1_done_counter_byte_count
+
+        # -- load_balance_counter: Int32 scalar (atomic_counter mode only).
+        if self.impl.load_balance_mode == "atomic_counter":
+            load_balance_counter_torch = ws[offset : offset + 4].view(torch.int32)
+            offset += 4
+        else:
+            load_balance_counter_torch = None
+
+        return (
+            fc1_output_torch,
+            fc1_output_sf_torch,
+            fc1_done_counter_torch,
+            load_balance_counter_torch,
+        )
+
+    # ------------------------------------------------------------------
+    # Kernel call
+    # ------------------------------------------------------------------
+
+    def run_kernel(self) -> None:
+        """Instantiate the fused kernel, partition workspace, compile, launch.
+
+          1. Instantiate the kernel via :meth:`_instantiate_kernel` (forwards
+             ``ProblemDesc`` dims as ``static_expert_shape`` when
+             ``impl.enable_static_expert_shape`` is set).
+          2. Query ``HardwareInfo().get_max_active_clusters(cluster_size)``
+             and use it both for the kernel's ``max_active_clusters``
+             constexpr and to default-fill ``impl.group_hint`` when it was
+             passed as ``None``.
+          3. Query ``kernel.get_workspace_size_in_bytes(...)``; reallocate
+             ``self.workspace`` and zero-initialize it.
+          4. Partition ``self.workspace`` into per-section torch views.
+          5. Convert every torch tensor to a cute tensor.
+          6. ``cute.compile`` once and stash the compiled callable.
+          7. Launch.
+
+        Lazy-imports ``cuda`` / ``cutlass`` so the harness-only paths
+        (``generate_inputs`` + ``compute_reference``) can be exercised on
+        machines without a working cute install.
+        """
+        import cuda.bindings.driver as cuda
+        import cutlass.cute as cute
+        import cutlass.torch as cutlass_torch
+        import cutlass.utils as utils
+
+        required = (
+            self.activation, self.fc1_weight, self.fc2_weight,
+            self.activation_sf, self.fc1_weight_sf, self.fc2_weight_sf,
+            self.topk_scores, self.fc2_output, self.offs,
+        )
+        if any(t is None for t in required):
+            raise RuntimeError("run_kernel requires generate_inputs first.")
+
+        # Cluster size + max_active_clusters + group_hint default fill.
+        cluster_size = (
+            self.impl.cluster_shape_mnk[0] * self.impl.cluster_shape_mnk[1]
+        )
+        max_active_clusters = utils.HardwareInfo().get_max_active_clusters(
+            cluster_size
+        )
+        group_hint = self.impl.group_hint
+        if group_hint is None:
+            group_hint = max_active_clusters
+
+        # Static expert shape (codegen-time triple) -- when the
+        # ImplDesc flag is set, hand the kernel the three dims as Python
+        # ints; otherwise None lets the kernel read them as dynamic Int32
+        # from the per-launch tensors.
+        if self.impl.enable_static_expert_shape:
+            static_expert_shape = (
+                self.problem.experts,
+                self.problem.intermediate,
+                self.problem.hidden,
+            )
+        else:
+            static_expert_shape = None
+
+        # -- 1. Instantiate the kernel (kind hook) --
+        common_kwargs = dict(
+            mma_tiler_mnk=self.impl.mma_tiler_mnk,
+            cluster_shape_mnk=self.impl.cluster_shape_mnk,
+            use_2cta_instrs=self.impl.use_2cta_instrs,
+            group_hint=group_hint,
+            token_padding_block=self._epilogue_token_tile,
+            sf_padding_block=SfPaddingBlock,
+            load_balance_mode=self.impl.load_balance_mode,
+            static_expert_shape=static_expert_shape,
+            force_static_sched=self.impl.force_static_sched,
+            clc_bundle_size=self.impl.clc_bundle_size,
+            num_sched_stages=self.impl.num_sched_stages,
+            sf_vec_size=kind_sf_vec_size(self.problem.kind),
+        )
+        kernel = self._instantiate_kernel(common_kwargs)
+
+        # -- 2. Workspace sizing + zero-init --
+        # Zero-init is REQUIRED before each launch (fc1_done_counter and,
+        # under atomic_counter mode, load_balance_counter both rely on
+        # zero-init semantics).
+        required_workspace_bytes = kernel.get_workspace_size_in_bytes(
+            self.activation, self.fc1_weight
+        )
+        self.workspace = torch.zeros(
+            (required_workspace_bytes,), dtype=torch.uint8, device="cpu"
+        ).to("cuda")
+
+        # -- 3. Workspace partition (torch views) --
+        #
+        # ``mma_tiler_n`` is the token-axis CTA tile size under swap-AB
+        # (see ``_partition_workspace`` docstring); it drives the
+        # fc1_done counter slot count via the same formula the kernel
+        # side uses in ``get_workspace_size_in_bytes``.
+        mma_tiler_n = self.impl.mma_tiler_mnk[1]
+        (
+            fc1_output_torch,
+            fc1_output_sf_torch,
+            fc1_done_counter_torch,
+            load_balance_counter_torch,
+        ) = self._partition_workspace(mma_tiler_n)
+
+        # -- 4. Torch -> cute --
+        def _to_cute(tensor: torch.Tensor, assumed_align: int = 16):
+            cute_tensor = cutlass_torch.from_dlpack(tensor, assumed_align=assumed_align)
+            leading_dim = cutlass_torch.get_leading_dim(tensor)
+            return cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+
+        activation_cute = _to_cute(self.activation)
+        fc1_weight_cute = _to_cute(self.fc1_weight)
+        activation_sf_cute = _to_cute(self.activation_sf)
+        fc1_weight_sf_cute = _to_cute(self.fc1_weight_sf)
+        fc1_output_cute = _to_cute(fc1_output_torch)
+        fc1_output_sf_cute = _to_cute(fc1_output_sf_torch)
+        fc2_weight_cute = _to_cute(self.fc2_weight)
+        fc2_weight_sf_cute = _to_cute(self.fc2_weight_sf)
+        fc2_output_cute = _to_cute(self.fc2_output)
+        topk_scores_cute = _to_cute(self.topk_scores)
+        fc1_done_counter_cute = _to_cute(fc1_done_counter_torch, assumed_align=4)
+        offs_cute = _to_cute(self.offs)
+
+        # ``load_balance_counter`` is required iff
+        # ``load_balance_mode == 'atomic_counter'``.  In 'static' mode the
+        # workspace partition returns None and we omit the kwarg entirely;
+        # the kernel's __call__ defaults it to None and const_expr-skips
+        # the counter wiring.
+        load_balance_counter_cute = (
+            _to_cute(load_balance_counter_torch, assumed_align=4)
+            if load_balance_counter_torch is not None
+            else None
+        )
+
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+        # -- 5. cute.compile --
+        # All kernel inputs go through ``runtime_kwargs``; ``compile_kwargs``
+        # adds compile-only items (``max_active_clusters`` Constexpr,
+        # cute.compile ``options`` flag).  The two dicts share their
+        # runtime keys so the runtime invocation reuses the same dict
+        # without recomputing.
+        runtime_kwargs = dict(
+            activation=activation_cute,
+            fc1_weight=fc1_weight_cute,
+            activation_sf=activation_sf_cute,
+            fc1_weight_sf=fc1_weight_sf_cute,
+            fc1_output=fc1_output_cute,
+            fc1_output_sf=fc1_output_sf_cute,
+            fc2_weight=fc2_weight_cute,
+            fc2_weight_sf=fc2_weight_sf_cute,
+            fc2_output=fc2_output_cute,
+            topk_scores=topk_scores_cute,
+            fc1_done_counter=fc1_done_counter_cute,
+            offs=offs_cute,
+            stream=stream,
+        )
+        if load_balance_counter_cute is not None:
+            runtime_kwargs["load_balance_counter"] = load_balance_counter_cute
+        # Optional per-expert alpha (NVFP4 tester only).  Omitted entirely when
+        # unset so kinds whose kernel has no alpha param (mxfp8) are unaffected.
+        if self.fc1_alpha is not None:
+            runtime_kwargs["fc1_alpha"] = _to_cute(self.fc1_alpha, assumed_align=4)
+        if self.fc2_alpha is not None:
+            runtime_kwargs["fc2_alpha"] = _to_cute(self.fc2_alpha, assumed_align=4)
+
+        # Subclass hook: inject extra tensor kwargs (e.g. generate_c output).
+        for k, v in self._extra_runtime_kwargs().items():
+            runtime_kwargs[k] = v
+
+        compile_kwargs = dict(runtime_kwargs)
+        compile_kwargs["max_active_clusters"] = max_active_clusters
+        if self.misc.enable_iket:
+            compile_kwargs["options"] = "iket"
+
+        compiled_kernel = cute.compile(kernel, **compile_kwargs)
+        self._compiled_kernel = compiled_kernel
+
+        # Stash launch-side handles + workspace partition torch views so the
+        # debug paths (``_check_kernel_determinism`` re-launches the same
+        # kernel; ``_validate_fc1_phase`` reads the kernel-written
+        # fc1_output / fc1_output_sf bytes) can do their work without
+        # re-running the entire setup.  Cheap; no extra alloc / launch.
+        self._ws_fc1_output_torch = fc1_output_torch
+        self._ws_fc1_output_sf_torch = fc1_output_sf_torch
+        self._launch_runtime_kwargs = runtime_kwargs
+
+        # -- 6. Launch --
+        if not self.misc.run_target_kernel_only:
+            with torch.profiler.profile(
+                activities=[
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                ],
+            ) as prof:
+                compiled_kernel(**runtime_kwargs)
+                torch.cuda.synchronize()
+            print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=-1))
+        else:
+            compiled_kernel(**runtime_kwargs)
+            torch.cuda.synchronize()
+
+    # ------------------------------------------------------------------
+    # Optional debug checks
+    # ------------------------------------------------------------------
+
+    def _check_kernel_determinism(self) -> None:
+        """Relaunch and byte-compare fc2 output plus fc1 workspace."""
+        if (
+            self._compiled_kernel is None
+            or self._launch_runtime_kwargs is None
+            or self.fc2_output is None
+            or self._ws_fc1_output_torch is None
+            or self._ws_fc1_output_sf_torch is None
+        ):
+            print("[determinism check] skipped (kernel not launched yet)")
+            return
+
+        # Snapshot first-launch outputs as raw bytes.
+        fc2_first = self.fc2_output.view(torch.uint8).clone()
+        fc1_out_first = self._ws_fc1_output_torch.view(torch.uint8).clone()
+        fc1_sf_first = self._ws_fc1_output_sf_torch.view(torch.uint8).clone()
+
+        # Counters require zero-init per launch.
+        self.workspace.zero_()
+
+        self._compiled_kernel(**self._launch_runtime_kwargs)
+        torch.cuda.synchronize()
+
+        fc2_curr = self.fc2_output.view(torch.uint8)
+        fc1_out_curr = self._ws_fc1_output_torch.view(torch.uint8)
+        fc1_sf_curr = self._ws_fc1_output_sf_torch.view(torch.uint8)
+
+        fc2_byte_diff = int((fc2_first != fc2_curr).sum().item())
+        fc1_out_byte_diff = int((fc1_out_first != fc1_out_curr).sum().item())
+        fc1_sf_byte_diff = int((fc1_sf_first != fc1_sf_curr).sum().item())
+
+        print("=" * 60)
+        print("[determinism check] re-launched kernel with identical inputs")
+        print(
+            f"  fc2_output     byte-diff: {fc2_byte_diff:>10d} / "
+            f"{fc2_first.numel():>10d} "
+            f"({fc2_byte_diff / max(fc2_first.numel(), 1) * 100:7.4f}%)"
+        )
+        print(
+            f"  fc1_output     byte-diff: {fc1_out_byte_diff:>10d} / "
+            f"{fc1_out_first.numel():>10d} "
+            f"({fc1_out_byte_diff / max(fc1_out_first.numel(), 1) * 100:7.4f}%)"
+        )
+        print(
+            f"  fc1_output_sf  byte-diff: {fc1_sf_byte_diff:>10d} / "
+            f"{fc1_sf_first.numel():>10d} "
+            f"({fc1_sf_byte_diff / max(fc1_sf_first.numel(), 1) * 100:7.4f}%)"
+        )
+        if fc2_byte_diff == 0 and fc1_out_byte_diff == 0 and fc1_sf_byte_diff == 0:
+            print(
+                "  -> kernel is BIT-DETERMINISTIC across re-launches; any "
+                "mismatch with ref must come from kernel-vs-host "
+                "accumulation order, not HW race"
+            )
+        else:
+            print(
+                "  -> kernel is NON-DETERMINISTIC (different bytes on "
+                "back-to-back identical launches); race condition / stale "
+                "barrier suspected"
+            )
+        print("=" * 60)
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def _actual_for_compare(
+        self, actual: torch.Tensor, d_start: int, v_e: int
+    ) -> torch.Tensor:
+        """Make the kernel's fc2 output comparable to the reference.
+
+        In ``transformers`` mode the fused fc12 kernel stores the **unweighted**
+        fc2 output (the standalone ``topk_reduce`` kernel applies the per-token
+        topk weight downstream), while the reference is topk-weighted.  Emulate
+        that downstream weight -- with the same store-dtype round-trip the real
+        reduce sees -- so the comparison is apples-to-apples.  ``deepgemm``
+        already folds the topk weight into fc1, so the output is returned as-is.
+        """
+        if self.misc.ref_compute_graph == "transformers":
+            topk = self.topk_scores[d_start : d_start + v_e].to(torch.float32)
+            actual = actual * topk.unsqueeze(-1)
+            actual = actual.to(self.problem.fc2_output_dtype).to(torch.float32)
+        return actual
+
+    def validate(self) -> None:
+        """Compare kernel output against the reference per-expert.
+
+        Tolerance is supplied by :meth:`_fc2_tolerance` (kind-specific).
+        Per-expert valid prefix is sliced via ``data_physical_offsets``;
+        padding rows are not compared (the kernel must not write them).
+
+        Optional debug checks re-launch the kernel and inspect the fc1
+        workspace (:meth:`_validate_fc1_phase`) before the fc2 comparison.
+        """
+        if self.misc.skip_ref_check:
+            return
+        if self.fc2_output_ref is None:
+            raise RuntimeError("validate requires compute_reference first.")
+        if self.fc2_output is None:
+            raise RuntimeError("validate requires generate_inputs first.")
+
+        self._check_kernel_determinism()
+        self._validate_fc1_phase()
+
+        atol, rtol = self._fc2_tolerance()
+
+        valid_tokens = self.valid_tokens_per_expert
+        data_offsets = self.data_physical_offsets
+
+        # NVFP4: fc2_output is 3D (M, 1, H); squeeze axis 1 for comparison.
+        # MXFP8: fc2_output is 2D (M, H); squeeze(1) is a no-op.
+        actual_fp32 = self.fc2_output.squeeze(1).to(torch.float32)
+        ref_fp32 = self.fc2_output_ref.to(torch.float32)
+
+        print("=" * 60)
+        print("[fc2 output] kernel vs ref per expert")
+        print(
+            f"{'expert':>6} {'v_e':>6} {'max_diff':>12} "
+            f"{'mean_diff':>12} {'n_bad':>10} {'%bad':>8}"
+        )
+
+        failed_experts = []
+        for expert_idx in range(self.problem.experts):
+            v_e = valid_tokens[expert_idx]
+            if v_e == 0:
+                continue
+            d_start = data_offsets[expert_idx]
+            actual = self._actual_for_compare(
+                actual_fp32[d_start : d_start + v_e], d_start, v_e
+            )
+            ref = ref_fp32[d_start : d_start + v_e]
+            diff = (actual - ref).abs()
+            max_d = diff.max().item()
+            mean_d = diff.mean().item()
+            n = diff.numel()
+            n_bad = int((diff > atol).sum().item())
+            pct = 100.0 * n_bad / max(n, 1)
+            print(
+                f"{expert_idx:>6} {v_e:>6} {max_d:>12.4g} "
+                f"{mean_d:>12.4g} {n_bad:>10} {pct:>7.3f}%"
+            )
+            if n_bad > 0:
+                failed_experts.append(expert_idx)
+
+        print("=" * 60)
+
+        if failed_experts:
+            # Print detailed mismatch for each failing expert.
+            for expert_idx in failed_experts:
+                v_e = valid_tokens[expert_idx]
+                d_start = data_offsets[expert_idx]
+                actual = self._actual_for_compare(
+                    actual_fp32[d_start : d_start + v_e], d_start, v_e
+                )
+                ref = ref_fp32[d_start : d_start + v_e]
+                compare_and_report_mismatches(
+                    actual, ref,
+                    name=f"fc2_output_expert{expert_idx}",
+                    atol=atol, rtol=rtol, max_mismatches=8,
+                )
+        else:
+            print("Validation PASSED (fc2_output within tolerance)")
+
+    # ------------------------------------------------------------------
+    # Scheduler layout preview (group-cut + per-expert tile counts)
+    # ------------------------------------------------------------------
+
+    def _print_scheduler_layout(self) -> None:
+        """Print scheduler-side per-expert + group layout preview.
+
+        Thin wrapper that maps the user-view ``ImplDesc`` into the
+        post-swap form ``FusedFc12Simulator`` consumes, then defers to
+        ``FusedFc12Simulator.print_layout``.  Always invoked from
+        ``run()`` right after the physical-offset summary, before
+        reference / kernel execution -- intended as a hand-eyeball check
+        of how the static scheduler will pack experts into groups and
+        how many fc1 / fc2 work tiles each group emits.
+
+        User-view -> post-swap mapping:
+          - ``cta_tile_token``       = ``mma_tiler_mnk[1]``
+                                       (user N = post-swap M = token axis)
+          - ``cluster_tile_n_post``  = ``mma_tiler_mnk[0] * cluster_shape_mnk[0]``
+                                       (user M dim x user cluster_m)
+          - ``num_fc1_n_blocks``     = ``ceil_div(intermediate, cluster_tile_n_post)``
+          - ``num_fc2_n_blocks``     = ``ceil_div(hidden,       cluster_tile_n_post)``
+          - ``group_hint``           = ``impl.group_hint`` (fall back to
+                                       ``HardwareInfo().get_max_active_clusters``)
+        """
+        impl = self.impl
+        problem = self.problem
+        cta_tile_token = impl.mma_tiler_mnk[1]
+        cluster_tile_n_post_swap = (
+            impl.mma_tiler_mnk[0] * impl.cluster_shape_mnk[0]
+        )
+        num_fc1_n_blocks = ceil_div(problem.intermediate, cluster_tile_n_post_swap)
+        num_fc2_n_blocks = ceil_div(problem.hidden, cluster_tile_n_post_swap)
+
+        group_hint = impl.group_hint
+        if group_hint is None:
+            cluster_size = (
+                impl.cluster_shape_mnk[0] * impl.cluster_shape_mnk[1]
+            )
+            group_hint = HardwareInfo().get_max_active_clusters(cluster_size)
+
+        sim = FusedFc12Simulator(
+            offsets=self.offs.cpu().tolist(),
+            cta_tile_token=cta_tile_token,
+            num_fc1_n_blocks=num_fc1_n_blocks,
+            num_fc2_n_blocks=num_fc2_n_blocks,
+            group_hint=group_hint,
+        )
+
+        print()
+        sim.print_layout()
+        print()
+
+    # ------------------------------------------------------------------
+    # Verbose information dump
+    # ------------------------------------------------------------------
+
+    def _print_layout_info(self) -> None:
+        """Print every host tensor's shape/stride/dtype + the scheduler-layout
+        preview.  Gated behind ``misc.verbose`` by the caller."""
+        valid_tokens = self.valid_tokens_per_expert
+        data_offsets = self.data_physical_offsets
+        sf_offsets = self.sf_physical_offsets
+
+        print(
+            f"activation: shape={tuple(self.activation.shape)}  "
+            f"stride={self.activation.stride()}  dtype={self.activation.dtype}"
+        )
+        print(
+            f"fc1_weight: shape={tuple(self.fc1_weight.shape)}  "
+            f"stride={self.fc1_weight.stride()}  dtype={self.fc1_weight.dtype}"
+        )
+        print(
+            f"fc2_weight: shape={tuple(self.fc2_weight.shape)}  "
+            f"stride={self.fc2_weight.stride()}  dtype={self.fc2_weight.dtype}"
+        )
+        print(
+            f"activation_sf: shape={tuple(self.activation_sf.shape)}  "
+            f"stride={self.activation_sf.stride()}  dtype={self.activation_sf.dtype}"
+        )
+        print(
+            f"fc1_weight_sf: shape={tuple(self.fc1_weight_sf.shape)}  "
+            f"stride={self.fc1_weight_sf.stride()}  dtype={self.fc1_weight_sf.dtype}"
+        )
+        print(
+            f"fc2_weight_sf: shape={tuple(self.fc2_weight_sf.shape)}  "
+            f"stride={self.fc2_weight_sf.stride()}  dtype={self.fc2_weight_sf.dtype}"
+        )
+        print(
+            f"topk_scores: shape={tuple(self.topk_scores.shape)}  "
+            f"stride={self.topk_scores.stride()}  dtype={self.topk_scores.dtype}"
+        )
+        print(
+            f"fc2_output: shape={tuple(self.fc2_output.shape)}  "
+            f"stride={self.fc2_output.stride()}  dtype={self.fc2_output.dtype}"
+        )
+        print(
+            f"workspace: shape={tuple(self.workspace.shape)}  "
+            f"stride={self.workspace.stride()}  dtype={self.workspace.dtype}"
+        )
+        if not self.misc.run_target_kernel_only:
+            print(f"activation_global_scale: {self.activation_global_scale.cpu().tolist()}")
+            print(f"fc1_weight_global_scale: {self.fc1_weight_global_scale.cpu().tolist()}")
+            print(f"fc2_weight_global_scale: {self.fc2_weight_global_scale.cpu().tolist()}")
+        print(f"offs (valid cumsum): {self.offs.cpu().tolist()}")
+        print(f"  valid_tokens_per_expert: {valid_tokens}")
+        print(f"  data_physical_offsets:   {data_offsets}")
+        print(f"  sf_physical_offsets:     {sf_offsets}")
+
+        self._print_scheduler_layout()
+
+    # ------------------------------------------------------------------
+    # Top-level entry
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        # generate test input / output tensors
+        self.generate_inputs()
+
+        if self.misc.verbose:
+            print(self.problem)
+            print(self.impl)
+            print(self.misc)
+            self._print_layout_info()
+
+        # ``perf_run`` would imply a benchmark + skip_ref path, but the
+        # benchmark path is intentionally not built in this runner.  Honour
+        # ``perf_run`` here only as a "use random-byte" data switch (already
+        # wired through the per-kind tensor creation hooks).
+        skip_ref = (
+            self.misc.skip_ref_check
+            or self.misc.run_target_kernel_only
+            or self.misc.perf_run
+        )
+
+        if not skip_ref:
+            self.compute_reference()
+            if self.fc2_output_ref is not None:
+                print(
+                    f"fc2_output_ref: shape={tuple(self.fc2_output_ref.shape)}  "
+                    f"stride={self.fc2_output_ref.stride()}  "
+                    f"dtype={self.fc2_output_ref.dtype}"
+                )
+
+        # Kernel launch.  ``run_kernel`` instantiates the fused kernel,
+        # queries / partitions the workspace, transitions torch tensors to
+        # cute, compiles, and launches.
+        self.run_kernel()
+
+        if not skip_ref:
+            self.validate()
+        print("DONE")
+
+    # ------------------------------------------------------------------
+    # Kind-entangled hooks (implemented by concrete subclasses)
+    # ------------------------------------------------------------------
+
+    def _fc2_output_shape(self, data_total_rows: int) -> Tuple[int, ...]:
+        """Storage shape of ``fc2_output`` for this kind."""
+        raise NotImplementedError
+
+    def _create_input_data_tensors(self, data_total_rows: int) -> None:
+        """Populate ``self.activation`` / ``fc1_weight`` / ``fc2_weight``."""
+        raise NotImplementedError
+
+    def _alloc_fc2_output(self, data_total_rows: int) -> None:
+        """Allocate ``self.fc2_output`` with the 0xFF sentinel byte fill."""
+        raise NotImplementedError
+
+    def _quantize_fc1(
+        self, swiglu: torch.Tensor, norm_const_val: float
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Quantize the post-SwiGLU fc1 output; return ``(q, raw_sf)``."""
+        raise NotImplementedError
+
+    def _apply_topk_post_fc2(
+        self, fc2_fp32: torch.Tensor, topk_slice: torch.Tensor
+    ) -> torch.Tensor:
+        """Optionally post-multiply topk weight after the fc2 GEMM.
+
+        Default: no-op.
+        """
+        return fc2_fp32
+
+    def _extra_runtime_kwargs(self) -> dict:
+        """Return extra kwargs to merge into runtime_kwargs before cute.compile.
+
+        Default returns empty dict.  Subclasses override to inject optional
+        tensors (e.g. the raw fc1 accumulator output buffer for generate_c).
+        """
+        return {}
+
+    def _instantiate_kernel(self, common_kwargs: dict):
+        """Construct and return the kind-specific fused fc12 kernel object."""
+        raise NotImplementedError
+
+    def _validate_fc1_phase(self) -> None:
+        """Read back kernel-written fc1 workspace and compare to reference."""
+        raise NotImplementedError
+
+    def _fc2_tolerance(self) -> Tuple[float, float]:
+        """Return ``(atol, rtol)`` for the fc2-output comparison."""
+        raise NotImplementedError
+
+
+# =============================================================================
+# Shared CLI helpers
+# =============================================================================
+
+
+def parse_tuple(s: str) -> Tuple[int, ...]:
+    return tuple(int(x) for x in s.split(","))
+
+
+def parse_output_dtype(s: str) -> torch.dtype:
+    mapping = {
+        "bf16": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "fp16": torch.float16,
+        "float16": torch.float16,
+        "half": torch.float16,
+    }
+    if s not in mapping:
+        raise argparse.ArgumentTypeError(
+            f"fc2_output_dtype must be one of {sorted(mapping.keys())}, got {s!r}"
+        )
+    return mapping[s]
+
+
+def add_common_fc12_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register the argparse flags shared by both fused-fc12 runners.
+
+    Excludes ``--kind`` and any kind-specific flags (e.g. NVFP4's
+    ``--use_bulk_fc2_store`` / ``--in_kernel_fc2_reduce``), which each
+    runner adds for itself.
+    """
+    # -- Problem --
+    parser.add_argument(
+        "--tokens_after_topk", type=int, default=2048,
+        help="Total VALID token slots after top-k routing (NOT padded).",
+    )
+    parser.add_argument("--experts", type=int, default=8)
+    parser.add_argument(
+        "--balance_route", action="store_true", default=False,
+        help="Distribute tokens evenly across experts; otherwise Dirichlet(alpha=0.5).",
+    )
+    parser.add_argument("--hidden", type=int, default=2048)
+    parser.add_argument("--intermediate", type=int, default=1024)
+    parser.add_argument(
+        "--simulate_ep", type=int, default=None,
+        help="Simulate Expert Parallelism by reducing per-rank tokens.",
+    )
+    parser.add_argument(
+        "--fc2_output_dtype", type=parse_output_dtype, default=torch.bfloat16,
+        help="fc2 output dtype: bf16 (default) or fp16.",
+    )
+
+    # -- Impl --
+    parser.add_argument(
+        "--mma_tiler_mnk", type=str, default="128,128,256",
+        help="Comma-separated (M, N, K); K is refined at compile time.",
+    )
+    parser.add_argument("--cluster_shape_mnk", type=str, default="1,1,1")
+    parser.add_argument("--use_2cta_instrs", action="store_true", default=False)
+    parser.add_argument(
+        "--enable_static_expert_shape", action="store_true", default=False,
+        help=(
+            "Bind ``static_expert_shape = (experts, intermediate, hidden)`` "
+            "at codegen time, taken from the ProblemDesc.  Default (off) "
+            "binds the three dims as dynamic Int32 values at launch."
+        ),
+    )
+    parser.add_argument(
+        "--dynamic_sched", action="store_true", default=False,
+        help="Use CLC-based dynamic scheduler (default: static lean 7-warp).",
+    )
+    parser.add_argument(
+        "--clc_bundle_size", type=int, default=None,
+        help="Static CLC bundle size S (only meaningful when --dynamic_sched).",
+    )
+    parser.add_argument(
+        "--num_sched_stages", type=int, default=None,
+        help="Scheduler pipeline stages (only meaningful when --dynamic_sched).",
+    )
+    parser.add_argument(
+        "--load_balance_mode", type=str, default="static",
+        choices=["static", "atomic_counter"],
+        help=(
+            "Load-balance strategy for the fused-fc12 scheduler.  "
+            "'static' is the v1 default (stride mode); 'atomic_counter' "
+            "uses a GMEM counter to claim cluster-linear tile ids."
+        ),
+    )
+    parser.add_argument(
+        "--group_hint", type=int, default=None,
+        help="Per-group fc1 tile threshold; None means defer to "
+        "HardwareInfo().get_max_active_clusters(cluster_size).",
+    )
+
+    # -- Misc --
+    parser.add_argument(
+        "--perf_run", action="store_true", default=False,
+        help="Use random-byte FP4/FP8 data instead of sparse {0, +/-1} (data switch only).",
+    )
+    parser.add_argument(
+        "--skip_ref_check", action="store_true", default=False,
+        help="Skip both compute_reference and validate.",
+    )
+    parser.add_argument(
+        "--run_target_kernel_only", action="store_true", default=False,
+        help="Only for perf simulators: all tensors except offs are empty / undefined.",
+    )
+    parser.add_argument(
+        "--enable_debug_checks",
+        action="store_true",
+        default=False,
+        help="Run determinism and fc1 workspace diagnostics during validate.",
+    )
+    parser.add_argument(
+        "--ref_compute_graph",
+        type=str,
+        default="deepgemm",
+        choices=["transformers", "deepgemm"],
+        help=(
+            "Reference compute graph (see MiscDesc docstring).  "
+            "'deepgemm' (default): Path A -topk weight pre-multiplied "
+            "into swiglu fp32 BEFORE NVFP4 quantize, matches the kernel.  "
+            "'transformers': HF semantics -topk weight applied AFTER "
+            "fc2 GEMM in fp32, then cast to bf16/fp16.  (NVFP4 only; the "
+            "MXFP8 reference applies no topk weighting.)"
+        ),
+    )
+    parser.add_argument(
+        "--enable_iket", action="store_true", default=False,
+        help=(
+            "Compile with ``options=\"iket\"`` so ``iket.range_push`` / "
+            "``iket.range_pop`` / ``iket.mark`` ops survive ``strip-iket-ops`` "
+            "and reach LLVM lowering.  Pair with ``run-iket --output-dir ... "
+            "profile -- env DKG_IKET_INSTRUMENTATION_METHOD=NativeDump python "
+            "<runner>.py --enable_iket ...`` to produce a warp-phase trace."
+        ),
+    )
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument(
+        "--verbose", action="store_true", default=False,
+        help=(
+            "Print the per-tensor layout dump (shape/stride/dtype) and the "
+            "scheduler-layout preview before the kernel runs.  Off by default."
+        ),
+    )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/simulate_fc1_fc2_sched.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/simulate_fc1_fc2_sched.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Pure-Python preview of the fused fc1+fc2 static scheduler decode."""
+
+import sys
+from enum import IntEnum
+from math import ceil
+from typing import IO, Iterator, List, Optional, Tuple
+
+
+class BlockPhase(IntEnum):
+    None_ = 0
+    Linear1 = 1
+    Linear2 = 2
+
+
+def ceil_div(numerator: int, denominator: int) -> int:
+    return (numerator + denominator - 1) // denominator
+
+
+class FusedFc12Simulator:
+    def __init__(
+        self,
+        offsets: List[int],
+        cta_tile_token: int,
+        num_fc1_n_blocks: int,
+        num_fc2_n_blocks: int,
+        group_hint: int,
+    ):
+        if any(off < 0 for off in offsets):
+            raise ValueError("offsets entries must be non-negative")
+        if any(b < a for a, b in zip(offsets, offsets[1:])):
+            raise ValueError("offsets must be non-decreasing (it's a cumsum)")
+        if cta_tile_token <= 0 or num_fc1_n_blocks <= 0 or num_fc2_n_blocks <= 0:
+            raise ValueError("tile / block counts must be positive")
+        if group_hint <= 0:
+            raise ValueError("group_hint must be positive")
+
+        self.offsets = list(offsets)
+        self.expert_count = len(offsets)
+        self.cta_tile_token = cta_tile_token
+        self.num_fc1_n_blocks = num_fc1_n_blocks
+        self.num_fc2_n_blocks = num_fc2_n_blocks
+        self.group_hint = group_hint
+        self._reset_state()
+
+    def _reset_state(self) -> None:
+        self.current_group_idx = -1
+        self.current_group_first_expert = 0
+        self.current_group_last_expert_exclusive = 0
+        self.current_phase = BlockPhase.None_
+        self.current_expert_idx = -1
+        self.current_expert_tile_start = 0
+        self.current_expert_tile_end = 0
+        self.current_group_fc1_subphase_end = 0
+        self.current_group_end = 0
+        self.cumulative_fc1_tiles_at_group_end = 0
+        self.cumulative_fc2_tiles_at_group_end = 0
+        self.current_token_block_count = 0
+        self.current_token_offset = 0
+        self.current_this_expert_token_cnt = 0
+        self.exhausted = False
+
+    def _get_token_count(self, expert_idx: int) -> int:
+        if expert_idx == 0:
+            return self.offsets[0]
+        return self.offsets[expert_idx] - self.offsets[expert_idx - 1]
+
+    def _get_token_block_count(self, expert_idx: int) -> int:
+        return ceil_div(self._get_token_count(expert_idx), self.cta_tile_token)
+
+    def _find_next_group_end(
+        self,
+        group_first_expert: int,
+        base_fc1: int,
+        base_fc2: int,
+    ) -> Tuple[int, int, int]:
+        threshold = base_fc1 + self.group_hint
+        cumulative_fc1 = base_fc1
+        cumulative_fc2 = base_fc2
+        cursor = group_first_expert
+        while cursor < self.expert_count:
+            token_block_count = self._get_token_block_count(cursor)
+            cumulative_fc1 += token_block_count * self.num_fc1_n_blocks
+            cumulative_fc2 += token_block_count * self.num_fc2_n_blocks
+            cursor += 1
+            if cumulative_fc1 >= threshold:
+                break
+        return cursor, cumulative_fc1, cumulative_fc2
+
+    def _advance_expert_within_phase(self) -> None:
+        self.current_expert_idx += 1
+        if self.current_expert_idx >= self.current_group_last_expert_exclusive:
+            return
+        self.current_token_offset = (
+            0 if self.current_expert_idx == 0
+            else self.offsets[self.current_expert_idx - 1]
+        )
+        self.current_this_expert_token_cnt = self._get_token_count(self.current_expert_idx)
+        self.current_token_block_count = ceil_div(
+            self.current_this_expert_token_cnt, self.cta_tile_token
+        )
+        self.current_expert_tile_start = self.current_expert_tile_end
+        if self.current_phase == BlockPhase.Linear1:
+            self.current_expert_tile_end += (
+                self.current_token_block_count * self.num_fc1_n_blocks
+            )
+        else:
+            self.current_expert_tile_end += (
+                self.current_token_block_count * self.num_fc2_n_blocks
+            )
+
+    def _switch_to_fc2(self) -> None:
+        self.current_phase = BlockPhase.Linear2
+        self.current_expert_idx = self.current_group_first_expert - 1
+        self.current_expert_tile_end = self.current_group_fc1_subphase_end
+        self._advance_expert_within_phase()
+
+    def _advance_group(self) -> None:
+        if self.current_group_last_expert_exclusive >= self.expert_count:
+            self.exhausted = True
+            return
+        base_fc1 = self.cumulative_fc1_tiles_at_group_end
+        base_fc2 = self.cumulative_fc2_tiles_at_group_end
+        self.current_group_idx += 1
+        self.current_group_first_expert = self.current_group_last_expert_exclusive
+        next_end, new_fc1, new_fc2 = self._find_next_group_end(
+            self.current_group_first_expert, base_fc1, base_fc2,
+        )
+        self.current_group_last_expert_exclusive = next_end
+        self.cumulative_fc1_tiles_at_group_end = new_fc1
+        self.cumulative_fc2_tiles_at_group_end = new_fc2
+
+        group_total_fc1 = new_fc1 - base_fc1
+        group_total_fc2 = new_fc2 - base_fc2
+        group_start_tile = self.current_group_end
+        self.current_group_fc1_subphase_end = group_start_tile + group_total_fc1
+        self.current_group_end = self.current_group_fc1_subphase_end + group_total_fc2
+
+        # Empty group (all experts inside have 0 tokens) ⇒ fc1 / fc2 sub-segments
+        # are 0 wide; the outer driver will re-enter advance_group via the
+        # `while linear_idx >= current_group_end` loop.
+        self.current_phase = BlockPhase.Linear1
+        self.current_expert_idx = self.current_group_first_expert - 1
+        self.current_expert_tile_end = group_start_tile
+        self._advance_expert_within_phase()
+
+    def _decode_inside_expert(self, linear_idx: int) -> dict:
+        local_id = linear_idx - self.current_expert_tile_start
+        if self.current_phase == BlockPhase.Linear1:
+            token_block_idx = local_id // self.num_fc1_n_blocks
+            n_block_idx = local_id % self.num_fc1_n_blocks
+        else:
+            if self.current_token_block_count <= self.num_fc2_n_blocks:
+                token_block_idx = local_id % self.current_token_block_count
+                n_block_idx = local_id // self.current_token_block_count
+            else:
+                token_block_idx = local_id // self.num_fc2_n_blocks
+                n_block_idx = local_id % self.num_fc2_n_blocks
+        return {
+            "linear_idx": linear_idx,
+            "group_idx": self.current_group_idx,
+            "expert_idx": self.current_expert_idx,
+            "phase": self.current_phase,
+            "token_block_idx": token_block_idx,
+            "intermediate_or_hidden_block_idx": n_block_idx,
+        }
+
+    def gen_next_work(self, linear_idx: int) -> Optional[dict]:
+        while linear_idx >= self.current_group_end:
+            self._advance_group()
+            if self.exhausted:
+                return None
+        if (self.current_phase == BlockPhase.Linear1
+                and linear_idx >= self.current_group_fc1_subphase_end):
+            self._switch_to_fc2()
+        while linear_idx >= self.current_expert_tile_end:
+            self._advance_expert_within_phase()
+            if self.current_expert_idx >= self.current_group_last_expert_exclusive:
+                return None
+        return self._decode_inside_expert(linear_idx)
+
+    def simulate(self) -> Iterator[dict]:
+        self._reset_state()
+        linear_idx = 0
+        while True:
+            tile = self.gen_next_work(linear_idx)
+            if tile is None:
+                break
+            yield tile
+            linear_idx += 1
+
+    def enumerate_groups(self) -> Iterator[dict]:
+        """Walk the group cutting state machine and yield one dict per group.
+        Mutates state; ``simulate()`` calls ``_reset_state()`` so reuse is OK."""
+        self._reset_state()
+        while True:
+            prev_fc1 = self.cumulative_fc1_tiles_at_group_end
+            prev_fc2 = self.cumulative_fc2_tiles_at_group_end
+            prev_end = self.current_group_end
+            self._advance_group()
+            if self.exhausted:
+                break
+            yield {
+                "group_idx": self.current_group_idx,
+                "first_expert": self.current_group_first_expert,
+                "last_expert_exclusive": self.current_group_last_expert_exclusive,
+                "fc1_start": prev_end,
+                "fc1_end_exclusive": self.current_group_fc1_subphase_end,
+                "fc2_start": self.current_group_fc1_subphase_end,
+                "fc2_end_exclusive": self.current_group_end,
+                "group_total_fc1": (
+                    self.cumulative_fc1_tiles_at_group_end - prev_fc1
+                ),
+                "group_total_fc2": (
+                    self.cumulative_fc2_tiles_at_group_end - prev_fc2
+                ),
+            }
+
+    # ------------------------------------------------------------------
+    # Print helpers (shared by ``main()`` and external callers such as
+    # ``moe_nvfp4_swapab.runner_fc12``).  Each accepts ``prefix`` so
+    # shell-comment style (``"# "``) and plain-text style coexist.
+    # ------------------------------------------------------------------
+
+    def print_header(
+        self, *, prefix: str = "", file: Optional[IO[str]] = None
+    ) -> None:
+        """Print a one-line summary of the simulator parameters."""
+        if file is None:
+            file = sys.stdout
+        print(
+            f"{prefix}scheduler preview: "
+            f"cta_tile_token={self.cta_tile_token} "
+            f"num_fc1_n_blocks={self.num_fc1_n_blocks} "
+            f"num_fc2_n_blocks={self.num_fc2_n_blocks} "
+            f"group_hint={self.group_hint} "
+            f"expert_count={self.expert_count}",
+            file=file,
+        )
+
+    def print_per_expert_layout(
+        self, *, prefix: str = "", file: Optional[IO[str]] = None
+    ) -> Tuple[int, int]:
+        """Print per-expert tile counts. Returns ``(total_fc1, total_fc2)``."""
+        if file is None:
+            file = sys.stdout
+        print(f"{prefix}per-expert layout:", file=file)
+        print(
+            f"{prefix}  {'expert':>6} | {'tokens':>6} | {'m_blks':>6} | "
+            f"{'fc1_tiles':>10} | {'fc2_tiles':>10}",
+            file=file,
+        )
+        total_fc1 = 0
+        total_fc2 = 0
+        for expert_idx in range(self.expert_count):
+            token_count = self._get_token_count(expert_idx)
+            m_block_count = self._get_token_block_count(expert_idx)
+            fc1_tiles = m_block_count * self.num_fc1_n_blocks
+            fc2_tiles = m_block_count * self.num_fc2_n_blocks
+            total_fc1 += fc1_tiles
+            total_fc2 += fc2_tiles
+            print(
+                f"{prefix}  {'e' + str(expert_idx):>6} | "
+                f"{token_count:>6d} | {m_block_count:>6d} | "
+                f"{fc1_tiles:>10d} | {fc2_tiles:>10d}",
+                file=file,
+            )
+        last_offset = self.offsets[-1] if self.offsets else 0
+        print(
+            f"{prefix}  {'total':>6} | {last_offset:>6d} | "
+            f"{'':>6} | {total_fc1:>10d} | {total_fc2:>10d}",
+            file=file,
+        )
+        return total_fc1, total_fc2
+
+    def print_group_layout(
+        self, *, prefix: str = "", file: Optional[IO[str]] = None
+    ) -> None:
+        """Print the group-cut table from ``enumerate_groups``."""
+        if file is None:
+            file = sys.stdout
+        print(
+            f"{prefix}group layout "
+            f"(greedy cut at cumulative fc1 >= group_hint):",
+            file=file,
+        )
+        print(
+            f"{prefix}  {'group':>5} | {'experts':>12} | "
+            f"{'fc1 work_ids':>22} | {'fc2 work_ids':>22} | "
+            f"{'group_total':>11}",
+            file=file,
+        )
+        for g in self.enumerate_groups():
+            experts_str = (
+                f"[e{g['first_expert']}..e{g['last_expert_exclusive'] - 1}]"
+            )
+            fc1_str = f"[{g['fc1_start']}..{g['fc1_end_exclusive'] - 1}]"
+            fc2_str = f"[{g['fc2_start']}..{g['fc2_end_exclusive'] - 1}]"
+            total = g["group_total_fc1"] + g["group_total_fc2"]
+            print(
+                f"{prefix}  {'g' + str(g['group_idx']):>5} | "
+                f"{experts_str:>12} | {fc1_str:>22} | "
+                f"{fc2_str:>22} | {total:>11}",
+                file=file,
+            )
+
+    def print_layout(
+        self, *, prefix: str = "", file: Optional[IO[str]] = None
+    ) -> None:
+        """Convenience: header + per-expert layout + group layout + total tiles.
+
+        This is the entry point external callers (e.g. ``runner_fc12``)
+        invoke to dump everything except the per-tile dispatch sequence.
+        """
+        if file is None:
+            file = sys.stdout
+        self.print_header(prefix=prefix, file=file)
+        total_fc1, total_fc2 = self.print_per_expert_layout(
+            prefix=prefix, file=file
+        )
+        self.print_group_layout(prefix=prefix, file=file)
+        print(f"{prefix}total tiles = {total_fc1 + total_fc2}", file=file)
+
+
+def _format_tile(tile: dict) -> str:
+    phase = "fc1" if tile["phase"] == BlockPhase.Linear1 else "fc2"
+    return (
+        f"(work_id, expert_idx, token_tile_idx, i_or_h_tile_idx, phase): "
+        f"({tile['linear_idx']}, {tile['expert_idx']}, "
+        f"{tile['token_block_idx']}, {tile['intermediate_or_hidden_block_idx']}, {phase})"
+    )
+
+
+def main() -> None:
+    import argparse
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--offsets",
+        nargs="+", type=int, required=True,
+        help="cumsum of token counts per expert (each diff must be multiple of cta-tile-token)",
+    )
+    parser.add_argument("--cta-tile-token", type=int, required=True)
+    parser.add_argument("--num-fc1-n-blocks", type=int, required=True)
+    parser.add_argument("--num-fc2-n-blocks", type=int, required=True)
+    parser.add_argument("--group-hint", type=int, required=True)
+    parser.add_argument(
+        "--num-clusters", type=int, default=0,
+        help="if >0, also print the per-cluster sub-stream "
+             "(cluster c gets linear_idx in {c, c+C, c+2C, ...})",
+    )
+    args = parser.parse_args()
+
+    sim = FusedFc12Simulator(
+        offsets=args.offsets,
+        cta_tile_token=args.cta_tile_token,
+        num_fc1_n_blocks=args.num_fc1_n_blocks,
+        num_fc2_n_blocks=args.num_fc2_n_blocks,
+        group_hint=args.group_hint,
+    )
+
+    sim.print_layout(prefix="# ")
+    print()
+
+    tiles = list(sim.simulate())
+    for tile in tiles:
+        print(_format_tile(tile))
+
+    if args.num_clusters > 0:
+        print()
+        num_clusters = args.num_clusters
+        print(
+            f"# per-cluster dispatch (cluster c gets linear_idx in "
+            f"{{c, c+{num_clusters}, c+{2*num_clusters}, ...}}):"
+        )
+        for cluster_idx in range(num_clusters):
+            print(f"# --- cluster {cluster_idx} ---")
+            for tile in tiles[cluster_idx::num_clusters]:
+                print("  " + _format_tile(tile))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/topk_reduce.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/moe_nvfp4_swapab/topk_reduce.py
@@ -1,0 +1,505 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Device combine reduce: collapse per-(token, topk) fc2 cells into one row.
+
+The combine step writes one fc2 output per ``(token, topk)`` cell; this reduces
+over the topk axis into the token-centric ``(token, hidden)`` output. The wire
+format is a :class:`~src.token_comm.CombineFormat`:
+
+    bf16          -- no staging: bf16 terms reduced directly.
+    32e4m3xe8m0   -- MXFP8: fp8 e4m3 data + per-32 e8m0 (power-of-2) scale.
+    16e2m1xbf16   -- fp4 e2m1 data + per-16 bf16 amax (one level, no global);
+                     dequant per element x = fp4 * (amax * (1 / 6)).
+
+Task partition: each worker owns one ``(token, hidden_tile)`` and loops topk; the
+flat worker index decodes into ``(token_idx, hidden_tile_idx)`` via a constant
+divide by ``hidden_tiles``. The per-block scale is broadcast to a logical
+per-hidden view (stride 0) so it tiles by the same worker index as the data. The
+activation load stays in the topk loop (too large to hoist); the small scale and
+score loads are hoisted ahead of the loop when topk is small.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import ClassVar, Dict, Optional
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import Float32, Int32, T
+from cutlass._mlir.dialects import llvm
+
+from common.megamoe_constants import Nvfp4E2M1RcpLimit
+from src.token_comm import CombineFormat
+
+
+# ---------------------------------------------------------------------------
+# fp4 (e2m1) -> fp32 register decode.
+#
+# Blackwell has no e2m1->f32 upconvert: the framework's ``term.load().to(f32)``
+# lowers to an ALU subnormal-normalization path (~60% DRAM SOL). Both helpers
+# below force a table-driven decode instead; ``e2m1_reg`` (N e2m1 codes, N % 8
+# == 0) is read as packed b32 words and N fp32 values are written into
+# ``fp32_reg`` in code order. The 16 e2m1 values are exact in fp32, so the two
+# decoders are bit-for-bit identical (cross-check the optimal one against the
+# cvt one over all 16 codes).
+# ---------------------------------------------------------------------------
+
+
+@cute.jit
+def cvt_e2m1_to_fp32_cvt_ptx(e2m1_reg: cute.Tensor, fp32_reg: cute.Tensor) -> None:
+    """Decode via the e2m1->f16 HW cvt (``cvt.rn.f16x2.e2m1x2``) then widen f16->f32.
+
+    Safe baseline: the per-pair ``cvt`` instruction is itself a HW PRMT+F2FP, so
+    the e2m1->f16 step already avoids ALU normalization; f16->f32 is one cheap
+    ``cvt.f32.f16`` per element.
+    """
+    src_words = cute.recast_tensor(e2m1_reg, Int32)          # (N,) e2m1 -> (N/8,) b32
+    for w in cutlass.range_constexpr(cute.size(src_words)):
+        res = llvm.inline_asm(
+            llvm.StructType.get_literal([T.f32()] * 8),
+            [src_words[w].ir_value()],
+            "{\n"
+            "  .reg .b8  b0, b1, b2, b3;\n"
+            "  .reg .b32 p0, p1, p2, p3;\n"
+            "  .reg .b16 c0, d0, c1, d1, c2, d2, c3, d3;\n"
+            "  mov.b32 {b0, b1, b2, b3}, $8;\n"
+            "  cvt.rn.f16x2.e2m1x2 p0, b0;\n"
+            "  cvt.rn.f16x2.e2m1x2 p1, b1;\n"
+            "  cvt.rn.f16x2.e2m1x2 p2, b2;\n"
+            "  cvt.rn.f16x2.e2m1x2 p3, b3;\n"
+            "  mov.b32 {c0, d0}, p0;\n"
+            "  mov.b32 {c1, d1}, p1;\n"
+            "  mov.b32 {c2, d2}, p2;\n"
+            "  mov.b32 {c3, d3}, p3;\n"
+            "  cvt.f32.f16 $0, c0;\n"
+            "  cvt.f32.f16 $1, d0;\n"
+            "  cvt.f32.f16 $2, c1;\n"
+            "  cvt.f32.f16 $3, d1;\n"
+            "  cvt.f32.f16 $4, c2;\n"
+            "  cvt.f32.f16 $5, d2;\n"
+            "  cvt.f32.f16 $6, c3;\n"
+            "  cvt.f32.f16 $7, d3;\n"
+            "}",
+            "=f,=f,=f,=f,=f,=f,=f,=f,r",
+            has_side_effects=False,
+        )
+        for i in cutlass.range_constexpr(8):
+            fp32_reg[w * 8 + i] = Float32(llvm.extractvalue(T.f32(), res, [i]))
+
+
+@cute.jit
+def cvt_e2m1_to_fp32_optimal_ptx(e2m1_reg: cute.Tensor, fp32_reg: cute.Tensor) -> None:
+    """Decode via a register-resident bf16 LUT + PRMT, landing fp32 directly.
+
+    The 8 e2m1 magnitudes ``{0,.5,1,1.5,2,3,4,6}`` are exact bf16, so a PRMT
+    byte-gather of the per-magnitude hi/lo bytes builds the bf16; ``fp32 =
+    bf16 << 16`` makes the widen free. Sign (nibble bit3) is spread to the 4
+    output-byte MSBs with one ``prmt`` of ``{word<<4, word}`` (selector 0x5140),
+    avoiding the non-uniform shift the 4-bit-vs-8-bit stride would otherwise need.
+    """
+    src_words = cute.recast_tensor(e2m1_reg, Int32)          # (N,) e2m1 -> (N/8,) b32
+    dst_words = cute.recast_tensor(fp32_reg, Int32)           # write fp32 bit patterns
+    for w in cutlass.range_constexpr(cute.size(src_words)):
+        res = llvm.inline_asm(
+            llvm.StructType.get_literal([T.i32()] * 8),
+            [src_words[w].ir_value()],
+            "{\n"
+            "  .reg .b32 ha, hb, la, lb, inh, wl, ih, il, hl, ll, hh, lh, sl, sh, p0, p1, p2, p3;\n"
+            "  mov.b32 ha, 0x3F3F3F00;\n"      # hi byte LUT, magnitudes 0..3
+            "  mov.b32 hb, 0x40404040;\n"      # hi byte LUT, magnitudes 4..7
+            "  mov.b32 la, 0xC0800000;\n"      # lo byte LUT, magnitudes 0..3
+            "  mov.b32 lb, 0xC0804000;\n"      # lo byte LUT, magnitudes 4..7
+            "  shr.b32 inh, $8, 16;\n"          # high 4 elements -> low 16 bits
+            "  and.b32 il, $8, 0x00007777;\n"   # low 4 magnitude indices (clear sign)
+            "  and.b32 ih, inh, 0x00007777;\n"  # high 4 magnitude indices
+            "  prmt.b32 hl, ha, hb, il;\n"      # hi bytes for e0..e3
+            "  prmt.b32 ll, la, lb, il;\n"      # lo bytes for e0..e3
+            "  prmt.b32 hh, ha, hb, ih;\n"      # hi bytes for e4..e7
+            "  prmt.b32 lh, la, lb, ih;\n"      # lo bytes for e4..e7
+            "  shl.b32 wl, $8, 4;\n"
+            "  prmt.b32 sl, wl, $8, 0x5140;\n"  # gather s0..s3 to byte MSBs
+            "  and.b32 sl, sl, 0x80808080;\n"
+            "  or.b32  hl, hl, sl;\n"
+            "  shl.b32 wl, inh, 4;\n"
+            "  prmt.b32 sh, wl, inh, 0x5140;\n" # gather s4..s7 to byte MSBs
+            "  and.b32 sh, sh, 0x80808080;\n"
+            "  or.b32  hh, hh, sh;\n"
+            "  prmt.b32 p0, ll, hl, 0x5140;\n"  # {bf16(e0), bf16(e1)}
+            "  prmt.b32 p1, ll, hl, 0x7362;\n"  # {bf16(e2), bf16(e3)}
+            "  prmt.b32 p2, lh, hh, 0x5140;\n"  # {bf16(e4), bf16(e5)}
+            "  prmt.b32 p3, lh, hh, 0x7362;\n"  # {bf16(e6), bf16(e7)}
+            "  shl.b32 $0, p0, 16;\n"
+            "  and.b32 $1, p0, 0xFFFF0000;\n"
+            "  shl.b32 $2, p1, 16;\n"
+            "  and.b32 $3, p1, 0xFFFF0000;\n"
+            "  shl.b32 $4, p2, 16;\n"
+            "  and.b32 $5, p2, 0xFFFF0000;\n"
+            "  shl.b32 $6, p3, 16;\n"
+            "  and.b32 $7, p3, 0xFFFF0000;\n"
+            "}",
+            "=r,=r,=r,=r,=r,=r,=r,=r,r",
+            has_side_effects=False,
+        )
+        for i in cutlass.range_constexpr(8):
+            dst_words[w * 8 + i] = Int32(llvm.extractvalue(T.i32(), res, [i]))
+
+
+class TopkReduce:
+    """Combine reduce for a fixed ``(hidden, num_topk, combine_format)``.
+
+    ``__init__`` pins the static shape and format (and the derived launch
+    geometry); ``__call__`` (a ``@cute.jit`` launcher) sizes a 1D grid from the
+    runtime token count and dispatches the format's kernel. The caller owns the
+    torch->cute conversion and the ``cute.compile`` / ``aot_compile``.
+    """
+
+    _threads: ClassVar[int] = 128
+    # combine_format.name -> hidden elements per worker (one LDG of data:
+    # bf16 8*2B=16B, e4m3 16*1B=16B, e2m1 16*0.5B=8B). For quantized formats this
+    # stays <= the scale block, so each worker reads exactly one scale entry.
+    _hidden_per_thread: ClassVar[Dict[str, int]] = {
+        "bf16": 8,
+        "32e4m3xe8m0": 16,
+        "32e5m2xe8m0": 16,
+        "16e2m1xbf16": 16,
+    }
+    # topk count at/below which the scale + score loads are hoisted ahead of the
+    # topk loop (small enough to not bloat registers; a CTA-broadcast read).
+    _prefetch_limit: ClassVar[int] = 16
+
+    def __init__(self, hidden: int, num_topk: int, combine_format: CombineFormat) -> None:
+        self.hidden = int(hidden)
+        self.num_topk = int(num_topk)
+        self.combine_format = combine_format
+        self.hidden_per_thread = self._hidden_per_thread[combine_format.name]
+        # hidden must tile cleanly both into worker slices and into scale blocks.
+        align = max(combine_format.scale_block or self.hidden_per_thread, self.hidden_per_thread)
+        if self.hidden % align != 0:
+            raise ValueError(
+                f"hidden ({self.hidden}) must be divisible by max(scale_block, "
+                f"hidden_per_thread) = {align} for combine_format {combine_format}."
+            )
+        self.hidden_tiles = self.hidden // self.hidden_per_thread
+        # tail guard only needed when the worker count per token is not a whole
+        # number of CTAs; prefetch only when topk is small enough to hoist.
+        self.require_predicate = self.hidden_tiles % self._threads != 0
+        self.prefetch = self.num_topk <= self._prefetch_limit
+
+    # -- launcher -------------------------------------------------------------
+
+    @cute.jit
+    def __call__(
+        self,
+        combine_quant: cute.Tensor,         # (token, topk, hidden)
+        combine_sf: Optional[cute.Tensor],  # (token, topk, hidden)
+        reduced_output: cute.Tensor,        # (token, hidden)
+        topk_score: Optional[cute.Tensor],  # (token, topk)
+        stream: cuda.CUstream,
+    ):
+        threads = self._threads
+        total_workers = reduced_output.shape[0] * self.hidden_tiles
+        grid = [(total_workers + threads - 1) // threads, 1, 1]
+        block = [threads, 1, 1]
+
+        combine_quant = cute.make_tensor(
+            combine_quant.iterator,
+            cute.make_layout((combine_quant.shape[0], self.num_topk, self.hidden), stride=combine_quant.stride))
+        reduced_output = cute.make_tensor(
+            reduced_output.iterator, 
+            cute.make_layout((reduced_output.shape[0], self.hidden), stride=reduced_output.stride))
+        if cutlass.const_expr(topk_score is not None):
+            topk_score = cute.make_tensor(
+                topk_score.iterator, 
+                cute.make_layout((topk_score.shape[0], self.num_topk), stride=topk_score.stride))
+
+        if cutlass.const_expr(not self.combine_format.is_quantized):
+            self._reduce_bf16(combine_quant, topk_score, reduced_output).launch(
+                grid=grid, block=block, stream=stream,
+            )
+            return
+
+        # The mega kernel hands sf in already as the depth-2 broadcast layout; a
+        # plain (torch) sf is depth-1 and gets its hidden mode split into
+        # (sf_vec, hidden/sf_vec):(0, s_h) so logical hidden h reads block h//sf_vec.
+        sf_vec = self.combine_format.scale_block
+        if cutlass.const_expr(cute.depth(combine_sf.layout) >= 2):
+            sf = cute.make_tensor(
+                combine_sf.iterator, 
+                cute.make_layout((combine_sf.shape[0], self.num_topk, (sf_vec, self.hidden // sf_vec)), stride=combine_sf.stride))
+        else:
+            sf = cute.make_tensor(
+                combine_sf.iterator,
+                cute.make_layout(
+                    (combine_sf.shape[0], self.num_topk, (sf_vec, self.hidden // sf_vec)),
+                    stride=(combine_sf.stride[0], combine_sf.stride[1], (0, combine_sf.stride[2])),
+                ),
+            )
+
+        if cutlass.const_expr(self.combine_format.act_dtype in (cutlass.Float8E4M3FN, cutlass.Float8E5M2)):
+            self._reduce_mxfp8(combine_quant, sf, topk_score, reduced_output).launch(
+                grid=grid, block=block, stream=stream,
+            )
+        else:
+            self._reduce_fp4(combine_quant, sf, topk_score, reduced_output).launch(
+                grid=grid, block=block, stream=stream,
+            )
+
+    @cute.jit
+    def _mark_alignment(self, tensor: cute.Tensor, align_bytes: int) -> cute.Tensor:
+        p = tensor.iterator
+        return cute.make_tensor(
+            cute.make_ptr(p.dtype, p.toint(), p.memspace, assumed_align=align_bytes),
+            tensor.layout,
+        )
+
+    # -- kernels --------------------------------------------------------------
+
+    @cute.kernel
+    def _reduce_bf16(
+        self,
+        combine_output: cute.Tensor,
+        topk_score: Optional[cute.Tensor],
+        reduced_output: cute.Tensor,
+    ):
+        threads = self._threads
+        hidden_per_thread = self.hidden_per_thread
+        hidden_tiles = self.hidden_tiles
+        num_topk: cutlass.Constexpr[int] = self.num_topk
+        needs_guard = self.require_predicate
+        prefetch = self.prefetch
+        out_dtype = reduced_output.element_type
+
+        worker_idx = cute.arch.block_idx()[0] * Int32(threads) + cute.arch.thread_idx()[0]
+        token_idx = worker_idx // hidden_tiles
+        hidden_tile_idx = worker_idx % hidden_tiles
+
+        score_dtype = topk_score.dtype if cutlass.const_expr(topk_score is not None) else cutlass.Float32
+        score_reg = cute.make_rmem_tensor((num_topk,), score_dtype)
+
+        if (not needs_guard) or token_idx < reduced_output.shape[0]:
+            # (token, topk, hidden) -> (topk, hidden_per_thread)
+            terms = cute.zipped_divide(
+                combine_output[token_idx, None, None], (num_topk, hidden_per_thread),
+            )[(None, None), (0, hidden_tile_idx)]
+            # (token, hidden) -> (hidden_per_thread)
+            dst = cute.zipped_divide(
+                reduced_output[token_idx, None], (hidden_per_thread,),
+            )[(None,), (hidden_tile_idx,)]
+
+            if cutlass.const_expr(topk_score is not None):
+                if cutlass.const_expr(prefetch):
+                    cute.autovec_copy(topk_score[token_idx, None], score_reg)
+            else:
+                for k in cutlass.range_constexpr(num_topk):
+                    score_reg[k] = score_dtype(1)
+
+            load_atom = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), cutlass.BFloat16, num_bits_per_copy=128,
+            )
+            acc = cute.make_rmem_tensor((hidden_per_thread,), cutlass.Float32)
+
+            for k in cutlass.range_constexpr(0, num_topk, 1):
+                term = cute.make_rmem_tensor((hidden_per_thread,), cutlass.BFloat16)
+                cute.copy(load_atom, terms[k, None], term)
+                if cutlass.const_expr(topk_score is not None and not prefetch):
+                    score_reg[k] = topk_score[token_idx, Int32(k)]
+                score_pair = (Float32(score_reg[k]), Float32(score_reg[k]))
+
+                for i in cutlass.range_constexpr(0, hidden_per_thread, 2):
+                    value_pair = (Float32(term[i]), Float32(term[i + 1]))
+                    if cutlass.const_expr(k != 0):
+                        acc[i], acc[i + 1] = cute.arch.fma_packed_f32x2(value_pair, score_pair, (acc[i], acc[i + 1]))
+                    else:
+                        if cutlass.const_expr(topk_score is not None):
+                            acc[i], acc[i + 1] = cute.arch.mul_packed_f32x2(value_pair, score_pair)
+                        else:
+                            acc[i] = value_pair[0]
+                            acc[i + 1] = value_pair[1]
+
+            out = cute.make_rmem_tensor((hidden_per_thread,), out_dtype)
+            out.store(acc.load().to(out_dtype))
+            cute.copy(
+                cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), out_dtype, num_bits_per_copy=128),
+                out, self._mark_alignment(dst, hidden_per_thread * out_dtype.width // 8),
+            )
+
+    @cute.kernel
+    def _reduce_mxfp8(
+        self,
+        combine_quant: cute.Tensor,
+        combine_sf: cute.Tensor,            # depth-2 broadcast view: logical (token, topk, hidden) e8m0
+        topk_score: Optional[cute.Tensor],
+        reduced_output: cute.Tensor,
+    ):
+        threads = self._threads
+        hidden_per_thread = self.hidden_per_thread
+        hidden_tiles = self.hidden_tiles
+        num_topk: cutlass.Constexpr[int] = self.num_topk
+        needs_guard = self.require_predicate
+        prefetch = self.prefetch
+        out_dtype = reduced_output.element_type
+
+        worker_idx = cute.arch.block_idx()[0] * Int32(threads) + cute.arch.thread_idx()[0]
+        token_idx = worker_idx // hidden_tiles
+        hidden_tile_idx = worker_idx % hidden_tiles
+
+        score_dtype = topk_score.dtype if cutlass.const_expr(topk_score is not None) else cutlass.Float32
+        score_reg = cute.make_rmem_tensor((num_topk,), score_dtype)
+        scale_reg = cute.make_rmem_tensor((num_topk,), cutlass.Float8E8M0FNU)
+
+        if (not needs_guard) or token_idx < reduced_output.shape[0]:
+            # (token, topk, hidden) -> (topk, hidden_per_thread)
+            codes = cute.zipped_divide(
+                combine_quant[token_idx, None, None], (num_topk, hidden_per_thread),
+            )[(None, None), (0, hidden_tile_idx)]
+            # (token, topk, hidden) -> (topk, hidden_per_thread)
+            sf = cute.zipped_divide(
+                combine_sf[token_idx, None, None], (num_topk, hidden_per_thread),
+            )[(None, None), (0, hidden_tile_idx)]
+            # (token, hidden) -> (hidden_per_thread)
+            dst = cute.zipped_divide(
+                reduced_output[token_idx, None], (hidden_per_thread,),
+            )[(None,), (hidden_tile_idx,)]
+
+            if cutlass.const_expr(topk_score is not None):
+                if cutlass.const_expr(prefetch):
+                    cute.autovec_copy(topk_score[token_idx, None], score_reg)
+            else:
+                for k in cutlass.range_constexpr(num_topk):
+                    score_reg[k] = score_dtype(1)
+            if cutlass.const_expr(prefetch):
+                cute.autovec_copy(sf[None, 0], scale_reg)       # one scale per topk slot (stride-0 broadcast)
+
+            fp8_dtype = self.combine_format.act_dtype
+            load_atom = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), fp8_dtype, num_bits_per_copy=128,
+            )
+            acc = cute.make_rmem_tensor((hidden_per_thread,), cutlass.Float32)
+
+            for k in cutlass.range_constexpr(0, num_topk, 1):
+                term = cute.make_rmem_tensor((hidden_per_thread,), fp8_dtype)
+                cute.copy(load_atom, codes[k, None], term)
+                value = cute.make_rmem_tensor((hidden_per_thread,), cutlass.Float32)
+                value.store(term.load().to(cutlass.Float32))
+
+                if cutlass.const_expr(not prefetch):
+                    scale_reg[k] = sf[k, 0]
+                    if cutlass.const_expr(topk_score is not None):
+                        score_reg[k] = topk_score[token_idx, Int32(k)]
+
+                scale = Float32(scale_reg[k])                   # e8m0 -> f32
+                scale_pair = (scale, scale)
+                score_pair = (Float32(score_reg[k]), Float32(score_reg[k]))
+
+                for i in cutlass.range_constexpr(0, hidden_per_thread, 2):
+                    dequant_pair = cute.arch.mul_packed_f32x2((value[i], value[i + 1]), scale_pair)
+                    if cutlass.const_expr(k != 0):
+                        acc[i], acc[i + 1] = cute.arch.fma_packed_f32x2(dequant_pair, score_pair, (acc[i], acc[i + 1]))
+                    else:
+                        if cutlass.const_expr(topk_score is not None):
+                            acc[i], acc[i + 1] = cute.arch.mul_packed_f32x2(dequant_pair, score_pair)
+                        else:
+                            acc[i] = dequant_pair[0]
+                            acc[i + 1] = dequant_pair[1]
+
+            out = cute.make_rmem_tensor((hidden_per_thread,), out_dtype)
+            out.store(acc.load().to(out_dtype))
+            cute.copy(
+                cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), out_dtype, num_bits_per_copy=256),
+                out, self._mark_alignment(dst, hidden_per_thread * out_dtype.width // 8),
+            )
+
+    @cute.kernel
+    def _reduce_fp4(
+        self,
+        combine_quant: cute.Tensor,         # (token, topk, hidden) e2m1 (logical)
+        combine_sf: cute.Tensor,            # depth-2 broadcast view: logical (token, topk, hidden) bf16 amax
+        topk_score: Optional[cute.Tensor],
+        reduced_output: cute.Tensor,
+    ):
+        threads = self._threads
+        hidden_per_thread = self.hidden_per_thread
+        hidden_tiles = self.hidden_tiles
+        num_topk: cutlass.Constexpr[int] = self.num_topk
+        needs_guard = self.require_predicate
+        prefetch = self.prefetch
+        out_dtype = reduced_output.element_type
+
+        worker_idx = cute.arch.block_idx()[0] * Int32(threads) + cute.arch.thread_idx()[0]
+        token_idx = worker_idx // hidden_tiles
+        hidden_tile_idx = worker_idx % hidden_tiles
+
+        score_dtype = topk_score.dtype if cutlass.const_expr(topk_score is not None) else cutlass.Float32
+        score_reg = cute.make_rmem_tensor((num_topk,), score_dtype)
+        scale_reg = cute.make_rmem_tensor((num_topk,), cutlass.BFloat16)
+
+        if (not needs_guard) or token_idx < reduced_output.shape[0]:
+            # (token, topk, hidden) -> (topk, hidden_per_thread)
+            codes = cute.zipped_divide(
+                combine_quant[token_idx, None, None], (num_topk, hidden_per_thread),
+            )[(None, None), (0, hidden_tile_idx)]
+            # (token, topk, hidden) -> (topk, hidden_per_thread)
+            sf = cute.zipped_divide(
+                combine_sf[token_idx, None, None], (num_topk, hidden_per_thread),
+            )[(None, None), (0, hidden_tile_idx)]
+            # (token, hidden) -> (hidden_per_thread)
+            dst = cute.zipped_divide(
+                reduced_output[token_idx, None], (hidden_per_thread,),
+            )[(None,), (hidden_tile_idx,)]
+
+            if cutlass.const_expr(topk_score is not None):
+                if cutlass.const_expr(prefetch):
+                    cute.autovec_copy(topk_score[token_idx, None], score_reg)
+            else:
+                for k in cutlass.range_constexpr(num_topk):
+                    score_reg[k] = score_dtype(1)
+            if cutlass.const_expr(prefetch):
+                cute.autovec_copy(sf[None, 0], scale_reg)
+
+            load_atom = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), cutlass.Float4E2M1FN, num_bits_per_copy=64,
+            )
+            acc = cute.make_rmem_tensor((hidden_per_thread,), cutlass.Float32)
+
+            for k in cutlass.range_constexpr(0, num_topk, 1):
+                term = cute.make_rmem_tensor((hidden_per_thread,), cutlass.Float4E2M1FN)
+                cute.copy(load_atom, codes[k, None], term)
+                value = cute.make_rmem_tensor((hidden_per_thread,), cutlass.Float32)
+                # Dev-only knob (MEGA_F4CVT_USE_MANUAL): manual LUT/PRMT decode vs
+                # the HW cvt path, so both SASS forms can be compared on device;
+                # one is kept once chosen. Read inline on purpose -- never a
+                # customer-facing option. Both decoders are bit-exact.
+                if cutlass.const_expr(os.environ.get("MEGA_F4CVT_USE_MANUAL", "0") == "1"):
+                    cvt_e2m1_to_fp32_optimal_ptx(term, value)
+                else:
+                    cvt_e2m1_to_fp32_cvt_ptx(term, value)
+
+                if cutlass.const_expr(not prefetch):
+                    scale_reg[k] = sf[k, 0]
+                    if cutlass.const_expr(topk_score is not None):
+                        score_reg[k] = topk_score[token_idx, Int32(k)]
+
+                # amax (bf16) -> per-element scale; (1/6) folds the fp4 grid max.
+                scale = Float32(scale_reg[k]) * Float32(Nvfp4E2M1RcpLimit)
+                scale_pair = (scale, scale)
+                score_pair = (Float32(score_reg[k]), Float32(score_reg[k]))
+
+                for i in cutlass.range_constexpr(0, hidden_per_thread, 2):
+                    dequant_pair = cute.arch.mul_packed_f32x2((value[i], value[i + 1]), scale_pair)
+                    if cutlass.const_expr(k != 0):
+                        acc[i], acc[i + 1] = cute.arch.fma_packed_f32x2(dequant_pair, score_pair, (acc[i], acc[i + 1]))
+                    elif cutlass.const_expr(topk_score is not None):
+                        acc[i], acc[i + 1] = cute.arch.mul_packed_f32x2(dequant_pair, score_pair)
+                    else:
+                        acc[i] = dequant_pair[0]
+                        acc[i + 1] = dequant_pair[1]
+
+            out = cute.make_rmem_tensor((hidden_per_thread,), out_dtype)
+            out.store(acc.load().to(out_dtype))
+            cute.copy(
+                cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), out_dtype, num_bits_per_copy=256),
+                out, self._mark_alignment(dst, hidden_per_thread * out_dtype.width // 8),
+            )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/bootstrap.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/bootstrap.py
@@ -1,0 +1,473 @@
+"""Single-allocation symmetric workspace for the dispatch kernel.
+
+Mirrors mega_moe's pattern (``DeepGEMM/csrc/apis/mega.hpp`` chained
+``Buffer + slice_input_buffers``): one ``nvshmem.core.tensor((N,), uint8)``
+per rank, every named tensor is a torch view into that byte buffer. Because
+all ranks perform the same single collective allocation in the same order,
+the peer-pointer delta is one constant per peer that works for every
+sub-region (mega_moe ``SymBuffer.offsets`` / ``sym_buffer.cuh:34-37``).
+
+The kernel side uses ``sym_buffer.SymBuffer.map`` to translate any local
+pointer to its peer-rank counterpart -- no per-tensor peer-view lists
+needed.  ``Workspace.symmetric_base`` + ``peer_offsets_list`` carry the
+host-side payload used to build a ``SymBufferHost`` runtime argument.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+import nvshmem.core
+try:
+    from cuda.core import Device
+except ImportError:
+    from cuda.core.experimental import Device
+
+from .config import DSV4, DSV4Config, TOKEN_METADATA_BYTES
+
+
+# ----------------------------------------------------------------------
+# Region spec
+# ----------------------------------------------------------------------
+
+# nvshmem4py 0.3.0 doesn't support uint32/uint64 dtypes; we substitute signed
+# int32/int64 storage. Kernel atomics use raw PTX so bit-pattern semantics
+# are preserved end-to-end; host-side inspection wraps with ``.view(np.uint*)``.
+_DTYPE_BYTES = {
+    torch.uint8: 1,
+    torch.int8: 1,
+    torch.int16: 2,
+    torch.int32: 4,
+    torch.int64: 8,
+    torch.float32: 4,
+    torch.float64: 8,
+    torch.bfloat16: 2,
+    torch.float16: 2,
+}
+
+
+@dataclass(frozen=True)
+class _Region:
+    """One sub-region of the symmetric byte buffer.
+
+    ``align`` is in bytes; the region's offset is rounded up to ``align``
+    before placement. Default 16B matches the TMA descriptor minimum;
+    large FP8 token rows use 128B for ``cp.async.bulk`` efficiency.
+    """
+    name: str
+    dtype: torch.dtype
+    shape: Tuple[int, ...]
+    align: int = 16
+
+
+@dataclass(frozen=True)
+class _Shapes:
+    """Pool shapes derived from (world_size, num_tokens_per_rank).
+
+    Mirrors ``layout/mega_moe.cuh:get_num_max_pool_tokens`` /
+    ``get_num_padded_sf_pool_tokens``. Stored on ``Workspace`` so callers
+    don't recompute when ``num_tokens_per_rank`` is overridden per-launch.
+    """
+    num_tokens_per_rank: int
+    num_max_pool_tokens: int
+    num_max_pool_blocks: int
+    num_max_task_tiles: int
+    num_padded_sf_pool_tokens: int
+
+
+def _derive_shapes(
+    world_size: int,
+    num_tokens_per_rank: int,
+    config: DSV4Config = DSV4,
+) -> _Shapes:
+    K = config.num_topk
+    BM = config.block_m
+    SFBM = config.sf_block_m
+    CTM = config.effective_cluster_tile_m
+    E_local = config.num_experts_per_rank
+
+    num_max_recv = world_size * num_tokens_per_rank
+    num_max_per_tok = min(K, E_local)
+    raw = num_max_recv * num_max_per_tok + E_local * (BM - 1)
+    P_TOK = ((raw + BM - 1) // BM) * BM
+    P_BLK = P_TOK // BM
+    # Release-counter slot count: sized at ``cluster_tile_m`` granularity
+    # rather than ``block_m`` (see ``fc12_integrate_comm.md`` §4 C3).
+    P_TT = (P_TOK + CTM - 1) // CTM
+    P_SF = P_BLK * SFBM
+    return _Shapes(
+        num_tokens_per_rank=num_tokens_per_rank,
+        num_max_pool_tokens=P_TOK,
+        num_max_pool_blocks=P_BLK,
+        num_max_task_tiles=P_TT,
+        num_padded_sf_pool_tokens=P_SF,
+    )
+
+
+def _build_spec(
+    world_size: int,
+    shapes: _Shapes,
+    config: DSV4Config = DSV4,
+) -> Tuple[_Region, ...]:
+    """Region table for one DSV4 dispatch workspace at the given shapes.
+
+    ``config`` selects the wire format: DSV4 (FP8, hidden_bytes=7168) or
+    DSV4_nvfp4 (NVFP4, hidden_bytes=3584). Token buffers (uint8) and the L1
+    pool are sized by ``config.hidden_bytes``; SF buffers use
+    ``config.sf_uint32_per_token``.
+    """
+    R = world_size
+    K = config.num_topk
+    H_BYTES = config.hidden_bytes
+    SFU = config.sf_uint32_per_token
+    E_local = config.num_experts_per_rank
+    E_total = config.num_total_experts
+    T = shapes.num_tokens_per_rank
+    P_TOK = shapes.num_max_pool_tokens
+    P_TT = shapes.num_max_task_tiles
+    P_SF = shapes.num_padded_sf_pool_tokens
+    MAX_SLOT = T * K
+
+    return (
+        # Input region (per-rank source side).
+        _Region("input_token_buffer",         torch.uint8,   (T, H_BYTES),                    align=128),
+        _Region("input_sf_buffer",            torch.int32,   (T, SFU),                        align=16),
+        _Region("input_topk_idx_buffer",      torch.int64,   (T, K),                          align=16),
+        _Region("input_topk_weights_buffer",  torch.float32, (T, K),                          align=16),
+        # Counters (atomicAdd targets).
+        _Region("expert_send_count",          torch.int64,   (E_total,),                      align=16),
+        _Region("expert_recv_count",          torch.int64,   (R, E_local),                    align=16),
+        _Region("expert_recv_count_sum",      torch.int64,   (E_local,),                      align=16),
+        # Routing workspace.
+        _Region("src_token_topk_idx",         torch.int32,   (E_local, R, MAX_SLOT),          align=16),
+        _Region("token_src_metadata",         torch.uint8,   (P_TOK, TOKEN_METADATA_BYTES),   align=16),
+        # L1 receive-side pool.  Note: ``l1_arrival_count`` is sized at
+        # ``cluster_tile_m`` granularity (num_max_task_tiles), not at
+        # ``block_m`` granularity -- see fc12_integrate_comm.md §4 C3.
+        _Region("l1_arrival_count",           torch.int32,   (P_TT,),                         align=16),
+        _Region("l1_token_buffer",            torch.uint8,   (P_TOK, H_BYTES),                align=128),
+        _Region("l1_sf_buffer",               torch.int32,   (SFU, P_SF),                     align=16),
+        _Region("l1_topk_weights_buffer",     torch.float32, (P_TOK,),                        align=16),
+        # Cross-rank barrier signal (slot 0 = pre-pull, slot 1 = kernel-tail).
+        _Region("nvlink_barrier_signal",      torch.int32,   (R, 2),                          align=16),
+        # Phase counter for the sense-reversing nvlink barrier (low 2 bits =
+        # signal slot + direction). Local-only; lives in the symmetric heap for
+        # uniform layout only.
+        _Region("nvlink_barrier_counter",     torch.int32,   (1,),                            align=16),
+        # Local-only counter for software_grid_sync (carried in symmetric heap
+        # so layout is uniform; intra-rank, no peer reads).
+        _Region("grid_sync_counter",          torch.int32,   (2,),                            align=16),
+    )
+
+
+def _layout(spec: Tuple[_Region, ...]) -> Tuple[Dict[str, int], int]:
+    """Place regions sequentially with per-region alignment; return (offsets, total).
+
+    Final total is rounded up to 16B so the next allocation in a future
+    fused workspace stays TMA-friendly.
+    """
+    offsets: Dict[str, int] = {}
+    cursor = 0
+    for region in spec:
+        cursor = ((cursor + region.align - 1) // region.align) * region.align
+        # Sub-region offset must satisfy dtype alignment for ``.view(dtype)``.
+        assert cursor % _DTYPE_BYTES[region.dtype] == 0, (
+            f"Region {region.name}: offset {cursor} not aligned for dtype {region.dtype}"
+        )
+        offsets[region.name] = cursor
+        cursor += math.prod(region.shape) * _DTYPE_BYTES[region.dtype]
+    total = ((cursor + 15) // 16) * 16
+    return offsets, total
+
+
+# ----------------------------------------------------------------------
+# Workspace
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Workspace:
+    """Symmetric-memory workspace for one rank's dispatch kernel run.
+
+    Every named tensor is a typed torch view into ``_byte_buf``, the single
+    symmetric byte allocation. ``peer_offsets_list[r] = peer_r_base -
+    local_base`` (bytes) and is the only cross-rank pointer table the
+    kernel needs --
+    the same delta works for every sub-region (mega_moe ``SymBuffer.map``
+    semantics, ``sym_buffer.cuh:34-37``).
+    """
+    # Input region.
+    input_token_buffer: torch.Tensor
+    input_sf_buffer: torch.Tensor
+    input_topk_idx_buffer: torch.Tensor
+    input_topk_weights_buffer: torch.Tensor
+    # Counters.
+    expert_send_count: torch.Tensor
+    expert_recv_count: torch.Tensor
+    expert_recv_count_sum: torch.Tensor
+    # Routing workspace.
+    src_token_topk_idx: torch.Tensor
+    token_src_metadata: torch.Tensor
+    # L1 receive pool.
+    l1_arrival_count: torch.Tensor
+    l1_token_buffer: torch.Tensor
+    l1_sf_buffer: torch.Tensor
+    l1_topk_weights_buffer: torch.Tensor
+    # Cross-rank barrier.
+    nvlink_barrier_signal: torch.Tensor
+    nvlink_barrier_counter: torch.Tensor
+    grid_sync_counter: torch.Tensor
+    # Peer-pointer delta data (HOST-side Python ints; the generated host
+    # wrapper packs them into a SymBuffer{world_size} kernel param. No
+    # GMEM allocation -- offsets live in the kernel param bank via CUDA
+    # byval ABI). ``peer_offsets_list[r] = peer_r_base - local_base`` in
+    # bytes; ``peer_offsets_list[local_rank] == 0``.
+    symmetric_base: int
+    peer_offsets_list: tuple   # tuple[int, ...] length = world_size
+    local_rank: int
+    # Derived pool shapes (so callers don't recompute when num_tokens_per_rank
+    # is overridden per-launch).
+    num_tokens_per_rank: int
+    num_max_pool_tokens: int
+    num_max_pool_blocks: int
+    num_max_task_tiles: int
+    num_padded_sf_pool_tokens: int
+    # Keep-alive root buffer (do NOT drop -- views are non-owning).
+    _byte_buf: torch.Tensor
+
+    def release(self) -> None:
+        """Free the symmetric byte buffer back to the NVSHMEM heap.
+
+        Must be called collectively on every rank BEFORE
+        ``nvshmem.core.finalize()`` (otherwise NVSHMEM logs a
+        "Symmetric memory was not freed explicitly" error and the leak
+        can surface as a hang in the next allocation cycle).
+        """
+        # NVSHMEM tracks the allocation by `data_ptr()` of the root byte
+        # buffer. Drop our reference first so torch's caching allocator
+        # doesn't hold a phantom view while we call free_tensor.
+        try:
+            nvshmem.core.free_tensor(self._byte_buf)
+        except Exception:  # noqa: BLE001
+            # Best-effort: if NVSHMEM has already torn down (e.g. the
+            # process is exiting mid-fault), don't shadow the real error.
+            pass
+
+
+def alloc_workspace(
+    rank: int,
+    world_size: int = DSV4.num_ranks,
+    num_tokens_per_rank: int = DSV4.num_tokens_per_rank,
+    *,
+    config: DSV4Config = DSV4,
+    verbose: bool = False,
+) -> Workspace:
+    """Allocate ONE symmetric byte buffer and slice into typed views.
+
+    All ranks call this collectively with identical arguments; nvshmem4py
+    keeps the heap layout symmetric across ranks, so peer-pointer deltas
+    are a single constant per peer.
+
+    ``config`` selects the wire format (DSV4=FP8 default, DSV4_nvfp4=NVFP4).
+    The byte buffer is zeroed (NVSHMEM allocation is not guaranteed
+    initialised), then ``token_src_metadata`` is filled with the 0xFF
+    pool-slot-empty sentinel that both kernel and host-check rely on.
+    """
+    assert world_size > 0, f"world_size must be positive, got {world_size}"
+
+    shapes = _derive_shapes(world_size, num_tokens_per_rank, config)
+    spec = _build_spec(world_size, shapes, config)
+    offsets, total_bytes = _layout(spec)
+
+    if verbose and rank == 0:
+        print(
+            f"[bootstrap] alloc_workspace: world_size={world_size} "
+            f"num_tokens_per_rank={num_tokens_per_rank} "
+            f"total_bytes={total_bytes:,} ({total_bytes / (1 << 20):.1f} MiB)"
+        )
+        for region in spec:
+            nbytes = math.prod(region.shape) * _DTYPE_BYTES[region.dtype]
+            print(
+                f"[bootstrap]   {region.name:30s} off={offsets[region.name]:>11,}  "
+                f"bytes={nbytes:>12,}  shape={tuple(region.shape)}  dtype={region.dtype}"
+            )
+
+    byte_buf = nvshmem.core.tensor((total_bytes,), dtype=torch.uint8)
+    byte_buf.zero_()
+
+    views: Dict[str, torch.Tensor] = {}
+    for region in spec:
+        off = offsets[region.name]
+        nbytes = math.prod(region.shape) * _DTYPE_BYTES[region.dtype]
+        sub = byte_buf.narrow(0, off, nbytes)
+        v = sub.view(region.dtype).reshape(region.shape)
+        # Layout invariant: every typed view must point exactly at its
+        # offset within byte_buf. If this fails, peer_offsets won't work
+        # for that region and cross-rank ops will land at wrong addresses.
+        assert v.data_ptr() == byte_buf.data_ptr() + off, (
+            f"Region {region.name}: data_ptr {v.data_ptr():#x} != "
+            f"byte_buf {byte_buf.data_ptr():#x} + off {off}"
+        )
+        views[region.name] = v
+
+    # Pool-slot-empty sentinel: kernel writes 0xFF only on padding slots,
+    # host-check uses (token_src_metadata != 0xFF).any() to find populated
+    # entries. mega_moe init_padding_kernel does the same.
+    views["token_src_metadata"].fill_(0xFF)
+
+    # Build peer offsets table as plain Python ints.
+    # ``nvshmem.core.get_peer_tensor()`` tracks allocations by exact
+    # ``data_ptr()``; it must be called on the root byte buffer, since
+    # subview lookups would not match any tracked allocation.
+    # No GMEM tensor: callers pass these ints via SymBufferHost, and the
+    # generated host wrapper packs them into SymBuffer{world_size} before
+    # launching the device kernel (CUDA byval ABI -> param bank).
+    local_addr = int(byte_buf.data_ptr())
+    peer_offsets_list = tuple(
+        int(nvshmem.core.get_peer_tensor(byte_buf, r).data_ptr()) - local_addr
+        for r in range(world_size)
+    )
+    assert peer_offsets_list[rank] == 0, (
+        f"peer_offsets_list[rank={rank}] expected 0, got "
+        f"{peer_offsets_list[rank]}"
+    )
+
+    return Workspace(
+        **views,
+        symmetric_base=local_addr,
+        peer_offsets_list=peer_offsets_list,
+        local_rank=rank,
+        num_tokens_per_rank=shapes.num_tokens_per_rank,
+        num_max_pool_tokens=shapes.num_max_pool_tokens,
+        num_max_pool_blocks=shapes.num_max_pool_blocks,
+        num_max_task_tiles=shapes.num_max_task_tiles,
+        num_padded_sf_pool_tokens=shapes.num_padded_sf_pool_tokens,
+        _byte_buf=byte_buf,
+    )
+
+
+# ----------------------------------------------------------------------
+# Reusable bootstrap: torch.distributed + NVSHMEM init/finalize.
+#
+# Pattern follows dlarch-fastkernels CuTeDSL distributed/dispatch_and_combine
+# (`torchrun_uid_init_bcast`). One init function for every launcher
+# (torchrun / srun / mp.spawn) so test scripts don't each re-roll their own.
+# ----------------------------------------------------------------------
+
+
+def _discover_ranks() -> tuple[int, int, int, str | None]:
+    """Detect launcher type and return (local_rank, global_rank, world_size,
+    init_method). ``init_method`` is None for torchrun (env:// default) or
+    a ``tcp://master:port`` URL for srun.
+
+    Recognises:
+      - torchrun / torch.distributed.run / pytest+torchrun:
+            RANK + LOCAL_RANK + WORLD_SIZE
+      - srun / sbatch:
+            SLURM_PROCID + SLURM_LOCALID + SLURM_NTASKS + MASTER_ADDR
+      - mp.spawn (single-node) with manually-set env:
+            RANK + LOCAL_RANK + WORLD_SIZE (same as torchrun; caller is
+            responsible for setting MASTER_ADDR + MASTER_PORT)
+    """
+    if "RANK" in os.environ and "LOCAL_RANK" in os.environ:
+        return (
+            int(os.environ["LOCAL_RANK"]),
+            int(os.environ["RANK"]),
+            int(os.environ.get("WORLD_SIZE", "1")),
+            None,
+        )
+    if "SLURM_PROCID" in os.environ:
+        global_rank = int(os.environ["SLURM_PROCID"])
+        local_rank = int(os.environ["SLURM_LOCALID"])
+        world_size = int(os.environ["SLURM_NTASKS"])
+        master_addr = os.environ["MASTER_ADDR"]
+        master_port = int(os.environ.get("MASTER_PORT", "29500"))
+        # Mirror SLURM_NTASKS_PER_NODE -> LOCAL_WORLD_SIZE so downstream
+        # code that wants a "node_id" computation has it without caring
+        # which launcher it ran under.
+        os.environ.setdefault(
+            "LOCAL_WORLD_SIZE",
+            os.environ.get("SLURM_NTASKS_PER_NODE", str(world_size)),
+        )
+        return local_rank, global_rank, world_size, f"tcp://{master_addr}:{master_port}"
+    raise RuntimeError(
+        "Cannot bootstrap: neither RANK/LOCAL_RANK (torchrun) nor "
+        "SLURM_PROCID (srun) are set in the environment."
+    )
+
+
+def init_dist_and_nvshmem() -> tuple[int, int, int, Device]:
+    """Bootstrap torch.distributed (gloo+nccl) and NVSHMEM via UID broadcast.
+
+    Returns ``(local_rank, rank, world_size, dev)``. The
+    ``cuda.core.Device`` handle is the same one NVSHMEM
+    was initialised with, so callers can reuse it for ``cute.compile``.
+
+    Re-entrancy: if torch.distributed is already initialised (e.g. the
+    caller staged it themselves before calling here) the existing group
+    is reused; NVSHMEM is initialised exactly once.
+    """
+    local_rank, rank, world_size, init_method = _discover_ranks()
+
+    torch.cuda.set_device(local_rank)
+    dev = Device(local_rank)
+    dev.set_current()
+
+    if not dist.is_initialized():
+        if init_method is None:
+            dist.init_process_group(backend="cpu:gloo,cuda:nccl")
+        else:
+            dist.init_process_group(
+                backend="cpu:gloo,cuda:nccl",
+                init_method=init_method,
+                rank=rank,
+                world_size=world_size,
+            )
+
+    # Only global rank 0 generates the real UID; everyone else allocates
+    # an empty placeholder that the broadcast overwrites. Using local_rank
+    # here would have one rank-0 per node, all colliding in NVSHMEM init.
+    uid = nvshmem.core.get_unique_id(empty=(rank != 0))
+    uid_bytes = uid._data.view(np.uint8).copy()
+    uid_tensor = torch.from_numpy(uid_bytes).cuda()
+    dist.broadcast(uid_tensor, src=0)
+    dist.barrier()
+    uid._data[:] = uid_tensor.cpu().numpy().view(uid._data.dtype)
+
+    nvshmem.core.init(
+        device=dev,
+        uid=uid,
+        rank=rank,
+        nranks=world_size,
+        initializer_method="uid",
+    )
+    return local_rank, rank, world_size, dev
+
+
+def finalize_dist_and_nvshmem(workspace: Workspace | None = None) -> None:
+    """Tear down NVSHMEM and torch.distributed.
+
+    Pass ``workspace`` (if any) so its symmetric byte buffer is freed
+    before ``nvshmem.core.finalize()``. Without this, NVSHMEM logs
+    "Symmetric memory was not freed explicitly" on every rank.
+    """
+    if workspace is not None:
+        workspace.release()
+    try:
+        nvshmem.core.finalize()
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        if dist.is_initialized():
+            dist.destroy_process_group()
+    except Exception:  # noqa: BLE001
+        pass
+
+

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/cleanup_kernel.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/cleanup_kernel.py
@@ -1,0 +1,148 @@
+"""Host-callable cuTeDSL cleanup kernel for the dispatch workspace.
+
+Replicates the cleanup chunk of mega_moe's dispatch slice
+(``DeepGEMM/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh``
+lines 723-766) as a standalone kernel so the dispatch kernel can be
+re-launched without observing residual workspace state from the previous
+round.
+
+Cleared regions
+---------------
+* ``expert_send_count`` (``num_total_experts`` u64) -- the per-rank
+  publisher histogram populated by ``_dispatch_prep`` round 2 (mega_moe
+  line 462-466). Mega_moe clears this on SM 0 (line 727-728).
+* ``expert_recv_count`` (``num_ranks`` x ``num_experts_per_rank`` u64) --
+  the per-(src_rank, local_expert) recv-count table populated by
+  ``_dispatch_barrier`` (mega_moe line 547). Mega_moe clears this on the
+  non-zero SMs as part of the per-expert sweep at lines 748-749; this
+  replica flattens the ``num_ranks * num_experts_per_rank`` entries and
+  clears them from SM 0 since the DSV4 problem size is small (4 * 64 = 256
+  u64 entries).
+* ``expert_recv_count_sum`` (``num_experts_per_rank`` u64) -- per-expert
+  publisher count + token sum. Mega_moe clears this on the non-zero SMs at
+  line 744-745; this replica clears it on SM 0.
+* ``l1_arrival_count`` (``num_max_task_tiles`` u32) -- the per-task-tile
+  release-add counter the GEMM consumer spins on. Mega_moe clears only the
+  *populated* prefix per expert (lines 752-754) using the freshly read
+  ``num_recv_m_blocks``; this replica conservatively clears the full pool
+  via SMs 1..num_sms-1 because the kernel does not have access to the
+  per-expert counts post-barrier (they are themselves cleared above).
+* ``nvlink_barrier_signal`` (``num_ranks`` x 2 i32) -- both barrier slots
+  (slot 0 = pre-pull, slot 1 = kernel-tail) of the symmetric NVLink signal
+  buffer. Mega_moe carries the signal across rounds via a sign-toggle
+  scheme (``barrier.cuh`` lines 28-72); the DSV4 cuTeDSL replica fires each
+  slot exactly once per launch and resets both to zero here.
+* ``grid_sync_counter`` (1 or 2 u32) -- per-rank scratch slot for the
+  software grid sync. The phase-flip pattern in ``grid_sync.py`` leaves
+  this slot at one of ``{0x80000000, 0}`` after every round, so a future
+  round would observe the *previous* terminal value as the round-0 phase
+  bit. Resetting to zero here makes every dispatch launch start from the
+  same canonical phase regardless of how many barriers the previous
+  launch executed.
+
+Not cleared (per DEC-12 + cleanup plan)
+---------------------------------------
+* ``src_token_topk_idx`` -- overwritten in full by the next dispatch
+  round 3 advertise STG (mega_moe line 469-475).
+* ``token_src_metadata`` -- only valid pool-token rows are written by
+  ``_dispatch_pull`` (mega_moe lines 692-693); the padding rows are
+  sentinel-init'd by the next dispatch's pool walker.
+* ``l1_token_buffer``, ``l1_sf_buffer``, ``l1_topk_weights_buffer`` --
+  data-plane buffers; their valid regions are TMA-stored over by the
+  next dispatch.
+
+Work distribution
+-----------------
+SM 0 clears the small counter region (256 + 256 + 64 u64s + 8 i32s + 2 u32s
+~ 4.7 KB total). SMs 1..num_sms-1 cooperatively clear the
+``num_max_task_tiles`` u32 ``l1_arrival_count`` slice; for DSV4 the slice is
+192 entries which fits in one SM's clearing pass, but the slot_per_sm
+striping below scales to larger pools without code changes.
+"""
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import Int32, Int64, Uint32
+
+
+_CLEANUP_THREADS_PER_CTA = 384
+
+
+@cute.kernel
+def cleanup_kernel(
+    expert_send_count: cute.Tensor,
+    expert_recv_count: cute.Tensor,
+    expert_recv_count_sum: cute.Tensor,
+    l1_arrival_count: cute.Tensor,
+    nvlink_barrier_signal: cute.Tensor,
+    nvlink_barrier_counter: cute.Tensor,
+    grid_sync_counter: cute.Tensor,
+    num_total_experts: cutlass.Constexpr[int],
+    num_experts_per_rank: cutlass.Constexpr[int],
+    num_ranks: cutlass.Constexpr[int],
+    num_max_task_tiles: cutlass.Constexpr[int],
+    num_sms: cutlass.Constexpr[int],
+    grid_sync_counter_len: cutlass.Constexpr[int],
+):
+    """Zero the dispatch workspace counter / signal regions.
+
+    Mirrors ``sm100_fp8_fp4_mega_moe.cuh`` lines 723-766. SM 0 clears the
+    small counter region (``expert_send_count``, ``expert_recv_count``,
+    ``expert_recv_count_sum``, ``nvlink_barrier_signal`` slot 0 + slot 1,
+    ``nvlink_barrier_counter``, ``grid_sync_counter``); SMs 1..num_sms-1
+    cooperatively clear
+    ``l1_arrival_count``.
+    """
+    sm_idx = cute.arch.block_idx()[0]
+    tid = cute.arch.thread_idx()[0]
+
+    if sm_idx == Int32(0):
+        for offset in cutlass.range(0, num_total_experts, _CLEANUP_THREADS_PER_CTA):
+            i = Int32(offset) + tid
+            if i < Int32(num_total_experts):
+                expert_send_count[i] = Int64(0)
+
+        recv_count_total: cutlass.Constexpr[int] = num_ranks * num_experts_per_rank
+        for offset in cutlass.range(0, recv_count_total, _CLEANUP_THREADS_PER_CTA):
+            i = Int32(offset) + tid
+            if i < Int32(recv_count_total):
+                rank_idx = i // Int32(num_experts_per_rank)
+                expert_idx = i % Int32(num_experts_per_rank)
+                expert_recv_count[rank_idx, expert_idx] = Int64(0)
+
+        for offset in cutlass.range(0, num_experts_per_rank, _CLEANUP_THREADS_PER_CTA):
+            i = Int32(offset) + tid
+            if i < Int32(num_experts_per_rank):
+                expert_recv_count_sum[i] = Int64(0)
+
+        # Both NVLink barrier slots: slot 0 (pre-pull) and slot 1 (kernel-tail).
+        nvlink_signal_total: cutlass.Constexpr[int] = num_ranks * 2
+        for offset in cutlass.range(0, nvlink_signal_total, _CLEANUP_THREADS_PER_CTA):
+            i = Int32(offset) + tid
+            if i < Int32(nvlink_signal_total):
+                nvlink_barrier_signal[i] = Int32(0)
+
+        # Sense-reversing barrier phase counter (single Int32).
+        if tid == Int32(0):
+            nvlink_barrier_counter[0] = Int32(0)
+
+        for offset in cutlass.range(0, grid_sync_counter_len, _CLEANUP_THREADS_PER_CTA):
+            i = Int32(offset) + tid
+            if i < Int32(grid_sync_counter_len):
+                grid_sync_counter[i] = Uint32(0)
+    else:
+        # SMs 1..num_sms-1 split l1_arrival_count clearing. The
+        slot_per_sm: cutlass.Constexpr[int] = (
+            num_max_task_tiles + num_sms - 2
+        ) // (num_sms - 1)
+        my_start = (sm_idx - Int32(1)) * Int32(slot_per_sm)
+        my_end_unclamped = my_start + Int32(slot_per_sm)
+        end_limit = Int32(num_max_task_tiles)
+        my_end = my_end_unclamped if my_end_unclamped < end_limit else end_limit
+
+        i = my_start + tid
+        while i < my_end:
+            l1_arrival_count[i] = Uint32(0)
+            i = i + Int32(_CLEANUP_THREADS_PER_CTA)

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/config.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/config.py
@@ -1,0 +1,171 @@
+"""DSV4 configuration constants and host-side index utilities (no GPU dependencies).
+
+Pool sizing follows mega_moe (`layout/mega_moe.cuh::get_num_max_pool_tokens` and
+`get_num_padded_sf_pool_tokens`) so the workspace is large enough for the
+worst-case routing distribution. The plan's `kNumPaddedSFPoolTokens=1088`
+reflects an expected-case sizing only — see goal-tracker Open Issues.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+
+def _align_up(x: int, m: int) -> int:
+    return ((x + m - 1) // m) * m
+
+
+def _num_max_pool_tokens(num_ranks: int, num_tokens_per_rank: int, num_topk: int,
+                         num_experts_per_rank: int, block_m: int) -> int:
+    num_max_recv = num_ranks * num_tokens_per_rank
+    num_max_experts_per_token = min(num_topk, num_experts_per_rank)
+    raw = num_max_recv * num_max_experts_per_token + num_experts_per_rank * (block_m - 1)
+    return _align_up(raw, block_m)
+
+
+def _num_padded_sf_pool_tokens(num_max_pool_tokens: int, block_m: int, sf_block_m: int) -> int:
+    return (num_max_pool_tokens // block_m) * sf_block_m
+
+
+@dataclass(frozen=True)
+class DSV4Config:
+    # DeepSeek V4 routing config (DeepGEMM/tests/test_mega_moe.py defaults):
+    #   num_experts=384, num_topk=6, hidden=7168, intermediate_hidden=3072.
+    # 4-rank EP target -> num_experts_per_rank = 384 / 4 = 96.
+    #
+    # `hidden` is the logical token element count (always 7168 for DSV4).
+    # `hidden_bytes` is the wire-format byte count per token, which differs
+    # by token dtype:
+    #   FP8 dispatch:   hidden_bytes = hidden     × 1   = 7168 (default)
+    #   NVFP4 dispatch: hidden_bytes = hidden / 2 × 1   = 3584 (see DSV4_nvfp4)
+    # All in-kernel byte arithmetic (TMA descriptors, SMEM pull buffer, mbarrier
+    # expect_tx) uses `hidden_bytes`; element-count math (sf groups, oracle
+    # logical layout) uses `hidden`.
+    num_ranks: int = 4
+    hidden: int = 7168
+    hidden_bytes: int = 7168
+    num_topk: int = 6
+    num_experts_per_rank: int = 96
+    num_total_experts: int = 384
+    block_m: int = 192
+    sf_block_m: int = 256
+    num_tokens_per_rank: int = 1024
+    num_sms: int = 152
+    sf_uint32_per_token: int = 56  # FP8 vec_size=128 -> hidden / 128 = 56
+    # Downstream consumer's task-tile granularity, drives the
+    # ``l1_arrival_count`` release-counter index granularity inside
+    # ``_dispatch_pull``.  Decoupled from ``block_m`` (which controls pool
+    # layout / TMA-store granularity only) so that the fused fc12 fc1 spin
+    # sees one counter per work tile.  Default ``None`` falls back to
+    # ``block_m`` via ``effective_cluster_tile_m``, recovering the legacy
+    # per-pool-block counter layout for the standalone dispatch path.  Set
+    # explicitly when fusing with a downstream GEMM whose task-tile
+    # granularity differs from the dispatch pool granularity.  See
+    # ``fc12_integrate_comm.md`` §4 (C3) for the full contract.
+    cluster_tile_m: Optional[int] = None
+
+    @property
+    def effective_cluster_tile_m(self) -> int:
+        return self.cluster_tile_m if self.cluster_tile_m is not None else self.block_m
+
+    @property
+    def num_max_pool_tokens(self) -> int:
+        return _num_max_pool_tokens(self.num_ranks, self.num_tokens_per_rank,
+                                    self.num_topk, self.num_experts_per_rank, self.block_m)
+
+    @property
+    def num_padded_sf_pool_tokens(self) -> int:
+        return _num_padded_sf_pool_tokens(self.num_max_pool_tokens, self.block_m, self.sf_block_m)
+
+    @property
+    def num_max_pool_blocks(self) -> int:
+        return self.num_max_pool_tokens // self.block_m
+
+    @property
+    def num_max_task_tiles(self) -> int:
+        """Sized for the release-counter array (``l1_arrival_count``).
+
+        Upper-bound on the number of distinct ``task_tile_idx`` slots
+        ``_dispatch_pull`` will release-add into across all experts:
+        ``sum_e ceil_div(valid_e, cluster_tile_m)``.  We bound it by the
+        same worst-case pool sizing formula used for
+        ``num_max_pool_tokens`` (rounded up to ``effective_cluster_tile_m``
+        granularity).
+        """
+        ctm = self.effective_cluster_tile_m
+        return (self.num_max_pool_tokens + ctm - 1) // ctm
+
+
+DSV4 = DSV4Config()
+
+# NVFP4 dispatch variant. Same logical model (hidden=7168, topk=6, ...) but the
+# token wire format is NVFP4 (4-bit data + 8-bit shared scale-factor per 16
+# elements):
+#   * hidden_bytes = 7168 / 2 = 3584  (4 bits/elem packed)
+#   * sf_uint32_per_token = 7168 / 16 / 4 = 112  (vec_size=16, 4 SF/uint32)
+# Combine still uses BF16; this only changes the dispatch-side wire bytes and
+# the SF granularity (LDG loop runs 4 passes instead of 2).
+DSV4_nvfp4 = DSV4Config(
+    hidden_bytes=3584,
+    sf_uint32_per_token=112,
+)
+
+# 8-rank EP across 2 nodes (GB200 NVL72 same-clique cross-node NVLink).
+# 384 experts / 8 ranks = 48 experts per rank.
+DSV4_8rank = DSV4Config(
+    num_ranks=8,
+    num_experts_per_rank=48,
+)
+
+DSV4_8rank_nvfp4 = DSV4Config(
+    num_ranks=8,
+    num_experts_per_rank=48,
+    hidden_bytes=3584,
+    sf_uint32_per_token=112,
+)
+
+# 6-rank EP across 2 nodes (e.g. 3 GPUs/node * 2 nodes). 384/6 = 64.
+DSV4_6rank = DSV4Config(
+    num_ranks=6,
+    num_experts_per_rank=64,
+)
+
+DSV4_6rank_nvfp4 = DSV4Config(
+    num_ranks=6,
+    num_experts_per_rank=64,
+    hidden_bytes=3584,
+    sf_uint32_per_token=112,
+)
+
+# Lookup table for CLI / test parametrization. Keep keys stable; scripts read
+# them from --config.
+DSV4_CONFIGS = {
+    "DSV4": DSV4,
+    "DSV4_nvfp4": DSV4_nvfp4,
+    "DSV4_8rank": DSV4_8rank,
+    "DSV4_8rank_nvfp4": DSV4_8rank_nvfp4,
+    "DSV4_6rank": DSV4_6rank,
+    "DSV4_6rank_nvfp4": DSV4_6rank_nvfp4,
+}
+
+MAX_SLOT: int = DSV4.num_tokens_per_rank * DSV4.num_topk  # 6144
+
+# Host-side mirror of ``TokenSrcMetadata.nbytes`` (one packed i64 per pool
+# token).  config stays GPU-free, so it cannot import the device object; keep
+# this in sync with ``src/token_comm.py``.
+TOKEN_METADATA_BYTES: int = 8
+
+
+def transform_sf_token_idx_numpy(token_idx_in_expert):
+    """Host-side replica of mega_moe transform_sf_token_idx (UTCCP 4x32 swizzle)."""
+    t = np.asarray(token_idx_in_expert, dtype=np.int32)
+    idx = t % np.int32(DSV4.block_m)
+    return (
+        (t // np.int32(DSV4.block_m)) * np.int32(DSV4.sf_block_m)
+        + (idx & np.int32(-128))
+        + (idx & np.int32(31)) * np.int32(4)
+        + ((idx >> np.int32(5)) & np.int32(3))
+    ).astype(np.int32)

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/dispatch_kernel.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/dispatch_kernel.py
@@ -1,0 +1,167 @@
+"""Standalone dispatch-kernel entry backed by src.token_comm.
+
+The token communication implementation lives in ``src.token_comm``.  This file
+keeps the standalone ``dispatch_kernel`` entry used by tests and experiments.
+"""
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import Int32
+
+try:
+    from cutlass.cute import iket as _iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from .iket_compat import iket as _iket
+
+from .token_comm import (
+    TokenInPullTokenBackPush,
+)
+
+
+@cute.kernel
+def dispatch_kernel(
+    input_token_buffer: cute.Tensor,
+    input_sf_buffer: cute.Tensor,
+    input_topk_idx_buffer: cute.Tensor,
+    input_topk_weights_buffer: cute.Tensor,
+    expert_send_count: cute.Tensor,
+    expert_recv_count: cute.Tensor,
+    expert_recv_count_sum: cute.Tensor,
+    src_token_topk_idx: cute.Tensor,
+    token_src_metadata: cute.Tensor,
+    l1_arrival_count: cute.Tensor,
+    l1_token_buffer: cute.Tensor,
+    l1_sf_buffer: cute.Tensor,
+    l1_topk_weights_buffer: cute.Tensor,
+    nvlink_barrier_signal: cute.Tensor,
+    nvlink_barrier_counter: cute.Tensor,
+    grid_sync_counter: cute.Tensor,
+    peer_rank_ptr_mapper,
+    local_rank: cutlass.Constexpr[int],
+    world_size: cutlass.Constexpr[int],
+    num_tokens: cutlass.Constexpr[int],
+    num_topk: cutlass.Constexpr[int],
+    num_sms: cutlass.Constexpr[int],
+    num_experts_per_rank: cutlass.Constexpr[int],
+    num_total_experts: cutlass.Constexpr[int],
+    block_m: cutlass.Constexpr[int],
+    cluster_tile_m: cutlass.Constexpr[int],
+    sf_block_m: cutlass.Constexpr[int],
+    hidden: cutlass.Constexpr[int],
+    fc1_token_dtype: cutlass.Constexpr[type],
+    sf_uint32_per_token: cutlass.Constexpr[int],
+    num_padded_sf_pool_tokens: cutlass.Constexpr[int],
+    flag_batch: cutlass.Constexpr[int] = 1,
+):
+    """Standalone token-in dispatch kernel used by tests and experiments.
+
+    Launched with ``block = num_dispatch_warps * 32`` (default 128); there
+    are no cohabit warps, so ``num_other_warps=0`` and every CTA-wide
+    rendezvous in :class:`TokenInPullTokenBackPush` collapses to a
+    dispatch-only barrier.
+    """
+    token_comm = TokenInPullTokenBackPush(
+        world_size=world_size,
+        num_topk=num_topk,
+        num_experts_per_rank=num_experts_per_rank,
+        num_total_experts=num_total_experts,
+        hidden=hidden,
+        fc1_token_dtype=fc1_token_dtype,
+        sf_uint32_per_token=sf_uint32_per_token,
+        token_padding_block=block_m,
+        sf_padding_block=sf_block_m,
+        cluster_tile_tokens=cluster_tile_m,
+        cluster_shape_mn=(1, 1),
+        dispatch_warp_start=0,
+        num_other_warps=0,
+        flag_batch=flag_batch,
+        is_swap_ab=True,
+    )
+    smem = cutlass.utils.SmemAllocator()
+    storage = smem.allocate(token_comm.extra_smem_storage_class())
+
+    sm_idx = cute.arch.block_idx()[0]
+    tid = cute.arch.thread_idx()[0]
+    warp_idx = tid // 32
+    lane_idx = tid % 32
+
+    _iket_active = (sm_idx == Int32(0)) and (warp_idx == Int32(0))
+    if _iket_active:
+        _iket.range_push("Dispatch_Prep")
+
+    token_comm.dispatch_prep(
+        storage,
+        input_topk_idx_buffer,
+        expert_send_count,
+        src_token_topk_idx,
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        local_rank=local_rank,
+        num_tokens=num_tokens,
+        num_sms=num_sms,
+    )
+
+    if _iket_active:
+        _iket.range_pop()
+        _iket.range_push("Dispatch_Barrier")
+
+    token_comm.dispatch_barrier(
+        expert_send_count,
+        expert_recv_count,
+        expert_recv_count_sum,
+        nvlink_barrier_signal,
+        grid_sync_counter,
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        local_rank=local_rank,
+        num_sms=num_sms,
+        nvlink_barrier_counter=nvlink_barrier_counter,
+    )
+
+    if _iket_active:
+        _iket.range_pop()
+        _iket.range_push("Dispatch_Pull")
+
+    _, _ = token_comm.dispatch_pull(
+        storage,
+        input_token_buffer,
+        input_sf_buffer,
+        input_topk_weights_buffer,
+        src_token_topk_idx,
+        expert_recv_count,
+        expert_recv_count_sum,
+        l1_token_buffer,
+        l1_sf_buffer,
+        l1_topk_weights_buffer,
+        l1_arrival_count,
+        token_src_metadata,
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        num_sms=num_sms,
+    )
+
+    if _iket_active:
+        _iket.range_pop()
+        _iket.range_push("Kernel_Tail")
+
+    token_comm.nvlink_barrier(
+        nvlink_barrier_signal,
+        nvlink_barrier_counter,
+        grid_sync_counter,
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        num_sms=num_sms,
+        prologue_grid_sync=True,
+        epilogue_grid_sync=True,
+    )
+
+    if _iket_active:
+        _iket.range_pop()

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/flag_batch.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/flag_batch.py
@@ -1,0 +1,140 @@
+"""Rotating-lane delayed release helpers for done-counter publishing."""
+
+import dataclasses
+from typing import Any
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import Int64
+from cutlass.cute.typing import AddressSpace
+
+from .ptx_helpers import (
+    red_add_release_gpu_s32,
+    red_add_release_sys_s32_raw,
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class FlagBatchTrackerBase:
+    """Loop-carried per-thread state for batched release-counter publishing."""
+
+    flag_addr: Int64                # per-lane counter-slot address (0 == null)
+    cumulated_flags: cutlass.Int32  # current batch fill count (uniform)
+    phase: cutlass.Int32            # current accumulated phase (uniform)
+    tid: cutlass.Int32              # lane/thread id within the rotating group
+
+    @cute.jit
+    def _make(
+        self,
+        flag_addr: Int64,
+        cumulated_flags: cutlass.Int32,
+        phase: cutlass.Int32,
+    ) -> "FlagBatchTrackerBase":
+        return FlagBatchTrackerBase(
+            flag_addr=flag_addr,
+            cumulated_flags=cumulated_flags,
+            phase=phase,
+            tid=self.tid,
+        )
+
+    @cute.jit
+    def fire(self) -> None:
+        """Publish this lane's pending slot. Subclasses define the scope."""
+        raise NotImplementedError
+
+    @cute.jit
+    def accumulate(
+        self,
+        next_phase: Any,
+        flush_threshold: int,
+        flag_addr: Int64,
+        no_fire: bool = False,
+    ) -> "FlagBatchTrackerBase":
+        if cutlass.const_expr(flush_threshold == 1):
+            if cutlass.const_expr(not no_fire):
+                per_lane_addr = Int64(0)
+                if self.tid == 0:
+                    per_lane_addr = flag_addr
+                self._make(
+                    flag_addr=per_lane_addr,
+                    cumulated_flags=cutlass.Int32(1),
+                    phase=self.phase,
+                ).fire()
+            return self._make(
+                flag_addr=Int64(0),
+                cumulated_flags=cutlass.Int32(0),
+                phase=cutlass.Int32(next_phase),
+            )
+
+        cur_addr = self.flag_addr
+        cumulated = self.cumulated_flags
+        if self.tid == cumulated:
+            cur_addr = flag_addr
+        cumulated = cumulated + 1
+
+        if cumulated == flush_threshold or next_phase != self.phase:
+            if not no_fire:
+                self._make(
+                    flag_addr=cur_addr,
+                    cumulated_flags=cumulated,
+                    phase=self.phase,
+                ).fire()
+            cumulated = cutlass.Int32(0)
+            cur_addr = Int64(0)
+
+        return self._make(
+            flag_addr=cur_addr,
+            cumulated_flags=cumulated,
+            phase=cutlass.Int32(next_phase),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class GpuReleaseFlagBatchTracker(FlagBatchTrackerBase):
+    """Batched done-counter publisher using GPU-scope release reductions."""
+
+    @cute.jit
+    def _make(
+        self,
+        flag_addr: Int64,
+        cumulated_flags: cutlass.Int32,
+        phase: cutlass.Int32,
+    ) -> "GpuReleaseFlagBatchTracker":
+        return GpuReleaseFlagBatchTracker(
+            flag_addr=flag_addr,
+            cumulated_flags=cumulated_flags,
+            phase=phase,
+            tid=self.tid,
+        )
+
+    @cute.jit
+    def fire(self) -> None:
+        if self.flag_addr != Int64(0):
+            ptr = cute.make_ptr(
+                cutlass.Int32, self.flag_addr, AddressSpace.gmem, assumed_align=4,
+            )
+            red_add_release_gpu_s32(ptr, cutlass.Int32(1))
+
+
+@dataclasses.dataclass(frozen=True)
+class SysReleaseFlagBatchTracker(FlagBatchTrackerBase):
+    """Batched done-counter publisher using system-scope release reductions."""
+
+    @cute.jit
+    def _make(
+        self,
+        flag_addr: Int64,
+        cumulated_flags: cutlass.Int32,
+        phase: cutlass.Int32,
+    ) -> "SysReleaseFlagBatchTracker":
+        return SysReleaseFlagBatchTracker(
+            flag_addr=flag_addr,
+            cumulated_flags=cumulated_flags,
+            phase=phase,
+            tid=self.tid,
+        )
+
+    @cute.jit
+    def fire(self) -> None:
+        if self.flag_addr != Int64(0):
+            red_add_release_sys_s32_raw(self.flag_addr, cutlass.Int32(1))

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/grid_sync.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/grid_sync.py
@@ -1,0 +1,135 @@
+"""Software grid-sync primitive for cuTeDSL kernels.
+
+Replicates the mega_moe `grid_sync` from
+`DeepGEMM/deep_gemm/include/deep_gemm/comm/barrier.cuh` since cuTeDSL has no
+cooperative-launch entrypoint. Uses the canonical phase-flip pattern: a single
+u32 slot whose bit 31 (kFinishSumTag = 0x80000000) acts as the round-phase, and
+whose low bits accumulate per-CTA arrivals. The first CTA (sm_idx == 0) adds
+`(kFinishSumTag - (num_sms - 1))`, every other CTA adds 1, so after all CTAs
+arrive the slot equals `kFinishSumTag` (bit 31 toggled vs. its pre-round value),
+which both signals completion and primes the slot for the next round.
+"""
+
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op, Int32
+
+import cutlass
+import cutlass.cute as cute
+
+
+_FINISH_SUM_TAG = 0x80000000
+
+
+@dsl_user_op
+@cute.jit
+def software_grid_sync(counter_ptr, sm_idx, num_sms, tid_in_group,
+                       *, num_threads=None, loc=None, ip=None):
+    """Grid-wide barrier replacing cooperative_groups::this_grid().sync().
+
+    counter_ptr  : Pointer to a single u32 in global memory, zero-initialised
+                   before the first call. Every barrier round leaves it equal
+                   to one of {0x80000000, 0} (alternating), so it is reusable
+                   across rounds without an explicit reset.
+    sm_idx       : The block index this CTA was launched as (typically
+                   ``cute.arch.block_idx()[0]``). Used to pick the special
+                   delta for sm 0.
+    num_sms      : Total number of CTAs participating. Must equal grid_dim.
+    tid_in_group : Logical thread index within the calling participant group,
+                   0-indexed.  The thread with ``tid_in_group == 0`` is the
+                   *leader* that issues the atomic add and spin-wait; all
+                   others just wait on the surrounding NamedBarrier.
+
+                   This MUST be the logical (group-relative) tid, NOT the
+                   hardware ``%tid.x``.  In fused kernels the dispatch warps
+                   may start at a non-zero ``%tid.x`` base (e.g. MegaMoE puts
+                   them at warps 8-11 / tid_x [256, 384)).  Reading ``%tid.x``
+                   directly inside the PTX would then find no leader and
+                   silently degenerate the grid_sync into a CTA-local NB10
+                   sandwich -- the entire grid-wide sync becomes a no-op.
+                   Caller is responsible for computing this; e.g.
+                   ``tid_in_group = local_warp_idx * 32 + lane_idx`` where
+                   ``local_warp_idx`` is the warp index *within* the dispatch
+                   group (0..3 for the 4 dispatch warps).
+    num_threads  : Number of threads participating on the wrapping
+                   NamedBarrier.  Default ``None`` -> ``cute.arch.sync_threads()``
+                   (= bar.sync 0, full CTA). Pass an explicit count (e.g. 128
+                   = number of dispatch threads) when only a subset of the
+                   CTA's warps participate in this grid sync; needed when the
+                   kernel also launches non-participating warps (e.g. the
+                   placeholder epilogue group), because ``bar.sync 0`` without
+                   a count waits for every thread in the CTA and would
+                   deadlock against those non-participating warps sitting on
+                   a different ``bar.sync`` id.
+    """
+    # NamedBarrier ID 10 (NOT 0!): ID 0 is implicitly used by cuTeDSL's
+    # ``cute.arch.sync_threads()`` and may also be touched by various
+    # pipeline / mbarrier primitives from concurrent warp groups.  When the
+    # caller uses ``num_threads != None`` (= a subset of the CTA), reusing
+    # ID 0 can race with other warps' implicit ``bar.sync 0`` and release
+    # this grid sync prematurely (e.g. SM-X exits before the SM-0 publish
+    # it is supposed to wait for, causing stale GMEM reads downstream).
+    # Must match TokenInPullTokenBackPush.dispatch_intra_cta_bar_id.
+    if num_threads is None:
+        cute.arch.sync_threads(loc=loc, ip=ip)
+    else:
+        # TODO: Remove this hardcode.
+        cute.arch.barrier(barrier_id=10, number_of_threads=num_threads,
+                          loc=loc, ip=ip)
+
+    # PTX add.u32 treats the operand as a raw 32-bit bit pattern so signed
+    # underflow of (kFinishSumTag - (num_sms - 1)) is benign and matches mega_moe.
+    if cutlass.const_expr(isinstance(num_sms, int)):
+        sm_zero_bits = (_FINISH_SUM_TAG - (num_sms - 1)) & 0xFFFFFFFF
+        if cutlass.const_expr(sm_zero_bits >= 0x80000000):
+            sm_zero_bits -= 0x100000000
+        sm_zero_delta = Int32(sm_zero_bits)
+    else:
+        sm_zero_delta = Int32(-_FINISH_SUM_TAG) - (Int32(num_sms) - Int32(1))
+    other_delta = Int32(1)
+
+    # Accept either a Pointer (which has `.toint()`) or a cute.Tensor (which
+    # exposes the underlying pointer via `.iterator`).
+    if cutlass.const_expr(hasattr(counter_ptr, "iterator")):
+        counter_ptr = counter_ptr.iterator
+    # $0=counter_ptr, $1=sm_idx, $2=sm_zero_delta, $3=other_delta,
+    # $4=tid_in_group (leader predicate source).
+    llvm.inline_asm(
+        None,
+        [
+            counter_ptr.toint(loc=loc, ip=ip).ir_value(),
+            Int32(sm_idx).ir_value(),
+            sm_zero_delta.ir_value(),
+            other_delta.ir_value(),
+            Int32(tid_in_group).ir_value(),
+        ],
+        (
+            "{\n\t"
+            ".reg .b32 %delta; .reg .b32 %old; .reg .b32 %cur;\n\t"
+            ".reg .pred %not_leader; .reg .pred %is_sm0; .reg .pred %waiting;\n\t"
+            "setp.ne.u32 %not_leader, $4, 0;\n\t"
+            "@%not_leader bra DONE;\n\t"
+            "setp.eq.u32 %is_sm0, $1, 0;\n\t"
+            "selp.b32 %delta, $2, $3, %is_sm0;\n\t"
+            "atom.release.gpu.global.add.u32 %old, [$0], %delta;\n\t"
+            "SPIN:\n\t"
+            "ld.relaxed.gpu.global.b32 %cur, [$0];\n\t"
+            "xor.b32 %cur, %cur, %old;\n\t"
+            "and.b32 %cur, %cur, 0x80000000;\n\t"
+            "setp.eq.u32 %waiting, %cur, 0;\n\t"
+            "@%waiting bra SPIN;\n\t"
+            "fence.acq_rel.gpu;\n\t"
+            "DONE:\n\t"
+            "}"
+        ),
+        "l,r,r,r,r",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+    if cutlass.const_expr(num_threads is None):
+        cute.arch.sync_threads(loc=loc, ip=ip)
+    else:
+        cute.arch.barrier(barrier_id=10, number_of_threads=num_threads,
+                          loc=loc, ip=ip)

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/iket_compat.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/iket_compat.py
@@ -1,0 +1,40 @@
+"""Compatibility wrapper for optional ``cutlass.cute.iket`` support."""
+
+# IKET (In-Kernel Event Tracing) markers are only available in cutlass-dsl
+# wheels that ship the ``iket`` dialect. Functional tests do not need the
+# dialect, so fall back to no-op markers when the import is unavailable.
+try:
+    from cutlass.cute.experimental import iket  # Latest tot DKG.
+except (ImportError, NotImplementedError):  # pragma: no cover -- fallback for wheels without cute.iket
+    # ``cute.experimental`` raises NotImplementedError (NOT ImportError) on
+    # CUDA toolkits < 13.1, so the public-release / CTK-12.9 CI wheels land
+    # here; catch both so the no-op shim below actually takes over instead
+    # of propagating up through ``epilogue.py``'s ImportError-only guard.
+    try:
+        from cutlass.cute import iket  # type: ignore
+    except (ImportError, NotImplementedError):
+        print("!!!! Iket is not enabled !!!!")
+        class _IketShim:
+            """No-op IKET shim used when the dialect is not available."""
+
+            @staticmethod
+            def range_push(_name, *_args, **_kwargs):
+                return None
+
+            @staticmethod
+            def range_pop(*_args, **_kwargs):
+                return None
+
+            @staticmethod
+            def range_start(_name, *_args, **_kwargs):
+                return None
+
+            @staticmethod
+            def range_end(_token=None, *_args, **_kwargs):
+                return None
+
+            @staticmethod
+            def mark(_name, *_args, **_kwargs):
+                return None
+
+        iket = _IketShim()  # type: ignore

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/inputs_process.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/inputs_process.py
@@ -1,0 +1,742 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Fused bf16 -> quantized-activation staging for MegaMoE.
+
+One launch turns bf16 hidden states into the packed activation + block-scale
+layout the MegaMoE GEMMs consume, and repacks the routing tensors (topk idx /
+weights) with padding-token masking. The quant kind is fixed at construction:
+
+    nvfp4        E2M1 data + per-16 E4M3 block scale + a per-tensor global scale
+                 (``norm_const``). E4M3 block scales need that global scale to
+                 stay in range; it is either an offline-calibrated constant or
+                 computed online from the activation amax.
+    mxfp8_e4m3   E4M3 data + per-32 E8M0 block scale. Self-contained: the
+    mxfp8_e5m2   power-of-two E8M0 scale needs no global scale.
+
+Padding tokens (``token_padding_info[token]`` truthy) get ``topk_idx = -1`` and
+``topk_weights = 0`` so downstream dispatch skips them; their quantized rows are
+still written but never read.
+"""
+
+import os
+import sys
+from typing import Literal, Optional, Union
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cutlass_dsl import Float32, Int32, Int64
+
+from common.megamoe_constants import (
+    Fp8E4M3FNMax,
+    Fp8E4M3RcpLimit,
+    Fp8E5M2RcpLimit,
+    Fp32Max,
+    Mxfp8BlockSize,
+    Nvfp4BlockSize,
+    Nvfp4E2M1Max,
+    Nvfp4E2M1RcpLimit,
+)
+from common.moe_utils import cvt_f32_to_f8_to_f32
+from src.ptx_helpers import max_abs_bf16x2, red_min_relaxed_gpu_u32_from_f32_raw
+
+
+class DataPreprocess:
+    """Staging launcher pinned to one ``(topk, quant_type)``.
+
+    ``__init__`` pins the static config (quant dtypes, scale-block size);
+    ``__call__`` is the ``@cute.jit`` launcher that sizes the grid from the
+    runtime token count and dispatches the quant kind's kernel. The caller owns
+    the torch->cute conversion and the ``cute.compile`` / ``aot_compile``.
+    """
+
+    # One CTA per token; threads split that token's hidden row.
+    _threads_per_cta: int = 128
+    _amax_threads_per_cta: int = 128
+    _amax_load_vec: int = 8  # 8 bf16 = 16 B per load
+
+    def __init__(
+        self,
+        topk: int,
+        hidden: int,
+        quant_type: Literal["nvfp4", "mxfp8_e5m2", "mxfp8_e4m3"],
+    ) -> None:
+        self.topk = int(topk)
+        # The routing repack assigns one lane per topk slot, so topk cannot
+        # exceed the CTA width.
+        if self.topk > self._threads_per_cta:
+            raise ValueError(
+                f"topk ({self.topk}) must be <= threads_per_cta "
+                f"({self._threads_per_cta}); the routing repack uses one lane "
+                "per topk slot."
+            )
+        # Compile-time: the quant kernel stages the whole row into (static) smem.
+        self.hidden = int(hidden)
+        self.quant_type = quant_type
+        self.is_nvfp4 = quant_type == "nvfp4"
+        if quant_type == "nvfp4":
+            self.sf_vec = Nvfp4BlockSize
+            self.quant_dtype = cutlass.Float4E2M1FN
+            self.sf_dtype = cutlass.Float8E4M3FN
+        elif quant_type == "mxfp8_e4m3":
+            self.sf_vec = Mxfp8BlockSize
+            self.quant_dtype = cutlass.Float8E4M3FN
+            self.sf_dtype = cutlass.Float8E8M0FNU
+            self._mxfp8_data_rcp_limit = float(Fp8E4M3RcpLimit)  # 1 / 448
+        elif quant_type == "mxfp8_e5m2":
+            self.sf_vec = Mxfp8BlockSize
+            self.quant_dtype = cutlass.Float8E5M2
+            self.sf_dtype = cutlass.Float8E8M0FNU
+            self._mxfp8_data_rcp_limit = float(Fp8E5M2RcpLimit)  # 1 / 57344
+        else:
+            raise ValueError(f"Unsupported quant_type: {quant_type!r}")
+
+        # nvfp4 encode constants (see `nvfp4_quant_and_process_impl`):
+        #   stored E4M3 block scale = block_amax * rcp_limit * norm_const
+        #   norm_const at amax        = (E4M3_max * E2M1_max) / amax_tensor
+        self._nvfp4_rcp_limit = float(Nvfp4E2M1RcpLimit)          # 1 / 6
+        self._nvfp4_norm_numer = float(Fp8E4M3FNMax * Nvfp4E2M1Max)  # 448 * 6
+
+    # -- launcher -------------------------------------------------------------
+
+    @cute.jit
+    def __call__(
+        self,
+        # inputs
+        activation_bf16: cute.Tensor,               # (token, hidden)
+        topk_idx: cute.Tensor,                      # (token, topk)
+        topk_weights: cute.Tensor,                  # (token, topk)
+        token_padding_info: Optional[cute.Tensor],  # (token,) ; None => no padding
+        # outputs
+        activation_quant: cute.Tensor,      # (token, hidden) fp4/fp8 elements
+                                            # (cute sees the real fp4 dtype, not
+                                            # torch's pack2 uint8 -> full hidden)
+        activation_sf: cute.Tensor,         # (token, hidden // sf_vec) block scales,
+                                            # rebuilt below into a (token, hidden)
+                                            # broadcast view over the block dim
+        topk_idx_output: cute.Tensor,       # (token, topk)
+        topk_weights_output: cute.Tensor,   # (token, topk)
+        cuda_stream: cuda.CUstream,
+        # nvfp4 only: exactly one of the two is valid (see class docstring).
+        #   online:  (1,) output buffer -- caller does NOT zero it; staging zeros
+        #            it, reduces the activation amax into it, and leaves the
+        #            derived scale for the caller to fold into fc1_alpha.
+        #   offline: runtime f32 scalar, read-only calibrated scale.
+        online_norm_const: Optional[cute.Tensor] = None,
+        offline_norm_const: Optional[cutlass.Float32] = None,
+    ) -> None:
+        # Mode invariants resolve at trace time (the scale args are None-or-not
+        # when the kernel is compiled).
+        if cutlass.const_expr(self.is_nvfp4):
+            if cutlass.const_expr((online_norm_const is None) == (offline_norm_const is None)):
+                raise ValueError(
+                    "nvfp4 staging needs exactly one of `online_norm_const` "
+                    "(output buffer, staging-zeroed) or `offline_norm_const` "
+                    "(calibrated constant); got both or neither."
+                )
+        else:
+            if cutlass.const_expr(
+                online_norm_const is not None or offline_norm_const is not None
+            ):
+                raise ValueError(
+                    f"{self.quant_type} staging is self-scaled; do not pass "
+                    "`online_norm_const` / `offline_norm_const`."
+                )
+
+        num_tokens = activation_bf16.shape[0]
+        grid = [num_tokens, 1, 1]
+        block = [self._threads_per_cta, 1, 1]
+
+        # Rebuild the block scales into the cute-idiomatic broadcast layout so
+        # they index in the same (token, hidden) space as the data: the inner
+        # sf_vec mode carries stride 0, so every element in a block maps to that
+        # block's single scale entry.
+        #   (token, hidden // sf_vec) -> (token, (sf_vec, hidden // sf_vec))
+        #                                stride (d_token, (0, d_block))
+        num_sf_blocks = activation_sf.shape[1]
+        activation_sf = cute.make_tensor(
+            activation_sf.iterator,
+            cute.make_layout(
+                (activation_sf.shape[0], (self.sf_vec, num_sf_blocks)),
+                stride=(activation_sf.stride[0], (0, activation_sf.stride[1])),
+            ),
+        )
+
+        if cutlass.const_expr(not self.is_nvfp4):
+            self.mxfp8_quant_and_process_impl(
+                activation_bf16,
+                topk_idx,
+                topk_weights,
+                token_padding_info,
+                activation_quant,
+                activation_sf,
+                topk_idx_output,
+                topk_weights_output,
+            ).launch(grid=grid, block=block, stream=cuda_stream)
+            return
+
+        # nvfp4: online derives the per-tensor scale in-band (zero -> amax ->
+        # quant, three launches so kernel boundaries stand in for a grid barrier
+        # with no extra workspace); offline reads the caller's constant in one
+        # launch. Perf-critical callers should calibrate offline.
+        if cutlass.const_expr(online_norm_const is not None):
+            self._init_online_scale_impl(online_norm_const).launch(
+                grid=[1, 1, 1], block=[1, 1, 1], stream=cuda_stream,
+            )
+            self.nvfp4_amax_impl(
+                activation_bf16,
+                token_padding_info,
+                online_norm_const,
+            ).launch(
+                grid=grid,
+                block=[self._amax_threads_per_cta, 1, 1],
+                stream=cuda_stream,
+            )
+            norm_const = online_norm_const
+        else:
+            norm_const = offline_norm_const
+
+        self.nvfp4_quant_and_process_impl(
+            activation_bf16,
+            topk_idx,
+            topk_weights,
+            token_padding_info,
+            activation_quant,
+            activation_sf,
+            topk_idx_output,
+            topk_weights_output,
+            norm_const,
+        ).launch(grid=grid, block=block, stream=cuda_stream)
+
+    # -- shared device helpers ------------------------------------------------
+
+    @cute.jit
+    def _mark_alignment(self, tensor: cute.Tensor, align_bytes: int) -> cute.Tensor:
+        # Re-tag a tensor's pointer with a stronger alignment so vectorized
+        # copies are legal (mirrors topk_reduce._mark_alignment).
+        p = tensor.iterator
+        return cute.make_tensor(
+            cute.make_ptr(p.dtype, p.toint(), p.memspace, assumed_align=align_bytes),
+            tensor.layout,
+        )
+
+    @cute.jit
+    def _repack_routing(
+        self,
+        token_idx,
+        tid,
+        topk_idx: cute.Tensor,
+        topk_weights: cute.Tensor,
+        token_padding_info: Optional[cute.Tensor],
+        topk_idx_output: cute.Tensor,
+        topk_weights_output: cute.Tensor,
+    ) -> None:
+        # One thread per topk slot repacks routing into the int64/float32 layout
+        # the MegaMoE kernels consume; padding tokens are masked to (-1, 0).
+        topk: cutlass.Constexpr[int] = self.topk
+        if tid < Int32(topk):
+            is_padding = False
+            if cutlass.const_expr(token_padding_info is not None):
+                is_padding = token_padding_info[token_idx] != Int32(0)
+            idx = Int64(-1) if is_padding else Int64(topk_idx[token_idx, tid])
+            weight = Float32(0.0) if is_padding else Float32(topk_weights[token_idx, tid])
+            topk_idx_output[token_idx, tid] = idx
+            topk_weights_output[token_idx, tid] = weight
+
+    # -- kernels --------------------------------------------------------------
+
+    @cute.kernel
+    def _init_online_scale_impl(self, scale: cute.Tensor) -> None:
+        # Seed the (1,) online scale slot with the atomic-min identity (a large
+        # positive sentinel) before the amax reduction runs against it.
+        scale[0] = Fp32Max
+
+    @cute.kernel
+    def nvfp4_amax_impl(
+        self,
+        activation_bf16: cute.Tensor,
+        token_padding_info: Optional[cute.Tensor],
+        online_norm_const: cute.Tensor,
+    ) -> None:
+        # One CTA per token reduces its (non-padding) row amax, converts it to a
+        # per-token norm_const candidate, and atomic-mins it into the shared
+        # slot. norm_const = numer / amax is monotone-decreasing in amax, so
+        # min over tokens == numer / max amax == the global norm_const.
+        threads: cutlass.Constexpr[int] = self._amax_threads_per_cta
+        num_warps: cutlass.Constexpr[int] = threads // 32
+        load_vec: cutlass.Constexpr[int] = self._amax_load_vec
+        token_idx = cute.arch.block_idx()[0]
+        tid = cute.arch.thread_idx()[0]
+        hidden = activation_bf16.shape[1]
+
+        smem = cutlass.utils.SmemAllocator()
+        warp_partials = smem.allocate_array(Float32, num_warps)
+
+        is_padding = False
+        if cutlass.const_expr(token_padding_info is not None):
+            is_padding = token_padding_info[token_idx] != Int32(0)
+
+        if not is_padding:
+            # 16 B vectorized loads: each thread strides over load_vec-wide chunks.
+            a_chunks = cute.zipped_divide(activation_bf16[token_idx, None], (load_vec,))
+            load_atom = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                cutlass.BFloat16,
+                num_bits_per_copy=load_vec * 16,
+            )
+            num_chunks = hidden // load_vec
+            # Stay in bf16: max.xorsign.abs.bf16x2 does per-lane abs-max on two
+            # packed bf16, so no per-element fp32 convert. The junk xor-sign is
+            # masked at the end; the single per-thread amax is converted once.
+            acc_pair = Int32(0)
+            c = tid
+            while c < num_chunks:
+                chunk = cute.make_rmem_tensor((load_vec,), cutlass.BFloat16)
+                # Each chunk starts at c*16 B (16 B aligned); re-tag so the
+                # 128-bit copy's static alignment check passes.
+                cute.copy(load_atom, self._mark_alignment(a_chunks[(None,), (c,)], 16), chunk)
+                pairs = cute.recast_tensor(chunk, Int32)
+                for p in cutlass.range_constexpr(load_vec // 2):
+                    acc_pair = max_abs_bf16x2(acc_pair, pairs[p])
+                c += Int32(threads)
+
+            # Fold the two bf16 lanes together, mask the junk sign, convert once.
+            acc_pair = max_abs_bf16x2(acc_pair, acc_pair >> Int32(16))
+            local_bits = cute.make_rmem_tensor((1,), Int32)
+            local_bits[0] = acc_pair & Int32(0x7FFF)
+            local_amax = Float32(cute.recast_tensor(local_bits, cutlass.BFloat16)[0])
+
+            # Warp reduce -> num_warps STS partials -> warp 0 LDS -> warp reduce
+            # -> atomic. num_warps (<= 32) partials fit in warp 0's lanes.
+            warp_amax = cute.arch.warp_redux_sync(local_amax, "fmax", abs=True)
+            warp_idx = tid // Int32(32)
+            lane_idx = tid % Int32(32)
+            if lane_idx == Int32(0):
+                warp_partials[warp_idx] = warp_amax
+            cute.arch.sync_threads()
+
+            if warp_idx == Int32(0):
+                partial = Float32(0.0)
+                if lane_idx < Int32(num_warps):
+                    partial = warp_partials[lane_idx]
+                token_amax = cute.arch.warp_redux_sync(partial, "fmax", abs=True)
+                if lane_idx == Int32(0):
+                    # token_amax == 0 -> candidate +inf, harmless under min.
+                    candidate = Float32(self._nvfp4_norm_numer) * cute.arch.rcp_approx(
+                        token_amax
+                    )
+                    red_min_relaxed_gpu_u32_from_f32_raw(
+                        online_norm_const.iterator.toint(), candidate
+                    )
+
+    @cute.kernel
+    def nvfp4_quant_and_process_impl(
+        self,
+        activation_bf16: cute.Tensor,
+        topk_idx: cute.Tensor,
+        topk_weights: cute.Tensor,
+        token_padding_info: Optional[cute.Tensor],
+        activation_quant: cute.Tensor,
+        activation_sf: cute.Tensor,
+        topk_idx_output: cute.Tensor,
+        topk_weights_output: cute.Tensor,
+        norm_const: Union[cute.Tensor, cutlass.Float32],  # online (1,) tensor or offline f32 scalar
+    ) -> None:
+        threads: cutlass.Constexpr[int] = self._threads_per_cta
+        sf_vec: cutlass.Constexpr[int] = self.sf_vec
+        hidden: cutlass.Constexpr[int] = self.hidden
+        load_vec: cutlass.Constexpr[int] = 8  # 8 bf16 = 16 B per cp.async
+        num_blocks: cutlass.Constexpr[int] = hidden // sf_vec
+        num_chunks: cutlass.Constexpr[int] = hidden // load_vec
+        chunks_per_thread: cutlass.Constexpr[int] = (num_chunks + threads - 1) // threads
+        blocks_per_thread: cutlass.Constexpr[int] = (num_blocks + threads - 1) // threads
+        token_idx = cute.arch.block_idx()[0]
+        tid = cute.arch.thread_idx()[0]
+
+        if cutlass.const_expr(isinstance(norm_const, cute.Tensor)):
+            nc = Float32(norm_const[0])  # online: derived scale slot
+        else:
+            nc = norm_const  # offline: runtime f32 scalar
+        rcp_limit = Float32(self._nvfp4_rcp_limit)
+        fp32_max = Fp32Max
+
+        # Stage the whole bf16 row into swizzled smem via cp.async (LDGSTS):
+        # coalesced 16 B loads (8 bf16/lane), all issued up front, no mbarrier.
+        # The swizzle makes the later per-block LDS.128 bank-conflict free.
+        smem = cutlass.utils.SmemAllocator()
+        smem_row = smem.allocate_tensor(
+            cutlass.BFloat16,
+            cute.make_layout(hidden),
+            1024,
+            swizzle=cute.make_swizzle(1, 4, 3),
+        )
+        g_chunks = cute.zipped_divide(activation_bf16[token_idx, None], (load_vec,))
+        s_chunks = cute.zipped_divide(smem_row, (load_vec,))
+        g2s_atom = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            cutlass.BFloat16,
+            num_bits_per_copy=load_vec * 16,
+        )
+        # Issue every cp.async up front, committing a group every 2 load rounds
+        # (= one quant round's worth of blocks). num_groups == blocks_per_thread
+        # (nested ceil-div identity), so group j feeds quant round j 1:1.
+        num_groups: cutlass.Constexpr[int] = (chunks_per_thread + 1) // 2
+        for i in cutlass.range_constexpr(chunks_per_thread):
+            c = tid + Int32(i * threads)
+            if c < Int32(num_chunks):
+                cute.copy(
+                    g2s_atom,
+                    self._mark_alignment(g_chunks[(None,), (c,)], 16),
+                    s_chunks[(None,), (c,)],
+                )
+            if cutlass.const_expr(i % 2 == 1 or i == chunks_per_thread - 1):
+                cute.arch.cp_async_commit_group()
+
+        # Quantize each 16-block from smem; block amax is register-local, so no
+        # cross-thread reduce. Read via LDS.128 to benefit from the swizzle.
+        s_blk = cute.zipped_divide(smem_row, (sf_vec,))
+        q_blk = cute.zipped_divide(activation_quant[token_idx, None], (sf_vec,))
+        lds_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), cutlass.BFloat16, num_bits_per_copy=128
+        )
+        store_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), cutlass.Float4E2M1FN, num_bits_per_copy=sf_vec * 4
+        )
+        for j in cutlass.range_constexpr(blocks_per_thread):
+            # A dummy commit each round keeps the target group a fixed depth from
+            # the tail, so the wait arg stays the constant `num_groups` (waits for
+            # exactly group j; later groups keep loading underneath). Barrier
+            # makes the cooperatively loaded smem region visible to all threads.
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(num_groups)
+            cute.arch.sync_threads()
+            b = tid + Int32(j * threads)
+            if b < Int32(num_blocks):
+                block_bf16 = cute.make_rmem_tensor((sf_vec,), cutlass.BFloat16)
+                cute.copy(lds_atom, s_blk[(None,), (b,)], block_bf16)
+                vals = cute.make_rmem_tensor((sf_vec,), Float32)
+                vals.store(block_bf16.load().to(Float32))
+
+                absmax = Float32(0.0)
+                for i in cutlass.range_constexpr(sf_vec):
+                    absmax = cute.arch.fmax(absmax, cute.arch.fmax(vals[i], -vals[i]))
+
+                # Stored per-block E4M3 scale; .to() clamps to the E4M3 range.
+                sfc_e4m3 = (absmax * rcp_limit * nc).to(cutlass.Float8E4M3FN)
+                sfc_rt = Float32(sfc_e4m3)
+                # Per-element encode scale; the mask zeros the sfc==0 (all-zero
+                # block) case so its fp4 codes stay 0 instead of NaN.
+                acc_scale = cute.arch.fmin(nc * cute.arch.rcp_approx(sfc_rt), fp32_max)
+                acc_scale = acc_scale * cute.arch.fmin(
+                    sfc_rt * Float32(1.0e30), Float32(1.0)
+                )
+
+                scaled = cute.make_rmem_tensor((sf_vec,), Float32)
+                for i in cutlass.range_constexpr(sf_vec):
+                    scaled[i] = vals[i] * acc_scale
+                fp4 = cute.make_rmem_tensor((sf_vec,), cutlass.Float4E2M1FN)
+                fp4.store(scaled.load().to(cutlass.Float4E2M1FN))
+
+                cute.copy(
+                    store_atom, fp4, self._mark_alignment(q_blk[(None,), (b,)], sf_vec // 2)
+                )
+                activation_sf[token_idx, (0, b)] = sfc_e4m3
+
+        self._repack_routing(
+            token_idx,
+            tid,
+            topk_idx,
+            topk_weights,
+            token_padding_info,
+            topk_idx_output,
+            topk_weights_output,
+        )
+
+    @cute.kernel
+    def mxfp8_quant_and_process_impl(
+        self,
+        activation_bf16: cute.Tensor,
+        topk_idx: cute.Tensor,
+        topk_weights: cute.Tensor,
+        token_padding_info: Optional[cute.Tensor],
+        activation_quant: cute.Tensor,
+        activation_sf: cute.Tensor,
+        topk_idx_output: cute.Tensor,
+        topk_weights_output: cute.Tensor,
+    ) -> None:
+        # Same cp.async staging + swizzle + block pipeline as the nvfp4 path; the
+        # per-block encode differs: per-32 E8M0 (power-of-2) scale, no global
+        # scale. See nvfp4_quant_and_process_impl for the pipeline commentary.
+        threads: cutlass.Constexpr[int] = self._threads_per_cta
+        sf_vec: cutlass.Constexpr[int] = self.sf_vec
+        hidden: cutlass.Constexpr[int] = self.hidden
+        load_vec: cutlass.Constexpr[int] = 8  # 8 bf16 = 16 B per cp.async
+        rounds_per_group: cutlass.Constexpr[int] = sf_vec // load_vec
+        num_blocks: cutlass.Constexpr[int] = hidden // sf_vec
+        num_chunks: cutlass.Constexpr[int] = hidden // load_vec
+        chunks_per_thread: cutlass.Constexpr[int] = (num_chunks + threads - 1) // threads
+        blocks_per_thread: cutlass.Constexpr[int] = (num_blocks + threads - 1) // threads
+        num_groups: cutlass.Constexpr[int] = (
+            chunks_per_thread + rounds_per_group - 1
+        ) // rounds_per_group
+        token_idx = cute.arch.block_idx()[0]
+        tid = cute.arch.thread_idx()[0]
+
+        data_rcp_limit = Float32(self._mxfp8_data_rcp_limit)
+        fp32_max = Fp32Max
+
+        smem = cutlass.utils.SmemAllocator()
+        smem_row = smem.allocate_tensor(
+            cutlass.BFloat16,
+            cute.make_layout(hidden),
+            1024,
+            swizzle=cute.make_swizzle(1, 4, 3),
+        )
+        g_chunks = cute.zipped_divide(activation_bf16[token_idx, None], (load_vec,))
+        s_chunks = cute.zipped_divide(smem_row, (load_vec,))
+        g2s_atom = cute.make_copy_atom(
+            cute.nvgpu.cpasync.CopyG2SOp(),
+            cutlass.BFloat16,
+            num_bits_per_copy=load_vec * 16,
+        )
+        # Issue all cp.async up front, one group per quant round's worth of
+        # blocks (rounds_per_group load rounds == 128 blocks).
+        for i in cutlass.range_constexpr(chunks_per_thread):
+            c = tid + Int32(i * threads)
+            if c < Int32(num_chunks):
+                cute.copy(
+                    g2s_atom,
+                    self._mark_alignment(g_chunks[(None,), (c,)], 16),
+                    s_chunks[(None,), (c,)],
+                )
+            if cutlass.const_expr(
+                (i + 1) % rounds_per_group == 0 or i == chunks_per_thread - 1
+            ):
+                cute.arch.cp_async_commit_group()
+
+        s_blk = cute.zipped_divide(smem_row, (sf_vec,))
+        q_blk = cute.zipped_divide(activation_quant[token_idx, None], (sf_vec,))
+        lds_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), cutlass.BFloat16, num_bits_per_copy=128
+        )
+        store_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self.quant_dtype, num_bits_per_copy=128
+        )
+        for j in cutlass.range_constexpr(blocks_per_thread):
+            cute.arch.cp_async_commit_group()
+            cute.arch.cp_async_wait_group(num_groups)
+            cute.arch.sync_threads()
+            b = tid + Int32(j * threads)
+            if b < Int32(num_blocks):
+                block_bf16 = cute.make_rmem_tensor((sf_vec,), cutlass.BFloat16)
+                cute.copy(lds_atom, s_blk[(None,), (b,)], block_bf16)
+                vals = cute.make_rmem_tensor((sf_vec,), Float32)
+                vals.store(block_bf16.load().to(Float32))
+
+                absmax = Float32(0.0)
+                for i in cutlass.range_constexpr(sf_vec):
+                    absmax = cute.arch.fmax(absmax, cute.arch.fmax(vals[i], -vals[i]))
+
+                # Per-32 E8M0 (power-of-2) scale, rounded up (cvt.rp) so the block
+                # never overflows the fp8 range; rcp is exact for a power of two.
+                scale_f32 = Float32(
+                    cvt_f32_to_f8_to_f32(absmax * data_rcp_limit, cutlass.Float8E8M0FNU)
+                )
+                sf_e8m0 = scale_f32.to(cutlass.Float8E8M0FNU)
+                acc_scale = cute.arch.fmin(cute.arch.rcp_approx(scale_f32), fp32_max)
+
+                scaled = cute.make_rmem_tensor((sf_vec,), Float32)
+                for i in cutlass.range_constexpr(sf_vec):
+                    scaled[i] = vals[i] * acc_scale
+                data = cute.make_rmem_tensor((sf_vec,), self.quant_dtype)
+                data.store(scaled.load().to(self.quant_dtype))
+
+                cute.copy(
+                    store_atom, data, self._mark_alignment(q_blk[(None,), (b,)], sf_vec)
+                )
+                activation_sf[token_idx, (0, b)] = sf_e8m0
+
+        self._repack_routing(
+            token_idx,
+            tid,
+            topk_idx,
+            topk_weights,
+            token_padding_info,
+            topk_idx_output,
+            topk_weights_output,
+        )
+
+    # # This might not be needed right now.
+    # @cute.kernel
+    # def mxfp4_quant_and_process_impl(self, ...):
+    #     ...
+
+
+# =============================================================================
+# Correctness harness (GPU only; needs cutlass + torch fp4/e8m0 dtypes).
+# Runs each path and checks the quant output against the repo's bit-matched
+# reference quantizers, plus an exact routing-repack check.
+#   python -m src.inputs_process
+# =============================================================================
+
+
+def _run_case(quant_type: str, mode: str, num_tokens: int, hidden: int, topk: int) -> bool:
+    import torch
+    import cuda.bindings.driver as cuda_driver
+    from cutlass.torch import from_dlpack
+
+    from moe_nvfp4_swapab.runner_common import (
+        nvfp4_quantize_per_block_16,
+        dequant_block_scale_to_fp32,
+    )
+    from common.host_utils import mxfp8_quantize_per_block_32
+
+    torch.manual_seed(0)
+    is_nvfp4 = quant_type == "nvfp4"
+    sf_vec = 16 if is_nvfp4 else 32
+    num_blocks = hidden // sf_vec
+    torch_quant_dtype = {
+        "mxfp8_e4m3": torch.float8_e4m3fn,
+        "mxfp8_e5m2": torch.float8_e5m2,
+    }.get(quant_type)
+
+    x = torch.randn(num_tokens, hidden, dtype=torch.bfloat16, device="cuda")
+    topk_idx_in = torch.randint(0, 64, (num_tokens, topk), dtype=torch.int32, device="cuda")
+    topk_w_in = torch.rand(num_tokens, topk, dtype=torch.float32, device="cuda")
+
+    if is_nvfp4:
+        quant = torch.empty(num_tokens, hidden // 2, dtype=torch.uint8, device="cuda").view(
+            torch.float4_e2m1fn_x2
+        )
+        sf = torch.empty(num_tokens, num_blocks, dtype=torch.float8_e8m0fnu, device="cuda").view(
+            torch.float8_e4m3fn
+        )
+    else:
+        quant = torch.empty(num_tokens, hidden, dtype=torch_quant_dtype, device="cuda")
+        sf = torch.empty(num_tokens, num_blocks, dtype=torch.float8_e8m0fnu, device="cuda")
+    idx_out = torch.empty(num_tokens, topk, dtype=torch.int64, device="cuda")
+    w_out = torch.empty(num_tokens, topk, dtype=torch.float32, device="cuda")
+
+    dp = DataPreprocess(topk=topk, hidden=hidden, quant_type=quant_type)
+
+    def to_cute(t, align=16):
+        return from_dlpack(t, assumed_align=align).mark_layout_dynamic()
+
+    stream = cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    online_norm_const = None
+    offline_norm_const = None
+    online_t = None
+    norm_const_used = None
+    if is_nvfp4 and mode == "online":
+        online_t = torch.zeros(1, dtype=torch.float32, device="cuda")
+        online_norm_const = to_cute(online_t, 4)
+    elif is_nvfp4:
+        norm_const_used = 2.0
+        offline_norm_const = cutlass.Float32(norm_const_used)
+
+    # import nvtx
+    # with nvtx.annotate("cute_dsl_prof"):
+    dp(
+        to_cute(x),
+        to_cute(topk_idx_in, 4),
+        to_cute(topk_w_in, 4),
+        None,
+        to_cute(quant),
+        to_cute(sf, 4),
+        to_cute(idx_out, 4),
+        to_cute(w_out, 4),
+        stream,
+        online_norm_const=online_norm_const,
+        offline_norm_const=offline_norm_const,
+    )
+    torch.cuda.synchronize()
+
+    ok = True
+
+    # -- routing (exact) --
+    if not torch.equal(idx_out, topk_idx_in.to(torch.int64)):
+        print(f"  [FAIL] topk_idx mismatch")
+        ok = False
+    if not torch.equal(w_out, topk_w_in):
+        print(f"  [FAIL] topk_weights mismatch")
+        ok = False
+
+    # -- quant vs reference quantizer --
+    x_fp32 = x.float()
+    if is_nvfp4:
+        if mode == "online":
+            norm_const_used = float(online_t[0].item())
+            expected = 2688.0 / x_fp32.abs().amax().item()
+            rel = abs(norm_const_used - expected) / expected
+            print(f"  online norm_const={norm_const_used:.4g} expected={expected:.4g} rel={rel:.2e}")
+            if rel > 1e-2:
+                print(f"  [FAIL] online norm_const off")
+                ok = False
+        ref_q, ref_sf = nvfp4_quantize_per_block_16(x_fp32, norm_const_used)
+        deq_ker = dequant_block_scale_to_fp32(quant, sf, sf_vec)
+        deq_ref = dequant_block_scale_to_fp32(ref_q, ref_sf, sf_vec)
+        sf_exact = torch.equal(sf.view(torch.uint8), ref_sf.view(torch.uint8))
+    else:
+        ref_q, ref_sf = mxfp8_quantize_per_block_32(x_fp32, torch_quant_dtype)
+        deq_ker = dequant_block_scale_to_fp32(quant, sf, sf_vec)
+        deq_ref = dequant_block_scale_to_fp32(ref_q, ref_sf, sf_vec)
+        sf_exact = torch.equal(sf.view(torch.uint8), ref_sf.view(torch.uint8))
+
+    signal = deq_ref.pow(2).mean()
+    noise = (deq_ker - deq_ref).pow(2).mean()
+    snr_db = float("inf") if noise == 0 else 10.0 * torch.log10(signal / noise).item()
+    max_abs = (deq_ker - deq_ref).abs().max().item()
+    print(f"  sf_exact={sf_exact} quant_snr={snr_db:.1f}dB max_abs_diff={max_abs:.3e}")
+    if not sf_exact or snr_db < 40.0:
+        print(f"  [FAIL] quant vs reference")
+        ok = False
+
+    return ok
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="inputs_process correctness harness")
+    parser.add_argument("--tokens", type=int, default=8)
+    parser.add_argument("--hidden", type=int, default=512)
+    parser.add_argument("--topk", type=int, default=4)
+    parser.add_argument(
+        "--quant_kind",
+        default="all",
+        choices=["all", "nvfp4", "mxfp8_e4m3", "mxfp8_e5m2"],
+    )
+    args = parser.parse_args()
+
+    # nvfp4 runs both scale sources; mxfp8 is self-scaled (single mode).
+    if args.quant_kind == "all":
+        cases = [("nvfp4", "offline"), ("nvfp4", "online"), ("mxfp8_e4m3", "-")]
+    elif args.quant_kind == "nvfp4":
+        cases = [("nvfp4", "offline"), ("nvfp4", "online")]
+    else:
+        cases = [(args.quant_kind, "-")]
+
+    all_ok = True
+    for quant_type, mode in cases:
+        print(f"[case] {quant_type} {mode} (tokens={args.tokens} hidden={args.hidden} topk={args.topk})")
+        try:
+            case_ok = _run_case(quant_type, mode, args.tokens, args.hidden, args.topk)
+        except Exception as exc:  # noqa: BLE001 -- smoke harness, report and continue
+            import traceback
+
+            print(f"  [ERROR] {type(exc).__name__}: {exc}")
+            traceback.print_exc()
+            case_ok = False
+        print(f"  => {'PASS' if case_ok else 'FAIL'}")
+        all_ok = all_ok and case_ok
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/ptx_helpers.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/ptx_helpers.py
@@ -1,0 +1,519 @@
+"""Inline-PTX wrappers (TMA 1D load/store, fns.b32, raw-int64 peer ops) for the cuTeDSL kernels."""
+
+from typing import Optional
+
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass.cutlass_dsl import Float32, Int32, Int64
+
+
+# CUTLASS ``cute::TMA::CacheHintSm100`` policy descriptors
+# (`copy_sm90_desc.hpp:193-196`). At large per-launch transfer sizes
+# (e.g. 1+ GB/launch for T=32k batches) the L2 (~128 MB on B200/GB200) is
+# heavily over-subscribed, so cache hints matter. mega_moe defaults TMA
+# loads to EVICT_FIRST (single-use peer data) and TMA stores to
+# EVICT_NORMAL (just-pulled data will be re-read shortly by the GEMM
+# consumer). cuTeDSL was passing hint=0 (undefined policy) on loads and
+# omitting the cache_hint operand entirely on stores -- both lead to L2
+# pollution at large batch.
+_TMA_CACHE_HINT_EVICT_NORMAL = 0x1000000000000000
+_TMA_CACHE_HINT_EVICT_FIRST = 0x12F0000000000000
+
+
+@dsl_user_op
+def tma_load_1d(dst_smem, src_gmem, mbar_smem, num_bytes, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            dst_smem.toint(loc=loc, ip=ip).ir_value(),
+            src_gmem.toint(loc=loc, ip=ip).ir_value(),
+            num_bytes.ir_value(),
+            mbar_smem.toint(loc=loc, ip=ip).ir_value(),
+            Int64(_TMA_CACHE_HINT_EVICT_FIRST).ir_value(),
+        ],
+        "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint "
+        "[$0], [$1], $2, [$3], $4;",
+        "r,l,r,r,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_load_1d_raw(dst_smem, src_gmem_addr: Int64, mbar_smem, num_bytes, *, loc=None, ip=None):
+    """Variant of ``tma_load_1d`` that takes a raw int64 GMEM byte address.
+
+    Used for cross-rank TMA load via ``peer_rank_ptr_mapper.map`` style: source
+    address is computed dynamically as ``peer_rank_ptr_mapper.map(local_iter.toint(),
+    dst_rank, element_offset)``, bypassing per-tensor constexpr fanout.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            dst_smem.toint(loc=loc, ip=ip).ir_value(),
+            src_gmem_addr.ir_value(),
+            num_bytes.ir_value(),
+            mbar_smem.toint(loc=loc, ip=ip).ir_value(),
+            Int64(_TMA_CACHE_HINT_EVICT_FIRST).ir_value(),
+        ],
+        "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.L2::cache_hint "
+        "[$0], [$1], $2, [$3], $4;",
+        "r,l,r,r,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def tma_store_1d(dst_gmem, src_smem, num_bytes, *, loc=None, ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            dst_gmem.toint(loc=loc, ip=ip).ir_value(),
+            src_smem.toint(loc=loc, ip=ip).ir_value(),
+            num_bytes.ir_value(),
+            Int64(_TMA_CACHE_HINT_EVICT_NORMAL).ir_value(),
+        ],
+        "cp.async.bulk.global.shared::cta.bulk_group.L2::cache_hint "
+        "[$0], [$1], $2, $3;",
+        "l,r,r,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_async_bulk_s2g(dst_gmem, src_smem, size_bytes, *, loc=None, ip=None) -> None:
+    """Issue descriptor-free ``cp.async.bulk`` SMEM->GMEM.
+
+    The caller owns ``cp_async_bulk_commit_group`` so copy and reduce bulk
+    paths can share the same group boundary.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            dst_gmem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            src_smem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            size_bytes.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.global.shared::cta.bulk_group [$0], [$1], $2;",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_reduce_async_bulk_add_noftz_bf16_s2g(
+    dst_gmem,
+    src_smem,
+    size_bytes,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue descriptor-free ``cp.reduce.async.bulk`` for BF16 add."""
+    llvm.inline_asm(
+        None,
+        [
+            dst_gmem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            src_smem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            size_bytes.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.noftz.bf16 "
+        "[$0], [$1], $2;",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def max_abs_bf16x2(lhs: Int32, rhs: Int32, *, loc=None, ip=None) -> Int32:
+    """Per-lane abs-max of two packed bf16x2 words (``max.xorsign.abs.bf16x2``).
+
+    Returns ``max(|lhs|, |rhs|)`` for each of the two bf16 lanes. The result's
+    sign per lane is the xor of the input signs (junk), so callers mask 0x7FFF
+    before reading a lane back. Stays in bf16 -- no fp32 convert needed to find
+    an amax.
+    """
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [lhs.ir_value(), rhs.ir_value()],
+            "max.xorsign.abs.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            asm_dialect=0,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def fns_b32(mask: Int32, base: Int32, n: Int32, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [mask.ir_value(), base.ir_value(), n.ir_value()],
+            "fns.b32 $0, $1, $2, $3;",
+            "=r,r,r,r",
+            has_side_effects=False,
+            asm_dialect=0,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+# -----------------------------------------------------------------------------
+# Raw-int64-pointer GMEM ops for the cross-rank ``peer_rank_ptr_mapper.map`` pattern.
+# -----------------------------------------------------------------------------
+# Each helper takes a 64-bit byte address (local iterator's ``.toint()`` +
+# peer-rank offset + element offset) and emits the corresponding PTX op
+# without requiring a cute.Tensor / iterator wrap. Mirrors mega_moe's pattern
+# of computing ``peer_rank_ptr_mapper.map(local_ptr, dst_rank)`` and dereferencing it
+# directly (sym_buffer.cuh:34-37).
+
+
+@dsl_user_op
+def ldg_b32_raw(addr: Int64, *, loc=None, ip=None) -> Int32:
+    """``ld.global.u32`` via raw int64 byte address."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [addr.ir_value()],
+            "ld.global.u32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            asm_dialect=0,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def ldg_f32_raw(addr: Int64, *, loc=None, ip=None) -> Float32:
+    """``ld.global.f32`` via raw int64 byte address."""
+    return Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [addr.ir_value()],
+            "ld.global.f32 $0, [$1];",
+            "=f,l",
+            has_side_effects=False,
+            asm_dialect=0,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def stg_b32_raw(addr: Int64, val: Int32, *, loc=None, ip=None) -> None:
+    """``st.global.u32`` via raw int64 byte address."""
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), val.ir_value()],
+        "st.global.u32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def stg_b64_raw(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """``st.global.u64`` via raw int64 byte address."""
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), val.ir_value()],
+        "st.global.u64 [$0], $1;",
+        "l,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def stg_e8m0_from_f32(addr: Int64, fp32_val: Float32, *, loc=None, ip=None) -> None:
+    """Convert ``fp32_val`` to E8M0 via PTX and store the 1-byte result to global memory.
+
+    Uses ``cvt.rp.satfinite.ue8m0x2.f32`` which is the correct PTX path for
+    fp32 → E8M0.  Avoids CuTe DSL's generic ``.to(Float8E8M0FNU)`` which does
+    not lower correctly for the non-IEEE-754 E8M0 type.
+    """
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), fp32_val.ir_value()],
+        "{\n"
+        "  .reg .b16 bf_lo;\n"
+        "  .reg .u32 tmp;\n"
+        "  cvt.rp.satfinite.ue8m0x2.f32 bf_lo, 0f00000000, $1;\n"
+        "  cvt.u32.u16 tmp, bf_lo;\n"
+        "  st.global.b8 [$0], tmp;\n"
+        "}",
+        "l,f",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def stg_e8m0x8_from_f32(
+    addr: Int64,
+    v0: Float32, v1: Float32, v2: Float32, v3: Float32,
+    v4: Float32, v5: Float32, v6: Float32, v7: Float32,
+    *, loc=None, ip=None,
+) -> None:
+    """Convert 8 fp32 values to E8M0 and store them as 8 contiguous bytes in one shot.
+
+    Batched form of ``stg_e8m0_from_f32``: four ``cvt.rp.satfinite.ue8m0x2.f32``
+    each pack two E8M0 bytes (``d.lo = cvt(b)``, ``d.hi = cvt(a)``), the four
+    ``.b16`` results are assembled into two ``.b32`` words, and a single
+    ``st.global.v2.u32`` writes all 8 bytes.  Halves the cvt count and turns 8
+    one-byte stores into one 64-bit store.  ``addr`` must be 8-byte aligned;
+    output byte ``k`` holds E8M0(``v{k}``).
+    """
+    llvm.inline_asm(
+        None,
+        [
+            addr.ir_value(),
+            v0.ir_value(), v1.ir_value(), v2.ir_value(), v3.ir_value(),
+            v4.ir_value(), v5.ir_value(), v6.ir_value(), v7.ir_value(),
+        ],
+        "{\n"
+        "  .reg .b16 p0, p1, p2, p3;\n"
+        "  .reg .b32 w0, w1;\n"
+        "  cvt.rp.satfinite.ue8m0x2.f32 p0, $2, $1;\n"
+        "  cvt.rp.satfinite.ue8m0x2.f32 p1, $4, $3;\n"
+        "  cvt.rp.satfinite.ue8m0x2.f32 p2, $6, $5;\n"
+        "  cvt.rp.satfinite.ue8m0x2.f32 p3, $8, $7;\n"
+        "  mov.b32 w0, {p0, p1};\n"
+        "  mov.b32 w1, {p2, p3};\n"
+        "  st.global.v2.u32 [$0], {w0, w1};\n"
+        "}",
+        "l,f,f,f,f,f,f,f,f",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_release_sys_u64_raw(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """``red.release.sys.global.add.u64`` via raw int64 byte address.
+
+    Fire-and-forget atomic add (no return value) -- mega_moe uses this
+    pattern for ``expert_recv_count_sum`` cross-rank publish where the
+    fetched-old is unused (sm100_fp8_fp4_mega_moe.cuh:511-513).
+    """
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), val.ir_value()],
+        "red.release.sys.global.add.u64 [$0], $1;",
+        "l,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_relaxed_sys_u64_raw(addr: Int64, val: Int64, *, loc=None, ip=None) -> None:
+    """``red.relaxed.sys.global.add.u64`` via raw int64 byte address.
+
+    Relaxed (no release fence) sibling of ``red_add_release_sys_u64_raw``.  Use
+    when an enclosing ``bar.sync`` + a later release fence (e.g. the trailing
+    ``nvlink_barrier`` publish) already provides cross-rank ordering, so the
+    per-op release fence would just emit a redundant ``membar.sys`` drain.
+    """
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), val.ir_value()],
+        "red.relaxed.sys.global.add.u64 [$0], $1;",
+        "l,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_release_sys_s32_raw(addr: Int64, val: Int32, *, loc=None, ip=None) -> None:
+    """``red.release.sys.global.add.s32`` via raw int64 byte address.
+
+    Used for the NVLink barrier signal cross-rank fan-out (matches
+    mega_moe ``ptx::red_add_rel_sys`` at barrier.cuh:50).
+    """
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), val.ir_value()],
+        "red.release.sys.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_relaxed_sys_v2_bf16x2(
+    addr,
+    val0_packed_bf16x2,
+    val1_packed_bf16x2,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue ``red.relaxed.sys.global.add.v2.bf16x2 [addr], {v0, v1};``."""
+    llvm.inline_asm(
+        None,
+        [
+            addr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            val0_packed_bf16x2.ir_value(loc=loc, ip=ip),
+            val1_packed_bf16x2.ir_value(loc=loc, ip=ip),
+        ],
+        "red.relaxed.sys.global.add.noftz.v2.bf16x2 [$0], {$1, $2};",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_release_gpu_s32(
+    counter_ptr,
+    value,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue ``red.release.gpu.global.add.s32`` to a GMEM int32 location."""
+    llvm.inline_asm(
+        None,
+        [
+            counter_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            value.ir_value(loc=loc, ip=ip),
+        ],
+        "red.release.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_min_relaxed_gpu_u32_from_f32_raw(
+    addr: Int64, value: Float32, *, loc=None, ip=None
+) -> None:
+    """``red.relaxed.gpu.global.min.u32`` on the bit pattern of a non-negative f32.
+
+    PTX has no float min-reduce; for non-negative floats the u32 bit order
+    matches the float order, so a u32 min on the reinterpreted bits realises a
+    float min. The target slot must be seeded with a large positive sentinel
+    (e.g. ``Fp32Max``) and only fed non-negative candidates. Relaxed/GPU scope
+    suffices: a kernel boundary separates the reduction from its reader.
+    """
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), value.ir_value()],
+        "{ .reg .b32 t; mov.b32 t, $1; red.relaxed.gpu.global.min.u32 [$0], t; }",
+        "l,f",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_async_add_release_sys_u32_raw(addr: Int64, val: Int32, *, loc=None, ip=None) -> None:
+    """``red.async.release.sys.global.add.u32`` via raw int64 byte address.
+
+    sm_90+ async reduction — fire-and-forget; the issuing SM does NOT
+    wait for the L2/HBM round-trip. Same architectural release/sys
+    semantics as the synchronous form, but the SM can continue issuing
+    instructions immediately. Used in cuTeDSL dispatch_pull V2 to
+    replace the synchronous ``atom.release.gpu.global.add.u32`` for
+    l1_arrival_count, eliminating the per-token atomic-wait stall.
+    """
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), val.ir_value()],
+        "red.async.release.sys.global.add.u32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def read_clock64(*, loc=None, ip=None) -> Int64:
+    return Int64(
+        llvm.inline_asm(
+            T.i64(),
+            [],
+            "mov.u64 $0, %clock64;",
+            "=l",
+            has_side_effects=True,
+            asm_dialect=0,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+@dsl_user_op
+def _fence_rel_sys(
+    *, loc: Optional[ir.Location] = None, ip: Optional[ir.InsertionPoint] = None
+) -> None:
+    """
+    Fence operation with acquire-release semantics at system scope.
+
+    See the `PTX documentation <https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar>`__.
+    """
+    llvm.fence(llvm.AtomicOrdering.release, loc=loc, ip=ip)
+
+@dsl_user_op
+def _fence_rel_gpu(
+    *, loc: Optional[ir.Location] = None, ip: Optional[ir.InsertionPoint] = None
+) -> None:
+    """
+    Fence operation with acquire-release semantics at system scope.
+
+    See the `PTX documentation <https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar>`__.
+    """
+    llvm.fence(llvm.AtomicOrdering.release, syncscope="device", loc=loc, ip=ip)

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/reference.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/reference.py
@@ -1,0 +1,307 @@
+"""Pure-Python reference oracle for the dispatch kernel.
+
+Simulates the entire dispatch protocol on the CPU and returns the expected
+state of the nine workspace buffers, per receiving rank, after the kernel
+finishes. Result is the byte-level ground truth used to validate the GPU
+kernel output.
+
+The simulation mirrors the receiver-driven advertise + pull dispatch protocol
+implemented in
+``DeepGEMM/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh``
+(lines 432-766). Each receiving rank's pool is laid out by iterating the
+local experts in order, and within each expert the tokens are placed in the
+exact round-robin (min-peeling) order produced by the device-side scheduler.
+
+Token metadata 12-byte packing convention (matches ``TokenSrcMetadata`` in
+``DeepGEMM/deep_gemm/include/deep_gemm/layout/mega_moe.cuh``):
+``[rank_idx: u32 LE][token_idx: u32 LE][topk_idx: u32 LE]``.
+Padding entries are filled with ``0xFF`` per byte (sentinel).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import numpy as np
+
+from .config import DSV4Config, DSV4, MAX_SLOT, TOKEN_METADATA_BYTES, transform_sf_token_idx_numpy
+
+
+_METADATA_PAD_BYTE: int = 0xFF
+
+
+@dataclass
+class ExpectedBuffers:
+    """Expected state of the nine workspace buffers for one receiving rank."""
+
+    expert_send_count: np.ndarray            # (num_total_experts,)              uint64 (bit-packed)
+    expert_recv_count: np.ndarray            # (num_ranks, num_experts_per_rank) uint64
+    expert_recv_count_sum: np.ndarray        # (num_experts_per_rank,)           uint64 (bit-packed)
+    src_token_topk_idx: np.ndarray           # (num_experts_per_rank, num_ranks, MAX_SLOT) uint32
+    token_src_metadata: np.ndarray           # (num_max_pool_tokens, 8)          uint8
+    l1_arrival_count: np.ndarray             # (num_max_task_tiles,)             uint32
+    l1_token_buffer: np.ndarray              # (num_max_pool_tokens, hidden_bytes) uint8
+    l1_sf_buffer: np.ndarray                 # (sf_uint32_per_token, num_padded_sf_pool_tokens) uint32
+    l1_topk_weights_buf: np.ndarray          # (num_max_pool_tokens,)            float32
+
+
+def _pack_metadata(rank_idx: int, token_idx: int, topk_idx: int) -> np.ndarray:
+    """Pack {rank, token, topk} into the i64 record written by
+    ``TokenSrcMetadata.store``: low 32b = token, high 32b = (rank << 16) | topk.
+    """
+    rec = np.zeros(TOKEN_METADATA_BYTES, dtype=np.uint8)
+    hi = ((int(rank_idx) << 16) | int(topk_idx)) & 0xFFFFFFFF
+    rec[0:4] = np.frombuffer(np.uint32(token_idx).tobytes(), dtype=np.uint8)
+    rec[4:8] = np.frombuffer(np.uint32(hi).tobytes(), dtype=np.uint8)
+    return rec
+
+
+def _round_robin_pool_order(rank_counts: np.ndarray) -> List[int]:
+    """Return the source-rank for each pool slot inside one expert.
+
+    Mirrors the device-side round-robin min-peeling loop: each round contributes
+    ``length * num_active_ranks`` tokens, where ``length`` is the smallest
+    non-zero per-rank remaining count. Within a round the source ranks are
+    visited in ascending rank-id order (lane order on the device).
+    """
+    remaining = rank_counts.astype(np.int64).copy()
+    order: List[int] = []
+    while True:
+        active = [r for r, n in enumerate(remaining) if n > 0]
+        if not active:
+            break
+        length = min(remaining[r] for r in active)
+        for _ in range(int(length)):
+            for r in active:
+                order.append(r)
+        for r in active:
+            remaining[r] -= length
+    return order
+
+
+def dispatch_oracle(
+    input_token_buffer: np.ndarray,
+    input_sf_buffer: np.ndarray,
+    input_topk_idx_buffer: np.ndarray,
+    input_topk_weights_buffer: np.ndarray,
+    config: DSV4Config = DSV4,
+) -> List[ExpectedBuffers]:
+    """Compute the expected per-rank workspace state after dispatch.
+
+    Args:
+        input_token_buffer: shape ``(num_ranks, num_tokens_per_rank,
+            hidden_bytes)`` uint8 tensor holding every rank's token bodies
+            (FP8 = 7168 B/token, NVFP4 = 3584 B/token).
+        input_sf_buffer: shape ``(num_ranks, num_tokens_per_rank,
+            sf_uint32_per_token)`` uint32 tensor of per-token scaling-factor
+            columns.
+        input_topk_idx_buffer: shape ``(num_ranks, num_tokens_per_rank,
+            num_topk)`` int64 tensor of routing destinations. Negative values
+            mean masked routing (the entry is skipped, matching DEC-4).
+        input_topk_weights_buffer: shape ``(num_ranks, num_tokens_per_rank,
+            num_topk)`` float32 tensor of routing weights.
+        config: locked test configuration (DSV4 by default).
+
+    Returns:
+        A list of length ``num_ranks``; entry ``r`` describes the expected
+        workspace state on the rank with rank-id ``r``.
+    """
+    R = config.num_ranks
+    T = config.num_tokens_per_rank
+    K = config.num_topk
+    H_BYTES = config.hidden_bytes
+    E_local = config.num_experts_per_rank
+    E_total = config.num_total_experts
+    P_TOK = config.num_max_pool_tokens
+    P_SF = config.num_padded_sf_pool_tokens
+    P_TT = config.num_max_task_tiles
+    SFU = config.sf_uint32_per_token
+    BM = config.block_m
+    CTM = config.effective_cluster_tile_m
+    SFBM = config.sf_block_m
+    NSM = config.num_sms
+
+    assert input_token_buffer.shape == (R, T, H_BYTES)
+    assert input_sf_buffer.shape == (R, T, SFU)
+    assert input_topk_idx_buffer.shape == (R, T, K)
+    assert input_topk_weights_buffer.shape == (R, T, K)
+    assert E_total == R * E_local
+
+    # Per-(src_rank, global_expert) token counts.
+    per_src_send = np.zeros((R, E_total), dtype=np.int64)
+    for src_rank in range(R):
+        for src_token in range(T):
+            for src_topk in range(K):
+                expert_id = int(input_topk_idx_buffer[src_rank, src_token, src_topk])
+                if expert_id >= 0:
+                    per_src_send[src_rank, expert_id] += 1
+
+    # Build initial expected buffers (zero-fill matches kernel post-conditions
+    # for unused regions, except token_src_metadata which uses 0xFF sentinel).
+    expected: List[ExpectedBuffers] = []
+    for _ in range(R):
+        expected.append(
+            ExpectedBuffers(
+                expert_send_count=np.zeros((E_total,), dtype=np.uint64),
+                expert_recv_count=np.zeros((R, E_local), dtype=np.uint64),
+                expert_recv_count_sum=np.zeros((E_local,), dtype=np.uint64),
+                src_token_topk_idx=np.zeros((E_local, R, MAX_SLOT), dtype=np.uint32),
+                token_src_metadata=np.full((P_TOK, TOKEN_METADATA_BYTES), _METADATA_PAD_BYTE, dtype=np.uint8),
+                l1_arrival_count=np.zeros((P_TT,), dtype=np.uint32),
+                l1_token_buffer=np.zeros((P_TOK, H_BYTES), dtype=np.uint8),
+                l1_sf_buffer=np.zeros((SFU, P_SF), dtype=np.uint32),
+                l1_topk_weights_buf=np.zeros((P_TOK,), dtype=np.float32),
+            )
+        )
+
+    # expert_send_count on rank ``src_rank``: low 32 bits = local token count,
+    # high 32 bits = publisher count (one per dispatch SM).
+    publisher_per_rank = np.uint64(NSM)
+    for src_rank in range(R):
+        for expert_id in range(E_total):
+            tokens = np.uint64(int(per_src_send[src_rank, expert_id]))
+            expected[src_rank].expert_send_count[expert_id] = (publisher_per_rank << np.uint64(32)) | tokens
+
+    # expert_recv_count[recv_rank][src_rank, local_expert]: low 32 = token count,
+    # high 32 = 0 (high half is delivered to expert_recv_count_sum instead).
+    for recv_rank in range(R):
+        for src_rank in range(R):
+            for local_expert in range(E_local):
+                global_expert = recv_rank * E_local + local_expert
+                tokens = np.uint64(int(per_src_send[src_rank, global_expert]))
+                expected[recv_rank].expert_recv_count[src_rank, local_expert] = tokens
+
+    # expert_recv_count_sum[recv_rank][local_expert]: low 32 = sum_over_src tokens,
+    # high 32 = num_ranks * num_sms = sum of publisher counts from every rank's SMs.
+    publishers_global = np.uint64(R * NSM)
+    for recv_rank in range(R):
+        for local_expert in range(E_local):
+            global_expert = recv_rank * E_local + local_expert
+            tokens = np.uint64(int(per_src_send[:, global_expert].sum()))
+            expected[recv_rank].expert_recv_count_sum[local_expert] = (
+                (publishers_global << np.uint64(32)) | tokens
+            )
+
+    # Populate src_token_topk_idx by replaying each source rank's topk scan.
+    # Slot is per (local_expert, src_rank): the advertise-table layout already
+    # separates src_rank into its own dimension, so each (local_expert, src_rank)
+    # series starts at slot 0.
+    for src_rank in range(R):
+        cursor = np.zeros(E_total, dtype=np.int64)
+        for src_token in range(T):
+            for src_topk in range(K):
+                expert_id = int(input_topk_idx_buffer[src_rank, src_token, src_topk])
+                if expert_id < 0:
+                    continue
+                dst_rank = expert_id // E_local
+                local_expert = expert_id % E_local
+                slot = int(cursor[expert_id])
+                cursor[expert_id] += 1
+                token_topk_word = np.uint32(src_token * K + src_topk)
+                expected[dst_rank].src_token_topk_idx[local_expert, src_rank, slot] = token_topk_word
+
+    # Pool layout per receiving rank: experts in order; within each expert the
+    # per-rank counts decide a round-robin order matching the kernel scheduler.
+    for recv_rank in range(R):
+        eb = expected[recv_rank]
+        pool_block_offset = 0
+        task_tile_offset = 0
+        for local_expert in range(E_local):
+            global_expert = recv_rank * E_local + local_expert
+            rank_counts = per_src_send[:, global_expert].astype(np.int64)
+            T_e = int(rank_counts.sum())
+            if T_e == 0:
+                continue
+
+            order = _round_robin_pool_order(rank_counts)
+            assert len(order) == T_e
+
+            per_rank_cursor = np.zeros((R,), dtype=np.int64)
+            for token_idx_in_expert, src_rank in enumerate(order):
+                token_idx_in_rank = int(per_rank_cursor[src_rank])
+                per_rank_cursor[src_rank] += 1
+
+                src_token_topk = int(eb.src_token_topk_idx[local_expert, src_rank, token_idx_in_rank])
+                src_token = src_token_topk // K
+                src_topk = src_token_topk % K
+
+                pool_token_idx = pool_block_offset * BM + token_idx_in_expert
+
+                eb.l1_token_buffer[pool_token_idx, :] = input_token_buffer[src_rank, src_token, :]
+                eb.l1_topk_weights_buf[pool_token_idx] = input_topk_weights_buffer[
+                    src_rank, src_token, src_topk
+                ]
+
+                sf_pool_token_idx = (
+                    pool_block_offset * SFBM
+                    + int(transform_sf_token_idx_numpy(token_idx_in_expert))
+                )
+                eb.l1_sf_buffer[:, sf_pool_token_idx] = input_sf_buffer[src_rank, src_token, :]
+
+                eb.token_src_metadata[pool_token_idx, :] = _pack_metadata(
+                    src_rank, src_token, src_topk
+                )
+
+                task_tile = task_tile_offset + token_idx_in_expert // CTM
+                eb.l1_arrival_count[task_tile] += np.uint32(1)
+
+            pool_block_offset += (T_e + BM - 1) // BM
+            task_tile_offset += (T_e + CTM - 1) // CTM
+
+    return expected
+
+
+def assert_buffer_equal(
+    actual: np.ndarray,
+    expected: np.ndarray,
+    name: str,
+    mode: str = "byte_exact",
+) -> None:
+    """Compare ``actual`` against ``expected`` and raise on mismatch.
+
+    Args:
+        actual: device-side result, already moved to host as a NumPy array.
+        expected: oracle result.
+        name: human-readable label printed on mismatch.
+        mode: ``"byte_exact"`` requires ``np.array_equal``; ``"logical"``
+            tolerates floating-point round-off via ``np.allclose`` for float
+            arrays and exact equality otherwise.
+
+    Raises:
+        AssertionError: if any element differs (according to the chosen mode),
+            with a message that pinpoints the first differing flat index and
+            the actual / expected scalar values there.
+    """
+    if actual.shape != expected.shape:
+        raise AssertionError(
+            f"[{name}] shape mismatch: actual={actual.shape} expected={expected.shape}"
+        )
+    if actual.dtype != expected.dtype:
+        raise AssertionError(
+            f"[{name}] dtype mismatch: actual={actual.dtype} expected={expected.dtype}"
+        )
+
+    if mode == "byte_exact":
+        if np.array_equal(actual, expected):
+            return
+        diff_mask = actual != expected
+    elif mode == "logical":
+        if np.issubdtype(actual.dtype, np.floating):
+            if np.allclose(actual, expected, rtol=1e-5, atol=1e-6, equal_nan=True):
+                return
+            diff_mask = ~np.isclose(actual, expected, rtol=1e-5, atol=1e-6, equal_nan=True)
+        else:
+            if np.array_equal(actual, expected):
+                return
+            diff_mask = actual != expected
+    else:
+        raise ValueError(f"Unknown comparison mode: {mode!r}")
+
+    flat_idx = int(np.argmax(diff_mask.reshape(-1)))
+    multi_idx = np.unravel_index(flat_idx, actual.shape)
+    raise AssertionError(
+        f"[{name}] mismatch at index {multi_idx} (flat {flat_idx}): "
+        f"actual={actual[multi_idx]!r} expected={expected[multi_idx]!r} "
+        f"(total mismatches={int(diff_mask.sum())})"
+    )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/sf_swizzle.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/sf_swizzle.py
@@ -1,0 +1,78 @@
+"""Device-side scaling-factor index swizzle for cute SFA/SFB atom layout.
+
+cute's NVFP4 SF atom (32x4x4 swizzle) byte layout per 512-byte atom::
+
+    layout: ((32, 4), (vec_size, 4)) : ((16, 4), (0, 1))   (byte units)
+    --> for token ``t`` in the atom (0 <= t < 128), K-bank ``k`` in [0, 4):
+        byte_in_atom(t, k) = (t % 32) * 16 + (t // 32) * 4 + k
+
+Each atom holds 128 tokens x 4 K-banks (= 4 fp8 scale factors) = 512 byte.
+Across atoms in K direction (`k_atom_idx >= 1`), atoms are placed
+contiguously after the previous one (inner K-atom).  Across atoms in M
+direction, the next M atom follows all K atoms of the previous M atom::
+
+    atom_idx = row_block_idx * num_k_atoms + k_atom_idx
+    atom_byte_start = atom_idx * 512
+
+This file holds the device-side helpers that compute the linear Int32
+position of a (token, K-atom) cell inside ``l1_sf_buffer`` such that the
+cute mma side (via ``tile_atom_to_shape_SF``) reads back the exact bytes
+dispatch wrote.
+"""
+
+from cutlass.cutlass_dsl import Int32, dsl_user_op
+
+
+# Cute SF atom geometry (NVFP4 standard, 32x4x4 swizzle).
+SF_ATOM_BLOCK_TOKENS: int = 128
+"""Tokens covered by one M-direction SF atom (= 32 inner * 4 outer)."""
+
+SF_ATOM_BYTES: int = 512
+"""Bytes per atom (= 128 tokens * 4 K-banks * 1 byte/fp8)."""
+
+SF_ATOM_INT32_PER_ATOM: int = 128
+"""Int32 slots per atom (= 512 byte / 4 byte per Int32)."""
+
+
+@dsl_user_op
+def sf_atom_int32_offset(
+    token_idx_in_pool_sf_axis,
+    k_atom_idx,
+    *,
+    num_k_atoms: int,
+    loc=None,
+    ip=None,
+):
+    """Linear Int32 offset inside ``l1_sf_buffer`` for one (token, K-atom) cell.
+
+    ``token_idx_in_pool_sf_axis`` is the token's M-axis index relative to the
+    pool's SF axis start (must already include per-expert padding, i.e.
+    ``expert_pool_block_offset * sf_block_m + token_idx_in_expert``).  The
+    caller is responsible for keeping the per-expert offset atom-aligned (a
+    multiple of ``SF_ATOM_BLOCK_TOKENS``), which falls out naturally when
+    ``sf_block_m`` is itself a multiple of ``SF_ATOM_BLOCK_TOKENS``.
+
+    ``k_atom_idx`` is the K-atom index (``0 <= k_atom_idx < num_k_atoms``);
+    each K-atom holds one Int32 (= 4 fp8 K-bank SFs) per token.
+
+    ``num_k_atoms`` is the per-token K-atom count (equal to
+    ``sf_uint32_per_token`` on the dispatch side); declared as a kwarg-only
+    Python ``int`` so it folds to a Constexpr at trace time.
+
+    Returns the Int32-position to use as ``l1_sf_buffer_flat[<offset>]``.
+    The Int32 store at that position covers 4 contiguous bytes inside the
+    target atom's atom-inner byte layout.
+    """
+    t = Int32(token_idx_in_pool_sf_axis)
+    row_block_idx = t // Int32(SF_ATOM_BLOCK_TOKENS)
+    t_in_atom = t % Int32(SF_ATOM_BLOCK_TOKENS)
+    # Atom outer (M-row block, K-atom interleaved).
+    atom_idx = row_block_idx * Int32(num_k_atoms) + Int32(k_atom_idx)
+    # Atom inner Int32 offset: byte (t%32)*16 + (t//32)*4 divided by 4
+    #   -> (t%32)*4 + (t//32).  Each Int32 spans 4 consecutive K-bank bytes
+    #   inside the atom (= one full Int32 worth of fp8 SF values).
+    return (
+        atom_idx * Int32(SF_ATOM_INT32_PER_ATOM)
+        + (t_in_atom % Int32(32)) * Int32(4)
+        + (t_in_atom // Int32(32))
+    )

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/sym_buffer.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/sym_buffer.py
@@ -1,0 +1,270 @@
+"""Symmetric-heap peer pointer mapper.
+
+The device-side SymBuffer carries ONLY the per-rank offset table.  Layout is
+chosen at trace time by ``num_max_ranks`` (a constexpr):
+
+* ``<= 16`` ranks: a ``cute_nvgpu.grid_constant`` / ``llvm.byval`` pointer to a
+  ``struct<(array<16 x i64>)>`` (exactly 128B).  ``map`` does a runtime-indexed
+  ``getelementptr`` + ``load`` that lowers to a const-bank ``LDC c[bnk][Ra]``.
+  The 128B byval size matches the host-side ``createKernelArgs`` copy (hardcoded
+  to 128B today), so it is corruption-safe up to EP16.
+
+* ``> 16`` ranks: a by-value ``vector<N x i64>`` read with ``extractelement``.
+  Correct but spills the runtime index -- the fallback until the byval-size fix
+  reaches public cutedsl.
+
+``base``/``rank_idx`` are intentionally dropped: ``get_base_ptr`` had no callers
+and ``rank_idx`` is the owning rank's own constexpr (never read on device), so
+freeing those slots lets all 16 byval lanes hold offsets (EP16, not EP14).
+"""
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import AddressSpace
+from cutlass.cutlass_dsl import Int32, Int64, dsl_user_op
+from cutlass.base_dsl.dsl import (
+    extract_mlir_values,
+    get_mlir_types,
+    new_from_mlir_values,
+)
+from cutlass.base_dsl.runtime.jit_arg_adapters import JitArgAdapterRegistry
+from cutlass.base_dsl.typing import get_c_pointers
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import arith, llvm
+
+try:
+    # GEP encodes a runtime index by storing this sentinel in rawConstantIndices;
+    # it is MLIR's LLVM::GEPOp::kDynamicIndex (== INT32_MIN), frozen by the IR
+    # encoding ABI.  Track the canonical constant rather than re-hardcoding it.
+    from cutlass.base_dsl.typing import MLIR_DYNAMIC_INDEX
+except ImportError:  # older wheels: value is fixed by the GEP encoding ABI
+    MLIR_DYNAMIC_INDEX = -(2**31)
+
+_BYVAL_RANK_LIMIT = 16             # struct<(array<16 x i64>)> == exactly 128B
+
+
+#TODO: Fix this when compiler fixed. This is a shit WAR due to the cuda-to-llvm bug, it just treats any kernel arg to tma_desc as long as it's marked `grid_constant + byval`
+def _byval_struct_ty() -> Any:
+    """128B byval pointee shared by alloca / GEP / the ``llvm.byval`` attr."""
+    return ir.Type.parse(f"!llvm.struct<(array<{_BYVAL_RANK_LIMIT} x i64>)>")
+
+
+@dataclass(frozen=True)
+class SymBufferDeviceBase:
+    """Device-side SymBuffer: the per-rank offset table only.
+
+    ``val`` is a ``!llvm.ptr`` to a byval/grid_constant ``struct<(array<16 x i64>)>``
+    when ``num_max_ranks <= 16`` (``map`` -> GEP + load -> ``LDC``), else a by-value
+    ``vector<N x i64>`` (``map`` -> ``extractelement``, spills).
+    """
+
+    val: Any
+    num_max_ranks: cutlass.Constexpr[int]
+
+    def __extract_mlir_values__(self) -> list:
+        return [self.val]
+
+    def __new_from_mlir_values__(self, values: list) -> "SymBufferDeviceBase":
+        return SymBufferDeviceBase(val=values[0], num_max_ranks=self.num_max_ranks)
+
+    def __get_mlir_types__(self) -> list:
+        if self.num_max_ranks <= _BYVAL_RANK_LIMIT:
+            return [ir.Type.parse("!llvm.ptr")]
+        return [ir.Type.parse(f"vector<{self.num_max_ranks}xi64>")]
+
+    def __extract_mlir_attributes__(self) -> list:
+        if self.num_max_ranks <= _BYVAL_RANK_LIMIT:
+            return [ir.DictAttr.get({
+                "cute_nvgpu.grid_constant": ir.UnitAttr.get(),
+                "llvm.byval": ir.TypeAttr.get(_byval_struct_ty()),
+            })]
+        return [ir.DictAttr.get({})]
+
+    @cute.jit
+    def map(
+        self,
+        local_ptr: Int64,
+        dst_rank_idx: Int32,
+        byte_off: Int64 = Int64(0),
+    ) -> Int64:
+        if cutlass.const_expr(self.num_max_ranks <= _BYVAL_RANK_LIMIT):
+            # Opaque ptr -> the offsets array sits at byte 0 of the byval struct,
+            # so a flat ``gep i64, ptr, dst_rank`` reaches offsets[dst_rank]
+            # directly; the byval struct type only governs the 128B const-bank copy.
+            i64_ty = ir.Type.parse("i64")
+            off_ptr = llvm.getelementptr(
+                ir.Type.parse("!llvm.ptr"),
+                self.val,
+                [dst_rank_idx.ir_value()],
+                [MLIR_DYNAMIC_INDEX],
+                i64_ty,
+                no_wrap_flags="None",
+            )
+            off = Int64(llvm.load(i64_ty, off_ptr))
+        else:
+            off = Int64(llvm.extractelement(self.val, dst_rank_idx.ir_value()))
+        return local_ptr + off + byte_off
+
+    @cute.jit
+    def ptr_map_to_rank(self, ptr, dst_rank_idx: Int32, byte_align: Optional[int] = None):
+        if cutlass.const_expr(ptr.memspace != AddressSpace.gmem):
+            raise ValueError(
+                f"ptr_map_to_rank: source pointer must live in GMEM "
+                f"(NVSHMEM symmetric heap), got memspace={ptr.memspace}."
+            )
+        if cutlass.const_expr(byte_align is None):
+            byte_align = ptr.max_alignment
+        peer_addr = self.map(ptr.toint(), dst_rank_idx, Int64(0))
+        return cute.make_ptr(
+            ptr.dtype,
+            peer_addr,
+            ptr.memspace,
+            assumed_align=byte_align,
+        )
+
+
+@dataclass(frozen=True)
+class SymBufferHost:
+    """Runtime launch payload for a device-side ``SymBuffer{N}``.
+
+    Field annotations are tvm-ffi-aware (the args-spec converter dispatches the
+    dataclass field-by-field): ``Int64`` / ``Int32`` make the scalar fields land on
+    the converter's typed-scalar branch (``arg_type in AcceptableNumericTypesForScalar``,
+    i64/i32) even when the held value is a plain Python ``int`` -- the AOT-compile
+    spec is what fixes the width, runtime values just marshal into it. ``offsets`` is
+    a bare ``tuple`` (not ``Tuple[int, ...]``): the converter's variadic-``Tuple``
+    handling assumes a fixed arity (``get_args`` -> ``(elem, Ellipsis)``) and would
+    raise a length mismatch for ``world != 1``; a bare ``tuple`` takes the generic
+    element-by-element path whose per-element width is driven by the value type
+    (so the fake's offset values are built as ``Int64`` -> i64). The non-tvm
+    ``_SymBufferHostAdapter`` is unaffected (it re-wraps with ``Int64(...)``)."""
+
+    base_addr: Int64
+    offsets: tuple
+    rank_idx: Int32
+    num_max_ranks: cutlass.Constexpr[int]
+
+    @staticmethod
+    def _as_int64(value) -> Int64:
+        return value if isinstance(value, Int64) else Int64(int(value))
+
+    @staticmethod
+    def _as_int32(value) -> Int32:
+        return value if isinstance(value, Int32) else Int32(int(value))
+
+    @dsl_user_op
+    def make_device_obj(self, *, loc=None, ip=None) -> Any:
+        """Build the offsets-only device obj (see module docstring for layout)."""
+        offsets = tuple(self.offsets)
+        num_max_ranks = self.num_max_ranks
+        if len(offsets) != num_max_ranks:
+            raise ValueError(
+                f"len(offsets)={len(offsets)} must equal "
+                f"num_max_ranks={num_max_ranks}."
+            )
+
+        if num_max_ranks <= _BYVAL_RANK_LIMIT:
+            ptr_ty = ir.Type.parse("!llvm.ptr")
+            st_ty = _byval_struct_ty()
+            i64_ty = ir.Type.parse("i64")
+            one = arith.constant(
+                value=ir.IntegerAttr.get(i64_ty, 1),
+                result=i64_ty, loc=loc, ip=ip,
+            )
+            buf = llvm.alloca(
+                res=ptr_ty, elem_type=st_ty, array_size=one,
+                alignment=64, loc=loc, ip=ip,
+            )
+            for i, off in enumerate(offsets):
+                slot = llvm.getelementptr(
+                    ptr_ty, buf, [], [i], i64_ty,
+                    no_wrap_flags="None", loc=loc, ip=ip,
+                )
+                llvm.store(self._as_int64(off).ir_value(), slot, loc=loc, ip=ip)
+            return SymBufferDeviceBase(val=buf, num_max_ranks=num_max_ranks)
+
+        i32_ty = ir.Type.parse("i32")
+        vec_ty = ir.Type.parse(f"vector<{num_max_ranks}xi64>")
+        vec = llvm.mlir_zero(vec_ty, loc=loc, ip=ip)
+        for i, off in enumerate(offsets):
+            idx = arith.constant(
+                value=ir.IntegerAttr.get(i32_ty, i),
+                result=i32_ty, loc=loc, ip=ip,
+            )
+            vec = llvm.insertelement(
+                vec, self._as_int64(off).ir_value(), idx, loc=loc, ip=ip,
+            )
+        return SymBufferDeviceBase(val=vec, num_max_ranks=num_max_ranks)
+
+
+@JitArgAdapterRegistry.register_jit_arg_adapter(SymBufferHost)
+class _SymBufferHostAdapter:
+    """JIT boundary adapter for ``SymBufferHost``.
+
+    Python-side ``SymBufferHost`` stays pure host data (ints + tuple).  The
+    adapter is the only place that maps it to DSL scalar arguments:
+    base/offsets are i64, rank_idx is i32, and num_max_ranks remains a
+    constexpr carried through reconstruction.
+    """
+
+    def __init__(self, arg: SymBufferHost) -> None:
+        self._arg = arg
+        if len(tuple(arg.offsets)) != int(arg.num_max_ranks):
+            raise ValueError(
+                f"len(offsets)={len(tuple(arg.offsets))} must equal "
+                f"num_max_ranks={int(arg.num_max_ranks)}."
+            )
+        self._fields = (
+            Int64(arg.base_addr),
+            *(Int64(x) for x in arg.offsets),
+            Int32(arg.rank_idx),
+        )
+
+    def __c_pointers__(self) -> list[Any]:
+        c_pointers: list[Any] = []
+        for field in self._fields:
+            c_pointers.extend(get_c_pointers(field))
+        return c_pointers
+
+    def __get_mlir_types__(self) -> list[Any]:
+        types: list[Any] = []
+        for field in self._fields:
+            types.extend(get_mlir_types(field))
+        return types
+
+    def __extract_mlir_values__(self) -> list[ir.Value]:
+        values: list[ir.Value] = []
+        for field in self._fields:
+            values.extend(extract_mlir_values(field))
+        return values
+
+    def __new_from_mlir_values__(self, values: list[ir.Value]) -> SymBufferHost:
+        idx = 0
+
+        base_n = len(get_mlir_types(self._fields[0]))
+        base_addr = new_from_mlir_values(self._fields[0], values[idx:idx + base_n])
+        idx += base_n
+
+        offsets = []
+        for field in self._fields[1:-1]:
+            n = len(get_mlir_types(field))
+            offsets.append(new_from_mlir_values(field, values[idx:idx + n]))
+            idx += n
+
+        rank_n = len(get_mlir_types(self._fields[-1]))
+        rank_idx = new_from_mlir_values(self._fields[-1], values[idx:idx + rank_n])
+        idx += rank_n
+        if idx != len(values):
+            raise ValueError(
+                f"SymBufferHost adapter consumed {idx} values, got {len(values)}"
+            )
+
+        obj = object.__new__(SymBufferHost)
+        object.__setattr__(obj, "base_addr", base_addr)
+        object.__setattr__(obj, "offsets", tuple(offsets))
+        object.__setattr__(obj, "rank_idx", rank_idx)
+        object.__setattr__(obj, "num_max_ranks", self._arg.num_max_ranks)
+        return obj

--- a/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/token_comm.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/src/token_comm.py
@@ -1,0 +1,2375 @@
+"""Token communication implementations for MegaMoE-style kernels.
+
+Current implementation: token-in pull with token-back push.  The standalone
+``dispatch_kernel`` uses the same object methods as the fused MegaMoE kernel.
+"""
+
+import dataclasses
+import os
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+from cutlass.cute.typing import AddressSpace
+from cutlass.cutlass_dsl import (
+    Float32,
+    Int32,
+    Int64,
+    Uint8,
+    Uint32,
+    extract_mlir_values,
+    new_from_mlir_values,
+)
+from cutlass.base_dsl.dsl import extract_mlir_attributes
+
+try:
+    from cutlass.cute import iket as _iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from .iket_compat import iket as _iket
+
+from .grid_sync import software_grid_sync
+from .ptx_helpers import (
+    cp_reduce_async_bulk_add_noftz_bf16_s2g,
+    fns_b32,
+    ldg_b32_raw,
+    ldg_f32_raw,
+    read_clock64,
+    red_add_relaxed_sys_u64_raw,
+    red_add_release_sys_s32_raw,
+    red_add_release_sys_u64_raw,
+    stg_b32_raw,
+    stg_b64_raw,
+    tma_load_1d_raw,
+    tma_store_1d,
+    _fence_rel_sys,
+)
+from .flag_batch import GpuReleaseFlagBatchTracker
+from .sf_swizzle import sf_atom_int32_offset
+from cutlass._mlir import ir
+from moe_nvfp4_swapab.moe_utils import _nanosleep, spin_wait
+
+
+# ---------------------------------------------------------------------------
+# Low-precision combine wire format (the central driver for the token-back
+# quantized combine path: fc2 epilogue encoder, token_comm push, and the
+# topk_reduce receiver all describe themselves through one CombineFormat).
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class CombineFormat:
+    """Wire format of the cross-rank combine (token-back) payload.
+
+    The fc2 epilogue quantizes each token's hidden vector into a packed data
+    plane (``combine_quant``) plus a per-block scale plane (``combine_sf``); the
+    receiver (topk_reduce) dequantizes and reduces over topk. The consumer is
+    ALWAYS a software dequant -- never a tensor-core MMA -- so the format is
+    fully self-defined here, with no hardware scale-layout constraint.
+
+    Canonical string ``"{scale_block}{act}x{scale}"`` (leading number = scale
+    block size in hidden elements), e.g. ``"16e2m1xbf16"`` (per-16 bf16 amax +
+    fp4 data) or ``"32e4m3xe8m0"`` (standard MXFP8). ``"bf16"`` is the
+    no-staging baseline: bf16 fc2 terms reduced directly, no scale plane.
+    """
+
+    # Element/scale tag <-> cuTe dtype.  Only the dtypes a real format uses
+    # today (the bf16 baseline is ``scale_dtype is None``); extend when a new
+    # format is actually added rather than ahead of need.
+    _act_by_tag: ClassVar[Dict[str, type]] = {
+        "e2m1": cutlass.Float4E2M1FN,
+        "e4m3": cutlass.Float8E4M3FN,
+        "e5m2": cutlass.Float8E5M2,
+    }
+    _scale_by_tag: ClassVar[Dict[str, type]] = {
+        "bf16": cutlass.BFloat16,
+        "e8m0": cutlass.Float8E8M0FNU,
+    }
+
+    act_dtype: type              # cuTe dtype of the packed data-plane element
+    scale_dtype: Optional[type]  # cuTe dtype of a scale entry; None == bf16 baseline
+    scale_block: Optional[int]   # hidden elements per scale entry; None == baseline
+
+    def __post_init__(self):
+        allowed_act = {cutlass.BFloat16, *self._act_by_tag.values()}
+        if self.act_dtype not in allowed_act:
+            raise ValueError(f"combine act_dtype {self.act_dtype} not in {allowed_act}.")
+        allowed_scale = {None, *self._scale_by_tag.values()}
+        if self.scale_dtype not in allowed_scale:
+            raise ValueError(f"combine scale_dtype {self.scale_dtype} not in {allowed_scale}.")
+        if self.scale_dtype is None:                       # bf16 no-staging baseline
+            if self.act_dtype is not cutlass.BFloat16 or self.scale_block is not None:
+                raise ValueError("baseline must be bf16 act with scale_block=None.")
+            return
+        if self.act_dtype is cutlass.BFloat16:
+            raise ValueError("a quantized combine cannot use a bf16 act dtype.")
+        # The scale dtype pins the block: per-16 bf16 amax / per-32 e8m0 power-of-two.
+        if self.scale_dtype is cutlass.BFloat16 and self.scale_block != 16:
+            raise ValueError("bf16 amax scale requires scale_block == 16.")
+        if self.scale_dtype is cutlass.Float8E8M0FNU and self.scale_block != 32:
+            raise ValueError("e8m0 scale requires scale_block == 32.")
+
+    @property
+    def is_quantized(self) -> bool:
+        """``False`` for the bf16 (no-staging) baseline."""
+        return self.scale_dtype is not None
+
+    @property
+    def name(self) -> str:
+        if not self.is_quantized:
+            return "bf16"
+        act_tag = next(t for t, d in self._act_by_tag.items() if d is self.act_dtype)
+        scale_tag = next(t for t, d in self._scale_by_tag.items() if d is self.scale_dtype)
+        return f"{self.scale_block}{act_tag}x{scale_tag}"
+
+    def __str__(self) -> str:
+        return self.name
+
+    @classmethod
+    def parse(cls, text: str) -> "CombineFormat":
+        """Build a CombineFormat from its canonical string (the argparser entry).
+
+        Only the handful of supported wire formats are accepted; each key is the
+        exact string ``name`` produces (so ``parse(str(fmt)) == fmt``).
+        """
+        # (act_dtype, scale_dtype, scale_block); None scale == bf16 baseline.
+        specs = {
+            "bf16":        (cutlass.BFloat16,     None,                  None),
+            "16e2m1xbf16": (cutlass.Float4E2M1FN, cutlass.BFloat16,      16),
+            "32e4m3xe8m0": (cutlass.Float8E4M3FN, cutlass.Float8E8M0FNU, 32),
+            "32e5m2xe8m0": (cutlass.Float8E5M2,   cutlass.Float8E8M0FNU, 32),
+        }
+        token = text.strip().lower()
+        if token not in specs:
+            raise ValueError(
+                f"invalid combine_format {text!r}: expected one of {tuple(specs)}."
+            )
+        act_dtype, scale_dtype, scale_block = specs[token]
+        return cls(act_dtype=act_dtype, scale_dtype=scale_dtype, scale_block=scale_block)
+
+
+@dataclasses.dataclass(frozen=True)
+class TokenSrcMetadata:
+    """Per pool-token routing record: written by token-in, read by token-back
+    and the fc2 combine-redirect epilogue.
+
+    Wire format is one i64: low 32b = ``src_token`` (needs full width); high 32b
+    = ``(src_rank << 16) | flags | src_topk``.  ``src_rank < world_size`` fits
+    16b; ``src_topk < num_topk <= 16`` fits 8b, freeing bits [8:13) of the low
+    halfword for the combine pre-reduce flags: bits [8:12) = ``reduce_n``
+    (this row is a reduction ANCHOR summing n partner rows), bit 12 =
+    ``consumed`` (this row's output is folded into an anchor; token-back skips
+    its push).  Both are zero everywhere unless combine pre-reduce is active.
+    ``load`` / ``store`` accept either a ``cute.Pointer`` or a raw ``Int64``
+    byte address.
+    """
+
+    src_rank: Int32
+    src_token: Int32
+    src_topk: Int32
+    reduce_n: Union[Int32, int] = 0
+    consumed: Union[Int32, int] = 0
+
+    nbytes: ClassVar[int] = 8
+
+    def _pack(self) -> Int64:
+        hi = (
+            (Int64(self.src_rank) << Int64(16))
+            | (Int64(self.consumed) << Int64(12))
+            | (Int64(self.reduce_n) << Int64(8))
+            | Int64(self.src_topk)
+        )
+        return (hi << Int64(32)) | (Int64(self.src_token) & Int64(0xFFFFFFFF))
+
+    @staticmethod
+    def _i64_ptr(addr: Union[cute.Pointer, Int64]) -> cute.Pointer:
+        addr_i = addr if isinstance(addr, Int64) else addr.toint()
+        return cute.make_ptr(Int64, addr_i, AddressSpace.gmem, assumed_align=8)
+
+    def store(self, addr: Union[cute.Pointer, Int64]) -> None:
+        cute.arch.store(self._i64_ptr(addr), self._pack(), scope="gpu")
+
+    @classmethod
+    def load(cls, addr: Union[cute.Pointer, Int64]) -> "TokenSrcMetadata":
+        v = Int64(cute.arch.load(cls._i64_ptr(addr), Int64, scope="gpu"))
+        hi = v >> Int64(32)
+        return cls(
+            src_rank=Int32((hi >> Int64(16)) & Int64(0xFFFF)),
+            src_token=Int32(v & Int64(0xFFFFFFFF)),
+            src_topk=Int32(hi & Int64(0xFF)),
+            reduce_n=Int32((hi >> Int64(8)) & Int64(0xF)),
+            consumed=Int32((hi >> Int64(12)) & Int64(0x1)),
+        )
+
+
+_MLIR_VALUE_FIELDS = (
+    "input_token_buffer",
+    "input_sf_buffer",
+    "topk_idx",
+    "input_topk_weights_buffer",
+    "expert_send_count",
+    "expert_recv_count",
+    "expert_recv_count_sum",
+    "src_token_topk_idx",
+    "dup_link",
+    "reduce_list",
+    "fc1_input_token_buffer",
+    "fc1_input_sf_buffer",
+    "fc1_input_topk_weights_buffer",
+    "fc1_ready_counter",
+    "token_src_metadata",
+    "combine_output",
+    "combine_sf",
+    "fc2_output_workspace",
+    "fc2_output_sf",
+    "fc2_done_counter",
+    "token_back_schedule_counter",
+    "nvlink_barrier_signal",
+    "nvlink_barrier_counter",
+    "grid_sync_counter",
+    "local_zero_prefix",
+    "shared_zero_prefix",
+    "peer_rank_ptr_mapper",
+    "local_rank",
+)
+
+_CONST_FIELDS = (
+    "world_size",
+    "num_total_experts",
+    "num_experts_per_rank",
+    "num_topk",
+    "hidden_bytes",
+    "sf_uint32_per_token",
+    "token_padding_block",
+    "sf_padding_block",
+    "sm_count",
+)
+
+class TokenCommArgs:
+    """MegaMoE token communication argument bundle."""
+
+    def __init__(
+        self,
+        *,
+        input_token_buffer: cute.Tensor,
+        input_sf_buffer: cute.Tensor,
+        topk_idx: cute.Tensor,
+        input_topk_weights_buffer: cute.Tensor,
+        expert_send_count: cute.Tensor,
+        expert_recv_count: cute.Tensor,
+        expert_recv_count_sum: cute.Tensor,
+        src_token_topk_idx: cute.Tensor,
+        fc1_input_token_buffer: cute.Tensor,
+        fc1_input_sf_buffer: cute.Tensor,
+        fc1_input_topk_weights_buffer: cute.Tensor,
+        fc1_ready_counter: cute.Tensor,
+        token_src_metadata: cute.Tensor,
+        combine_output: cute.Tensor,
+        nvlink_barrier_signal: cute.Tensor,
+        nvlink_barrier_counter: cute.Tensor,
+        grid_sync_counter: cute.Tensor,
+        local_zero_prefix: cute.Tensor,
+        shared_zero_prefix: cute.Tensor,
+        peer_rank_ptr_mapper: Any,
+        world_size: int,
+        local_rank: int,
+        num_total_experts: int,
+        num_experts_per_rank: int,
+        num_topk: int,
+        hidden_bytes: int,
+        sf_uint32_per_token: int,
+        token_padding_block: int,
+        sf_padding_block: int,
+        sm_count: int,
+        fc2_output_workspace: cute.Tensor = None,
+        fc2_done_counter: cute.Tensor = None,
+        token_back_schedule_counter: cute.Pointer = None,
+        combine_sf: cute.Tensor = None,
+        fc2_output_sf: cute.Tensor = None,
+        dup_link: cute.Tensor = None,
+        reduce_list: cute.Tensor = None,
+    ):
+        self.input_token_buffer = input_token_buffer
+        self.input_sf_buffer = input_sf_buffer
+        self.topk_idx = topk_idx
+        self.input_topk_weights_buffer = input_topk_weights_buffer
+        self.expert_send_count = expert_send_count
+        self.expert_recv_count = expert_recv_count
+        self.expert_recv_count_sum = expert_recv_count_sum
+        self.src_token_topk_idx = src_token_topk_idx
+        self.dup_link = dup_link
+        self.reduce_list = reduce_list
+        self.fc1_input_token_buffer = fc1_input_token_buffer
+        self.fc1_input_sf_buffer = fc1_input_sf_buffer
+        self.fc1_input_topk_weights_buffer = fc1_input_topk_weights_buffer
+        self.fc1_ready_counter = fc1_ready_counter
+        self.token_src_metadata = token_src_metadata
+        self.combine_output = combine_output
+        self.combine_sf = combine_sf
+        self.fc2_output_workspace = fc2_output_workspace
+        self.fc2_output_sf = fc2_output_sf
+        self.fc2_done_counter = fc2_done_counter
+        self.token_back_schedule_counter = token_back_schedule_counter
+        self.nvlink_barrier_signal = nvlink_barrier_signal
+        self.nvlink_barrier_counter = nvlink_barrier_counter
+        self.grid_sync_counter = grid_sync_counter
+        self.local_zero_prefix = local_zero_prefix
+        self.shared_zero_prefix = shared_zero_prefix
+        self.peer_rank_ptr_mapper = peer_rank_ptr_mapper
+        self.world_size = world_size
+        self.local_rank = local_rank
+        self.num_total_experts = num_total_experts
+        self.num_experts_per_rank = num_experts_per_rank
+        self.num_topk = num_topk
+        self.hidden_bytes = hidden_bytes
+        self.sf_uint32_per_token = sf_uint32_per_token
+        self.token_padding_block = token_padding_block
+        self.sf_padding_block = sf_padding_block
+        self.sm_count = sm_count
+
+    def __extract_mlir_values__(self) -> List[ir.Value]:
+        values: List[ir.Value] = []
+        for name in _MLIR_VALUE_FIELDS:
+            attr = getattr(self, name)
+            if attr is None:
+                continue
+            values.extend(extract_mlir_values(attr))
+        return values
+
+    def __extract_mlir_attributes__(self) -> List[Any]:
+        # Mirror __extract_mlir_values__ 1:1 so per-arg attrs stay aligned; the
+        # only non-empty entry is peer_rank_ptr_mapper's byval/grid_constant.
+        attrs: List[Any] = []
+        for name in _MLIR_VALUE_FIELDS:
+            attr = getattr(self, name)
+            if attr is None:
+                continue
+            attrs.extend(extract_mlir_attributes(attr))
+        return attrs
+
+    def __new_from_mlir_values__(
+        self, values: List[ir.Value]
+    ) -> "TokenCommArgs":
+        idx = 0
+        rebuilt: Dict[str, Any] = {}
+        for name in _MLIR_VALUE_FIELDS:
+            proto = getattr(self, name)
+            if proto is None:
+                rebuilt[name] = None
+                continue
+            n = len(extract_mlir_values(proto))
+            rebuilt[name] = new_from_mlir_values(proto, values[idx : idx + n])
+            idx += n
+        assert idx == len(values), (
+            f"TokenCommArgs serialization mismatch: "
+            f"consumed={idx} provided={len(values)}"
+        )
+        const_kwargs = {name: getattr(self, name) for name in _CONST_FIELDS}
+        return TokenCommArgs(**rebuilt, **const_kwargs)
+
+class TokenInPullTokenBackPush:
+    """Current implementation: token-in pull, token-back push."""
+
+    num_dispatch_warps: int = 4
+    warp_threads: int = 32
+    num_dispatch_threads: int = num_dispatch_warps * warp_threads
+    dispatch_intra_cta_bar_id: int = 10
+    kernel_tail_named_barrier_id: int = 8
+    dispatch_to_sched_named_barrier_id: int = 9
+    # dispatch_to_sched / kernel_tail thread counts are per-instance (see __init__).
+    experts_per_dispatch_pass: int = num_dispatch_threads
+    # Developer-only knob (MEGA_TOKEN_BACK_ATOMIC_BATCH); not user-facing.
+    token_back_atomic_batch: int = int(
+        os.environ.get("MEGA_TOKEN_BACK_ATOMIC_BATCH", "1")
+    )
+
+
+    def __init__(
+        self,
+        *,
+        world_size: int,
+        num_topk: int,
+        num_experts_per_rank: int,
+        num_total_experts: int,
+        hidden: int,
+        fc1_token_dtype,
+        sf_uint32_per_token: int,
+        token_padding_block: int,
+        sf_padding_block: int,
+        cluster_tile_tokens: int,
+        cluster_shape_mn,
+        dispatch_warp_start: int,
+        num_other_warps: int,
+        combine_format: "CombineFormat" = None,
+        token_back_by_dispatch: bool = False,
+        fc2_publishes_per_token_cluster_tile: int = 0,
+        token_back_reduce_topk: bool = False,
+        token_back_standalone: bool = False,
+        flag_batch: int = 1,
+        is_swap_ab: bool = False,
+        token_back_schedule_mode: Literal["static", "atomic_counter"] = "static",
+        dedup_dispatch: bool = False,
+        combine_pre_reduce: bool = False,
+    ) -> None:
+        self.world_size = world_size
+        self.num_topk = num_topk
+        self.num_experts_per_rank = num_experts_per_rank
+        self.num_total_experts = num_total_experts
+        self.hidden = hidden
+        self.fc1_token_dtype = fc1_token_dtype
+        self.hidden_bytes = hidden * int(fc1_token_dtype.width) // 8
+        self.sf_uint32_per_token = sf_uint32_per_token
+        self.token_padding_block = token_padding_block
+        self.sf_padding_block = sf_padding_block
+        self.cluster_tile_tokens = cluster_tile_tokens
+        self.cluster_shape_mn = cluster_shape_mn
+        if flag_batch < 1 or flag_batch > 32:
+            raise ValueError(f"flag_batch must be in [1, 32], got {flag_batch}.")
+        # Release-flag batch size consumed by dispatch_pull as a Python int.
+        # One warp lane carries one delayed release target.
+        self._flag_batch = flag_batch
+        self.is_swap_ab = is_swap_ab
+
+        # Rank-level dispatch dedup: a token routed to multiple experts on the
+        # same destination rank crosses NVLink once; the receiving warp fans the
+        # pulled row out to the duplicate pool slots locally.  Word/link bit
+        # encodings below bound the supported geometry.
+        self.dedup_dispatch = dedup_dispatch and num_topk > 1
+        if dedup_dispatch:
+            if num_experts_per_rank > 256:
+                raise ValueError(
+                    "dedup_dispatch: num_experts_per_rank must fit the 8-bit "
+                    f"dup_link expert field, got {num_experts_per_rank}."
+                )
+            if num_topk > 16:
+                raise ValueError(
+                    "dedup_dispatch: num_topk must fit the 4-bit dup_link "
+                    f"topk field, got {num_topk}."
+                )
+            if world_size > 16:
+                raise ValueError(
+                    "dedup_dispatch: world_size must be <= 16 (warp-ballot "
+                    f"rank masks), got {world_size}."
+                )
+        # Combine pre-reduce: same-rank partial top-k sums are folded into a
+        # per-group ANCHOR row locally (HBM) before the token-back push, so
+        # combine crosses NVLink once per (token, source rank).  Requires the
+        # dedup groups (built at dispatch) and the REDG token-back (the anchor
+        # pushes a partial sum, which must add into the 2D output).
+        self.combine_pre_reduce = combine_pre_reduce and self.dedup_dispatch
+        if combine_pre_reduce:
+            if not self.dedup_dispatch:
+                raise ValueError(
+                    "combine_pre_reduce requires dedup_dispatch=True "
+                    "(reduction groups are discovered at dispatch time)."
+                )
+            if not token_back_reduce_topk:
+                raise ValueError(
+                    "combine_pre_reduce requires token_back_reduce_topk=True "
+                    "(anchors push partial sums via REDG add)."
+                )
+
+        if token_back_schedule_mode not in ("static", "atomic_counter"):
+            raise ValueError(
+                "token_back_schedule_mode must be 'static' or "
+                f"'atomic_counter'; got {token_back_schedule_mode!r}."
+            )
+        self.token_back_schedule_mode = token_back_schedule_mode
+        self.dispatch_warp_start = dispatch_warp_start
+        # Warps that share this CTA with the dispatch group but are not part
+        # of it. They participate in kernel-tail / dispatch-with-other
+        # rendezvous and determine `number_of_threads` for those barriers.
+        # Pure standalone dispatch passes 0 (no cohabitants -> barriers
+        # collapse to dispatch-only).
+        self.num_other_warps = num_other_warps
+        self.num_other_threads = num_other_warps * self.warp_threads
+
+        if combine_format is None:
+            combine_format = CombineFormat(
+                act_dtype=cutlass.BFloat16, scale_dtype=None, scale_block=None,
+            )
+        self.combine_format = combine_format
+        self.token_back_by_dispatch = token_back_by_dispatch
+        self.push_data = token_back_by_dispatch
+        self.push_sf = combine_format.is_quantized
+
+        # Standalone token-back: a dedicated warpgroup (size == dispatch group)
+        self.token_back_standalone = token_back_standalone
+        self.num_token_back_warps = self.num_dispatch_warps if self.token_back_standalone else 0
+        self.num_token_back_threads = self.num_token_back_warps * self.warp_threads
+        self.token_back_warp_start = dispatch_warp_start + self.num_dispatch_warps
+        # Standalone token-back per-warp pull buffer; token is moved in
+        # tb_chunk_bytes pieces (last piece carries the remainder), so this is
+        # independent of hidden.
+        self.tb_chunk_bytes = 2048
+
+        self.num_total_threads = (
+            self.num_dispatch_threads
+            + self.num_other_threads
+            + self.num_token_back_threads
+        )
+        self.dispatch_to_sched_threads = (
+            self.num_dispatch_warps + 1 + self.num_token_back_warps
+        ) * self.warp_threads
+        self.kernel_tail_threads = self.num_total_threads
+
+        # The DATA wire dtype is the combine act dtype (bf16 baseline -> bf16;
+        # fp4/e4m3 quantized), NOT the kernel's fc2 output dtype: the cross-rank
+        # payload is what the receiver dequantizes.
+        self.fc2_output_dtype = combine_format.act_dtype
+        if token_back_reduce_topk:
+            if not token_back_by_dispatch:
+                raise ValueError(
+                    "token_back_reduce_topk=True requires the dispatch "
+                    "token-back DATA path (token_back_by_dispatch)."
+                )
+            if combine_format.act_dtype is not cutlass.BFloat16:
+                raise NotImplementedError(
+                    "token_back_reduce_topk currently supports a bf16 combine "
+                    f"only, got {combine_format}."
+                )
+        self.token_back_reduce_topk = token_back_reduce_topk
+        if self.enable_token_back:
+            self.fc2_token_bytes = hidden * int(combine_format.act_dtype.width) // 8
+            if self.fc2_token_bytes % self.hidden_bytes != 0:
+                raise ValueError(
+                    f"fc2_token_bytes={self.fc2_token_bytes} must be a "
+                    f"multiple of hidden_bytes={self.hidden_bytes} so the "
+                    f"per-warp pull buffer can be reused chunk-by-chunk."
+                )
+            self.fc2_num_chunks = self.fc2_token_bytes // self.hidden_bytes
+            if fc2_publishes_per_token_cluster_tile <= 0:
+                raise ValueError(
+                    "fc2_publishes_per_token_cluster_tile must be > 0 when "
+                    "token-back is enabled (it gates the per-expert push)."
+                )
+            self.fc2_publishes_per_token_cluster_tile = (
+                fc2_publishes_per_token_cluster_tile
+            )
+        else:
+            self.fc2_token_bytes = 0
+            self.fc2_num_chunks = 0
+            self.fc2_publishes_per_token_cluster_tile = 0
+
+    @property
+    def enable_token_back(self) -> bool:
+        # token-back warps run if they push the DATA plane, the SF plane, or both.
+        return self.push_data or self.push_sf
+
+    def extra_smem_storage_class(self) -> type:
+        hidden_bytes = self.hidden_bytes
+        num_total_experts = self.num_total_experts
+
+        if self.token_back_standalone:
+            @cute.struct
+            class TokenCommStorage:
+                pull_mbar: cute.struct.MemRange[Int64, self.num_dispatch_warps]
+                smem_expert_count: cute.struct.MemRange[
+                    Int32, num_total_experts
+                ]
+                pull_buffer: cute.struct.Align[cute.struct.MemRange[Uint8, self.num_dispatch_warps * hidden_bytes], 16]
+                tb_pull_mbar: cute.struct.MemRange[Int64, self.num_token_back_warps]
+                tb_pull_buffer: cute.struct.Align[cute.struct.MemRange[Uint8, self.num_token_back_warps * self.tb_chunk_bytes], 16]
+
+            return TokenCommStorage
+
+        @cute.struct
+        class TokenCommStorage:
+            pull_mbar: cute.struct.MemRange[Int64, self.num_dispatch_warps]
+            smem_expert_count: cute.struct.MemRange[
+                Int32, num_total_experts
+            ]
+            pull_buffer: cute.struct.Align[cute.struct.MemRange[Uint8, self.num_dispatch_warps * hidden_bytes], 16]
+
+        return TokenCommStorage
+
+    def fc1_ready_counter_ptr(self, token_comm_args):
+        return token_comm_args.fc1_ready_counter.iterator
+
+    @cute.jit
+    def sched_warp_pre_init_wait(self, token_comm_args):
+        nb = pipeline.NamedBarrier(
+            barrier_id=self.dispatch_to_sched_named_barrier_id,
+            num_threads=self.dispatch_to_sched_threads,
+        )
+        nb.arrive_and_wait()
+
+    @cute.jit
+    def fc1_tma_b_predispatch_spin(self, token_comm_args, work_tile_info):
+        if cutlass.const_expr(self.is_swap_ab):
+            counter_slot = work_tile_info.cumulative_token_block_count + work_tile_info.tile_n_idx
+            peek_threshold = work_tile_info.valid_tokens_in_cta_tile
+        else:
+            counter_slot = (
+                work_tile_info.cumulative_token_block_count
+                + work_tile_info.tile_m_idx // cutlass.Int32(self.cluster_shape_mn[0])
+            )
+            peek_threshold = work_tile_info.valid_tokens_in_cluster_tile
+
+        counter_ptr = token_comm_args.fc1_ready_counter.iterator + counter_slot
+        if not work_tile_info.peek_ready:
+            _iket.range_push("tma_token_fc1_wait")
+            spin_wait(
+                counter_ptr,
+                lambda v: v >= peek_threshold,
+                fail_sleep_cycles=1000,
+            )
+            _iket.range_pop()
+
+    @cute.jit
+    def dispatch_prep(
+        self,
+        token_comm_storage,
+        topk_idx,
+        expert_send_count,
+        src_token_topk_idx,
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        *,
+        local_rank,
+        num_tokens,
+        num_sms,
+        dup_link=None,
+    ):
+        thread_idx_in_dispatch = Int32(warp_idx * self.warp_threads + lane_idx)
+        smem_count_ptr = token_comm_storage.smem_expert_count.data_ptr()
+        i = thread_idx_in_dispatch
+        while i < Int32(self.num_total_experts):
+            (smem_count_ptr + i).store(Int32(0))
+            i = i + Int32(self.num_dispatch_threads)
+        cute.arch.barrier(
+            barrier_id=self.dispatch_intra_cta_bar_id,
+            number_of_threads=self.num_dispatch_threads,
+        )
+
+        tokens_per_warp: cutlass.Constexpr[int] = 32 // self.num_topk
+        active_lanes: cutlass.Constexpr[int] = tokens_per_warp * self.num_topk
+        num_dispatch_warps_per_grid: cutlass.Constexpr[int] = num_sms * self.num_dispatch_warps
+
+        base_token_for_warp = (sm_idx * self.num_dispatch_warps + warp_idx) * tokens_per_warp
+        grid_token_stride = num_dispatch_warps_per_grid * tokens_per_warp
+
+        t = base_token_for_warp
+        while t < num_tokens:
+            token_offset_in_warp = lane_idx // self.num_topk
+            token_global = t + token_offset_in_warp
+            if lane_idx < active_lanes and token_global < num_tokens:
+                topk_slot = lane_idx % self.num_topk
+                expert_id = Int32(topk_idx[token_global, topk_slot])
+                if expert_id >= Int32(0):
+                    cute.arch.atomic_add(
+                        smem_count_ptr + expert_id,
+                        Int32(1),
+                        sem="relaxed",
+                        scope="cta",
+                    )
+            cute.arch.sync_warp()
+            t += grid_token_stride
+
+        cute.arch.barrier(
+            barrier_id=self.dispatch_intra_cta_bar_id,
+            number_of_threads=self.num_dispatch_threads,
+        )
+
+        for offset in cutlass.range_constexpr(
+            0, self.num_total_experts, self.experts_per_dispatch_pass,
+        ):
+            expert_id = Int32(offset + warp_idx * self.warp_threads + lane_idx)
+            if expert_id < Int32(self.num_total_experts):
+                slot_ptr = smem_count_ptr + expert_id
+                local_count = (slot_ptr).load()
+                delta = (Int64(1) << Int64(32)) | (Int64(local_count) & Int64(0xFFFFFFFF))
+                old_packed = cute.arch.atomic_add(
+                    expert_send_count.iterator + expert_id,
+                    delta,
+                    sem="relaxed",
+                    scope="gpu",
+                )
+                base_slot = Int32(old_packed & Int64(0xFFFFFFFF))
+                (slot_ptr).store(base_slot)
+        cute.arch.barrier(
+            barrier_id=self.dispatch_intra_cta_bar_id,
+            number_of_threads=self.num_dispatch_threads,
+        )
+
+        if cutlass.const_expr(not self.dedup_dispatch):
+            t = base_token_for_warp
+            while t < num_tokens:
+                token_offset_in_warp = lane_idx // self.num_topk
+                token_global = t + token_offset_in_warp
+                if lane_idx < active_lanes and token_global < num_tokens:
+                    topk_slot = lane_idx % self.num_topk
+                    expert_id = Int32(topk_idx[token_global, topk_slot])
+                    if expert_id >= Int32(0):
+                        dst_rank = expert_id // Int32(self.num_experts_per_rank)
+                        local_expert = expert_id % Int32(self.num_experts_per_rank)
+                        slot = cute.arch.atomic_add(
+                            smem_count_ptr + expert_id,
+                            Int32(1),
+                            sem="relaxed",
+                            scope="cta",
+                        )
+                        token_topk_word = Int32(token_global * self.num_topk + topk_slot)
+                        MAX_SLOT_C: cutlass.Constexpr[int] = num_tokens * self.num_topk
+                        elem_off = (
+                            (local_expert * Int32(self.world_size) + Int32(local_rank))
+                            * Int32(MAX_SLOT_C)
+                            + slot
+                        ) * Int32(4)
+                        peer_addr = peer_rank_ptr_mapper.map(
+                            src_token_topk_idx.iterator.toint(),
+                            dst_rank, Int64(elem_off),
+                        )
+                        stg_b32_raw(peer_addr, token_topk_word)
+                cute.arch.sync_warp()
+                t += grid_token_stride
+        else:
+            # Dedup variant.  A token's K routed copies live on K adjacent
+            # lanes; warp shuffles find same-destination-rank groups.  The
+            # copy targeting the SMALLEST local expert on a rank is the
+            # PRIMARY: the receiver walks experts in ascending order, so
+            # every duplicate row (always in a LATER expert) is delivered
+            # before its expert's turn — the pull->fc1 readiness order is
+            # preserved.  The primary writes a flat list of its duplicates
+            # into ``dup_link[e, src_rank, slot, 0..n)`` (independent reads
+            # on the receiver, no pointer chasing), each entry:
+            #   bits [0:18)  dup slot within its (expert, src_rank) stream
+            #   bits [18:26) dup local expert id
+            #   bits [26:30) dup topk slot (for the routing-weight store)
+            # src_token_topk_idx words gain flags (payload < 2^18):
+            #   bits [24:28) primary's duplicate count n (0 = plain row)
+            #   bit  28      DUP (receiver: skip, a primary delivers this row)
+            t = base_token_for_warp
+            while t < num_tokens:
+                token_offset_in_warp = lane_idx // self.num_topk
+                token_global = t + token_offset_in_warp
+                topk_slot = lane_idx % self.num_topk
+                tok_base_lane = token_offset_in_warp * Int32(self.num_topk)
+                expert_id = Int32(-1)
+                if lane_idx < active_lanes and token_global < num_tokens:
+                    expert_id = Int32(topk_idx[token_global, topk_slot])
+                dst_rank = Int32(-1)
+                local_expert = Int32(0)
+                if expert_id >= Int32(0):
+                    dst_rank = expert_id // Int32(self.num_experts_per_rank)
+                    local_expert = expert_id % Int32(self.num_experts_per_rank)
+                # Every valid copy still claims a slot: the pool row layout
+                # (contiguous per expert) is unchanged, only the wire is deduped.
+                slot = Int32(0)
+                if expert_id >= Int32(0):
+                    slot = cute.arch.atomic_add(
+                        smem_count_ptr + expert_id,
+                        Int32(1),
+                        sem="relaxed",
+                        scope="cta",
+                    )
+                # Same-rank group scan over the token's K lanes (full-warp
+                # shuffles; invalid lanes carry dst_rank == -1 and never
+                # match).  I am a DUP if any same-rank copy has a smaller
+                # (expert, topk_slot); otherwise I am the group's primary and
+                # I emit one dup_link entry per later-ordered same-rank copy.
+                is_dup = Int32(0)
+                n_dup = Int32(0)
+                MAX_SLOT_C: cutlass.Constexpr[int] = num_tokens * self.num_topk
+                my_list_base = (
+                    (local_expert * Int32(self.world_size) + Int32(local_rank))
+                    * Int32(MAX_SLOT_C)
+                    + slot
+                ) * Int32(self.num_topk - 1)
+                for j in cutlass.range_constexpr(0, self.num_topk, 1):
+                    r_j = cute.arch.shuffle_sync(
+                        dst_rank, tok_base_lane + Int32(j)
+                    )
+                    e_j = cute.arch.shuffle_sync(
+                        local_expert, tok_base_lane + Int32(j)
+                    )
+                    s_j = cute.arch.shuffle_sync(
+                        slot, tok_base_lane + Int32(j)
+                    )
+                    if (
+                        dst_rank >= Int32(0)
+                        and r_j == dst_rank
+                        and Int32(j) != topk_slot
+                    ):
+                        j_before = (e_j < local_expert) or (
+                            e_j == local_expert and Int32(j) < topk_slot
+                        )
+                        if j_before:
+                            is_dup = Int32(1)
+                        if is_dup == Int32(0) and not j_before:
+                            # I'm (so far) the primary; record copy j.
+                            entry = (
+                                (s_j & Int32(0x3FFFF))
+                                | (e_j << Int32(18))
+                                | (Int32(j) << Int32(26))
+                            )
+                            entry_addr = peer_rank_ptr_mapper.map(
+                                dup_link.iterator.toint(),
+                                dst_rank,
+                                Int64((my_list_base + n_dup) * Int32(4)),
+                            )
+                            stg_b32_raw(entry_addr, entry)
+                            n_dup = n_dup + Int32(1)
+                if expert_id >= Int32(0):
+                    token_topk_word = Int32(token_global * self.num_topk + topk_slot)
+                    if is_dup == Int32(1):
+                        token_topk_word = token_topk_word | Int32(1 << 28)
+                    else:
+                        token_topk_word = token_topk_word | (n_dup << Int32(24))
+                    elem_off = (
+                        (local_expert * Int32(self.world_size) + Int32(local_rank))
+                        * Int32(MAX_SLOT_C)
+                        + slot
+                    ) * Int32(4)
+                    peer_addr = peer_rank_ptr_mapper.map(
+                        src_token_topk_idx.iterator.toint(),
+                        dst_rank, Int64(elem_off),
+                    )
+                    stg_b32_raw(peer_addr, token_topk_word)
+                cute.arch.sync_warp()
+                t += grid_token_stride
+
+    @cute.jit
+    def dispatch_barrier(
+        self,
+        expert_send_count,
+        expert_recv_count,
+        expert_recv_count_sum,
+        nvlink_barrier_signal,
+        grid_sync_counter,
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        *,
+        local_rank,
+        num_sms,
+        nvlink_barrier_counter,
+    ):
+        # software_grid_sync expects a dispatch-group-relative thread id.
+        tid_in_group = warp_idx * Int32(self.warp_threads) + lane_idx
+
+        software_grid_sync(grid_sync_counter, sm_idx, num_sms, tid_in_group,
+                           num_threads=self.num_dispatch_threads)
+
+        if sm_idx == 0:
+            for offset in cutlass.range_constexpr(
+                0, self.num_total_experts, self.experts_per_dispatch_pass,
+            ):
+                expert_id = Int32(offset + warp_idx * self.warp_threads + lane_idx)
+                if expert_id < Int32(self.num_total_experts):
+                    dst_rank = expert_id // Int32(self.num_experts_per_rank)
+                    dst_local_expert = expert_id % Int32(self.num_experts_per_rank)
+                    status_u64 = cute.arch.load(
+                        expert_send_count.iterator + expert_id,
+                        Int64,
+                        sem="relaxed",
+                        scope="gpu",
+                    )
+                    token_count_u32 = Int32(status_u64 & Int64(0xFFFFFFFF))
+                    erc_local_base = expert_recv_count.iterator.toint()
+                    erc_elem_off = (
+                        Int32(local_rank) * Int32(self.num_experts_per_rank) + dst_local_expert
+                    ) * Int32(8)
+                    erc_peer_addr = peer_rank_ptr_mapper.map(
+                        erc_local_base, dst_rank, Int64(erc_elem_off),
+                    )
+                    stg_b64_raw(erc_peer_addr, Int64(token_count_u32))
+                    ercs_local_base = expert_recv_count_sum.iterator.toint()
+                    ercs_peer_addr = peer_rank_ptr_mapper.map(
+                        ercs_local_base, dst_rank,
+                        Int64(dst_local_expert * Int32(8)),
+                    )
+                    red_add_relaxed_sys_u64_raw(ercs_peer_addr, status_u64)
+            cute.arch.fence_acq_rel_sys()
+        cute.arch.barrier(
+            barrier_id=self.dispatch_intra_cta_bar_id,
+            number_of_threads=self.num_dispatch_threads,
+        )
+
+        self.nvlink_barrier(
+            nvlink_barrier_signal,
+            nvlink_barrier_counter,
+            grid_sync_counter,
+            peer_rank_ptr_mapper,
+            sm_idx,
+            warp_idx,
+            lane_idx,
+            num_sms=num_sms,
+            prologue_grid_sync=False,
+            epilogue_grid_sync=True,
+        )
+    @cute.jit
+    def dispatch_pull(
+        self,
+        token_comm_storage,
+        input_token_buffer,
+        input_sf_buffer,
+        input_topk_weights_buffer,
+        src_token_topk_idx,
+        expert_recv_count,
+        expert_recv_count_sum,
+        fc1_input_token_buffer,
+        fc1_input_sf_buffer,
+        fc1_input_topk_weights_buffer,
+        fc1_ready_counter,
+        token_src_metadata,
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        *,
+        num_sms,
+        dup_link=None,
+        reduce_list=None,
+    ):
+        # MemRange does not support dynamic indexing here; use raw pointers.
+        pull_mbar_ptr = token_comm_storage.pull_mbar.data_ptr()
+        pull_buffer_ptr = token_comm_storage.pull_buffer.data_ptr()
+        if lane_idx == Int32(0):
+            cute.arch.mbarrier_init(pull_mbar_ptr + warp_idx, 1)
+        cute.arch.sync_warp()
+
+
+        phase_bit = Int32(0)
+
+        current_expert_idx = Int32(-1)
+        expert_start_idx = Int32(0)
+        expert_end_idx = Int32(0)
+        expert_pool_block_offset = Int32(0)
+        expert_task_tile_offset = Int32(0)
+        # SF rows use their own padding; token and SF pool offsets can diverge.
+        expert_sf_pool_block_offset = Int32(0)
+
+        # ── Release-flag batching ────────────────────────────────────────
+        # Delay fc1-ready counter publication with the same rotating-lane
+        # tracker used by the epilogue.  Each token's TMA store to the FC1 pool
+        # is drained CTA-locally by ``cp_async_bulk_wait_group(0)`` before its
+        # release target is accumulated; the eventual red.release.gpu add
+        # publishes the corresponding pool data to GPU scope.
+        flag_tracker = GpuReleaseFlagBatchTracker(
+            flag_addr=Int64(0),
+            cumulated_flags=Int32(0),
+            phase=Int32(0),
+            tid=lane_idx,
+        )
+
+        stored_rank_count_lane = Int32(0)
+
+        NUM_EXPERTS_PER_LANE: cutlass.Constexpr[int] = (
+            self.num_experts_per_rank + 31
+        ) // 32
+        stored_num_tokens_per_expert = []
+        for _ in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+            stored_num_tokens_per_expert.append(Int32(0))
+        for i in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+            e_idx_for_lane = Int32(i * self.warp_threads) + lane_idx
+            if e_idx_for_lane < Int32(self.num_experts_per_rank):
+                sum_packed_init = expert_recv_count_sum[e_idx_for_lane]
+                stored_num_tokens_per_expert[i] = Int32(
+                    Int64(sum_packed_init) & Int64(0xFFFFFFFF)
+                )
+        cute.arch.sync_warp()
+
+        # Dedup fan-out needs random-access per-expert pool offsets (a dup's
+        # target expert is unrelated to the expert this warp is walking), so
+        # precompute exclusive prefix offsets once: lane (e % 32) stores the
+        # offsets for expert e in slot e // 32, mirroring the incremental
+        # cumulation the main walk performs expert-by-expert.
+        pool_block_prefix = []
+        sf_block_prefix = []
+        task_tile_prefix = []
+        if cutlass.const_expr(self.dedup_dispatch):
+            for _ in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+                pool_block_prefix.append(Int32(0))
+                sf_block_prefix.append(Int32(0))
+                task_tile_prefix.append(Int32(0))
+            run_pool = Int32(0)
+            run_sf = Int32(0)
+            run_tile = Int32(0)
+            for e in cutlass.range_constexpr(0, self.num_experts_per_rank, 1):
+                cnt_e = cute.arch.shuffle_sync(
+                    stored_num_tokens_per_expert[e // self.warp_threads],
+                    Int32(e % self.warp_threads),
+                )
+                for i in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+                    if Int32(e) == Int32(i * self.warp_threads) + lane_idx:
+                        pool_block_prefix[i] = run_pool
+                        sf_block_prefix[i] = run_sf
+                        task_tile_prefix[i] = run_tile
+                run_pool = run_pool + (
+                    cnt_e + Int32(self.token_padding_block) - Int32(1)
+                ) // Int32(self.token_padding_block)
+                run_sf = run_sf + (
+                    cnt_e + Int32(self.sf_padding_block) - Int32(1)
+                ) // Int32(self.sf_padding_block)
+                run_tile = run_tile + (
+                    cnt_e + Int32(self.cluster_tile_tokens) - Int32(1)
+                ) // Int32(self.cluster_tile_tokens)
+            cute.arch.sync_warp()
+
+        num_global_warps: cutlass.Constexpr[int] = num_sms * self.num_dispatch_warps
+        token_idx = sm_idx * Int32(self.num_dispatch_warps) + warp_idx
+
+        _iket_pull_emit = (
+            (sm_idx == Int32(0))
+            and (warp_idx == Int32(0))
+            and (lane_idx == Int32(0))
+        )
+
+        while current_expert_idx < Int32(self.num_experts_per_rank):
+            if _iket_pull_emit:
+                _iket.range_push("Pull.ChooseToken")
+            old_expert_idx = current_expert_idx
+            while (token_idx >= expert_end_idx) and (
+                current_expert_idx < Int32(self.num_experts_per_rank)
+            ):
+                prev_valid_count = expert_end_idx - expert_start_idx
+                prev_block_count = (
+                    prev_valid_count + Int32(self.token_padding_block) - Int32(1)
+                ) // Int32(self.token_padding_block)
+                expert_pool_block_offset = (
+                    expert_pool_block_offset + prev_block_count
+                )
+                # Mirror cumul for the release-counter granularity (self.cluster_tile_tokens).
+                prev_task_tile_count = (
+                    prev_valid_count + Int32(self.cluster_tile_tokens) - Int32(1)
+                ) // Int32(self.cluster_tile_tokens)
+                expert_task_tile_offset = (
+                    expert_task_tile_offset + prev_task_tile_count
+                )
+                # Mirror cumul for the SF axis granularity (self.sf_padding_block).
+                prev_sf_block_count = (
+                    prev_valid_count + Int32(self.sf_padding_block) - Int32(1)
+                ) // Int32(self.sf_padding_block)
+                expert_sf_pool_block_offset = (
+                    expert_sf_pool_block_offset + prev_sf_block_count
+                )
+                current_expert_idx = current_expert_idx + Int32(1)
+                if current_expert_idx < Int32(self.num_experts_per_rank):
+                    expert_start_idx = expert_end_idx
+                    valid_value = Int32(0)
+                    for i in cutlass.range_constexpr(
+                        0, NUM_EXPERTS_PER_LANE, 1
+                    ):
+                        if current_expert_idx == Int32(i * self.warp_threads) + lane_idx:
+                            valid_value = stored_num_tokens_per_expert[i]
+                    total_for_expert = cute.arch.shuffle_sync(
+                        valid_value, current_expert_idx % Int32(self.warp_threads)
+                    )
+                    expert_end_idx = expert_end_idx + total_for_expert
+
+            if current_expert_idx < Int32(self.num_experts_per_rank):
+                if old_expert_idx != current_expert_idx:
+                    if lane_idx < Int32(self.world_size):
+                        stored_rank_count_lane = Int32(
+                            expert_recv_count[lane_idx, current_expert_idx]
+                        )
+                    else:
+                        stored_rank_count_lane = Int32(0)
+
+                token_idx_in_expert = token_idx - expert_start_idx
+                slot_idx = token_idx_in_expert
+                offset = Int32(0)
+                remaining_lane = stored_rank_count_lane
+
+                current_rank_in_expert_idx = Int32(0)
+                token_idx_in_rank = Int32(0)
+
+                decided = Int32(0)
+                for _round in cutlass.range_constexpr(0, self.world_size + 1, 1):
+                    if decided == Int32(0):
+                        active = remaining_lane > Int32(0)
+                        mask = cute.arch.vote_ballot_sync(active)
+                        num_active_ranks = Int32(cute.arch.popc(Int32(mask)))
+                        v_for_min = Int32(0x7FFFFFFF)
+                        if active:
+                            v_for_min = remaining_lane
+                        length = Int32(
+                            cute.arch.warp_redux_sync(v_for_min, "min")
+                        )
+
+                        if num_active_ranks > Int32(0):
+                            num_round_tokens = length * num_active_ranks
+                            if slot_idx < num_round_tokens:
+                                slot_idx_in_round = slot_idx % num_active_ranks
+                                current_rank_in_expert_idx = fns_b32(
+                                    Int32(mask),
+                                    Int32(0),
+                                    slot_idx_in_round + Int32(1),
+                                )
+                                token_idx_in_rank = offset + (
+                                    slot_idx // num_active_ranks
+                                )
+                                decided = Int32(1)
+                            else:
+                                slot_idx = slot_idx - num_round_tokens
+                                offset = offset + length
+                                if remaining_lane > length:
+                                    remaining_lane = remaining_lane - length
+                                else:
+                                    remaining_lane = Int32(0)
+                        else:
+                            decided = Int32(1)
+
+                if _iket_pull_emit:
+                    _iket.range_pop()  # Pull.ChooseToken
+
+                src_token_topk = Uint32(
+                    src_token_topk_idx[
+                        current_expert_idx,
+                        current_rank_in_expert_idx,
+                        token_idx_in_rank,
+                    ]
+                )
+                skip_dup = Int32(0)
+                n_dup = Int32(0)
+                if cutlass.const_expr(self.dedup_dispatch):
+                    skip_dup = Int32((src_token_topk >> Uint32(28)) & Uint32(1))
+                    n_dup = Int32((src_token_topk >> Uint32(24)) & Uint32(0xF))
+                    src_token_topk = src_token_topk & Uint32(0x3FFFF)
+                src_token = Int32(src_token_topk // Uint32(self.num_topk))
+                src_topk = Int32(src_token_topk % Uint32(self.num_topk))
+
+                # DUP rows are fully delivered (data, SF, weight, metadata,
+                # arrival release) by the warp that pulls their PRIMARY, so
+                # their own iteration is a pure skip.
+                if skip_dup == Int32(0):
+                    if _iket_pull_emit:
+                        _iket.range_push("Pull.TMA_NVLink_Roundtrip")
+
+                    cur_peer_offset = peer_rank_ptr_mapper.map(
+                        Int64(0), current_rank_in_expert_idx, Int64(0)
+                    )
+                    inp_tok_local_base = input_token_buffer.iterator.toint()
+                    inp_sf_local_base = input_sf_buffer.iterator.toint()
+                    inp_w_local_base = input_topk_weights_buffer.iterator.toint()
+
+                    with cute.arch.elect_one():
+                        pull_buffer_warp_ptr = pull_buffer_ptr + (
+                            warp_idx * Int32(self.hidden_bytes)
+                        )
+                        tma_src_addr = (
+                            inp_tok_local_base
+                            + cur_peer_offset
+                            + Int64(src_token * Int32(self.hidden_bytes))
+                        )
+                        tma_load_1d_raw(
+                            pull_buffer_warp_ptr,
+                            tma_src_addr,
+                            pull_mbar_ptr + warp_idx,
+                            Int32(self.hidden_bytes),
+                        )
+                    cute.arch.sync_warp()
+
+                    if _iket_pull_emit:
+                        _iket.range_push("Pull.SF_LDG_STG")
+
+                    sf_token_in_pool_axis = (
+                        expert_sf_pool_block_offset * Int32(self.sf_padding_block)
+                        + token_idx_in_expert
+                    )
+                    pool_token_idx = (
+                        expert_pool_block_offset * Int32(self.token_padding_block)
+                        + token_idx_in_expert
+                    )
+                    sf_passes: cutlass.Constexpr[int] = (
+                        self.sf_uint32_per_token + 31
+                    ) // 32
+
+                    sf_vals = []
+                    for _ in cutlass.range_constexpr(0, sf_passes, 1):
+                        sf_vals.append(Int32(0))
+
+                    for i in cutlass.range_constexpr(0, sf_passes, 1):
+                        j = Int32(i * self.warp_threads) + lane_idx
+                        if j < Int32(self.sf_uint32_per_token):
+                            sf_addr = (
+                                inp_sf_local_base
+                                + cur_peer_offset
+                                + Int64(
+                                    (src_token * Int32(self.sf_uint32_per_token) + j)
+                                    * Int32(4)
+                                )
+                            )
+                            sf_vals[i] = ldg_b32_raw(sf_addr)
+
+                    weight = Float32(0.0)
+                    if lane_idx == Int32(0):
+                        weight_addr = (
+                            inp_w_local_base
+                            + cur_peer_offset
+                            + Int64(
+                                (src_token * Int32(self.num_topk) + src_topk) * Int32(4)
+                            )
+                        )
+                        weight = ldg_f32_raw(weight_addr)
+                    # Dedup: prefetch the token's whole topk-weight vector
+                    # (one coalesced remote read, overlapped with the TMA
+                    # round trip) so the fan-out never touches NVLink again.
+                    w_all = Float32(0.0)
+                    if cutlass.const_expr(self.dedup_dispatch):
+                        if n_dup > Int32(0) and lane_idx < Int32(self.num_topk):
+                            w_all_addr = (
+                                inp_w_local_base
+                                + cur_peer_offset
+                                + Int64(
+                                    (src_token * Int32(self.num_topk) + lane_idx)
+                                    * Int32(4)
+                                )
+                            )
+                            w_all = ldg_f32_raw(w_all_addr)
+
+                    if _iket_pull_emit:
+                        _iket.range_pop()  # Pull.SF_LDG_STG  (= LD phase)
+                        _iket.range_push("Pull.Weight_LDG")   # (= ST phase)
+
+                    for i in cutlass.range_constexpr(0, sf_passes, 1):
+                        j = Int32(i * self.warp_threads) + lane_idx
+                        if j < Int32(self.sf_uint32_per_token):
+                            sf_int32_pos = sf_atom_int32_offset(
+                                sf_token_in_pool_axis,
+                                j,
+                                num_k_atoms=self.sf_uint32_per_token,
+                            )
+                            fc1_input_sf_buffer[sf_int32_pos] = sf_vals[i]
+                    cute.arch.sync_warp()
+
+                    if lane_idx == Int32(0):
+                        fc1_input_topk_weights_buffer[pool_token_idx] = weight
+
+                    with cute.arch.elect_one():
+                        cute.arch.mbarrier_arrive_and_expect_tx(
+                            pull_mbar_ptr + warp_idx, Int32(self.hidden_bytes)
+                        )
+                        cute.arch.mbarrier_wait(
+                            pull_mbar_ptr + warp_idx,
+                            phase_bit,
+                        )
+
+                    if _iket_pull_emit:
+                        _iket.range_pop()  # Pull.Weight_LDG (ST phase)
+                        _iket.range_pop()  # Pull.TMA_NVLink_Roundtrip (outer)
+                        _iket.range_push("Pull.TMA_Store")
+
+                    with cute.arch.elect_one():
+                        pull_buffer_warp_ptr = pull_buffer_ptr + (
+                            warp_idx * Int32(self.hidden_bytes)
+                        )
+                        tma_store_1d(
+                            fc1_input_token_buffer.iterator
+                            # T=128k) × self.hidden_bytes overflows int32 (max 2.1 G).
+                            # 64-bit address math is required for large token pools.
+                            + (Int64(pool_token_idx) * Int64(self.hidden_bytes)),
+                            pull_buffer_warp_ptr,
+                            Int32(self.hidden_bytes),
+                        )
+
+                    # Combine pre-reduce: the primary (min-expert) row of a
+                    # group is always folded into the group's anchor, so its
+                    # own token-back push is skipped.
+                    p_consumed = Int32(0)
+                    if cutlass.const_expr(self.combine_pre_reduce):
+                        if n_dup > Int32(0):
+                            p_consumed = Int32(1)
+                    with cute.arch.elect_one():
+                        TokenSrcMetadata(
+                            src_rank=current_rank_in_expert_idx,
+                            src_token=src_token,
+                            src_topk=src_topk,
+                            consumed=p_consumed,
+                        ).store(
+                            token_src_metadata.iterator
+                            + Int64(pool_token_idx) * Int64(TokenSrcMetadata.nbytes)
+                        )
+
+                    with cute.arch.elect_one():
+                        cute.arch.cp_async_bulk_commit_group()
+                        cute.arch.cp_async_bulk_wait_group(0)
+
+                    if _iket_pull_emit:
+                        _iket.range_pop()  # Pull.TMA_Store
+                        _iket.range_push("Pull.Arrival_Atomic")
+
+                    # Accumulate this token's release target into the rotating-lane
+                    # batch tracker.  task_tile_idx is warp-uniform (token_idx /
+                    # expert offsets are warp-wide), so every lane runs the same
+                    # state-machine transition while only one lane records the
+                    # current address.
+                    task_tile_idx = expert_task_tile_offset + (
+                        token_idx_in_expert // Int32(self.cluster_tile_tokens)
+                    )
+
+                    task_tile_addr = (fc1_ready_counter.iterator + task_tile_idx).toint()
+                    flag_tracker = flag_tracker.accumulate(
+                        Int32(0), self._flag_batch, task_tile_addr,
+                    )
+                    cute.arch.sync_warp()
+
+                    if _iket_pull_emit:
+                        _iket.range_pop()  # Pull.Arrival_Atomic
+
+                    phase_bit = phase_bit ^ Int32(1)
+
+                    # ── Dedup fan-out ────────────────────────────────────
+                    # The token's data (and SF words) are still live in this
+                    # warp's smem pull buffer / registers; deliver every
+                    # duplicate pool row locally (flat dup_link list, no
+                    # pointer chasing).  All duplicate TMA stores share ONE
+                    # commit/drain, and their fc1-ready releases fire only
+                    # after that drain (same contract as the primary row).
+                    if cutlass.const_expr(self.dedup_dispatch and self.num_topk > 1):
+                        d_tile_addrs = []
+                        d_pool_rows = []
+                        link_words = []
+                        for _ in cutlass.range_constexpr(0, self.num_topk - 1, 1):
+                            d_tile_addrs.append(Int64(0))
+                            d_pool_rows.append(Int32(0))
+                            link_words.append(Int32(0))
+                        # Hoisted independent link reads + combine-anchor scan:
+                        # the group's anchor is its max-local-expert row (fc2
+                        # completes in ascending expert order, so when the
+                        # anchor's expert is done every partner row is ready).
+                        for ci in cutlass.range_constexpr(0, self.num_topk - 1, 1):
+                            if Int32(ci) < n_dup:
+                                link_words[ci] = Int32(
+                                    dup_link[
+                                        current_expert_idx,
+                                        current_rank_in_expert_idx,
+                                        token_idx_in_rank,
+                                        Int32(ci),
+                                    ]
+                                )
+                        max_e = Int32(-1)
+                        if cutlass.const_expr(self.combine_pre_reduce):
+                            for ci in cutlass.range_constexpr(
+                                0, self.num_topk - 1, 1
+                            ):
+                                if Int32(ci) < n_dup:
+                                    e_ci = (link_words[ci] >> Int32(18)) & Int32(0xFF)
+                                    if e_ci > max_e:
+                                        max_e = e_ci
+                        anchor_row = Int32(0)
+                        for ci in cutlass.range_constexpr(0, self.num_topk - 1, 1):
+                            d_valid = Int32(0)
+                            if Int32(ci) < n_dup:
+                                d_valid = Int32(1)
+                            link = link_words[ci]
+                            d_slot = link & Int32(0x3FFFF)
+                            d_e = (link >> Int32(18)) & Int32(0xFF)
+                            d_topk = (link >> Int32(26)) & Int32(0xF)
+
+                            # Invert the round-robin slot interleave: the dup's
+                            # index within its (expert, src_rank) stream ->
+                            # its row in the expert's pull-order stream.
+                            rem = Int32(0)
+                            if d_valid == Int32(1) and lane_idx < Int32(self.world_size):
+                                rem = Int32(expert_recv_count[lane_idx, d_e])
+                            inv_off = Int32(0)
+                            inv_base = Int32(0)
+                            d_tie = Int32(0)
+                            inv_done = Int32(0)
+                            if d_valid == Int32(0):
+                                inv_done = Int32(1)
+                            for _round in cutlass.range_constexpr(
+                                0, self.world_size + 1, 1
+                            ):
+                                if inv_done == Int32(0):
+                                    active = rem > Int32(0)
+                                    mask = cute.arch.vote_ballot_sync(active)
+                                    num_active_ranks = Int32(
+                                        cute.arch.popc(Int32(mask))
+                                    )
+                                    v_for_min = Int32(0x7FFFFFFF)
+                                    if active:
+                                        v_for_min = rem
+                                    length = Int32(
+                                        cute.arch.warp_redux_sync(v_for_min, "min")
+                                    )
+                                    if num_active_ranks > Int32(0):
+                                        r_active = (
+                                            Int32(mask) >> current_rank_in_expert_idx
+                                        ) & Int32(1)
+                                        if (r_active == Int32(1)) and (
+                                            d_slot < inv_off + length
+                                        ):
+                                            pos_r = Int32(
+                                                cute.arch.popc(
+                                                    Int32(mask)
+                                                    & (
+                                                        (Int32(1) << current_rank_in_expert_idx)
+                                                        - Int32(1)
+                                                    )
+                                                )
+                                            )
+                                            d_tie = (
+                                                inv_base
+                                                + (d_slot - inv_off) * num_active_ranks
+                                                + pos_r
+                                            )
+                                            inv_done = Int32(1)
+                                        else:
+                                            inv_base = (
+                                                inv_base + length * num_active_ranks
+                                            )
+                                            inv_off = inv_off + length
+                                            if rem > length:
+                                                rem = rem - length
+                                            else:
+                                                rem = Int32(0)
+                                    else:
+                                        inv_done = Int32(1)
+
+                            # Dup expert's pool/SF/task-tile base offsets from
+                            # the precomputed prefix arrays.
+                            sel_pool = Int32(0)
+                            sel_sf = Int32(0)
+                            sel_tile = Int32(0)
+                            for i in cutlass.range_constexpr(
+                                0, NUM_EXPERTS_PER_LANE, 1
+                            ):
+                                if d_e == Int32(i * self.warp_threads) + lane_idx:
+                                    sel_pool = pool_block_prefix[i]
+                                    sel_sf = sf_block_prefix[i]
+                                    sel_tile = task_tile_prefix[i]
+                            src_l = d_e % Int32(self.warp_threads)
+                            d_pool_block = cute.arch.shuffle_sync(sel_pool, src_l)
+                            d_sf_block = cute.arch.shuffle_sync(sel_sf, src_l)
+                            d_tile_base = cute.arch.shuffle_sync(sel_tile, src_l)
+                            d_pool_row = (
+                                d_pool_block * Int32(self.token_padding_block)
+                                + d_tie
+                            )
+                            d_sf_pos = (
+                                d_sf_block * Int32(self.sf_padding_block) + d_tie
+                            )
+
+                            # SF replica (values still in registers).
+                            for i in cutlass.range_constexpr(0, sf_passes, 1):
+                                j = Int32(i * self.warp_threads) + lane_idx
+                                if d_valid == Int32(1) and j < Int32(
+                                    self.sf_uint32_per_token
+                                ):
+                                    d_sf_int32_pos = sf_atom_int32_offset(
+                                        d_sf_pos,
+                                        j,
+                                        num_k_atoms=self.sf_uint32_per_token,
+                                    )
+                                    fc1_input_sf_buffer[d_sf_int32_pos] = sf_vals[i]
+
+                            # Dup's routing weight from the prefetched vector.
+                            d_weight = cute.arch.shuffle_sync(w_all, d_topk)
+                            if d_valid == Int32(1) and lane_idx == Int32(0):
+                                fc1_input_topk_weights_buffer[d_pool_row] = d_weight
+
+                            # Local data fan-out from the already-pulled smem
+                            # row (drained once, after the loop).
+                            # Combine pre-reduce roles: the max-expert dup is
+                            # the group's ANCHOR (sums n_dup partners: the
+                            # primary + every other dup); all other dups are
+                            # consumed.
+                            d_reduce_n = Int32(0)
+                            d_consumed = Int32(0)
+                            if cutlass.const_expr(self.combine_pre_reduce):
+                                if d_valid == Int32(1):
+                                    if d_e == max_e:
+                                        d_reduce_n = n_dup
+                                        anchor_row = d_pool_row
+                                    else:
+                                        d_consumed = Int32(1)
+
+                            if d_valid == Int32(1):
+                                with cute.arch.elect_one():
+                                    d_pull_src_ptr = pull_buffer_ptr + (
+                                        warp_idx * Int32(self.hidden_bytes)
+                                    )
+                                    tma_store_1d(
+                                        fc1_input_token_buffer.iterator
+                                        + (
+                                            Int64(d_pool_row)
+                                            * Int64(self.hidden_bytes)
+                                        ),
+                                        d_pull_src_ptr,
+                                        Int32(self.hidden_bytes),
+                                    )
+                                with cute.arch.elect_one():
+                                    TokenSrcMetadata(
+                                        src_rank=current_rank_in_expert_idx,
+                                        src_token=src_token,
+                                        src_topk=d_topk,
+                                        reduce_n=d_reduce_n,
+                                        consumed=d_consumed,
+                                    ).store(
+                                        token_src_metadata.iterator
+                                        + Int64(d_pool_row)
+                                        * Int64(TokenSrcMetadata.nbytes)
+                                    )
+
+                            d_task_tile = d_tile_base + (
+                                d_tie // Int32(self.cluster_tile_tokens)
+                            )
+                            if d_valid == Int32(1):
+                                d_tile_addrs[ci] = (
+                                    fc1_ready_counter.iterator + d_task_tile
+                                ).toint()
+                                # reduce_list entry: row | (local expert << 24)
+                                # (the anchor spins on each partner expert's
+                                # fc2_done before reading its row).
+                                d_pool_rows[ci] = d_pool_row | (d_e << Int32(24))
+                        cute.arch.sync_warp()
+
+                        # Combine pre-reduce: publish the anchor's partner
+                        # list (the primary row + every non-anchor dup row).
+                        # Written before the group's fc1-ready releases below,
+                        # so any consumer past fc2 observes it.
+                        if cutlass.const_expr(self.combine_pre_reduce):
+                            if n_dup > Int32(0) and lane_idx == Int32(0):
+                                r_idx = Int32(0)
+                                reduce_list[anchor_row, r_idx] = (
+                                    pool_token_idx
+                                    | (current_expert_idx << Int32(24))
+                                )
+                                r_idx = Int32(1)
+                                for ci in cutlass.range_constexpr(
+                                    0, self.num_topk - 1, 1
+                                ):
+                                    if (
+                                        Int32(ci) < n_dup
+                                        and (d_pool_rows[ci] & Int32(0xFFFFFF))
+                                        != anchor_row
+                                    ):
+                                        reduce_list[anchor_row, r_idx] = (
+                                            d_pool_rows[ci]
+                                        )
+                                        r_idx = r_idx + Int32(1)
+                            cute.arch.sync_warp()
+
+                        if n_dup > Int32(0):
+                            with cute.arch.elect_one():
+                                cute.arch.cp_async_bulk_commit_group()
+                                cute.arch.cp_async_bulk_wait_group(0)
+
+                        # Null addresses are no-ops inside the tracker's fire().
+                        for ci in cutlass.range_constexpr(0, self.num_topk - 1, 1):
+                            flag_tracker = flag_tracker.accumulate(
+                                Int32(0), self._flag_batch, d_tile_addrs[ci],
+                            )
+                        cute.arch.sync_warp()
+
+                token_idx = token_idx + Int32(num_global_warps)
+
+        # Tail flush: publish any leftover (< self._flag_batch) accumulated release.
+        flag_tracker.fire()
+        cute.arch.sync_warp()
+
+        return phase_bit, stored_num_tokens_per_expert
+
+    @cute.jit
+    def _adaptive_pace(
+        self,
+        avg,
+        current_window,
+        *,
+        lo: cutlass.Constexpr[int],
+        hi: cutlass.Constexpr[int],
+    ):
+        # NVLink pacing: EMA the measured round-trip and nanosleep the deviation
+        # so outstanding NVLink requests stay bounded and don't head-of-line
+        # block this SM's non-NVLink (local) load/store traffic.
+        if current_window > avg:
+            avg = avg + ((current_window - avg + Int32(3)) // Int32(4))
+            sleep_cycle = current_window - avg
+            if sleep_cycle > Int32(hi):
+                sleep_cycle = Int32(hi)
+            if sleep_cycle > Int32(50):
+                _nanosleep(sleep_cycle)
+        else:
+            avg = avg - ((avg - current_window + Int32(3)) // Int32(4))
+            sleep_cycle = avg - current_window
+            if sleep_cycle > Int32(50):
+                _nanosleep(sleep_cycle)
+        if avg > Int32(hi):
+            avg = Int32(hi)
+        if avg < Int32(lo):
+            avg = Int32(lo)
+        return avg
+
+    @cute.jit
+    def token_back_by_push(
+        self,
+        pull_buffer_ptr,
+        pull_mbar_ptr,
+        fc2_output_workspace,
+        fc2_done_counter,
+        token_src_metadata,
+        combine_output,
+        combine_sf,
+        fc2_output_sf,
+        token_back_schedule_counter,
+        peer_rank_ptr_mapper,
+        phase_bit,
+        stored_num_tokens_per_expert,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        *,
+        local_rank,
+        num_sms,
+        chunk_bytes: cutlass.Constexpr[int],
+        reduce_list=None,
+    ):
+        _iket_emit = (sm_idx == Int32(0)) and (warp_idx == Int32(0))
+        avg_token_back_window = Int32(2500)
+
+        # Chunk the fc2 token in ``chunk_bytes`` pieces; the last piece carries
+        # the remainder so any chunk_bytes works for any fc2_token_bytes.
+        fc2_token_bytes: cutlass.Constexpr[int] = self.fc2_token_bytes
+        num_chunks: cutlass.Constexpr[int] = (
+            fc2_token_bytes + chunk_bytes - 1
+        ) // chunk_bytes
+        last_chunk_bytes: cutlass.Constexpr[int] = (
+            fc2_token_bytes - (num_chunks - 1) * chunk_bytes
+        )
+
+        if cutlass.const_expr(self.push_sf):
+            # (token, topk, hidden):(d_topkxhidden, d_hidden, 1)
+            combine_sf_u8 = cute.recast_tensor(combine_sf, Uint8)
+            sf_token_bytes: cutlass.Constexpr[int] = cute.size(combine_sf_u8[0, None, 0].stride)
+            num_sf_chunks: cutlass.Constexpr[int] = (
+                sf_token_bytes + chunk_bytes - 1
+            ) // chunk_bytes
+            last_sf_chunk_bytes: cutlass.Constexpr[int] = (
+                sf_token_bytes - (num_sf_chunks - 1) * chunk_bytes
+            )
+
+        num_experts_per_lane: cutlass.Constexpr[int] = (
+            self.num_experts_per_rank + 31
+        ) // 32
+        num_global_warps: cutlass.Constexpr[int] = (
+            num_sms * self.num_dispatch_warps
+        )
+        schedule_mode = self.token_back_schedule_mode
+        atomic_batch = self.token_back_atomic_batch
+
+        # static: stride by the global warp count.  atomic_counter: consume one
+        # slot of the current batch, refilling via one grid-scoped
+        # atomicAdd(atomic_batch) when exhausted so fast warps keep stealing
+        # work.  cuTeDSL forbids closures over enclosing locals -> pass all in.
+        def update_token_idx(
+            token_idx, batch_remaining, lane_idx, schedule_counter,
+            schedule_mode, atomic_batch, num_global_warps,
+        ):
+            if cutlass.const_expr(schedule_mode == "atomic_counter"):
+                batch_remaining = batch_remaining - Int32(1)
+                if batch_remaining == Int32(0):
+                    base = Int32(0)
+                    if lane_idx == Int32(0):
+                        base = cute.arch.atomic_add(
+                            schedule_counter, Int32(atomic_batch),
+                            sem="relaxed", scope="gpu",
+                        )
+                    token_idx = cute.arch.shuffle_sync(base, Int32(0))
+                    batch_remaining = Int32(atomic_batch)
+                else:
+                    token_idx = token_idx + Int32(1)
+            else:
+                token_idx = token_idx + Int32(num_global_warps)
+            return token_idx, batch_remaining
+
+        if cutlass.const_expr(schedule_mode == "atomic_counter"):
+            # Prime the first batch: batch_remaining=1 makes update_token_idx
+            # decrement to 0 and pull the initial atomic batch.
+            token_idx = Int32(0)
+            batch_remaining = Int32(1)
+            token_idx, batch_remaining = update_token_idx(
+                token_idx, batch_remaining, lane_idx,
+                token_back_schedule_counter,
+                schedule_mode, atomic_batch, num_global_warps,
+            )
+        else:
+            token_idx = sm_idx * Int32(self.num_dispatch_warps) + warp_idx
+            batch_remaining = Int32(0)
+
+        current_expert_idx = Int32(-1)
+        confirmed_expert_idx = Int32(-1)
+        cur_expert_expected = Int32(0)
+        expert_start_idx = Int32(0)
+        expert_end_idx = Int32(0)
+        expert_pool_block_offset = Int32(0)
+
+        while current_expert_idx < Int32(self.num_experts_per_rank):
+            while (token_idx >= expert_end_idx) and (
+                current_expert_idx < Int32(self.num_experts_per_rank)
+            ):
+                prev_valid_count = expert_end_idx - expert_start_idx
+                prev_block_count = (
+                    prev_valid_count + Int32(self.token_padding_block) - Int32(1)
+                ) // Int32(self.token_padding_block)
+                expert_pool_block_offset = (
+                    expert_pool_block_offset + prev_block_count
+                )
+
+                current_expert_idx = current_expert_idx + Int32(1)
+                if current_expert_idx < Int32(self.num_experts_per_rank):
+                    expert_start_idx = expert_end_idx
+                    valid_value = Int32(0)
+                    for i in cutlass.range_constexpr(
+                        0, num_experts_per_lane, 1
+                    ):
+                        if current_expert_idx == Int32(
+                            i * self.warp_threads
+                        ) + lane_idx:
+                            valid_value = stored_num_tokens_per_expert[i]
+                    total_for_expert = cute.arch.shuffle_sync(
+                        valid_value,
+                        current_expert_idx % Int32(self.warp_threads),
+                    )
+                    expert_end_idx = expert_end_idx + total_for_expert
+
+                    cluster_tile_cnt = (
+                        total_for_expert
+                        + Int32(self.cluster_tile_tokens)
+                        - Int32(1)
+                    ) // Int32(self.cluster_tile_tokens)
+                    # Stash the threshold; the wait is deferred to the expert we
+                    # actually land on, so stepped-over experts are never waited.
+                    cur_expert_expected = cluster_tile_cnt * Int32(
+                        self.fc2_publishes_per_token_cluster_tile
+                    )
+
+            if current_expert_idx < Int32(self.num_experts_per_rank):
+                # Wait once per processed expert (both indices monotonic; fc2
+                # completes in expert order so confirming k implies all < k).
+                if current_expert_idx > confirmed_expert_idx:
+                    spin_wait(
+                        fc2_done_counter.iterator + current_expert_idx,
+                        lambda v: v >= cur_expert_expected,
+                        fail_sleep_cycles=500,
+                    )
+                    confirmed_expert_idx = current_expert_idx
+
+                remain_experts = Int32(self.num_experts_per_rank) - current_expert_idx
+                token_idx_in_expert = token_idx - expert_start_idx
+                pool_token_idx = (
+                    expert_pool_block_offset * Int32(self.token_padding_block)
+                    + token_idx_in_expert
+                )
+
+                md = TokenSrcMetadata.load(
+                    token_src_metadata.iterator
+                    + Int64(pool_token_idx) * Int64(TokenSrcMetadata.nbytes)
+                )
+                src_rank = md.src_rank
+                src_token = md.src_token
+                src_topk = md.src_topk
+                is_remote_token_back = src_rank != Int32(local_rank)
+                # Combine pre-reduce roles (zero everywhere when disabled).
+                md_consumed = Int32(0)
+                md_reduce_n = Int32(0)
+                if cutlass.const_expr(self.combine_pre_reduce):
+                    md_consumed = md.consumed
+                    md_reduce_n = md.reduce_n
+
+                smem_ptr_warp = pull_buffer_ptr + warp_idx * Int32(chunk_bytes)
+                mbar_ptr_warp = pull_mbar_ptr + warp_idx
+
+                if _iket_emit:
+                    _iket.range_push("token_back")
+                cute.arch.sync_warp()
+
+                # DATA plane: only the dispatch DATA path pushes here; epi_warps
+                # has the epilogue STG/UBLK the data straight to the peer.
+                # Combine pre-reduce: CONSUMED rows push nothing (their output
+                # is folded into their group's anchor row below), and an ANCHOR
+                # first accumulates its partner rows locally (HBM bulk-add)
+                # before its single cross-rank REDG push.  Partner rows'
+                # fc2 outputs are complete: the anchor lives in the group's
+                # max expert and fc2 completes in ascending expert order.
+                if cutlass.const_expr(self.push_data):
+                    local_token_addr = (
+                        fc2_output_workspace.iterator.toint()
+                        + Int64(pool_token_idx) * Int64(fc2_token_bytes)
+                    )
+                    if cutlass.const_expr(self.combine_pre_reduce):
+                        if md_reduce_n > Int32(0):
+                            for pi in cutlass.range_constexpr(
+                                0, self.num_topk - 1, 1
+                            ):
+                                if Int32(pi) < md_reduce_n:
+                                    p_word = Int32(
+                                        reduce_list[pool_token_idx, Int32(pi)]
+                                    )
+                                    p_row = p_word & Int32(0xFFFFFF)
+                                    p_e = (p_word >> Int32(24)) & Int32(0xFF)
+                                    # fc2 completion is only tracked per
+                                    # expert; the partner lives in an earlier
+                                    # expert than this anchor, so wait on ITS
+                                    # counter before reading its row.
+                                    p_cnt = Int32(0)
+                                    for i in cutlass.range_constexpr(
+                                        0, num_experts_per_lane, 1
+                                    ):
+                                        if p_e == Int32(
+                                            i * self.warp_threads
+                                        ) + lane_idx:
+                                            p_cnt = stored_num_tokens_per_expert[i]
+                                    p_total = cute.arch.shuffle_sync(
+                                        p_cnt, p_e % Int32(self.warp_threads)
+                                    )
+                                    p_expected = (
+                                        (
+                                            p_total
+                                            + Int32(self.cluster_tile_tokens)
+                                            - Int32(1)
+                                        )
+                                        // Int32(self.cluster_tile_tokens)
+                                    ) * Int32(
+                                        self.fc2_publishes_per_token_cluster_tile
+                                    )
+                                    spin_wait(
+                                        fc2_done_counter.iterator + p_e,
+                                        lambda v: v >= p_expected,
+                                        fail_sleep_cycles=500,
+                                    )
+                                    p_addr = (
+                                        fc2_output_workspace.iterator.toint()
+                                        + Int64(p_row) * Int64(fc2_token_bytes)
+                                    )
+                                    for chunk in cutlass.range(
+                                        num_chunks, unroll=1
+                                    ):
+                                        chunk_off = Int64(chunk * chunk_bytes)
+                                        this_bytes = Int32(chunk_bytes)
+                                        if cutlass.const_expr(
+                                            last_chunk_bytes != chunk_bytes
+                                        ):
+                                            if chunk == Int32(num_chunks - 1):
+                                                this_bytes = Int32(last_chunk_bytes)
+                                        with cute.arch.elect_one():
+                                            tma_load_1d_raw(
+                                                smem_ptr_warp,
+                                                p_addr + chunk_off,
+                                                mbar_ptr_warp,
+                                                this_bytes,
+                                            )
+                                            cute.arch.mbarrier_arrive_and_expect_tx(
+                                                mbar_ptr_warp, this_bytes,
+                                            )
+                                            cute.arch.mbarrier_wait(
+                                                mbar_ptr_warp, phase_bit,
+                                            )
+                                            cp_reduce_async_bulk_add_noftz_bf16_s2g(
+                                                fc2_output_workspace.iterator
+                                                + (
+                                                    Int64(pool_token_idx)
+                                                    * Int64(fc2_token_bytes)
+                                                    + chunk_off
+                                                ),
+                                                smem_ptr_warp,
+                                                this_bytes,
+                                            )
+                                        phase_bit = phase_bit ^ Int32(1)
+                                        cute.arch.cp_async_bulk_commit_group()
+                                        cute.arch.cp_async_bulk_wait_group(0)
+                    peer_combine_ptr = peer_rank_ptr_mapper.ptr_map_to_rank(
+                        combine_output.iterator, src_rank,
+                    )
+                    if cutlass.const_expr(self.token_back_reduce_topk):
+                        peer_token_offset = Int64(src_token) * Int64(fc2_token_bytes)
+                    else:
+                        peer_token_offset = (
+                            Int64(src_token * Int32(self.num_topk) + src_topk)
+                            * Int64(fc2_token_bytes)
+                        )
+                    peer_token_ptr = peer_combine_ptr + peer_token_offset
+
+                    for chunk in cutlass.range(num_chunks, unroll=1):
+                        t0 = read_clock64()
+                        chunk_off = Int64(chunk * chunk_bytes)
+                        peer_chunk_ptr = peer_token_ptr + chunk_off
+
+                        this_bytes = Int32(chunk_bytes)
+                        if cutlass.const_expr(last_chunk_bytes != chunk_bytes):
+                            if chunk == Int32(num_chunks - 1):
+                                this_bytes = Int32(last_chunk_bytes)
+
+                        if md_consumed == Int32(0):
+                            with cute.arch.elect_one():
+                                tma_load_1d_raw(
+                                    smem_ptr_warp,
+                                    local_token_addr + chunk_off,
+                                    mbar_ptr_warp,
+                                    this_bytes,
+                                )
+                                cute.arch.mbarrier_arrive_and_expect_tx(
+                                    mbar_ptr_warp, this_bytes,
+                                )
+                                cute.arch.mbarrier_wait(mbar_ptr_warp, phase_bit)
+                                if cutlass.const_expr(self.token_back_reduce_topk):
+                                    cp_reduce_async_bulk_add_noftz_bf16_s2g(
+                                        peer_chunk_ptr,
+                                        smem_ptr_warp,
+                                        this_bytes,
+                                    )
+                                else:
+                                    tma_store_1d(
+                                        peer_chunk_ptr,
+                                        smem_ptr_warp,
+                                        this_bytes,
+                                    )
+                            phase_bit = phase_bit ^ Int32(1)
+                            cute.arch.cp_async_bulk_commit_group()
+                            cute.arch.cp_async_bulk_wait_group(0)
+                            t1 = read_clock64()
+                            current_window = Int32(t1 - t0)
+                            if is_remote_token_back and remain_experts > Int32(4):
+                                avg_token_back_window = self._adaptive_pace(
+                                    avg_token_back_window, current_window,
+                                    lo=1000, hi=5000,
+                                )
+
+                if cutlass.const_expr(self.push_sf):
+                    sf_local_addr = fc2_output_sf[pool_token_idx, 0, None].iterator.toint()
+                    sf_peer_ptr = peer_rank_ptr_mapper.ptr_map_to_rank(
+                        combine_sf_u8[src_token, src_topk, None].iterator, src_rank,
+                    )
+                    for chunk in cutlass.range(num_sf_chunks, unroll=1):
+                        t0 = read_clock64()
+                        chunk_off = Int64(chunk * chunk_bytes)
+                        this_bytes = Int32(chunk_bytes)
+                        if cutlass.const_expr(last_sf_chunk_bytes != chunk_bytes):
+                            if chunk == Int32(num_sf_chunks - 1):
+                                this_bytes = Int32(last_sf_chunk_bytes)
+                        with cute.arch.elect_one():
+                            tma_load_1d_raw(
+                                smem_ptr_warp,
+                                sf_local_addr + chunk_off,
+                                mbar_ptr_warp,
+                                this_bytes,
+                            )
+                            cute.arch.mbarrier_arrive_and_expect_tx(
+                                mbar_ptr_warp, this_bytes,
+                            )
+                            cute.arch.mbarrier_wait(mbar_ptr_warp, phase_bit)
+                            tma_store_1d(
+                                sf_peer_ptr + chunk_off,
+                                smem_ptr_warp,
+                                this_bytes,
+                            )
+                        phase_bit = phase_bit ^ Int32(1)
+                        cute.arch.cp_async_bulk_commit_group()
+                        cute.arch.cp_async_bulk_wait_group(0)
+                        if is_remote_token_back:
+                            round_trip = Int32(read_clock64() - t0)
+                            if round_trip <= this_bytes * Int32(5) // Int32(4):
+                                _nanosleep(this_bytes // Int32(4))
+
+                if _iket_emit:
+                    _iket.range_pop()
+
+                token_idx, batch_remaining = update_token_idx(
+                    token_idx, batch_remaining, lane_idx,
+                    token_back_schedule_counter,
+                    schedule_mode, atomic_batch, num_global_warps,
+                )
+
+        cute.arch.fence_acq_rel_sys()
+        # _fence_rel_sys()
+
+    @cute.jit
+    def nvlink_barrier(
+        self,
+        nvlink_barrier_signal,
+        nvlink_barrier_counter,
+        grid_sync_counter,
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        *,
+        num_sms,
+        prologue_grid_sync: cutlass.Constexpr[bool],
+        epilogue_grid_sync: cutlass.Constexpr[bool],
+    ):
+        # software_grid_sync expects a dispatch-group-relative thread id.
+        tid_in_group = warp_idx * Int32(self.warp_threads) + lane_idx
+
+        if prologue_grid_sync:
+            software_grid_sync(grid_sync_counter, sm_idx, num_sms, tid_in_group,
+                               num_threads=self.num_dispatch_threads)
+
+        if sm_idx == 0:
+            if warp_idx == 0:
+                # Sense-reversing ping-pong barrier. The low 2 bits of the counter
+                # pick the signal slot (phase 0/1) and the direction (+1 up to
+                # world_size, then -1 back to 0), so the two slots self-cancel over
+                # a 4-call cycle and never need an explicit reset -- required
+                # because the signal is symmetric peer memory that ncu kernel
+                # replay cannot snapshot/restore.
+                status = nvlink_barrier_counter[0] & Int32(3)
+                signal_phase = status & Int32(1)
+                signal_sign = status >> Int32(1)
+                signal_delta = Int32(1)
+                target = Int32(self.world_size)
+                if signal_sign != Int32(0):
+                    signal_delta = Int32(-1)
+                    target = Int32(0)
+
+                nbs_local_base = nvlink_barrier_signal.iterator.toint()
+                if lane_idx < Int32(self.world_size):
+                    lane_peer_addr = peer_rank_ptr_mapper.map(
+                        nbs_local_base, lane_idx,
+                        Int64(signal_phase * Int32(4)),
+                    )
+                    red_add_release_sys_s32_raw(lane_peer_addr, signal_delta)
+                cute.arch.sync_warp()
+
+                if lane_idx == 0:
+                    cute.arch.atomic_add(
+                        nvlink_barrier_counter.iterator,
+                        Int32(1),
+                        sem="relaxed",
+                        scope="gpu",
+                    )
+                    local_signal_ptr = nvlink_barrier_signal.iterator + signal_phase
+                    while cute.arch.load(local_signal_ptr, Int32, sem="acquire", scope="sys") != target:
+                        pass
+
+        if epilogue_grid_sync:
+            software_grid_sync(grid_sync_counter, sm_idx, num_sms, tid_in_group,
+                               num_threads=self.num_dispatch_threads)
+
+    @cute.jit
+    def dispatch_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        bidx, bidy, bidz = cute.arch.block_idx()
+        cta_linear_id = (
+            Int32(bidx)
+            + Int32(self.cluster_shape_mn[1]) * Int32(bidy)
+            + Int32(self.cluster_shape_mn[1] * self.cluster_shape_mn[0])
+            * Int32(bidz)
+        )
+        local_warp_idx = Int32(warp_idx) - Int32(self.dispatch_warp_start)
+
+        iket_active = (cta_linear_id == Int32(0)) and (local_warp_idx == Int32(0))
+        if iket_active:
+            _iket.range_push("Dispatch_Prep")
+
+        self.dispatch_prep(
+            token_comm_storage,
+            token_comm_args.topk_idx,
+            token_comm_args.expert_send_count,
+            token_comm_args.src_token_topk_idx,
+            token_comm_args.peer_rank_ptr_mapper,
+            cta_linear_id,
+            local_warp_idx,
+            lane_idx,
+            local_rank=token_comm_args.local_rank,
+            num_tokens=token_comm_args.input_token_buffer.shape[0],
+            num_sms=token_comm_args.sm_count,
+            dup_link=token_comm_args.dup_link,
+        )
+
+        if iket_active:
+            _iket.range_pop()
+            _iket.range_push("Dispatch_Barrier")
+
+        self.dispatch_barrier(
+            token_comm_args.expert_send_count,
+            token_comm_args.expert_recv_count,
+            token_comm_args.expert_recv_count_sum,
+            token_comm_args.nvlink_barrier_signal,
+            token_comm_args.grid_sync_counter,
+            token_comm_args.peer_rank_ptr_mapper,
+            cta_linear_id,
+            local_warp_idx,
+            lane_idx,
+            local_rank=token_comm_args.local_rank,
+            num_sms=token_comm_args.sm_count,
+            nvlink_barrier_counter=token_comm_args.nvlink_barrier_counter,
+        )
+
+        nb_dispatch_to_sched = pipeline.NamedBarrier(
+            barrier_id=self.dispatch_to_sched_named_barrier_id,
+            num_threads=self.dispatch_to_sched_threads,
+        )
+        nb_dispatch_to_sched.arrive()
+
+        if iket_active:
+            _iket.range_pop()
+            _iket.range_push("Dispatch_Pull")
+
+        phase_bit, stored_num_tokens_per_expert = self.dispatch_pull(
+            token_comm_storage,
+            token_comm_args.input_token_buffer,
+            token_comm_args.input_sf_buffer,
+            token_comm_args.input_topk_weights_buffer,
+            token_comm_args.src_token_topk_idx,
+            token_comm_args.expert_recv_count,
+            token_comm_args.expert_recv_count_sum,
+            token_comm_args.fc1_input_token_buffer,
+            token_comm_args.fc1_input_sf_buffer,
+            token_comm_args.fc1_input_topk_weights_buffer,
+            token_comm_args.fc1_ready_counter,
+            token_comm_args.token_src_metadata,
+            token_comm_args.peer_rank_ptr_mapper,
+            cta_linear_id,
+            local_warp_idx,
+            lane_idx,
+            num_sms=token_comm_args.sm_count,
+            dup_link=token_comm_args.dup_link,
+            reduce_list=token_comm_args.reduce_list,
+        )
+
+        if iket_active:
+            _iket.range_pop()
+
+        if cutlass.const_expr(self.enable_token_back and not self.token_back_standalone):
+            if iket_active:
+                _iket.range_push("Token_Back_By_Push")
+
+            self.token_back_by_push(
+                token_comm_storage.pull_buffer.data_ptr(),
+                token_comm_storage.pull_mbar.data_ptr(),
+                token_comm_args.fc2_output_workspace,
+                token_comm_args.fc2_done_counter,
+                token_comm_args.token_src_metadata,
+                token_comm_args.combine_output,
+                token_comm_args.combine_sf,
+                token_comm_args.fc2_output_sf,
+                token_comm_args.token_back_schedule_counter,
+                token_comm_args.peer_rank_ptr_mapper,
+                phase_bit,
+                stored_num_tokens_per_expert,
+                cta_linear_id,
+                local_warp_idx,
+                lane_idx,
+                local_rank=token_comm_args.local_rank,
+                num_sms=token_comm_args.sm_count,
+                chunk_bytes=self.hidden_bytes,
+                reduce_list=token_comm_args.reduce_list,
+            )
+
+            if iket_active:
+                _iket.range_pop()
+
+    @cute.jit
+    def token_back_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        bidx, bidy, bidz = cute.arch.block_idx()
+        cta_linear_id = (
+            Int32(bidx)
+            + Int32(self.cluster_shape_mn[1]) * Int32(bidy)
+            + Int32(self.cluster_shape_mn[1] * self.cluster_shape_mn[0])
+            * Int32(bidz)
+        )
+        local_warp_idx = Int32(warp_idx) - Int32(self.token_back_warp_start)
+
+        # Handshake: dispatch_barrier done => expert_recv_count_sum populated.
+        nb_dispatch_to_sched = pipeline.NamedBarrier(
+            barrier_id=self.dispatch_to_sched_named_barrier_id,
+            num_threads=self.dispatch_to_sched_threads,
+        )
+        nb_dispatch_to_sched.arrive_and_wait()
+
+        tb_pull_mbar_ptr = token_comm_storage.tb_pull_mbar.data_ptr()
+        tb_pull_buffer_ptr = token_comm_storage.tb_pull_buffer.data_ptr()
+        if lane_idx == Int32(0):
+            cute.arch.mbarrier_init(tb_pull_mbar_ptr + local_warp_idx, 1)
+        cute.arch.sync_warp()
+
+        NUM_EXPERTS_PER_LANE: cutlass.Constexpr[int] = (
+            self.num_experts_per_rank + 31
+        ) // 32
+        stored_num_tokens_per_expert = []
+        for _ in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+            stored_num_tokens_per_expert.append(Int32(0))
+        for i in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+            e_idx_for_lane = Int32(i * self.warp_threads) + lane_idx
+            if e_idx_for_lane < Int32(self.num_experts_per_rank):
+                sum_packed_init = token_comm_args.expert_recv_count_sum[e_idx_for_lane]
+                stored_num_tokens_per_expert[i] = Int32(
+                    Int64(sum_packed_init) & Int64(0xFFFFFFFF)
+                )
+        cute.arch.sync_warp()
+
+        iket_active = (cta_linear_id == Int32(0)) and (local_warp_idx == Int32(0))
+        if iket_active:
+            _iket.range_push("Token_Back_By_Push_Standalone")
+
+        self.token_back_by_push(
+            tb_pull_buffer_ptr,
+            tb_pull_mbar_ptr,
+            token_comm_args.fc2_output_workspace,
+            token_comm_args.fc2_done_counter,
+            token_comm_args.token_src_metadata,
+            token_comm_args.combine_output,
+            token_comm_args.combine_sf,
+            token_comm_args.fc2_output_sf,
+            token_comm_args.token_back_schedule_counter,
+            token_comm_args.peer_rank_ptr_mapper,
+            Int32(0),
+            stored_num_tokens_per_expert,
+            cta_linear_id,
+            local_warp_idx,
+            lane_idx,
+            local_rank=token_comm_args.local_rank,
+            num_sms=token_comm_args.sm_count,
+            chunk_bytes=self.tb_chunk_bytes,
+            reduce_list=token_comm_args.reduce_list,
+        )
+
+        if iket_active:
+            _iket.range_pop()
+
+    @cute.jit
+    def tail_reset_counters(
+        self,
+        token_comm_args,
+        target_zero_tensor,
+        *,
+        cta_linear_id,
+        local_warp_idx,
+        lane_idx,
+    ):
+        """Per-lane 4B (Int32) bulk-zero of one accumulating-counter prefix.
+
+        ``target_zero_tensor`` is an Int32 view over a workspace's front counter
+        region (megamoe_kernel front-places every counter that must restart at 0
+        each launch; data buffers and the phase-flip ``nvlink_barrier_signal`` sit
+        after the prefix and are untouched). The zeroing is spread across all
+        dispatch threads grid-wide. kernel_tail calls this twice:
+          * SHARED prefix (expert_recv_count / _sum) BETWEEN the two nvlink
+            barriers, so the final barrier publishes the zeros cross-rank -- needed
+            when the next launch is another MegaMoE reusing the shared workspace
+            with no intervening rank sync;
+          * LOCAL prefix (l1_arrival / expert_send / grid_sync / nvlink_barrier /
+            fc1_done [+ fc2_done / token_back_schedule / load_balance]) AFTER the
+            last barrier -- rank-local (next kernel sees it via stream order) and
+            grid_sync/nvlink barrier counters stay live until that last barrier.
+        Only the FIRST launch relies on a caller-zeroed workspace.
+        """
+        thread_linear = (
+            (cta_linear_id * Int32(self.num_dispatch_warps) + local_warp_idx)
+            * Int32(self.warp_threads)
+            + lane_idx
+        )
+        stride = Int32(token_comm_args.sm_count * self.num_dispatch_threads)
+
+        count = cute.size(target_zero_tensor)
+        i = thread_linear
+        while i < Int32(count):
+            target_zero_tensor[i] = Int32(0)
+            i = i + stride
+
+    @cute.jit
+    def kernel_tail(
+        self,
+        token_comm_args,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        nb_kernel_tail = pipeline.NamedBarrier(
+            barrier_id=self.kernel_tail_named_barrier_id,
+            num_threads=self.kernel_tail_threads,
+        )
+        nb_kernel_tail.arrive_and_wait()
+
+        # Only the dispatch warps run NVLink cleanup; standalone token-back
+        # warps (>= token_back_warp_start) just join the rendezvous above.
+        if (warp_idx >= self.dispatch_warp_start) and (
+            warp_idx < self.dispatch_warp_start + self.num_dispatch_warps
+        ):
+            bidx, bidy, bidz = cute.arch.block_idx()
+            cta_linear_id = (
+                Int32(bidx)
+                + Int32(self.cluster_shape_mn[1]) * Int32(bidy)
+                + Int32(self.cluster_shape_mn[1] * self.cluster_shape_mn[0])
+                * Int32(bidz)
+            )
+            local_warp_idx = Int32(warp_idx) - Int32(self.dispatch_warp_start)
+            # Per-launch nvlink barrier count must be a multiple of 4 so the
+            # sense-reversing signal self-cancels back to its start state. The
+            # launch already does 1 (dispatch_barrier) + 2 below (drain + publish,
+            # around the shared reset) = 3. Under ncu kernel replay the signal is
+            # cross-device and can't be restored across passes, so pad with one
+            # extra drain to reach 4. Non-ncu rides the phase counter across launch
+            # boundaries and needs only 3.
+            #
+            # MEGA_USE_NCU is a dev-only profiling hack -- read inline here on
+            # purpose: it is never exposed to customers and the ncu path is not
+            # kept in production, so it must NOT become a constructor field or a
+            # kernel-name constexpr.
+            if cutlass.const_expr(os.environ.get("MEGA_USE_NCU", "0") == "1"):
+                self.nvlink_barrier(
+                    token_comm_args.nvlink_barrier_signal,
+                    token_comm_args.nvlink_barrier_counter,
+                    token_comm_args.grid_sync_counter,
+                    token_comm_args.peer_rank_ptr_mapper,
+                    cta_linear_id,
+                    local_warp_idx,
+                    lane_idx,
+                    num_sms=token_comm_args.sm_count,
+                    prologue_grid_sync=True,
+                    epilogue_grid_sync=True,
+                )
+            self.nvlink_barrier(
+                token_comm_args.nvlink_barrier_signal,
+                token_comm_args.nvlink_barrier_counter,
+                token_comm_args.grid_sync_counter,
+                token_comm_args.peer_rank_ptr_mapper,
+                cta_linear_id,
+                local_warp_idx,
+                lane_idx,
+                num_sms=token_comm_args.sm_count,
+                prologue_grid_sync=True,
+                epilogue_grid_sync=True,
+            )
+            # Shared counters between the barriers: the slot=0 barrier below
+            # publishes these zeros cross-rank for a back-to-back MegaMoE relaunch.
+            self.tail_reset_counters(
+                token_comm_args,
+                token_comm_args.shared_zero_prefix,
+                cta_linear_id=cta_linear_id,
+                local_warp_idx=local_warp_idx,
+                lane_idx=lane_idx,
+            )
+            self.nvlink_barrier(
+                token_comm_args.nvlink_barrier_signal,
+                token_comm_args.nvlink_barrier_counter,
+                token_comm_args.grid_sync_counter,
+                token_comm_args.peer_rank_ptr_mapper,
+                cta_linear_id,
+                local_warp_idx,
+                lane_idx,
+                num_sms=token_comm_args.sm_count,
+                prologue_grid_sync=True,
+                epilogue_grid_sync=True,
+            )
+            # Local counters last: rank-local, and grid_sync/nvlink_barrier
+            # counters above stay live until this final barrier completes.
+            self.tail_reset_counters(
+                token_comm_args,
+                token_comm_args.local_zero_prefix,
+                cta_linear_id=cta_linear_id,
+                local_warp_idx=local_warp_idx,
+                lane_idx=lane_idx,
+            )

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/BWD_DESIGN.md
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/BWD_DESIGN.md
@@ -1,0 +1,261 @@
+# fp8 bprop megakernel — design
+
+Goal: replace `megamoe/fp8_bwd.py` (manual torch mxfp8 backward, 7.34 ms hot)
+with a CuTe DSL backward megakernel in the mold of the forward
+(`cutedsl_megamoe/moe_mxfp8_glu/megamoe_kernel_mxfp8.py`). Budget from
+`bench/bench_fair_bprop` @ T=16384 H=2048 I=1024 E=8 K=2, GB200 world=1:
+
+    fp8 bwd today: gemm 0.58 | comm-adj 1.84 | dispatch 1.33 | elemwise 1.30
+                   | prep 1.21 | act-quant 1.04  = 7.34 ms
+    bf16-EP bwd baseline: 3.82 ms      fused-equivalent floor: ~3.7 ms
+
+Everything outside the GEMMs is glue the megakernel absorbs, exactly like the
+forward did (0.45 vs 2.45 ms).
+
+## The adjoint is the forward dataflow
+
+Per dispatched copy the forward computes (tw folded into fc1 epilogue,
+`apply_topk_in_fc1=True`):
+
+    g = x@Wg, u = x@Wu   (one interleaved GEMM vs w13)
+    A = tw * silu(g) * u
+    y_copy = A @ W2                       out = sum_k y_copy   (TopkReduce)
+
+Backward for the same copy, given dout at the source rank:
+
+    dA  = tw * (dout @ W2^T)              <- GEMM1, tw via apply_topk_in_fc1
+    dg  = dA * u * s(g)(1 + g(1-s(g)))    <- elemwise, s = sigmoid
+    du  = dA * silu(g)                       needs RAW g,u  == fc1_c stash
+    dx_copy = [du,dg] @ W13               <- GEMM2 (contraction over 2I)
+    dx  = sum_k dx_copy                   <- plain topk sum == TopkReduce
+    dtw = <dout, y_copy> = <dout@W2^T, silu(g)*u>   (pre-tw acc dot — no /tw)
+
+So the backward megakernel IS the forward megakernel — dispatch(dout) ->
+grouped GEMM -> elemwise -> grouped GEMM -> token-back + TopkReduce — with
+swapped operands and a different elemwise. Shape walk per phase:
+
+    forward:  H --fc1(N=2I,K=H)--> 2I --SwiGLU--> I --fc2(N=H,K=I)--> H
+    backward: H --g1 (N=I, K=H)--> I --SwiGLU'--> 2I --g2 (N=H,K=2I)--> H
+
+## Verified contracts (2026-07-19, source review)
+
+1. **fc1_c stash is RAW pre-SwiGLU, pre-clamp, pre-tw gate+up**
+   (`epilogue_mxfp8.py`: `_store_fc1_c_subtile` at L711 runs before the clamp
+   at L725 and the tw multiply inside `swiglu_act` at L741). Exactly the g,u
+   the elemwise needs. bf16, gate/up interleaved in 32-col blocks.
+2. **fc1_c row layout**: grouped by local expert, expert e's arrivals start at
+   `doff[e] = cumsum(round_up(valid_tokens, 128))` (`mega_runner.py` L609-626;
+   `token_padding_block=128` when generate_c). Token order WITHIN an expert
+   slot is non-deterministic in the multi-rank dispatch path (the runner's own
+   validator sorts before comparing, L465).
+3. **token_src_metadata**: one i64 per pool row in the persistent local
+   workspace — lo32 = src_token, hi32 = (src_rank<<16)|flags|src_topk
+   (`src/token_comm.py` L150). This is the exact routing record the backward
+   needs to invert dispatch and to address the dx push-back.
+4. **Local workspace persists across launches**: the in-kernel tail reset only
+   zeros the counter prefix BEFORE `l1_token_buffer`
+   (`megamoe_kernel_mxfp8.py` L477); data regions (`l1_token_buffer` = the
+   dispatched quantized X pool, `l1_topk_weights_buffer`, `token_src_metadata`,
+   `fc1_output`) survive until the next forward. Region byte offsets are
+   host-visible (`kernel._local_offsets` / `_local_region_by_name`) so the
+   wrapper can build torch views with zero kernel changes.
+5. **TopkReduce is already a plain top-k sum** (weighting folded into fc1), so
+   the dx combine needs NO adjoint variant — the forward token-back + reduce
+   path applies verbatim to dx_copy.
+6. **Weight operands already exist in host code**: `fp8_bwd.quant_weights_3d`
+   produces W2^T (E,I,H) quantized along H and W13^T (E,H,2I) along 2I — same
+   (data, swizzled-SF) format `megamoe/weights.py` feeds the kernel. GEMM1's B
+   is layout-identical to forward fc1's B (K=H), GEMM2's B to forward fc2's B
+   (K widened to 2I).
+
+## Kernel deltas vs forward (the actual work)
+
+D1. **Dispatch -> metadata-driven gather.** A second launch that re-runs the
+    routing walk would pull dout into a DIFFERENT pool order than forward
+    (contract 2) and misalign every fc1_c row. Instead the backward dispatch
+    warps iterate the forward's pool rows and pull `dout[src_token]` from
+    `src_rank` per `token_src_metadata` — inheriting forward's pool ordering,
+    128-aligned expert offsets, and recv counts (all still in the persistent
+    workspace). No routing recount, no expert_send_count exchange.
+    Source side: dout is staged quantized (fp8+SF along H) by the existing
+    `DataPreprocess` into a sym-heap dout pool (routing repack skipped).
+
+D2. **GEMM1 shape**: N = I instead of 2I, B = W2^T. Same K=H mainloop.
+
+D3. **Epilogue elemwise**: forward reads a (gate,up) interleaved acc PAIR and
+    writes one 32-block of quantized A (2:1 contraction). Backward reads ONE
+    32-block of dA acc + the matching (g,u) pair from fc1_c, computes (du,dg),
+    requants, writes an interleaved PAIR into a 2I-wide fc1_output pool
+    (1:2 expansion). The tw multiply is reused as-is (dA *= tw). This inverts
+    the epilogue's hardcoded 2:1 gate/up ratio — main surgery site
+    (`epilogue_mxfp8.py` subtile path + `fc1_fc2_fuse_sched.py` N/K
+    bookkeeping + fc1_output/fc1_output_sf region widths).
+    Concretely (source-verified): a forward subtile is one (gate,up) pair of
+    EpilogueTileN=32 tmem cols each (`_subtile_local_tmem_tensor_pair`,
+    subtile_col_off = subtile_idx*64; subtile_cnt = cta_tile_n/2/32), and the
+    generate_c store stages a (cta_tile_m=128, 2*32=64) TMA tile per subtile
+    (`_epi_tile_c`). The backward subtile inverts exactly this: 32 tmem acc
+    cols (single-tensor loader replaces the pair loader) + one (128, 64)
+    fc1_c TMA LOAD (same tile geometry as the C store, reversed direction,
+    same SMEM stage) -> SwiGLU' -> two quant_sfd_row calls -> a 64-col
+    interleaved store. fc1_output width and its SF cols double; per-warp
+    subtile count doubles for the same cta_tile_n.
+
+D4. **GEMM2 shape**: K = 2I instead of I, B = W13^T (interleaved column order
+    matching the DFC1 pool layout). N = H unchanged, so token-back + combine
+    staging + TopkReduce run verbatim -> dx.
+
+D5. **Stashes for wgrad** (generate_c mechanism reused): the backward's own
+    `generate_c` writes raw bf16 (du,dg) = DFC1 to a caller buffer. Together
+    with fc1_c (recompute A elemwise) and the persistent l1 X pool, all wgrad
+    operands are on the owner rank with no extra comm.
+
+## dtw
+
+`dtw = <dout, y_copy> = <GEMM1 pre-tw accumulator row, silu(g)*u row>` — all
+present in the backward epilogue; a per-row fp32 dot written to a
+(pool_rows,) side buffer, returned to sources with a scalar-payload a2a (tiny,
+torch for v1; possibly folded into the dx token-back payload later).
+v0 alternative (no kernel change): reuse forward's per-copy combine staging
+(shared region, (T, K, H)) — dtw = einsum(dout, staged)/tw; needs a tw floor,
+so v1's in-epilogue dot is the keeper.
+
+## wgrad
+
+    dW2 [h,i] = sum_m dout_pool[m,h] * (tw*A)[m,i]
+    dW13[2i,h] = sum_m DFC1[m,2i]   * X_pool[m,h]
+
+Contractions over TOKENS -> both operands need token-axis (trans)quant, a
+different animal than the megakernel's row-quant world.
+
+- **v1**: keep `fp8_bwd.gmm_wgrad_2d2d` (torch `_scaled_grouped_mm`, 2d-2d)
+  fed by the kernel stashes: DFC1 (D5), A = elemwise(fc1_c), X = dequant of
+  the persistent l1 pool, dout_pool = dequant of the backward's l1 pool. The
+  128-row expert slots line up with GroupedPad by construction. GEMM+quant
+  cost today: well under 1 ms.
+  Staleness caveat: pool/stash PAD rows are zero on a fresh buffer (probe C5)
+  but are NOT re-zeroed per launch — a pad row that was valid under an
+  earlier routing keeps its old bytes. Token-K contractions must therefore
+  zero/mask pad rows explicitly (bwd_v0 sidesteps this by rebuilding all
+  wgrad operands zero-padded on the host side).
+- **v2**: second small kernel (or tail phase): fused transquant + grouped
+  wgrad GEMMs consuming the same pools.
+
+## Status (2026-07-19)
+
+- M0/M1 done (probe all-PASS; bwd_v0 `bwd_impl="pool"` parity-PASS, bwd
+  5.80 ms vs fp8 7.89 / bf16-EP 3.83).
+- M2.A done: `megamoe/bwd_kernel/` backward FC12 kernel — dgrad chain in one
+  launch, `test_bwd_fc12` PASS (dXG rel_l2 1.6e-2, DFC1 bf16 stash 1.7e-3).
+  The base kernel/scheduler/TMA paths needed zero changes; only two
+  `//2`→`*2` host derivations + the epilogue inversion.
+- M2.B done (`bwd_impl="mega"`, `bwd_kernel/backward.py`): compile-once
+  wrapper feeding the kernel from the forward pools (zero-copy tw + fc1_c),
+  uint8 gathers, wgrads on the kernel's DFC1 stash, dtw from combine
+  staging. Parity PASS 1+4-rank (vs replay <= 5.3% on all grads). Bench:
+  mega bwd 5.64 ms (pool 5.84, fp8 7.89, bf16-EP 3.83); best total step
+  6.13 ms vs bf16-EP 7.18. Breakdown: the WHOLE dgrad chain = 0.46 ms
+  in-kernel; the rest is glue — elemwise 1.81 (wgrad operand prep) + prep
+  1.34 (host routing) + comm-adj 0.90 (dtw einsum + dx index_add) +
+  dispatch 0.50 + act-quant 0.43.
+  Gotchas hit: fp8/e8m0 tensors need uint8 views for indexing/NCCL; the
+  kernel specializes activation_sf's dtype from the baked tensor — it must
+  be `float8_e8m0fnu`, a uint8 buffer makes `cute.compile` die with a
+  SILENT exit(1) (no traceback); `python -m` imports the package before
+  `__main__` runs, so `MEGA_NO_DIST` must be set in the shell env.
+- M2.C (in-kernel comm) — split into two halves; the dx token-back half is
+  DONE, the dout dispatch half is next.
+  - **dx token-back DONE (2026-07-20).** No new kernel code: the backward
+    kernel + `epilogue_bwd.py` were copied from the forward WITH the full
+    token-back machinery intact (`Fc2OutputDest`, the `fc2_in_kernel_topk_reduce`
+    REDG path at `epilogue_bwd.py` ~L1038 `_red_add_relaxed_sys_v2_bf16x2`).
+    Turning it on: set `fc2_in_kernel_topk_reduce=True` and pass a
+    `token_comm_args` bundle (only 3 live fields — `combine_output`,
+    `token_src_metadata`, `peer_rank_ptr_mapper`; everything else None,
+    skipped by TokenCommArgs' MLIR serialization). The epilogue pushes each
+    dx_copy row to `peer(src_rank).dx_pool[src_token, 0, :]` and REDG-adds
+    the top-k copies on the fly (`reduce_topk_in_kernel` collapses src_topk→0)
+    = dx. Replaces the wrapper's torch `index_add_ + all_reduce` (part of
+    comm-adj 0.90 ms). Wiring is `bwd_kernel/backward.py` (sym-heap `dx_pool`
+    `(T,1,H)`, peer mapper via `_compute_peer_offsets`) + a small
+    `token_comm_args` build at the top of `kernel_bwd_fc12.py::__call__`
+    (gated on the peer-mapper kwarg; None keeps the lean dgrad path byte-identical).
+    Verified: world=1 `repro_mega` `|dx|=231.071` == baseline `231.072`
+    (fp summation-order diff 1e-3); `test_bwd_fc12` still PASS (lean path
+    unchanged); 4-rank `test_hybrid_training_dist` mega vs reference PASS.
+    KEY FACTS for the next half: token_src_metadata is READ from the FORWARD's
+    persistent local-workspace region (data region, NOT zeroed — survives),
+    in the SAME pool order the backward GEMM walks (offs_padded matches), so
+    `pool_token_global` in the epilogue == the forward metadata row. The
+    per-expert counts (`expert_recv_count_sum`) are in the SHARED counter
+    prefix which IS zeroed at the forward's kernel_tail — so the backward must
+    supply counts itself (host `offs`), it cannot read them back from the
+    forward workspace.
+  - **dout dispatch (D1) DONE (2026-07-20).** `bwd_kernel/kernel_bwd_mega.py`:
+    `BwdGatherComm` (a trimmed `TokenInPullTokenBackPush`) + `Sm100MegaMoEMxfp8-
+    BwdKernel` (enable_token_comm=True, 12-warp topology, delegates the token-
+    comm hooks like the forward). Per pool row the dispatch warps (8-11) read
+    `token_src_metadata` → `peer_rank_ptr_mapper.map` → TMA peer-pull the
+    quantized dout row + ldg the SF from a sym-heap `my_dout`/`my_dout_sf`
+    into `act_pool`, then publish `fc1_ready_counter[expert_task_tile_offset +
+    token_idx_in_expert // cluster_tile_tokens]` — the SAME slot the GEMM's
+    TMA-B `fc1_tma_b_predispatch_spin` waits on. REUSED verbatim: the pull/store
+    TMA ops, SF ldg/store, the `GpuReleaseFlagBatchTracker`, the `pull_buffer`
+    SMEM, the spin + sched-ext threshold. DROPPED vs the forward: the routing
+    walk (ChooseToken), dedup, `src_token_topk_idx`, `expert_send_count`,
+    `dispatch_prep`/`dispatch_barrier`/NVLink barrier (my_dout is host-staged
+    before the collective launch; no cross-rank sends), and the metadata WRITE.
+    Per-expert counts come from host `offs` (staged into `expert_recv_count_sum`;
+    the forward's are zeroed at kernel_tail). Removes the wrapper's
+    `mxfp8_rowquant(dout)` + allgather + scatter (dispatch 0.50). Default ON
+    (`MEGA_BWD_INKERNEL_DISPATCH=0` falls back to the torch gather) — bench:
+    mega bwd beats M2.B at world=1 (4.95 vs 5.12 ms; bf16-EP 3.86) AND 4-rank
+    (3.46 vs 3.50 ms, T/rank=2048; fp8 3.92). 4-rank margin is modest because
+    the WGRAD path still allgathers dout+x — the next win.
+    Verified: world=1 `repro_mega` |dx|=231.071 == baseline (act_pool filled
+    ONLY by the in-kernel gather); 4-rank `test_hybrid_training_dist`
+    `HYBRID DIST PASS` (mega dX=0.051 vs ref, real cross-rank pull) — first
+    compile modulo one fix (NVSHMEM has no fp8 dtype → allocate `my_dout` via
+    `_sym_zeros_byte_view_1b`, the forward's my_activation trick).
+    KEY GOTCHA: `act_pool` doubles as GEMM-A AND the dispatch DEST
+    (`fc1_input_token_buffer=act_pool`), with `my_dout` (T rows) the separate
+    SOURCE — so no GEMM-A/pool restructure was needed. All sym-heap allocs share
+    one peer delta, so the dx peer mapper covers `my_dout` pulls too.
+  - Remaining M2.C — profiled priorities (mega bwd phase breakdown, D1 default,
+    world=1 T=16384: sum 4.74 ms, was fp8 7.48):
+    * **elemwise 1.84 ms (38.7%)** — THE target. wgrad operand prep: the
+      `A = tw·silu(g)·u` recompute (fp32 over Mp×I) + `X`/`dout` dequant.
+      Kill via an in-kernel **A stash** (the fc1 epilogue at
+      `epilogue_bwd.py::_run_fc1_subtile` L736 already has `r_gate`,`r_up`,`topk`
+      right after `swiglu_bwd` — add a 2nd generate_c-style TMA stash of
+      `swiglu_act(g)·u·tw`, mirroring the DFC1 stash). Note the wgrad `dout`/`x`
+      pools carry SWIZZLED SF, so `dequant_mxfp8_pool` (row-major) can't read
+      them directly — the allgather-free operand path needs an SF unswizzle or
+      the raw stash.
+    * **prep 1.16 ms (24.5%)** — host routing (bincount + `.tolist()` sync +
+      offs/metadata/`_col_atom_order`). Move on-device (dynamic-shape: Mp/doffs
+      are consumed host-side for slicing, so this needs a restructure).
+    * **comm-adj 0.47 ms (10%)** — in-epilogue dtw dot: accumulate
+      `sum_i r_dacc[i]·silu(g[i])·u[i]` (pre-tw) per row across the fc1 subtiles
+      → a (pool_rows,) side buffer; kills the torch einsum + combine-staging dep.
+    * dispatch is DONE (0.20 ms, was 1.40). Each item above is a dedicated
+      kernel/host milestone with GPU iteration — bench-guided, do elemwise first.
+
+## Execution plan
+
+- **M0 probe** (`megamoe/tests/probe_bwd_contracts.py`): validate contracts
+  1-5 on GPU — fc1_c content vs dequant-pool recompute, metadata decode,
+  pool persistence after launch, order (in)stability across launches.
+  Wrapper accessor `megamoe/pools.py` builds the region views.
+- **M1 v0 backward, no new kernel**: metadata-driven torch backward — gather
+  dout by metadata (replaces dispatch+GroupedPad), reuse pools for X/g/u
+  (kills prep + FC1-recompute GEMM + Y GEMM), grouped GEMMs via
+  `_scaled_grouped_mm`, dx return via a2a + index_add. Validates the whole
+  adjoint-by-metadata story and should already cut several ms.
+- **M2 dgrad megakernel**: kernel deltas D1-D4, `bwd_kernel/` package
+  subclassing/copying from `cutedsl_megamoe` (clone stays unmodified), wrapper
+  `megamoe/backward.py` mirroring `forward.py` (persistent buffers, one
+  compile, `load_weights_bwd` from the fp8_bwd wcache quantizers).
+- **M3 wgrad v1 + dtw** around the kernel; integrate as `bwd_impl="mega"` in
+  `MegaMoeHybridMxfp8Layer`; 4-rank parity vs `fp8_backward`.
+- **M4 bench** vs bf16-EP 3.82 ms; then wgrad v2 / dtw-in-kernel / knob sweep.

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/README.md
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/README.md
@@ -1,0 +1,97 @@
+# megamoe — hackable CuTe DSL MegaMoE forward for the torch pipeline
+
+A small, flat wrapper around the `cutedsl_megamoe` MXFP8 GLU mega-kernel
+(dispatch → grouped FC1 SwiGLU → FC2 → combine, all in ONE kernel launch over
+NVSHMEM) so it can be dropped into a PyTorch expert-parallel pipeline (e.g. as
+a drop-in replacement for `pt/layer.py::MoEEpTrainingLayer.forward`).
+
+Source of truth: the sibling clone `../cutedsl_megamoe` (latest `main`,
+override with `MEGAMOE_REPO=`). Nothing in the clone is modified; this package
+only re-hosts the launch path so it is easy to hack on.
+
+```
+repo_path.py   sys.path shim for the cutedsl_megamoe clone
+weights.py     bf16 w13/w2 (pt/ convention) -> kernel MXFP8 layout:
+               gate/up 32-block interleave, per-32 E8M0 block scales,
+               32x4x4 atom-swizzled weight SFs (to_blocked)
+forward.py     MegaMoeMxfp8Forward: persistent sym-heap buffers, one-time
+               cute.compile of (a) DataPreprocess (fused bf16->mxfp8 quant +
+               routing repack, src/inputs_process.py — the framework
+               integration path added in `ag_dev/fi_input_quant`) and
+               (b) Sm100MegaMoEMxfp8Kernel; forward() = copy-in + 2 launches
+turboquant.py  MegaMoeTurboQuantForward: randomized block-Hadamard (b=128)
+               incoherence on the hidden dim — activation rotated in forward,
+               counter-rotation folded into fc1 weights (exact math)
+tests/         torchrun parity test vs compute_megamoe_reference_mxfp8
+               + turboquant numerics validation vs an exact fp32 oracle
+```
+
+## Usage
+
+```python
+from megamoe import MegaMoeForwardConfig, MegaMoeMxfp8Forward
+from src.bootstrap import init_dist_and_nvshmem   # via megamoe.repo_path
+
+_, rank, world_size, _ = init_dist_and_nvshmem()
+cfg = MegaMoeForwardConfig(
+    max_tokens_per_rank=1024, hidden=2048, intermediate=512,  # I per branch
+    num_total_experts=32, num_topk=4,
+)
+fwd = MegaMoeMxfp8Forward(cfg, rank=rank, world_size=world_size)
+fwd.load_weights(w13, w2)      # [E_local, 2I, H], [E_local, H, I] bf16
+out = fwd(x, topk_idx, topk_weights)   # (T, hidden) bf16, T <= max_tokens
+```
+
+Contracts:
+- `forward` is collective — every EP rank must call it (in-kernel NVLink
+  barriers). Stream-ordered, no host sync inside.
+- `topk_idx` holds **global** expert ids; expert `e` lives on rank
+  `e // (num_total_experts // world_size)` (contiguous sharding, same as pt/).
+- Math convention matches pt/: `silu(gate) * linear` with
+  `w13[:, :I]` = linear/up, `w13[:, I:]` = gate; topk weights are folded into
+  the fc1 epilogue (`apply_topk_in_fc1=True`, kernel-exact).
+- `load_weights` re-quantizes in place — call per optimizer step, no
+  recompile.
+- Output is a view of a persistent buffer; clone if kept across steps.
+
+## Test
+
+Inside the GPU container (needs `nvidia-cutlass-dsl`, `nvshmem4py`, GB200):
+
+```bash
+cd moe_ep_training
+torchrun --nproc_per_node=4 --standalone -m megamoe.tests.test_forward_parity
+MEGA_NO_DIST=1 python -m megamoe.tests.test_forward_parity   # single-rank
+```
+
+Reference tolerance is the repo's own (atol=rtol=1e-2 vs
+`compute_megamoe_reference_mxfp8`, which consumes the device-quantized
+activations read back from the sym heap).
+
+## Tuning the kernel knobs
+
+`MegaMoeForwardConfig.impl` (a `TrainingImplDesc`) carries the tunables:
+`mma_tiler_mnk`, `cluster_shape_mnk`, `load_balance_mode`
+(`static`/`atomic_counter`), `group_hint`, `flag_batch`, `epi_flag_batch`,
+`token_back_mode`, `in_kernel_fc2_reduce`, `use_stg_fc1`. Sweep them with the
+repo's tester and paste the winner:
+
+```bash
+cd ../cutedsl_megamoe
+torchrun --nproc_per_node=4 -m tester.tester --problems problems.jsonl \
+    --mode Perf --sweep --use_knob mma_tiler_mnk=256,256,128 --results out.jsonl
+```
+
+(Problem jsonls come from `tester/problem_gen`; `tester.tester --help` for the
+knob grammar. Note the tester's Perf solver covers the NVFP4 kernel; for MXFP8
+knob sweeps use `moe_mxfp8_glu.mega_runner --perf_run --use_torch_profiler`.)
+
+## Next steps / optimization hooks
+
+- **turboquant / network-specific quant**: replace `DataPreprocess` (activation
+  side) and/or `weights.py` (weight side) — everything downstream only sees
+  fp8 bytes + E8M0 SFs in the fixed layout.
+- `impl.generate_c=True` stashes the pre-SwiGLU fc1 gate+up (bf16) the future
+  backward needs.
+- `combine_format="32e4m3xe8m0"` halves combine NVLink bytes.
+- Baseline to beat: `bench/bench_training_forward.py` (pure-torch pt/ path).

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/__init__.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/__init__.py
@@ -1,0 +1,11 @@
+# Hackable single-call MegaMoE forward (CuTe DSL mxfp8 GLU kernel) for use
+# inside a PyTorch pipeline.  See README.md in this directory.
+from megamoe.forward import MegaMoeMxfp8Forward, MegaMoeForwardConfig
+from megamoe.weights import quantize_moe_weights_mxfp8, QuantizedExpertWeights
+
+__all__ = [
+    "MegaMoeMxfp8Forward",
+    "MegaMoeForwardConfig",
+    "quantize_moe_weights_mxfp8",
+    "QuantizedExpertWeights",
+]

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/__init__.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Backward (dgrad) MegaMoE kernel package — see megamoe/BWD_DESIGN.md.
+
+M2.A: backward variant of the standalone Sm100SwigluMxfp8Fc12Kernel
+(gemm1 dA = dout@W2^T -> SwiGLU-bwd epilogue vs the fc1_c stash ->
+gemm2 [dg,du]@W13^T).  M2.B grafts it into the mega kernel (metadata-
+driven dout gather + token-back dx).
+"""

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/backward.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/backward.py
@@ -1,0 +1,444 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""M2.B backward wrapper: the backward FC12 kernel fed from the forward pools.
+
+``MegaMoeMxfp8Backward`` mirrors ``megamoe/forward.py``: persistent
+capacity-sized buffers, one-time ``cute.compile``, per-step launch with
+baked kwargs.  The dgrad chain (gemm1 dA -> SwiGLU-bwd(fc1_c) -> gemm2 dxg
++ bf16 DFC1 stash) runs in ONE kernel; around it, thin torch glue does the
+metadata-driven dout gather, the dx top-k sum, dtw from the forward's
+per-copy combine staging, and the token-K wgrads (fp8_bwd's
+``gmm_wgrad_2d2d``) on the kernel stashes.
+
+v1 comm model: same as bwd_v0 (allgather for world>1; world=1 = pure local
+gathers).  The in-kernel peer-pull dispatch / token-back push (BWD_DESIGN.md
+D1) replaces the gathers in M2.C.
+
+Collective contract: every rank calls backward each step (world>1 has
+allgathers/all_reduce).  Requires the forward layer built with
+``impl.generate_c=True`` and bf16 combine staging (default).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+import torch.distributed as dist
+
+import megamoe.repo_path  # noqa: F401
+
+from pt.quant import rotate_trailing
+
+from megamoe.fp8_bwd import (
+    _col_atom_order,
+    _pack_scales_rowgroups,
+    _phase,
+    _round_up,
+    gmm_wgrad_2d2d,
+)
+from megamoe.pools import decode_token_src_metadata, local_pool_views, shared_pool_views
+from megamoe.quant_kernels import mxfp8_rowquant
+from megamoe.training import dequant_mxfp8_pool  # noqa: F401  (XG dequant)
+
+from megamoe.bwd_kernel.weights_bwd import quantize_moe_weights_mxfp8_bwd
+
+
+class MegaMoeMxfp8Backward:
+    """Compile-once backward kernel around a live MegaMoeMxfp8Forward."""
+
+    def __init__(self, fwd, ep_cfg):
+        self.fwd = fwd
+        self.ep = ep_cfg
+        H, I = ep_cfg.hidden_size, ep_cfg.intermediate_size
+        self.E_local = ep_cfg.num_experts // ep_cfg.ep_size
+        cap = fwd.fc1_c.shape[0]           # world*T*K + E_local*128
+        self.capacity = cap
+        dev = "cuda"
+
+        # persistent kernel-facing buffers (baked into compiled kwargs)
+        self.act_pool = torch.zeros((cap, H), dtype=torch.float8_e4m3fn, device=dev)
+        # SF dtype must be e8m0 — the kernel specializes activation_sf's
+        # cute dtype from this tensor (uint8 breaks the SFA TMA path).
+        self.act_sf_swz = torch.zeros(
+            (cap, H // 32), dtype=torch.uint8, device=dev
+        ).view(torch.float8_e8m0fnu)
+        self.fc2_output = torch.zeros((cap, H), dtype=torch.bfloat16, device=dev)
+        self.dfc1_stash = torch.zeros((cap, 2 * I), dtype=torch.bfloat16, device=dev)
+        self.offs_buf = torch.zeros((self.E_local,), dtype=torch.int32, device=dev)
+
+        # M2.C in-kernel dx token-back: sym-heap per-rank (T, H) buffer the
+        # epilogue REDG-adds each source token's summed-over-topk dx into
+        # (fc2_in_kernel_topk_reduce).  world=1 degrades to a plain cuda tensor.
+        # (T, 1, H) so a plain DLPack view gives the (H, H, 1) layout the
+        # epilogue's Fc2OutputDest slices as [src_token, 0, :].
+        import os
+        from moe_nvfp4_swapab.mega_runner import _sym_zeros
+        from moe_nvfp4_swapab.runner_common import round_up as _round_up_sf
+        self.T = fwd.cfg.max_tokens_per_rank
+        self.dx_pool = _sym_zeros((self.T, 1, H), torch.bfloat16)
+
+        # M2.C part 2 (D1): in-kernel dout gather.  Default ON — verified
+        # (world=1 + 4-rank parity) and faster than the torch dispatch at both
+        # world=1 (4.95 vs 5.12 ms bwd) and 4-rank (3.46 vs 3.50 ms).  Set
+        # MEGA_BWD_INKERNEL_DISPATCH=0 to fall back to the torch gather.
+        self.in_kernel_dispatch = bool(
+            int(os.environ.get("MEGA_BWD_INKERNEL_DISPATCH", "1"))
+        )
+        if self.in_kernel_dispatch:
+            # sym-heap dout SOURCE (staged locally each step, no allgather).
+            # NVSHMEM has no fp8/e8m0 dtype, so allocate byte buffers viewed as
+            # fp8/e8m0 (same trick as the forward's my_activation).
+            from moe_mxfp8_glu.mega_runner import _sym_zeros_byte_view_1b
+            sf_cols_padded = _round_up_sf(H // 32, 4)
+            self.my_dout = _sym_zeros_byte_view_1b(
+                (self.T, H), torch.float8_e4m3fn
+            )
+            self.my_dout_sf = _sym_zeros_byte_view_1b(
+                (self.T, sf_cols_padded), torch.float8_e8m0fnu
+            )
+            # per-expert token totals the gather walks (low32 = count).
+            self.recv_count_sum = torch.zeros(
+                (self.E_local,), dtype=torch.int64, device=dev
+            )
+            # fc1-ready release counter: one Int32 per cluster tile + slack.
+            cluster_tile_tokens = 256  # == mma_tiler_mnk[0]
+            self.fc1_ready_slots = cap // cluster_tile_tokens + self.E_local
+            self.fc1_ready_counter = torch.zeros(
+                (self.fc1_ready_slots,), dtype=torch.int32, device=dev
+            )
+
+        # workspace (mirror of the kernel's get_workspace_size layout, 2I wide)
+        downproj = 2 * I
+        from common.megamoe_constants import SfPaddingBlock
+
+        sf_rows = cap + self.E_local * SfPaddingBlock
+        sf_cols = ((downproj // 32) + 3) // 4 * 4
+        self._counter_slots = (cap + 255) // 256 + self.E_local
+        n0 = cap * downproj
+        n1 = sf_rows * sf_cols
+        n2 = self._counter_slots * 4
+        self.workspace = torch.zeros((n0 + n1 + n2,), dtype=torch.uint8, device=dev)
+        self.fc1_output = self.workspace[:n0].view(torch.float8_e4m3fn).view(cap, downproj)
+        self.fc1_output_sf = self.workspace[n0 : n0 + n1].view(sf_rows, sf_cols)
+        self.fc1_done_counter = self.workspace[n0 + n1 : n0 + n1 + n2].view(torch.int32)
+
+        self._weights = None
+        self._compiled = None
+
+    def load_weights(self, w13: torch.Tensor, w2: torch.Tensor) -> None:
+        q = quantize_moe_weights_mxfp8_bwd(w13, w2)
+        if self._weights is None:
+            self._weights = q
+        else:
+            self._weights.gemm1_weight.copy_(q.gemm1_weight)
+            self._weights.gemm1_weight_sf.view(torch.uint8).copy_(
+                q.gemm1_weight_sf.view(torch.uint8)
+            )
+            self._weights.gemm2_weight.copy_(q.gemm2_weight)
+            self._weights.gemm2_weight_sf.view(torch.uint8).copy_(
+                q.gemm2_weight_sf.view(torch.uint8)
+            )
+
+    def _compile(self):
+        import cuda.bindings.driver as cuda
+        import cutlass
+        import cutlass.cute as cute
+        import cutlass.torch as cutlass_torch
+        import cutlass.utils as utils
+
+        from common.megamoe_constants import SfPaddingBlock
+        from megamoe.bwd_kernel.kernel_bwd_fc12 import Sm100SwigluMxfp8Fc12Kernel
+
+        ep = self.ep
+        H, I = ep.hidden_size, ep.intermediate_size
+        mma_tiler = (256, 256, 128)
+        cluster = (2, 1, 1)
+        max_active = utils.HardwareInfo().get_max_active_clusters(
+            cluster[0] * cluster[1]
+        )
+        base_kw = dict(
+            mma_tiler_mnk=mma_tiler,
+            cluster_shape_mnk=cluster,
+            use_2cta_instrs=True,
+            group_hint=max_active,
+            token_padding_block=128,
+            sf_padding_block=SfPaddingBlock,
+            load_balance_mode="static",
+            static_expert_shape=(self.E_local, I, H),   # gemm1 N = I
+            ab_dtype=cutlass.Float8E4M3FN,
+            sf_vec_size=32,
+            apply_topk_in_fc1=True,
+            generate_c=True,
+            use_stg_fc1=True,
+        )
+        if self.in_kernel_dispatch:
+            # D1: dispatch warps gather dout; epilogue still pushes dx
+            # (fc2_in_kernel_topk_reduce is forced on inside the subclass).
+            from megamoe.bwd_kernel.kernel_bwd_mega import Sm100MegaMoEMxfp8BwdKernel
+            self._kernel = Sm100MegaMoEMxfp8BwdKernel(
+                world_size=ep.ep_size,
+                local_rank=ep.ep_rank,
+                num_topk=ep.top_k,
+                max_tokens_per_rank=self.T,
+                **base_kw,
+            )
+            self._kernel.comm_sm_count = max_active * (cluster[0] * cluster[1])
+        else:
+            self._kernel = Sm100SwigluMxfp8Fc12Kernel(
+                # M2.C part 1: epilogue REDG-adds dx across the top-k copies.
+                fc2_in_kernel_topk_reduce=True, **base_kw,
+            )
+        self._kernel.comm_world_size = ep.ep_size
+        self._kernel.comm_local_rank = ep.ep_rank
+        self._kernel.comm_num_topk = ep.top_k
+
+        def to_cute(t):
+            ct = cutlass_torch.from_dlpack(t, assumed_align=16)
+            return ct.mark_layout_dynamic(
+                leading_dim=cutlass_torch.get_leading_dim(t)
+            )
+
+        # tw pool: the forward's persistent l1_topk_weights_buffer, zero-copy.
+        # Its own capacity (pool_token_capacity) can differ from fc1_c's row
+        # count; the kernel only ever indexes rows < Mp <= both.
+        lv = local_pool_views(self.fwd)
+        tw_pool = lv["l1_topk_weights_buffer"]
+
+        # -- M2.C in-kernel dx push plumbing --------------------------------
+        # peer mapper over the dx sym-heap buffer (identity delta for world=1);
+        # combine_output is the (T, 1, H) view the epilogue's Fc2OutputDest
+        # slices as [src_token, 0, :]; token_src_metadata is the forward's
+        # persistent record (same pool order the backward GEMM walks).
+        from moe_nvfp4_swapab.mega_runner import _compute_peer_offsets
+        from src.sym_buffer import SymBufferHost
+
+        sym_base, peer_offsets = _compute_peer_offsets(self.dx_pool, ep.ep_size)
+        self._peer_mapper = SymBufferHost(
+            base_addr=sym_base,
+            offsets=tuple(peer_offsets),
+            rank_idx=ep.ep_rank,
+            num_max_ranks=ep.ep_size,
+        )
+        self._combine_out_cute = to_cute(self.dx_pool)
+        self._md_cute = to_cute(lv["token_src_metadata"])
+
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+        self._kwargs = dict(
+            activation=to_cute(self.act_pool),
+            activation_sf=to_cute(self.act_sf_swz),
+            fc1_weight=to_cute(self._weights.gemm1_weight),
+            fc1_weight_sf=to_cute(self._weights.gemm1_weight_sf),
+            fc1_output=to_cute(self.fc1_output),
+            fc1_output_sf=to_cute(self.fc1_output_sf),
+            fc2_weight=to_cute(self._weights.gemm2_weight),
+            fc2_weight_sf=to_cute(self._weights.gemm2_weight_sf),
+            fc2_output=to_cute(self.fc2_output),
+            topk_scores=to_cute(tw_pool),
+            fc1_done_counter=to_cute(self.fc1_done_counter),
+            offs=to_cute(self.offs_buf),
+            fc1_c=to_cute(self.fwd.fc1_c),
+            fc1_c_out=to_cute(self.dfc1_stash),
+            peer_rank_ptr_mapper_host=self._peer_mapper,
+            combine_output_bwd=self._combine_out_cute,
+            token_src_metadata_bwd=self._md_cute,
+            stream=stream,
+        )
+        if self.in_kernel_dispatch:
+            # byte views for the peer-pulled fp8 source + activation pool;
+            # SF pool as flat int32 (the gather writes swizzled Int32 words).
+            act_sf_i32 = self.act_sf_swz.view(torch.uint8).view(torch.int32).reshape(-1)
+            self._kwargs.update(
+                input_token_buffer_bwd=to_cute(self.my_dout.view(torch.uint8)),
+                input_sf_buffer_bwd=to_cute(self.my_dout_sf.view(torch.uint8)),
+                fc1_input_token_buffer_bwd=to_cute(self.act_pool.view(torch.uint8)),
+                fc1_input_sf_buffer_bwd=to_cute(act_sf_i32),
+                fc1_ready_counter_bwd=to_cute(self.fc1_ready_counter),
+                expert_recv_count_sum_bwd=to_cute(self.recv_count_sum),
+            )
+        compile_kwargs = dict(self._kwargs)
+        compile_kwargs["max_active_clusters"] = max_active
+        self._compiled = cute.compile(self._kernel, **compile_kwargs)
+
+    def launch(self):
+        if self._compiled is None:
+            self._compile()
+        self._compiled(**self._kwargs)
+
+
+def mega_backward(layer, topk_ids, topk_weights, dout, T):
+    """Kernel-dgrad mxfp8 backward; returns (dx, dtw, dw13, dw2)."""
+    ep = layer.ep_cfg
+    H, I, K = ep.hidden_size, ep.intermediate_size, ep.top_k
+    E_local = ep.num_experts // ep.ep_size
+    expert_start = ep.ep_rank * E_local
+    world = ep.ep_size
+    fwd = layer._fwd
+    device = dout.device
+    group = ep.process_group
+
+    bwd: MegaMoeMxfp8Backward = layer._mega_bwd
+    if getattr(layer, "_mega_bwd_wdirty", True):
+        with _phase("weight-quant"):
+            w13 = layer.w13.detach().to(torch.bfloat16)
+            if layer.qcfg.turboquant:
+                w13 = rotate_trailing(w13, layer.q_rot)
+            bwd.load_weights(w13, layer.w2.detach().to(torch.bfloat16))
+        layer._mega_bwd_wdirty = False
+
+    with _phase("prep"):
+        if world > 1:
+            ids_all = torch.empty((world, T, K), dtype=topk_ids.dtype, device=device)
+            dist.all_gather_into_tensor(ids_all, topk_ids.contiguous(), group=group)
+        else:
+            ids_all = topk_ids.view(1, T, K)
+        local = ids_all.reshape(-1) - expert_start
+        counts = torch.bincount(
+            local[(local >= 0) & (local < E_local)], minlength=E_local
+        ).tolist()
+        padded = [_round_up(n, 128) for n in counts]
+        Mp = max(sum(padded), 128)
+        offs_valid = torch.tensor(
+            [sum(counts[: i + 1]) for i in range(E_local)],
+            device=device, dtype=torch.int32,
+        )
+        offs_padded = torch.tensor(
+            [sum(padded[: i + 1]) for i in range(E_local)],
+            device=device, dtype=torch.int32,
+        )
+        doffs = [sum(padded[:i]) for i in range(E_local)]
+        valid = torch.cat(
+            [torch.arange(o, o + n, device=device) for o, n in zip(doffs, counts)]
+        ) if sum(counts) else torch.empty(0, dtype=torch.long, device=device)
+
+        lv = local_pool_views(fwd)
+        src_rank, src_token, src_topk, _, _ = decode_token_src_metadata(
+            lv["token_src_metadata"][:Mp]
+        )
+        sr, st, sk = src_rank[valid].long(), src_token[valid].long(), src_topk[valid].long()
+        flat = (sr * T + st) if world > 1 else st
+
+        cbt = Mp // 128
+        order_h = _col_atom_order(offs_padded, H // 128, cbt)
+        order_2i = _col_atom_order(offs_padded, (2 * I) // 128, cbt)
+        order_i = _col_atom_order(offs_padded, I // 128, cbt)
+
+    with torch.no_grad():
+        with _phase("dispatch"):
+            if bwd.in_kernel_dispatch:
+                # D1: stage dout locally into the sym source (no allgather);
+                # the kernel's dispatch warps peer-pull it into act_pool by
+                # metadata.  Pool + SF start zero so pad rows stay clean.
+                dout_q, dout_sf = mxfp8_rowquant(dout.to(torch.bfloat16))
+                bwd.my_dout.view(torch.uint8).copy_(dout_q.view(torch.uint8))
+                bwd.my_dout_sf.view(torch.uint8)[:, : H // 32].copy_(
+                    dout_sf.contiguous().view(torch.uint8)
+                )
+                bwd.recv_count_sum.copy_(
+                    torch.tensor(counts, device=device, dtype=torch.int64)
+                )
+                bwd.act_pool.view(torch.uint8).zero_()
+                bwd.act_sf_swz.view(torch.uint8).zero_()
+                bwd.fc1_ready_counter.zero_()
+                if world > 1:
+                    # all ranks must finish staging before any peer pull.
+                    torch.cuda.synchronize()
+                    dist.barrier(group=group)
+            else:
+                # quantize dout ONCE per source token, gather fp8 bytes + SFs.
+                # All indexing/collectives run on uint8 views (fp8/e8m0 advanced
+                # indexing and NCCL support are not implemented).
+                dout_q, dout_sf = mxfp8_rowquant(dout.to(torch.bfloat16))
+                q_local = dout_q.view(torch.uint8)
+                sf_local = dout_sf.contiguous().view(torch.uint8)
+                if world > 1:
+                    q_all = torch.empty((world * T, H), dtype=torch.uint8, device=device)
+                    dist.all_gather_into_tensor(q_all, q_local, group=group)
+                    sf_all = torch.empty(
+                        (world * T, H // 32), dtype=torch.uint8, device=device
+                    )
+                    dist.all_gather_into_tensor(sf_all, sf_local, group=group)
+                else:
+                    q_all, sf_all = q_local, sf_local
+                bwd.act_pool[:Mp].view(torch.uint8).zero_()
+                bwd.act_pool.view(torch.uint8)[valid] = q_all[flat]
+                sf_pool = torch.zeros((Mp, H // 32), dtype=torch.uint8, device=device)
+                sf_pool[valid] = sf_all[flat]
+                packed = _pack_scales_rowgroups(sf_pool, offs_padded)
+                bwd.act_sf_swz.view(torch.uint8).view(-1)[: packed.numel()].copy_(
+                    packed.view(torch.uint8).view(-1)
+                )
+            bwd.offs_buf.copy_(offs_valid)
+            bwd.fc1_done_counter.zero_()
+            # dx REDG target must start at zero each step (epilogue accumulates).
+            bwd.dx_pool.zero_()
+
+        with _phase("gemm"):
+            bwd.launch()   # dgrad chain + DFC1 stash + in-kernel dx push
+
+        with _phase("elemwise"):
+            # wgrad operands from the stashes
+            pair = fwd.fc1_c[:Mp].float().view(Mp, I // 32, 2, 32)
+            gate, up = pair[:, :, 0].reshape(Mp, I), pair[:, :, 1].reshape(Mp, I)
+            tw_pool = local_pool_views(fwd)["l1_topk_weights_buffer"][:Mp]
+            actw = (F.silu(gate) * up) * tw_pool[:, None]
+            ACTW = torch.zeros((Mp, I), dtype=torch.bfloat16, device=device)
+            ACTW[valid] = actw[valid].to(torch.bfloat16)
+            # wgrad dY operand: gather the raw bf16 dout (the wgrad
+            # transquant re-quantizes along tokens anyway — same semantics
+            # as fp8_bwd/pool, and far cheaper than dequantizing the pool)
+            if world > 1:
+                dout_all = torch.empty(
+                    (world * T, H), dtype=torch.bfloat16, device=device
+                )
+                dist.all_gather_into_tensor(
+                    dout_all, dout.to(torch.bfloat16).contiguous(), group=group
+                )
+            else:
+                dout_all = dout.to(torch.bfloat16)
+            DOUTG = torch.zeros((Mp, H), dtype=torch.bfloat16, device=device)
+            DOUTG[valid] = dout_all[flat]
+            x_q = dequant_mxfp8_pool(
+                fwd.my_activation[:T], fwd.my_activation_sf[:T], H
+            ).to(torch.bfloat16)
+            if world > 1:
+                x_all = torch.empty((world * T, H), dtype=x_q.dtype, device=device)
+                dist.all_gather_into_tensor(x_all, x_q, group=group)
+            else:
+                x_all = x_q
+            XG = torch.zeros((Mp, H), dtype=torch.bfloat16, device=device)
+            XG[valid] = x_all[flat]
+
+        # wgrads (tokens on K); DFC1 stash is (dg, du)-interleaved
+        dw13_int = gmm_wgrad_2d2d(
+            bwd.dfc1_stash[:Mp], XG, offs_padded, order_2i, order_h
+        )
+        dw13_pair = dw13_int.view(E_local, I // 32, 2, 32, H)
+        dw13 = torch.cat(
+            [dw13_pair[:, :, 1], dw13_pair[:, :, 0]], dim=1
+        ).reshape(E_local, 2 * I, H)                      # pt [lin | gate]
+        if layer.qcfg.turboquant:
+            dw13 = rotate_trailing(dw13.float(), layer.q_rot.t())
+        dw13 = dw13.to(layer.w13.dtype)
+        dw2 = gmm_wgrad_2d2d(DOUTG, ACTW, offs_padded, order_h, order_i).to(
+            layer.w2.dtype
+        )
+
+        with _phase("comm-adj"):
+            # dtw from the forward's per-copy combine staging (local, C4)
+            staged = shared_pool_views(fwd)["combine_quant"][:T]   # (T, K, H) bf16
+            dtw = torch.einsum(
+                "th,tkh->tk", dout.float(), staged.float()
+            ) / topk_weights.float().clamp_min(1e-12)
+
+            # dx: the kernel already pushed each dispatched dx_copy row to its
+            # source rank and REDG-added the top-k copies into dx_pool[src_token]
+            # (in-epilogue, fc2_in_kernel_topk_reduce).  For world>1 the peer
+            # red.adds are cross-rank, so fence the reads with a barrier.
+            if world > 1:
+                torch.cuda.synchronize()
+                dist.barrier(group=group)
+            dx = bwd.dx_pool[:T, 0, :].float()
+            if layer.qcfg.turboquant:
+                dx = rotate_trailing(dx, layer.q_rot.t())
+
+    return dx.to(torch.bfloat16), dtw, dw13, dw2

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/epilogue_bwd.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/epilogue_bwd.py
@@ -1,0 +1,1497 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""Autonomous epilogue for the fused fc1+fc2 swap-AB MegaMoE kernel.
+
+Component boundaries use ``TensorWithContract`` to keep per-thread RMEM layout
+semantics explicit.  See ``megamoe_design.md`` for the epilogue dataflow.
+"""
+
+from typing import Optional, Tuple, Type, Union, Any
+import dataclasses
+
+import cutlass
+import cutlass.cute as cute
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.typing import AddressSpace
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+import cutlass.utils.blackwell_helpers as sm100_utils
+
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import arith as _arith
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op, Int32 as _epi_Int32, Int64
+
+from src.flag_batch import GpuReleaseFlagBatchTracker
+from src.token_comm import CombineFormat, TokenSrcMetadata
+from src.ptx_helpers import stg_e8m0_from_f32, stg_e8m0x8_from_f32
+
+from moe_nvfp4_swapab.contract import (
+    Contract,
+    FunctionMapping,
+    Space,
+    TensorWithContract,
+    assert_contract_equivalent,
+)
+from moe_nvfp4_swapab.fc1_fc2_fuse_sched import BlockPhase
+from common.megamoe_constants import Nvfp4BlockSize
+
+from common.moe_utils import fmin, fmax, swiglu_act, quant_sfd_row
+
+from megamoe.bwd_kernel.moe_utils_bwd import swiglu_bwd
+from cutlass.cute.typing import Float32
+from moe_nvfp4_swapab.epilogue import (
+    _TmemTranspose16x32Core,
+    _red_add_release_gpu_s32,
+    _red_add_relaxed_sys_v2_bf16x2,
+    SwapABSwigluFp4Epilogue,
+    EpilogueTokenTile,
+    Fc2AccLoadAndPack,
+    TmemTranspose16x32Packed,
+    Fc2UnpackPermuteStg,
+    Region,
+)
+
+Fc1GateUpInterleave = 32
+EpilogueTileN = 32
+Fc1EpilogueOutputTileM = 256
+Fc1EpilogueOutputTileN = 128
+WarpThreadCount = 32
+EpiWarpCount = 4
+Fc1CTMAStages = 1
+
+
+# =============================================================================
+# Fc2OutputDest  (MegaMoE fc2 STG destination resolver, non-swap MXFP8 path)
+# =============================================================================
+
+
+@dataclasses.dataclass(frozen=True)
+class Fc2OutputDest:
+    """fc2 output destination in MoE-domain ``(token_max, topk, hidden)`` layout.
+
+    Mirrors the indirect-mode resolution used by the NVFP4 ``Fc2ReturnTile``
+    (``moe_nvfp4_swapab.epilogue``) but specialised for the non-swap-AB MXFP8
+    epilogue, whose fc2 STG is already a simple per-(token_row, hidden) store.
+
+    * ``metadata`` / ``peer_rank_ptr_mapper`` both ``None`` -- **direct mode**:
+      the row is ``tensor[pool_token, 0, :]`` on the local rank.
+    * Both non-``None`` -- **indirect mode** (MegaMoE form A): each lane LDGs
+      ``(src_rank, src_token, src_topk)`` from ``metadata[pool_token, :]`` and
+      writes to ``peer(src_rank).tensor[src_token, src_topk, :]`` via
+      ``peer_rank_ptr_mapper.ptr_map_to_rank(local_addr, src_rank)``.
+
+    ``metadata`` is the ``(pool_token_count, TokenSrcMetadata.nbytes)`` Uint8 view
+    (or any recast with the same base pointer) of the dispatch warps'
+    ``token_src_metadata`` record; each record is one packed Int64 decoded by
+    ``TokenSrcMetadata.load()``.  ``peer_rank_ptr_mapper``
+    is a ``SymBuffer{world_size}`` instance (returns a zero delta when
+    ``src_rank == local_rank``, so single-rank runs fold to a no-op).
+    """
+
+    tensor: cute.Tensor
+    metadata: Optional[cute.Tensor] = None
+    peer_rank_ptr_mapper: Any = None
+    reduce_topk_in_kernel: bool = False
+
+    def __post_init__(self) -> None:
+        if (self.metadata is None) != (self.peer_rank_ptr_mapper is None):
+            raise ValueError(
+                "Fc2OutputDest: ``metadata`` and ``peer_rank_ptr_mapper`` must be "
+                "both None (direct mode) or both non-None (MegaMoE / indirect "
+                "mode).  Got metadata="
+                f"{'set' if self.metadata is not None else 'None'}, "
+                f"peer_rank_ptr_mapper="
+                f"{'set' if self.peer_rank_ptr_mapper is not None else 'None'}."
+            )
+
+    @cute.jit
+    def resolve_token_row(self, pool_token_global) -> cute.Tensor:
+        """Return the ``(hidden,)`` BF16 GMEM row this pool token's STG lands on.
+
+        Direct mode: ``tensor[pool_token_global, 0, :]`` on the local rank.
+        Indirect mode: LDG packed i64 from ``metadata`` at byte offset
+        ``pool_token_global * TokenSrcMetadata.nbytes``, unpack via
+        ``TokenSrcMetadata.load()`` to get ``(src_rank, src_token, src_topk)``,
+        build the local-rank row view, then rebase the row's GMEM pointer
+        through ``peer_rank_ptr_mapper.ptr_map_to_rank`` so the iterator points
+        at the source rank's combine slot.
+        """
+        if cutlass.const_expr(self.metadata is None):
+            return cute.slice_(self.tensor, (pool_token_global, 0, None))
+
+        md = TokenSrcMetadata.load(
+            self.metadata.iterator.toint()
+            + Int64(pool_token_global) * Int64(TokenSrcMetadata.nbytes)
+        )
+        src_rank = md.src_rank
+        src_token = md.src_token
+        if cutlass.const_expr(self.reduce_topk_in_kernel):
+            src_topk = cutlass.Int32(0)
+        else:
+            src_topk = md.src_topk
+        local_row = cute.slice_(self.tensor, (src_token, src_topk, None))
+        peer_iter = self.peer_rank_ptr_mapper.ptr_map_to_rank(
+            local_row.iterator, src_rank,
+        )
+        return cute.make_tensor(peer_iter, local_row.layout)
+
+
+# =============================================================================
+# GluMxfp8Epilogue
+# =============================================================================
+
+class GluMxfp8Epilogue:
+
+    _SubtileBarIdBase = 4
+    # Named barrier for cross-warp sync during raw-C TMA stores.
+    _CStoreBarId = 10
+
+    def __init__(
+        self,
+        *,
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        use_2cta_instrs: bool,
+        sf_vec_size: int,
+        fc1_output_dtype: Type[cutlass.Numeric],
+        fc1_output_layout: utils.LayoutEnum,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        sf_dtype: Type[cutlass.Numeric] = cutlass.Float8E8M0FNU,
+        c_dtype: Type[cutlass.Numeric] = cutlass.BFloat16,
+        glu_clamp: Optional[float] = None,
+        allow_overlap_acc: bool = True,
+        epilog_sync_bar_id: int = 1,
+        epilogue_warp_ids: Tuple[int, ...] = (0, 1, 2, 3),
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,
+        fc2_in_kernel_topk_reduce: bool = False,
+        token_back_by_dispatch: bool = False,
+        epi_flag_batch: Union[int, Tuple[int, int]] = 1,
+        apply_topk_in_fc1: bool = False,
+        generate_c: bool = False,
+        use_stg_fc1: bool = False,
+        combine_format: Optional[Any] = None,
+    ) -> None:
+        self.fc1_output_dtype = fc1_output_dtype
+        self.fc1_output_layout = fc1_output_layout
+        self.acc_dtype = acc_dtype
+        self.sf_dtype = sf_dtype
+        self._sf_vec_size = sf_vec_size
+        self._c_dtype = c_dtype
+        self._epilog_sync_bar_id = epilog_sync_bar_id
+        self._epilogue_warp_ids = epilogue_warp_ids
+        self._use_2cta_instrs = use_2cta_instrs
+
+        self._atom_thr_size = 2 if use_2cta_instrs else 1
+        self._cta_tile_m = mma_tiler_mnk[0] // self._atom_thr_size
+        self._cta_tile_n = mma_tiler_mnk[1]
+        self._mma_tiler_k = mma_tiler_mnk[2]
+        self._cta_tile_n_sfb = ((mma_tiler_mnk[1] + 127) // 128) * 128
+        self._static_expert_shape = static_expert_shape
+        if (
+            static_expert_shape is not None
+            and static_expert_shape[2] % (self._cta_tile_m * cluster_shape_mn[0]) == 0
+        ):
+            self._fc2_stg_needs_predicate: bool = False
+        else:
+            self._fc2_stg_needs_predicate: bool = True
+
+        # Non-swap-AB: TMA tile is (EpilogueTileN tokens, Fc1EpilogueOutputTileN intermediates)
+        self._epi_tile = (EpilogueTileN, Fc1EpilogueOutputTileN)
+        # BWD: gemm1's accumulator is a plain dA block (no gate/up pair), so
+        # the accumulator subtile count is cta_tile_n/32 (like fc2), while the
+        # OUTPUT per subtile is a 64-col interleaved (dg, du) pair — the
+        # forward's 2:1 contraction becomes a 1:2 expansion (BWD_DESIGN.md D3).
+        self._subtile_cnt = self._cta_tile_n // EpilogueTileN
+        if not generate_c:
+            raise ValueError(
+                "backward epilogue requires generate_c=True: the fc1_c tensor "
+                "is the (gate, up) stash CONSUMED by SwiGLU-bwd"
+            )
+        if not use_stg_fc1:
+            raise ValueError(
+                "backward epilogue v0 only implements the use_stg_fc1 store "
+                "path (the SMEM+TMA fc1_output path is not widened to 2I)"
+            )
+        if glu_clamp is not None:
+            raise ValueError(
+                "backward epilogue does not implement the clamp derivative"
+            )
+
+        self._overlapping_accum = allow_overlap_acc and (
+            self._cta_tile_n == EpiWarpCount * EpilogueTileN * 2
+        )
+        self._overlapping_accum = True
+
+        self._num_acc_stage = 2
+        self._num_acc_pipeline_stages = (
+            1 if self._overlapping_accum else self._num_acc_stage
+        )
+
+        k = self._mma_tiler_k
+        self._num_sfa_tmem_cols = self._cta_tile_m * k // sf_vec_size * 4 // 4 // 128
+        self._num_sfb_tmem_cols = (
+            self._cta_tile_n_sfb * k // sf_vec_size * 4 // 4 // 128
+        )
+        self._num_sf_tmem_cols = 32 # self._num_sfa_tmem_cols + self._num_sfb_tmem_cols
+
+        self._num_accumulator_tmem_cols = self._cta_tile_n * self._num_acc_stage - (
+            self._num_sf_tmem_cols if self._overlapping_accum else 0
+        )
+
+        self._iter_acc_early_release = (
+            self._num_sf_tmem_cols + EpilogueTileN - 1
+        ) // EpilogueTileN
+
+        self._fc2_in_kernel_topk_reduce = fc2_in_kernel_topk_reduce
+        self._token_back_by_dispatch = token_back_by_dispatch
+        self._apply_topk_in_fc1 = apply_topk_in_fc1
+        self._generate_c = generate_c
+        self._use_stg_fc1 = use_stg_fc1
+        # combine_format determines fc2 output encoding: bf16 (default) or quantized.
+        if combine_format is None:
+            combine_format = CombineFormat.parse("bf16")
+        self._combine_format = combine_format
+        self._combine_mxfp8 = combine_format.is_quantized
+        # sf_block_pad for fc2 MXFP8 combine: number of E8M0 entries per pool
+        # token, padded to 16 (= 16-byte TMA alignment for E8M0 1 byte/element).
+        # EpilogueTileN = 32 = sf_vec_size, so hidden // EpilogueTileN = sf_blocks.
+        if self._combine_mxfp8 and static_expert_shape is not None:
+            _hidden_fc2 = static_expert_shape[2]
+            _sf_blocks_fc2 = _hidden_fc2 // EpilogueTileN
+            self._fc2_sf_block_pad = ((_sf_blocks_fc2 + 15) // 16) * 16
+            self._hidden_fc2 = _hidden_fc2
+        else:
+            self._fc2_sf_block_pad = 0
+            self._hidden_fc2 = 0
+        # stg.64 SF batching: when hidden is a whole multiple of cta_tile_n every
+        # scheduled fc2 N-tile owns a full run of fc2_subtile_cnt (= 8) contiguous,
+        # in-bounds E8M0 blocks per token (the plane is token-row-major, block
+        # stride 1), so a thread's 8 per-subtile scales flush as one 64-bit store.
+        # Otherwise the ragged tail tile falls back to per-block 1-byte stores.
+        self._fc2_sf_batch8 = (
+            self._combine_mxfp8
+            and self._hidden_fc2 > 0
+            and (self._hidden_fc2 % self._cta_tile_n == 0)
+            and (self._cta_tile_n // EpilogueTileN == 8)
+        )
+        self._epi_tile_c = (self._cta_tile_m, 2 * Fc1GateUpInterleave)
+        if isinstance(epi_flag_batch, tuple):
+            self._epi_fc1_batch = max(1, epi_flag_batch[0])
+            self._epi_fc2_batch = max(1, epi_flag_batch[1])
+        else:
+            self._epi_fc1_batch = max(1, epi_flag_batch)
+            self._epi_fc2_batch = max(1, epi_flag_batch)
+
+        self.glu_clamp = (
+            cutlass.Float32(glu_clamp) if glu_clamp is not None else None
+        )
+
+    # -- Codegen-time queries  --
+
+    @property
+    def epi_tile(self) -> Tuple[int, int]:
+        return self._epi_tile
+
+    @property
+    def overlapping_accum(self) -> bool:
+        return self._overlapping_accum
+
+    @property
+    def num_acc_pipeline_stages(self) -> int:
+        return self._num_acc_pipeline_stages
+
+    @property
+    def num_acc_stage(self) -> int:
+        return self._num_acc_stage
+
+    @property
+    def iter_acc_early_release(self) -> int:
+        return self._iter_acc_early_release
+
+    @property
+    def subtile_cnt(self) -> int:
+        return self._subtile_cnt
+
+    @property
+    def cta_tile_n(self) -> int:
+        return self._cta_tile_n
+
+    @property
+    def num_sf_tmem_cols(self) -> int:
+        return self._num_sf_tmem_cols
+
+    @property
+    def num_sfa_tmem_cols(self) -> int:
+        return self._num_sfa_tmem_cols
+
+    @property
+    def num_sfb_tmem_cols(self) -> int:
+        return self._num_sfb_tmem_cols
+
+    @property
+    def num_accumulator_tmem_cols(self) -> int:
+        return self._num_accumulator_tmem_cols
+
+    def staged_smem_layout(
+        self,
+        n_stages: int,
+    ) -> Union[cute.Layout, cute.ComposedLayout]:
+        return sm100_utils.make_smem_layout_epi(
+            self.fc1_output_dtype,
+            self.fc1_output_layout,
+            self._epi_tile,
+            n_stages,
+        )
+
+    @property
+    def smem_layout_one_stage(self) -> Union[cute.Layout, cute.ComposedLayout]:
+        staged = self.staged_smem_layout(1)
+        return cute.select(staged, mode=[0, 1])
+
+    @property
+    def bytes_per_stage(self) -> int:
+        return cute.size_in_bytes(self.fc1_output_dtype, self.smem_layout_one_stage)
+
+    @property
+    def epi_tile_c(self) -> Tuple[int, int]:
+        """TMA tile for raw gate+up output: (cta_tile_m=128, 2*Fc1GateUpInterleave=64) fp32."""
+        return self._epi_tile_c
+
+    def staged_c_smem_layout(self, n_stages: int):
+        """SMEM layout for n_stages of raw gate+up (Float32, row-major, epi_tile_c)."""
+        return sm100_utils.make_smem_layout_epi(
+            self._c_dtype,
+            self.fc1_output_layout,  # same N-major direction as fc1 output
+            self._epi_tile_c,
+            n_stages,
+        )
+
+    @property
+    def c_smem_layout_one_stage(self):
+        return cute.select(self.staged_c_smem_layout(1), mode=[0, 1])
+
+    @property
+    def c_bytes_per_stage(self) -> int:
+        return cute.size_in_bytes(self._c_dtype, self.c_smem_layout_one_stage)
+
+    @staticmethod
+    @cute.jit
+    def tma_store_fc1_output(
+        warp_idx,
+        sC,
+        store_idx,
+        tma_atom_fc1_output: cute.CopyAtom,
+        g_fc1_output_subtile_view: cute.Tensor,
+        valid_tokens,
+    ) -> None:
+        """
+        Per-warp TMA store for non-swap-AB MXFP8 FC1 output.
+        Uses rotated-leader pattern (leader = warp store_idx).
+        SMEM stage store_idx has (EpilogueTileN tokens × Fc1EpilogueOutputTileN intermediates).
+        All 4 warps arrive at barrier store_idx+_SubtileBarIdBase, leader issues TMA.
+        """
+        cute.arch.fence_proxy("async.shared", space="cta")
+        sC_stage = cute.slice_(sC, (None, None, store_idx))
+        g_fc1_output_2d = cute.slice_(g_fc1_output_subtile_view, (None, None, 0))
+        bSG_sC, bSG_g = cpasync.tma_partition(
+            tma_atom_fc1_output,
+            0,
+            cute.make_layout(1),
+            cute.group_modes(sC_stage, 0, 2),
+            cute.group_modes(g_fc1_output_2d, 0, 2),
+        )
+
+        leader_warp = store_idx
+        tile_has_valid = (
+            store_idx * cutlass.Int32(EpilogueTileN) < valid_tokens
+        )
+
+        bar_id = store_idx + cutlass.Int32(GluMxfp8Epilogue._SubtileBarIdBase)
+        bar = pipeline.NamedBarrier(
+            barrier_id=bar_id,
+            num_threads=EpiWarpCount * WarpThreadCount,
+        )
+        if warp_idx == leader_warp:
+            bar.arrive_and_wait()
+            # TMA bulk-tensor stores are all-or-nothing per issue (no per-element
+            # `pred` mask, no scalar predicate arg), so guard the whole copy with
+            # a runtime `if`.  Skips fully-padding token-tiles that would alias
+            # the next expert's region.
+            if tile_has_valid:
+                cute.copy(tma_atom_fc1_output, bSG_sC, bSG_g)
+        else:
+            bar.arrive()
+
+    @cute.jit
+    def _store_fc1_c_subtile(
+        self,
+        r_gate: cute.Tensor,
+        r_up: cute.Tensor,
+        smem_c_buffer: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        gmem_c_subtile_view: cute.Tensor,
+        c_buffer_idx,
+        work_tile_info,
+        warp_idx: int,
+        tidx,
+        c_pipeline,
+    ) -> None:
+        """Store pre-SwiGLU gate/up accumulators to the global C tensor via SMEM staging."""
+        r_layout = cute.make_layout((((Fc1GateUpInterleave,), 1),), stride=(((1,), 0),))
+
+        # Cast acc_dtype (Float32) → c_dtype (e.g. BFloat16) before R2S.
+        # smem stage is guaranteed free by the producer_acquire() from the previous call.
+        r_gate_c = cute.make_rmem_tensor(r_layout.shape, self._c_dtype)
+        r_up_c = cute.make_rmem_tensor(r_layout.shape, self._c_dtype)
+        r_gate_c.store(r_gate.load().to(self._c_dtype))
+        r_up_c.store(r_up.load().to(self._c_dtype))
+
+        r2s_c_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(), self._c_dtype, num_bits_per_copy=128,
+        )
+        thread_in_warp_c = tidx % cutlass.Int32(WarpThreadCount)
+        c_row = cutlass.Int32(warp_idx * EpilogueTileN) + thread_in_warp_c
+        sC_raw_stage = cute.slice_(smem_c_buffer, (None, None, c_buffer_idx))
+        c_gate_smem = cute.local_tile(
+            sC_raw_stage, (1, Fc1GateUpInterleave), (c_row, cutlass.Int32(0)),
+        )
+        cute.copy(r2s_c_atom, cute.coalesce(r_gate_c), cute.coalesce(c_gate_smem))
+        c_up_smem = cute.local_tile(
+            sC_raw_stage, (1, Fc1GateUpInterleave), (c_row, cutlass.Int32(1)),
+        )
+        cute.copy(r2s_c_atom, cute.coalesce(r_up_c), cute.coalesce(c_up_smem))
+
+        # Fence + barrier: ensure all warps have written before TMA issue.
+        cute.arch.fence_proxy("async.shared", space="cta")
+        c_store_bar = pipeline.NamedBarrier(
+            barrier_id=self._CStoreBarId,
+            num_threads=EpiWarpCount * WarpThreadCount,
+        )
+        c_store_bar.arrive_and_wait()
+
+        # Warp 0 issues TMA S2G, commits, then pre-acquires the next stage so
+        # smem is guaranteed free before the next call's R2S writes.
+        if warp_idx == 0:
+            if work_tile_info.valid_tokens_in_cta_tile > cutlass.Int32(0):
+                g_c_2d = cute.slice_(gmem_c_subtile_view, (None, None, 0))
+                bSG_sC, bSG_gC = cpasync.tma_partition(
+                    tma_atom_c, 0, cute.make_layout(1),
+                    cute.group_modes(sC_raw_stage, 0, 2),
+                    cute.group_modes(g_c_2d, 0, 2),
+                )
+                cute.copy(tma_atom_c, bSG_sC, bSG_gC)
+            c_pipeline.producer_commit()
+
+    def _subtile_local_tmem_tensor_single(
+        self,
+        tmem_acc_tensor: cute.Tensor,
+        subtile_idx,
+        warp_idx,
+    ) -> cute.Tensor:
+        """BWD: one 32-col dA TMEM view (the forward's (gate, up) pair reader
+        collapsed to a single tensor; subtile stride is 32 cols, not 64)."""
+        base = tmem_acc_tensor.iterator
+        warp_lane_off = warp_idx * WarpThreadCount
+        subtile_col_off = subtile_idx * EpilogueTileN
+        total = (warp_lane_off << 16) + subtile_col_off
+        subtile_ptr = base + cute.assume(total, divby=16)
+        return cute.make_tensor(
+            subtile_ptr,
+            _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+        )
+
+    def _subtile_forward_tmem_tensor(
+        self,
+        tmem_dacc_tensor: cute.Tensor,
+        col_offset: int,
+    ) -> cute.Tensor:
+        """Move the dA tmem tensor to the next subtile position."""
+        tmem_ptr = tmem_dacc_tensor.iterator + cute.assume(col_offset, divby=16)
+        return cute.make_tensor(
+            tmem_ptr,
+            _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+        )
+
+    # -- fc1 subtile: SM100 path --
+    @cute.jit
+    def _run_fc1_task_tile(
+        self,
+        work_tile_info,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn,
+        smem_fc1_output_buffer: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        sched_ext,
+        gmem_fc1_output: cute.Tensor,
+        gmem_fc1_output_sf: cute.Tensor,
+        gmem_topk_scores: cute.Tensor,
+        warp_idx: int,
+        tidx,
+        alpha,
+        norm_const,
+        smem_c_buffer: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        gmem_c: cute.Tensor,
+        gmem_c_in: cute.Tensor,
+        c_pipeline,
+    ) -> None:
+        """BWD fc1 task-tile: dA TMEM loading + fc1_c LDGs + DFC1 stash store."""
+        real_fc1_output, _    = sched_ext.get_gmem_tensor("d",    gmem_fc1_output,    work_tile_info)
+        real_fc1_output_sf, _ = sched_ext.get_gmem_tensor("sfd",  gmem_fc1_output_sf, work_tile_info)
+        real_topk_scores, _   = sched_ext.get_gmem_tensor("topk", gmem_topk_scores,   work_tile_info)
+
+        if cutlass.const_expr(self._generate_c):
+            real_c, _ = sched_ext.get_gmem_tensor("c", gmem_c, work_tile_info)
+            real_c_in, _ = sched_ext.get_gmem_tensor("c", gmem_c_in, work_tile_info)
+            c_n_base = work_tile_info.tile_n_idx * cutlass.Int32(self._subtile_cnt)
+
+        acc_pipeline.consumer_wait(acc_consumer_state)
+        iket.range_push("mxfp8_fc1_epi_tile")
+
+        if cutlass.const_expr(self._overlapping_accum):
+            acc_stage_col_offset = cutlass.Int32(acc_consumer_state.phase) * (
+                256 - self._num_sf_tmem_cols
+            )
+        else:
+            acc_stage_col_offset = (
+                cutlass.Int32(acc_consumer_state.index) * self._cta_tile_n
+            )
+
+        subtile_cnt  = self._subtile_cnt
+        tmem_dacc = self._subtile_local_tmem_tensor_single(
+            tmem_acc_tensor, subtile_cnt - 1 if is_odd_turn else 0, warp_idx,
+        )
+        tmem_forward_cols = EpilogueTileN
+        if cutlass.const_expr(self._overlapping_accum):
+            if is_odd_turn:
+                tmem_forward_cols = -EpilogueTileN
+
+        # two E8M0 scales (dg, du) per accumulator subtile
+        layout_sf = cute.make_layout(2 * self._subtile_cnt)
+        rmem_sf = cute.make_rmem_tensor(layout_sf.shape, self.acc_dtype)
+
+        # ── Set up RMEM→SMEM copy atom (direct CopyUniversalOp) ──
+        r2s_copy_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyUniversalOp(),
+            self.fc1_output_dtype,
+            num_bits_per_copy=128,
+        )
+        tRS_sC = None
+
+        for i in cutlass.range(0, subtile_cnt, 1, unroll=1):
+            if cutlass.const_expr(self._overlapping_accum):
+                subtile_idx = cutlass.Int32(i)
+                if is_odd_turn:
+                    subtile_idx = cutlass.Int32(subtile_cnt - 1 - i)
+            else:
+                subtile_idx = cutlass.Int32(i)
+
+            # BWD: the fc1_c stash pair (gate, up) for THIS dA subtile —
+            # pair index over 2I = tile_n_idx * subtile_cnt + subtile_idx.
+            # The DFC1 stash-out tile has the same coordinates on real_c.
+            g_c_in_subtile = cute.local_tile(
+                real_c_in,
+                (self._cta_tile_m, 2 * Fc1GateUpInterleave, 1),
+                (work_tile_info.tile_m_idx, c_n_base + subtile_idx, cutlass.Int32(0)),
+            )
+            g_c_out_subtile = cute.local_tile(
+                real_c,
+                (self._cta_tile_m, 2 * Fc1GateUpInterleave, 1),
+                (work_tile_info.tile_m_idx, c_n_base + subtile_idx, cutlass.Int32(0)),
+            )
+            c_buffer_idx = cutlass.Int32(i % Fc1CTMAStages)
+
+            self._run_fc1_subtile(
+                subtile_idx=subtile_idx,
+                tmem_dacc_tensor=tmem_dacc,
+                real_fc1_output=real_fc1_output,
+                real_topk_scores=real_topk_scores,
+                work_tile_info=work_tile_info,
+                warp_idx=warp_idx,
+                tidx=tidx,
+                norm_const=norm_const,
+                rmem_sf=rmem_sf,
+                acc_is_release=(i == 0),
+                acc_pipeline=acc_pipeline,
+                acc_consumer_state=acc_consumer_state,
+                gmem_c_subtile_view=g_c_in_subtile,
+                smem_c_buffer=smem_c_buffer,
+                tma_atom_c=tma_atom_c,
+                gmem_c_out_subtile_view=g_c_out_subtile,
+                c_buffer_idx=c_buffer_idx,
+                c_pipeline=c_pipeline,
+            )
+
+            tmem_dacc = self._subtile_forward_tmem_tensor(tmem_dacc, tmem_forward_cols)
+
+        if not cutlass.const_expr(self._overlapping_accum):
+            self._acc_pipeline_consumer_release(acc_pipeline, acc_consumer_state, True)
+
+        self._stg_sf_fc1(rmem_sf, real_fc1_output_sf, work_tile_info, tidx)
+
+        # ── TMA store: 4 stores (one per warp group) after all subtiles ──
+        if cutlass.const_expr(not self._use_stg_fc1):
+            base_token_tile = (
+                work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m // EpilogueTileN)
+            )
+            for idx in cutlass.range_constexpr(EpiWarpCount):
+                g_fc1_output_warp_view = cute.local_tile(
+                    real_fc1_output,
+                    (EpilogueTileN, Fc1EpilogueOutputTileN, 1),
+                    (base_token_tile + idx, work_tile_info.tile_n_idx, 0),
+                )
+                GluMxfp8Epilogue.tma_store_fc1_output(
+                    warp_idx, smem_fc1_output_buffer, idx,
+                    tma_atom_fc1_output, g_fc1_output_warp_view,
+                    work_tile_info.valid_tokens_in_cta_tile,
+                )
+
+        iket.range_pop()
+
+    @cute.jit
+    def _run_fc1_subtile(
+        self,
+        subtile_idx,
+        tmem_dacc_tensor: cute.Tensor,
+        real_fc1_output: cute.Tensor,
+        real_topk_scores: cute.Tensor,
+        work_tile_info,
+        warp_idx: int,
+        tidx,
+        norm_const,
+        rmem_sf: cute.Tensor,
+        acc_is_release: bool,
+        acc_pipeline,
+        acc_consumer_state,
+        gmem_c_subtile_view: cute.Tensor,
+        smem_c_buffer: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        gmem_c_out_subtile_view: cute.Tensor,
+        c_buffer_idx,
+        c_pipeline,
+    ) -> None:
+        """BWD gemm1 subtile: dA (32 tmem cols) + per-thread LDG of the fc1_c
+        (gate, up) pair -> SwiGLU-bwd -> bf16 (dg, du) stash TMA store +
+        two quantized 32-col blocks into the 2I-wide fc1_output
+        (BWD_DESIGN.md D3/D5)."""
+        iket.range_push("mxfp8_bwd_fc1_epilogue_subtile")
+
+        r_layout = cute.make_layout((((Fc1GateUpInterleave,), 1),), stride=(((1,), 0),))
+        r_dacc = cute.make_rmem_tensor(r_layout.shape, self.acc_dtype)
+
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.Ld32x32bOp(tcgen05.Repetition.x32), self.acc_dtype,
+        )
+        cute.copy(atom_t2r, tmem_dacc_tensor, r_dacc)
+
+        self._acc_pipeline_consumer_release(acc_pipeline, acc_consumer_state, acc_is_release)
+
+        # ── per-thread LDG of this row's stashed raw (gate, up) 32-blocks.
+        # Lane L of warp W owns token row W*32+L (same ownership as the
+        # forward C-store); each block is 32 contiguous bf16 = 64 B.
+        thread_in_warp = tidx % cutlass.Int32(WarpThreadCount)
+        c_row = cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+        r_gate = cute.make_rmem_tensor(r_layout.shape, self.acc_dtype)
+        r_up = cute.make_rmem_tensor(r_layout.shape, self.acc_dtype)
+        r_c_bf16 = cute.make_rmem_tensor(r_layout.shape, self._c_dtype)
+        for half in cutlass.range_constexpr(2):
+            g_half = cute.local_tile(
+                gmem_c_subtile_view,
+                (1, Fc1GateUpInterleave, 1),
+                (c_row, cutlass.Int32(half), cutlass.Int32(0)),
+            )
+            # runtime row coord drops assumed_align to the element size;
+            # block starts are 64 B-aligned (row stride 2I*2 B, col offset
+            # a multiple of 64 B) — reassert 16 B for vectorized LDG.
+            half_ptr = cute.make_ptr(
+                self._c_dtype,
+                g_half.iterator.toint(),
+                cute.AddressSpace.gmem,
+                assumed_align=16,
+            )
+            g_vec = cute.make_tensor(half_ptr, cute.make_layout(Fc1GateUpInterleave))
+            cute.autovec_copy(g_vec, cute.coalesce(r_c_bf16))
+            if cutlass.const_expr(half == 0):
+                r_gate.store(r_c_bf16.load().to(self.acc_dtype))
+            else:
+                r_up.store(r_c_bf16.load().to(self.acc_dtype))
+
+        topk = None
+        if cutlass.const_expr(self._apply_topk_in_fc1):
+            token_in_tile_topk = (
+                work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                + cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+            )
+            topk = Float32(real_topk_scores[token_in_tile_topk])
+
+        r_du = cute.make_rmem_tensor(r_layout.shape, self.acc_dtype)
+        r_dg = cute.make_rmem_tensor(r_layout.shape, self.acc_dtype)
+        swiglu_bwd(r_du, r_dg, r_dacc, r_up, r_gate, topk)
+
+        # ── stash raw bf16 (dg, du) for the host-side wgrads via the
+        # generate_c TMA-store machinery (must run BEFORE quant_sfd_row —
+        # it scales its src rmem in place).  Slot order (dg, du) matches
+        # the (gate, up) store layout.
+        self._store_fc1_c_subtile(
+            r_gate=r_dg,
+            r_up=r_du,
+            smem_c_buffer=smem_c_buffer,
+            tma_atom_c=tma_atom_c,
+            gmem_c_subtile_view=gmem_c_out_subtile_view,
+            c_buffer_idx=c_buffer_idx,
+            work_tile_info=work_tile_info,
+            warp_idx=warp_idx,
+            tidx=tidx,
+            c_pipeline=c_pipeline,
+        )
+
+        # quantize both 32-blocks; scale order (dg, du) matches the gate-first
+        # interleave of the output pair and of W13^T's K axis (weights_bwd).
+        c_dg = cute.make_rmem_tensor(r_layout.shape, self.fc1_output_dtype)
+        c_du = cute.make_rmem_tensor(r_layout.shape, self.fc1_output_dtype)
+        qp_dg = quant_sfd_row(r_dg, c_dg, norm_const, self._sf_vec_size, self.sf_dtype, self.fc1_output_dtype)
+        qp_du = quant_sfd_row(r_du, c_du, norm_const, self._sf_vec_size, self.sf_dtype, self.fc1_output_dtype)
+        for k in cutlass.range_constexpr(self._subtile_cnt):
+            if subtile_idx == k:
+                rmem_sf[2 * k] = qp_dg
+                rmem_sf[2 * k + 1] = qp_du
+
+        # ── direct STG.256 x2 into the 2I-wide fc1_output (use_stg_fc1 path).
+        token_in_tile = cutlass.Int32(warp_idx * EpilogueTileN) + thread_in_warp
+        if token_in_tile < work_tile_info.valid_tokens_in_cta_tile:
+            abs_token = (
+                work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                + cutlass.Int32(warp_idx * EpilogueTileN) + thread_in_warp
+            )
+            # pair base over the interleaved 2I output axis
+            col_elem = (
+                (work_tile_info.tile_n_idx * cutlass.Int32(self._subtile_cnt) + subtile_idx)
+                * cutlass.Int32(2 * Fc1GateUpInterleave)
+            )
+            stg_atom = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(), self.fc1_output_dtype, num_bits_per_copy=256,
+            )
+            g_base_dg = cute.local_tile(
+                real_fc1_output,
+                (1, 1, 1),
+                (abs_token, col_elem, cutlass.Int32(0)),
+            )
+            iter_dg = cute.make_ptr(
+                self.fc1_output_dtype,
+                g_base_dg.iterator.toint(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            g_vec_dg = cute.make_tensor(iter_dg, cute.make_layout(Fc1GateUpInterleave))
+            cute.copy(stg_atom, cute.coalesce(c_dg), g_vec_dg)
+            g_base_du = cute.local_tile(
+                real_fc1_output,
+                (1, 1, 1),
+                (abs_token, col_elem + cutlass.Int32(Fc1GateUpInterleave), cutlass.Int32(0)),
+            )
+            iter_du = cute.make_ptr(
+                self.fc1_output_dtype,
+                g_base_du.iterator.toint(),
+                cute.AddressSpace.gmem,
+                assumed_align=32,
+            )
+            g_vec_du = cute.make_tensor(iter_du, cute.make_layout(Fc1GateUpInterleave))
+            cute.copy(stg_atom, cute.coalesce(c_du), g_vec_du)
+
+        # single-stage C-store ping-pong: the stage must drain before the
+        # next subtile reuses it (mirrors the forward generate_c path).
+        if warp_idx == 0:
+            c_pipeline.producer_acquire()
+        c_store_bar = pipeline.NamedBarrier(
+            barrier_id=self._CStoreBarId,
+            num_threads=EpiWarpCount * WarpThreadCount,
+        )
+        c_store_bar.arrive_and_wait()
+
+        iket.range_pop()
+
+    @cute.jit
+    def _subtile_fc2_tmem_tensor(
+        self,
+        tmem_acc_tensor: cute.Tensor,
+        subtile_idx,
+        warp_idx,
+    ) -> cute.Tensor:
+        """
+        Per-warp TMEM view for one fc2 subtile (EpilogueTileN=32 cols).
+        """
+        base = tmem_acc_tensor.iterator
+        warp_lane_off = warp_idx * WarpThreadCount
+        subtile_col_off = subtile_idx * EpilogueTileN
+        total = (warp_lane_off << 16) + subtile_col_off
+        subtile_ptr = base + cute.assume(total, divby=16)
+        return cute.make_tensor(
+            subtile_ptr,
+            _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+        )
+
+    @cute.jit
+    def _advance_fc2_tmem_tensor(
+        self,
+        tmem_tensor: cute.Tensor,
+        col_offset: int,
+    ) -> cute.Tensor:
+        """Advance the fc2 TMEM tensor by col_offset cols (mirrors _subtile_forward_tmem_tensor)."""
+        new_ptr = tmem_tensor.iterator + cute.assume(col_offset, divby=16)
+        return cute.make_tensor(
+            new_ptr,
+            _TmemTranspose16x32Core._tmem_layout(32, EpilogueTileN),
+        )
+
+    @cute.jit
+    def _acc_pipeline_consumer_release(
+        self,
+        acc_pipeline,
+        acc_consumer_state,
+        is_release: bool,
+    ) -> None:
+        """Release the acc pipeline consumer."""
+        if is_release:
+            cute.arch.fence_view_async_tmem_load()
+            acc_pipeline.consumer_release(acc_consumer_state)
+
+    @cute.jit
+    def _run_fc2_subtile(
+        self,
+        subtile_idx,
+        tmem_subtile_tensor: cute.Tensor,
+        real_fc2_output: cute.Tensor,
+        work_tile_info,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+        token_comm_args=None,
+        rmem_sf_fc2=None,
+        *,
+        preload_acc=None,
+    ) -> None:
+        """fc2 subtile: LDTM + encode + STG.
+
+        Encoding follows ``self._combine_format``:
+          * BF16 (default): fp32->bf16 conversion, 256-bit STG × 2 half-tiles.
+          * MXFP8: quant_sfd_row fp32->e4m3 (32 elems = one block), single
+            256-bit STG for data; E8M0 scale written to local fc2_output_sf.
+
+        When ``token_comm_args`` is not None (MegaMoE path), the data STG is
+        routed to ``combine_output[src_token, src_topk, :]`` on the source rank
+        via ``Fc2OutputDest``; for token_back_by_dispatch the epilogue writes to
+        the local ``fc2_output_workspace`` pool instead.
+        """
+        iket.range_push("mxfp8_fc2_epilogue_subtile")
+
+        fc2_subtile_cnt = self._cta_tile_n // EpilogueTileN  # = 8
+        hidden_group = (
+            work_tile_info.tile_n_idx * cutlass.Int32(fc2_subtile_cnt) + subtile_idx
+        )
+        hidden_col_start = (
+            work_tile_info.tile_n_idx * cutlass.Int32(self._cta_tile_n)
+            + subtile_idx * cutlass.Int32(EpilogueTileN)
+        )
+        r_acc_layout = cute.make_layout((((EpilogueTileN,), 1),), stride=(((1,), 0),))
+        atom_t2r = cute.make_copy_atom(
+            tcgen05.Ld32x32bOp(tcgen05.Repetition.x32), self.acc_dtype,
+        )
+        r_acc = cute.make_rmem_tensor(r_acc_layout.shape, self.acc_dtype)
+        cute.copy(atom_t2r, tmem_subtile_tensor, r_acc)
+        thread_in_warp = tidx % WarpThreadCount
+        token_row_in_cta = cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+        valid_tokens = work_tile_info.valid_tokens_in_cta_tile
+        if token_row_in_cta < valid_tokens and hidden_col_start < valid_hidden:
+            if cutlass.const_expr(
+                token_comm_args is not None
+                and not self._token_back_by_dispatch
+                and self._combine_mxfp8
+            ):
+                # MegaMoE Form A, quantized combine:
+                # 1. Quantize fp32 → fp8 + compute E8M0 block scale.
+                # 2. STG fp8 data to peer's combine_output.
+                # 3. Write E8M0 scale to local fc2_output_sf for token-back push.
+                fp8_dtype = self._combine_format.act_dtype
+                r_fp8 = cute.make_rmem_tensor(r_acc_layout.shape, fp8_dtype)
+                qpvscale = quant_sfd_row(
+                    r_acc, r_fp8, 1.0, EpilogueTileN,
+                    cutlass.Float8E8M0FNU, fp8_dtype,
+                )
+                pool_token_global = (
+                    work_tile_info.cumulative_data_physical_row
+                    + work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                    + token_row_in_cta
+                )
+                metadata_u32 = cute.recast_tensor(
+                    token_comm_args.token_src_metadata, cutlass.Uint32,
+                )
+                fc2_output_dest = Fc2OutputDest(
+                    tensor=token_comm_args.combine_output,
+                    metadata=metadata_u32,
+                    peer_rank_ptr_mapper=token_comm_args.peer_rank_ptr_mapper,
+                )
+                dest_row = fc2_output_dest.resolve_token_row(pool_token_global)
+                # STG 32 fp8 elements = 256 bits in one shot.
+                r_fp8_flat = cute.make_tensor(r_fp8.iterator, cute.make_layout(32))
+                stg_fp8_atom = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), fp8_dtype,
+                    num_bits_per_copy=256,
+                )
+                dest_fp8_ptr = cute.make_ptr(
+                    fp8_dtype,
+                    dest_row.iterator.toint() + Int64(hidden_col_start),
+                    cute.AddressSpace.gmem,
+                    assumed_align=32,
+                )
+                cute.copy(
+                    stg_fp8_atom, r_fp8_flat,
+                    cute.make_tensor(dest_fp8_ptr, cute.make_layout(32)),
+                )
+                # Buffer the E8M0 scale; the whole task tile's 8 scales are
+                # flushed together by _stg_sf_fc2 (single stg.64 when aligned).
+                self._write_sf_fc2_buffer(rmem_sf_fc2, subtile_idx, qpvscale)
+            elif cutlass.const_expr(
+                self._token_back_by_dispatch and self._combine_mxfp8
+            ):
+                # MegaMoE token-back-by-dispatch + quantized combine:
+                # Epilogue writes fp8 data to local pool; dispatch warps push
+                # both data (fc2_output_workspace) and SF (fc2_output_sf) to peers.
+                pool_token_global = (
+                    work_tile_info.cumulative_data_physical_row
+                    + work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                    + token_row_in_cta
+                )
+                fp8_dtype = self._combine_format.act_dtype
+                r_fp8 = cute.make_rmem_tensor(r_acc_layout.shape, fp8_dtype)
+                qpvscale = quant_sfd_row(
+                    r_acc, r_fp8, 1.0, EpilogueTileN,
+                    cutlass.Float8E8M0FNU, fp8_dtype,
+                )
+                # Write 32 fp8 elements to local fc2_output_workspace pool.
+                fp8_byte_addr = (
+                    token_comm_args.fc2_output_workspace.iterator.toint()
+                    + Int64(pool_token_global) * Int64(self._hidden_fc2)
+                    + Int64(hidden_col_start)
+                )
+                stg_fp8_atom = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), fp8_dtype,
+                    num_bits_per_copy=256,
+                )
+                aligned_fp8_iter = cute.make_ptr(
+                    fp8_dtype,
+                    fp8_byte_addr,
+                    cute.AddressSpace.gmem,
+                    assumed_align=32,
+                )
+                r_fp8_flat = cute.make_tensor(r_fp8.iterator, cute.make_layout(EpilogueTileN))
+                cute.copy(
+                    stg_fp8_atom, r_fp8_flat,
+                    cute.make_tensor(aligned_fp8_iter, cute.make_layout(EpilogueTileN)),
+                )
+                # Buffer the E8M0 scale; flushed together by _stg_sf_fc2 after
+                # the subtile loop (single stg.64 when hidden-aligned).
+                self._write_sf_fc2_buffer(rmem_sf_fc2, subtile_idx, qpvscale)
+            else:
+                # BF16 path (default): fp32->bf16, two 256-bit STGs.
+                r_bf16 = cute.make_rmem_tensor(r_acc_layout.shape, cutlass.BFloat16)
+                r_bf16.store(r_acc.load().to(cutlass.BFloat16))
+                stg_atom = cute.make_copy_atom(
+                    cute.nvgpu.CopyUniversalOp(), cutlass.BFloat16, num_bits_per_copy=256,
+                )
+                for stg_half in cutlass.range_constexpr(EpilogueTileN // 16):
+                    reg_view = cute.make_tensor(
+                        r_bf16.iterator + stg_half * 16,
+                        cute.make_layout(16),
+                    )
+                    if cutlass.const_expr(
+                        token_comm_args is not None and not self._token_back_by_dispatch
+                    ):
+                        metadata_u32 = cute.recast_tensor(
+                            token_comm_args.token_src_metadata, cutlass.Uint32,
+                        )
+                        fc2_output_dest = Fc2OutputDest(
+                            tensor=token_comm_args.combine_output,
+                            metadata=metadata_u32,
+                            peer_rank_ptr_mapper=token_comm_args.peer_rank_ptr_mapper,
+                            reduce_topk_in_kernel=self._fc2_in_kernel_topk_reduce,
+                        )
+                        pool_token_global = (
+                            work_tile_info.cumulative_data_physical_row
+                            + work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                            + token_row_in_cta
+                        )
+                        dest_row = fc2_output_dest.resolve_token_row(pool_token_global)
+                        hidden_off = hidden_col_start + cutlass.Int32(stg_half * 16)
+                        dest_ptr = cute.make_ptr(
+                            cutlass.BFloat16,
+                            dest_row.iterator.toint() + hidden_off * cutlass.Int64(2),
+                            cute.AddressSpace.gmem,
+                            assumed_align=32,
+                        )
+                        if cutlass.const_expr(self._fc2_in_kernel_topk_reduce):
+                            reg_u32 = cute.recast_tensor(reg_view, cutlass.Uint32)
+                            for pair in cutlass.range_constexpr(16 // 4):
+                                _red_add_relaxed_sys_v2_bf16x2(
+                                    dest_ptr + cutlass.Int32(pair * 4),
+                                    cutlass.Uint32(reg_u32[pair * 2]),
+                                    cutlass.Uint32(reg_u32[pair * 2 + 1]),
+                                )
+                        else:
+                            cute.copy(
+                                stg_atom, reg_view,
+                                cute.make_tensor(dest_ptr, cute.make_layout(16)),
+                            )
+                    else:
+                        g_fc2_output_tile = cute.local_tile(
+                            real_fc2_output,
+                            (self._cta_tile_m, EpilogueTileN, 1),
+                            (work_tile_info.tile_m_idx, hidden_group, 0),
+                        )
+                        g_fc2_slice = cute.slice_(g_fc2_output_tile, (None, None, 0))
+                        g_thread_row = cute.local_tile(
+                            g_fc2_slice, (1, 16), (token_row_in_cta, stg_half),
+                        )
+                        g_flat = cute.coalesce(g_thread_row)
+                        aligned_iter = cute.make_ptr(
+                            cutlass.BFloat16,
+                            g_flat.iterator.toint(),
+                            cute.AddressSpace.gmem,
+                            assumed_align=32,
+                        )
+                        cute.copy(stg_atom, reg_view, cute.make_tensor(aligned_iter, g_flat.layout))
+
+        iket.range_pop()
+
+
+    @cute.jit
+    def _write_sf_fc2_buffer(self, rmem_sf_fc2, subtile_idx, qpvscale) -> None:
+        """Scatter one subtile's E8M0 scale into the per-tile SF buffer.
+
+        ``subtile_idx`` is runtime (the overlap-acc walk reverses it on odd
+        turns), so index with a const_expr if-chain -- mirrors fc1's rmem_sf.
+        """
+        for j in cutlass.range_constexpr(self._cta_tile_n // EpilogueTileN):
+            if subtile_idx == cutlass.Int32(j):
+                rmem_sf_fc2[j] = qpvscale
+
+    @cute.jit
+    def _stg_sf_fc2(
+        self,
+        rmem_sf_fc2: cute.Tensor,
+        token_comm_args,
+        work_tile_info,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+    ) -> None:
+        """Flush a task tile's fc2 E8M0 scales to local ``fc2_output_sf``.
+
+        The SF plane is token-row-major (blocks contiguous, stride 1), so this
+        thread's ``fc2_subtile_cnt`` scales land on contiguous bytes at
+        ``pool_token * sf_block_pad + tile_n * fc2_subtile_cnt``.  When hidden is
+        a whole multiple of ``cta_tile_n`` every N-tile is fully in-bounds, so
+        the 8 scales go out as one 64-bit store; otherwise fall back to per-block
+        predicated 1-byte stores for the ragged tail tile.
+
+        Token predicate mirrors ``_run_fc2_subtile``'s data STG: thread owns one
+        token row, so a single ``token_row_in_cta < valid_tokens`` guards the
+        whole flush (all subtiles share the token, only the block index moves).
+        """
+        fc2_subtile_cnt = self._cta_tile_n // EpilogueTileN
+        thread_in_warp = tidx % WarpThreadCount
+        token_row_in_cta = cutlass.Int32(warp_idx * WarpThreadCount) + thread_in_warp
+        if token_row_in_cta < work_tile_info.valid_tokens_in_cta_tile:
+            pool_token_global = (
+                work_tile_info.cumulative_data_physical_row
+                + work_tile_info.tile_m_idx * cutlass.Int32(self._cta_tile_m)
+                + token_row_in_cta
+            )
+            hidden_group_base = (
+                work_tile_info.tile_n_idx * cutlass.Int32(fc2_subtile_cnt)
+            )
+            sf_byte_addr = (
+                token_comm_args.fc2_output_sf.iterator.toint()
+                + Int64(pool_token_global) * Int64(self._fc2_sf_block_pad)
+                + Int64(hidden_group_base)
+            )
+            if cutlass.const_expr(self._fc2_sf_batch8):
+                stg_e8m0x8_from_f32(
+                    sf_byte_addr,
+                    rmem_sf_fc2[0], rmem_sf_fc2[1], rmem_sf_fc2[2], rmem_sf_fc2[3],
+                    rmem_sf_fc2[4], rmem_sf_fc2[5], rmem_sf_fc2[6], rmem_sf_fc2[7],
+                )
+            else:
+                for j in cutlass.range_constexpr(fc2_subtile_cnt):
+                    block_hidden_start = (
+                        work_tile_info.tile_n_idx * cutlass.Int32(self._cta_tile_n)
+                        + cutlass.Int32(j * EpilogueTileN)
+                    )
+                    if block_hidden_start < valid_hidden:
+                        stg_e8m0_from_f32(sf_byte_addr + Int64(j), rmem_sf_fc2[j])
+
+    @cute.jit
+    def _run_fc2_task_tile(
+        self,
+        work_tile_info,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        acc_consumer_state,
+        is_odd_turn,
+        sched_ext,
+        gmem_fc2_output: cute.Tensor,
+        valid_hidden,
+        warp_idx: int,
+        tidx,
+        token_comm_args=None,
+    ) -> None:
+        """fc2 (Linear2) task-tile body following fc1 pattern exactly.
+
+        Key alignment with fc1:
+          - acc_stage_col_offset = 0 for overlapping_accum (single physical stage)
+          - is_odd_turn determines start subtile (7 odd, 0 even) and direction
+          - consumer_release after first subtile (i==0) when overlapping_accum
+          - TMEM tensor advances by +/- EpilogueTileN each iteration
+        """
+        real_fc2_output, _ = sched_ext.get_gmem_tensor(
+            "d", gmem_fc2_output, work_tile_info,
+        )
+        acc_pipeline.consumer_wait(acc_consumer_state)
+        iket.range_push("mxfp8_fc2_epi_tile")
+
+        # For overlapping_accum: phase selects which TMEM stage holds the result,
+        # mirroring the fc1 epilogue formula.  When a cluster processes an fc1 tile
+        # before fc2, acc_consumer_state.phase is 1 and the result lives in the
+        # second physical stage (col offset 256-num_sf_tmem_cols).  Hardcoding 0
+        # reads the wrong stage for phase=1 clusters.
+        # For non-overlapping: stage index selects the physical region.
+        if cutlass.const_expr(self._overlapping_accum):
+            acc_stage_col_offset = cutlass.Int32(acc_consumer_state.phase) * (
+                256 - self._num_sf_tmem_cols
+            )
+        else:
+            acc_stage_col_offset = (
+                cutlass.Int32(acc_consumer_state.index) * self._cta_tile_n
+            )
+
+        fc2_subtile_cnt = self._cta_tile_n // EpilogueTileN  # = 8
+
+        # Start subtile mirrors fc1: last for odd turn, first for even.
+        start_subtile = fc2_subtile_cnt - 1 if is_odd_turn else 0
+        tmem_t = self._subtile_fc2_tmem_tensor(
+            tmem_acc_tensor, cutlass.Int32(start_subtile), warp_idx,
+        )
+
+        # Step direction mirrors fc1 gate/up: +EpilogueTileN (even) or -EpilogueTileN (odd).
+        tmem_forward_cols = EpilogueTileN
+        if cutlass.const_expr(self._overlapping_accum):
+            if is_odd_turn:
+                tmem_forward_cols = -EpilogueTileN
+
+        # Quantized combine: buffer the per-subtile E8M0 scales and flush them in
+        # one stg.64 after the loop (see _stg_sf_fc2).  Indexed by subtile_idx, so
+        # the reversed odd-turn walk fills the same slots.
+        if cutlass.const_expr(self._combine_mxfp8 and token_comm_args is not None):
+            layout_sf_fc2 = cute.make_layout(fc2_subtile_cnt)
+            rmem_sf_fc2 = cute.make_rmem_tensor(layout_sf_fc2.shape, self.acc_dtype)
+        else:
+            rmem_sf_fc2 = None
+
+        for i in cutlass.range(0, fc2_subtile_cnt, 1, unroll=1):
+            if cutlass.const_expr(self._overlapping_accum):
+                subtile_idx = cutlass.Int32(i)
+                if is_odd_turn:
+                    subtile_idx = cutlass.Int32(fc2_subtile_cnt - 1 - i)
+            else:
+                subtile_idx = cutlass.Int32(i)
+
+            self._run_fc2_subtile(
+                subtile_idx=subtile_idx,
+                tmem_subtile_tensor=tmem_t,
+                real_fc2_output=real_fc2_output,
+                work_tile_info=work_tile_info,
+                valid_hidden=valid_hidden,
+                warp_idx=warp_idx,
+                tidx=tidx,
+                token_comm_args=token_comm_args,
+                rmem_sf_fc2=rmem_sf_fc2,
+            )
+
+            if cutlass.const_expr(self._overlapping_accum):
+                self._acc_pipeline_consumer_release(acc_pipeline, acc_consumer_state, i == 0)
+
+            tmem_t = self._advance_fc2_tmem_tensor(tmem_t, tmem_forward_cols)
+
+        # Release AFTER all subtile reads (never early-release for FC2).
+        if not cutlass.const_expr(self._overlapping_accum):
+            self._acc_pipeline_consumer_release(acc_pipeline, acc_consumer_state, True)
+
+        # Flush the buffered E8M0 scales (one stg.64 per thread when aligned).
+        if cutlass.const_expr(self._combine_mxfp8 and token_comm_args is not None):
+            self._stg_sf_fc2(
+                rmem_sf_fc2=rmem_sf_fc2,
+                token_comm_args=token_comm_args,
+                work_tile_info=work_tile_info,
+                valid_hidden=valid_hidden,
+                warp_idx=warp_idx,
+                tidx=tidx,
+            )
+
+        iket.range_pop()
+
+
+    @cute.jit
+    def _stg_sf_fc1(
+        self,
+        rmem_sf_f32: cute.Tensor,
+        real_fc1_output_sf: cute.Tensor,
+        work_tile_info,
+        tidx,
+    ) -> None:
+        """Compute gmem SF tile coords and store fc1 scale factors to gmem.
+
+        Predicated on ``valid_tokens_in_cta_tile``: thread ``tidx`` owns the
+        CTA-relative token ``tidx``, so padding threads
+        (``tidx >= valid_tokens``) must skip the store.  SF is only padded to
+        ``SfPaddingBlock`` (128), but a CTA tile spans 128 tokens / a cluster
+        block 256, so an over-padded thread's SF GMEM row aliases the START of
+        the NEXT expert's SF region -- writing it corrupts that expert's scale
+        factors (off-by-one E8M0 exponent -> factor-of-2 output error).  Mirror
+        of the predicate in ``tma_store_fc1_output`` for the data store.
+        """
+        bx, _, _ = cute.arch.block_idx()
+        sf_idx = work_tile_info.tile_n_idx
+        token_idx = (
+            work_tile_info.tile_m_idx * self._cta_tile_m
+            + tidx
+        )
+        # BWD: 2*subtile_cnt scales per token per task tile (the output span
+        # is 2*cta_tile_n elements), flushed as groups of 4 contiguous E8M0
+        # bytes (4 blocks = 128 elements per group, same wire unit as fwd).
+        # Each group goes through the helper so unrolled iterations get fresh
+        # local scopes (the DSL rejects name rebinding inside a dynamic if).
+        num_groups = (2 * self._subtile_cnt) // 4
+        if tidx < work_tile_info.valid_tokens_in_cta_tile:
+            for g in cutlass.range_constexpr(num_groups):
+                self._stg_sf_fc1_group(
+                    rmem_sf_f32, real_fc1_output_sf, token_idx,
+                    sf_idx * cutlass.Int32(2 * self._cta_tile_n)
+                    + cutlass.Int32(g * 128),
+                    g,
+                )
+
+    @cute.jit
+    def _stg_sf_fc1_group(
+        self,
+        rmem_sf_f32: cute.Tensor,
+        real_fc1_output_sf: cute.Tensor,
+        token_idx,
+        elem_col,
+        group_idx: cutlass.Constexpr,
+    ) -> None:
+        """Store one 4-scale E8M0 group (128 output elements) for this token."""
+        sf_base = cute.local_tile(
+            real_fc1_output_sf,
+            (1, 1, 1),
+            (token_idx, elem_col, cutlass.Int32(0)),
+        )
+        # local_tile() with a runtime token_idx drops the pointer's
+        # assumed_align to 1 byte (the E8M0 element size), but the region
+        # base is 4B-aligned -- reassert that so the 4 bytes coalesce into
+        # a single STG.E.U32.
+        sf_ptr = cute.make_ptr(
+            self.sf_dtype,
+            sf_base.iterator.toint(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        )
+        gmem_sf_f8 = cute.make_tensor(sf_ptr, cute.make_layout(4))
+        sf_layout = cute.make_layout(4)
+        r_sf_grp = cute.make_rmem_tensor(sf_layout.shape, self.acc_dtype)
+        for j in cutlass.range_constexpr(4):
+            r_sf_grp[j] = rmem_sf_f32[group_idx * 4 + j]
+        r_sf_f8 = cute.make_rmem_tensor(sf_layout.shape, self.sf_dtype)
+        r_sf_f8.store(r_sf_grp.load().to(self.sf_dtype))
+        cute.autovec_copy(r_sf_f8, gmem_sf_f8)
+
+
+    @cute.jit
+    def run(
+        self,
+        tmem_acc_tensor: cute.Tensor,
+        acc_pipeline,
+        sched_consumer,
+        sched_ext,
+        smem_fc1_output_buffer: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        gmem_fc1_output: cute.Tensor,
+        gmem_fc1_output_sf: cute.Tensor,
+        gmem_topk_scores: cute.Tensor,
+        gmem_fc2_output: cute.Tensor,
+        gmem_fc1_done_counter: cute.Tensor,
+        warp_idx: int,
+        tidx,
+        alpha,
+        norm_const,
+        token_comm_args=None,
+        # generate_c: pass real sC / tma_atom_c / tma_tensor_c when True;
+        # pass smem_fc1_output_buffer / tma_atom_fc1_output / gmem_fc1_output as
+        # dummies when False — const_expr guards ensure no access.
+        smem_c_buffer: cute.Tensor = None,
+        tma_atom_c: cute.CopyAtom = None,
+        gmem_c: cute.Tensor = None,
+        gmem_c_in: cute.Tensor = None,
+    ) -> None:
+        """
+        Run the full MXFP8 fc1+fc2-fused epilogue task-tile loop.
+
+        ``token_comm_args`` (MegaMoE path) is forwarded to the fc2 task tile so
+        the fc2 STG is routed to the source rank's combine output.
+        """
+        acc_consumer_state = pipeline.make_pipeline_state(
+            pipeline.PipelineUserType.Consumer, self._num_acc_pipeline_stages
+        )
+
+        if cutlass.const_expr(self._generate_c):
+            _c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=Fc1CTMAStages,
+                producer_group=pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread,
+                    EpiWarpCount * WarpThreadCount,
+                ),
+            )
+        else:
+            _c_pipeline = None
+
+        task_tile_boundary_bar = pipeline.NamedBarrier(
+            barrier_id=self._epilog_sync_bar_id,
+            num_threads=32 * len(self._epilogue_warp_ids),
+        )
+
+        valid_hidden = cutlass.Int32(gmem_fc2_output.shape[1])
+
+        # Init=1 (reverse): overlap-acc path walks subtiles N-1, 0, ..., N-2
+        # so the overlap-region TMEM cols are released first.
+        is_odd_turn = cutlass.Int32(1)
+
+        bidx, bidy, bidz = cute.arch.block_idx()
+        work_tile_info = sched_consumer.consume_work()
+
+        flag_tracker = GpuReleaseFlagBatchTracker(
+            flag_addr=Int64(0),
+            cumulated_flags=cutlass.Int32(0),
+            phase=cutlass.Int32(work_tile_info.phase),
+            tid=tidx % (len(self._epilogue_warp_ids) * WarpThreadCount),
+        )
+
+        while work_tile_info.is_valid_tile:
+            acc_stage_index = 0 if is_odd_turn else 1
+            tmem_acc_stage_tesnor = tmem_acc_tensor[(None, None, None, acc_stage_index)]
+
+            if work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1):
+                if cutlass.const_expr(self._generate_c):
+                    _smem_c_buf = smem_c_buffer
+                    _tma_atom_c  = tma_atom_c
+                    _gmem_c      = gmem_c
+                    _gmem_c_in   = gmem_c_in
+                else:
+                    _smem_c_buf = smem_fc1_output_buffer
+                    _tma_atom_c  = tma_atom_fc1_output
+                    _gmem_c      = gmem_fc1_output
+                    _gmem_c_in   = gmem_fc1_output
+                self._run_fc1_task_tile(
+                    work_tile_info=work_tile_info,
+                    tmem_acc_tensor=tmem_acc_stage_tesnor,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                    is_odd_turn=is_odd_turn,
+                    smem_fc1_output_buffer=smem_fc1_output_buffer,
+                    tma_atom_fc1_output=tma_atom_fc1_output,
+                    sched_ext=sched_ext,
+                    gmem_fc1_output=gmem_fc1_output,
+                    gmem_fc1_output_sf=gmem_fc1_output_sf,
+                    gmem_topk_scores=gmem_topk_scores,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                    alpha=alpha,
+                    norm_const=norm_const,
+                    smem_c_buffer=_smem_c_buf,
+                    tma_atom_c=_tma_atom_c,
+                    gmem_c=_gmem_c,
+                    gmem_c_in=_gmem_c_in,
+                    c_pipeline=_c_pipeline,
+                )
+            else:
+                self._run_fc2_task_tile(
+                    work_tile_info=work_tile_info,
+                    tmem_acc_tensor=tmem_acc_stage_tesnor,
+                    acc_pipeline=acc_pipeline,
+                    acc_consumer_state=acc_consumer_state,
+                    is_odd_turn=is_odd_turn,
+                    sched_ext=sched_ext,
+                    gmem_fc2_output=gmem_fc2_output,
+                    valid_hidden=valid_hidden,
+                    warp_idx=warp_idx,
+                    tidx=tidx,
+                    token_comm_args=token_comm_args,
+                )
+
+            acc_consumer_state.advance()
+            if cutlass.const_expr(self._overlapping_accum):
+                is_odd_turn = cutlass.Int32(1) - is_odd_turn
+
+            cur_was_linear1 = work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+            # Use tile_m_idx // atom_thr_size (= cluster-level token block index)
+            # NOT tile_n_idx (= intermediate N-tile index).  Both fc1 N-tiles
+            # for the same token block share the same tile_m_idx, so all their
+            # increments target the same counter slot.  Using tile_n_idx splits
+            # increments across slots and deadlocks fc2's spin-wait.
+            cur_fc1_counter_slot = (
+                work_tile_info.cumulative_token_block_count
+                + work_tile_info.tile_m_idx // cutlass.Int32(self._atom_thr_size)
+            )
+            cur_fc2_expert_idx = work_tile_info.expert_idx
+
+            work_tile_info = sched_consumer.consume_work()
+
+            # Drain fc1 TMA/STG stores before publishing the fc1-done counter.
+            if cur_was_linear1:
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+                cute.arch.fence_acq_rel_gpu()
+
+            task_tile_boundary_bar.arrive_and_wait()
+
+            if cur_was_linear1:
+                flag_tracker = flag_tracker.accumulate(
+                    work_tile_info.phase,
+                    self._epi_fc1_batch,
+                    (gmem_fc1_done_counter.iterator + cur_fc1_counter_slot).toint(),
+                )
+            else:
+                if cutlass.const_expr(self._token_back_by_dispatch):
+                    # Fence before (deferred) counter release: make the fc2
+                    # pool-output STG writes device-visible.  The release
+                    # atomic in flag_tracker.fire() then signals completion.
+                    cute.arch.fence_acq_rel_gpu()
+                    fc2_flag_addr = (
+                        token_comm_args.fc2_done_counter.iterator + cur_fc2_expert_idx
+                    ).toint()
+                else:
+                    fc2_flag_addr = Int64(0)
+                no_fire: cutlass.Constexpr = not self._token_back_by_dispatch
+                flag_tracker = flag_tracker.accumulate(
+                    work_tile_info.phase,
+                    self._epi_fc2_batch,
+                    fc2_flag_addr,
+                    no_fire,
+                )
+
+        flag_tracker.fire()
+

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/kernel_bwd_fc12.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/kernel_bwd_fc12.py
@@ -1,0 +1,2413 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Fused fc1+fc2 GLU MXFP8 MegaMoE kernel for SM100.
+"""
+
+from typing import Literal, Optional, Tuple, Type, Union
+
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+try:
+    from cutlass.cute import iket  # type: ignore
+except ImportError:  # pragma: no cover -- fallback for wheels without cute.iket
+    from src.iket_compat import iket
+from cutlass.cute.nvgpu import cpasync, tcgen05
+import cutlass.utils as utils
+import cutlass.pipeline as pipeline
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+
+from moe_nvfp4_swapab.epilogue import SwapABSwigluFp4Epilogue, _TmemTranspose16x32Core
+from megamoe.bwd_kernel.epilogue_bwd import GluMxfp8Epilogue
+from moe_nvfp4_swapab.fc1_fc2_fuse_sched import (
+    BlockPhase,
+    MoEFusedFc12SchedulerParams,
+)
+from moe_nvfp4_swapab.custom_ext import GluMxFp8Fc12SchedExtension
+from common.megamoe_constants import (
+    Mxfp8BlockSize,
+    Nvfp4BlockSize,
+    SupportedMmaTileM,
+    SupportedMmaTileN,
+)
+from moe_nvfp4_swapab.moe_utils import spin_wait
+
+
+# =============================================================================
+# Sm100SwigluMxfp8Fc12Kernel
+# =============================================================================
+
+class Sm100SwigluMxfp8Fc12Kernel:
+
+    # SMEM budget for all "non-problem-tensor" buffers (mbarriers, sched
+    # work-tile buffer, TMEM allocator state).  Reserved at host side in
+    # ``_compute_stages``.  Bump if ``SharedStorage`` over-allocates SMEM.
+    _SmemMiscBudget = 1024
+
+    # Supported (ab_dtype, sf_vec_size) pairings.
+    # MXFP8 → Float8E4M3FN / Float8E5M2 + sf_vec_size=32  (FP8-E8M0 scales, MmaMXF8Op)
+    VALID_AB_DTYPE_SF_SIZE: dict = {
+        32: (cutlass.Float8E4M3FN, cutlass.Float8E5M2,),
+    }
+
+    # Interleave granularity for gate and up in SwiGLU / GeGlu
+    GateUpInterleave: int = 32
+
+    def __init__(
+        self,
+        # Geometry (no defaults; perf-sensitive + coupled by the validator:
+        # mma_tiler_m / cluster_m == 128;  use_2cta_instrs ⇔ mma_tiler_m == 256)
+        mma_tiler_mnk: Tuple[int, int, int],
+        cluster_shape_mnk: Tuple[int, int, int],
+        use_2cta_instrs: bool,
+        # Fused fc1+fc2 sched-side knobs
+        group_hint: int,
+        token_padding_block: int,
+        sf_padding_block: int,
+        load_balance_mode: Literal["static", "atomic_counter"] = "static",
+        # Optional sched knobs (None = sane internal default).
+        # ``static_expert_shape`` binds (experts, intermediate_gateup, hidden)
+        # at codegen time; None keeps those dims runtime-dynamic.
+        static_expert_shape: Optional[Tuple[int, int, int]] = None,
+        force_static_sched: bool = True,
+        clc_bundle_size: Optional[int] = None,
+        num_sched_stages: Optional[int] = None,
+        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+        sf_vec_size: int = 32,
+        ab_dtype: Type[cutlass.Numeric] = cutlass.Float4E2M1FN,
+        scenario: Literal["2Dx3D"] = "2Dx3D",
+        fc2_in_kernel_topk_reduce: bool = False,
+        token_back_by_dispatch: bool = False,
+        epi_flag_batch: Optional[Tuple[int, int]] = (1, 1),
+        gate_up_clamp: Optional[float] = None,
+        apply_topk_in_fc1: bool = False,
+        generate_c: bool = False,
+        use_stg_fc1: bool = False,
+    ) -> None:
+        # v1 only the lean static-sched path; dyn_2d3d 12-warp path
+        # (empty + drain_aux warps) is future work.
+        if not force_static_sched:
+            raise NotImplementedError(
+                "v1 only implements force_static_sched=True (lean 7-warp). "
+                "Dynamic CLC (force_static_sched=False) is future work."
+            )
+
+        # Validate (ab_dtype, sf_vec_size) pairing.
+        if sf_vec_size in self.VALID_AB_DTYPE_SF_SIZE:
+            valid_ab = self.VALID_AB_DTYPE_SF_SIZE[sf_vec_size]
+            if ab_dtype not in valid_ab:
+                raise ValueError(
+                    f"ab_dtype={ab_dtype.__name__} is not valid for "
+                    f"sf_vec_size={sf_vec_size}. "
+                    f"Expected one of: {[t.__name__ for t in valid_ab_tuple]}."
+                )
+        else:
+            raise NotImplementedError(
+                f"sf_vec_size must be {Mxfp8BlockSize} (MXFP8)"
+            )
+
+
+        if scenario != "2Dx3D":
+            raise NotImplementedError(
+                f"v1 fused fc12 only supports scenario='2Dx3D' (forward); "
+                f"got {scenario!r}."
+            )
+        if load_balance_mode not in ("static", "atomic_counter"):
+            raise ValueError(
+                f"load_balance_mode must be 'static' or 'atomic_counter'; "
+                f"got {load_balance_mode!r}."
+            )
+
+        # Only (M=256, N=256) with 2-CTA instructions is validated now.
+        m, n, _k = mma_tiler_mnk
+        if (m, n) != (256, 256) or not use_2cta_instrs:
+            raise ValueError(
+                "Sm100SwigluMxfp8Fc12Kernel only supports mma_tiler (M, N) = "
+                "(256, 256) with use_2cta_instrs=True; "
+                f"got mma_tiler_mnk={mma_tiler_mnk}, use_2cta_instrs={use_2cta_instrs}."
+            )
+
+        # Store ab_dtype so workspace-size helpers can use it without tensors.
+        self.ab_dtype = ab_dtype
+        self.c_dtype = cutlass.BFloat16
+
+        self.fc2_in_kernel_topk_reduce = fc2_in_kernel_topk_reduce
+        self.token_back_by_dispatch = token_back_by_dispatch
+        self.epi_flag_batch = epi_flag_batch
+        self.apply_topk_in_fc1 = apply_topk_in_fc1
+        self.generate_c = generate_c
+        self.use_stg_fc1 = use_stg_fc1
+        self.gate_up_clamp = (
+            abs(gate_up_clamp) if gate_up_clamp is not None else None
+        )
+
+        self.acc_dtype = acc_dtype
+        self.mma_tiler_mnk = mma_tiler_mnk
+        self.cluster_shape_mn = (cluster_shape_mnk[0], cluster_shape_mnk[1])
+        self.use_2cta_instrs = use_2cta_instrs
+        self.force_static_sched = force_static_sched
+        # static_expert_shape / clc_bundle_size / num_sched_stages: accepted
+        # for API parity with the runner; scheduler reads expert_cnt from
+        # ``offs.shape[0]`` at runtime when ``static_expert_shape`` is None.
+        self.static_expert_shape = static_expert_shape
+        self.clc_bundle_size = clc_bundle_size
+        self.num_sched_stages = num_sched_stages
+
+        # Fused fc12 sched-side knobs
+        self.group_hint = group_hint
+        self.token_padding_block = token_padding_block
+        self.sf_padding_block = sf_padding_block
+        self.load_balance_mode = load_balance_mode
+
+        self.sf_vec_size = sf_vec_size
+        self.scenario = scenario
+        self.arch = "sm_100"
+
+        self._validate_mma_tiler_and_cluster_shape()
+        self.mma_tiler = mma_tiler_mnk
+
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        # Warp specialization (lean 8-warp / 256 thread)
+        self.occupancy = 1
+        self.epilogue_warp_id = (0, 1, 2, 3)
+        self.mma_warp_id = 4
+        self.tma_a_warp_id = 5
+        self.tma_b_warp_id = 6
+        self.sched_warp_id = 7
+        self.threads_per_cta = 32 * len(
+            (
+                self.mma_warp_id,
+                self.tma_a_warp_id,
+                self.tma_b_warp_id,
+                self.sched_warp_id,
+                *self.epilogue_warp_id,
+            )
+        )
+
+        # NamedBarrier IDs.
+        #
+        # Per-subtile rotated-leader scheme lives inside the epilogue; this
+        # kernel only owns the four reserved IDs and forwards
+        # them via ``self.epilog_sync_bar_id`` to the epilogue ctor.
+        # IDs 8 and 9 are reserved for MXFP8 warp-pair absmax exchange.
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+        self.tmem_dealloc_sync_bar_id = 3
+        self.epi_subtile_bar_ids = (4, 5, 6, 7)
+
+        # MegaMoE toggle.  False for the lean base; subclasses (e.g.
+        # ``Sm100MegaMoEMxfp8Kernel``) set this to True in their own
+        # ``__init__`` after ``super().__init__`` returns.
+        # ``_setup_attributes()`` reads it inside ``__call__`` to expand the
+        # warp topology to the 12-warp MegaMoE layout.
+        self.enable_token_comm: bool = False
+        self.dispatch_warp_id: Optional[Tuple[int, int, int, int]] = None
+        self.token_back_warp_id: Optional[Tuple[int, int, int, int]] = None
+        self.token_back_standalone: bool = False
+
+        # M2.C in-kernel dx token-back (fc2_in_kernel_topk_reduce): the epilogue
+        # REDG-adds each dx_copy row into peer(src_rank).combine_output[src_token]
+        # (src_topk collapsed to 0), summing the top-k copies on the fly -> dx.
+        # No dispatch/token-back warps; only the epilogue push path is used.
+        # The wrapper sets these before ``cute.compile`` and passes the matching
+        # ``peer_rank_ptr_mapper_host`` / ``combine_output_bwd`` /
+        # ``token_src_metadata_bwd`` runtime kwargs to ``__call__``.
+        self.comm_world_size: int = 1
+        self.comm_local_rank: int = 0
+        self.comm_num_topk: int = 1
+        # Set by the D1 dispatch subclass / wrapper; unused on the dx-only path.
+        self.comm_sf_uint32_per_token: int = 1
+        self.comm_sm_count: int = 1
+
+        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
+
+    def _validate_mma_tiler_and_cluster_shape(self) -> None:
+        """Validate user-provided geometry against v1 fused-fc12 constraints.
+
+        ``mma_tiler_n`` is restricted to {128, 256}.  Short-N is handled by
+        the swap-AB scheduler via subtile-level early-exit.
+        """
+        m, n, k = self.mma_tiler_mnk
+        cm, cn = self.cluster_shape_mn
+
+        if m not in SupportedMmaTileM:
+            raise ValueError(
+                f"mma_tiler M ({m}) must be one of {SupportedMmaTileM}"
+            )
+
+        per_cta_m = m // (2 if self.use_2cta_instrs else 1)
+        if per_cta_m != 128:
+            raise ValueError(
+                f"per-CTA mma_tiler M must be 128, got {per_cta_m} "
+                f"(mma_tiler_m={m}, use_2cta_instrs={self.use_2cta_instrs})"
+            )
+
+        if n not in SupportedMmaTileN:
+            raise ValueError(
+                f"mma_tiler N ({n}) must be one of {SupportedMmaTileN} in fused fc12 "
+                f"(N=64 SFB hack is dropped; swap-AB sched handles short-N "
+                f"via subtile early-exit)."
+            )
+
+        sf_k_granularity = self.sf_vec_size * 4
+        if k % sf_k_granularity != 0:
+            raise ValueError(
+                f"mma_tiler K ({k}) must be a multiple of "
+                f"sf_vec_size * 4 = {sf_k_granularity}"
+            )
+
+        if cm % (2 if self.use_2cta_instrs else 1) != 0:
+            raise ValueError(
+                f"cluster_shape M ({cm}) must be even when use_2cta_instrs=True"
+            )
+
+        is_pow2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        if cm * cn > 16 or not is_pow2(cm) or not is_pow2(cn) or cm > 4 or cn > 4:
+            raise ValueError(
+                f"Invalid cluster_shape ({cm}, {cn}): each dim must be "
+                f"a power of 2 and <= 4, product must be <= 16"
+            )
+
+        # v1 swap-AB requires cluster_n == 1.
+        if cn != 1:
+            raise NotImplementedError(
+                f"v1 fused fc12 requires cluster_n == 1 (got {cn}).  "
+                f"cluster_n > 1 needs sentinel-style acc/ab pipeline release."
+            )
+
+    def _create_tiled_mmas(self) -> Tuple[cute.TiledMma, cute.TiledMma]:
+        """Return ``(tiled_mma, tiled_mma_sfb)``.
+
+        Both phases share the same MMA configuration because ``mma_tiler_mnk``
+        is shared.  Phase selection is
+        purely a matter of which TMA load fills SMEM / which acc TMEM stage
+        the MMA writes -- the tiled MMA atoms themselves are phase-invariant.
+
+        SFB always uses ``CtaGroup.ONE``: SFB is not multicast across the
+        2-CTA pair under ``use_2cta_instrs``.
+        """
+        common = (
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+        )
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            *common, self.cta_group, self.mma_inst_shape_mn,
+        )
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            *common, tcgen05.CtaGroup.ONE, self.mma_inst_shape_mn_sfb,
+        )
+        return tiled_mma, tiled_mma_sfb
+
+    def _setup_attributes(self) -> None:
+        """Set up MMA / cluster / tile shapes, SMEM layouts, stage counts.
+
+        The fc12 path shares ``mma_tiler_mnk`` and SMEM layouts across phases.
+        """
+        if self.enable_token_comm:
+            self.dispatch_warp_id = (8, 9, 10, 11)
+            num_token_back_warps = (
+                len(self.token_back_warp_id) if self.token_back_standalone else 0
+            )
+            self.threads_per_cta = 32 * (
+                len(self.epilogue_warp_id)
+                + 1  # mma
+                + 1  # tma_a
+                + 1  # tma_b
+                + 1  # sched
+                + len(self.dispatch_warp_id)
+                + num_token_back_warps
+            )
+
+        self.mma_inst_shape_mn = (self.mma_tiler[0], self.mma_tiler[1])
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma, tiled_mma_sfb = self._create_tiled_mmas()
+
+        mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
+        assert self.mma_tiler[2] % mma_inst_shape_k == 0, (
+            f"mma_tiler K ({self.mma_tiler[2]}) must be a multiple of "
+            f"MMA instruction K ({mma_inst_shape_k})"
+        )
+
+        # SFB-specific tiler: rounded-up MN; same K as main tiler.
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mn_sfb[0],
+            self.mma_inst_shape_mn_sfb[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Multicast CTA counts
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+
+        # Epilogue is autonomous: it owns all epi-side decisions (overlap,
+        # acc stages, subtile dispatch, TMA commit/drain, piggyback red.add).
+        # We pass kernel-level params + ``allow_overlap_acc`` hint and read
+        # the decisions back via @property below.
+        _epi_common = dict(
+            mma_tiler_mnk=self.mma_tiler,
+            cluster_shape_mn=self.cluster_shape_mn,
+            use_2cta_instrs=self.use_2cta_instrs,
+            sf_vec_size=self.sf_vec_size,
+            fc1_output_dtype=self.fc1_output_dtype,
+            fc1_output_layout=self.fc1_output_layout,
+            acc_dtype=self.acc_dtype,
+            allow_overlap_acc=True,
+            epilog_sync_bar_id=self.epilog_sync_bar_id,
+            epilogue_warp_ids=self.epilogue_warp_id,
+            static_expert_shape=self.static_expert_shape,
+            fc2_in_kernel_topk_reduce=self.fc2_in_kernel_topk_reduce,
+            token_back_by_dispatch=self.token_back_by_dispatch,
+            epi_flag_batch=self.epi_flag_batch,
+            glu_clamp=self.gate_up_clamp,
+            apply_topk_in_fc1=self.apply_topk_in_fc1,
+            generate_c=self.generate_c,
+            use_stg_fc1=self.use_stg_fc1,
+            combine_format=getattr(self, "combine_format", None),
+        )
+        self.epilogue = GluMxfp8Epilogue(**_epi_common)
+
+        if self.num_sched_stages is None:
+            self.num_sched_stages = 2
+
+        # sD stages locked to subtile_cnt: one full CTA output tile lives in
+        # sD at a time.  Per-subtile producer_acquire/commit go
+        # away — only one batched commit + drain happens per task tile (in
+        # the epilogue's ``run`` loop body).
+        self.num_d_stage = self.epilogue.subtile_cnt
+        # fc1 output (fp8 quantised) SMEM — always present.
+        d_bytes_total = self.epilogue.bytes_per_stage * self.num_d_stage
+        # Raw gate+up SMEM (BF16, ping-pong) — only when generate_c=True.
+        c_bytes_total = 0
+        if self.generate_c:
+            from moe_mxfp8_glu.epilogue_mxfp8 import Fc1CTMAStages
+            self.num_c_raw_stage = Fc1CTMAStages
+            c_bytes_total += self.epilogue.c_bytes_per_stage * self.num_c_raw_stage
+        else:
+            self.num_c_raw_stage = 0
+
+        (
+            self.num_acc_stage,
+            self.num_a_stage,
+            self.num_b_stage,
+            self.num_sched_stages,
+        ) = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.sf_dtype,
+            self.sf_vec_size,
+            c_bytes_total + d_bytes_total,
+            self.smem_capacity,
+            self.occupancy,
+            self.num_sched_stages,
+        )
+
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_a_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_b_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_a_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_b_stage,
+        )
+        self.d_smem_layout_staged = self.epilogue.staged_smem_layout(
+            self.num_d_stage,
+        )
+        # Raw gate+up SMEM layout (only meaningful when generate_c=True; pass as
+        # dummy to kernel when False).
+        if self.generate_c:
+            self.c_smem_layout_staged = self.epilogue.staged_c_smem_layout(
+                self.num_c_raw_stage
+            )
+        else:
+            self.c_smem_layout_staged = None
+
+        # Read epilogue's autonomous decisions.
+        self.overlapping_accum = self.epilogue.overlapping_accum
+        self.num_acc_pipeline_stages = self.epilogue.num_acc_pipeline_stages
+        self.num_acc_stage = self.epilogue.num_acc_stage
+        self.num_sfa_tmem_cols = self.epilogue.num_sfa_tmem_cols
+        self.num_sfb_tmem_cols = self.epilogue.num_sfb_tmem_cols
+        self.num_sf_tmem_cols = self.epilogue.num_sf_tmem_cols
+        self.num_accumulator_tmem_cols = self.epilogue.num_accumulator_tmem_cols
+        self.iter_acc_early_release_in_epilogue = self.epilogue.iter_acc_early_release
+
+        # TMA load bytes per stage (A + B + SFA + SFB).
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+        self.atom_thr_size = atom_thr_size  # store as Python int for use in @cute.kernel
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_a_bytes = (a_copy_size + sfa_copy_size) * atom_thr_size
+        self.num_tma_load_b_bytes = (b_copy_size + sfb_copy_size) * atom_thr_size
+
+    def _smem_misc_budget_bytes(self) -> int:
+        """Per-CTA SMEM reserved outside the AB-stage pipeline.
+
+        Lean fc12 path: only the fixed ``_SmemMiscBudget``.  Subclasses (the
+        MegaMoE wrapper) extend this to also reserve SMEM for the dispatch
+        warps' pull_buffer / pull_mbar / smem_expert_count regions;
+        ``_compute_stages`` reads this hook so the AB-stage count comes out
+        small enough to leave room for those extra regions.
+        """
+        return self._SmemMiscBudget
+
+    def _compute_stages(
+        self,
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        b_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_bytes_total: int,
+        smem_capacity: int,
+        occupancy: int,
+        num_sched_stages: int,
+    ) -> Tuple[int, int, int]:
+        """Compute stage counts for ACC, AB+SF, and scheduler.
+        """
+        num_acc_stage = 2
+
+        a_smem_layout_staged_one = sm100_utils.make_smem_layout_a(
+            tiled_mma, mma_tiler_mnk, a_dtype, 1,
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma, mma_tiler_mnk, b_dtype, 1,
+        )
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma, mma_tiler_mnk, sf_vec_size, 1,
+        )
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma, mma_tiler_mnk, sf_vec_size, 1,
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_staged_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+        b_bytes_per_stage = (
+            cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+
+        fixed_overhead = (
+            self._smem_misc_budget_bytes() + c_bytes_total
+        )
+
+        num_ab_stage = (
+            smem_capacity // occupancy - fixed_overhead
+        ) // ab_bytes_per_stage
+        num_a_stage = num_ab_stage
+        num_b_stage = num_ab_stage
+
+        smem_per_cta = smem_capacity // occupancy
+        unused_smem = smem_per_cta - fixed_overhead - num_ab_stage * ab_bytes_per_stage
+        if unused_smem > b_bytes_per_stage:
+            num_b_stage = num_b_stage + 1
+            unused_smem = unused_smem - b_bytes_per_stage
+        print(
+            f"[fc12 stages] num_ab_stage={num_a_stage, num_b_stage} "
+            f"num_acc_stage={num_acc_stage} "
+            f"misc_budget={self._smem_misc_budget_bytes()} "
+            f"c_bytes_total={c_bytes_total} "
+            f"smem_cap={smem_capacity} "
+            f"unused_smem={unused_smem}"
+        )
+
+        return num_acc_stage, num_a_stage, num_b_stage, num_sched_stages
+
+    def get_workspace_size_in_bytes(
+        self,
+        fc1_activation_tensor,
+        fc1_weight_tensor,
+    ) -> int:
+        """Compute opaque workspace size for one fused fc1+fc2 launch."""
+        sf_padding_block = self.sf_padding_block
+        sf_vec_size = self.sf_vec_size
+
+        mma_tiler_n = self.mma_tiler_mnk[1]
+
+        data_total_rows, _hidden = fc1_activation_tensor.shape
+        experts, _hidden_w, intermediate_gateup = fc1_weight_tensor.shape
+        # BWD: gemm1's N is I (plain dA, no gate/up pair); the epilogue's
+        # (dg, du) expansion makes the workspace 2*I wide (BWD_DESIGN.md D3).
+        intermediate_downproj = intermediate_gateup * 2
+
+        # Conservative upper bound for sf_total_rows.
+        sf_total_rows_upper = data_total_rows + experts * sf_padding_block
+
+        # fc1_output byte size depends on the ab_dtype element width:
+        #   MXFP8 (Float8E4M3FN/Float8E5M2, 8-bit): 1 element per byte → inter bytes/row
+        fc1_output_bytes = (
+            data_total_rows * intermediate_downproj * self.ab_dtype.width // 8
+        )
+
+        # fc1_output_sf sf_vec_size matches the kernel's sf_vec_size.
+        fc1_out_sf_vec_size = self.sf_vec_size
+        sf_block_cols = (
+            (intermediate_downproj // fc1_out_sf_vec_size) + 3
+        ) // 4 * 4
+        fc1_output_sf_bytes = sf_total_rows_upper * sf_block_cols
+
+        # fc1_done_counter: one Int32 per global token block, plus expert slack.
+        counter_slots_upper = (
+            (data_total_rows + mma_tiler_n - 1) // mma_tiler_n
+            + experts
+        )
+        fc1_done_counter_bytes = counter_slots_upper * 4
+
+        # load_balance_counter: Int32 scalar.
+        if self.load_balance_mode == "atomic_counter":
+            load_balance_counter_bytes = 4
+        else:
+            load_balance_counter_bytes = 0
+
+        total = (
+            fc1_output_bytes
+            + fc1_output_sf_bytes
+            + fc1_done_counter_bytes
+            + load_balance_counter_bytes
+        )
+
+        # 128B align (TMA tensor base address alignment requirement).
+        alignment = 128
+        total = ((total + alignment - 1) // alignment) * alignment
+        return total
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """SMEM → TMEM tiled copy + partition for SFA / SFB."""
+        tCsSF_compact = cute.filter_zeros(sSF)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t, tCsSF_compact_s2t_
+        )
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    # ── MegaMoE communication hook stubs ─────────────────────────────────────
+    #
+    # No-op base implementations for the lean fc1+fc2 path.  Mirroring the
+    # identically-named stubs in the NVFP4 base (``kernel_fc12.py``).
+    # ``Sm100MegaMoEMxfp8Kernel`` (megamoe_kernel_mxfp8.py) overrides all of
+    # them to delegate to ``src/token_comm.py``.
+
+    def token_comm_extra_smem_storage_class(self) -> type:
+        """Return a ``@cute.struct`` for dispatch-warp SMEM, or None."""
+        return None
+
+    def token_comm_hook_fc1_ready_counter_ptr(self, token_comm_args):
+        """Return dispatch->fc1 release counter pointer, or None (lean: disabled)."""
+        return None
+
+    def sched_ext_fc1_peek_threshold(self) -> int:
+        """Return the fc1 ready-counter peek threshold for GluMxFp8Fc12SchedExtension.
+
+        Must match the spin threshold in ``token_comm_hook_fc1_tma_b_predispatch_spin``
+        so that an early peek hit does not skip the spin and expose stale pool rows.
+        Default 0 → use ``valid_tokens_in_tile`` (no cluster, base class behaviour).
+        MegaMoE overrides to return ``cluster_tile_tokens`` to match the cluster spin.
+        """
+        return 0
+
+    def sched_ext_fc1_counter_cumul_scale(self) -> int:
+        """Return the scale factor for the fc1 ready-counter slot formula.
+
+        Slot = scale * (cumul + fc1_counter_index) + tile_m_idx % scale.
+        Default 1 = cluster-level granularity (slot = cumul + cluster_token_block_idx).
+        A MegaMoE subclass can override to cluster_m for per-CTA granularity.
+        """
+        return 1
+
+    @cute.jit
+    def token_comm_hook_sched_warp_pre_init_wait(self, token_comm_args):
+        """Sched warp: wait for dispatch barrier before reading sizes.  No-op base."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_fc1_tma_b_predispatch_spin(self, token_comm_args, work_tile_info):
+        """TMA warp: spin until dispatch-pulled tokens are resident.  No-op base."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_dispatch_warp_body(
+        self, token_comm_args, token_comm_storage, *, warp_idx, lane_idx, tidx,
+    ):
+        """Body for dispatch warps 8-11 (MegaMoE-only).  No-op base."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_token_back_warp_body(
+        self, token_comm_args, token_comm_storage, *, warp_idx, lane_idx, tidx,
+    ):
+        """Body for standalone token-back warps 12-15 (MegaMoE-only).  No-op base."""
+        pass
+
+    @cute.jit
+    def token_comm_hook_kernel_tail(self, token_comm_args, *, warp_idx, lane_idx, tidx):
+        """All-warp kernel tail (NVLink release, etc.).  No-op base."""
+        pass
+
+    @cute.jit
+    def __call__(
+        self,
+        # ── fc1 (Linear1) problem tensors ────────────────────────────────
+        activation: cute.Tensor,           # (token_sum_padded, hidden)
+        fc1_weight: cute.Tensor,           # (experts, hidden, intermediate_gateup)
+        activation_sf: cute.Tensor,         # (token_sum_padded_sf, hidden / sf_vec_size)
+        fc1_weight_sf: cute.Tensor,         # (experts, intermediate_gateup_padded * hidden / sf_vec_size)
+        # ── fc1 workspace consumed as fc2 GEMM-B ─────────────────────────
+        fc1_output: cute.Tensor,         # (token_sum_padded, intermediate_downproj)
+        fc1_output_sf: cute.Tensor,      # (token_sum_padded_sf, intermediate_downproj / sf_vec_size)
+        # ── fc2 (Linear2) problem tensors ────────────────────────────────
+        fc2_weight: cute.Tensor,          # (experts, intermediate_downproj, hidden)
+        fc2_weight_sf: cute.Tensor,        # (experts, hidden_padded * intermediate_downproj / sf_vec_size)
+        fc2_output: cute.Tensor,         # (token_sum_padded, hidden) BFloat16, hidden stride-1
+        # ── topk weights (Path A) ────────────────────────────────────────
+        topk_scores: cute.Tensor,     # (token_sum_padded,) Float32
+        # ── Cross-phase workspace ────────────────────────────────────────
+        fc1_done_counter: cute.Tensor,  # (max_token_block_per_rank,) Int32
+        # ── Sched / runtime ──────────────────────────────────────────────
+        offs: Optional[cute.Tensor] = None,  # (experts,) Int32 cumulative end offsets
+        max_active_clusters: cutlass.Constexpr = None,
+        stream: cuda.CUstream = None,
+        # ── Optional epi-side scaling ────────────────────────────────────
+        norm_const_tensor: Optional[cute.Tensor] = None,
+        global_activation_sf: Optional[cute.Tensor] = None,
+        global_fc1_weight_sf: Optional[cute.Tensor] = None,
+        # ── Optional dynamic load-balance counter ────────────────────────
+        load_balance_counter: Optional[cute.Tensor] = None,
+        # ── Sizes-mode per-expert token count (MegaMoE path) ─────────────
+        # Exactly one of ``offs`` / ``expert_token_sizes`` must be non-None.
+        # MegaMoE subclass passes a zero-copy ``i32 stride=(2,)`` view onto
+        # ``expert_recv_count_sum`` filled by the dispatch warps.
+        expert_token_sizes: Optional[cute.Tensor] = None,
+        # ── MegaMoE token-comm bundle (None on the lean path) ────────────
+        # All MegaMoE-specific device branches are gated by
+        # ``cutlass.const_expr(token_comm_args is not None)`` so they vanish
+        # at codegen time on the lean path.
+        token_comm_args=None,
+        # ── Raw fc1 accumulator output (generate_c path) ─────────────────
+        # Shape: (token_sum_padded, intermediate_gateup) Float32.
+        fc1_c: Optional[cute.Tensor] = None,
+        # BWD: bf16 DFC1 stash target (token_sum_padded, 2I) — the raw
+        # (dg, du) pairs TMA-stored for the host-side wgrads.  fc1_c above is
+        # the CONSUMED forward stash; this is the backward's own store.
+        fc1_c_out: Optional[cute.Tensor] = None,
+        # ── M2.C in-kernel dx token-back (fc2_in_kernel_topk_reduce) ──────
+        # When provided, the epilogue pushes each dx_copy row to
+        # ``combine_output_bwd`` on the source rank (REDG-add, top-k collapsed)
+        # instead of writing the local ``fc2_output`` pool.  All three come
+        # together or not at all; None keeps the lean dgrad path unchanged.
+        peer_rank_ptr_mapper_host=None,
+        combine_output_bwd: Optional[cute.Tensor] = None,
+        token_src_metadata_bwd: Optional[cute.Tensor] = None,
+        # ── M2.C part 2 (D1): in-kernel dout gather (None = torch dispatch) ──
+        input_token_buffer_bwd: Optional[cute.Tensor] = None,
+        input_sf_buffer_bwd: Optional[cute.Tensor] = None,
+        fc1_input_token_buffer_bwd: Optional[cute.Tensor] = None,
+        fc1_input_sf_buffer_bwd: Optional[cute.Tensor] = None,
+        fc1_ready_counter_bwd: Optional[cute.Tensor] = None,
+        expert_recv_count_sum_bwd: Optional[cute.Tensor] = None,
+    ) -> None:
+        """Launch the fused fc1+fc2 GLU MXFP8 kernel."""
+
+        # Build the token-comm bundle for the in-kernel dx push.  Only the three
+        # fields the ``fc2_in_kernel_topk_reduce`` epilogue path reads are live
+        # (combine_output, token_src_metadata, peer_rank_ptr_mapper); every other
+        # field is None and is skipped by TokenCommArgs' MLIR serialization.
+        if cutlass.const_expr(peer_rank_ptr_mapper_host is not None):
+            from src.token_comm import TokenCommArgs
+
+            token_comm_args = TokenCommArgs(
+                input_token_buffer=input_token_buffer_bwd,
+                input_sf_buffer=input_sf_buffer_bwd,
+                topk_idx=None,
+                input_topk_weights_buffer=None,
+                expert_send_count=None,
+                expert_recv_count=None,
+                expert_recv_count_sum=expert_recv_count_sum_bwd,
+                src_token_topk_idx=None,
+                fc1_input_token_buffer=fc1_input_token_buffer_bwd,
+                fc1_input_sf_buffer=fc1_input_sf_buffer_bwd,
+                fc1_input_topk_weights_buffer=None,
+                fc1_ready_counter=fc1_ready_counter_bwd,
+                token_src_metadata=token_src_metadata_bwd,
+                combine_output=combine_output_bwd,
+                nvlink_barrier_signal=None,
+                nvlink_barrier_counter=None,
+                grid_sync_counter=None,
+                local_zero_prefix=None,
+                shared_zero_prefix=None,
+                peer_rank_ptr_mapper=peer_rank_ptr_mapper_host.make_device_obj(),
+                world_size=self.comm_world_size,
+                local_rank=self.comm_local_rank,
+                num_total_experts=self.comm_world_size
+                * self.static_expert_shape[0],
+                num_experts_per_rank=self.static_expert_shape[0],
+                num_topk=self.comm_num_topk,
+                hidden_bytes=self.static_expert_shape[2],
+                sf_uint32_per_token=self.comm_sf_uint32_per_token,
+                token_padding_block=self.token_padding_block,
+                sf_padding_block=self.sf_padding_block,
+                sm_count=self.comm_sm_count,
+            )
+
+        # Bind data-tensor shapes to codegen-time expert dims when requested.
+        # Strides, token rows, and SF tensors stay runtime-dynamic because they
+        # encode host padding/swizzle choices.
+        if cutlass.const_expr(self.static_expert_shape is not None):
+            (
+                experts_static,
+                intermediate_gateup_static,
+                hidden_static,
+            ) = self.static_expert_shape
+            # BWD: fc1_output / fc2 K = 2 * gemm1_N (see get_workspace_size).
+            intermediate_downproj_static = intermediate_gateup_static * 2
+
+            fc1_weight = cute.make_tensor(
+                fc1_weight.iterator,
+                cute.make_layout(
+                    (experts_static, hidden_static, intermediate_gateup_static),
+                    stride=fc1_weight.stride,
+                ),
+            )
+            fc2_weight = cute.make_tensor(
+                fc2_weight.iterator,
+                cute.make_layout(
+                    (experts_static, intermediate_downproj_static, hidden_static),
+                    stride=fc2_weight.stride,
+                ),
+            )
+            activation = cute.make_tensor(
+                activation.iterator,
+                cute.make_layout(
+                    (activation.shape[0], hidden_static),
+                    stride=activation.stride,
+                ),
+            )
+            fc1_output = cute.make_tensor(
+                fc1_output.iterator,
+                cute.make_layout(
+                    (fc1_output.shape[0], intermediate_downproj_static),
+                    stride=fc1_output.stride,
+                ),
+            )
+            # fc2_output is 2D (tokens, hidden) on the lean path and 3D
+            # (max_tokens, topk, hidden) on the MegaMoE path.  Bind only the
+            # hidden dim to a codegen-time const; keep the other dims dynamic.
+            if cutlass.const_expr(len(fc2_output.shape) == 3):
+                fc2_output = cute.make_tensor(
+                    fc2_output.iterator,
+                    cute.make_layout(
+                        (fc2_output.shape[0], fc2_output.shape[1], hidden_static),
+                        stride=fc2_output.stride,
+                    ),
+                )
+            else:
+                fc2_output = cute.make_tensor(
+                    fc2_output.iterator,
+                    cute.make_layout(
+                        (fc2_output.shape[0], hidden_static),
+                        stride=fc2_output.stride,
+                    ),
+                )
+
+        # ── GEMM-domain transform for fc1 phase (non-swap-AB) ──
+        c1 = cutlass.Int32(1)
+        c0 = cutlass.Int32(0)
+
+        # A_gemm (fc1 activations): (tokens_sum, hidden) -> (M=tokens, K=hidden, L=1).
+        tokens_sum, hidden = activation.shape
+        activation_gemm = cute.make_tensor(
+            activation.iterator,
+            cute.make_layout(
+                (tokens_sum, hidden, 1),
+                stride=(activation.stride[0], activation.stride[1], 0),
+            ),
+        )
+
+        # B_gemm (fc1 weights): (experts, hidden, intermediate_gateup) with hidden stride-1 (K-major)
+        # -> (N=intermediate_gateup, K=hidden, L=experts).
+        experts, hidden_b, intermediate_gateup = fc1_weight.shape
+        fc1_weight_gemm = cute.make_tensor(
+            fc1_weight.iterator,
+            cute.make_layout(
+                (intermediate_gateup, hidden_b, experts),
+                stride=(fc1_weight.stride[2], fc1_weight.stride[1], fc1_weight.stride[0]),
+            ),
+        )
+
+        # D_gemm is a user-view output tensor; epilogue owns its store path.
+        intermediate_downproj = fc1_output.shape[1]
+        fc1_output_gemm = cute.make_tensor(
+            fc1_output.iterator,
+            cute.make_layout(
+                (tokens_sum, intermediate_downproj, 1),
+                stride=(fc1_output.stride[0], fc1_output.stride[1], 0),
+            ),
+        )
+
+        # SFA / SFB scale tensors (atom-tiled) — fc1 phase.
+        #   SFA (mma M-side) = activation_sf (activation scales, A-side)
+        #   SFB (mma N-side) = fc1_weight_sf (weight scales, B-side)
+        tokens_sum_padded = activation_sf.shape[0]
+        hidden_padded = activation_sf.shape[1] * self.sf_vec_size
+        activation_sf_gemm = cute.make_tensor(
+            activation_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded, hidden_padded, 1), self.sf_vec_size
+            ),
+        )
+        intermediate_gateup_padded_mul_hidden_padded = fc1_weight_sf.shape[1]
+        intermediate_gateup_padded = (
+            intermediate_gateup_padded_mul_hidden_padded * self.sf_vec_size
+        ) // hidden_padded
+        fc1_weight_sf_gemm = cute.make_tensor(
+            fc1_weight_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (intermediate_gateup_padded, hidden_padded, experts),
+                self.sf_vec_size,
+            ),
+        )
+
+        # ── GEMM-domain transform for fc2 phase ──
+        #
+        # fc2 roles: M=hidden, N=tokens_sum, K=intermediate_downproj.
+
+        # A_gemm (fc2 weights): (experts, intermediate_downproj, hidden)
+        # -> (M=hidden, K=intermediate_downproj, L=experts).
+        experts2, intermediate_downproj_b2, hidden_b2 = fc2_weight.shape
+        fc2_weight_gemm = cute.make_tensor(
+            fc2_weight.iterator,
+            cute.make_layout(
+                (hidden_b2, intermediate_downproj_b2, experts2),
+                stride=(fc2_weight.stride[2], fc2_weight.stride[1], fc2_weight.stride[0]),
+            ),
+        )
+
+        # fc2 phase B operand = fc1 output reused (no new view needed:
+        # ``fc1_output_gemm`` was built from ``fc1_output.iterator`` with the same
+        # (tokens_sum, intermediate_downproj, fake-L=1) layout that fc2's
+        # GEMM-B view wants; reuse it directly when wiring fc2 TMA-B atom).
+
+        # C_gemm (fc2 output, BFloat16; STG.256-driven by the epilogue's
+        # ``Fc2UnpackPermuteStg`` — no TMA store path).
+        # We still build a GEMM-domain view so ``ext.get_gmem_tensor("d", ...)``
+        # can apply the per-expert offset.  TMA atom is NOT built for fc2_output.
+        # MegaMoE passes a 3D (max_tokens, topk, hidden) combine output; the lean
+        # path passes 2D (tokens, hidden).  In both cases build a 3D GEMM-domain
+        # view (rows, hidden, fake-L=1) folding the topk axis into the row
+        # stride.  In MegaMoE mode the epilogue bypasses this view for STG (it
+        # uses Fc2OutputDest from token_comm_args), but get_gmem_tensor("d", ...)
+        # is still called, so the layout must be valid.
+        if cutlass.const_expr(len(fc2_output.shape) == 3):
+            fc2_hidden_out = fc2_output.shape[2]
+            fc2_output_gemm = cute.make_tensor(
+                fc2_output.iterator,
+                cute.make_layout(
+                    (fc2_output.shape[0], fc2_hidden_out, c1),
+                    stride=(fc2_output.stride[0], fc2_output.stride[2], c0),
+                ),
+            )
+        else:
+            fc2_hidden_out = fc2_output.shape[1]
+            fc2_output_gemm = cute.make_tensor(
+                fc2_output.iterator,
+                cute.make_layout(
+                    (tokens_sum, fc2_hidden_out, c1),
+                    stride=(fc2_output.stride[0], fc2_output.stride[1], c0),
+                ),
+            )
+
+        # SFA / SFB for fc2:
+        #   SFA (mma M-side) = fc2_weight_sf (fc2 weight scales, sf_vec_size)
+        #   SFB (mma N-side) = fc1_output_sf (fc1 epilogue SFs, uses sf_vec_size)
+        # Both paths produce SFs with self.sf_vec_size:
+        fc1_out_sf_vec_size = self.sf_vec_size
+        tokens_sum_padded_sf = fc1_output_sf.shape[0]
+        intermediate_downproj_padded = fc1_output_sf.shape[1] * fc1_out_sf_vec_size
+        fc1_output_sf_gemm_for_fc2_load = cute.make_tensor(
+            fc1_output_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded_sf, intermediate_downproj_padded, 1),
+                fc1_out_sf_vec_size,
+            ),
+        )
+
+        hidden_padded_fc2_mul_intermediate_downproj_padded = fc2_weight_sf.shape[1]
+        hidden_padded_fc2 = (
+            hidden_padded_fc2_mul_intermediate_downproj_padded * self.sf_vec_size
+        ) // intermediate_downproj_padded
+        fc2_weight_sf_gemm = cute.make_tensor(
+            fc2_weight_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (hidden_padded_fc2, intermediate_downproj_padded, experts2),
+                self.sf_vec_size,
+            ),
+        )
+
+        expert_cnt = experts
+        # ``intermediate_gateup`` (= fc1_weight.shape[2]) is what we pass to the
+        # scheduler via ``expert_shape``; see ``MoESchedulerParamsBase``
+        # docstring for the precise contract.
+        hidden_dim = hidden
+
+        # ── Infer dtypes and major modes ──
+        # Phases share dtypes by construction. For MXFP8: A/B/fc1_output
+        # are Float8E4M3FN/Float8E5M2 and SFs are Float8E8M0FNU.
+        # ``self.fc1_output_dtype`` drives the sD SMEM element type and flows
+        # into the epilogue ctor as ``fc1_output_dtype``.
+        self.a_dtype: Type[cutlass.Numeric] = activation_gemm.element_type
+        self.b_dtype: Type[cutlass.Numeric] = fc1_weight_gemm.element_type
+        self.fc1_output_dtype: Type[cutlass.Numeric] = fc1_output_gemm.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = activation_sf_gemm.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(activation_gemm).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(fc1_weight_gemm).mma_major_mode()
+        self.fc1_output_layout = utils.LayoutEnum.from_tensor(fc1_output_gemm)
+
+        self._setup_attributes()
+        tiled_mma, tiled_mma_sfb = self._create_tiled_mmas()
+
+        # ── fc1 TMA atoms ──
+
+        # TMA load A1 (= fc1 activations, non-swap-AB: A=activations)
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_fc1_activation, tma_tensor_fc1_activation = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            activation_gemm,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load B1 (= fc1 weights, non-swap-AB: B=weights)
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_fc1_weight, tma_tensor_fc1_weight = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            fc1_weight_gemm,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+        )
+
+        # TMA load SFA1 (= activation_sf, non-swap-AB: SFA=activation SFs, A-side)
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_fc1_activation_sf, tma_tensor_fc1_activation_sf = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            activation_sf_gemm,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.cluster_layout_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+
+        # TMA load SFB1 (= fc1_weight_sf, non-swap-AB: SFB=weight SFs, B-side)
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_fc1_weight_sf, tma_tensor_fc1_weight_sf = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            fc1_weight_sf_gemm,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Uint64,
+        )
+
+        # TMA store for fc1 MXFP8 output.
+        # Per-subtile issue lives in
+        # ``self.epilogue.tma_store_fc1_output``; commit / drain lives
+        # inside the epilogue's ``run`` loop body.
+        fc1_output_tma_op = cpasync.CopyBulkTensorTileS2GOp()
+        tma_atom_fc1_output, tma_tensor_fc1_output = cpasync.make_tiled_tma_atom(
+            fc1_output_tma_op,
+            fc1_output_gemm,
+            self.epilogue.smem_layout_one_stage,
+            self.epilogue.epi_tile,
+        )
+
+        # BWD: fc1_c is the forward's (gate, up) stash CONSUMED via per-thread
+        # LDGs (plain gmem view, no atom); fc1_c_out is the backward's own
+        # (dg, du) bf16 stash, TMA-stored with the original generate_c
+        # machinery (same (128, 64) tiles, width 2I = intermediate_downproj).
+        if cutlass.const_expr(self.generate_c):
+            c_gemm_in = cute.make_tensor(
+                fc1_c.iterator,
+                cute.make_layout(
+                    (tokens_sum, intermediate_downproj, 1),
+                    stride=(fc1_c.stride[0], fc1_c.stride[1], 0),
+                ),
+            )
+            c_gemm_out = cute.make_tensor(
+                fc1_c_out.iterator,
+                cute.make_layout(
+                    (tokens_sum, intermediate_downproj, 1),
+                    stride=(fc1_c_out.stride[0], fc1_c_out.stride[1], 0),
+                ),
+            )
+            tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                c_gemm_out,
+                self.epilogue.c_smem_layout_one_stage,
+                self.epilogue.epi_tile_c,
+            )
+        else:
+            # Dummy — never used by the kernel (const_expr gated).
+            tma_atom_c = tma_atom_fc1_output
+            tma_tensor_c = tma_tensor_fc1_output
+            c_gemm_in = tma_tensor_fc1_output
+
+        # fc1 SFC GMEM tensor (= fc1_output_sf user view).  No TMA atom; it is
+        # per-thread STG.
+        fc1_output_sf_gemm = cute.make_tensor(
+            fc1_output_sf.iterator,
+            blockscaled_utils.tile_atom_to_shape_SF(
+                (tokens_sum_padded, intermediate_downproj, 1),
+                self.sf_vec_size,
+            ),
+        )
+
+        # ── fc2 TMA atoms: fc1_output → A-side (M=tokens), fc2_weight → B-side (N=hidden) ──
+        # Non-swap-AB fc2: activation (fc1_output) is GEMM-A (M=tokens),
+        # weight (fc2_weight) is GEMM-B (N=hidden). Same SMEM layouts as fc1.
+
+        tma_atom_fc2_activation, tma_tensor_fc2_activation = (
+            cute.nvgpu.make_tiled_tma_atom_A(
+                a_op,
+                fc1_output_gemm,
+                a_smem_layout,
+                self.mma_tiler,
+                tiled_mma,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_atom_fc2_weight, tma_tensor_fc2_weight = (
+            cute.nvgpu.make_tiled_tma_atom_B(
+                b_op,
+                fc2_weight_gemm,
+                b_smem_layout,
+                self.mma_tiler,
+                tiled_mma,
+                self.cluster_layout_vmnk.shape,
+            )
+        )
+        tma_atom_fc2_activation_sf, tma_tensor_fc2_activation_sf = (
+            cute.nvgpu.make_tiled_tma_atom_A(
+                sfa_op,
+                fc1_output_sf_gemm_for_fc2_load,
+                sfa_smem_layout,
+                self.mma_tiler,
+                tiled_mma,
+                self.cluster_layout_vmnk.shape,
+                internal_type=cutlass.Uint64,
+            )
+        )
+        tma_atom_fc2_weight_sf, tma_tensor_fc2_weight_sf = (
+            cute.nvgpu.make_tiled_tma_atom_B(
+                sfb_op,
+                fc2_weight_sf_gemm,
+                sfb_smem_layout,
+                self.mma_tiler_sfb,
+                tiled_mma_sfb,
+                self.cluster_layout_sfb_vmnk.shape,
+                internal_type=cutlass.Uint64,
+            )
+        )
+
+        # ── Scheduler params + grid + launch ──
+        #
+        # ``expert_cnt`` / ``intermediate_gateup`` / ``hidden_dim`` are
+        # extracted from the (possibly rewritten) tensor shapes above:
+        #   - static path (``static_expert_shape`` bound): they are
+        #     codegen-time Python int constants; the new base
+        #     ``MoESchedulerParamsBase.__init__`` preserves the Python
+        #     int type and ``__extract_mlir_values__`` skips them, so
+        #     they remain inlined literals across the scheduler's scf
+        #     region boundaries (no demotion to iter_arg / kernel-arg).
+        #   - dynamic path: they are runtime Int32 from tensor metadata.
+        #
+        # ``expert_shape[1]`` carries ``intermediate_gateup`` semantics
+        # (= fc1_weight.shape[2]) per the ``MoESchedulerParamsBase.__init__``
+        # contract.  The fused fc12 scheduler reads it as fc1 GEMM-M
+        # (under swap-AB) and derives ``num_fc1_intermediate_blocks``
+        # from it.
+        # atomic_counter mode requires a host-allocated GMEM Int32 scalar
+        # whose pointer lives in scheduler params; static mode passes
+        # None (params validate this).  Caller's contract from __call__:
+        # ``load_balance_counter`` is required iff ``load_balance_mode ==
+        # 'atomic_counter'``; otherwise may be None.
+        if cutlass.const_expr(self.load_balance_mode == "atomic_counter"):
+            if cutlass.const_expr(load_balance_counter is None):
+                raise ValueError(
+                    "load_balance_counter must be provided when "
+                    "load_balance_mode == 'atomic_counter'"
+                )
+            load_balance_counter_ptr = load_balance_counter.iterator
+        else:
+            load_balance_counter_ptr = None
+
+        if cutlass.const_expr((offs is None) == (expert_token_sizes is None)):
+            raise ValueError(
+                "Exactly one of `offs` / `expert_token_sizes` must be "
+                "provided; got "
+                f"offs={'set' if offs is not None else 'None'}, "
+                f"expert_token_sizes="
+                f"{'set' if expert_token_sizes is not None else 'None'}."
+            )
+
+        sched_params = MoEFusedFc12SchedulerParams(
+            scenario=self.scenario,
+            expert_shape=(expert_cnt, intermediate_gateup, hidden_dim),
+            cta_tile_shape_mnk=self.cta_tile_shape_mnk,
+            cluster_shape_mn=self.cluster_shape_mn,
+            group_hint=self.group_hint,
+            token_padding_block=self.token_padding_block,
+            sf_padding_block=self.sf_padding_block,
+            load_balance_mode=self.load_balance_mode,
+            load_balance_counter_ptr=load_balance_counter_ptr,
+            override_num_stages=self.num_sched_stages,
+            is_swap_ab=False,
+            expert_token_prefix_sum=offs,
+            expert_token_sizes=expert_token_sizes,
+        )
+        grid = sched_params.get_grid_shape(max_active_clusters)
+
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            # fc1 TMA atoms / tensors (non-swap-AB: A=activations, B=weights)
+            tma_atom_fc1_activation,
+            tma_tensor_fc1_activation,
+            tma_atom_fc1_weight,
+            tma_tensor_fc1_weight,
+            tma_atom_fc1_activation_sf,
+            tma_tensor_fc1_activation_sf,
+            tma_atom_fc1_weight_sf,
+            tma_tensor_fc1_weight_sf,
+            tma_atom_fc1_output,
+            tma_tensor_fc1_output,
+            # fc2 TMA atoms / tensors (fc1_output→A, fc2_weight→B)
+            tma_atom_fc2_activation,
+            tma_tensor_fc2_activation,
+            tma_atom_fc2_weight,
+            tma_tensor_fc2_weight,
+            tma_atom_fc2_activation_sf,
+            tma_tensor_fc2_activation_sf,
+            tma_atom_fc2_weight_sf,
+            tma_tensor_fc2_weight_sf,
+            # GEMM-domain tensors (fc1)
+            activation_gemm,
+            fc1_weight_gemm,
+            fc1_output_gemm,
+            activation_sf_gemm,
+            fc1_weight_sf_gemm,
+            fc1_output_sf_gemm,
+            # GEMM-domain tensors (fc2)
+            fc2_weight_gemm,
+            fc2_output_gemm,
+            fc2_weight_sf_gemm,
+            fc1_output_sf_gemm_for_fc2_load,
+            # topk + cross-phase sync workspace
+            topk_scores,
+            fc1_done_counter,
+            # Scheduling
+            offs,
+            sched_params,
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            # SMEM layouts
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.d_smem_layout_staged,
+            self.c_smem_layout_staged,
+            tma_atom_c,
+            tma_tensor_c,
+            c_gemm_in,
+            token_comm_args,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=self.occupancy,
+        )
+
+
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        # fc1 TMA atoms / tensors
+        tma_atom_fc1_activation_1: cute.CopyAtom,
+        tma_tensor_fc1_activation_1: cute.Tensor,
+        tma_atom_weight: cute.CopyAtom,
+        tma_tensor_weight: cute.Tensor,
+        tma_atom_fc1_activation_1_sf: cute.CopyAtom,
+        tma_tensor_fc1_activation_1_sf: cute.Tensor,
+        tma_atom_fc1_weight_sf: cute.CopyAtom,
+        tma_tensor_fc1_weight_sf: cute.Tensor,
+        tma_atom_fc1_output: cute.CopyAtom,
+        tma_tensor_fc1_output: cute.Tensor,
+        # fc2 TMA atoms / tensors (fc1_output→A, fc2_weight→B)
+        tma_atom_fc2_activation: cute.CopyAtom,
+        tma_tensor_fc2_activation: cute.Tensor,
+        tma_atom_fc2_weight: cute.CopyAtom,
+        tma_tensor_fc2_weight: cute.Tensor,
+        tma_atom_fc2_activation_sf: cute.CopyAtom,
+        tma_tensor_fc2_activation_sf: cute.Tensor,
+        tma_atom_fc2_weight_sf: cute.CopyAtom,
+        tma_tensor_fc2_weight_sf: cute.Tensor,
+        # GEMM-domain tensors (fc1)
+        activation_gemm: cute.Tensor,
+        fc1_weight_gemm: cute.Tensor,
+        fc1_output_gemm: cute.Tensor,
+        activation_sf_gemm: cute.Tensor,
+        fc1_weight_sf_gemm: cute.Tensor,
+        fc1_output_sf_gemm: cute.Tensor,
+        # GEMM-domain tensors (fc2)
+        fc2_weight_gemm: cute.Tensor,
+        fc2_output_gemm: cute.Tensor,
+        fc2_weight_sf_gemm: cute.Tensor,
+        fc1_output_sf_gemm_for_fc2_load: cute.Tensor,
+        # topk + cross-phase sync workspace
+        topk_scores: cute.Tensor,
+        fc1_done_counter: cute.Tensor,
+        # debug: (total_tokens, intermediate_half*3) fp32 for swiglu comparison
+        # Scheduling
+        offs: Optional[cute.Tensor],
+        sched_params: MoEFusedFc12SchedulerParams,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        # SMEM layouts
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        d_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
+        c_smem_layout_staged:  Optional[Union[cute.Layout, cute.ComposedLayout]] = None,
+        tma_atom_c: Optional[cute.CopyAtom] = None,
+        tma_tensor_c: Optional[cute.Tensor] = None,
+        tma_tensor_c_in: Optional[cute.Tensor] = None,
+        token_comm_args=None,
+    ):
+        """Device kernel for fused fc1+fc2 swap-AB GLU MXFP8 grouped GEMM.
+
+        Lean (``force_static_sched=True``) path: 7-warp specialization with
+        no empty / drain_aux warps and no expert-wise TMA desc rewriting
+        (every desc is tile-invariant under swap-AB).
+
+        Epilogue is fully owned by ``self.epilogue.run(...)`` -- the four epi
+        warps make a single call that drives the entire 2-phase task-tile
+        loop (acc consumer state, subtile dispatch, TMA commit/drain, and
+        the piggyback ``red.release.gpu.add.s32`` to ``fc1_done_counter``).
+        """
+        a_smem_layout = cute.slice_(a_smem_layout_staged, (None, None, None, 0))
+        b_smem_layout = cute.slice_(b_smem_layout_staged, (None, None, None, 0))
+        sfa_smem_layout = cute.slice_(sfa_smem_layout_staged, (None, None, None, 0))
+        sfb_smem_layout = cute.slice_(sfb_smem_layout_staged, (None, None, None, 0))
+
+        # fc2 waits for all fc1 intermediate N-tiles in the same token block.
+        # Each N-tile is processed by atom_thr_size CTAs (both CTA0 and CTA1 increment
+        # the counter), so the threshold must account for both CTAs' contributions.
+        ext_fc2_spin_threshold = (
+            fc1_weight_gemm.shape[0] + self.cta_tile_shape_mnk[1] - 1
+        ) // self.cta_tile_shape_mnk[1] * self.epilogue._atom_thr_size
+
+        ext = GluMxFp8Fc12SchedExtension(
+            sf_vec_size=self.sf_vec_size,
+            fc1_done_counter_ptr=fc1_done_counter.iterator,
+            fc2_spin_threshold=ext_fc2_spin_threshold,
+            fc1_ready_counter_ptr=self.token_comm_hook_fc1_ready_counter_ptr(
+                token_comm_args
+            ),
+            cluster_m=self.epilogue._atom_thr_size,
+        )
+
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        bidx, _, _ = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        tidx, _, _ = cute.arch.thread_idx()
+
+        # SharedStorage.
+        SchedCls = sched_params.get_scheduler_type()
+        SchedStorage = SchedCls.make_storage_struct(
+            sched_params, ext, num_drain_warps=0
+        )
+
+        @cute.struct
+        class SharedStorage:
+            a_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_a_stage * 2]
+            b_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_b_stage * 2]
+            acc_full_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.num_acc_pipeline_stages * 2
+            ]
+            sched_storage: SchedStorage
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        # MegaMoE-only dispatch-warp SMEM (pull_buffer, mbarriers, etc.).
+        # Kept out of ``SharedStorage`` so the lean path never allocates it.
+        TokenCommStorageCls = self.token_comm_extra_smem_storage_class()
+        if cutlass.const_expr(TokenCommStorageCls is not None):
+            token_comm_storage = smem.allocate(TokenCommStorageCls)
+        else:
+            token_comm_storage = None
+
+        # ── Pipelines: separate producer/consumer groups for A and B. ──
+
+        a_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, 1
+        )
+        a_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mcast_ctas_a
+        )
+        a_producer, a_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.a_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_a_stage,
+            producer_group=a_pipeline_producer_group,
+            consumer_group=a_pipeline_consumer_group,
+            tx_count=self.num_tma_load_a_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+        b_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, 1
+        )
+        b_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, self.num_mcast_ctas_b
+        )
+        b_producer, b_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.b_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_b_stage,
+            producer_group=b_pipeline_producer_group,
+            consumer_group=b_pipeline_consumer_group,
+            tx_count=self.num_tma_load_b_bytes,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = (
+            len(self.epilogue_warp_id) * 32 * (2 if use_2cta_instrs else 1)
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_pipeline_stages,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        # TMEM allocator
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
+        )
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+        )
+
+        # Sched
+        num_sched_consumer_threads = 32 * len(
+            (
+                self.tma_a_warp_id,
+                self.tma_b_warp_id,
+                self.mma_warp_id,
+                *self.epilogue_warp_id,
+            )
+        )
+        scheduler = SchedCls.create(
+            sched_params,
+            cute.arch.block_idx(),
+            cute.arch.grid_dim(),
+            sched_storage=storage.sched_storage,
+            num_consumer_threads=num_sched_consumer_threads,
+            ext=ext,
+        )
+        sched_consumer = scheduler.make_consumer()
+
+        # Issue the first scheduler claim before cluster init wait so the
+        # atomic/offsets latency overlaps with pipeline setup.
+        # Under MegaMoE + static load-balance, ``internal_init`` walks
+        # per-expert sizes from ``expert_recv_count_sum`` -- those are not
+        # valid until the dispatch barrier completes, so we defer init to the
+        # sched warp (after ``token_comm_hook_sched_warp_pre_init_wait``).
+        early_internal_init = (
+            (self.load_balance_mode == "atomic_counter")
+            or (not self.enable_token_comm)
+        )
+
+        if cutlass.const_expr(early_internal_init):
+            scheduler.internal_init(
+                warp_idx=warp_idx,
+                sched_warp_id=self.sched_warp_id,
+            )
+
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        # ── SMEM tensors A / B / SFA / SFB (shared by fc1 / fc2) ──
+        sA = smem.allocate_tensor(
+            element_type=self.a_dtype,
+            layout=a_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=a_smem_layout_staged.inner,
+        )
+        sB = smem.allocate_tensor(
+            element_type=self.b_dtype,
+            layout=b_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=b_smem_layout_staged.inner,
+        )
+        sSFA = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfa_smem_layout_staged,
+            byte_alignment=128,
+        )
+        sSFB = smem.allocate_tensor(
+            element_type=self.sf_dtype,
+            layout=sfb_smem_layout_staged,
+            byte_alignment=128,
+        )
+
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+
+        # acc_fake layout: (MMA, MMA_M, MMA_N, STAGE).  Under
+        # ``overlapping_accum`` the two acc buffers share TMEM with SF
+        # columns; we shrink the stage stride so the second buffer
+        # starts at ``(256 - num_sf_tmem_cols)`` cols instead of 256.
+        acc_fake = tiled_mma.make_fragment_C(
+            cute.append(acc_shape, self.num_acc_stage)
+        )
+        if cutlass.const_expr(self.overlapping_accum):
+            acc_fake = cute.make_tensor(
+                acc_fake.iterator,
+                cute.make_layout(
+                    acc_fake.shape,
+                    stride=(
+                        acc_fake.stride[0],
+                        acc_fake.stride[1],
+                        acc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * acc_fake.stride[0][1],
+                    ),
+                ),
+            )
+
+        # Cluster wait before TMEM alloc.
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        mma_tiler_k = self.mma_tiler[2]
+        # ``fc1_weight_gemm.shape[1]`` / ``fc2_weight_gemm.shape[1]``
+        # both resolve to ``hidden`` / ``intermediate_downproj``.  Under
+        # ``static_expert_shape`` they are codegen-time Python ints
+        # (rewritten on ``fc1_weight`` / ``fc2_weight`` at ``__call__``
+        # entry); otherwise they are runtime Int32 from tensor metadata.
+        # The arithmetic below folds to an immediate in the static path.
+        k_tile_cnt_fc1 = (fc1_weight_gemm.shape[1] + mma_tiler_k - 1) // mma_tiler_k
+        k_tile_cnt_fc2 = (fc2_weight_gemm.shape[1] + mma_tiler_k - 1) // mma_tiler_k
+        # fc2 spin threshold: each fc1 N-tile (intermediate direction) is incremented
+        # by atom_thr_size CTAs.  In non-swap-AB, fc1_weight_gemm.shape[0] is the N
+        # dimension (intermediate_gateup), so divide by cta_tile_shape_mnk[1] (N tile),
+        # not cta_tile_shape_mnk[0] (M/token tile).  Matches ext_fc2_spin_threshold.
+        fc2_spin_threshold = (
+            (fc1_weight_gemm.shape[0] + self.cta_tile_shape_mnk[1] - 1)
+            // self.cta_tile_shape_mnk[1]
+        ) * self.epilogue._atom_thr_size
+
+        # ════════════════════════════════════════════════════════════════════
+        # Scheduler warp (warp 7) — lean path
+        # ════════════════════════════════════════════════════════════════════
+        if warp_idx == self.sched_warp_id:
+            self.token_comm_hook_sched_warp_pre_init_wait(token_comm_args)
+            if cutlass.const_expr(not early_internal_init):
+                scheduler.internal_init(
+                    warp_idx=warp_idx,
+                    sched_warp_id=self.sched_warp_id,
+                )
+            scheduler.gen_next_work()
+            while scheduler.current_work.is_valid_tile:
+                ext.prefetch_for_expert(scheduler.current_work.expert_idx)
+                scheduler.publish_work()
+                scheduler.gen_next_work()
+            # Sentinel publish (current_work is already invalid here).
+            scheduler.publish_work()
+            scheduler.produce_tail()
+
+        # ════════════════════════════════════════════════════════════════════
+        # TMA load warps (warps 5 / 6)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # TMA-A loads activations/SFA into the A pipeline.
+        # TMA-B loads weights/SFB into the B pipeline and waits for
+        # fc1 workspace readiness in the fc2 phase.
+
+        # ── TMA-A warp (warp 5) ─────────────────────────────────────────────
+        if warp_idx == self.tma_a_warp_id:
+            _iket_active = (tidx == cutlass.Int32(160))
+            a_full_mcast_mask = None
+            sfa_full_mcast_mask = None
+            if cutlass.const_expr(self.is_a_mcast or use_2cta_instrs):
+                a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+                sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+
+            # non-swap-AB FC1: activation (A) is partitioned per-CTA (like original B).
+            # b_cta_layout=(2,) and mcast_mode=1 → each CTA loads its own token range.
+            b_full_mcast_mask = None
+            if cutlass.const_expr(self.is_b_mcast or use_2cta_instrs):
+                b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+                )
+            b_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+            )
+
+            a_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+            )
+            sfa_cta_layout = a_cta_layout
+
+            thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+                if is_phase_linear1:
+                    # ── fc1 phase A-side (non-swap-AB: A=activations, per-CTA partitioned) ──
+                    # Activations are split per CTA (tokens 0-127 for CTA 0, 128-255 for CTA 1).
+                    # Use b_cta_layout + m-coord so each CTA loads its own token range.
+                    # mcast_mode=1 → same M-coord = only self → no actual multicast. ✓
+                    if _iket_active:
+                        iket.range_push("tma_weight_fc1")
+                    # MegaMoE: spin until the dispatch warps have pulled this
+                    # task tile's token activations into the L1 token buffer.
+                    # No-op on the lean path (activations resident at launch).
+                    self.token_comm_hook_fc1_tma_b_predispatch_spin(
+                        token_comm_args, work_tile_info,
+                    )
+
+                    k_tile_cnt = k_tile_cnt_fc1
+                    real_a, desc_ptr_a = ext.get_gmem_tensor(
+                        "fc1_activation", tma_tensor_fc1_activation_1, work_tile_info,
+                    )
+                    real_sfa, desc_ptr_sfa = ext.get_gmem_tensor(
+                        "fc1_activation_sf", tma_tensor_fc1_activation_1_sf, work_tile_info,
+                    )
+
+                    gA_mkl = cute.local_tile(
+                        real_a,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    gSFA_mkl = cute.local_tile(
+                        real_sfa,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    tCgA = thr_mma.partition_A(gA_mkl)
+                    tCgSFA = thr_mma.partition_A(gSFA_mkl)
+
+                    tAsA, tAgA = cpasync.tma_partition(
+                        tma_atom_fc1_activation_1,
+                        block_in_cluster_coord_vmnk[2],
+                        a_cta_layout,
+                        cute.group_modes(sA, 0, 3),
+                        cute.group_modes(tCgA, 0, 3),
+                    )
+                    tAsSFA, tAgSFA = cpasync.tma_partition(
+                        tma_atom_fc1_activation_1_sf,
+                        block_in_cluster_coord_vmnk[2],
+                        sfa_cta_layout,
+                        cute.group_modes(sSFA, 0, 3),
+                        cute.group_modes(tCgSFA, 0, 3),
+                    )
+                    tAsSFA = cute.filter_zeros(tAsSFA)
+                    tAgSFA = cute.filter_zeros(tAgSFA)
+
+                    mma_tile_m = work_tile_info.tile_m_idx // cute.size(
+                        tiled_mma.thr_id.shape
+                    )
+                    tAgA_slice = tAgA[(None, mma_tile_m, None, 0)]
+                    tAgSFA_slice = tAgSFA[(None, mma_tile_m, None, 0)]
+
+                    a_producer.reset()
+                    peek_a_empty_status = a_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = a_producer.acquire_and_advance(
+                            peek_a_empty_status
+                        )
+                        peek_a_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_a_empty_status = a_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc1_activation_1,
+                            tAgA_slice[(None, handle.count)],
+                            tAsA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_a,
+                            mcast_mask=a_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc1_activation_1_sf,
+                            tAgSFA_slice[(None, handle.count)],
+                            tAsSFA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfa,
+                            mcast_mask=sfa_full_mcast_mask,
+                        )
+                else:
+                    # ── fc2 phase A-side: load fc1_output (M=tokens) + wait for fc1 done ──
+                    #
+                    # Non-swap-AB fc2: A=fc1_output (M=tokens). tile_m_idx is the
+                    # CTA-level token block. Counter wait moved here from TMA-B.
+                    if _iket_active:
+                        iket.range_push("tma_token_fc2")
+                    counter_slot = (
+                        work_tile_info.cumulative_token_block_count
+                        + work_tile_info.tile_m_idx // cutlass.Int32(self.epilogue._atom_thr_size)
+                    )
+                    counter_ptr = fc1_done_counter.iterator + counter_slot
+                    # Always spin (no peek shortcut) to guarantee counter=4 in this warp,
+                    # then use acquire semantics + cross-proxy fence to ensure fc1_output
+                    # writes (from generic proxy) are visible to the TMA async proxy load.
+                    if _iket_active:
+                        iket.range_push("tma_token_fc2_a_wait")
+                    spin_wait(
+                        counter_ptr,
+                        lambda v: v >= fc2_spin_threshold,
+                        fail_sleep_cycles=20,
+                    )
+                    if _iket_active:
+                        iket.range_pop()
+                    cute.arch.load(counter_ptr, counter_ptr.dtype, sem="acquire", scope="gpu")
+                    cute.arch.fence_proxy("async")
+                    cute.arch.fence_proxy("async.global")
+
+                    # DEBUG: print counter slot/value after spin exits for first hidden N-tile only.
+                    # Using tidx == tma_a_warp_id*32 since tidx==0 never fires in warp 5.
+                    if (
+                        tidx == cutlass.Int32(32 * self.tma_a_warp_id)
+                        and work_tile_info.tile_n_idx == cutlass.Int32(0)
+                    ):
+                        counter_val_post = cute.arch.load(
+                            counter_ptr, counter_ptr.dtype, cop="cg"
+                        )
+                        # Also load first Int32 from fc1_output for this tile to
+                        # check if TMA S2G stores are visible (non-zero = stored).
+                        fc1_byte_offset = (
+                            work_tile_info.cumulative_data_physical_row
+                            + work_tile_info.tile_m_idx
+                            // cutlass.Int32(self.epilogue._atom_thr_size)
+                            * cutlass.Int32(self.epilogue._cta_tile_m)
+                        ) * fc1_output_gemm.stride[0]
+                        fc1_probe_ptr = cute.make_ptr(
+                            cutlass.Int32,
+                            fc1_output_gemm.iterator.toint() + fc1_byte_offset,
+                            cute.AddressSpace.gmem,
+                        )
+                        fc1_first_i32 = cute.arch.load(fc1_probe_ptr, cutlass.Int32, cop="cg")
+                        # cute.printf(
+                        #     "[fc2_spin_exit] slot=%d counter=%d thresh=%d "
+                        #     "tile_m=%d cumul=%d fc1_first_i32=0x%08x",
+                        #     counter_slot,
+                        #     counter_val_post,
+                        #     fc2_spin_threshold,
+                        #     work_tile_info.tile_m_idx,
+                        #     work_tile_info.cumulative_token_block_count,
+                        #     fc1_first_i32,
+                        # )
+
+                    k_tile_cnt = k_tile_cnt_fc2
+                    real_a, desc_ptr_a = ext.get_gmem_tensor(
+                        "fc2_activation", tma_tensor_fc2_activation, work_tile_info,
+                    )
+                    real_sfa, desc_ptr_sfa = ext.get_gmem_tensor(
+                        "fc2_activation_sf", tma_tensor_fc2_activation_sf, work_tile_info,
+                    )
+
+                    gA_mkl = cute.local_tile(
+                        real_a,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    gSFA_mkl = cute.local_tile(
+                        real_sfa,
+                        cute.slice_(self.mma_tiler, (None, 0, None)),
+                        (None, None, None),
+                    )
+                    tCgA = thr_mma.partition_A(gA_mkl)
+                    tCgSFA = thr_mma.partition_A(gSFA_mkl)
+
+                    tAsA, tAgA = cpasync.tma_partition(
+                        tma_atom_fc2_activation,
+                        block_in_cluster_coord_vmnk[2],
+                        a_cta_layout,
+                        cute.group_modes(sA, 0, 3),
+                        cute.group_modes(tCgA, 0, 3),
+                    )
+                    tAsSFA, tAgSFA = cpasync.tma_partition(
+                        tma_atom_fc2_activation_sf,
+                        block_in_cluster_coord_vmnk[2],
+                        sfa_cta_layout,
+                        cute.group_modes(sSFA, 0, 3),
+                        cute.group_modes(tCgSFA, 0, 3),
+                    )
+                    tAsSFA = cute.filter_zeros(tAsSFA)
+                    tAgSFA = cute.filter_zeros(tAgSFA)
+
+                    # fc2 A-side = fc1_output (M=tokens). tAgA is cluster-level
+                    # indexed, so divide tile_m_idx by cluster_m to get the
+                    # cluster block index — same formula as fc1 A-side.
+                    mma_tile_m = work_tile_info.tile_m_idx // cute.size(
+                        tiled_mma.thr_id.shape
+                    )
+                    tAgA_slice = tAgA[(None, mma_tile_m, None, 0)]
+                    tAgSFA_slice = tAgSFA[(None, mma_tile_m, None, 0)]
+
+                    a_producer.reset()
+                    peek_a_empty_status = a_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = a_producer.acquire_and_advance(
+                            peek_a_empty_status
+                        )
+                        peek_a_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_a_empty_status = a_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc2_activation,
+                            tAgA_slice[(None, handle.count)],
+                            tAsA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_a,
+                            mcast_mask=a_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc2_activation_sf,
+                            tAgSFA_slice[(None, handle.count)],
+                            tAsSFA[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfa,
+                            mcast_mask=sfa_full_mcast_mask,
+                        )
+
+                if _iket_active:
+                    iket.range_pop()
+                work_tile_info = sched_consumer.consume_work()
+
+            a_producer.tail()
+
+        # ── TMA-B warp (warp 6) ─────────────────────────────────────────────
+        if warp_idx == self.tma_b_warp_id:
+            _iket_active = (tidx == cutlass.Int32(192))
+            b_full_mcast_mask = None
+            sfb_full_mcast_mask = None
+            if cutlass.const_expr(self.is_b_mcast or use_2cta_instrs):
+                b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+                )
+                sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_sfb_vmnk,
+                    block_in_cluster_coord_sfb_vmnk,
+                    mcast_mode=1,
+                )
+
+            # non-swap-AB FC1: weight (B) is multicast (like original A).
+            # a_full_mcast_mask with mcast_mode=2 → covers all CTAs with same N-coord = all CTAs.
+            a_full_mcast_mask = None
+            if cutlass.const_expr(self.is_a_mcast or use_2cta_instrs):
+                a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                    cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+                )
+            a_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+            )
+
+            b_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+            )
+            sfb_cta_layout = cute.make_layout(
+                cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+            )
+
+            thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+            thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+
+                if is_phase_linear1:
+                    # ── fc1 phase B-side (fc1_weight, N-side GEMM-B) ──
+                    # Weight is expert-indexed (key "a") and N-side: use tile_n_idx
+                    # (not tile_m_idx) to select the N-tile. tile_m_idx counts token
+                    # blocks and grows with more tokens, causing OOB on the weight's
+                    # N-dimension when tile_m_idx >= 2.
+                    if _iket_active:
+                        iket.range_push("tma_token_fc1")
+
+                    k_tile_cnt = k_tile_cnt_fc1
+                    real_b, desc_ptr_b = ext.get_gmem_tensor(
+                        "fc1_weight", tma_tensor_weight, work_tile_info,
+                    )
+                    real_sfb, desc_ptr_sfb = ext.get_gmem_tensor(
+                        "fc1_weight_sf", tma_tensor_fc1_weight_sf, work_tile_info,
+                    )
+
+                    # N-K tiling for N-side weight (N=intermediate, K=hidden).
+                    gB_nkl = cute.local_tile(
+                        real_b,
+                        cute.slice_(self.mma_tiler, (0, None, None)),
+                        (None, None, None),
+                    )
+                    gSFB_nkl = cute.local_tile(
+                        real_sfb,
+                        cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+                        (None, None, None),
+                    )
+                    # No coord flip for MXFP8 (non-swap-AB); partition_B for N-side.
+                    tCgB = thr_mma.partition_B(gB_nkl)
+                    tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                    tBsB, tBgB = cpasync.tma_partition(
+                        tma_atom_weight,
+                        block_in_cluster_coord_vmnk[1],
+                        b_cta_layout,
+                        cute.group_modes(sB, 0, 3),
+                        cute.group_modes(tCgB, 0, 3),
+                    )
+                    tBsSFB, tBgSFB = cpasync.tma_partition(
+                        tma_atom_fc1_weight_sf,
+                        block_in_cluster_coord_sfb_vmnk[1],
+                        sfb_cta_layout,
+                        cute.group_modes(sSFB, 0, 3),
+                        cute.group_modes(tCgSFB, 0, 3),
+                    )
+                    tBsSFB = cute.filter_zeros(tBsSFB)
+                    tBgSFB = cute.filter_zeros(tBgSFB)
+
+                    # Use tile_n_idx for N-side weight: invariant across token blocks.
+                    tBgB_slice = tBgB[(None, work_tile_info.tile_n_idx, None, 0)]
+                    tBgSFB_slice = tBgSFB[(None, work_tile_info.tile_n_idx, None, 0)]
+
+                    b_producer.reset()
+                    peek_b_empty_status = b_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = b_producer.acquire_and_advance(
+                            peek_b_empty_status
+                        )
+                        peek_b_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_b_empty_status = b_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_weight,
+                            tBgB_slice[(None, handle.count)],
+                            tBsB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_b,
+                            mcast_mask=a_full_mcast_mask,  # same as A-loading for weights
+                        )
+                        cute.copy(
+                            tma_atom_fc1_weight_sf,
+                            tBgSFB_slice[(None, handle.count)],
+                            tBsSFB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfb,
+                            mcast_mask=sfb_full_mcast_mask,
+                        )
+                else:
+                    # ── fc2 phase B-side: load fc2_weight (N=hidden), no counter wait ──
+                    # fc2_weight is independent of fc1; counter wait is in TMA-A.
+                    if _iket_active:
+                        iket.range_push("tma_weight_fc2")
+                    k_tile_cnt = k_tile_cnt_fc2
+                    real_b, desc_ptr_b = ext.get_gmem_tensor(
+                        "fc2_weight", tma_tensor_fc2_weight, work_tile_info,
+                    )
+                    real_sfb, desc_ptr_sfb = ext.get_gmem_tensor(
+                        "fc2_weight_sf", tma_tensor_fc2_weight_sf, work_tile_info,
+                    )
+
+                    gB_nkl = cute.local_tile(
+                        real_b,
+                        cute.slice_(self.mma_tiler, (0, None, None)),
+                        (None, None, None),
+                    )
+                    gSFB_nkl = cute.local_tile(
+                        real_sfb,
+                        cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+                        (None, None, None),
+                    )
+                    tCgB = thr_mma.partition_B(gB_nkl)
+                    tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+
+                    tBsB, tBgB = cpasync.tma_partition(
+                        tma_atom_fc2_weight,
+                        block_in_cluster_coord_vmnk[1],
+                        b_cta_layout,
+                        cute.group_modes(sB, 0, 3),
+                        cute.group_modes(tCgB, 0, 3),
+                    )
+                    tBsSFB, tBgSFB = cpasync.tma_partition(
+                        tma_atom_fc2_weight_sf,
+                        block_in_cluster_coord_sfb_vmnk[1],
+                        sfb_cta_layout,
+                        cute.group_modes(sSFB, 0, 3),
+                        cute.group_modes(tCgSFB, 0, 3),
+                    )
+                    tBsSFB = cute.filter_zeros(tBsSFB)
+                    tBgSFB = cute.filter_zeros(tBgSFB)
+
+                    # fc2 B-side = fc2_weight (N=hidden). tile_n_idx is the
+                    # CTA-level hidden block index; invariant across token blocks.
+                    fc2_b_hidden_tile = work_tile_info.tile_n_idx
+                    tBgB_slice = tBgB[(None, fc2_b_hidden_tile, None, 0)]
+                    tBgSFB_slice = tBgSFB[(None, fc2_b_hidden_tile, None, 0)]
+
+                    b_producer.reset()
+                    peek_b_empty_status = b_producer.try_acquire()
+
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle = b_producer.acquire_and_advance(
+                            peek_b_empty_status
+                        )
+                        peek_b_empty_status = cutlass.Boolean(1)
+                        if handle.count + 1 < k_tile_cnt:
+                            peek_b_empty_status = b_producer.try_acquire()
+                        cute.copy(
+                            tma_atom_fc2_weight,
+                            tBgB_slice[(None, handle.count)],
+                            tBsB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_b,
+                            mcast_mask=b_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_fc2_weight_sf,
+                            tBgSFB_slice[(None, handle.count)],
+                            tBsSFB[(None, handle.index)],
+                            tma_bar_ptr=handle.barrier,
+                            tma_desc_ptr=desc_ptr_sfb,
+                            mcast_mask=sfb_full_mcast_mask,
+                        )
+                if _iket_active:
+                    iket.range_pop()
+                work_tile_info = sched_consumer.consume_work()
+
+            b_producer.tail()
+
+        # ════════════════════════════════════════════════════════════════════
+        # MMA warp (warp 4)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # Both phases share tiled_mma and TMEM; only K-tile count differs.
+        if warp_idx == self.mma_warp_id:
+            _iket_active = (tidx == cutlass.Int32(128))
+
+            tCrA = tiled_mma.make_fragment_A(sA)
+            tCrB = tiled_mma.make_fragment_B(sB)
+
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            acc_base = cute.make_tensor(acc_tmem_ptr, acc_fake.layout)
+
+            # SFA TMEM tensor (placed after the acc cols).
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # SFB TMEM tensor (after acc + SFA cols).
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_pipeline_stages
+            )
+
+            # K-tile counts ``k_tile_cnt_fc1`` / ``k_tile_cnt_fc2`` come
+            # from the enclosing scope (computed once before the TMA warps).
+
+            work_tile_info = sched_consumer.consume_work()
+
+            while work_tile_info.is_valid_tile:
+                is_phase_linear1 = (
+                    work_tile_info.phase == cutlass.Int32(BlockPhase.Linear1)
+                )
+                # Prebind k_tile_cnt due to DSL AST.
+                k_tile_cnt = cutlass.Int32(0)
+                if is_phase_linear1:
+                    k_tile_cnt = k_tile_cnt_fc1
+                    if _iket_active:
+                        iket.range_push("mma_fc1")
+                else:
+                    k_tile_cnt = k_tile_cnt_fc2
+                    if _iket_active:
+                        iket.range_push("mma_fc2")
+
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+
+                if is_leader_cta:
+                    tCtAcc = acc_base[(None, None, None, acc_stage_index)]
+
+                    if _iket_active:
+                        iket.range_push("mma_ab_wait")
+                    a_consumer.reset()
+                    b_consumer.reset()
+                    peek_a_full_status = cutlass.Boolean(1)
+                    peek_b_full_status = cutlass.Boolean(1)
+                    if k_tile_cnt > 0:
+                        peek_a_full_status = a_consumer.try_wait()
+                        peek_b_full_status = b_consumer.try_wait()
+                        acc_pipeline.producer_acquire(acc_producer_state)
+                    if _iket_active:
+                        iket.range_pop()
+
+                    tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                    for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                        handle_a = a_consumer.wait_and_advance(peek_a_full_status)
+                        handle_b = b_consumer.wait_and_advance(peek_b_full_status)
+                        peek_a_full_status = cutlass.Boolean(1)
+                        peek_b_full_status = cutlass.Boolean(1)
+                        if handle_a.count + 1 < k_tile_cnt:
+                            peek_a_full_status = a_consumer.try_wait()
+                            peek_b_full_status = b_consumer.try_wait()
+
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t[(None, None, None, None, handle_a.index)],
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t[(None, None, None, None, handle_b.index)],
+                            tCtSFB_compact_s2t,
+                        )
+
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                        cute.gemm(
+                            tiled_mma,
+                            tCtAcc,
+                            [tCrA[(None, None, None, handle_a.index)], tCtSFA],
+                            [tCrB[(None, None, None, handle_b.index)], tCtSFB],
+                            tCtAcc,
+                        )
+                        handle_a.release()
+                        handle_b.release()
+
+                    if k_tile_cnt > 0:
+                        acc_pipeline.producer_commit(acc_producer_state)
+                if k_tile_cnt > 0:
+                    acc_producer_state.advance()
+
+                if _iket_active:
+                    iket.range_pop()
+
+                work_tile_info = sched_consumer.consume_work()
+
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        # ── sD SMEM (fc1 output staging; fc2 doesn't use it) ──
+        # Always allocated for correct typing in const_expr-gated TMA dead branches.
+        sD = smem.allocate_tensor(
+            element_type=self.fc1_output_dtype,
+            layout=d_smem_layout_staged.outer,
+            byte_alignment=128,
+            swizzle=d_smem_layout_staged.inner,
+        )
+
+        # ── sC SMEM (raw gate+up Float32, ping-pong; only when generate_c=True) ──
+        if cutlass.const_expr(self.generate_c):
+            sC = smem.allocate_tensor(
+                element_type=self.epilogue._c_dtype,
+                layout=c_smem_layout_staged.outer,
+                byte_alignment=128,
+                swizzle=c_smem_layout_staged.inner,
+            )
+
+        # ════════════════════════════════════════════════════════════════════
+        # Epilogue warps (warps 0-3)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # Fully delegated to ``self.epilogue.run(...)`` -- the epilogue owns
+        # the entire 2-phase task-tile loop.
+        if warp_idx < self.mma_warp_id:
+            epi_warp_idx = warp_idx
+
+            tmem.allocate(self.num_tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            acc_tensor = cute.make_tensor(acc_tmem_ptr, acc_fake.layout)
+
+            #acc_tensor = cute.make_tensor(
+            #    acc_tmem_ptr,
+            #    cute.make_layout(
+            #        (((128, self.cta_tile_shape_mnk[1]), 1),),
+            #        stride=(((1 << 16, 1), 0),),
+            #    ),
+            #)
+
+            # Build common kwargs shared by both epilogue flavours.
+            if cutlass.const_expr(self.generate_c):
+                _smem_c_raw_arg = sC
+                _tma_atom_c_arg = tma_atom_c
+                _gmem_c_arg = tma_tensor_c
+                _gmem_c_in_arg = tma_tensor_c_in
+            else:
+                _smem_c_raw_arg = None
+                _tma_atom_c_arg = None
+                _gmem_c_arg = None
+                _gmem_c_in_arg = None
+            if cutlass.const_expr(self.use_stg_fc1):
+                _gmem_fc1_output_arg = fc1_output_gemm
+            else:
+                _gmem_fc1_output_arg = tma_tensor_fc1_output
+            _run_kwargs = dict(
+                tmem_acc_tensor=acc_tensor,
+                acc_pipeline=acc_pipeline,
+                sched_consumer=sched_consumer,
+                sched_ext=ext,
+                smem_fc1_output_buffer=sD,
+                tma_atom_fc1_output=tma_atom_fc1_output,
+                gmem_fc1_output=_gmem_fc1_output_arg,
+                gmem_fc1_output_sf=fc1_output_sf_gemm,
+                gmem_topk_scores=topk_scores,
+                gmem_fc2_output=fc2_output_gemm,
+                gmem_fc1_done_counter=fc1_done_counter,
+                smem_c_buffer=_smem_c_raw_arg,
+                tma_atom_c=_tma_atom_c_arg,
+                gmem_c=_gmem_c_arg,
+                gmem_c_in=_gmem_c_in_arg,
+                warp_idx=epi_warp_idx,
+                tidx=tidx,
+                alpha=cutlass.Float32(1.0),
+                norm_const=cutlass.Float32(1.0),
+            )
+
+            # MegaMoE: pass token_comm_args only when it is a real bundle (not
+            # None).  Passing Python None explicitly to @cute.jit methods
+            # triggers a CuteDSL codegen issue; const_expr dispatch avoids any
+            # None-as-JIT-argument path.
+            if cutlass.const_expr(token_comm_args is not None):
+                self.epilogue.run(**_run_kwargs, token_comm_args=token_comm_args)
+            else:
+                self.epilogue.run(**_run_kwargs)
+
+            tmem.relinquish_alloc_permit()
+            tmem.free(acc_tmem_ptr)
+            if cutlass.const_expr(self.enable_token_comm):
+                cute.arch.fence_acq_rel_sys()
+
+        # ════════════════════════════════════════════════════════════════════
+        # Dispatch warps hook (warps 8-11; MegaMoE-only)
+        # ════════════════════════════════════════════════════════════════════
+        #
+        # ``enable_token_comm=False`` → warps 8-11 don't exist (threads_per_cta
+        # = 256), so the guard is const_expr-eliminated in the lean path.
+        if cutlass.const_expr(self.enable_token_comm):
+            if warp_idx >= self.dispatch_warp_id[0]:
+                lane_idx_for_dispatch = cute.arch.lane_idx()
+                if cutlass.const_expr(self.token_back_standalone):
+                    if warp_idx < self.token_back_warp_id[0]:
+                        self.token_comm_hook_dispatch_warp_body(
+                            token_comm_args,
+                            token_comm_storage,
+                            warp_idx=warp_idx,
+                            lane_idx=lane_idx_for_dispatch,
+                            tidx=tidx,
+                        )
+                    else:
+                        self.token_comm_hook_token_back_warp_body(
+                            token_comm_args,
+                            token_comm_storage,
+                            warp_idx=warp_idx,
+                            lane_idx=lane_idx_for_dispatch,
+                            tidx=tidx,
+                        )
+                else:
+                    self.token_comm_hook_dispatch_warp_body(
+                        token_comm_args,
+                        token_comm_storage,
+                        warp_idx=warp_idx,
+                        lane_idx=lane_idx_for_dispatch,
+                        tidx=tidx,
+                    )
+
+            # ════════════════════════════════════════════════════════════════════
+            # Kernel tail hook (MegaMoE-only; lean base = no-op)
+            # ════════════════════════════════════════════════════════════════════
+            lane_idx = cute.arch.lane_idx()
+            self.token_comm_hook_kernel_tail(
+                token_comm_args,
+                warp_idx=warp_idx,
+                lane_idx=lane_idx,
+                tidx=tidx,
+            )
+

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/kernel_bwd_mega.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/kernel_bwd_mega.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""M2.C part 2 (D1): in-kernel metadata-gather dout dispatch.
+
+``BwdGatherComm`` is a trimmed ``TokenInPullTokenBackPush``: it drops the
+forward's routing walk / count-exchange / dedup and instead drives the pull
+straight off the FORWARD's persistent ``token_src_metadata``.  Per pool row it
+reads ``(src_rank, src_token)`` from the metadata and peer-pulls the quantized
+``dout`` row (+ SF) from a sym-heap ``my_dout`` buffer into the activation pool,
+publishing ``fc1_ready_counter`` on the SAME slot the GEMM's TMA-B warp spins on
+(``expert_task_tile_offset + token_idx_in_expert // cluster_tile_tokens``).
+
+Everything else — the pull/store TMA ops, the SF ldg/store, the fc1-ready
+release tracker, the SMEM ``pull_buffer`` storage, the TMA-B predispatch spin,
+and the sched handshake — is REUSED verbatim from the forward comm (contracts
+in ``BWD_DESIGN.md`` §D1).  Preconditions vs the forward: ``my_dout`` is staged
+host-side before the collective launch and there are no cross-rank sends, so
+``dispatch_prep`` / ``dispatch_barrier`` / the NVLink barrier are all skipped.
+
+``Sm100MegaMoEMxfp8BwdKernel`` mirrors the forward's ``Sm100MegaMoEMxfp8Kernel``
+delegation surface: it flips ``enable_token_comm`` on, builds the comm object,
+and forwards the token-comm hooks.  It keeps ``fc2_in_kernel_topk_reduce=True``
+so the dx token-back (M2.C part 1) still runs in the same launch.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple, Type
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+from cutlass.cutlass_dsl import Int32, Int64, Float32
+from cutlass.cute.typing import AddressSpace
+
+from common.megamoe_constants import SfPaddingBlock
+
+from src.token_comm import TokenInPullTokenBackPush, TokenSrcMetadata
+from src.ptx_helpers import tma_load_1d_raw, tma_store_1d, ldg_b32_raw
+from src.flag_batch import GpuReleaseFlagBatchTracker
+from src.sf_swizzle import sf_atom_int32_offset
+
+from megamoe.bwd_kernel.kernel_bwd_fc12 import Sm100SwigluMxfp8Fc12Kernel
+
+
+class BwdGatherComm(TokenInPullTokenBackPush):
+    """Metadata-driven dout gather (no routing walk / sends / dedup)."""
+
+    @cute.jit
+    def dispatch_warp_body(
+        self, token_comm_args, token_comm_storage, *, warp_idx, lane_idx, tidx,
+    ):
+        bidx, bidy, bidz = cute.arch.block_idx()
+        cta_linear_id = (
+            Int32(bidx)
+            + Int32(self.cluster_shape_mn[1]) * Int32(bidy)
+            + Int32(self.cluster_shape_mn[1] * self.cluster_shape_mn[0])
+            * Int32(bidz)
+        )
+        local_warp_idx = Int32(warp_idx) - Int32(self.dispatch_warp_start)
+
+        # Sizes are host-supplied (offs); nothing to prep / exchange.  Just
+        # release the sched warp (it arrive_and_waits on this same barrier).
+        nb = pipeline.NamedBarrier(
+            barrier_id=self.dispatch_to_sched_named_barrier_id,
+            num_threads=self.dispatch_to_sched_threads,
+        )
+        nb.arrive()
+
+        self.dispatch_pull_by_metadata(
+            token_comm_storage,
+            token_comm_args.input_token_buffer,
+            token_comm_args.input_sf_buffer,
+            token_comm_args.expert_recv_count_sum,
+            token_comm_args.fc1_input_token_buffer,
+            token_comm_args.fc1_input_sf_buffer,
+            token_comm_args.fc1_ready_counter,
+            token_comm_args.token_src_metadata,
+            token_comm_args.peer_rank_ptr_mapper,
+            cta_linear_id,
+            local_warp_idx,
+            lane_idx,
+            num_sms=token_comm_args.sm_count,
+        )
+
+    @cute.jit
+    def dispatch_pull_by_metadata(
+        self,
+        token_comm_storage,
+        input_token_buffer,      # sym-heap my_dout (peer-pull SOURCE)
+        input_sf_buffer,         # sym-heap my_dout_sf
+        expert_recv_count_sum,   # host-staged per-expert token totals (i64)
+        fc1_input_token_buffer,  # activation pool (peer-pull DEST = GEMM-A)
+        fc1_input_sf_buffer,     # activation SF pool
+        fc1_ready_counter,       # per-tile release counter (GEMM spins on it)
+        token_src_metadata,      # forward's persistent record (READ)
+        peer_rank_ptr_mapper,
+        sm_idx,
+        warp_idx,
+        lane_idx,
+        *,
+        num_sms,
+    ):
+        pull_mbar_ptr = token_comm_storage.pull_mbar.data_ptr()
+        pull_buffer_ptr = token_comm_storage.pull_buffer.data_ptr()
+        if lane_idx == Int32(0):
+            cute.arch.mbarrier_init(pull_mbar_ptr + warp_idx, 1)
+        cute.arch.sync_warp()
+
+        phase_bit = Int32(0)
+        current_expert_idx = Int32(-1)
+        expert_start_idx = Int32(0)
+        expert_end_idx = Int32(0)
+        expert_pool_block_offset = Int32(0)
+        expert_task_tile_offset = Int32(0)
+        expert_sf_pool_block_offset = Int32(0)
+
+        flag_tracker = GpuReleaseFlagBatchTracker(
+            flag_addr=Int64(0),
+            cumulated_flags=Int32(0),
+            phase=Int32(0),
+            tid=lane_idx,
+        )
+
+        NUM_EXPERTS_PER_LANE: cutlass.Constexpr[int] = (
+            self.num_experts_per_rank + 31
+        ) // 32
+        stored_num_tokens_per_expert = []
+        for _ in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+            stored_num_tokens_per_expert.append(Int32(0))
+        for i in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+            e_idx_for_lane = Int32(i * self.warp_threads) + lane_idx
+            if e_idx_for_lane < Int32(self.num_experts_per_rank):
+                sum_packed_init = expert_recv_count_sum[e_idx_for_lane]
+                stored_num_tokens_per_expert[i] = Int32(
+                    Int64(sum_packed_init) & Int64(0xFFFFFFFF)
+                )
+        cute.arch.sync_warp()
+
+        num_global_warps: cutlass.Constexpr[int] = num_sms * self.num_dispatch_warps
+        token_idx = sm_idx * Int32(self.num_dispatch_warps) + warp_idx
+
+        while current_expert_idx < Int32(self.num_experts_per_rank):
+            while (token_idx >= expert_end_idx) and (
+                current_expert_idx < Int32(self.num_experts_per_rank)
+            ):
+                prev_valid_count = expert_end_idx - expert_start_idx
+                prev_block_count = (
+                    prev_valid_count + Int32(self.token_padding_block) - Int32(1)
+                ) // Int32(self.token_padding_block)
+                expert_pool_block_offset = expert_pool_block_offset + prev_block_count
+                prev_task_tile_count = (
+                    prev_valid_count + Int32(self.cluster_tile_tokens) - Int32(1)
+                ) // Int32(self.cluster_tile_tokens)
+                expert_task_tile_offset = (
+                    expert_task_tile_offset + prev_task_tile_count
+                )
+                prev_sf_block_count = (
+                    prev_valid_count + Int32(self.sf_padding_block) - Int32(1)
+                ) // Int32(self.sf_padding_block)
+                expert_sf_pool_block_offset = (
+                    expert_sf_pool_block_offset + prev_sf_block_count
+                )
+                current_expert_idx = current_expert_idx + Int32(1)
+                if current_expert_idx < Int32(self.num_experts_per_rank):
+                    expert_start_idx = expert_end_idx
+                    valid_value = Int32(0)
+                    for i in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+                        if current_expert_idx == Int32(
+                            i * self.warp_threads
+                        ) + lane_idx:
+                            valid_value = stored_num_tokens_per_expert[i]
+                    total_for_expert = cute.arch.shuffle_sync(
+                        valid_value, current_expert_idx % Int32(self.warp_threads)
+                    )
+                    expert_end_idx = expert_end_idx + total_for_expert
+
+            if current_expert_idx < Int32(self.num_experts_per_rank):
+                token_idx_in_expert = token_idx - expert_start_idx
+                pool_token_idx = (
+                    expert_pool_block_offset * Int32(self.token_padding_block)
+                    + token_idx_in_expert
+                )
+                sf_token_in_pool_axis = (
+                    expert_sf_pool_block_offset * Int32(self.sf_padding_block)
+                    + token_idx_in_expert
+                )
+
+                md = TokenSrcMetadata.load(
+                    token_src_metadata.iterator
+                    + Int64(pool_token_idx) * Int64(TokenSrcMetadata.nbytes)
+                )
+                src_rank = md.src_rank
+                src_token = md.src_token
+
+                cur_peer_offset = peer_rank_ptr_mapper.map(
+                    Int64(0), src_rank, Int64(0)
+                )
+                inp_tok_local_base = input_token_buffer.iterator.toint()
+                inp_sf_local_base = input_sf_buffer.iterator.toint()
+
+                with cute.arch.elect_one():
+                    pull_buffer_warp_ptr = pull_buffer_ptr + (
+                        warp_idx * Int32(self.hidden_bytes)
+                    )
+                    tma_src_addr = (
+                        inp_tok_local_base
+                        + cur_peer_offset
+                        + Int64(src_token * Int32(self.hidden_bytes))
+                    )
+                    tma_load_1d_raw(
+                        pull_buffer_warp_ptr,
+                        tma_src_addr,
+                        pull_mbar_ptr + warp_idx,
+                        Int32(self.hidden_bytes),
+                    )
+                cute.arch.sync_warp()
+
+                sf_passes: cutlass.Constexpr[int] = (
+                    self.sf_uint32_per_token + 31
+                ) // 32
+                sf_vals = []
+                for _ in cutlass.range_constexpr(0, sf_passes, 1):
+                    sf_vals.append(Int32(0))
+                for i in cutlass.range_constexpr(0, sf_passes, 1):
+                    j = Int32(i * self.warp_threads) + lane_idx
+                    if j < Int32(self.sf_uint32_per_token):
+                        sf_addr = (
+                            inp_sf_local_base
+                            + cur_peer_offset
+                            + Int64(
+                                (src_token * Int32(self.sf_uint32_per_token) + j)
+                                * Int32(4)
+                            )
+                        )
+                        sf_vals[i] = ldg_b32_raw(sf_addr)
+
+                for i in cutlass.range_constexpr(0, sf_passes, 1):
+                    j = Int32(i * self.warp_threads) + lane_idx
+                    if j < Int32(self.sf_uint32_per_token):
+                        sf_int32_pos = sf_atom_int32_offset(
+                            sf_token_in_pool_axis,
+                            j,
+                            num_k_atoms=self.sf_uint32_per_token,
+                        )
+                        fc1_input_sf_buffer[sf_int32_pos] = sf_vals[i]
+                cute.arch.sync_warp()
+
+                with cute.arch.elect_one():
+                    cute.arch.mbarrier_arrive_and_expect_tx(
+                        pull_mbar_ptr + warp_idx, Int32(self.hidden_bytes)
+                    )
+                    cute.arch.mbarrier_wait(pull_mbar_ptr + warp_idx, phase_bit)
+
+                with cute.arch.elect_one():
+                    pull_buffer_warp_ptr = pull_buffer_ptr + (
+                        warp_idx * Int32(self.hidden_bytes)
+                    )
+                    tma_store_1d(
+                        fc1_input_token_buffer.iterator
+                        + (Int64(pool_token_idx) * Int64(self.hidden_bytes)),
+                        pull_buffer_warp_ptr,
+                        Int32(self.hidden_bytes),
+                    )
+                with cute.arch.elect_one():
+                    cute.arch.cp_async_bulk_commit_group()
+                    cute.arch.cp_async_bulk_wait_group(0)
+
+                task_tile_idx = expert_task_tile_offset + (
+                    token_idx_in_expert // Int32(self.cluster_tile_tokens)
+                )
+                task_tile_addr = (fc1_ready_counter.iterator + task_tile_idx).toint()
+                flag_tracker = flag_tracker.accumulate(
+                    Int32(0), self._flag_batch, task_tile_addr,
+                )
+                cute.arch.sync_warp()
+                phase_bit = phase_bit ^ Int32(1)
+
+            token_idx = token_idx + Int32(num_global_warps)
+
+        flag_tracker.fire()
+
+
+class Sm100MegaMoEMxfp8BwdKernel(Sm100SwigluMxfp8Fc12Kernel):
+    """Backward FC12 kernel with in-kernel dout gather + dx token-back."""
+
+    def __init__(
+        self,
+        *,
+        world_size: int,
+        local_rank: int,
+        num_topk: int,
+        max_tokens_per_rank: int,
+        **base_kwargs,
+    ) -> None:
+        super().__init__(fc2_in_kernel_topk_reduce=True, **base_kwargs)
+
+        self.comm_world_size = world_size
+        self.comm_local_rank = local_rank
+        self.comm_num_topk = num_topk
+
+        num_experts_per_rank = self.static_expert_shape[0]
+        # MXFP8: 1 byte / elem; SF pulled in uint32 units (4 E8M0 per word).
+        sf_atom_k_elements = 4 * self.sf_vec_size
+        self.comm_sf_uint32_per_token = (
+            (self.static_expert_shape[2] + sf_atom_k_elements - 1)
+            // sf_atom_k_elements
+        )
+
+        # 12-warp topology (epilogue 0-3, mma/tma_a/tma_b/sched 4-7, dispatch 8-11).
+        self.enable_token_comm = True
+        self.dispatch_warp_id = (8, 9, 10, 11)
+        self.token_back_standalone = False
+        self.token_back_warp_id = None
+
+        num_other_warps = len(self.epilogue_warp_id) + 4  # + mma/tma_a/tma_b/sched
+        self.token_comm = BwdGatherComm(
+            world_size=world_size,
+            num_topk=num_topk,
+            num_experts_per_rank=num_experts_per_rank,
+            num_total_experts=world_size * num_experts_per_rank,
+            hidden=self.static_expert_shape[2],
+            fc1_token_dtype=self.ab_dtype,
+            sf_uint32_per_token=self.comm_sf_uint32_per_token,
+            token_padding_block=self.token_padding_block,
+            sf_padding_block=self.sf_padding_block,
+            cluster_tile_tokens=self.mma_tiler_mnk[0],
+            cluster_shape_mn=self.cluster_shape_mn,
+            dispatch_warp_start=self.dispatch_warp_id[0],
+            num_other_warps=num_other_warps,
+            token_back_by_dispatch=False,
+            token_back_standalone=False,
+            combine_format=None,       # bf16 combine (dx via fc2_in_kernel_topk_reduce)
+            flag_batch=1,
+        )
+
+    # -- token-comm delegation surface (mirrors Sm100MegaMoEMxfp8Kernel) ----
+
+    def token_comm_extra_smem_storage_class(self) -> type:
+        return self.token_comm.extra_smem_storage_class()
+
+    def token_comm_hook_fc1_ready_counter_ptr(self, token_comm_args):
+        return self.token_comm.fc1_ready_counter_ptr(token_comm_args)
+
+    def sched_ext_fc1_peek_threshold(self) -> int:
+        return self.cluster_tile_tokens
+
+    @cute.jit
+    def token_comm_hook_sched_warp_pre_init_wait(self, token_comm_args):
+        self.token_comm.sched_warp_pre_init_wait(token_comm_args)
+
+    @cute.jit
+    def token_comm_hook_fc1_tma_b_predispatch_spin(self, token_comm_args, work_tile_info):
+        self.token_comm.fc1_tma_b_predispatch_spin(token_comm_args, work_tile_info)
+
+    @cute.jit
+    def token_comm_hook_dispatch_warp_body(
+        self, token_comm_args, token_comm_storage, *, warp_idx, lane_idx, tidx,
+    ):
+        self.token_comm.dispatch_warp_body(
+            token_comm_args, token_comm_storage,
+            warp_idx=warp_idx, lane_idx=lane_idx, tidx=tidx,
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/moe_utils_bwd.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/moe_utils_bwd.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Device helpers for the backward epilogue (SwiGLU-bwd elemwise).
+
+Adjoint of ``common/moe_utils.py::swiglu_act`` (A = prob * silu(g) * u):
+
+    dA_eff = prob * dacc            (prob = the row's topk weight; the GEMM1
+                                     accumulator is pre-prob, BWD_DESIGN.md)
+    du     = dA_eff * silu(g)
+    dg     = dA_eff * u * s * (1 + g * (1 - s)),   s = sigmoid(g)
+
+Same fastmath/exp2 sigmoid construction as swiglu_act so forward/backward
+use identical nonlinearity approximations.
+"""
+
+from typing import Optional
+
+import cutlass
+import cutlass.cute as cute
+from cutlass import Float32
+
+import megamoe.repo_path  # noqa: F401
+
+from common.megamoe_constants import Log2E
+
+
+@cute.jit
+def swiglu_bwd(
+    t_du: cute.Tensor,
+    t_dg: cute.Tensor,
+    t_dacc: cute.Tensor,
+    t_up: cute.Tensor,
+    t_gate: cute.Tensor,
+    prob: Optional[Float32] = None,
+) -> None:
+    """du/dg from the GEMM1 accumulator block + stashed raw gate/up block."""
+    for i in cutlass.range_constexpr(0, cute.size(t_du), 2):
+        # s = sigmoid(gate) = 1 / (1 + exp2(-gate * log2(e)))
+        neg = cute.arch.mul_packed_f32x2(
+            (t_gate[i], t_gate[i + 1]), (-Log2E, -Log2E), rnd="rn", ftz=False,
+        )
+        s0, s1 = cute.arch.add_packed_f32x2(
+            (
+                cute.math.exp2(neg[0], fastmath=True),
+                cute.math.exp2(neg[1], fastmath=True),
+            ),
+            (1.0, 1.0),
+        )
+        s0 = cute.arch.rcp_approx(s0)
+        s1 = cute.arch.rcp_approx(s1)
+
+        da0, da1 = t_dacc[i], t_dacc[i + 1]
+        if cutlass.const_expr(prob is not None):
+            da0, da1 = cute.arch.mul_packed_f32x2(
+                (da0, da1), (prob, prob), rnd="rn", ftz=False,
+            )
+
+        # du = da * s * g   (silu(g) = s * g)
+        silu0, silu1 = cute.arch.mul_packed_f32x2(
+            (s0, s1), (t_gate[i], t_gate[i + 1]), rnd="rn", ftz=False,
+        )
+        t_du[i], t_du[i + 1] = cute.arch.mul_packed_f32x2(
+            (da0, da1), (silu0, silu1), rnd="rn", ftz=False,
+        )
+
+        # dg = da * u * s * (1 + g - g*s)
+        gs0, gs1 = cute.arch.mul_packed_f32x2(
+            (t_gate[i], t_gate[i + 1]), (s0, s1), rnd="rn", ftz=False,
+        )
+        f0 = 1.0 + t_gate[i] - gs0
+        f1 = 1.0 + t_gate[i + 1] - gs1
+        dau0, dau1 = cute.arch.mul_packed_f32x2(
+            (da0, da1), (t_up[i], t_up[i + 1]), rnd="rn", ftz=False,
+        )
+        sf0, sf1 = cute.arch.mul_packed_f32x2(
+            (s0, s1), (f0, f1), rnd="rn", ftz=False,
+        )
+        t_dg[i], t_dg[i + 1] = cute.arch.mul_packed_f32x2(
+            (dau0, dau1), (sf0, sf1), rnd="rn", ftz=False,
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/repro_mega.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/repro_mega.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Minimal mega-backward repro with step prints (debugging aid)."""
+
+import faulthandler
+import os
+import sys
+
+faulthandler.enable()
+os.environ.setdefault("MEGA_NO_DIST", "1")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import dataclasses
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+
+def log(msg):
+    print(f"[repro] {msg}", flush=True)
+
+
+def main():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    import torch.distributed as dist
+
+    if not dist.is_initialized():
+        dist.init_process_group(
+            "nccl", init_method="tcp://127.0.0.1:29541", world_size=1, rank=0
+        )
+
+    from pt import EpConfig, QuantConfig
+    from megamoe.forward import MegaMoeForwardConfig
+    from megamoe.training import MegaMoeHybridMxfp8Layer
+
+    T, H, I, E, K = 4096, 1024, 512, 32, 4
+    gen = torch.Generator(device=device).manual_seed(4242)
+    x = (torch.randn((T, H), device=device, generator=gen) / 10.0).bfloat16()
+    scores = torch.rand((T, E), device=device, generator=gen)
+    _, ids = scores.topk(K, dim=-1)
+    w = torch.rand((T, K), device=device, generator=gen) + 0.1
+    tw = (w / w.sum(-1, keepdim=True)).float()
+    dout = torch.randn((T, H), device=device, generator=gen).bfloat16()
+    w13 = (torch.randn((E, 2 * I, H), device=device, generator=gen) * 0.05).bfloat16()
+    w2 = (torch.randn((E, H, I), device=device, generator=gen) * 0.05).bfloat16()
+
+    ep_cfg = EpConfig(num_experts=E, top_k=K, hidden_size=H,
+                      intermediate_size=I, ep_size=1, ep_rank=0)
+    mm_cfg = MegaMoeForwardConfig(
+        max_tokens_per_rank=T, hidden=H, intermediate=I,
+        num_total_experts=E, num_topk=K,
+    )
+    mm_cfg = dataclasses.replace(
+        mm_cfg, impl=dataclasses.replace(mm_cfg.impl, generate_c=True)
+    )
+    log("building layer")
+    layer = MegaMoeHybridMxfp8Layer(
+        ep_cfg, mm_cfg, w13, w2,
+        qcfg=QuantConfig(fprop_fmt="mxfp8", quant_bprop=True), bwd_impl="mega",
+    )
+    log("forward")
+    x_l = x.detach().clone().requires_grad_()
+    tw_l = tw.detach().clone().requires_grad_()
+    out = layer(x_l, ids, tw_l)
+    torch.cuda.synchronize()
+    log(f"forward done, out norm {out.float().norm().item():.4f}")
+    log("backward (compiles bwd kernel on first call)")
+    dx, dtw, dw13, dw2 = torch.autograd.grad(
+        out, (x_l, tw_l, layer.w13, layer.w2), dout
+    )
+    torch.cuda.synchronize()
+    log(f"backward done: |dx|={dx.float().norm():.4f} |dtw|={dtw.float().norm():.4f} "
+        f"|dw13|={dw13.float().norm():.4f} |dw2|={dw2.float().norm():.4f}")
+    nan = any(t.float().isnan().any().item() for t in (dx, dtw, dw13, dw2))
+    log(f"nan check: {'FAIL' if nan else 'ok'}")
+    layer.finalize()
+    dist.destroy_process_group()
+    log("DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/test_bwd_fc12.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/test_bwd_fc12.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""M2.A parity: the backward FC12 kernel vs a torch mxfp8 reference chain.
+
+Standalone (no NVSHMEM): feeds pool-order inputs directly —
+
+    activation  = quantized DOUT pool (Mp, H) fp8 + swizzled SFs
+    fc1_weight  = W2^T  (E, H, I) view   (gemm1: dA = dout @ W2^T)
+    fc1_c       = forward's raw (gate, up) stash (Mp, 2I) bf16 interleaved
+    topk_scores = per-pool-row tw        (gemm1 epilogue: dA *= tw)
+    fc2_weight  = W13^T (E, 2I, H) view  (gemm2: dx = [dg,du] @ W13^T)
+
+and checks BOTH the 2I-wide fc1_output workspace (DFC1, dequantized) and the
+final fc2_output (dXG) against the same chain computed in torch with the
+identical quantized operands.
+
+Launch:  python -m megamoe.bwd_kernel.test_bwd_fc12
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import torch
+import torch.nn.functional as F
+
+import megamoe.repo_path  # noqa: F401
+
+from megamoe.fp8_bwd import _pack_scales_rowgroups, _round_up
+from megamoe.quant_kernels import mxfp8_rowquant
+from megamoe.bwd_kernel.weights_bwd import quantize_moe_weights_mxfp8_bwd
+from megamoe.weights import interleave_gate_up
+
+HIDDEN = 1024
+INTERMEDIATE = 512      # per-branch I; gemm1 N = I, gemm2 K = 2I
+NUM_EXPERTS = 4
+COUNTS = [300, 128, 0, 517]
+SEED = 4242
+
+
+def dequant(q, sf_plain):
+    scale = torch.exp2(sf_plain.view(torch.uint8).float() - 127.0)
+    return q.float() * scale.repeat_interleave(32, dim=-1)
+
+
+def main():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    gen = torch.Generator(device=device).manual_seed(SEED)
+    E, H, I = NUM_EXPERTS, HIDDEN, INTERMEDIATE
+
+    padded = [_round_up(n, 128) for n in COUNTS]
+    doffs = [sum(padded[:i]) for i in range(E)]
+    Mp = sum(padded)
+    valid = torch.cat([
+        torch.arange(o, o + n, device=device) for o, n in zip(doffs, COUNTS) if n
+    ])
+
+    # ---- synthetic forward state: stash + tw + dout, zero pad rows ----
+    def pool_randn(cols, scale):
+        t = torch.zeros((Mp, cols), device=device, dtype=torch.bfloat16)
+        t[valid] = (torch.randn((valid.numel(), cols), device=device,
+                                generator=gen) * scale).bfloat16()
+        return t
+
+    x_pool = pool_randn(H, 0.1)
+    dout_pool = pool_randn(H, 1.0)
+    tw = torch.zeros((Mp,), device=device, dtype=torch.float32)
+    tw[valid] = torch.rand((valid.numel(),), device=device, generator=gen) + 0.1
+    w13 = (torch.randn((E, 2 * I, H), device=device, generator=gen) * 0.05).bfloat16()
+    w2 = (torch.randn((E, H, I), device=device, generator=gen) * 0.05).bfloat16()
+
+    # fc1_c = raw pre-SwiGLU gate+up in kernel interleave, per expert slot
+    w13_int = interleave_gate_up(w13)
+    fc1_c = torch.zeros((Mp, 2 * I), device=device, dtype=torch.bfloat16)
+    for e in range(E):
+        rows = slice(doffs[e], doffs[e] + COUNTS[e])
+        fc1_c[rows] = (x_pool[rows].float() @ w13_int[e].float().t()).bfloat16()
+
+    # ---- kernel operands ----
+    qw = quantize_moe_weights_mxfp8_bwd(w13, w2)
+    dout_q, dout_sf = mxfp8_rowquant(dout_pool)          # (Mp,H) fp8 + (Mp,H/32)
+    offs_padded = torch.tensor(
+        [sum(padded[: i + 1]) for i in range(E)], device=device, dtype=torch.int32
+    )
+    act_sf_swz = _pack_scales_rowgroups(dout_sf, offs_padded)
+    offs_valid = torch.tensor(
+        [sum(COUNTS[: i + 1]) for i in range(E)], device=device, dtype=torch.int32
+    )
+
+    # ---- torch reference chain (same quantized bytes) ----
+    w2t_fq = dequant(
+        qw.gemm1_weight.permute(0, 2, 1).reshape(-1, H),
+        qw.gemm1_weight_sf_plain.reshape(-1, H // 32),
+    ).view(E, I, H)
+    w13t_fq = dequant(
+        qw.gemm2_weight.permute(0, 2, 1).reshape(-1, 2 * I),
+        qw.gemm2_weight_sf_plain.reshape(-1, 2 * I // 32),
+    ).view(E, H, 2 * I)
+    dout_fq = dequant(dout_q, dout_sf)
+
+    ref_dfc1 = torch.zeros((Mp, 2 * I), device=device, dtype=torch.float32)
+    for e in range(E):
+        rows = slice(doffs[e], doffs[e] + COUNTS[e])
+        dacc = dout_fq[rows] @ w2t_fq[e].t()
+        da = dacc * tw[rows, None]
+        pair = fc1_c[rows].float().view(-1, I // 32, 2, 32)
+        g, u = pair[:, :, 0].reshape(-1, I), pair[:, :, 1].reshape(-1, I)
+        s = torch.sigmoid(g)
+        dg = da * u * s * (1 + g * (1 - s))
+        du = da * F.silu(g)
+        out = torch.stack(
+            [dg.view(-1, I // 32, 32), du.view(-1, I // 32, 32)], dim=2
+        ).reshape(-1, 2 * I)                              # (dg, du) interleave
+        ref_dfc1[rows] = out
+    # fc2 ref consumes the REQUANTIZED dfc1 (what the kernel's gemm2 reads)
+    from pt.quant import fake_quant_mxfp8
+
+    dfc1_fq = fake_quant_mxfp8(ref_dfc1.bfloat16())
+    ref_out = torch.zeros((Mp, H), device=device, dtype=torch.float32)
+    for e in range(E):
+        rows = slice(doffs[e], doffs[e] + COUNTS[e])
+        ref_out[rows] = dfc1_fq[rows] @ w13t_fq[e].t()
+
+    # ---- kernel ----
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.torch as cutlass_torch
+    import cutlass.utils as utils
+
+    from common.megamoe_constants import SfPaddingBlock
+    from megamoe.bwd_kernel.kernel_bwd_fc12 import Sm100SwigluMxfp8Fc12Kernel
+
+    mma_tiler = (256, 256, 128)
+    cluster = (2, 1, 1)
+    max_active = utils.HardwareInfo().get_max_active_clusters(cluster[0] * cluster[1])
+    kernel = Sm100SwigluMxfp8Fc12Kernel(
+        mma_tiler_mnk=mma_tiler,
+        cluster_shape_mnk=cluster,
+        use_2cta_instrs=True,
+        group_hint=max_active,
+        token_padding_block=128,
+        sf_padding_block=SfPaddingBlock,
+        load_balance_mode="static",
+        static_expert_shape=(E, I, H),      # gemm1 N = I
+        ab_dtype=cutlass.Float8E4M3FN,
+        sf_vec_size=32,
+        apply_topk_in_fc1=True,
+        generate_c=True,
+        use_stg_fc1=True,
+    )
+
+    def to_cute(t, align=16):
+        ct = cutlass_torch.from_dlpack(t, assumed_align=align)
+        return ct.mark_layout_dynamic(leading_dim=cutlass_torch.get_leading_dim(t))
+
+    fc1_weight_t = qw.gemm1_weight       # (E, H, I) view
+    fc2_weight_t = qw.gemm2_weight       # (E, 2I, H) view
+    ws_bytes = kernel.get_workspace_size_in_bytes(
+        to_cute(dout_q), to_cute(fc1_weight_t)
+    )
+    workspace = torch.zeros((ws_bytes,), dtype=torch.uint8, device=device)
+
+    # partition (mirror runner_fc12_common._partition_workspace, downproj=2I)
+    downproj = 2 * I
+    sf_rows_upper = Mp + E * SfPaddingBlock
+    sf_block_cols = ((downproj // 32) + 3) // 4 * 4
+    counter_slots = (Mp + mma_tiler[1] - 1) // mma_tiler[1] + E
+    n0 = Mp * downproj
+    n1 = sf_rows_upper * sf_block_cols
+    n2 = counter_slots * 4
+    fc1_output = workspace[:n0].view(torch.float8_e4m3fn).view(Mp, downproj)
+    fc1_output_sf = workspace[n0 : n0 + n1].view(sf_rows_upper, sf_block_cols)
+    fc1_done_counter = workspace[n0 + n1 : n0 + n1 + n2].view(torch.int32)
+
+    fc2_output = torch.full((Mp, H), float("nan"), device=device, dtype=torch.bfloat16)
+    dfc1_stash = torch.full(
+        (Mp, 2 * I), float("nan"), device=device, dtype=torch.bfloat16
+    )
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    runtime_kwargs = dict(
+        activation=to_cute(dout_q),
+        activation_sf=to_cute(act_sf_swz),
+        fc1_weight=to_cute(fc1_weight_t),
+        fc1_weight_sf=to_cute(qw.gemm1_weight_sf),
+        fc1_output=to_cute(fc1_output),
+        fc1_output_sf=to_cute(fc1_output_sf),
+        fc2_weight=to_cute(fc2_weight_t),
+        fc2_weight_sf=to_cute(qw.gemm2_weight_sf),
+        fc2_output=to_cute(fc2_output),
+        topk_scores=to_cute(tw),
+        fc1_done_counter=to_cute(fc1_done_counter),
+        offs=to_cute(offs_valid),
+        fc1_c=to_cute(fc1_c),
+        fc1_c_out=to_cute(dfc1_stash),
+        stream=stream,
+    )
+    compile_kwargs = dict(runtime_kwargs)
+    compile_kwargs["max_active_clusters"] = max_active
+    compiled = cute.compile(kernel, **compile_kwargs)
+    compiled(**runtime_kwargs)
+    torch.cuda.synchronize()
+
+    # ---- compare ----
+    ok = True
+    got_stash = dfc1_stash.float()[valid]
+    want_stash = ref_dfc1[valid]
+    r0 = ((got_stash - want_stash).norm() / want_stash.norm().clamp_min(1e-12)).item()
+    print(f"dfc1 bf16 stash   rel_l2 = {r0:.4e}")
+    ok &= r0 < 5e-3  # bf16 rounding only — same operands, no requant
+
+    got_out = fc2_output.float()[valid]
+    want_out = ref_out[valid]
+    r2 = ((got_out - want_out).norm() / want_out.norm().clamp_min(1e-12)).item()
+    print(f"fc2_output (dXG)  rel_l2 = {r2:.4e}")
+    ok &= r2 < 2e-2
+
+    print("BWD_FC12 " + ("PASS" if ok else "FAIL"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/weights_bwd.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_kernel/weights_bwd.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""bf16 expert weights -> the backward kernel's MXFP8 B operands.
+
+Mirrors megamoe/weights.py but for the adjoint GEMMs (BWD_DESIGN.md D2/D4):
+
+  gemm1 (dA = doutg @ W2^T):    B = W2^T, logical (E, hidden, I) with hidden
+                                stride-1 (K=H), quantized along H.
+  gemm2 (dxg = DFC1 @ W13^T):   B = W13^T over the INTERLEAVED gate/up axis,
+                                logical (E, 2I, hidden) with 2I stride-1
+                                (K=2I), quantized along 2I.
+
+Column convention: the backward epilogue writes DFC1 pool columns as
+interleaved 32-blocks in (gate, up) slot order — [dgate_b0 | dup_b0 | ...] —
+so gemm2's K axis must use the same `interleave_gate_up` ordering as the
+forward fc1 N axis.  SFs are per-expert 32x4x4 atom-swizzled (`to_blocked`),
+plain copies kept for host reference dequant.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+from common.host_utils import mxfp8_quantize_per_block_32
+from common.megamoe_constants import Mxfp8BlockSize
+from moe_nvfp4_swapab.runner_common import (
+    to_blocked,
+    _stack_byte_reinterpretable_tensors,
+)
+
+from megamoe.weights import _KIND_TO_TORCH_DTYPE, interleave_gate_up
+
+
+@dataclass
+class QuantizedBwdWeights:
+    """Kernel-ready backward B operands (+ plain SFs for host reference)."""
+
+    gemm1_weight: torch.Tensor         # (E, H, I) fp8 view, H stride-1
+    gemm1_weight_sf: torch.Tensor      # (E, flat) E8M0, atom-swizzled
+    gemm2_weight: torch.Tensor         # (E, 2I, H) fp8 view, 2I stride-1
+    gemm2_weight_sf: torch.Tensor      # (E, flat) E8M0, atom-swizzled
+    gemm1_weight_sf_plain: torch.Tensor  # (E, I, H//32) E8M0
+    gemm2_weight_sf_plain: torch.Tensor  # (E, H, 2I//32) E8M0
+
+
+def quantize_moe_weights_mxfp8_bwd(
+    w13: torch.Tensor,     # [E, 2I, H] bf16, pt layout ([:I]=linear/up, [I:]=gate)
+    w2: torch.Tensor,      # [E, H, I] bf16
+    kind: str = "mxfp8_e4m3",
+) -> QuantizedBwdWeights:
+    """Quantize bf16 masters into the backward kernel's MXFP8 layout."""
+    data_dtype = _KIND_TO_TORCH_DTYPE[kind]
+    E, two_i, H = w13.shape
+    I = two_i // 2
+    if w2.shape != (E, H, I):
+        raise ValueError(f"w2 must be (E={E}, H={H}, I={I}), got {tuple(w2.shape)}.")
+    if H % Mxfp8BlockSize or I % Mxfp8BlockSize:
+        raise ValueError(
+            f"hidden ({H}) and intermediate ({I}) must be multiples of "
+            f"{Mxfp8BlockSize}."
+        )
+
+    # gemm1: W2^T (E, I, H) contiguous, quantize along K=hidden.
+    g1_f32 = w2.float().cuda().transpose(1, 2).contiguous()
+    g1_q, g1_sf = mxfp8_quantize_per_block_32(g1_f32.reshape(E * I, H), data_dtype)
+    g1_q = g1_q.reshape(E, I, H)
+    g1_sf_plain = g1_sf.reshape(E, I, H // Mxfp8BlockSize)
+    gemm1_weight = g1_q.permute(0, 2, 1)  # logical (E, H, I), H stride-1
+
+    # gemm2: W13^T over the interleaved gate/up axis, (E, H, 2I) contiguous,
+    # quantize along K=2I.
+    g2_f32 = interleave_gate_up(w13).float().cuda().transpose(1, 2).contiguous()
+    g2_q, g2_sf = mxfp8_quantize_per_block_32(g2_f32.reshape(E * H, two_i), data_dtype)
+    g2_q = g2_q.reshape(E, H, two_i)
+    g2_sf_plain = g2_sf.reshape(E, H, two_i // Mxfp8BlockSize)
+    gemm2_weight = g2_q.permute(0, 2, 1)  # logical (E, 2I, H), 2I stride-1
+
+    g1_sf_sw = _stack_byte_reinterpretable_tensors(
+        [to_blocked(g1_sf_plain[e]) for e in range(E)], dim=0
+    )
+    g2_sf_sw = _stack_byte_reinterpretable_tensors(
+        [to_blocked(g2_sf_plain[e]) for e in range(E)], dim=0
+    )
+
+    return QuantizedBwdWeights(
+        gemm1_weight=gemm1_weight,
+        gemm1_weight_sf=g1_sf_sw,
+        gemm2_weight=gemm2_weight,
+        gemm2_weight_sf=g2_sf_sw,
+        gemm1_weight_sf_plain=g1_sf_plain,
+        gemm2_weight_sf_plain=g2_sf_plain,
+    )

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_v0.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/bwd_v0.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""M1 pool-reuse backward (BWD_DESIGN.md): the megakernel's dataflow, in torch.
+
+Same gradient semantics as ``fp8_bwd.fp8_backward`` (mxfp8 on every GEMM
+operand) but organized the way the backward megakernel will run, consuming
+the forward kernel's persistent pools instead of rebuilding EP state:
+
+- NO routing plan / dispatch of x: pool row -> token mapping comes from
+  ``token_src_metadata``; the pool layout (128-aligned expert slots) IS the
+  grouped-GEMM ``offs``.
+- NO fc1/act/y recompute GEMMs: raw gate+up comes from the ``generate_c``
+  stash ``fc1_c``; d(topk_weights) = <gemm1_out_pre_tw, silu(g)*u> needs no y.
+- dout reaches pool order by one gather (world=1) or one allgather + gather
+  (world>1) — the kernel replaces this with metadata-driven peer pulls.
+- backward GEMM chain:  dA = tw * (doutg @ W2^T)   [gmm 2d3d, K=H]
+                        du,dg = SwiGLU'(dA; g,u)   [elemwise]
+                        dxg  = [du,dg] @ W13^T     [gmm 2d3d, K=2I]
+  wgrads on the same pool-ordered operands [gmm 2d2d, K=tokens].
+
+Weight quantizations (W2^T along H, W13^T along 2I) are cached on the layer
+until ``refresh_weights``; with turboquant they are built in the rotated
+basis and dX/dW13 are rotated back through Q^T (same contract as fp8_bwd).
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+import torch.distributed as dist
+
+import megamoe.repo_path  # noqa: F401
+
+from pt.quant import rotate_trailing
+
+from megamoe.fp8_bwd import (
+    _col_atom_order,
+    _phase,
+    _round_up,
+    gmm_2d3d,
+    gmm_wgrad_2d2d,
+    quant_weights_3d,
+)
+from megamoe.pools import decode_token_src_metadata, local_pool_views
+from megamoe.training import dequant_mxfp8_pool
+
+
+def _weight_cache(layer):
+    """Only the two dgrad operands (no recompute weights needed)."""
+    wc = getattr(layer, "_pool_bwd_wcache", None)
+    if wc is not None:
+        return wc
+    with _phase("weight-quant"):
+        w13 = layer.w13.detach().to(torch.bfloat16)
+        if layer.qcfg.turboquant:
+            w13 = rotate_trailing(w13, layer.q_rot)
+        w2 = layer.w2.detach().to(torch.bfloat16)
+        wc = {
+            "w2t_kh": quant_weights_3d(w2.transpose(1, 2).contiguous()),      # (E,I,H)  K=H
+            "w13t_k2i": quant_weights_3d(w13.transpose(1, 2).contiguous()),   # (E,H,2I) K=2I
+        }
+    layer._pool_bwd_wcache = wc
+    return wc
+
+
+def pool_backward(layer, topk_ids, topk_weights, dout, T):
+    """Metadata-driven mxfp8 backward; returns (dx, dtw, dw13, dw2)."""
+    ep = layer.ep_cfg
+    H, I, K = ep.hidden_size, ep.intermediate_size, ep.top_k
+    E_local = ep.num_experts // ep.ep_size
+    expert_start = ep.ep_rank * E_local
+    world = ep.ep_size
+    fwd = layer._fwd
+    device = dout.device
+    group = ep.process_group
+
+    with _phase("prep"):
+        # global routing counts -> this rank's pool layout (host-side; the
+        # kernel version inherits these from the forward launch instead).
+        if world > 1:
+            ids_all = torch.empty(
+                (world, T, K), dtype=topk_ids.dtype, device=device
+            )
+            dist.all_gather_into_tensor(ids_all, topk_ids.contiguous(), group=group)
+        else:
+            ids_all = topk_ids.view(1, T, K)
+        local = ids_all.reshape(-1) - expert_start
+        counts = torch.bincount(
+            local[(local >= 0) & (local < E_local)], minlength=E_local
+        ).tolist()
+
+        padded = [_round_up(n, 128) for n in counts]
+        Mp = max(sum(padded), 128)
+        offs = torch.tensor(
+            [sum(padded[: i + 1]) for i in range(E_local)],
+            device=device, dtype=torch.int32,
+        )
+        doffs = [sum(padded[:i]) for i in range(E_local)]
+        valid = torch.cat(
+            [torch.arange(o, o + n, device=device) for o, n in zip(doffs, counts)]
+        ) if sum(counts) else torch.empty(0, dtype=torch.long, device=device)
+
+        lv = local_pool_views(fwd)
+        src_rank, src_token, src_topk, _, _ = decode_token_src_metadata(
+            lv["token_src_metadata"][:Mp]
+        )
+        sr = src_rank[valid].long()
+        st = src_token[valid].long()
+        sk = src_topk[valid].long()
+        tw_rows = lv["l1_topk_weights_buffer"][:Mp][valid].float()
+
+        wc = _weight_cache(layer)
+        w2tq_kh, sw2t_kh = wc["w2t_kh"]
+        w13tq_k2i, sw13t_k2i = wc["w13t_k2i"]
+
+        # wgrad scale atom permutations for the pool layout
+        cbt = Mp // 128
+        order_h = _col_atom_order(offs, H // 128, cbt)
+        order_2i = _col_atom_order(offs, (2 * I) // 128, cbt)
+        order_i = _col_atom_order(offs, I // 128, cbt)
+
+    with torch.no_grad():
+        with _phase("dispatch"):
+            # dout (and, for wgrad, the quantized x) in pool order by gather
+            dout_b = dout.to(torch.bfloat16)
+            x_q = dequant_mxfp8_pool(
+                fwd.my_activation[:T], fwd.my_activation_sf[:T], H
+            ).to(torch.bfloat16)
+            if world > 1:
+                dout_all = torch.empty((world * T, H), dtype=dout_b.dtype, device=device)
+                dist.all_gather_into_tensor(dout_all, dout_b.contiguous(), group=group)
+                x_all = torch.empty((world * T, H), dtype=x_q.dtype, device=device)
+                dist.all_gather_into_tensor(x_all, x_q, group=group)
+                flat = sr * T + st
+            else:
+                dout_all, x_all, flat = dout_b, x_q, st
+            DOUTG = dout_b.new_zeros((Mp, H))
+            DOUTG.index_copy_(0, valid, dout_all[flat])
+            XG = x_q.new_zeros((Mp, H))
+            XG.index_copy_(0, valid, x_all[flat])
+
+        # gate/up from the forward stash (raw, pre-tw; kernel interleave)
+        with _phase("elemwise"):
+            pair = fwd.fc1_c[:Mp].view(Mp, I // 32, 2, 32)
+            gate = pair[:, :, 0].reshape(Mp, I).float()
+            up = pair[:, :, 1].reshape(Mp, I).float()
+            act_raw = F.silu(gate) * up                       # silu(g)*u, no tw
+            ACTW = act_raw.new_zeros((Mp, I), dtype=torch.bfloat16)
+            ACTW.index_copy_(
+                0, valid, (act_raw[valid] * tw_rows[:, None]).to(torch.bfloat16)
+            )
+
+        # dgrad chain
+        G1 = gmm_2d3d(DOUTG, offs, w2tq_kh, sw2t_kh)          # doutg @ W2^T (pre-tw)
+        with _phase("elemwise"):
+            dtw_rows = (G1[valid].float() * act_raw[valid]).sum(dim=-1)
+            dA = G1.float()
+            dA[valid] *= tw_rows[:, None]
+            sg = torch.sigmoid(gate)
+            dgate = dA * up * sg * (1 + gate * (1 - sg))
+            dup = dA * F.silu(gate)
+            # pad rows: dA==0 there (zero DOUTG rows, zero fc1_c rows — probe
+            # C5), and every term multiplies dA, so DFC1 pads are zero.
+            DFC1 = torch.cat([dup, dgate], dim=-1).to(torch.bfloat16)  # pt [lin|gate]
+        DXG = gmm_2d3d(DFC1, offs, w13tq_k2i, sw13t_k2i)      # (Mp, H)
+
+        # wgrads (tokens on K); pool rows are zero-padded by construction
+        dw13 = gmm_wgrad_2d2d(DFC1, XG, offs, order_2i, order_h)
+        if layer.qcfg.turboquant:
+            dw13 = rotate_trailing(dw13.float(), layer.q_rot.t())
+        dw13 = dw13.to(layer.w13.dtype)
+        dw2 = gmm_wgrad_2d2d(DOUTG, ACTW, offs, order_h, order_i).to(layer.w2.dtype)
+
+        with _phase("comm-adj"):
+            # dx: sum pool contributions back to (src_rank, src_token)
+            dx_all = torch.zeros((world * T, H), device=device, dtype=torch.float32)
+            dx_all.index_add_(0, flat, DXG[valid].float())
+            # dtw: scatter scalars back to (src_rank, src_token, src_topk)
+            dtw_all = torch.zeros((world * T, K), device=device, dtype=torch.float32)
+            dtw_all[flat, sk] = dtw_rows
+            if world > 1:
+                dist.all_reduce(dx_all, group=group)
+                dist.all_reduce(dtw_all, group=group)
+            r0 = ep.ep_rank * T
+            dx = dx_all[r0 : r0 + T]
+            dtw = dtw_all[r0 : r0 + T]
+            if layer.qcfg.turboquant:
+                dx = rotate_trailing(dx, layer.q_rot.t())
+
+    return dx.to(torch.bfloat16), dtw, dw13, dw2

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/forward.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/forward.py
@@ -1,0 +1,392 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Hackable single-call MegaMoE forward for a PyTorch pipeline.
+
+A thin, flat re-package of ``moe_mxfp8_glu/mega_runner.py::run_kernel`` with
+the tester scaffolding (input generation / reference / validation) removed:
+
+  1. ctor          -- persistent sym-heap staging buffers, workspaces,
+                      kernel + preprocess ``cute.compile`` (all one-time).
+  2. load_weights  -- bf16 -> MXFP8 quant into persistent weight buffers
+                      (repeatable; no recompile on weight updates).
+  3. forward(x, topk_idx, topk_weights) -> (T, hidden) bf16
+                      copy-in -> fused device quant (``DataPreprocess``)
+                      -> one mega-kernel launch (dispatch + grouped FC1 GLU
+                      + FC2 + combine).  Stream-ordered; no host sync.
+
+All ranks must call ``forward`` collectively (the kernel contains NVLink
+barriers).  Everything is deliberately kept in this one file so it is easy
+to hack on (swap quant schemes, insert turboquant, add hooks, ...).
+
+Env: ``MEGA_NO_DIST=1`` runs single-rank without torch.distributed/NVSHMEM
+(sym buffers degrade to plain cuda tensors) -- handy for kernel debugging.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+import torch
+
+import megamoe.repo_path  # noqa: F401  (sys.path side effect)
+
+from common.megamoe_constants import Mxfp8BlockSize, SfPaddingBlock
+from moe_nvfp4_swapab.runner_common import ceil_div, round_up, Mxfp8ScaleDtype
+from moe_nvfp4_swapab.mega_runner import (
+    _NO_DIST,
+    _sym_zeros,
+    _compute_peer_offsets,
+)
+from moe_mxfp8_glu.mega_runner import (
+    _KIND_TO_TORCH_DTYPE,
+    _kind_to_cutlass_dtype,
+    _sym_zeros_byte_view_1b,
+)
+from moe_mxfp8_glu.runner_common import TrainingImplDesc
+from src.token_comm import CombineFormat
+
+from megamoe.weights import quantize_moe_weights_mxfp8, QuantizedExpertWeights
+
+
+@dataclass
+class MegaMoeForwardConfig:
+    """Problem shape + kernel knobs.
+
+    ``intermediate`` is the per-GLU-branch FFN width I (pt/ convention:
+    w13 is [E, 2*I, H]).  The kernel-side gate+up width is 2*I.
+
+    ``impl`` carries the tunable kernel knobs (mma_tiler_mnk,
+    cluster_shape_mnk, load_balance_mode, flag batching, ...).  Tune them
+    with the repo's tester (``torchrun ... -m tester.tester --mode Perf
+    --sweep --use_knob ...``) and paste the winner here.
+    """
+
+    max_tokens_per_rank: int
+    hidden: int
+    intermediate: int              # per-branch I; kernel sees 2*I
+    num_total_experts: int
+    num_topk: int
+    kind: str = "mxfp8_e4m3"
+    gate_up_clamp: Optional[float] = None
+    combine_format: str = "bf16"   # "bf16" | "32e4m3xe8m0" | "32e5m2xe8m0"
+    impl: TrainingImplDesc = field(
+        default_factory=lambda: TrainingImplDesc(
+            # validated MXFP8 tile/cluster; generate_c off until bwd needs it
+            generate_c=False,
+            token_back_mode="standalone_warps",
+            epi_flag_batch=(2, 4),
+            flag_batch=1,
+            # 2026-07-12 sweep (fwd_20260712_bucket_sweep.csv): group_hint=160
+            # beats the max_active_clusters default at EVERY token bucket
+            # (-8..-16%, balanced AND power-law routing) at 256E/top8/H7168.
+            group_hint=160,
+        )
+    )
+
+    @property
+    def intermediate_gateup(self) -> int:
+        return 2 * self.intermediate
+
+
+class MegaMoeMxfp8Forward:
+    def __init__(
+        self,
+        cfg: MegaMoeForwardConfig,
+        *,
+        rank: int,
+        world_size: int,
+    ) -> None:
+        if cfg.hidden % Mxfp8BlockSize or cfg.intermediate % Mxfp8BlockSize:
+            raise ValueError("hidden and intermediate must be multiples of 32.")
+        if cfg.num_total_experts % world_size:
+            raise ValueError("num_total_experts must divide by world_size.")
+        self.cfg = cfg
+        self.rank = rank
+        self.world_size = world_size
+        self.num_local_experts = cfg.num_total_experts // world_size
+        self.torch_ab_dtype = _KIND_TO_TORCH_DTYPE[cfg.kind]
+        self._combine_format = CombineFormat.parse(cfg.combine_format)
+        self._apply_topk_in_fc1 = True   # matches MegaMoEMxfp8Tester
+        self._compiled_mega = None
+        self._compiled_preproc = None
+        self._weights: Optional[QuantizedExpertWeights] = None
+        self._padding_valid_tokens = -1  # cached T of token_padding_info
+
+        T, H, K = cfg.max_tokens_per_rank, cfg.hidden, cfg.num_topk
+        sf_cols = ceil_div(H, Mxfp8BlockSize)
+        self._sf_cols_padded = round_up(sf_cols, 4)  # LDG.32 wire format
+
+        # -- persistent local staging (raw bf16 inputs land here each step) --
+        self.x_staging = torch.zeros((T, H), dtype=torch.bfloat16, device="cuda")
+        self.topk_idx_in = torch.full((T, K), -1, dtype=torch.int64, device="cuda")
+        self.topk_weights_in = torch.zeros((T, K), dtype=torch.float32, device="cuda")
+        self.token_padding_info = torch.ones((T,), dtype=torch.int32, device="cuda")
+
+        # -- persistent sym-heap kernel inputs (peer-pulled by dispatch) --
+        self.my_activation = _sym_zeros_byte_view_1b((T, H), self.torch_ab_dtype)
+        self.my_activation_sf = _sym_zeros_byte_view_1b(
+            (T, self._sf_cols_padded), Mxfp8ScaleDtype
+        )
+        self.my_topk_idx = _sym_zeros((T, K), torch.int64)
+        self.my_topk_weights = _sym_zeros((T, K), torch.float32)
+
+        # -- output: sym-heap iff it is the in-kernel REDG target --
+        if cfg.impl.in_kernel_fc2_reduce or getattr(
+            cfg.impl, "combine_in_flight_reduce", False
+        ):
+            self.output_activation = _sym_zeros((T, H), torch.bfloat16)
+        else:
+            self.output_activation = torch.zeros(
+                (T, H), dtype=torch.bfloat16, device="cuda"
+            )
+
+        # -- optional fc1 stash for training bwd (generate_c): the kernel
+        # streams the pre-SwiGLU gate+up fc1 output here from the epilogue.
+        # Sized for worst-case arrivals + per-expert 128-row padding.
+        if cfg.impl.generate_c:
+            c_rows = world_size * T * K + self.num_local_experts * 128
+            self.fc1_c = torch.zeros(
+                (c_rows, cfg.intermediate_gateup), dtype=torch.bfloat16, device="cuda"
+            )
+        else:
+            self.fc1_c = None
+
+        # weight buffers allocated on first load_weights (contiguous storage;
+        # the kernel-facing permuted views are built once there).
+        self.fc1_weight = None      # storage (E, 2I, H) fp8; view (E, H, 2I)
+        self.fc1_weight_sf = None   # (E, flat) swizzled E8M0
+        self.fc2_weight = None      # storage (E, H, I) fp8; view (E, I, H)
+        self.fc2_weight_sf = None
+
+    # ------------------------------------------------------------------
+    # weights
+    # ------------------------------------------------------------------
+
+    def load_weights(self, w13: torch.Tensor, w2: torch.Tensor) -> None:
+        """Quantize local-expert bf16 weights into the persistent buffers.
+
+        w13 [E_local, 2*I, H] ([:I]=linear/up, [I:]=gate), w2 [E_local, H, I].
+        Call again anytime the master weights change (e.g. every optimizer
+        step) -- buffers are updated in place, no recompile.
+        """
+        E, cfg = self.num_local_experts, self.cfg
+        if w13.shape != (E, cfg.intermediate_gateup, cfg.hidden):
+            raise ValueError(
+                f"w13 must be {(E, cfg.intermediate_gateup, cfg.hidden)}, "
+                f"got {tuple(w13.shape)}."
+            )
+        q = quantize_moe_weights_mxfp8(w13, w2, kind=cfg.kind)
+        if self.fc1_weight is None:
+            self.fc1_weight = q.fc1_weight
+            self.fc1_weight_sf = q.fc1_weight_sf
+            self.fc2_weight = q.fc2_weight
+            self.fc2_weight_sf = q.fc2_weight_sf
+        else:  # in-place update, keep pointers baked into runtime kwargs valid
+            self.fc1_weight.copy_(q.fc1_weight)
+            self.fc1_weight_sf.view(torch.uint8).copy_(q.fc1_weight_sf.view(torch.uint8))
+            self.fc2_weight.copy_(q.fc2_weight)
+            self.fc2_weight_sf.view(torch.uint8).copy_(q.fc2_weight_sf.view(torch.uint8))
+        self._weights = q
+
+    # ------------------------------------------------------------------
+    # compile (lazy, one-time)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_cute(tensor: torch.Tensor, assumed_align: int = 16, force_static=False):
+        import cutlass.torch as cutlass_torch
+
+        cute_tensor = cutlass_torch.from_dlpack(tensor, assumed_align=assumed_align)
+        if force_static:
+            return cute_tensor
+        leading_dim = cutlass_torch.get_leading_dim(tensor)
+        return cute_tensor.mark_layout_dynamic(leading_dim=leading_dim)
+
+    def _compile(self) -> None:
+        import cuda.bindings.driver as cuda
+        import cutlass.cute as cute
+        import cutlass.utils as utils
+
+        from moe_nvfp4_swapab.epilogue import EpilogueTokenTile
+        from moe_mxfp8_glu.megamoe_kernel_mxfp8 import Sm100MegaMoEMxfp8Kernel
+        from src.sym_buffer import SymBufferHost
+        from src.inputs_process import DataPreprocess
+
+        cfg, impl = self.cfg, self.cfg.impl
+        if self._weights is None:
+            raise RuntimeError("load_weights must be called before the first forward.")
+
+        cluster_size = impl.cluster_shape_mnk[0] * impl.cluster_shape_mnk[1]
+        max_active_clusters = utils.HardwareInfo().get_max_active_clusters(cluster_size)
+        group_hint = impl.group_hint if impl.group_hint is not None else max_active_clusters
+
+        self._kernel = Sm100MegaMoEMxfp8Kernel(
+            mma_tiler_mnk=impl.mma_tiler_mnk,
+            cluster_shape_mnk=impl.cluster_shape_mnk,
+            use_2cta_instrs=impl.use_2cta_instrs,
+            group_hint=group_hint,
+            token_padding_block=128 if impl.generate_c else EpilogueTokenTile,
+            sf_padding_block=SfPaddingBlock,
+            load_balance_mode=impl.load_balance_mode,
+            static_expert_shape=(
+                self.num_local_experts, cfg.intermediate_gateup, cfg.hidden,
+            ),
+            force_static_sched=impl.force_static_sched,
+            clc_bundle_size=impl.clc_bundle_size,
+            num_sched_stages=impl.num_sched_stages,
+            ab_dtype=_kind_to_cutlass_dtype(cfg.kind),
+            sf_vec_size=Mxfp8BlockSize,
+            world_size=self.world_size,
+            local_rank=self.rank,
+            num_topk=cfg.num_topk,
+            max_tokens_per_rank=cfg.max_tokens_per_rank,
+            hidden=cfg.hidden,
+            fc2_in_kernel_topk_reduce=impl.in_kernel_fc2_reduce,
+            token_back_mode=impl.token_back_mode,
+            epi_flag_batch=impl.epi_flag_batch,
+            flag_batch=impl.flag_batch,
+            gate_up_clamp=cfg.gate_up_clamp,
+            apply_topk_in_fc1=self._apply_topk_in_fc1,
+            generate_c=impl.generate_c,
+            use_stg_fc1=impl.use_stg_fc1,
+            combine_format=self._combine_format,
+            dedup_dispatch=getattr(impl, "dedup_dispatch", False),
+            combine_in_flight_reduce=getattr(
+                impl, "combine_in_flight_reduce", False
+            ),
+            combine_pre_reduce=getattr(impl, "combine_pre_reduce", False),
+        )
+
+        # workspaces: local plain cuda, shared on the sym heap (its peer-delta
+        # table covers every sym sub-allocation in the heap).
+        local_ws_bytes, shared_ws_bytes = self._kernel.get_workspace_sizes()
+        self.local_workspace = torch.zeros((local_ws_bytes,), dtype=torch.uint8, device="cuda")
+        self.shared_workspace = _sym_zeros((shared_ws_bytes,), torch.uint8)
+        symmetric_base, peer_offsets = _compute_peer_offsets(
+            self.shared_workspace, self.world_size
+        )
+        peer_mapper = SymBufferHost(
+            base_addr=symmetric_base,
+            offsets=tuple(peer_offsets),
+            rank_idx=self.rank,
+            num_max_ranks=self.world_size,
+        )
+
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+        # -- mega kernel: runtime kwargs are baked to the persistent buffers --
+        self._mega_kwargs = dict(
+            activation=self._to_cute(self.my_activation),
+            activation_sf=self._to_cute(self.my_activation_sf),
+            topk_idx=self._to_cute(self.my_topk_idx),
+            topk_weights=self._to_cute(self.my_topk_weights),
+            fc1_weight=self._to_cute(self.fc1_weight),
+            fc1_weight_sf=self._to_cute(self.fc1_weight_sf),
+            fc2_weight=self._to_cute(self.fc2_weight),
+            fc2_weight_sf=self._to_cute(self.fc2_weight_sf),
+            output_activation=self._to_cute(self.output_activation),
+            local_workspace=self._to_cute(self.local_workspace, force_static=True),
+            shared_workspace=self._to_cute(self.shared_workspace),
+            peer_rank_ptr_mapper_host=peer_mapper,
+            fc1_c=self._to_cute(self.fc1_c) if self.fc1_c is not None else None,
+            stream=stream,
+        )
+        compile_kwargs = dict(self._mega_kwargs)
+        compile_kwargs["max_active_clusters"] = max_active_clusters
+        self._compiled_mega = cute.compile(self._kernel, **compile_kwargs)
+
+        # -- fused bf16 -> mxfp8 staging kernel (quant + routing repack) --
+        self._preproc = DataPreprocess(
+            topk=cfg.num_topk, hidden=cfg.hidden, quant_type=cfg.kind,
+        )
+        sf_cols = ceil_div(cfg.hidden, Mxfp8BlockSize)
+        self._preproc_kwargs = dict(
+            activation_bf16=self._to_cute(self.x_staging),
+            topk_idx=self._to_cute(self.topk_idx_in),
+            topk_weights=self._to_cute(self.topk_weights_in),
+            token_padding_info=self._to_cute(self.token_padding_info),
+            activation_quant=self._to_cute(self.my_activation),
+            # unpadded (T, H//32) view; padded tail cols stay zero from alloc
+            activation_sf=self._to_cute(self.my_activation_sf[:, :sf_cols]),
+            topk_idx_output=self._to_cute(self.my_topk_idx),
+            topk_weights_output=self._to_cute(self.my_topk_weights),
+            cuda_stream=stream,
+        )
+        self._compiled_preproc = cute.compile(self._preproc, **self._preproc_kwargs)
+
+    # ------------------------------------------------------------------
+    # forward
+    # ------------------------------------------------------------------
+
+    def _stage_input(self, x: torch.Tensor, T: int) -> None:
+        """Land the raw bf16 activation in the staging buffer (overridable —
+        the turboquant mixin fuses its rotation into this write)."""
+        self.x_staging[:T].copy_(x)
+
+    def forward(
+        self,
+        x: torch.Tensor,             # (T, hidden) bf16, T <= max_tokens_per_rank
+        topk_idx: torch.Tensor,      # (T, num_topk) int, global expert ids
+        topk_weights: torch.Tensor,  # (T, num_topk) float
+    ) -> torch.Tensor:
+        """One expert-parallel MoE forward.  Collective: every rank must call.
+
+        Returns the (T, hidden) bf16 combined output (a view into the
+        persistent output buffer -- clone it if you need it past the next
+        forward).
+        """
+        if self._compiled_mega is None:
+            self._compile()
+
+        T = x.shape[0]
+        Tmax = self.cfg.max_tokens_per_rank
+        if T > Tmax:
+            raise ValueError(f"got {T} tokens > max_tokens_per_rank ({Tmax}).")
+
+        self._stage_input(x, T)
+        self.topk_idx_in[:T].copy_(topk_idx)
+        self.topk_weights_in[:T].copy_(topk_weights)
+        if T != self._padding_valid_tokens:
+            self.token_padding_info[:T].zero_()
+            self.token_padding_info[T:].fill_(1)
+            if T < Tmax:  # belt & braces: mask staged routing of pad rows too
+                self.topk_idx_in[T:].fill_(-1)
+                self.topk_weights_in[T:].zero_()
+            self._padding_valid_tokens = T
+
+        # REDG accumulates into output (in_kernel_reduce) and padding rows are
+        # never written -- start from zeros every step.
+        self.output_activation.zero_()
+
+        self._compiled_preproc(**self._preproc_kwargs)
+        self._compiled_mega(**self._mega_kwargs)
+        return self.output_activation[:T]
+
+    __call__ = forward
+
+    # ------------------------------------------------------------------
+    # teardown
+    # ------------------------------------------------------------------
+
+    def finalize(self) -> None:
+        """Free sym-heap tensors (call before nvshmem finalize)."""
+        self._compiled_mega = None
+        self._compiled_preproc = None
+        self._kernel = None
+        if _NO_DIST:
+            return
+        import nvshmem.core
+
+        sym = [
+            self.my_activation, self.my_activation_sf,
+            self.my_topk_idx, self.my_topk_weights,
+            getattr(self, "shared_workspace", None),
+        ]
+        if self.cfg.impl.in_kernel_fc2_reduce or getattr(
+            self.cfg.impl, "combine_in_flight_reduce", False
+        ):
+            sym.append(self.output_activation)
+        for t in sym:
+            if t is not None:
+                try:
+                    nvshmem.core.free_tensor(t)
+                except Exception:  # noqa: BLE001
+                    pass

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/forward_nvfp4.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/forward_nvfp4.py
@@ -1,0 +1,415 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Hackable single-call NVFP4 (4-bit) MegaMoE forward.
+
+NVFP4 sibling of ``megamoe.forward.MegaMoeMxfp8Forward``, wrapping
+``moe_nvfp4_swapab.megamoe_kernel.Sm100MegaMoEKernel`` (swap-AB): E2M1 data,
+per-16 FP8-E4M3 block scales, plus a per-tensor global scale ("norm_const")
+per operand.  Half the dispatch wire bytes of MXFP8.
+
+Global-scale bookkeeping (see moe_nvfp4_swapab/mega_reference.py):
+
+  quantized(x) satisfies  data * sf = x * norm_x   (norm_x = 2688 / amax(x))
+  GEMM(a_q, b_q)          = (x . w) * norm_x * norm_w
+  =>  fc1_alpha[e]        = 1 / (norm_act * norm_w13[e])
+      fc1_norm_const[e]   = norm chosen for the in-kernel fc1-out requant
+      fc2_alpha[e]        = 1 / (fc1_norm_const[e] * norm_w2[e])
+
+``DataPreprocess`` (online mode) derives ``norm_act`` from the activation
+amax on device and leaves it in a (1,) buffer; ``forward`` folds it into the
+persistent ``fc1_alpha`` tensor with one on-stream torch op — no host sync.
+Weight norms are per-expert, computed at ``load_weights``.
+"""
+
+from typing import Optional
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+from common.megamoe_constants import (
+    Fp8E4M3FNMax,
+    Nvfp4BlockSize,
+    Nvfp4E2M1Max,
+    SfPaddingBlock,
+)
+from moe_nvfp4_swapab.runner_common import (
+    ceil_div,
+    round_up,
+    to_blocked,
+    nvfp4_quantize_per_block_16,
+    _stack_byte_reinterpretable_tensors,
+)
+from moe_nvfp4_swapab.mega_runner import (
+    _NO_DIST,
+    _sym_zeros,
+    _sym_zeros_byte_view,
+    _compute_peer_offsets,
+)
+from src.token_comm import CombineFormat
+
+from megamoe.forward import MegaMoeForwardConfig, MegaMoeMxfp8Forward
+
+Nvfp4DataDtype = torch.float4_e2m1fn_x2
+Nvfp4ScaleDtype = torch.float8_e4m3fn
+_NORM_NUMER = float(Fp8E4M3FNMax * Nvfp4E2M1Max)  # 448 * 6
+_GATE_UP_INTERLEAVE = 16  # kernel's fc1 gate/up column interleave (NVFP4)
+
+
+class MegaMoeNvfp4Forward(MegaMoeMxfp8Forward):
+    """4-bit dispatch + swap-AB fc12.  Reuses the mxfp8 class's compile/launch
+    skeleton; overrides the quant staging, weight layout, and epilogue scalars.
+
+    ``cfg.kind`` is ignored (NVFP4 is fixed); ``fc1_out_amax_estimate``
+    calibrates the in-kernel fc1-out requant's global scale.
+    """
+
+    def __init__(self, cfg: MegaMoeForwardConfig, *, rank: int, world_size: int,
+                 fc1_out_amax_estimate: float = 8.0) -> None:
+        # Deliberately NOT calling super().__init__ — buffer dtypes/shapes
+        # differ; replicate the skeleton with NVFP4 legs.
+        if cfg.hidden % 32:
+            raise ValueError("hidden must be a multiple of 32 (fp4 pack + TMA).")
+        if cfg.intermediate % (2 * _GATE_UP_INTERLEAVE):
+            raise ValueError("intermediate must be a multiple of 32.")
+        if cfg.num_total_experts % world_size:
+            raise ValueError("num_total_experts must divide by world_size.")
+        # The config's default impl carries the MXFP8-validated geometry
+        # (256x256x128, 2-CTA); swap in the NVFP4 swap-AB kernel's own
+        # defaults unless the caller explicitly set an nvfp4-legal tile.
+        from moe_nvfp4_swapab.runner_fc12_common import ImplDesc
+        if cfg.impl.mma_tiler_mnk == (256, 256, 128):
+            cfg = MegaMoeForwardConfig(
+                **{**cfg.__dict__, "impl": ImplDesc(
+                    load_balance_mode=cfg.impl.load_balance_mode,
+                    in_kernel_fc2_reduce=cfg.impl.in_kernel_fc2_reduce,
+                )},
+            )
+        self.cfg = cfg
+        self.rank = rank
+        self.world_size = world_size
+        self.num_local_experts = cfg.num_total_experts // world_size
+        self._combine_format = CombineFormat.parse(cfg.combine_format)
+        self._apply_topk_in_fc1 = True   # deepgemm graph
+        self._compiled_mega = None
+        self._compiled_preproc = None
+        self._weights = None
+        self._padding_valid_tokens = -1
+        self.torch_ab_dtype = Nvfp4DataDtype
+        self.fc1_out_norm_const = _NORM_NUMER / float(fc1_out_amax_estimate)
+
+        T, H, K, E = (cfg.max_tokens_per_rank, cfg.hidden, cfg.num_topk,
+                      self.num_local_experts)
+        sf_cols = ceil_div(H, Nvfp4BlockSize)
+        self._sf_cols_padded = round_up(sf_cols, 4)
+
+        self.x_staging = torch.zeros((T, H), dtype=torch.bfloat16, device="cuda")
+        self.topk_idx_in = torch.full((T, K), -1, dtype=torch.int64, device="cuda")
+        self.topk_weights_in = torch.zeros((T, K), dtype=torch.float32, device="cuda")
+        self.token_padding_info = torch.ones((T,), dtype=torch.int32, device="cuda")
+        self.act_norm_const = torch.ones((1,), dtype=torch.float32, device="cuda")
+
+        # sym-heap kernel inputs; fp4 packs 2/byte (storage (T, H/2)).
+        self.my_activation = _sym_zeros_byte_view((T, H), Nvfp4DataDtype)
+        self.my_activation_sf = _sym_zeros_byte_view(
+            (T, self._sf_cols_padded), Nvfp4ScaleDtype
+        )
+        self.my_topk_idx = _sym_zeros((T, K), torch.int64)
+        self.my_topk_weights = _sym_zeros((T, K), torch.float32)
+
+        if cfg.impl.in_kernel_fc2_reduce:
+            self.output_activation = _sym_zeros((T, H), torch.bfloat16)
+        else:
+            self.output_activation = torch.zeros(
+                (T, H), dtype=torch.bfloat16, device="cuda"
+            )
+
+        # per-expert epilogue scalars (fc1_alpha is act-norm-dependent ->
+        # rewritten on-stream each forward; the others are static per weights).
+        self.fc1_alpha = torch.ones((E,), dtype=torch.float32, device="cuda")
+        self.fc2_alpha = torch.ones((E,), dtype=torch.float32, device="cuda")
+        self.fc1_norm_const = torch.full(
+            (E,), self.fc1_out_norm_const, dtype=torch.float32, device="cuda"
+        )
+        self._fc1_alpha_base = torch.ones((E,), dtype=torch.float32, device="cuda")
+
+        self.fc1_weight = None
+        self.fc1_weight_sf = None
+        self.fc2_weight = None
+        self.fc2_weight_sf = None
+
+    # ------------------------------------------------------------------
+    # weights
+    # ------------------------------------------------------------------
+
+    def load_weights(self, w13: torch.Tensor, w2: torch.Tensor) -> None:
+        """Quantize [E,2I,H] / [E,H,I] bf16 weights to NVFP4 kernel layout."""
+        E, cfg = self.num_local_experts, self.cfg
+        I = cfg.intermediate
+        H = cfg.hidden
+        if w13.shape != (E, 2 * I, H) or w2.shape != (E, H, I):
+            raise ValueError(f"bad weight shapes: {tuple(w13.shape)}, {tuple(w2.shape)}")
+
+        # gate/up 16-column interleave: [gate16 | up16 | ...] (gate slot 0).
+        up = w13[:, :I].reshape(E, I // _GATE_UP_INTERLEAVE, _GATE_UP_INTERLEAVE, H)
+        gate = w13[:, I:].reshape(E, I // _GATE_UP_INTERLEAVE, _GATE_UP_INTERLEAVE, H)
+        fc1 = torch.stack((gate, up), dim=2).reshape(E, 2 * I, H).float().cuda()
+        fc2 = w2.float().cuda()  # (E, H, I): quantize along K=I
+
+        fc1_q, fc1_sf, fc2_q, fc2_sf = [], [], [], []
+        fc1_norm_w = torch.empty((E,), dtype=torch.float32, device="cuda")
+        fc2_norm_w = torch.empty((E,), dtype=torch.float32, device="cuda")
+        for e in range(E):
+            n1 = _NORM_NUMER / fc1[e].abs().amax().clamp(min=1e-12)
+            n2 = _NORM_NUMER / fc2[e].abs().amax().clamp(min=1e-12)
+            fc1_norm_w[e], fc2_norm_w[e] = n1, n2
+            q1, s1 = nvfp4_quantize_per_block_16(fc1[e], float(n1.item()))
+            q2, s2 = nvfp4_quantize_per_block_16(fc2[e], float(n2.item()))
+            fc1_q.append(q1)   # (2I, H/2) fp4x2
+            fc1_sf.append(s1)  # (2I, H/16) fp8
+            fc2_q.append(q2)   # (H, I/2)
+            fc2_sf.append(s2)  # (H, I/16)
+
+        fc1_weight = _stack_byte_reinterpretable_tensors(fc1_q, dim=0)  # (E,2I,H/2)
+        fc2_weight = _stack_byte_reinterpretable_tensors(fc2_q, dim=0)  # (E,H,I/2)
+        fc1_sf_plain = _stack_byte_reinterpretable_tensors(fc1_sf, dim=0)
+        fc2_sf_plain = _stack_byte_reinterpretable_tensors(fc2_sf, dim=0)
+        fc1_sf_sw = _stack_byte_reinterpretable_tensors(
+            [to_blocked(s) for s in fc1_sf], dim=0
+        )
+        fc2_sf_sw = _stack_byte_reinterpretable_tensors(
+            [to_blocked(s) for s in fc2_sf], dim=0
+        )
+
+        if self.fc1_weight is None:
+            # kernel layouts: fc1 (E, H_packed, 2I) K stride-1; fc2 (E, I_packed, H).
+            self.fc1_weight = fc1_weight.permute(0, 2, 1)
+            self.fc1_weight_sf = fc1_sf_sw
+            self.fc2_weight = fc2_weight.permute(0, 2, 1)
+            self.fc2_weight_sf = fc2_sf_sw
+        else:
+            self.fc1_weight.view(torch.uint8).copy_(
+                fc1_weight.permute(0, 2, 1).view(torch.uint8))
+            self.fc1_weight_sf.view(torch.uint8).copy_(fc1_sf_sw.view(torch.uint8))
+            self.fc2_weight.view(torch.uint8).copy_(
+                fc2_weight.permute(0, 2, 1).view(torch.uint8))
+            self.fc2_weight_sf.view(torch.uint8).copy_(fc2_sf_sw.view(torch.uint8))
+
+        # static epilogue scalars (act norm folded in per-forward).
+        self._fc1_alpha_base.copy_(1.0 / fc1_norm_w)
+        self.fc2_alpha.copy_(1.0 / (self.fc1_out_norm_const * fc2_norm_w))
+
+        # keep plain SFs + norms for host references / debugging
+        self._weights = dict(
+            fc1_sf_plain=fc1_sf_plain, fc2_sf_plain=fc2_sf_plain,
+            fc1_norm_w=fc1_norm_w, fc2_norm_w=fc2_norm_w,
+        )
+
+    # ------------------------------------------------------------------
+    # compile
+    # ------------------------------------------------------------------
+
+    def _compile(self) -> None:
+        import cuda.bindings.driver as cuda
+        import cutlass
+        import cutlass.cute as cute
+        import cutlass.utils as utils
+        from cutlass.cute.typing import AddressSpace
+
+        from moe_nvfp4_swapab.megamoe_kernel import Sm100MegaMoEKernel
+        from moe_nvfp4_swapab.epilogue_refactor import SwapABSwigluFp4Epilogue
+        from src.sym_buffer import SymBufferHost
+        from src.inputs_process import DataPreprocess
+
+        cfg, impl = self.cfg, self.cfg.impl
+        if self._weights is None:
+            raise RuntimeError("load_weights must be called before the first forward.")
+
+        cluster_size = impl.cluster_shape_mnk[0] * impl.cluster_shape_mnk[1]
+        max_active_clusters = utils.HardwareInfo().get_max_active_clusters(cluster_size)
+        group_hint = impl.group_hint if impl.group_hint is not None else max_active_clusters
+
+        self._kernel = Sm100MegaMoEKernel(
+            mma_tiler_mnk=impl.mma_tiler_mnk,
+            cluster_shape_mnk=impl.cluster_shape_mnk,
+            use_2cta_instrs=impl.use_2cta_instrs,
+            group_hint=group_hint,
+            token_padding_block=SwapABSwigluFp4Epilogue._EpilogueTokenTileSize,
+            sf_padding_block=SfPaddingBlock,
+            load_balance_mode=impl.load_balance_mode,
+            static_expert_shape=(
+                self.num_local_experts, 2 * cfg.intermediate, cfg.hidden,
+            ),
+            force_static_sched=impl.force_static_sched,
+            clc_bundle_size=impl.clc_bundle_size,
+            num_sched_stages=impl.num_sched_stages,
+            world_size=self.world_size,
+            num_topk=cfg.num_topk,
+            max_tokens_per_rank=cfg.max_tokens_per_rank,
+            hidden=cfg.hidden,
+            fc2_output_dtype=cutlass.BFloat16,
+            combine_format=self._combine_format,
+            non_ubulk_fc2_store=impl.non_ubulk_fc2_store,
+            in_kernel_fc2_reduce=impl.in_kernel_fc2_reduce,
+            token_back_mode=impl.token_back_mode,
+            apply_topk_in_fc1=True,
+            gate_up_clamp=cfg.gate_up_clamp,
+            flag_batch=impl.flag_batch,
+            epi_flag_batch=impl.epi_flag_batch,
+        )
+
+        local_ws_bytes, shared_ws_bytes = self._kernel.get_workspace_sizes()
+        self.local_workspace = torch.zeros((local_ws_bytes,), dtype=torch.uint8, device="cuda")
+        self.shared_workspace = _sym_zeros((shared_ws_bytes,), torch.uint8)
+        symmetric_base, peer_offsets = _compute_peer_offsets(
+            self.shared_workspace, self.world_size
+        )
+        peer_mapper = SymBufferHost(
+            base_addr=symmetric_base, offsets=tuple(peer_offsets),
+            rank_idx=self.rank, num_max_ranks=self.world_size,
+        )
+
+        def _ptr(tensor, assumed_align=16):
+            return cute.runtime.make_ptr(
+                cutlass.Uint8, tensor.data_ptr(), AddressSpace.gmem,
+                assumed_align=assumed_align,
+            )
+
+        stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+
+        self._mega_kwargs = dict(
+            activation=self._to_cute(self.my_activation),
+            activation_sf=self._to_cute(self.my_activation_sf),
+            topk_idx=self._to_cute(self.my_topk_idx),
+            topk_weights=self._to_cute(self.my_topk_weights),
+            fc1_weight=self._to_cute(self.fc1_weight),
+            fc1_weight_sf=self._to_cute(self.fc1_weight_sf),
+            fc2_weight=self._to_cute(self.fc2_weight),
+            fc2_weight_sf=self._to_cute(self.fc2_weight_sf),
+            fc1_alpha=self._to_cute(self.fc1_alpha, assumed_align=4),
+            fc2_alpha=self._to_cute(self.fc2_alpha, assumed_align=4),
+            fc1_norm_const=self._to_cute(self.fc1_norm_const, assumed_align=4),
+            output_activation=self._to_cute(self.output_activation),
+            local_workspace=_ptr(self.local_workspace),
+            shared_workspace=_ptr(self.shared_workspace),
+            peer_rank_ptr_mapper_host=peer_mapper,
+            stream=stream,
+        )
+        compile_kwargs = dict(self._mega_kwargs)
+        compile_kwargs["max_active_clusters"] = max_active_clusters
+        self._compiled_mega = cute.compile(self._kernel, **compile_kwargs)
+
+        # Preprocess is split at the amax/quant boundary: the kernel has ONE
+        # fc1_alpha per local expert but receives tokens from EVERY rank, so
+        # the activation norm_const must be globally consistent — a 4-byte
+        # NCCL MIN-reduce of the per-rank online norms runs between the two
+        # stages (forward()).  The stages reuse DataPreprocess's own device
+        # kernels unchanged.
+
+        class _SplitNvfp4Preprocess(DataPreprocess):
+            @cute.jit
+            def amax_stage(self, activation_bf16, token_padding_info,
+                           online_norm_const, cuda_stream):
+                num_tokens = activation_bf16.shape[0]
+                self._init_online_scale_impl(online_norm_const).launch(
+                    grid=[1, 1, 1], block=[1, 1, 1], stream=cuda_stream,
+                )
+                self.nvfp4_amax_impl(
+                    activation_bf16, token_padding_info, online_norm_const,
+                ).launch(
+                    grid=[num_tokens, 1, 1],
+                    block=[self._amax_threads_per_cta, 1, 1],
+                    stream=cuda_stream,
+                )
+
+            @cute.jit
+            def quant_stage(self, activation_bf16, topk_idx, topk_weights,
+                            token_padding_info, activation_quant, activation_sf,
+                            topk_idx_output, topk_weights_output, norm_const,
+                            cuda_stream):
+                num_tokens = activation_bf16.shape[0]
+                num_sf_blocks = activation_sf.shape[1]
+                # same broadcast SF view rebuild as DataPreprocess.__call__
+                activation_sf = cute.make_tensor(
+                    activation_sf.iterator,
+                    cute.make_layout(
+                        (activation_sf.shape[0], (self.sf_vec, num_sf_blocks)),
+                        stride=(activation_sf.stride[0], (0, activation_sf.stride[1])),
+                    ),
+                )
+                self.nvfp4_quant_and_process_impl(
+                    activation_bf16, topk_idx, topk_weights, token_padding_info,
+                    activation_quant, activation_sf, topk_idx_output,
+                    topk_weights_output, norm_const,
+                ).launch(
+                    grid=[num_tokens, 1, 1],
+                    block=[self._threads_per_cta, 1, 1],
+                    stream=cuda_stream,
+                )
+
+        self._preproc = _SplitNvfp4Preprocess(
+            topk=cfg.num_topk, hidden=cfg.hidden, quant_type="nvfp4",
+        )
+        sf_cols = ceil_div(cfg.hidden, Nvfp4BlockSize)
+        norm_cute = self._to_cute(self.act_norm_const, assumed_align=4)
+        self._amax_kwargs = dict(
+            activation_bf16=self._to_cute(self.x_staging),
+            token_padding_info=self._to_cute(self.token_padding_info),
+            online_norm_const=norm_cute,
+            cuda_stream=stream,
+        )
+        self._quant_kwargs = dict(
+            activation_bf16=self._to_cute(self.x_staging),
+            topk_idx=self._to_cute(self.topk_idx_in),
+            topk_weights=self._to_cute(self.topk_weights_in),
+            token_padding_info=self._to_cute(self.token_padding_info),
+            activation_quant=self._to_cute(self.my_activation),
+            activation_sf=self._to_cute(self.my_activation_sf[:, :sf_cols]),
+            topk_idx_output=self._to_cute(self.my_topk_idx),
+            topk_weights_output=self._to_cute(self.my_topk_weights),
+            norm_const=norm_cute,
+            cuda_stream=stream,
+        )
+        self._compiled_amax = cute.compile(self._preproc.amax_stage, **self._amax_kwargs)
+        self._compiled_quant = cute.compile(self._preproc.quant_stage, **self._quant_kwargs)
+        self._compiled_preproc = True  # sentinel for the base-class None check
+
+    # ------------------------------------------------------------------
+    # forward
+    # ------------------------------------------------------------------
+
+    def forward(self, x, topk_idx, topk_weights):
+        if self._compiled_mega is None:
+            self._compile()
+
+        T = x.shape[0]
+        Tmax = self.cfg.max_tokens_per_rank
+        if T > Tmax:
+            raise ValueError(f"got {T} tokens > max_tokens_per_rank ({Tmax}).")
+
+        self._stage_input(x, T)
+        self.topk_idx_in[:T].copy_(topk_idx)
+        self.topk_weights_in[:T].copy_(topk_weights)
+        if T != self._padding_valid_tokens:
+            self.token_padding_info[:T].zero_()
+            self.token_padding_info[T:].fill_(1)
+            if T < Tmax:
+                self.topk_idx_in[T:].fill_(-1)
+                self.topk_weights_in[T:].zero_()
+            self._padding_valid_tokens = T
+
+        self.output_activation.zero_()
+        # amax -> global norm (4-byte NCCL MIN, on-stream, no host sync) ->
+        # quant with the GLOBAL norm (so every rank's sf bytes share one
+        # scale convention) -> fold norm into fc1_alpha -> mega kernel.
+        self._compiled_amax(**self._amax_kwargs)
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            torch.distributed.all_reduce(
+                self.act_norm_const, op=torch.distributed.ReduceOp.MIN
+            )
+        self._compiled_quant(**self._quant_kwargs)
+        # fc1_alpha[e] = (1/norm_w13[e]) / norm_act
+        torch.div(self._fc1_alpha_base, self.act_norm_const, out=self.fc1_alpha)
+        self._compiled_mega(**self._mega_kwargs)
+        return self.output_activation[:T]
+
+    __call__ = forward

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/fp8_bwd.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/fp8_bwd.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Manual MXFP8 backward for the hybrid layer — real fp8 grouped GEMMs.
+
+Replaces the autograd fake-quant replay with explicit phases running on
+``torch._scaled_grouped_mm`` (validated contracts:
+pt/tests/test_scaled_grouped_mm_mxfp8.py for 2d-2d wgrad, torch's
+test_scaled_matmul_cuda.py recipe for 2d-3d):
+
+    combine-adjoint a2a -> [2d-3d] fc1/act recompute -> [2d-3d] y for dTW
+    -> [2d-3d] dgrad chain (SwiGLU-bwd in torch) -> [2d-2d] wgrads
+    -> dispatch-adjoint a2a
+
+Token groups are zero-padded to 128-row alignment; pad rows quantize to
+zero blocks and contribute nothing. 128 (= 4 scale cols = 1 swizzle atom
+col) makes the per-group to_blocked concatenation expressible as pure
+tensor views: row-group packing IS the whole-tensor swizzle, and K-group
+packing is one atom-permutation index_select — no per-group python loops.
+All feature dims (H, 2I, I) must be multiples of 128. Weight
+quantizations (both contraction axes) are cached on the layer until
+``refresh_weights`` invalidates them.
+
+Gradient semantics match the replay with ``quant_bprop=True`` (mxfp8 on
+every GEMM operand, same scale convention); small deviations come from the
+grouped GEMM's bf16 output rounding vs the replay's fp32 simulation.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import torch
+import torch.nn.functional as F
+
+# Optional phase instrumentation: a bench installs a list here and phases
+# append (name, start_event, end_event); None (default) is zero-overhead.
+TIMER = None
+
+
+@contextmanager
+def _phase(name):
+    if TIMER is None:
+        yield
+        return
+    s, e = torch.cuda.Event(True), torch.cuda.Event(True)
+    s.record()
+    try:
+        yield
+    finally:
+        e.record()
+        TIMER.append((name, s, e))
+
+import megamoe.repo_path  # noqa: F401
+
+from moe_nvfp4_swapab.runner_common import to_blocked
+
+from pt.quant import MXFP8_BLOCK, quant_mxfp8_tensors, rotate_trailing
+
+from megamoe.quant_kernels import mxfp8_rowquant, mxfp8_transquant
+
+
+def _round_up(x: int, y: int) -> int:
+    return ((x + y - 1) // y) * y
+
+
+class GroupedPad:
+    """Zero-pad a grouped-by-expert row tensor to align-multiple group sizes."""
+
+    def __init__(self, tokens_per_expert, align: int, device):
+        counts = [_round_up(n, align) for n in tokens_per_expert]
+        self.total = sum(counts)
+        self.offs = torch.tensor(
+            [sum(counts[: i + 1]) for i in range(len(counts))],
+            device=device, dtype=torch.int32,
+        )
+        idx, row = [], 0
+        for n, c in zip(tokens_per_expert, counts):
+            idx.append(torch.arange(row, row + n, device=device))
+            row += c
+        self.src_rows = (
+            torch.cat(idx) if idx else torch.empty(0, device=device, dtype=torch.long)
+        )
+
+    def pack(self, t: torch.Tensor) -> torch.Tensor:
+        out = t.new_zeros((self.total, t.shape[1]))
+        out.index_copy_(0, self.src_rows, t)
+        return out
+
+    def unpack(self, t: torch.Tensor) -> torch.Tensor:
+        return t.index_select(0, self.src_rows)
+
+
+def _pack_scales_rowgroups_ref(s: torch.Tensor, offs: torch.Tensor) -> torch.Tensor:
+    """Loop reference: per-row-group to_blocked of (M, Kc) scales -> (-1, Kc)."""
+    kc = s.shape[1]
+    parts, lo = [], 0
+    for hi in offs.tolist():
+        if hi > lo:
+            parts.append(to_blocked(s[lo:hi]))
+        lo = hi
+    return torch.cat(parts).reshape(-1, kc)
+
+
+def _atoms(s: torch.Tensor) -> torch.Tensor:
+    """(M, Kc) e8m0 (M%128==0, Kc%4==0) -> (M/128 * Kc/4, 512) swizzled atoms
+    in row-block-major order (the 32x4x4 within-atom rearrange applied)."""
+    rb, cb = s.shape[0] // 128, s.shape[1] // 4
+    return (
+        s.view(rb, 128, cb, 4).permute(0, 2, 1, 3)
+        .reshape(-1, 4, 32, 4).transpose(1, 2).reshape(rb * cb, 512)
+    )
+
+
+def _pack_scales_rowgroups(s: torch.Tensor, offs: torch.Tensor) -> torch.Tensor:
+    """Vectorized per-row-group swizzle. With every group's row count a
+    multiple of 128, the concatenation of per-group to_blocked layouts IS the
+    whole-tensor swizzle (group row-blocks are contiguous), so no loop."""
+    kc = s.shape[1]
+    if kc % 4:
+        raise ValueError(f"scale cols ({kc}) must be a multiple of 4 (K % 128 == 0)")
+    if s.shape[0] % 128:
+        raise ValueError("row groups must be padded to 128")
+    return _atoms(s).reshape(-1, kc)
+
+
+def quant_weights_3d(w: torch.Tensor):
+    """(E, N, K) bf16 -> (fp8 data, stacked per-expert blocked scales)."""
+    wq, sw = quant_mxfp8_tensors(w, dim=-1)
+    sw_b = torch.stack([to_blocked(sw[e]) for e in range(w.shape[0])])
+    return wq, sw_b
+
+
+def gmm_2d3d(
+    x: torch.Tensor,           # (Mtot, K) bf16, row groups 32-aligned
+    offs: torch.Tensor,        # int32 group end offsets over M
+    wq: torch.Tensor,          # (E, N, K) fp8 (from quant_weights_3d)
+    sw_b: torch.Tensor,        # stacked blocked scales
+) -> torch.Tensor:
+    """out[rows g] = x[rows g] @ w[g].T -> (Mtot, N) bf16."""
+    with _phase("act-quant"):
+        xq, sx = mxfp8_rowquant(x)
+        sx_b = _pack_scales_rowgroups(sx, offs)
+    with _phase("gemm"):
+        return torch._scaled_grouped_mm(
+            xq, wq.transpose(-2, -1), sx_b, sw_b, offs=offs, out_dtype=torch.bfloat16
+        )
+
+
+def _pack_scales_colgroups_ref(
+    s: torch.Tensor, offs: torch.Tensor, mn: int
+) -> torch.Tensor:
+    """Loop reference: per-K-group to_blocked of (MN, Ktot/32) scales -> 2D."""
+    parts, lo = [], 0
+    for hi in offs.tolist():
+        if hi > lo:
+            parts.append(to_blocked(s[:, lo // MXFP8_BLOCK : hi // MXFP8_BLOCK]))
+        lo = hi
+    return torch.cat(parts).reshape(_round_up(mn, 128), -1)
+
+
+def _col_atom_order(offs: torch.Tensor, rb: int, cbt: int) -> torch.Tensor:
+    """Atom permutation: row-block-major atoms -> per-K-group (group outer,
+    row-block, col-block) order matching cat-of-per-group to_blocked."""
+    device = offs.device
+    rows = torch.arange(rb, device=device) * cbt
+    parts, lo = [], 0
+    for hi in offs.tolist():
+        cb0, cb1 = lo // 128, hi // 128  # 128 tokens = 4 scale cols = 1 atom col
+        if cb1 > cb0:
+            cols = torch.arange(cb0, cb1, device=device)
+            parts.append(
+                (rows[:, None] + cols[None, :]).reshape(-1)
+            )
+        lo = hi
+    return torch.cat(parts)
+
+
+def _pack_scales_colgroups(
+    s: torch.Tensor, offs: torch.Tensor, mn: int, atom_order: torch.Tensor
+) -> torch.Tensor:
+    """Vectorized per-K-group swizzle: whole-tensor atomization + one cached
+    index_select. Requires MN%128==0 and 128-aligned K groups."""
+    if mn % 128 or s.shape[1] % 4:
+        raise ValueError("colgroup swizzle needs MN%128==0 and 128-aligned groups")
+    return _atoms(s)[atom_order].reshape(mn, -1)
+
+
+def gmm_wgrad_2d2d(
+    dy: torch.Tensor,   # (Ktot, M) bf16, token groups 128-aligned
+    act: torch.Tensor,  # (Ktot, N) bf16
+    offs: torch.Tensor,
+    atom_order_m: torch.Tensor,
+    atom_order_n: torch.Tensor,
+) -> torch.Tensor:
+    """dW[e] = dy[ke].T @ act[ke] -> (E, M, N) bf16, tokens on K."""
+    with _phase("act-quant"):
+        a, sa = mxfp8_transquant(dy)
+        bt, sb = mxfp8_transquant(act)
+        sa_b = _pack_scales_colgroups(sa, offs, dy.shape[1], atom_order_m)
+        sb_b = _pack_scales_colgroups(sb, offs, act.shape[1], atom_order_n)
+    with _phase("gemm"):
+        return torch._scaled_grouped_mm(
+            a, bt.t(), sa_b, sb_b, offs=offs, out_dtype=torch.bfloat16
+        )
+
+
+def fp8_backward(layer, topk_ids, topk_weights, dout, T):
+    """Manual mxfp8 backward; returns (dx, dtw, dw13, dw2)."""
+    from pt.dispatch_combine import dispatch
+    from pt.routing import build_routing_plan
+
+    from megamoe.training import dequant_mxfp8_pool
+
+    ep = layer.ep_cfg
+    H, K = ep.hidden_size, ep.top_k
+    fwd = layer._fwd
+    comm = layer.comm
+
+    with _phase("prep"):
+        x_q = dequant_mxfp8_pool(
+            fwd.my_activation[:T], fwd.my_activation_sf[:T], H
+        ).to(torch.bfloat16)
+        plan = build_routing_plan(topk_ids, ep, comm)
+        pad = GroupedPad(plan.tokens_per_expert, 128, dout.device)
+
+    with torch.no_grad():
+        with _phase("dispatch"):
+            # arrivals (reuse of the quantized pool payload) + dispatched dout
+            xg = dispatch(x_q, plan, comm)
+            doutg = dispatch(dout.to(torch.bfloat16), plan, comm)
+            XG, DOUTG = pad.pack(xg), pad.pack(doutg)
+
+            # wgrad scale atom permutations (routing-dependent, cheap)
+            cbt = pad.total // 128
+            order_h = _col_atom_order(pad.offs, H // 128, cbt)
+            order_2i = _col_atom_order(pad.offs, (2 * ep.intermediate_size) // 128, cbt)
+            order_i = _col_atom_order(pad.offs, ep.intermediate_size // 128, cbt)
+
+        # weight quantizations (both contraction axes), cached until
+        # refresh_weights() invalidates. With turboquant the pool activation
+        # is in the ROTATED basis, so fc1-side weights are rotated to match
+        # (exactly what the kernel's load_weights folded in); dW13 and dX are
+        # rotated back through Q^T at the end.
+        tq = layer.qcfg.turboquant
+        wc = layer._bwd_wcache
+        if wc is None:
+            with _phase("weight-quant"):
+                w13 = layer.w13.detach().to(torch.bfloat16)
+                if tq:
+                    w13 = rotate_trailing(w13, layer.q_rot)
+                w2 = layer.w2.detach().to(torch.bfloat16)
+                wc = layer._bwd_wcache = {
+                    "w13_kh": quant_weights_3d(w13),                                # (E,2I,H) K=H
+                    "w2_ki": quant_weights_3d(w2),                                  # (E,H,I)  K=I
+                    "w2t_kh": quant_weights_3d(w2.transpose(1, 2).contiguous()),    # (E,I,H)  K=H
+                    "w13t_k2i": quant_weights_3d(w13.transpose(1, 2).contiguous()),  # (E,H,2I) K=2I
+                }
+        w13q_kh, sw13_kh = wc["w13_kh"]
+        w2q_ki, sw2_ki = wc["w2_ki"]
+        w2tq_kh, sw2t_kh = wc["w2t_kh"]
+        w13tq_k2i, sw13t_k2i = wc["w13t_k2i"]
+
+        # recompute fc1 / act / y (fp8 grouped)
+        FC1 = gmm_2d3d(XG, pad.offs, w13q_kh, sw13_kh)              # (Mp, 2I)
+        with _phase("elemwise"):
+            lin, gate = FC1.chunk(2, dim=-1)
+            ACT = (F.silu(gate.float()) * lin.float()).to(torch.bfloat16)
+        Y = gmm_2d3d(ACT, pad.offs, w2q_ki, sw2_ki)                 # (Mp, H)
+
+        with _phase("comm-adj"):
+            # d(topk_weights): per-copy <dout, y> on owner side, scalars back
+            dtw_g = (Y.float() * DOUTG.float()).sum(dim=-1, keepdim=True)
+            dtw_recv = pad.unpack(dtw_g)[plan.inv_recv_sort_idx]
+            dtw_sorted = comm.all_to_all_no_grad(
+                dtw_recv, plan.input_splits, plan.output_splits
+            )
+            dtw = dtw_sorted[plan.inv_sort_idx].view(T, K).float()
+
+            # combine adjoint: dY to owners
+            dy_flat = (
+                dout.float().unsqueeze(1) * topk_weights.float().unsqueeze(-1)
+            ).reshape(T * K, H).to(torch.bfloat16)
+            dy_recv = comm.all_to_all_no_grad(
+                dy_flat[plan.sort_idx], plan.output_splits, plan.input_splits
+            )
+            DYG = pad.pack(dy_recv[plan.recv_sort_idx])
+
+        # dgrad chain
+        DACT = gmm_2d3d(DYG, pad.offs, w2tq_kh, sw2t_kh)            # (Mp, I)
+        with _phase("elemwise"):
+            g32, l32 = gate.float(), lin.float()
+            sg = torch.sigmoid(g32)
+            dgate = DACT.float() * l32 * sg * (1 + g32 * (1 - sg))
+            dlin = DACT.float() * F.silu(g32)
+            DFC1 = torch.cat([dlin, dgate], dim=-1).to(torch.bfloat16)  # (Mp, 2I)
+        DXG = gmm_2d3d(DFC1, pad.offs, w13tq_k2i, sw13t_k2i)        # (Mp, H)
+
+        # wgrads (tokens on K); dW13 lands in the rotated basis under tq
+        dw13 = gmm_wgrad_2d2d(DFC1, XG, pad.offs, order_2i, order_h)
+        if tq:
+            dw13 = rotate_trailing(dw13.float(), layer.q_rot.t())
+        dw13 = dw13.to(layer.w13.dtype)
+        dw2 = gmm_wgrad_2d2d(DYG, ACT, pad.offs, order_h, order_i).to(layer.w2.dtype)
+
+        with _phase("comm-adj"):
+            # dispatch adjoint: dX back to sources, sum over top-k copies
+            dx_sorted = comm.all_to_all_no_grad(
+                pad.unpack(DXG)[plan.inv_recv_sort_idx],
+                plan.input_splits, plan.output_splits,
+            )
+            dx = torch.zeros((T, H), device=dout.device, dtype=torch.float32)
+            dx.index_add_(0, plan.copy_token_idx, dx_sorted.float())
+            if tq:
+                dx = rotate_trailing(dx, layer.q_rot.t())
+
+    return dx.to(torch.bfloat16), dtw, dw13, dw2

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/pools.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/pools.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Torch views into the MegaMoE kernel's persistent workspace pools.
+
+The kernel lays out its local/shared workspaces from host-visible region
+tables (``kernel._local_offsets`` / ``_local_region_specs``; see
+``megamoe_kernel_mxfp8._build_local_region_specs``).  Only the counter prefix
+before ``l1_token_buffer`` (local) / ``src_token_topk_idx`` (shared) is
+zeroed between launches, so every data region — the dispatched-token pool,
+``token_src_metadata``, ``fc1_output``, the ``combine_quant`` staging — is
+readable after a forward until the next launch overwrites it.  The backward
+megakernel (see BWD_DESIGN.md) builds on exactly these pools; this module
+gives the host-side (probe / v0 backward) access to the same bytes.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import torch
+
+_CUTE_TO_TORCH = {
+    "Uint8": torch.uint8,
+    "Int32": torch.int32,
+    "Int64": torch.int64,
+    "Float32": torch.float32,
+    "Float16": torch.float16,
+    "BFloat16": torch.bfloat16,
+    "Float8E4M3FN": torch.float8_e4m3fn,
+    "Float8E5M2": torch.float8_e5m2,
+    "Float8E8M0FNU": getattr(torch, "float8_e8m0fnu", torch.uint8),
+}
+
+
+def _torch_dtype(cute_dtype) -> torch.dtype:
+    name = getattr(cute_dtype, "__name__", None) or type(cute_dtype).__name__
+    if name not in _CUTE_TO_TORCH:
+        raise KeyError(f"no torch dtype mapping for cute dtype {name!r}")
+    return _CUTE_TO_TORCH[name]
+
+
+def _region_views(
+    workspace: torch.Tensor, specs, offsets
+) -> Dict[str, torch.Tensor]:
+    views: Dict[str, torch.Tensor] = {}
+    for spec in specs:
+        dt = _torch_dtype(spec.cute_dtype)
+        off = offsets[spec.name]
+        raw = workspace[off : off + spec.nbytes]
+        views[spec.name] = raw.view(dt).view(*spec.shape)
+    return views
+
+
+def local_pool_views(fwd) -> Dict[str, torch.Tensor]:
+    """Views into ``fwd.local_workspace`` (compile must have happened)."""
+    k = fwd._kernel
+    return _region_views(fwd.local_workspace, k._local_region_specs, k._local_offsets)
+
+
+def shared_pool_views(fwd) -> Dict[str, torch.Tensor]:
+    """Views into this rank's ``fwd.shared_workspace`` slice."""
+    k = fwd._kernel
+    return _region_views(
+        fwd.shared_workspace, k._shared_region_specs, k._shared_offsets
+    )
+
+
+def decode_token_src_metadata(
+    meta_bytes: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """(rows, 8) uint8 -> (src_rank, src_token, src_topk, reduce_n, consumed).
+
+    Wire format (src/token_comm.py::TokenSrcMetadata): one little-endian i64,
+    lo32 = src_token, hi32 = (src_rank << 16) | (consumed << 12)
+    | (reduce_n << 8) | src_topk.
+    """
+    v = meta_bytes.contiguous().view(torch.int64).view(-1)
+    lo = (v & 0xFFFFFFFF).to(torch.int32)
+    hi = (v >> 32).to(torch.int64)
+    src_rank = ((hi >> 16) & 0xFFFF).to(torch.int32)
+    src_topk = (hi & 0xFF).to(torch.int32)
+    reduce_n = ((hi >> 8) & 0xF).to(torch.int32)
+    consumed = ((hi >> 12) & 0x1).to(torch.int32)
+    return src_rank, lo, src_topk, reduce_n, consumed
+
+
+def expert_slot_offsets(
+    arrivals_per_expert, pad: int = 128
+) -> Tuple[list, list]:
+    """Pool/fc1_c row layout: expert e's arrivals start at ``doff[e]``,
+    slots padded to ``pad`` rows (mega_runner.py generate_c offsets)."""
+    doff, cursor = [], 0
+    for n in arrivals_per_expert:
+        doff.append(cursor)
+        cursor += -(-int(n) // pad) * pad
+    return doff, [int(n) for n in arrivals_per_expert]

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/quant_kernels.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/quant_kernels.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Triton MXFP8 quantizers for the fp8 backward's hot paths.
+
+Same numerics as pt.quant.quant_mxfp8_tensors (ceil-log2 E8M0 per-32
+scales, RN-saturating E4M3 cast), but the E8M0 exponent is computed with
+exact bit ops instead of float log2: for amax = m * 2^e (1 <= m < 2),
+ceil(log2(amax / 448)) = e - 8 + (m > 1.75). Two kernels:
+
+- ``mxfp8_rowquant(x)``   — quantize (M, K) along K (one fused kernel vs
+  ~8 torch launches).
+- ``mxfp8_transquant(x)`` — for wgrad operands: quantize (Ktot, N) along
+  the TOKEN dim and emit the (N, Ktot) transposed fp8 layout directly,
+  replacing ``x.t().contiguous()`` + rowquant.
+
+Both fall back to the torch implementation when triton is unavailable.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from pt.quant import MXFP8_BLOCK, quant_mxfp8_tensors
+
+try:
+    import triton
+    import triton.language as tl
+
+    HAVE_TRITON = True
+except Exception:  # noqa: BLE001
+    HAVE_TRITON = False
+
+
+if HAVE_TRITON:
+
+    @triton.jit
+    def _e8m0_from_amax(amax):
+        """ceil(log2(amax/448)) + 127 as uint8 semantics (0 when amax==0)."""
+        bits = amax.to(tl.int32, bitcast=True)
+        e = (bits >> 23) - 127
+        m_gt = (bits & 0x7FFFFF) > 0x600000  # mantissa > 1.75
+        se = e - 8 + tl.where(m_gt, 1, 0)
+        se = tl.where(amax > 0, se, -127)
+        return tl.minimum(tl.maximum(se + 127, 0), 254)
+
+    @triton.jit
+    def _rowquant_kernel(
+        x_ptr, q_ptr, s_ptr,
+        K, sxm, sxk,
+        BLOCK_K: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_k = tl.program_id(1)
+        offs_k = pid_k * BLOCK_K + tl.arange(0, BLOCK_K)
+        mask = offs_k < K
+        x = tl.load(
+            x_ptr + pid_m * sxm + offs_k * sxk, mask=mask, other=0.0
+        ).to(tl.float32)
+        xb = tl.reshape(x, (BLOCK_K // 32, 32))
+        u8 = _e8m0_from_amax(tl.max(tl.abs(xb), axis=1))
+        scale = tl.exp2((u8 - 127).to(tl.float32))
+        qv = xb / scale[:, None]
+        qv = tl.minimum(tl.maximum(qv, -448.0), 448.0)
+        q = tl.reshape(qv, (BLOCK_K,)).to(tl.float8e4nv)
+        tl.store(q_ptr + pid_m * K + offs_k, q, mask=mask)
+        offs_s = pid_k * (BLOCK_K // 32) + tl.arange(0, BLOCK_K // 32)
+        tl.store(
+            s_ptr + pid_m * (K // 32) + offs_s,
+            u8.to(tl.uint8),
+            mask=offs_s < K // 32,
+        )
+
+    @triton.jit
+    def _transquant_kernel(
+        x_ptr, q_ptr, s_ptr,
+        Kt, N, sxk, sxn,
+        BLOCK_N: tl.constexpr,
+    ):
+        pid_k = tl.program_id(0)  # one 32-token scale block
+        pid_n = tl.program_id(1)
+        offs_t = pid_k * 32 + tl.arange(0, 32)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        mask_n = offs_n < N
+        x = tl.load(
+            x_ptr + offs_t[:, None] * sxk + offs_n[None, :] * sxn,
+            mask=mask_n[None, :], other=0.0,
+        ).to(tl.float32)
+        u8 = _e8m0_from_amax(tl.max(tl.abs(x), axis=0))  # per output col
+        scale = tl.exp2((u8 - 127).to(tl.float32))
+        qv = tl.minimum(tl.maximum(x / scale[None, :], -448.0), 448.0)
+        q = tl.trans(qv).to(tl.float8e4nv)  # (BLOCK_N, 32)
+        tl.store(
+            q_ptr + offs_n[:, None] * Kt + offs_t[None, :],
+            q, mask=mask_n[:, None],
+        )
+        tl.store(
+            s_ptr + offs_n * (Kt // 32) + pid_k,
+            u8.to(tl.uint8), mask=mask_n,
+        )
+
+
+def mxfp8_rowquant(x: torch.Tensor):
+    """(M, K) -> (fp8 (M, K), e8m0 (M, K/32)) quantized along K."""
+    if not HAVE_TRITON:
+        return quant_mxfp8_tensors(x, dim=-1)
+    M, K = x.shape
+    if K % MXFP8_BLOCK:
+        raise ValueError(f"K ({K}) must be a multiple of {MXFP8_BLOCK}")
+    q = torch.empty((M, K), device=x.device, dtype=torch.float8_e4m3fn)
+    s = torch.empty((M, K // 32), device=x.device, dtype=torch.uint8)
+    if M:
+        BLOCK_K = 256 if K % 256 == 0 else 128 if K % 128 == 0 else 32
+        grid = (M, triton.cdiv(K, BLOCK_K))
+        _rowquant_kernel[grid](
+            x, q, s, K, x.stride(0), x.stride(1), BLOCK_K=BLOCK_K
+        )
+    return q, s.view(torch.float8_e8m0fnu)
+
+
+def mxfp8_transquant(x: torch.Tensor):
+    """(Ktot, N) -> (fp8 (N, Ktot), e8m0 (N, Ktot/32)) quantized along the
+    token (Ktot) dim, transposed output — the wgrad operand layout."""
+    if not HAVE_TRITON:
+        return quant_mxfp8_tensors(x.t().contiguous(), dim=-1)
+    Kt, N = x.shape
+    if Kt % MXFP8_BLOCK:
+        raise ValueError(f"Ktot ({Kt}) must be a multiple of {MXFP8_BLOCK}")
+    q = torch.empty((N, Kt), device=x.device, dtype=torch.float8_e4m3fn)
+    s = torch.empty((N, Kt // 32), device=x.device, dtype=torch.uint8)
+    if Kt and N:
+        BLOCK_N = 64
+        grid = (Kt // 32, triton.cdiv(N, BLOCK_N))
+        _transquant_kernel[grid](
+            x, q, s, Kt, N, x.stride(0), x.stride(1), BLOCK_N=BLOCK_N
+        )
+    return q, s.view(torch.float8_e8m0fnu)

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/repo_path.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/repo_path.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Make the sibling cutedsl_megamoe clone importable.
+
+The kernel repo is not pip-installed; its own modules assume the repo root
+(and moe_nvfp4_swapab, for the mxfp8 package's cross-imports) are on
+sys.path.  Import this module before importing anything from the repo.
+
+Override the clone location with MEGAMOE_REPO=/path/to/cutedsl_megamoe.
+"""
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_TRAINING_ROOT = os.path.dirname(_HERE)
+
+REPO_ROOT = os.environ.get(
+    "MEGAMOE_REPO", os.path.join(_TRAINING_ROOT, "cutedsl_megamoe")
+)
+if not os.path.isdir(os.path.join(REPO_ROOT, "moe_mxfp8_glu")):
+    raise ImportError(
+        f"cutedsl_megamoe clone not found at {REPO_ROOT!r}; clone "
+        "https://gitlab-master.nvidia.com/bangyus/cutedsl_megamoe there or "
+        "set MEGAMOE_REPO."
+    )
+
+for _p in (REPO_ROOT, os.path.join(REPO_ROOT, "moe_nvfp4_swapab"), _TRAINING_ROOT):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/probe_bwd_contracts.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/probe_bwd_contracts.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""M0 probe for the bprop megakernel (BWD_DESIGN.md): validate on GPU every
+pool/stash contract the backward builds on.
+
+    C1  pool row layout + token_src_metadata: expert e's arrivals live at
+        128-aligned slot doff[e], and each row's (src_token, src_topk)
+        decodes to a routing entry for expert e.
+    C2  l1_topk_weights_buffer[row] == topk_weights[src_token, src_topk].
+    C3  fc1_c stash row == RAW pre-SwiGLU gate+up: dequant(my_activation
+        [src_token]) @ fakequant(w13_interleaved[e]).T  — and is NOT
+        tw-weighted.
+    C4  combine_quant staging (T, K, H) persists after forward and holds the
+        per-copy weighted y: fakequant(tw * silu(g) * u) @ fakequant(w2).T
+        (dtw v0 source).
+    C5  padding rows: report whether fc1_c / pool rows inside the 128-pad
+        tails are zero (wgrad-from-stash masking decision).
+    C6  pool order stability: run the same forward twice, compare metadata
+        snapshots (informational — the backward gathers BY metadata, so
+        instability across launches is fine; instability of fc1_c vs its
+        OWN launch's metadata would not be).
+
+Launch (single rank):   MEGA_NO_DIST=1 python -m megamoe.tests.probe_bwd_contracts
+"""
+
+import os
+import sys
+
+os.environ.setdefault("MEGA_NO_DIST", "1")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import dataclasses
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+from megamoe.forward import MegaMoeForwardConfig, MegaMoeMxfp8Forward
+from megamoe.pools import (
+    decode_token_src_metadata,
+    expert_slot_offsets,
+    local_pool_views,
+    shared_pool_views,
+)
+from megamoe.training import dequant_mxfp8_pool
+
+from pt.quant import fake_quant_mxfp8
+
+TOKENS = 4096
+HIDDEN = 1024
+INTERMEDIATE = 512
+NUM_EXPERTS = 32
+TOPK = 4
+SEED = 4242
+
+_failures = []
+
+
+def check(name, ok, detail=""):
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f"  {detail}" if detail else ""))
+    if not ok:
+        _failures.append(name)
+
+
+def gen_problem(device):
+    gen = torch.Generator(device=device).manual_seed(SEED)
+    x = (torch.randn((TOKENS, HIDDEN), device=device, generator=gen) / 10.0).bfloat16()
+    scores = torch.rand((TOKENS, NUM_EXPERTS), device=device, generator=gen)
+    _, ids = scores.topk(TOPK, dim=-1)
+    w = torch.rand((TOKENS, TOPK), device=device, generator=gen) + 0.1
+    tw = (w / w.sum(-1, keepdim=True)).float()
+    w13 = (torch.randn((NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN),
+                       device=device, generator=gen) * 0.05).bfloat16()
+    w2 = (torch.randn((NUM_EXPERTS, HIDDEN, INTERMEDIATE),
+                      device=device, generator=gen) * 0.05).bfloat16()
+    return x, ids.long(), tw, w13, w2
+
+
+def dequant_weight(q: torch.Tensor, sf_plain: torch.Tensor) -> torch.Tensor:
+    """(N, K) fp8 + (N, K//32) E8M0 -> fp32."""
+    scale = torch.exp2(sf_plain.view(torch.uint8).float() - 127.0)
+    return q.float() * scale.repeat_interleave(32, dim=-1)
+
+
+def main():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    x, ids, tw, w13, w2 = gen_problem(device)
+
+    cfg = MegaMoeForwardConfig(
+        max_tokens_per_rank=TOKENS, hidden=HIDDEN, intermediate=INTERMEDIATE,
+        num_total_experts=NUM_EXPERTS, num_topk=TOPK,
+    )
+    cfg = dataclasses.replace(cfg, impl=dataclasses.replace(cfg.impl, generate_c=True))
+    fwd = MegaMoeMxfp8Forward(cfg, rank=0, world_size=1)
+    fwd.load_weights(w13, w2)
+
+    out = fwd(x, ids, tw).clone()
+    torch.cuda.synchronize()
+
+    lv = local_pool_views(fwd)
+    sv = shared_pool_views(fwd)
+    src_rank, src_token, src_topk, _, _ = decode_token_src_metadata(
+        lv["token_src_metadata"]
+    )
+
+    counts = torch.bincount(ids.reshape(-1), minlength=NUM_EXPERTS).tolist()
+    doff, _ = expert_slot_offsets(counts, pad=128)
+
+    # fake-quant weights in kernel layout (the exact bytes the kernel read)
+    qw = fwd._weights
+    w13_int_fq = dequant_weight(
+        qw.fc1_weight.permute(0, 2, 1).reshape(-1, HIDDEN),
+        qw.fc1_weight_sf_plain.reshape(-1, HIDDEN // 32),
+    ).view(NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN)
+    w2_fq = dequant_weight(
+        qw.fc2_weight.permute(0, 2, 1).reshape(-1, INTERMEDIATE),
+        qw.fc2_weight_sf_plain.reshape(-1, INTERMEDIATE // 32),
+    ).view(NUM_EXPERTS, HIDDEN, INTERMEDIATE)
+
+    x_deq_all = dequant_mxfp8_pool(
+        fwd.my_activation[:TOKENS], fwd.my_activation_sf[:TOKENS], HIDDEN
+    )  # fp32 (T, H): exactly the quantized activation the kernel multiplied
+
+    combine_staged = sv["combine_quant"]  # (T, K, H) bf16
+
+    c1_ok = c2_ok = True
+    c3_max = c3_tw_max = c4_max = 0.0
+    pad_fc1_max = pad_pool_max = 0.0
+    fc1_c = fwd.fc1_c
+    pool_tokens = lv["l1_token_buffer"]
+
+    for e in range(NUM_EXPERTS):
+        n = counts[e]
+        if n == 0:
+            continue
+        rows = torch.arange(doff[e], doff[e] + n, device=device)
+        st, sk = src_token[rows].long(), src_topk[rows].long()
+
+        # C1: metadata routes every slot row to this expert
+        c1_ok &= bool((ids[st, sk] == e).all()) and bool((src_rank[rows] == 0).all())
+
+        # C2: pool topk weights match
+        c2_ok &= bool(
+            torch.allclose(lv["l1_topk_weights_buffer"][rows], tw[st, sk], atol=0)
+        )
+
+        # C3: fc1_c == raw gate+up of THIS row's token
+        ref = (x_deq_all[st] @ w13_int_fq[e].t()).to(torch.bfloat16).float()
+        got = fc1_c[rows].float()
+        c3_max = max(c3_max, (got - ref).abs().max().item())
+        c3_tw_max = max(
+            c3_tw_max, (got - ref * tw[st, sk, None].float()).abs().max().item()
+        )
+
+        # C4: staged per-copy y == fq(tw * silu(gate) * up) @ w2
+        pair = got.view(n, INTERMEDIATE // 32, 2, 32)
+        gate, up = pair[:, :, 0].reshape(n, -1), pair[:, :, 1].reshape(n, -1)
+        a = torch.nn.functional.silu(gate) * up * tw[st, sk, None].float()
+        a_q = fake_quant_mxfp8(a.to(torch.bfloat16)).float()
+        y_ref = a_q @ w2_fq[e].t()
+        y_got = combine_staged[st, sk].float()
+        c4_max = max(c4_max, (y_got - y_ref).abs().max().item())
+
+        # C5: padding tail of this expert's slot
+        pad_rows = torch.arange(
+            doff[e] + n, doff[e] + -(-n // 128) * 128, device=device
+        )
+        if pad_rows.numel():
+            pad_fc1_max = max(pad_fc1_max, fc1_c[pad_rows].float().abs().max().item())
+            pad_pool_max = max(
+                pad_pool_max,
+                pool_tokens[pad_rows].view(torch.float8_e4m3fn)[:, :HIDDEN]
+                .float().abs().max().item(),
+            )
+
+    check("C1 slot layout + metadata routing", c1_ok)
+    check("C2 pool topk weights", c2_ok)
+    check("C3 fc1_c = raw gate+up", c3_max < 0.5, f"max_abs_diff={c3_max:.3e}")
+    check(
+        "C3b fc1_c is pre-tw (tw-folded ref must mismatch)",
+        c3_tw_max > 10 * max(c3_max, 1e-6),
+        f"tw-folded diff={c3_tw_max:.3e}",
+    )
+    check("C4 combine staging holds per-copy weighted y", c4_max < 0.5,
+          f"max_abs_diff={c4_max:.3e}")
+    print(f"  [INFO] C5 padding rows: fc1_c max_abs={pad_fc1_max:.3e}  "
+          f"pool max_abs={pad_pool_max:.3e}")
+
+    # C6: order stability across an identical relaunch
+    meta_snap = lv["token_src_metadata"].clone()
+    out2 = fwd(x, ids, tw).clone()
+    torch.cuda.synchronize()
+    stable = bool(torch.equal(meta_snap, lv["token_src_metadata"]))
+    print(f"  [INFO] C6 pool order stable across relaunch: {stable}")
+    check("C6b relaunch output parity",
+          (out - out2).abs().max().item() < 1e-2)
+
+    # sanity: dtw from staging (the v0 recipe) vs autograd-free finite formula
+    dout = torch.randn_like(out).float()
+    dtw_v0 = torch.einsum("th,tkh->tk", dout, combine_staged.float()[:TOKENS]) / tw
+    print(f"  [INFO] dtw v0 sample (t=0): {dtw_v0[0].tolist()}")
+
+    fwd.finalize()
+    print("PROBE " + ("PASS" if not _failures else f"FAIL ({_failures})"))
+    return 0 if not _failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/smoke_generate_c.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/smoke_generate_c.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""generate_c smoke: does the fc1-intermediate epilogue stash work, and what
+does it cost fprop? (The stash-vs-recompute data point for training bwd.)
+
+Launch:
+
+    MEGA_NO_DIST=1 python -m megamoe.tests.smoke_generate_c
+
+Runs the same problem through MegaMoeMxfp8Forward with impl.generate_c off
+and on, checks output parity between the two, reports whether fc1_c was
+populated, and times both (CUDA events, median of ITERS).
+"""
+
+import os
+import sys
+
+os.environ.setdefault("MEGA_NO_DIST", "1")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import dataclasses
+import statistics
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+from megamoe.forward import MegaMoeForwardConfig, MegaMoeMxfp8Forward
+
+TOKENS = 4096
+HIDDEN = 1024
+INTERMEDIATE = 512
+NUM_EXPERTS = 32
+TOPK = 4
+SEED = 4242
+ITERS = 20
+
+
+def gen_problem(device):
+    gen = torch.Generator(device=device).manual_seed(SEED)
+    x = (torch.randn((TOKENS, HIDDEN), device=device, generator=gen) / 10.0).bfloat16()
+    scores = torch.rand((TOKENS, NUM_EXPERTS), device=device, generator=gen)
+    _, ids = scores.topk(TOPK, dim=-1)
+    w = torch.rand((TOKENS, TOPK), device=device, generator=gen) + 0.1
+    tw = (w / w.sum(-1, keepdim=True)).float()
+    w13 = (torch.randn((NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN),
+                       device=device, generator=gen) * 0.05).bfloat16()
+    w2 = (torch.randn((NUM_EXPERTS, HIDDEN, INTERMEDIATE),
+                      device=device, generator=gen) * 0.05).bfloat16()
+    return x, ids.long(), tw, w13, w2
+
+
+def bench(fwd, x, ids, tw):
+    out = None
+    for _ in range(3):
+        out = fwd(x, ids, tw)
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(ITERS):
+        s, e = torch.cuda.Event(True), torch.cuda.Event(True)
+        s.record()
+        out = fwd(x, ids, tw)
+        e.record()
+        torch.cuda.synchronize()
+        times.append(s.elapsed_time(e))
+    return out.clone(), statistics.median(times)
+
+
+def main():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    x, ids, tw, w13, w2 = gen_problem(device)
+
+    cfg_off = MegaMoeForwardConfig(
+        max_tokens_per_rank=TOKENS, hidden=HIDDEN, intermediate=INTERMEDIATE,
+        num_total_experts=NUM_EXPERTS, num_topk=TOPK,
+    )
+    cfg_on = dataclasses.replace(
+        cfg_off, impl=dataclasses.replace(cfg_off.impl, generate_c=True)
+    )
+
+    results = {}
+    for name, cfg in (("generate_c=off", cfg_off), ("generate_c=on", cfg_on)):
+        fwd = MegaMoeMxfp8Forward(cfg, rank=0, world_size=1)
+        fwd.load_weights(w13, w2)
+        out, ms = bench(fwd, x, ids, tw)
+        stash_rows = 0
+        if fwd.fc1_c is not None:
+            stash_rows = int((fwd.fc1_c.abs().sum(dim=-1) > 0).sum().item())
+        results[name] = (out, ms, stash_rows, fwd)
+        print(f"{name:<16} median {ms:.3f} ms   fc1_c nonzero rows: {stash_rows}"
+              + (f"/{fwd.fc1_c.shape[0]} (shape {tuple(fwd.fc1_c.shape)})"
+                 if fwd.fc1_c is not None else ""))
+
+    out_off, ms_off, _, f_off = results["generate_c=off"]
+    out_on, ms_on, rows_on, f_on = results["generate_c=on"]
+    d = (out_off.float() - out_on.float()).abs().max().item()
+    print(f"output parity off-vs-on: max_abs_diff={d:.3e}")
+    print(f"stash overhead: {ms_on - ms_off:+.3f} ms ({100*(ms_on/ms_off-1):+.1f}%)")
+    ok = d < 1e-2 and rows_on > 0
+    f_off.finalize()
+    f_on.finalize()
+    print("GENERATE_C SMOKE " + ("PASS" if ok else "INCONCLUSIVE"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_bwd_v0_parity.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_bwd_v0_parity.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Gradient parity for the M1 pool-reuse backward (bwd_v0.pool_backward).
+
+Drives the SAME MegaMoeHybridMxfp8Layer through three backwards — the
+autograd fake-quant replay oracle, the manual fp8 backward, and the new
+pool-reuse backward — one forward each (fresh pools per generation), same
+dout, and compares (dx, dtw, dw13, dw2).
+
+Acceptance is distance to the replay oracle (the STE-exact fake-quant
+gradient of the quantized forward). pool and fp8 factor tw differently
+(fp8/replay quantize tw*dout; pool applies tw in fp32 after quantizing
+dout — the kernel's factorization), so pool-vs-fp8 sits at mxfp8
+rounding-noise level (~5% rel L2) BY CONSTRUCTION and is reported as info,
+not asserted tightly.
+
+Launch:
+    MEGA_NO_DIST=1 python -m megamoe.tests.test_bwd_v0_parity
+    torchrun --nproc_per_node=4 --standalone -m megamoe.tests.test_bwd_v0_parity
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import dataclasses
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+from megamoe.forward import MegaMoeForwardConfig
+
+TOKENS = 4096
+HIDDEN = 1024
+INTERMEDIATE = 512
+NUM_EXPERTS = 32
+TOPK = 4
+SEED = 4242
+
+TOL_VS_REPLAY = 0.06   # rel-L2 vs the fake-quant oracle (quant-noise floor)
+
+_failures = []
+
+
+def rel_l2(a, b):
+    return ((a.float() - b.float()).norm() / b.float().norm().clamp_min(1e-12)).item()
+
+
+def gen_problem(device, rank):
+    gen = torch.Generator(device=device).manual_seed(SEED + rank)
+    x = (torch.randn((TOKENS, HIDDEN), device=device, generator=gen) / 10.0).bfloat16()
+    scores = torch.rand((TOKENS, NUM_EXPERTS), device=device, generator=gen)
+    _, ids = scores.topk(TOPK, dim=-1)
+    w = torch.rand((TOKENS, TOPK), device=device, generator=gen) + 0.1
+    tw = (w / w.sum(-1, keepdim=True)).float()
+    dout = torch.randn((TOKENS, HIDDEN), device=device, generator=gen).bfloat16()
+    return x, ids.long(), tw, dout
+
+
+def gen_weights(device):
+    gen = torch.Generator(device=device).manual_seed(SEED)  # same on all ranks
+    w13 = (torch.randn((NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN),
+                       device=device, generator=gen) * 0.05).bfloat16()
+    w2 = (torch.randn((NUM_EXPERTS, HIDDEN, INTERMEDIATE),
+                      device=device, generator=gen) * 0.05).bfloat16()
+    return w13, w2
+
+
+def main():
+    no_dist = os.environ.get("MEGA_NO_DIST", "0") == "1"
+    if no_dist:
+        rank, world = 0, 1
+        torch.cuda.set_device(0)
+        import torch.distributed as dist
+
+        if not dist.is_initialized():
+            dist.init_process_group(
+                "nccl", init_method="tcp://127.0.0.1:29531", world_size=1, rank=0
+            )
+    else:
+        from src.bootstrap import init_dist_and_nvshmem
+
+        _, rank, world, _ = init_dist_and_nvshmem()
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    from pt import EpConfig, QuantConfig
+    from megamoe.training import MegaMoeHybridMxfp8Layer
+
+    x, ids, tw, dout = gen_problem(device, rank)
+    w13_full, w2_full = gen_weights(device)
+    e_loc = NUM_EXPERTS // world
+    w13 = w13_full[rank * e_loc : (rank + 1) * e_loc].clone()
+    w2 = w2_full[rank * e_loc : (rank + 1) * e_loc].clone()
+
+    ep_cfg = EpConfig(
+        num_experts=NUM_EXPERTS, top_k=TOPK, hidden_size=HIDDEN,
+        intermediate_size=INTERMEDIATE, ep_size=world, ep_rank=rank,
+    )
+    mm_cfg = MegaMoeForwardConfig(
+        max_tokens_per_rank=TOKENS, hidden=HIDDEN, intermediate=INTERMEDIATE,
+        num_total_experts=NUM_EXPERTS, num_topk=TOPK,
+    )
+    mm_cfg = dataclasses.replace(
+        mm_cfg, impl=dataclasses.replace(mm_cfg.impl, generate_c=True)
+    )
+    layer = MegaMoeHybridMxfp8Layer(
+        ep_cfg, mm_cfg, w13, w2,
+        qcfg=QuantConfig(fprop_fmt="mxfp8", quant_bprop=True),
+        bwd_impl="pool",
+    )
+
+    grads = {}
+    for impl in ("replay", "fp8", "pool", "mega"):
+        layer.bwd_impl = impl
+        layer.w13.grad = layer.w2.grad = None
+        x_l = x.detach().clone().requires_grad_()
+        tw_l = tw.detach().clone().requires_grad_()
+        out = layer(x_l, ids, tw_l)
+        dx, dtw, dw13, dw2 = torch.autograd.grad(
+            out, (x_l, tw_l, layer.w13, layer.w2), dout
+        )
+        grads[impl] = dict(dx=dx, dtw=dtw, dw13=dw13, dw2=dw2)
+        torch.cuda.synchronize()
+
+    for name in ("dx", "dtw", "dw13", "dw2"):
+        for a, b, tol in (
+            ("pool", "replay", TOL_VS_REPLAY),
+            ("fp8", "replay", TOL_VS_REPLAY),
+            ("mega", "replay", TOL_VS_REPLAY),
+            ("mega", "pool", None),   # info: same factorization, kernel GEMMs
+            ("pool", "fp8", None),    # info: differs by tw factorization noise
+        ):
+            r = rel_l2(grads[a][name], grads[b][name])
+            if tol is None:
+                if rank == 0:
+                    print(f"  [INFO] {a} vs {b:<6} {name:<5} rel_l2={r:.4f}")
+                continue
+            ok = r < tol
+            if not ok:
+                _failures.append(f"{name}: {a} vs {b}")
+            if rank == 0:
+                print(f"  [{'PASS' if ok else 'FAIL'}] {a} vs {b:<6} {name:<5} "
+                      f"rel_l2={r:.4f} (tol {tol})")
+
+    layer.finalize()
+    if rank == 0:
+        print("BWD_V0 PARITY " + ("PASS" if not _failures else f"FAIL ({_failures})"))
+    import torch.distributed as dist
+
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
+    return 0 if not _failures else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_forward_parity.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_forward_parity.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Parity test: MegaMoeMxfp8Forward vs compute_megamoe_reference_mxfp8.
+
+Launch (from moe_ep_training/):
+
+    torchrun --nproc_per_node=4 --standalone -m megamoe.tests.test_forward_parity
+
+or single-rank without NVSHMEM:
+
+    MEGA_NO_DIST=1 python -m megamoe.tests.test_forward_parity
+
+Each rank builds real bf16 inputs + local expert weights, runs the hackable
+forward, then reads back the DEVICE-quantized activation/sf and the staged
+routing tensors, all-gathers the global view, and feeds the repo's own MXFP8
+reference (apply_topk_in_fc1=True, deepgemm graph).  Tolerances match the
+repo validator (atol=rtol=1e-2): the only unmodeled error sources are the
+fc1-out MXFP8 round-trip RTNE vs the host quantizer and fp32 GEMM noise.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+from common.host_utils import compare_and_report_mismatches
+from common.megamoe_constants import Mxfp8BlockSize
+from moe_nvfp4_swapab.runner_common import ceil_div
+from moe_mxfp8_glu.mega_reference_mxfp8 import compute_megamoe_reference_mxfp8
+
+from megamoe.forward import MegaMoeForwardConfig, MegaMoeMxfp8Forward
+
+_NO_DIST = bool(int(os.environ.get("MEGA_NO_DIST", "0")))
+
+# problem shape (small; multi-rank exercises dispatch/combine across NVLink)
+TOKENS = 128
+HIDDEN = 2048
+INTERMEDIATE = 512          # per-branch I  ->  kernel gate+up width 1024
+NUM_TOTAL_EXPERTS = 32
+TOPK = 4
+KIND = "mxfp8_e4m3"
+SEED = 1234
+
+
+def _all_gather_stack(t: torch.Tensor, world_size: int) -> torch.Tensor:
+    """all_gather -> (world_size, *t.shape); fp8/e8m0 go through uint8 views."""
+    if world_size == 1:
+        return t.unsqueeze(0)
+    byte_backed = t.element_size() == 1 and t.dtype != torch.uint8
+    src = t.contiguous()
+    view = src.view(torch.uint8) if byte_backed else src
+    out = [torch.empty_like(view) for _ in range(world_size)]
+    torch.distributed.all_gather(out, view)
+    stacked = torch.stack(out, dim=0)
+    return stacked.view(t.dtype) if byte_backed else stacked
+
+
+def _make_routing(gen, num_tokens, rank):
+    scores = torch.rand(
+        (num_tokens, NUM_TOTAL_EXPERTS), device="cuda", generator=gen
+    )
+    _, topk_idx = scores.topk(TOPK, dim=-1)
+    w = torch.rand((num_tokens, TOPK), device="cuda", generator=gen) + 0.1
+    topk_weights = w / w.sum(dim=-1, keepdim=True)
+    return topk_idx.to(torch.int64), topk_weights.float()
+
+
+def _run_and_check(fwd, rank, world_size, num_tokens, weights_q, tag):
+    gen = torch.Generator(device="cuda")
+    gen.manual_seed(SEED + 1000 * rank + num_tokens)
+    x = (torch.rand((num_tokens, HIDDEN), device="cuda", generator=gen) - 0.5).bfloat16()
+    topk_idx, topk_weights = _make_routing(gen, num_tokens, rank)
+
+    out = fwd(x, topk_idx, topk_weights)
+    torch.cuda.synchronize()
+
+    # global view for the reference: device-quantized activation + staged
+    # (repacked, padding-masked) routing, straight from the forward's buffers.
+    sf_cols = ceil_div(HIDDEN, Mxfp8BlockSize)
+    g_act = _all_gather_stack(fwd.my_activation, world_size)
+    g_act_sf = _all_gather_stack(fwd.my_activation_sf[:, :sf_cols], world_size)
+    g_topk_idx = _all_gather_stack(fwd.my_topk_idx, world_size)
+    g_topk_w = _all_gather_stack(fwd.my_topk_weights, world_size)
+
+    # weights: reference wants (R, E, hidden, 2I) hidden-stride-1 fc1 and
+    # (R, E, I, hidden) I-stride-1 fc2 -- gather the contiguous storages and
+    # permute per rank.
+    g_fc1 = _all_gather_stack(weights_q.fc1_weight.permute(0, 2, 1), world_size)
+    g_fc1_sf = _all_gather_stack(weights_q.fc1_weight_sf_plain, world_size)
+    g_fc2 = _all_gather_stack(weights_q.fc2_weight.permute(0, 2, 1), world_size)
+    g_fc2_sf = _all_gather_stack(weights_q.fc2_weight_sf_plain, world_size)
+
+    combine_ref = compute_megamoe_reference_mxfp8(
+        input_activation=g_act,
+        input_activation_sf=g_act_sf,
+        input_topk_idx=g_topk_idx,
+        input_topk_weights=g_topk_w,
+        fc1_weight=g_fc1.permute(0, 1, 3, 2),  # (R, E, H, 2I), H stride-1
+        fc1_weight_sf=g_fc1_sf,
+        fc2_weight=g_fc2.permute(0, 1, 3, 2),  # (R, E, I, H), I stride-1
+        fc2_weight_sf=g_fc2_sf,
+        ab_dtype=fwd.torch_ab_dtype,
+        fc2_output_dtype=torch.bfloat16,
+        combine_format=fwd._combine_format,
+        apply_topk_in_fc1=True,
+    )
+    # apply_topk_in_fc1: weights already folded in -> plain sum over topk.
+    ref_reduced = combine_ref[rank, :num_tokens].float().sum(dim=1)
+
+    compare_and_report_mismatches(
+        out.float(),
+        ref_reduced,
+        name=f"[{tag}] combine_output[rank{rank}] T={num_tokens}",
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+
+def main() -> int:
+    if _NO_DIST:
+        torch.cuda.set_device(0)
+        rank, world_size = 0, 1
+    else:
+        from src.bootstrap import init_dist_and_nvshmem, finalize_dist_and_nvshmem
+        _, rank, world_size, _ = init_dist_and_nvshmem()
+
+    E_local = NUM_TOTAL_EXPERTS // world_size
+    cfg = MegaMoeForwardConfig(
+        max_tokens_per_rank=TOKENS,
+        hidden=HIDDEN,
+        intermediate=INTERMEDIATE,
+        num_total_experts=NUM_TOTAL_EXPERTS,
+        num_topk=TOPK,
+        kind=KIND,
+    )
+    # MEGA_DEDUP_DISPATCH=1 exercises the rank-dedup dispatch kernel variant;
+    # MEGA_COMBINE_IFR=1 the in-flight combine reduce; MEGA_COMBINE_PRE=1 the
+    # same-rank combine pre-reduce (implies the other two).
+    if bool(int(os.environ.get("MEGA_COMBINE_PRE", "0"))):
+        cfg.impl.dedup_dispatch = True
+        cfg.impl.combine_in_flight_reduce = True
+        cfg.impl.combine_pre_reduce = True
+    if bool(int(os.environ.get("MEGA_COMBINE_IFR", "0"))):
+        cfg.impl.combine_in_flight_reduce = True
+    if bool(int(os.environ.get("MEGA_DEDUP_DISPATCH", "0"))):
+        cfg.impl.dedup_dispatch = True
+    if rank == 0:
+        print(f"[parity] impl: dedup={cfg.impl.dedup_dispatch} "
+              f"ifr={cfg.impl.combine_in_flight_reduce} "
+              f"pre={cfg.impl.combine_pre_reduce}")
+    fwd = MegaMoeMxfp8Forward(cfg, rank=rank, world_size=world_size)
+
+    wgen = torch.Generator(device="cuda")
+    wgen.manual_seed(SEED + 7 * rank)
+    scale = 0.05  # keep fc outputs O(1) so the 1e-2 atol is meaningful
+    w13 = (torch.randn((E_local, 2 * INTERMEDIATE, HIDDEN), device="cuda",
+                       generator=wgen) * scale).bfloat16()
+    w2 = (torch.randn((E_local, HIDDEN, INTERMEDIATE), device="cuda",
+                      generator=wgen) * scale).bfloat16()
+    fwd.load_weights(w13, w2)
+
+    _run_and_check(fwd, rank, world_size, TOKENS, fwd._weights, "full")
+    _run_and_check(fwd, rank, world_size, TOKENS // 2, fwd._weights, "padded")
+
+    # weight update in place (no recompile), then re-verify
+    fwd.load_weights((w13.float() * 1.5).bfloat16(), (w2.float() * 1.5).bfloat16())
+    _run_and_check(fwd, rank, world_size, TOKENS, fwd._weights, "reload")
+
+    if rank == 0:
+        print("ALL PARITY CHECKS PASS")
+
+    fwd.finalize()
+    if not _NO_DIST:
+        finalize_dist_and_nvshmem()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_hybrid_training.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_hybrid_training.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Hybrid training layer validation: kernel fprop + torch bprop, single GPU.
+
+Launch:
+
+    MEGA_NO_DIST=1 python -m megamoe.tests.test_hybrid_training
+
+Checks:
+
+1. **Pool conformance** — dequant(my_activation/_sf) must reproduce
+   pt's ``fake_quant_mxfp8(x)``: the device DataPreprocess quant and the
+   host/pt quantizer must agree, or the backward replay consumes different
+   bytes than the kernel multiplied.
+2. **Forward numerics** — hybrid (kernel) output vs the pt simulated-mxfp8
+   reference and vs the exact fp32 oracle.
+3. **Backward numerics** — hybrid grads (dX, dTW, dW13, dW2) vs
+   ``ReferenceMoEFp4(mxfp8)`` grads. With check 1 holding, the replay sees
+   the same quantized operands, so these should agree tightly.
+4. **Generation hazard** — two forwards then backward on the first must
+   raise (the pools were overwritten).
+5. **Train-step smoke** — Adam step + refresh_weights + another fwd/bwd.
+"""
+
+import os
+import sys
+
+os.environ.setdefault("MEGA_NO_DIST", "1")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import torch
+import torch.distributed as dist
+
+import megamoe.repo_path  # noqa: F401
+
+from megamoe.forward import MegaMoeForwardConfig
+from megamoe.training import MegaMoeHybridMxfp8Layer, dequant_mxfp8_pool
+
+from pt import EpConfig, QuantConfig, ReferenceMoE, ReferenceMoEFp4
+from pt.quant import fake_quant_mxfp8
+
+TOKENS = 128
+HIDDEN = 1024
+INTERMEDIATE = 512
+NUM_EXPERTS = 32
+TOPK = 4
+SEED = 4242
+OUTLIER_FRAC = 0.01
+OUTLIER_SCALE = 30.0
+
+
+def rel_err(a, b):
+    denom = b.float().norm().item()
+    return (a.float() - b.float()).norm().item() / max(denom, 1e-30)
+
+
+def gen_problem(device):
+    gen = torch.Generator(device=device).manual_seed(SEED)
+    x = torch.randn((TOKENS, HIDDEN), device=device, generator=gen) / 10.0
+    hot = torch.randperm(HIDDEN, generator=gen, device=device)[
+        : max(1, int(HIDDEN * OUTLIER_FRAC))
+    ]
+    x[:, hot] *= OUTLIER_SCALE
+    scores = torch.rand((TOKENS, NUM_EXPERTS), device=device, generator=gen)
+    _, ids = scores.topk(TOPK, dim=-1)
+    w = torch.rand((TOKENS, TOPK), device=device, generator=gen) + 0.1
+    tw = (w / w.sum(-1, keepdim=True)).float()
+    w13 = (torch.randn((NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN),
+                       device=device, generator=gen) * 0.05).bfloat16()
+    w2 = (torch.randn((NUM_EXPERTS, HIDDEN, INTERMEDIATE),
+                      device=device, generator=gen) * 0.05).bfloat16()
+    gout = (torch.randn((TOKENS, HIDDEN), device=device, generator=gen)).bfloat16()
+    return x.bfloat16(), ids.long(), tw, w13, w2, gout
+
+
+def run_ref(cls, x, ids, tw, gout, w13, w2, **kw):
+    x_r = x.detach().clone().requires_grad_()
+    tw_r = tw.detach().clone().requires_grad_()
+    m = cls(w13.detach().clone(), w2.detach().clone(), **kw)
+    out = m(x_r, ids, tw_r)
+    out.backward(gout)
+    return out.detach(), x_r.grad, tw_r.grad, m.w13.grad, m.w2.grad
+
+
+def main():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    if not dist.is_initialized():
+        dist.init_process_group(
+            "nccl", init_method="tcp://127.0.0.1:29517", world_size=1, rank=0
+        )
+
+    x, ids, tw, w13, w2, gout = gen_problem(device)
+    qcfg = QuantConfig(fprop_fmt="mxfp8", quant_bprop=True)
+
+    ep_cfg = EpConfig(
+        num_experts=NUM_EXPERTS, top_k=TOPK, hidden_size=HIDDEN,
+        intermediate_size=INTERMEDIATE, ep_size=1, ep_rank=0,
+    )
+    mm_cfg = MegaMoeForwardConfig(
+        max_tokens_per_rank=TOKENS, hidden=HIDDEN, intermediate=INTERMEDIATE,
+        num_total_experts=NUM_EXPERTS, num_topk=TOPK,
+    )
+    hybrid = MegaMoeHybridMxfp8Layer(
+        ep_cfg, mm_cfg, w13.detach().clone(), w2.detach().clone(), qcfg
+    )
+
+    # ---- fwd + bwd through the hybrid ----
+    x_h = x.detach().clone().requires_grad_()
+    tw_h = tw.detach().clone().requires_grad_()
+    out_h = hybrid(x_h, ids, tw_h)
+    out_h.backward(gout)
+
+    # ---- [1] pool conformance: device preproc quant vs pt quantizer ----
+    pool = dequant_mxfp8_pool(
+        hybrid._fwd.my_activation[:TOKENS],
+        hybrid._fwd.my_activation_sf[:TOKENS],
+        HIDDEN,
+    )
+    host = fake_quant_mxfp8(x.float(), dim=-1)
+    n_diff = (pool != host).sum().item()
+    print(f"[1] pool vs pt quantizer: {n_diff}/{pool.numel()} mismatched")
+    assert n_diff <= pool.numel() * 1e-4, "DataPreprocess and pt quantizer diverge"
+
+    # ---- [2] forward numerics ----
+    ref_fp4 = run_ref(ReferenceMoEFp4, x, ids, tw, gout, w13, w2, qcfg=qcfg)
+    exact = run_ref(
+        ReferenceMoE, x.float(), ids, tw, gout.float(), w13.float(), w2.float()
+    )
+    e_vs_sim = rel_err(out_h, ref_fp4[0])
+    e_vs_fp32 = rel_err(out_h, exact[0])
+    e_sim_fp32 = rel_err(ref_fp4[0], exact[0])
+    print(f"[2] fwd rel_err: hybrid-vs-sim={e_vs_sim:.4f}  "
+          f"hybrid-vs-fp32={e_vs_fp32:.4f}  (sim-vs-fp32={e_sim_fp32:.4f})")
+    assert e_vs_fp32 < 0.15, "kernel fwd far from fp32 oracle"
+    assert e_vs_sim < 0.10, "kernel fwd far from pt simulation"
+
+    # ---- [3] backward numerics vs the pt simulated reference ----
+    names = ("dX", "dTW", "dW13", "dW2")
+    got = (x_h.grad, tw_h.grad, hybrid.w13.grad, hybrid.w2.grad)
+    errs = {n: rel_err(g, r) for n, g, r in zip(names, got, ref_fp4[1:])}
+    print("[3] bwd rel_err vs ReferenceMoEFp4: "
+          + "  ".join(f"{n}={e:.4f}" for n, e in errs.items()))
+    for n, e in errs.items():
+        assert e < 0.05, (n, e, "hybrid replay grads diverge from simulation")
+
+    # ---- [3a] vectorized scale swizzle == per-group to_blocked loop ----
+    from megamoe.fp8_bwd import (
+        _col_atom_order,
+        _pack_scales_colgroups,
+        _pack_scales_colgroups_ref,
+        _pack_scales_rowgroups,
+        _pack_scales_rowgroups_ref,
+    )
+    gen = torch.Generator(device=device).manual_seed(SEED + 3)
+    tpe = [256, 0, 768, 1024]  # 128-aligned token groups, one empty
+    offs = torch.tensor([256, 256, 1024, 2048], device=device, dtype=torch.int32)
+    s_col = torch.randint(
+        0, 255, (1024, 2048 // 32), device=device, dtype=torch.uint8, generator=gen
+    ).view(torch.float8_e8m0fnu)
+    order = _col_atom_order(offs, 1024 // 128, 2048 // 128)
+    v = _pack_scales_colgroups(s_col, offs, 1024, order)
+    r = _pack_scales_colgroups_ref(s_col, offs, 1024)
+    assert torch.equal(v.view(torch.uint8), r.view(torch.uint8)), "colgroup swizzle"
+    s_row = torch.randint(
+        0, 255, (2048, 1024 // 32), device=device, dtype=torch.uint8, generator=gen
+    ).view(torch.float8_e8m0fnu)
+    v2 = _pack_scales_rowgroups(s_row, offs)
+    r2 = _pack_scales_rowgroups_ref(s_row, offs)
+    assert torch.equal(v2.view(torch.uint8), r2.view(torch.uint8)), "rowgroup swizzle"
+    print("[3a] vectorized swizzle == per-group to_blocked (col + row groups)")
+
+    # Triton quantizers must be bit-identical to the torch reference.
+    from megamoe.quant_kernels import HAVE_TRITON, mxfp8_rowquant, mxfp8_transquant
+    from pt.quant import quant_mxfp8_tensors
+    if HAVE_TRITON:
+        t = torch.randn((640, 1024), device=device, generator=gen).bfloat16()
+        t[:, :4] *= 30.0
+        q_t, s_t = mxfp8_rowquant(t)
+        q_r, s_r = quant_mxfp8_tensors(t, dim=-1)
+        assert torch.equal(q_t.view(torch.uint8), q_r.view(torch.uint8)), "rowquant data"
+        assert torch.equal(s_t.view(torch.uint8), s_r.view(torch.uint8)), "rowquant scales"
+        q_t2, s_t2 = mxfp8_transquant(t)
+        q_r2, s_r2 = quant_mxfp8_tensors(t.t().contiguous(), dim=-1)
+        assert torch.equal(q_t2.view(torch.uint8), q_r2.view(torch.uint8)), "transquant data"
+        assert torch.equal(s_t2.view(torch.uint8), s_r2.view(torch.uint8)), "transquant scales"
+        print("[3a'] triton rowquant/transquant bit-identical to torch reference")
+    else:
+        print("[3a'] triton unavailable — torch fallback in use")
+
+    # ---- [3b] fp8 manual backward vs the replay ----
+    hybrid8 = MegaMoeHybridMxfp8Layer(
+        ep_cfg, mm_cfg, w13.detach().clone(), w2.detach().clone(), qcfg,
+        bwd_impl="fp8",
+    )
+    x_8 = x.detach().clone().requires_grad_()
+    tw_8 = tw.detach().clone().requires_grad_()
+    out_8 = hybrid8(x_8, ids, tw_8)
+    out_8.backward(gout)
+    got8 = (x_8.grad, tw_8.grad, hybrid8.w13.grad, hybrid8.w2.grad)
+    errs8 = {n: rel_err(g, r) for n, g, r in zip(names, got8, got)}
+    print("[3b] fp8-bwd rel_err vs replay-bwd: "
+          + "  ".join(f"{n}={e:.4f}" for n, e in errs8.items()))
+    for n, e in errs8.items():
+        assert e < 0.05, (n, e, "fp8 manual backward diverges from replay")
+    hybrid8.finalize()
+
+    # ---- [4] generation hazard ----
+    x_a = x.detach().clone().requires_grad_()
+    out_a = hybrid(x_a, ids, tw.detach().clone().requires_grad_())
+    _ = hybrid(x.detach().clone(), ids, tw.detach().clone())
+    try:
+        out_a.backward(gout)
+        raise AssertionError("stale-generation backward did not raise")
+    except RuntimeError as e:
+        assert "generation" in str(e)
+        print("[4] generation hazard raises as expected")
+
+    # ---- [4b] turboquant hybrid: fwd + grads vs the tq reference ----
+    qcfg_tq = QuantConfig(fprop_fmt="mxfp8", quant_bprop=True, turboquant=True)
+    ref_tq = run_ref(ReferenceMoEFp4, x, ids, tw, gout, w13, w2, qcfg=qcfg_tq)
+    for impl, tol in (("replay", 0.02), ("fp8", 0.05)):
+        h_tq = MegaMoeHybridMxfp8Layer(
+            ep_cfg, mm_cfg, w13.detach().clone(), w2.detach().clone(),
+            qcfg_tq, bwd_impl=impl,
+        )
+        x_t = x.detach().clone().requires_grad_()
+        tw_t = tw.detach().clone().requires_grad_()
+        out_t = h_tq(x_t, ids, tw_t)
+        out_t.backward(gout)
+        e_fwd = rel_err(out_t, ref_tq[0])
+        got_t = (x_t.grad, tw_t.grad, h_tq.w13.grad, h_tq.w2.grad)
+        errs_t = {n: rel_err(g, r) for n, g, r in zip(names, got_t, ref_tq[1:])}
+        print(f"[4b] tq {impl:<6}: fwd={e_fwd:.4f}  "
+              + "  ".join(f"{n}={e:.4f}" for n, e in errs_t.items()))
+        assert e_fwd < 0.10, ("tq fwd", impl, e_fwd)
+        for n, e in errs_t.items():
+            assert e < tol, ("tq bwd", impl, n, e)
+        h_tq.finalize()
+
+    # ---- [5] train-step smoke: perturbed start, must descend toward the
+    # fp32 teacher output (grads flow -> optimizer -> refresh_weights -> next
+    # fwd sees updated kernel weight buffers) ----
+    gen = torch.Generator(device=device).manual_seed(SEED + 7)
+    student = MegaMoeHybridMxfp8Layer(
+        ep_cfg, mm_cfg,
+        (w13.float() * (1 + 0.2 * torch.randn(w13.shape, device=device, generator=gen))).bfloat16(),
+        (w2.float() * (1 + 0.2 * torch.randn(w2.shape, device=device, generator=gen))).bfloat16(),
+        qcfg,
+    )
+    opt = torch.optim.Adam(student.parameters(), lr=2e-3)
+    losses = []
+    for _ in range(20):
+        x_s = x.detach().clone().requires_grad_()
+        out = student(x_s, ids, tw.detach().clone())
+        loss = torch.nn.functional.mse_loss(out.float(), exact[0].float())
+        opt.zero_grad(set_to_none=True)
+        loss.backward()
+        opt.step()
+        student.refresh_weights()
+        losses.append(loss.item())
+    print(f"[5] 20-step train smoke, loss {losses[0]:.5f} -> {losses[-1]:.5f}")
+    assert losses[-1] < losses[0] * 0.5, ("training did not descend", losses)
+    student.finalize()
+
+    hybrid.finalize()
+    dist.destroy_process_group()
+    print("HYBRID TRAINING PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_hybrid_training_dist.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_hybrid_training_dist.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Multi-rank hybrid training validation: kernel fprop + fp8/replay bprop
+with REAL all-to-all adjoints.
+
+Launch (from moe_ep_training/):
+
+    torchrun --nproc_per_node=4 --standalone -m megamoe.tests.test_hybrid_training_dist
+
+Every rank regenerates the same global problem from a shared seed (the
+repo's parity-test pattern), evaluates the single-process fp4/fp8 reference
+on the full batch, and runs the hybrid layer on its token/expert shard:
+
+1. hybrid replay-bwd grads   == ReferenceMoEFp4(mxfp8) shard slices (tight)
+2. hybrid fp8-bwd grads      ~  reference (bf16 grouped-GEMM rounding)
+3. per-rank fwd / fp8-bwd timing with real NCCL a2a in backward
+"""
+
+import os
+import statistics
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+from megamoe.forward import MegaMoeForwardConfig
+from megamoe.training import MegaMoeHybridMxfp8Layer
+
+from pt import EpConfig, QuantConfig, ReferenceMoEFp4
+
+TOKENS_PER_RANK = 2048
+HIDDEN = 1024
+INTERMEDIATE = 512
+NUM_EXPERTS = 32
+TOPK = 4
+SEED = 4242
+ITERS = 10
+
+
+def rel_err(a, b):
+    d = b.float().norm().item()
+    return (a.float() - b.float()).norm().item() / max(d, 1e-30)
+
+
+def gen_global(world, device):
+    gen = torch.Generator(device=device).manual_seed(SEED)
+    total = world * TOKENS_PER_RANK
+    x = torch.randn((total, HIDDEN), device=device, generator=gen) / 10.0
+    hot = torch.randperm(HIDDEN, generator=gen, device=device)[:10]
+    x[:, hot] *= 30.0
+    scores = torch.rand((total, NUM_EXPERTS), device=device, generator=gen)
+    _, ids = scores.topk(TOPK, dim=-1)
+    w = torch.rand((total, TOPK), device=device, generator=gen) + 0.1
+    tw = (w / w.sum(-1, keepdim=True)).float()
+    w13 = (torch.randn((NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN),
+                       device=device, generator=gen) * 0.05).bfloat16()
+    w2 = (torch.randn((NUM_EXPERTS, HIDDEN, INTERMEDIATE),
+                      device=device, generator=gen) * 0.05).bfloat16()
+    gout = torch.randn((total, HIDDEN), device=device, generator=gen).bfloat16()
+    return x.bfloat16(), ids.long(), tw, w13, w2, gout
+
+
+def run_hybrid(layer, x, ids, tw, gout):
+    x_h = x.detach().clone().requires_grad_()
+    tw_h = tw.detach().clone().requires_grad_()
+    out = layer(x_h, ids, tw_h)
+    out.backward(gout)
+    return out.detach(), x_h.grad, tw_h.grad, layer.w13.grad, layer.w2.grad
+
+
+def main():
+    from src.bootstrap import init_dist_and_nvshmem, finalize_dist_and_nvshmem
+
+    _, rank, world, _ = init_dist_and_nvshmem()
+    device = torch.device("cuda", torch.cuda.current_device())
+
+    x_g, ids_g, tw_g, w13_g, w2_g, gout_g = gen_global(world, device)
+    qcfg = QuantConfig(fprop_fmt="mxfp8", quant_bprop=True)
+
+    # single-process reference on the global batch (redundant per rank)
+    x_r = x_g.detach().clone().requires_grad_()
+    tw_r = tw_g.detach().clone().requires_grad_()
+    ref = ReferenceMoEFp4(w13_g.detach().clone(), w2_g.detach().clone(), qcfg)
+    ref_out = ref(x_r, ids_g, tw_r)
+    ref_out.backward(gout_g)
+
+    lo, hi = rank * TOKENS_PER_RANK, (rank + 1) * TOKENS_PER_RANK
+    n_local = NUM_EXPERTS // world
+    elo, ehi = rank * n_local, (rank + 1) * n_local
+
+    ep_cfg = EpConfig(
+        num_experts=NUM_EXPERTS, top_k=TOPK, hidden_size=HIDDEN,
+        intermediate_size=INTERMEDIATE, ep_size=world, ep_rank=rank,
+    )
+    mm_cfg = MegaMoeForwardConfig(
+        max_tokens_per_rank=TOKENS_PER_RANK, hidden=HIDDEN,
+        intermediate=INTERMEDIATE, num_total_experts=NUM_EXPERTS,
+        num_topk=TOPK,
+    )
+    # bwd_impl="mega" reads the forward's fc1_c stash (generate_c); harmless
+    # for replay/fp8 (they just ignore the extra stash).
+    import dataclasses
+    mm_cfg = dataclasses.replace(
+        mm_cfg, impl=dataclasses.replace(mm_cfg.impl, generate_c=True)
+    )
+
+    names = ("fwd", "dX", "dTW", "dW13", "dW2")
+    refs = (ref_out[lo:hi], x_r.grad[lo:hi], tw_r.grad[lo:hi],
+            ref.w13.grad[elo:ehi], ref.w2.grad[elo:ehi])
+
+    any_failed = False
+    layers = {}
+    for impl, tol in (("replay", 1e-3), ("fp8", 0.05), ("mega", 0.06)):
+        layer = MegaMoeHybridMxfp8Layer(
+            ep_cfg, mm_cfg,
+            w13_g[elo:ehi].detach().clone(), w2_g[elo:ehi].detach().clone(),
+            qcfg, bwd_impl=impl,
+        )
+        layers[impl] = layer
+        got = run_hybrid(layer, x_g[lo:hi], ids_g[lo:hi], tw_g[lo:hi], gout_g[lo:hi])
+        errs = {n: rel_err(g, r) for n, g, r in zip(names, got, refs)}
+        line = "  ".join(f"{n}={e:.4f}" for n, e in errs.items())
+        print(f"[rank {rank}] bwd_impl={impl:<6} vs reference: {line}")
+        # fwd goes through the kernel either way; grads carry the impl tol.
+        if errs["fwd"] > 0.05 or any(e > tol for n, e in errs.items() if n != "fwd"):
+            any_failed = True
+            print(f"[rank {rank}] FAIL bwd_impl={impl} (tol={tol})")
+
+    # ---- timing with real a2a (collective; all ranks iterate together) ----
+    def time_layer(layer):
+        torch.distributed.barrier()
+        fwd_ms, bwd_ms = [], []
+        for _ in range(3 + ITERS):
+            x_h = x_g[lo:hi].detach().clone().requires_grad_()
+            tw_h = tw_g[lo:hi].detach().clone().requires_grad_()
+            s, m, e = (torch.cuda.Event(True) for _ in range(3))
+            s.record()
+            out = layer(x_h, ids_g[lo:hi], tw_h)
+            m.record()
+            out.backward(gout_g[lo:hi])
+            e.record()
+            torch.cuda.synchronize()
+            fwd_ms.append(s.elapsed_time(m))
+            bwd_ms.append(m.elapsed_time(e))
+            torch.distributed.barrier()
+        return statistics.median(fwd_ms[3:]), statistics.median(bwd_ms[3:])
+
+    for name in ("fp8", "mega"):
+        fwd, bwd = time_layer(layers[name])
+        print(f"[rank {rank}] T/rank={TOKENS_PER_RANK} world={world}: "
+              f"fwd {fwd:.3f} ms  {name}-bwd {bwd:.3f} ms ({bwd/fwd:.1f}x fwd)")
+
+    for layer in layers.values():
+        layer.finalize()
+    torch.distributed.barrier()
+    if rank == 0 and not any_failed:
+        print("HYBRID DIST PASS")
+    finalize_dist_and_nvshmem()
+    return 1 if any_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_turboquant_numerics.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/tests/test_turboquant_numerics.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""TurboQuant numerics validation: rotated vs plain MXFP8 forward accuracy.
+
+Launch (from moe_ep_training/):
+
+    torchrun --nproc_per_node=4 --standalone -m megamoe.tests.test_turboquant_numerics
+    MEGA_NO_DIST=1 python -m megamoe.tests.test_turboquant_numerics
+
+Three checks, on activations with realistic per-channel outliers (the case
+incoherence processing exists for):
+
+1. **Fold exactness** (fp32, no quant): the exact MoE on (x Q, W13 Q) equals
+   the exact MoE on (x, W13) — the rotation is mathematically a no-op.
+2. **Correctness sanity**: both the plain and the TurboQuant MXFP8 forwards
+   stay within a loose tolerance of the exact fp32 MoE.
+3. **Accuracy win**: the TurboQuant forward's relative error vs the exact
+   fp32 MoE is <= the plain forward's (expected strictly smaller with
+   outliers present).
+
+Every rank regenerates the global problem from shared seeds (like the repo's
+runner), so no gathers are needed for the exact reference.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import torch
+import torch.nn.functional as F
+
+import megamoe.repo_path  # noqa: F401
+
+from megamoe.forward import MegaMoeForwardConfig, MegaMoeMxfp8Forward
+from megamoe.forward_nvfp4 import MegaMoeNvfp4Forward
+from megamoe.turboquant import (
+    MegaMoeTurboQuantForward,
+    MegaMoeTurboQuantNvfp4Forward,
+    make_rotation,
+    rotate_hidden,
+)
+
+_NO_DIST = bool(int(os.environ.get("MEGA_NO_DIST", "0")))
+
+TOKENS = 128
+HIDDEN = 1024
+INTERMEDIATE = 512
+NUM_TOTAL_EXPERTS = 32
+TOPK = 4
+SEED = 4242
+OUTLIER_FRAC = 0.01   # ~1% hot channels, x30 — typical LLM activation shape
+OUTLIER_SCALE = 30.0
+
+
+def _gen_global(world_size):
+    """Deterministic global problem, identical on every rank."""
+    gen = torch.Generator(device="cuda").manual_seed(SEED)
+    E_local = NUM_TOTAL_EXPERTS // world_size
+
+    x_clean = torch.randn((world_size, TOKENS, HIDDEN), device="cuda", generator=gen) / 10.0
+    n_out = max(1, int(HIDDEN * OUTLIER_FRAC))
+    hot = torch.randperm(HIDDEN, generator=gen, device="cuda")[:n_out]
+    x = x_clean.clone()
+    x[..., hot] *= OUTLIER_SCALE
+    x = x.bfloat16()
+    x_clean = x_clean.bfloat16()
+
+    scores = torch.rand((world_size, TOKENS, NUM_TOTAL_EXPERTS), device="cuda", generator=gen)
+    _, topk_idx = scores.topk(TOPK, dim=-1)
+    w = torch.rand((world_size, TOKENS, TOPK), device="cuda", generator=gen) + 0.1
+    topk_w = (w / w.sum(-1, keepdim=True)).float()
+
+    w13 = (torch.randn((world_size, E_local, 2 * INTERMEDIATE, HIDDEN),
+                       device="cuda", generator=gen) * 0.05).bfloat16()
+    w2 = (torch.randn((world_size, E_local, HIDDEN, INTERMEDIATE),
+                      device="cuda", generator=gen) * 0.05).bfloat16()
+    return x, x_clean, topk_idx.to(torch.int64), topk_w, w13, w2
+
+
+def exact_moe_fp32(xg, idxg, wg, w13g, w2g):
+    """Unquantized fp32 MoE oracle: silu(gate)*linear, weights in fc1 position."""
+    R, T, H = xg.shape
+    E_local = w13g.shape[1]
+    out = torch.zeros((R, T, H), device="cuda", dtype=torch.float32)
+    for e_global in range(R * E_local):
+        r_e, e_l = divmod(e_global, E_local)
+        rows = (idxg == e_global).nonzero(as_tuple=False)
+        if rows.numel() == 0:
+            continue
+        xs = xg[rows[:, 0], rows[:, 1]].float()
+        h = xs @ w13g[r_e, e_l].float().T                      # (n, 2I)
+        up, gate = h[:, :INTERMEDIATE], h[:, INTERMEDIATE:]
+        act = F.silu(gate) * up
+        act = act * wg[rows[:, 0], rows[:, 1], rows[:, 2]].float()[:, None]
+        y = act @ w2g[r_e, e_l].float().T                      # (n, H)
+        out.index_put_((rows[:, 0], rows[:, 1]), y, accumulate=True)
+    return out
+
+
+def rel_err(a, b):
+    return (a.float() - b.float()).norm().item() / b.float().norm().item()
+
+
+def main() -> int:
+    if _NO_DIST:
+        torch.cuda.set_device(0)
+        rank, world = 0, 1
+    else:
+        from src.bootstrap import init_dist_and_nvshmem, finalize_dist_and_nvshmem
+        _, rank, world, _ = init_dist_and_nvshmem()
+
+    xg, x_clean, idxg, wg, w13g, w2g = _gen_global(world)
+    exact = exact_moe_fp32(xg, idxg, wg, w13g, w2g)
+
+    # Outlier-free twin of the same problem: establishes the pipeline's
+    # intrinsic mxfp8 error floor (fc1-out requant + weight quant + combine),
+    # which no activation-side rotation can go below.
+    exact_clean = exact_moe_fp32(x_clean, idxg, wg, w13g, w2g)
+
+    # -- check 1: rotation fold is exact in fp32 (independent of the kernel) --
+    q = make_rotation()
+    x_rot = rotate_hidden(xg.float(), q).bfloat16()
+    w13_rot = rotate_hidden(w13g.float(), q).bfloat16()
+    exact_rot = exact_moe_fp32(x_rot, idxg, wg, w13_rot, w2g)
+    fold_err = rel_err(exact_rot, exact)
+    if rank == 0:
+        print(f"[1] rotation-fold exactness (fp32+bf16 roundtrip): rel_err={fold_err:.2e}")
+    assert fold_err < 5e-3, f"rotation fold not identity-preserving: {fold_err}"
+
+    cfg = MegaMoeForwardConfig(
+        max_tokens_per_rank=TOKENS, hidden=HIDDEN, intermediate=INTERMEDIATE,
+        num_total_experts=NUM_TOTAL_EXPERTS, num_topk=TOPK,
+    )
+
+    impls = {
+        "mxfp8": (MegaMoeMxfp8Forward, MegaMoeTurboQuantForward),
+        "nvfp4": (MegaMoeNvfp4Forward, MegaMoeTurboQuantNvfp4Forward),
+    }
+    summary = {}
+    for fmt, (plain_cls, tq_cls) in impls.items():
+        plain = plain_cls(cfg, rank=rank, world_size=world)
+        plain.load_weights(w13g[rank], w2g[rank])
+        floor = rel_err(
+            plain(x_clean[rank], idxg[rank], wg[rank]).clone(), exact_clean[rank]
+        )
+        plain_e = rel_err(
+            plain(xg[rank], idxg[rank], wg[rank]).clone(), exact[rank]
+        )
+        plain.finalize()
+
+        turbo = tq_cls(cfg, rank=rank, world_size=world)
+        turbo.load_weights(w13g[rank], w2g[rank])
+        turbo_e = rel_err(
+            turbo(xg[rank], idxg[rank], wg[rank]).clone(), exact[rank]
+        )
+        turbo.finalize()
+
+        excess_plain = plain_e - floor
+        excess_turbo = turbo_e - floor
+        recovered = (
+            1.0 - excess_turbo / excess_plain if excess_plain > 0 else float("nan")
+        )
+        summary[fmt] = (floor, plain_e, turbo_e)
+        print(
+            f"[2] rank{rank} {fmt}: rel_err vs exact fp32:\n"
+            f"      floor (no outliers)  = {floor:.4e}\n"
+            f"      plain (outliers)     = {plain_e:.4e} (excess {excess_plain:+.2e})\n"
+            f"      turboquant (outliers)= {turbo_e:.4e} (excess {excess_turbo:+.2e})\n"
+            f"[3] rank{rank} {fmt}: outlier-induced excess error recovered by "
+            f"rotation: {100.0 * recovered:.0f}%"
+        )
+        # Must-hold invariants; the decomposition above is the deliverable.
+        # mxfp8: rotation must recover outlier damage (validated claim).
+        # nvfp4: per-16 fp8 block scales already absorb outliers (the block's
+        # scale adapts to its own outlier), so spreading energy via rotation
+        # only exposes more values to e2m1's ~9%/element rounding — rotation
+        # is expected NEUTRAL-TO-NEGATIVE here. Record it, bound it loosely.
+        if fmt == "mxfp8":
+            assert turbo_e <= plain_e * 1.02, (fmt, summary[fmt])
+            assert turbo_e < floor + max(0.02, 0.3 * floor), (fmt, summary[fmt])
+        else:
+            assert plain_e < 0.35 and turbo_e < 0.35, (fmt, summary[fmt])
+            assert turbo_e <= plain_e * 1.25, (fmt, summary[fmt])
+
+    if rank == 0:
+        print("TURBOQUANT NUMERICS PASS")
+    if not _NO_DIST:
+        finalize_dist_and_nvshmem()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/training.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/training.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Hybrid MoE-EP training layer: MegaMoE MXFP8 kernel fprop + torch bprop.
+
+Step 1 of the bprop-megakernel plan: forward runs at (near-)inference speed
+through :class:`megamoe.forward.MegaMoeMxfp8Forward`; backward is a pure
+PyTorch *replay* of the quantized forward built from tensors REUSED FROM THE
+KERNEL'S PERSISTENT POOLS — no stash copies:
+
+- ``my_activation`` / ``my_activation_sf`` (the fused DataPreprocess quant
+  output, sym-heap) are dequantized in backward and become the replay's
+  activation. pt/quant.py's ``fake_quant_mxfp8`` was proven bit-exact vs the
+  host quantizer (pt/tests/test_quant_vs_kernel.py), so re-quantizing the
+  dequantized values inside the replay is idempotent — the replay consumes
+  exactly the bytes the kernel multiplied.
+- Weights are re-quantized in the replay from the bf16 masters with the same
+  (conformance-tested) algorithm ``load_weights`` used, so no unswizzling of
+  the kernel's weight buffers is needed.
+
+The pool-reuse contract is enforced with a GENERATION COUNTER: backward
+asserts no later ``forward`` has overwritten the pools (one fwd per bwd; for
+gradient accumulation a stash ring is needed — deliberately out of scope
+here). The kernel output view is cloned before autograd sees it (the buffer
+is zeroed at the next forward).
+
+Gradients (dX, d topk_weights, dW13, dW2) are the STE/quantized-bprop grads
+of the replayed quantized function, produced by ``torch.autograd.grad``
+through pt's differentiable dispatch/combine (NCCL all-to-all adjoints) and
+``QuantGemmT``. This backward is the SLOW oracle baseline the future bprop
+megakernel replaces stage by stage; profile it to see where the time goes.
+
+Collective contract: every EP rank must call forward AND backward each step
+(both contain all-to-alls). Not compatible with ``turboquant`` yet.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+import megamoe.repo_path  # noqa: F401
+
+from dataclasses import replace as dc_replace
+
+from megamoe.forward import MegaMoeForwardConfig, MegaMoeMxfp8Forward
+
+from pt.comm import TokenComm, create_comm
+from pt.config import EpConfig
+from pt.dispatch_combine import combine, dispatch
+from pt.experts_fp4 import grouped_expert_ffn_fp4
+from pt.quant import MXFP8_BLOCK, QuantConfig, make_rotation, rotate_trailing
+from pt.routing import build_routing_plan
+
+
+def dequant_mxfp8_pool(
+    vals_fp8: torch.Tensor, sf_e8m0: torch.Tensor, hidden: int
+) -> torch.Tensor:
+    """Dequantize a kernel pool tensor: fp8-e4m3 values + per-32 E8M0 scales
+    (scale cols possibly padded). Returns fp32 ``[rows, hidden]``."""
+    sf_cols = (hidden + MXFP8_BLOCK - 1) // MXFP8_BLOCK
+    scale = torch.exp2(sf_e8m0[:, :sf_cols].view(torch.uint8).float() - 127.0)
+    vals = vals_fp8[:, :hidden].float()
+    return vals * scale.repeat_interleave(MXFP8_BLOCK, dim=-1)[:, :hidden]
+
+
+class _HybridMoEFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, topk_weights, w13, w2, topk_ids, layer):
+        out = layer._fwd(x.detach(), topk_ids, topk_weights.detach())
+        layer._generation += 1
+        ctx.layer = layer
+        ctx.generation = layer._generation
+        ctx.num_tokens = x.shape[0]
+        # topk tensors are saved (tiny) — the pool copies may be repacked by
+        # DataPreprocess, which would scramble the d(topk_weights) layout.
+        ctx.save_for_backward(topk_ids, topk_weights)
+        # The output is a view into the persistent buffer (zeroed next fwd).
+        return out.clone()
+
+    @staticmethod
+    def backward(ctx, dout):
+        layer = ctx.layer
+        topk_ids, topk_weights = ctx.saved_tensors
+        if layer._generation != ctx.generation:
+            raise RuntimeError(
+                "hybrid backward after a later forward overwrote the kernel "
+                f"pools (saved generation {ctx.generation}, current "
+                f"{layer._generation}); run backward before the next forward "
+                "or add a stash ring for gradient accumulation."
+            )
+        T = ctx.num_tokens
+        if layer.bwd_impl == "fp8":
+            from megamoe.fp8_bwd import fp8_backward
+
+            dx, dtw, dw13, dw2 = fp8_backward(layer, topk_ids, topk_weights, dout, T)
+            return dx, dtw, dw13, dw2, None, None
+        if layer.bwd_impl == "pool":
+            from megamoe.bwd_v0 import pool_backward
+
+            dx, dtw, dw13, dw2 = pool_backward(layer, topk_ids, topk_weights, dout, T)
+            return dx, dtw, dw13, dw2, None, None
+        if layer.bwd_impl == "mega":
+            from megamoe.bwd_kernel.backward import (
+                MegaMoeMxfp8Backward,
+                mega_backward,
+            )
+
+            if layer._mega_bwd is None:
+                layer._mega_bwd = MegaMoeMxfp8Backward(layer._fwd, layer.ep_cfg)
+            dx, dtw, dw13, dw2 = mega_backward(layer, topk_ids, topk_weights, dout, T)
+            return dx, dtw, dw13, dw2, None, None
+        fwd = layer._fwd
+
+        # Reuse the pool: the exact quantized activation the kernel consumed.
+        x_q = dequant_mxfp8_pool(
+            fwd.my_activation[:T], fwd.my_activation_sf[:T], layer.ep_cfg.hidden_size
+        ).to(torch.bfloat16)
+
+        tq = layer.qcfg.turboquant
+        with torch.enable_grad():
+            # With turboquant the pool holds the ROTATED quantized activation
+            # (the mixin rotates at staging); replay in the rotated basis with
+            # w13 rotated IN-GRAPH so autograd delivers dW13 in the master
+            # basis, and rotate dX back through Q^T afterwards.
+            xl = x_q.requires_grad_()
+            twl = topk_weights.detach().clone().requires_grad_()
+            w13l = layer.w13.detach().requires_grad_()
+            w2l = layer.w2.detach().requires_grad_()
+            plan = build_routing_plan(topk_ids, layer.ep_cfg, layer.comm)
+            xg = dispatch(xl, plan, layer.comm)
+            w13_eff = rotate_trailing(w13l, layer.q_rot) if tq else w13l
+            yg = grouped_expert_ffn_fp4(
+                xg, plan.tokens_per_expert, w13_eff, w2l,
+                dc_replace(layer.qcfg, turboquant=False), None,
+            )
+            out = combine(yg, twl, plan, torch.bfloat16, layer.comm)
+            dx, dtw, dw13, dw2 = torch.autograd.grad(
+                out, (xl, twl, w13l, w2l), dout
+            )
+        if tq:
+            dx = rotate_trailing(dx, layer.q_rot.t())
+        return dx, dtw, dw13, dw2, None, None
+
+
+class MegaMoeHybridMxfp8Layer(nn.Module):
+    """Trainable EP MoE: MegaMoE MXFP8 mega-kernel forward, torch backward.
+
+    ``w13`` ``[num_local_experts, 2*intermediate, hidden]`` bf16,
+    ``w2`` ``[num_local_experts, hidden, intermediate]`` bf16 — this rank's
+    expert shard, wrapped as master parameters. Call :meth:`refresh_weights`
+    after each optimizer step to re-quantize the masters into the kernel's
+    weight buffers (in-place, no recompile).
+    """
+
+    def __init__(
+        self,
+        ep_cfg: EpConfig,
+        mm_cfg: MegaMoeForwardConfig,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        qcfg: QuantConfig | None = None,
+        comm: str = "torch_dist",
+        bwd_impl: str = "replay",
+    ):
+        """``bwd_impl``: "replay" (autograd fake-quant oracle), "fp8"
+        (manual backward on real torch._scaled_grouped_mm fp8 GEMMs — same
+        gradient semantics, ~bf16-rounding deviations, much faster), or
+        "pool" (fp8 GEMMs fed straight from the kernel's persistent pools +
+        generate_c stash via token_src_metadata — the megakernel dataflow;
+        requires ``mm_cfg.impl.generate_c=True``)."""
+        super().__init__()
+        if bwd_impl not in ("replay", "fp8", "pool", "mega"):
+            raise ValueError(
+                f"bwd_impl must be 'replay', 'fp8', 'pool' or 'mega', got {bwd_impl}"
+            )
+        if bwd_impl in ("pool", "mega") and not mm_cfg.impl.generate_c:
+            raise ValueError(
+                f"bwd_impl={bwd_impl!r} needs mm_cfg.impl.generate_c=True"
+            )
+        if bwd_impl == "mega" and mm_cfg.combine_format != "bf16":
+            raise ValueError("bwd_impl='mega' dtw path needs bf16 combine staging")
+        self.bwd_impl = bwd_impl
+        if (
+            mm_cfg.hidden != ep_cfg.hidden_size
+            or mm_cfg.intermediate != ep_cfg.intermediate_size
+            or mm_cfg.num_total_experts != ep_cfg.num_experts
+            or mm_cfg.num_topk != ep_cfg.top_k
+        ):
+            raise ValueError("ep_cfg and mm_cfg problem shapes disagree")
+        self.ep_cfg = ep_cfg
+        self.qcfg = qcfg or QuantConfig(fprop_fmt="mxfp8", quant_bprop=True)
+        if self.qcfg.fprop_fmt != "mxfp8":
+            raise ValueError("hybrid layer is mxfp8-fprop (kernel format)")
+        self.w13 = w13 if isinstance(w13, nn.Parameter) else nn.Parameter(w13)
+        self.w2 = w2 if isinstance(w2, nn.Parameter) else nn.Parameter(w2)
+        self.comm: TokenComm = create_comm(comm, group=ep_cfg.process_group)
+        if self.qcfg.turboquant:
+            # TurboQuant training: masters stay UNROTATED. The kernel mixin
+            # rotates activations at staging and folds Q into fc1 weights at
+            # load_weights; backward rotates dX / dW13 back through Q^T.
+            if ep_cfg.hidden_size % self.qcfg.rotation_block:
+                raise ValueError(
+                    f"hidden_size ({ep_cfg.hidden_size}) must be a multiple "
+                    f"of rotation_block ({self.qcfg.rotation_block})"
+                )
+            from megamoe.turboquant import MegaMoeTurboQuantForward
+
+            self._fwd = MegaMoeTurboQuantForward(
+                mm_cfg, rank=ep_cfg.ep_rank, world_size=ep_cfg.ep_size,
+                rotation_block=self.qcfg.rotation_block,
+                rotation_seed=self.qcfg.rotation_seed,
+            )
+            self.register_buffer(
+                "q_rot",
+                make_rotation(
+                    self.qcfg.rotation_block, self.qcfg.rotation_seed,
+                    device=self.w13.device,
+                ),
+            )
+        else:
+            self._fwd = MegaMoeMxfp8Forward(
+                mm_cfg, rank=ep_cfg.ep_rank, world_size=ep_cfg.ep_size
+            )
+            self.q_rot = None
+        self._generation = 0
+        self._bwd_wcache = None
+        self._mega_bwd = None
+        self.refresh_weights()
+
+    def refresh_weights(self) -> None:
+        """Quantize the bf16 masters into the kernel's persistent buffers
+        (and invalidate the fp8 backward's cached weight quantizations)."""
+        with torch.no_grad():
+            self._fwd.load_weights(self.w13.data, self.w2.data)
+        self._bwd_wcache = None
+        self._pool_bwd_wcache = None
+        self._mega_bwd_wdirty = True
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        return _HybridMoEFn.apply(
+            hidden_states, topk_weights, self.w13, self.w2, topk_ids, self
+        )
+
+    def finalize(self) -> None:
+        self._fwd.finalize()

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/turboquant.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/turboquant.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""TurboQuant-style incoherence processing for the MegaMoE forward.
+
+Randomized block-Hadamard rotation of the hidden dimension (DRIVE/EDEN/
+QuaRot/TurboQuant lineage): rotate activations by an orthogonal Q before
+MXFP8 quantization and fold Q into the fc1 weight rows offline, so
+``(x Q) @ (W1^T Q)^T == x @ W1^T`` exactly.  The rotation spreads
+per-channel outliers across each 128-wide block, so the per-32 E8M0 block
+scales waste fewer bits on a single hot channel — better quant SNR on
+BOTH the dispatch wire payload and the fc1 GEMM A-operand, at the cost of
+one small block-diagonal bmm on the activation per forward.
+
+The rotation lives entirely outside the kernel: only the bytes fed to
+``DataPreprocess`` / ``load_weights`` change.  fc2 and the combine path are
+untouched (the SwiGLU intermediate is requantized inside the kernel, and
+the fc2 output leaves the rotated basis by construction).
+
+Q = diag(rademacher_signs) @ H_b / sqrt(b), block-diagonal over
+``hidden / b`` blocks with the same b x b block (b=128 aligns with 4
+adjacent 32-wide scale blocks). Seed-deterministic, identical on every
+rank (weights and activations must share Q).
+"""
+
+import math
+
+import torch
+
+import megamoe.repo_path  # noqa: F401
+
+from megamoe.forward import MegaMoeMxfp8Forward, MegaMoeForwardConfig  # noqa: F401
+
+
+def hadamard_matrix(n: int, device="cuda") -> torch.Tensor:
+    """Sylvester Hadamard matrix (n a power of two), entries +-1, fp32."""
+    if n & (n - 1):
+        raise ValueError(f"hadamard_matrix needs a power of two, got {n}.")
+    h = torch.ones((1, 1), dtype=torch.float32, device=device)
+    while h.shape[0] < n:
+        h = torch.cat(
+            [torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0
+        )
+    return h
+
+
+def make_rotation(block: int = 128, seed: int = 20260712, device="cuda") -> torch.Tensor:
+    """Orthogonal randomized-Hadamard block: Q = diag(signs) @ H / sqrt(b)."""
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    signs = (torch.randint(0, 2, (block,), generator=gen) * 2 - 1).float().to(device)
+    return (signs[:, None] * hadamard_matrix(block, device)) / math.sqrt(block)
+
+
+def rotate_hidden(t: torch.Tensor, q: torch.Tensor) -> torch.Tensor:
+    """Rotate the trailing (hidden) dim block-diagonally by q (b x b), fp32 math."""
+    b = q.shape[0]
+    *lead, hidden = t.shape
+    if hidden % b:
+        raise ValueError(f"hidden ({hidden}) must be a multiple of block ({b}).")
+    out = t.reshape(-1, hidden // b, b).float() @ q
+    return out.reshape(*lead, hidden)
+
+
+class TurboQuantMixin:
+    """fc1-side randomized-Hadamard incoherence, format-agnostic.
+
+    The rotation is FUSED into the staging write: instead of copy_(x), the
+    staging buffer is produced by one (T*hidden/b, b) x (b, b) bf16 GEMM with
+    ``out=`` — no extra pass over the activation, so the marginal cost over
+    the plain forward is just GEMM-vs-copy on the same bytes.
+    load_weights rotates w13's hidden dim (one-time, fp32).
+    Compose left of a concrete forward class (mxfp8 / nvfp4).
+    """
+
+    def __init__(self, cfg, *, rank, world_size, rotation_block: int = 128,
+                 rotation_seed: int = 20260712, **kwargs):
+        if cfg.hidden % rotation_block:
+            raise ValueError(
+                f"hidden ({cfg.hidden}) must be a multiple of rotation_block "
+                f"({rotation_block})."
+            )
+        super().__init__(cfg, rank=rank, world_size=world_size, **kwargs)
+        self.q_fp32 = make_rotation(rotation_block, rotation_seed)
+        self.q_bf16 = self.q_fp32.bfloat16()
+        self.rotation_block = rotation_block
+
+    def load_weights(self, w13: torch.Tensor, w2: torch.Tensor) -> None:
+        # Fold Q into fc1's K(hidden) axis; w2 is untouched (its K is the
+        # intermediate dim, whose quant lives inside the kernel).
+        super().load_weights(rotate_hidden(w13, self.q_fp32), w2)
+
+    def _stage_input(self, x, T):
+        b = self.rotation_block
+        torch.matmul(
+            x.to(torch.bfloat16).reshape(-1, b), self.q_bf16,
+            out=self.x_staging[:T].view(-1, b),
+        )
+
+
+class MegaMoeTurboQuantForward(TurboQuantMixin, MegaMoeMxfp8Forward):
+    """MXFP8 forward + incoherence."""
+
+
+from megamoe.forward_nvfp4 import MegaMoeNvfp4Forward  # noqa: E402
+
+
+class MegaMoeTurboQuantNvfp4Forward(TurboQuantMixin, MegaMoeNvfp4Forward):
+    """NVFP4 (4-bit dispatch) forward + incoherence — the combination
+    turboquant exists for: 4-bit outlier damage is catastrophic without
+    rotation."""

--- a/python/cudnn/moe_ep/_megamoe_backend/megamoe/weights.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/megamoe/weights.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""bf16 expert weights -> the MXFP8 layout the MegaMoE kernel consumes.
+
+Input convention (matches `pt/` and flashinfer.moe_ep):
+
+  w13  [E, 2*I, H]  rows [:I] = linear/up projection, rows [I:] = gate;
+                    activation is silu(gate) * linear.
+  w2   [E, H, I]    down projection.
+
+Kernel convention (see moe_mxfp8_glu/mega_runner.py + mega_reference_mxfp8.py):
+
+  fc1_weight     logical (E, hidden, 2*I) with hidden stride-1 (K-major);
+                 the N=2*I axis interleaves gate/up in 32-wide blocks:
+                 [gate_block0 | up_block0 | gate_block1 | up_block1 | ...]
+                 ("PostSwigluHalf" interleave, Mxfp8BlockSize granularity).
+  fc2_weight     logical (E, I, hidden) with I stride-1 (K-major).
+  *_weight_sf    per-expert 32x4x4 atom-swizzled flat E8M0 tensors
+                 (`to_blocked`); the plain per-32-block SFs are kept too so
+                 host references can dequantize.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+import megamoe.repo_path  # noqa: F401  (sys.path side effect)
+
+from common.host_utils import mxfp8_quantize_per_block_32
+from common.megamoe_constants import Mxfp8BlockSize
+from moe_nvfp4_swapab.runner_common import (
+    to_blocked,
+    _stack_byte_reinterpretable_tensors,
+)
+
+_KIND_TO_TORCH_DTYPE = {
+    "mxfp8_e4m3": torch.float8_e4m3fn,
+    "mxfp8_e5m2": torch.float8_e5m2,
+}
+
+
+@dataclass
+class QuantizedExpertWeights:
+    """Kernel-ready weights (+ plain SFs for host reference dequant)."""
+
+    fc1_weight: torch.Tensor        # (E, H, 2I) fp8 view, H stride-1
+    fc1_weight_sf: torch.Tensor     # (E, flat) E8M0, atom-swizzled
+    fc2_weight: torch.Tensor        # (E, I, H) fp8 view, I stride-1
+    fc2_weight_sf: torch.Tensor     # (E, flat) E8M0, atom-swizzled
+    fc1_weight_sf_plain: torch.Tensor  # (E, 2I, H//32) E8M0
+    fc2_weight_sf_plain: torch.Tensor  # (E, H, I//32) E8M0
+
+
+def interleave_gate_up(w13: torch.Tensor) -> torch.Tensor:
+    """[E, 2I, H] ([:I]=up/linear, [I:]=gate) -> kernel N-interleaved [E, 2I, H]."""
+    E, two_i, H = w13.shape
+    I = two_i // 2
+    if I % Mxfp8BlockSize != 0:
+        raise ValueError(f"intermediate ({I}) must be a multiple of {Mxfp8BlockSize}.")
+    up = w13[:, :I].reshape(E, I // Mxfp8BlockSize, Mxfp8BlockSize, H)
+    gate = w13[:, I:].reshape(E, I // Mxfp8BlockSize, Mxfp8BlockSize, H)
+    # pair order (gate, up): mega_reference_mxfp8 splits _reshaped[:, :, 0]=gate,
+    # [:, :, 1]=up.
+    inter = torch.stack((gate, up), dim=2)  # (E, I/32, 2, 32, H)
+    return inter.reshape(E, two_i, H)
+
+
+def quantize_moe_weights_mxfp8(
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    kind: str = "mxfp8_e4m3",
+) -> QuantizedExpertWeights:
+    """Quantize bf16/fp32 expert weights into the kernel's MXFP8 layout."""
+    data_dtype = _KIND_TO_TORCH_DTYPE[kind]
+    E, two_i, H = w13.shape
+    I = two_i // 2
+    if w2.shape != (E, H, I):
+        raise ValueError(f"w2 must be (E={E}, H={H}, I={I}), got {tuple(w2.shape)}.")
+    if H % Mxfp8BlockSize != 0 or I % Mxfp8BlockSize != 0:
+        raise ValueError(
+            f"hidden ({H}) and intermediate ({I}) must be multiples of "
+            f"{Mxfp8BlockSize}."
+        )
+
+    # fc1: interleave gate/up, quantize along K=hidden in 32-blocks.
+    fc1_bf16 = interleave_gate_up(w13).float().cuda()
+    fc1_q, fc1_sf = mxfp8_quantize_per_block_32(fc1_bf16.reshape(E * two_i, H), data_dtype)
+    fc1_q = fc1_q.reshape(E, two_i, H)
+    fc1_sf_plain = fc1_sf.reshape(E, two_i, H // Mxfp8BlockSize)
+    # (E, 2I, H) contiguous -> logical (E, H, 2I), hidden stride-1.  Do NOT
+    # .contiguous() -- the K-as-stride-1 invariant is what the kernel expects.
+    fc1_weight = fc1_q.permute(0, 2, 1)
+
+    # fc2: quantize along K=intermediate in 32-blocks.
+    fc2_f32 = w2.float().cuda()
+    fc2_q, fc2_sf = mxfp8_quantize_per_block_32(fc2_f32.reshape(E * H, I), data_dtype)
+    fc2_q = fc2_q.reshape(E, H, I)
+    fc2_sf_plain = fc2_sf.reshape(E, H, I // Mxfp8BlockSize)
+    fc2_weight = fc2_q.permute(0, 2, 1)  # logical (E, I, H), I stride-1
+
+    # 32x4x4 atom swizzle per expert (what the TMA SFA descriptor reads).
+    fc1_sf_sw = _stack_byte_reinterpretable_tensors(
+        [to_blocked(fc1_sf_plain[e]) for e in range(E)], dim=0
+    )
+    fc2_sf_sw = _stack_byte_reinterpretable_tensors(
+        [to_blocked(fc2_sf_plain[e]) for e in range(E)], dim=0
+    )
+
+    return QuantizedExpertWeights(
+        fc1_weight=fc1_weight,
+        fc1_weight_sf=fc1_sf_sw,
+        fc2_weight=fc2_weight,
+        fc2_weight_sf=fc2_sf_sw,
+        fc1_weight_sf_plain=fc1_sf_plain,
+        fc2_weight_sf_plain=fc2_sf_plain,
+    )

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/__init__.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Transparent pure-PyTorch MoE-EP with autograd (training bprop oracle).
+
+See moe_ep_training/README.md for layout and conventions.
+"""
+
+from .config import EpConfig
+from .layer import MoEEpTrainingLayer
+from .layer_fp4 import MoEEpTrainingLayerFp4
+from .quant import QuantConfig
+from .reference import ReferenceMoE
+from .reference_fp4 import ReferenceMoEFp4
+
+__all__ = [
+    "EpConfig",
+    "MoEEpTrainingLayer",
+    "MoEEpTrainingLayerFp4",
+    "QuantConfig",
+    "ReferenceMoE",
+    "ReferenceMoEFp4",
+]

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/comm/__init__.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/comm/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+from .base import TokenComm, create_comm, register_comm
+from . import torch_dist as _torch_dist  # noqa: F401  (registers "torch_dist")
+
+__all__ = ["TokenComm", "create_comm", "register_comm"]

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/comm/base.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/comm/base.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Pluggable token-exchange interface for the EP dispatch/combine comm.
+
+The layer only ever talks to :class:`TokenComm`; ``torch_dist`` (c10d
+``all_to_all_single``) is the baseline oracle backend, and an NVSHMEM
+symmetric-heap backend will implement the same interface later so the
+transparent layer and the future megakernel share one comm contract.
+
+Contract:
+
+- ``all_to_all(x, output_splits, input_splits)`` is DIFFERENTIABLE. Its
+  backward must be the adjoint exchange: the same all-to-all with
+  ``input_splits`` and ``output_splits`` swapped (grads flow back to the
+  ranks that sent the corresponding rows).
+- ``all_to_all_no_grad`` is the same data movement for non-differentiable
+  payloads (routing metadata such as expert ids).
+- ``exchange_counts(send_counts)`` swaps a per-destination-rank int64 count
+  vector so each rank learns its per-source receive counts. Not
+  differentiable.
+
+Split sizes are Python ints (row counts per rank), so building them forces a
+device->host sync once per dispatch — accepted cost for the transparent
+version.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, Sequence
+
+import torch
+
+
+class TokenComm(ABC):
+    """Row-wise all-to-all over the EP group."""
+
+    @abstractmethod
+    def all_to_all(
+        self,
+        x: torch.Tensor,
+        output_splits: Sequence[int],
+        input_splits: Sequence[int],
+    ) -> torch.Tensor:
+        """Differentiable uneven all-to-all along dim 0.
+
+        ``x`` has ``sum(input_splits)`` rows grouped by destination rank in
+        ascending rank order; the result has ``sum(output_splits)`` rows
+        grouped by source rank in ascending rank order.
+        """
+
+    @abstractmethod
+    def all_to_all_no_grad(
+        self,
+        x: torch.Tensor,
+        output_splits: Sequence[int],
+        input_splits: Sequence[int],
+    ) -> torch.Tensor:
+        """Same exchange for non-differentiable payloads (metadata)."""
+
+    @abstractmethod
+    def exchange_counts(self, send_counts: torch.Tensor) -> torch.Tensor:
+        """Exchange a ``[ep_size]`` int64 per-rank count vector.
+
+        Entry ``r`` of the input is the number of rows this rank will send to
+        rank ``r``; entry ``r`` of the result is the number of rows this rank
+        will receive from rank ``r``.
+        """
+
+
+_COMM_REGISTRY: Dict[str, Callable[..., TokenComm]] = {}
+
+
+def register_comm(name: str) -> Callable[[Callable[..., TokenComm]], Callable[..., TokenComm]]:
+    def deco(factory: Callable[..., TokenComm]) -> Callable[..., TokenComm]:
+        if name in _COMM_REGISTRY:
+            raise ValueError(f"comm backend {name!r} already registered")
+        _COMM_REGISTRY[name] = factory
+        return factory
+
+    return deco
+
+
+def create_comm(name: str, **kwargs) -> TokenComm:
+    try:
+        factory = _COMM_REGISTRY[name]
+    except KeyError:
+        raise ValueError(
+            f"unknown comm backend {name!r}; available: {sorted(_COMM_REGISTRY)}"
+        ) from None
+    return factory(**kwargs)

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/comm/torch_dist.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/comm/torch_dist.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""c10d (torch.distributed) TokenComm backend.
+
+The only custom autograd op in the whole EP layer lives here: raw c10d
+collectives are not differentiable, so ``_AllToAllSingle`` provides the
+adjoint explicitly — backward is the same ``all_to_all_single`` with input
+and output split sizes swapped. Everything around it (permutations, top-k
+replication, weighted combine) is autograd-native, which makes the full
+dispatch/combine backward readable directly from the forward code.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import torch
+import torch.distributed as dist
+
+from .base import TokenComm, register_comm
+
+
+def _all_to_all_single(
+    x: torch.Tensor,
+    output_splits: Sequence[int],
+    input_splits: Sequence[int],
+    group: Optional[dist.ProcessGroup],
+) -> torch.Tensor:
+    out = x.new_empty((sum(output_splits),) + tuple(x.shape[1:]))
+    dist.all_to_all_single(
+        out,
+        x.contiguous(),
+        output_split_sizes=list(output_splits),
+        input_split_sizes=list(input_splits),
+        group=group,
+    )
+    return out
+
+
+class _AllToAllSingle(torch.autograd.Function):
+    """Differentiable uneven all-to-all; backward = adjoint exchange."""
+
+    @staticmethod
+    def forward(ctx, x, output_splits, input_splits, group):
+        ctx.output_splits = tuple(output_splits)
+        ctx.input_splits = tuple(input_splits)
+        ctx.group = group
+        return _all_to_all_single(x, output_splits, input_splits, group)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        # Rows this rank sent to rank r in forward came back as grad rows
+        # from rank r here: swap the split-size lists.
+        grad_in = _all_to_all_single(
+            grad_out, ctx.input_splits, ctx.output_splits, ctx.group
+        )
+        return grad_in, None, None, None
+
+
+@register_comm("torch_dist")
+class TorchDistComm(TokenComm):
+    def __init__(self, group: Optional[dist.ProcessGroup] = None):
+        if not dist.is_available() or not dist.is_initialized():
+            raise RuntimeError(
+                "torch_dist comm backend requires torch.distributed to be "
+                "initialized (init_process_group) before layer construction"
+            )
+        self._group = group
+
+    def all_to_all(self, x, output_splits, input_splits):
+        return _AllToAllSingle.apply(x, output_splits, input_splits, self._group)
+
+    def all_to_all_no_grad(self, x, output_splits, input_splits):
+        with torch.no_grad():
+            return _all_to_all_single(x, output_splits, input_splits, self._group)
+
+    def exchange_counts(self, send_counts):
+        recv_counts = torch.empty_like(send_counts)
+        dist.all_to_all_single(recv_counts, send_counts.contiguous(), group=self._group)
+        return recv_counts

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/config.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/config.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""EP sizing + sharding config for the transparent PyTorch MoE-EP layer.
+
+Deliberately much smaller than flashinfer's ``BootstrapConfig`` /
+``FleetParams``: no transport knobs, no capacity (``max_tokens_per_rank``) —
+the training path is dropless, so buffers are sized by the actual routed
+token counts each iteration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    import torch.distributed
+
+
+@dataclass(frozen=True)
+class EpConfig:
+    """Expert-parallel MoE sizing.
+
+    ``ep_size`` / ``ep_rank`` describe the EP comm domain (analogue of
+    ``BootstrapConfig.world_size`` / ``rank``). ``process_group`` is the
+    torch process group to run collectives on; ``None`` means the default
+    (WORLD) group. Expert ``e`` is owned by rank ``e // num_local_experts``
+    (contiguous sharding, matching flashinfer moe_ep).
+    """
+
+    num_experts: int
+    top_k: int
+    hidden_size: int
+    intermediate_size: int
+    ep_size: int
+    ep_rank: int
+    process_group: Optional["torch.distributed.ProcessGroup"] = field(
+        default=None, compare=False, hash=False
+    )
+
+    def __post_init__(self) -> None:
+        for name in ("num_experts", "top_k", "hidden_size", "intermediate_size", "ep_size"):
+            v = getattr(self, name)
+            if v <= 0:
+                raise ValueError(f"EpConfig.{name} must be positive, got {v}")
+        if not (0 <= self.ep_rank < self.ep_size):
+            raise ValueError(f"ep_rank {self.ep_rank} not in [0, {self.ep_size})")
+        if self.num_experts % self.ep_size != 0:
+            raise ValueError(
+                f"num_experts ({self.num_experts}) must be divisible by "
+                f"ep_size ({self.ep_size})"
+            )
+        if self.top_k > self.num_experts:
+            raise ValueError(
+                f"top_k ({self.top_k}) must be <= num_experts ({self.num_experts})"
+            )
+
+    @property
+    def num_local_experts(self) -> int:
+        return self.num_experts // self.ep_size
+
+    @property
+    def first_local_expert(self) -> int:
+        """Global id of this rank's first local expert."""
+        return self.ep_rank * self.num_local_experts

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/dispatch_combine.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/dispatch_combine.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Differentiable dispatch / combine around the token all-to-all.
+
+Forward data path (mirrors flashinfer moe_ep's split mode):
+
+    dispatch:  x[T,H] --replicate by top-k & sort by dest expert-->
+               a2a --> arrivals[R,H] --group by local expert--> x_grouped
+    combine:   y_grouped --ungroup--> a2a (reversed splits) -->
+               unsort --> [T,K,H] --fp32 top-k weighted sum--> out[T,H]
+
+Backward comes out as the exact adjoint by construction:
+
+- gather ``x[copy_token_idx]`` <-> scatter-add over the K copies of a token
+- the all-to-all's backward is the swapped-splits all-to-all
+  (see comm/torch_dist.py)
+- the fp32 weighted sum routes grads to both ``y`` and ``topk_weights``
+
+so dispatch.backward is combine-shaped and combine.backward is
+dispatch-shaped — the property the future megakernel bprop must reproduce.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .comm.base import TokenComm
+from .routing import RoutingPlan
+
+
+def dispatch(
+    x: torch.Tensor, plan: RoutingPlan, comm: TokenComm
+) -> torch.Tensor:
+    """Route ``x [T, hidden]`` to expert owners.
+
+    Returns ``x_grouped [num_recv_tokens, hidden]`` on this rank, grouped by
+    local expert (layout consumed by :func:`experts.grouped_expert_ffn`).
+    """
+    # Replicate each token for its top-k destinations, already in
+    # dest-expert-sorted order. Differentiable: backward scatter-adds the K
+    # copies' grads back into each source token row.
+    x_sorted = x[plan.copy_token_idx]  # [T*K, hidden]
+    x_recv = comm.all_to_all(x_sorted, plan.output_splits, plan.input_splits)
+    # Arrival order -> grouped-by-local-expert order.
+    return x_recv[plan.recv_sort_idx]
+
+
+def combine(
+    y_grouped: torch.Tensor,
+    topk_weights: torch.Tensor,
+    plan: RoutingPlan,
+    out_dtype: torch.dtype,
+    comm: TokenComm,
+) -> torch.Tensor:
+    """Return expert outputs to source ranks and reduce over top-k.
+
+    ``y_grouped`` is ``[num_recv_tokens, hidden]`` in grouped-by-local-expert
+    order; ``topk_weights`` is ``[T, K]`` (fp32 recommended; grads flow to it
+    through the reweighting). Returns ``out [T, hidden]`` in ``out_dtype``.
+    """
+    # Grouped order -> arrival order, then the reverse exchange (splits
+    # swapped relative to dispatch).
+    y_recv = y_grouped[plan.inv_recv_sort_idx]
+    y_sorted = comm.all_to_all(y_recv, plan.input_splits, plan.output_splits)
+    # Sorted-copy order -> original (token-major) copy order.
+    y_flat = y_sorted[plan.inv_sort_idx]  # [T*K, hidden]
+
+    num_tokens, top_k = topk_weights.shape
+    y_tk = y_flat.view(num_tokens, top_k, -1)
+    out = (y_tk.float() * topk_weights.float().unsqueeze(-1)).sum(dim=1)
+    return out.to(out_dtype)

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/experts.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/experts.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Grouped SiLU-GLU expert FFN, shared by the EP layer and the reference.
+
+Weight layout matches flashinfer's canonical ``MoEWeightPack``:
+
+- ``w13`` ``[num_experts, 2*intermediate, hidden]``; ``fc1 = x @ w13[e].T``
+  splits as ``linear = fc1[:, :intermediate]``, ``gate = fc1[:, intermediate:]``
+  and the activation is ``silu(gate) * linear`` (same split as
+  flashinfer-moe_ep/tests/moe_ep/test_moe_ep_compute_correctness.py).
+- ``w2`` ``[num_experts, hidden, intermediate]``; ``y = act @ w2[e].T``.
+
+Fully autograd-native. Empty segments still run their (M=0) GEMMs so every
+expert's weights participate in the graph and get well-defined zero grads.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+import torch.nn.functional as F
+
+
+def expert_ffn(x: torch.Tensor, w13_e: torch.Tensor, w2_e: torch.Tensor) -> torch.Tensor:
+    """One expert's FFN on its ``[n, hidden]`` token slab (n may be 0)."""
+    fc1 = x @ w13_e.t()  # [n, 2*intermediate]
+    linear, gate = fc1.chunk(2, dim=-1)
+    return (F.silu(gate) * linear) @ w2_e.t()  # [n, hidden]
+
+
+def grouped_expert_ffn(
+    x_grouped: torch.Tensor,
+    tokens_per_expert: Sequence[int],
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+) -> torch.Tensor:
+    """FFN over a token slab pre-grouped by expert.
+
+    ``x_grouped`` is ``[N, hidden]`` where rows ``[offset_e, offset_e + n_e)``
+    all belong to expert ``e`` (offsets from ``tokens_per_expert``). Returns
+    the same layout.
+    """
+    if len(tokens_per_expert) != w13.shape[0]:
+        raise ValueError(
+            f"tokens_per_expert has {len(tokens_per_expert)} entries but "
+            f"w13 has {w13.shape[0]} experts"
+        )
+    if sum(tokens_per_expert) != x_grouped.shape[0]:
+        raise ValueError(
+            f"tokens_per_expert sums to {sum(tokens_per_expert)} but "
+            f"x_grouped has {x_grouped.shape[0]} rows"
+        )
+    outs = []
+    start = 0
+    for e, n in enumerate(tokens_per_expert):
+        outs.append(expert_ffn(x_grouped[start : start + n], w13[e], w2[e]))
+        start += n
+    if not outs:
+        return x_grouped.new_zeros((0, w2.shape[1]))
+    return torch.cat(outs, dim=0)

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/experts_fp4.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/experts_fp4.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Simulated-NVFP4 grouped SiLU-GLU expert FFN — quantized twin of experts.py.
+
+Same weight layout and grouping contract as :mod:`pt.experts`; both GEMMs
+per expert go through :class:`pt.quant.QuantGemmT` (fake-quantized operands,
+fp32 accumulate). With ``qcfg.turboquant`` the fc1 hidden dim is rotated by
+a randomized-Hadamard block Q, applied IN-GRAPH to both the token slab and
+w13 — mathematically a no-op pre-quantization, and autograd supplies the
+exact adjoint so master weights stay unrotated. fc2 is untouched (its K is
+the intermediate dim), mirroring megamoe/turboquant.py.
+
+Note: here the rotation/quantization happens after dispatch (per-token ops
+commute with the permutation), so the pt path's all-to-all wire stays bf16;
+the megamoe kernel's 4-bit wire has the same numerics as fc1's quantized
+A-operand, which IS modeled.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import torch
+import torch.nn.functional as F
+
+from .quant import QuantConfig, QuantGemmT, rotate_trailing
+
+
+def expert_ffn_fp4(
+    x: torch.Tensor, w13_e: torch.Tensor, w2_e: torch.Tensor, qcfg: QuantConfig
+) -> torch.Tensor:
+    """One expert's FFN on its ``[n, hidden]`` token slab (n may be 0)."""
+    fc1 = QuantGemmT.apply(
+        x, w13_e, qcfg.fprop_fmt, qcfg.bprop_fmt,
+        qcfg.quant_bprop, qcfg.stochastic_rounding_grads,
+    )
+    linear, gate = fc1.chunk(2, dim=-1)
+    return QuantGemmT.apply(
+        F.silu(gate) * linear, w2_e, qcfg.fprop_fmt, qcfg.bprop_fmt,
+        qcfg.quant_bprop, qcfg.stochastic_rounding_grads,
+    )
+
+
+def grouped_expert_ffn_fp4(
+    x_grouped: torch.Tensor,
+    tokens_per_expert: Sequence[int],
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    qcfg: QuantConfig,
+    q_rot: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Quantized FFN over a token slab pre-grouped by expert (same contract
+    as :func:`pt.experts.grouped_expert_ffn`)."""
+    if len(tokens_per_expert) != w13.shape[0]:
+        raise ValueError(
+            f"tokens_per_expert has {len(tokens_per_expert)} entries but "
+            f"w13 has {w13.shape[0]} experts"
+        )
+    if sum(tokens_per_expert) != x_grouped.shape[0]:
+        raise ValueError(
+            f"tokens_per_expert sums to {sum(tokens_per_expert)} but "
+            f"x_grouped has {x_grouped.shape[0]} rows"
+        )
+    if qcfg.turboquant:
+        if q_rot is None:
+            raise ValueError("qcfg.turboquant requires q_rot")
+        x_grouped = rotate_trailing(x_grouped, q_rot)
+        w13 = rotate_trailing(w13, q_rot)
+    outs = []
+    start = 0
+    for e, n in enumerate(tokens_per_expert):
+        outs.append(expert_ffn_fp4(x_grouped[start : start + n], w13[e], w2[e], qcfg))
+        start += n
+    if not outs:
+        return x_grouped.new_zeros((0, w2.shape[1]))
+    return torch.cat(outs, dim=0)

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/layer.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/layer.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""MoEEpTrainingLayer — transparent EP MoE with autograd.
+
+The training analogue of flashinfer's ``MoEEpSplitLayer``:
+dispatch -> grouped expert FFN -> combine, all differentiable.
+
+Each rank holds only its local experts' weights (``w13`` / ``w2`` in the
+canonical flashinfer layout, sliced to ``num_local_experts``). Inputs are
+per-rank token shards; ``forward`` returns the combined MoE output for this
+rank's tokens and autograd produces:
+
+- ``hidden_states.grad``   (dX, flows back through combine->FFN->dispatch)
+- ``w13.grad`` / ``w2.grad`` (local expert wgrads, already summed over every
+  rank's tokens that routed here — no extra reduction needed)
+- ``topk_weights.grad``    (router gradient, via the combine reweighting)
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .comm import TokenComm, create_comm
+from .config import EpConfig
+from .dispatch_combine import combine, dispatch
+from .experts import grouped_expert_ffn
+from .routing import RoutingPlan, build_routing_plan
+
+
+class MoEEpTrainingLayer(nn.Module):
+    def __init__(
+        self,
+        cfg: EpConfig,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        comm: str = "torch_dist",
+    ):
+        """``w13`` ``[num_local_experts, 2*intermediate, hidden]``,
+        ``w2`` ``[num_local_experts, hidden, intermediate]`` — this rank's
+        expert shard. Tensors are wrapped as parameters (not copied) unless
+        they already are parameters.
+        """
+        super().__init__()
+        expected_w13 = (cfg.num_local_experts, 2 * cfg.intermediate_size, cfg.hidden_size)
+        expected_w2 = (cfg.num_local_experts, cfg.hidden_size, cfg.intermediate_size)
+        if tuple(w13.shape) != expected_w13:
+            raise ValueError(f"w13 shape {tuple(w13.shape)} != {expected_w13}")
+        if tuple(w2.shape) != expected_w2:
+            raise ValueError(f"w2 shape {tuple(w2.shape)} != {expected_w2}")
+        self.cfg = cfg
+        self.w13 = w13 if isinstance(w13, nn.Parameter) else nn.Parameter(w13)
+        self.w2 = w2 if isinstance(w2, nn.Parameter) else nn.Parameter(w2)
+        self.comm: TokenComm = create_comm(comm, group=cfg.process_group)
+        self.last_plan: RoutingPlan | None = None  # exposed for tests/debug
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        """``hidden_states [T, hidden]``, ``topk_ids [T, K]`` int,
+        ``topk_weights [T, K]`` float (fp32 recommended). Returns
+        ``[T, hidden]`` in ``hidden_states.dtype``.
+
+        Collective: every EP rank must call forward (and backward) each
+        iteration, even with T=0, since dispatch/combine are all-to-alls.
+        """
+        cfg = self.cfg
+        if hidden_states.dim() != 2 or hidden_states.shape[1] != cfg.hidden_size:
+            raise ValueError(
+                f"hidden_states must be [T, {cfg.hidden_size}], "
+                f"got {tuple(hidden_states.shape)}"
+            )
+        if topk_ids.shape != topk_weights.shape or topk_ids.shape[0] != hidden_states.shape[0]:
+            raise ValueError("topk_ids / topk_weights must both be [T, top_k]")
+
+        plan = build_routing_plan(topk_ids, cfg, self.comm)
+        self.last_plan = plan
+
+        x_grouped = dispatch(hidden_states, plan, self.comm)
+        y_grouped = self._ffn(x_grouped, plan.tokens_per_expert)
+        return combine(
+            y_grouped, topk_weights, plan, hidden_states.dtype, self.comm
+        )
+
+    def _ffn(self, x_grouped: torch.Tensor, tokens_per_expert) -> torch.Tensor:
+        """Expert-compute hook; quantized variants (layer_fp4) override this."""
+        return grouped_expert_ffn(x_grouped, tokens_per_expert, self.w13, self.w2)

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/layer_fp4.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/layer_fp4.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""MoEEpTrainingLayerFp4 — the EP training layer with simulated-NVFP4
+expert GEMMs (optionally + TurboQuant rotation, quantized bprop, stochastic
+rounding on grads). See pt/quant.py for what is and isn't modeled.
+
+Drop-in for :class:`pt.layer.MoEEpTrainingLayer`: identical dispatch /
+combine / routing and gradient contract; only the expert FFN hook changes.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .config import EpConfig
+from .experts_fp4 import grouped_expert_ffn_fp4
+from .layer import MoEEpTrainingLayer
+from .quant import QuantConfig, make_rotation
+
+
+class MoEEpTrainingLayerFp4(MoEEpTrainingLayer):
+    def __init__(
+        self,
+        cfg: EpConfig,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        qcfg: QuantConfig | None = None,
+        comm: str = "torch_dist",
+    ):
+        super().__init__(cfg, w13, w2, comm)
+        self.qcfg = qcfg or QuantConfig()
+        if self.qcfg.turboquant:
+            if cfg.hidden_size % self.qcfg.rotation_block:
+                raise ValueError(
+                    f"hidden_size ({cfg.hidden_size}) must be a multiple of "
+                    f"rotation_block ({self.qcfg.rotation_block})"
+                )
+            # Seed-deterministic => identical on every rank, like megamoe.
+            self.register_buffer(
+                "q_rot",
+                make_rotation(
+                    self.qcfg.rotation_block,
+                    self.qcfg.rotation_seed,
+                    device=self.w13.device,
+                ),
+            )
+        else:
+            self.q_rot = None
+
+    def _ffn(self, x_grouped: torch.Tensor, tokens_per_expert) -> torch.Tensor:
+        return grouped_expert_ffn_fp4(
+            x_grouped, tokens_per_expert, self.w13, self.w2, self.qcfg, self.q_rot
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/quant.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/quant.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""NVFP4 / MXFP8 fake-quantization + TurboQuant rotation for the pt path.
+
+Simulated (quantize-dequantize) block formats, mirroring the megamoe
+kernels' schemes:
+
+- **nvfp4**: E2M1 values in per-16 blocks, FP8-E4M3 block scales, one fp32
+  per-tensor scale (cutedsl_megamoe/moe_nvfp4_swapab/runner_common.py's
+  ``nvfp4_quantize_per_block_16``);
+- **mxfp8**: E4M3 values in per-32 blocks, E8M0 shared scales with the same
+  ceil-log2 convention as cutedsl_megamoe's ``mxfp8_quantize_per_block_32``.
+
+GEMMs run in fp32 on dequantized operands,
+so this path answers the ACCURACY question of fp4 training only — it is
+slower than the bf16 path, not faster; the speed arrives with a real fp4
+bprop megakernel, for which this path is the numerics spec.
+
+Deliberate differences vs the kernel:
+
+- the per-tensor scale is the per-GEMM-call amax (no cross-rank MIN-reduced
+  global norm_const) — the outer scale is fp32, so this has negligible
+  accuracy effect;
+- round-to-nearest ties break toward the lower-magnitude grid point
+  (hardware E2M1 casts are ties-to-even; ties are measure-zero here).
+
+Backward modes (:class:`QuantConfig`):
+
+- ``quant_bprop=False`` (default): straight-through — grads are the EXACT
+  gradients of the quantized forward, computed on the dequantized forward
+  operands (``dX = dY @ Q(W)``, ``dW = dY^T @ Q(X)``).
+- ``quant_bprop=True``: additionally NVFP4-quantize every backward GEMM's
+  operands along that GEMM's contraction dim (``dY`` along out-features for
+  dgrad; ``dY`` and ``X`` along the token dim for wgrad — the transposed
+  requant a real bprop kernel must do). Token-dim blocks are zero-padded
+  to 16, as a kernel would pad.
+- ``stochastic_rounding_grads``: stochastic instead of nearest rounding when
+  quantizing ``dY`` (the NVFP4 pretraining recipe's gradient treatment;
+  uses the global torch RNG — seed for reproducibility, disable for parity
+  tests).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+F4_MAX = 6.0  # E2M1 max magnitude
+F8E4M3_MAX = 448.0
+NVFP4_BLOCK = 16
+MXFP8_BLOCK = 32
+_E2M1_GRID = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+FORMATS = ("nvfp4", "mxfp8")
+
+
+@dataclass
+class QuantConfig:
+    """Knobs for the simulated-quantized pt path.
+
+    ``fprop_fmt`` quantizes both forward GEMM operands; ``bprop_fmt`` (used
+    only with ``quant_bprop=True``) quantizes the backward GEMM operands and
+    defaults to ``fprop_fmt``. The interesting mixed recipe is
+    ``fprop_fmt="nvfp4", bprop_fmt="mxfp8"`` — 4-bit fprop speed with 8-bit
+    gradient fidelity.
+    """
+
+    fprop_fmt: str = "nvfp4"  # "nvfp4" | "mxfp8"
+    bprop_fmt: str | None = None  # None -> same as fprop_fmt
+    turboquant: bool = False  # randomized-Hadamard rotation on fc1's hidden dim
+    rotation_block: int = 128
+    rotation_seed: int = 20260712
+    quant_bprop: bool = False  # quantize backward GEMM operands too
+    stochastic_rounding_grads: bool = False  # SR on dY quant (needs quant_bprop)
+
+    def __post_init__(self) -> None:
+        if self.fprop_fmt not in FORMATS:
+            raise ValueError(f"fprop_fmt must be one of {FORMATS}, got {self.fprop_fmt}")
+        if self.bprop_fmt is None:
+            self.bprop_fmt = self.fprop_fmt
+        if self.bprop_fmt not in FORMATS:
+            raise ValueError(f"bprop_fmt must be one of {FORMATS}, got {self.bprop_fmt}")
+
+
+# ---------------------------------------------------------------------------
+# TurboQuant rotation (same construction as megamoe/turboquant.py, but
+# device-agnostic and applied IN-GRAPH so master weights stay unrotated and
+# autograd supplies the exact adjoint).
+# ---------------------------------------------------------------------------
+
+
+def hadamard_matrix(n: int, device="cpu") -> torch.Tensor:
+    """Sylvester Hadamard matrix (n a power of two), entries +-1, fp32."""
+    if n & (n - 1):
+        raise ValueError(f"hadamard_matrix needs a power of two, got {n}.")
+    h = torch.ones((1, 1), dtype=torch.float32, device=device)
+    while h.shape[0] < n:
+        h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
+    return h
+
+
+def make_rotation(block: int = 128, seed: int = 20260712, device="cpu") -> torch.Tensor:
+    """Orthogonal randomized-Hadamard block: Q = diag(signs) @ H / sqrt(b)."""
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    signs = (torch.randint(0, 2, (block,), generator=gen) * 2 - 1).float().to(device)
+    return (signs[:, None] * hadamard_matrix(block, device)) / math.sqrt(block)
+
+
+def rotate_trailing(t: torch.Tensor, q: torch.Tensor) -> torch.Tensor:
+    """Rotate the trailing dim block-diagonally by q (b x b). Differentiable;
+    fp32 math, cast back to ``t.dtype``."""
+    b = q.shape[0]
+    *lead, h = t.shape
+    if h % b:
+        raise ValueError(f"trailing dim ({h}) must be a multiple of block ({b}).")
+    out = (t.reshape(-1, b).float() @ q).reshape(*lead, h)
+    return out.to(t.dtype)
+
+
+# ---------------------------------------------------------------------------
+# NVFP4 quantize-dequantize
+# ---------------------------------------------------------------------------
+
+
+def _round_e2m1(y: torch.Tensor, stochastic: bool) -> torch.Tensor:
+    """Round block-scaled values (|y| expected <= 6) onto the E2M1 grid."""
+    grid = torch.tensor(_E2M1_GRID, device=y.device, dtype=torch.float32)
+    sign = torch.sign(y)
+    a = y.abs().clamp(max=F4_MAX)
+    last = len(_E2M1_GRID) - 1
+    lo = torch.bucketize(a, grid, right=True).sub_(1).clamp_(0, last)
+    hi = torch.clamp(lo + 1, max=last)
+    glo, ghi = grid[lo], grid[hi]
+    if stochastic:
+        span = ghi - glo
+        p = (a - glo) / torch.where(span > 0, span, torch.ones_like(span))
+        q = torch.where(torch.rand_like(a) < p, ghi, glo)
+    else:
+        q = torch.where(a - glo <= ghi - a, glo, ghi)
+    return sign * q
+
+
+def fake_quant_nvfp4(
+    t: torch.Tensor, dim: int = -1, *, stochastic: bool = False
+) -> torch.Tensor:
+    """Quantize-dequantize ``t`` to NVFP4 along ``dim`` (per-16 E2M1 blocks,
+    FP8-E4M3 block scales, fp32 per-tensor scale). Returns fp32. ``dim`` is
+    zero-padded to a multiple of 16 (padding stripped on return)."""
+    if t.numel() == 0:
+        return t.float()
+    x = t.float().movedim(dim, -1)
+    n = x.shape[-1]
+    pad = (-n) % NVFP4_BLOCK
+    if pad:
+        x = F.pad(x, (0, pad))
+    blocks = x.reshape(-1, NVFP4_BLOCK)
+    amax = blocks.abs().amax()
+    if amax == 0:
+        return torch.zeros_like(t, dtype=torch.float32)
+    s_t = amax / (F8E4M3_MAX * F4_MAX)  # per-tensor scale, block scale <= 448
+    sf = (blocks.abs().amax(dim=-1, keepdim=True) / (F4_MAX * s_t)).clamp(max=F8E4M3_MAX)
+    sf = sf.to(torch.float8_e4m3fn).float()  # RN cast + roundtrip = decode value
+    scale = sf * s_t
+    inv = torch.where(scale > 0, scale.reciprocal(), torch.zeros_like(scale))
+    q = _round_e2m1(blocks * inv, stochastic)
+    out = (q * scale).reshape(x.shape)
+    if pad:
+        out = out[..., :n]
+    return out.movedim(-1, dim)
+
+
+def _round_e4m3(y: torch.Tensor, stochastic: bool) -> torch.Tensor:
+    """Round block-scaled values (|y| <= 448) to E4M3 via the native cast.
+
+    Stochastic mode uses ulp-wide uniform dither before the RN cast, which
+    equals true stochastic rounding for values between two representables one
+    ulp apart (approximate only where the exponent steps)."""
+    y = y.clamp(-F8E4M3_MAX, F8E4M3_MAX)
+    if stochastic:
+        # e4m3: 3 mantissa bits, min normal 2^-6 (subnormal ulp 2^-9).
+        e = torch.floor(torch.log2(y.abs().clamp(min=2.0**-9))).clamp(min=-6.0)
+        ulp = torch.exp2(e - 3.0)
+        y = (y + (torch.rand_like(y) - 0.5) * ulp).clamp(-F8E4M3_MAX, F8E4M3_MAX)
+    return y.to(torch.float8_e4m3fn).float()
+
+
+def fake_quant_mxfp8(
+    t: torch.Tensor, dim: int = -1, *, stochastic: bool = False
+) -> torch.Tensor:
+    """Quantize-dequantize ``t`` to MXFP8 along ``dim`` (per-32 E4M3 blocks,
+    E8M0 shared scales; same ceil-log2 scale convention as
+    cutedsl_megamoe's ``mxfp8_quantize_per_block_32``). Returns fp32."""
+    if t.numel() == 0:
+        return t.float()
+    x = t.float().movedim(dim, -1)
+    n = x.shape[-1]
+    pad = (-n) % MXFP8_BLOCK
+    if pad:
+        x = F.pad(x, (0, pad))
+    blocks = x.reshape(-1, MXFP8_BLOCK)
+    absmax = blocks.abs().amax(dim=-1, keepdim=True)
+    scale_exp = torch.ceil(torch.log2(absmax.clamp(min=1e-30) / F8E4M3_MAX))
+    scale = torch.exp2(scale_exp.clamp(-127.0, 127.0))
+    q = _round_e4m3(blocks / scale, stochastic)
+    out = torch.where(absmax > 0, q * scale, torch.zeros_like(blocks)).reshape(x.shape)
+    if pad:
+        out = out[..., :n]
+    return out.movedim(-1, dim)
+
+
+def quant_mxfp8_tensors(
+    t: torch.Tensor, dim: int = -1
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """REAL MXFP8 quantization along ``dim`` (must be a multiple of 32):
+    returns ``(fp8_e4m3 data, e8m0 scales)`` — the tensors an actual fp8 GEMM
+    (e.g. ``torch._scaled_grouped_mm``) consumes, same ceil-log2 scale
+    convention as :func:`fake_quant_mxfp8` (dequant of these reproduces it
+    bit-exactly)."""
+    x = t.float().movedim(dim, -1).contiguous()
+    n = x.shape[-1]
+    if n % MXFP8_BLOCK:
+        raise ValueError(f"quant dim ({n}) must be a multiple of {MXFP8_BLOCK}")
+    blocks = x.reshape(-1, MXFP8_BLOCK)
+    absmax = blocks.abs().amax(dim=-1, keepdim=True)
+    scale_exp = torch.ceil(torch.log2(absmax.clamp(min=1e-30) / F8E4M3_MAX))
+    e_u8 = (scale_exp + 127.0).clamp(0.0, 254.0).to(torch.uint8)
+    e_u8 = torch.where(absmax == 0, torch.zeros_like(e_u8), e_u8)
+    scale = torch.exp2(e_u8.float() - 127.0)
+    data = (
+        (blocks / scale).clamp(-F8E4M3_MAX, F8E4M3_MAX).to(torch.float8_e4m3fn)
+    ).reshape(x.shape)
+    scales = e_u8.view(torch.float8_e8m0fnu).reshape(*x.shape[:-1], n // MXFP8_BLOCK)
+    return data.movedim(-1, dim), scales
+
+
+_FAKE_QUANT = {"nvfp4": fake_quant_nvfp4, "mxfp8": fake_quant_mxfp8}
+
+
+def fake_quant(
+    t: torch.Tensor, fmt: str, dim: int = -1, *, stochastic: bool = False
+) -> torch.Tensor:
+    return _FAKE_QUANT[fmt](t, dim, stochastic=stochastic)
+
+
+# ---------------------------------------------------------------------------
+# Quantized GEMM (y = Q(x) @ Q(w)^T) with configurable backward
+# ---------------------------------------------------------------------------
+
+
+class QuantGemmT(torch.autograd.Function):
+    """``y = Q(x) @ Q(w)^T`` with fake-quant along each GEMM's contraction
+    dim; fp32 accumulate, output cast back to ``x.dtype``. Forward and
+    backward operand formats are independent (fprop_fmt / bprop_fmt)."""
+
+    @staticmethod
+    def forward(ctx, x, w, fprop_fmt, bprop_fmt, quant_bprop, sr_grads):
+        ctx.save_for_backward(x, w)
+        ctx.fprop_fmt = fprop_fmt
+        ctx.bprop_fmt = bprop_fmt
+        ctx.quant_bprop = quant_bprop
+        ctx.sr_grads = sr_grads
+        xq = fake_quant(x, fprop_fmt, dim=-1)
+        wq = fake_quant(w, fprop_fmt, dim=-1)
+        return (xq @ wq.t()).to(x.dtype)
+
+    @staticmethod
+    def backward(ctx, gy):
+        x, w = ctx.saved_tensors
+        gy = gy.float()
+        if ctx.quant_bprop:
+            # dgrad contracts over out-features; wgrad over tokens. Each
+            # operand is requantized along that GEMM's K dim.
+            fmt, sr = ctx.bprop_fmt, ctx.sr_grads
+            dx = fake_quant(gy, fmt, dim=-1, stochastic=sr) @ fake_quant(w, fmt, dim=0)
+            gw = fake_quant(gy, fmt, dim=0, stochastic=sr).t() @ fake_quant(x, fmt, dim=0)
+        else:
+            # Exact-STE: true gradient of the quantized forward.
+            dx = gy @ fake_quant(w, ctx.fprop_fmt, dim=-1)
+            gw = gy.t() @ fake_quant(x, ctx.fprop_fmt, dim=-1)
+        return dx.to(x.dtype), gw.to(w.dtype), None, None, None, None

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/reference.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/reference.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Single-process full-expert MoE reference (the numerics oracle).
+
+Holds ALL experts' weights and processes the full global batch in one
+process — no distribution, plain autograd. Op order deliberately mirrors the
+EP layer (sort-by-expert -> grouped FFN -> unsort -> fp32 weighted top-k
+sum) so forward parity vs the EP path is tight: per-token FFN rows are
+independent, and the combine sums the same values in the same order.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from .experts import grouped_expert_ffn
+
+
+class ReferenceMoE(nn.Module):
+    def __init__(self, w13: torch.Tensor, w2: torch.Tensor):
+        """``w13`` ``[num_experts, 2*intermediate, hidden]``,
+        ``w2`` ``[num_experts, hidden, intermediate]`` — the FULL expert set.
+        """
+        super().__init__()
+        if w13.dim() != 3 or w2.dim() != 3 or w13.shape[0] != w2.shape[0]:
+            raise ValueError("w13/w2 must be [num_experts, ...] with matching expert dim")
+        if w13.shape[1] != 2 * w2.shape[2] or w13.shape[2] != w2.shape[1]:
+            raise ValueError(
+                f"inconsistent shapes: w13 {tuple(w13.shape)}, w2 {tuple(w2.shape)}"
+            )
+        self.w13 = w13 if isinstance(w13, nn.Parameter) else nn.Parameter(w13)
+        self.w2 = w2 if isinstance(w2, nn.Parameter) else nn.Parameter(w2)
+
+    @property
+    def num_experts(self) -> int:
+        return self.w13.shape[0]
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        num_tokens, top_k = topk_ids.shape
+        flat_expert = topk_ids.reshape(-1).long()
+
+        sort_idx = torch.argsort(flat_expert, stable=True)
+        inv_sort_idx = torch.argsort(sort_idx)
+        copy_token_idx = torch.div(sort_idx, top_k, rounding_mode="floor")
+        tokens_per_expert = [
+            int(c)
+            for c in torch.bincount(flat_expert, minlength=self.num_experts).tolist()
+        ]
+
+        x_grouped = hidden_states[copy_token_idx]  # [T*K, hidden]
+        y_grouped = self._ffn(x_grouped, tokens_per_expert)
+        y_flat = y_grouped[inv_sort_idx]
+
+        y_tk = y_flat.view(num_tokens, top_k, -1)
+        # Combine in at least fp32 (mirrors the EP layer) but never downcast:
+        # fp64 stays fp64 so the oracle is exact under gradcheck/naive tests.
+        acc = torch.promote_types(hidden_states.dtype, torch.float32)
+        out = (y_tk.to(acc) * topk_weights.to(acc).unsqueeze(-1)).sum(dim=1)
+        return out.to(hidden_states.dtype)
+
+    def _ffn(self, x_grouped: torch.Tensor, tokens_per_expert) -> torch.Tensor:
+        """Expert-compute hook; quantized variants (reference_fp4) override this."""
+        return grouped_expert_ffn(x_grouped, tokens_per_expert, self.w13, self.w2)

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/reference_fp4.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/reference_fp4.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Single-process full-expert MoE with simulated-NVFP4 expert GEMMs.
+
+Quantized twin of :class:`pt.reference.ReferenceMoE` (same op order), used
+as the single-GPU vehicle for fp4/turboquant accuracy experiments and as
+the oracle for the fp4 EP parity test.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .experts_fp4 import grouped_expert_ffn_fp4
+from .quant import QuantConfig, make_rotation
+from .reference import ReferenceMoE
+
+
+class ReferenceMoEFp4(ReferenceMoE):
+    def __init__(
+        self,
+        w13: torch.Tensor,
+        w2: torch.Tensor,
+        qcfg: QuantConfig | None = None,
+    ):
+        super().__init__(w13, w2)
+        self.qcfg = qcfg or QuantConfig()
+        if self.qcfg.turboquant:
+            hidden = self.w13.shape[2]
+            if hidden % self.qcfg.rotation_block:
+                raise ValueError(
+                    f"hidden ({hidden}) must be a multiple of "
+                    f"rotation_block ({self.qcfg.rotation_block})"
+                )
+            self.register_buffer(
+                "q_rot",
+                make_rotation(
+                    self.qcfg.rotation_block,
+                    self.qcfg.rotation_seed,
+                    device=self.w13.device,
+                ),
+            )
+        else:
+            self.q_rot = None
+
+    def _ffn(self, x_grouped: torch.Tensor, tokens_per_expert) -> torch.Tensor:
+        return grouped_expert_ffn_fp4(
+            x_grouped, tokens_per_expert, self.w13, self.w2, self.qcfg, self.q_rot
+        )

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/routing.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/routing.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Routing metadata for dropless token-major dispatch.
+
+Given ``topk_ids [T, K]``, each of the ``T*K`` routed copies is sorted by
+destination global expert id (stable). Because experts are sharded
+contiguously (expert ``e`` -> rank ``e // num_local_experts``), sorting by
+expert id also groups copies by destination rank in ascending rank order —
+exactly the layout ``all_to_all_single`` wants — AND keeps the sorted stream
+per destination rank identical to what that rank's reverse (combine)
+exchange returns, so one permutation and its inverse round-trip the data.
+
+Everything here is pure index bookkeeping on non-differentiable integer
+tensors; gradients never flow through routing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import torch
+
+from .comm.base import TokenComm
+from .config import EpConfig
+
+
+@dataclass
+class RoutingPlan:
+    """Send-side and receive-side routing metadata for one forward.
+
+    Saved by the layer for the whole forward/backward round trip (backward
+    reuses the same permutations and split sizes in reverse).
+    """
+
+    # --- send side (this rank's T*K routed copies) ---
+    sort_idx: torch.Tensor        # [T*K] int64; copy indices sorted by dest expert
+    inv_sort_idx: torch.Tensor    # [T*K] int64; inverse permutation of sort_idx
+    copy_token_idx: torch.Tensor  # [T*K] int64; source token for each sorted copy
+    input_splits: List[int]       # rows sent to each rank (len ep_size)
+    output_splits: List[int]      # rows received from each rank (len ep_size)
+
+    # --- receive side (rows landed on this rank, arrival order) ---
+    recv_sort_idx: torch.Tensor      # [R] int64; arrival rows sorted by local expert
+    inv_recv_sort_idx: torch.Tensor  # [R] int64; inverse of recv_sort_idx
+    tokens_per_expert: List[int]     # per-local-expert row counts (len num_local_experts)
+
+    @property
+    def num_recv_tokens(self) -> int:
+        return int(self.recv_sort_idx.numel())
+
+
+def build_routing_plan(
+    topk_ids: torch.Tensor, cfg: EpConfig, comm: TokenComm
+) -> RoutingPlan:
+    """Compute the full routing plan; one host sync (split sizes)."""
+    if topk_ids.dim() != 2 or topk_ids.shape[1] != cfg.top_k:
+        raise ValueError(
+            f"topk_ids must be [T, {cfg.top_k}], got {tuple(topk_ids.shape)}"
+        )
+    device = topk_ids.device
+    num_local = cfg.num_local_experts
+    top_k = cfg.top_k
+
+    flat_expert = topk_ids.reshape(-1).long()  # [T*K]
+    if flat_expert.numel() > 0 and (
+        int(flat_expert.min()) < 0 or int(flat_expert.max()) >= cfg.num_experts
+    ):
+        raise ValueError("topk_ids out of range [0, num_experts)")
+
+    # Stable sort by destination expert; contiguous sharding => also grouped
+    # by destination rank in ascending order.
+    sort_idx = torch.argsort(flat_expert, stable=True)
+    inv_sort_idx = torch.argsort(sort_idx)
+    sorted_expert = flat_expert[sort_idx]
+    copy_token_idx = torch.div(sort_idx, top_k, rounding_mode="floor")
+
+    dest_rank = torch.div(sorted_expert, num_local, rounding_mode="floor")
+    send_counts = torch.bincount(dest_rank, minlength=cfg.ep_size)
+    recv_counts = comm.exchange_counts(send_counts)
+
+    # Host sync: all_to_all_single needs Python-int split sizes.
+    input_splits = [int(c) for c in send_counts.tolist()]
+    output_splits = [int(c) for c in recv_counts.tolist()]
+
+    # Receiver side: exchange each copy's global expert id, then group the
+    # arrivals by local expert for the grouped FFN.
+    recv_expert = comm.all_to_all_no_grad(
+        sorted_expert, output_splits, input_splits
+    )
+    local_expert = recv_expert - cfg.first_local_expert
+    if local_expert.numel() > 0 and (
+        int(local_expert.min()) < 0 or int(local_expert.max()) >= num_local
+    ):
+        raise RuntimeError("received a token routed to a non-local expert")
+
+    recv_sort_idx = torch.argsort(local_expert, stable=True)
+    inv_recv_sort_idx = torch.argsort(recv_sort_idx)
+    tokens_per_expert = [
+        int(c) for c in torch.bincount(local_expert, minlength=num_local).tolist()
+    ]
+
+    return RoutingPlan(
+        sort_idx=sort_idx,
+        inv_sort_idx=inv_sort_idx,
+        copy_token_idx=copy_token_idx,
+        input_splits=input_splits,
+        output_splits=output_splits,
+        recv_sort_idx=recv_sort_idx.to(device),
+        inv_recv_sort_idx=inv_recv_sort_idx.to(device),
+        tokens_per_expert=tokens_per_expert,
+    )

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/tests/parity_ep_vs_reference.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/tests/parity_ep_vs_reference.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Multirank EP forward+backward parity vs the single-process reference.
+
+Launch:  torchrun --standalone --nproc-per-node=4 parity_ep_vs_reference.py
+
+Every rank deterministically builds the SAME global problem from a shared
+seed (CPU generator), so the single-process reference can be evaluated
+redundantly on each rank with the full expert set and the full global batch;
+the EP layer runs on this rank's token shard with its local expert shard.
+
+Checks per (dtype, routing) case:
+- forward:        ep_out            == ref_out[rank shard]
+- dgrad:          x_local.grad      == x_ref.grad[rank shard]
+- router grad:    topk_w_local.grad == topk_w_ref.grad[rank shard]
+- wgrad:          w13/w2 local .grad == full ref .grad[local expert slice]
+  (wgrads need no cross-rank reduction: every copy of a token routed to a
+  local expert already arrived here in forward)
+
+Row order inside each expert's GEMM is identical between EP and reference
+(global tokens are concatenated in rank order, and dispatch preserves
+source-rank-then-copy order within each expert), so tolerances can stay
+tight even in bf16.
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from pt import EpConfig, MoEEpTrainingLayer, ReferenceMoE  # noqa: E402
+
+TOLERANCES = {
+    torch.float32: dict(rtol=2e-4, atol=2e-5),
+    torch.bfloat16: dict(rtol=3e-2, atol=3e-2),
+}
+# topk_weights grads are always fp32 (leaf dtype), but they accumulate
+# through the activation dtype, so tolerance follows the activation dtype.
+
+
+def make_global_problem(
+    *, seed, world, tokens_per_rank, num_experts, top_k, hidden, intermediate, skew
+):
+    """Same seed => bit-identical problem on every rank (CPU generator)."""
+    gen = torch.Generator().manual_seed(seed)
+    total = world * tokens_per_rank
+    x = torch.randn(total, hidden, generator=gen) * 0.5
+    scores = torch.randn(total, num_experts, generator=gen)
+    if skew:
+        # Pile most of the traffic onto rank 0's experts to exercise the
+        # reversed uneven splits in backward.
+        scores[:, 0] += 6.0
+        scores[:, 1] += 4.0
+    topk_weights, topk_ids = torch.topk(torch.softmax(scores, dim=-1), top_k)
+    topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    w13 = torch.randn(num_experts, 2 * intermediate, hidden, generator=gen) * hidden**-0.5
+    w2 = torch.randn(num_experts, hidden, intermediate, generator=gen) * intermediate**-0.5
+    grad_out = torch.randn(total, hidden, generator=gen)
+    return x, topk_ids, topk_weights.float(), w13, w2, grad_out
+
+
+def check(name, actual, expected, dtype, failures):
+    tol = TOLERANCES[dtype]
+    a, e = actual.float(), expected.float()
+    max_abs = (a - e).abs().max().item() if a.numel() else 0.0
+    ok = torch.allclose(a, e, **tol)
+    if not ok:
+        failures.append(f"{name}: max_abs_diff={max_abs:.3e} (tol={tol})")
+    return max_abs
+
+
+def run_case(*, dtype, skew, rank, world, device):
+    tokens_per_rank, num_experts, top_k = 64, 4 * world, 4
+    hidden, intermediate = 128, 256
+
+    x_g, ids_g, tw_g, w13_g, w2_g, gout_g = make_global_problem(
+        seed=1234 + int(skew),
+        world=world,
+        tokens_per_rank=tokens_per_rank,
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden=hidden,
+        intermediate=intermediate,
+        skew=skew,
+    )
+    x_g = x_g.to(device=device, dtype=dtype)
+    ids_g = ids_g.to(device)
+    tw_g = tw_g.to(device)  # stays fp32
+    w13_g = w13_g.to(device=device, dtype=dtype)
+    w2_g = w2_g.to(device=device, dtype=dtype)
+    gout_g = gout_g.to(device=device, dtype=dtype)
+
+    # ---- single-process reference on the full global batch ----
+    x_ref = x_g.detach().clone().requires_grad_()
+    tw_ref = tw_g.detach().clone().requires_grad_()
+    ref = ReferenceMoE(w13_g.detach().clone(), w2_g.detach().clone())
+    ref_out = ref(x_ref, ids_g, tw_ref)
+    ref_out.backward(gout_g)
+
+    # ---- EP layer on this rank's shards ----
+    lo, hi = rank * tokens_per_rank, (rank + 1) * tokens_per_rank
+    num_local = num_experts // world
+    elo, ehi = rank * num_local, (rank + 1) * num_local
+
+    x_loc = x_g[lo:hi].detach().clone().requires_grad_()
+    tw_loc = tw_g[lo:hi].detach().clone().requires_grad_()
+    cfg = EpConfig(
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        ep_size=world,
+        ep_rank=rank,
+    )
+    layer = MoEEpTrainingLayer(
+        cfg,
+        w13_g[elo:ehi].detach().clone(),
+        w2_g[elo:ehi].detach().clone(),
+    ).to(device)
+    ep_out = layer(x_loc, ids_g[lo:hi], tw_loc)
+    ep_out.backward(gout_g[lo:hi])
+
+    # ---- compare ----
+    failures = []
+    check("forward out", ep_out, ref_out[lo:hi], dtype, failures)
+    check("dX", x_loc.grad, x_ref.grad[lo:hi], dtype, failures)
+    check("d(topk_weights)", tw_loc.grad, tw_ref.grad[lo:hi], dtype, failures)
+    check("dW13", layer.w13.grad, ref.w13.grad[elo:ehi], dtype, failures)
+    check("dW2", layer.w2.grad, ref.w2.grad[elo:ehi], dtype, failures)
+    return failures
+
+
+def main():
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank % max(torch.cuda.device_count(), 1)))
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+
+    any_failed = False
+    for dtype in (torch.float32, torch.bfloat16):
+        for skew in (False, True):
+            case = f"dtype={dtype} skew={skew}"
+            failures = run_case(
+                dtype=dtype, skew=skew, rank=rank, world=world, device=device
+            )
+            if failures:
+                any_failed = True
+                print(f"[rank {rank}] FAIL {case}:\n  " + "\n  ".join(failures))
+            elif rank == 0:
+                print(f"[rank 0] PASS {case}")
+            dist.barrier()
+
+    dist.barrier()
+    dist.destroy_process_group()
+    if any_failed:
+        sys.exit(1)
+    if rank == 0:
+        print("all parity cases passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/tests/parity_ep_vs_reference_fp4.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/tests/parity_ep_vs_reference_fp4.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Multirank fp4 EP forward+backward parity vs the single-process fp4 reference.
+
+Launch:  torchrun --standalone --nproc-per-node=4 parity_ep_vs_reference_fp4.py
+
+Same scaffolding as parity_ep_vs_reference.py, but BOTH sides run the
+simulated-NVFP4 expert FFN with the same QuantConfig, so this checks that
+the EP wiring (dispatch/combine/grouping) is transparent to quantization:
+each expert sees the identical token slab in the identical order on both
+sides, hence identical block scales, identical fake-quant values, and
+grads matching to bf16 tolerance. Stochastic rounding stays OFF here
+(nondeterministic by design); it is covered by test_fp4_qat_numerics.
+"""
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from pt import (  # noqa: E402
+    EpConfig,
+    MoEEpTrainingLayerFp4,
+    QuantConfig,
+    ReferenceMoEFp4,
+)
+from pt.tests.parity_ep_vs_reference import (  # noqa: E402
+    TOLERANCES,
+    check,
+    make_global_problem,
+)
+
+QCFGS = {
+    "nvfp4": QuantConfig(),
+    "nvfp4+tq": QuantConfig(turboquant=True),
+    "nvfp4+qb": QuantConfig(quant_bprop=True),
+    "nvfp4+tq+qb": QuantConfig(turboquant=True, quant_bprop=True),
+    "mxfp8+tq+qb": QuantConfig(fprop_fmt="mxfp8", turboquant=True, quant_bprop=True),
+    "nvfp4/8bw": QuantConfig(bprop_fmt="mxfp8", quant_bprop=True),
+}
+
+
+def run_case(*, qcfg, skew, rank, world, device):
+    dtype = torch.bfloat16
+    tokens_per_rank, num_experts, top_k = 64, 4 * world, 4
+    hidden, intermediate = 128, 256  # hidden == rotation_block
+
+    x_g, ids_g, tw_g, w13_g, w2_g, gout_g = make_global_problem(
+        seed=1234 + int(skew),
+        world=world,
+        tokens_per_rank=tokens_per_rank,
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden=hidden,
+        intermediate=intermediate,
+        skew=skew,
+    )
+    x_g = x_g.to(device=device, dtype=dtype)
+    ids_g = ids_g.to(device)
+    tw_g = tw_g.to(device)  # stays fp32
+    w13_g = w13_g.to(device=device, dtype=dtype)
+    w2_g = w2_g.to(device=device, dtype=dtype)
+    gout_g = gout_g.to(device=device, dtype=dtype)
+
+    # ---- single-process fp4 reference on the full global batch ----
+    x_ref = x_g.detach().clone().requires_grad_()
+    tw_ref = tw_g.detach().clone().requires_grad_()
+    ref = ReferenceMoEFp4(w13_g.detach().clone(), w2_g.detach().clone(), qcfg).to(device)
+    ref_out = ref(x_ref, ids_g, tw_ref)
+    ref_out.backward(gout_g)
+
+    # ---- fp4 EP layer on this rank's shards ----
+    lo, hi = rank * tokens_per_rank, (rank + 1) * tokens_per_rank
+    num_local = num_experts // world
+    elo, ehi = rank * num_local, (rank + 1) * num_local
+
+    x_loc = x_g[lo:hi].detach().clone().requires_grad_()
+    tw_loc = tw_g[lo:hi].detach().clone().requires_grad_()
+    cfg = EpConfig(
+        num_experts=num_experts,
+        top_k=top_k,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        ep_size=world,
+        ep_rank=rank,
+    )
+    layer = MoEEpTrainingLayerFp4(
+        cfg,
+        w13_g[elo:ehi].detach().clone(),
+        w2_g[elo:ehi].detach().clone(),
+        qcfg,
+    ).to(device)
+    ep_out = layer(x_loc, ids_g[lo:hi], tw_loc)
+    ep_out.backward(gout_g[lo:hi])
+
+    failures = []
+    check("forward out", ep_out, ref_out[lo:hi], dtype, failures)
+    check("dX", x_loc.grad, x_ref.grad[lo:hi], dtype, failures)
+    check("d(topk_weights)", tw_loc.grad, tw_ref.grad[lo:hi], dtype, failures)
+    check("dW13", layer.w13.grad, ref.w13.grad[elo:ehi], dtype, failures)
+    check("dW2", layer.w2.grad, ref.w2.grad[elo:ehi], dtype, failures)
+    return failures
+
+
+def main():
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank % max(torch.cuda.device_count(), 1)))
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+
+    any_failed = False
+    for name, qcfg in QCFGS.items():
+        for skew in (False, True):
+            case = f"qcfg={name} skew={skew}"
+            failures = run_case(
+                qcfg=qcfg, skew=skew, rank=rank, world=world, device=device
+            )
+            if failures:
+                any_failed = True
+                print(f"[rank {rank}] FAIL {case}:\n  " + "\n  ".join(failures))
+            elif rank == 0:
+                print(f"[rank 0] PASS {case}")
+            dist.barrier()
+
+    dist.barrier()
+    dist.destroy_process_group()
+    if any_failed:
+        sys.exit(1)
+    if rank == 0:
+        print("all fp4 parity cases passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/tests/run_tests.sh
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/tests/run_tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run the moe_ep_training test suite (needs GPUs; not a login node).
+#   ./run_tests.sh          # reference pytest + torchrun -n4 parity
+#   NPROC=2 ./run_tests.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "== single-process reference tests (CPU ok) =="
+python -m pytest -q test_reference.py
+
+echo "== single-GPU fp4/fp8 QAT numerics =="
+python test_fp4_qat_numerics.py
+
+echo "== single-GPU quantizer conformance vs cutedsl kernels =="
+python test_quant_vs_kernel.py
+
+NPROC="${NPROC:-4}"
+echo "== ${NPROC}-rank EP fwd+bwd parity =="
+torchrun --standalone --nproc-per-node="${NPROC}" parity_ep_vs_reference.py
+
+echo "== ${NPROC}-rank fp4 EP fwd+bwd parity =="
+torchrun --standalone --nproc-per-node="${NPROC}" parity_ep_vs_reference_fp4.py

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/tests/test_fp4_qat_numerics.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/tests/test_fp4_qat_numerics.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""NVFP4(+TurboQuant) training numerics for the pt path — the accuracy
+experiment behind "would fp4 training work, and does rotation help?"
+
+Launch (single GPU, no dist):
+
+    python -m pt.tests.test_fp4_qat_numerics
+
+Part 1 — one-step accuracy: against an fp32 oracle (plain ReferenceMoE in
+fp32), measure relative error of the forward output AND every training
+gradient (dX, d topk_weights, dW13, dW2) for:
+
+    bf16            — the current pt path (precision floor)
+    mxfp8[+tq/+qb]  — 8-bit GEMMs; the regime where turboquant helps
+    nvfp4[+tq/+qb/+sr] — 4-bit GEMMs; tq expected ~neutral
+    nvfp4/8bw[+tq]  — the mixed recipe: nvfp4 fprop, mxfp8 quantized bprop
+
+on activations with realistic per-channel outliers (1% hot channels x30 —
+the case incoherence processing exists for).
+
+Part 2 — convergence: short Adam distillation (student regresses a frozen
+fp32 teacher's outputs from perturbed weights) comparing loss trajectories
+across the same variants.
+
+Expectations encoded in the asserts (from megamoe's forward measurement,
+test_turboquant_numerics.py): nvfp4's per-16 fp8 scales already absorb
+outliers, so turboquant is neutral-to-slightly-negative here — the table
+quantifies it for GRADS, which is the new information.
+"""
+
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from pt import QuantConfig, ReferenceMoE, ReferenceMoEFp4  # noqa: E402
+
+TOKENS = 256
+HIDDEN = 1024
+INTERMEDIATE = 512
+NUM_EXPERTS = 32
+TOPK = 4
+SEED = 4242
+OUTLIER_FRAC = 0.01
+OUTLIER_SCALE = 30.0
+
+TRAIN_STEPS = 200
+TRAIN_BATCHES = 8
+TRAIN_TOKENS = 128
+LR = 2e-3
+WEIGHT_NOISE = 0.3  # relative perturbation of the student's start point
+
+
+def gen_problem(device):
+    gen = torch.Generator(device=device).manual_seed(SEED)
+    x = torch.randn((TOKENS, HIDDEN), device=device, generator=gen) / 10.0
+    n_out = max(1, int(HIDDEN * OUTLIER_FRAC))
+    hot = torch.randperm(HIDDEN, generator=gen, device=device)[:n_out]
+    x[:, hot] *= OUTLIER_SCALE
+
+    scores = torch.rand((TOKENS, NUM_EXPERTS), device=device, generator=gen)
+    _, topk_ids = scores.topk(TOPK, dim=-1)
+    w = torch.rand((TOKENS, TOPK), device=device, generator=gen) + 0.1
+    topk_w = (w / w.sum(-1, keepdim=True)).float()
+
+    w13 = torch.randn((NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN), device=device, generator=gen) * 0.05
+    w2 = torch.randn((NUM_EXPERTS, HIDDEN, INTERMEDIATE), device=device, generator=gen) * 0.05
+    gout = torch.randn((TOKENS, HIDDEN), device=device, generator=gen)
+    return x, topk_ids.long(), topk_w, w13, w2, gout
+
+
+def rel_err(a, b):
+    denom = b.float().norm().item()
+    return (a.float() - b.float()).norm().item() / max(denom, 1e-30)
+
+
+def run_variant(ctor, x, ids, tw, gout):
+    """Forward+backward one step; return (out, dX, dTW, dW13, dW2)."""
+    torch.manual_seed(SEED)  # fixes SR draws so variants are reproducible
+    x_v = x.detach().clone().requires_grad_()
+    tw_v = tw.detach().clone().requires_grad_()
+    m = ctor()
+    out = m(x_v, ids, tw_v)
+    out.backward(gout)
+    return out.detach(), x_v.grad, tw_v.grad, m.w13.grad, m.w2.grad
+
+
+def make_variants(w13b, w2b):
+    def fp4(**kw):
+        return lambda: ReferenceMoEFp4(
+            w13b.detach().clone(), w2b.detach().clone(), QuantConfig(**kw)
+        )
+
+    return {
+        "bf16": lambda: ReferenceMoE(w13b.detach().clone(), w2b.detach().clone()),
+        "mxfp8": fp4(fprop_fmt="mxfp8"),
+        "mxfp8+tq": fp4(fprop_fmt="mxfp8", turboquant=True),
+        "mxfp8+qb": fp4(fprop_fmt="mxfp8", quant_bprop=True),
+        "mxfp8+tq+qb": fp4(fprop_fmt="mxfp8", turboquant=True, quant_bprop=True),
+        "nvfp4": fp4(),
+        "nvfp4+tq": fp4(turboquant=True),
+        "nvfp4+qb": fp4(quant_bprop=True),
+        "nvfp4+tq+qb": fp4(turboquant=True, quant_bprop=True),
+        "nvfp4+qb+sr": fp4(quant_bprop=True, stochastic_rounding_grads=True),
+        "nvfp4/8bw": fp4(bprop_fmt="mxfp8", quant_bprop=True),
+        "nvfp4/8bw+tq": fp4(bprop_fmt="mxfp8", quant_bprop=True, turboquant=True),
+    }
+
+
+def part1_accuracy(device):
+    x, ids, tw, w13, w2, gout = gen_problem(device)
+
+    # fp32 oracle
+    ref = run_variant(
+        lambda: ReferenceMoE(w13.detach().clone(), w2.detach().clone()),
+        x, ids, tw, gout,
+    )
+
+    x_b, w13_b, w2_b, gout_b = x.bfloat16(), w13.bfloat16(), w2.bfloat16(), gout.bfloat16()
+    variants = make_variants(w13_b, w2_b)
+
+    names = ("fwd", "dX", "dTW", "dW13", "dW2")
+    results = {}
+    print(f"\n== Part 1: one-step rel_err vs fp32 oracle "
+          f"(T={TOKENS} H={HIDDEN} I={INTERMEDIATE} E={NUM_EXPERTS} K={TOPK}, "
+          f"{OUTLIER_FRAC:.0%} channels x{OUTLIER_SCALE:.0f}) ==")
+    print(f"{'variant':<14}" + "".join(f"{n:>12}" for n in names))
+    for name, ctor in variants.items():
+        got = run_variant(ctor, x_b, ids, tw, gout_b)
+        errs = tuple(rel_err(g, r) for g, r in zip(got, ref))
+        results[name] = dict(zip(names, errs))
+        print(f"{name:<14}" + "".join(f"{e:>12.4f}" for e in errs))
+
+    r = results
+    # Sanity: bf16 floor is tight; everything stays in a usable regime.
+    assert r["bf16"]["fwd"] < 0.02, r["bf16"]
+    for name, e in r.items():
+        assert e["fwd"] < 0.35, (name, e)
+        assert max(e["dX"], e["dW13"], e["dW2"]) < 0.60, (name, e)
+    # mxfp8 is the low-loss regime (~0.07 fwd rel_err under these 1%x30
+    # outliers), and the one where turboquant must not hurt (megamoe fwd
+    # measurement: rotation recovers outlier damage).
+    assert r["mxfp8"]["fwd"] < 0.10, r["mxfp8"]
+    assert r["mxfp8+tq"]["fwd"] <= r["mxfp8"]["fwd"] * 1.05, (r["mxfp8"], r["mxfp8+tq"])
+    # Known result (megamoe fwd measurement): turboquant is ~neutral on
+    # nvfp4. Bound the regression loosely.
+    assert r["nvfp4+tq"]["fwd"] <= r["nvfp4"]["fwd"] * 1.25, (r["nvfp4"], r["nvfp4+tq"])
+    # The mixed recipe's grads must sit at-or-below full-fp4 bprop grads.
+    assert r["nvfp4/8bw"]["dW13"] <= r["nvfp4+qb"]["dW13"] * 1.05, (
+        r["nvfp4/8bw"], r["nvfp4+qb"]
+    )
+    return results
+
+
+def part2_convergence(device):
+    gen = torch.Generator(device=device).manual_seed(SEED + 1)
+    w13 = torch.randn((NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN), device=device, generator=gen) * 0.05
+    w2 = torch.randn((NUM_EXPERTS, HIDDEN, INTERMEDIATE), device=device, generator=gen) * 0.05
+    teacher = ReferenceMoE(w13.detach().clone(), w2.detach().clone())
+
+    n_hot = max(1, int(HIDDEN * OUTLIER_FRAC))
+    batches = []
+    for _ in range(TRAIN_BATCHES):
+        x = torch.randn((TRAIN_TOKENS, HIDDEN), device=device, generator=gen) / 10.0
+        hot = torch.randperm(HIDDEN, generator=gen, device=device)[:n_hot]
+        x[:, hot] *= OUTLIER_SCALE
+        scores = torch.rand((TRAIN_TOKENS, NUM_EXPERTS), device=device, generator=gen)
+        _, ids = scores.topk(TOPK, dim=-1)
+        w = torch.rand((TRAIN_TOKENS, TOPK), device=device, generator=gen) + 0.1
+        tw = (w / w.sum(-1, keepdim=True)).float()
+        with torch.no_grad():
+            y = teacher(x, ids.long(), tw)
+        batches.append((x.bfloat16(), ids.long(), tw, y))
+
+    # Perturbed student start, shared by every variant.
+    noise13 = torch.randn(w13.shape, device=device, generator=gen)
+    noise2 = torch.randn(w2.shape, device=device, generator=gen)
+    s13 = (w13 * (1 + WEIGHT_NOISE * noise13)).bfloat16()
+    s2 = (w2 * (1 + WEIGHT_NOISE * noise2)).bfloat16()
+
+    variants = make_variants(s13, s2)
+    marks = [0, TRAIN_STEPS // 4, TRAIN_STEPS // 2, 3 * TRAIN_STEPS // 4, TRAIN_STEPS - 1]
+
+    print(f"\n== Part 2: {TRAIN_STEPS}-step Adam distillation vs fp32 teacher "
+          f"(MSE, lr={LR}, {WEIGHT_NOISE:.0%} weight perturbation) ==")
+    print(f"{'variant':<14}" + "".join(f"{('step ' + str(s)):>12}" for s in marks))
+    finals = {}
+    for name, ctor in variants.items():
+        torch.manual_seed(SEED)  # same SR/optimizer determinism per variant
+        m = ctor()
+        opt = torch.optim.Adam(m.parameters(), lr=LR)
+        curve = {}
+        for step in range(TRAIN_STEPS):
+            x, ids, tw, y = batches[step % TRAIN_BATCHES]
+            out = m(x, ids, tw)
+            loss = torch.nn.functional.mse_loss(out.float(), y.float())
+            if step in marks:
+                curve[step] = loss.item()
+            opt.zero_grad(set_to_none=True)
+            loss.backward()
+            opt.step()
+        finals[name] = curve
+        print(f"{name:<14}" + "".join(f"{curve[s]:>12.5f}" for s in marks))
+
+    # Every variant must actually train (loss falls substantially).
+    for name, curve in finals.items():
+        assert curve[marks[-1]] < curve[0] * 0.5, (name, curve)
+    return finals
+
+
+def main():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    part1_accuracy(device)
+    part2_convergence(device)
+    print("\nFP4 QAT NUMERICS PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/tests/test_quant_vs_kernel.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/tests/test_quant_vs_kernel.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Conformance check: pt/quant.py fake-quant vs the cutedsl_megamoe host
+quantizers (the numerics the real kernels consume).
+
+Launch (single GPU, needs the cutedsl_megamoe clone + triton):
+
+    python -m pt.tests.test_quant_vs_kernel
+
+Checks:
+
+1. **mxfp8 — bit-exact.** ``fake_quant_mxfp8`` must reproduce
+   ``mxfp8_quantize_per_block_32``'s dequantized values exactly (same
+   ceil-log2 E8M0 scales, same RN E4M3 cast).
+2. **nvfp4 — enumerated divergence.** ``fake_quant_nvfp4`` vs
+   ``nvfp4_quantize_per_block_16`` (+ ``unpack_fp4_to_f32``) with
+   ``norm_const = 448*6/amax`` (the same per-tensor scale, expressed the
+   kernel's way). Block scales must match exactly. Element values may
+   differ ONLY at rounding boundaries, from two known sources:
+     - the kernel scales by ``norm_const * rcp.approx.ftz(sfc)`` (approximate
+       reciprocal) where the simulation divides exactly;
+     - the kernel's HW cast is RTNE where the simulation breaks ties toward
+       the lower-magnitude grid point.
+   Every mismatch must be exactly one E2M1 grid step at the same block
+   scale, and the mismatch fraction must stay tiny.
+"""
+
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import megamoe.repo_path  # noqa: F401  (puts cutedsl_megamoe on sys.path)
+
+from common.host_utils import mxfp8_quantize_per_block_32  # noqa: E402
+from moe_nvfp4_swapab.runner_common import (  # noqa: E402
+    nvfp4_quantize_per_block_16,
+    unpack_fp4_to_f32,
+)
+
+from pt.quant import (  # noqa: E402
+    F4_MAX,
+    F8E4M3_MAX,
+    NVFP4_BLOCK,
+    fake_quant_mxfp8,
+    fake_quant_nvfp4,
+)
+
+SEED = 20260719
+CASES = {
+    "gaussian": lambda g: torch.randn((512, 1024), device="cuda", generator=g),
+    "outliers": lambda g: _outliers(g),
+    "tiny": lambda g: torch.randn((512, 1024), device="cuda", generator=g) * 1e-6,
+    "hot-rows": lambda g: torch.randn((512, 1024), device="cuda", generator=g)
+    * torch.logspace(-3, 3, 512, device="cuda")[:, None],
+}
+
+
+def _outliers(g):
+    x = torch.randn((512, 1024), device="cuda", generator=g) / 10.0
+    hot = torch.randperm(1024, generator=g, device="cuda")[:10]
+    x[:, hot] *= 30.0
+    return x
+
+
+def check_mxfp8(name, x):
+    mine = fake_quant_mxfp8(x, dim=-1)
+    c_fp8, sfc_e8m0 = mxfp8_quantize_per_block_32(x, torch.float8_e4m3fn)
+    scale = torch.exp2(sfc_e8m0.view(torch.uint8).float() - 127.0)
+    theirs = c_fp8.float() * scale.repeat_interleave(32, dim=-1)
+    n_diff = (mine != theirs).sum().item()
+    print(f"[mxfp8] {name:<10} mismatched elements: {n_diff}/{x.numel()}")
+    assert n_diff == 0, f"mxfp8 not bit-exact on {name}: {n_diff} diffs"
+
+
+def check_nvfp4(name, x):
+    amax = x.abs().amax().item()
+    norm_const = (F8E4M3_MAX * F4_MAX) / amax  # == 1 / s_t of the simulation
+    mine = fake_quant_nvfp4(x, dim=-1)
+
+    c_fp4, sfc_fp8 = nvfp4_quantize_per_block_16(x, norm_const)
+    q = unpack_fp4_to_f32(c_fp4)
+    sf = sfc_fp8.float()
+    theirs = q * (sf / norm_const).repeat_interleave(NVFP4_BLOCK, dim=-1)
+
+    # Block scales must agree exactly (bitwise, modulo fp32 op-order in the
+    # pre-cast product; count any flips).
+    my_sf = (
+        x.view(x.shape[0], -1, NVFP4_BLOCK).abs().amax(dim=-1)
+        * (norm_const / F4_MAX)
+    ).clamp(max=F8E4M3_MAX).to(torch.float8_e4m3fn).float()
+    sf_diff = (my_sf != sf).sum().item()
+
+    # Compare in grid-step units: a genuine rounding flip moves >= 0.5 steps
+    # (adjacent E2M1 magnitudes differ by >= 0.5 scaled units). Sub-step
+    # residue is dequant-arithmetic noise only — the simulation multiplies by
+    # ``s_t`` where the kernel path divides by ``norm_const`` (reciprocals
+    # differ by <= 1 ulp); the CODES and SCALES the kernel consumes are what
+    # must match.
+    scale_full = (sf / norm_const).repeat_interleave(NVFP4_BLOCK, dim=-1)
+    steps = (mine - theirs).abs() / torch.where(
+        scale_full > 0, scale_full, torch.ones_like(scale_full)
+    )
+    flips = steps > 0.25
+    n_flip = flips.sum().item()
+    frac = n_flip / x.numel()
+    max_step = steps[flips].max().item() if n_flip else 0.0
+    noise = steps[~flips].max().item() if (~flips).any() else 0.0
+    print(
+        f"[nvfp4] {name:<10} scale flips: {sf_diff}/{sf.numel()}  "
+        f"code flips: {n_flip}/{x.numel()} ({100*frac:.4f}%)  "
+        f"max flip dist: {max_step:.3f} steps  dequant noise: {noise:.2e} steps"
+    )
+    assert sf_diff <= sf.numel() * 1e-4, f"nvfp4 {name}: block scales diverge"
+    assert frac < 0.01, f"nvfp4 {name}: {100*frac:.3f}% codes diverge"
+    # One E2M1 step is at most 2.0 (4 -> 6) in scaled units.
+    assert max_step <= 2.0 + 1e-6, f"nvfp4 {name}: non-boundary divergence"
+    assert noise < 1e-4, f"nvfp4 {name}: dequant arithmetic drifted ({noise})"
+
+
+def main():
+    torch.cuda.set_device(0)
+    gen = torch.Generator(device="cuda").manual_seed(SEED)
+    for name, make in CASES.items():
+        x = make(gen).float()
+        check_mxfp8(name, x)
+        check_nvfp4(name, x)
+    print("QUANT-VS-KERNEL CONFORMANCE PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/tests/test_reference.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/tests/test_reference.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Single-process oracle checks (no GPUs / no dist required).
+
+1. ReferenceMoE forward matches a naive per-token/per-k double loop (fp64).
+2. torch.autograd.gradcheck on the full reference (x, w13, w2, topk_weights)
+   in fp64 on tiny sizes.
+3. Edge cases: duplicate expert in a token's top-k, experts with zero tokens.
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from pt.reference import ReferenceMoE  # noqa: E402
+
+
+def naive_moe(x, topk_ids, topk_weights, w13, w2):
+    """Straight-line per-token loop; the most obviously-correct spelling."""
+    num_tokens, top_k = topk_ids.shape
+    intermediate = w2.shape[2]
+    out = torch.zeros(num_tokens, x.shape[1], dtype=torch.float64)
+    for t in range(num_tokens):
+        for k in range(top_k):
+            e = int(topk_ids[t, k])
+            fc1 = x[t].double() @ w13[e].double().t()
+            linear, gate = fc1[:intermediate], fc1[intermediate:]
+            y = (F.silu(gate) * linear) @ w2[e].double().t()
+            out[t] += topk_weights[t, k].double() * y
+    return out.to(x.dtype)
+
+
+def make_problem(seed=0, num_tokens=13, top_k=3, num_experts=5, hidden=8, intermediate=11):
+    gen = torch.Generator().manual_seed(seed)
+    x = torch.randn(num_tokens, hidden, generator=gen, dtype=torch.float64)
+    scores = torch.randn(num_tokens, num_experts, generator=gen)
+    topk_weights, topk_ids = torch.topk(torch.softmax(scores, dim=-1), top_k)
+    topk_weights = (topk_weights / topk_weights.sum(-1, keepdim=True)).double()
+    w13 = torch.randn(num_experts, 2 * intermediate, hidden, generator=gen, dtype=torch.float64)
+    w2 = torch.randn(num_experts, hidden, intermediate, generator=gen, dtype=torch.float64)
+    return x, topk_ids, topk_weights, w13, w2
+
+
+def test_reference_matches_naive():
+    x, topk_ids, topk_weights, w13, w2 = make_problem()
+    ref = ReferenceMoE(w13.clone(), w2.clone())
+    out = ref(x, topk_ids, topk_weights)
+    expected = naive_moe(x, topk_ids, topk_weights, w13, w2)
+    torch.testing.assert_close(out, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_reference_duplicate_topk_and_empty_expert():
+    x, _, topk_weights, w13, w2 = make_problem(num_experts=6)
+    # Every token picks expert 1 twice and expert 2 once; experts 0,3,4,5 idle.
+    topk_ids = torch.tensor([[1, 1, 2]]).repeat(x.shape[0], 1)
+    ref = ReferenceMoE(w13.clone(), w2.clone())
+    out = ref(x, topk_ids, topk_weights)
+    expected = naive_moe(x, topk_ids, topk_weights, w13, w2)
+    torch.testing.assert_close(out, expected, rtol=1e-12, atol=1e-12)
+
+
+def test_reference_gradcheck():
+    x, topk_ids, topk_weights, w13, w2 = make_problem(
+        num_tokens=5, top_k=2, num_experts=4, hidden=6, intermediate=7
+    )
+    x = x.requires_grad_()
+    topk_weights = topk_weights.requires_grad_()
+    w13 = w13.requires_grad_()
+    w2 = w2.requires_grad_()
+
+    def fn(x_, tw_, w13_, w2_):
+        return ReferenceMoE.forward(
+            _make_module(w13_, w2_), x_, topk_ids, tw_
+        )
+
+    def _make_module(w13_, w2_):
+        # Bypass nn.Parameter wrapping so gradcheck's raw tensors stay in
+        # the graph; ReferenceMoE.forward only reads self.w13 / self.w2.
+        m = ReferenceMoE.__new__(ReferenceMoE)
+        torch.nn.Module.__init__(m)
+        object.__setattr__(m, "w13", w13_)
+        object.__setattr__(m, "w2", w2_)
+        return m
+
+    assert torch.autograd.gradcheck(
+        fn, (x, topk_weights, w13, w2), eps=1e-6, atol=1e-8, rtol=1e-6
+    )
+
+
+def test_grad_flows_to_all_inputs():
+    x, topk_ids, topk_weights, w13, w2 = make_problem()
+    x = x.requires_grad_()
+    topk_weights = topk_weights.requires_grad_()
+    ref = ReferenceMoE(w13.clone(), w2.clone())
+    out = ref(x, topk_ids, topk_weights)
+    out.sum().backward()
+    assert x.grad is not None and torch.isfinite(x.grad).all()
+    assert topk_weights.grad is not None and torch.isfinite(topk_weights.grad).all()
+    assert ref.w13.grad is not None and torch.isfinite(ref.w13.grad).all()
+    assert ref.w2.grad is not None and torch.isfinite(ref.w2.grad).all()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/python/cudnn/moe_ep/_megamoe_backend/pt/tests/test_scaled_grouped_mm_mxfp8.py
+++ b/python/cudnn/moe_ep/_megamoe_backend/pt/tests/test_scaled_grouped_mm_mxfp8.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+"""Numerics + timing for torch._scaled_grouped_mm as the MXFP8 wgrad unit.
+
+Launch (single GPU):
+
+    python -m pt.tests.test_scaled_grouped_mm_mxfp8
+
+wgrad is the 2Dx2D grouped GEMM with TOKENS ON K:
+
+    dW[e] = dY[ke_lo:ke_hi, :].T @ act[ke_lo:ke_hi, :]
+          = a[:, ke_lo:ke_hi] @ b[ke_lo:ke_hi, :]       (a = dY^T, b = act)
+
+with both operands MXFP8-quantized along the token (contraction) dim — the
+transposed requant a bprop kernel must do.
+
+Scale layout (from torch's test_scaled_matmul_cuda.py 2d-2d recipe and the
+mslk grouped_common.cuh contract): per group, 32x4x4-swizzle (`to_blocked`)
+the (MN, K_g/32) e8m0 scales — each group contributes
+``round_up(MN,128) * round_up(K_g/32, 4)`` elements — concatenate in group
+order, reshape 2D. Group token counts must be multiples of 32; empty groups
+contribute nothing.
+"""
+
+import os
+import statistics
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+import megamoe.repo_path  # noqa: F401
+
+from moe_nvfp4_swapab.runner_common import to_blocked  # noqa: E402
+
+from pt.quant import MXFP8_BLOCK, quant_mxfp8_tensors  # noqa: E402
+
+SEED = 20260719
+
+
+def rel_err(a, b):
+    d = b.float().norm().item()
+    return (a.float() - b.float()).norm().item() / max(d, 1e-30)
+
+
+def round_up(x, y):
+    return ((x + y - 1) // y) * y
+
+
+def make_problem(tokens_per_expert, M, N, device, gen):
+    ntot = sum(tokens_per_expert)
+    dy = torch.randn((ntot, M), device=device, generator=gen).bfloat16()
+    act = torch.randn((ntot, N), device=device, generator=gen).bfloat16()
+    dy[:, :8] *= 20.0  # hot channels so scales vary
+    act[:, :8] *= 20.0
+    offs = torch.tensor(
+        [sum(tokens_per_expert[: i + 1]) for i in range(len(tokens_per_expert))],
+        device=device, dtype=torch.int32,
+    )
+    return dy, act, offs
+
+
+def pack_scales(s, offs, MN):
+    """(MN, Ktot/32) e8m0 -> grouped 32x4x4-blocked 2D layout."""
+    parts, lo = [], 0
+    for hi in offs.tolist():
+        if hi > lo:
+            parts.append(to_blocked(s[:, lo // MXFP8_BLOCK : hi // MXFP8_BLOCK]))
+        lo = hi
+    return torch.cat(parts).reshape(round_up(MN, 128), -1)
+
+
+def quantize_operands(dy, act, offs):
+    # a = dY^T [M, Ktot] row-major, b = act [Ktot, N] col-major view,
+    # both quantized along K(tokens). 32-aligned groups => whole-tensor
+    # quantization equals per-group (blocks never span groups).
+    a, sa = quant_mxfp8_tensors(dy.t().contiguous(), dim=-1)
+    bt, sb = quant_mxfp8_tensors(act.t().contiguous(), dim=-1)
+    M, N = dy.shape[1], act.shape[1]
+    return a, pack_scales(sa, offs, M), sa, bt.t(), pack_scales(sb, offs, N), sb
+
+
+def reference(a, sa_plain, b, sb_plain, offs):
+    """Exact fp32 grouped product of the dequantized operands."""
+    deq_a = a.float() * sa_plain.float().repeat_interleave(MXFP8_BLOCK, dim=-1)
+    deq_b = (
+        b.t().float() * sb_plain.float().repeat_interleave(MXFP8_BLOCK, dim=-1)
+    ).t()
+    outs, lo = [], 0
+    for hi in offs.tolist():
+        outs.append(deq_a[:, lo:hi] @ deq_b[lo:hi, :])
+        lo = hi
+    return torch.stack(outs)
+
+
+def main():
+    torch.cuda.set_device(0)
+    device = torch.device("cuda", 0)
+    gen = torch.Generator(device=device).manual_seed(SEED)
+
+    # ---- numerics: uneven 32-aligned groups ----
+    tpe = [32 * k for k in (1, 4, 2, 8, 3, 1, 6, 7)]
+    M, N = 512, 256
+    dy, act, offs = make_problem(tpe, M, N, device, gen)
+    a, sa_b, sa, b, sb_b, sb = quantize_operands(dy, act, offs)
+    out = torch._scaled_grouped_mm(a, b, sa_b, sb_b, offs=offs, out_dtype=torch.bfloat16)
+    ref = reference(a, sa, b, sb, offs)
+    e = rel_err(out, ref)
+    print(f"[numerics] uneven groups: rel_err={e:.3e}  out={tuple(out.shape)}")
+    assert e < 1e-2, f"grouped mm math wrong: {e}"
+
+    # ---- empty-expert group ----
+    tpe0 = [128, 0, 96, 256, 0, 64, 32, 160]
+    dy0, act0, offs0 = make_problem([t for t in tpe0], M, N, device, gen)
+    a0, sa0_b, sa0, b0, sb0_b, sb0 = quantize_operands(dy0, act0, offs0)
+    try:
+        out0 = torch._scaled_grouped_mm(
+            a0, b0, sa0_b, sb0_b, offs=offs0, out_dtype=torch.bfloat16
+        )
+        ref0 = reference(a0, sa0, b0, sb0, offs0)
+        nonempty = [i for i, t in enumerate(tpe0) if t > 0]
+        e0 = rel_err(out0[nonempty], ref0[nonempty])
+        print(f"[empty-expert] OK rel_err(non-empty groups)={e0:.3e}")
+        assert e0 < 1e-2
+    except Exception as ex:  # noqa: BLE001
+        print(f"[empty-expert] unsupported: {type(ex).__name__}: {str(ex)[:150]}")
+
+    # ---- timing at wgrad-realistic size ----
+    E2, M2, N2 = 32, 1024, 512
+    dy2, act2, offs2 = make_problem([512] * E2, M2, N2, device, gen)
+    a2, sa2_b, _, b2, sb2_b, _ = quantize_operands(dy2, act2, offs2)
+
+    def timeit(fn, iters=50):
+        for _ in range(5):
+            fn()
+        torch.cuda.synchronize()
+        ts = []
+        for _ in range(iters):
+            s, e_ = torch.cuda.Event(True), torch.cuda.Event(True)
+            s.record()
+            fn()
+            e_.record()
+            torch.cuda.synchronize()
+            ts.append(s.elapsed_time(e_))
+        return statistics.median(ts)
+
+    t_fp8 = timeit(lambda: torch._scaled_grouped_mm(
+        a2, b2, sa2_b, sb2_b, offs=offs2, out_dtype=torch.bfloat16
+    ))
+    t_quant = timeit(lambda: quantize_operands(dy2, act2, offs2))
+
+    def bf16_loop():
+        lo, outs = 0, []
+        for hi in offs2.tolist():
+            outs.append(dy2[lo:hi].t() @ act2[lo:hi])
+            lo = hi
+        torch.stack(outs)
+
+    t_bf16 = timeit(bf16_loop)
+    print(f"[timing] wgrad 32E x 512tok ({M2}x{N2}): "
+          f"fp8 grouped {t_fp8:.3f} ms | quant+pack {t_quant:.3f} ms | "
+          f"bf16 loop {t_bf16:.3f} ms  (gemm speedup {t_bf16 / t_fp8:.1f}x)")
+
+    print("SCALED_GROUPED_MM MXFP8 PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/cudnn/moe_ep/api.py
+++ b/python/cudnn/moe_ep/api.py
@@ -1,0 +1,339 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Python API surface for fused SwiGLU MoE with expert parallelism.
+
+The public contract is present before the device implementation so callers and
+the PyTorch reference can be wired into tests.  ``MoeEp.__call__`` currently
+allocates output storage but does not launch a backend kernel.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.distributed as dist
+
+
+class MoeFormat(str, Enum):
+    """Data formats supported by the MoE+EP interface."""
+
+    BF16 = "bf16"
+    MXFP8 = "mxfp8"
+    NVFP4 = "nvfp4"
+
+
+def _parse_format(value: Union[MoeFormat, str]) -> MoeFormat:
+    if isinstance(value, MoeFormat):
+        return value
+    try:
+        return MoeFormat(value.lower())
+    except (AttributeError, ValueError) as exc:
+        choices = ", ".join(item.value for item in MoeFormat)
+        raise ValueError(f"unsupported format {value!r}; expected one of: {choices}") from exc
+
+
+def _require_torch_dtype(name: str) -> torch.dtype:
+    dtype = getattr(torch, name, None)
+    if dtype is None:
+        raise RuntimeError(f"this PyTorch build does not provide torch.{name}")
+    return dtype
+
+
+def _normalize_axis(axis: int, ndim: int) -> int:
+    normalized = axis + ndim if axis < 0 else axis
+    if normalized < 0 or normalized >= ndim:
+        raise IndexError(f"axis {axis} is out of range for a {ndim}-D tensor")
+    return normalized
+
+
+@dataclass(frozen=True)
+class BlockScaledTensor:
+    """Data-plus-scale result returned for MXFP8 and NVFP4 outputs."""
+
+    data: torch.Tensor
+    scale: torch.Tensor
+    format: Union[MoeFormat, str]
+    logical_shape: Tuple[int, ...]
+    axis: int = -1
+
+    def __post_init__(self) -> None:
+        fmt = _parse_format(self.format)
+        if fmt is MoeFormat.BF16:
+            raise ValueError("BlockScaledTensor only represents mxfp8 or nvfp4")
+        logical_shape = tuple(int(dim) for dim in self.logical_shape)
+        axis = _normalize_axis(self.axis, len(logical_shape))
+        object.__setattr__(self, "format", fmt)
+        object.__setattr__(self, "logical_shape", logical_shape)
+        object.__setattr__(self, "axis", axis)
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self.logical_shape
+
+    @property
+    def device(self) -> torch.device:
+        return self.data.device
+
+    @property
+    def block_size(self) -> int:
+        return 32 if self.format is MoeFormat.MXFP8 else 16
+
+    def dequantize(self, dtype: torch.dtype = torch.float32) -> torch.Tensor:
+        """Decode the logical, unswizzled block-scaled representation."""
+
+        logical_extent = self.logical_shape[self.axis]
+        scale = self.scale.movedim(self.axis, -1).float()
+        expanded_scale = scale.repeat_interleave(self.block_size, dim=-1)[..., :logical_extent]
+
+        if self.format is MoeFormat.MXFP8:
+            values = self.data.movedim(self.axis, -1).float()
+        else:
+            packed = self.data.movedim(self.axis, -1)
+            low = packed & 0x0F
+            high = packed >> 4
+            codes = torch.stack((low, high), dim=-1).flatten(-2)[..., :logical_extent]
+            table = torch.tensor(
+                [
+                    0.0,
+                    0.5,
+                    1.0,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    6.0,
+                    -0.0,
+                    -0.5,
+                    -1.0,
+                    -1.5,
+                    -2.0,
+                    -3.0,
+                    -4.0,
+                    -6.0,
+                ],
+                dtype=torch.float32,
+                device=packed.device,
+            )
+            values = table[codes.long()]
+
+        return (values * expanded_scale).movedim(-1, self.axis).to(dtype)
+
+
+MoeTensor = Union[torch.Tensor, BlockScaledTensor]
+
+
+def _logical_shape(tensor: MoeTensor) -> Tuple[int, ...]:
+    if isinstance(tensor, BlockScaledTensor):
+        return tensor.logical_shape
+    return tuple(tensor.shape)
+
+
+def _tensor_device(tensor: MoeTensor) -> torch.device:
+    return tensor.device
+
+
+class MoeEp:
+    """Fused SwiGLU MoE operator with contiguous expert parallel sharding.
+
+    Global expert ``e`` belongs to group-relative EP rank
+    ``e // experts_per_rank``.  The constructor captures static configuration;
+    calling the instance accepts runtime tensors for this rank.
+
+    With ``generate_c=True`` (training integration), ``__call__`` additionally
+    returns ``fc1_c`` and ``route_metadata``.  ``fc1_c`` is the raw pre-SwiGLU
+    FC1 accumulator for every route this rank's experts processed, BF16, shape
+    ``(local_routes, 2 * intermediate)``.  Rows are grouped by local expert
+    (ascending) and ordered within each expert by source rank, then the source
+    rank's token-major route order.  The rows are captured before the gate/up
+    clamp and carry no router weight.  ``route_metadata`` is Int32
+    ``(local_routes, 4)`` with columns
+    ``(local_expert, src_rank, src_token, src_slot)``, row-aligned with
+    ``fc1_c``, identifying each route for the backward gradient re-dispatch.
+
+    The backend launch is intentionally a TODO.  Until it is implemented,
+    ``__call__`` returns newly allocated, uninitialized output storage with the
+    correct public representation.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        top_k: int,
+        ep_group: Optional[dist.ProcessGroup] = None,
+        max_tokens_per_rank: Optional[int] = None,
+        output_format: Union[MoeFormat, str] = MoeFormat.BF16,
+        combine_format: Union[MoeFormat, str] = MoeFormat.BF16,
+        apply_topk_in_fc1: bool = True,
+        gate_up_clamp: Optional[float] = None,
+        generate_c: bool = False,
+    ) -> None:
+        for name, value in (
+            ("num_experts", num_experts),
+            ("hidden_size", hidden_size),
+            ("intermediate_size", intermediate_size),
+            ("top_k", top_k),
+        ):
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer, got {value!r}")
+        if top_k > num_experts:
+            raise ValueError(f"top_k ({top_k}) cannot exceed num_experts ({num_experts})")
+        if max_tokens_per_rank is not None and max_tokens_per_rank < 0:
+            raise ValueError("max_tokens_per_rank must be non-negative")
+
+        if ep_group is None:
+            ep_size, ep_rank = 1, 0
+        else:
+            if not dist.is_available() or not dist.is_initialized():
+                raise RuntimeError("ep_group requires an initialized torch.distributed process group")
+            ep_size = dist.get_world_size(ep_group)
+            ep_rank = dist.get_rank(ep_group)
+        if num_experts % ep_size != 0:
+            raise ValueError(f"num_experts ({num_experts}) must be divisible by EP size ({ep_size})")
+
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.top_k = top_k
+        self.ep_group = ep_group
+        self.ep_size = ep_size
+        self.ep_rank = ep_rank
+        self.experts_per_rank = num_experts // ep_size
+        self.max_tokens_per_rank = max_tokens_per_rank
+        self.output_format = _parse_format(output_format)
+        self.combine_format = _parse_format(combine_format)
+        self.apply_topk_in_fc1 = bool(apply_topk_in_fc1)
+        self.gate_up_clamp = None if gate_up_clamp is None else abs(float(gate_up_clamp))
+        self.generate_c = bool(generate_c)
+
+        for name, fmt in (
+            ("output_format", self.output_format),
+            ("combine_format", self.combine_format),
+        ):
+            required_multiple = 32 if fmt is MoeFormat.MXFP8 else 16 if fmt is MoeFormat.NVFP4 else 1
+            if hidden_size % required_multiple != 0:
+                raise ValueError(f"hidden_size ({hidden_size}) must be divisible by " f"{required_multiple} for {name}={fmt.value}")
+
+    def _allocate_output(self, token_count: int, device: torch.device) -> MoeTensor:
+        logical_shape = (token_count, self.hidden_size)
+        if self.output_format is MoeFormat.BF16:
+            return torch.empty(logical_shape, dtype=torch.bfloat16, device=device)
+        if self.output_format is MoeFormat.MXFP8:
+            data = torch.empty(
+                logical_shape,
+                dtype=_require_torch_dtype("float8_e4m3fn"),
+                device=device,
+            )
+            scale = torch.empty(
+                (token_count, self.hidden_size // 32),
+                dtype=_require_torch_dtype("float8_e8m0fnu"),
+                device=device,
+            )
+        else:
+            data = torch.empty(
+                (token_count, self.hidden_size // 2),
+                dtype=torch.uint8,
+                device=device,
+            )
+            scale = torch.empty(
+                (token_count, self.hidden_size // 16),
+                dtype=_require_torch_dtype("float8_e4m3fn"),
+                device=device,
+            )
+        return BlockScaledTensor(
+            data=data,
+            scale=scale,
+            format=self.output_format,
+            logical_shape=logical_shape,
+            axis=-1,
+        )
+
+    def _count_local_routes(self, topk_idx: torch.Tensor) -> int:
+        """Number of valid routes this rank's experts receive.
+
+        Data-dependent: single-rank counts locally, EP exchanges per-rank
+        route counts (the same exchange the device dispatch performs).
+        """
+
+        flat = topk_idx.reshape(-1).to(torch.int64)
+        expert = flat[flat != -1]
+        if expert.numel() > 0 and bool(((expert < 0) | (expert >= self.num_experts)).any().item()):
+            raise ValueError("topk_idx contains out-of-range expert ids")
+        if self.ep_size == 1:
+            return int(expert.numel())
+        destination = torch.div(expert, self.experts_per_rank, rounding_mode="floor")
+        send_counts = torch.bincount(destination, minlength=self.ep_size)
+        if send_counts.device.type != "cpu" and dist.get_backend(self.ep_group) == "gloo":
+            send_counts = send_counts.cpu()
+        recv_counts = torch.empty_like(send_counts)
+        dist.all_to_all_single(recv_counts, send_counts, group=self.ep_group)
+        return int(recv_counts.sum().item())
+
+    def __call__(
+        self,
+        activation: MoeTensor,
+        fc1_weight: MoeTensor,
+        fc2_weight: MoeTensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> Union[MoeTensor, Tuple[MoeTensor, torch.Tensor, torch.Tensor]]:
+        """Allocate the result for a future backend MoE+EP launch.
+
+        Expected logical shapes are ``activation=(T,H)``,
+        ``fc1_weight=(E_local,H,2I)``, ``fc2_weight=(E_local,I,H)``, and
+        ``topk_idx=topk_weights=(T,K)``.
+
+        Returns the ``(T, H)`` result, or ``(result, fc1_c, route_metadata)``
+        when the operator was constructed with ``generate_c=True``.
+        """
+
+        activation_shape = _logical_shape(activation)
+        if len(activation_shape) != 2 or activation_shape[1] != self.hidden_size:
+            raise ValueError(f"activation logical shape must be (T, {self.hidden_size}), got {activation_shape}")
+        token_count = activation_shape[0]
+        expected_fc1 = (self.experts_per_rank, self.hidden_size, 2 * self.intermediate_size)
+        expected_fc2 = (self.experts_per_rank, self.intermediate_size, self.hidden_size)
+        if _logical_shape(fc1_weight) != expected_fc1:
+            raise ValueError(f"fc1_weight logical shape must be {expected_fc1}")
+        if _logical_shape(fc2_weight) != expected_fc2:
+            raise ValueError(f"fc2_weight logical shape must be {expected_fc2}")
+        route_shape = (token_count, self.top_k)
+        if tuple(topk_idx.shape) != route_shape:
+            raise ValueError(f"topk_idx shape must be {route_shape}, got {tuple(topk_idx.shape)}")
+        if tuple(topk_weights.shape) != route_shape:
+            raise ValueError(f"topk_weights shape must be {route_shape}, got {tuple(topk_weights.shape)}")
+        if self.max_tokens_per_rank is not None and token_count > self.max_tokens_per_rank:
+            raise ValueError(f"token count {token_count} exceeds max_tokens_per_rank={self.max_tokens_per_rank}")
+
+        device = _tensor_device(activation)
+        for name, tensor in (
+            ("fc1_weight", fc1_weight),
+            ("fc2_weight", fc2_weight),
+            ("topk_idx", topk_idx),
+            ("topk_weights", topk_weights),
+        ):
+            if _tensor_device(tensor) != device:
+                raise ValueError(f"{name} must be on {device}, got {_tensor_device(tensor)}")
+
+        # TODO: dispatch routes, launch local expert FC1/SwiGLU/FC2, return
+        # contributions, reduce top-k, and write this allocation.
+        output = self._allocate_output(token_count, device)
+        if not self.generate_c:
+            return output
+        local_routes = self._count_local_routes(topk_idx)
+        fc1_c = torch.empty(
+            (local_routes, 2 * self.intermediate_size),
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        route_metadata = torch.empty((local_routes, 4), dtype=torch.int32, device=device)
+        return output, fc1_c, route_metadata
+
+
+__all__ = ["BlockScaledTensor", "MoeEp", "MoeFormat", "MoeTensor"]

--- a/python/cudnn/moe_ep/api.py
+++ b/python/cudnn/moe_ep/api.py
@@ -161,8 +161,7 @@ class MoeEp:
     output storage with the correct public representation (the original
     API-stub behavior).  ``CUDNN_MOE_EP_BACKEND=megamoe|auto|none`` selects
     the policy; the megamoe package (with its CuTe DSL kernels) ships
-    vendored in ``moe_ep/_megamoe_backend`` and ``CUDNN_MEGAMOE_ROOT`` can
-    point at an external checkout instead.
+    inside cuDNN under ``moe_ep/_megamoe_backend``.
     """
 
     def __init__(

--- a/python/cudnn/moe_ep/api.py
+++ b/python/cudnn/moe_ep/api.py
@@ -154,9 +154,13 @@ class MoeEp:
     ``(local_expert, src_rank, src_token, src_slot)``, row-aligned with
     ``fc1_c``, identifying each route for the backward gradient re-dispatch.
 
-    The backend launch is intentionally a TODO.  Until it is implemented,
-    ``__call__`` returns newly allocated, uninitialized output storage with the
-    correct public representation.
+    Backend execution: when the MegaMoE device backend is available and the
+    configuration is supported (see ``moe_ep._megamoe``), ``__call__`` and
+    ``backward`` launch the fused SM100 kernels and return real results.
+    Otherwise they fall back to returning newly allocated, uninitialized
+    output storage with the correct public representation (the original
+    API-stub behavior).  ``CUDNN_MOE_EP_BACKEND=megamoe|auto|none`` selects
+    the policy; ``CUDNN_MEGAMOE_ROOT`` locates the megamoe package.
     """
 
     def __init__(
@@ -211,6 +215,8 @@ class MoeEp:
         self.apply_topk_in_fc1 = bool(apply_topk_in_fc1)
         self.gate_up_clamp = None if gate_up_clamp is None else abs(float(gate_up_clamp))
         self.generate_c = bool(generate_c)
+        self._backend = None
+        self._backend_resolved = False
 
         for name, fmt in (
             ("output_format", self.output_format),
@@ -283,7 +289,8 @@ class MoeEp:
         topk_idx: torch.Tensor,
         topk_weights: torch.Tensor,
     ) -> Union[MoeTensor, Tuple[MoeTensor, torch.Tensor, torch.Tensor]]:
-        """Allocate the result for a future backend MoE+EP launch.
+        """Run the MoE+EP forward (MegaMoE backend when available, otherwise
+        allocate-only).
 
         Expected logical shapes are ``activation=(T,H)``,
         ``fc1_weight=(E_local,H,2I)``, ``fc2_weight=(E_local,I,H)``, and
@@ -321,8 +328,18 @@ class MoeEp:
             if _tensor_device(tensor) != device:
                 raise ValueError(f"{name} must be on {device}, got {_tensor_device(tensor)}")
 
-        # TODO: dispatch routes, launch local expert FC1/SwiGLU/FC2, return
-        # contributions, reduce top-k, and write this allocation.
+        if not self._backend_resolved:
+            from . import _megamoe
+
+            self._backend = _megamoe.maybe_create(self, device, token_count)
+            self._backend_resolved = True
+        if self._backend is not None:
+            return self._backend.forward(
+                activation, fc1_weight, fc2_weight, topk_idx, topk_weights
+            )
+
+        # No device backend for this configuration/environment: return newly
+        # allocated, uninitialized storage (the original API-stub contract).
         output = self._allocate_output(token_count, device)
         if not self.generate_c:
             return output
@@ -346,7 +363,8 @@ class MoeEp:
         fc1_c: torch.Tensor,
         route_metadata: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Allocate gradients for a future backend MoE+EP backward launch.
+        """Run the MoE+EP backward (MegaMoE backend when available, otherwise
+        allocate-only).
 
         Requires ``generate_c=True``; consumes the forward stash
         (``fc1_c``, ``route_metadata``) plus the re-supplied forward inputs.
@@ -369,8 +387,20 @@ class MoeEp:
             raise ValueError(f"fc1_c shape must be {(int(route_metadata.shape[0]), two_i)}, got {tuple(fc1_c.shape)}")
 
         device = _tensor_device(activation)
-        # TODO: re-dispatch grad_output rows, recompute SwiGLU from fc1_c,
-        # accumulate weight gradients, and return route gradients to sources.
+        if self._backend is not None:
+            return self._backend.backward(
+                grad_output,
+                activation,
+                fc1_weight,
+                fc2_weight,
+                topk_idx,
+                topk_weights,
+                fc1_c,
+                route_metadata,
+            )
+
+        # No device backend: return newly allocated, uninitialized gradient
+        # storage (the original API-stub contract).
         return (
             torch.empty((token_count, self.hidden_size), dtype=torch.float32, device=device),
             torch.empty(

--- a/python/cudnn/moe_ep/api.py
+++ b/python/cudnn/moe_ep/api.py
@@ -160,7 +160,9 @@ class MoeEp:
     Otherwise they fall back to returning newly allocated, uninitialized
     output storage with the correct public representation (the original
     API-stub behavior).  ``CUDNN_MOE_EP_BACKEND=megamoe|auto|none`` selects
-    the policy; ``CUDNN_MEGAMOE_ROOT`` locates the megamoe package.
+    the policy; the megamoe package (with its CuTe DSL kernels) ships
+    vendored in ``moe_ep/_megamoe_backend`` and ``CUDNN_MEGAMOE_ROOT`` can
+    point at an external checkout instead.
     """
 
     def __init__(

--- a/python/cudnn/moe_ep/api.py
+++ b/python/cudnn/moe_ep/api.py
@@ -335,5 +335,56 @@ class MoeEp:
         route_metadata = torch.empty((local_routes, 4), dtype=torch.int32, device=device)
         return output, fc1_c, route_metadata
 
+    def backward(
+        self,
+        grad_output: torch.Tensor,
+        activation: MoeTensor,
+        fc1_weight: MoeTensor,
+        fc2_weight: MoeTensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        fc1_c: torch.Tensor,
+        route_metadata: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Allocate gradients for a future backend MoE+EP backward launch.
+
+        Requires ``generate_c=True``; consumes the forward stash
+        (``fc1_c``, ``route_metadata``) plus the re-supplied forward inputs.
+        Returns float32 ``(grad_activation, grad_fc1_weight, grad_fc2_weight,
+        grad_topk_weights)``.  Semantics are defined by
+        ``MoeEpReference.backward``.
+        """
+
+        if not self.generate_c:
+            raise RuntimeError("backward requires the operator to be constructed with generate_c=True")
+        token_count = topk_idx.shape[0]
+        if tuple(grad_output.shape) != (token_count, self.hidden_size):
+            raise ValueError(f"grad_output shape must be {(token_count, self.hidden_size)}, got {tuple(grad_output.shape)}")
+        if not grad_output.is_floating_point():
+            raise TypeError(f"grad_output must be floating point, got {grad_output.dtype}")
+        two_i = 2 * self.intermediate_size
+        if route_metadata.ndim != 2 or route_metadata.shape[1] != 4:
+            raise ValueError(f"route_metadata shape must be (local_routes, 4), got {tuple(route_metadata.shape)}")
+        if tuple(fc1_c.shape) != (int(route_metadata.shape[0]), two_i):
+            raise ValueError(f"fc1_c shape must be {(int(route_metadata.shape[0]), two_i)}, got {tuple(fc1_c.shape)}")
+
+        device = _tensor_device(activation)
+        # TODO: re-dispatch grad_output rows, recompute SwiGLU from fc1_c,
+        # accumulate weight gradients, and return route gradients to sources.
+        return (
+            torch.empty((token_count, self.hidden_size), dtype=torch.float32, device=device),
+            torch.empty(
+                (self.experts_per_rank, self.hidden_size, two_i),
+                dtype=torch.float32,
+                device=device,
+            ),
+            torch.empty(
+                (self.experts_per_rank, self.intermediate_size, self.hidden_size),
+                dtype=torch.float32,
+                device=device,
+            ),
+            torch.empty((token_count, self.top_k), dtype=torch.float32, device=device),
+        )
+
 
 __all__ = ["BlockScaledTensor", "MoeEp", "MoeFormat", "MoeTensor"]

--- a/python/cudnn/moe_ep/api.py
+++ b/python/cudnn/moe_ep/api.py
@@ -334,9 +334,7 @@ class MoeEp:
             self._backend = _megamoe.maybe_create(self, device, token_count)
             self._backend_resolved = True
         if self._backend is not None:
-            return self._backend.forward(
-                activation, fc1_weight, fc2_weight, topk_idx, topk_weights
-            )
+            return self._backend.forward(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
 
         # No device backend for this configuration/environment: return newly
         # allocated, uninitialized storage (the original API-stub contract).

--- a/test/python/fe_api/moe_ep/RUNBOOK.md
+++ b/test/python/fe_api/moe_ep/RUNBOOK.md
@@ -27,6 +27,46 @@ wheel to graft the `moe_ep` package onto (see §4).  A known-good container:
 /lustre/fsw/coreai_libraries_cudnn/mhoqueanik/flashinfer-ep-pt2605-mega_moe_ep-20260712.sqsh
 ```
 
+### 2a. Creating the environment from scratch
+
+Start from the NVIDIA PyTorch NGC image (known-good base:
+`nvcr.io/nvidia/pytorch:26.05-py3` — torch 2.10 / CUDA 13.x on SM100) and
+install the kernel dependencies pinned in the bundle:
+
+```bash
+docker run --gpus all -it --network=host --ipc=host \
+  -v <clone>:/workspace/cudnn-frontend \
+  nvcr.io/nvidia/pytorch:26.05-py3
+
+# inside the container; PIP_CONSTRAINT= overrides the NGC image's constraint
+# file so the requirements' own pins (cutlass-dsl 4.5.2, nvshmem4py) resolve
+PIP_CONSTRAINT="" pip install --no-cache-dir \
+  -r /workspace/cudnn-frontend/python/cudnn/moe_ep/_megamoe_backend/cutedsl_megamoe/ci/requirements.txt
+```
+
+The pins that matter are `nvidia-cutlass-dsl[cu13]==4.5.2` (the CuTe DSL
+version the kernels are written against — other versions may not compile),
+`nvshmem4py-cu13>=0.1.3`, and `torch>=2.10`; `pytest>=8.0` covers the test
+suite.  Smoke-check before running anything:
+
+```bash
+python - <<'EOF'
+import cutlass; assert cutlass.__version__.startswith("4.5.2"), cutlass.__version__
+import cutlass.cute, nvshmem.core, cuda.bindings.driver, torch
+print("torch", torch.__version__, "cuda", torch.version.cuda,
+      "sm", torch.cuda.get_device_capability())
+EOF
+```
+
+Expect `sm (10, 0)` — the kernels are SM100-only.  To bake a reusable sqsh
+for SLURM/pyxis clusters, run the same pip install under
+`srun --container-image=nvcr.io/nvidia/pytorch:26.05-py3
+--container-save=<out>.sqsh`.
+
+Multi-rank (EP) runs additionally need NVSHMEM's usual fabric access
+(`--ipc=host`, and on SLURM the pyxis defaults suffice); single-rank runs
+with `MEGA_NO_DIST=1` need none of that.
+
 Backend policy knob (the only env variable):
 
 | `CUDNN_MOE_EP_BACKEND` | Meaning |

--- a/test/python/fe_api/moe_ep/RUNBOOK.md
+++ b/test/python/fe_api/moe_ep/RUNBOOK.md
@@ -21,13 +21,9 @@ sources — nothing is loaded from an external checkout).
 
 Requirements for the device backend: SM100+ GPU (GB200), PyTorch with CUDA
 13.x, `nvidia-cutlass-dsl` (CuTe DSL), `nvshmem4py`, and a `cudnn` Python
-wheel to graft the `moe_ep` package onto (see §4).  A known-good container:
+wheel to graft the `moe_ep` package onto (see §4).
 
-```
-/lustre/fsw/coreai_libraries_cudnn/mhoqueanik/flashinfer-ep-pt2605-mega_moe_ep-20260712.sqsh
-```
-
-### 2a. Creating the environment from scratch
+### 2a. Creating the environment
 
 Start from the NVIDIA PyTorch NGC image (known-good base:
 `nvcr.io/nvidia/pytorch:26.05-py3` — torch 2.10 / CUDA 13.x on SM100) and
@@ -58,10 +54,11 @@ print("torch", torch.__version__, "cuda", torch.version.cuda,
 EOF
 ```
 
-Expect `sm (10, 0)` — the kernels are SM100-only.  To bake a reusable sqsh
-for SLURM/pyxis clusters, run the same pip install under
+Expect `sm (10, 0)` — the kernels are SM100-only.  On SLURM/pyxis clusters
+you can bake a reusable image once by running the same pip install under
 `srun --container-image=nvcr.io/nvidia/pytorch:26.05-py3
---container-save=<out>.sqsh`.
+--container-save=<out>.sqsh`, then pass `--container-image=<out>.sqsh` to
+later jobs.
 
 Multi-rank (EP) runs additionally need NVSHMEM's usual fabric access
 (`--ipc=host`, and on SLURM the pyxis defaults suffice); single-rank runs
@@ -82,13 +79,19 @@ is the safe habit).
 ## 3. One-shot validation (recommended)
 
 Runs the pytest suite, a bundled-kernel import check (FP4 forward + FP8 mega
-backward), and the single-rank kernel parity, in that order:
+backward), and the single-rank kernel parity, in that order.  From inside
+the §2a environment (the script locates the clone from its own path):
 
 ```bash
-ROOT=/lustre/fsw/coreai_libraries_cudnn/mhoqueanik   # container/mount root
-srun -A coreai_libraries_cudnn -p batch -N1 --ntasks=1 -t 60 \
-  --container-image=$ROOT/flashinfer-ep-pt2605-mega_moe_ep-20260712.sqsh \
-  --container-mounts=$ROOT:$ROOT \
+bash <clone>/test/python/fe_api/moe_ep/run_pr_tests.sh
+```
+
+On a SLURM/pyxis cluster, the same thing as a one-node GPU job:
+
+```bash
+srun -N1 --ntasks=1 --gpus-per-node=1 -t 60 \
+  --container-image=<env-image>.sqsh \
+  --container-mounts=<clone>:<clone> \
   bash <clone>/test/python/fe_api/moe_ep/run_pr_tests.sh
 ```
 

--- a/test/python/fe_api/moe_ep/RUNBOOK.md
+++ b/test/python/fe_api/moe_ep/RUNBOOK.md
@@ -1,0 +1,139 @@
+# Runbook: running and testing the `cudnn.MoeEp` PR
+
+How to validate this PR end to end: the pure-Python API/reference tests and
+the MegaMoE (CuTe DSL) device backend that ships inside cuDNN under
+`python/cudnn/moe_ep/_megamoe_backend/` (megamoe + pt + the CuTe DSL kernel
+sources — nothing is loaded from an external checkout).
+
+## 1. What is under test
+
+| Piece | Where | Needs GPU? |
+|---|---|---|
+| Public API (`cudnn.MoeEp`, `MoeFormat`, `BlockScaledTensor`) | `python/cudnn/moe_ep/api.py` | no (stub path) |
+| PyTorch FP32 oracle | `test/python/fe_api/moe_ep/moe_ep_reference.py` | CPU ok |
+| pytest suite (API + reference semantics) | `test/python/fe_api/moe_ep/test_moe_ep.py` | 1 GPU for two tests |
+| Device backend shim | `python/cudnn/moe_ep/_megamoe.py` | — |
+| Bundled kernels (MXFP8 fwd, NVFP4 fwd, FP8 mega bwd — bprop from the Flashinfer team, not FastKernel) | `python/cudnn/moe_ep/_megamoe_backend/` | SM100 (GB200) |
+| Kernel-vs-oracle parity driver | `test/python/fe_api/moe_ep/megamoe_backend_parity.py` | SM100 (GB200) |
+| One-shot wrapper for all of the above | `test/python/fe_api/moe_ep/run_pr_tests.sh` | SM100 (GB200) |
+
+## 2. Environment
+
+Requirements for the device backend: SM100+ GPU (GB200), PyTorch with CUDA
+13.x, `nvidia-cutlass-dsl` (CuTe DSL), `nvshmem4py`, and a `cudnn` Python
+wheel to graft the `moe_ep` package onto (see §4).  A known-good container:
+
+```
+/lustre/fsw/coreai_libraries_cudnn/mhoqueanik/flashinfer-ep-pt2605-mega_moe_ep-20260712.sqsh
+```
+
+Backend policy knob (the only env variable):
+
+| `CUDNN_MOE_EP_BACKEND` | Meaning |
+|---|---|
+| `auto` (default) | use the kernel when the config is supported, else warn once and fall back to allocate-only stubs |
+| `megamoe` | required — any backend failure raises (use for validation/CI) |
+| `none` | never use the device backend |
+
+`MEGA_NO_DIST=1` must be exported for single-GPU runs **before** any megamoe
+import (the shim sets it for `ep_group=None`, but exporting it in the shell
+is the safe habit).
+
+## 3. One-shot validation (recommended)
+
+Runs the pytest suite, a bundled-kernel import check (FP4 forward + FP8 mega
+backward), and the single-rank kernel parity, in that order:
+
+```bash
+ROOT=/lustre/fsw/coreai_libraries_cudnn/mhoqueanik   # container/mount root
+srun -A coreai_libraries_cudnn -p batch -N1 --ntasks=1 -t 60 \
+  --container-image=$ROOT/flashinfer-ep-pt2605-mega_moe_ep-20260712.sqsh \
+  --container-mounts=$ROOT:$ROOT \
+  bash <clone>/test/python/fe_api/moe_ep/run_pr_tests.sh
+```
+
+Expected tail: `ALL PR TESTS PASSED` (exit 0).  Budget ~10 min: the first
+parity call pays the one-time `cute.compile` (~3–5 min per kernel).
+
+## 4. Step-by-step (what the wrapper does)
+
+### 4a. pytest suite
+
+If the installed `cudnn` wheel predates this PR, graft the pure-Python
+package onto it first (container overlay, nothing persists):
+
+```bash
+SITE=$(python -c "import cudnn,os;print(os.path.dirname(cudnn.__file__))")
+cp -r <clone>/python/cudnn/moe_ep $SITE/
+grep -q moe_ep $SITE/__init__.py || \
+  echo "from .moe_ep import BlockScaledTensor, MoeEp, MoeFormat, MoeTensor" >> $SITE/__init__.py
+cd <clone>/test/python
+NVIDIA_TF32_OVERRIDE=0 python -m pytest fe_api/moe_ep/test_moe_ep.py -q
+```
+
+Expected: **`18 passed, 7 xfailed`**.
+
+- The 7 xfails are *intended*: strict `xfail` gates asserting bit-exact
+  API-vs-oracle equality, which an MXFP8-compute kernel can never satisfy
+  against an FP32 oracle.  Strict means an unexpected pass (`XPASS`) errors,
+  so they double as tripwires.  Any `failed`/`error` count > 0 is a real
+  regression.
+- `NVIDIA_TF32_OVERRIDE=0` is required: NGC containers default TF32 on and
+  `test_four_rank_expert_parallel` compares GPU fp32 GEMMs against CPU at
+  fp32 tolerance.
+
+### 4b. Kernel parity vs the PyTorch oracle (single rank)
+
+```bash
+cd <clone>/test/python
+CUDNN_MOE_EP_BACKEND=megamoe MEGA_NO_DIST=1 \
+  python fe_api/moe_ep/megamoe_backend_parity.py
+```
+
+Expected (baseline 2026-08-05, T=128 H=1024 I=512 E=8 K=4; gate is 0.10):
+
+```
+fwd rel_err ≈ 6.5e-02    fc1_c rel_err ≈ 3.8e-02    metadata equal=True
+bwd rel_err ≈ 6.5e-02 for grad_activation / grad_fc1_weight /
+             grad_fc2_weight / grad_topk_weights    dtw[-1 slot]==0: True
+mxfp8 output quantizer bit-exact vs reference: True
+PASS
+```
+
+How to read it: the ~6.5e-2 relative errors are MXFP8-compute vs FP32-oracle
+noise — drift well beyond that (or past the 0.10 gate) is a numerical
+regression.  `metadata equal=True` and the quantizer bit-exactness are hard
+invariants — any regression there is a wiring bug, not noise.
+
+### 4c. Kernel parity, 4-rank expert parallel (one GB200 node)
+
+```bash
+cd <clone>/test/python
+CUDNN_MOE_EP_BACKEND=megamoe \
+  torchrun --nproc_per_node=4 --standalone fe_api/moe_ep/megamoe_backend_parity.py
+```
+
+Same expected numbers, printed per rank; NVSHMEM is bootstrapped over the
+torchrun world.
+
+## 5. Gotchas
+
+1. **Stub fallback returns uninitialized memory silently** — that is the
+   PR's documented contract for unsupported configs under `auto`.  During
+   validation always set `CUDNN_MOE_EP_BACKEND=megamoe` so misconfigurations
+   raise instead.
+2. **Supported envelope** (outside it `auto` falls back): SM100+,
+   `apply_topk_in_fc1=True`, `hidden_size`/`intermediate_size` % 32 == 0
+   (% 128 for the `generate_c`/backward path), `combine_format='bf16'` for
+   training (`mxfp8` is forward-only, `nvfp4` combine unsupported).
+3. **One backward per forward** on the same `MoeEp` instance — backward
+   consumes the kernel pool stash of the immediately preceding forward.
+4. **Process mode is frozen at first megamoe import**: one process serves
+   either single-rank (`MEGA_NO_DIST=1`) or EP/NVSHMEM instances, not both.
+5. **`max_tokens_per_rank`**: if omitted, kernel buffers are sized to the
+   first call's token count and larger later calls raise.  Pass it
+   explicitly for variable batch sizes.
+6. **Compile cache**: every new process pays `cute.compile` once per kernel;
+   shim/API edits don't recompile, kernel-source edits do.
+7. The vendored `_megamoe_backend/` tree is a verbatim copy (provenance in
+   its README) and is excluded from black — don't reformat it.

--- a/test/python/fe_api/moe_ep/megamoe_backend_parity.py
+++ b/test/python/fe_api/moe_ep/megamoe_backend_parity.py
@@ -3,9 +3,10 @@
 
 """Parity driver: cudnn.MoeEp on the MegaMoE backend vs MoeEpReference.
 
-Runs at kernel-supported shapes (H, I multiples of 128) on SM100 with the
-megamoe training repo importable (CUDNN_MEGAMOE_ROOT).  Not a pytest module:
-the first call compiles the CuTe DSL kernels (minutes).
+Runs at kernel-supported shapes (H, I multiples of 128) on SM100 using the
+megamoe package vendored in python/cudnn/moe_ep/_megamoe_backend (or an
+external checkout via CUDNN_MEGAMOE_ROOT).  Not a pytest module: the first
+call compiles the CuTe DSL kernels (minutes).
 
 Single rank:
     CUDNN_MOE_EP_BACKEND=megamoe MEGA_NO_DIST=1 python megamoe_backend_parity.py
@@ -65,7 +66,11 @@ def as_float(output):
 def main():
     multi = "RANK" in os.environ and int(os.environ.get("WORLD_SIZE", "1")) > 1
     if multi:
-        sys.path.insert(0, os.environ["CUDNN_MEGAMOE_ROOT"])
+        import importlib
+
+        _shim = importlib.import_module("cudnn_moe_ep._megamoe")
+        root = os.environ.get("CUDNN_MEGAMOE_ROOT") or _shim.bundled_root()
+        sys.path.insert(0, root)
         import megamoe.repo_path  # noqa: F401
         from src.bootstrap import init_dist_and_nvshmem
 

--- a/test/python/fe_api/moe_ep/megamoe_backend_parity.py
+++ b/test/python/fe_api/moe_ep/megamoe_backend_parity.py
@@ -82,14 +82,8 @@ def main():
     x = (torch.randn((TOKENS, HIDDEN), device=device, generator=gen) / 10).bfloat16()
     # PR layouts: fc1 (E_local, H, 2I) gate-first, fc2 (E_local, I, H)
     e_local = EXPERTS // world
-    fc1_w = (
-        torch.randn((e_local, HIDDEN, 2 * INTERMEDIATE), device=device, generator=gen)
-        * 0.05
-    ).bfloat16()
-    fc2_w = (
-        torch.randn((e_local, INTERMEDIATE, HIDDEN), device=device, generator=gen)
-        * 0.05
-    ).bfloat16()
+    fc1_w = (torch.randn((e_local, HIDDEN, 2 * INTERMEDIATE), device=device, generator=gen) * 0.05).bfloat16()
+    fc2_w = (torch.randn((e_local, INTERMEDIATE, HIDDEN), device=device, generator=gen) * 0.05).bfloat16()
     scores = torch.rand((TOKENS, EXPERTS), device=device, generator=gen)
     _, ids = scores.topk(TOPK, dim=-1)
     ids = ids.long()
@@ -138,9 +132,7 @@ def main():
     }
     dtw_drop_zero = bool((dtw[0, TOPK - 1] == 0).item())
     print(
-        f"[rank {rank}] bwd rel_err: "
-        + "  ".join(f"{k}={v:.3e}" for k, v in errs.items())
-        + f"  dtw[-1 slot]==0: {dtw_drop_zero}",
+        f"[rank {rank}] bwd rel_err: " + "  ".join(f"{k}={v:.3e}" for k, v in errs.items()) + f"  dtw[-1 slot]==0: {dtw_drop_zero}",
         flush=True,
     )
 

--- a/test/python/fe_api/moe_ep/megamoe_backend_parity.py
+++ b/test/python/fe_api/moe_ep/megamoe_backend_parity.py
@@ -4,9 +4,8 @@
 """Parity driver: cudnn.MoeEp on the MegaMoE backend vs MoeEpReference.
 
 Runs at kernel-supported shapes (H, I multiples of 128) on SM100 using the
-megamoe package vendored in python/cudnn/moe_ep/_megamoe_backend (or an
-external checkout via CUDNN_MEGAMOE_ROOT).  Not a pytest module: the first
-call compiles the CuTe DSL kernels (minutes).
+megamoe package bundled in python/cudnn/moe_ep/_megamoe_backend.  Not a
+pytest module: the first call compiles the CuTe DSL kernels (minutes).
 
 Single rank:
     CUDNN_MOE_EP_BACKEND=megamoe MEGA_NO_DIST=1 python megamoe_backend_parity.py
@@ -69,8 +68,7 @@ def main():
         import importlib
 
         _shim = importlib.import_module("cudnn_moe_ep._megamoe")
-        root = os.environ.get("CUDNN_MEGAMOE_ROOT") or _shim.bundled_root()
-        sys.path.insert(0, root)
+        sys.path.insert(0, _shim.bundled_root())
         import megamoe.repo_path  # noqa: F401
         from src.bootstrap import init_dist_and_nvshmem
 

--- a/test/python/fe_api/moe_ep/megamoe_backend_parity.py
+++ b/test/python/fe_api/moe_ep/megamoe_backend_parity.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Parity driver: cudnn.MoeEp on the MegaMoE backend vs MoeEpReference.
+
+Runs at kernel-supported shapes (H, I multiples of 128) on SM100 with the
+megamoe training repo importable (CUDNN_MEGAMOE_ROOT).  Not a pytest module:
+the first call compiles the CuTe DSL kernels (minutes).
+
+Single rank:
+    CUDNN_MOE_EP_BACKEND=megamoe MEGA_NO_DIST=1 python megamoe_backend_parity.py
+Multi rank (EP):
+    CUDNN_MOE_EP_BACKEND=megamoe torchrun --nproc_per_node=4 --standalone \
+        megamoe_backend_parity.py
+
+The backend computes in MXFP8 (device-quantized activations/weights), so
+outputs are compared against the FP32 reference at MXFP8-level tolerance.
+route_metadata must match exactly.
+"""
+
+import importlib.util
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_CLONE = os.path.abspath(os.path.join(_HERE, "..", "..", "..", ".."))
+
+# Import the moe_ep package straight from source files so this driver does
+# not need the compiled cudnn pybind module.
+_spec = importlib.util.spec_from_file_location(
+    "cudnn_moe_ep",
+    os.path.join(_CLONE, "python", "cudnn", "moe_ep", "__init__.py"),
+    submodule_search_locations=[os.path.join(_CLONE, "python", "cudnn", "moe_ep")],
+)
+_pkg = importlib.util.module_from_spec(_spec)
+sys.modules["cudnn_moe_ep"] = _pkg
+_spec.loader.exec_module(_pkg)
+MoeEp = _pkg.MoeEp
+
+sys.path.insert(0, os.path.join(_CLONE, "test", "python"))
+from fe_api.moe_ep.moe_ep_reference import MoeEpReference  # noqa: E402
+
+TOKENS = 128
+HIDDEN = 1024
+INTERMEDIATE = 512
+EXPERTS = 8
+TOPK = 4
+SEED = 1234
+
+
+def rel_err(a, b):
+    denom = b.float().norm().item()
+    return (a.float() - b.float()).norm().item() / max(denom, 1e-30)
+
+
+def as_float(output):
+    if isinstance(output, torch.Tensor):
+        return output.float()
+    return output.dequantize()
+
+
+def main():
+    multi = "RANK" in os.environ and int(os.environ.get("WORLD_SIZE", "1")) > 1
+    if multi:
+        sys.path.insert(0, os.environ["CUDNN_MEGAMOE_ROOT"])
+        import megamoe.repo_path  # noqa: F401
+        from src.bootstrap import init_dist_and_nvshmem
+
+        _, rank, world, _ = init_dist_and_nvshmem()
+        ep_group = dist.group.WORLD
+        device = torch.device("cuda", torch.cuda.current_device())
+    else:
+        os.environ.setdefault("MEGA_NO_DIST", "1")
+        rank, world, ep_group = 0, 1, None
+        torch.cuda.set_device(0)
+        device = torch.device("cuda", 0)
+
+    gen = torch.Generator(device=device).manual_seed(SEED + rank)
+    x = (torch.randn((TOKENS, HIDDEN), device=device, generator=gen) / 10).bfloat16()
+    # PR layouts: fc1 (E_local, H, 2I) gate-first, fc2 (E_local, I, H)
+    e_local = EXPERTS // world
+    fc1_w = (
+        torch.randn((e_local, HIDDEN, 2 * INTERMEDIATE), device=device, generator=gen)
+        * 0.05
+    ).bfloat16()
+    fc2_w = (
+        torch.randn((e_local, INTERMEDIATE, HIDDEN), device=device, generator=gen)
+        * 0.05
+    ).bfloat16()
+    scores = torch.rand((TOKENS, EXPERTS), device=device, generator=gen)
+    _, ids = scores.topk(TOPK, dim=-1)
+    ids = ids.long()
+    ids[0, TOPK - 1] = -1  # exercise a dropped route
+    w = torch.rand((TOKENS, TOPK), device=device, generator=gen) + 0.1
+    tw = (w / w.sum(-1, keepdim=True)).float()
+    tw[0, TOPK - 1] = 0.0
+    gout = torch.randn((TOKENS, HIDDEN), device=device, generator=gen)
+
+    kwargs = dict(
+        num_experts=EXPERTS,
+        hidden_size=HIDDEN,
+        intermediate_size=INTERMEDIATE,
+        top_k=TOPK,
+        ep_group=ep_group,
+        max_tokens_per_rank=TOKENS,
+        generate_c=True,
+    )
+    api = MoeEp(**kwargs)
+    ref = MoeEpReference(**kwargs)
+    args = (x, fc1_w, fc2_w, ids, tw)
+
+    print(f"[rank {rank}] forward (compiles kernels on first call)...", flush=True)
+    out, fc1_c, meta = api(*args)
+    ref_out, ref_fc1_c, ref_meta = ref(*args)
+
+    fwd_err = rel_err(as_float(out), as_float(ref_out))
+    meta_ok = torch.equal(meta, ref_meta)
+    fc1_err = rel_err(fc1_c, ref_fc1_c) if fc1_c.shape == ref_fc1_c.shape else float("inf")
+    print(
+        f"[rank {rank}] fwd rel_err={fwd_err:.3e}  "
+        f"fc1_c shape={tuple(fc1_c.shape)} vs ref {tuple(ref_fc1_c.shape)} "
+        f"rel_err={fc1_err:.3e}  metadata equal={meta_ok}",
+        flush=True,
+    )
+
+    print(f"[rank {rank}] backward (compiles bwd kernel on first call)...", flush=True)
+    dx, dw1, dw2, dtw = api.backward(gout, *args, fc1_c, meta)
+    rdx, rdw1, rdw2, rdtw = ref.backward(gout, *args, ref_fc1_c, ref_meta)
+
+    errs = {
+        "grad_activation": rel_err(dx, rdx),
+        "grad_fc1_weight": rel_err(dw1, rdw1),
+        "grad_fc2_weight": rel_err(dw2, rdw2),
+        "grad_topk_weights": rel_err(dtw, rdtw),
+    }
+    dtw_drop_zero = bool((dtw[0, TOPK - 1] == 0).item())
+    print(
+        f"[rank {rank}] bwd rel_err: "
+        + "  ".join(f"{k}={v:.3e}" for k, v in errs.items())
+        + f"  dtw[-1 slot]==0: {dtw_drop_zero}",
+        flush=True,
+    )
+
+    # host-side output quantizer must match the reference bit for bit
+    from fe_api.moe_ep.moe_ep_reference import quantize_blockwise
+
+    _megamoe = sys.modules["cudnn_moe_ep._megamoe"]
+    bf16_out = as_float(out).bfloat16()
+    got_q = _megamoe._quantize_output(bf16_out, _pkg.MoeFormat.MXFP8).dequantize()
+    want_q = quantize_blockwise(bf16_out, "mxfp8", axis=1).dequantize()
+    quant_exact = torch.equal(got_q, want_q)
+    print(f"[rank {rank}] mxfp8 output quantizer bit-exact vs reference: {quant_exact}", flush=True)
+
+    tol = 0.10
+    failures = [k for k, v in {**errs, "forward": fwd_err}.items() if v > tol]
+    ok = not failures and meta_ok and dtw_drop_zero and quant_exact
+    print(f"[rank {rank}] {'PASS' if ok else 'FAIL ' + str(failures)}", flush=True)
+    if multi:
+        dist.barrier()
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/python/fe_api/moe_ep/moe_ep_reference.py
+++ b/test/python/fe_api/moe_ep/moe_ep_reference.py
@@ -1,0 +1,792 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Pure PyTorch semantic reference for a SwiGLU MoE with expert parallelism.
+
+The implementation deliberately favors readable semantics over performance.  It
+supports a one-rank execution path and a variable-size ``all_to_all_single`` EP
+path, plus BF16, MXFP8, and NVFP4 block-scaled public outputs.
+
+The quantized tensor layouts are logical (unswizzled) layouts.  A production
+kernel may reorder scale factors internally without changing this API contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Sequence, Tuple, Union
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+
+class MoeFormat(str, Enum):
+    """Public and communication formats supported by the reference."""
+
+    BF16 = "bf16"
+    MXFP8 = "mxfp8"
+    NVFP4 = "nvfp4"
+
+
+def _parse_format(value: Union[MoeFormat, str]) -> MoeFormat:
+    if isinstance(value, MoeFormat):
+        return value
+    try:
+        return MoeFormat(value.lower())
+    except (AttributeError, ValueError) as exc:
+        choices = ", ".join(item.value for item in MoeFormat)
+        raise ValueError(f"unsupported format {value!r}; expected one of: {choices}") from exc
+
+
+def _require_torch_dtype(name: str) -> torch.dtype:
+    dtype = getattr(torch, name, None)
+    if dtype is None:
+        raise RuntimeError(f"this PyTorch build does not provide torch.{name}")
+    return dtype
+
+
+def _normalize_axis(axis: int, ndim: int) -> int:
+    normalized = axis + ndim if axis < 0 else axis
+    if normalized < 0 or normalized >= ndim:
+        raise IndexError(f"axis {axis} is out of range for a {ndim}-D tensor")
+    return normalized
+
+
+def _shape_with_axis(shape: Sequence[int], axis: int, value: int) -> Tuple[int, ...]:
+    result = list(shape)
+    result[axis] = value
+    return tuple(result)
+
+
+def _ceil_div(numerator: int, denominator: int) -> int:
+    return (numerator + denominator - 1) // denominator
+
+
+@dataclass(frozen=True)
+class BlockScaledTensor:
+    """Portable data-plus-scale representation for MXFP8 or NVFP4.
+
+    ``logical_shape`` describes the dequantized tensor.  For MXFP8, ``data``
+    has that shape and uses E4M3.  For NVFP4, ``data`` is a uint8 tensor with
+    two E2M1 values per byte along ``axis`` (low nibble first).  ``scale``
+    replaces that axis by one scale per block.
+    """
+
+    data: torch.Tensor
+    scale: torch.Tensor
+    format: Union[MoeFormat, str]
+    logical_shape: Tuple[int, ...]
+    axis: int = -1
+
+    def __post_init__(self) -> None:
+        fmt = _parse_format(self.format)
+        if fmt is MoeFormat.BF16:
+            raise ValueError("BlockScaledTensor only represents mxfp8 or nvfp4")
+        shape = tuple(int(dim) for dim in self.logical_shape)
+        if not shape or any(dim < 0 for dim in shape):
+            raise ValueError(f"logical_shape must contain non-negative dimensions, got {shape}")
+        axis = _normalize_axis(self.axis, len(shape))
+        object.__setattr__(self, "format", fmt)
+        object.__setattr__(self, "logical_shape", shape)
+        object.__setattr__(self, "axis", axis)
+        self._validate_storage()
+
+    @property
+    def block_size(self) -> int:
+        return 32 if self.format is MoeFormat.MXFP8 else 16
+
+    @property
+    def shape(self) -> Tuple[int, ...]:
+        return self.logical_shape
+
+    @property
+    def device(self) -> torch.device:
+        return self.data.device
+
+    def _validate_storage(self) -> None:
+        if self.data.device != self.scale.device:
+            raise ValueError("block-scaled data and scale must be on the same device")
+
+        logical_extent = self.logical_shape[self.axis]
+        scale_shape = _shape_with_axis(
+            self.logical_shape,
+            self.axis,
+            _ceil_div(logical_extent, self.block_size),
+        )
+        if tuple(self.scale.shape) != scale_shape:
+            raise ValueError(f"scale shape must be {scale_shape}, got {tuple(self.scale.shape)}")
+
+        if self.format is MoeFormat.MXFP8:
+            expected_dtype = _require_torch_dtype("float8_e4m3fn")
+            expected_scale_dtype = _require_torch_dtype("float8_e8m0fnu")
+            data_shape = self.logical_shape
+            if self.data.dtype != expected_dtype:
+                raise TypeError(f"mxfp8 data must have dtype {expected_dtype}, got {self.data.dtype}")
+        else:
+            expected_scale_dtype = _require_torch_dtype("float8_e4m3fn")
+            fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+            if self.data.dtype != torch.uint8 and self.data.dtype != fp4_dtype:
+                raise TypeError("nvfp4 data must be packed uint8 or torch.float4_e2m1fn_x2")
+            data_shape = _shape_with_axis(
+                self.logical_shape,
+                self.axis,
+                _ceil_div(logical_extent, 2),
+            )
+
+        if tuple(self.data.shape) != data_shape:
+            raise ValueError(f"data shape must be {data_shape}, got {tuple(self.data.shape)}")
+        if self.scale.dtype != expected_scale_dtype:
+            raise TypeError(f"scale must have dtype {expected_scale_dtype}, got {self.scale.dtype}")
+
+    def dequantize(self, dtype: torch.dtype = torch.float32) -> torch.Tensor:
+        """Return the logical tensor with block scales applied."""
+
+        logical_extent = self.logical_shape[self.axis]
+        scale = self.scale.movedim(self.axis, -1).float()
+        expanded_scale = scale.repeat_interleave(self.block_size, dim=-1)[..., :logical_extent]
+
+        if self.format is MoeFormat.MXFP8:
+            values = self.data.movedim(self.axis, -1).float()
+        else:
+            packed = self.data
+            if packed.dtype != torch.uint8:
+                packed = packed.view(torch.uint8)
+            packed = packed.movedim(self.axis, -1)
+            low = packed & 0x0F
+            high = packed >> 4
+            codes = torch.stack((low, high), dim=-1).flatten(-2)[..., :logical_extent]
+            table = torch.tensor(
+                [
+                    0.0,
+                    0.5,
+                    1.0,
+                    1.5,
+                    2.0,
+                    3.0,
+                    4.0,
+                    6.0,
+                    -0.0,
+                    -0.5,
+                    -1.0,
+                    -1.5,
+                    -2.0,
+                    -3.0,
+                    -4.0,
+                    -6.0,
+                ],
+                dtype=torch.float32,
+                device=packed.device,
+            )
+            values = table[codes.long()]
+
+        return (values * expanded_scale).movedim(-1, self.axis).to(dtype)
+
+
+def _nearest_e2m1_codes(values: torch.Tensor) -> torch.Tensor:
+    """Quantize to E2M1 nibble codes with round-to-nearest, ties-to-even."""
+
+    levels = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+        dtype=torch.float32,
+        device=values.device,
+    )
+    magnitudes = values.abs().unsqueeze(-1)
+    distances = (magnitudes - levels).abs()
+    minimum = distances.amin(dim=-1, keepdim=True)
+    candidates = distances == minimum
+    codes = torch.arange(8, dtype=torch.int64, device=values.device)
+    any_code = torch.where(candidates, codes, 8).amin(dim=-1)
+    even_code = torch.where(candidates & ((codes & 1) == 0), codes, 8).amin(dim=-1)
+    magnitude_code = torch.where(even_code < 8, even_code, any_code)
+    sign_code = torch.signbit(values).to(torch.int64) << 3
+    return magnitude_code | sign_code
+
+
+def quantize_blockwise(
+    tensor: torch.Tensor,
+    format: Union[MoeFormat, str],
+    *,
+    axis: int = -1,
+) -> BlockScaledTensor:
+    """Quantize a floating tensor into logical MXFP8 or NVFP4 blocks.
+
+    MXFP8 uses 32-value blocks, E4M3 payloads, and E8M0 scales rounded toward
+    positive infinity.  NVFP4 uses 16-value blocks, packed E2M1 payloads, and
+    E4M3 scales rounded to nearest.
+    """
+
+    fmt = _parse_format(format)
+    if fmt is MoeFormat.BF16:
+        raise ValueError("quantize_blockwise requires mxfp8 or nvfp4")
+    if not tensor.is_floating_point():
+        raise TypeError(f"tensor must be floating point, got {tensor.dtype}")
+
+    axis = _normalize_axis(axis, tensor.ndim)
+    logical_shape = tuple(tensor.shape)
+    moved = tensor.float().movedim(axis, -1)
+    logical_extent = moved.shape[-1]
+    block_size = 32 if fmt is MoeFormat.MXFP8 else 16
+    block_count = _ceil_div(logical_extent, block_size)
+    padded_extent = block_count * block_size
+    if padded_extent != logical_extent:
+        moved = F.pad(moved, (0, padded_extent - logical_extent))
+    blocks = moved.reshape(*moved.shape[:-1], block_count, block_size)
+
+    value_limit = 448.0 if fmt is MoeFormat.MXFP8 else 6.0
+    scale_float = blocks.abs().amax(dim=-1) / value_limit
+    if fmt is MoeFormat.MXFP8:
+        safe_scale = torch.where(scale_float > 0, scale_float, 1.0)
+        scale_float = torch.where(
+            scale_float > 0,
+            torch.pow(2.0, torch.ceil(torch.log2(safe_scale))),
+            torch.zeros_like(scale_float),
+        )
+        scale_dtype = _require_torch_dtype("float8_e8m0fnu")
+    else:
+        scale_dtype = _require_torch_dtype("float8_e4m3fn")
+
+    scale = scale_float.to(scale_dtype)
+    scale_for_math = scale.float()
+    reciprocal = torch.where(scale_for_math > 0, scale_for_math.reciprocal(), 0.0)
+    normalized = (blocks * reciprocal.unsqueeze(-1)).clamp(-value_limit, value_limit)
+
+    if fmt is MoeFormat.MXFP8:
+        data_dtype = _require_torch_dtype("float8_e4m3fn")
+        data = normalized.to(data_dtype).reshape(*moved.shape)[..., :logical_extent]
+    else:
+        codes = _nearest_e2m1_codes(normalized).reshape(*moved.shape)
+        low = codes[..., 0::2]
+        high = codes[..., 1::2]
+        data = (low | (high << 4)).to(torch.uint8)[..., : _ceil_div(logical_extent, 2)]
+
+    return BlockScaledTensor(
+        data=data.movedim(-1, axis).contiguous(),
+        scale=scale.movedim(-1, axis).contiguous(),
+        format=fmt,
+        logical_shape=logical_shape,
+        axis=axis,
+    )
+
+
+MoeTensor = Union[torch.Tensor, BlockScaledTensor]
+
+
+@dataclass(frozen=True)
+class _DispatchPlan:
+    """Send-side routing derived from ``topk_idx``; identical in fwd and bwd."""
+
+    send_expert: torch.Tensor  # local expert id per sent route
+    send_weight: torch.Tensor  # router weight per sent route
+    send_token_idx: torch.Tensor  # source token per sent route
+    send_slot_idx: torch.Tensor  # source top-k slot per sent route
+    send_counts: Tuple[int, ...]  # routes sent to each rank
+    recv_counts: Tuple[int, ...]  # routes received from each rank
+
+
+def _tensor_device(tensor: MoeTensor) -> torch.device:
+    return tensor.device
+
+
+def _decode_tensor(
+    tensor: MoeTensor,
+    *,
+    name: str,
+    expected_shape: Tuple[int, ...],
+    quantized_axis: int,
+) -> torch.Tensor:
+    if isinstance(tensor, BlockScaledTensor):
+        if tensor.logical_shape != expected_shape:
+            raise ValueError(f"{name} logical shape must be {expected_shape}, got {tensor.logical_shape}")
+        if tensor.axis != _normalize_axis(quantized_axis, len(expected_shape)):
+            raise ValueError(f"{name} must be block-scaled along axis {quantized_axis}")
+        return tensor.dequantize()
+
+    if tuple(tensor.shape) != expected_shape:
+        raise ValueError(f"{name} shape must be {expected_shape}, got {tuple(tensor.shape)}")
+    if not tensor.is_floating_point():
+        raise TypeError(f"{name} must be floating point or BlockScaledTensor, got {tensor.dtype}")
+    return tensor.float()
+
+
+def _format_round_trip(tensor: torch.Tensor, format: MoeFormat) -> torch.Tensor:
+    if format is MoeFormat.BF16:
+        return tensor.to(torch.bfloat16).float()
+    return quantize_blockwise(tensor, format, axis=-1).dequantize()
+
+
+class MoeEpReference:
+    """Reference implementation of routed SwiGLU experts plus EP dispatch.
+
+    Global experts are assigned contiguously: rank ``r`` owns
+    ``[r * experts_per_rank, (r + 1) * experts_per_rank)``.  Pass an explicit
+    initialized process group for multi-rank execution; ``None`` means a
+    one-rank reference even if the default distributed group is initialized.
+    """
+
+    def __init__(
+        self,
+        *,
+        num_experts: int,
+        hidden_size: int,
+        intermediate_size: int,
+        top_k: int,
+        ep_group: Optional[dist.ProcessGroup] = None,
+        max_tokens_per_rank: Optional[int] = None,
+        output_format: Union[MoeFormat, str] = MoeFormat.BF16,
+        combine_format: Union[MoeFormat, str] = MoeFormat.BF16,
+        apply_topk_in_fc1: bool = True,
+        gate_up_clamp: Optional[float] = None,
+        generate_c: bool = False,
+    ) -> None:
+        for name, value in (
+            ("num_experts", num_experts),
+            ("hidden_size", hidden_size),
+            ("intermediate_size", intermediate_size),
+            ("top_k", top_k),
+        ):
+            if not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer, got {value!r}")
+        if top_k > num_experts:
+            raise ValueError(f"top_k ({top_k}) cannot exceed num_experts ({num_experts})")
+        if max_tokens_per_rank is not None and max_tokens_per_rank < 0:
+            raise ValueError("max_tokens_per_rank must be non-negative")
+
+        if ep_group is None:
+            ep_size, ep_rank = 1, 0
+        else:
+            if not dist.is_available() or not dist.is_initialized():
+                raise RuntimeError("ep_group requires an initialized torch.distributed process group")
+            ep_size = dist.get_world_size(ep_group)
+            ep_rank = dist.get_rank(ep_group)
+        if num_experts % ep_size != 0:
+            raise ValueError(f"num_experts ({num_experts}) must be divisible by EP size ({ep_size})")
+
+        self.num_experts = num_experts
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.top_k = top_k
+        self.ep_group = ep_group
+        self.ep_size = ep_size
+        self.ep_rank = ep_rank
+        self.experts_per_rank = num_experts // ep_size
+        self.max_tokens_per_rank = max_tokens_per_rank
+        self.output_format = _parse_format(output_format)
+        self.combine_format = _parse_format(combine_format)
+        self.apply_topk_in_fc1 = bool(apply_topk_in_fc1)
+        self.gate_up_clamp = None if gate_up_clamp is None else abs(float(gate_up_clamp))
+        self.generate_c = bool(generate_c)
+
+        for name, fmt in (("output_format", self.output_format), ("combine_format", self.combine_format)):
+            required_multiple = 32 if fmt is MoeFormat.MXFP8 else 16 if fmt is MoeFormat.NVFP4 else 1
+            if hidden_size % required_multiple != 0:
+                raise ValueError(f"hidden_size ({hidden_size}) must be divisible by {required_multiple} for {name}={fmt.value}")
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}("
+            f"experts={self.num_experts}, local_experts={self.experts_per_rank}, "
+            f"hidden={self.hidden_size}, intermediate={self.intermediate_size}, "
+            f"top_k={self.top_k}, ep_rank={self.ep_rank}/{self.ep_size}, "
+            f"output={self.output_format.value}, combine={self.combine_format.value})"
+        )
+
+    def _collective_device(self, device: torch.device) -> torch.device:
+        """Device the process group can run ``all_to_all_single`` on.
+
+        Gloo only implements all-to-all for CPU tensors, so CUDA tensors are
+        staged through host memory; NCCL groups communicate in place.
+        """
+        if device.type != "cpu" and dist.get_backend(self.ep_group) == "gloo":
+            return torch.device("cpu")
+        return device
+
+    def _exchange_counts(self, send_counts: torch.Tensor) -> torch.Tensor:
+        if self.ep_size == 1:
+            return send_counts.clone()
+        comm_device = self._collective_device(send_counts.device)
+        staged = send_counts.to(comm_device)
+        recv_counts = torch.empty_like(staged)
+        dist.all_to_all_single(recv_counts, staged, group=self.ep_group)
+        return recv_counts.to(send_counts.device)
+
+    def _all_to_all(
+        self,
+        send: torch.Tensor,
+        send_counts: Sequence[int],
+        recv_counts: Sequence[int],
+    ) -> torch.Tensor:
+        if self.ep_size == 1:
+            return send.clone()
+        comm_device = self._collective_device(send.device)
+        staged = send.contiguous().to(comm_device)
+        output_shape = (sum(recv_counts), *send.shape[1:])
+        recv = torch.empty(output_shape, dtype=send.dtype, device=comm_device)
+        dist.all_to_all_single(
+            recv,
+            staged,
+            output_split_sizes=list(recv_counts),
+            input_split_sizes=list(send_counts),
+            group=self.ep_group,
+        )
+        return recv.to(send.device)
+
+    def _dispatch_plan(self, topk_idx: torch.Tensor, topk_weights: torch.Tensor) -> _DispatchPlan:
+        """Route valid ``topk_idx`` entries to destination ranks, stably by rank.
+
+        Backward reuses this so gradient re-dispatch reproduces the exact
+        forward route order.
+        """
+
+        device = topk_idx.device
+        token_count = topk_idx.shape[0]
+        flat_expert = topk_idx.reshape(-1).to(torch.int64)
+        flat_weight = topk_weights.reshape(-1).float()
+        valid = flat_expert != -1
+        invalid_negative = flat_expert < -1
+        invalid_high = flat_expert >= self.num_experts
+        if bool((invalid_negative | invalid_high).any().item()):
+            bad = flat_expert[invalid_negative | invalid_high][0].item()
+            raise ValueError(f"topk_idx contains out-of-range expert id {bad}")
+
+        flat_token = torch.arange(token_count, device=device).repeat_interleave(self.top_k)
+        flat_slot = torch.arange(self.top_k, device=device).repeat(token_count)
+        expert = flat_expert[valid]
+        destination = torch.div(expert, self.experts_per_rank, rounding_mode="floor")
+        order = torch.argsort(destination, stable=True)
+
+        send_counts_tensor = torch.bincount(destination.index_select(0, order), minlength=self.ep_size).to(torch.int64)
+        recv_counts_tensor = self._exchange_counts(send_counts_tensor)
+        return _DispatchPlan(
+            send_expert=expert.index_select(0, order).remainder(self.experts_per_rank),
+            send_weight=flat_weight[valid].index_select(0, order),
+            send_token_idx=flat_token[valid].index_select(0, order),
+            send_slot_idx=flat_slot[valid].index_select(0, order),
+            send_counts=tuple(int(v) for v in send_counts_tensor.cpu().tolist()),
+            recv_counts=tuple(int(v) for v in recv_counts_tensor.cpu().tolist()),
+        )
+
+    def _run_local_experts(
+        self,
+        tokens: torch.Tensor,
+        local_expert_idx: torch.Tensor,
+        route_weight: torch.Tensor,
+        fc1_weight: torch.Tensor,
+        fc2_weight: torch.Tensor,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        output = torch.empty(
+            (tokens.shape[0], self.hidden_size),
+            dtype=torch.float32,
+            device=tokens.device,
+        )
+        fc1_c_rows = [] if self.generate_c else None
+        for expert in range(self.experts_per_rank):
+            positions = torch.nonzero(local_expert_idx == expert, as_tuple=False).flatten()
+            if positions.numel() == 0:
+                continue
+            expert_tokens = tokens.index_select(0, positions)
+            gate_up = expert_tokens @ fc1_weight[expert]
+            if fc1_c_rows is not None:
+                # Raw pre-SwiGLU accumulator: before clamp, no router weight.
+                fc1_c_rows.append(gate_up.to(torch.bfloat16))
+            gate, up = gate_up.split(self.intermediate_size, dim=-1)
+            if self.gate_up_clamp is not None:
+                gate = gate.clamp(max=self.gate_up_clamp)
+                up = up.clamp(min=-self.gate_up_clamp, max=self.gate_up_clamp)
+            intermediate = F.silu(gate) * up
+            weights = route_weight.index_select(0, positions).unsqueeze(-1)
+            if self.apply_topk_in_fc1:
+                intermediate = intermediate * weights
+            expert_output = intermediate @ fc2_weight[expert]
+            if not self.apply_topk_in_fc1:
+                expert_output = expert_output * weights
+            expert_output = _format_round_trip(expert_output, self.combine_format)
+            output.index_copy_(0, positions, expert_output)
+        fc1_c = None
+        if fc1_c_rows is not None:
+            fc1_c = torch.cat(fc1_c_rows) if fc1_c_rows else torch.empty((0, 2 * self.intermediate_size), dtype=torch.bfloat16, device=tokens.device)
+        return output, fc1_c
+
+    def __call__(
+        self,
+        activation: MoeTensor,
+        fc1_weight: MoeTensor,
+        fc2_weight: MoeTensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> Union[MoeTensor, Tuple[MoeTensor, torch.Tensor, torch.Tensor]]:
+        """Run dispatch, local experts, return routing, top-k reduce, and encode.
+
+        Shapes:
+            activation: ``(T, H)``
+            fc1_weight: ``(E_local, H, 2 * I)``
+            fc2_weight: ``(E_local, I, H)``
+            topk_idx/topk_weights: ``(T, K)``
+
+        Returns the ``(T, H)`` result, or ``(result, fc1_c, route_metadata)``
+        when constructed with ``generate_c=True``.  ``fc1_c`` is the BF16
+        pre-SwiGLU FC1 accumulator of every route this rank's experts
+        processed, ``(local_routes, 2 * I)``, grouped by local expert and
+        ordered within each expert by (source rank, source token-major route
+        order); captured before the gate/up clamp, without the router weight.
+        ``route_metadata`` is Int32 ``(local_routes, 4)`` with columns
+        ``(local_expert, src_rank, src_token, src_slot)``; row ``i`` identifies
+        the route behind ``fc1_c`` row ``i`` for the backward gradient
+        re-dispatch.
+        """
+
+        if topk_idx.ndim != 2:
+            raise ValueError(f"topk_idx must be 2-D, got shape {tuple(topk_idx.shape)}")
+        token_count = topk_idx.shape[0]
+        route_shape = (token_count, self.top_k)
+        if tuple(topk_idx.shape) != route_shape:
+            raise ValueError(f"topk_idx shape must be {route_shape}, got {tuple(topk_idx.shape)}")
+        if tuple(topk_weights.shape) != route_shape:
+            raise ValueError(f"topk_weights shape must be {route_shape}, got {tuple(topk_weights.shape)}")
+        if topk_idx.dtype not in (torch.int32, torch.int64):
+            raise TypeError(f"topk_idx must be int32 or int64, got {topk_idx.dtype}")
+        if not topk_weights.is_floating_point():
+            raise TypeError(f"topk_weights must be floating point, got {topk_weights.dtype}")
+        if self.max_tokens_per_rank is not None and token_count > self.max_tokens_per_rank:
+            raise ValueError(f"token count {token_count} exceeds max_tokens_per_rank={self.max_tokens_per_rank}")
+
+        device = _tensor_device(activation)
+        inputs = {
+            "fc1_weight": _tensor_device(fc1_weight),
+            "fc2_weight": _tensor_device(fc2_weight),
+            "topk_idx": topk_idx.device,
+            "topk_weights": topk_weights.device,
+        }
+        for name, input_device in inputs.items():
+            if input_device != device:
+                raise ValueError(f"{name} must be on {device}, got {input_device}")
+
+        activation_float = _decode_tensor(
+            activation,
+            name="activation",
+            expected_shape=(token_count, self.hidden_size),
+            quantized_axis=1,
+        )
+        fc1_float = _decode_tensor(
+            fc1_weight,
+            name="fc1_weight",
+            expected_shape=(self.experts_per_rank, self.hidden_size, 2 * self.intermediate_size),
+            quantized_axis=1,
+        )
+        fc2_float = _decode_tensor(
+            fc2_weight,
+            name="fc2_weight",
+            expected_shape=(self.experts_per_rank, self.intermediate_size, self.hidden_size),
+            quantized_axis=1,
+        )
+
+        plan = self._dispatch_plan(topk_idx, topk_weights)
+        send_token_idx = plan.send_token_idx
+        send_slot_idx = plan.send_slot_idx
+        send_counts, recv_counts = plan.send_counts, plan.recv_counts
+        send_tokens = activation_float.index_select(0, send_token_idx)
+
+        recv_tokens = self._all_to_all(send_tokens, send_counts, recv_counts)
+        recv_expert = self._all_to_all(plan.send_expert, send_counts, recv_counts)
+        recv_weight = self._all_to_all(plan.send_weight, send_counts, recv_counts)
+
+        route_metadata = None
+        if self.generate_c:
+            recv_src_rank = torch.repeat_interleave(
+                torch.arange(self.ep_size, device=device),
+                torch.tensor(recv_counts, device=device),
+            )
+            recv_token = self._all_to_all(send_token_idx, send_counts, recv_counts)
+            recv_slot = self._all_to_all(send_slot_idx, send_counts, recv_counts)
+            # Stable sort by local expert reproduces the fc1_c row order
+            # (grouped by expert; source order preserved within each group).
+            fc1_c_order = torch.argsort(recv_expert, stable=True)
+            route_metadata = torch.stack((recv_expert, recv_src_rank, recv_token, recv_slot), dim=1).index_select(0, fc1_c_order).to(torch.int32)
+        # recv rows are ordered by source rank, then that source's token-major
+        # route order, so the per-expert position grouping below realizes the
+        # documented fc1_c ordering.
+        recv_output, fc1_c = self._run_local_experts(
+            recv_tokens,
+            recv_expert,
+            recv_weight,
+            fc1_float,
+            fc2_float,
+        )
+
+        returned = self._all_to_all(recv_output, recv_counts, send_counts)
+        combine_plane = torch.zeros(
+            (token_count * self.top_k, self.hidden_size),
+            dtype=torch.float32,
+            device=device,
+        )
+        send_flat_slot = send_token_idx * self.top_k + send_slot_idx
+        combine_plane.index_copy_(0, send_flat_slot, returned)
+        reduced = combine_plane.view(token_count, self.top_k, self.hidden_size).sum(dim=1)
+
+        if self.output_format is MoeFormat.BF16:
+            output = reduced.to(torch.bfloat16)
+        else:
+            output = quantize_blockwise(reduced, self.output_format, axis=-1)
+        if self.generate_c:
+            return output, fc1_c, route_metadata
+        return output
+
+    def backward(
+        self,
+        grad_output: torch.Tensor,
+        activation: MoeTensor,
+        fc1_weight: MoeTensor,
+        fc2_weight: MoeTensor,
+        topk_idx: torch.Tensor,
+        topk_weights: torch.Tensor,
+        fc1_c: torch.Tensor,
+        route_metadata: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Backward pass consuming the ``generate_c=True`` stash.
+
+        ``fc1_c`` is the recompute source: gate/up, the clamp masks, SwiGLU,
+        and the FC2 input are all rebuilt from it, so no post-SwiGLU forward
+        intermediate needs to be saved.  ``route_metadata`` alone reconstructs
+        the mapping between re-dispatched rows and ``fc1_c`` rows and drives
+        the gradient return scatter.
+
+        Quantization round-trips (input decode, ``combine_format``,
+        ``output_format``) are treated as straight-through identities;
+        ``grad_output`` is the ``(T, H)`` gradient of the dequantized output.
+
+        Returns ``(grad_activation, grad_fc1_weight, grad_fc2_weight,
+        grad_topk_weights)`` in float32.
+        """
+
+        if not self.generate_c:
+            raise RuntimeError("backward requires the operator to be constructed with generate_c=True")
+        token_count = topk_idx.shape[0]
+        if tuple(grad_output.shape) != (token_count, self.hidden_size):
+            raise ValueError(f"grad_output shape must be {(token_count, self.hidden_size)}, got {tuple(grad_output.shape)}")
+        if not grad_output.is_floating_point():
+            raise TypeError(f"grad_output must be floating point, got {grad_output.dtype}")
+
+        device = _tensor_device(activation)
+        two_i = 2 * self.intermediate_size
+        activation_float = _decode_tensor(
+            activation,
+            name="activation",
+            expected_shape=(token_count, self.hidden_size),
+            quantized_axis=1,
+        )
+        fc1_float = _decode_tensor(
+            fc1_weight,
+            name="fc1_weight",
+            expected_shape=(self.experts_per_rank, self.hidden_size, two_i),
+            quantized_axis=1,
+        )
+        fc2_float = _decode_tensor(
+            fc2_weight,
+            name="fc2_weight",
+            expected_shape=(self.experts_per_rank, self.intermediate_size, self.hidden_size),
+            quantized_axis=1,
+        )
+        if fc1_c.shape != (int(route_metadata.shape[0]), two_i):
+            raise ValueError(f"fc1_c shape must be {(int(route_metadata.shape[0]), two_i)}, got {tuple(fc1_c.shape)}")
+
+        # Re-dispatch the FC1 inputs, router weights, and output gradients
+        # along the identical forward routes.
+        plan = self._dispatch_plan(topk_idx, topk_weights)
+        send_counts, recv_counts = plan.send_counts, plan.recv_counts
+        grad_output_float = grad_output.float()
+        recv_tokens = self._all_to_all(activation_float.index_select(0, plan.send_token_idx), send_counts, recv_counts)
+        recv_weight = self._all_to_all(plan.send_weight, send_counts, recv_counts)
+        recv_grad = self._all_to_all(grad_output_float.index_select(0, plan.send_token_idx), send_counts, recv_counts)
+
+        # route_metadata rows are in fc1_c order; sorting them by
+        # (src_rank, src_token, src_slot) reproduces the receive order, giving
+        # the permutation between re-dispatched rows and fc1_c rows.
+        metadata = route_metadata.to(device=device, dtype=torch.int64)
+        local_routes = metadata.shape[0]
+        if local_routes > 0:
+            token_span = int(metadata[:, 2].max().item()) + 1
+            recv_key = (metadata[:, 1] * token_span + metadata[:, 2]) * self.top_k + metadata[:, 3]
+            perm = torch.argsort(recv_key)  # perm[j] = fc1_c row at receive position j
+        else:
+            perm = torch.empty((0,), dtype=torch.int64, device=device)
+        x_rows = torch.empty_like(recv_tokens)
+        x_rows.index_copy_(0, perm, recv_tokens)
+        w_rows = torch.empty_like(recv_weight)
+        w_rows.index_copy_(0, perm, recv_weight)
+        dy_rows = torch.empty_like(recv_grad)
+        dy_rows.index_copy_(0, perm, recv_grad)
+
+        c_rows = fc1_c.float()
+        expert_rows = metadata[:, 0]
+        d_x_rows = torch.zeros((local_routes, self.hidden_size), dtype=torch.float32, device=device)
+        d_w_rows = torch.zeros((local_routes,), dtype=torch.float32, device=device)
+        grad_fc1 = torch.zeros_like(fc1_float)
+        grad_fc2 = torch.zeros_like(fc2_float)
+        for expert in range(self.experts_per_rank):
+            positions = torch.nonzero(expert_rows == expert, as_tuple=False).flatten()
+            if positions.numel() == 0:
+                continue
+            c = c_rows.index_select(0, positions)
+            x = x_rows.index_select(0, positions)
+            w = w_rows.index_select(0, positions).unsqueeze(-1)
+            d_y = dy_rows.index_select(0, positions)
+
+            gate, up = c.split(self.intermediate_size, dim=-1)
+            if self.gate_up_clamp is not None:
+                g = gate.clamp(max=self.gate_up_clamp)
+                u = up.clamp(min=-self.gate_up_clamp, max=self.gate_up_clamp)
+            else:
+                g, u = gate, up
+            sig = torch.sigmoid(g)
+            s = g * sig
+            h = s * u
+
+            if self.apply_topk_in_fc1:
+                h_fc2 = h * w
+                d_y_pre = d_y
+            else:
+                h_fc2 = h
+                d_y_pre = d_y * w
+            grad_fc2[expert] = h_fc2.transpose(0, 1) @ d_y_pre
+            d_h_fc2 = d_y_pre @ fc2_float[expert].transpose(0, 1)
+            if self.apply_topk_in_fc1:
+                d_h = d_h_fc2 * w
+                d_w_rows[positions] = (d_h_fc2 * h).sum(dim=-1)
+            else:
+                d_h = d_h_fc2
+                d_w_rows[positions] = (d_y * (h @ fc2_float[expert])).sum(dim=-1)
+
+            d_g = d_h * u * (sig * (1 + g * (1 - sig)))
+            d_u = d_h * s
+            if self.gate_up_clamp is not None:
+                d_gate = d_g * (gate <= self.gate_up_clamp)
+                d_up = d_u * ((up >= -self.gate_up_clamp) & (up <= self.gate_up_clamp))
+            else:
+                d_gate, d_up = d_g, d_u
+            d_c = torch.cat((d_gate, d_up), dim=-1)
+            grad_fc1[expert] = x.transpose(0, 1) @ d_c
+            d_x_rows.index_copy_(0, positions, d_c @ fc1_float[expert].transpose(0, 1))
+
+        # Return the route gradients to their source ranks and scatter-add.
+        returned_dx = self._all_to_all(d_x_rows.index_select(0, perm), recv_counts, send_counts)
+        returned_dw = self._all_to_all(d_w_rows.index_select(0, perm), recv_counts, send_counts)
+        grad_activation = torch.zeros((token_count, self.hidden_size), dtype=torch.float32, device=device)
+        grad_activation.index_add_(0, plan.send_token_idx, returned_dx)
+        grad_topk_weights = torch.zeros((token_count * self.top_k,), dtype=torch.float32, device=device)
+        grad_topk_weights.index_copy_(0, plan.send_token_idx * self.top_k + plan.send_slot_idx, returned_dw)
+        return (
+            grad_activation,
+            grad_fc1,
+            grad_fc2,
+            grad_topk_weights.view(token_count, self.top_k),
+        )
+
+
+__all__ = [
+    "BlockScaledTensor",
+    "MoeEpReference",
+    "MoeFormat",
+    "MoeTensor",
+    "quantize_blockwise",
+]

--- a/test/python/fe_api/moe_ep/run_pr_tests.sh
+++ b/test/python/fe_api/moe_ep/run_pr_tests.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
-# PR validation for the self-sufficient (vendored) MegaMoE backend.
-# Runs inside the flashinfer-ep container on a GB200 node.  Deliberately
-# does NOT set CUDNN_MEGAMOE_ROOT: everything must come from the vendored
-# python/cudnn/moe_ep/_megamoe_backend tree.
+# PR validation for the MegaMoE backend bundled inside cuDNN
+# (python/cudnn/moe_ep/_megamoe_backend).  Runs inside the flashinfer-ep
+# container on a GB200 node.
 set -x
-unset CUDNN_MEGAMOE_ROOT MEGAMOE_REPO
 export CLONE=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)
 
 echo "=== 1. PR pytest suite (reference/API tests) ==="

--- a/test/python/fe_api/moe_ep/run_pr_tests.sh
+++ b/test/python/fe_api/moe_ep/run_pr_tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# PR validation for the self-sufficient (vendored) MegaMoE backend.
+# Runs inside the flashinfer-ep container on a GB200 node.  Deliberately
+# does NOT set CUDNN_MEGAMOE_ROOT: everything must come from the vendored
+# python/cudnn/moe_ep/_megamoe_backend tree.
+set -x
+unset CUDNN_MEGAMOE_ROOT MEGAMOE_REPO
+export CLONE=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)
+
+echo "=== 1. PR pytest suite (reference/API tests) ==="
+SITE=$(python -c "import cudnn,os;print(os.path.dirname(cudnn.__file__))")
+cp -r $CLONE/python/cudnn/moe_ep $SITE/
+grep -q moe_ep $SITE/__init__.py || \
+  echo "from .moe_ep import BlockScaledTensor, MoeEp, MoeFormat, MoeTensor" >> $SITE/__init__.py
+cd $CLONE/test/python
+NVIDIA_TF32_OVERRIDE=0 python -m pytest fe_api/moe_ep/test_moe_ep.py -q || exit 1
+
+echo "=== 2. Vendored kernel imports (fp4 forward + fp8 mega backward) ==="
+MEGA_NO_DIST=1 python - <<'EOF' || exit 1
+import sys, os
+sys.path.insert(0, os.path.join(os.environ["CLONE"], "python", "cudnn", "moe_ep", "_megamoe_backend"))
+import megamoe.repo_path
+from megamoe.forward import MegaMoeMxfp8Forward
+from megamoe.forward_nvfp4 import MegaMoeNvfp4Forward
+from megamoe.bwd_kernel.backward import MegaMoeMxfp8Backward, mega_backward
+import megamoe.repo_path as rp
+assert "_megamoe_backend" in rp.REPO_ROOT, rp.REPO_ROOT
+print("vendored imports OK, kernel repo root:", rp.REPO_ROOT)
+EOF
+
+echo "=== 3. Single-rank megamoe backend parity (compiles kernels, ~5 min) ==="
+cd $CLONE/test/python
+CUDNN_MOE_EP_BACKEND=megamoe MEGA_NO_DIST=1 \
+  python fe_api/moe_ep/megamoe_backend_parity.py || exit 1
+echo "ALL PR TESTS PASSED"

--- a/test/python/fe_api/moe_ep/test_moe_ep.py
+++ b/test/python/fe_api/moe_ep/test_moe_ep.py
@@ -1,0 +1,771 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+from datetime import timedelta
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+from fe_api.moe_ep.moe_ep_reference import (
+    BlockScaledTensor,
+    MoeEpReference,
+    MoeFormat,
+    quantize_blockwise,
+)
+
+pytestmark = pytest.mark.L0
+
+
+def _output_as_float(output):
+    if isinstance(output, torch.Tensor):
+        return output.float()
+    return output.dequantize()
+
+
+def _naive_reference(
+    activation,
+    fc1_weight,
+    fc2_weight,
+    topk_idx,
+    topk_weights,
+    *,
+    apply_topk_in_fc1,
+    clamp=None,
+    combine_format=MoeFormat.BF16,
+):
+    token_count, top_k = topk_idx.shape
+    hidden_size = activation.shape[1]
+    intermediate_size = fc2_weight.shape[1]
+    combine = torch.zeros(token_count, top_k, hidden_size, dtype=torch.float32)
+    for token in range(token_count):
+        for slot in range(top_k):
+            expert = int(topk_idx[token, slot])
+            if expert == -1:
+                continue
+            gate_up = activation[token].float() @ fc1_weight[expert].float()
+            gate, up = gate_up.split(intermediate_size)
+            if clamp is not None:
+                gate = gate.clamp(max=clamp)
+                up = up.clamp(-clamp, clamp)
+            intermediate = F.silu(gate) * up
+            route_weight = topk_weights[token, slot].float()
+            if apply_topk_in_fc1:
+                intermediate = intermediate * route_weight
+            result = intermediate @ fc2_weight[expert].float()
+            if not apply_topk_in_fc1:
+                result = result * route_weight
+            if combine_format is MoeFormat.BF16:
+                result = result.to(torch.bfloat16).float()
+            else:
+                result = quantize_blockwise(result, combine_format).dequantize()
+            combine[token, slot] = result
+    return combine.sum(dim=1).to(torch.bfloat16)
+
+
+@pytest.mark.parametrize(
+    "format,expected_data_shape,expected_scale_shape,scale_dtype",
+    [
+        (MoeFormat.MXFP8, (3, 64), (3, 2), torch.float8_e8m0fnu),
+        (MoeFormat.NVFP4, (3, 32), (3, 4), torch.float8_e4m3fn),
+    ],
+)
+def test_block_scaled_round_trip(format, expected_data_shape, expected_scale_shape, scale_dtype):
+    values = torch.linspace(-4.0, 4.0, 3 * 64).reshape(3, 64)
+    quantized = quantize_blockwise(values, format)
+
+    assert isinstance(quantized, BlockScaledTensor)
+    assert quantized.format is format
+    assert quantized.logical_shape == (3, 64)
+    assert tuple(quantized.data.shape) == expected_data_shape
+    assert tuple(quantized.scale.shape) == expected_scale_shape
+    assert quantized.scale.dtype == scale_dtype
+    assert quantized.dequantize().shape == values.shape
+    assert torch.isfinite(quantized.dequantize()).all()
+
+
+def test_quantization_along_weight_reduction_axis():
+    values = torch.randn(2, 64, 48)
+    quantized = quantize_blockwise(values, MoeFormat.NVFP4, axis=1)
+
+    assert quantized.logical_shape == (2, 64, 48)
+    assert quantized.data.shape == (2, 32, 48)
+    assert quantized.scale.shape == (2, 4, 48)
+    assert quantized.dequantize().shape == values.shape
+
+
+@pytest.mark.parametrize("apply_topk_in_fc1", [False, True])
+def test_single_rank_bf16_matches_naive(apply_topk_in_fc1):
+    torch.manual_seed(7)
+    experts, tokens, hidden, intermediate, top_k = 4, 5, 32, 24, 2
+    activation = torch.randn(tokens, hidden, dtype=torch.bfloat16)
+    fc1_weight = torch.randn(experts, hidden, 2 * intermediate, dtype=torch.bfloat16) / 8
+    fc2_weight = torch.randn(experts, intermediate, hidden, dtype=torch.bfloat16) / 8
+    topk_idx = torch.tensor([[0, 3], [2, 1], [1, -1], [3, 0], [2, 0]], dtype=torch.int64)
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.2, 0.8], [1.0, 0.0], [0.55, 0.45], [0.6, 0.4]],
+        dtype=torch.float32,
+    )
+
+    op = MoeEpReference(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=top_k,
+        combine_format="bf16",
+        output_format="bf16",
+        apply_topk_in_fc1=apply_topk_in_fc1,
+        gate_up_clamp=2.5,
+    )
+    actual = op(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    expected = _naive_reference(
+        activation,
+        fc1_weight,
+        fc2_weight,
+        topk_idx,
+        topk_weights,
+        apply_topk_in_fc1=apply_topk_in_fc1,
+        clamp=2.5,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_generate_c_single_rank_matches_naive():
+    """fc1_c is the pre-clamp, unweighted gate+up accumulator, grouped by expert."""
+
+    torch.manual_seed(37)
+    experts, tokens, hidden, intermediate, top_k = 4, 5, 32, 24, 2
+    activation = torch.randn(tokens, hidden)
+    fc1_weight = torch.randn(experts, hidden, 2 * intermediate) / 8
+    fc2_weight = torch.randn(experts, intermediate, hidden) / 8
+    topk_idx = torch.tensor([[0, 3], [2, 1], [1, -1], [3, 0], [2, 0]], dtype=torch.int64)
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.2, 0.8], [1.0, 0.0], [0.55, 0.45], [0.6, 0.4]],
+        dtype=torch.float32,
+    )
+
+    op = MoeEpReference(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=top_k,
+        gate_up_clamp=2.5,
+        generate_c=True,
+    )
+    output, fc1_c, route_metadata = op(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+
+    expected_rows = []
+    expected_metadata = []
+    for expert in range(experts):
+        for token in range(tokens):
+            for slot in range(top_k):
+                if int(topk_idx[token, slot]) == expert:
+                    expected_rows.append(activation[token] @ fc1_weight[expert])
+                    expected_metadata.append([expert, 0, token, slot])
+    expected_fc1_c = torch.stack(expected_rows).to(torch.bfloat16)
+
+    assert fc1_c.dtype == torch.bfloat16
+    assert fc1_c.shape == (int((topk_idx != -1).sum()), 2 * intermediate)
+    torch.testing.assert_close(fc1_c, expected_fc1_c, atol=0, rtol=0)
+
+    assert route_metadata.dtype == torch.int32
+    assert route_metadata.tolist() == expected_metadata
+
+    expected_output = _naive_reference(
+        activation,
+        fc1_weight,
+        fc2_weight,
+        topk_idx,
+        topk_weights,
+        apply_topk_in_fc1=True,
+        clamp=2.5,
+    )
+    torch.testing.assert_close(output, expected_output, atol=0, rtol=0)
+
+
+def _autograd_replica_grads(
+    activation,
+    fc1_weight,
+    fc2_weight,
+    topk_idx,
+    topk_weights,
+    grad_output,
+    *,
+    apply_topk_in_fc1=True,
+    clamp=None,
+):
+    """Autograd gradients of a per-route replica of the reference forward.
+
+    The FC1 accumulator is rounded to bf16 with a straight-through gradient,
+    matching a backward pass that recomputes SwiGLU from the bf16 fc1_c stash.
+    Combine/output round-trips are omitted (straight-through), as in
+    ``MoeEpReference.backward``.
+    """
+
+    a = activation.detach().clone().float().requires_grad_()
+    w1 = fc1_weight.detach().clone().float().requires_grad_()
+    w2 = fc2_weight.detach().clone().float().requires_grad_()
+    tw = topk_weights.detach().clone().float().requires_grad_()
+    token_count, top_k = topk_idx.shape
+    intermediate = w2.shape[1]
+    rows = []
+    for token in range(token_count):
+        acc = torch.zeros(a.shape[1], dtype=torch.float32)
+        for slot in range(top_k):
+            expert = int(topk_idx[token, slot])
+            if expert == -1:
+                continue
+            c = a[token] @ w1[expert]
+            c = c + (c.to(torch.bfloat16).float() - c).detach()
+            gate, up = c.split(intermediate)
+            if clamp is not None:
+                gate = gate.clamp(max=clamp)
+                up = up.clamp(-clamp, clamp)
+            h = F.silu(gate) * up
+            weight = tw[token, slot]
+            if apply_topk_in_fc1:
+                h = h * weight
+            y = h @ w2[expert]
+            if not apply_topk_in_fc1:
+                y = y * weight
+            acc = acc + y
+        rows.append(acc)
+    torch.stack(rows).backward(grad_output.float())
+    return a.grad, w1.grad, w2.grad, tw.grad
+
+
+@pytest.mark.parametrize("apply_topk_in_fc1", [False, True])
+def test_backward_single_rank_matches_autograd(apply_topk_in_fc1):
+    torch.manual_seed(43)
+    experts, tokens, hidden, intermediate, top_k = 4, 5, 32, 24, 2
+    activation = torch.randn(tokens, hidden)
+    fc1_weight = torch.randn(experts, hidden, 2 * intermediate) / 8
+    fc2_weight = torch.randn(experts, intermediate, hidden) / 8
+    topk_idx = torch.tensor([[0, 3], [2, 1], [1, -1], [3, 0], [2, 0]], dtype=torch.int64)
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.2, 0.8], [1.0, 0.0], [0.55, 0.45], [0.6, 0.4]],
+        dtype=torch.float32,
+    )
+    grad_output = torch.randn(tokens, hidden)
+
+    op = MoeEpReference(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=top_k,
+        apply_topk_in_fc1=apply_topk_in_fc1,
+        gate_up_clamp=2.5,
+        generate_c=True,
+    )
+    _, fc1_c, route_metadata = op(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    grad_activation, grad_fc1, grad_fc2, grad_topk = op.backward(
+        grad_output,
+        activation,
+        fc1_weight,
+        fc2_weight,
+        topk_idx,
+        topk_weights,
+        fc1_c,
+        route_metadata,
+    )
+    expected_ga, expected_g1, expected_g2, expected_gw = _autograd_replica_grads(
+        activation,
+        fc1_weight,
+        fc2_weight,
+        topk_idx,
+        topk_weights,
+        grad_output,
+        apply_topk_in_fc1=apply_topk_in_fc1,
+        clamp=2.5,
+    )
+
+    torch.testing.assert_close(grad_activation, expected_ga, rtol=1e-4, atol=1e-6)
+    torch.testing.assert_close(grad_fc1, expected_g1, rtol=1e-4, atol=1e-6)
+    torch.testing.assert_close(grad_fc2, expected_g2, rtol=1e-4, atol=1e-6)
+    torch.testing.assert_close(grad_topk, expected_gw, rtol=1e-4, atol=1e-6)
+    assert grad_topk[2, 1].item() == 0.0  # -1 slot receives no gradient
+
+
+@pytest.mark.parametrize("input_format", [MoeFormat.MXFP8, MoeFormat.NVFP4])
+def test_backward_quantized_inputs_matches_autograd(input_format):
+    """Backward with block-scaled inputs and quantized combine/output formats.
+
+    Gradients are straight-through with respect to the dequantized values, so
+    the expected gradients come from the autograd replica run on the decoded
+    tensors; the combine/output encodes must not perturb backward.
+    """
+
+    torch.manual_seed(47)
+    experts, tokens, hidden, intermediate, top_k = 2, 4, 32, 16, 2
+    device = torch.device("cpu")
+    activation, fc1_weight, fc2_weight = _block_scaled_inputs(input_format, experts, tokens, hidden, intermediate, device)
+    topk_idx = torch.tensor([[0, 1], [1, 0], [0, -1], [1, 0]], dtype=torch.int64)
+    topk_weights = torch.tensor([[0.7, 0.3], [0.6, 0.4], [1.0, 0.0], [0.55, 0.45]])
+    grad_output = torch.randn(tokens, hidden)
+
+    op = MoeEpReference(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=top_k,
+        output_format=input_format,
+        combine_format=input_format,
+        generate_c=True,
+    )
+    _, fc1_c, route_metadata = op(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    grad_activation, grad_fc1, grad_fc2, grad_topk = op.backward(
+        grad_output,
+        activation,
+        fc1_weight,
+        fc2_weight,
+        topk_idx,
+        topk_weights,
+        fc1_c,
+        route_metadata,
+    )
+    expected_ga, expected_g1, expected_g2, expected_gw = _autograd_replica_grads(
+        activation.dequantize(),
+        fc1_weight.dequantize(),
+        fc2_weight.dequantize(),
+        topk_idx,
+        topk_weights,
+        grad_output,
+    )
+
+    torch.testing.assert_close(grad_activation, expected_ga, rtol=1e-4, atol=1e-6)
+    torch.testing.assert_close(grad_fc1, expected_g1, rtol=1e-4, atol=1e-6)
+    torch.testing.assert_close(grad_fc2, expected_g2, rtol=1e-4, atol=1e-6)
+    torch.testing.assert_close(grad_topk, expected_gw, rtol=1e-4, atol=1e-6)
+
+
+@pytest.mark.parametrize("combine_format", [MoeFormat.MXFP8, MoeFormat.NVFP4])
+def test_quantized_combine_round_trip(combine_format):
+    torch.manual_seed(13)
+    experts, tokens, hidden, intermediate = 2, 4, 32, 16
+    activation = torch.randn(tokens, hidden)
+    fc1_weight = torch.randn(experts, hidden, 2 * intermediate) / 8
+    fc2_weight = torch.randn(experts, intermediate, hidden) / 8
+    topk_idx = torch.tensor([[0, 1], [1, 0], [0, -1], [1, 0]], dtype=torch.int64)
+    topk_weights = torch.tensor([[0.7, 0.3], [0.6, 0.4], [1.0, 0.0], [0.55, 0.45]])
+    op = MoeEpReference(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=2,
+        combine_format=combine_format,
+    )
+
+    actual = op(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    expected = _naive_reference(
+        activation,
+        fc1_weight,
+        fc2_weight,
+        topk_idx,
+        topk_weights,
+        apply_topk_in_fc1=True,
+        combine_format=combine_format,
+    )
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_quantized_inputs_and_weights_use_logical_shapes():
+    torch.manual_seed(19)
+    experts, tokens, hidden, intermediate = 2, 3, 32, 32
+    activation = torch.randn(tokens, hidden)
+    fc1_weight = torch.randn(experts, hidden, 2 * intermediate) / 8
+    fc2_weight = torch.randn(experts, intermediate, hidden) / 8
+    q_activation = quantize_blockwise(activation, "mxfp8", axis=1)
+    q_fc1 = quantize_blockwise(fc1_weight, "mxfp8", axis=1)
+    q_fc2 = quantize_blockwise(fc2_weight, "nvfp4", axis=1)
+    topk_idx = torch.tensor([[0], [1], [0]], dtype=torch.int64)
+    topk_weights = torch.ones(tokens, 1)
+    op = MoeEpReference(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=1,
+    )
+
+    actual = op(q_activation, q_fc1, q_fc2, topk_idx, topk_weights)
+    expected = _naive_reference(
+        q_activation.dequantize(),
+        q_fc1.dequantize(),
+        q_fc2.dequantize(),
+        topk_idx,
+        topk_weights,
+        apply_topk_in_fc1=True,
+    )
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("output_format", ["bf16", "mxfp8", "nvfp4"])
+@pytest.mark.xfail(
+    strict=True,
+    reason="MoeEp.__call__ only allocates output; the device implementation is not wired yet",
+)
+def test_moe_ep_api_matches_reference(output_format):
+    """Exercise the public API and reference through the same tensor contract."""
+
+    from cudnn import MoeEp
+
+    torch.manual_seed(23)
+    device = torch.device("cuda")
+    experts, tokens, hidden, intermediate, top_k = 2, 4, 32, 16, 2
+    activation = torch.randn(tokens, hidden, dtype=torch.bfloat16, device=device)
+    fc1_weight = (
+        torch.randn(
+            experts,
+            hidden,
+            2 * intermediate,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / 8
+    )
+    fc2_weight = (
+        torch.randn(
+            experts,
+            intermediate,
+            hidden,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        / 8
+    )
+    topk_idx = torch.tensor(
+        [[0, 1], [1, 0], [0, -1], [1, 0]],
+        dtype=torch.int64,
+        device=device,
+    )
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.6, 0.4], [1.0, 0.0], [0.55, 0.45]],
+        dtype=torch.float32,
+        device=device,
+    )
+
+    kwargs = dict(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=top_k,
+        output_format=output_format,
+        combine_format="bf16",
+    )
+    api = MoeEp(**kwargs)
+    reference = MoeEpReference(**kwargs)
+
+    actual = api(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    expected = reference(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+
+    actual_shape = tuple(actual.shape) if isinstance(actual, torch.Tensor) else actual.logical_shape
+    assert actual_shape == (tokens, hidden)
+    torch.testing.assert_close(
+        _output_as_float(actual),
+        _output_as_float(expected),
+        atol=0,
+        rtol=0,
+    )
+
+
+def _block_scaled_inputs(input_format, experts, tokens, hidden, intermediate, device):
+    """Quantized inputs whose scale factors ride inside each BlockScaledTensor.
+
+    Everything is block-scaled along the GEMM reduction axis: activation along
+    hidden, fc1_weight along hidden, fc2_weight along intermediate.
+    """
+
+    activation = quantize_blockwise(
+        torch.randn(tokens, hidden, device=device),
+        input_format,
+        axis=1,
+    )
+    fc1_weight = quantize_blockwise(
+        torch.randn(experts, hidden, 2 * intermediate, device=device) / 8,
+        input_format,
+        axis=1,
+    )
+    fc2_weight = quantize_blockwise(
+        torch.randn(experts, intermediate, hidden, device=device) / 8,
+        input_format,
+        axis=1,
+    )
+    return activation, fc1_weight, fc2_weight
+
+
+@pytest.mark.parametrize("input_format", [MoeFormat.MXFP8, MoeFormat.NVFP4])
+def test_moe_ep_api_accepts_block_scaled_inputs(input_format):
+    """The API takes data+scale bundles where the kernel takes separate sf args."""
+
+    from cudnn import MoeEp
+
+    torch.manual_seed(29)
+    device = torch.device("cuda")
+    experts, tokens, hidden, intermediate = 2, 4, 32, 16
+    activation, fc1_weight, fc2_weight = _block_scaled_inputs(input_format, experts, tokens, hidden, intermediate, device)
+
+    api = MoeEp(num_experts=experts, hidden_size=hidden, intermediate_size=intermediate, top_k=1)
+    output = api(
+        activation,
+        fc1_weight,
+        fc2_weight,
+        torch.tensor([[0], [1], [0], [1]], dtype=torch.int64, device=device),
+        torch.ones(tokens, 1, device=device),
+    )
+
+    assert isinstance(output, torch.Tensor)
+    assert output.shape == (tokens, hidden)
+    assert output.dtype == torch.bfloat16
+
+
+def test_moe_ep_api_generate_c_allocates_fc1_c():
+    """generate_c=True returns (output, fc1_c) sized by this rank's valid routes."""
+
+    from cudnn import MoeEp
+
+    device = torch.device("cuda")
+    experts, tokens, hidden, intermediate = 2, 4, 32, 16
+    api = MoeEp(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=2,
+        generate_c=True,
+    )
+    topk_idx = torch.tensor([[0, 1], [1, 0], [0, -1], [1, 0]], dtype=torch.int64, device=device)
+    output, fc1_c, route_metadata = api(
+        torch.empty(tokens, hidden, dtype=torch.bfloat16, device=device),
+        torch.empty(experts, hidden, 2 * intermediate, dtype=torch.bfloat16, device=device),
+        torch.empty(experts, intermediate, hidden, dtype=torch.bfloat16, device=device),
+        topk_idx,
+        torch.ones(tokens, 2, dtype=torch.float32, device=device),
+    )
+
+    valid_routes = int((topk_idx != -1).sum())
+    assert output.shape == (tokens, hidden)
+    assert fc1_c.dtype == torch.bfloat16
+    assert fc1_c.shape == (valid_routes, 2 * intermediate)
+    assert fc1_c.device.type == "cuda"
+    assert route_metadata.dtype == torch.int32
+    assert route_metadata.shape == (valid_routes, 4)
+    assert route_metadata.device.type == "cuda"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="MoeEp.__call__ only allocates output; the device implementation is not wired yet",
+)
+def test_moe_ep_api_generate_c_matches_reference():
+    from cudnn import MoeEp
+
+    torch.manual_seed(41)
+    device = torch.device("cuda")
+    experts, tokens, hidden, intermediate, top_k = 2, 4, 32, 16, 2
+    activation = torch.randn(tokens, hidden, dtype=torch.bfloat16, device=device)
+    fc1_weight = torch.randn(experts, hidden, 2 * intermediate, dtype=torch.bfloat16, device=device) / 8
+    fc2_weight = torch.randn(experts, intermediate, hidden, dtype=torch.bfloat16, device=device) / 8
+    topk_idx = torch.tensor([[0, 1], [1, 0], [0, -1], [1, 0]], dtype=torch.int64, device=device)
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.6, 0.4], [1.0, 0.0], [0.55, 0.45]],
+        dtype=torch.float32,
+        device=device,
+    )
+
+    kwargs = dict(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=top_k,
+        generate_c=True,
+    )
+    actual, actual_fc1_c, actual_metadata = MoeEp(**kwargs)(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    expected, expected_fc1_c, expected_metadata = MoeEpReference(**kwargs)(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+
+    torch.testing.assert_close(_output_as_float(actual), _output_as_float(expected), atol=0, rtol=0)
+    torch.testing.assert_close(actual_fc1_c, expected_fc1_c, atol=0, rtol=0)
+    torch.testing.assert_close(actual_metadata, expected_metadata, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("input_format", ["mxfp8", "nvfp4"])
+@pytest.mark.xfail(
+    strict=True,
+    reason="MoeEp.__call__ only allocates output; the device implementation is not wired yet",
+)
+def test_moe_ep_api_quantized_inputs_match_reference(input_format):
+    """Quantized activations/weights carry their scale factors through both paths."""
+
+    from cudnn import MoeEp
+
+    torch.manual_seed(31)
+    device = torch.device("cuda")
+    experts, tokens, hidden, intermediate, top_k = 2, 4, 32, 16, 2
+    activation, fc1_weight, fc2_weight = _block_scaled_inputs(input_format, experts, tokens, hidden, intermediate, device)
+    topk_idx = torch.tensor([[0, 1], [1, 0], [0, -1], [1, 0]], dtype=torch.int64, device=device)
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.6, 0.4], [1.0, 0.0], [0.55, 0.45]],
+        dtype=torch.float32,
+        device=device,
+    )
+
+    kwargs = dict(num_experts=experts, hidden_size=hidden, intermediate_size=intermediate, top_k=top_k)
+    actual = MoeEp(**kwargs)(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    expected = MoeEpReference(**kwargs)(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+
+    torch.testing.assert_close(
+        _output_as_float(actual),
+        _output_as_float(expected),
+        atol=0,
+        rtol=0,
+    )
+
+
+def _distributed_worker(rank, world_size, init_file):
+    device = torch.device("cuda", rank % torch.cuda.device_count())
+    torch.cuda.set_device(device)
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=60),
+    )
+    try:
+        experts, hidden, intermediate, top_k = 2 * world_size, 32, 16, 2
+        torch.manual_seed(1234)
+        global_fc1 = torch.randn(experts, hidden, 2 * intermediate) / 8
+        global_fc2 = torch.randn(experts, intermediate, hidden) / 8
+        experts_per_rank = experts // world_size
+        begin = rank * experts_per_rank
+        end = begin + experts_per_rank
+
+        generator = torch.Generator().manual_seed(2000 + rank)
+        token_count = 3 + rank
+        activation = torch.randn(token_count, hidden, generator=generator)
+        topk_idx = torch.tensor(
+            [[(rank + token) % experts, (rank + token + 2) % experts] for token in range(token_count)],
+            dtype=torch.int64,
+        )
+        topk_weights = torch.tensor([[0.625, 0.375]]).expand(token_count, -1).contiguous()
+
+        op = MoeEpReference(
+            num_experts=experts,
+            hidden_size=hidden,
+            intermediate_size=intermediate,
+            top_k=top_k,
+            ep_group=dist.group.WORLD,
+            combine_format="bf16",
+            output_format="bf16",
+            generate_c=True,
+        )
+        actual, fc1_c, route_metadata = op(
+            activation.to(device),
+            global_fc1[begin:end].contiguous().to(device),
+            global_fc2[begin:end].contiguous().to(device),
+            topk_idx.to(device),
+            topk_weights.to(device),
+        )
+        assert actual.device.type == "cuda"
+        expected = _naive_reference(
+            activation,
+            global_fc1,
+            global_fc2,
+            topk_idx,
+            topk_weights,
+            apply_topk_in_fc1=True,
+        )
+        # GPU and CPU float32 GEMMs accumulate in different orders, so the
+        # cross-device comparison uses bf16-level tolerances instead of exact.
+        torch.testing.assert_close(actual.cpu(), expected)
+
+        # fc1_c contract: rows grouped by local expert, ordered by source rank,
+        # then the source's token-major route order.  Every rank can rebuild all
+        # source ranks' inputs because they derive from deterministic seeds.
+        expected_rows = []
+        expected_metadata = []
+        for local_expert in range(experts_per_rank):
+            global_expert = begin + local_expert
+            for src_rank in range(world_size):
+                src_generator = torch.Generator().manual_seed(2000 + src_rank)
+                src_token_count = 3 + src_rank
+                src_activation = torch.randn(src_token_count, hidden, generator=src_generator)
+                for token in range(src_token_count):
+                    for slot, slot_expert in enumerate(
+                        (
+                            (src_rank + token) % experts,
+                            (src_rank + token + 2) % experts,
+                        )
+                    ):
+                        if slot_expert == global_expert:
+                            expected_rows.append(src_activation[token] @ global_fc1[global_expert])
+                            expected_metadata.append([local_expert, src_rank, token, slot])
+        if expected_rows:
+            expected_fc1_c = torch.stack(expected_rows).to(torch.bfloat16)
+        else:
+            expected_fc1_c = torch.empty((0, 2 * intermediate), dtype=torch.bfloat16)
+        assert fc1_c.shape == expected_fc1_c.shape
+        assert route_metadata.dtype == torch.int32
+        assert route_metadata.cpu().tolist() == expected_metadata
+
+        # Backward: gradients re-dispatch along the same routes.  Expected
+        # values come from autograd replicas over every rank's reconstructed
+        # inputs: token/router grads are local to this rank's tokens, while
+        # weight grads accumulate contributions from all source ranks.
+        grad_output = torch.randn(token_count, hidden, generator=torch.Generator().manual_seed(3000 + rank))
+        grad_activation, grad_fc1, grad_fc2, grad_topk = op.backward(
+            grad_output.to(device),
+            activation.to(device),
+            global_fc1[begin:end].contiguous().to(device),
+            global_fc2[begin:end].contiguous().to(device),
+            topk_idx.to(device),
+            topk_weights.to(device),
+            fc1_c,
+            route_metadata,
+        )
+
+        expected_g1_global = torch.zeros_like(global_fc1)
+        expected_g2_global = torch.zeros_like(global_fc2)
+        for src_rank in range(world_size):
+            src_token_count = 3 + src_rank
+            src_activation = torch.randn(src_token_count, hidden, generator=torch.Generator().manual_seed(2000 + src_rank))
+            src_topk_idx = torch.tensor(
+                [[(src_rank + token) % experts, (src_rank + token + 2) % experts] for token in range(src_token_count)],
+                dtype=torch.int64,
+            )
+            src_topk_weights = torch.tensor([[0.625, 0.375]]).expand(src_token_count, -1).contiguous()
+            src_grad_output = torch.randn(src_token_count, hidden, generator=torch.Generator().manual_seed(3000 + src_rank))
+            src_ga, src_g1, src_g2, src_gw = _autograd_replica_grads(
+                src_activation,
+                global_fc1,
+                global_fc2,
+                src_topk_idx,
+                src_topk_weights,
+                src_grad_output,
+                apply_topk_in_fc1=True,
+            )
+            expected_g1_global += src_g1
+            expected_g2_global += src_g2
+            if src_rank == rank:
+                expected_ga, expected_gw = src_ga, src_gw
+
+        # GPU/CPU GEMM rounding and rare bf16-stash boundary flips justify the
+        # loose tolerance.
+        torch.testing.assert_close(grad_activation.cpu(), expected_ga, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(grad_topk.cpu(), expected_gw, rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(grad_fc1.cpu(), expected_g1_global[begin:end], rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(grad_fc2.cpu(), expected_g2_global[begin:end], rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(fc1_c.cpu(), expected_fc1_c)
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not dist.is_available() or not dist.is_nccl_available() or torch.cuda.device_count() < 4,
+    reason="requires NCCL and at least 4 GPUs",
+)
+def test_four_rank_expert_parallel(tmp_path):
+    """One GPU per rank; NCCL runs the token all-to-all device-to-device."""
+
+    init_file = tmp_path / "moe_ep_nccl_init"
+    mp.spawn(_distributed_worker, args=(4, str(init_file)), nprocs=4, join=True)

--- a/test/python/fe_api/moe_ep/test_moe_ep.py
+++ b/test/python/fe_api/moe_ep/test_moe_ep.py
@@ -588,6 +588,90 @@ def test_moe_ep_api_generate_c_matches_reference():
     torch.testing.assert_close(actual_metadata, expected_metadata, atol=0, rtol=0)
 
 
+def test_moe_ep_api_backward_allocates_grads():
+    """MoeEp.backward returns the four gradient allocations of the contract."""
+
+    from cudnn import MoeEp
+
+    torch.manual_seed(53)
+    device = torch.device("cuda")
+    experts, tokens, hidden, intermediate, top_k = 2, 4, 32, 16, 2
+    api = MoeEp(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=top_k,
+        generate_c=True,
+    )
+    activation = torch.randn(tokens, hidden, dtype=torch.bfloat16, device=device)
+    fc1_weight = torch.randn(experts, hidden, 2 * intermediate, dtype=torch.bfloat16, device=device)
+    fc2_weight = torch.randn(experts, intermediate, hidden, dtype=torch.bfloat16, device=device)
+    topk_idx = torch.tensor([[0, 1], [1, 0], [0, -1], [1, 0]], dtype=torch.int64, device=device)
+    topk_weights = torch.ones(tokens, top_k, device=device)
+
+    _, fc1_c, route_metadata = api(activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    grads = api.backward(
+        torch.randn(tokens, hidden, device=device),
+        activation,
+        fc1_weight,
+        fc2_weight,
+        topk_idx,
+        topk_weights,
+        fc1_c,
+        route_metadata,
+    )
+
+    expected_shapes = [
+        (tokens, hidden),
+        (experts, hidden, 2 * intermediate),
+        (experts, intermediate, hidden),
+        (tokens, top_k),
+    ]
+    assert [tuple(grad.shape) for grad in grads] == expected_shapes
+    assert all(grad.dtype == torch.float32 for grad in grads)
+    assert all(grad.device.type == "cuda" for grad in grads)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="MoeEp.backward only allocates gradients; the device implementation is not wired yet",
+)
+def test_moe_ep_api_backward_matches_reference():
+    from cudnn import MoeEp
+
+    torch.manual_seed(59)
+    device = torch.device("cuda")
+    experts, tokens, hidden, intermediate, top_k = 2, 4, 32, 16, 2
+    activation = torch.randn(tokens, hidden, device=device)
+    fc1_weight = torch.randn(experts, hidden, 2 * intermediate, device=device) / 8
+    fc2_weight = torch.randn(experts, intermediate, hidden, device=device) / 8
+    topk_idx = torch.tensor([[0, 1], [1, 0], [0, -1], [1, 0]], dtype=torch.int64, device=device)
+    topk_weights = torch.tensor(
+        [[0.7, 0.3], [0.6, 0.4], [1.0, 0.0], [0.55, 0.45]],
+        dtype=torch.float32,
+        device=device,
+    )
+    grad_output = torch.randn(tokens, hidden, device=device)
+
+    kwargs = dict(
+        num_experts=experts,
+        hidden_size=hidden,
+        intermediate_size=intermediate,
+        top_k=top_k,
+        generate_c=True,
+    )
+    api = MoeEp(**kwargs)
+    reference = MoeEpReference(**kwargs)
+    forward_args = (activation, fc1_weight, fc2_weight, topk_idx, topk_weights)
+    _, ref_fc1_c, ref_metadata = reference(*forward_args)
+    _, api_fc1_c, api_metadata = api(*forward_args)
+
+    actual = api.backward(grad_output, *forward_args, api_fc1_c, api_metadata)
+    expected = reference.backward(grad_output, *forward_args, ref_fc1_c, ref_metadata)
+    for actual_grad, expected_grad in zip(actual, expected):
+        torch.testing.assert_close(actual_grad, expected_grad, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize("input_format", ["mxfp8", "nvfp4"])
 @pytest.mark.xfail(
     strict=True,


### PR DESCRIPTION
## Wire the MegaMoE backend into `cudnn.MoeEp`

This PR completes the `cudnn.MoeEp` API introduced in #389 by replacing the allocate-only implementation with a real device backend.

`MoeEp.__call__` and `backward` now execute fused SM100 (GB200) MegaMoE megakernels:

- **Forward:** NVSHMEM dispatch → grouped FC1/SwiGLU/FC2 → combine in a single launch
- **Backward:** fused mega backward producing all four gradients

The kernel sources are now bundled inside cuDNN, so a fresh clone requires no external checkout or path environment variables.

The bundle includes:

- MXFP8 forward (training path)
- CuTe DSL NVFP4 (FP4) forward
- FP8 mega backward

> **Note:** the backward (bprop) implementation is from the FlashInfer team, not the FastKernel team.

### Backend behavior

- `CUDNN_MOE_EP_BACKEND=auto|megamoe|none` is the only backend knob.
- `auto` (default) executes the bundled backend when supported and otherwise falls back to the allocate-only implementation from #389 with a one-time warning.
- `megamoe` raises on backend failures.
- `none` always uses the stub implementation.

Supported configurations:

- SM100+
- `apply_topk_in_fc1=True`
- hidden/intermediate dimensions multiples of 32 (128 for the `generate_c`/backward path)
- `combine_format="bf16"` for training

Internal compute uses MXFP8, so outputs match the FP32 reference within ~1e-2–7e-2 relative tolerance. `route_metadata` and quantized outputs remain bit-exact.

### Validation

- **Pytest:** 18 passed, 7 xfailed (expected strict bit-exact gates)
- **Kernel parity:** forward rel_err `6.5e-2`; all four backward gradients ≤ `6.6e-2` (gate `0.10`); metadata equal; output quantizer bit-exact
- **Runner:** `test/python/fe_api/moe_ep/run_pr_tests.sh`
- **Runbook:** `test/python/fe_api/moe_ep/RUNBOOK.md`

### Files touched

#### Integration

| File | Change |
|------|--------|
| `python/cudnn/moe_ep/_megamoe.py` | New backend shim and backend integration |
| `python/cudnn/moe_ep/api.py` | `MoeEp.__call__`/`backward` delegate to backend while preserving fallback |
| `test/python/fe_api/moe_ep/megamoe_backend_parity.py` | New kernel-vs-reference parity test |
| `test/python/fe_api/moe_ep/run_pr_tests.sh` | One-shot validation runner |
| `test/python/fe_api/moe_ep/RUNBOOK.md` | Environment setup and validation guide |
| `docs/fe-oss-apis/moe_ep.md` | Backend status and attribution updates |
| `.pre-commit-config.yaml` | Exclude vendored backend from Black |

#### Vendored backend

103 files under `python/cudnn/moe_ep/_megamoe_backend/` containing the MegaMoE Python package, CuTe DSL kernels (MXFP8 + NVFP4), FP8 mega backward, PyTorch reference package, NVSHMEM infrastructure, and provenance/requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public Mixture-of-Experts API with expert-parallel execution support.
  * Added BF16, MXFP8, and NVFP4 output and combine formats, including block-scaled tensor dequantization.
  * Added forward and backward support with routing metadata and training intermediates.
  * Added optimized GPU execution for supported configurations.

* **Documentation**
  * Added API guidance covering tensor contracts, quantization formats, setup, and supported configurations.

* **Tests**
  * Added reference implementations, quantization checks, parity validation, and single- and multi-device coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->