### PR TITLE
CSA compressor: review-response fixups for the ratio=128 kernels (follow-up to #427)

### DIFF
--- a/benchmark/csa/reg_probe_csa_compressor_r128.py
+++ b/benchmark/csa/reg_probe_csa_compressor_r128.py
@@ -8,7 +8,8 @@ head_dim {128, 512} (16 kernels) — then runs ``ptxas -v`` on each kernel's PTX
 prints a table of registers / spill bytes / stack bytes / ex2.approx count. This
 reproduces the register table published in docs/fe-oss-apis/csa.md.
 
-Exits nonzero if any kernel spills, uses stack, or fails ptxas.
+Exits nonzero if any kernel spills, uses stack, fails ptxas, or exposes no PTX
+(PTX retention off).
 
 Requires a CC 10.0 GPU (the JIT needs a device), ``ptxas`` on PATH, and the
 ``cudnn[cutedsl]`` install. Not collected by pytest. Run, e.g.::
@@ -24,7 +25,7 @@ import subprocess
 import sys
 import tempfile
 
-os.environ.setdefault("CUTE_DSL_KEEP", "ptx")  # keep PTX artifacts on the compiled handles
+os.environ.setdefault("CUTE_DSL_KEEP", "ptx")  # PTX retention: exposes each kernel's PTX via the handle's __ptx__ property
 
 import torch  # noqa: E402
 
@@ -72,6 +73,7 @@ def main():
 
     all_clean = True
     n = 0
+    n_skipped = 0
     for key, fn in sorted(M._COMPILED.items(), key=str):
         kind, _ratio, d, coff, sched, _dev = key
         if kind == "r128fwd":
@@ -80,15 +82,26 @@ def main():
         else:
             vec, tchunks, threads_x, fastexp = sched
             tag = f"bwd_c{coff}d{d}_v{vec}t{tchunks}x{threads_x}" + ("_fexp" if fastexp else "")
-        all_clean = ptxas_one(tag, fn.artifacts.PTX, args.arch, out_dir) and all_clean
+        # __ptx__ is the DSL's documented PTX accessor (a JitCompiledFunction
+        # property); it is None when PTX retention is off, and can be a stale dump
+        # path (no newline) if the dump file vanished before the handle read it.
+        ptx = fn.__ptx__
+        if not ptx or "\n" not in ptx:
+            print(f"{tag:36} SKIPPED: no PTX retained on the compiled handle (need CUTE_DSL_KEEP=ptx)", flush=True)
+            n_skipped += 1
+            continue
+        all_clean = ptxas_one(tag, ptx, args.arch, out_dir) and all_clean
         n += 1
-    print(f"{n} kernels probed ({args.arch}); {'ALL 0 spill / 0 stack' if all_clean else 'SPILL/STACK OR PTXAS FAILURE DETECTED'}", flush=True)
+    verdict = "ALL 0 spill / 0 stack" if all_clean else "SPILL/STACK OR PTXAS FAILURE DETECTED"
+    if n_skipped:
+        verdict += f"; {n_skipped} kernel(s) skipped with no PTX -- nothing verified for them"
+    print(f"{n} kernels probed ({args.arch}); {verdict}", flush=True)
     if args.keep_ptx:
         print(f"PTX kept in {out_dir}", flush=True)
     else:
         os.chdir(tempfile.gettempdir())
         shutil.rmtree(out_dir, ignore_errors=True)
-    sys.exit(0 if all_clean else 1)
+    sys.exit(0 if all_clean and not n_skipped else 1)
 
 
 if __name__ == "__main__":

--- a/benchmark/csa/reg_probe_csa_compressor_r128.py
+++ b/benchmark/csa/reg_probe_csa_compressor_r128.py
@@ -80,8 +80,8 @@ def main():
             vec, tchunks, threads_x, twophase, fastexp = sched
             tag = f"fwd_c{coff}d{d}_v{vec}t{tchunks}x{threads_x}" + ("_2ph" if twophase else "") + ("_fexp" if fastexp else "")
         else:
-            vec, tchunks, threads_x, fastexp = sched
-            tag = f"bwd_c{coff}d{d}_v{vec}t{tchunks}x{threads_x}" + ("_fexp" if fastexp else "")
+            vec, tchunks, threads_x, fastexp, goreuse = sched
+            tag = f"bwd_c{coff}d{d}_v{vec}t{tchunks}x{threads_x}" + ("_fexp" if fastexp else "") + ("_gor" if goreuse else "")
         # __ptx__ is the DSL's documented PTX accessor (a JitCompiledFunction
         # property); it is None when PTX retention is off, and can be a stale dump
         # path (no newline) if the dump file vanished before the handle read it.

--- a/docs/fe-oss-apis/csa.md
+++ b/docs/fe-oss-apis/csa.md
@@ -347,14 +347,21 @@ stays bitwise run-to-run: fixed chunk boundaries and merge orders, no atomics in
 forward/`dKV`/`dScore`.
 
 Both kernels are register-flat in the window length (ptxas sm_100a: forward 32-51
-registers, backward 48-128 registers, 0 spill / 0 stack across every shipped
+registers, backward 64-128 registers, 0 spill / 0 stack across every shipped
 (config, schedule) kernel — 16 kernels total; reproduce the per-kernel table with
 `benchmark/csa/reg_probe_csa_compressor_r128.py`) and JIT in ~0.4-1.0 s per
 configuration.
 The backward picks its `rows_per_cta` at launch time (a runtime argument — no
 recompile) so the grid fits one resident wave; the static row capacity fixes it under
 CUDA-graph capture. Small packs (`nb_total <= 192`, d=128) switch the backward to a
-vec=1 schedule bucket (also precompiled) for grid-fill.
+vec=1 schedule bucket (also precompiled) for grid-fill. Every backward bucket except
+the c1d128 default additionally loads `grad_out` once per row and keeps the register
+vec live across the phase barriers (the `goreuse` schedule field): adopted per bucket
+on measured pure-kernel wins — up to ~26% on the vec=1 small buckets, whose small
+grids underfill the machine, so the +16/+1 register cost is not the binding
+constraint — while the c1d128 default measured ~1.3% slower with it at 131k tokens
+and keeps the phase-4 reload. `dKV`/`dScore` are bitwise-identical with and without
+the field (the same read-only values move into registers).
 
 Measured on 1x B200 (CC 10.0, driver 590.48.01), torch 2.13.0 / CUDA 13.3 /
 `nvidia-cutlass-dsl` 4.6.1; eager baseline = the fp32-intermediate reference region of
@@ -371,9 +378,9 @@ forward at long context):
 
 | config | tokens | eager fwd | fused fwd | fwd | eager bwd | fused bwd | bwd | fused fwd+bwd total |
 |---|---|---|---|---|---|---|---|---|
-| coff 1, d 128 | 8192 | 84.7 us | 5.7 us | **15.0x** | 127.3 us | 8.4 us | **15.2x** | 15.1 us |
+| coff 1, d 128 | 8192 | 84.7 us | 5.7 us | **15.0x** | 127.3 us | 6.3 us | **20.2x** | 13.0 us |
 | coff 1, d 128 | 131072 | 451.8 us | 14.9 us | **30.2x** | 471.9 us | 63.7 us | **7.4x** | 82.5 us |
-| coff 2, d 128 | 8192 | 187.1 us | 6.4 us | **29.1x** | 246.2 us | 11.2 us | **21.9x** | 18.9 us |
+| coff 2, d 128 | 8192 | 187.1 us | 6.4 us | **29.1x** | 246.2 us | 10.5 us | **23.4x** | 18.1 us |
 | coff 2, d 128 | 65536 | 726.3 us | 16.4 us | **44.4x** | 960.0 us | 61.2 us | **15.7x** | 76.7 us |
 | coff 1, d 512 | 65536 | 641.1 us | 48.4 us | **13.2x** | 795.0 us | 104.2 us | **7.6x** | 150.0 us |
 | coff 2, d 512 | 65536 | 2315.2 us | 78.8 us | **29.4x** | 3261.9 us | 205.8 us | **15.9x** | 287.7 us |
@@ -386,9 +393,9 @@ kernels):
 
 | config | tokens | fused fwd | fused bwd |
 |---|---|---|---|
-| coff 1, d 128 | 8192 | 14.1 us | 24.3 us |
+| coff 1, d 128 | 8192 | 14.1 us | 20.8 us |
 | coff 1, d 128 | 131072 | 24.4 us | 82.1 us |
-| coff 2, d 128 | 8192 | 15.2 us | 26.3 us |
+| coff 2, d 128 | 8192 | 15.2 us | 25.3 us |
 | coff 2, d 128 | 65536 | 25.5 us | 75.6 us |
 | coff 1, d 512 | 65536 | 56.3 us | 118.9 us |
 | coff 2, d 512 | 65536 | 88.1 us | 220.8 us |

--- a/python/cudnn/csa/compressor/compressor_sm100_r128.py
+++ b/python/cudnn/csa/compressor/compressor_sm100_r128.py
@@ -60,7 +60,11 @@ The backward kernel (``_compressor_bwd_r128_kernel``) stages each row's window i
 shared memory chunk-parallel, accumulates per-chunk partial ``den`` / ``S`` sums
 inside the e-pass (the approved ratio=128 deterministic tolerance contract), merges
 them per column in a FIXED chunk order, and stores gradients with a hoisted ``1/den``
-multiply — no serial sweeps, no per-element division. dKV/dScore are deterministic
+multiply — no serial sweeps, no per-element division. Most schedule buckets load
+``grad_out`` once per row and hold the register vec across the phase barriers (the
+``goreuse`` schedule field — adopted per bucket on measured pure-kernel wins and
+bitwise-neutral for dKV/dScore; see ``_bwd_schedule_r128``). dKV/dScore are
+deterministic
 (fixed orders, no atomics) and match the fp32-intermediate eager autograd within the
 r128 tolerance contract (same values within the gate tolerances — absolute thresholds
 calibrated on the gate's documented input distribution — the eager reference's NaN/Inf
@@ -643,6 +647,7 @@ def _compressor_bwd_r128_kernel(
     tchunks: cutlass.Constexpr,
     threads_x: cutlass.Constexpr,
     fastexp: cutlass.Constexpr,
+    goreuse: cutlass.Constexpr,
 ):
     """Backward: staged-smem chunk-parallel phases with fused reductions.
 
@@ -853,12 +858,15 @@ def _compressor_bwd_r128_kernel(
 
             # ---- phase 2: chunk-parallel e-pass (mx merge + exp + den/S' partials) ----
             # This pass ALSO accumulates the chunk's partial den / S' sums
-            # (registers, then one smem slot per (chunk, column)).
+            # (registers, then one smem slot per (chunk, column)). grad_out is loaded
+            # once here; in ``goreuse`` buckets the register vec stays live for
+            # phase 4 (mGO is read-only), the others reload it there (see
+            # ``_bwd_schedule_r128`` for the measured per-bucket decision).
+            fr_go = cute.make_rmem_tensor((vec,), cutlass.BFloat16)
             if col < ncol:
                 sbase = k0 * cols_pc + tidx * vec
-                fr_go2 = cute.make_rmem_tensor((vec,), cutlass.BFloat16)
-                gooff2 = cute.assume(bb * d + cvec, divby=vec)
-                cute.autovec_copy(cute.make_tensor(mGO.iterator + gooff2, cute.make_layout(vec)), fr_go2)
+                gooff = cute.assume(bb * d + cvec, divby=vec)
+                cute.autovec_copy(cute.make_tensor(mGO.iterator + gooff, cute.make_layout(vec)), fr_go)
                 for j in cutlass.range_constexpr(vec):
                     # Chunk-max merge: max is order-independent, so the chunked max
                     # equals the ratio=4 kernel's serial scan bitwise. Redundant per
@@ -871,7 +879,7 @@ def _compressor_bwd_r128_kernel(
                             mx = v
                     # Invalid slots become exp(-inf - mx) == 0 exactly, the value the
                     # ratio=4 kernel's serial window feeds its den sum.
-                    go2 = cutlass.Float32(fr_go2[j])
+                    go2 = cutlass.Float32(fr_go[j])
                     den_p = cutlass.Float32(0.0)
                     sp_p = cutlass.Float32(0.0)
                     for kk in cutlass.range(C, unroll=8):
@@ -909,11 +917,13 @@ def _compressor_bwd_r128_kernel(
             cute.arch.barrier()
 
             # ---- phase 4: chunk-parallel gradient stores + dAPE accumulation ----
+            # ``goreuse`` buckets: fr_go still holds this row's grad_out vec from
+            # phase 2; the others reload it (baseline dataflow).
             if col < ncol:
                 sbase = k0 * cols_pc + tidx * vec
-                fr_go = cute.make_rmem_tensor((vec,), cutlass.BFloat16)
-                gooff = cute.assume(bb * d + cvec, divby=vec)
-                cute.autovec_copy(cute.make_tensor(mGO.iterator + gooff, cute.make_layout(vec)), fr_go)
+                if cutlass.const_expr(not goreuse):
+                    gooff4 = cute.assume(bb * d + cvec, divby=vec)
+                    cute.autovec_copy(cute.make_tensor(mGO.iterator + gooff4, cute.make_layout(vec)), fr_go)
                 if run_chunk:
                     for kk in cutlass.range_constexpr(C):
                         off = cute.assume((tok_row0 + kk) * W + colbase, divby=vec)
@@ -988,6 +998,7 @@ def _compressor_bwd_r128_launch(
     tchunks: cutlass.Constexpr,
     threads_x: cutlass.Constexpr,
     fastexp: cutlass.Constexpr,
+    goreuse: cutlass.Constexpr,
 ):
     """JIT entry point that wraps raw pointers into tensors and launches backward."""
     lay = cute.make_layout(_EXT)
@@ -1024,6 +1035,7 @@ def _compressor_bwd_r128_launch(
         tchunks,
         threads_x,
         fastexp,
+        goreuse,
     ).launch(grid=(gx, gy, 1), block=(threads_x, tchunks, 1), stream=stream)
 
 
@@ -1036,12 +1048,25 @@ def _compressor_bwd_r128_launch(
 # boundary measured at 192 (win) / 256 (loss). The vec=1 buckets keep the exact exp:
 # fastexp measured 0.905x (c1) / 1.003x (c2) on top of them.
 _BWD_SMALL_NB_MAX = 192
-# (coff, d) -> (vec, tchunks, fastexp); threads_x is always derived (one warp per
-# chunk-row).
+# (coff, d) -> (vec, tchunks, fastexp, goreuse); threads_x is always derived (one warp
+# per chunk-row).
 _BWD_SMALL_SCHEDULES = {
-    (1, 128): (1, 8, False),
-    (2, 128): (1, 8, False),
+    (1, 128): (1, 8, False, True),
+    (2, 128): (1, 8, False, True),
 }
+
+# grad_out register reuse (the ``goreuse`` schedule field): phase 2 loads grad_out
+# once and keeps the register vec live across the phase 2->4 barriers instead of
+# re-reading the L1-resident line in phase 4. Decided per bucket by measured
+# pure-kernel time (interleaved A/B, B200, median-100; ptxas may only veto on actual
+# spill — none anywhere, sm_100a): the vec=1 small buckets win big (c1d128 1x8192
+# 8.45 -> 6.27 us, 3x8192 16.1 -> 11.7, c2d128 1x8192 11.3 -> 10.7 despite the
+# 48 -> 64 / 77 -> 78 register growth — their small grids underfill the machine, so
+# residency is not the binding constraint), the defaults win ~1.5-2.1% at their
+# short-context shapes and tie at 64k+ — EXCEPT the c1d128 default, which measured
+# 63.9 -> 64.7 us (-1.3%, reproduced order-swapped) at 131k and keeps the phase-4
+# reload. Default-bucket membership:
+_DEFAULT_GOREUSE = {(2, 128), (1, 512), (2, 512)}
 
 _SM_COUNT_CACHE = {}
 
@@ -1056,8 +1081,8 @@ def _sm_count(dev):
 
 
 def _bwd_schedule_r128(ratio, d, coff, nb_total=None):
-    """Launch schedule ``(vec, tchunks, threads_x, fastexp)`` for the ratio=128
-    backward.
+    """Launch schedule ``(vec, tchunks, threads_x, fastexp, goreuse)`` for the
+    ratio=128 backward.
 
     ``vec = 2`` (32-bit paired bf16 accesses) for even ``d``, scalar ``vec = 1`` for
     odd ``d`` — no ``vec = 4`` variant: it doubles the smem tiles and registers
@@ -1071,15 +1096,19 @@ def _bwd_schedule_r128(ratio, d, coff, nb_total=None):
     wins ~25% at long context. ``coff == 2`` additionally requires chunks not to
     straddle the half-window boundary. ``fastexp`` (see ``_exp_fast``) measured a
     uniform +3-8% everywhere EXCEPT the vec=1 small buckets — the default is True
-    outside them.
+    outside them. ``goreuse`` (single grad_out load held across the phase barriers;
+    see ``_DEFAULT_GOREUSE``) is on everywhere EXCEPT the c1d128 default bucket,
+    which measured slower with it; dKV/dScore are bitwise-identical either way (the
+    same read-only values move into registers).
     """
     W = coff * d
     vec = 2 if d % 2 == 0 else 1
     tchunks = 4 if coff == 1 and d >= 512 else 8
     fastexp = True
+    goreuse = (coff, d) in _DEFAULT_GOREUSE
     if nb_total is not None:
         if nb_total <= _BWD_SMALL_NB_MAX and (coff, d) in _BWD_SMALL_SCHEDULES:
-            vec, tchunks, fastexp = _BWD_SMALL_SCHEDULES[(coff, d)]
+            vec, tchunks, fastexp, goreuse = _BWD_SMALL_SCHEDULES[(coff, d)]
     if d % vec != 0:
         raise ValueError(f"vec={vec} must divide head_dim ({d})")
     ncol = d // vec
@@ -1096,7 +1125,7 @@ def _bwd_schedule_r128(ratio, d, coff, nb_total=None):
     smem_bytes = win * threads_x * vec * 6 + 3 * tchunks * threads_x * vec * 4 + 2 * threads_x * vec * 4 + 64
     if smem_bytes > 227 * 1024:
         raise ValueError(f"backward smem tile too large ({smem_bytes} B) for W={W}")
-    return vec, tchunks, threads_x, fastexp
+    return vec, tchunks, threads_x, fastexp, goreuse
 
 
 def _bwd_rows_per_cta(nb_total, ratio, d, coff, dev):

--- a/test/python/fe_api/csa/test_CSA_compressor.py
+++ b/test/python/fe_api/csa/test_CSA_compressor.py
@@ -353,7 +353,7 @@ def _r128_module():
 # Expected shipped schedules per (coff, d, nb_total) bucket — hardcoded on purpose: an
 # edit that silently changes any shipped launch geometry or bucket boundary must fail
 # here. Forward tuples are (vec, tchunks, threads_x, twophase, fastexp); backward
-# tuples are (vec, tchunks, threads_x, fastexp).
+# tuples are (vec, tchunks, threads_x, fastexp, goreuse).
 _FWD_BUCKETS = [
     (1, 128, 64, (2, 8, 32, False, False)),  # small
     (1, 128, 256, (2, 4, 32, False, False)),  # default
@@ -367,13 +367,13 @@ _FWD_BUCKETS = [
     (2, 512, 1024, (4, 4, 32, False, True)),  # large
 ]
 _BWD_BUCKETS = [
-    (1, 128, 64, (1, 8, 32, False)),  # small pack: vec=1, exact exp
-    (1, 128, 256, (2, 8, 32, True)),  # default (fast exp)
-    (2, 128, 64, (1, 8, 32, False)),  # small
-    (2, 128, 256, (2, 8, 32, True)),  # default
-    (1, 512, 256, (2, 4, 32, True)),  # default (tchunks=4 at coff=1, d>=512)
-    (2, 512, 64, (2, 8, 32, True)),  # no bwd small entry at d=512 -> default
-    (2, 512, 256, (2, 8, 32, True)),  # default
+    (1, 128, 64, (1, 8, 32, False, True)),  # small pack: vec=1, exact exp, grad_out reuse
+    (1, 128, 256, (2, 8, 32, True, False)),  # default (fast exp; goreuse measured slower here)
+    (2, 128, 64, (1, 8, 32, False, True)),  # small
+    (2, 128, 256, (2, 8, 32, True, True)),  # default
+    (1, 512, 256, (2, 4, 32, True, True)),  # default (tchunks=4 at coff=1, d>=512)
+    (2, 512, 64, (2, 8, 32, True, True)),  # no bwd small entry at d=512 -> default
+    (2, 512, 256, (2, 8, 32, True, True)),  # default
 ]
 
 


### PR DESCRIPTION
### What

Two review-response fixups from the CodeRabbit round on #427 that were ready on the
review branch but missed the merge window (#427 merged at head d77e48e6). Both were
built on exactly that head; the cherry-pick onto `develop` (b950af1) is clean and the
CSA files are byte-identical to the reviewed pre-merge state, except a one-line
stale-comment fix in the test file (flagged in review; no functional change).

- **`678fca3f` — bench(csa): use the DSL's documented `__ptx__` accessor in the r128
  register probe.** `fn.artifacts` is nvidia-cutlass-dsl's internal
  `JitFunctionArtifacts` dataclass; the documented accessor on the compiled handle is
  the `__ptx__` property (`JitCompiledFunction`), which is `None` when PTX retention
  (`CUTE_DSL_KEEP=ptx`) is off instead of poisoning ptxas input. Kernels that expose
  no PTX are now skipped with a clear message and a nonzero exit (a kernel that
  wasn't probed wasn't verified). Verified against nvidia-cutlass-dsl 4.6.1;
  identical 16-kernel table, ALL 0 spill / 0 stack.

- **`037a53ba` — CSA compressor: adopt per-bucket grad_out register reuse in the r128
  backward.** The backward loaded each row's grad_out vec twice (phases 2 and 4).
  Loading it once and holding the register vec across the phase barriers is now a
  per-bucket schedule field (`goreuse`), decided by measured time and adopted in
  **5 of 6** backward buckets; the one measured loser (c1d128 default) keeps the
  reload and compiles to byte-identical PTX vs the pre-change kernel. dKV/dScore are
  bitwise-identical with and without the field on every schedule; no schedule spills
  either way (0 spill / 0 stack, sm_100a).

### Performance (goreuse commit)

*Methodology: nsys pure-kernel per-launch durations (kernel time only — no wrapper,
launch, or sync overhead), median of 100 after 30 warmup; both variants interleaved
in one process on the same clocks and the same input tensors; reproduced
order-swapped. One B200. Measured on the review branch at e70f6140, whose CSA files
are byte-identical to this branch apart from the one-line test-comment fix, and the
adopted buckets compile to byte-identical PTX vs the measured kernels — byte-identical
PTX means the measured kernels are the shipped kernels (absolute timings vary within
the session-noise envelope below).*

| bwd bucket | shape | base → reuse (µs) | delta (run1/run2) | decision |
|---|---|---|---|---|
| c1d128 small | 1x8192 | 8.45 → 6.27 | **+25.8% / +25.8%** | adopt |
| c1d128 small | 3x8192 | 16.10 → 11.68 | **+27.4% / +27.6%** | adopt |
| c1d128 default | 1x131072 | 63.87 → 64.70 | −1.3% / −1.6% | keep reload |
| c2d128 small | 1x8192 | 11.30 → 10.66 | +5.7% / +7.1% | adopt |
| c2d128 default | 1x65536 | 61.25 → 60.32 | +1.5% / +1.5% | adopt |
| c1d512 default | 1x8192 | 17.65 → 17.28 | +2.1% / +2.0% (65k tie) | adopt |
| c2d512 default | 1x8192 | 28.27 → 27.84 | +1.5% / +1.9% (65k tie) | adopt |

Docs tables updated for the two configurations (both tables) that moved outside
session noise (c1d128 8192: bwd 8.4 → 6.3 µs; c2d128 8192: 11.2 → 10.5 µs
kernel-time); long-context rows measured within the ±3% session-noise envelope of
their published cells and stand.

### Responds to CodeRabbit feedback on #427

- **Comment 1** (`fn.artifacts.PTX` is a non-public surface) → fixed in `678fca3f`
  as described above.
- **Comment 2** (bwd grad_out loaded twice) → measured per schedule bucket and
  adopted where it wins, `037a53ba`. The register table was a poor predictor: the
  bucket with the largest growth (c1d128 small, 48 → 64 regs) wins the most because
  its small grid underfills the machine, while the one loser has unchanged registers
  (80 → 80).
- **Comment 3** (eager reference duplicated between the gate and the test suite) →
  no code change; the duplication is deliberate and staked in the gate's docstring.
  The gate is the PR's numerics authority, so its reference should be auditable in
  place rather than imported across `benchmark/` ↔ `test/python` (neither is a
  package; conftest import-order constraints). Drift is checked, not trusted: every
  gate run first cross-checks the copied reference against the shipped production
  ratio=4 backward (bitwise dKV/dScore, `validate_reference()`) and fails before
  gating anything if the copy has drifted.

### Validation (re-run on this branch, `develop` + these 2 commits, B200, 2026-07-30)

- ratio=128 contract gate: **PASS 21/21** (3-run determinism, tolerance vs fp32
  eager, fp64-oracle parity, overflow NaN-pattern case; schedule coverage fwd 10/10,
  bwd 6/6 asserted through the dispatch tables, including the goreuse fields).
- pytest `-m "L0 or L1" fe_api/csa/test_CSA_compressor.py`: **98 passed, 1 skipped**.
- register probe (via the fixed `__ptx__` path): **16 kernels probed (sm_100a);
  ALL 0 spill / 0 stack**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional backward-kernel scheduling setting that can improve register reuse and performance.
  * Updated ratio-128 scheduling to select and validate the new setting across supported configurations.

* **Documentation**
  * Clarified backward scheduling behavior, launch-time row selection, and register reuse effects.
  * Updated ratio-128 performance measurements.

* **Bug Fixes**
  * Improved benchmark reporting when kernel PTX is unavailable, ensuring incomplete results are reported as failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->