### PR TITLE
BSA: fix the cute-dsl bulk-copy elect gate for 4.6.2 and 4.7

### DIFF
--- a/python/cudnn/block_sparse_attention/csrc/utils/copy_utils.py
+++ b/python/cudnn/block_sparse_attention/csrc/utils/copy_utils.py
@@ -6,6 +6,7 @@
 # maintained locally so BSA does not require Quack at runtime.
 
 import contextlib
+import re
 from typing import Callable, Optional, Tuple, Type
 
 import cutlass
@@ -18,12 +19,30 @@ from cutlass.cutlass_dsl import dsl_user_op
 from cutlass._mlir.dialects import llvm
 import cutlass.pipeline
 
+# cute.copy elects a single lane internally for raw bulk-copy atoms only on
+# cute-dsl 4.6.0 and 4.6.1; on every other version the caller must elect.
+_ELECT_FIRST = (4, 6, 0)
+_ELECT_LAST = (4, 6, 1)
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?P<pre>.*)$")
+
 
 def _cute_dsl_bulk_copy_self_elects() -> bool:
-    try:
-        return tuple(int(p) for p in cutlass.__version__.split(".")[:2]) >= (4, 6)
-    except (AttributeError, ValueError):
-        return True
+    """Whether cute.copy already elects a single lane for raw bulk-copy atoms.
+
+    Either answer hangs the warp if it is wrong: electing around a copy that
+    already elects deadlocks at the inner election, and not electing lets all 32
+    lanes issue the copy and over-complete the mbarrier transaction.
+    """
+    version = getattr(cutlass, "__version__", "").strip().split("+", 1)[0]
+    match = _VERSION_RE.match(version)
+    if match is None:
+        return False
+    if not _ELECT_FIRST <= tuple(int(part) for part in match.group(1, 2, 3)) <= _ELECT_LAST:
+        return False
+    # Within that range only the final releases shipped the internal election;
+    # a pre-release such as 4.6.0.dev0 predates it.
+    return not match.group("pre")
 
 
 _BULK_COPY_SELF_ELECTS = _cute_dsl_bulk_copy_self_elects()
@@ -32,12 +51,14 @@ _BULK_COPY_SELF_ELECTS = _cute_dsl_bulk_copy_self_elects()
 def bulk_copy_elect_one():
     """elect_one() guard for bulk-async copies (cpasync.CopyBulk*, TMA atoms).
 
-    On cute-dsl <= 4.5.x the bulk copy does not elect a lane internally, so the
-    caller must wrap it in cute.arch.elect_one() to issue it once per warp.
-    On cute-dsl >= 4.6.0 cute.copy elects internally via a warp-collective
-    elect; an outer elect_one() leaves only one lane active at that inner
-    collective and deadlocks the warp. Use this guard instead of a bare
-    elect_one() around such copies.
+    A raw bulk copy is a per-thread issue path, so on most cute-dsl versions the
+    caller must wrap it in cute.arch.elect_one() to issue it once per warp;
+    otherwise all 32 lanes issue, each completing the mbarrier transaction, and
+    the over-completed barrier desynchronises the pipeline. On the 4.6.0/4.6.1
+    releases cute.copy elects internally instead, and there an outer elect_one()
+    leaves a single lane at the inner warp-collective elect and deadlocks. Use
+    this guard rather than a bare elect_one() so the right one is chosen; see
+    _cute_dsl_bulk_copy_self_elects() for the version rule and the evidence.
     """
     if _BULK_COPY_SELF_ELECTS:
         return contextlib.nullcontext()


### PR DESCRIPTION
Authored by **XiaoDong** (@xiaod, xiaod@nvidia.com) — ported from an internal change; the commit preserves the original authorship.

Fixes BSA blk128 backward hangs on SM100 with cute-dsl 4.6.2 and 4.7.0a0 (passes on 4.6.1).

Affected tests (all the same kernel — `supported_block_size(backward=True)` is 128 on SM10x):
- `test_bsa_attention_backward_fixed_blocks`
- `test_bsa_attention_backward_blk128_dk_zero_init_accumulate_transition[1]` / `[4]`

Under `pytest -n=4 --timeout=300` the hang surfaces as `worker 'gwN' crashed … node down`.

### Cause

The `elect_one()` guard was gated on `cutlass.__version__[:2] >= (4, 6)`, matching a cute-dsl change that made the raw `cp.async.bulk.*` lowering elect a lane internally. That change has since been reverted on every cute-dsl line (shipped in 4.6.2 and 4.7.0a0), restoring the pre-4.6 contract that the caller elects — see NVIDIA/cutlass#3391.

Because the gate only compares major.minor, 4.6.2 and 4.7 still take the "the DSL elects for me" branch. Nothing elects, so all 32 lanes issue the same `cp.async.bulk…complete_tx::bytes` for the LSE/dPsum stats copies. `producer_acquire` sized `expect_tx` for a single copy, so the barrier is over-completed 32x and the pipeline wedges.

### Fix

Only 4.6.0 and 4.6.1 ever shipped the internal election. Match that release range instead of `>= 4.6`; pre-releases (e.g. `4.6.0.dev0`) and everything else fall through to "the caller elects".

### Why not just revert the original gate

On 4.6.0/4.6.1 a caller-side `elect_one()` nests with the internal one and deadlocks — that is what the original gate fixed. Both are inside the declared support range (`nvidia-cutlass-dsl>=4.5.0`), so the gate has to stay; it just has to name the right versions. Measured on B200/SM100a with a full-warp `cute.copy(CopyBulkG2SOp, mbar_ptr=…)`:

| cute-dsl | caller elects | `elect.sync` in PTX | launch |
|---|---|---|---|
| 4.6.0 / 4.6.1 | no | 1 | ok |
| 4.6.0 / 4.6.1 | yes | 2 | **wedges** |
| 4.7.0a0 | no | 0 | **wedges** |
| 4.7.0a0 | yes | 1 | ok |

### Verification

Fresh clone + real `pip install` per leg, nothing patched in place:

| cute-dsl | before | with this change |
|---|---|---|
| 4.7.0a0 | **hang, killed at timeout** | 3 passed · `fe_api/bsa` 17 passed |
| 4.6.1 | — | 3 passed · `fe_api/bsa` 17 passed |
| 4.6.0 | — | 3 passed · `fe_api/bsa` 17 passed |

Full `fe_api` under nightly settings: 80 failed / 2179 passed / 1668 skipped, **zero hangs**; residual failures match the baseline family-for-family (`gemm_swiglu` 64, `sdpa_bwd` 12, `dsa` 4) with only the 3 BSA ones removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for block-sparse attention across supported CUTLASS versions.
  * Prevented potential deadlocks or barrier synchronization issues during bulk-copy operations.
  * Refined version detection to handle patch releases and pre-release versions more accurately.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->