### PR TITLE
Follow-up to #449: allowlist I/O dtype check on both SDPA paths

### DIFF
--- a/include/cudnn_frontend/node/sdpa_support_surface.h
+++ b/include/cudnn_frontend/node/sdpa_support_surface.h
@@ -409,12 +409,39 @@ SDPA_attributes::verify_sdpa_support_surface_for_implementation(const detail::Co
         return it != outputs.end() && it->second != nullptr;
     };
 
+    // Whether every present Q/K/V/O I/O tensor uses a dtype within `allowed`. NOT_SET
+    // passes: the dtype is resolved from the graph default before real validation
+    // re-runs this check.
+    auto const io_dtypes_within = [this, &has_input, &has_output](std::unordered_set<DataType_t> const& allowed) {
+        auto const ok = [&allowed](DataType_t dt) {
+            return dt == DataType_t::NOT_SET || allowed.find(dt) != allowed.end();
+        };
+        for (auto const name : {input_names::Q, input_names::K, input_names::V}) {
+            if (has_input(name) && !ok(inputs.at(name)->get_data_type())) {
+                return false;
+            }
+        }
+        if (has_output(output_names::O) && !ok(outputs.at(output_names::O)->get_data_type())) {
+            return false;
+        }
+        return true;
+    };
+
     switch (impl) {
         case AttentionImplementation_t::AUTO:
             // This function should not be called with AUTO.
             return {error_code_t::INVALID_VALUE,
                     "Can't call verify_sdpa_support_surface_for_implementation with impl=AUTO"};
         case AttentionImplementation_t::COMPOSITE:
+            RETURN_CUDNN_FRONTEND_ERROR_IF(
+                !io_dtypes_within({DataType_t::HALF,
+                                   DataType_t::BFLOAT16,
+                                   DataType_t::FP8_E4M3,
+                                   DataType_t::FP8_E5M2,
+                                   DataType_t::FLOAT}),
+                error_code_t::GRAPH_NOT_SUPPORTED,
+                "Composite SDPA node supports only FP16/BF16/FP8/FP32 Q/K/V/O I/O; the requested "
+                "I/O data type is not supported.");
             RETURN_CUDNN_FRONTEND_ERROR_IF(has_input(input_names::Block_mask),
                                            error_code_t::GRAPH_NOT_SUPPORTED,
                                            "Composite SDPA node doesn't support Block_mask input");
@@ -441,30 +468,17 @@ SDPA_attributes::verify_sdpa_support_surface_for_implementation(const detail::Co
                                            error_code_t::GRAPH_NOT_SUPPORTED,
                                            "Unified SDPA node requires cuDNN 9.13.1");
 
-            RETURN_CUDNN_FRONTEND_ERROR_IF(context.get_dynamic_shape_enabled(),
-                                           error_code_t::GRAPH_NOT_SUPPORTED,
-                                           "Unified SDPA node doesn't yet support dynamic shape");
+            RETURN_CUDNN_FRONTEND_ERROR_IF(
+                context.get_dynamic_shape_enabled(),
+                error_code_t::GRAPH_NOT_SUPPORTED,
+                "Unified SDPA node doesn't support dynamic shape. Use override shape instead.");
 
-            // The unified engine only implements FP16/BF16/FP8/MXFP8 inputs/outputs.
-            // NOT_SET is allowed to pass (the dtype is resolved from the graph default before
-            // real validation re-runs this check).
-            auto const io_dtype_supported = [](DataType_t dt) {
-                return dt == DataType_t::NOT_SET || dt == DataType_t::HALF || dt == DataType_t::BFLOAT16 ||
-                       dt == DataType_t::FP8_E4M3 || dt == DataType_t::FP8_E5M2;
-            };
-            bool bad_io = false;
-            for (auto const name : {input_names::Q, input_names::K, input_names::V}) {
-                if (has_input(name) && !io_dtype_supported(inputs.at(name)->get_data_type())) {
-                    bad_io = true;
-                }
-            }
-            if (has_output(output_names::O) && !io_dtype_supported(outputs.at(output_names::O)->get_data_type())) {
-                bad_io = true;
-            }
-            RETURN_CUDNN_FRONTEND_ERROR_IF(bad_io,
-                                           error_code_t::GRAPH_NOT_SUPPORTED,
-                                           "Unified SDPA node only supports FP16/BF16/FP8 Q/K/V/O I/O (FP32 I/O is not "
-                                           "supported); use the composite implementation for FP32.");
+            RETURN_CUDNN_FRONTEND_ERROR_IF(
+                !io_dtypes_within({DataType_t::HALF, DataType_t::BFLOAT16, DataType_t::FP8_E4M3, DataType_t::FP8_E5M2}),
+                error_code_t::GRAPH_NOT_SUPPORTED,
+                "Unified SDPA node supports only FP16/BF16/FP8 Q/K/V/O I/O; the requested I/O data "
+                "type is not supported by the unified implementation. (FP32 I/O is available via the "
+                "composite implementation, e.g. AttentionImplementation_t::AUTO.)");
 
             // TODO: Provide smarter error messages that provide the required cuDNN version for each input.
             std::unordered_set<SDPA_attributes::input_names> allowed_input_names{

--- a/test/python/test_sdpa_fp32_rejected.py
+++ b/test/python/test_sdpa_fp32_rejected.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.L0
 
 _DTYPE = {
     torch.float32: cudnn.data_type.FLOAT,
+    torch.float64: cudnn.data_type.DOUBLE,
     torch.float16: cudnn.data_type.HALF,
     torch.bfloat16: cudnn.data_type.BFLOAT16,
 }
@@ -59,22 +60,41 @@ def _build_sdpa(io_dtype, implementation):
 
 
 def test_fp32_unified_rejected():
-    """FP32 forced onto the unified node fails cleanly instead of crashing."""
+    """FP32 forced onto the unified node fails cleanly (it has no FP32 kernel)
+    instead of crashing -- the original issue #424."""
     with pytest.raises(cudnn.cudnnGraphNotSupportedError):
         _build_sdpa(torch.float32, cudnn.attention_implementation.UNIFIED)
 
 
+@pytest.mark.parametrize(
+    "implementation",
+    [cudnn.attention_implementation.UNIFIED, cudnn.attention_implementation.COMPOSITE],
+)
+def test_fp64_rejected(implementation):
+    """FP64 I/O is supported by no SDPA engine and must be rejected on both the
+    unified and composite paths. The guards are allowlists, so they cover dtypes
+    beyond the FP32 case from issue #424 (e.g. avoid 'someone files a bug for
+    FP64 next'). Under AUTO, neither path accepts FP64, so auto-select instead
+    fails to find any implementation -- covered by the framework, not here."""
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError):
+        _build_sdpa(torch.float64, implementation)
+
+
 @pytest.mark.parametrize("io_dtype", [torch.float16, torch.bfloat16])
 def test_fp16_bf16_unified_supported(io_dtype):
-    """The FP32 guard must not over-reject the supported FP16/BF16 I/O dtypes."""
+    """The FP32/FP64 guard must not over-reject the supported FP16/BF16 dtypes."""
     _build_sdpa(io_dtype, cudnn.attention_implementation.UNIFIED)
 
 
-def test_fp32_auto_routes_to_composite():
-    """Under AUTO, FP32 must not be routed to the unified node; it builds via
-    the composite implementation where a real FP32 kernel exists."""
+@pytest.mark.parametrize(
+    "implementation",
+    [cudnn.attention_implementation.COMPOSITE, cudnn.attention_implementation.AUTO],
+)
+def test_fp32_composite_supported(implementation):
+    """FP32 must not be routed to the unified node; it is accepted by the
+    composite engines (AUTO auto-selects composite for FP32)."""
     try:
-        _build_sdpa(torch.float32, cudnn.attention_implementation.AUTO)
+        _build_sdpa(torch.float32, implementation)
     except cudnn.cudnnGraphNotSupportedError:
         # No composite FP32 engine available on this architecture; the important
         # invariant (FP32 is not silently sent to the unified node) still holds.

--- a/test/python/test_sdpa_fp32_rejected.py
+++ b/test/python/test_sdpa_fp32_rejected.py
@@ -8,9 +8,11 @@ HALF in ``Graph::sdpa()`` regardless of the I/O dtype, so an FP32 graph would
 previously build and then dispatch a half-precision kernel onto 4-byte data,
 reading/writing shared memory out of bounds (a CUDA invalid memory reference).
 
-The support surface now rejects unsupported unified Q/K/V/O I/O dtypes, so such a
-graph fails cleanly at build time with GRAPH_NOT_SUPPORTED. Under AUTO, FP32 is
-routed to the composite implementation, which does support FP32 I/O.
+``verify_sdpa_support_surface_for_implementation`` now checks each Q/K/V/O I/O
+dtype against an allowlist on both paths: the unified path allows FP16/BF16/FP8,
+the composite path additionally allows FP32; neither allows FP64 or anything
+else. Unsupported dtypes fail cleanly at build time with GRAPH_NOT_SUPPORTED.
+Under AUTO, FP32 is routed to the composite implementation.
 """
 
 import cudnn
@@ -26,20 +28,32 @@ _DTYPE = {
     torch.bfloat16: cudnn.data_type.BFLOAT16,
 }
 
+_PORTS = ["q", "k", "v", "o"]
 
-def _build_sdpa(io_dtype, implementation):
+
+def _build_sdpa(implementation, base_dtype=torch.float16, *, overrides=None):
+    """Build and finalize an SDPA graph.
+
+    Every Q/K/V/O tensor uses ``base_dtype`` except the ports named in
+    ``overrides`` ({port: torch_dtype}). Overriding a single port lets each
+    port's dtype check be exercised independently.
+    """
+    overrides = overrides or {}
     b, h, s, d = 2, 4, 128, 64
-    cudnn_dtype = _DTYPE[io_dtype]
+
+    def dt(port):
+        return _DTYPE[overrides.get(port, base_dtype)]
+
     graph = cudnn.pygraph(
-        io_data_type=cudnn_dtype,
+        io_data_type=_DTYPE[base_dtype],
         intermediate_data_type=cudnn.data_type.FLOAT,
         compute_data_type=cudnn.data_type.FLOAT,
     )
     dim = [b, h, s, d]
     stride = [h * s * d, s * d, d, 1]
-    q = graph.tensor(name="q", dim=dim, stride=stride, data_type=cudnn_dtype)
-    k = graph.tensor(name="k", dim=dim, stride=stride, data_type=cudnn_dtype)
-    v = graph.tensor(name="v", dim=dim, stride=stride, data_type=cudnn_dtype)
+    q = graph.tensor(name="q", dim=dim, stride=stride, data_type=dt("q"))
+    k = graph.tensor(name="k", dim=dim, stride=stride, data_type=dt("k"))
+    v = graph.tensor(name="v", dim=dim, stride=stride, data_type=dt("v"))
     o, _ = graph.sdpa(
         name="sdpa",
         q=q,
@@ -49,7 +63,7 @@ def _build_sdpa(io_dtype, implementation):
         attn_scale=1.0 / (d**0.5),
         implementation=implementation,
     )
-    o.set_output(True).set_dim(dim).set_stride(stride)
+    o.set_output(True).set_dim(dim).set_stride(stride).set_data_type(dt("o"))
 
     graph.validate()
     graph.build_operation_graph()
@@ -59,31 +73,45 @@ def _build_sdpa(io_dtype, implementation):
     return graph
 
 
-def test_fp32_unified_rejected():
-    """FP32 forced onto the unified node fails cleanly (it has no FP32 kernel)
-    instead of crashing -- the original issue #424."""
-    with pytest.raises(cudnn.cudnnGraphNotSupportedError):
-        _build_sdpa(torch.float32, cudnn.attention_implementation.UNIFIED)
+@pytest.mark.parametrize("bad_dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("port", _PORTS)
+def test_unified_rejects_unsupported_io_dtype(port, bad_dtype):
+    """Each Q/K/V/O port is checked independently on the unified path: an
+    unsupported dtype on any single port (the rest FP16) is rejected by the
+    unified support surface. Covers FP32 (issue #424) and FP64. The ``match``
+    asserts the rejection comes from our dtype check, not an incidental one."""
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Unified SDPA node"):
+        _build_sdpa(
+            cudnn.attention_implementation.UNIFIED,
+            torch.float16,
+            overrides={port: bad_dtype},
+        )
 
 
-@pytest.mark.parametrize(
-    "implementation",
-    [cudnn.attention_implementation.UNIFIED, cudnn.attention_implementation.COMPOSITE],
-)
-def test_fp64_rejected(implementation):
-    """FP64 I/O is supported by no SDPA engine and must be rejected on both the
-    unified and composite paths. The guards are allowlists, so they cover dtypes
-    beyond the FP32 case from issue #424 (e.g. avoid 'someone files a bug for
-    FP64 next'). Under AUTO, neither path accepts FP64, so auto-select instead
-    fails to find any implementation -- covered by the framework, not here."""
-    with pytest.raises(cudnn.cudnnGraphNotSupportedError):
-        _build_sdpa(torch.float64, implementation)
+@pytest.mark.parametrize("port", _PORTS)
+def test_composite_rejects_fp64_io_dtype(port):
+    """The composite path additionally supports FP32 but not FP64; an FP64 dtype
+    on any single port (the rest FP16) is rejected, per-port, by our check."""
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Composite SDPA node"):
+        _build_sdpa(
+            cudnn.attention_implementation.COMPOSITE,
+            torch.float16,
+            overrides={port: torch.float64},
+        )
 
 
 @pytest.mark.parametrize("io_dtype", [torch.float16, torch.bfloat16])
 def test_fp16_bf16_unified_supported(io_dtype):
     """The FP32/FP64 guard must not over-reject the supported FP16/BF16 dtypes."""
-    _build_sdpa(io_dtype, cudnn.attention_implementation.UNIFIED)
+    try:
+        _build_sdpa(cudnn.attention_implementation.UNIFIED, io_dtype)
+    except cudnn.cudnnGraphNotSupportedError as e:
+        # Our dtype allowlist must never reject FP16/BF16; a rejection naming the
+        # I/O data type is exactly the over-rejection this test guards against.
+        # Anything else means unified SDPA is unsupported on this cuDNN/GPU combo
+        # (e.g. too-old backend), so skip rather than fail.
+        assert "data type" not in str(e), f"FP16/BF16 wrongly rejected by the guard: {e}"
+        pytest.skip(f"unified FP16/BF16 SDPA unsupported on this setup: {e}")
 
 
 @pytest.mark.parametrize(
@@ -94,8 +122,10 @@ def test_fp32_composite_supported(implementation):
     """FP32 must not be routed to the unified node; it is accepted by the
     composite engines (AUTO auto-selects composite for FP32)."""
     try:
-        _build_sdpa(torch.float32, implementation)
-    except cudnn.cudnnGraphNotSupportedError:
-        # No composite FP32 engine available on this architecture; the important
-        # invariant (FP32 is not silently sent to the unified node) still holds.
+        _build_sdpa(implementation, torch.float32)
+    except cudnn.cudnnGraphNotSupportedError as e:
+        # A unified-routing rejection here would be a real regression (FP32 must
+        # never reach the unified node), so only skip on a genuine
+        # composite-engine unavailability -- never on the unified rejection.
+        assert "Unified" not in str(e), f"FP32 wrongly rejected by the unified node: {e}"
         pytest.skip("no composite FP32 SDPA engine available on this GPU")

--- a/test/python/test_sdpa_fp32_rejected.py
+++ b/test/python/test_sdpa_fp32_rejected.py
@@ -31,6 +31,17 @@ _DTYPE = {
 _PORTS = ["q", "k", "v", "o"]
 
 
+def _is_dtype_allowlist_rejection(exc):
+    """Whether ``exc`` is our unified/composite support-surface dtype rejection.
+
+    Both allowlist messages lead with "<impl> SDPA node supports only ... I/O",
+    so a positive test that hits this has been wrongly rejected by the very
+    contract under test (a regression) -- as opposed to a genuine engine/backend
+    unavailability, which raises a different message and is safe to skip.
+    """
+    return "SDPA node supports only" in str(exc)
+
+
 def _build_sdpa(implementation, base_dtype=torch.float16, *, overrides=None):
     """Build and finalize an SDPA graph.
 
@@ -106,11 +117,11 @@ def test_fp16_bf16_unified_supported(io_dtype):
     try:
         _build_sdpa(cudnn.attention_implementation.UNIFIED, io_dtype)
     except cudnn.cudnnGraphNotSupportedError as e:
-        # Our dtype allowlist must never reject FP16/BF16; a rejection naming the
-        # I/O data type is exactly the over-rejection this test guards against.
-        # Anything else means unified SDPA is unsupported on this cuDNN/GPU combo
-        # (e.g. too-old backend), so skip rather than fail.
-        assert "data type" not in str(e), f"FP16/BF16 wrongly rejected by the guard: {e}"
+        # Our dtype allowlist must never reject FP16/BF16 -- that over-rejection is
+        # exactly what this test guards against. Any other rejection means unified
+        # SDPA is unsupported on this cuDNN/GPU combo (e.g. too-old backend), so
+        # skip rather than fail.
+        assert not _is_dtype_allowlist_rejection(e), f"FP16/BF16 wrongly rejected by the guard: {e}"
         pytest.skip(f"unified FP16/BF16 SDPA unsupported on this setup: {e}")
 
 
@@ -124,8 +135,9 @@ def test_fp32_composite_supported(implementation):
     try:
         _build_sdpa(implementation, torch.float32)
     except cudnn.cudnnGraphNotSupportedError as e:
-        # A unified-routing rejection here would be a real regression (FP32 must
-        # never reach the unified node), so only skip on a genuine
-        # composite-engine unavailability -- never on the unified rejection.
-        assert "Unified" not in str(e), f"FP32 wrongly rejected by the unified node: {e}"
+        # Either a unified misroute (FP32 must never reach the unified node) or a
+        # composite over-rejection would surface as our allowlist message and is a
+        # real regression -- fail. Only skip on a genuine composite-engine
+        # unavailability, which raises a different message.
+        assert not _is_dtype_allowlist_rejection(e), f"FP32 wrongly rejected by a support surface: {e}"
         pytest.skip("no composite FP32 SDPA engine available on this GPU")


### PR DESCRIPTION
Follow-up to #449 addressing review feedback. Together with #449 this should fully resolve #424 (which was re-opened because #449 alone wasn't fully satisfactory).

Fixes #424.

## Changes

- **Check the Q/K/V/O I/O dtype on both the UNIFIED and COMPOSITE paths** of `verify_sdpa_support_surface_for_implementation`, via a shared `io_dtypes_within` allowlist helper.
  - Unified allows `{fp16, bf16, fp8}`.
  - Composite additionally allows **fp32** — matching the composite forward and backward engines, which support FP32/FP16/BF16/FP8 I/O and nothing else.
  - Neither allows fp64 (or any other dtype).
- **Error "with what is allowed."** The messages lead with the supported set and reject any other dtype generically, so e.g. fp64 is caught with a sensible message instead of prompting a follow-up bug.
- Correct the unified **dynamic-shape** message — dynamic shape is not planned; override shape is the supported mechanism.

## Behavior

- fp32 is rejected on unified, accepted on composite; under `AUTO`, fp32 auto-selects composite (unchanged from #449).
- fp64 (and other unsupported dtypes) are rejected on both explicit paths; under `AUTO`, neither path accepts them so auto-select finds no implementation.

## Testing

`test/python/test_sdpa_fp32_rejected.py`, addressing the review comments on #449/#454:
- Each Q/K/V/O port is checked independently (one unsupported port, rest FP16), asserting the rejection comes from our unified/composite dtype check.
- fp64 rejected on unified + composite; fp32 rejected on unified but accepted on composite/AUTO.
- The fp32-composite and fp16/bf16-unified positive tests fail on a wrong-path rejection but skip on genuine engine/capability unavailability.

Verified on A100 (sm80) and H100 (sm90): 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SDPA validation for tensor data types across unified and composite implementations.
  * Composite attention now supports FP32 tensors while continuing to reject unsupported FP64 tensors.
  * Unified attention consistently enforces supported FP16, BF16, and FP8 data types.
  * Clarified dynamic-shape validation messages.

* **Tests**
  * Expanded coverage for per-port Q/K/V/output data-type validation.
  * Verified that automatic implementation selection routes FP32 workloads to the composite implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->