### PR TITLE
Integrate Rubin wgrad cutedsl kernel and fix an issue in rebased rubin branch

### DIFF
--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/_blockscaled_api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/_blockscaled_api.py
@@ -19,6 +19,23 @@ from .moe_blockscaled_grouped_gemm_wgrad import BlockScaledMoEGroupedGemmWgradKe
 from ..moe_utils import MoEWeightMode, WGradInputOrder
 
 
+def _get_rubin_kernel():
+    from .moe_blockscaled_grouped_gemm_wgrad_rubin import (
+        BlockScaledMoEGroupedGemmWgradRubinKernel,
+    )
+
+    return BlockScaledMoEGroupedGemmWgradRubinKernel
+
+
+def _is_supported_rubin_quantization(ab_dtype: torch.dtype, sf_dtype: torch.dtype, sf_vec_size: int) -> bool:
+    is_fp4 = ab_dtype in (torch.float4_e2m1fn_x2, torch.uint8)
+    if is_fp4:
+        return (sf_dtype == torch.float8_e4m3fn and sf_vec_size == 16) or (
+            sf_dtype == torch.float8_e8m0fnu and sf_vec_size == 32
+        )
+    return ab_dtype in (torch.float8_e4m3fn, torch.float8_e5m2) and sf_dtype == torch.float8_e8m0fnu and sf_vec_size == 32
+
+
 def _round_up(a: int, b: int) -> int:
     return ceil_div(a, b) * b
 
@@ -118,7 +135,7 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
         self.cluster_shape_mn = cluster_shape_mn or ((2, 1) if self.use_2cta_instrs else (1, 1))
         self.accumulate_on_output = accumulate_on_output
-        self._kernel = BlockScaledMoEGroupedGemmWgradKernel
+        self._kernel = _get_rubin_kernel() if self._is_rubin_kernel else BlockScaledMoEGroupedGemmWgradKernel
         self._workspace = None
 
     def _validate_offsets(self, offsets_tensor: torch.Tensor, tokens_sum: int, name: str) -> Tuple[int, ...]:
@@ -142,6 +159,27 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
             self._value_error_if(tokens_sum != 0, f"{name} cannot be empty when total tokens is {tokens_sum}")
 
         return offset_values
+
+    def _check_rubin_quantization_support(self) -> None:
+        if not self._is_rubin_kernel:
+            return
+
+        self._value_error_if(
+            self.sfa_desc.dtype != self.sfb_desc.dtype,
+            "Rubin wgrad requires sample_sfa and sample_sfb to have the same dtype",
+        )
+        self._value_error_if(
+            not _is_supported_rubin_quantization(self.a_desc.dtype, self.sfa_desc.dtype, self.sf_vec_size),
+            "Rubin wgrad supports NVFP4 (E2M1/E4M3, vec16), MXFP4 "
+            "(E2M1/E8M0, vec32), and MXFP8 (E4M3 or E5M2/E8M0, vec32)",
+        )
+        self._value_error_if(self.acc_dtype != torch.float32, "Rubin wgrad requires float32 accumulation")
+
+        if self._is_fp4x2(self.a_desc):
+            self._value_error_if(
+                self.a_desc.stride[1] != 1 or self.b_desc.stride[0] != 1,
+                "Four-bit Rubin wgrad requires K-major sample_a and sample_b layouts",
+            )
 
     def check_support(self) -> bool:
         m, tokens_sum = self._tensor_shape(self.a_desc, name="sample_a")
@@ -167,6 +205,7 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
             "sample_sfb",
             extra_error_msg="sample_sfb must have dtype float8_e8m0fnu or float8_e4m3fn",
         )
+        self._check_rubin_quantization_support()
         self._check_dtype(self.offsets_desc, torch.int32, "sample_offsets", extra_error_msg="sample_offsets must be int32")
         self._check_dtype(
             self.wgrad_dtype, [torch.bfloat16, torch.float16, torch.float32], "wgrad_dtype", extra_error_msg="wgrad_dtype must be bfloat16, float16, or float32"

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/api.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/api.py
@@ -11,7 +11,7 @@ import os
 import torch
 from cuda.bindings import driver as cuda
 
-from cudnn.api_base import APIBase, TupleDict
+from cudnn.api_base import APIBase, TupleDict, get_device_type
 from cudnn.discrete_grouped_gemm.discrete_kernel_utils import _require_pointer_tensor
 
 from ..grouped_gemm_utils import (
@@ -36,7 +36,11 @@ _cache_of_GroupedGemmWgradSm100Objects = {}
 
 
 from ._bf16_api import GroupedGemmWgradBf16API
-from ._blockscaled_api import GroupedGemmWgradBlockScaledAPI
+from ._blockscaled_api import (
+    GroupedGemmWgradBlockScaledAPI,
+    _get_rubin_kernel,
+    _is_supported_rubin_quantization,
+)
 
 
 class GroupedGemmWgradSm100(APIBase):
@@ -259,6 +263,7 @@ def grouped_gemm_wgrad_wrapper_sm100(
             wgrad_tensor = allocator((expert_cnt, hidden, intermediate), dtype=wgrad_dtype, device=a_tensor.device)
     cache_key = backend_cache_key(
         backend,
+        get_device_type(),
         output_mode,
         _wgrad_tensor_signature(a_tensor, dynamic_dims=(1,), exact_stride=False),
         _wgrad_tensor_signature(b_tensor, dynamic_dims=(0,), exact_stride=False),

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -633,6 +633,16 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         """
         from ..moe_utils import WgradSfTensormapConstructor
 
+        # Build C's operation in the helper-kernel IR context. In particular,
+        # TMA reduce requires its SMEM layout and CTA V-map to be static in
+        # that context; reusing the host-created operation leaves a dynamic
+        # CTA V-map for discrete accumulated wgrad.
+        if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE):
+            if cutlass.const_expr(self.accumulate_on_output):
+                c_tma_op = cpasync.CopyReduceBulkTensorTileS2GOp()
+            else:
+                c_tma_op = cpasync.CopyBulkTensorTileS2GOp()
+
         ctor = WgradSfTensormapConstructor(
             sf_vec_size=self.sf_vec_size,
             weight_mode=self.weight_mode,

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -1524,7 +1524,10 @@ class BlockScaledMoEGroupedGemmWgradKernel:
                     cute.arch.fence_proxy("async.shared", space="cta")
                     epilog_sync_barrier.arrive_and_wait()
 
-                    if warp_idx == self.epilogue_warp_id[0]:
+                    # A 2-CTA MMA exposes the same completed accumulator to
+                    # both participating CTAs. Only the leader may issue the
+                    # final store; otherwise TMA reduce adds every tile twice.
+                    if warp_idx == self.epilogue_warp_id[0] and is_leader_cta:
                         cute.copy(
                             tma_atom_c,
                             bSG_sC[(None, c_buffer)],

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -730,10 +730,10 @@ class BlockScaledMoEGroupedGemmWgradKernel:
 
         bidx, bidy, bidz = cute.arch.block_idx()
         mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
-        is_leader_cta = mma_tile_coord_v == 0
         cta_rank_in_cluster = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(cta_rank_in_cluster)
         block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(cta_rank_in_cluster)
+        is_leader_cta = block_in_cluster_coord_vmnk[0] == 0
         tidx, _, _ = cute.arch.thread_idx()
 
         # =================================================================

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -1524,10 +1524,7 @@ class BlockScaledMoEGroupedGemmWgradKernel:
                     cute.arch.fence_proxy("async.shared", space="cta")
                     epilog_sync_barrier.arrive_and_wait()
 
-                    # A 2-CTA MMA exposes the same completed accumulator to
-                    # both participating CTAs. Only the leader may issue the
-                    # final store; otherwise TMA reduce adds every tile twice.
-                    if warp_idx == self.epilogue_warp_id[0] and is_leader_cta:
+                    if warp_idx == self.epilogue_warp_id[0]:
                         cute.copy(
                             tma_atom_c,
                             bSG_sC[(None, c_buffer)],

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -454,7 +454,6 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         # Dense passes None for C-related params; no if-else branch needed.
         sfa_smem_layout = cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0))
         sfb_smem_layout = cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0))
-        epi_smem_layout_helper = cute.select(self.c_smem_layout_staged, mode=[0, 1]) if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None
         if cutlass.const_expr(self.input_order == WGradInputOrder.TensorRagged):
             a_gemm_helper = a_gemm
             b_gemm_helper = b_gemm
@@ -485,9 +484,6 @@ class BlockScaledMoEGroupedGemmWgradKernel:
             self.cluster_layout_sfb_vmnk.shape,
             out if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
             c_gemm if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
-            c_tma_op if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
-            epi_smem_layout_helper,
-            self.epi_tile if cutlass.const_expr(self.weight_mode == MoEWeightMode.DISCRETE) else None,
             a_gemm_helper,
             b_gemm_helper,
             a_op_helper,
@@ -616,9 +612,6 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         cluster_layout_sfb_vmnk_shape: cutlass.Constexpr,
         c_ptrs=None,
         c_single_expert=None,
-        c_tma_op: cutlass.Constexpr = None,
-        epi_smem_layout=None,
-        epi_tile=None,
         a_tensor=None,
         b_tensor=None,
         a_tma_op: cutlass.Constexpr = None,
@@ -642,6 +635,18 @@ class BlockScaledMoEGroupedGemmWgradKernel:
                 c_tma_op = cpasync.CopyReduceBulkTensorTileS2GOp()
             else:
                 c_tma_op = cpasync.CopyBulkTensorTileS2GOp()
+            c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+                self.c_dtype,
+                self.c_layout,
+                self.epi_tile,
+                self.num_c_stage,
+            )
+            epi_smem_layout = cute.select(c_smem_layout_staged, mode=[0, 1])
+            epi_tile = self.epi_tile
+        else:
+            c_tma_op = None
+            epi_smem_layout = None
+            epi_tile = None
 
         ctor = WgradSfTensormapConstructor(
             sf_vec_size=self.sf_vec_size,

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -315,13 +315,14 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         out_single_expert: Optional[cute.Tensor] = None,
     ) -> None:
 
-        # This should be removed after from_dlpack fix.
-        if cutlass.const_expr(mat_a.iterator.dtype.width < 8):
+        # SM100 still needs the packed-FP4 from_dlpack layout workaround.
+        # Rubin consumes the native 4-bit layout directly.
+        if cutlass.const_expr(self.architecture != "sm_107" and mat_a.iterator.dtype.width < 8):
             mat_a = cute.make_tensor(
                 mat_a.iterator,
                 cute.recast_layout(mat_a.iterator.dtype.width, 8, mat_a.layout),
             )
-        if cutlass.const_expr(mat_b.iterator.dtype.width < 8):
+        if cutlass.const_expr(self.architecture != "sm_107" and mat_b.iterator.dtype.width < 8):
             mat_b = cute.make_tensor(
                 mat_b.iterator,
                 cute.recast_layout(mat_b.iterator.dtype.width, 8, mat_b.layout),

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -112,8 +112,9 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         self.tmem_alloc_sync_bar_id = 2
         self.tmem_dealloc_sync_bar_id = 3
 
-        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
-        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols("sm_100")
+        self.architecture = "sm_100"
+        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.architecture)
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.architecture)
 
     # ------------------------------------------------------------------
     # Workspace
@@ -139,6 +140,9 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         mma_inst_shape_k = cute.size(tiled_mma.shape_mnk, mode=[2])
         mma_inst_tile_k = 4
         mma_tiler_k = mma_inst_shape_k * mma_inst_tile_k
+        self.sf_window_k = mma_tiler_k
+        self.num_sf_windows_per_ab_stage = 1
+        self.num_mma_instructions_per_sf_window = mma_inst_tile_k
         self.mma_tiler = (
             self.mma_inst_shape_mn[0],
             self.mma_inst_shape_mn[1],
@@ -785,6 +789,7 @@ class BlockScaledMoEGroupedGemmWgradKernel:
             allocator_warp_id=self.epilogue_warp_id[0],
             is_two_cta=use_2cta_instrs,
             two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+            arch=self.architecture,
         )
 
         # Scheduler (CLC-based for 2Dx2D)
@@ -1134,11 +1139,25 @@ class BlockScaledMoEGroupedGemmWgradKernel:
                 acc_tmem_ptr + self.num_accumulator_tmem_cols,
                 dtype=self.sf_dtype,
             )
+            sf_window_tiler_mnk = (
+                self.mma_tiler[0],
+                self.mma_tiler[1],
+                self.sf_window_k,
+            )
+            sfa_window_smem_layout = cute.slice_(
+                blockscaled_utils.make_smem_layout_sfa(
+                    tiled_mma,
+                    sf_window_tiler_mnk,
+                    self.sf_vec_size,
+                    1,
+                ),
+                (None, None, None, 0),
+            )
             tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
                 tiled_mma,
-                self.mma_tiler,
+                sf_window_tiler_mnk,
                 self.sf_vec_size,
-                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+                sfa_window_smem_layout,
             )
             tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
 
@@ -1146,11 +1165,20 @@ class BlockScaledMoEGroupedGemmWgradKernel:
                 acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
                 dtype=self.sf_dtype,
             )
+            sfb_window_smem_layout = cute.slice_(
+                blockscaled_utils.make_smem_layout_sfb(
+                    tiled_mma,
+                    sf_window_tiler_mnk,
+                    self.sf_vec_size,
+                    1,
+                ),
+                (None, None, None, 0),
+            )
             tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
                 tiled_mma,
-                self.mma_tiler,
+                sf_window_tiler_mnk,
                 self.sf_vec_size,
-                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+                sfb_window_smem_layout,
             )
             tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
 
@@ -1214,27 +1242,100 @@ class BlockScaledMoEGroupedGemmWgradKernel:
                         if handle.count + 1 < k_tile_cnt:
                             peek_ab_full_status = ab_consumer.try_wait()
 
-                        s2t_stage_coord = (None, None, None, None, handle.index)
-                        cute.copy(
-                            tiled_copy_s2t_sfa,
-                            tCsSFA_compact_s2t[s2t_stage_coord],
-                            tCtSFA_compact_s2t,
-                        )
-                        cute.copy(
-                            tiled_copy_s2t_sfb,
-                            tCsSFB_compact_s2t[s2t_stage_coord],
-                            tCtSFB_compact_s2t,
-                        )
+                        if cutlass.const_expr(self.num_sf_windows_per_ab_stage == 1):
+                            s2t_stage_coord = (None, None, None, None, handle.index)
+                            cute.copy(
+                                tiled_copy_s2t_sfa,
+                                tCsSFA_compact_s2t[s2t_stage_coord],
+                                tCtSFA_compact_s2t,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfb,
+                                tCsSFB_compact_s2t[s2t_stage_coord],
+                                tCtSFB_compact_s2t,
+                            )
 
-                        tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
-                        tile_crd = (None, None, None, handle.index)
-                        cute.gemm(
-                            tiled_mma,
-                            tCtAcc,
-                            [tCrA[tile_crd], tCtSFA],
-                            [tCrB[tile_crd], tCtSFB_mma],
-                            tCtAcc,
-                        )
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, k_tile != 0)
+                            tile_crd = (None, None, None, handle.index)
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                [tCrA[tile_crd], tCtSFA],
+                                [tCrB[tile_crd], tCtSFB_mma],
+                                tCtAcc,
+                            )
+                        else:
+                            for sf_window_idx in cutlass.range_constexpr(
+                                self.num_sf_windows_per_ab_stage
+                            ):
+                                for window_k_block in cutlass.range_constexpr(
+                                    self.num_mma_instructions_per_sf_window
+                                ):
+                                    stage_k_block = (
+                                        sf_window_idx
+                                        * self.num_mma_instructions_per_sf_window
+                                        + window_k_block
+                                    )
+                                    s2t_source_coord = (
+                                        None,
+                                        None,
+                                        None,
+                                        stage_k_block,
+                                        handle.index,
+                                    )
+                                    s2t_destination_coord = (
+                                        None,
+                                        None,
+                                        None,
+                                        window_k_block,
+                                    )
+                                    cute.copy(
+                                        tiled_copy_s2t_sfa,
+                                        tCsSFA_compact_s2t[s2t_source_coord],
+                                        tCtSFA_compact_s2t[s2t_destination_coord],
+                                    )
+                                    cute.copy(
+                                        tiled_copy_s2t_sfb,
+                                        tCsSFB_compact_s2t[s2t_source_coord],
+                                        tCtSFB_compact_s2t[s2t_destination_coord],
+                                    )
+
+                                for window_k_block in cutlass.range_constexpr(
+                                    self.num_mma_instructions_per_sf_window
+                                ):
+                                    stage_k_block = (
+                                        sf_window_idx
+                                        * self.num_mma_instructions_per_sf_window
+                                        + window_k_block
+                                    )
+                                    tiled_mma.set(
+                                        tcgen05.Field.ACCUMULATE,
+                                        k_tile != 0 if stage_k_block == 0 else True,
+                                    )
+                                    ab_stage_coord = (
+                                        None,
+                                        None,
+                                        stage_k_block,
+                                        handle.index,
+                                    )
+                                    sf_window_coord = (
+                                        None,
+                                        None,
+                                        window_k_block,
+                                    )
+                                    cute.gemm(
+                                        tiled_mma,
+                                        tCtAcc,
+                                        [
+                                            tCrA[ab_stage_coord],
+                                            tCtSFA[sf_window_coord],
+                                        ],
+                                        [
+                                            tCrB[ab_stage_coord],
+                                            tCtSFB[sf_window_coord],
+                                        ],
+                                        tCtAcc,
+                                    )
                         handle.release()
 
                     if k_tile_cnt > 0:

--- a/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad_rubin.py
+++ b/python/cudnn/grouped_gemm/grouped_gemm_wgrad/moe_blockscaled_grouped_gemm_wgrad_rubin.py
@@ -1,0 +1,351 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Rubin (SM107) block-scaled MoE grouped GEMM weight-gradient kernel."""
+
+from dataclasses import dataclass
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+import cutlass.utils.rubin_helpers as sm107_utils
+from cutlass.cute.nvgpu import OperandMajorMode, tcgen05
+
+from ..moe_kernel_helpers import compute_stages_wgrad
+from .moe_blockscaled_grouped_gemm_wgrad import (
+    BlockScaledMoEGroupedGemmWgradKernel,
+)
+
+
+@dataclass(frozen=True)
+class _TmemPlan:
+    allocation_columns: int
+    accumulator_columns: int
+    accumulator_stage_count: int
+    accumulator_pipeline_stages: int
+    sfa_columns: int
+    sfb_columns: int
+
+
+def _round_tmem_allocation_columns(used_columns: int, capacity_columns: int) -> int:
+    if used_columns <= 512:
+        allocation_columns = max(32, 1 << (used_columns - 1).bit_length())
+    else:
+        allocation_columns = (used_columns + 31) // 32 * 32
+    if allocation_columns > capacity_columns:
+        raise ValueError(
+            f"Rubin wgrad needs {allocation_columns} TMEM columns, "
+            f"exceeding {capacity_columns}."
+        )
+    return allocation_columns
+
+
+def _make_tmem_plan(
+    *,
+    tile_n: int,
+    tile_k: int,
+    sf_vec_size: int,
+    architecture: str,
+) -> _TmemPlan:
+    """Plan disjoint accumulator and scale-factor TMEM regions for Rubin."""
+    if not isinstance(sf_vec_size, int) or isinstance(sf_vec_size, bool):
+        raise TypeError("sf_vec_size must be a Python integer.")
+    if sf_vec_size <= 0:
+        raise ValueError("sf_vec_size must be positive.")
+    if tile_k % sf_vec_size != 0:
+        raise ValueError("SF window K must be divisible by sf_vec_size.")
+    if tile_k % (sf_vec_size * 4) != 0:
+        raise ValueError(
+            "SF window K must contain complete block-scaled basic chunks."
+        )
+    capacity_columns = cute.arch.get_max_tmem_alloc_cols(architecture)
+    sfa_columns = tile_k // sf_vec_size
+    sfb_columns = max(tile_n // 128, 1) * tile_k // sf_vec_size
+    scale_factor_columns = sfa_columns + sfb_columns
+    accumulator_stage_count = (
+        capacity_columns - scale_factor_columns
+    ) // tile_n
+    if accumulator_stage_count < 1:
+        raise ValueError("Scale-factor TMEM leaves no accumulator stage.")
+
+    accumulator_columns = accumulator_stage_count * tile_n
+    allocation_columns = _round_tmem_allocation_columns(
+        accumulator_columns + scale_factor_columns,
+        capacity_columns,
+    )
+    return _TmemPlan(
+        allocation_columns=allocation_columns,
+        accumulator_columns=accumulator_columns,
+        accumulator_stage_count=accumulator_stage_count,
+        accumulator_pipeline_stages=accumulator_stage_count,
+        sfa_columns=sfa_columns,
+        sfb_columns=sfb_columns,
+    )
+
+
+class BlockScaledMoEGroupedGemmWgradRubinKernel(
+    BlockScaledMoEGroupedGemmWgradKernel
+):
+    """SM107 specialization retaining the cuDNN FE wgrad scheduler topology."""
+
+    FIX_PAD_SIZE = 256
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.architecture = "sm_107"
+        self.smem_capacity = utils.get_smem_capacity_in_bytes(self.architecture)
+        self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(
+            self.architecture
+        )
+
+    def _setup_attributes(self) -> None:
+        mma_cta_count = 2 if self.use_2cta_instrs else 1
+        self.instruction_k = 128 if self.a_dtype.width == 4 else 64
+        mma_inst_tile_k = 4
+        mma_tiler_k = self.instruction_k * mma_inst_tile_k
+
+        valid_quantization = (
+            self.a_dtype is cutlass.Float4E2M1FN
+            and self.b_dtype is cutlass.Float4E2M1FN
+            and (
+                (
+                    self.sf_dtype is cutlass.Float8E4M3FN
+                    and self.sf_vec_size == 16
+                )
+                or (
+                    self.sf_dtype is cutlass.Float8E8M0FNU
+                    and self.sf_vec_size == 32
+                )
+            )
+        ) or (
+            self.a_dtype in (cutlass.Float8E4M3FN, cutlass.Float8E5M2)
+            and self.b_dtype is self.a_dtype
+            and self.sf_dtype is cutlass.Float8E8M0FNU
+            and self.sf_vec_size == 32
+        )
+        if not valid_quantization:
+            raise ValueError(
+                "Rubin wgrad supports NVFP4, MXFP4, MXFP8-E4M3, "
+                "or MXFP8-E5M2 block scaling."
+            )
+        if self.acc_dtype is not cutlass.Float32:
+            raise ValueError("Rubin wgrad requires Float32 accumulators.")
+        if self.a_dtype.width == 4 and (
+            self.a_major_mode != OperandMajorMode.K
+            or self.b_major_mode != OperandMajorMode.K
+        ):
+            raise ValueError(
+                "Four-bit Rubin TCGen05 operands require K-major A and B."
+            )
+
+        self.mma_inst_shape_mn = (self.mma_tiler[0], self.mma_tiler[1])
+        self.mma_inst_shape_mnk = (*self.mma_inst_shape_mn, self.instruction_k)
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // mma_cta_count,
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+        self.mma_inst_shape_mnk_sfb = (
+            *self.mma_inst_shape_mn_sfb,
+            self.instruction_k,
+        )
+        self.mma_tiler = (*self.mma_inst_shape_mn, mma_tiler_k)
+        self.mma_tiler_sfb = (*self.mma_inst_shape_mn_sfb, mma_tiler_k)
+
+        use_sf_window = (
+            self.sf_vec_size == 16
+            and self.sf_dtype is cutlass.Float8E4M3FN
+            and self.mma_tiler[1] == 256
+            and self.mma_tiler[2] == 512
+        )
+        self.sf_window_k = (
+            self.instruction_k * 2 if use_sf_window else self.mma_tiler[2]
+        )
+        self.num_mma_instructions_per_sf_window = (
+            self.sf_window_k // self.instruction_k
+        )
+        self.num_sf_windows_per_ab_stage = (
+            self.mma_tiler[2] // self.sf_window_k
+        )
+
+        tiled_mma = self._create_tiled_mma()
+        tiled_mma_sfb = self._create_tiled_mma_sfb()
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        if self.cta_tile_shape_mnk[0] != 128:
+            raise ValueError("Rubin wgrad requires a per-CTA M tile of 128.")
+        if self.mma_tiler[1] not in (128, 256):
+            raise ValueError("Rubin wgrad supports MMA tile N of 128 or 256.")
+
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+
+        self.epi_tile = (128, 64)
+        self.epi_tile_n = 64
+        _, self.num_ab_stage, self.num_c_stage = compute_stages_wgrad(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
+        )
+        self.num_sched_stages = 2
+
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+            self.c_dtype,
+            self.c_layout,
+            self.epi_tile,
+            self.num_c_stage,
+        )
+
+        tmem_plan = _make_tmem_plan(
+            tile_n=self.mma_tiler[1],
+            tile_k=self.sf_window_k,
+            sf_vec_size=self.sf_vec_size,
+            architecture=self.architecture,
+        )
+        self.num_tmem_alloc_cols = tmem_plan.allocation_columns
+        self.num_accumulator_tmem_cols = tmem_plan.accumulator_columns
+        self.num_acc_stage = tmem_plan.accumulator_stage_count
+        self.num_acc_pipeline_stages = (
+            tmem_plan.accumulator_pipeline_stages
+        )
+        self.num_sfa_tmem_cols = tmem_plan.sfa_columns
+        self.num_sfb_tmem_cols = tmem_plan.sfb_columns
+        self.num_sf_tmem_cols = (
+            self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        )
+        self.overlapping_accum = False
+        self.iter_acc_early_release_in_epilogue = 0
+
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+        stage = (None, None, None, 0)
+        a_copy_size = cute.size_in_bytes(
+            self.a_dtype, cute.slice_(self.a_smem_layout_staged, stage)
+        )
+        b_copy_size = cute.size_in_bytes(
+            self.b_dtype, cute.slice_(self.b_smem_layout_staged, stage)
+        )
+        sfa_copy_size = cute.size_in_bytes(
+            self.sf_dtype, cute.slice_(self.sfa_smem_layout_staged, stage)
+        )
+        sfb_copy_size = cute.size_in_bytes(
+            self.sf_dtype, cute.slice_(self.sfb_smem_layout_staged, stage)
+        )
+        self.num_tma_load_bytes = (
+            a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size
+        ) * atom_thr_size
+
+    def _create_tiled_mma(self):
+        return sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mnk,
+        )
+
+    def _create_tiled_mma_sfb(self):
+        return sm107_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.b_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mnk_sfb,
+        )
+
+    def mainloop_s2t_copy_and_partition(self, sSF, tSF):
+        compact_smem = cute.filter_zeros(sSF)
+        compact_tmem = cute.filter_zeros(tSF)
+        copy_atom = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy = tcgen05.make_s2t_copy(copy_atom, compact_tmem)
+        thread_copy = tiled_copy.get_slice(0)
+
+        mn_mode = cute.get(compact_smem.layout, mode=[0, 0])
+        mn_mode = cute.append(mn_mode, cute.make_layout((4,), stride=(0,)))
+        broadcast_layout = cute.append(
+            cute.group_modes(mn_mode, 0),
+            cute.get(compact_smem.layout, mode=[0, 1]),
+        )
+        broadcast_layout = cute.append(
+            cute.group_modes(broadcast_layout, 0),
+            cute.get(compact_smem.layout, mode=[1]),
+        )
+        broadcast_layout = cute.append(
+            broadcast_layout, cute.get(compact_smem.layout, mode=[2])
+        )
+        broadcast_layout = cute.append(
+            broadcast_layout, cute.get(compact_smem.layout, mode=[3])
+        )
+        broadcast_smem = cute.make_tensor(
+            compact_smem.iterator, broadcast_layout
+        )
+
+        partitioned_smem = thread_copy.partition_S(broadcast_smem)
+        partitioned_smem = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy, partitioned_smem
+        )
+        partitioned_tmem = thread_copy.partition_D(compact_tmem)
+        return tiled_copy, partitioned_smem, partitioned_tmem
+
+
+__all__ = ["BlockScaledMoEGroupedGemmWgradRubinKernel"]

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
@@ -14,7 +14,7 @@ from fe_api.grouped_gemm.test_grouped_gemm_wgrad_utils import (
     check_ref_grouped_gemm_wgrad,
     wgrad_to_ragged_layout,
 )
-from test_grouped_gemm_wgrad_bf16_utils import (
+from fe_api.test_grouped_gemm_wgrad_bf16_utils import (
     assert_grouped_gemm_wgrad_close as assert_grouped_gemm_wgrad_bf16_close,
     grouped_gemm_wgrad_bf16_reference,
     make_grouped_gemm_wgrad_bf16_problem,

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
@@ -73,8 +73,6 @@ def _test_grouped_gemm_wgrad_dense_compile_execute(
     )
     inputs = allocate_grouped_gemm_wgrad_tensors(cfg)
     wgrad_tensor = allocate_grouped_gemm_wgrad_output(cfg)
-    if accumulate_on_output:
-        wgrad_tensor.zero_()
 
     op = cudnn.GroupedGemmWgradSm100(
         sample_a=inputs["a_tensor"],
@@ -273,7 +271,12 @@ def _test_grouped_gemm_wgrad_discrete_compile_execute(
         sf_dtype=sf_dtype,
     )
     inputs = allocate_grouped_gemm_wgrad_tensors(cfg)
-    wgrad_tensor = allocate_grouped_gemm_wgrad_output(cfg)
+    wgrad_tensor = allocate_grouped_gemm_wgrad_output(cfg, accumulate_on_output=accumulate_on_output)
+    expected = inputs["ref_result"]
+    if accumulate_on_output:
+        wgrad_tensor.fill_(1)
+        if expected is not None:
+            expected = expected + 1
 
     op = cudnn.GroupedGemmWgradSm100(
         sample_a=inputs["a_tensor"],
@@ -309,7 +312,7 @@ def _test_grouped_gemm_wgrad_discrete_compile_execute(
         global_scale_b=inputs["global_scale_b"],
     )
     torch.cuda.synchronize()
-    check_ref_grouped_gemm_wgrad(wgrad_tensor, inputs["ref_result"], cfg["tolerance"])
+    check_ref_grouped_gemm_wgrad(wgrad_tensor, expected, cfg["tolerance"])
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
@@ -473,7 +473,10 @@ def _test_grouped_gemm_wgrad_dynamic_tokens_compile_execute(
         sf_vec_size=sf_vec_size,
         sf_dtype=sf_dtype,
     )
-    runtime_cfg = _cfg_with_group_k_list(compile_cfg, [128, 128])
+    runtime_group_k_list = [128, 128]
+    if torch.cuda.get_device_capability() == (10, 7) and ab_dtype == torch.float4_e2m1fn_x2:
+        runtime_group_k_list = [256, 256]
+    runtime_cfg = _cfg_with_group_k_list(compile_cfg, runtime_group_k_list)
 
     compile_inputs = allocate_grouped_gemm_wgrad_tensors(compile_cfg)
     runtime_inputs = allocate_grouped_gemm_wgrad_tensors(runtime_cfg)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
@@ -73,6 +73,8 @@ def _test_grouped_gemm_wgrad_dense_compile_execute(
     )
     inputs = allocate_grouped_gemm_wgrad_tensors(cfg)
     wgrad_tensor = allocate_grouped_gemm_wgrad_output(cfg)
+    if accumulate_on_output:
+        wgrad_tensor.zero_()
 
     op = cudnn.GroupedGemmWgradSm100(
         sample_a=inputs["a_tensor"],
@@ -259,6 +261,7 @@ def _test_grouped_gemm_wgrad_discrete_compile_execute(
     cluster_shape_mn,
     sf_vec_size,
     sf_dtype,
+    accumulate_on_output=False,
 ):
     cfg = grouped_gemm_wgrad_init(
         ab_dtype=ab_dtype,
@@ -288,6 +291,7 @@ def _test_grouped_gemm_wgrad_discrete_compile_execute(
         mma_tiler_mn=cfg["mma_tiler_mn"],
         cluster_shape_mn=cfg["cluster_shape_mn"],
         sf_vec_size=cfg["sf_vec_size"],
+        accumulate_on_output=accumulate_on_output,
     )
     try:
         assert op.check_support()
@@ -351,6 +355,30 @@ def test_grouped_gemm_wgrad_discrete_compile_execute_fp8(
         cluster_shape_mn=cluster_shape_mn,
         sf_vec_size=sf_vec_size,
         sf_dtype=sf_dtype,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_grouped_gemm_wgrad_params_fp8
+def test_grouped_gemm_wgrad_discrete_accumulate_compile_execute_fp8(
+    ab_dtype,
+    wgrad_dtype,
+    acc_dtype,
+    mma_tiler_mn,
+    cluster_shape_mn,
+    sf_vec_size,
+    sf_dtype,
+):
+    _test_grouped_gemm_wgrad_discrete_compile_execute(
+        ab_dtype=ab_dtype,
+        wgrad_dtype=wgrad_dtype,
+        acc_dtype=acc_dtype,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+        sf_vec_size=sf_vec_size,
+        sf_dtype=sf_dtype,
+        accumulate_on_output=True,
     )
 
 

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad.py
@@ -363,6 +363,30 @@ def test_grouped_gemm_wgrad_discrete_compile_execute_fp8(
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
+@with_grouped_gemm_wgrad_params_fp4
+def test_grouped_gemm_wgrad_discrete_accumulate_compile_execute_fp4(
+    ab_dtype,
+    wgrad_dtype,
+    acc_dtype,
+    mma_tiler_mn,
+    cluster_shape_mn,
+    sf_vec_size,
+    sf_dtype,
+):
+    _test_grouped_gemm_wgrad_discrete_compile_execute(
+        ab_dtype=ab_dtype,
+        wgrad_dtype=wgrad_dtype,
+        acc_dtype=acc_dtype,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+        sf_vec_size=sf_vec_size,
+        sf_dtype=sf_dtype,
+        accumulate_on_output=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
 @with_grouped_gemm_wgrad_params_fp8
 def test_grouped_gemm_wgrad_discrete_accumulate_compile_execute_fp8(
     ab_dtype,

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_wgrad_utils.py
@@ -173,11 +173,17 @@ def grouped_gemm_wgrad_init(
     if compute_capability < 100:
         pytest.skip(f"Environment not supported: requires compute capability >= 100, found {compute_capability}")
 
+    group_k_list = [256, 384]
+    if compute_capability == 107 and ab_dtype == torch.float4_e2m1fn_x2:
+        # The upstream Rubin FP4 wgrad contract requires each expert K to be
+        # a multiple of its fixed 256-token padding granularity.
+        group_k_list = [256, 512]
+
     return {
         "m": 384,
         "n": 640,
         "l": 2,
-        "group_k_list": [256, 384],
+        "group_k_list": group_k_list,
         "ab_dtype": ab_dtype,
         "wgrad_dtype": wgrad_dtype,
         "acc_dtype": acc_dtype,

--- a/test/python/fe_api/test_rubin_kernel_dispatch.py
+++ b/test/python/fe_api/test_rubin_kernel_dispatch.py
@@ -38,6 +38,13 @@ RUBIN_DISPATCH_CASES = [
         "moe_blockscaled_grouped_gemm_dglu_rubin.py",
         id="grouped_gemm_dglu",
     ),
+    pytest.param(
+        "cudnn.grouped_gemm.grouped_gemm_wgrad.api",
+        "cudnn.grouped_gemm.grouped_gemm_wgrad.moe_blockscaled_grouped_gemm_wgrad",
+        "BlockScaledMoEGroupedGemmWgradKernel",
+        "moe_blockscaled_grouped_gemm_wgrad_rubin.py",
+        id="grouped_gemm_wgrad",
+    ),
 ]
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -118,7 +125,10 @@ def test_get_rubin_kernel_lazy_import(
 
     assert rubin_kernel is not default_kernel
     assert rubin_kernel.__name__ != default_kernel.__name__ or rubin_kernel.__module__ != default_kernel.__module__
-    assert rubin_kernel.FIX_PAD_SIZE == default_kernel.FIX_PAD_SIZE == 256
+    if hasattr(default_kernel, "FIX_PAD_SIZE"):
+        assert rubin_kernel.FIX_PAD_SIZE == default_kernel.FIX_PAD_SIZE == 256
+    else:
+        assert rubin_kernel.FIX_PAD_SIZE == 256
 
 
 @pytest.mark.parametrize(
@@ -165,3 +175,50 @@ def test_grouped_gemm_quant_has_rubin_compile_branches():
     assert 'kernel_kwargs["generate_c"] = False' in source
     assert 'compile_kwargs["c"]' in source
     assert "if self._is_rubin_kernel:" in source
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "ab_dtype_name,sf_dtype_name,sf_vec_size,expected",
+    [
+        ("float4_e2m1fn_x2", "float8_e4m3fn", 16, True),
+        ("float4_e2m1fn_x2", "float8_e8m0fnu", 32, True),
+        ("float8_e4m3fn", "float8_e8m0fnu", 32, True),
+        ("float8_e5m2", "float8_e8m0fnu", 32, True),
+        ("float4_e2m1fn_x2", "float8_e4m3fn", 32, False),
+        ("float8_e4m3fn", "float8_e4m3fn", 16, False),
+        ("bfloat16", "float8_e8m0fnu", 32, False),
+    ],
+)
+def test_grouped_gemm_wgrad_rubin_quantization_validation(
+    ab_dtype_name,
+    sf_dtype_name,
+    sf_vec_size,
+    expected,
+):
+    api_mod = _import_api_module("cudnn.grouped_gemm.grouped_gemm_wgrad.api")
+    torch = api_mod.torch
+
+    assert (
+        api_mod._is_supported_rubin_quantization(
+            getattr(torch, ab_dtype_name),
+            getattr(torch, sf_dtype_name),
+            sf_vec_size,
+        )
+        is expected
+    )
+
+
+@pytest.mark.L0
+def test_grouped_gemm_wgrad_rubin_tmem_plan_rejects_invalid_sf_vector():
+    rubin_mod = importlib.import_module(
+        "cudnn.grouped_gemm.grouped_gemm_wgrad.moe_blockscaled_grouped_gemm_wgrad_rubin"
+    )
+
+    with pytest.raises(ValueError, match="divisible by sf_vec_size"):
+        rubin_mod._make_tmem_plan(
+            tile_n=256,
+            tile_k=256,
+            sf_vec_size=24,
+            architecture="sm_107",
+        )


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Rubin-based grouped GEMM weight-gradient workloads.
  - Added validation for supported FP4/FP8 quantization, scaling-factor formats, accumulation type, and layout requirements.
  - Added support for accumulating results directly into an existing output buffer.

- **Bug Fixes**
  - Improved device-aware kernel selection and caching.
  - Updated FP4 and FP8 handling for Rubin configurations and dynamic token sizes.

- **Tests**
  - Expanded coverage for Rubin dispatch, quantization validation, invalid configurations, and output accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->