### PR TITLE
Fix ragged SDPA backward workspace under-allocation for non-token-major stats layouts

### DIFF
--- a/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
+++ b/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
@@ -1091,6 +1091,19 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
     std::shared_ptr<Tensor_attributes> alibi_slopes;
     int64_t alibi_slopes_size = 0;
 
+    // Byte span of a workspace tensor packed (ragged) over the token axis: the sequence axis is
+    // bounded by max_total_seq_len instead of dim[2], every other axis contributes its own extent.
+    // Sizing from stride[2] alone under-allocates any layout whose per-token footprint is not
+    // stride[2] -- e.g. head-major [h, t] stats, where stride[2] == 1.
+    static int64_t
+    ragged_workspace_size(int64_t max_total_seq_len,
+                          std::vector<int64_t> const& dim,
+                          std::vector<int64_t> const& stride,
+                          int64_t elem_size) {
+        return ((max_total_seq_len - 1) * stride[2] + (dim[1] - 1) * stride[1] + (dim[3] - 1) * stride[3] + 1) *
+               elem_size;
+    }
+
     mutable bool has_workaround_padding_mask         = false;  // Will be edited in pre_validate_node()
     mutable int32_t s_q_for_workaround_padding_mask  = 0;      // Will be edited in pre_validate_node()
     mutable int32_t s_kv_for_workaround_padding_mask = 0;      // Will be edited in pre_validate_node()
@@ -1711,8 +1724,10 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
             // sized TH1 softmax_sum
             softmax_sum->set_stride(attributes.inputs[input_names::Stats]->get_stride());
             softmax_sum->set_ragged_offset(attributes.inputs[input_names::Stats]->get_ragged_offset());
-            softmax_sum_size = attributes.max_total_seq_len_q.value() *
-                               (attributes.inputs[input_names::Stats]->get_stride())[2] * sizeof(float);
+            softmax_sum_size = ragged_workspace_size(attributes.max_total_seq_len_q.value(),
+                                                     softmax_sum->get_dim(),
+                                                     softmax_sum->get_stride(),
+                                                     sizeof(float));
         } else {
             // sized BHS1 softmax_sum
             softmax_sum->set_stride({h_q * s_q, s_q, 1, 1});
@@ -1921,7 +1936,8 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
                 dV_fullhead->set_ragged_offset(attributes.outputs[output_names::dV]->get_ragged_offset());
                 // non virtual dV full head
                 dV_fullhead->set_is_virtual(false);
-                dV_fullhead_size = attributes.max_total_seq_len_kv.value() * dV_fullhead_stride[2] * sizeof(float);
+                dV_fullhead_size = ragged_workspace_size(
+                    attributes.max_total_seq_len_kv.value(), dV_fullhead->get_dim(), dV_fullhead_stride, sizeof(float));
             } else {
                 // sized BHSD dQ_accum
                 dV_fullhead->set_stride({h_q * s_kv * d_v, s_kv * d_v, d_v, 1});
@@ -2033,7 +2049,8 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
                 dK_fullhead->set_ragged_offset(attributes.outputs[output_names::dK]->get_ragged_offset());
                 // non virtual dK full head
                 dK_fullhead->set_is_virtual(false);
-                dK_fullhead_size = attributes.max_total_seq_len_kv.value() * dK_fullhead_stride[2] * sizeof(float);
+                dK_fullhead_size = ragged_workspace_size(
+                    attributes.max_total_seq_len_kv.value(), dK_fullhead->get_dim(), dK_fullhead_stride, sizeof(float));
             } else {
                 // sized BHSD dQ_accum
                 dK_fullhead->set_stride({h_q * s_kv * d_qk, s_kv * d_qk, d_qk, 1});
@@ -2070,8 +2087,8 @@ class CompositeSDPABackwardNode : public NodeCRTP<CompositeSDPABackwardNode> {
                 // sized THD dQ_accum
                 dQ_accum->set_stride(attributes.outputs[output_names::dQ]->get_stride());
                 dQ_accum->set_ragged_offset(attributes.outputs[output_names::dQ]->get_ragged_offset());
-                dQ_accum_size = attributes.max_total_seq_len_q.value() *
-                                (attributes.outputs[output_names::dQ]->get_stride())[2] * sizeof(float);
+                dQ_accum_size = ragged_workspace_size(
+                    attributes.max_total_seq_len_q.value(), dQ_accum->get_dim(), dQ_accum->get_stride(), sizeof(float));
             } else {
                 // sized BHSD dQ_accum
                 dQ_accum->set_stride({h_q * s_q * d_qk, s_q * d_qk, d_qk, 1});

--- a/test/python/sdpa/fp16.py
+++ b/test/python/sdpa/fp16.py
@@ -8,6 +8,7 @@ from enum import IntEnum
 from looseversion import LooseVersion
 
 from .fp16_ref import compute_ref, compute_ref_backward
+from .random_config import packed_token_capacity
 from .helpers import (
     convert_to_cudnn_type,
     exact_equal,
@@ -130,8 +131,8 @@ def validate_config(cfg):
 
 def allocate_tensors(cfg, rng_data_gen, perf=False):
     allocs = {}
-    max_t_q = max(64, ((sum(cfg.seq_len_q) + 63) // 64) * 64) if cfg.is_ragged else None
-    max_t_kv = max(64, ((sum(cfg.seq_len_kv) + 63) // 64) * 64) if cfg.is_ragged else None
+    max_t_q = packed_token_capacity(cfg.seq_len_q) if cfg.is_ragged else None
+    max_t_kv = packed_token_capacity(cfg.seq_len_kv) if cfg.is_ragged else None
 
     # When perf mode is enabled, use normal distribution instead of sparse small integers
     # to avoid artificially fast timings from GPU memory compression of sparse data.
@@ -142,9 +143,12 @@ def allocate_tensors(cfg, rng_data_gen, perf=False):
         allocs[TensorUid.k] = alloc_tensor((max_t_kv, cfg.h_k, cfg.d_qk), cfg.data_type, rng=rng_data_gen, mean=-0.5, std=1.0, sparse_int=si)
         allocs[TensorUid.v] = alloc_tensor((max_t_kv, cfg.h_v, cfg.d_v), cfg.data_type, rng=rng_data_gen, mean=-0.5, std=1.0, sparse_int=si)
         allocs[TensorUid.o] = alloc_tensor((max_t_q, cfg.h_q, cfg.d_v), cfg.data_type)
-        allocs[TensorUid.stats] = alloc_tensor((max_t_q, cfg.h_q, 1), torch.float32) if cfg.is_train else (None, None, None)
-        allocs[TensorUid.score_max] = alloc_tensor((max_t_q, cfg.h_q, 1), torch.float32) if cfg.with_score_max else (None, None, None)
-        allocs[TensorUid.score_sum_exp] = alloc_tensor((max_t_q, cfg.h_q, 1), torch.float32) if cfg.with_score_sum_exp else (None, None, None)
+        # cfg.stride_stats is 4-D (b, h, s, 1); its [1] and [2] entries are the head and token
+        # strides of the packed buffer, which is exactly the (h, s) part of the 3-D alloc below.
+        stats_strides = (cfg.stride_stats[2], cfg.stride_stats[1], 1)
+        allocs[TensorUid.stats] = alloc_tensor((max_t_q, cfg.h_q, 1), torch.float32, strides=stats_strides) if cfg.is_train else (None, None, None)
+        allocs[TensorUid.score_max] = alloc_tensor((max_t_q, cfg.h_q, 1), torch.float32, strides=stats_strides) if cfg.with_score_max else (None, None, None)
+        allocs[TensorUid.score_sum_exp] = alloc_tensor((max_t_q, cfg.h_q, 1), torch.float32, strides=stats_strides) if cfg.with_score_sum_exp else (None, None, None)
         if cfg.is_train:
             allocs[TensorUid.dQ] = alloc_tensor((max_t_q, cfg.h_q, cfg.d_qk), cfg.data_type)
             allocs[TensorUid.dK] = alloc_tensor((max_t_kv, cfg.h_k, cfg.d_qk), cfg.data_type)
@@ -193,7 +197,9 @@ def allocate_tensors(cfg, rng_data_gen, perf=False):
         allocs[TensorUid.k_ragged_offset] = ((prefix_sum(seq_len_kv_gpu) * cfg.h_k * cfg.d_qk // k_off_mult).to(torch.int64), None, None)
         allocs[TensorUid.v_ragged_offset] = ((prefix_sum(seq_len_kv_gpu) * cfg.h_v * cfg.d_v // v_off_mult).to(torch.int64), None, None)
         allocs[TensorUid.o_ragged_offset] = ((prefix_sum(seq_len_q_gpu) * cfg.h_q * cfg.d_v // o_off_mult).to(torch.int64), None, None)
-        allocs[TensorUid.stats_ragged_offset] = ((prefix_sum(seq_len_q_gpu) * cfg.h_q * 1).to(torch.int64), None, None)
+        # Stats offsets are in elements and scale by its token stride: h_q for token-major stats,
+        # 1 for head-major.
+        allocs[TensorUid.stats_ragged_offset] = ((prefix_sum(seq_len_q_gpu) * cfg.stride_stats[2]).to(torch.int64), None, None)
 
     if cfg.is_bias:
         allocs[TensorUid.bias] = alloc_tensor((1, cfg.h_q, cfg.s_q, cfg.s_kv), cfg.data_type, rng=rng_data_gen, mean=0.0, std=1.0, sparse_int=si)

--- a/test/python/sdpa/random_config.py
+++ b/test/python/sdpa/random_config.py
@@ -41,6 +41,11 @@ def get_strides_from_indices(shape, indices=[0, 1, 2, 3], gaps=[0, 0, 0, 0], rng
     return tuple(strides)
 
 
+def packed_token_capacity(seq_lens):
+    """Token capacity of a packed (ragged) buffer, rounded up to a multiple of 64."""
+    return max(64, ((sum(seq_lens) + 63) // 64) * 64)
+
+
 def get_strides_from_layout(shape, layout, gaps=[0, 0, 0, 0], rng_geom=None):
     """Compute strides for a given layout string (e.g. 'bshd', 'bhsd')."""
     assert "".join(sorted(layout)) == "bdhs", f"wrong layout '{layout}'"
@@ -96,6 +101,9 @@ class ExecConfig:
     # cu_seq_len_kv). The mixed forms require cuDNN 9.25+.
     cu_seq_len_sides: str = "both"
     is_ragged: bool = None
+    # "token_major" ([t, h, 1], sequence stride h_q) or "head_major" ([h, t], sequence stride 1).
+    # None when not ragged.
+    ragged_stats_layout: str = None
     is_dropout: bool = None
     is_determin: bool = None
     is_mxfp8: bool = False
@@ -318,8 +326,16 @@ class RandomizationContext:
         if randoms_.is_ragged:  # Ideally Q, O, and Stats are all ragged
             randoms_.stride_q = get_strides_from_layout(randoms_.shape_q, "bshd")
             randoms_.stride_o = get_strides_from_layout(randoms_.shape_o, "bshd")
-            randoms_.stride_stats = get_strides_from_layout(randoms_.shape_stats, "bshd")
+            if randoms_.ragged_stats_layout == "head_major":
+                # [h, t] stats: tokens contiguous within a head, heads strided by the whole packed
+                # buffer. This is FlashAttention's / PyTorch varlen's softmax_lse layout; unlike the
+                # token-major one its sequence stride is 1 instead of h_q.
+                t_q = packed_token_capacity(randoms_.seq_len_q)
+                randoms_.stride_stats = (randoms_.h_q * t_q, t_q, 1, 1)
+            else:
+                randoms_.stride_stats = get_strides_from_layout(randoms_.shape_stats, "bshd")
         else:
+            randoms_.ragged_stats_layout = None
             indices = [0, 1, 2]
             rng.shuffle(indices)
             indices.append(3)
@@ -599,6 +615,7 @@ def test_randomization_context(seed):
             }
         ),
         is_ragged_or_padded_or_full=RandomChoice({"ragged": 1, "padded": 1, "full": 1}),
+        ragged_stats_layout=RandomChoice({"token_major": 1, "head_major": 1}),
     ) as ctx:
         return ctx
 

--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -365,6 +365,7 @@ def test_sdpa_random_fwd_ragged_L0(env_info, test_no, request, cudnn_handle):
         diag_align=RandomChoice({cudnn.diagonal_alignment.TOP_LEFT : 1, cudnn.diagonal_alignment.BOTTOM_RIGHT : 1}),
         is_ragged_or_padded_or_full=RandomChoice({"ragged" : 1, "padded" : 0, "full" : 0}),
         with_sink_token=RandomChoice({True : 1, False : 3}),
+        ragged_stats_layout=RandomChoice({"token_major" : 1, "head_major" : 1}),
     ) as randomization_ctx:
         test.cfg = randomization_ctx(rng, data_seed, geom_seed)
 
@@ -465,6 +466,7 @@ def test_sdpa_random_bwd_ragged_L0(env_info, test_no, request, cudnn_handle):
         diag_align=RandomChoice({cudnn.diagonal_alignment.TOP_LEFT : 1, cudnn.diagonal_alignment.BOTTOM_RIGHT : 1}),
         is_ragged_or_padded_or_full=RandomChoice({"ragged" : 1, "padded" : 0, "full" : 0}),
         is_deterministic=RandomChoice({True : 3, False : 1}),
+        ragged_stats_layout=RandomChoice({"token_major" : 1, "head_major" : 1}),
     ) as randomization_ctx:
         test.cfg = randomization_ctx(rng, data_seed, geom_seed)
 


### PR DESCRIPTION
## What

A ragged (THD) `sdpa_backward` graph that sets `max_total_seq_len_q` silently returns **all-zero dQ/dK/dV** when the `Stats` tensor is head-major. The forward `O` and `stats` are correct and no error is raised, so this corrupts training without ever surfacing. Present unchanged in 9.22, 9.23, 9.24, 9.25 and 9.26, on both sm90 and sm100.

Head-major `[h, total_q]` is FlashAttention's and PyTorch varlen's `softmax_lse` layout, so this is reachable from exactly the integrations that would reach for `max_total_seq_len` in the first place.

## Root cause

`max_total_seq_len_*` is documented as a workspace-sizing hint. It is not — setting it makes `CompositeSDPABackwardNode` re-lay-out its non-virtual intermediates onto the corresponding user tensor's stride and ragged offset, and then size them from a single stride element:

```cpp
softmax_sum->set_stride(Stats->get_stride());
softmax_sum->set_ragged_offset(Stats->get_ragged_offset());
softmax_sum_size = max_total_seq_len_q.value() * (Stats->get_stride())[2] * sizeof(float);
```

`stride[2]` is the *sequence* stride, so the formula assumes the per-token footprint is `stride[2]`. That is true only for token-major `[t, h, 1]` stats, where `stride[2] == h_q`. For head-major `[h, t]` stats `stride[2] == 1`, and the buffer is under-allocated by exactly `h_q`.

`softmax_sum` then writes `(h_q - 1) * t_q * 4` bytes past its slot. The frontend places the backend engine's own workspace immediately after the FE region (`graph_interface.h`: `engine_workspace = workspace + fe_workspace_size`), and the first word of that region is the persistent scheduler's tile counter. Every CTA claims work with `tile_id = atomicAdd(tile_id_counter, 1)` and retires unless `tile_id < num_tiles`; `tile_id` is `uint32_t`, so any nonzero float bit pattern is astronomically out of range. Every CTA therefore retires without storing anything — no dQ accumulation, no dK/dV TMA store — and the gradients are simply never written. No fault, no error, no hang.

Measured directly, comparing the exact `int32` bits of the clobbered word against the true `softmax_sum` value at the same element from a clean run at the same geometry:

```
observed at engine workspace[0] = -1067984384   (f32 -3.3726807)
true softmax_sum(b=0, h=1, s=0) = -1067984512   (f32 -3.3726501)
difference                      = +128
```

A float bit pattern plus exactly 128 integer increments — one `atomicAdd` per CTA, every one of which then failed the tile bound and retired.

The mask plays no part in the trigger: `TOP_LEFT` and the completely unmasked case fail identically. It only decides whether the clobbering bytes happen to be zero — a fully-masked leading query row has row-sum 0, which is what the memset already put there. That is why a handful of geometries appear to work, and why one intermediate case produces `|dQ| ≈ 6e36` garbage rather than zeros.

## The fix (commit 1)

Size the workspace from every axis instead of from `stride[2]` alone:

```cpp
static int64_t
ragged_workspace_size(int64_t max_total_seq_len,
                      std::vector<int64_t> const& dim,
                      std::vector<int64_t> const& stride,
                      int64_t elem_size) {
    return ((max_total_seq_len - 1) * stride[2] + (dim[1] - 1) * stride[1] + (dim[3] - 1) * stride[3] + 1) *
           elem_size;
}
```

applied to `softmax_sum`, `dQ_accum`, `dK_fullhead` and `dV_fullhead`.

For token-major inputs the new expression is **bit-identical** to the old one — `softmax_sum` gives `(maxT-1)·h_q + (h_q-1)·1 + 0 + 1 = maxT·h_q`, `dQ_accum` gives `(maxT-1)·h_q·d + (h_q-1)·d + (d-1) + 1 = maxT·h_q·d`. Allocations are unchanged for every layout that works today; only non-token-major layouts move.

## Why this was never caught (commit 2)

`test/python/sdpa/fp16.py` only ever allocated token-major ragged stats, the one layout for which the old formula happens to be exactly right. There was no coverage of any other packed `Stats` layout, so the suite was structurally blind to this class of defect.

Commit 2 adds a `ragged_stats_layout` axis to `ExecConfig`, randomized in the ragged fwd/bwd tests, choosing between token-major and head-major. The stats allocation and the stats ragged offset now both derive from `cfg.stride_stats` rather than hardcoding the token-major assumption.

Against the **unpatched** frontend the new axis reproduces the defect immediately — 11 tests fail with `Backward workspace overwritten outside its boundaries` (the suite's existing guard-band check) before the run aborts. The first failing config has `stride_stats = (58880, 7360, 1, 1)`, i.e. sequence stride 1.

## Verification

| | unpatched | with fix |
|---|---|---|
| `-k ragged` (fwd + bwd), sm100 | 11 failures, then abort | 370 passed, 78 skipped |
| head-major direct probe, sm100 | 3/4 all-zero | 4/4 correct |
| head-major direct probe, sm90 | 3/4 all-zero | 4/4 correct |
| token-major workspace sizes | — | byte-identical to unpatched |

Sanity check on the numbers rather than just pass/fail: with the fix, a `TOP_LEFT` 2048/512 case with `max_total_seq_len` set gives `|dQ| = 5.53e5`, exactly matching the same case with `max_total_seq_len` unset; a `BOTTOM_RIGHT` 512/512 case gives `1.976e5` in both.

## Not addressed here

- `docs/operations/Attention.md` still describes `max_total_seq_len_*` as a workspace allocation hint. It changes intermediate tensor layout and can change results, and should say so.
- The formula still assumes `ragged_offset == cum_token × stride[2]`. Offsets carrying inter-sequence padding would still under-allocate, and the frontend cannot detect this since the offsets are device data. This wants either a documented contract or for `max_total_seq_len` to move into the backend attention descriptor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace sizing for ragged attention operations, accounting for full tensor strides and dimensions.
  * Corrected ragged statistics offsets and memory capacities for packed token layouts.
  * Added support for both token-major and head-major ragged statistics layouts.
  * Improved handling of ragged training and statistics tensors across varied sequence configurations.

* **Tests**
  * Expanded randomized attention testing to cover multiple ragged statistics layouts and packed token capacities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->