### PR TITLE
CSA: request ex2.approx.ftz through fastmath= so the compressor builds at the cutlass-dsl floor

### DIFF
--- a/python/cudnn/csa/compressor/compressor_sm100_r128.py
+++ b/python/cudnn/csa/compressor/compressor_sm100_r128.py
@@ -125,9 +125,18 @@ _L2E_HI = 1.4426950216293335  # fp32(log2(e))
 _L2E_LO = 1.925963033500011e-08  # fp32(log2(e) - _L2E_HI); residual ~4e-16
 
 
+# ``cute.math.exp2``'s ``approx``/``ftz`` keywords are newer than the
+# ``nvidia-cutlass-dsl>=4.5.0`` floor this project's dependency spec resolves to, so the
+# same instruction is requested through ``fastmath=True``, which both versions accept.
+# Both spellings lower to ``ex2.approx.ftz.f32`` -- the form the tolerance contract is
+# calibrated on: on 4.6.1 the 16-kernel ``reg_probe_csa_compressor_r128.py`` PTX is
+# byte-identical either way (1104 ``ex2.approx.ftz.f32``, same registers, no spills), and
+# on 4.5.0 the same 1104 instructions are emitted.
+
+
 def _exp_fast(x):
     y = _ffma_rn(x, cutlass.Float32(_L2E_LO), _fmul_rn(x, cutlass.Float32(_L2E_HI)))
-    return cute_math.exp2(y, approx=True, ftz=True)
+    return cute_math.exp2(y, fastmath=True)
 
 
 @cute.kernel


### PR DESCRIPTION
``cute.math.exp2``'s ``approx``/``ftz`` keywords are newer than the
``nvidia-cutlass-dsl[cu13]>=4.5.0`` floor python/pyproject.toml resolves to, so the
ratio=128 compressor's fast-exp path raised ``TypeError: exp2() got an unexpected
keyword argument 'approx'`` on any environment that installs that floor -- 14 failures
in test/python/fe_api/csa/test_CSA_compressor.py, all from this one call site (#460).

``fastmath=True`` is accepted by both versions and lowers to the same
``ex2.approx.ftz.f32`` the r128 tolerance contract is calibrated on, so this is a pure
spelling change:

* cutlass-dsl 4.5.0 before: 14 failed, 74 passed. After: 88 passed, 1 skipped.
* cutlass-dsl 4.6.1 after: the 16-kernel reg_probe_csa_compressor_r128.py PTX is
  byte-identical to before this change -- same register counts, 0 spill / 0 stack, and
  1104 ex2.approx.ftz.f32 across the set -- so nothing changes on 4.6.
* cutlass-dsl 4.5.0 after: the same 1104 ex2.approx.ftz.f32, and no no-.ftz
  ex2.approx.f32 anywhere.
* gate_csa_compressor_r128.py: GATE PASS 21/21 on both 4.5.0 and 4.6.1.

Verified on B200 (CC 10.0), cuDNN 9.23, driver 590.48.01.

Signed-off-by: zky <kaiyue.zhou@z.ai>

This addresses the **CSA half** of #460 only (the 14 `test_CSA_compressor.py` failures attributed to `b950af1`). It does not touch the 25 wgrad failures from #456 -- those reproduce on 4.6.1 as well per the table in the issue, and `cutlass.utils.rubin_helpers` is a separate gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of the fast exponential calculation while preserving approximate, flush-to-zero behavior.
  * No user-facing API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->