### PR TITLE
Guard causal conv1d kernel sizes in Python bindings

### DIFF
--- a/docs/operations/CausalConv1d.md
+++ b/docs/operations/CausalConv1d.md
@@ -1,22 +1,39 @@
 # Causal Conv1d
 
-Depthwise causal 1-D convolution with optional fused activation:
+The NCW and NWH APIs compute depthwise causal 1-D convolution with optional fused activation:
 
 $$ y = \text{activation}(\text{conv1d\_causal}(x, w) + b) $$
 
-Causal padding: $(K - 1)$ zeros on the left, $0$ on the right, where $K$ is the kernel size. Each channel is convolved independently with its own 1-D filter (depthwise).
+Causal padding: $(K - 1)$ zeros on the left, $0$ on the right, where $K$ is the kernel size. Each channel is convolved independently with its own 1-D filter (depthwise). The B2B API fuses two causal convolutions with a fixed gating sequence described below.
 
 Supports forward and backward passes with `torch.autograd` and `torch.compile`.
 
 ## Support
 
-- **Architectures**: Blackwell (SM100+)
+- **Architectures**: Turing (SM75) or later
 - **Data types**: FP32, FP16, BF16
-- **Activations**: `identity`, `silu`
+- **Activations**: `identity` and `silu` for NCW and NWH; B2B uses fixed gating
+
+### Kernel sizes
+
+The supported kernel-size range depends on the layout and, for the fused B2B operation, the role of the kernel:
+
+| Frontend entry point | Kernel role | Supported kernel size |
+|---|---|---:|
+| `cudnn.ops.causal_conv1d` | NCW convolution | 2–256 |
+| `cudnn.ops.causal_conv1d_nwh` | NWH convolution | 2–128 |
+| `cudnn.ops.b2b_causal_conv1d` | Projection | 2–32 |
+| `cudnn.ops.b2b_causal_conv1d` | Mixer | 2–256 |
+
+The same limits apply to forward and backward execution.
 
 ## Python API
 
-The high-level entry point is `cudnn.ops.causal_conv1d`:
+Three high-level Python APIs are available for NCW, NWH, and fused back-to-back (B2B) causal convolution.
+
+### `cudnn.ops.causal_conv1d`
+
+Runs depthwise causal convolution with NCW tensor layout:
 
 ```python
 import cudnn
@@ -24,14 +41,20 @@ import cudnn
 y = cudnn.ops.causal_conv1d(x, weight, bias=None, activation="identity")
 ```
 
+**Minimum cuDNN version:** 9.22.0.
+
+**Supported kernel size:** 2–256, inclusive.
+
 **Args:**
-- `x` (torch.Tensor): Input tensor of shape $(B, D, L)$. Must be contiguous and on CUDA.
-- `weight` (torch.Tensor): Filter tensor of shape $(D, K)$. Same dtype as `x`.
+- `x` (torch.Tensor): Input tensor of shape $(B, D, L)$. Must be on CUDA.
+- `weight` (torch.Tensor): Filter tensor of shape $(D, K)$. Same dtype as `x`. $K$ must be between 2 and 256, inclusive.
 - `bias` (torch.Tensor | None): Optional bias of shape $(D,)$. Same dtype as `x`. Defaults to zeros if `None`.
 - `activation` (str): `"identity"` (default) or `"silu"`.
 
 **Returns:**
 - `y` (torch.Tensor): Output of shape $(B, D, L)$, same dtype as `x`.
+
+The API supports `torch.autograd` and `torch.compile` for forward and backward execution. Backward computes `dx` with shape $(B, D, L)$, `dweight` with shape $(D, K)$, and `dbias` with shape $(D,)$. The supported kernel-size range remains 2–256 for both directions.
 
 Where:
 - $B$ is the batch size
@@ -39,63 +62,112 @@ Where:
 - $L$ is the sequence length
 - $K$ is the kernel size
 
-### Low-level primitives
+See the [NCW forward notebook](../../samples/python/60_causal_conv1d_forward.ipynb) and [NCW backward notebook](../../samples/python/61_causal_conv1d_backward.ipynb) for PyTorch references and numerical comparisons.
+
+### `cudnn.ops.causal_conv1d_nwh`
+
+Runs the same depthwise causal convolution with NWH tensor layout. NWH stores the channel dimension last, so input and output use $(B, L, D)$ while the filter uses $(K, D)$. The operation is equivalent to:
+
+```python
+import torch
+
+K, D = weight.shape
+x_ncw = x.transpose(1, 2)                             # (B, D, L)
+weight_ncw = weight.T.unsqueeze(1)                    # (D, 1, K)
+x_padded = torch.nn.functional.pad(x_ncw, (K - 1, 0))
+y_ncw = torch.nn.functional.conv1d(
+    x_padded, weight_ncw, bias=bias, groups=D
+)
+if activation == "silu":
+    y_ncw = torch.nn.functional.silu(y_ncw)
+y = y_ncw.transpose(1, 2)                             # (B, L, D)
+```
+
+Each channel is convolved independently, and causal padding adds $K-1$ elements on the left and none on the right.
+
+The public API call is:
+
+```python
+import cudnn
+
+y = cudnn.ops.causal_conv1d_nwh(x, weight, bias=None, activation="identity")
+```
+
+**Minimum cuDNN version:** 9.24.0.
+
+**Supported kernel size:** 2–128, inclusive.
+
+**Args:**
+- `x` (torch.Tensor): Input tensor of shape $(B, L, D)$. Must be on CUDA.
+- `weight` (torch.Tensor): Filter tensor of shape $(K, D)$. Same dtype as `x`. $K$ must be between 2 and 128, inclusive.
+- `bias` (torch.Tensor | None): Optional bias of shape $(D,)$. Same dtype as `x`. Defaults to zeros if `None`.
+- `activation` (str): `"identity"` (default) or `"silu"`.
+
+**Returns:**
+- `y` (torch.Tensor): Output of shape $(B, L, D)$, same dtype as `x`.
+
+The API supports `torch.autograd` and `torch.compile` for forward and backward execution. Backward computes `dx` with shape $(B, L, D)$, `dweight` with shape $(K, D)$, and `dbias` with shape $(D,)$. The supported kernel-size range remains 2–128 for both directions.
+
+See the [NWH forward notebook](../../samples/python/62_causal_conv1d_nwh_forward.ipynb) and [NWH backward notebook](../../samples/python/63_causal_conv1d_nwh_backward.ipynb) for PyTorch references and numerical comparisons.
+
+### `cudnn.ops.b2b_causal_conv1d`
+
+Fuses projection convolution, gating, mixer convolution, a skip connection, and post-gating into a single kernel launch. The three projection channels for each output dimension are interleaved:
+
+```python
+proj = causal_conv1d(x, weights_proj)                       # (B, 3D, L)
+gated = proj[:, 1::3, :] * proj[:, 2::3, :]                # (B, D, L)
+y = causal_conv1d(gated, weights_mixer)                    # (B, D, L)
+y = y + skip_bias[None, :, None] * gated
+y_gated = y * proj[:, 0::3, :]                             # (B, D, L)
+```
+
+The API returns the final post-gated output `y_gated`:
+
+```python
+import cudnn
+
+y_gated = cudnn.ops.b2b_causal_conv1d(x, weights_proj, weights_mixer, skip_bias)
+```
+
+**Minimum cuDNN version:** 9.24.0.
+
+**Supported kernel sizes:**
+- Projection kernel: 2–32, inclusive.
+- Mixer kernel: 2–256, inclusive.
+
+**Args:**
+- `x` (torch.Tensor): Input tensor of shape $(B, 3D, L)$. Must be on CUDA.
+- `weights_proj` (torch.Tensor): Projection filter of shape $(3D, K_{proj})$. Same dtype as `x`. $K_{proj}$ must be between 2 and 32, inclusive.
+- `weights_mixer` (torch.Tensor): Mixer filter of shape $(D, K_{mixer})$. Same dtype as `x`. $K_{mixer}$ must be between 2 and 256, inclusive.
+- `skip_bias` (torch.Tensor): Skip-connection bias of shape $(D,)$. Same dtype as `x`.
+
+**Returns:**
+- `y_gated` (torch.Tensor): Post-gated output of shape $(B, D, L)$, same dtype as `x`.
+
+The API supports `torch.autograd` and `torch.compile` for forward and backward execution. Backward computes `dx` with shape $(B, 3D, L)$, `dweights_proj` with shape $(3D, K_{proj})$, `dweights_mixer` with shape $(D, K_{mixer})$, and `dskip_bias` with shape $(D,)$. The projection and mixer kernel-size ranges are unchanged for backward.
+
+See the [B2B forward notebook](../../samples/python/64_b2b_causal_conv1d_forward.ipynb) and [B2B backward notebook](../../samples/python/65_b2b_causal_conv1d_backward.ipynb) for decomposed PyTorch references and numerical comparisons.
+
+### Low-level bindings
 
 The forward and backward C-level bindings are re-exported at the top level:
+
+NCW layout, requiring cuDNN 9.22.0 or later and supporting kernel size 2–256:
 
 - `cudnn.causal_conv1d_forward(stream, x_ptr, weight_ptr, bias_ptr, out_ptr, batch, dim, seq_len, kernel_size, data_type, activation)`
 - `cudnn.causal_conv1d_backward(stream, x_ptr, weight_ptr, bias_ptr, dy_ptr, dx_ptr, dweight_ptr, dbias_ptr, batch, dim, seq_len, kernel_size, data_type, dw_data_type, activation)`
 
-In most cases you should use `cudnn.ops.causal_conv1d` instead, which handles autograd, `torch.compile`, and tensor management automatically.
+NWH layout, requiring cuDNN 9.24.0 or later and supporting kernel size 2–128:
 
-### Tensors
+- `cudnn.causal_conv1d_nwh_forward(stream, x_ptr, weight_ptr, bias_ptr, out_ptr, batch, dim, seq_len, kernel_size, data_type, activation)`
+- `cudnn.causal_conv1d_nwh_backward(stream, x_ptr, weight_ptr, bias_ptr, dy_ptr, dx_ptr, dweight_ptr, dbias_ptr, batch, dim, seq_len, kernel_size, data_type, dw_data_type, activation)`
 
-#### Input Tensors (Forward)
+B2B, requiring cuDNN 9.24.0 or later, with projection kernel size 2–32 and mixer kernel size 2–256:
 
-| Tensor | Device | Data Type | Shape |
-|--------|--------|-----------|-------|
-| x | GPU | FP32, FP16, or BF16 | $(B, D, L)$ |
-| weight | GPU | same as x | $(D, K)$ |
-| bias | GPU | same as x | $(D,)$ |
+- `cudnn.b2b_causal_conv1d_forward(stream, x_ptr, weights_proj_ptr, weights_mixer_ptr, skip_bias_ptr, y_ptr, y_gated_ptr, batch, dim, seq_len, kernel_size_proj, kernel_size_mixer, data_type)`
+- `cudnn.b2b_causal_conv1d_backward(stream, x_ptr, weights_proj_ptr, weights_mixer_ptr, skip_bias_ptr, y_ptr, dy_ptr, dx_ptr, dweights_proj_ptr, dweights_mixer_ptr, dskip_bias_ptr, batch, dim, seq_len, kernel_size_proj, kernel_size_mixer, data_type, dw_data_type)`
 
-#### Output Tensors (Forward)
+The low-level B2B forward binding writes both the mixer-plus-skip intermediate `y` and the final post-gated `y_gated`; the high-level API returns only `y_gated`.
 
-| Tensor | Device | Data Type | Shape |
-|--------|--------|-----------|-------|
-| y | GPU | same as x | $(B, D, L)$ |
-
-#### Additional Input Tensors (Backward)
-
-| Tensor | Device | Data Type | Shape |
-|--------|--------|-----------|-------|
-| grad_out (dy) | GPU | same as x | $(B, D, L)$ |
-
-#### Output Tensors (Backward)
-
-| Tensor | Device | Data Type | Shape |
-|--------|--------|-----------|-------|
-| dx | GPU | same as x | $(B, D, L)$ |
-| dweight | GPU | same as x | $(D, K)$ |
-| dbias | GPU | same as x | $(D,)$ |
-
-## Example
-
-```python
-import torch
-import cudnn
-
-B, D, L, K = 2, 768, 4096, 4
-
-x = torch.randn(B, D, L, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-w = torch.randn(D, K, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-b = torch.randn(D, dtype=torch.bfloat16, device="cuda", requires_grad=True)
-
-y = cudnn.ops.causal_conv1d(x, w, bias=b, activation="silu")
-
-loss = y.sum()
-loss.backward()  # x.grad, w.grad, b.grad are populated
-```
-
-## Samples
-
-- C++ sample: [samples/cpp/causal_conv1d](https://github.com/NVIDIA/cudnn-frontend/tree/main/samples/cpp/causal_conv1d)
+In most cases, use the corresponding `cudnn.ops` API, which handles autograd, `torch.compile`, and tensor management automatically.

--- a/docs/operations/CausalConv1d.md
+++ b/docs/operations/CausalConv1d.md
@@ -1,6 +1,6 @@
 # Causal Conv1d
 
-The NCW and NWH APIs compute depthwise causal 1-D convolution with optional fused activation:
+The NHW and NWH APIs compute depthwise causal 1-D convolution with optional fused activation:
 
 $$ y = \text{activation}(\text{conv1d\_causal}(x, w) + b) $$
 
@@ -12,7 +12,7 @@ Supports forward and backward passes with `torch.autograd` and `torch.compile`.
 
 - **Architectures**: Turing (SM75) or later
 - **Data types**: FP32, FP16, BF16
-- **Activations**: `identity` and `silu` for NCW and NWH; B2B uses fixed gating
+- **Activations**: `identity` and `silu` for NHW and NWH; B2B uses fixed gating
 
 ### Kernel sizes
 
@@ -20,7 +20,7 @@ The supported kernel-size range depends on the layout and, for the fused B2B ope
 
 | Frontend entry point | Kernel role | Supported kernel size |
 |---|---|---:|
-| `cudnn.ops.causal_conv1d` | NCW convolution | 2–256 |
+| `cudnn.ops.causal_conv1d` | NHW convolution | 2–256 |
 | `cudnn.ops.causal_conv1d_nwh` | NWH convolution | 2–128 |
 | `cudnn.ops.b2b_causal_conv1d` | Projection | 2–32 |
 | `cudnn.ops.b2b_causal_conv1d` | Mixer | 2–256 |
@@ -29,11 +29,11 @@ The same limits apply to forward and backward execution.
 
 ## Python API
 
-Three high-level Python APIs are available for NCW, NWH, and fused back-to-back (B2B) causal convolution.
+Three high-level Python APIs are available for NHW, NWH, and fused back-to-back (B2B) causal convolution.
 
 ### `cudnn.ops.causal_conv1d`
 
-Runs depthwise causal convolution with NCW tensor layout:
+Runs depthwise causal convolution with NHW tensor layout:
 
 ```python
 import cudnn
@@ -62,7 +62,7 @@ Where:
 - $L$ is the sequence length
 - $K$ is the kernel size
 
-See the [NCW forward notebook](../../samples/python/60_causal_conv1d_forward.ipynb) and [NCW backward notebook](../../samples/python/61_causal_conv1d_backward.ipynb) for PyTorch references and numerical comparisons.
+See the [NHW forward notebook](../../samples/python/60_causal_conv1d_forward.ipynb) and [NHW backward notebook](../../samples/python/61_causal_conv1d_backward.ipynb) for PyTorch references and numerical comparisons.
 
 ### `cudnn.ops.causal_conv1d_nwh`
 
@@ -72,15 +72,15 @@ Runs the same depthwise causal convolution with NWH tensor layout. NWH stores th
 import torch
 
 K, D = weight.shape
-x_ncw = x.transpose(1, 2)                             # (B, D, L)
-weight_ncw = weight.T.unsqueeze(1)                    # (D, 1, K)
-x_padded = torch.nn.functional.pad(x_ncw, (K - 1, 0))
-y_ncw = torch.nn.functional.conv1d(
-    x_padded, weight_ncw, bias=bias, groups=D
+x_nhw = x.transpose(1, 2)                             # (B, D, L)
+weight_nhw = weight.T.unsqueeze(1)                    # (D, 1, K)
+x_padded = torch.nn.functional.pad(x_nhw, (K - 1, 0))
+y_nhw = torch.nn.functional.conv1d(
+    x_padded, weight_nhw, bias=bias, groups=D
 )
 if activation == "silu":
-    y_ncw = torch.nn.functional.silu(y_ncw)
-y = y_ncw.transpose(1, 2)                             # (B, L, D)
+    y_nhw = torch.nn.functional.silu(y_nhw)
+y = y_nhw.transpose(1, 2)                             # (B, L, D)
 ```
 
 Each channel is convolved independently, and causal padding adds $K-1$ elements on the left and none on the right.
@@ -153,7 +153,7 @@ See the [B2B forward notebook](../../samples/python/64_b2b_causal_conv1d_forward
 
 The forward and backward C-level bindings are re-exported at the top level:
 
-NCW layout, requiring cuDNN 9.22.0 or later and supporting kernel size 2–256:
+NHW layout, requiring cuDNN 9.22.0 or later and supporting kernel size 2–256:
 
 - `cudnn.causal_conv1d_forward(stream, x_ptr, weight_ptr, bias_ptr, out_ptr, batch, dim, seq_len, kernel_size, data_type, activation)`
 - `cudnn.causal_conv1d_backward(stream, x_ptr, weight_ptr, bias_ptr, dy_ptr, dx_ptr, dweight_ptr, dbias_ptr, batch, dim, seq_len, kernel_size, data_type, dw_data_type, activation)`

--- a/python/cudnn/ops/causal_conv1d.py
+++ b/python/cudnn/ops/causal_conv1d.py
@@ -217,9 +217,10 @@ def causal_conv1d(
 
     Args:
         x (torch.Tensor): Input tensor of shape ``(batch, dim, seq_len)``.
-            Must be BF16, FP16, or FP32. Must be contiguous and on CUDA.
+            Must be BF16, FP16, or FP32 and on CUDA.
         weight (torch.Tensor): Filter tensor of shape ``(dim, kernel_size)``.
-            Same dtype as *x*.
+            Same dtype as *x*. ``kernel_size`` must be between 2 and 256,
+            inclusive.
         bias (torch.Tensor | None): Optional bias of shape ``(dim,)``.
             Same dtype as *x*. Defaults to zeros if ``None``.
         activation (str): ``"identity"`` (default) or ``"silu"``.
@@ -417,9 +418,13 @@ def causal_conv1d_nwh(
 
         y = activation(conv1d_causal(x, weight) + bias)
 
+    Supports ``torch.compile`` and ``torch.autograd`` — backward is handled
+    automatically when inputs require gradients.
+
     Args:
         x (torch.Tensor): Input tensor of shape ``(batch, seq_len, dim)``.
         weight (torch.Tensor): Filter tensor of shape ``(kernel_size, dim)``.
+            ``kernel_size`` must be between 2 and 128, inclusive.
         bias (torch.Tensor | None): Optional bias of shape ``(dim,)``.
         activation (str): ``"identity"`` (default) or ``"silu"``.
 
@@ -683,13 +688,18 @@ def b2b_causal_conv1d(
 
         proj       = causal_conv1d(x, weights_proj)            # (batch, 3*dim, seq_len)
         gated      = proj[:, 1::3, :] * proj[:, 2::3, :]       # Q * K gate
-        y          = causal_conv1d(gated, weights_mixer) + skip_bias * gated
+        y          = causal_conv1d(gated, weights_mixer) + skip_bias[:, None] * gated
         y_gated    = y * proj[:, 0::3, :]                      # final * V
+
+    Supports ``torch.compile`` and ``torch.autograd`` — backward is handled
+    automatically when inputs require gradients.
 
     Args:
         x (torch.Tensor): Input tensor of shape ``(batch, 3*dim, seq_len)``.
         weights_proj (torch.Tensor): Projection filter ``(3*dim, kernel_size_proj)``.
+            ``kernel_size_proj`` must be between 2 and 32, inclusive.
         weights_mixer (torch.Tensor): Mixer filter ``(dim, kernel_size_mixer)``.
+            ``kernel_size_mixer`` must be between 2 and 256, inclusive.
         skip_bias (torch.Tensor): Skip-connection bias ``(dim,)``.
 
     Returns:

--- a/python/pycudnn.cpp
+++ b/python/pycudnn.cpp
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdexcept>
 #include <utility>
 
 #include "pybind11/pybind11.h"
@@ -23,6 +24,70 @@ void *cudnn_dlhandle = nullptr;
 #endif
 
 namespace python_bindings {
+
+namespace {
+
+constexpr int CAUSAL_CONV1D_MIN_KERNEL_SIZE           = 2;
+constexpr int CAUSAL_CONV1D_MAX_KERNEL_SIZE           = 256;
+constexpr int CAUSAL_CONV1D_NWH_MAX_KERNEL_SIZE       = 128;
+constexpr int B2B_CAUSAL_CONV1D_PROJ_MAX_KERNEL_SIZE  = 32;
+constexpr int B2B_CAUSAL_CONV1D_MIXER_MAX_KERNEL_SIZE = 256;
+
+cudnnStatus_t
+precheck_causal_conv1d_kernel_size(int const kernel_size, int const max_kernel_size) {
+    return kernel_size > max_kernel_size ? CUDNN_STATUS_NOT_SUPPORTED : CUDNN_STATUS_SUCCESS;
+}
+
+bool
+is_causal_conv1d_kernel_size_out_of_range(int const kernel_size, int const max_kernel_size) {
+    return kernel_size < CAUSAL_CONV1D_MIN_KERNEL_SIZE || kernel_size > max_kernel_size;
+}
+
+[[noreturn]] void
+throw_causal_conv1d_kernel_size_error(char const *api_name,
+                                      char const *argument_name,
+                                      int const kernel_size,
+                                      int const max_kernel_size) {
+    throw std::invalid_argument(std::string(api_name) + " " + argument_name + " must be between " +
+                                std::to_string(CAUSAL_CONV1D_MIN_KERNEL_SIZE) + " and " +
+                                std::to_string(max_kernel_size) + ", inclusive; got " + std::to_string(kernel_size));
+}
+
+void
+throw_if_causal_conv1d_failed(cudnnStatus_t const status,
+                              char const *operation,
+                              char const *api_name,
+                              int const kernel_size,
+                              int const max_kernel_size) {
+    if (status == CUDNN_STATUS_SUCCESS) return;
+
+    if (is_causal_conv1d_kernel_size_out_of_range(kernel_size, max_kernel_size)) {
+        throw_causal_conv1d_kernel_size_error(api_name, "kernel_size", kernel_size, max_kernel_size);
+    }
+
+    throw std::runtime_error(std::string(operation) + " failed with status " + std::to_string(status));
+}
+
+void
+throw_if_b2b_causal_conv1d_failed(cudnnStatus_t const status,
+                                  char const *operation,
+                                  int const kernel_size_proj,
+                                  int const kernel_size_mixer) {
+    if (status == CUDNN_STATUS_SUCCESS) return;
+
+    if (is_causal_conv1d_kernel_size_out_of_range(kernel_size_proj, B2B_CAUSAL_CONV1D_PROJ_MAX_KERNEL_SIZE)) {
+        throw_causal_conv1d_kernel_size_error(
+            "b2b_causal_conv1d", "kernel_size_proj", kernel_size_proj, B2B_CAUSAL_CONV1D_PROJ_MAX_KERNEL_SIZE);
+    }
+    if (is_causal_conv1d_kernel_size_out_of_range(kernel_size_mixer, B2B_CAUSAL_CONV1D_MIXER_MAX_KERNEL_SIZE)) {
+        throw_causal_conv1d_kernel_size_error(
+            "b2b_causal_conv1d", "kernel_size_mixer", kernel_size_mixer, B2B_CAUSAL_CONV1D_MIXER_MAX_KERNEL_SIZE);
+    }
+
+    throw std::runtime_error(std::string(operation) + " failed with status " + std::to_string(status));
+}
+
+}  // namespace
 
 // Raise C++ exceptions corresponding to C++ FE error codes.
 // Pybinds will automatically convert C++ exceptions to python exceptions.
@@ -111,19 +176,22 @@ PYBIND11_MODULE(_compiled_module, m) {
              int kernel_size,
              int data_type,
              int activation) {
-              auto status = detail::causal_conv1d_forward(reinterpret_cast<cudaStream_t>(stream),
-                                                          reinterpret_cast<const void *>(x_ptr),
-                                                          reinterpret_cast<const void *>(weight_ptr),
-                                                          reinterpret_cast<const void *>(bias_ptr),
-                                                          reinterpret_cast<void *>(out_ptr),
-                                                          batch,
-                                                          dim,
-                                                          seq_len,
-                                                          kernel_size,
-                                                          static_cast<cudnnDataType_t>(data_type),
-                                                          static_cast<cudnnCausalConv1dActivation_t>(activation));
-              if (status != 0)
-                  throw std::runtime_error("cudnnCausalConv1dForward failed with status " + std::to_string(status));
+              auto status = precheck_causal_conv1d_kernel_size(kernel_size, CAUSAL_CONV1D_MAX_KERNEL_SIZE);
+              if (status == CUDNN_STATUS_SUCCESS) {
+                  status = detail::causal_conv1d_forward(reinterpret_cast<cudaStream_t>(stream),
+                                                         reinterpret_cast<const void *>(x_ptr),
+                                                         reinterpret_cast<const void *>(weight_ptr),
+                                                         reinterpret_cast<const void *>(bias_ptr),
+                                                         reinterpret_cast<void *>(out_ptr),
+                                                         batch,
+                                                         dim,
+                                                         seq_len,
+                                                         kernel_size,
+                                                         static_cast<cudnnDataType_t>(data_type),
+                                                         static_cast<cudnnCausalConv1dActivation_t>(activation));
+              }
+              throw_if_causal_conv1d_failed(
+                  status, "cudnnCausalConv1dForward", "causal_conv1d", kernel_size, CAUSAL_CONV1D_MAX_KERNEL_SIZE);
           });
 
     m.def("causal_conv1d_backward",
@@ -142,23 +210,26 @@ PYBIND11_MODULE(_compiled_module, m) {
              int data_type,
              int dw_data_type,
              int activation) {
-              auto status = detail::causal_conv1d_backward(reinterpret_cast<cudaStream_t>(stream),
-                                                           reinterpret_cast<const void *>(x_ptr),
-                                                           reinterpret_cast<const void *>(weight_ptr),
-                                                           reinterpret_cast<const void *>(bias_ptr),
-                                                           reinterpret_cast<const void *>(dy_ptr),
-                                                           reinterpret_cast<void *>(dx_ptr),
-                                                           reinterpret_cast<void *>(dweight_ptr),
-                                                           reinterpret_cast<void *>(dbias_ptr),
-                                                           batch,
-                                                           dim,
-                                                           seq_len,
-                                                           kernel_size,
-                                                           static_cast<cudnnDataType_t>(data_type),
-                                                           static_cast<cudnnDataType_t>(dw_data_type),
-                                                           static_cast<cudnnCausalConv1dActivation_t>(activation));
-              if (status != 0)
-                  throw std::runtime_error("cudnnCausalConv1dBackward failed with status " + std::to_string(status));
+              auto status = precheck_causal_conv1d_kernel_size(kernel_size, CAUSAL_CONV1D_MAX_KERNEL_SIZE);
+              if (status == CUDNN_STATUS_SUCCESS) {
+                  status = detail::causal_conv1d_backward(reinterpret_cast<cudaStream_t>(stream),
+                                                          reinterpret_cast<const void *>(x_ptr),
+                                                          reinterpret_cast<const void *>(weight_ptr),
+                                                          reinterpret_cast<const void *>(bias_ptr),
+                                                          reinterpret_cast<const void *>(dy_ptr),
+                                                          reinterpret_cast<void *>(dx_ptr),
+                                                          reinterpret_cast<void *>(dweight_ptr),
+                                                          reinterpret_cast<void *>(dbias_ptr),
+                                                          batch,
+                                                          dim,
+                                                          seq_len,
+                                                          kernel_size,
+                                                          static_cast<cudnnDataType_t>(data_type),
+                                                          static_cast<cudnnDataType_t>(dw_data_type),
+                                                          static_cast<cudnnCausalConv1dActivation_t>(activation));
+              }
+              throw_if_causal_conv1d_failed(
+                  status, "cudnnCausalConv1dBackward", "causal_conv1d", kernel_size, CAUSAL_CONV1D_MAX_KERNEL_SIZE);
           });
 
     m.def("causal_conv1d_nwh_forward",
@@ -173,19 +244,25 @@ PYBIND11_MODULE(_compiled_module, m) {
              int kernel_size,
              int data_type,
              int activation) {
-              auto status = detail::causal_conv1d_nwh_forward(reinterpret_cast<cudaStream_t>(stream),
-                                                              reinterpret_cast<const void *>(x_ptr),
-                                                              reinterpret_cast<const void *>(weight_ptr),
-                                                              reinterpret_cast<const void *>(bias_ptr),
-                                                              reinterpret_cast<void *>(out_ptr),
-                                                              batch,
-                                                              dim,
-                                                              seq_len,
-                                                              kernel_size,
-                                                              static_cast<cudnnDataType_t>(data_type),
-                                                              static_cast<cudnnCausalConv1dActivation_t>(activation));
-              if (status != 0)
-                  throw std::runtime_error("cudnnCausalConv1dNwhForward failed with status " + std::to_string(status));
+              auto status = precheck_causal_conv1d_kernel_size(kernel_size, CAUSAL_CONV1D_NWH_MAX_KERNEL_SIZE);
+              if (status == CUDNN_STATUS_SUCCESS) {
+                  status = detail::causal_conv1d_nwh_forward(reinterpret_cast<cudaStream_t>(stream),
+                                                             reinterpret_cast<const void *>(x_ptr),
+                                                             reinterpret_cast<const void *>(weight_ptr),
+                                                             reinterpret_cast<const void *>(bias_ptr),
+                                                             reinterpret_cast<void *>(out_ptr),
+                                                             batch,
+                                                             dim,
+                                                             seq_len,
+                                                             kernel_size,
+                                                             static_cast<cudnnDataType_t>(data_type),
+                                                             static_cast<cudnnCausalConv1dActivation_t>(activation));
+              }
+              throw_if_causal_conv1d_failed(status,
+                                            "cudnnCausalConv1dNwhForward",
+                                            "causal_conv1d_nwh",
+                                            kernel_size,
+                                            CAUSAL_CONV1D_NWH_MAX_KERNEL_SIZE);
           });
 
     m.def("causal_conv1d_nwh_backward",
@@ -204,96 +281,116 @@ PYBIND11_MODULE(_compiled_module, m) {
              int data_type,
              int dw_data_type,
              int activation) {
-              auto status = detail::causal_conv1d_nwh_backward(reinterpret_cast<cudaStream_t>(stream),
-                                                               reinterpret_cast<const void *>(x_ptr),
-                                                               reinterpret_cast<const void *>(weight_ptr),
-                                                               reinterpret_cast<const void *>(bias_ptr),
-                                                               reinterpret_cast<const void *>(dy_ptr),
-                                                               reinterpret_cast<void *>(dx_ptr),
-                                                               reinterpret_cast<void *>(dweight_ptr),
-                                                               reinterpret_cast<void *>(dbias_ptr),
-                                                               batch,
-                                                               dim,
-                                                               seq_len,
-                                                               kernel_size,
-                                                               static_cast<cudnnDataType_t>(data_type),
-                                                               static_cast<cudnnDataType_t>(dw_data_type),
-                                                               static_cast<cudnnCausalConv1dActivation_t>(activation));
-              if (status != 0)
-                  throw std::runtime_error("cudnnCausalConv1dNwhBackward failed with status " + std::to_string(status));
-          });
-
-    m.def("b2b_causal_conv1d_forward",
-          [](std::intptr_t stream,
-             std::intptr_t x_ptr,
-             std::intptr_t weights_proj_ptr,
-             std::intptr_t weights_mixer_ptr,
-             std::intptr_t skip_bias_ptr,
-             std::intptr_t y_ptr,
-             std::intptr_t y_gated_ptr,
-             int batch,
-             int dim,
-             int seq_len,
-             int kernel_size_proj,
-             int kernel_size_mixer,
-             int data_type) {
-              auto status = detail::b2b_causal_conv1d_forward(reinterpret_cast<cudaStream_t>(stream),
+              auto status = precheck_causal_conv1d_kernel_size(kernel_size, CAUSAL_CONV1D_NWH_MAX_KERNEL_SIZE);
+              if (status == CUDNN_STATUS_SUCCESS) {
+                  status = detail::causal_conv1d_nwh_backward(reinterpret_cast<cudaStream_t>(stream),
                                                               reinterpret_cast<const void *>(x_ptr),
-                                                              reinterpret_cast<const void *>(weights_proj_ptr),
-                                                              reinterpret_cast<const void *>(weights_mixer_ptr),
-                                                              reinterpret_cast<const void *>(skip_bias_ptr),
-                                                              reinterpret_cast<void *>(y_ptr),
-                                                              reinterpret_cast<void *>(y_gated_ptr),
+                                                              reinterpret_cast<const void *>(weight_ptr),
+                                                              reinterpret_cast<const void *>(bias_ptr),
+                                                              reinterpret_cast<const void *>(dy_ptr),
+                                                              reinterpret_cast<void *>(dx_ptr),
+                                                              reinterpret_cast<void *>(dweight_ptr),
+                                                              reinterpret_cast<void *>(dbias_ptr),
                                                               batch,
                                                               dim,
                                                               seq_len,
-                                                              kernel_size_proj,
-                                                              kernel_size_mixer,
-                                                              static_cast<cudnnDataType_t>(data_type));
-              if (status != 0)
-                  throw std::runtime_error("cudnnB2BCausalConv1dForward failed with status " + std::to_string(status));
+                                                              kernel_size,
+                                                              static_cast<cudnnDataType_t>(data_type),
+                                                              static_cast<cudnnDataType_t>(dw_data_type),
+                                                              static_cast<cudnnCausalConv1dActivation_t>(activation));
+              }
+              throw_if_causal_conv1d_failed(status,
+                                            "cudnnCausalConv1dNwhBackward",
+                                            "causal_conv1d_nwh",
+                                            kernel_size,
+                                            CAUSAL_CONV1D_NWH_MAX_KERNEL_SIZE);
           });
 
-    m.def("b2b_causal_conv1d_backward",
-          [](std::intptr_t stream,
-             std::intptr_t x_ptr,
-             std::intptr_t weights_proj_ptr,
-             std::intptr_t weights_mixer_ptr,
-             std::intptr_t skip_bias_ptr,
-             std::intptr_t y_ptr,
-             std::intptr_t dy_ptr,
-             std::intptr_t dx_ptr,
-             std::intptr_t dweights_proj_ptr,
-             std::intptr_t dweights_mixer_ptr,
-             std::intptr_t dskip_bias_ptr,
-             int batch,
-             int dim,
-             int seq_len,
-             int kernel_size_proj,
-             int kernel_size_mixer,
-             int data_type,
-             int dw_data_type) {
-              auto status = detail::b2b_causal_conv1d_backward(reinterpret_cast<cudaStream_t>(stream),
-                                                               reinterpret_cast<const void *>(x_ptr),
-                                                               reinterpret_cast<const void *>(weights_proj_ptr),
-                                                               reinterpret_cast<const void *>(weights_mixer_ptr),
-                                                               reinterpret_cast<const void *>(skip_bias_ptr),
-                                                               reinterpret_cast<const void *>(y_ptr),
-                                                               reinterpret_cast<const void *>(dy_ptr),
-                                                               reinterpret_cast<void *>(dx_ptr),
-                                                               reinterpret_cast<void *>(dweights_proj_ptr),
-                                                               reinterpret_cast<void *>(dweights_mixer_ptr),
-                                                               reinterpret_cast<void *>(dskip_bias_ptr),
-                                                               batch,
-                                                               dim,
-                                                               seq_len,
-                                                               kernel_size_proj,
-                                                               kernel_size_mixer,
-                                                               static_cast<cudnnDataType_t>(data_type),
-                                                               static_cast<cudnnDataType_t>(dw_data_type));
-              if (status != 0)
-                  throw std::runtime_error("cudnnB2BCausalConv1dBackward failed with status " + std::to_string(status));
-          });
+    m.def(
+        "b2b_causal_conv1d_forward",
+        [](std::intptr_t stream,
+           std::intptr_t x_ptr,
+           std::intptr_t weights_proj_ptr,
+           std::intptr_t weights_mixer_ptr,
+           std::intptr_t skip_bias_ptr,
+           std::intptr_t y_ptr,
+           std::intptr_t y_gated_ptr,
+           int batch,
+           int dim,
+           int seq_len,
+           int kernel_size_proj,
+           int kernel_size_mixer,
+           int data_type) {
+            auto status = precheck_causal_conv1d_kernel_size(kernel_size_proj, B2B_CAUSAL_CONV1D_PROJ_MAX_KERNEL_SIZE);
+            if (status == CUDNN_STATUS_SUCCESS) {
+                status = precheck_causal_conv1d_kernel_size(kernel_size_mixer, B2B_CAUSAL_CONV1D_MIXER_MAX_KERNEL_SIZE);
+            }
+            if (status == CUDNN_STATUS_SUCCESS) {
+                status = detail::b2b_causal_conv1d_forward(reinterpret_cast<cudaStream_t>(stream),
+                                                           reinterpret_cast<const void *>(x_ptr),
+                                                           reinterpret_cast<const void *>(weights_proj_ptr),
+                                                           reinterpret_cast<const void *>(weights_mixer_ptr),
+                                                           reinterpret_cast<const void *>(skip_bias_ptr),
+                                                           reinterpret_cast<void *>(y_ptr),
+                                                           reinterpret_cast<void *>(y_gated_ptr),
+                                                           batch,
+                                                           dim,
+                                                           seq_len,
+                                                           kernel_size_proj,
+                                                           kernel_size_mixer,
+                                                           static_cast<cudnnDataType_t>(data_type));
+            }
+            throw_if_b2b_causal_conv1d_failed(
+                status, "cudnnB2BCausalConv1dForward", kernel_size_proj, kernel_size_mixer);
+        });
+
+    m.def(
+        "b2b_causal_conv1d_backward",
+        [](std::intptr_t stream,
+           std::intptr_t x_ptr,
+           std::intptr_t weights_proj_ptr,
+           std::intptr_t weights_mixer_ptr,
+           std::intptr_t skip_bias_ptr,
+           std::intptr_t y_ptr,
+           std::intptr_t dy_ptr,
+           std::intptr_t dx_ptr,
+           std::intptr_t dweights_proj_ptr,
+           std::intptr_t dweights_mixer_ptr,
+           std::intptr_t dskip_bias_ptr,
+           int batch,
+           int dim,
+           int seq_len,
+           int kernel_size_proj,
+           int kernel_size_mixer,
+           int data_type,
+           int dw_data_type) {
+            auto status = precheck_causal_conv1d_kernel_size(kernel_size_proj, B2B_CAUSAL_CONV1D_PROJ_MAX_KERNEL_SIZE);
+            if (status == CUDNN_STATUS_SUCCESS) {
+                status = precheck_causal_conv1d_kernel_size(kernel_size_mixer, B2B_CAUSAL_CONV1D_MIXER_MAX_KERNEL_SIZE);
+            }
+            if (status == CUDNN_STATUS_SUCCESS) {
+                status = detail::b2b_causal_conv1d_backward(reinterpret_cast<cudaStream_t>(stream),
+                                                            reinterpret_cast<const void *>(x_ptr),
+                                                            reinterpret_cast<const void *>(weights_proj_ptr),
+                                                            reinterpret_cast<const void *>(weights_mixer_ptr),
+                                                            reinterpret_cast<const void *>(skip_bias_ptr),
+                                                            reinterpret_cast<const void *>(y_ptr),
+                                                            reinterpret_cast<const void *>(dy_ptr),
+                                                            reinterpret_cast<void *>(dx_ptr),
+                                                            reinterpret_cast<void *>(dweights_proj_ptr),
+                                                            reinterpret_cast<void *>(dweights_mixer_ptr),
+                                                            reinterpret_cast<void *>(dskip_bias_ptr),
+                                                            batch,
+                                                            dim,
+                                                            seq_len,
+                                                            kernel_size_proj,
+                                                            kernel_size_mixer,
+                                                            static_cast<cudnnDataType_t>(data_type),
+                                                            static_cast<cudnnDataType_t>(dw_data_type));
+            }
+            throw_if_b2b_causal_conv1d_failed(
+                status, "cudnnB2BCausalConv1dBackward", kernel_size_proj, kernel_size_mixer);
+        });
 #endif
 }
 

--- a/test/python/test_causal_conv1d.py
+++ b/test/python/test_causal_conv1d.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import cudnn
+
+pytestmark = pytest.mark.L0
+
+
+@pytest.mark.parametrize(
+    "binding,args,kernel_size_index,api_name,argument_name,max_kernel_size",
+    [
+        (
+            cudnn.causal_conv1d_forward,
+            (0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0),
+            8,
+            "causal_conv1d",
+            "kernel_size",
+            256,
+        ),
+        (
+            cudnn.causal_conv1d_backward,
+            (0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0),
+            11,
+            "causal_conv1d",
+            "kernel_size",
+            256,
+        ),
+        (
+            cudnn.causal_conv1d_nwh_forward,
+            (0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0),
+            8,
+            "causal_conv1d_nwh",
+            "kernel_size",
+            128,
+        ),
+        (
+            cudnn.causal_conv1d_nwh_backward,
+            (0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0),
+            11,
+            "causal_conv1d_nwh",
+            "kernel_size",
+            128,
+        ),
+        (
+            cudnn.b2b_causal_conv1d_forward,
+            (0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 2, 0),
+            10,
+            "b2b_causal_conv1d",
+            "kernel_size_proj",
+            32,
+        ),
+        (
+            cudnn.b2b_causal_conv1d_backward,
+            (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 2, 0, 0),
+            14,
+            "b2b_causal_conv1d",
+            "kernel_size_proj",
+            32,
+        ),
+        (
+            cudnn.b2b_causal_conv1d_forward,
+            (0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 0, 0),
+            11,
+            "b2b_causal_conv1d",
+            "kernel_size_mixer",
+            256,
+        ),
+        (
+            cudnn.b2b_causal_conv1d_backward,
+            (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 0, 0, 0),
+            15,
+            "b2b_causal_conv1d",
+            "kernel_size_mixer",
+            256,
+        ),
+    ],
+)
+@pytest.mark.parametrize("boundary", ["below", "above"])
+def test_causal_conv1d_rejects_unsupported_kernel_size(binding, args, kernel_size_index, api_name, argument_name, max_kernel_size, boundary):
+    kernel_size = 1 if boundary == "below" else max_kernel_size + 1
+    args = list(args)
+    args[kernel_size_index] = kernel_size
+
+    message = rf"{api_name} {argument_name} must be between 2 and {max_kernel_size}, inclusive; got {kernel_size}"
+    with pytest.raises(ValueError, match=message):
+        binding(*args)


### PR DESCRIPTION
Guard causal conv1d kernel sizes in Python bindings

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.

## Affected area

- Python API or bindings
- Documentation or samples
- CI or test infrastructure

## Summary

- Add shared Python-binding kernel-size prechecks for causal conv1d forward and backward entry points.
- Enforce the documented limits for NCW (2–256), NWH (2–128), B2B projection (2–32), and B2B mixer (2–256).
- Normalize frontend and backend kernel-size failures to range-specific Python `ValueError` messages.
- Document all high-level and low-level causal conv1d APIs, tensor layouts, kernel-size ranges, minimum cuDNN versions, and Turing (SM75)+ architecture support.
- Add lower- and upper-bound regression coverage for every raw forward/backward binding.

## Why

The NWH backend can launch an unsupported width-specialized kernel instead of returning a status. Widths at and above 138 have been observed to fault on SM90, invalidating the CUDA context. The supported NWH range is 2–128.

The Python bindings return no status value and already translate backend failures into exceptions. Synthesizing `CUDNN_STATUS_NOT_SUPPORTED` before an unsupported upper-bound launch, then routing both frontend and backend failures through one translator, prevents the device fault and gives callers coherent errors. Applying the same validation structure to NCW and B2B keeps all causal conv1d bindings consistent.

## Related issues

None.

## API and compatibility impact

No API signatures change. Unsupported kernel sizes now raise a range-specific Python `ValueError` before an unsafe backend launch. Other backend failures remain operation-specific `RuntimeError` exceptions.

Documented GPU support is corrected to Turing (SM75) or later.

## Testing

- Built the Python compiled module successfully.
- `python -m pytest test_causal_conv1d.py -o addopts= --tb=short -q`: 16 passed with cuDNN 9.30 on SM100.
- Ran high-level NCW, NWH, B2B projection, and B2B mixer upper-bound rejection smoke tests; all produced the expected `ValueError`.
- Verified a subsequent CUDA operation succeeds after all rejection cases.
- `uvx pre-commit run --files docs/operations/CausalConv1d.md python/pycudnn.cpp python/cudnn/ops/causal_conv1d.py test/python/test_causal_conv1d.py`: passed.
- Reviewed the current causal conv1d sample architecture gates. Runtime execution on SM75 was not available in the local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded causal convolution documentation for NHW, NWH, and fused B2B APIs.
  * Added guidance on layouts, datatypes, activations, supported architectures, kernel sizes, output shapes, and usage examples.
  * Documented forward and backward operations for supported convolution variants.

* **Bug Fixes**
  * Improved validation and error messages for unsupported kernel sizes.
  * Corrected B2B skip-bias broadcasting behavior and documentation.

* **Tests**
  * Added coverage for invalid kernel sizes across forward and backward APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->