### PR TITLE
Reshape: guard the 9.22 reshape-mode attribute at runtime, not just at compile time

### DIFF
--- a/include/cudnn_frontend/node/reshape.h
+++ b/include/cudnn_frontend/node/reshape.h
@@ -112,14 +112,23 @@ class ReshapeNode : public NodeCRTP<ReshapeNode> {
                                                        1,
                                                        &x_desc));
 #if (CUDNN_VERSION >= 92200)
-        // Set reshape mode
-        cudnnBackendReshapeMode_t cudnn_reshape_mode;
-        _CUDNN_CHECK_CUDNN_ERROR(detail::convert_to_cudnn_type(attributes.get_reshape_mode(), cudnn_reshape_mode));
-        _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(reshape_operation.get_raw_desc(),
-                                                       CUDNN_ATTR_OPERATION_RESHAPE_MODE,
-                                                       CUDNN_TYPE_RESHAPE_MODE,
-                                                       1,
-                                                       &cudnn_reshape_mode));
+        // Pre-9.22 reshape is view-only, so skipping the attribute matches it; an explicit LOGICAL
+        // cannot be honoured there, hence reject rather than silently downgrade.
+        // NV_CUDNN_FE_DYNAMIC_CHECK_* is avoided on purpose: it is a no-op unless
+        // NV_CUDNN_FRONTEND_USE_DYNAMIC_LOADING is defined (cudnn_frontend_shim.h:213-215).
+        if (detail::get_backend_version() >= 92200) {
+            cudnnBackendReshapeMode_t cudnn_reshape_mode;
+            _CUDNN_CHECK_CUDNN_ERROR(detail::convert_to_cudnn_type(attributes.get_reshape_mode(), cudnn_reshape_mode));
+            _CUDNN_CHECK_CUDNN_ERROR(detail::set_attribute(reshape_operation.get_raw_desc(),
+                                                           CUDNN_ATTR_OPERATION_RESHAPE_MODE,
+                                                           CUDNN_TYPE_RESHAPE_MODE,
+                                                           1,
+                                                           &cudnn_reshape_mode));
+        } else {
+            RETURN_CUDNN_FRONTEND_ERROR_IF(attributes.get_reshape_mode() == ReshapeMode_t::LOGICAL,
+                                           error_code_t::GRAPH_NOT_SUPPORTED,
+                                           "Reshape mode LOGICAL requires cuDNN 9.22.0 or newer at runtime");
+        }
 #endif
         // Set output tensor Y
         CUDNN_FE_VALIDATE_AND_ASSIGN_OUTPUT_TENSOR(Y, Reshape_attributes::output_names::Y);


### PR DESCRIPTION
`CUDNN_ATTR_OPERATION_RESHAPE_MODE` is set under `#if (CUDNN_VERSION >= 92200)` alone
(`node/reshape.h:109`). The compile-time guard is necessary but not sufficient: a frontend built
against >= 9.22 headers and run against an older runtime sets an attribute that runtime does not
know, and the failure takes down every graph containing a Reshape node — in practice all of
`sdpa_backward`, on 9.18 / 9.19 / 9.20 / 9.21.

Fix: nest a runtime check inside the existing compile-time guard, the idiom already used at
`node/reduction.h:96-97`.

Two decisions that aren't obvious from the diff:

- **`LOGICAL` is rejected rather than silently skipped.** Not setting the attribute reproduces an old
  runtime's behaviour exactly, because pre-9.22 reshape has one semantics and it is the view-only one
  (`CUDNN_RESHAPE_VIEW_ONLY == 0`, *"no data movement"*) — also this frontend's default. But an
  explicit `LOGICAL` request cannot be honoured there, and downgrading it to view-only would change
  results, so it returns `GRAPH_NOT_SUPPORTED`.

- **The check is spelled out instead of using `NV_CUDNN_FE_DYNAMIC_CHECK_CUDNN_BACKEND_VERSION`.**
  That macro expands to nothing unless `NV_CUDNN_FRONTEND_USE_DYNAMIC_LOADING` is defined
  (`cudnn_frontend_shim.h:213-215`), so it would be a no-op in an ordinary C++ build — the exact
  configuration this needs to protect. Same caveat applies to sites that do use the macro
  (e.g. `node/transpose.h:99`); not addressed here.

`g++ -fsyntax-only -std=c++17` clean; `clang-format` clean (pre-commit passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reshape operation compatibility across supported runtime versions.
  * View-only reshape operations now work correctly with older runtimes.
  * Logical reshape operations on runtimes that do not support them now report a clear “graph not supported” result instead of failing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->