### PR TITLE
Reshape: apply the runtime version guard to the legacy OperationBuilder_v8 too

### DIFF
--- a/include/cudnn_frontend_Operation.h
+++ b/include/cudnn_frontend_Operation.h
@@ -1806,8 +1806,21 @@ class OperationBuilder_v8 {
         }
 
 #if (CUDNN_VERSION >= 92200)
-        // Set reshape mode if it's not NOT_SET
-        if (m_operation.reshape_mode != ReshapeMode_t::NOT_SET) {
+        // Same runtime-vs-compile-time split as cudnn_frontend/node/reshape.h. The attribute does
+        // not exist before 9.22 and setting it there returns BAD_PARAM. This builder is worse off
+        // than the graph API: reshape_mode defaults to VIEW_ONLY rather than NOT_SET, so the guard
+        // below is always true and every legacy reshape sends the attribute to whatever runtime is
+        // loaded. A pre-9.22 reshape is view-only by construction, so only an explicit LOGICAL
+        // request has to be refused rather than silently downgraded.
+        if (detail::get_backend_version() < 92200) {
+            if (m_operation.reshape_mode == ReshapeMode_t::LOGICAL) {
+                set_error_and_throw_exception(
+                    &m_operation,
+                    CUDNN_STATUS_NOT_SUPPORTED,
+                    "CUDNN_BACKEND_OPERATION: ReshapeMode_t::LOGICAL requires a cuDNN 9.22 or newer runtime");
+                return std::move(m_operation);
+            }
+        } else if (m_operation.reshape_mode != ReshapeMode_t::NOT_SET) {
             cudnnBackendReshapeMode_t cudnn_reshape_mode;
             status = detail::convert_to_cudnn_type(m_operation.reshape_mode, cudnn_reshape_mode);
             if (status == CUDNN_STATUS_SUCCESS) {


### PR DESCRIPTION
Follow-up to the graph-API fix already on `develop`, which gates
`CUDNN_ATTR_OPERATION_RESHAPE_MODE` on `detail::get_backend_version()` in
`cudnn_frontend/node/reshape.h`.

The legacy `OperationBuilder_v8` reshape at `cudnn_frontend_Operation.h:1808` has the identical
defect and is **worse off**: `reshape_mode` defaults to `ReshapeMode_t::VIEW_ONLY` rather than
`NOT_SET` (`:240`), so the existing `if (reshape_mode != NOT_SET)` guard is always true and *every*
legacy reshape sends the attribute to whatever runtime is loaded. Against a pre-9.22 library that
returns `CUDNN_STATUS_BAD_PARAM` and fails the operation.

Same shape of fix, same reasoning about semantics: skipping the attribute on a pre-9.22 runtime
reproduces that runtime's only behaviour, which is view-only. An explicit `ReshapeMode_t::LOGICAL`
request cannot be honoured there, so it is refused rather than silently downgraded.

It does not show up in an SDPA reproducer — the SDPA nodes use the graph API — which is why it was
missed when the graph-API half was fixed.

Setting attribute 2202 in isolation reproduces the underlying split: `BAD_PARAM` on 9.13.1 / 9.18.0 /
9.21.0, success on 9.22.0. The graph-API half was verified end to end by driving an SDPA-backward
graph through `validate → build_operation_graph → create_execution_plans → check_support` with the
frontend headers held constant and only the runtime library swapped; this half has no SDPA path to
exercise, so it is justified by symmetry with that fix rather than by its own A/B.

Found by an independent review of the graph-API patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reshape operation compatibility across cuDNN runtime versions.
  * Explicit logical reshapes now report unsupported status on older runtimes.
  * View-only reshapes continue to work on older runtimes without unsupported settings.
  * Newer runtimes retain configured reshape-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->