### PR TITLE
Fix causal conv1d test collection with older cuDNN

### DIFF
--- a/test/python/test_causal_conv1d.py
+++ b/test/python/test_causal_conv1d.py
@@ -9,10 +9,10 @@ pytestmark = pytest.mark.L0
 
 
 @pytest.mark.parametrize(
-    "binding,args,kernel_size_index,api_name,argument_name,max_kernel_size",
+    "binding_name,args,kernel_size_index,api_name,argument_name,max_kernel_size",
     [
         (
-            cudnn.causal_conv1d_forward,
+            "causal_conv1d_forward",
             (0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0),
             8,
             "causal_conv1d",
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.L0
             256,
         ),
         (
-            cudnn.causal_conv1d_backward,
+            "causal_conv1d_backward",
             (0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0),
             11,
             "causal_conv1d",
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.L0
             256,
         ),
         (
-            cudnn.causal_conv1d_nwh_forward,
+            "causal_conv1d_nwh_forward",
             (0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0),
             8,
             "causal_conv1d_nwh",
@@ -36,7 +36,7 @@ pytestmark = pytest.mark.L0
             128,
         ),
         (
-            cudnn.causal_conv1d_nwh_backward,
+            "causal_conv1d_nwh_backward",
             (0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0),
             11,
             "causal_conv1d_nwh",
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.L0
             128,
         ),
         (
-            cudnn.b2b_causal_conv1d_forward,
+            "b2b_causal_conv1d_forward",
             (0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 2, 0),
             10,
             "b2b_causal_conv1d",
@@ -52,7 +52,7 @@ pytestmark = pytest.mark.L0
             32,
         ),
         (
-            cudnn.b2b_causal_conv1d_backward,
+            "b2b_causal_conv1d_backward",
             (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 2, 0, 0),
             14,
             "b2b_causal_conv1d",
@@ -60,7 +60,7 @@ pytestmark = pytest.mark.L0
             32,
         ),
         (
-            cudnn.b2b_causal_conv1d_forward,
+            "b2b_causal_conv1d_forward",
             (0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 0, 0),
             11,
             "b2b_causal_conv1d",
@@ -68,7 +68,7 @@ pytestmark = pytest.mark.L0
             256,
         ),
         (
-            cudnn.b2b_causal_conv1d_backward,
+            "b2b_causal_conv1d_backward",
             (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 0, 0, 0),
             15,
             "b2b_causal_conv1d",
@@ -78,7 +78,11 @@ pytestmark = pytest.mark.L0
     ],
 )
 @pytest.mark.parametrize("boundary", ["below", "above"])
-def test_causal_conv1d_rejects_unsupported_kernel_size(binding, args, kernel_size_index, api_name, argument_name, max_kernel_size, boundary):
+def test_causal_conv1d_rejects_unsupported_kernel_size(binding_name, args, kernel_size_index, api_name, argument_name, max_kernel_size, boundary):
+    binding = getattr(cudnn, binding_name, None)
+    if binding is None:
+        pytest.skip(f"{binding_name} is unavailable in this cuDNN frontend build")
+
     kernel_size = 1 if boundary == "below" else max_kernel_size + 1
     args = list(args)
     args[kernel_size_index] = kernel_size


### PR DESCRIPTION
## What changed

- Resolve causal-conv1d test bindings lazily with `getattr(cudnn, binding_name, None)`.
- Skip only parameter cases whose binding is absent from the frontend build.

## Why

cuDNN builds older than 9.22 do not export these optional Python symbols. Referencing them directly in pytest parametrization raises `AttributeError` during module collection, before pytest can skip unsupported cases.

Binding presence is the source of truth here, so the test does not duplicate effective cuDNN backend-version logic already enforced by the binding layer.

## Validation

Built the current frontend branch from source twice against matched headers and runtime libraries from official packages:

- `nvidia-cudnn-cu13==9.22.0.52`: `cudnn.backend_version() == 92200`; `16 passed`
- `nvidia-cudnn-cu13==9.24.0.43`: `cudnn.backend_version() == 92400`; `16 passed`
- `black --check --line-length 160 --fast test/python/test_causal_conv1d.py`
- `git diff --check origin/develop..HEAD`

Fixes #468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved causal convolution compatibility checks across cuDNN frontend builds.
  * Test cases now skip unavailable bindings while continuing to validate unsupported kernel-size handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->