### PR TITLE
OSS SDPA prefill: restrict the SM100 engine to sm_100 and skip samples elsewhere

### DIFF
--- a/include/cudnn_frontend/experimental/sm100_sdpa_prefill_engine.h
+++ b/include/cudnn_frontend/experimental/sm100_sdpa_prefill_engine.h
@@ -30,12 +30,15 @@ namespace experimental {
 
 /// @brief Look up the SM100 kernel specification for a given head dimension.
 /// @param d Head dimension (d_qk). Currently supports 64 and 128.
-/// @param sm_version SM version from cudaDeviceProp (e.g. 100, 101).
+/// @param sm_version SM version from cudaDeviceProp (e.g. 100).
 /// @return Pointer to static KernelSpec, or nullptr if unsupported.
 inline const KernelSpec*
 lookup_sm100_kernel_spec(int d, int sm_version) {
-    // SM100 family: sm_version 100..109
-    if (sm_version / 10 != 10) return nullptr;
+    // SM100 only: the kernels below are compiled with --gpu-architecture=sm_100a,
+    // an architecture-specific binary that does not load on other SM10x parts
+    // (sm_101, sm_103, ...). Admitting them here makes check_support() pass and
+    // build() fail later with "OSS SDPA engine not built".
+    if (sm_version != 100) return nullptr;
 
     static const KernelSpec spec_d128 = {
         generated::sm100_d128_fprop_source,

--- a/samples/cpp/sdpa/prefill_oss_engine.cpp
+++ b/samples/cpp/sdpa/prefill_oss_engine.cpp
@@ -30,10 +30,13 @@ namespace fe = cudnn_frontend;
 // ---------------------------------------------------------------------------
 // Helper: returns true if the current GPU is Hopper (SM90) or Blackwell
 // (SM100), i.e. any architecture supported by the OSS prefill engines.
+// The engine kernels are compiled with --gpu-architecture=sm_90a/sm_100a,
+// which are architecture-specific binaries: other SM10x parts (sm_101,
+// sm_103, ...) cannot load them, so they must skip, not run.
 // ---------------------------------------------------------------------------
 static bool
 is_oss_supported_arch() {
-    return is_hopper_arch() || is_blackwell_computing_arch();
+    return is_hopper_arch() || get_compute_capability() == 100;
 }
 
 // ---------------------------------------------------------------------------
@@ -1127,12 +1130,12 @@ TEST_CASE("SM100 Prefill OSS Engine Direct API", "[graph][sdpa][sm100][oss][dire
     // ---- Build engine once ----
     fe::experimental::Sm100SdpaPrefillEngine engine;
 
-    if (is_blackwell_computing_arch()) {
+    if (get_compute_capability() == 100) {
         REQUIRE(engine.check_support(shape, static_cast<int>(sm_version)).is_good());
         REQUIRE(engine.build().is_good());
     } else {
         REQUIRE(engine.check_support(shape, static_cast<int>(sm_version)).is_bad());
-        SKIP("Test requires Blackwell (SM10X) architecture");
+        SKIP("Test requires Blackwell (SM100) architecture");
         return;
     }
 


### PR DESCRIPTION
### Problem
On non-SM100 Blackwell-family parts, four `prefill_oss_engine.cpp` sample test cases fail with `OSS SDPA engine not built` instead of skipping.

Root cause: the SM100 prefill engine's kernels are compiled with `--gpu-architecture=sm_100a`, an architecture-specific binary that only loads on SM100 proper — but `lookup_sm100_kernel_spec()` admitted the whole SM10x family (`sm_version / 10 == 10`). So `check_support()` succeeded and `build()` then failed at NVRTC/module load. The sample guards (`is_oss_supported_arch()` / `is_blackwell_computing_arch()`) had the same too-broad admit, so the tests ran and FAILED instead of skipping.

### Changes
- `sm100_sdpa_prefill_engine.h`: `lookup_sm100_kernel_spec()` rejects `sm_version != 100`, so `check_support()` reports `GRAPH_NOT_SUPPORTED` up front (this also gives the graph-level OPENSOURCE engine selection a clean not-supported instead of a late build failure).
- `prefill_oss_engine.cpp`: tighten `is_oss_supported_arch()` and the SM100 Direct API gate to `get_compute_capability() == 100`, so the test cases SKIP on unsupported parts (mirroring the existing SM90 Direct API behavior).

### Validation
On a non-SM100 Blackwell-family board (develop + this patch): the five OSS prefill test cases report `5 skipped` with the two `check_support(...).is_bad()` assertions passing; previously 4 of them FAILED. No behavior change on SM100 (spec lookup unchanged for `sm_version == 100`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted SM100 kernel selection to exact SM100 hardware.
  * Prevented unsupported SM10x architectures, including SM101, from using SM100 kernels.
  * Updated prefill tests to run only on supported Hopper (SM90) and SM100 devices.
  * Improved skip messaging for unsupported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->