### PR TITLE
BSA: add Sage FP8 forward support for Blackwell

### DIFF
--- a/docs/fe-oss-apis/bsa.md
+++ b/docs/fe-oss-apis/bsa.md
@@ -23,8 +23,7 @@ list of key/value blocks per **query block**. NSA Selection supplies routing
 metadata at query-token granularity and is one component of the larger NSA
 pipeline.
 
-This package contains only Python CuTe DSL/JIT kernels. The C++/CUTLASS AOT
-extension from the source repository is not included.
+BSA is implemented with Python CuTe DSL/JIT kernels.
 
 ## Installation
 
@@ -33,6 +32,12 @@ Install the CuTe DSL optional dependencies:
 ```bash
 pip install nvidia-cudnn-frontend[cutedsl]
 ```
+
+The package-wide `nvidia-cutlass-dsl[cu13]>=4.5.0` dependency floor applies to
+BSA. The FP16/BF16 APIs continue to work with supported CuTe DSL 4.5 releases.
+The Sage FP8 API below performs an additional runtime check and requires
+`nvidia-cutlass-dsl>=4.6.1`; this narrower requirement does not change the
+package dependency floor or make importing `cudnn` require CuTe DSL 4.6.1.
 
 ## Forward
 
@@ -94,7 +99,7 @@ is consumed. Values in the inactive suffix are ignored.
   `[0, K_max]` when `allow_empty_block_nums=True`, and in `[1, K_max]`
   otherwise. Backward variable counts may be in `[0, K_max]`.
 - With fixed counts, `block_sparse_num` must be in `[1, K_max]`. The
-  SM100/SM110 blk128 path additionally requires an even value, i.e. an even
+  SM100/SM103 blk128 path additionally requires an even value, i.e. an even
   `block_sparse_num` in `[2, K_max]`.
 - The `block_sizes` entry for every physical KV block referenced by an active
   `q2k_block_index` value must be in `[1, sparse_block_size]`. Entries for
@@ -106,7 +111,7 @@ Tensor value ranges and per-row uniqueness are not validated at runtime.
 Violating the contract is unsupported and may produce invalid results or
 invalid device memory accesses.
 
-On the SM100/SM110 blk128 path, `pack_gqa=None` automatically packs GQA when
+On the SM100/SM103 blk128 path, `pack_gqa=None` automatically packs GQA when
 the GQA ratio `r = H_q / H_kv` divides 128. Packed metadata has shape
 `(B, H_kv, ceil(S_q * r / 128), K_max)`. Pass `pack_gqa=False` to use the
 unpacked `(B, H_q, ceil(S_q / 128), K_max)` contract on every architecture.
@@ -117,22 +122,65 @@ Provide `block_sizes` whenever a referenced final block is only partially
 valid.
 
 `sparse_block_size=None` chooses blk64 on SM90/SM120 and blk128 on
-SM100/SM110. Passing `sparse_block_size=64` explicitly selects the SM100/SM110
+SM100/SM103. Passing `sparse_block_size=64` explicitly selects the SM100/SM103
 blk64 CuTe DSL path, whose shape support is narrower. `kv_splits` is available
 on SM90 and the explicit Blackwell blk64 path; `use_clc` applies only to the
 explicit Blackwell blk64 path.
 
 `kv_splits=2..256` computes FP32 partial outputs and combines them, with
 workspace growing linearly in the split count. SM90 accepts an explicit integer
-split count. The SM100/SM110 blk64 path also accepts `kv_splits="auto"`; CLC is
-disabled for split execution, and an explicit `use_clc=True` is incompatible
-with `kv_splits>1`. Every sparse row must contain at least the selected number
-of valid KV blocks so that every split is non-empty; this caller contract is not
-validated at runtime. Automatic split selection uses metadata capacity rather
-than per-row count values, so variable-count callers must also satisfy the
-automatically selected split count. It falls back to a smaller split count when
-the estimated live workspace does not fit the available CUDA allocator budget;
-an explicit split count that exceeds that budget raises `RuntimeError`.
+split count. The SM100/SM103 blk64 path also accepts `kv_splits="auto"`; CLC is
+compatible with split execution. Pass `use_clc=True` to use persistent CLC
+scheduling with `kv_splits>1`, or `use_clc=False` to use one tile per CTA. The
+default `use_clc=None` keeps CLC disabled for split execution because the
+automatic scheduler policy has not been tuned for that combination. Automatic
+split selection uses metadata capacity rather than per-row count values. It
+falls back to a smaller split count when the estimated live workspace does not
+fit the available CUDA allocator budget; an explicit split count that exceeds
+that budget raises `RuntimeError`.
+
+## Sage FP8 forward
+
+Sage FP8 is a forward-only blk64 path. Its public wrapper accepts contiguous
+BF16 Q, K, and V tensors in `BHSD` layout and performs FP8 quantization
+internally:
+
+```python
+fp8_result = BSA.block_sparse_attention_fp8_forward(
+    q,
+    k,
+    v,
+    q2k_block_index,
+    block_sparse_num=4,
+)
+o_fp8 = fp8_result["o_tensor"]
+```
+
+Q, K, and V must be BF16 MHA tensors in contiguous BHSD layout, have matching
+batch and head counts, and use `D=128`. The wrapper accepts the same blk64
+sparse index metadata used by the regular forward API. It lazily loads the
+quantizer, creates the E4M3 tensors and FP32 scales needed by the kernel, and
+does not expose those implementation details as public inputs or outputs.
+
+The result is a one-key `TupleDict` containing `o_tensor`, a contiguous BF16
+tensor of shape `(B, H, S_q, 128)`. This API does not return LSE and has no
+backward implementation.
+
+The architecture-specific FP8 contracts are:
+
+- SM100/SM103 requires `B=1`, `H` equal to 4 or 8, and both sequence lengths
+  to be multiples of 64. It uses fixed `block_sparse_num` with full 64-token
+  KV blocks; `q2k_block_nums` and `block_sizes` are not supported. Split-KV is
+  selected internally, and the public FP8 API does not expose `kv_splits` or
+  `use_clc`.
+- SM120 accepts any positive batch and head counts, non-aligned Q/KV sequence
+  tails, fixed or per-query-block counts, and `block_sizes` shaped `(N_kv,)`,
+  `(B, N_kv)`, or `(B, H, N_kv)`. It does not use split-KV.
+
+`block_sparse_attention_fp8_forward` requires CuTe DSL 4.6.1 or newer at call
+time. Its internal Q/K/V quantizer is also implemented in CuTe DSL and is
+loaded lazily, so importing `cudnn` still works with the package-wide CuTe DSL
+4.5 dependency floor.
 
 ## Backward
 
@@ -162,24 +210,26 @@ The backward implementation builds a bucketed K-to-Q CSR task layout on the
 GPU. `bucket_size_blocks` is an optional tuning override; leaving it unset uses
 the backend default.
 
-Backward defaults to blk64 on SM90 and blk128 on SM100/SM110. Pass the same
+Backward defaults to blk64 on SM90 and blk128 on SM100/SM103. Pass the same
 explicit `sparse_block_size` used by forward when selecting the Blackwell blk64
-path. SM100/SM110 blk128 backward does not yet consume `block_sizes`; it
+path. SM100/SM103 blk128 backward does not yet consume `block_sizes`; it
 therefore requires full physical KV blocks and `block_sizes=None`.
 
 ## Current support
 
 ### Forward
 
-| Architecture | Sparse block | Dtype | QK / V dimensions | Attention |
+| Architecture | Sparse block | Public input / kernel dtype | QK / V dimensions | Attention |
 | --- | ---: | --- | --- | --- |
 | SM90 | 64 | FP16, BF16 | each of 64, 96, 128 | MHA, GQA, MQA |
-| SM100/SM110 | 128 | FP16, BF16 | QK=V=64, 96, or 128 | MHA, GQA, MQA |
-| SM100/SM110 | 64 (explicit) | BF16 | QK=128, V=128 | MHA |
+| SM100/SM103 | 128 | FP16, BF16 | QK=V=64, 96, or 128 | MHA, GQA, MQA |
+| SM100/SM103 | 64 (explicit) | BF16 | QK=128, V=128 | MHA |
+| SM100/SM103 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA (B=1, H=4 or 8) |
 | SM120 | 64 | FP16, BF16 | QK=128, V=128 | MHA, GQA, MQA |
+| SM120 | 64 | BF16 / FP8 E4M3 | QK=128, V=128 | MHA |
 
 SM90 currently requires `S_q` to be a multiple of 64. Its fixed count may be
-any positive value. The SM100/SM110 blk128 fixed count must be even and at
+any positive value. The SM100/SM103 blk128 fixed count must be even and at
 least two; SM120 and the explicit Blackwell blk64 path accept any positive
 fixed count. Variable counts use `q2k_block_nums`. `allow_empty_block_nums`
 defaults to `False`; when it is `True`, empty rows (`q2k_block_nums == 0`)
@@ -192,8 +242,8 @@ branch-free fast path. Split-KV execution therefore excludes empty rows.
 | Architecture | Sparse block | Dtype | Head dimension | Attention |
 | --- | ---: | --- | ---: | --- |
 | SM90 | 64 | BF16 | 128 | MHA |
-| SM100/SM110 | 64 | BF16 | 128 | MHA |
-| SM100/SM110 | 128 | BF16 | 64 or 128 | MHA |
+| SM100/SM103 | 64 | BF16 | 128 | MHA |
+| SM100/SM103 | 128 | BF16 | 64 or 128 | MHA |
 
 Backward is not implemented for SM120. It requires equal QK/V dimensions and
 does not currently support GQA/MQA.
@@ -202,9 +252,11 @@ does not currently support GQA/MQA.
 
 The current sparse kernels do not implement causal or local masking, dropout,
 `mask_mod`, `score_mod`, paged KV cache, softcap, or variable-length packed
-sequences. Inputs must be rank four, use FP16/BF16 as allowed above, and have a
-contiguous last (head-dimension) axis. Forward outputs are contiguous in the
-requested BHSD or BSHD layout, including split-KV execution.
+sequences. Regular forward/backward inputs must be rank four, use FP16/BF16 as
+allowed above, and have a contiguous last (head-dimension) axis. Sage FP8 uses
+the stricter BF16 BHSD contract described above and quantizes to E4M3
+internally. Regular forward outputs are contiguous in the requested BHSD or
+BSHD layout, including split-KV execution; FP8 output is contiguous BF16 BHSD.
 
 Compilation is lazy. The first call for a new static configuration JIT-compiles
 the relevant kernel; subsequent calls reuse an in-process cache.
@@ -216,10 +268,7 @@ lifecycle for BSA.
 Correctness tests and FP32 references are under
 `test/python/fe_api/bsa`.
 
-## Source provenance
+## Acknowledgements
 
-The kernel sources were adapted from the
-[`Block-Sparse-Attention`](https://github.com/NVIDIA-JerryChen/Block-Sparse-Attention/tree/a9fa5f2966aa17fcf1ce2890c489d45a4a89acf1)
-checkout at commit `a9fa5f2966aa17fcf1ce2890c489d45a4a89acf1`. See
-`python/cudnn/block_sparse_attention/PROVENANCE.md` for the migrated scope and
-integration changes.
+We thank <huangyitong.hyt@alibaba-inc.com> and
+<wenting.swt@alibaba-inc.com> for testing the BSA kernels and reporting issues.

--- a/docs/fe-oss-apis/bsa.md
+++ b/docs/fe-oss-apis/bsa.md
@@ -10,7 +10,7 @@ be its query-block index and let `K_m` be the union of the key/value blocks
 listed for that query block. The operation is
 
 $$
-O_i = \operatorname{softmax}_{j \in K_m}
+O_i = \text{softmax}_{j \in K_m}
 \left(\frac{Q_i K_j^T}{\sqrt{D}}\right)V_j.
 $$
 
@@ -270,5 +270,7 @@ Correctness tests and FP32 references are under
 
 ## Acknowledgements
 
-We thank <huangyitong.hyt@alibaba-inc.com> and
-<wenting.swt@alibaba-inc.com> for testing the BSA kernels and reporting issues.
+We would like to express our gratitude to <huangyitong.hyt@alibaba-inc.com> and
+<wenting.swt@alibaba-inc.com> for providing testing and optimization feedback
+throughout the deployment process, which has continuously advanced the BSA kernel
+toward Speed of Light.

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -308,6 +308,7 @@ _OPTIONAL_DEPENDENCY_INSTALL_HINT = "Install with 'pip install nvidia-cudnn-fron
 _LAZY_OPTIONAL_IMPORTS = {
     "BSA": (".block_sparse_attention", "BSA"),
     "block_sparse_attention_forward": (".block_sparse_attention", "block_sparse_attention_forward"),
+    "block_sparse_attention_fp8_forward": (".block_sparse_attention", "block_sparse_attention_fp8_forward"),
     "block_sparse_attention_backward": (".block_sparse_attention", "block_sparse_attention_backward"),
     "DSA": (".deepseek_sparse_attention", "DSA"),
     "CSA": (".csa", "CSA"),

--- a/python/cudnn/block_sparse_attention/__init__.py
+++ b/python/cudnn/block_sparse_attention/__init__.py
@@ -5,6 +5,7 @@ from importlib import import_module
 
 _SYMBOLS = {
     "block_sparse_attention_forward": (".api", "block_sparse_attention_forward"),
+    "block_sparse_attention_fp8_forward": (".api", "block_sparse_attention_fp8_forward"),
     "block_sparse_attention_backward": (".api", "block_sparse_attention_backward"),
 }
 

--- a/python/cudnn/block_sparse_attention/_fp8_quant.py
+++ b/python/cudnn/block_sparse_attention/_fp8_quant.py
@@ -1,0 +1,507 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Private CuTe DSL Sage FP8 quantization for contiguous BHSD tensors."""
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import torch
+from cutlass import BFloat16, Float8E4M3FN, Float32, Int32
+
+from cudnn.block_sparse_attention.csrc.utils.cute_dsl_utils import to_cute_tensor
+
+
+class _SageFp8Quantizer:
+    """Quantize Q/K/V with the scale and rounding contract used by Sage."""
+
+    HEAD_DIM = 128
+    Q_THREADS = 32
+    Q_ELEMS_PER_LANE = HEAD_DIM // Q_THREADS
+    K_BLOCK_ROWS = 16
+    K_BLOCK_ELEMS = K_BLOCK_ROWS * HEAD_DIM
+    K_THREADS = 256
+    K_ELEMS_PER_THREAD = K_BLOCK_ELEMS // K_THREADS
+    K_WARPS = K_THREADS // 32
+    REDUCTION_THREADS = 128
+    ROWS_PER_CHUNK = 256
+
+    @cute.kernel
+    def _quantize_q_kernel(
+        self,
+        mQ: cute.Tensor,
+        mQFp8: cute.Tensor,
+        mQScale: cute.Tensor,
+    ):
+        lane_idx = cute.arch.thread_idx()[0]
+        row_idx = cute.arch.block_idx()[0]
+        row_base = row_idx * self.HEAD_DIM + lane_idx * self.Q_ELEMS_PER_LANE
+
+        values = cute.make_rmem_tensor(
+            cute.make_layout((self.Q_ELEMS_PER_LANE,)),
+            BFloat16,
+        )
+        local_amax = Float32(0.0)
+        for elem_idx in cutlass.range_constexpr(self.Q_ELEMS_PER_LANE):
+            value = mQ[row_base + elem_idx]
+            values[elem_idx] = value
+            value_f32 = value.to(Float32)
+            local_amax = cute.arch.fmax(
+                local_amax,
+                cute.arch.fmax(value_f32, -value_f32),
+            )
+
+        row_amax = cute.arch.warp_redux_sync(local_amax, "fmax")
+        row_scale = cute.math.div(
+            cute.arch.fmax(row_amax, Float32(1.0e-3)),
+            Float32(448.0),
+            full=True,
+        )
+        if lane_idx == 0:
+            mQScale[row_idx] = row_scale
+
+        # Match the customer recipe exactly: scale, reciprocal, and multiply
+        # are each rounded through BF16 before the E4M3 conversion.
+        scale_bf16 = row_scale.to(BFloat16)
+        reciprocal_bf16 = (BFloat16(1.0) / scale_bf16).to(BFloat16)
+        for elem_idx in cutlass.range_constexpr(self.Q_ELEMS_PER_LANE):
+            scaled_bf16 = (values[elem_idx] * reciprocal_bf16).to(BFloat16)
+            mQFp8[row_base + elem_idx] = scaled_bf16.to(Float8E4M3FN)
+
+    @cute.kernel
+    def _k_mean_partial_kernel(
+        self,
+        mK: cute.Tensor,
+        mKMeanPartial: cute.Tensor,
+        seqlen_k: Int32,
+        num_chunks: Int32,
+    ):
+        dim_idx = cute.arch.thread_idx()[0]
+        task_idx = cute.arch.block_idx()[0]
+        group_idx = task_idx // num_chunks
+        chunk_idx = task_idx - group_idx * num_chunks
+        seq_start = chunk_idx * self.ROWS_PER_CHUNK
+        group_base = group_idx * seqlen_k * self.HEAD_DIM
+
+        partial_sum = Float32(0.0)
+        for row_offset in cutlass.range(self.ROWS_PER_CHUNK, unroll=1):
+            seq_idx = seq_start + row_offset
+            if seq_idx < seqlen_k:
+                partial_sum += mK[group_base + seq_idx * self.HEAD_DIM + dim_idx].to(Float32)
+        mKMeanPartial[task_idx * self.HEAD_DIM + dim_idx] = partial_sum
+
+    @cute.kernel
+    def _k_mean_finalize_kernel(
+        self,
+        mKMeanPartial: cute.Tensor,
+        mKMean: cute.Tensor,
+        num_chunks: Int32,
+        seqlen_k_float: Float32,
+    ):
+        dim_idx = cute.arch.thread_idx()[0]
+        group_idx = cute.arch.block_idx()[0]
+        partial_base = group_idx * num_chunks * self.HEAD_DIM
+
+        total = Float32(0.0)
+        for chunk_idx in cutlass.range(num_chunks, unroll=1):
+            total += mKMeanPartial[partial_base + chunk_idx * self.HEAD_DIM + dim_idx]
+        mKMean[group_idx * self.HEAD_DIM + dim_idx] = cute.math.div(total, seqlen_k_float, full=True)
+
+    @cute.kernel
+    def _quantize_k_kernel(
+        self,
+        mK: cute.Tensor,
+        mKFp8: cute.Tensor,
+        mKScale: cute.Tensor,
+        mKMean: cute.Tensor,
+        seqlen_k: Int32,
+        num_k_blocks: Int32,
+    ):
+        thread_idx = cute.arch.thread_idx()[0]
+        lane_idx = cute.arch.lane_idx()
+        warp_idx = cute.arch.warp_idx()
+        task_idx = cute.arch.block_idx()[0]
+        group_idx = task_idx // num_k_blocks
+        block_idx = task_idx - group_idx * num_k_blocks
+        seq_start = block_idx * self.K_BLOCK_ROWS
+        group_base = group_idx * seqlen_k * self.HEAD_DIM
+        local_offset = thread_idx * self.K_ELEMS_PER_THREAD
+
+        smem = utils.SmemAllocator()
+        warp_amax = smem.allocate_tensor(
+            Float32,
+            cute.make_layout((self.K_WARPS,)),
+            byte_alignment=4,
+        )
+        block_scale = smem.allocate_tensor(
+            Float32,
+            cute.make_layout((1,)),
+            byte_alignment=4,
+        )
+
+        centered = cute.make_rmem_tensor(
+            cute.make_layout((self.K_ELEMS_PER_THREAD,)),
+            Float32,
+        )
+        local_amax = Float32(0.0)
+        for elem_idx in cutlass.range_constexpr(self.K_ELEMS_PER_THREAD):
+            block_offset = local_offset + elem_idx
+            row_offset = block_offset // self.HEAD_DIM
+            dim_idx = block_offset - row_offset * self.HEAD_DIM
+            seq_idx = seq_start + row_offset
+            is_valid = seq_idx < seqlen_k
+            raw_value = Float32(0.0)
+            if is_valid:
+                raw_value = mK[group_base + seq_idx * self.HEAD_DIM + dim_idx].to(Float32)
+            centered_value = raw_value - mKMean[group_idx * self.HEAD_DIM + dim_idx]
+            centered[elem_idx] = centered_value
+            local_amax = cute.arch.fmax(
+                local_amax,
+                cute.arch.fmax(centered_value, -centered_value),
+            )
+
+        per_warp_amax = cute.arch.warp_redux_sync(local_amax, "fmax")
+        if lane_idx == 0:
+            warp_amax[warp_idx] = per_warp_amax
+        cute.arch.barrier()
+
+        cta_amax = Float32(0.0)
+        if lane_idx < self.K_WARPS:
+            cta_amax = warp_amax[lane_idx]
+        cta_amax = cute.arch.warp_redux_sync(cta_amax, "fmax")
+        if thread_idx == 0:
+            block_scale[0] = cute.math.div(
+                cute.arch.fmax(cta_amax, Float32(1.0e-3)),
+                Float32(448.0),
+                full=True,
+            )
+            mKScale[task_idx] = block_scale[0]
+        cute.arch.barrier()
+
+        scale = block_scale[0]
+        for elem_idx in cutlass.range_constexpr(self.K_ELEMS_PER_THREAD):
+            block_offset = local_offset + elem_idx
+            row_offset = block_offset // self.HEAD_DIM
+            dim_idx = block_offset - row_offset * self.HEAD_DIM
+            seq_idx = seq_start + row_offset
+            if seq_idx < seqlen_k:
+                output_idx = group_base + seq_idx * self.HEAD_DIM + dim_idx
+                mKFp8[output_idx] = cute.math.div(centered[elem_idx], scale, full=True).to(Float8E4M3FN)
+
+    @cute.kernel
+    def _v_amax_partial_kernel(
+        self,
+        mV: cute.Tensor,
+        mVAmaxPartial: cute.Tensor,
+        batch_size: Int32,
+        num_heads: Int32,
+        seqlen_k: Int32,
+        num_chunks: Int32,
+    ):
+        dim_idx = cute.arch.thread_idx()[0]
+        task_idx = cute.arch.block_idx()[0]
+        head_idx = task_idx // num_chunks
+        chunk_idx = task_idx - head_idx * num_chunks
+        row_start = chunk_idx * self.ROWS_PER_CHUNK
+        total_rows = batch_size * seqlen_k
+
+        local_amax = Float32(0.0)
+        for row_offset in cutlass.range(self.ROWS_PER_CHUNK, unroll=1):
+            flat_row = row_start + row_offset
+            if flat_row < total_rows:
+                batch_idx = flat_row // seqlen_k
+                seq_idx = flat_row - batch_idx * seqlen_k
+                input_idx = ((batch_idx * num_heads + head_idx) * seqlen_k + seq_idx) * self.HEAD_DIM + dim_idx
+                value = mV[input_idx].to(Float32)
+                local_amax = cute.arch.fmax(
+                    local_amax,
+                    cute.arch.fmax(value, -value),
+                )
+        mVAmaxPartial[task_idx * self.HEAD_DIM + dim_idx] = local_amax
+
+    @cute.kernel
+    def _v_scale_finalize_kernel(
+        self,
+        mVAmaxPartial: cute.Tensor,
+        mVScale: cute.Tensor,
+        num_chunks: Int32,
+    ):
+        dim_idx = cute.arch.thread_idx()[0]
+        head_idx = cute.arch.block_idx()[0]
+        partial_base = head_idx * num_chunks * self.HEAD_DIM
+
+        amax = Float32(0.0)
+        for chunk_idx in cutlass.range(num_chunks, unroll=1):
+            amax = cute.arch.fmax(
+                amax,
+                mVAmaxPartial[partial_base + chunk_idx * self.HEAD_DIM + dim_idx],
+            )
+        mVScale[head_idx * self.HEAD_DIM + dim_idx] = cute.math.div(
+            cute.arch.fmax(amax, Float32(1.0e-3)),
+            Float32(448.0),
+            full=True,
+        )
+
+    @cute.kernel
+    def _quantize_v_kernel(
+        self,
+        mV: cute.Tensor,
+        mVFp8: cute.Tensor,
+        mVScale: cute.Tensor,
+        num_heads: Int32,
+        seqlen_k: Int32,
+    ):
+        dim_idx = cute.arch.thread_idx()[0]
+        row_idx = cute.arch.block_idx()[0]
+        group_idx = row_idx // seqlen_k
+        head_idx = group_idx - (group_idx // num_heads) * num_heads
+        input_idx = row_idx * self.HEAD_DIM + dim_idx
+
+        reciprocal_bf16 = cute.math.div(
+            Float32(1.0),
+            mVScale[head_idx * self.HEAD_DIM + dim_idx],
+            full=True,
+        ).to(BFloat16)
+        scaled_bf16 = (mV[input_idx] * reciprocal_bf16).to(BFloat16)
+        mVFp8[input_idx] = scaled_bf16.to(Float8E4M3FN)
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mQFp8: cute.Tensor,
+        mKFp8: cute.Tensor,
+        mVFp8: cute.Tensor,
+        mQScale: cute.Tensor,
+        mKScale: cute.Tensor,
+        mVScale: cute.Tensor,
+        mKMeanPartial: cute.Tensor,
+        mKMean: cute.Tensor,
+        mVAmaxPartial: cute.Tensor,
+        batch_size: Int32,
+        num_heads: Int32,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        num_k_chunks: Int32,
+        num_v_chunks: Int32,
+        seqlen_k_float: Float32,
+        stream: cuda.CUstream,
+    ):
+        num_q_rows = batch_size * num_heads * seqlen_q
+        num_groups = batch_size * num_heads
+        num_k_blocks = (seqlen_k + self.K_BLOCK_ROWS - 1) // self.K_BLOCK_ROWS
+
+        self._quantize_q_kernel(mQ, mQFp8, mQScale).launch(
+            grid=(num_q_rows, 1, 1),
+            block=(self.Q_THREADS, 1, 1),
+            stream=stream,
+        )
+        self._k_mean_partial_kernel(
+            mK,
+            mKMeanPartial,
+            seqlen_k,
+            num_k_chunks,
+        ).launch(
+            grid=(num_groups * num_k_chunks, 1, 1),
+            block=(self.REDUCTION_THREADS, 1, 1),
+            stream=stream,
+        )
+        self._k_mean_finalize_kernel(
+            mKMeanPartial,
+            mKMean,
+            num_k_chunks,
+            seqlen_k_float,
+        ).launch(
+            grid=(num_groups, 1, 1),
+            block=(self.REDUCTION_THREADS, 1, 1),
+            stream=stream,
+        )
+        self._quantize_k_kernel(
+            mK,
+            mKFp8,
+            mKScale,
+            mKMean,
+            seqlen_k,
+            num_k_blocks,
+        ).launch(
+            grid=(num_groups * num_k_blocks, 1, 1),
+            block=(self.K_THREADS, 1, 1),
+            smem=self.K_WARPS * 4 + 4,
+            stream=stream,
+        )
+        self._v_amax_partial_kernel(
+            mV,
+            mVAmaxPartial,
+            batch_size,
+            num_heads,
+            seqlen_k,
+            num_v_chunks,
+        ).launch(
+            grid=(num_heads * num_v_chunks, 1, 1),
+            block=(self.REDUCTION_THREADS, 1, 1),
+            stream=stream,
+        )
+        self._v_scale_finalize_kernel(
+            mVAmaxPartial,
+            mVScale,
+            num_v_chunks,
+        ).launch(
+            grid=(num_heads, 1, 1),
+            block=(self.REDUCTION_THREADS, 1, 1),
+            stream=stream,
+        )
+        self._quantize_v_kernel(
+            mV,
+            mVFp8,
+            mVScale,
+            num_heads,
+            seqlen_k,
+        ).launch(
+            grid=(num_groups * seqlen_k, 1, 1),
+            block=(self.REDUCTION_THREADS, 1, 1),
+            stream=stream,
+        )
+
+
+def _to_dynamic_cute_tensor(tensor: torch.Tensor) -> cute.Tensor:
+    return to_cute_tensor(
+        tensor.view(-1),
+        assumed_align=16,
+        fully_dynamic=True,
+        enable_tvm_ffi=False,
+    )
+
+
+def _quantize_sage_bhsd(
+    q_bhsd: torch.Tensor,
+    k_bhsd: torch.Tensor,
+    v_bhsd: torch.Tensor,
+):
+    """Quantize BF16 BHSD Q/K/V using private CuTe DSL kernels."""
+    tensors = (q_bhsd, k_bhsd, v_bhsd)
+    if any(tensor.ndim != 4 for tensor in tensors):
+        raise ValueError("Q, K, and V must be rank-4 BHSD tensors")
+    if any(tensor.dtype != torch.bfloat16 for tensor in tensors):
+        raise TypeError("Sage FP8 quantization currently requires BF16 inputs")
+    if any(not tensor.is_cuda for tensor in tensors):
+        raise ValueError("Q, K, and V must be CUDA tensors")
+    if any(not tensor.is_contiguous() for tensor in tensors):
+        raise ValueError("Q, K, and V must use contiguous BHSD storage")
+    if any(tensor.device != q_bhsd.device for tensor in tensors[1:]):
+        raise ValueError("Q, K, and V must be on the same CUDA device")
+
+    batch_size, num_heads, seqlen_q, head_dim = q_bhsd.shape
+    if batch_size < 1 or num_heads < 1 or seqlen_q < 1:
+        raise ValueError("Sage FP8 quantization requires positive batch, head, and sequence counts")
+    if head_dim != _SageFp8Quantizer.HEAD_DIM:
+        raise ValueError("Sage FP8 quantization requires D=128")
+    if k_bhsd.shape[:2] != (batch_size, num_heads) or k_bhsd.shape[-1] != head_dim:
+        raise ValueError("K must match Q batch, heads, and head dimension")
+    if v_bhsd.shape != k_bhsd.shape:
+        raise ValueError("V must have the same shape as K")
+
+    seqlen_k = k_bhsd.shape[2]
+    if seqlen_k < 1:
+        raise ValueError("Sage FP8 quantization requires positive batch, head, and sequence counts")
+    is_sm120 = torch.cuda.get_device_capability(q_bhsd.device)[0] == 12
+    if not is_sm120 and (batch_size != 1 or num_heads not in (4, 8)):
+        raise ValueError("Sage FP8 v1 requires B=1, H in {4, 8}, and D=128")
+    if not is_sm120 and (seqlen_q % 64 or seqlen_k % 64):
+        raise ValueError("Q and K/V sequence lengths must be multiples of 64")
+
+    num_groups = batch_size * num_heads
+    num_k_chunks = (seqlen_k + _SageFp8Quantizer.ROWS_PER_CHUNK - 1) // _SageFp8Quantizer.ROWS_PER_CHUNK
+    num_v_chunks = (batch_size * seqlen_k + _SageFp8Quantizer.ROWS_PER_CHUNK - 1) // _SageFp8Quantizer.ROWS_PER_CHUNK
+    num_k_blocks = (seqlen_k + _SageFp8Quantizer.K_BLOCK_ROWS - 1) // _SageFp8Quantizer.K_BLOCK_ROWS
+    device = q_bhsd.device
+
+    with torch.cuda.device(device):
+        q_fp8 = torch.empty_like(q_bhsd, dtype=torch.float8_e4m3fn)
+        k_fp8 = torch.empty_like(k_bhsd, dtype=torch.float8_e4m3fn)
+        v_fp8 = torch.empty_like(v_bhsd, dtype=torch.float8_e4m3fn)
+        q_scale = torch.empty(
+            (batch_size, num_heads, seqlen_q),
+            dtype=torch.float32,
+            device=device,
+        )
+        k_scale = torch.empty(
+            (batch_size, num_heads, num_k_blocks),
+            dtype=torch.float32,
+            device=device,
+        )
+        v_scale = torch.empty(
+            (num_heads, head_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+        k_mean_partial = torch.empty(
+            (num_groups, num_k_chunks, head_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+        k_mean = torch.empty(
+            (num_groups, head_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+        v_amax_partial = torch.empty(
+            (num_heads, num_v_chunks, head_dim),
+            dtype=torch.float32,
+            device=device,
+        )
+
+        runtime_tensors = (
+            q_bhsd,
+            k_bhsd,
+            v_bhsd,
+            q_fp8,
+            k_fp8,
+            v_fp8,
+            q_scale,
+            k_scale,
+            v_scale,
+            k_mean_partial,
+            k_mean,
+            v_amax_partial,
+        )
+        cute_tensors = tuple(_to_dynamic_cute_tensor(tensor) for tensor in runtime_tensors)
+        current_stream = cuda.CUstream(torch.cuda.current_stream(device).cuda_stream)
+        compile_key = torch.cuda.get_device_capability(device)
+        if compile_key not in _quantize_sage_bhsd.compile_cache:
+            quantizer = _SageFp8Quantizer()
+            _quantize_sage_bhsd.compile_cache[compile_key] = cute.compile(
+                quantizer,
+                *cute_tensors,
+                Int32(batch_size),
+                Int32(num_heads),
+                Int32(seqlen_q),
+                Int32(seqlen_k),
+                Int32(num_k_chunks),
+                Int32(num_v_chunks),
+                Float32(seqlen_k),
+                cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+            )
+
+        _quantize_sage_bhsd.compile_cache[compile_key](
+            *cute_tensors,
+            Int32(batch_size),
+            Int32(num_heads),
+            Int32(seqlen_q),
+            Int32(seqlen_k),
+            Int32(num_k_chunks),
+            Int32(num_v_chunks),
+            Float32(seqlen_k),
+            current_stream,
+        )
+
+    if not (q_fp8.is_contiguous() and k_fp8.is_contiguous() and v_fp8.is_contiguous()):
+        raise RuntimeError("quantized Q, K, and V must remain BHSD-contiguous")
+    return q_fp8, k_fp8, v_fp8, q_scale, k_scale, v_scale
+
+
+_quantize_sage_bhsd.compile_cache = {}
+
+__all__ = []

--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -85,6 +85,34 @@ def _get_device_arch():
     return _get_device_arch_for_device(torch.cuda.current_device())
 
 
+def _cutlass_dsl_version() -> tuple[int, int, int]:
+    """Return the installed CUTLASS DSL version without adding a dependency."""
+    version = getattr(cutlass, "__version__", None)
+    try:
+        parts = str(version).split(".")
+        parsed = []
+        for index in range(3):
+            digits = ""
+            for character in parts[index]:
+                if not character.isdigit():
+                    break
+                digits += character
+            if not digits:
+                raise ValueError
+            parsed.append(int(digits))
+        return tuple(parsed)
+    except (IndexError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"Cannot parse CUTLASS DSL version {version!r}") from exc
+
+
+def _require_sage_fp8_cutedsl() -> None:
+    """Gate the new Sage FP8 kernels while preserving the package's 4.5 floor."""
+    if _cutlass_dsl_version() < (4, 6, 1):
+        raise RuntimeError(
+            "Sage FP8 block-sparse attention requires nvidia-cutlass-dsl>=4.6.1; " "the BF16/FP16 BSA paths remain available with the package minimum of 4.5.0"
+        )
+
+
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x
 
@@ -115,8 +143,14 @@ def _to_cute_tensor_dynamic_compact_shape(
     leading_dim: int = -1,
     divisibility: int = 1,
     stride_order: tuple[int, ...] | None = None,
+    enable_tvm_ffi: bool = True,
 ) -> cute.Tensor:
-    tensor = _to_cute_tensor(t, assumed_align=assumed_align, leading_dim=leading_dim)
+    tensor = _to_cute_tensor(
+        t,
+        assumed_align=assumed_align,
+        leading_dim=leading_dim,
+        enable_tvm_ffi=enable_tvm_ffi,
+    )
     if isinstance(mode, int):
         mode = (mode,)
     stride_order = t.dim_order() if stride_order is None else stride_order
@@ -140,6 +174,7 @@ def _to_sm90_bwd_cute_tensor(t: torch.Tensor, assumed_align: int = 16, enable_tv
 torch2cute_dtype_map = {
     torch.float16: cutlass.Float16,
     torch.bfloat16: cutlass.BFloat16,
+    torch.float8_e4m3fn: cutlass.Float8E4M3FN,
     torch.float32: cutlass.Float32,
 }
 
@@ -357,6 +392,29 @@ def _sm100_blk64_auto_kv_splits(
     else:
         splits = 1
     return max(1, min(int(splits), int(max_kv_splits), kv_blocks))
+
+
+def _sm100_blk64_auto_fp8_kv_splits(
+    topk_num: int,
+    heads: int = 4,
+    seqlen_q: int = 64,
+) -> int:
+    """Choose Sage FP8 splits for short-Q launch parallelism."""
+    topk_num = int(topk_num)
+    heads = int(heads)
+    q_tiles = heads * _ceil_div_int(seqlen_q, 64)
+    if q_tiles >= 512:
+        return 4 if topk_num >= 900 else 1
+    if topk_num < 128:
+        return 1
+    if heads == 8:
+        if topk_num < 256:
+            return 4
+        if topk_num < 500:
+            return 8
+    elif 224 <= topk_num < 400:
+        return 8
+    return 16
 
 
 def _build_sm100_blk64_kv_split_offsets(
@@ -878,11 +936,170 @@ def _bsa_attn_fwd_sm120_blk64(
     return out, lse
 
 
+def _bsa_attn_fwd_sm120_fp8_blk64(
+    q_fp8: torch.Tensor,
+    k_fp8: torch.Tensor,
+    v_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    q2k_block_index: torch.Tensor,
+    block_sparse_num: int,
+    softmax_scale: float,
+    block_sizes: Optional[torch.Tensor] = None,
+    q2k_block_nums: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Launch the JIT-only SM120 Sage FP8 blk64 kernel on BHSD tensors."""
+    _require_sage_fp8_cutedsl()
+    from cudnn.block_sparse_attention.csrc.fwd.sm120_blk64.bsa_fwd_sm120_fp8 import (
+        BlockSparseAttnForwardFp8Sm120Blk64,
+    )
+
+    batch, num_heads, seqlen_q, head_dim = q_fp8.shape
+    seqlen_k = k_fp8.shape[2]
+    assert q_fp8.dtype == torch.float8_e4m3fn
+    assert k_fp8.dtype == q_fp8.dtype and v_fp8.dtype == q_fp8.dtype
+    assert k_fp8.shape == (batch, num_heads, seqlen_k, head_dim)
+    assert v_fp8.shape == k_fp8.shape
+    assert q_scale.shape == (batch, num_heads, seqlen_q)
+    assert k_scale.shape == (batch, num_heads, _ceil_div_int(seqlen_k, 16))
+    assert v_scale.shape == (num_heads, head_dim)
+
+    num_q_blocks = _ceil_div_int(seqlen_q, SM120_FWD_BLOCK_SIZE)
+    num_kv_blocks = _ceil_div_int(seqlen_k, SM120_FWD_BLOCK_SIZE)
+    assert q2k_block_index.dtype == torch.int32
+    assert q2k_block_index.shape[:3] == (batch, num_heads, num_q_blocks)
+    q2k_block_index = q2k_block_index.contiguous()
+
+    has_block_nums = q2k_block_nums is not None and q2k_block_nums.numel() > 0
+    if has_block_nums:
+        assert q2k_block_nums.dtype == torch.int32
+        assert q2k_block_nums.shape == (batch, num_heads, num_q_blocks)
+        q2k_block_nums = q2k_block_nums.contiguous()
+        fixed_block_sparse_num = 0
+    else:
+        assert 1 <= block_sparse_num <= q2k_block_index.shape[-1]
+        fixed_block_sparse_num = int(block_sparse_num)
+
+    has_block_sizes = block_sizes is not None and block_sizes.numel() > 0
+    block_sizes_mode = 0
+    if has_block_sizes:
+        assert block_sizes.dtype == torch.int32
+        if block_sizes.ndim == 1:
+            assert block_sizes.shape == (num_kv_blocks,)
+            block_sizes_t = block_sizes.contiguous()
+            block_sizes_mode = 1
+        elif block_sizes.ndim == 2:
+            assert block_sizes.shape == (batch, num_kv_blocks)
+            block_sizes_t = block_sizes.contiguous().permute(1, 0)
+            block_sizes_mode = 2
+        else:
+            assert block_sizes.ndim == 3
+            assert block_sizes.shape == (batch, num_heads, num_kv_blocks)
+            block_sizes_t = block_sizes.contiguous().permute(2, 1, 0)
+            block_sizes_mode = 3
+
+    out = torch.empty(
+        (batch, num_heads, seqlen_q, head_dim),
+        dtype=torch.bfloat16,
+        device=q_fp8.device,
+    )
+    lse = torch.empty(
+        (batch, num_heads, seqlen_q),
+        dtype=torch.float32,
+        device=q_fp8.device,
+    )
+
+    q_t = q_fp8.permute(2, 3, 1, 0)
+    k_t = k_fp8.permute(2, 3, 1, 0)
+    v_t = v_fp8.permute(3, 2, 1, 0)
+    out_t = out.permute(2, 3, 1, 0)
+    lse_t = lse.permute(2, 1, 0)
+    q_scale_t = q_scale.permute(2, 1, 0)
+    k_scale_t = k_scale.permute(2, 1, 0)
+    v_scale_t = v_scale.permute(1, 0)
+    q2k_t = q2k_block_index.permute(3, 2, 1, 0)
+    q2k_nums_t = q2k_block_nums.permute(2, 1, 0) if has_block_nums else q2k_t
+    if not has_block_sizes:
+        block_sizes_t = q2k_nums_t
+
+    runtime_tensors = (
+        q_t,
+        k_t,
+        v_t,
+        out_t,
+        lse_t,
+        q_scale_t,
+        k_scale_t,
+        v_scale_t,
+        q2k_t,
+        q2k_nums_t,
+        block_sizes_t,
+    )
+    cute_tensors = tuple(
+        _to_cute_tensor(
+            tensor,
+            assumed_align=(128 if index < 4 else 4 if index in (4, 5, 6, 7) else None),
+            leading_dim=(1 if index in (0, 1, 3) else 0),
+            enable_tvm_ffi=False,
+        )
+        for index, tensor in enumerate(runtime_tensors)
+    )
+    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    fwd_kernel = BlockSparseAttnForwardFp8Sm120Blk64(
+        gqa_ratio=1,
+        head_dim=head_dim,
+        value_dim=head_dim,
+        blocksparse_blocksize_q=SM120_FWD_BLOCK_SIZE,
+        blocksparse_blocksize_k=SM120_FWD_BLOCK_SIZE,
+        dtype=cutlass.Float8E4M3FN,
+        acc_dtype=cutlass.Float32,
+        has_block_sizes=has_block_sizes,
+        has_block_nums=has_block_nums,
+        block_sizes_mode=block_sizes_mode,
+    )
+    compile_key = _dynamic_tensors_compile_key(
+        "sm120_fp8_blk64",
+        (
+            _get_device_arch(),
+            head_dim,
+            has_block_nums,
+            has_block_sizes,
+            block_sizes_mode,
+        ),
+        runtime_tensors,
+        leading_dims=(1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0),
+    )
+    args = (
+        *cute_tensors[:10],
+        fixed_block_sparse_num,
+        cute_tensors[10],
+        softmax_scale,
+    )
+    if compile_key not in _bsa_attn_fwd_sm120_fp8_blk64.compile_cache:
+        _bsa_attn_fwd_sm120_fp8_blk64.compile_cache[compile_key] = cute.compile(
+            fwd_kernel,
+            *args,
+            cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        )
+
+    with torch.cuda.nvtx.range("bsa_attn_fwd_sm120_fp8_blk64_kernel"):
+        _bsa_attn_fwd_sm120_fp8_blk64.compile_cache[compile_key](
+            *args,
+            current_stream,
+        )
+    return out, lse
+
+
+_bsa_attn_fwd_sm120_fp8_blk64.compile_cache = {}
+
+
 def _combine_blk64_kv_bucketed_partials(
     q: torch.Tensor,
     o_partial_phys: torch.Tensor,
     lse_partial_phys: torch.Tensor,
     kv_splits: int,
+    output_dtype: Optional[torch.dtype] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Combine KV-bucketed partial outputs using the shared CuTeDSL combine kernel."""
     if BlockSparseAttnForwardCombine is None:
@@ -895,6 +1112,7 @@ def _combine_blk64_kv_bucketed_partials(
     head_dim = o_partial_phys.shape[-1]
     if o_partial_phys.dtype != torch.float32:
         raise TypeError("KV-bucketed blk64 fwd requires fp32 O partial")
+    output_dtype = q.dtype if output_dtype is None else output_dtype
 
     split_heads = kv_splits * num_heads
     o_partial = o_partial_phys.as_strided(
@@ -918,7 +1136,7 @@ def _combine_blk64_kv_bucketed_partials(
     )
     out_bshd = torch.empty(
         (batch, seqlen_q, num_heads, head_dim),
-        dtype=q.dtype,
+        dtype=output_dtype,
         device=q.device,
     )
     lse_bsh = torch.empty(
@@ -926,7 +1144,7 @@ def _combine_blk64_kv_bucketed_partials(
         dtype=torch.float32,
         device=q.device,
     )
-    dtype = torch2cute_dtype_map[q.dtype]
+    dtype = torch2cute_dtype_map[output_dtype]
     log_max_splits = _ceil_log2_int(kv_splits)
     # Baseline combine geometry; a single configuration is easier to maintain.
     combine_tile_m = 16
@@ -1071,9 +1289,24 @@ def bsa_attn_fwd_blk64_cutedsl(
     allow_empty_block_nums: bool = False,
     use_clc: Optional[bool] = None,
     kv_splits: int | str = 1,
+    q_scale: Optional[torch.Tensor] = None,
+    k_scale: Optional[torch.Tensor] = None,
+    v_scale: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """BSA forward attention through an independent blk64 CuTeDSL kernel class."""
-    assert q.dtype == torch.bfloat16, "blk64 CuTeDSL requires bf16"
+    """Run the SM100/SM110 blk64 CuTe DSL kernel, including Sage FP8."""
+    is_sage_fp8 = q_scale is not None
+    if is_sage_fp8:
+        _require_sage_fp8_cutedsl()
+        assert k_scale is not None and v_scale is not None, "FP8 requires Q/K/V scales"
+        assert q.dtype == torch.float8_e4m3fn, "FP8 inputs must use float8_e4m3fn"
+        assert k.dtype == q.dtype and v.dtype == q.dtype
+        assert q_scale.dtype == k_scale.dtype == v_scale.dtype == torch.float32
+        assert q2k_block_nums is None, "SM100 FP8 requires a uniform top-k"
+        assert block_sizes is None, "SM100 FP8 requires full 64-token KV blocks"
+        assert layout == "bhsd", "Sage FP8 currently requires BHSD layout"
+    else:
+        assert k_scale is None and v_scale is None, "Q/K/V scales must be provided together"
+        assert q.dtype == torch.bfloat16, "blk64 CuTe DSL requires BF16"
     assert q.is_cuda and k.is_cuda and v.is_cuda
     assert q.dim() == 4 and k.dim() == 4 and v.dim() == 4
     auto_kv_splits = isinstance(kv_splits, str)
@@ -1101,6 +1334,16 @@ def bsa_attn_fwd_blk64_cutedsl(
     assert num_head == num_head_kv, "blk64 CuTeDSL currently supports MHA only"
     assert k_bhsd.shape == (batch_size, num_head_kv, seqlen_k, head_dim)
     assert v_bhsd.shape == (batch_size, num_head_kv, seqlen_k, head_dim_v)
+    if is_sage_fp8:
+        assert batch_size == 1, "SM100 FP8 requires batch size 1"
+        assert num_head in (4, 8), "SM100 FP8 supports H=4 or H=8"
+        assert seqlen_q % 64 == 0 and seqlen_k % 64 == 0, "SM100 FP8 requires Sq and Sk to be multiples of 64"
+        q_scale = maybe_contiguous(q_scale)
+        k_scale = maybe_contiguous(k_scale)
+        v_scale = maybe_contiguous(v_scale)
+        assert q_scale.shape == (batch_size, num_head, seqlen_q)
+        assert k_scale.shape == (batch_size, num_head, _ceil_div_int(seqlen_k, 16))
+        assert v_scale.shape == (num_head, head_dim_v)
     assert q2k_block_index.dtype == torch.int32
     q2k_block_index = maybe_contiguous(q2k_block_index)
     has_block_sizes = block_sizes is not None and block_sizes.numel() > 0
@@ -1146,8 +1389,8 @@ def bsa_attn_fwd_blk64_cutedsl(
         softmax_scale = head_dim**-0.5
 
     dtype = torch2cute_dtype_map[q_bhsd.dtype]
+    output_dtype = torch.bfloat16 if is_sage_fp8 else q_bhsd.dtype
     arch = _get_device_arch()
-    allow_empty_block_nums = has_variable_block_nums and allow_empty_block_nums
     sparse_block_size = 64
     qhead_per_kvhead = 1
     tile_m = 64
@@ -1164,6 +1407,7 @@ def bsa_attn_fwd_blk64_cutedsl(
         kv_splits_i,
         allow_fallback=auto_kv_splits,
     )
+    allow_empty_block_nums = (has_variable_block_nums and allow_empty_block_nums) or kv_splits_i > 1
     if use_clc is None:
         if kv_splits_i > 1:
             use_clc_scheduler = False
@@ -1176,22 +1420,24 @@ def bsa_attn_fwd_blk64_cutedsl(
             )
     else:
         use_clc_scheduler = bool(use_clc)
-    assert not (kv_splits_i > 1 and use_clc_scheduler), "blk64 CuTeDSL kv_splits>1 does not support use_clc=True"
     is_persistent = use_clc_scheduler
     pack_gqa = False
     input_layout = "bhsd_native"
 
     split_offsets = None
     if kv_splits_i > 1:
-        split_offsets = _build_sm100_blk64_kv_split_offsets(
-            q2k_block_nums,
-            uniform_block_sparse_num,
-            batch_size,
-            num_head,
-            num_q_blocks,
-            kv_splits_i,
-            q_bhsd.device,
-        )
+        # Fixed-count static kernels derive aligned split boundaries in-kernel.
+        # Variable counts and CLC scheduling need explicit per-row offsets.
+        if has_variable_block_nums or use_clc_scheduler:
+            split_offsets = _build_sm100_blk64_kv_split_offsets(
+                q2k_block_nums,
+                uniform_block_sparse_num,
+                batch_size,
+                num_head,
+                num_q_blocks,
+                kv_splits_i,
+                q_bhsd.device,
+            )
         out_bhsd = torch.empty(
             (batch_size, kv_splits_i * num_head, seqlen_q, head_dim_v),
             dtype=torch.float32,
@@ -1205,7 +1451,7 @@ def bsa_attn_fwd_blk64_cutedsl(
     else:
         out_bhsd = torch.empty(
             (batch_size, num_head, seqlen_q, head_dim_v),
-            dtype=q_bhsd.dtype,
+            dtype=output_dtype,
             device=q_bhsd.device,
         )
         lse = torch.empty(
@@ -1237,6 +1483,7 @@ def bsa_attn_fwd_blk64_cutedsl(
             use_clc_scheduler,
             input_layout,
             use_int64_kv_strides,
+            is_sage_fp8,
         ),
         (
             q_bhsd,
@@ -1248,6 +1495,9 @@ def bsa_attn_fwd_blk64_cutedsl(
             block_sizes,
             q2k_block_nums,
             split_offsets,
+            q_scale,
+            k_scale,
+            v_scale,
         ),
     )
 
@@ -1258,6 +1508,9 @@ def bsa_attn_fwd_blk64_cutedsl(
         block_sizes_tensor = _to_cute_tensor(block_sizes) if has_block_sizes else None
         block_nums_tensor = _to_cute_tensor(q2k_block_nums) if has_variable_block_nums else None
         split_offsets_tensor = _to_cute_tensor(split_offsets) if split_offsets is not None else None
+        q_scale_tensor = _to_cute_tensor(q_scale, assumed_align=4) if is_sage_fp8 else None
+        k_scale_tensor = _to_cute_tensor(k_scale, assumed_align=4) if is_sage_fp8 else None
+        v_scale_tensor = _to_cute_tensor(v_scale, assumed_align=4) if is_sage_fp8 else None
 
         bsa_fwd = BlockSparseAttnForwardSm100Blk64(
             head_dim,
@@ -1282,6 +1535,9 @@ def bsa_attn_fwd_blk64_cutedsl(
             v_tensor,
             o_tensor,
             lse_tensor,
+            q_scale_tensor,
+            k_scale_tensor,
+            v_scale_tensor,
             softmax_scale,
             block_index_tensor,
             block_sizes_tensor,
@@ -1299,6 +1555,9 @@ def bsa_attn_fwd_blk64_cutedsl(
             v_bhsd.detach(),
             out_bhsd.detach(),
             lse,
+            q_scale.detach() if is_sage_fp8 else None,
+            k_scale.detach() if is_sage_fp8 else None,
+            v_scale.detach() if is_sage_fp8 else None,
             softmax_scale,
             q2k_block_index.detach(),
             block_sizes.detach() if has_block_sizes else None,
@@ -1314,6 +1573,7 @@ def bsa_attn_fwd_blk64_cutedsl(
             out_bhsd,
             lse,
             kv_splits_i,
+            output_dtype=output_dtype,
         )
         # Keep split_offsets alive through the combine launch on the same stream.
         _ = split_offsets
@@ -1325,6 +1585,111 @@ def bsa_attn_fwd_blk64_cutedsl(
 bsa_attn_fwd_blk64_cutedsl.compile_cache = {}
 
 bsa_attn_fwd_blk64 = bsa_attn_fwd_blk64_cutedsl
+
+
+def bsa_fp8_blk64_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    q2k_block_index: torch.Tensor,
+    block_sparse_num: int,
+    softmax_scale: Optional[float] = None,
+    *,
+    block_sizes: Optional[torch.Tensor] = None,
+    q2k_block_nums: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Quantize BF16 BHSD inputs privately and launch Sage FP8 blk64 BSA."""
+    _require_sage_fp8_cutedsl()
+    from cudnn.block_sparse_attention._fp8_quant import _quantize_sage_bhsd
+
+    quantized = _quantize_sage_bhsd(q, k, v)
+    return _bsa_fp8_blk64_fwd_quantized(
+        *quantized,
+        q2k_block_index,
+        block_sparse_num,
+        softmax_scale,
+        block_sizes=block_sizes,
+        q2k_block_nums=q2k_block_nums,
+    )
+
+
+def _bsa_fp8_blk64_fwd_quantized(
+    q_fp8: torch.Tensor,
+    k_fp8: torch.Tensor,
+    v_fp8: torch.Tensor,
+    q_scale: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    q2k_block_index: torch.Tensor,
+    block_sparse_num: int,
+    softmax_scale: Optional[float] = None,
+    *,
+    block_sizes: Optional[torch.Tensor] = None,
+    q2k_block_nums: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Launch Sage FP8 blk64 BSA from private quantized inputs."""
+    _require_sage_fp8_cutedsl()
+    assert q_fp8.dim() == k_fp8.dim() == v_fp8.dim() == 4
+    batch, heads, seqlen_q, head_dim = q_fp8.shape
+    seqlen_k = k_fp8.shape[2]
+    assert head_dim == 128 and k_fp8.shape == (batch, heads, seqlen_k, 128)
+    assert v_fp8.shape == k_fp8.shape
+    assert q_fp8.dtype == torch.float8_e4m3fn
+    assert k_fp8.dtype == q_fp8.dtype and v_fp8.dtype == q_fp8.dtype
+    assert q_fp8.is_cuda and k_fp8.is_cuda and v_fp8.is_cuda
+    assert k_fp8.device == q_fp8.device and v_fp8.device == q_fp8.device
+
+    q_scale = q_scale.reshape(batch, heads, -1)
+    k_scale = k_scale.reshape(batch, heads, -1)
+    v_scale = v_scale.reshape(heads, 128)
+    assert q_scale.dtype == k_scale.dtype == v_scale.dtype == torch.float32
+    assert q_scale.shape[-1] == seqlen_q
+    assert k_scale.shape[-1] == _ceil_div_int(seqlen_k, 16)
+    assert q_scale.device == k_scale.device == v_scale.device == q_fp8.device
+    if softmax_scale is None:
+        softmax_scale = 128**-0.5
+
+    arch_family = _get_device_arch() // 10
+    assert arch_family in (10, 11, 12), "FP8 blk64 BSA only supports SM100/SM110/SM120"
+    if arch_family == 12:
+        out, _ = _bsa_attn_fwd_sm120_fp8_blk64(
+            q_fp8,
+            k_fp8,
+            v_fp8,
+            q_scale.contiguous(),
+            k_scale.contiguous(),
+            v_scale.contiguous(),
+            q2k_block_index,
+            block_sparse_num,
+            softmax_scale,
+            block_sizes=block_sizes,
+            q2k_block_nums=q2k_block_nums,
+        )
+        return out
+
+    assert q2k_block_nums is None, "SM100/SM110 FP8 does not support q2k_block_nums"
+    assert block_sizes is None, "SM100/SM110 FP8 does not support block_sizes"
+    kv_splits = _sm100_blk64_auto_fp8_kv_splits(
+        block_sparse_num,
+        heads,
+        seqlen_q,
+    )
+    out, _ = bsa_attn_fwd_blk64_cutedsl(
+        q_fp8,
+        k_fp8,
+        v_fp8,
+        q2k_block_index,
+        None,
+        softmax_scale=softmax_scale,
+        layout="bhsd",
+        block_sparse_num=block_sparse_num,
+        use_clc=False,
+        kv_splits=kv_splits,
+        q_scale=q_scale.contiguous(),
+        k_scale=k_scale.contiguous(),
+        v_scale=v_scale.contiguous(),
+    )
+    return out
 
 
 def bsa_attn_fwd(

--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -1394,6 +1394,8 @@ def bsa_attn_fwd_blk64_cutedsl(
         block_sizes,
         q2k_block_nums,
     )
+    if is_sage_fp8:
+        assert q_bhsd.is_contiguous() and k_bhsd.is_contiguous() and v_bhsd.is_contiguous(), "Sage FP8 requires fully contiguous BHSD Q/K/V tensors"
     use_exact_kv_layout = _sm100_blk64_requires_int64_kv_strides(k_bhsd, v_bhsd)
 
     if softmax_scale is None:

--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -383,6 +383,14 @@ def _sm100_blk64_auto_kv_splits(
     if kv_blocks <= 1:
         return 1
 
+    # Large-Q workloads already expose enough independent Q tiles to fill the
+    # GPU. Splitting KV adds FP32 partial output traffic and a combine launch
+    # without providing useful extra parallelism.
+    batch, heads, seqlen_q, _ = q.shape
+    total_q_tiles = batch * heads * _ceil_div_int(seqlen_q, 64)
+    if total_q_tiles >= 512:
+        return 1
+
     if kv_blocks >= 900:
         splits = 8
     elif kv_blocks >= 450:
@@ -1256,14 +1264,14 @@ def choose_blk64_use_clc(
         batch, h, seqlen_q, _ = q.shape
 
     num_m_blocks = (seqlen_q + 63) // 64
-    large_long_topk = num_m_blocks >= 8192 and block_sparse_num >= 512
+    total_tiles = batch * h * num_m_blocks
+    large_long_topk = total_tiles >= 8192 and block_sparse_num >= 256
     if large_long_topk:
         return True
 
     if h == 1:
         return False
 
-    total_tiles = batch * h * num_m_blocks
     enough_tiles = num_m_blocks >= 128 and total_tiles >= 512
     light_tile = block_sparse_num <= (64 if h == 2 else 128)
     return enough_tiles and light_tile
@@ -1386,7 +1394,7 @@ def bsa_attn_fwd_blk64_cutedsl(
         block_sizes,
         q2k_block_nums,
     )
-    use_int64_kv_strides = _sm100_blk64_requires_int64_kv_strides(k_bhsd, v_bhsd)
+    use_exact_kv_layout = _sm100_blk64_requires_int64_kv_strides(k_bhsd, v_bhsd)
 
     if softmax_scale is None:
         softmax_scale = head_dim**-0.5
@@ -1493,7 +1501,7 @@ def bsa_attn_fwd_blk64_cutedsl(
             is_persistent,
             use_clc_scheduler,
             input_layout,
-            use_int64_kv_strides,
+            use_exact_kv_layout,
             is_sage_fp8,
         ),
         (
@@ -1536,7 +1544,7 @@ def bsa_attn_fwd_blk64_cutedsl(
             allow_empty_block_nums=allow_empty_block_nums,
             has_block_sizes=has_block_sizes,
             num_splits=kv_splits_i,
-            use_int64_kv_strides=use_int64_kv_strides,
+            use_exact_kv_layout=use_exact_kv_layout,
         )
 
         bsa_attn_fwd_blk64_cutedsl.compile_cache[compile_key] = cute.compile(

--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -467,13 +467,15 @@ def _blk64_split_workspace_bytes(
     q: torch.Tensor,
     value_dim: int,
     kv_splits: int,
+    output_dtype: Optional[torch.dtype] = None,
 ) -> int:
     """Estimate live split-KV partial, combine-output, and offset storage."""
     batch, num_heads, seqlen_q, _ = q.shape
     num_q_blocks = _ceil_div_int(seqlen_q, 64)
     rows = batch * num_heads * seqlen_q
+    output_element_size = q.element_size() if output_dtype is None else output_dtype.itemsize
     partial_bytes = kv_splits * rows * (value_dim + 1) * 4
-    final_bytes = rows * (value_dim * q.element_size() + 4)
+    final_bytes = rows * (value_dim * output_element_size + 4)
     offset_bytes = batch * num_heads * num_q_blocks * (kv_splits + 1) * 4
     return int(partial_bytes + final_bytes + offset_bytes)
 
@@ -483,6 +485,7 @@ def _resolve_blk64_split_workspace(
     value_dim: int,
     kv_splits: int,
     allow_fallback: bool,
+    output_dtype: Optional[torch.dtype] = None,
 ) -> int:
     """Fit split-KV workspace to currently available CUDA allocator capacity."""
     kv_splits = int(kv_splits)
@@ -499,7 +502,7 @@ def _resolve_blk64_split_workspace(
 
     candidate = kv_splits
     while candidate > 1:
-        required_bytes = _blk64_split_workspace_bytes(q, value_dim, candidate)
+        required_bytes = _blk64_split_workspace_bytes(q, value_dim, candidate, output_dtype)
         if required_bytes <= budget_bytes:
             return candidate
         if not allow_fallback:
@@ -1396,16 +1399,24 @@ def bsa_attn_fwd_blk64_cutedsl(
     tile_m = 64
     tile_n = 256
     if auto_kv_splits:
-        kv_splits_i = _sm100_blk64_auto_kv_splits(
-            q_bhsd,
-            q2k_block_index,
-            uniform_block_sparse_num,
-        )
+        if is_sage_fp8:
+            kv_splits_i = _sm100_blk64_auto_fp8_kv_splits(
+                uniform_block_sparse_num,
+                num_head,
+                seqlen_q,
+            )
+        else:
+            kv_splits_i = _sm100_blk64_auto_kv_splits(
+                q_bhsd,
+                q2k_block_index,
+                uniform_block_sparse_num,
+            )
     kv_splits_i = _resolve_blk64_split_workspace(
         q_bhsd,
         head_dim_v,
         kv_splits_i,
         allow_fallback=auto_kv_splits,
+        output_dtype=output_dtype,
     )
     allow_empty_block_nums = (has_variable_block_nums and allow_empty_block_nums) or kv_splits_i > 1
     if use_clc is None:
@@ -1669,11 +1680,6 @@ def _bsa_fp8_blk64_fwd_quantized(
 
     assert q2k_block_nums is None, "SM100/SM110 FP8 does not support q2k_block_nums"
     assert block_sizes is None, "SM100/SM110 FP8 does not support block_sizes"
-    kv_splits = _sm100_blk64_auto_fp8_kv_splits(
-        block_sparse_num,
-        heads,
-        seqlen_q,
-    )
     out, _ = bsa_attn_fwd_blk64_cutedsl(
         q_fp8,
         k_fp8,
@@ -1684,7 +1690,7 @@ def _bsa_fp8_blk64_fwd_quantized(
         layout="bhsd",
         block_sparse_num=block_sparse_num,
         use_clc=False,
-        kv_splits=kv_splits,
+        kv_splits="auto",
         q_scale=q_scale.contiguous(),
         k_scale=k_scale.contiguous(),
         v_scale=v_scale.contiguous(),

--- a/python/cudnn/block_sparse_attention/api.py
+++ b/python/cudnn/block_sparse_attention/api.py
@@ -145,6 +145,28 @@ def _validate_backward_tensors(
             raise ValueError(f"{name} must be on the same CUDA device as q with a contiguous head dimension")
 
 
+def _validate_sage_inputs(
+    q_tensor: torch.Tensor,
+    k_tensor: torch.Tensor,
+    v_tensor: torch.Tensor,
+) -> tuple[int, int, int, int]:
+    if any(tensor.ndim != 4 for tensor in (q_tensor, k_tensor, v_tensor)):
+        raise ValueError("Sage q, k, and v must be rank-4 BHSD tensors")
+    batch, heads, seqlen_q, head_dim = q_tensor.shape
+    seqlen_k = k_tensor.shape[2]
+    if min(batch, heads, seqlen_q, seqlen_k) < 1:
+        raise ValueError("Sage q, k, and v dimensions must be positive")
+    if head_dim != 128 or k_tensor.shape != (batch, heads, seqlen_k, 128) or v_tensor.shape != k_tensor.shape:
+        raise ValueError("Sage q, k, and v must use matching BHSD shapes with D=128")
+    if any(tensor.dtype != torch.bfloat16 for tensor in (q_tensor, k_tensor, v_tensor)):
+        raise ValueError("Sage q, k, and v must use bfloat16")
+    if any(not tensor.is_cuda or tensor.device != q_tensor.device for tensor in (q_tensor, k_tensor, v_tensor)):
+        raise ValueError("Sage q, k, and v must be on the same CUDA device")
+    if any(not tensor.is_contiguous() for tensor in (q_tensor, k_tensor, v_tensor)):
+        raise ValueError("Sage q, k, and v must use contiguous BHSD storage")
+    return batch, heads, seqlen_q, seqlen_k
+
+
 def block_sparse_attention_forward(
     q_tensor: torch.Tensor,
     k_tensor: torch.Tensor,
@@ -283,6 +305,66 @@ def block_sparse_attention_forward(
     return TupleDict(o_tensor=out, lse_tensor=lse)
 
 
+def block_sparse_attention_fp8_forward(
+    q_tensor: torch.Tensor,
+    k_tensor: torch.Tensor,
+    v_tensor: torch.Tensor,
+    q2k_block_index: torch.Tensor,
+    block_sparse_num: Optional[int] = None,
+    block_sizes: Optional[torch.Tensor] = None,
+    q2k_block_nums: Optional[torch.Tensor] = None,
+    *,
+    softmax_scale: Optional[float] = None,
+) -> TupleDict:
+    """Quantize BF16 inputs internally and run forward-only Sage FP8 blk64 BSA."""
+    batch, heads, seqlen_q, seqlen_k = _validate_sage_inputs(q_tensor, k_tensor, v_tensor)
+    arch = _device_arch(q_tensor)
+    arch_family = arch // 10
+    if arch_family not in {10, 11, 12}:
+        raise RuntimeError(f"Sage FP8 block sparse attention requires SM100-SM120, found SM{arch}")
+    if arch_family in {10, 11}:
+        if batch != 1 or heads not in {4, 8}:
+            raise NotImplementedError("SM100/SM110 Sage FP8 requires B=1 and H in {4, 8}")
+        if seqlen_q % 64 or seqlen_k % 64:
+            raise NotImplementedError("SM100/SM110 Sage FP8 requires Sq and Sk to be multiples of 64")
+        if q2k_block_nums is not None or block_sizes is not None:
+            raise NotImplementedError("q2k_block_nums and block_sizes are supported by Sage FP8 only on SM120")
+
+    expected_prefix = (batch, heads, (seqlen_q + 63) // 64)
+    _validate_sparse_metadata(
+        q2k_block_index,
+        q2k_block_nums,
+        block_sizes,
+        expected_prefix=expected_prefix,
+        num_kv_blocks=(seqlen_k + 63) // 64,
+        device=q_tensor.device,
+        allowed_block_size_ranks=(1, 2, 3) if arch_family == 12 else (1,),
+    )
+    if block_sparse_num is None:
+        block_sparse_num = int(q2k_block_index.shape[-1])
+    if q2k_block_nums is None:
+        _validate_fixed_block_count(
+            block_sparse_num,
+            q2k_block_index.shape[-1],
+            require_even=False,
+        )
+
+    with torch.cuda.device(q_tensor.device):
+        from . import _interface
+
+        out = _interface.bsa_fp8_blk64_fwd(
+            q_tensor,
+            k_tensor,
+            v_tensor,
+            q2k_block_index,
+            block_sparse_num,
+            softmax_scale,
+            block_sizes=block_sizes,
+            q2k_block_nums=q2k_block_nums,
+        )
+    return TupleDict(o_tensor=out)
+
+
 def block_sparse_attention_backward(
     do_tensor: torch.Tensor,
     q_tensor: torch.Tensor,
@@ -399,5 +481,6 @@ def block_sparse_attention_backward(
 
 __all__ = [
     "block_sparse_attention_forward",
+    "block_sparse_attention_fp8_forward",
     "block_sparse_attention_backward",
 ]

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk128/bsa_fwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk128/bsa_fwd_sm100.py
@@ -1174,12 +1174,6 @@ class BlockSparseAttnForwardSm100Blk128:
                         if const_expr(self.uneven_kv_smem):
                             sV_cur = self.offset_kv_smem(sV_cur, Vi_index, Vi_phase)
                         mma_kv_consumer_state.advance()
-                        # Wait K
-                        pipeline_kv.consumer_wait(mma_kv_consumer_state)
-                        Ki_index, Ki_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
-                        sK_cur = sK[None, None, None, Ki_index]
-                        if const_expr(self.uneven_kv_smem):
-                            sK_cur = self.offset_kv_smem(sK_cur, Ki_index, Ki_phase)
                         pipeline_s_p_o.producer_acquire_w_index_phase(stage, phase_cur)
                         gemm_Pi[stage](
                             tCrB=tOrVi,
@@ -1188,6 +1182,12 @@ class BlockSparseAttnForwardSm100Blk128:
                             mbar_ptr=pipeline_p_lastsplit.sync_object_full.get_barrier(stage) if self.split_P_arrive > 0 else None,
                             mbar_phase=phase_cur,
                         )
+                        # Overlap the independent K wait with the issued PV MMA.
+                        pipeline_kv.consumer_wait(mma_kv_consumer_state)
+                        Ki_index, Ki_phase = mma_kv_consumer_state.index, mma_kv_consumer_state.phase
+                        sK_cur = sK[None, None, None, Ki_index]
+                        if const_expr(self.uneven_kv_smem):
+                            sK_cur = self.offset_kv_smem(sK_cur, Ki_index, Ki_phase)
                         gemm_Si[stage](smem_desc_start_b=sm100_desc.make_smem_desc_start_addr(sK_cur.iterator))
                         pipeline_s_p_o.producer_commit_w_index(stage)
                         if const_expr(stage == 0):

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_helpers.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_helpers.py
@@ -9,7 +9,10 @@ from cutlass.cutlass_dsl import T
 from cutlass._mlir.dialects import llvm
 
 from cudnn.block_sparse_attention.csrc.utils import mma_sm100_desc as sm100_desc
-from cudnn.block_sparse_attention.csrc.utils.tcgen05_mma_helpers import i64_to_i32x2
+from cudnn.block_sparse_attention.csrc.utils.tcgen05_mma_helpers import (
+    _tcgen05_mma_kind,
+    i64_to_i32x2,
+)
 
 
 @cute.jit
@@ -67,6 +70,19 @@ def tcgen05_fence_after_thread_sync() -> None:
         None,
         [],
         "tcgen05.fence::after_thread_sync;",
+        "",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def tcgen05_fence_before_thread_sync() -> None:
+    llvm.inline_asm(
+        None,
+        [],
+        "tcgen05.fence::before_thread_sync;",
         "",
         has_side_effects=True,
         is_align_stack=False,
@@ -149,6 +165,32 @@ def cvt_f32x2_to_bf16x2(a: Float32, b: Float32) -> Int32:
 
 
 @cute.jit
+def cvt_f32x4_to_e4m3x4(a: Float32, b: Float32, c: Float32, d: Float32) -> Int32:
+    """Pack four FP32 values into one E4M3x4 register."""
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Float32(a).ir_value(),
+                Float32(b).ir_value(),
+                Float32(c).ir_value(),
+                Float32(d).ir_value(),
+            ],
+            "{\n\t"
+            ".reg .b16 out01, out23;\n\t"
+            "cvt.rn.satfinite.e4m3x2.f32 out01, $2, $1;\n\t"
+            "cvt.rn.satfinite.e4m3x2.f32 out23, $4, $3;\n\t"
+            "mov.b32 $0, {out01, out23};\n\t"
+            "}",
+            "=r,f,f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@cute.jit
 def shr_u32(x: Uint32, shift: Uint32) -> Uint32:
     return Uint32(
         llvm.inline_asm(
@@ -216,6 +258,22 @@ def tmem_store_bf16x16(tmem_addr: Int32, vals: cute.Tensor) -> None:
         [Int32(cute.arch.make_warp_uniform(tmem_addr)).ir_value()] + [Int32(vals[i]).ir_value() for i in range(16)],
         f"tcgen05.st.sync.aligned.32x32b.x16.b32 [$0], {{{regs}}};",
         ",".join(["r"] * 17),
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
+def tmem_store_e4m3x8(tmem_addr: Int32, vals: cute.Tensor) -> None:
+    """Store 32 packed E4M3 values (8 b32 registers) into TMEM."""
+    assert cute.size(vals) == 8
+    regs = ", ".join(f"${i + 1}" for i in range(8))
+    llvm.inline_asm(
+        None,
+        [Int32(cute.arch.make_warp_uniform(tmem_addr)).ir_value()] + [Int32(vals[i]).ir_value() for i in range(8)],
+        f"tcgen05.st.sync.aligned.32x32b.x8.b32 [$0], {{{regs}}};",
+        ",".join(["r"] * 9),
         has_side_effects=True,
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,
@@ -380,6 +438,85 @@ def smem_exchange_reduce_store_bf16x32(
 
 
 @cute.jit
+def smem_exchange_reduce_scale_store_bf16x32(
+    own_exchange_smem_addr: Int32,
+    partner_exchange_smem_addr: Int32,
+    sO_smem_addr0: Int32,
+    sO_smem_addr1: Int32,
+    sO_smem_addr2: Int32,
+    sO_smem_addr3: Int32,
+    scale_smem_addr0: Int32,
+    scale_smem_addr1: Int32,
+    scale_smem_addr2: Int32,
+    scale_smem_addr3: Int32,
+) -> None:
+    """Reduce two FP32 exchange tiles, apply V scale, then convert once."""
+    load_ops = "\n\t".join(
+        f"add.u32 addr_own, own, {group * 32 * 4 * 4};\n\t"
+        f"add.u32 addr_partner, partner, {group * 32 * 4 * 4};\n\t"
+        f"ld.shared.v4.b32 {{a{group * 4 + 0}, a{group * 4 + 1}, a{group * 4 + 2}, a{group * 4 + 3}}}, [addr_own];\n\t"
+        f"ld.shared.v4.b32 {{b{group * 4 + 0}, b{group * 4 + 1}, b{group * 4 + 2}, b{group * 4 + 3}}}, [addr_partner];"
+        for group in range(8)
+    )
+    scale_load_ops = "\n\t".join(f"ld.shared.b32 v{group * 8 + item}, [${6 + group}+{item * 4}];" for group in range(4) for item in range(8))
+    add_scale_ops = "\n\t".join(
+        f"mov.b64 la, {{a{i}, a{i + 1}}};\n\t"
+        f"mov.b64 lb, {{b{i}, b{i + 1}}};\n\t"
+        f"mov.b64 lv, {{v{i}, v{i + 1}}};\n\t"
+        "add.rn.f32x2 la, la, lb;\n\t"
+        "mul.rn.f32x2 la, la, lv;\n\t"
+        f"mov.b64 {{a{i}, a{i + 1}}}, la;"
+        for i in range(0, 32, 2)
+    )
+    store_ops = "\n\t".join(
+        f"cvt.rn.satfinite.bf16x2.f32 p0, a{j + 1}, a{j + 0};\n\t"
+        f"cvt.rn.satfinite.bf16x2.f32 p1, a{j + 3}, a{j + 2};\n\t"
+        f"cvt.rn.satfinite.bf16x2.f32 p2, a{j + 5}, a{j + 4};\n\t"
+        f"cvt.rn.satfinite.bf16x2.f32 p3, a{j + 7}, a{j + 6};\n\t"
+        f"st.shared.v4.b32 [${2 + j // 8}], {{p0, p1, p2, p3}};"
+        for j in range(0, 32, 8)
+    )
+    llvm.inline_asm(
+        None,
+        [
+            Int32(own_exchange_smem_addr).ir_value(),
+            Int32(partner_exchange_smem_addr).ir_value(),
+            Int32(sO_smem_addr0).ir_value(),
+            Int32(sO_smem_addr1).ir_value(),
+            Int32(sO_smem_addr2).ir_value(),
+            Int32(sO_smem_addr3).ir_value(),
+            Int32(scale_smem_addr0).ir_value(),
+            Int32(scale_smem_addr1).ir_value(),
+            Int32(scale_smem_addr2).ir_value(),
+            Int32(scale_smem_addr3).ir_value(),
+        ],
+        "{\n\t"
+        ".reg .b32 own;\n\t"
+        ".reg .b32 partner;\n\t"
+        ".reg .b32 addr_own;\n\t"
+        ".reg .b32 addr_partner;\n\t"
+        ".reg .b32 a<32>;\n\t"
+        ".reg .b32 b<32>;\n\t"
+        ".reg .b32 v<32>;\n\t"
+        ".reg .b32 p<4>;\n\t"
+        ".reg .b64 la;\n\t"
+        ".reg .b64 lb;\n\t"
+        ".reg .b64 lv;\n\t"
+        "mov.b32 own, $0;\n\t"
+        "mov.b32 partner, $1;\n\t"
+        f"{load_ops}\n\t"
+        f"{scale_load_ops}\n\t"
+        f"{add_scale_ops}\n\t"
+        f"{store_ops}\n\t"
+        "}\n",
+        "r,r,r,r,r,r,r,r,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@cute.jit
 def smem_exchange_reduce_store_f32x32(
     own_exchange_smem_addr: Int32,
     partner_exchange_smem_addr: Int32,
@@ -504,7 +641,8 @@ def gemm_ptx_partial(
     pred_str = "p" if zero_init_is_dynamic else "0" if zero_init else "1"
     pred_input = zero_init if zero_init_is_dynamic else not zero_init
     pred_setp = "setp.eq.b32" if zero_init_is_dynamic else "setp.ne.b32"
-    mma_instr = "tcgen05.mma.ws.cta_group::1.kind::f16"
+    mma_kind = _tcgen05_mma_kind(op)
+    mma_instr = f"tcgen05.mma.ws.cta_group::1.kind::{mma_kind}"
     mma_suffix = ", 0"
     if const_expr(not is_ts):
         assert mbar_ptr is None, "mbar_ptr must be None when a_src is not TMEM"
@@ -574,7 +712,7 @@ def gemm_ptx_partial(
                 "mbarrier.try_wait.parity.shared::cta.b64 P1, [$4], $5, 1; \n\t"
                 "@P1 bra.uni DONE; \n\t"
                 "bra.uni LAB_WAIT; \n\t"
-                "DONE: \n\t"
+                "DONE: \n\t" + ("tcgen05.fence::after_thread_sync; \n\t" if const_expr(op.a_dtype.width == 8) else "")
             )
         else:
             split_arrive_idx = 0

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_helpers.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_helpers.py
@@ -150,6 +150,31 @@ def tmem_load_32dp32b32x(tmem_addr: Int32) -> Tuple[Float32, ...]:
 
 
 @cute.jit
+def tmem_load_red_max_32dp32b32x(
+    tmem_addr: Int32,
+) -> Tuple[Tuple[Float32, ...], Float32]:
+    """Load 32 FP32 TMEM values and return their hardware-reduced maximum."""
+    out = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32()] * 33),
+        [Int32(cute.arch.make_warp_uniform(tmem_addr)).ir_value()],
+        "tcgen05.ld.red.sync.aligned.32x32b.x32.max.f32 "
+        "{"
+        "$0, $1, $2, $3, $4, $5, $6, $7, "
+        "$8, $9, $10, $11, $12, $13, $14, $15, "
+        "$16, $17, $18, $19, $20, $21, $22, $23, "
+        "$24, $25, $26, $27, $28, $29, $30, $31"
+        "}, $32, [$33];",
+        ",".join(["=r"] * 33 + ["r"]),
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    values = tuple(Float32(llvm.extractvalue(T.f32(), out, [i])) for i in range(32))
+    row_max = Float32(llvm.extractvalue(T.f32(), out, [32]))
+    return values, row_max
+
+
+@cute.jit
 def cvt_f32x2_to_bf16x2(a: Float32, b: Float32) -> Int32:
     return Int32(
         llvm.inline_asm(

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py
@@ -68,7 +68,7 @@ class BlockSparseAttnForwardSm100Blk64:
         allow_empty_block_nums: cutlass.Constexpr[bool] = False,
         has_block_sizes: cutlass.Constexpr[bool] = True,
         num_splits: cutlass.Constexpr[int] = 1,
-        use_int64_kv_strides: cutlass.Constexpr[bool] = False,
+        use_exact_kv_layout: cutlass.Constexpr[bool] = False,
     ):
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
@@ -127,7 +127,7 @@ class BlockSparseAttnForwardSm100Blk64:
         self.is_split_kv = num_splits > 1
         self.allow_empty_block_nums = allow_empty_block_nums
         self.has_block_sizes = has_block_sizes
-        self.use_int64_kv_strides = use_int64_kv_strides
+        self.use_exact_kv_layout = use_exact_kv_layout
         self.qhead_per_kvhead = qhead_per_kvhead
         self.pack_gqa = pack_gqa
         if pack_gqa:
@@ -321,13 +321,11 @@ class BlockSparseAttnForwardSm100Blk64:
         num_splits = Int32(self.num_splits)
         mO = cute.make_tensor(mO.iterator, cute.select(mO.layout, mode=O_layout_transpose))
         mLSE = cute.make_tensor(mLSE.iterator, cute.select(mLSE.layout, mode=LSE_layout_transpose)) if const_expr(mLSE is not None) else None
-        # The fast rank-6 view matches the C++ sparse-block layout. CuTe DSL
-        # cannot lower an Int64 basis in that rank-6 TMA view, so layouts with
-        # large active strides use a rank-5 Int64 view and divide it into
-        # sparse blocks in the device kernel instead.
+        # The normal layout maps physical 64-token KV blocks directly. Keep the
+        # exact rank-5 layout only for strides outside the TMA coordinate range.
         k_dim_half = self.head_dim_padded // 2
         v_dim_part = self.head_dim_v_padded // 2
-        if const_expr(self.use_int64_kv_strides):
+        if const_expr(self.use_exact_kv_layout):
             k_stride_s = Int64(mK_seq.layout.stride[0])
             k_stride_d = Int64(mK_seq.layout.stride[1])
             k_stride_h = Int64(mK_seq.layout.stride[2])
@@ -777,6 +775,7 @@ class BlockSparseAttnForwardSm100Blk64:
             mbar_O_full: cute.struct.MemRange[Int64, self.s_stage * 2]
             mbar_softmax_stats: cute.struct.MemRange[Int64, self.s_stage * 2]
             mbar_O_epi: cute.struct.MemRange[Int64, self.s_stage * 2]
+            mbar_load_epi: cute.struct.MemRange[Int64, 2]
             # Tmem holding buffer
             tmem_holding_buf: Int32
             # Per warp-pair reduction barriers for correction exchange.
@@ -924,10 +923,12 @@ class BlockSparseAttnForwardSm100Blk64:
         ThreadCooperativeGroup = partial(pipeline.CooperativeGroup, pipeline.Agent.Thread)
         mma_warp = ThreadCooperativeGroup(len([self.mma_warp_id]))
         tma_warp = ThreadCooperativeGroup(1)
+        load_warps = ThreadCooperativeGroup(len(self.load_warp_ids))
         softmax_warps = ThreadCooperativeGroup(len(self.softmax0_warp_ids))
         softmax_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE * len(self.softmax0_warp_ids))
         correction_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE * len(self.correction_warp_ids))
         softmax_correction_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE * len(self.softmax0_warp_ids + self.correction_warp_ids))
+        epilogue_warps = ThreadCooperativeGroup(len(self.epilogue_warp_ids))
         epilogue_threads = ThreadCooperativeGroup(cute.arch.WARP_SIZE * len(self.epilogue_warp_ids))
         pipeline_q = pipeline_custom.PipelineTmaUmma.create(
             barrier_storage=storage.mbar_load_Q.data_ptr(),
@@ -988,6 +989,16 @@ class BlockSparseAttnForwardSm100Blk64:
             consumer_group=epilogue_threads,
             defer_sync=True,
         )
+        pipeline_load_epi = None
+        if const_expr(self.is_persistent):
+            # Protect aliased KV/O storage across persistent work tiles.
+            pipeline_load_epi = pipeline_custom.PipelineAsync.create(
+                barrier_storage=storage.mbar_load_epi.data_ptr(),
+                num_stages=1,
+                producer_group=epilogue_warps,
+                consumer_group=load_warps,
+                defer_sync=True,
+            )
 
         if warp_idx == self.empty_warp_ids[0]:
             with cute.arch.elect_one():
@@ -1121,6 +1132,7 @@ class BlockSparseAttnForwardSm100Blk64:
                 tma_atom_V,
                 pipeline_q,
                 pipeline_kv,
+                pipeline_load_epi,
                 tile_scheduler,
                 mBlockIndex,
                 block_sparse_num,
@@ -1180,6 +1192,7 @@ class BlockSparseAttnForwardSm100Blk64:
                 gmem_tiled_copy_O,
                 tma_atom_O,
                 pipeline_o_epi,
+                pipeline_load_epi,
                 SeqlenInfoCls,
                 tile_scheduler,
                 num_q_heads,
@@ -1358,6 +1371,7 @@ class BlockSparseAttnForwardSm100Blk64:
         tma_atom_V: cute.CopyAtom,
         pipeline_q: pipeline.PipelineAsync,
         pipeline_kv: pipeline.PipelineAsync,
+        pipeline_load_epi: Optional[pipeline.PipelineAsync],
         tile_scheduler: TileSchedulerProtocol,
         mBlockIndex: cute.Tensor,
         block_sparse_num: Int32,
@@ -1369,6 +1383,7 @@ class BlockSparseAttnForwardSm100Blk64:
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         q_producer_phase = Int32(1)
         kv_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.kv_stage)
+        load_epi_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1) if const_expr(pipeline_load_epi is not None) else None
         tiler_gQ = ((self.mma_tiler_qk[0] * self.q_stage), self.head_dim_padded)
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
@@ -1398,7 +1413,7 @@ class BlockSparseAttnForwardSm100Blk64:
                 load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(tma_atom_Q, 0, cute.make_layout(1), tSgQ, sQ)
 
             head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
-            if const_expr(self.use_int64_kv_strides):
+            if const_expr(self.use_exact_kv_layout):
                 mK_cur = mK[None, None, None, head_idx_kv, batch_idx]
                 mV_cur = mV[None, None, None, head_idx_kv, batch_idx]
                 gK_tma = cute.zipped_divide(mK_cur, (self.sparse_block_size, self.head_dim_padded // 2, 2))
@@ -1510,6 +1525,11 @@ class BlockSparseAttnForwardSm100Blk64:
 
             tile_scheduler.prefetch_next_work()
             work_tile = tile_scheduler.consumer_advance()
+            if const_expr(pipeline_load_epi is not None):
+                pipeline_load_epi.consumer_wait(load_epi_consumer_state)
+                with cute.arch.elect_one():
+                    pipeline_load_epi.consumer_release(load_epi_consumer_state)
+                load_epi_consumer_state.advance()
             # End of persistent scheduler loop
 
         pipeline_kv.producer_tail(kv_producer_state)
@@ -2055,6 +2075,32 @@ class BlockSparseAttnForwardSm100Blk64:
         return tile_block_indices[idx]
 
     @cute.jit
+    def update_row_max_precomputed(
+        self,
+        softmax: SoftmaxSm100,
+        row_max_tile: Float32,
+        is_first: bool,
+    ) -> Tuple[Float32, Float32]:
+        """Update online-softmax state from an already reduced tile maximum."""
+        if const_expr(is_first):
+            row_max_new = row_max_tile
+            row_max_safe = row_max_new if row_max_new != -Float32.inf else Float32(0.0)
+            acc_scale = Float32(0.0)
+        else:
+            row_max_old = softmax.row_max[0]
+            row_max_new = cute.arch.fmax(row_max_tile, row_max_old)
+            row_max_safe = row_max_new if row_max_new != -Float32.inf else Float32(0.0)
+            acc_scale_log2 = (row_max_old - row_max_safe) * softmax.scale_log2
+            acc_scale = cute.math.exp2(acc_scale_log2, fastmath=True)
+            if const_expr(softmax.rescale_threshold > 0.0):
+                if acc_scale_log2 >= -softmax.rescale_threshold:
+                    row_max_new = row_max_old
+                    row_max_safe = row_max_old
+                    acc_scale = Float32(1.0)
+        softmax.row_max[0] = row_max_new
+        return row_max_safe, acc_scale
+
+    @cute.jit
     def softmax_step(
         self,
         mma_si_consumer_phase: Int32,
@@ -2116,9 +2162,15 @@ class BlockSparseAttnForwardSm100Blk64:
                     cache_idx = stage * 16 + (warp_col + block_idx * 2) * 4 + key_scale_group
                     qk_scales[scale_idx] = q_log2_scale * sKScale[cache_idx]
 
+        use_ldred_rowmax = self.arch >= Arch.sm_103 and self.arch <= Arch.sm_103f and not self.is_sage_fp8
         tSrS_t2r = cute.make_rmem_tensor((128,), Float32)
+        row_max_tile = -Float32.inf
         for c in cutlass.range_constexpr(4):
-            vals = bsa_fwd_helpers.tmem_load_32dp32b32x(tmem_s_addr + c * 32)
+            if const_expr(use_ldred_rowmax):
+                vals, row_max_chunk = bsa_fwd_helpers.tmem_load_red_max_32dp32b32x(tmem_s_addr + c * 32)
+                row_max_tile = cute.arch.fmax(row_max_tile, row_max_chunk)
+            else:
+                vals = bsa_fwd_helpers.tmem_load_32dp32b32x(tmem_s_addr + c * 32)
             for j in cutlass.range_constexpr(32):
                 tSrS_t2r[c * 32 + j] = vals[j]
 
@@ -2158,7 +2210,20 @@ class BlockSparseAttnForwardSm100Blk64:
                         scaled_group_max[scale_idx] = group_max * qk_scale
             row_max, acc_scale = softmax.update_row_max(scaled_group_max.load(), is_first)
         else:
-            row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
+            if const_expr(use_ldred_rowmax):
+                full_blocks = (block_size_lo == Int32(self.sparse_block_size)) & (block_size_hi == Int32(self.sparse_block_size))
+                row_max = Float32(0.0)
+                acc_scale = Float32(0.0)
+                if full_blocks:
+                    row_max, acc_scale = self.update_row_max_precomputed(
+                        softmax,
+                        row_max_tile,
+                        is_first,
+                    )
+                else:
+                    row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
+            else:
+                row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
 
         if const_expr(not is_first):
             sScale[tidx + stage * self.stats_stride] = acc_scale
@@ -2726,11 +2791,13 @@ class BlockSparseAttnForwardSm100Blk64:
         gmem_tiled_copy_O: cute.TiledCopy,
         tma_atom_O: Optional[cute.CopyAtom],
         pipeline_o_epi: pipeline.PipelineAsync,
+        pipeline_load_epi: Optional[pipeline.PipelineAsync],
         SeqlenInfoCls: Callable,
         tile_scheduler: TileSchedulerProtocol,
         num_heads: Int32,
     ):
         epi_consumer_phase = Int32(0)
+        load_epi_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1) if const_expr(pipeline_load_epi is not None) else None
         tiler_gO = ((self.mma_tiler_pv[0] * self.q_stage), self.head_dim_v_padded)
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
@@ -2786,6 +2853,12 @@ class BlockSparseAttnForwardSm100Blk64:
                     pipeline_o_epi.consumer_release_w_index(stage)
 
             epi_consumer_phase ^= 1
+
+            if const_expr(pipeline_load_epi is not None):
+                pipeline_load_epi.producer_acquire(load_epi_producer_state)
+                with cute.arch.elect_one():
+                    pipeline_load_epi.producer_commit(load_epi_producer_state)
+                load_epi_producer_state.advance()
 
             # Advance to next tile
             work_tile = tile_scheduler.consumer_advance()

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm100_blk64/bsa_fwd_sm100.py
@@ -47,6 +47,10 @@ from cudnn.block_sparse_attention.csrc.utils.block_sparse_tile_scheduler import 
 )
 from cudnn.block_sparse_attention.csrc.utils.tile_scheduler import SingleTileScheduler
 
+SAGE_P_QUANT_SCALE = 256.0
+SAGE_P_QUANT_LOG2_SCALE = math.log2(SAGE_P_QUANT_SCALE)
+SAGE_P_RESCALE_THRESHOLD = math.log2(448.0 / SAGE_P_QUANT_SCALE)
+
 
 class BlockSparseAttnForwardSm100Blk64:
 
@@ -119,7 +123,6 @@ class BlockSparseAttnForwardSm100Blk64:
         self.sched_stages = 1
         self.scheduling_mode = SchedulingMode.CLC if self.use_clc_scheduler else SchedulingMode.STATIC
         assert num_splits >= 1, "num_splits must be >= 1"
-        assert not (num_splits > 1 and self.use_clc_scheduler), "split-KV CuTeDSL fwd does not support CLC"
         self.num_splits = num_splits
         self.is_split_kv = num_splits > 1
         self.allow_empty_block_nums = allow_empty_block_nums
@@ -167,7 +170,9 @@ class BlockSparseAttnForwardSm100Blk64:
         self.tmem_p_offset = self.tmem_s_offset
         self.tmem_s_to_p_offset = 0
         self.epi_exchange_f32_count = 4 * 4 * 32 * 32
-        self.epi_sO_bf16_offset = self.epi_exchange_f32_count * 2
+        # Filled in once the input dtype is known.  This is an offset in
+        # elements of the shared K/V allocation, not an offset in bytes.
+        self.epi_sO_input_offset = self.epi_exchange_f32_count * 2
 
         # vec buffer for row_max & row_sum
         self.tmem_vec_offset = self.tmem_s_offset
@@ -177,14 +182,8 @@ class BlockSparseAttnForwardSm100Blk64:
             self.num_regs_correction = 64
             self.num_regs_other = 48
         else:
-            if not self.enable_ex2_emu:
-                self.num_regs_softmax = 184
-            else:
-                self.num_regs_softmax = 184
-            if not self.enable_ex2_emu:
-                self.num_regs_correction = 88
-            else:
-                self.num_regs_correction = 88
+            self.num_regs_softmax = 184
+            self.num_regs_correction = 88
             self.num_regs_other = 48
 
         self.buffer_align_bytes = 1024
@@ -199,6 +198,13 @@ class BlockSparseAttnForwardSm100Blk64:
         - Configures pipeline stages for softmax, correction, and epilogue operations
         """
 
+        # Sage keeps both P and V in E4M3 for one native FP8 PV MMA. Map the
+        # unnormalized softmax probabilities from [0, 1] to the full E4M3
+        # nominal range [0, 256]. Values may use the remaining E4M3 headroom up
+        # to 448 while online softmax keeps its old reference maximum across
+        # small increases, avoiding an O TMEM rescale. The same factor is carried
+        # by the softmax sum, so it cancels during normalization and only V's
+        # per-channel scale remains.
         smem_size_q = self.q_stage * self.m_block_size * self.head_dim_padded * self.q_dtype.width // 8
         smem_size_o = self.s_stage * self.m_block_size * self.head_dim_v_padded * self.o_dtype.width // 8
         smem_size_q_o = smem_size_q + smem_size_o if not self.overlap_sO_sQ else max(smem_size_q, smem_size_o)
@@ -230,6 +236,9 @@ class BlockSparseAttnForwardSm100Blk64:
         mV: cute.Tensor,  # (b_k, h_k, s_k, dv)
         mO: cute.Tensor,  # (b, h, s_q, dv)
         mLSE: Optional[cute.Tensor],
+        mQScale: Optional[cute.Tensor],  # Sage FP8: (b, h, s_q)
+        mKScale: Optional[cute.Tensor],  # Sage FP8: (b, h, ceil(s_k / 16))
+        mVScale: Optional[cute.Tensor],  # Sage FP8: (h, dv)
         softmax_scale: Float32,
         mBlockIndex: cute.Tensor,  # (batch, heads, num_q_blocks, max_kv_blocks), int32
         mBlockSizes: Optional[cute.Tensor],  # (num_kv_blocks,), int32 or None
@@ -256,9 +265,54 @@ class BlockSparseAttnForwardSm100Blk64:
         self.k_dtype = mK.element_type
         self.v_dtype = mV.element_type
         self.o_dtype = mO.element_type
+        self.epi_sO_input_offset = self.epi_exchange_f32_count * (Float32.width // self.k_dtype.width)
+        self.is_sage_fp8 = mQScale is not None
+        if const_expr(self.is_sage_fp8):
+            if const_expr(mKScale is None or mVScale is None):
+                raise TypeError("Sage FP8 requires Q, K, and V scale tensors")
+            if const_expr(self.q_dtype != cutlass.Float8E4M3FN):
+                raise TypeError("Sage FP8 inputs must be E4M3")
+            if const_expr(mQScale.element_type != Float32 or mKScale.element_type != Float32 or mVScale.element_type != Float32):
+                raise TypeError("Sage FP8 scales must be FP32")
+            expected_o_dtype = Float32 if const_expr(self.is_split_kv) else cutlass.BFloat16
+            if const_expr(self.o_dtype != expected_o_dtype):
+                raise TypeError("Sage FP8 output must be FP32 partials for split-KV, otherwise BF16")
+        elif const_expr(mKScale is not None or mVScale is not None):
+            raise TypeError("Q, K, and V scales must be provided together")
         mQ, mK, mV, mO = [assume_tensor_aligned(t) for t in (mQ, mK, mV, mO)]
         Q_layout_transpose = [2, 3, 1, 0]
-        mQ = cute.make_tensor(mQ.iterator, cute.select(mQ.layout, mode=Q_layout_transpose))
+        mQ_seq = cute.make_tensor(mQ.iterator, cute.select(mQ.layout, mode=Q_layout_transpose))
+        seqlen_q_static = mQ_seq.shape[0]
+        num_q_heads_static = mQ_seq.shape[2]
+        batch_size_static = mQ_seq.shape[3]
+        if const_expr(self.is_sage_fp8):
+            q_stride_s = Int32(mQ_seq.layout.stride[0])
+            q_stride_d = Int32(mQ_seq.layout.stride[1])
+            q_stride_h = Int32(mQ_seq.layout.stride[2])
+            q_stride_b = Int32(mQ_seq.layout.stride[3])
+            mQ = cute.make_tensor(
+                mQ_seq.iterator,
+                cute.make_layout(
+                    (
+                        self.head_dim_padded,
+                        32,
+                        2,
+                        mQ_seq.shape[2],
+                        cute.ceil_div(mQ_seq.shape[0], self.m_block_size),
+                        mQ_seq.shape[3],
+                    ),
+                    stride=(
+                        q_stride_d,
+                        q_stride_s,
+                        32 * q_stride_s,
+                        q_stride_h,
+                        self.m_block_size * q_stride_s,
+                        q_stride_b,
+                    ),
+                ),
+            )
+        else:
+            mQ = mQ_seq
         # (s_k, d, h_k, b_k)
         KV_layout_transpose = [2, 3, 1, 0]
         mK_seq, mV_seq = [cute.make_tensor(t.iterator, cute.select(t.layout, mode=KV_layout_transpose)) for t in (mK, mV)]
@@ -325,52 +379,101 @@ class BlockSparseAttnForwardSm100Blk64:
             k_stride_d = Int32(mK_seq.layout.stride[1])
             k_stride_h = Int32(mK_seq.layout.stride[2])
             k_stride_b = Int32(mK_seq.layout.stride[3])
-            mK = cute.make_tensor(
-                mK_seq.iterator,
-                cute.make_layout(
-                    (
-                        self.sparse_block_size,
-                        k_dim_half,
-                        2,
-                        mK_seq.shape[2],
-                        cute.ceil_div(mK_seq.shape[0], self.sparse_block_size),
-                        mK_seq.shape[3],
+            if const_expr(self.is_sage_fp8):
+                mK = cute.make_tensor(
+                    mK_seq.iterator,
+                    cute.make_layout(
+                        (
+                            self.head_dim_padded,
+                            32,
+                            2,
+                            mK_seq.shape[2],
+                            cute.ceil_div(mK_seq.shape[0], self.sparse_block_size),
+                            mK_seq.shape[3],
+                        ),
+                        stride=(
+                            k_stride_d,
+                            k_stride_s,
+                            32 * k_stride_s,
+                            k_stride_h,
+                            self.sparse_block_size * k_stride_s,
+                            k_stride_b,
+                        ),
                     ),
-                    stride=(
-                        k_stride_s,
-                        k_stride_d,
-                        k_dim_half * k_stride_d,
-                        k_stride_h,
-                        self.sparse_block_size * k_stride_s,
-                        k_stride_b,
+                )
+            else:
+                mK = cute.make_tensor(
+                    mK_seq.iterator,
+                    cute.make_layout(
+                        (
+                            self.sparse_block_size,
+                            k_dim_half,
+                            2,
+                            mK_seq.shape[2],
+                            cute.ceil_div(mK_seq.shape[0], self.sparse_block_size),
+                            mK_seq.shape[3],
+                        ),
+                        stride=(
+                            k_stride_s,
+                            k_stride_d,
+                            k_dim_half * k_stride_d,
+                            k_stride_h,
+                            self.sparse_block_size * k_stride_s,
+                            k_stride_b,
+                        ),
                     ),
-                ),
-            )
+                )
             v_stride_s = Int32(mV_seq.layout.stride[0])
             v_stride_d = Int32(mV_seq.layout.stride[1])
             v_stride_h = Int32(mV_seq.layout.stride[2])
             v_stride_b = Int32(mV_seq.layout.stride[3])
-            mV = cute.make_tensor(
-                mV_seq.iterator,
-                cute.make_layout(
-                    (
-                        v_dim_part,
-                        self.sparse_block_size,
-                        2,
-                        mV_seq.shape[2],
-                        cute.ceil_div(mV_seq.shape[0], self.sparse_block_size),
-                        mV_seq.shape[3],
+            if const_expr(self.is_sage_fp8):
+                # FP8 PV uses the native SM100 B-major layout: D is
+                # contiguous and a 64-token sparse block is represented as
+                # two 32-token MMA-K groups.
+                mV = cute.make_tensor(
+                    mV_seq.iterator,
+                    cute.make_layout(
+                        (
+                            self.head_dim_v_padded,
+                            32,
+                            2,
+                            mV_seq.shape[2],
+                            cute.ceil_div(mV_seq.shape[0], self.sparse_block_size),
+                            mV_seq.shape[3],
+                        ),
+                        stride=(
+                            v_stride_d,
+                            v_stride_s,
+                            32 * v_stride_s,
+                            v_stride_h,
+                            self.sparse_block_size * v_stride_s,
+                            v_stride_b,
+                        ),
                     ),
-                    stride=(
-                        v_stride_d,
-                        v_stride_s,
-                        v_dim_part * v_stride_d,
-                        v_stride_h,
-                        self.sparse_block_size * v_stride_s,
-                        v_stride_b,
+                )
+            else:
+                mV = cute.make_tensor(
+                    mV_seq.iterator,
+                    cute.make_layout(
+                        (
+                            v_dim_part,
+                            self.sparse_block_size,
+                            2,
+                            mV_seq.shape[2],
+                            cute.ceil_div(mV_seq.shape[0], self.sparse_block_size),
+                            mV_seq.shape[3],
+                        ),
+                        stride=(
+                            v_stride_d,
+                            v_stride_s,
+                            v_dim_part * v_stride_d,
+                            v_stride_h,
+                            self.sparse_block_size * v_stride_s,
+                            v_stride_b,
+                        ),
                     ),
-                ),
-            )
+                )
 
         # check type consistency
         if const_expr(self.q_dtype != self.k_dtype):
@@ -378,7 +481,10 @@ class BlockSparseAttnForwardSm100Blk64:
         if const_expr(self.q_dtype != self.v_dtype):
             raise TypeError(f"Type mismatch: {self.q_dtype} != {self.v_dtype}")
         self._setup_attributes()
-        self.use_tma_O = self.arch >= Arch.sm_90
+        # Sage V has a different scale for every output channel.  The FP8
+        # path therefore uses the register epilogue so that scale can be
+        # applied immediately before the BF16 store.
+        self.use_tma_O = self.arch >= Arch.sm_90 and not self.is_sage_fp8
         # This can be tuned
         # This is currently very ad-hoc, we should tune it systematically
         self.ex2_emu_freq = 0
@@ -418,64 +524,100 @@ class BlockSparseAttnForwardSm100Blk64:
         self.epi_tile = (self.m_block_size, self.head_dim_v_padded)
 
         sQ_layout = sm100_utils_basic.make_smem_layout_a(tiled_mma_qk, self.mma_tiler_qk, self.q_dtype, self.q_stage)
+        sQ_tma_layout = (
+            cute.make_composed_layout(
+                cute.make_swizzle(3, 4, 3),
+                0,
+                cute.make_layout(
+                    (self.head_dim_padded, 32, 2),
+                    stride=(1, self.head_dim_padded, 32 * self.head_dim_padded),
+                ),
+            )
+            if const_expr(self.is_sage_fp8)
+            else None
+        )
         sK_layout = sm100_utils_basic.make_smem_layout_b(tiled_mma_qk, self.mma_tiler_qk, self.k_dtype, self.kv_stage)
         tP_layout = sm100_utils_basic.make_smem_layout_a(tiled_mma_pv, self.mma_tiler_pv, self.q_dtype, self.s_stage)
         # C++ SmemLayoutVDual in the MMA-fragment shape expected by CuTeDSL.
         # The K-groups must stay nested as (4,2): the second dim half jumps by
         # 16384 elements, while groups inside one half advance by 1024.
-        sV_layout = cute.make_composed_layout(
-            cute.make_swizzle(3, 4, 3),
-            0,
-            cute.make_layout(
-                (
-                    ((v_dim_part, self.sparse_blocks_per_kv), 16),
-                    1,
-                    (4, 2),
-                    self.kv_stage,
-                ),
-                stride=(
-                    ((1, v_dim_part * self.sparse_block_size), v_dim_part),
-                    0,
+        if const_expr(self.is_sage_fp8):
+            sV_layout = sm100_utils_basic.make_smem_layout_b(
+                tiled_mma_pv,
+                self.mma_tiler_pv,
+                self.v_dtype,
+                self.kv_stage,
+            )
+        else:
+            sV_layout = cute.make_composed_layout(
+                cute.make_swizzle(3, 4, 3),
+                0,
+                cute.make_layout(
                     (
-                        16 * v_dim_part,
-                        v_dim_part * self.sparse_block_size * self.sparse_blocks_per_kv,
+                        ((v_dim_part, self.sparse_blocks_per_kv), 16),
+                        1,
+                        (4, 2),
+                        self.kv_stage,
                     ),
-                    self.kv_elems_per_stage,
+                    stride=(
+                        ((1, v_dim_part * self.sparse_block_size), v_dim_part),
+                        0,
+                        (
+                            16 * v_dim_part,
+                            v_dim_part * self.sparse_block_size * self.sparse_blocks_per_kv,
+                        ),
+                        self.kv_elems_per_stage,
+                    ),
                 ),
-            ),
-        )
+            )
         # Exact C++ SmemLayoutKWide:
         #   Sw<3,4,3> o _0 o (_64,_64,_2):(_64,_1,_16384)
         # A sparse sub-block advances by 4096 elements, while the second
         # dim half jumps by the full 256-token half stride.
-        sK_tma_layout = cute.make_composed_layout(
-            cute.make_swizzle(3, 4, 3),
-            0,
-            cute.make_layout(
-                (self.sparse_block_size, k_dim_half, 2),
-                stride=(
-                    k_dim_half,
-                    1,
-                    self.n_block_size * k_dim_half,
+        if const_expr(self.is_sage_fp8):
+            sK_tma_layout = cute.make_composed_layout(
+                cute.make_swizzle(3, 4, 3),
+                0,
+                cute.make_layout(
+                    (self.head_dim_padded, 32, 2),
+                    stride=(1, self.head_dim_padded, 32 * self.head_dim_padded),
                 ),
-            ),
-        )
+            )
+        else:
+            sK_tma_layout = cute.make_composed_layout(
+                cute.make_swizzle(3, 4, 3),
+                0,
+                cute.make_layout(
+                    (self.sparse_block_size, k_dim_half, 2),
+                    stride=(k_dim_half, 1, self.n_block_size * k_dim_half),
+                ),
+            )
         # Exact C++ SmemLayoutVWide:
         #   Sw<3,4,3> o _0 o (_64,_64,_2):(_1,_64,_4096)
         # It writes both 64-dim halves for one sparse 64-token block while
         # preserving the offsets consumed by the full VDual PV layout.
-        sV_tma_layout = cute.make_composed_layout(
-            cute.make_swizzle(3, 4, 3),
-            0,
-            cute.make_layout(
-                (v_dim_part, self.sparse_block_size, 2),
-                stride=(
-                    1,
-                    v_dim_part,
-                    v_dim_part * self.sparse_block_size,
+        if const_expr(self.is_sage_fp8):
+            sV_tma_layout = cute.make_composed_layout(
+                cute.make_swizzle(3, 4, 3),
+                0,
+                cute.make_layout(
+                    (self.head_dim_v_padded, 32, 2),
+                    stride=(1, self.head_dim_v_padded, 32 * self.head_dim_v_padded),
                 ),
-            ),
-        )
+            )
+        else:
+            sV_tma_layout = cute.make_composed_layout(
+                cute.make_swizzle(3, 4, 3),
+                0,
+                cute.make_layout(
+                    (v_dim_part, self.sparse_block_size, 2),
+                    stride=(
+                        1,
+                        v_dim_part,
+                        v_dim_part * self.sparse_block_size,
+                    ),
+                ),
+            )
         sO_layout = sm100_utils_basic.make_smem_layout_epi(self.o_dtype, self.o_layout, self.epi_tile, self.s_stage)
         if const_expr(not self.same_hdim_kv_padded):
             # sK and sV are using the same physical smem so we need to adjust the stride so that they line up
@@ -519,13 +661,21 @@ class BlockSparseAttnForwardSm100Blk64:
         tma_load_op = cpasync.CopyBulkTensorTileG2SOp(tcgen05.CtaGroup.ONE)
         tma_store_op = cpasync.CopyBulkTensorTileS2GOp()
 
-        tma_atom_Q, mQ = cute.nvgpu.make_tiled_tma_atom_A(
-            tma_load_op,
-            mQ,
-            cute.select(sQ_layout, mode=[0, 1, 2]),
-            self.mma_tiler_qk,
-            tiled_mma_qk,
-        )
+        if const_expr(self.is_sage_fp8):
+            tma_atom_Q, mQ = cpasync.make_tiled_tma_atom(
+                tma_load_op,
+                mQ,
+                cute.select(sQ_tma_layout, mode=[0, 1, 2]),
+                (self.head_dim_padded, 32, 2),
+            )
+        else:
+            tma_atom_Q, mQ = cute.nvgpu.make_tiled_tma_atom_A(
+                tma_load_op,
+                mQ,
+                cute.select(sQ_layout, mode=[0, 1, 2]),
+                self.mma_tiler_qk,
+                tiled_mma_qk,
+            )
 
         # K/V are sparse 64-block indexed. C++ blk64 issues four TMAs per
         # 64x256 KV iteration; each copy targets a sub-tile of the full
@@ -534,13 +684,13 @@ class BlockSparseAttnForwardSm100Blk64:
             tma_load_op,
             mK,
             cute.select(sK_tma_layout, mode=[0, 1, 2]),
-            (self.sparse_block_size, k_dim_half, 2),
+            ((self.head_dim_padded, 32, 2) if const_expr(self.is_sage_fp8) else (self.sparse_block_size, k_dim_half, 2)),
         )
         tma_atom_V, mV = cpasync.make_tiled_tma_atom(
             tma_load_op,
             mV,
             cute.select(sV_tma_layout, mode=[0, 1, 2]),
-            (v_dim_part, self.sparse_block_size, 2),
+            ((self.head_dim_v_padded, 32, 2) if const_expr(self.is_sage_fp8) else (v_dim_part, self.sparse_block_size, 2)),
         )
 
         self.num_epilogue_threads = cute.arch.WARP_SIZE * len(self.epilogue_warp_ids)
@@ -573,14 +723,20 @@ class BlockSparseAttnForwardSm100Blk64:
         else:
             TileScheduler = BlockSparsePersistentTileScheduler
         tile_sched_args = TileSchedulerArguments(
-            cute.ceil_div(cute.size(mQ.shape[0]), self.cta_tiler[0]),
-            cute.size(mQ.shape[2]),
-            cute.size(mQ.shape[3]),
+            (
+                cute.ceil_div(cute.size(seqlen_q_static), self.cta_tiler[0])
+                if const_expr(self.is_sage_fp8)
+                else cute.ceil_div(cute.size(mQ.shape[0]), self.cta_tiler[0])
+            ),
+            cute.size(num_q_heads_static) if const_expr(self.is_sage_fp8) else cute.size(mQ.shape[2]),
+            cute.size(batch_size_static) if const_expr(self.is_sage_fp8) else cute.size(mQ.shape[3]),
             num_splits,
-            cute.size(mK.shape[0]),
-            mQ.shape[1],
+            cute.size(mK_seq.shape[0]) if const_expr(self.is_sage_fp8) else cute.size(mK.shape[0]),
+            self.head_dim_padded if const_expr(self.is_sage_fp8) else mQ.shape[1],
             self.head_dim_v_padded,
-            total_q=cute.size(mQ.shape[0]) * cute.size(mQ.shape[3]),
+            total_q=(
+                cute.size(seqlen_q_static) * cute.size(batch_size_static) if const_expr(self.is_sage_fp8) else cute.size(mQ.shape[0]) * cute.size(mQ.shape[3])
+            ),
             tile_shape_mn=self.cta_tiler[:2],
             qhead_per_kvhead_packgqa=self.qhead_per_kvhead if const_expr(self.pack_gqa) else 1,
             element_size=self.k_dtype.width // 8,
@@ -597,9 +753,19 @@ class BlockSparseAttnForwardSm100Blk64:
             if const_expr(not self.overlap_sO_sQ)
             else cutlass.max(cute.cosize(sQ_layout), cute.cosize(sO_layout) * self.o_dtype.width // self.q_dtype.width)
         )
+        # K/V storage is reused by the correction exchange and O epilogue.
+        # FP8 split-KV writes FP32 partials, so its O scratch is twice as wide
+        # as the normal BF16 output and needs a larger backing allocation.
+        sO_size_in_k_elements = (sO_size * self.o_dtype.width + self.k_dtype.width - 1) // self.k_dtype.width
+        sKV_size = max(
+            cute.cosize(sK_layout),
+            self.epi_sO_input_offset + sO_size_in_k_elements,
+        )
 
         clc_response_size = self.sched_stages * 4 if self.use_clc_scheduler else 0
         clc_mbar_size = self.sched_stages * 2 if self.use_clc_scheduler else 0
+        v_scale_cache_size = self.head_dim_v_padded * len(self.correction_warp_ids) if self.is_sage_fp8 else 0
+        k_scale_cache_size = self.s_stage * 16 if self.is_sage_fp8 else 0
 
         @cute.struct
         class SharedStorage:
@@ -619,6 +785,11 @@ class BlockSparseAttnForwardSm100Blk64:
             # store row max and row sum
             sScale: cute.struct.MemRange[Float32, self.s_stage * self.stats_stride * 2]
             oStats: cute.struct.MemRange[Float32, 4 * 32 * 2]
+            # One 128-wide V-scale cache per correction warp. Separate slices
+            # avoid cross-tile overwrite between the two correction warp pairs.
+            sVScale: cute.struct.MemRange[Float32, v_scale_cache_size]
+            # One 16-value Sage K-scale vector per alternating score stage.
+            sKScale: cute.struct.MemRange[Float32, k_scale_cache_size]
             # CLC buffers (mbarriers + response storage)
             clc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, clc_mbar_size]
             clc_response: cute.struct.Align[
@@ -627,8 +798,8 @@ class BlockSparseAttnForwardSm100Blk64:
             ]
             sQ: cute.struct.Align[cute.struct.MemRange[self.q_dtype, sQ_size], self.buffer_align_bytes]
             sK: cute.struct.Align[
-                # cute.cosize(sK_layout) is correct even in the case of self.uneven_kv_smem
-                cute.struct.MemRange[self.k_dtype, cute.cosize(sK_layout)],
+                # Include any correction/epilogue scratch that shares the K/V allocation.
+                cute.struct.MemRange[self.k_dtype, sKV_size],
                 self.buffer_align_bytes,
             ]
 
@@ -644,6 +815,9 @@ class BlockSparseAttnForwardSm100Blk64:
             mV,
             mO,
             mLSE,
+            mQScale,
+            mKScale,
+            mVScale,
             tma_atom_Q,
             tma_atom_K,
             tma_atom_V,
@@ -651,6 +825,7 @@ class BlockSparseAttnForwardSm100Blk64:
             softmax_scale_log2,
             softmax_scale,
             sQ_layout,
+            sQ_tma_layout,
             sK_layout,
             sK_tma_layout,
             tP_layout,
@@ -682,6 +857,9 @@ class BlockSparseAttnForwardSm100Blk64:
         mV: cute.Tensor,  # Rank-5 Int64 or rank-6 sparse-block view
         mO: cute.Tensor,
         mLSE: Optional[cute.Tensor],
+        mQScale: Optional[cute.Tensor],
+        mKScale: Optional[cute.Tensor],
+        mVScale: Optional[cute.Tensor],
         tma_atom_Q: cute.CopyAtom,
         tma_atom_K: cute.CopyAtom,
         tma_atom_V: cute.CopyAtom,
@@ -689,6 +867,7 @@ class BlockSparseAttnForwardSm100Blk64:
         softmax_scale_log2: Float32,
         softmax_scale: Float32 | None,
         sQ_layout: cute.ComposedLayout,
+        sQ_tma_layout: Optional[cute.ComposedLayout],
         sK_layout: cute.ComposedLayout,
         sK_tma_layout: cute.ComposedLayout,
         tP_layout: cute.ComposedLayout,
@@ -830,12 +1009,14 @@ class BlockSparseAttnForwardSm100Blk64:
         # Match the C++ blk64 SharedStorage union: epilogue exchange/sO reuses
         # the large KV buffer after the mainloop has finished consuming it.
         sO = cute.make_tensor(
-            cute.recast_ptr(sKV_ptr + self.epi_sO_bf16_offset, sO_layout.inner, self.o_dtype),
+            cute.recast_ptr(sKV_ptr + self.epi_sO_input_offset, sO_layout.inner, self.o_dtype),
             sO_layout.outer,
         )
 
         sScale = storage.sScale.get_tensor(cute.make_layout(self.s_stage * self.stats_stride * 2))
         oStats = storage.oStats.get_tensor(cute.make_layout(4 * 32 * 2))
+        sVScale = storage.sVScale.get_tensor(cute.make_layout(self.head_dim_v_padded)) if const_expr(self.is_sage_fp8) else sScale
+        sKScale = storage.sKScale.get_tensor(cute.make_layout(self.s_stage * 16)) if const_expr(self.is_sage_fp8) else sScale
         oExchange = cute.make_tensor(
             cute.recast_ptr(sKV_ptr, dtype=Float32),
             cute.make_layout(self.epi_exchange_f32_count),
@@ -844,23 +1025,6 @@ class BlockSparseAttnForwardSm100Blk64:
         thr_mma_qk = tiled_mma_qk.get_slice(0)
         thr_mma_pv = tiled_mma_pv.get_slice(0)
 
-        qk_acc_shape = thr_mma_qk.partition_shape_C(self.mma_tiler_qk[:2])
-        # This is a fake tensor, by right we need to retrieve tmem_ptr. But we know that we always
-        # request 512 columns of tmem, so we know that it starts at 0.
-        # blk64 uses fixed TMEM columns: S0=0, S1=128, O0=256, O1=384.
-        # The default appended-stage layout would stride by the full N=256
-        # accumulator tile, so set the stage stride explicitly to 128 cols.
-        tStS_base = thr_mma_qk.make_fragment_C(qk_acc_shape)
-        tStS = cute.make_tensor(
-            tStS_base.iterator + self.tmem_s_offset[0],
-            cute.append(
-                tStS_base.layout,
-                cute.make_layout(
-                    (self.s_stage,),
-                    stride=(self.tmem_s_offset[1] - self.tmem_s_offset[0],),
-                ),
-            ),
-        )
         pv_acc_shape = thr_mma_pv.partition_shape_C(self.mma_tiler_pv[:2])
         tOtO_base = thr_mma_pv.make_fragment_C(pv_acc_shape)
         tOtO = cute.make_tensor(
@@ -883,13 +1047,15 @@ class BlockSparseAttnForwardSm100Blk64:
             tOrP_base.iterator + self.tmem_p_offset[0] * tP_width_ratio,
             cute.append(tOrP_base.layout, cute.make_layout((self.s_stage,), stride=(tP_stage_stride,))),
         )
-
         SeqlenInfoCls = partial(
             SeqlenInfoQK.create,
-            seqlen_q_static=mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1],
-            seqlen_k_static=mK.shape[0],
+            seqlen_q_static=(mO.shape[0] if const_expr(self.is_sage_fp8) else mQ.shape[0] if const_expr(not self.pack_gqa) else mQ.shape[0][1]),
+            seqlen_k_static=(mKScale.shape[2] * 16 if const_expr(self.is_sage_fp8) else mK.shape[0]),
         )
-        num_q_heads = cute.size(mQ.shape[2])
+        # Split-KV expands O's physical head axis to num_splits * H.  Scale
+        # tensors keep the logical H axis, which is what the scheduler and
+        # split output addressing need here.
+        num_q_heads = cute.size(mQScale.shape[1]) if const_expr(self.is_sage_fp8) else cute.size(mQ.shape[2])
         # Create tile scheduler (and CLC pipeline if enabled)
         if const_expr(self.use_clc_scheduler):
             clc_response_ptr = storage.clc_response.data_ptr()
@@ -947,6 +1113,7 @@ class BlockSparseAttnForwardSm100Blk64:
                 sK,
                 sV,
                 sKV_ptr,
+                sQ_tma_layout,
                 sK_tma_layout,
                 sV_tma_layout,
                 tma_atom_Q,
@@ -976,7 +1143,7 @@ class BlockSparseAttnForwardSm100Blk64:
                 sQ,
                 sK,
                 sV,
-                tStS,
+                sKScale,
                 tOtO,
                 tOrP,
                 pipeline_q,
@@ -985,10 +1152,16 @@ class BlockSparseAttnForwardSm100Blk64:
                 pipeline_p_lastsplit,
                 pipeline_o_acc,
                 tile_scheduler,
+                mBlockIndex,
+                mKScale,
                 block_sparse_num,
                 mBlockNums,
                 mSplitOffsets,
             )
+            if const_expr(self.is_sage_fp8):
+                # Order the final asynchronous tcgen05 operations before the
+                # allocator synchronization/deallocation sequence.
+                bsa_fwd_helpers.tcgen05_fence_before_thread_sync()
             # Dealloc the tensor memory buffer
             tmem.relinquish_alloc_permit()
             tmem_alloc_barrier.arrive_and_wait()
@@ -1002,6 +1175,8 @@ class BlockSparseAttnForwardSm100Blk64:
             self.epilogue_s2g(
                 mO,
                 sO,
+                mVScale,
+                sVScale,
                 gmem_tiled_copy_O,
                 tma_atom_O,
                 pipeline_o_epi,
@@ -1032,6 +1207,9 @@ class BlockSparseAttnForwardSm100Blk64:
                 tile_scheduler=tile_scheduler,
                 mBlockIndex=mBlockIndex,
                 mBlockSizes=mBlockSizes,
+                mQScale=mQScale,
+                mKScale=mKScale,
+                sKScale=sKScale,
                 block_sparse_num=block_sparse_num,
                 mBlockNums=mBlockNums,
                 mSplitOffsets=mSplitOffsets,
@@ -1056,9 +1234,7 @@ class BlockSparseAttnForwardSm100Blk64:
             tmem.wait_for_alloc()
             tmem_ptr = tmem.retrieve_ptr(self.qk_acc_dtype)
             self.correction_loop(
-                thr_mma_qk,
                 thr_mma_pv,
-                tStS,
                 tOtO,
                 sScale,
                 mO,
@@ -1072,9 +1248,11 @@ class BlockSparseAttnForwardSm100Blk64:
                 pipeline_o_epi,
                 gmem_tiled_copy_O,
                 tma_atom_O,
-                softmax_scale_log2,
+                Float32(1.0) if const_expr(self.is_sage_fp8) else softmax_scale_log2,
                 oStats,
                 oExchange,
+                mVScale,
+                sVScale,
                 SeqlenInfoCls,
                 tile_scheduler,
                 num_q_heads,
@@ -1130,6 +1308,21 @@ class BlockSparseAttnForwardSm100Blk64:
             split_start = mSplitOffsets[batch_idx, head_idx, m_block, split_idx]
             split_end = mSplitOffsets[batch_idx, head_idx, m_block, split_idx + 1]
             return split_end - split_start, split_start
+        if const_expr(self.is_split_kv):
+            num_splits = Int32(self.num_splits)
+            avg_blocks = block_sparse_num // num_splits
+            aligned_base = (avg_blocks // 8) * 8
+            split_start = Int32(0)
+            split_end = Int32(0)
+            if aligned_base > Int32(0):
+                remainder = block_sparse_num - aligned_base * num_splits
+                split_start = aligned_base * split_idx + cutlass.min(remainder, split_idx * 8)
+                split_next = split_idx + 1
+                split_end = aligned_base * split_next + cutlass.min(remainder, split_next * 8)
+            else:
+                split_start = (block_sparse_num * split_idx + num_splits - 1) // num_splits
+                split_end = (block_sparse_num * (split_idx + 1) + num_splits - 1) // num_splits
+            return split_end - split_start, split_start
         if const_expr(mBlockNums is not None):
             return mBlockNums[batch_idx, head_idx, m_block], Int32(0)
         return block_sparse_num, Int32(0)
@@ -1141,7 +1334,7 @@ class BlockSparseAttnForwardSm100Blk64:
         split_offset: Int32,
         mSplitOffsets: Optional[cute.Tensor],
     ) -> cute.Tensor:
-        if const_expr(mSplitOffsets is not None):
+        if const_expr(mSplitOffsets is not None or self.is_split_kv):
             return cute.domain_offset((split_offset,), tile_block_indices)
         return tile_block_indices
 
@@ -1157,6 +1350,7 @@ class BlockSparseAttnForwardSm100Blk64:
         sK: cute.Tensor,
         sV: cute.Tensor,
         sKV_ptr: cute.Pointer,
+        sQ_tma_layout: Optional[cute.ComposedLayout],
         sK_tma_layout: cute.ComposedLayout,
         sV_tma_layout: cute.ComposedLayout,
         tma_atom_Q: cute.CopyAtom,
@@ -1179,9 +1373,29 @@ class BlockSparseAttnForwardSm100Blk64:
         work_tile = tile_scheduler.initial_work_tile_info()
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
-            mQ_cur = mQ[None, None, None, batch_idx][None, None, head_idx]
-            gQ = cute.local_tile(mQ_cur, tiler_gQ, (m_block, 0))  # (128, 128)
-            gQ = layout_utils.select(cute.flat_divide(gQ, (self.mma_tiler_qk[0],)), mode=[0, 2, 1])  # (128, 128, 1)
+            if const_expr(self.is_sage_fp8):
+                mQ_cur = mQ[None, None, None, head_idx, None, batch_idx]
+                gQ_tma = cute.group_modes(mQ_cur, 0, 3)
+                tQsQ, tQgQ = cpasync.tma_partition(
+                    tma_atom_Q,
+                    0,
+                    cute.make_layout(1),
+                    cute.group_modes(
+                        cute.make_tensor(
+                            cute.recast_ptr(sQ.iterator, sQ_tma_layout.inner),
+                            cute.append(sQ_tma_layout.outer, cute.make_layout((self.q_stage,), stride=(cute.cosize(sQ_tma_layout.outer),))),
+                        ),
+                        0,
+                        3,
+                    ),
+                    gQ_tma,
+                )
+            else:
+                mQ_cur = mQ[None, None, None, batch_idx][None, None, head_idx]
+                gQ = cute.local_tile(mQ_cur, tiler_gQ, (m_block, 0))  # (64, 128)
+                gQ = layout_utils.select(cute.flat_divide(gQ, (self.mma_tiler_qk[0],)), mode=[0, 2, 1])
+                tSgQ = thr_mma_qk.partition_A(gQ)
+                load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(tma_atom_Q, 0, cute.make_layout(1), tSgQ, sQ)
 
             head_idx_kv = head_idx // self.qhead_per_kvhead if const_expr(not self.pack_gqa) else head_idx
             if const_expr(self.use_int64_kv_strides):
@@ -1195,8 +1409,6 @@ class BlockSparseAttnForwardSm100Blk64:
                 gK_tma = cute.group_modes(mK_cur, 0, 3)
                 gV_tma = cute.group_modes(mV_cur, 0, 3)
             tile_block_indices_base = mBlockIndex[batch_idx, head_idx, m_block, None]
-            tSgQ = thr_mma_qk.partition_A(gQ)
-            load_Q_fn, _, _ = copy_utils.tma_get_copy_fn(tma_atom_Q, 0, cute.make_layout(1), tSgQ, sQ)
 
             # n_block(i): maps logical index i to actual KV block index via q2k_block_index
             # C++ blk64 groups four sparse 64-blocks into one 64x256 KV iteration.
@@ -1226,7 +1438,15 @@ class BlockSparseAttnForwardSm100Blk64:
                 if const_expr(len(self.load_warp_ids) == 1) or warp_idx == self.load_warp_ids[0]:
                     pipeline_q.producer_acquire_w_index_phase(0, q_producer_phase)
                     tma_bar_ptr = pipeline_q.sync_object_full.get_barrier(0)
-                    load_Q_fn(src_idx=0, dst_idx=0, tma_bar_ptr=tma_bar_ptr)
+                    if const_expr(self.is_sage_fp8):
+                        cute.copy(
+                            tma_atom_Q,
+                            tQgQ[None, m_block],
+                            tQsQ[None, 0],
+                            tma_bar_ptr=tma_bar_ptr,
+                        )
+                    else:
+                        load_Q_fn(src_idx=0, dst_idx=0, tma_bar_ptr=tma_bar_ptr)
                 q_producer_phase ^= 1
 
                 kv_producer_state = self.load_K_group(
@@ -1305,7 +1525,7 @@ class BlockSparseAttnForwardSm100Blk64:
         sQ: cute.Tensor,
         sK: cute.Tensor,
         sV: cute.Tensor,
-        tStS: cute.Tensor,
+        sKScale: cute.Tensor,
         tOtO: cute.Tensor,
         tOrP: cute.Tensor,
         pipeline_q: pipeline.PipelineAsync,
@@ -1314,18 +1534,19 @@ class BlockSparseAttnForwardSm100Blk64:
         pipeline_p_lastsplit: pipeline.PipelineAsync,
         pipeline_o_acc: pipeline.PipelineAsync,
         tile_scheduler: TileSchedulerProtocol,
+        mBlockIndex: cute.Tensor,
+        mKScale: Optional[cute.Tensor],
         block_sparse_num: Int32,
         mBlockNums: Optional[cute.Tensor],
         mSplitOffsets: Optional[cute.Tensor],
     ):
+        tidx = cute.arch.thread_idx()[0] % cute.arch.WARP_SIZE
         tSrQ = tiled_mma_qk.make_fragment_A(sQ)
         tSrK = tiled_mma_qk.make_fragment_B(sK)
         tOrV = tiled_mma_pv.make_fragment_B(sV)
         # q_stage=1: both stages use the same Q (intra-warp overlap across n_blocks)
         tSrQ0 = tSrQ[None, None, None, 0]
         sQ0 = sQ[None, None, None, 0]
-        tStS0 = tStS[None, None, None, 0]
-        tStS1 = tStS[None, None, None, 1]
         tOrP0 = tOrP[None, None, None, 0]
         tOrP1 = tOrP[None, None, None, 1]
 
@@ -1347,7 +1568,7 @@ class BlockSparseAttnForwardSm100Blk64:
         while work_tile.is_valid_tile:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
 
-            raw_block_count, _ = self.get_tile_block_count_and_offset(
+            raw_block_count, split_offset = self.get_tile_block_count_and_offset(
                 mSplitOffsets,
                 mBlockNums,
                 batch_idx,
@@ -1358,6 +1579,13 @@ class BlockSparseAttnForwardSm100Blk64:
             )
             process_tile = raw_block_count > Int32(0) if const_expr(self.allow_empty_block_nums) else True
             block_iter_count = ((raw_block_count + 7) & ~7) // self.sparse_blocks_per_kv
+            tile_block_indices_base = mBlockIndex[batch_idx, head_idx, m_block, None]
+            tile_block_indices = self.offset_tile_block_indices(tile_block_indices_base, split_offset, mSplitOffsets)
+            n_block = partial(
+                self.get_tile_n_block_idx,
+                tile_block_indices,
+                max_i=cutlass.max(raw_block_count - 1, Int32(0)),
+            )
 
             if process_tile:
                 # ================================================================
@@ -1372,6 +1600,17 @@ class BlockSparseAttnForwardSm100Blk64:
                 mma_q_consumer_phase ^= 1
 
                 # S0 = Q @ K0
+                if const_expr(self.is_sage_fp8 and not self.is_split_kv):
+                    self.publish_k_scales(
+                        mKScale,
+                        sKScale,
+                        n_block,
+                        block_iter_count - 1,
+                        0,
+                        batch_idx,
+                        head_idx,
+                        tidx,
+                    )
                 bsa_fwd_helpers.mbar_wait(
                     Int32(pipeline_kv.sync_object_full.get_barrier(mma_kv_consumer_state.index).toint()),
                     mma_kv_consumer_state.phase,
@@ -1387,6 +1626,17 @@ class BlockSparseAttnForwardSm100Blk64:
                 mma_kv_consumer_state.advance()
 
                 # S1 = Q @ K1
+                if const_expr(self.is_sage_fp8 and not self.is_split_kv):
+                    self.publish_k_scales(
+                        mKScale,
+                        sKScale,
+                        n_block,
+                        block_iter_count - 2,
+                        1,
+                        batch_idx,
+                        head_idx,
+                        tidx,
+                    )
                 bsa_fwd_helpers.mbar_wait(
                     Int32(pipeline_kv.sync_object_full.get_barrier(mma_kv_consumer_state.index).toint()),
                     mma_kv_consumer_state.phase,
@@ -1421,14 +1671,23 @@ class BlockSparseAttnForwardSm100Blk64:
                         if const_expr(stage == 0):
                             phase_cur, O_acc_cur = phase_s0, O_acc_s0
                             spo_empty_mbar = spo_empty_mbar0
-                            tStS_stage = tStS0
                             tOrP_stage = tOrP0
                         else:
                             phase_cur, O_acc_cur = phase_s1, O_acc_s1
                             spo_empty_mbar = spo_empty_mbar1
-                            tStS_stage = tStS1
                             tOrP_stage = tOrP1
                         bsa_fwd_helpers.mbar_wait(spo_empty_mbar, phase_cur)
+                        if const_expr(self.is_sage_fp8 and not self.is_split_kv):
+                            self.publish_k_scales(
+                                mKScale,
+                                sKScale,
+                                n_block,
+                                block_iter_count - 3 - (i * self.s_stage + stage),
+                                stage,
+                                batch_idx,
+                                head_idx,
+                                tidx,
+                            )
                         # Wait V
                         bsa_fwd_helpers.mbar_wait(
                             Int32(pipeline_kv.sync_object_full.get_barrier(mma_kv_consumer_state.index).toint()),
@@ -1531,6 +1790,31 @@ class BlockSparseAttnForwardSm100Blk64:
         # pipeline_o_acc.producer_acquire() inside the loop.
 
     @cute.jit
+    def publish_k_scales(
+        self,
+        mKScale: cute.Tensor,
+        sKScale: cute.Tensor,
+        n_block: Callable,
+        kv_block_idx: Int32,
+        score_stage: int,
+        batch_idx: Int32,
+        head_idx: Int32,
+        tidx: Int32,
+    ):
+        """Load one KV tile's 16 K scales once for all softmax rows."""
+        if tidx < 16:
+            logical_sub = tidx // 4
+            scale_group = tidx % 4
+            key_block = n_block(kv_block_idx * self.sparse_blocks_per_kv + logical_sub)
+            sKScale[score_stage * 16 + tidx] = mKScale[
+                batch_idx,
+                head_idx,
+                key_block * 4 + scale_group,
+            ]
+        cute.arch.sync_warp()
+        cute.arch.fence_view_async_shared()
+
+    @cute.jit
     def ws_pv_gemm(
         self,
         pv_mma_op: cute.nvgpu.tcgen05.mma.MmaOp,
@@ -1592,6 +1876,9 @@ class BlockSparseAttnForwardSm100Blk64:
         tile_scheduler: TileSchedulerProtocol,
         mBlockIndex: cute.Tensor,
         mBlockSizes: Optional[cute.Tensor],
+        mQScale: Optional[cute.Tensor],
+        mKScale: Optional[cute.Tensor],
+        sKScale: cute.Tensor,
         block_sparse_num: Int32,
         mBlockNums: Optional[cute.Tensor],
         mSplitOffsets: Optional[cute.Tensor],
@@ -1641,8 +1928,8 @@ class BlockSparseAttnForwardSm100Blk64:
             )
 
             softmax = SoftmaxSm100.create(
-                softmax_scale_log2,
-                rescale_threshold=8.0 if const_expr(self.q_dtype.width == 16) else 0.0,
+                Float32(1.0) if const_expr(self.is_sage_fp8) else softmax_scale_log2,
+                rescale_threshold=(SAGE_P_RESCALE_THRESHOLD if const_expr(self.is_sage_fp8) else 8.0 if const_expr(self.q_dtype.width == 16) else 0.0),
                 softmax_scale=softmax_scale,
             )
             softmax.reset()
@@ -1656,7 +1943,18 @@ class BlockSparseAttnForwardSm100Blk64:
                 sm_stats_barrier=sm_stats_barrier,
                 sScale=sScale,
                 stage=stage,
+                mKScale=mKScale,
+                sKScale=sKScale,
+                batch_idx=batch_idx,
+                head_idx=head_idx,
+                score_scale_log2=softmax_scale_log2,
             )
+
+            if const_expr(self.is_sage_fp8):
+                q_row = m_block * self.m_block_size + (warp_idx & 1) * cute.arch.WARP_SIZE + (tidx % cute.arch.WARP_SIZE)
+                q_scale = mQScale[batch_idx, head_idx, q_row] if q_row < mQScale.shape[2] else Float32(1.0)
+            else:
+                q_scale = Float32(1.0)
 
             # Always acquire pipeline_sm_stats to stay in sync with correction
             pipeline_sm_stats.producer_acquire_w_index_phase(stage, sm_stats_producer_phase)
@@ -1670,12 +1968,17 @@ class BlockSparseAttnForwardSm100Blk64:
                 wg_count = block_iter_count // 2
                 warp_col = warp_idx // 2
 
-                first_bs_lo, first_bs_hi = self.get_softmax_block_sizes(Int32(0), stage, warp_col, block_iter_count, raw_block_count, n_block, mBlockSizes)
+                first_bs_lo, first_bs_hi, first_nb_lo, first_nb_hi = self.get_softmax_block_info(
+                    Int32(0), stage, warp_col, block_iter_count, raw_block_count, n_block, mBlockSizes
+                )
                 mma_si_consumer_phase, sm_stats_producer_phase = softmax_step(
                     mma_si_consumer_phase,
                     sm_stats_producer_phase,
                     block_size_lo=first_bs_lo,
                     block_size_hi=first_bs_hi,
+                    n_block_lo=first_nb_lo,
+                    n_block_hi=first_nb_hi,
+                    q_scale=q_scale,
                     tidx=tidx,
                     tmem_s_addr=tmem_s_addr,
                     tmem_p_addr=tmem_p_addr,
@@ -1683,12 +1986,17 @@ class BlockSparseAttnForwardSm100Blk64:
                     is_first=True,
                 )
                 for n_tile in cutlass.range(wg_count - 1, unroll=1):
-                    bs_lo, bs_hi = self.get_softmax_block_sizes(n_tile + 1, stage, warp_col, block_iter_count, raw_block_count, n_block, mBlockSizes)
+                    bs_lo, bs_hi, nb_lo, nb_hi = self.get_softmax_block_info(
+                        n_tile + 1, stage, warp_col, block_iter_count, raw_block_count, n_block, mBlockSizes
+                    )
                     mma_si_consumer_phase, sm_stats_producer_phase = softmax_step(
                         mma_si_consumer_phase,
                         sm_stats_producer_phase,
                         block_size_lo=bs_lo,
                         block_size_hi=bs_hi,
+                        n_block_lo=nb_lo,
+                        n_block_hi=nb_hi,
+                        q_scale=q_scale,
                         tidx=tidx,
                         tmem_s_addr=tmem_s_addr,
                         tmem_p_addr=tmem_p_addr,
@@ -1711,7 +2019,7 @@ class BlockSparseAttnForwardSm100Blk64:
         pipeline_sm_stats.producer_acquire_w_index_phase(stage, sm_stats_producer_phase)
 
     @cute.jit
-    def get_softmax_block_sizes(
+    def get_softmax_block_info(
         self,
         kv_iter: Int32,
         stage: int | Int32,
@@ -1720,7 +2028,7 @@ class BlockSparseAttnForwardSm100Blk64:
         raw_block_count: Int32,
         n_block: Callable,
         mBlockSizes: Optional[cute.Tensor],
-    ) -> Tuple[Int32, Int32]:
+    ) -> Tuple[Int32, Int32, Int32, Int32]:
         kv_block = block_iter_count - 1 - (self.s_stage * kv_iter + Int32(stage))
         logical_lo = kv_block * self.sparse_blocks_per_kv + warp_col
         logical_hi = logical_lo + 2
@@ -1730,7 +2038,11 @@ class BlockSparseAttnForwardSm100Blk64:
         else:
             bs_lo = Int32(0) if logical_lo >= raw_block_count else Int32(self.sparse_block_size)
             bs_hi = Int32(0) if logical_hi >= raw_block_count else Int32(self.sparse_block_size)
-        return bs_lo, bs_hi
+        # Invalid padded entries are masked to zero.  Clamp their lookup so no
+        # out-of-range global-memory access is generated in the FP8 scale path.
+        nb_lo = n_block(cutlass.min(logical_lo, cutlass.max(raw_block_count - 1, Int32(0))))
+        nb_hi = n_block(cutlass.min(logical_hi, cutlass.max(raw_block_count - 1, Int32(0))))
+        return bs_lo, bs_hi, nb_lo, nb_hi
 
     @cute.jit
     def get_tile_n_block_idx(
@@ -1756,6 +2068,14 @@ class BlockSparseAttnForwardSm100Blk64:
         stage: int | Int32,
         block_size_lo: Int32,
         block_size_hi: Int32,
+        n_block_lo: Int32,
+        n_block_hi: Int32,
+        q_scale: Float32,
+        mKScale: Optional[cute.Tensor],
+        sKScale: cute.Tensor,
+        batch_idx: Int32,
+        head_idx: Int32,
+        score_scale_log2: Float32,
         tidx: Int32,
         tmem_s_addr: Int32,
         tmem_p_addr: Int32,
@@ -1777,11 +2097,24 @@ class BlockSparseAttnForwardSm100Blk64:
         5. Computing row sums for normalization
         6. Coordinating pipeline synchronization between different processing stages
         """
+        if const_expr(self.is_sage_fp8 and not self.is_split_kv):
+            qk_scales = cute.make_rmem_tensor((8,), Float32)
+            q_log2_scale = q_scale * score_scale_log2
+
         # Wait for Si
         bsa_fwd_helpers.mbar_wait(
             Int32(pipeline_s_p_o.sync_object_full.get_barrier(stage).toint()),
             mma_si_consumer_phase,
         )
+
+        if const_expr(self.is_sage_fp8 and not self.is_split_kv):
+            warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx()) % 4
+            warp_col = warp_idx // 2
+            for block_idx in cutlass.range_constexpr(2):
+                for key_scale_group in cutlass.range_constexpr(4):
+                    scale_idx = block_idx * 4 + key_scale_group
+                    cache_idx = stage * 16 + (warp_col + block_idx * 2) * 4 + key_scale_group
+                    qk_scales[scale_idx] = q_log2_scale * sKScale[cache_idx]
 
         tSrS_t2r = cute.make_rmem_tensor((128,), Float32)
         for c in cutlass.range_constexpr(4):
@@ -1792,14 +2125,65 @@ class BlockSparseAttnForwardSm100Blk64:
         tSrS_blocks = cute.logical_divide(tSrS_t2r, cute.make_layout(self.sparse_block_size))
         bsa_fwd_helpers.apply_block_size_mask_64(tSrS_blocks[None, 0], block_size_lo)
         bsa_fwd_helpers.apply_block_size_mask_64(tSrS_blocks[None, 1], block_size_hi)
-        row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
+
+        if const_expr(self.is_sage_fp8):
+            # Q has one scale per row.  K has one scale per 16 consecutive
+            # tokens, hence four scale values inside each logical 64-token KV
+            # block.  Max-reduce the raw scores within each group first, then
+            # scale only the eight group maxima.  The score scale is fused into
+            # the later subtract-row-max FMA, avoiding a full extra score pass.
+            scaled_group_max = cute.make_rmem_tensor((8,), Float32)
+            tSrS_groups = cute.logical_divide(tSrS_t2r, cute.make_layout(16))
+            if const_expr(not self.is_split_kv):
+                for scale_idx in cutlass.range_constexpr(8):
+                    group_max = softmax._compute_row_max(tSrS_groups[None, scale_idx].load())
+                    scaled_group_max[scale_idx] = group_max * qk_scales[scale_idx]
+            else:
+                qk_scales = cute.make_rmem_tensor((8,), Float32)
+                q_log2_scale = q_scale * score_scale_log2
+                for block_idx in cutlass.range_constexpr(2):
+                    key_block = n_block_lo if const_expr(block_idx == 0) else n_block_hi
+                    for key_scale_group in cutlass.range_constexpr(4):
+                        scale_idx = block_idx * 4 + key_scale_group
+                        qk_scale = (
+                            q_log2_scale
+                            * mKScale[
+                                batch_idx,
+                                head_idx,
+                                key_block * 4 + key_scale_group,
+                            ]
+                        )
+                        qk_scales[scale_idx] = qk_scale
+                        group_max = softmax._compute_row_max(tSrS_groups[None, scale_idx].load())
+                        scaled_group_max[scale_idx] = group_max * qk_scale
+            row_max, acc_scale = softmax.update_row_max(scaled_group_max.load(), is_first)
+        else:
+            row_max, acc_scale = softmax.update_row_max(tSrS_t2r.load(), is_first)
 
         if const_expr(not is_first):
             sScale[tidx + stage * self.stats_stride] = acc_scale
         # Notify correction wg that row_max is ready
         sm_stats_barrier.arrive_w_index(index=sm_stats_bar_index)
 
-        softmax.scale_subtract_rowmax(tSrS_t2r, row_max)
+        if const_expr(self.is_sage_fp8):
+            # Generate P * 256 directly in exp2.  The softmax numerator and
+            # denominator carry the same fixed factor, so normalization is
+            # unchanged while the separate per-element multiply disappears.
+            p_log2_scale = Float32(SAGE_P_QUANT_LOG2_SCALE)
+            for scale_idx in cutlass.range_constexpr(8):
+                score_scale = qk_scales[scale_idx]
+                for token_idx in cutlass.range_constexpr(0, 16, 2):
+                    j = scale_idx * 16 + token_idx
+                    tSrS_t2r[j], tSrS_t2r[j + 1] = cute.arch.fma_packed_f32x2(
+                        (tSrS_t2r[j], tSrS_t2r[j + 1]),
+                        (score_scale, score_scale),
+                        (
+                            -row_max + p_log2_scale,
+                            -row_max + p_log2_scale,
+                        ),
+                    )
+        else:
+            softmax.scale_subtract_rowmax(tSrS_t2r, row_max)
         tSrS_frg = cute.logical_divide(tSrS_t2r, cute.make_layout(32))
         if const_expr(not is_first):
             sum0 = (softmax.row_sum[0] * acc_scale, 0.0)
@@ -1809,37 +2193,56 @@ class BlockSparseAttnForwardSm100Blk64:
         sum2 = (0.0, 0.0)
         sum3 = (0.0, 0.0)
         for i in cutlass.range_constexpr(4):
-            p_frag = cute.make_rmem_tensor((16,), Int32)
+            p_frag = cute.make_rmem_tensor((8 if const_expr(self.is_sage_fp8) else 16,), Int32)
             for j in cutlass.range_constexpr(0, 32, 8):
                 e0 = cute.math.exp2(tSrS_frg[j + 0, i], fastmath=True)
                 e1 = cute.math.exp2(tSrS_frg[j + 1, i], fastmath=True)
                 tSrS_frg[j + 0, i] = e0
                 tSrS_frg[j + 1, i] = e1
-                p_frag[j // 2 + 0] = bsa_fwd_helpers.cvt_f32x2_to_bf16x2(e0, e1)
 
                 e2 = cute.math.exp2(tSrS_frg[j + 2, i], fastmath=True)
                 e3 = cute.math.exp2(tSrS_frg[j + 3, i], fastmath=True)
                 tSrS_frg[j + 2, i] = e2
                 tSrS_frg[j + 3, i] = e3
-                p_frag[j // 2 + 1] = bsa_fwd_helpers.cvt_f32x2_to_bf16x2(e2, e3)
 
                 e4 = cute.math.exp2(tSrS_frg[j + 4, i], fastmath=True)
                 e5 = cute.math.exp2(tSrS_frg[j + 5, i], fastmath=True)
                 tSrS_frg[j + 4, i] = e4
                 tSrS_frg[j + 5, i] = e5
-                p_frag[j // 2 + 2] = bsa_fwd_helpers.cvt_f32x2_to_bf16x2(e4, e5)
 
                 e6 = cute.math.exp2(tSrS_frg[j + 6, i], fastmath=True)
                 e7 = cute.math.exp2(tSrS_frg[j + 7, i], fastmath=True)
                 tSrS_frg[j + 6, i] = e6
                 tSrS_frg[j + 7, i] = e7
-                p_frag[j // 2 + 3] = bsa_fwd_helpers.cvt_f32x2_to_bf16x2(e6, e7)
-            bsa_fwd_helpers.tmem_store_bf16x16(tmem_p_addr + i * 16, p_frag)
+                if const_expr(self.is_sage_fp8):
+                    p_frag[j // 4 + 0] = bsa_fwd_helpers.cvt_f32x4_to_e4m3x4(
+                        e0,
+                        e1,
+                        e2,
+                        e3,
+                    )
+                    p_frag[j // 4 + 1] = bsa_fwd_helpers.cvt_f32x4_to_e4m3x4(
+                        e4,
+                        e5,
+                        e6,
+                        e7,
+                    )
+                else:
+                    p_frag[j // 2 + 0] = bsa_fwd_helpers.cvt_f32x2_to_bf16x2(e0, e1)
+                    p_frag[j // 2 + 1] = bsa_fwd_helpers.cvt_f32x2_to_bf16x2(e2, e3)
+                    p_frag[j // 2 + 2] = bsa_fwd_helpers.cvt_f32x2_to_bf16x2(e4, e5)
+                    p_frag[j // 2 + 3] = bsa_fwd_helpers.cvt_f32x2_to_bf16x2(e6, e7)
+            if const_expr(self.is_sage_fp8):
+                bsa_fwd_helpers.tmem_store_e4m3x8(tmem_p_addr + i * 8, p_frag)
+            else:
+                bsa_fwd_helpers.tmem_store_bf16x16(tmem_p_addr + i * 16, p_frag)
             if const_expr(self.split_P_arrive > 0):
                 split_P_arrive_idx = self.split_P_arrive // 32
                 if const_expr(i + 1 == split_P_arrive_idx):
                     # Notify mma warp that the 1st half of P is ready
                     cute.arch.fence_view_async_tmem_store()
+                    if const_expr(self.is_sage_fp8):
+                        bsa_fwd_helpers.tcgen05_fence_before_thread_sync()
                     pipeline_s_p_o.consumer_release_w_index(stage)
             for j in cutlass.range_constexpr(0, 32, 8):
                 sum0 = cute.arch.add_packed_f32x2(sum0, (tSrS_frg[j + 0, i], tSrS_frg[j + 1, i]))
@@ -1848,6 +2251,8 @@ class BlockSparseAttnForwardSm100Blk64:
                 sum3 = cute.arch.add_packed_f32x2(sum3, (tSrS_frg[j + 6, i], tSrS_frg[j + 7, i]))
         # Notify mma warp that the 2nd half of P is ready
         cute.arch.fence_view_async_tmem_store()
+        if const_expr(self.is_sage_fp8):
+            bsa_fwd_helpers.tcgen05_fence_before_thread_sync()
         if const_expr(self.split_P_arrive > 0):
             cute.arch.sync_warp()
             with cute.arch.elect_one():
@@ -1867,9 +2272,7 @@ class BlockSparseAttnForwardSm100Blk64:
     @cute.jit
     def correction_loop(
         self,
-        thr_mma_qk: cute.ThrMma,
         thr_mma_pv: cute.ThrMma,
-        tStS: cute.Tensor,
         tOtO: cute.Tensor,
         sScale: cute.Tensor,
         mO: cute.Tensor,
@@ -1886,6 +2289,8 @@ class BlockSparseAttnForwardSm100Blk64:
         softmax_scale_log2: Float32,
         oStats: cute.Tensor,
         oExchange: cute.Tensor,
+        mVScale: Optional[cute.Tensor],
+        sVScale: cute.Tensor,
         SeqlenInfoCls: Callable,
         tile_scheduler: TileSchedulerProtocol,
         num_heads: Int32,
@@ -1912,6 +2317,13 @@ class BlockSparseAttnForwardSm100Blk64:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
             out_head_idx = head_idx + split_idx * num_heads if const_expr(self.is_split_kv) else head_idx
+
+            if const_expr(self.is_sage_fp8 and not self.is_split_kv):
+                lane_idx = tidx % cute.arch.WARP_SIZE
+                for vec in cutlass.range_constexpr(self.head_dim_v_padded // cute.arch.WARP_SIZE):
+                    col = lane_idx + vec * cute.arch.WARP_SIZE
+                    sVScale[warp_idx * self.head_dim_v_padded + col] = mVScale[head_idx, col]
+                cute.arch.sync_warp()
 
             mO_cur = mO[None, None, None, batch_idx][None, None, out_head_idx]
             # For q_stage=1, gO tiles span 1*m_block_size rows (single Q, combine writes one O)
@@ -2017,6 +2429,8 @@ class BlockSparseAttnForwardSm100Blk64:
                     sO[None, None, 0],
                     oStats,
                     oExchange,
+                    sVScale,
+                    warp_idx * self.head_dim_v_padded,
                     reduce_mbar_addr,
                     mLSE_cur,
                 )
@@ -2052,6 +2466,8 @@ class BlockSparseAttnForwardSm100Blk64:
                     sO[None, None, 0],
                     oStats,
                     oExchange,
+                    sVScale,
+                    warp_idx * self.head_dim_v_padded,
                     reduce_mbar_addr,
                     mLSE_cur,
                 )
@@ -2107,6 +2523,8 @@ class BlockSparseAttnForwardSm100Blk64:
         sO: cute.Tensor,
         oStats: cute.Tensor,
         oExchange: cute.Tensor,
+        sVScale: cute.Tensor,
+        v_scale_warp_base: Int32,
         reduce_mbar_addr: Int32,
         mLSE_cur: Optional[cute.Tensor] = None,
     ):
@@ -2191,14 +2609,28 @@ class BlockSparseAttnForwardSm100Blk64:
                         Int32((sO.iterator + sO.layout((out_row, col7))).toint()),
                     )
                 else:
-                    bsa_fwd_helpers.smem_exchange_reduce_store_bf16x32(
-                        Int32((oExchange.iterator + own_warp_base + off).toint()),
-                        Int32((oExchange.iterator + partner_warp_base + off).toint()),
-                        Int32((sO.iterator + sO.layout((out_row, col0))).toint()),
-                        Int32((sO.iterator + sO.layout((out_row, col1))).toint()),
-                        Int32((sO.iterator + sO.layout((out_row, col2))).toint()),
-                        Int32((sO.iterator + sO.layout((out_row, col3))).toint()),
-                    )
+                    if const_expr(self.is_sage_fp8):
+                        bsa_fwd_helpers.smem_exchange_reduce_scale_store_bf16x32(
+                            Int32((oExchange.iterator + own_warp_base + off).toint()),
+                            Int32((oExchange.iterator + partner_warp_base + off).toint()),
+                            Int32((sO.iterator + sO.layout((out_row, col0))).toint()),
+                            Int32((sO.iterator + sO.layout((out_row, col1))).toint()),
+                            Int32((sO.iterator + sO.layout((out_row, col2))).toint()),
+                            Int32((sO.iterator + sO.layout((out_row, col3))).toint()),
+                            Int32((sVScale.iterator + v_scale_warp_base + sVScale.layout(c * 32 + 0)).toint()),
+                            Int32((sVScale.iterator + v_scale_warp_base + sVScale.layout(c * 32 + 8)).toint()),
+                            Int32((sVScale.iterator + v_scale_warp_base + sVScale.layout(c * 32 + 16)).toint()),
+                            Int32((sVScale.iterator + v_scale_warp_base + sVScale.layout(c * 32 + 24)).toint()),
+                        )
+                    else:
+                        bsa_fwd_helpers.smem_exchange_reduce_store_bf16x32(
+                            Int32((oExchange.iterator + own_warp_base + off).toint()),
+                            Int32((oExchange.iterator + partner_warp_base + off).toint()),
+                            Int32((sO.iterator + sO.layout((out_row, col0))).toint()),
+                            Int32((sO.iterator + sO.layout((out_row, col1))).toint()),
+                            Int32((sO.iterator + sO.layout((out_row, col2))).toint()),
+                            Int32((sO.iterator + sO.layout((out_row, col3))).toint()),
+                        )
 
         cute.arch.fence_view_async_shared()
 
@@ -2211,7 +2643,10 @@ class BlockSparseAttnForwardSm100Blk64:
             valid_rows = seqlen_q - m_block * self.m_block_size
             if corr_warp < 2 and out_row < valid_rows:
                 LN2 = math.log(2.0)
-                lse = (max_total_safe * softmax_scale_log2 + cute.math.log2(sum_total, fastmath=True)) * LN2 if total_is_valid else -Float32.inf
+                lse_log2 = max_total_safe * softmax_scale_log2 + cute.math.log2(sum_total, fastmath=True)
+                if const_expr(self.is_sage_fp8):
+                    lse_log2 -= Float32(SAGE_P_QUANT_LOG2_SCALE)
+                lse = lse_log2 * LN2 if total_is_valid else -Float32.inf
                 mLSE_cur[m_block * self.m_block_size + out_row] = lse
 
     @cute.jit
@@ -2220,6 +2655,7 @@ class BlockSparseAttnForwardSm100Blk64:
         sO_stage: cute.Tensor,
         gO: cute.Tensor,
         mO_cur: cute.Tensor,
+        sVScale: cute.Tensor,
         gmem_tiled_copy_O: cute.TiledCopy,
         tidx: Int32,
         seqlen_q: Int32,
@@ -2240,20 +2676,44 @@ class BlockSparseAttnForwardSm100Blk64:
             self.qhead_per_kvhead,
         )
 
-        # load acc O from smem to rmem for wider vectorization
-        tOrO = cute.make_rmem_tensor_like(tOsO, self.o_dtype)
-        cute.autovec_copy(tOsO, tOrO)
-        # copy acc O from rmem to gmem
         if const_expr(not self.pack_gqa):
-            for rest_m in cutlass.range_constexpr(cute.size(tOrO.shape[1])):
+            # Stream one row fragment through registers at a time.  Materializing
+            # the complete per-thread O fragment before scaling makes the FP8
+            # epilogue spill heavily to local memory.
+            for rest_m in cutlass.range_constexpr(cute.size(tOsO.shape[1])):
                 if t0OcO[0, rest_m, 0][0] < seqlen_q - m_tile_idx * self.m_block_size - tOcO[0][0]:
+                    tOrO_row = cute.make_rmem_tensor_like(tOsO[None, rest_m, None], self.o_dtype)
+                    cute.autovec_copy(tOsO[None, rest_m, None], tOrO_row)
+                    if const_expr(self.is_sage_fp8 and self.is_split_kv):
+                        # P and the softmax denominator carry the same factor
+                        # of 256, so only V_scale remains after normalization.
+                        assert cute.size(tOrO_row.shape[0]) % 2 == 0
+                        for rest_n in cutlass.range_constexpr(cute.size(tOrO_row.shape[1])):
+                            for vec in cutlass.range_constexpr(0, cute.size(tOrO_row.shape[0]), 2):
+                                col0 = tOcO[vec, rest_m, rest_n][1]
+                                col1 = tOcO[vec + 1, rest_m, rest_n][1]
+                                value0 = tOrO_row[vec, rest_n].to(Float32)
+                                value1 = tOrO_row[vec + 1, rest_n].to(Float32)
+                                value0, value1 = cute.arch.mul_packed_f32x2(
+                                    (value0, value1),
+                                    (
+                                        sVScale[col0],
+                                        sVScale[col1],
+                                    ),
+                                )
+                                tOrO_row[vec, rest_n] = value0.to(self.o_dtype)
+                                tOrO_row[vec + 1, rest_n] = value1.to(self.o_dtype)
                     cute.copy(
                         gmem_tiled_copy_O,
-                        tOrO[None, rest_m, None],
+                        tOrO_row,
                         tOgO[None, rest_m, None],
                         pred=tOpO[None, rest_m, None] if const_expr(self.check_hdim_v_oob) else None,
                     )
         else:
+            # PackGQA retains the existing whole-fragment path. The supported
+            # Sage FP8 v1 contract does not use PackGQA.
+            tOrO = cute.make_rmem_tensor_like(tOsO, self.o_dtype)
+            cute.autovec_copy(tOsO, tOrO)
             pack_gqa.store_O(mO_cur, tOrO, gmem_tiled_copy_O, tidx, m_tile_idx, seqlen_q)
 
     @cute.jit
@@ -2261,6 +2721,8 @@ class BlockSparseAttnForwardSm100Blk64:
         self,
         mO: cute.Tensor,
         sO: cute.Tensor,
+        mVScale: Optional[cute.Tensor],
+        sVScale: cute.Tensor,
         gmem_tiled_copy_O: cute.TiledCopy,
         tma_atom_O: Optional[cute.CopyAtom],
         pipeline_o_epi: pipeline.PipelineAsync,
@@ -2275,6 +2737,16 @@ class BlockSparseAttnForwardSm100Blk64:
             m_block, head_idx, batch_idx, split_idx = work_tile.tile_idx
             seqlen = SeqlenInfoCls(batch_idx)
             out_head_idx = head_idx + split_idx * num_heads if const_expr(self.is_split_kv) else head_idx
+
+            tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.epilogue_warp_ids))
+            if const_expr(self.is_sage_fp8 and self.is_split_kv):
+                # One epilogue warp cooperatively stages all per-channel V
+                # scales.  This happens before waiting for O, so the loads can
+                # overlap the producer's final correction work.
+                for vec in cutlass.range_constexpr(self.head_dim_v_padded // cute.arch.WARP_SIZE):
+                    col = tidx + vec * cute.arch.WARP_SIZE
+                    sVScale[col] = mVScale[head_idx, col]
+                cute.arch.sync_warp()
 
             mO_cur = mO[None, None, None, batch_idx][None, None, out_head_idx]
             gO = cute.local_tile(mO_cur, tiler_gO, (m_block, 0))
@@ -2295,7 +2767,6 @@ class BlockSparseAttnForwardSm100Blk64:
                     cute.arch.cp_async_bulk_wait_group(self.q_stage - 1 - stage, read=True)
                     pipeline_o_epi.consumer_release_w_index(stage)
             else:
-                tidx = cute.arch.thread_idx()[0] % (cute.arch.WARP_SIZE * len(self.epilogue_warp_ids))
                 for stage in cutlass.range_constexpr(self.q_stage):
                     # wait from corr, issue tma store on smem
                     # 1. wait for O0 final
@@ -2306,6 +2777,7 @@ class BlockSparseAttnForwardSm100Blk64:
                         sO[None, None, stage],
                         gO[None, None, stage],
                         mO_cur,
+                        sVScale,
                         gmem_tiled_copy_O,
                         tidx,
                         seqlen.seqlen_q,
@@ -2345,7 +2817,7 @@ class BlockSparseAttnForwardSm100Blk64:
         for sub in cutlass.range_constexpr(self.sparse_blocks_per_kv):
             slot = 0 if const_expr(sub == 0) else 2 if const_expr(sub == 1) else 1 if const_expr(sub == 2) else 3
             sparse_idx = idx0 if const_expr(sub == 0) else idx1 if const_expr(sub == 1) else idx2 if const_expr(sub == 2) else idx3
-            smem_offset = stage_base + slot * self.sparse_block_size * (self.head_dim_padded // 2)
+            smem_offset = stage_base + slot * self.sparse_block_size * (self.head_dim_padded if const_expr(self.is_sage_fp8) else self.head_dim_padded // 2)
             sK_sub = cute.make_tensor(
                 cute.recast_ptr(sKV_ptr + smem_offset, sK_tma_layout.inner),
                 sK_tma_layout.outer,
@@ -2392,9 +2864,16 @@ class BlockSparseAttnForwardSm100Blk64:
 
         for sub in cutlass.range_constexpr(self.sparse_blocks_per_kv):
             sparse_idx = idx0 if const_expr(sub == 0) else idx1 if const_expr(sub == 1) else idx2 if const_expr(sub == 2) else idx3
-            smem_offset = (
-                stage_base + (sub & 1) * self.head_dim_v_padded * self.sparse_block_size + (sub >> 1) * self.head_dim_v_padded * self.sparse_block_size * 2
-            )
+            if const_expr(self.is_sage_fp8):
+                # The native FP8 B operand uses the same interleaved 64-token
+                # sub-block order as the QK N operand.  Keeping K and V in the
+                # same logical order is essential once selected blocks differ.
+                slot = 0 if const_expr(sub == 0) else 2 if const_expr(sub == 1) else 1 if const_expr(sub == 2) else 3
+                smem_offset = stage_base + slot * self.head_dim_v_padded * self.sparse_block_size
+            else:
+                smem_offset = (
+                    stage_base + (sub & 1) * self.head_dim_v_padded * self.sparse_block_size + (sub >> 1) * self.head_dim_v_padded * self.sparse_block_size * 2
+                )
             sV_sub = cute.make_tensor(
                 cute.recast_ptr(sKV_ptr + smem_offset, sV_tma_layout.inner),
                 sV_tma_layout.outer,

--- a/python/cudnn/block_sparse_attention/csrc/fwd/sm120_blk64/bsa_fwd_sm120_fp8.py
+++ b/python/cudnn/block_sparse_attention/csrc/fwd/sm120_blk64/bsa_fwd_sm120_fp8.py
@@ -1,0 +1,1077 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SM120 Sage FP8 block-sparse attention forward kernel."""
+
+import operator
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.hopper_helpers as sm90_utils
+import cuda.bindings.driver as cuda
+from cudnn.block_sparse_attention.csrc.utils import kernel_utils
+from cudnn.block_sparse_attention.csrc.utils import layout_utils
+from cudnn.block_sparse_attention.csrc.utils.batched_static_scheduler import (
+    BatchedStaticSchedulerMixin,
+)
+
+SM120_FWD_BLOCK_SIZE = 64
+
+
+# =============================================================================
+# Public kernel class
+# =============================================================================
+class BlockSparseAttnForwardFp8Sm120Blk64(BatchedStaticSchedulerMixin):
+    def __init__(
+        self,
+        gqa_ratio: int = 1,
+        head_dim: int = 128,
+        value_dim: int = 128,
+        blocksparse_blocksize_q: int = 64,
+        blocksparse_blocksize_k: int = 64,
+        dtype: type[cutlass.Numeric] = cutlass.Float8E4M3FN,
+        acc_dtype: type[cutlass.Numeric] = cutlass.Float32,
+        has_block_sizes: bool = True,
+        has_block_nums: bool = True,
+        block_sizes_mode: int = 0,
+    ):
+        self.dtype = dtype
+        self.acc_dtype = acc_dtype
+        assert self.dtype is cutlass.Float8E4M3FN, "SM120 FP8 blk64 fwd requires fp8_e4m3fn"
+        assert self.acc_dtype is cutlass.Float32
+        self.softmax_p_scale_log2 = 8.0
+
+        self.tile_size = 64
+
+        assert blocksparse_blocksize_q == 64, "Only block_size_m=64 is supported in this kernel."
+        assert blocksparse_blocksize_k in [64], "block_size_n should be one of [64]"
+        self.num_threads = 128
+        self.num_mma_warps = 4
+        self.kv_stage = 1
+        self.q_stage = 1
+        self.q_in_regs = True
+
+        assert gqa_ratio >= 1
+        assert head_dim == 128, "SM120 blk64 fwd currently requires QK dim 128"
+        assert value_dim == 128, "SM120 blk64 fwd currently requires value dim 128"
+        self.gqa_ratio = gqa_ratio
+        self.qk_dim = head_dim
+        self.value_dim = value_dim
+        self.tile_shape_qk = (self.tile_size, self.tile_size, self.qk_dim)
+        self.tile_shape_pv = (self.tile_size, self.value_dim, self.tile_size)
+
+        self.scheduler = None
+
+        self.use_tma_o = True
+        self.has_block_sizes = has_block_sizes
+        self.has_block_nums = has_block_nums
+        self.block_sizes_mode = block_sizes_mode
+
+    def check_dim(self, tensor: cute.Tensor | list[cute.Tensor], mode: int):
+        if isinstance(tensor, list):
+            for t in tensor:
+                self.check_dim(t, mode)
+            return
+        assert tensor.shape[mode] == 128, f"dim must be 128 in mode {mode}."
+        assert tensor.stride[mode] == 1, f"dim must be contiguous in mode {mode}."
+
+    @cute.kernel
+    def kernel(
+        self,
+        mQ: cute.Tensor,
+        mK: cute.Tensor,
+        mV: cute.Tensor,
+        mO: cute.Tensor,
+        mLSE: cute.Tensor,
+        mQScale: cute.Tensor,
+        mKScale: cute.Tensor,
+        mVScale: cute.Tensor,
+        tma_atom_Q: cute.CopyAtom,
+        tma_atom_K: cute.CopyAtom,
+        tma_atom_V: cute.CopyAtom,
+        tma_atom_O: cute.CopyAtom,
+        blocksparse_indices_q2k: cute.Tensor,
+        blocksparse_num_blocks_q2k: cute.Tensor,
+        block_sparse_num: cutlass.Int32,
+        blocksparse_varblk: cute.Tensor,
+        tiled_mma_qk: cute.TiledMma,
+        tiled_mma_pv: cute.TiledMma,
+        Q_smem_layout: cute.ComposedLayout,
+        K_smem_layout: cute.ComposedLayout,
+        V_smem_layout: cute.ComposedLayout,
+        Vt_smem_layout: cute.ComposedLayout,
+        O_smem_layout: cute.ComposedLayout,
+        scale_softmax_log2e: cutlass.Float32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        lane_idx = cute.arch.lane_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        work_desc = self.get_work_desc()
+        seqlen = mK.shape[0]
+        num_compute_tiles = cute.ceil_div(seqlen, self.tile_size)
+
+        shared_storage = cutlass.utils.SmemAllocator().allocate(self.shared_storage_t)
+
+        if warp_idx == 0 and lane_idx == 0:
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_Q)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_K)
+            cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_V)
+
+            if cutlass.const_expr(self.use_tma_o):
+                cute.nvgpu.cpasync.prefetch_descriptor(tma_atom_O)
+
+        cg = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+
+        # TMA load barriers. K/V use a 2-stage ring buffer.
+        Q_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=1,
+            producer_group=cg,
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.num_threads // 32),
+            tx_count=cute.size_in_bytes(self.Q_dtype, cute.select(Q_smem_layout, mode=[0, 1])),
+            barrier_storage=shared_storage.Q_barrier.data_ptr(),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        Q_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
+        Q_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+        K_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.kv_stage,
+            producer_group=cg,
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.num_threads // 32),
+            tx_count=cute.size_in_bytes(self.K_dtype, cute.select(K_smem_layout, mode=[0, 1])),
+            barrier_storage=shared_storage.K_barrier.data_ptr(),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        V_pipeline = pipeline.PipelineTmaAsync.create(
+            num_stages=self.kv_stage,
+            producer_group=cg,
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.num_threads // 32),
+            tx_count=cute.size_in_bytes(self.V_dtype, cute.select(V_smem_layout, mode=[0, 1])),
+            barrier_storage=shared_storage.V_barrier.data_ptr(),
+            cta_layout_vmnk=cute.make_layout((1, 1, 1, 1)),
+        )
+        K_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.kv_stage)
+        K_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.kv_stage)
+        V_producer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.kv_stage)
+        V_consumer_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.kv_stage)
+
+        # partition tensors
+        sQ = shared_storage.Q_smem.get_tensor(
+            Q_smem_layout.outer,
+            swizzle=Q_smem_layout.inner,
+        )
+        sK = shared_storage.K_smem.get_tensor(K_smem_layout.outer, swizzle=K_smem_layout.inner)
+        sV = shared_storage.V_smem.get_tensor(V_smem_layout.outer, swizzle=V_smem_layout.inner)
+        # This K-major view only defines the FP8 B-fragment layout. The direct
+        # transpose load below sources data from the N-major sV.
+        sO_buffer = shared_storage.O_smem.get_tensor(
+            O_smem_layout.outer,
+            swizzle=O_smem_layout.inner,
+        )
+        sVt = cute.make_tensor(
+            cute.recast_ptr(
+                sO_buffer.iterator,
+                Vt_smem_layout.inner,
+                dtype=self.V_dtype,
+            ),
+            Vt_smem_layout.outer,
+        )
+
+        mO_slice = mO[None, None, work_desc.qo_head_idx, work_desc.batch_idx]
+        mLSE_slice = mLSE[None, work_desc.qo_head_idx, work_desc.batch_idx]
+        mQ_slice = mQ[None, None, work_desc.qo_head_idx, work_desc.batch_idx]
+        mK_slice = mK[None, None, work_desc.kv_head_idx, work_desc.batch_idx]
+        mV_slice = mV[None, None, work_desc.kv_head_idx, work_desc.batch_idx]
+        gQScale = mQScale[None, work_desc.qo_head_idx, work_desc.batch_idx]
+        gKScale = mKScale[None, work_desc.kv_head_idx, work_desc.batch_idx]
+        gVScale = mVScale[None, work_desc.kv_head_idx]
+        gO = cute.local_tile(mO_slice, (self.tile_shape_pv[0], self.tile_shape_pv[1]), coord=(work_desc.qo_tile_idx, 0))
+        gQ = cute.local_tile(mQ_slice, (self.tile_shape_qk[0], self.tile_shape_qk[2]), coord=(work_desc.qo_tile_idx, 0))
+        gK = cute.local_tile(mK_slice, (self.tile_shape_qk[1], self.tile_shape_qk[2]), coord=(None, 0))
+        gV = cute.local_tile(mV_slice, (self.tile_shape_pv[1], self.tile_shape_pv[2]), coord=(0, None))
+
+        gIndices = blocksparse_indices_q2k[None, work_desc.qo_tile_idx, work_desc.qo_head_idx, work_desc.batch_idx]
+        if cutlass.const_expr(self.has_block_nums):
+            num_n_tiles = blocksparse_num_blocks_q2k[work_desc.qo_tile_idx, work_desc.qo_head_idx, work_desc.batch_idx]
+        else:
+            num_n_tiles = block_sparse_num
+        if cutlass.const_expr(self.has_block_sizes):
+            if cutlass.const_expr(self.block_sizes_mode == 1):
+                gBSZ = blocksparse_varblk
+            elif cutlass.const_expr(self.block_sizes_mode == 2):
+                gBSZ = blocksparse_varblk[None, work_desc.batch_idx]
+            else:
+                gBSZ = blocksparse_varblk[None, work_desc.qo_head_idx, work_desc.batch_idx]
+
+        cta_coord_layout = (0, cute.make_layout(1))  # CTA coord layout for TMA multicasting, effectively no multicast
+        tQsQ, tQgQ = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_Q,
+            *cta_coord_layout,
+            cute.group_modes(sQ, 0, 2),
+            cute.group_modes(gQ, 0, 2),
+        )
+        tKsK, tKgK = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_K,
+            *cta_coord_layout,
+            cute.group_modes(sK, 0, 2),
+            cute.group_modes(gK, 0, 2),
+        )
+        tVsV, tVgV = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_V,
+            *cta_coord_layout,
+            cute.group_modes(sV, 0, 2),
+            cute.group_modes(gV, 0, 2),
+        )
+
+        cS = cute.make_identity_tensor(self.tile_shape_qk[:2])
+
+        thr_mma_qk = tiled_mma_qk.get_slice(tidx)
+        tSsQ = thr_mma_qk.partition_A(sQ)
+        tSsK = thr_mma_qk.partition_B(sK)
+        tSrQ = tiled_mma_qk.make_fragment_A(tSsQ[None, None, None, 0])
+        tSrK = tiled_mma_qk.make_fragment_B(tSsK[None, None, None, 0])
+        tSrS = cute.make_rmem_tensor(thr_mma_qk.partition_shape_C((self.tile_shape_qk[0], self.tile_shape_qk[1])), self.acc_dtype)
+        tScS = thr_mma_qk.partition_C(cS)
+
+        thr_mma_pv = tiled_mma_pv.get_slice(tidx)
+        tOsV = thr_mma_pv.partition_B(sVt)
+        tOrV = tiled_mma_pv.make_fragment_B(tOsV[None, None, None, 0])
+        tOrO = cute.make_rmem_tensor(thr_mma_pv.partition_shape_C((self.tile_shape_pv[0], self.tile_shape_pv[1])), self.acc_dtype)
+        cO = cute.make_identity_tensor(self.tile_shape_pv[:2])
+        tOcO = thr_mma_pv.partition_C(cO)
+
+        atom_copy_ldmatrix_Q = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(
+                transpose=False,
+                num_matrices=4,
+            ),
+            self.Q_dtype,
+        )
+        atom_copy_ldmatrix_K = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix8x8x16bOp(
+                transpose=False,
+                num_matrices=4,
+            ),
+            self.K_dtype,
+        )
+        atom_copy_ldmatrix_V = cute.make_copy_atom(
+            cute.nvgpu.warp.LdMatrix16x16x8bOp(
+                transpose=True,
+                num_matrices=2,
+            ),
+            self.V_dtype,
+        )
+        smem_tiled_copy_Q = cute.make_tiled_copy_A(atom_copy_ldmatrix_Q, tiled_mma_qk)
+        smem_tiled_copy_K = cute.make_tiled_copy_B(atom_copy_ldmatrix_K, tiled_mma_qk)
+        smem_tiled_copy_V = cute.make_tiled_copy_B(
+            atom_copy_ldmatrix_V,
+            tiled_mma_pv,
+        )
+
+        thr_copy_Q = smem_tiled_copy_Q.get_slice(tidx)
+        thr_copy_K = smem_tiled_copy_K.get_slice(tidx)
+        thr_copy_V = smem_tiled_copy_V.get_slice(tidx)
+        tSsQ_copy = thr_copy_Q.partition_S(sQ)
+        tSrQ_copy = thr_copy_Q.retile(tSrQ)
+        tSsK_copy = thr_copy_K.partition_S(sK)
+        tOsV_copy = thr_copy_V.partition_S(sVt)
+
+        max_m_layout = cute.make_layout(cute.size(layout_utils.reshape_acc_to_mn(tOrO).layout, mode=[0]))
+        max_m = cute.make_rmem_tensor_like(max_m_layout, cutlass.Float32)
+        sum_m = cute.make_rmem_tensor_like(max_m, cutlass.Float32)
+        q_softmax_scale_log2e_m = cute.make_rmem_tensor_like(max_m, cutlass.Float32)
+        tScS_mn = layout_utils.reshape_acc_to_mn(tScS)
+        for m in cutlass.range_constexpr(cute.size(q_softmax_scale_log2e_m)):
+            row_idx = work_desc.qo_tile_idx * self.tile_size + tScS_mn[m, 0][0]
+            q_softmax_scale_log2e_m[m] = gQScale[row_idx] * scale_softmax_log2e if row_idx < mQ.shape[0] else cutlass.Float32(0.0)
+
+        tOrO.store(cute.full_like(tOrO, 0.0, self.acc_dtype))
+        max_m.store(cute.full_like(max_m, float("-inf"), cutlass.Float32))
+        sum_m.store(cute.full_like(sum_m, 0.0, cutlass.Float32))
+
+        if warp_idx == 0:
+            Q_pipeline.producer_acquire(Q_producer_state)
+            cute.copy(
+                tma_atom_Q,
+                tQgQ,
+                tQsQ[None, 0],
+                tma_bar_ptr=Q_pipeline.producer_get_barrier(Q_producer_state),
+            )
+            Q_pipeline.producer_commit(Q_producer_state)
+            Q_producer_state.advance()
+
+            preload_count = cutlass.Int32(0)
+            if preload_count < num_n_tiles:
+                logical_idx = num_n_tiles - 1 - preload_count
+                physical_idx = gIndices[logical_idx]
+                K_pipeline.producer_acquire(K_producer_state)
+                cute.copy(
+                    tma_atom_K,
+                    tKgK[None, physical_idx],
+                    tKsK[None, K_producer_state.index],
+                    tma_bar_ptr=K_pipeline.producer_get_barrier(K_producer_state),
+                )
+                K_pipeline.producer_commit(K_producer_state)
+                K_producer_state.advance()
+                V_pipeline.producer_acquire(V_producer_state)
+                cute.copy(
+                    tma_atom_V,
+                    tVgV[None, physical_idx],
+                    tVsV[None, V_producer_state.index],
+                    tma_bar_ptr=V_pipeline.producer_get_barrier(V_producer_state),
+                )
+                V_pipeline.producer_commit(V_producer_state)
+                V_producer_state.advance()
+            if cutlass.const_expr(self.kv_stage > 1):
+                preload_count = cutlass.Int32(1)
+                if preload_count < num_n_tiles:
+                    logical_idx = num_n_tiles - 1 - preload_count
+                    physical_idx = gIndices[logical_idx]
+                    K_pipeline.producer_acquire(K_producer_state)
+                    cute.copy(
+                        tma_atom_K,
+                        tKgK[None, physical_idx],
+                        tKsK[None, K_producer_state.index],
+                        tma_bar_ptr=K_pipeline.producer_get_barrier(K_producer_state),
+                    )
+                    K_pipeline.producer_commit(K_producer_state)
+                    K_producer_state.advance()
+                    V_pipeline.producer_acquire(V_producer_state)
+                    cute.copy(
+                        tma_atom_V,
+                        tVgV[None, physical_idx],
+                        tVsV[None, V_producer_state.index],
+                        tma_bar_ptr=V_pipeline.producer_get_barrier(V_producer_state),
+                    )
+                    V_pipeline.producer_commit(V_producer_state)
+                    V_producer_state.advance()
+
+        cute.arch.sync_threads()
+
+        Q_wait_status = Q_pipeline.consumer_try_wait(Q_consumer_state)
+        Q_pipeline.consumer_wait(Q_consumer_state, Q_wait_status)
+        if cutlass.const_expr(self.q_in_regs):
+            tQsQ_p = tSsQ_copy[None, None, None, 0]
+            for k_block_idx in cutlass.range_constexpr(cute.size(tSrQ, mode=[2])):
+                tQsQ_k = tQsQ_p[None, None, k_block_idx]
+                tQsQ_k = cute.make_tensor(
+                    tQsQ_k.iterator.align(16),
+                    tQsQ_k.layout,
+                )
+                cute.copy(
+                    smem_tiled_copy_Q,
+                    tQsQ_k,
+                    tSrQ_copy[None, None, k_block_idx],
+                )
+        Q_pipeline.consumer_release(Q_consumer_state)
+        Q_consumer_state.advance()
+
+        for load_count in cutlass.range(0, num_n_tiles, 1, unroll=1):
+            n_tile_ind = num_n_tiles - 1 - load_count
+            n_tile_idx = gIndices[n_tile_ind]
+            if cutlass.const_expr(self.has_block_sizes):
+                varblk = gBSZ[n_tile_idx]
+            else:
+                varblk = cutlass.Int32(self.tile_size)
+                if n_tile_idx == num_compute_tiles - 1:
+                    varblk = seqlen - n_tile_idx * self.tile_size
+
+            K_wait_status = K_pipeline.consumer_try_wait(K_consumer_state)
+            K_pipeline.consumer_wait(K_consumer_state, K_wait_status)
+
+            k_stage = K_consumer_state.index
+
+            _gemm_smem_zero_acc_fp8(
+                tiled_mma_qk,
+                tSrS,
+                tSrQ,
+                tSrK,
+                tSsQ_copy[None, None, None, 0],
+                tSsK_copy[None, None, None, k_stage],
+                smem_tiled_copy_Q,
+                smem_tiled_copy_K,
+                A_in_regs=self.q_in_regs,
+                B_uses_fp8_ldsm=True,
+            )
+
+            tKScale = _load_sage_k_scales_fp8(
+                tScS,
+                gKScale,
+                n_tile_idx,
+                self.tile_size,
+            )
+
+            K_pipeline.consumer_release(K_consumer_state)
+            K_consumer_state.advance()
+
+            preload_count = load_count + self.kv_stage
+            preload_physical = cutlass.Int32(0)
+            if warp_idx == 0 and preload_count < num_n_tiles:
+                preload_logical = num_n_tiles - 1 - preload_count
+                preload_physical = gIndices[preload_logical]
+                K_pipeline.producer_acquire(K_producer_state)
+                cute.copy(
+                    tma_atom_K,
+                    tKgK[None, preload_physical],
+                    tKsK[None, K_producer_state.index],
+                    tma_bar_ptr=K_pipeline.producer_get_barrier(K_producer_state),
+                )
+                K_pipeline.producer_commit(K_producer_state)
+                K_producer_state.advance()
+
+            if varblk < self.tile_size:
+                _mask_fp8(tiled_mma_qk, tSrS, tScS, varblk)
+            row_scale = _online_softmax_fp8(
+                tiled_mma_qk,
+                tSrS,
+                max_m,
+                sum_m,
+                q_softmax_scale_log2e_m,
+                self.softmax_p_scale_log2,
+                tKScale,
+            )
+
+            # Compute P @ V.
+            _rescale_o_for_next_acc_fp8(tiled_mma_pv, tOrO, row_scale)
+            tOrP = _make_acc_into_fp8_op(
+                tSrS,
+                tiled_mma_pv.tv_layout_A,
+                self.V_dtype,
+            )
+
+            V_wait_status = V_pipeline.consumer_try_wait(V_consumer_state)
+            V_pipeline.consumer_wait(V_consumer_state, V_wait_status)
+
+            # Load each 16x32 N-major V subtile with the native 8-bit
+            # transpose path. Hopper WGMMA writes the transposed values back
+            # to K-major SMEM, but SM120 warp MMA consumes B from registers,
+            # so the LDSM.T result can directly form the FP8 B fragment.
+            destination_layout = cute.make_layout(
+                ((4, (2, 2)),),
+                stride=((1, (16, 4)),),
+            )
+            for k_block in cutlass.range_constexpr(2):
+                for n_block in cutlass.range_constexpr(8):
+                    source_ptr = sV.iterator + cute.crd2idx(
+                        (n_block * 16, k_block * 32 + lane_idx, 0),
+                        sV.layout,
+                    )
+                    source = cute.make_tensor(
+                        source_ptr.align(16),
+                        cute.make_layout(16),
+                    )
+                    block_idx = k_block * 8 + n_block
+                    destination_base = (block_idx % 8) * 8 + (block_idx // 8) * 2
+                    destination = cute.make_tensor(
+                        tOrV.iterator + destination_base * 4,
+                        destination_layout,
+                    )
+                    cute.copy(
+                        atom_copy_ldmatrix_V,
+                        source,
+                        destination,
+                    )
+
+            _gemm_rs_fp8(
+                tiled_mma_pv,
+                tOrO,
+                tOrP,
+                tOrV,
+                tOsV_copy[None, None, None, 0],
+                smem_tiled_copy_V,
+                B_in_regs=True,
+            )
+            V_pipeline.consumer_release(V_consumer_state)
+            V_consumer_state.advance()
+
+            if warp_idx == 0 and preload_count < num_n_tiles:
+                V_pipeline.producer_acquire(V_producer_state)
+                cute.copy(
+                    tma_atom_V,
+                    tVgV[None, preload_physical],
+                    tVsV[None, V_producer_state.index],
+                    tma_bar_ptr=V_pipeline.producer_get_barrier(V_producer_state),
+                )
+                V_pipeline.producer_commit(V_producer_state)
+                V_producer_state.advance()
+
+        final_ratio, lse = _finalize_softmax_fp8(
+            max_m,
+            sum_m,
+            q_softmax_scale_log2e_m,
+            self.softmax_p_scale_log2,
+        )
+        _rescale_o_with_sage_v_scale_fp8(
+            tOrO,
+            tOcO,
+            final_ratio,
+            gVScale,
+        )
+        tScS_mn = layout_utils.reshape_acc_to_mn(tScS)
+        for m in cutlass.range_constexpr(cute.size(lse)):
+            row_idx = work_desc.qo_tile_idx * self.tile_size + tScS_mn[m, 0][0]
+            if tScS_mn[m, 0][1] == 0:
+                if row_idx < mQ.shape[0]:
+                    mLSE_slice[row_idx] = lse[m]
+
+        tOrO_cvt = cute.make_rmem_tensor_like(tOrO, self.O_dtype)
+        tOrO_cvt.store(tOrO.load().to(self.O_dtype))
+
+        # FP8 Q needs a separate, larger buffer for the BF16 output tile.
+        sO = shared_storage.O_smem.get_tensor(O_smem_layout.outer, swizzle=O_smem_layout.inner)
+        tiled_copy_o_r2s = cute.make_tiled_copy_C(
+            cute.make_copy_atom(
+                cute.nvgpu.warp.StMatrix8x8x16bOp(self.O_layout.is_m_major_c(), 4),
+                self.O_dtype,
+            ),
+            tiled_mma_pv,
+        )
+        tOrO_cv = tiled_copy_o_r2s.retile(tOrO_cvt)
+        tOsO = tiled_copy_o_r2s.get_slice(tidx).partition_D(sO)
+        cute.copy(tiled_copy_o_r2s, tOrO_cv, tOsO)
+
+        cute.arch.fence_view_async_shared()
+        cute.arch.sync_threads()
+
+        # S2G with explicit TMA store wait.
+        tOsO, tOgO = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_O,
+            *cta_coord_layout,
+            cute.group_modes(sO, 0, 2),
+            cute.group_modes(gO, 0, 2),
+        )
+        if warp_idx == 0:
+            cute.copy(tma_atom_O, tOsO, tOgO)
+            cute.arch.cp_async_bulk_commit_group()
+            cute.arch.cp_async_bulk_wait_group(0, read=True)
+
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,  # (head_dim, seqlen, nheads, batch)
+        mK: cute.Tensor,  # (head_dim, seqlen, nheads, batch)
+        mV: cute.Tensor,  # (value_dim, seqlen, nheads, batch)
+        mO: cute.Tensor,  # (value_dim, seqlen, nheads, batch)
+        mLSE: cute.Tensor,  # (seqlen, nheads, batch)
+        mQScale: cute.Tensor,  # (seqlen_q, nheads_q, batch)
+        mKScale: cute.Tensor,  # (ceil_div(seqlen_k, 16), nheads_kv, batch)
+        mVScale: cute.Tensor,  # (value_dim, nheads_kv)
+        blocksparse_indices_q2k: cute.Tensor,  # (k, q, nheads, batch)
+        blocksparse_num_blocks_q2k: cute.Tensor,  # (q, nheads, batch)
+        block_sparse_num: cutlass.Int32,
+        blocksparse_varblk: cute.Tensor,
+        softmax_scale: cutlass.Float32,
+        stream: cuda.CUstream,
+    ):
+        # Restore compile-time head dimensions while keeping runtime tensor
+        # modes dynamic for reusable JIT callables.
+        mQ = cute.make_tensor(
+            mQ.iterator,
+            cute.make_layout(
+                (mQ.shape[0], self.qk_dim, mQ.shape[2], mQ.shape[3]),
+                stride=mQ.stride,
+            ),
+        )
+        mK = cute.make_tensor(
+            mK.iterator,
+            cute.make_layout(
+                (mK.shape[0], self.qk_dim, mK.shape[2], mK.shape[3]),
+                stride=mK.stride,
+            ),
+        )
+        mV = cute.make_tensor(
+            mV.iterator,
+            cute.make_layout(
+                (self.value_dim, mV.shape[1], mV.shape[2], mV.shape[3]),
+                stride=mV.stride,
+            ),
+        )
+        mO = cute.make_tensor(
+            mO.iterator,
+            cute.make_layout(
+                (mO.shape[0], self.value_dim, mO.shape[2], mO.shape[3]),
+                stride=mO.stride,
+            ),
+        )
+        mVScale = cute.make_tensor(
+            mVScale.iterator,
+            cute.make_layout(
+                (self.value_dim, mVScale.shape[1]),
+                stride=mVScale.stride,
+            ),
+        )
+        self.check_dim([mQ, mK, mO], 1)
+        self.check_dim(mV, 0)
+
+        Q_layout = utils.LayoutEnum.from_tensor(mQ)
+        K_layout = utils.LayoutEnum.from_tensor(mK)
+        V_layout = utils.LayoutEnum.from_tensor(mV)
+        O_layout = utils.LayoutEnum.from_tensor(mO)
+
+        self.Q_dtype = mQ.element_type
+        self.K_dtype = mK.element_type
+        self.V_dtype = mV.element_type
+        self.O_dtype = mO.element_type
+        assert self.Q_dtype == self.K_dtype == self.V_dtype == cutlass.Float8E4M3FN
+        assert self.O_dtype is cutlass.BFloat16
+        self.Q_layout = Q_layout
+        self.K_layout = K_layout
+        self.V_layout = V_layout
+        self.O_layout = O_layout
+
+        atom_layout_mnk = (4, 1, 1)
+        mma_inst_mnk = (16, 8, 32)
+        permutation_mnk = (
+            atom_layout_mnk[0] * mma_inst_mnk[0],
+            atom_layout_mnk[1] * mma_inst_mnk[1] * 2,
+            atom_layout_mnk[2] * mma_inst_mnk[2],
+        )
+        mma_op_qk = cute.nvgpu.warp.MmaFP8Op(
+            self.Q_dtype,
+            self.acc_dtype,
+            mma_inst_mnk,
+        )
+        mma_op_pv = cute.nvgpu.warp.MmaFP8Op(
+            self.V_dtype,
+            self.acc_dtype,
+            mma_inst_mnk,
+        )
+        tiled_mma_qk = cute.make_tiled_mma(
+            mma_op_qk,
+            cute.make_layout(atom_layout_mnk),
+            permutation_mnk=permutation_mnk,
+        )
+        tiled_mma_pv = cute.make_tiled_mma(
+            mma_op_pv,
+            cute.make_layout(atom_layout_mnk),
+            permutation_mnk=permutation_mnk,
+        )
+
+        self.Q_smem_layout = sm90_utils.make_smem_layout_a(
+            Q_layout,
+            self.tile_shape_qk,
+            self.Q_dtype,
+            self.q_stage,
+        )
+        self.K_smem_layout = sm90_utils.make_smem_layout_b(
+            K_layout,
+            self.tile_shape_qk,
+            self.K_dtype,
+            self.kv_stage,
+        )
+        self.V_smem_layout = sm90_utils.make_smem_layout_b(
+            V_layout,
+            self.tile_shape_pv,
+            self.V_dtype,
+            self.kv_stage,
+        )
+        vt_smem_layout_atom = cute.nvgpu.tcgen05.make_smem_layout_atom(
+            cute.nvgpu.tcgen05.SmemLayoutAtomKind.K_SW64,
+            self.V_dtype,
+        )
+        self.Vt_smem_layout = cute.tile_to_shape(
+            vt_smem_layout_atom,
+            (*self.tile_shape_pv[1:], self.kv_stage),
+            order=(0, 1, 2),
+        )
+        O_smem_layout_staged = sm90_utils.make_smem_layout_epi(
+            self.O_dtype,
+            O_layout,
+            self.tile_shape_pv[:2],
+            1,
+        )
+        self.O_smem_layout = cute.select(O_smem_layout_staged, mode=[0, 1])
+
+        @cute.struct
+        class SharedStorage:
+            Q_barrier: cute.struct.MemRange[cutlass.Int64, self.q_stage * 2]
+            K_barrier: cute.struct.MemRange[cutlass.Int64, self.kv_stage * 2]
+            V_barrier: cute.struct.MemRange[cutlass.Int64, self.kv_stage * 2]
+
+            Q_smem: cute.struct.Align[cute.struct.MemRange[self.Q_dtype, cute.cosize(self.Q_smem_layout)], 128]
+            K_smem: cute.struct.Align[cute.struct.MemRange[self.K_dtype, cute.cosize(self.K_smem_layout)], 128]
+            V_smem: cute.struct.Align[cute.struct.MemRange[self.V_dtype, cute.cosize(self.V_smem_layout)], 128]
+            O_smem: cute.struct.Align[cute.struct.MemRange[self.O_dtype, cute.cosize(self.O_smem_layout)], 128]
+
+        self.shared_storage_t = SharedStorage
+
+        tma_copy_op = cute.nvgpu.cpasync.CopyBulkTensorTileG2SOp()
+        tma_atom_Q, tma_tensor_Q = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_copy_op,
+            mQ,
+            self.Q_smem_layout,
+            (self.tile_shape_qk[0], self.tile_shape_qk[2]),
+            num_multicast=1,
+        )
+        tma_atom_K, tma_tensor_K = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_copy_op,
+            mK,
+            self.K_smem_layout,
+            (self.tile_shape_qk[1], self.tile_shape_qk[2]),
+            num_multicast=1,
+        )
+        tma_atom_V, tma_tensor_V = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_copy_op,
+            mV,
+            self.V_smem_layout,
+            (self.tile_shape_pv[1], self.tile_shape_pv[2]),
+            num_multicast=1,
+        )
+
+        tma_copy_op = cute.nvgpu.cpasync.CopyBulkTensorTileS2GOp()
+        tma_atom_O, tma_tensor_O = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            tma_copy_op,
+            mO,
+            self.O_smem_layout,
+            (self.tile_shape_pv[0], self.tile_shape_pv[1]),
+            num_multicast=1,
+        )
+
+        log2_e = 1.44269504088896340736
+
+        grid_config = self.get_grid_config(mQ.shape[0], mQ.shape[2], mQ.shape[3])
+        block_config = (self.num_threads, 1, 1)
+
+        self.kernel(
+            tma_tensor_Q,
+            tma_tensor_K,
+            tma_tensor_V,
+            tma_tensor_O,
+            mLSE,
+            mQScale,
+            mKScale,
+            mVScale,
+            tma_atom_Q,
+            tma_atom_K,
+            tma_atom_V,
+            tma_atom_O,
+            blocksparse_indices_q2k,
+            blocksparse_num_blocks_q2k,
+            block_sparse_num,
+            blocksparse_varblk,
+            tiled_mma_qk,
+            tiled_mma_pv,
+            self.Q_smem_layout,
+            self.K_smem_layout,
+            self.V_smem_layout,
+            self.Vt_smem_layout,
+            self.O_smem_layout,
+            softmax_scale * log2_e,
+        ).launch(
+            grid=grid_config,
+            block=block_config,
+            cluster=(1, 1, 1),
+            smem=self.shared_storage_t.size_in_bytes(),
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+
+# =============================================================================
+# Local CuTe helpers
+# =============================================================================
+
+
+def _convert_c_layout_to_a_layout_fp8(c: cute.Layout, a: cute.Layout) -> cute.Layout:
+    """Reinterpret a C fragment with the logical shape of an A operand."""
+    a_layout = cute.make_layout(a)
+    c_atom_size = cute.size(c, mode=[0])
+    expansion = cute.size(a) // c_atom_size
+    return cute.make_layout(
+        (a, c.shape[1], c.shape[2] // expansion),
+        stride=(
+            a_layout.stride,
+            0,
+            cute.size(a),
+        ),
+    )
+
+
+@cute.jit
+def _make_acc_into_fp8_op(
+    acc: cute.Tensor,
+    operand_layout_tv: cute.Layout,
+    element: type[cutlass.Numeric],
+) -> cute.Tensor:
+    """Apply FA3's C-layout reinterpretation, E4M3 cast, and A-reg permutation."""
+    operand = cute.make_rmem_tensor_like(
+        _convert_c_layout_to_a_layout_fp8(acc.layout, operand_layout_tv.shape[1]),
+        element,
+    )
+    operand_as_acc = cute.make_tensor(operand.iterator, acc.layout)
+    operand_as_acc.store(acc.load().to(element))
+
+    # The C and FP8 A layouts distribute adjacent bytes differently across
+    # each quad. Exchange packed groups of four FP8 values in registers.
+    tidx, _, _ = cute.arch.thread_idx()
+    tid = tidx % 4
+    values_u32 = cute.recast_tensor(operand, cutlass.Uint32)
+    for n in cutlass.range_constexpr(cute.size(values_u32, mode=[1])):
+        for k in cutlass.range_constexpr(cute.size(values_u32, mode=[2])):
+            for ii in cutlass.range_constexpr(0, 8, 4):
+                values_tmp_0 = values_u32[ii // 2, n, k]
+                values_tmp_1 = values_u32[ii // 2 + 1, n, k]
+
+                use_first = tid == 1 or tid == 2
+                source_lane = (0x3021 >> (tid * 4)) & 0xF
+                values_tmp_a = values_tmp_0 if use_first else values_tmp_1
+                values_tmp_a = cute.arch.shuffle_sync_op(values_tmp_a, source_lane, 0xFFFFFFFF, 7199)
+
+                use_first = not use_first
+                source_lane = (0x2130 >> (tid * 4)) & 0xF
+                values_tmp_b = values_tmp_0 if use_first else values_tmp_1
+                values_tmp_b = cute.arch.shuffle_sync_op(values_tmp_b, source_lane, 0xFFFFFFFF, 7199)
+
+                selector = 0x1054 if use_first else 0x5410
+                values_u32[ii // 2, n, k] = cute.arch.prmt(values_tmp_a, values_tmp_b, selector)
+                selector = 0x3276 if use_first else 0x7632
+                values_u32[ii // 2 + 1, n, k] = cute.arch.prmt(values_tmp_a, values_tmp_b, selector)
+    return operand
+
+
+@cute.jit
+def _gemm_smem_zero_acc_fp8(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsA: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_tiled_copy_A: cute.TiledCopy,
+    smem_tiled_copy_B: cute.TiledCopy,
+    A_in_regs: bool = False,
+    B_uses_fp8_ldsm: bool = False,
+) -> None:
+    acc.fill(0.0)
+    tCrA_copy_view = smem_tiled_copy_A.retile(tCrA)
+    tCrB_copy_view = smem_tiled_copy_B.retile(tCrB)
+    if cutlass.const_expr(not A_in_regs):
+        cute.copy(smem_tiled_copy_A, tCsA[None, None, 0], tCrA_copy_view[None, None, 0])
+    tCsB_cur = tCsB[None, None, 0]
+    if cutlass.const_expr(B_uses_fp8_ldsm):
+        tCsB_cur = cute.make_tensor(
+            tCsB_cur.iterator.align(16),
+            tCsB_cur.layout,
+        )
+    cute.copy(smem_tiled_copy_B, tCsB_cur, tCrB_copy_view[None, None, 0])
+    for k_block_idx in cutlass.range_constexpr(cute.size(tCsB.shape[2])):
+        if k_block_idx < cute.size(tCsB.shape[2]) - 1:
+            if cutlass.const_expr(not A_in_regs):
+                cute.copy(
+                    smem_tiled_copy_A,
+                    tCsA[None, None, k_block_idx + 1],
+                    tCrA_copy_view[None, None, k_block_idx + 1],
+                )
+            tCsB_next = tCsB[None, None, k_block_idx + 1]
+            if cutlass.const_expr(B_uses_fp8_ldsm):
+                tCsB_next = cute.make_tensor(
+                    tCsB_next.iterator.align(16),
+                    tCsB_next.layout,
+                )
+            cute.copy(
+                smem_tiled_copy_B,
+                tCsB_next,
+                tCrB_copy_view[None, None, k_block_idx + 1],
+            )
+        cute.gemm(
+            tiled_mma,
+            acc,
+            tCrA[None, None, k_block_idx],
+            tCrB[None, None, k_block_idx],
+            acc,
+        )
+
+
+@cute.jit
+def _gemm_rs_fp8(
+    tiled_mma: cute.TiledMma,
+    acc: cute.Tensor,
+    tCrA: cute.Tensor,
+    tCrB: cute.Tensor,
+    tCsB: cute.Tensor,
+    smem_tiled_copy_B: cute.TiledCopy,
+    B_in_regs: bool = False,
+) -> None:
+    if cutlass.const_expr(not B_in_regs):
+        tCrB_copy_view = smem_tiled_copy_B.retile(tCrB)
+        tCsB_cur = tCsB[None, None, 0]
+        cute.copy(smem_tiled_copy_B, tCsB_cur, tCrB_copy_view[None, None, 0])
+    for k_block_idx in cutlass.range_constexpr(cute.size(tCrA.shape[2])):
+        if cutlass.const_expr(not B_in_regs):
+            if k_block_idx < cute.size(tCrA.shape[2]) - 1:
+                tCsB_next = tCsB[None, None, k_block_idx + 1]
+                cute.copy(
+                    smem_tiled_copy_B,
+                    tCsB_next,
+                    tCrB_copy_view[None, None, k_block_idx + 1],
+                )
+        cute.gemm(
+            tiled_mma,
+            acc,
+            tCrA[None, None, k_block_idx],
+            tCrB[None, None, k_block_idx],
+            acc,
+        )
+
+
+@cute.jit
+def _load_sage_k_scales_fp8(
+    tScS: cute.Tensor,
+    gKScale: cute.Tensor,
+    k_tile_idx: cutlass.Int32,
+    tile_size: cutlass.Constexpr[int],
+) -> cute.Tensor:
+    """Load the four per-token-group K descales for one KV tile."""
+    tScS_mn = layout_utils.reshape_acc_to_mn(tScS)
+    num_k_scales = tile_size // 16
+    tKScale = cute.make_rmem_tensor(
+        cute.make_layout(num_k_scales),
+        cutlass.Float32,
+    )
+    k_scale_base = k_tile_idx * num_k_scales
+    scores_per_k_scale = cute.size(tScS_mn, mode=[1]) // num_k_scales
+    for k_scale_group in cutlass.range_constexpr(num_k_scales):
+        tile_scale_idx = tScS_mn[0, k_scale_group * scores_per_k_scale][1] // 16
+        scale_idx = k_scale_base + tile_scale_idx
+        scale_idx = scale_idx if scale_idx < gKScale.shape[0] else gKScale.shape[0] - 1
+        tKScale[k_scale_group] = gKScale[scale_idx]
+    return tKScale
+
+
+@cute.jit
+def _mask_fp8(
+    qk_tiled_mma: cute.TiledMma,
+    tSrS: cute.ThrMma,
+    tScS: cute.Tensor,
+    varblk: cutlass.Int32,
+):
+    tSrS_mn = layout_utils.reshape_acc_to_mn(tSrS)
+    tScS_mn = layout_utils.reshape_acc_to_mn(tScS)
+
+    for n in cutlass.range(cute.size(tSrS_mn, mode=[1]), unroll_full=True):
+        should_mask = tScS_mn[0, n][1] >= varblk
+        for m in cutlass.range(cute.size(tSrS_mn, mode=[0]), unroll_full=True):
+            tSrS_mn[m, n] = -cutlass.Float32.inf if should_mask else tSrS_mn[m, n]
+
+
+@cute.jit
+def _online_softmax_fp8(
+    tiled_mma_qk: cute.TiledMma,
+    tSrS: cute.ThrMma,
+    row_max: cute.Tensor,
+    row_sum: cute.Tensor,
+    softmax_scale_log2e_m: cute.Tensor,
+    exp_scale_log2: cutlass.Float32,
+    tKScale: cute.Tensor,
+) -> cute.Tensor:
+    tSrS_mn = layout_utils.reshape_acc_to_mn(tSrS)
+    row_scale = cute.make_rmem_tensor_like(row_max, cutlass.Float32)
+    num_k_scales = cute.size(tKScale)
+    scores_per_k_scale = cute.size(tSrS_mn, mode=[1]) // num_k_scales
+
+    for m in cutlass.range(cute.size(row_max), unroll_full=True):
+        softmax_scale_log2e = softmax_scale_log2e_m[m]
+        row_max_local = row_max[m]
+        # K descales are positive and shared by each score group, so reduce
+        # unscaled scores first and apply one descale to the group maximum.
+        for k_scale_group in cutlass.range_constexpr(num_k_scales):
+            k_scale = tKScale[k_scale_group]
+            group_begin = k_scale_group * scores_per_k_scale
+            group_max = tSrS_mn[m, group_begin]
+            for n in cutlass.range_constexpr(
+                group_begin + 1,
+                (k_scale_group + 1) * scores_per_k_scale,
+            ):
+                group_max = cute.arch.fmax(group_max, tSrS_mn[m, n])
+            row_max_local = cute.arch.fmax(
+                row_max_local,
+                group_max * k_scale,
+            )
+        row_max_cur = cute.arch.warp_reduction_max(
+            row_max_local,
+            threads_in_group=4,
+        )
+
+        row_max_prev = row_max[m]
+        row_max[m] = row_max_cur
+        row_max_safe = cutlass.Float32(0.0) if row_max_cur == -cutlass.Float32.inf else row_max_cur
+        # Shift the exponent by log2(P scale) before FP8 conversion. Keeping
+        # row_sum in the same scale removes a vector multiply from every tile.
+        row_max_scaled = row_max_safe * softmax_scale_log2e - exp_scale_log2
+
+        for k_scale_group in cutlass.range_constexpr(num_k_scales):
+            score_scale_log2e = tKScale[k_scale_group] * softmax_scale_log2e
+            for n in cutlass.range_constexpr(
+                k_scale_group * scores_per_k_scale,
+                (k_scale_group + 1) * scores_per_k_scale,
+            ):
+                tSrS_mn[m, n] = cute.math.exp2(
+                    tSrS_mn[m, n] * score_scale_log2e - row_max_scaled,
+                    fastmath=True,
+                )
+        acc_S_row_exp = tSrS_mn[m, None].load()
+        row_scale[m] = cute.math.exp2(
+            (row_max_prev - row_max_safe) * softmax_scale_log2e,
+            fastmath=True,
+        )
+        row_sum[m] = kernel_utils.fadd_reduce(
+            acc_S_row_exp,
+            init_val=row_sum[m] * row_scale[m],
+            arch=80,
+        )
+        tSrS_mn[m, None].store(acc_S_row_exp)
+
+    return row_scale
+
+
+@cute.jit
+def _finalize_softmax_fp8(
+    row_max: cute.Tensor,
+    row_sum: cute.Tensor,
+    softmax_scale_log2e_m: cute.Tensor,
+    exp_scale_log2: cutlass.Float32,
+) -> cute.Tensor:
+    row_sum.store(kernel_utils.warp_reduce(row_sum.load(), operator.add, width=4))
+    final_ratio = cute.make_rmem_tensor_like(row_sum, cutlass.Float32)
+    lse = cute.make_rmem_tensor_like(row_sum, cutlass.Float32)
+
+    for m in cutlass.range(cute.size(row_sum), unroll_full=True):
+        softmax_scale_log2e = softmax_scale_log2e_m[m]
+        final_sum = row_sum[m]
+        is_zero_or_nan = final_sum == 0.0 or final_sum != final_sum
+        final_ratio[m] = cute.arch.rcp_approx(final_sum if not is_zero_or_nan else 1.0)
+
+        ln2 = 0.693147180559945309417
+        lse[m] = (
+            -cutlass.Float32.inf if is_zero_or_nan else (row_max[m] * softmax_scale_log2e + cute.math.log2(final_sum, fastmath=True) - exp_scale_log2) * ln2
+        )
+
+    return final_ratio, lse
+
+
+@cute.jit
+def _rescale_o_for_next_acc_fp8(
+    pv_tiled_mma: cute.TiledMma,
+    tOrO: cute.ThrMma,
+    prev_ratio_m: cute.Tensor,
+):
+    tOrO_mn = layout_utils.reshape_acc_to_mn(tOrO)
+    for m in cutlass.range(cute.size(prev_ratio_m), unroll_full=True):
+        tOrO_mn[m, None].store(tOrO_mn[m, None].load() * prev_ratio_m[m])
+
+
+@cute.jit
+def _rescale_o_with_sage_v_scale_fp8(
+    tOrO: cute.Tensor,
+    tOcO: cute.Tensor,
+    final_ratio_m: cute.Tensor,
+    gVScale: cute.Tensor,
+) -> None:
+    """Normalize O and apply the per-channel Sage V descale."""
+    tOrO_mn = layout_utils.reshape_acc_to_mn(tOrO)
+    tOcO_mn = layout_utils.reshape_acc_to_mn(tOcO)
+    for n in cutlass.range(cute.size(tOrO_mn, mode=[1]), unroll_full=True):
+        v_scale = gVScale[tOcO_mn[0, n][1]]
+        for m in cutlass.range(cute.size(final_ratio_m), unroll_full=True):
+            tOrO_mn[m, n] *= final_ratio_m[m] * v_scale

--- a/python/cudnn/block_sparse_attention/csrc/utils/block_sparse_tile_scheduler.py
+++ b/python/cudnn/block_sparse_attention/csrc/utils/block_sparse_tile_scheduler.py
@@ -226,9 +226,6 @@ class BlockSparsePersistentTileScheduler:
 
     def consumer_advance(self, *, loc=None, ip=None):
         if const_expr(self.params.scheduling_mode == SchedulingMode.CLC):
-            # Match blk64 C++ ClcPersistentTileScheduler::consumer_advance:
-            # all warps must converge before consuming the next CLC response.
-            cute.arch.sync_threads()
             self._clc_pipeline.consumer_wait(self._clc_consumer_state)
             work_tile = self.get_current_work()
             self._clc_pipeline.consumer_release(self._clc_consumer_state)

--- a/python/cudnn/block_sparse_attention/csrc/utils/block_sparse_tile_scheduler.py
+++ b/python/cudnn/block_sparse_attention/csrc/utils/block_sparse_tile_scheduler.py
@@ -33,10 +33,14 @@ class BlockSparsePersistentTileScheduler:
     class Params(ParamsBase):
         num_block_divmod: FastDivmodDivisor
         num_head_divmod: FastDivmodDivisor
+        num_splits_divmod: FastDivmodDivisor
+        total_base_blocks: Int32
         total_blocks: Int32
         num_block: Int32
         num_head: Int32
         num_batch: Int32
+        num_splits: Int32
+        is_split_kv: cutlass.Constexpr[bool] = False
         scheduling_mode: cutlass.Constexpr[SchedulingMode] = SchedulingMode.STATIC
 
         @staticmethod
@@ -47,14 +51,19 @@ class BlockSparsePersistentTileScheduler:
             loc=None,
             ip=None,
         ) -> "BlockSparsePersistentTileScheduler.Params":
-            total_blocks = args.num_block * args.num_head * args.num_batch
+            total_base_blocks = args.num_block * args.num_head * args.num_batch
+            total_blocks = total_base_blocks if scheduling_mode == SchedulingMode.CLC else total_base_blocks * (args.num_splits if args.is_split_kv else 1)
             return BlockSparsePersistentTileScheduler.Params(
                 FastDivmodDivisor(args.num_block),
                 FastDivmodDivisor(args.num_head),
+                FastDivmodDivisor(args.num_splits),
+                total_base_blocks,
                 total_blocks,
                 args.num_block,
                 args.num_head,
                 args.num_batch,
+                args.num_splits,
+                is_split_kv=args.is_split_kv,
                 scheduling_mode=scheduling_mode,
             )
 
@@ -96,12 +105,21 @@ class BlockSparsePersistentTileScheduler:
                 ClcDynamicPersistentTileSchedulerParams,
             )
 
-            cutlass_params = ClcDynamicPersistentTileSchedulerParams(
-                problem_shape_ntile_mnl=(
+            problem_shape_ntile_mnl = (
+                (
+                    params.total_base_blocks,
+                    params.num_splits,
+                    Int32(1),
+                )
+                if const_expr(params.is_split_kv)
+                else (
                     params.num_block,
                     params.num_head,
                     params.num_batch,
-                ),
+                )
+            )
+            cutlass_params = ClcDynamicPersistentTileSchedulerParams(
+                problem_shape_ntile_mnl=problem_shape_ntile_mnl,
                 cluster_shape_mnk=(1, 1, 1),
             )
             block_idx = cute.arch.block_idx()
@@ -125,6 +143,12 @@ class BlockSparsePersistentTileScheduler:
         ip=None,
     ) -> Tuple[Int32, Int32, Int32]:
         if const_expr(params.scheduling_mode == SchedulingMode.CLC):
+            if const_expr(params.is_split_kv):
+                return (
+                    params.total_base_blocks,
+                    params.num_splits,
+                    Int32(1),
+                )
             return (
                 params.num_block,
                 params.num_head,
@@ -137,10 +161,23 @@ class BlockSparsePersistentTileScheduler:
 
     @cute.jit
     def _clc_work_to_coords(self, work) -> WorkTileInfo:
-        """Convert CLC response (block, head, batch) to WorkTileInfo."""
-        batch_idx = work.tile_idx[2]
+        """Convert a CLC response to block-sparse attention work coordinates."""
+        if const_expr(self.params.is_split_kv):
+            hn_idx, block_idx = divmod(Int32(work.tile_idx[0]), self.params.num_block_divmod)
+            batch_idx, head_idx = divmod(hn_idx, self.params.num_head_divmod)
+            split_idx = Int32(work.tile_idx[1])
+        else:
+            block_idx = Int32(work.tile_idx[0])
+            head_idx = Int32(work.tile_idx[1])
+            batch_idx = Int32(work.tile_idx[2])
+            split_idx = Int32(0)
         return WorkTileInfo(
-            (Int32(work.tile_idx[0]), Int32(work.tile_idx[1]), Int32(batch_idx), Int32(0)),
+            (
+                Int32(block_idx),
+                Int32(head_idx),
+                Int32(batch_idx),
+                Int32(split_idx),
+            ),
             work.is_valid_tile,
         )
 
@@ -150,10 +187,23 @@ class BlockSparsePersistentTileScheduler:
             work = self._clc_scheduler.get_current_work()
             self._tile_idx = work.tile_idx[0]
             return self._clc_work_to_coords(work)
-        hn_idx, block_idx = divmod(self._tile_idx, self.params.num_block_divmod)
+        if const_expr(self.params.is_split_kv):
+            base_idx, split_idx = divmod(self._tile_idx, self.params.num_splits_divmod)
+        else:
+            base_idx = self._tile_idx
+            split_idx = Int32(0)
+        hn_idx, block_idx = divmod(base_idx, self.params.num_block_divmod)
         batch_idx, head_idx = divmod(hn_idx, self.params.num_head_divmod)
         is_valid = self._tile_idx < self.params.total_blocks
-        return WorkTileInfo((Int32(block_idx), Int32(head_idx), Int32(batch_idx), Int32(0)), is_valid)
+        return WorkTileInfo(
+            (
+                Int32(block_idx),
+                Int32(head_idx),
+                Int32(batch_idx),
+                Int32(split_idx),
+            ),
+            is_valid,
+        )
 
     @cute.jit
     def initial_work_tile_info(self, *, loc=None, ip=None):

--- a/python/cudnn/block_sparse_attention/csrc/utils/cute_dsl_utils.py
+++ b/python/cudnn/block_sparse_attention/csrc/utils/cute_dsl_utils.py
@@ -4,8 +4,9 @@
 #
 # The ParamsBase, make_fake_tensor, and sub_packed_f32x2 implementations in
 # this file are adapted from quack-kernels 0.4.1 (Apache-2.0) and modified for
-# cudnn-frontend's CUTLASS DSL 4.5 integration.
+# cudnn-frontend's CUTLASS DSL integration.
 
+import inspect
 from dataclasses import dataclass, fields
 from functools import partial
 from typing import Tuple, get_origin
@@ -27,23 +28,39 @@ _STATIC_TYPES = (cutlass.Constexpr, NumericMeta, int, bool, str, float, type(Non
 def _install_constexpr_tvm_ffi_converter() -> None:
     """Teach CUTLASS DSL's TVM-FFI converter about Constexpr annotations.
 
-    CUTLASS DSL 4.5 otherwise treats fields annotated as ``Constexpr[T]`` as
-    runtime arguments. Emitting ``ConstNone`` keeps those fields in the JIT
-    specialization and lets callers pass ``None`` at runtime. The NamedTuple
-    case preserves its concrete field annotations when a broader tuple type is
-    used at the call site.
+    Emitting ``ConstNone`` keeps static ``ParamsBase`` fields in the JIT
+    specialization, including tuple and enum values that CUTLASS DSL 4.6's
+    native Constexpr converter does not support. The NamedTuple case preserves
+    its concrete field annotations when a broader tuple type is used at the
+    call site.
     """
     import cutlass.cute._tvm_ffi_args_spec_converter as converter
 
     original = converter._convert_single_arg
     if getattr(original, "_cudnn_bsa_constexpr_compat", False):
         return
+    supports_is_constexpr = "is_constexpr" in inspect.signature(original).parameters
 
-    def convert_single_arg(arg, arg_name, arg_type, ctx):
+    def convert_single_arg(
+        arg,
+        arg_name,
+        arg_type,
+        ctx,
+        *,
+        is_constexpr=False,
+    ):
         if arg_type is not None and get_origin(arg_type) is cutlass.Constexpr:
             return spec.ConstNone(arg_name)
         if isinstance(arg, tuple) and hasattr(type(arg), "_fields") and (arg_type is None or not hasattr(arg_type, "_fields")):
-            return original(arg, arg_name, type(arg), ctx)
+            arg_type = type(arg)
+        if supports_is_constexpr:
+            return original(
+                arg,
+                arg_name,
+                arg_type,
+                ctx,
+                is_constexpr=is_constexpr,
+            )
         return original(arg, arg_name, arg_type, ctx)
 
     convert_single_arg._cudnn_bsa_constexpr_compat = True

--- a/python/cudnn/block_sparse_attention/csrc/utils/tcgen05_mma_helpers.py
+++ b/python/cudnn/block_sparse_attention/csrc/utils/tcgen05_mma_helpers.py
@@ -18,9 +18,28 @@ def _tcgen05_mma_kind(op: cute.nvgpu.tcgen05.mma.MmaOp) -> str:
         return "tf32"
     if isinstance(op, tcgen05.mma.MmaI8Op):
         return "i8"
-    if isinstance(op, tcgen05.mma.MmaF8F6F4Op):
+    # CUTLASS 4.4 renamed the ordinary (non block-scaled) FP8 op to
+    # MmaFP8Op.  Keep the old spelling as well so this repository remains
+    # usable with the CUTLASS revision it originally targeted.
+    fp8_op_types = tuple(
+        op_type
+        for op_type in (
+            getattr(tcgen05.mma, "MmaFP8Op", None),
+            getattr(tcgen05.mma, "MmaF8F6F4Op", None),
+        )
+        if op_type is not None
+    )
+    if isinstance(op, fp8_op_types):
         return "f8f6f4"
-    if isinstance(op, tcgen05.mma.MmaMXF8F6F4Op):
+    mxfp8_op_types = tuple(
+        op_type
+        for op_type in (
+            getattr(tcgen05.mma, "MmaMXF8Op", None),
+            getattr(tcgen05.mma, "MmaMXF8F6F4Op", None),
+        )
+        if op_type is not None
+    )
+    if isinstance(op, mxfp8_op_types):
         return "mxf8f6f4"
     if isinstance(op, tcgen05.mma.MmaMXF4Op):
         return "mxf4"

--- a/test/python/fe_api/bsa/test_BSA_attention_forward.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_forward.py
@@ -391,7 +391,7 @@ def test_bsa_attention_forward_sm100_blk64_workspace_fallback(monkeypatch):
     monkeypatch.setattr(
         interface,
         "_blk64_split_workspace_bytes",
-        lambda q, value_dim, kv_splits: kv_splits * gib // 2,
+        lambda q, value_dim, kv_splits, output_dtype=None: kv_splits * gib // 2,
     )
 
     assert interface._resolve_blk64_split_workspace(fake_q, 128, 8, allow_fallback=True) == 2
@@ -420,11 +420,12 @@ def test_bsa_attention_forward_sm100_blk64_auto_uses_workspace_fallback(monkeypa
 
     monkeypatch.setattr(interface, "_sm100_blk64_auto_kv_splits", lambda *args, **kwargs: 2)
 
-    def workspace_fallback(q_arg, value_dim, kv_splits, allow_fallback):
+    def workspace_fallback(q_arg, value_dim, kv_splits, allow_fallback, output_dtype=None):
         assert q_arg is not None
         assert value_dim == 128
         assert kv_splits == 2
         assert allow_fallback is True
+        assert output_dtype is torch.bfloat16
         raise WorkspaceFallbackCalled
 
     monkeypatch.setattr(interface, "_resolve_blk64_split_workspace", workspace_fallback)

--- a/test/python/fe_api/bsa/test_BSA_attention_forward.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_forward.py
@@ -443,6 +443,26 @@ def test_bsa_attention_forward_sm100_blk64_auto_uses_workspace_fallback(monkeypa
 
 
 @pytest.mark.L0
+def test_bsa_attention_forward_sm100_blk64_large_q_auto_scheduler_policy():
+    if not torch.cuda.is_available():
+        pytest.skip("block sparse attention tests require CUDA")
+    major, _ = torch.cuda.get_device_capability()
+    if major not in {10, 11}:
+        pytest.skip("large-Q scheduler policy is specific to SM100/SM110 blk64")
+
+    _import_bsa()
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    q_large = torch.empty((1, 40, 131072, 1), device="cuda", dtype=torch.int8)
+    q_small = torch.empty((1, 4, 128, 1), device="cuda", dtype=torch.int8)
+    q2k_block_index = torch.empty((1, 1, 1, 2048), device="cuda", dtype=torch.int32)
+
+    assert interface._sm100_blk64_auto_kv_splits(q_large, q2k_block_index, 2048) == 1
+    assert interface._sm100_blk64_auto_kv_splits(q_small, q2k_block_index, 2048) == 8
+    assert interface.choose_blk64_use_clc(q_large, 256)
+    assert interface.choose_blk64_use_clc(q_large, 2048)
+
+
+@pytest.mark.L0
 def test_bsa_attention_forward_sm120_static_compile_key_tracks_tensor_type():
     _import_bsa()
     interface = importlib.import_module("cudnn.block_sparse_attention._interface")

--- a/test/python/fe_api/bsa/test_BSA_attention_forward.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_forward.py
@@ -253,6 +253,78 @@ def test_bsa_attention_forward_sm100_blk64():
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=2029)
+def test_bsa_attention_forward_sm100_blk64_split_kv_clc_persistent_tiles():
+    if not torch.cuda.is_available():
+        pytest.skip("block sparse attention tests require CUDA")
+    major, _ = torch.cuda.get_device_capability()
+    if major not in {10, 11}:
+        pytest.skip("blk64 split-KV CLC scheduling is specific to SM100/SM110")
+
+    BSA = _import_bsa()
+    sm_count = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+    batch, heads, num_kv_blocks, head_dim = 2, 3, 8, 128
+    kv_splits = 3
+    num_q_blocks = max(32, 2 * sm_count // (batch * heads * kv_splits) + 1)
+    block_size = 64
+    seqlen_q, seqlen_k = num_q_blocks * block_size, num_kv_blocks * block_size
+    assert batch * heads * num_q_blocks * kv_splits > 2 * sm_count
+
+    q = torch.randn((batch, heads, seqlen_q, head_dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((batch, heads, seqlen_k, head_dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+    q2k = (
+        torch.arange(num_kv_blocks, device="cuda", dtype=torch.int32)
+        .view(1, 1, 1, num_kv_blocks)
+        .expand(batch, heads, num_q_blocks, num_kv_blocks)
+        .contiguous()
+    )
+    block_sizes = torch.full((num_kv_blocks,), block_size, device="cuda", dtype=torch.int32)
+
+    reference = BSA.block_sparse_attention_forward(
+        q,
+        k,
+        v,
+        q2k,
+        num_kv_blocks,
+        block_sizes,
+        sparse_block_size=block_size,
+        use_clc=False,
+        kv_splits=kv_splits,
+    )
+    torch.cuda.synchronize()
+    actual = BSA.block_sparse_attention_forward(
+        q,
+        k,
+        v,
+        q2k,
+        num_kv_blocks,
+        block_sizes,
+        sparse_block_size=block_size,
+        use_clc=True,
+        kv_splits=kv_splits,
+    )
+    torch.cuda.synchronize()
+    repeated = BSA.block_sparse_attention_forward(
+        q,
+        k,
+        v,
+        q2k,
+        num_kv_blocks,
+        block_sizes,
+        sparse_block_size=block_size,
+        use_clc=True,
+        kv_splits=kv_splits,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual["o_tensor"], reference["o_tensor"], rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(actual["lse_tensor"], reference["lse_tensor"], rtol=2e-3, atol=2e-3)
+    torch.testing.assert_close(repeated["o_tensor"], actual["o_tensor"], rtol=0.0, atol=0.0)
+    torch.testing.assert_close(repeated["lse_tensor"], actual["lse_tensor"], rtol=0.0, atol=0.0)
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=6)
 @pytest.mark.parametrize("seqlen_q", [1, 63, 65])
 def test_bsa_attention_forward_sm100_blk64_combine_partial_tail_rows(seqlen_q):

--- a/test/python/fe_api/bsa/test_BSA_attention_fp8.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_fp8.py
@@ -271,6 +271,40 @@ def test_bsa_fp8_sm100_auto_split_uses_workspace_fallback(monkeypatch):
 
 
 @pytest.mark.L0
+def test_bsa_fp8_quantized_inputs_require_fully_contiguous_bhsd():
+    _require_sm100_fp8()
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+
+    batch, heads, seqlen, head_dim = 1, 4, 64, 128
+
+    def make_padded_fp8():
+        storage = torch.empty((batch, heads, seqlen, head_dim + 1), device="cuda", dtype=torch.float8_e4m3fn)
+        return storage[..., :head_dim]
+
+    q = make_padded_fp8()
+    k = make_padded_fp8()
+    v = make_padded_fp8()
+    assert all(tensor.stride(-1) == 1 and not tensor.is_contiguous() for tensor in (q, k, v))
+
+    q_scale = torch.empty((batch, heads, seqlen), device="cuda", dtype=torch.float32)
+    k_scale = torch.empty((batch, heads, seqlen // 16), device="cuda", dtype=torch.float32)
+    v_scale = torch.empty((heads, head_dim), device="cuda", dtype=torch.float32)
+    q2k = torch.zeros((batch, heads, 1, 1), device="cuda", dtype=torch.int32)
+
+    with pytest.raises(AssertionError, match="fully contiguous BHSD"):
+        interface._bsa_fp8_blk64_fwd_quantized(
+            q,
+            k,
+            v,
+            q_scale,
+            k_scale,
+            v_scale,
+            q2k,
+            1,
+        )
+
+
+@pytest.mark.L0
 def test_bsa_fp8_split_workspace_estimate_uses_bf16_output_size():
     _import_bsa()
     interface = importlib.import_module("cudnn.block_sparse_attention._interface")

--- a/test/python/fe_api/bsa/test_BSA_attention_fp8.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_fp8.py
@@ -1,0 +1,264 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+import importlib
+import math
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+from cudnn.api_base import TupleDict
+from fe_api.bsa.bsa_reference import attention_reference, block_sparse_mask
+from test_utils import torch_fork_set_rng
+
+pytestmark = [pytest.mark.gpu_exclusive, pytest.mark.xdist_group(name="gpu_exclusive")]
+
+
+def _import_bsa():
+    try:
+        from cudnn import BSA
+
+        importlib.import_module("cudnn.block_sparse_attention._interface")
+        return BSA
+    except (ImportError, OSError) as error:
+        pytest.skip(f"block sparse attention optional dependencies are unavailable: {error}")
+
+
+def _require_sm100_fp8():
+    if not torch.cuda.is_available():
+        pytest.skip("Sage FP8 block sparse attention requires CUDA")
+    major, _ = torch.cuda.get_device_capability()
+    if major not in {10, 11}:
+        pytest.skip("this numerical Sage FP8 test requires SM100/SM110")
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    if interface._cutlass_dsl_version() < (4, 6, 1):
+        pytest.skip("Sage FP8 requires nvidia-cutlass-dsl>=4.6.1")
+    return _import_bsa()
+
+
+def _make_block_index(heads: int, seqlen_q: int, seqlen_k: int, topk: int) -> torch.Tensor:
+    num_q_blocks = math.ceil(seqlen_q / 64)
+    num_kv_blocks = math.ceil(seqlen_k / 64)
+    result = torch.empty((1, heads, num_q_blocks, topk), device="cuda", dtype=torch.int32)
+    block_ids = torch.arange(num_kv_blocks, device="cuda")
+    for head in range(heads):
+        for q_block in range(num_q_blocks):
+            selected = torch.roll(block_ids, shifts=head + q_block)[:topk].sort().values
+            result[0, head, q_block] = selected.to(torch.int32)
+    return result
+
+
+@pytest.mark.L0
+def test_bsa_fp8_public_exports_do_not_eagerly_import_quantizer():
+    private_module = "cudnn.block_sparse_attention._fp8_quant"
+    sys.modules.pop(private_module, None)
+
+    import cudnn
+
+    package = importlib.import_module("cudnn.block_sparse_attention")
+    assert cudnn.block_sparse_attention_fp8_forward is package.block_sparse_attention_fp8_forward
+    assert cudnn.BSA.block_sparse_attention_fp8_forward is package.block_sparse_attention_fp8_forward
+    assert not hasattr(cudnn, "quantize_sage_bhsd")
+    assert not hasattr(cudnn.BSA, "quantize_sage_bhsd")
+    assert not hasattr(package, "quantize_sage_bhsd")
+    assert private_module not in sys.modules
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    (
+        ("4.6.1", (4, 6, 1)),
+        ("4.6.1+cu13", (4, 6, 1)),
+        ("4.7.0.dev0", (4, 7, 0)),
+    ),
+)
+def test_bsa_fp8_cutedsl_version_parser(monkeypatch, version, expected):
+    _import_bsa()
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    monkeypatch.setattr(interface.cutlass, "__version__", version)
+    assert interface._cutlass_dsl_version() == expected
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("version", ("4.5.0", "4.6.0"))
+def test_bsa_fp8_runtime_gate_precedes_quantizer_import(monkeypatch, version):
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    private_module = "cudnn.block_sparse_attention._fp8_quant"
+    sys.modules.pop(private_module, None)
+    monkeypatch.setattr(interface.cutlass, "__version__", version)
+
+    with pytest.raises(RuntimeError, match=r"nvidia-cutlass-dsl>=4\.6\.1"):
+        interface.bsa_fp8_blk64_fwd(object(), object(), object(), object(), 1)
+    assert private_module not in sys.modules
+
+
+@pytest.mark.L0
+def test_bsa_fp8_interface_quantizes_before_private_launch(monkeypatch):
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    monkeypatch.setattr(interface, "_require_sage_fp8_cutedsl", lambda: None)
+
+    q, k, v = object(), object(), object()
+    q2k, block_sizes, q2k_nums = object(), object(), object()
+    quantized = tuple(object() for _ in range(6))
+    expected = object()
+
+    fake_quantizer = ModuleType("cudnn.block_sparse_attention._fp8_quant")
+
+    def fake_quantize(actual_q, actual_k, actual_v):
+        assert (actual_q, actual_k, actual_v) == (q, k, v)
+        return quantized
+
+    fake_quantizer._quantize_sage_bhsd = fake_quantize
+    monkeypatch.setitem(sys.modules, fake_quantizer.__name__, fake_quantizer)
+
+    def fake_launch(*args, **kwargs):
+        assert args[:6] == quantized
+        assert args[6:] == (q2k, 7, 0.125)
+        assert kwargs == {"block_sizes": block_sizes, "q2k_block_nums": q2k_nums}
+        return expected
+
+    monkeypatch.setattr(interface, "_bsa_fp8_blk64_fwd_quantized", fake_launch)
+    result = interface.bsa_fp8_blk64_fwd(
+        q,
+        k,
+        v,
+        q2k,
+        7,
+        0.125,
+        block_sizes=block_sizes,
+        q2k_block_nums=q2k_nums,
+    )
+    assert result is expected
+
+
+@pytest.mark.L0
+def test_bsa_fp8_forward_accepts_bf16_and_returns_documented_tupledict(monkeypatch):
+    BSA = _import_bsa()
+    api = importlib.import_module("cudnn.block_sparse_attention.api")
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    monkeypatch.setattr(api, "_device_arch", lambda tensor: 100)
+
+    shape = (1, 4, 64, 128)
+    q = torch.empty(shape, device="cuda", dtype=torch.bfloat16)
+    k = torch.empty_like(q)
+    v = torch.empty_like(q)
+    q2k = torch.zeros((1, 4, 1, 1), device="cuda", dtype=torch.int32)
+    expected = torch.empty(shape, device="cuda", dtype=torch.bfloat16)
+
+    def fake_forward(*args, **kwargs):
+        expected_args = (q, k, v, q2k)
+        assert all(actual is expected_arg for actual, expected_arg in zip(args[:4], expected_args))
+        assert args[4] == 1
+        assert args[5] is None
+        assert kwargs == {"block_sizes": None, "q2k_block_nums": None}
+        return expected
+
+    monkeypatch.setattr(interface, "bsa_fp8_blk64_fwd", fake_forward)
+    result = BSA.block_sparse_attention_fp8_forward(
+        q,
+        k,
+        v,
+        q2k,
+        block_sparse_num=1,
+    )
+
+    assert isinstance(result, TupleDict)
+    assert list(result.keys()) == ["o_tensor"]
+    assert result["o_tensor"] is expected
+    assert result[0] is expected
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=20260709)
+def test_bsa_fp8_private_cutedsl_quantizer_matches_recipe():
+    _require_sm100_fp8()
+    quantizer = importlib.import_module("cudnn.block_sparse_attention._fp8_quant")
+
+    batch, heads, seqlen_q, seqlen_k, head_dim = 1, 4, 128, 192, 128
+    q = torch.randn((batch, heads, seqlen_q, head_dim), device="cuda", dtype=torch.bfloat16)
+    k = torch.randn((batch, heads, seqlen_k, head_dim), device="cuda", dtype=torch.bfloat16)
+    v = torch.randn_like(k)
+
+    actual = quantizer._quantize_sage_bhsd(q, k, v)
+    torch.cuda.synchronize()
+
+    q_scale = q.float().abs().amax(dim=-1).clamp_min(1.0e-3) / 448.0
+    q_reciprocal = q_scale.to(torch.bfloat16).reciprocal().to(torch.bfloat16)
+    q_fp8 = (q * q_reciprocal.unsqueeze(-1)).to(torch.bfloat16).to(torch.float8_e4m3fn)
+
+    k_mean = k.float().mean(dim=2, keepdim=True)
+    k_centered = k.float() - k_mean
+    k_blocks = k_centered.reshape(batch, heads, seqlen_k // 16, 16, head_dim)
+    k_scale = k_blocks.abs().amax(dim=(-1, -2)).clamp_min(1.0e-3) / 448.0
+    k_fp8 = (k_blocks / k_scale[..., None, None]).to(torch.float8_e4m3fn).reshape_as(k)
+
+    v_scale = v.abs().float().amax(dim=(0, 2)).clamp_min(1.0e-3) / 448.0
+    v_reciprocal = v_scale.reciprocal().to(torch.bfloat16)
+    v_fp8 = (v * v_reciprocal[None, :, None, :]).to(torch.float8_e4m3fn)
+
+    expected = (q_fp8, k_fp8, v_fp8, q_scale, k_scale, v_scale)
+    assert all(tensor.is_contiguous() for tensor in actual)
+    assert torch.equal(actual[0].float(), expected[0].float())
+    assert torch.allclose(actual[1].float(), expected[1].float(), atol=4.0, rtol=0.0)
+    assert torch.equal(actual[2].float(), expected[2].float())
+    assert torch.equal(actual[3], expected[3])
+    assert torch.allclose(actual[4], expected[4], atol=1.0e-6, rtol=0.0)
+    assert torch.equal(actual[5], expected[5])
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("heads", "seqlen_q", "topk", "expected_splits"),
+    (
+        (4, 64, 127, 1),
+        (4, 64, 128, 16),
+        (4, 64, 224, 8),
+        (4, 64, 400, 16),
+        (8, 64, 128, 4),
+        (8, 64, 256, 8),
+        (8, 64, 500, 16),
+        (4, 8192, 899, 1),
+        (4, 8192, 900, 4),
+    ),
+)
+def test_bsa_fp8_sm100_sm110_auto_kv_splits(heads, seqlen_q, topk, expected_splits):
+    _import_bsa()
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    assert interface._sm100_blk64_auto_fp8_kv_splits(topk, heads, seqlen_q) == expected_splits
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=2026)
+def test_bsa_fp8_sm100_bf16_forward_matches_reference():
+    BSA = _require_sm100_fp8()
+    batch, heads, seqlen_q, seqlen_k, head_dim, topk = 1, 4, 128, 640, 128, 5
+    q = torch.randn((batch, heads, seqlen_q, head_dim), device="cuda", dtype=torch.bfloat16) * 0.5
+    k = torch.randn((batch, heads, seqlen_k, head_dim), device="cuda", dtype=torch.bfloat16) * 0.5
+    v = torch.randn_like(k) * 0.5
+    q2k = _make_block_index(heads, seqlen_q, seqlen_k, topk)
+
+    block_sizes = torch.full((seqlen_k // 64,), 64, device="cuda", dtype=torch.int32)
+    mask = block_sparse_mask(q2k, topk, block_sizes, seqlen_q, seqlen_k, 64)
+    softmax_scale = head_dim**-0.5
+    reference, _ = attention_reference(q, k, v, mask, softmax_scale)
+
+    result = BSA.block_sparse_attention_fp8_forward(
+        q,
+        k,
+        v,
+        q2k,
+        block_sparse_num=topk,
+        softmax_scale=softmax_scale,
+    )
+    torch.cuda.synchronize()
+
+    assert list(result.keys()) == ["o_tensor"]
+    actual = result["o_tensor"]
+    assert actual.dtype == torch.bfloat16
+    assert actual.shape == q.shape
+    difference = (actual.float() - reference).abs()
+    assert difference.max().item() < 0.2
+    assert (difference.mean() / reference.abs().mean().clamp_min(1e-8)).item() < 0.04

--- a/test/python/fe_api/bsa/test_BSA_attention_fp8.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_fp8.py
@@ -231,6 +231,62 @@ def test_bsa_fp8_sm100_sm110_auto_kv_splits(heads, seqlen_q, topk, expected_spli
 
 
 @pytest.mark.L0
+def test_bsa_fp8_sm100_auto_split_uses_workspace_fallback(monkeypatch):
+    _require_sm100_fp8()
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+    monkeypatch.setattr(interface, "_get_device_arch", lambda: 100)
+
+    batch, heads, seqlen_q, seqlen_k, head_dim, topk = 1, 4, 64, 64, 128, 128
+    q = torch.empty((batch, heads, seqlen_q, head_dim), device="cuda", dtype=torch.float8_e4m3fn)
+    k = torch.empty((batch, heads, seqlen_k, head_dim), device="cuda", dtype=torch.float8_e4m3fn)
+    v = torch.empty_like(k)
+    q_scale = torch.empty((batch, heads, seqlen_q), device="cuda", dtype=torch.float32)
+    k_scale = torch.empty((batch, heads, seqlen_k // 16), device="cuda", dtype=torch.float32)
+    v_scale = torch.empty((heads, head_dim), device="cuda", dtype=torch.float32)
+    q2k = torch.zeros((batch, heads, 1, topk), device="cuda", dtype=torch.int32)
+
+    class WorkspaceFallbackCalled(Exception):
+        pass
+
+    def workspace_fallback(q_arg, value_dim, kv_splits, allow_fallback, output_dtype=None):
+        assert q_arg is q
+        assert value_dim == head_dim
+        assert kv_splits == 16
+        assert allow_fallback is True
+        assert output_dtype is torch.bfloat16
+        raise WorkspaceFallbackCalled
+
+    monkeypatch.setattr(interface, "_resolve_blk64_split_workspace", workspace_fallback)
+    with pytest.raises(WorkspaceFallbackCalled):
+        interface._bsa_fp8_blk64_fwd_quantized(
+            q,
+            k,
+            v,
+            q_scale,
+            k_scale,
+            v_scale,
+            q2k,
+            topk,
+        )
+
+
+@pytest.mark.L0
+def test_bsa_fp8_split_workspace_estimate_uses_bf16_output_size():
+    _import_bsa()
+    interface = importlib.import_module("cudnn.block_sparse_attention._interface")
+
+    batch, heads, seqlen_q, value_dim, kv_splits = 1, 4, 64, 128, 2
+    q = torch.empty((batch, heads, seqlen_q, value_dim), dtype=torch.float8_e4m3fn)
+    rows = batch * heads * seqlen_q
+    num_q_blocks = math.ceil(seqlen_q / 64)
+    expected_bytes = (
+        kv_splits * rows * (value_dim + 1) * 4 + rows * (value_dim * torch.bfloat16.itemsize + 4) + batch * heads * num_q_blocks * (kv_splits + 1) * 4
+    )
+
+    assert interface._blk64_split_workspace_bytes(q, value_dim, kv_splits, output_dtype=torch.bfloat16) == expected_bytes
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=2026)
 def test_bsa_fp8_sm100_bf16_forward_matches_reference():
     BSA = _require_sm100_fp8()


### PR DESCRIPTION
  ## Summary

  - Add the public `block_sparse_attention_fp8_forward` API with lazy exports and a CUTLASS DSL 4.6.1 runtime gate.
  - Add private CuTe DSL kernels that quantize contiguous BF16 BHSD inputs to FP8 E4M3 using the Sage quantization recipe.
  - Extend the SM100/SM103 blk64 kernel with Sage FP8 execution and automatic split-KV selection.
  - Add a dedicated SM120 Sage FP8 blk64 forward kernel with sequence-tail, variable block-count, and batched block-size support.
  - Enable persistent CLC scheduling together with split-KV on the Blackwell blk64 path.
  - Update CUTLASS DSL converter and tcgen05 MMA compatibility, documentation, tests, and customer acknowledgements.

  ## Motivation

  BSA did not expose a forward-only Sage FP8 path. In addition, customer testing uncovered issues around split-KV persistent CLC scheduling and
  compatibility with newer CUTLASS DSL converter and MMA interfaces.

  The existing persistent scheduler did not explicitly encode and decode the split dimension in its work-tile mapping. This change adds that mapping
  and updates split-range calculation so split-KV can run correctly with CLC scheduling.

  ## User impact

  Callers can pass contiguous BF16 Q, K, and V tensors to the new API. Quantization is performed internally and the API returns a contiguous BF16
  output.

  The implementation supports:

  - SM100/SM103 with the documented batch, head-count, and sequence-alignment constraints.
  - SM120 with sequence tails, fixed or variable sparse counts, and supported batched `block_sizes` layouts.

  ## Validation

  Run on an NVIDIA B300 SXM6 AC (SM103) with CUTLASS DSL 4.6.1:

  - `test_BSA_attention_fp8.py`: 19 passed
  - `test_bsa_attention_forward_sm100_blk64_split_kv_clc_persistent_tiles`: 1 passed
  - Targeted pre-commit hooks: passed
  - Python syntax compilation: passed

  The SM120 runtime path was not executed locally because an SM120 GPU was not available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FP8 block-sparse attention for compatible NVIDIA GPU architectures.
  * Added a public forward API accepting BF16 or validated FP8 inputs and returning BF16 outputs.
  * Added automatic quantization, scaling, GQA packing, and split-KV execution.
  * Added support for SM100, SM103, SM110, and SM120 configurations.

* **Documentation**
  * Expanded guidance on supported architectures, input requirements, runtime requirements, limitations, and output behavior.

* **Bug Fixes**
  * Improved compatibility with newer CUTLASS DSL versions and FP8 operations.
  * Improved scheduling and workspace handling for large-query workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->