### PR TITLE
Fix absolute paths in installed CMake configs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,10 +40,12 @@ target_include_directories(
 
 # Find the cuda compiler
 find_package(CUDAToolkit REQUIRED)
+find_package(CUDNN REQUIRED)
 
-target_include_directories(
+target_link_libraries(
     cudnn_frontend INTERFACE
-    ${CUDAToolkit_INCLUDE_DIRS}
+    CUDA::toolkit
+    CuDNN::CuDNN
 )
 
 target_compile_features(cudnn_frontend INTERFACE cxx_std_17)

--- a/cudnn_frontend-config.cmake.in
+++ b/cudnn_frontend-config.cmake.in
@@ -3,4 +3,8 @@
 
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(CUDAToolkit)
+find_dependency(CUDNN)
+
 include(${CMAKE_CURRENT_LIST_DIR}/cudnn_frontend-targets.cmake)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [ ] I ran `pre-commit run` and committed any formatting changes.

As there are no code changes here I hope there is no formatting that would emit anyways.

## Affected area

- Build, packaging, or installation

## Summary

In https://github.com/microsoft/vcpkg/pull/53159 GPT 5.6 Sol observes:

> Upstream adds `${CUDAToolkit_INCLUDE_DIRS}` directly to the interface target in [`CMakeLists.txt`](https://github.com/NVIDIA/cudnn-frontend/blob/35fd7b0d0e1d4952b904c79341c5e84e3af0a328/CMakeLists.txt#L38-L47), then exports that target. The generated PR package consequently contains:
>
> ```cmake
> INTERFACE_INCLUDE_DIRECTORIES
>   "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.3/include;
>    C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.3/include/cccl"
> ```

This makes the resulting packages broken if the configs are used on a system where that absolute path is not the same.

GPT 5.6 Sol wrote this change: Use CMake targets and then let find_dependency find the real location of those dependencies when the config gets used.

## Why

(See "Summary")

## Related issues

https://github.com/microsoft/vcpkg/pull/53159

## API and compatibility impact

None expected. The CUDAToolkin module was added in CMake 3.17: https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html

## Testing

None yet. (I wanted to make the upstream submission before making the PR against https://github.com/microsoft/vcpkg/pull/53159)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Installation**
  * Improved CMake configuration for projects using cuDNN and the CUDA toolkit.
  * Consumers can now link against the cudnn-frontend interface with required CUDA and cuDNN components discovered automatically.
  * Removed reliance on manually specified CUDA include directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->