### PR TITLE
Fix default-stream race: resolve _get_default_stream(None) to torch's current stream

### DIFF
--- a/python/cudnn/api_base.py
+++ b/python/cudnn/api_base.py
@@ -526,8 +526,9 @@ class APIBase(ABC):
         """Get default CUDA stream if none provided.
 
         This is a convenience helper to handle optional stream parameters.
-        If a stream is provided, it is returned as-is. If None, the default
-        CUDA stream is returned.
+        If a stream is provided, it is returned as-is. If None, the caller's
+        current PyTorch stream is returned, so kernels stay ordered with
+        surrounding torch ops under ``with torch.cuda.stream(s):``.
 
         :param stream: CUDA stream or None
         :type stream: cuda.CUstream or None
@@ -540,8 +541,8 @@ class APIBase(ABC):
             ...     # Now current_stream is guaranteed to be a valid stream
         """
         if stream is None:
-            self._logger.debug(f"{self.__class__.__name__}: No CUDA stream provided, using default stream")
-            return cutlass.cuda.default_stream()
+            self._logger.debug(f"{self.__class__.__name__}: No CUDA stream provided, using torch current stream")
+            return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
         return stream
 
     def _pad_tensor_to_ndim(

--- a/test/python/sdpa/frost/test_sdpa_stream_ordering.py
+++ b/test/python/sdpa/frost/test_sdpa_stream_ordering.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Stream-ordering tests for the FROST SM100 DSL SDPA-forward engines.
+
+The DSL kernels are compiled with TVM-FFI. A kernel compiled without a
+stream parameter launches on the CUDA default stream regardless of
+``torch.cuda.current_stream()``, so under ``with torch.cuda.stream(s):`` the
+launch races the torch-side ops (input copies, ``zero_()`` resets) that were
+enqueued on ``s``. The kernels therefore take an env-stream parameter
+(``make_fake_stream(use_tvm_ffi_env_stream=True)``): TVM-FFI syncs it to
+torch's current stream before every call.
+
+These tests enqueue a long spin kernel on a side stream, mutate the inputs
+*behind* it, and immediately run SDPA on the same stream. If the kernel
+ignores the side stream it reads the pre-mutation garbage and the output is
+wrong; correct env-stream routing makes it wait for the mutation.
+"""
+
+import math
+
+import pytest
+import torch
+
+from test_utils import torch_fork_set_rng
+
+
+def _is_sm100() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+    return (major, minor) == (10, 0)
+
+
+pytestmark = pytest.mark.skipif(
+    not _is_sm100(),
+    reason="SM100 DSL SDPA engine requires an SM100 (Blackwell) device.",
+)
+
+# ~0.5-1 s of spin: long enough that an unordered kernel launch on the
+# default stream reliably overtakes the side-stream mutation.
+_SLEEP_CYCLES = 1_000_000_000
+
+
+def _ref_sdpa(q, k, v, *, scale):
+    q_ref, k_ref, v_ref = q.to(torch.float32), k.to(torch.float32), v.to(torch.float32)
+    scores = torch.matmul(q_ref, k_ref.transpose(-1, -2)) * scale
+    probs = torch.softmax(scores, dim=-1)
+    return torch.matmul(probs, v_ref).to(q.dtype)
+
+
+@pytest.mark.L0
+def test_get_default_stream_follows_torch_current_stream():
+    """APIBase._get_default_stream(None) must resolve to torch's *current*
+    stream (not legacy stream 0), so wrapper default paths stay ordered."""
+    from types import SimpleNamespace
+    import logging
+
+    from cudnn.api_base import APIBase
+
+    dummy = SimpleNamespace(_logger=logging.getLogger("test"))
+    s = torch.cuda.Stream()
+    with torch.cuda.stream(s):
+        resolved = APIBase._get_default_stream(dummy, None)
+        assert int(resolved) == s.cuda_stream
+    resolved_default = APIBase._get_default_stream(dummy, None)
+    assert int(resolved_default) == torch.cuda.current_stream().cuda_stream
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("d", [512, 256, 128], ids=["d512", "d256", "d128"])
+@torch_fork_set_rng(seed=0)
+def test_sdpa_fwd_dsl_side_stream_ordering(d):
+    """SDPA on a non-default stream must observe torch ops enqueued before it
+    on that stream (env-stream routing of the TVM-FFI kernel launch)."""
+    try:
+        import cutlass  # noqa: F401
+        from cudnn.sdpa.fwd.api_dsl import sdpa_fwd_wrapper_dsl_sm100 as sdpa_fwd_wrapper_dsl
+    except ImportError as e:
+        pytest.skip(f"DSL dependencies unavailable: {e}")
+
+    dev = torch.device("cuda")
+    dtype = torch.bfloat16
+    b, h, s_q, s_kv = 1, 4, 256, 256
+    scale = 1.0 / math.sqrt(d)
+
+    q_real = torch.randn(b, h, s_q, d, dtype=dtype, device=dev)
+    k = torch.randn(b, h, s_kv, d, dtype=dtype, device=dev)
+    v = torch.randn(b, h, s_kv, d, dtype=dtype, device=dev)
+    ref = _ref_sdpa(q_real, k, v, scale=scale)
+
+    # Warmup on the default stream: triggers compile + JIT and pins the
+    # object cache, so the timed trial below measures only stream ordering.
+    q = q_real.clone()
+    try:
+        out_warm = sdpa_fwd_wrapper_dsl(q, k, v, scale_softmax=scale)["o_tensor"]
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"DSL SDPA unsupported for d={d} on this build: {e}")
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out_warm, ref, atol=2e-2, rtol=2e-2)
+
+    # Race trial: poison Q, then on a side stream enqueue [sleep, restore Q,
+    # SDPA]. An unordered (default-stream) kernel launch overtakes the
+    # restore and reads the poisoned Q.
+    q.fill_(float("nan"))
+    torch.cuda.synchronize()
+    side = torch.cuda.Stream()
+    with torch.cuda.stream(side):
+        torch.cuda._sleep(_SLEEP_CYCLES)
+        q.copy_(q_real)
+        out = sdpa_fwd_wrapper_dsl(q, k, v, scale_softmax=scale)["o_tensor"]
+    torch.cuda.synchronize()
+
+    assert not torch.isnan(out).any(), "SDPA kernel read the poisoned Q: launch was not ordered after the " "side-stream copy (env-stream routing broken)"
+    torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)


### PR DESCRIPTION
## Problem

`APIBase._get_default_stream(None)` returns `cutlass.cuda.default_stream()` (legacy CUDA stream 0). Every `APIBase`-derived `execute()` called without an explicit stream therefore launches its TVM-FFI kernel on stream 0, while the surrounding torch-side ops (input copies, FP8 `amax_*.zero_()` resets, output allocations) run on torch's **current** stream. Under `with torch.cuda.stream(s):` — the exact usage the `execute()` docstrings advertise — the kernel races those ops.

Verified empirically on SM100 (B200): an SDPA forward called on a side stream reads stale inputs 7-8 times out of 8 once JIT warmup no longer masks the window. This also covers the FP8 per-tensor amax reset ordering flagged by CodeRabbit (`amax_o_buf.zero_()` vs kernel launch).

## Fix

Resolve `None` to `torch.cuda.current_stream()` instead, so the kernel and its surrounding torch ops land on the same stream. One change covers all 29 `_get_default_stream` resolution sites (SDPA DSL incl. the FP8 amax path, gemm/cutedsl, NSA). The SM120 execute path already carried this exact fallback locally; this hoists it into the shared helper.

## Tests

`test/python/sdpa/frost/test_sdpa_stream_ordering.py`:
- Unit test: `_get_default_stream(None)` matches `torch.cuda.current_stream()` inside and outside a side-stream context.
- Side-stream ordering tests (d128/d256/d512): poison Q with NaN, enqueue [~1s spin, restore Q, SDPA] on a side stream, require the output to reflect the restored Q. An unordered (stream-0) launch overtakes the restore and reads the poison.

All 4 tests **fail** on develop without this change and **pass** with it (SM100/B200). Full `test/python/sdpa/frost` suite run in progress; result will be posted as a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA stream handling to respect PyTorch’s currently active stream, helping operations execute in the expected order.
  * Improved FROST SDPA behavior when work is scheduled on non-default CUDA streams, reducing the risk of incorrect results caused by stream-ordering issues.

* **Tests**
  * Added coverage for current-stream selection and side-stream SDPA execution ordering on supported SM100 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->