### PR TITLE
frost(sdpa): causal right-band widening + per-sequence THD bottom-right diagonal on SM100

### DIFF
--- a/python/cudnn/frost/tile_dsl/mask.py
+++ b/python/cudnn/frost/tile_dsl/mask.py
@@ -15,13 +15,13 @@ def apply_mask_chunk(
     q_abs,
     kv_col_base,
     seq_kv_len,
-    swa_window: int,
+    window_left: int,
     mask_flags: int,
     N: int = 64,
-    causal_bottom_right: int = 0,
+    bottom_right: int = 0,
     causal_diag=None,
     mask_value: float = _NEG_INF_BITS,
-    band_right: int = 0,
+    window_right: int = 0,
 ):
     # mask_value: what a masked score becomes.  Default is the legacy finite
     # sentinel; the f16 prefill kernels pass float("-inf") so a fully-masked
@@ -31,16 +31,16 @@ def apply_mask_chunk(
         return reg_S
 
     neg_inf = cutlass.Float32(mask_value)
-    q_minus_w = q_abs - cutlass.Int32(swa_window) if (mask_flags & MASK_SWA) else None
-    # band_right is the compile-time diagonal-band right bound (cuDNN
-    # diagonal_band_right_bound): kv columns up to q + band_right (plus the
+    q_minus_w = q_abs - cutlass.Int32(window_left) if (mask_flags & MASK_SWA) else None
+    # window_right is the compile-time diagonal-band right bound (cuDNN
+    # diagonal_band_right_bound): kv columns up to q + window_right (plus the
     # bottom-right diagonal offset) stay unmasked. 0 = plain causal.
-    if cutlass.const_expr((mask_flags & MASK_CAUSAL) and causal_bottom_right):
+    if cutlass.const_expr((mask_flags & MASK_CAUSAL) and bottom_right):
         q_caus_lim = q_abs + causal_diag
     else:
         q_caus_lim = q_abs
-    if cutlass.const_expr((mask_flags & MASK_CAUSAL) and band_right != 0):
-        q_caus_lim = q_caus_lim + cutlass.Int32(band_right)
+    if cutlass.const_expr((mask_flags & MASK_CAUSAL) and window_right != 0):
+        q_caus_lim = q_caus_lim + cutlass.Int32(window_right)
 
     elems = []
     for i in range(N):

--- a/python/cudnn/frost/tile_dsl/mask.py
+++ b/python/cudnn/frost/tile_dsl/mask.py
@@ -21,6 +21,7 @@ def apply_mask_chunk(
     causal_bottom_right: int = 0,
     causal_diag=None,
     mask_value: float = _NEG_INF_BITS,
+    band_right: int = 0,
 ):
     # mask_value: what a masked score becomes.  Default is the legacy finite
     # sentinel; the f16 prefill kernels pass float("-inf") so a fully-masked
@@ -31,10 +32,15 @@ def apply_mask_chunk(
 
     neg_inf = cutlass.Float32(mask_value)
     q_minus_w = q_abs - cutlass.Int32(swa_window) if (mask_flags & MASK_SWA) else None
+    # band_right is the compile-time diagonal-band right bound (cuDNN
+    # diagonal_band_right_bound): kv columns up to q + band_right (plus the
+    # bottom-right diagonal offset) stay unmasked. 0 = plain causal.
     if cutlass.const_expr((mask_flags & MASK_CAUSAL) and causal_bottom_right):
         q_caus_lim = q_abs + causal_diag
     else:
         q_caus_lim = q_abs
+    if cutlass.const_expr((mask_flags & MASK_CAUSAL) and band_right != 0):
+        q_caus_lim = q_caus_lim + cutlass.Int32(band_right)
 
     elems = []
     for i in range(N):

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -23,10 +23,6 @@ from cudnn.frost.tile_dsl.constants import (
     DTYPE_E4M3,
     DTYPE_E5M2,
     DTYPE_FP16,
-    MASK_CAUSAL,
-    MASK_NONE,
-    MASK_PADDED,
-    MASK_SWA,
     SCHED_LPT,
     SCHED_NATURAL,
 )
@@ -260,6 +256,13 @@ class SdpaFwdDsl(APIBase):
         # widened by R columns. None = no right band; requires is_causal (the
         # band is the causal diagonal, possibly widened).
         self.window_size_right = window_size_right
+        # The ONE canonical band every adapter lowers (same model as the
+        # analyzer facts / config TemplateParams): per-side offsets from the
+        # diagonal, None = unbounded. is_causal means "right bound 0";
+        # window_size_right widens it (check_support validates it requires
+        # is_causal). The padding mask stays orthogonal (seq_kv_lens_present).
+        self.window_left: Optional[int] = window_size_left
+        self.window_right: Optional[int] = (window_size_right or 0) if self.is_causal else None
         self.scale_softmax = scale_softmax
         self.seq_kv_lens_present = bool(seq_kv_lens_present)
         # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b] write
@@ -463,8 +466,6 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
 
     def _initialize_implementation(self) -> None:
         self.flavor: Optional[tuple[int, int]] = None
-        self.mask_flags = 0
-        self.swa_window_runtime = 0
         self.thd_stats_head_major = False
         self.thd_stats_head_stride = 0
         self._k_mod = None
@@ -626,9 +627,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             band_right is not None and not self.is_causal,
             "SM100 DSL SDPA: window_size_right widens the causal diagonal and requires is_causal=True",
         )
-        # The kernels' bottom-right diagonal path supports plain causal only:
-        # CAUSAL_BOTTOM_RIGHT requires MASK_CAUSAL and excludes MASK_SWA
-        # (see config._validate_knobs).
+        # The kernels' bottom-right diagonal path excludes a left bound:
+        # bottom_right requires a right bound and rejects window_left
+        # (see config_sm100._validate_params).
         self._value_error_if(
             self.causal_bottom_right and not self.is_causal,
             "SM100 DSL SDPA: causal_bottom_right requires is_causal=True",
@@ -646,19 +647,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             "supported (kernel anchors the BR diagonal at the global S_q, not "
             "seq_len_q[b])",
         )
-        if self.is_causal:
-            self.mask_flags = MASK_CAUSAL | (MASK_SWA if swa_left is not None else 0)
-            self.swa_window_runtime = swa_left if swa_left is not None else 0
-        elif swa_left is not None:
-            self.mask_flags = MASK_SWA
-            self.swa_window_runtime = swa_left
-        else:
-            self.mask_flags = MASK_NONE
-            self.swa_window_runtime = 0
         if self.thd:
             self.seq_kv_lens_present = True
-        if self.seq_kv_lens_present:
-            self.mask_flags |= MASK_PADDED
         # Dense padded-Q trim backstops (engines.lower_dsl_prefill never sets
         # these combinations; a direct caller could).
         self._value_error_if(
@@ -729,15 +719,14 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         mxfp8 = self._fp8 and not self._pertensor
         fused_ldtm_stat = mxfp8 and (self._device_cc == (10, 3))
         sched_policy = self.sched_policy
-        if mxfp8 and sched_policy == SCHED_NATURAL and (self.mask_flags & MASK_CAUSAL):
+        if mxfp8 and sched_policy == SCHED_NATURAL and self.window_right is not None:
             sched_policy = SCHED_LPT
         params = Sm100TemplateParams(
             dtype_qkv=_SM100_DTYPE_QKV_CODE[self.dtype],
             dtype_o=_SM100_DTYPE_QKV_CODE[self.dtype_o],
-            mask_flags=self.mask_flags,
-            swa_window=int(self.swa_window_runtime),
-            band_right=int(self.window_size_right or 0),
-            causal_bottom_right=self.causal_bottom_right,
+            window_left=self.window_left,
+            window_right=self.window_right,
+            bottom_right=self.causal_bottom_right,
             has_sink=self.has_sink,
             seq_kv_lens_present=self.seq_kv_lens_present,
             seq_q_lens_present=self.seq_q_lens_present,
@@ -1739,9 +1728,9 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
 
         params = Sm120TemplateParams(
             dtype_qkv=_SM120_DTYPE_QKV_CODE[self.dtype],
-            is_causal=self.is_causal,
-            causal_bottom_right=self.causal_bottom_right,
-            window_size_left=self.window_size_left,
+            window_left=self.window_left,
+            window_right=self.window_right,
+            bottom_right=self.causal_bottom_right,
             seq_q_lens_present=self.seq_q_lens_present,
             seq_kv_lens_present=self.seq_kv_lens_present,
             has_sink=self.has_sink,

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -221,6 +221,7 @@ class SdpaFwdDsl(APIBase):
         is_causal: bool = False,
         causal_bottom_right: bool = False,
         window_size_left: Optional[int] = None,
+        window_size_right: Optional[int] = None,
         scale_softmax: Optional[float] = None,
         seq_kv_lens_present: bool = False,
         seq_q_lens_present: bool = False,
@@ -254,6 +255,11 @@ class SdpaFwdDsl(APIBase):
         self.causal_bottom_right = bool(causal_bottom_right)
         # window_size_left is an offset W ("keep k in [q-W, q]"); callers pass W = L - 1 for a cuDNN window length L.
         self.window_size_left = window_size_left
+        # window_size_right is the diagonal-band right bound R ("keep k in
+        # [.., q+R]", cuDNN diagonal_band_right_bound): the causal upper limit
+        # widened by R columns. None = no right band; requires is_causal (the
+        # band is the causal diagonal, possibly widened).
+        self.window_size_right = window_size_right
         self.scale_softmax = scale_softmax
         self.seq_kv_lens_present = bool(seq_kv_lens_present)
         # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b] write
@@ -611,6 +617,15 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             swa_left is not None and swa_left < 0,
             f"window_size_left must be >= 0; got {swa_left}",
         )
+        band_right = self.window_size_right
+        self._value_error_if(
+            band_right is not None and band_right < 0,
+            f"window_size_right must be >= 0; got {band_right}",
+        )
+        self._value_error_if(
+            band_right is not None and not self.is_causal,
+            "SM100 DSL SDPA: window_size_right widens the causal diagonal and requires is_causal=True",
+        )
         # The kernels' bottom-right diagonal path supports plain causal only:
         # CAUSAL_BOTTOM_RIGHT requires MASK_CAUSAL and excludes MASK_SWA
         # (see config._validate_knobs).
@@ -677,7 +692,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # kv > q for every query row). Otherwise the tail columns leak into
         # the softmax and the output is silently wrong.
         if int(s_kv) % _SM100_TILE_N != 0:
-            causal_covers_tail = self.is_causal and (self.causal_bottom_right or int(s_qo) <= int(s_kv))
+            # A right-widened band pushes the last unmasked column to
+            # (S_q - 1) + R (top-left) or (S_kv - 1) + R (bottom-right), so the
+            # KV tail is only provably masked when it stays below S_kv.
+            _br = int(self.window_size_right or 0)
+            causal_covers_tail = self.is_causal and ((self.causal_bottom_right and _br == 0) or (not self.causal_bottom_right and int(s_qo) + _br <= int(s_kv)))
             self._value_error_if(
                 not (self.seq_kv_lens_present or causal_covers_tail),
                 f"S_kv ({s_kv}) must be a multiple of {_SM100_TILE_N} unless a "
@@ -717,6 +736,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             dtype_o=_SM100_DTYPE_QKV_CODE[self.dtype_o],
             mask_flags=self.mask_flags,
             swa_window=int(self.swa_window_runtime),
+            band_right=int(self.window_size_right or 0),
             causal_bottom_right=self.causal_bottom_right,
             has_sink=self.has_sink,
             seq_kv_lens_present=self.seq_kv_lens_present,
@@ -1331,6 +1351,7 @@ class _SdpaFwdCacheKey:
     is_causal: bool
     causal_bottom_right: bool
     window_size_left: Optional[int]
+    window_size_right: Optional[int]
     scale_softmax: Optional[float]
     seq_q_lens_present: bool
     seq_kv_lens_present: bool
@@ -1366,6 +1387,7 @@ def _make_cache_key(
     is_causal: bool = False,
     causal_bottom_right: bool = False,
     window_size_left: Optional[int] = None,
+    window_size_right: Optional[int] = None,
     scale_softmax: Optional[float] = None,
     seq_q_lens_present: bool = False,
     seq_kv_lens_present: bool = False,
@@ -1386,6 +1408,7 @@ def _make_cache_key(
         is_causal=is_causal,
         causal_bottom_right=causal_bottom_right,
         window_size_left=window_size_left,
+        window_size_right=window_size_right,
         scale_softmax=scale_softmax,
         has_sink=has_sink,
         seq_q_lens_present=seq_q_lens_present,
@@ -1537,6 +1560,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         if self.thd:
             self._value_error_if(self.seq_q_lens_present, "seq_q_lens_present is dense-only (THD carries per-sequence Q lengths via cu_seqlens)")
             self.seq_kv_lens_present = True
+        self._value_error_if(
+            self.window_size_right is not None,
+            "SM120 DSL SDPA: window_size_right (causal right-band widening) is not plumbed for this kernel",
+        )
         self._value_error_if(
             self.sched_policy is not None and self.sched_policy != SCHED_NATURAL,
             f"SM120 DSL SDPA only supports sched_policy={SCHED_NATURAL}",

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -65,6 +65,7 @@ class TemplateParams:
     dtype_o: int = -1  # output dtype (0..3); -1 = inherit dtype_qkv. MXFP8 writes BF16/FP16.
     mask_flags: int = MASK_NONE
     swa_window: int = 0  # runtime left-window offset W (keep kv in [q-W, q])
+    band_right: int = 0  # diagonal-band right bound R (keep kv in [.., q+R]); 0 = plain causal
     causal_bottom_right: bool = False
     has_sink: bool = False
     seq_kv_lens_present: bool = False
@@ -99,6 +100,10 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
             raise ValueError(f"{flavor}: CAUSAL_BOTTOM_RIGHT requires MASK_CAUSAL (bit 1)")
         if k.mask_flags & MASK_SWA:
             raise ValueError(f"{flavor}: CAUSAL_BOTTOM_RIGHT + SWA is not supported")
+    if k.band_right < 0:
+        raise ValueError(f"{flavor}: BAND_RIGHT must be >= 0; got {k.band_right}")
+    if k.band_right > 0 and not (k.mask_flags & MASK_CAUSAL):
+        raise ValueError(f"{flavor}: BAND_RIGHT > 0 requires MASK_CAUSAL (the band's upper bound)")
     if k.thd_varlen:
         if not (k.mask_flags & MASK_PADDED):
             raise ValueError(f"{flavor}: THD/varlen implies per-sequence padded masking (MASK_PADDED)")
@@ -231,6 +236,7 @@ class CfgD256:
 
     MASK_FLAGS: int = MASK_NONE
     SWA_WINDOW: int = 0
+    BAND_RIGHT: int = 0
     HAS_SINK: int = 0
     CAUSAL_BOTTOM_RIGHT: int = 0
 
@@ -303,6 +309,7 @@ def make_cfg_d256(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
         TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
         MASK_FLAGS=params.mask_flags,
         SWA_WINDOW=params.swa_window,
+        BAND_RIGHT=params.band_right,
         HAS_SINK=int(params.has_sink),
         CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
         SCHEDULER_POLICY=params.sched_policy,
@@ -365,6 +372,7 @@ class CfgD512:
 
     MASK_FLAGS: int = MASK_NONE
     SWA_WINDOW: int = 0
+    BAND_RIGHT: int = 0
     HAS_SINK: int = 0
     CAUSAL_BOTTOM_RIGHT: int = 0
 
@@ -444,6 +452,7 @@ def make_cfg_d512(params: TemplateParams) -> Tuple[CfgD512, TmaIters]:
         TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
         MASK_FLAGS=params.mask_flags,
         SWA_WINDOW=params.swa_window,
+        BAND_RIGHT=params.band_right,
         HAS_SINK=int(params.has_sink),
         CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
         SCHEDULER_POLICY=params.sched_policy,
@@ -508,6 +517,7 @@ class CfgD128:
 
     MASK_FLAGS: int = MASK_NONE
     SWA_WINDOW: int = 0
+    BAND_RIGHT: int = 0
     HAS_SINK: int = 0
     CAUSAL_BOTTOM_RIGHT: int = 0
 
@@ -602,6 +612,7 @@ def make_cfg_d128(params: TemplateParams) -> Tuple[CfgD128, TmaIters]:
         STAGES_KV=4 if fp8 else 2,
         MASK_FLAGS=params.mask_flags,
         SWA_WINDOW=params.swa_window,
+        BAND_RIGHT=params.band_right,
         HAS_SINK=int(params.has_sink),
         CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
         SCHEDULER_POLICY=params.sched_policy,
@@ -670,6 +681,7 @@ def make_cfg_d192(params: TemplateParams) -> Tuple[CfgD192, TmaIters]:
         TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
         MASK_FLAGS=params.mask_flags,
         SWA_WINDOW=params.swa_window,
+        BAND_RIGHT=params.band_right,
         HAS_SINK=int(params.has_sink),
         CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
         SCHEDULER_POLICY=1,

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -21,7 +21,7 @@ those support checks have a gap.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Optional, Tuple
 
 from cudnn.frost.tile_dsl.constants import (
     DTYPE_BF16,
@@ -63,10 +63,19 @@ class TemplateParams:
 
     dtype_qkv: int = DTYPE_FP16  # E4M3/E5M2 (0/1, d128 MXFP8 only) or BF16/FP16 (2/3)
     dtype_o: int = -1  # output dtype (0..3); -1 = inherit dtype_qkv. MXFP8 writes BF16/FP16.
-    mask_flags: int = MASK_NONE
-    swa_window: int = 0  # runtime left-window offset W (keep kv in [q-W, q])
-    band_right: int = 0  # diagonal-band right bound R (keep kv in [.., q+R]); 0 = plain causal
-    causal_bottom_right: bool = False
+    # The mask is ONE diagonal band (the model FlashAttention / CUTLASS FMHA /
+    # the analyzer facts all share): per-side OFFSETS from the diagonal, None =
+    # unbounded on that side. Row q attends kv in [q - window_left, q +
+    # window_right] (shifted by S_kv - S_q when bottom_right):
+    #   window_right = None -> no upper bound;  0 -> plain causal;  R > 0 ->
+    #   causal widened by R future tokens (diagonal_band_right_bound).
+    #   window_left  = None -> no lower bound;  W -> sliding window of W past
+    #   tokens (cuDNN diagonal_band_left_bound - 1).
+    #   bottom_right anchors the band's diagonal at the bottom-right corner.
+    # make_cfg_* derives the kernels' MASK_FLAGS bits from these.
+    window_left: Optional[int] = None
+    window_right: Optional[int] = None
+    bottom_right: bool = False
     has_sink: bool = False
     seq_kv_lens_present: bool = False
     # Dense padded-Q trim: per-batch seq_len_q is a SEPARATE (B,)-int32
@@ -95,20 +104,17 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
         raise ValueError(f"{flavor}: DTYPE_O must be 0..3; got {dtype_o}")
     if not fp8 and dtype_o != k.dtype_qkv:
         raise ValueError(f"{flavor}: half input (BF16/FP16) requires DTYPE_O == DTYPE_QKV; got dtype_o={dtype_o}")
-    if k.causal_bottom_right:
-        if not (k.mask_flags & MASK_CAUSAL):
-            raise ValueError(f"{flavor}: CAUSAL_BOTTOM_RIGHT requires MASK_CAUSAL (bit 1)")
-        if k.mask_flags & MASK_SWA:
-            raise ValueError(f"{flavor}: CAUSAL_BOTTOM_RIGHT + SWA is not supported")
-    if k.band_right < 0:
-        raise ValueError(f"{flavor}: BAND_RIGHT must be >= 0; got {k.band_right}")
-    if k.band_right > 0 and not (k.mask_flags & MASK_CAUSAL):
-        raise ValueError(f"{flavor}: BAND_RIGHT > 0 requires MASK_CAUSAL (the band's upper bound)")
-    if k.thd_varlen:
-        if not (k.mask_flags & MASK_PADDED):
-            raise ValueError(f"{flavor}: THD/varlen implies per-sequence padded masking (MASK_PADDED)")
-        if not k.seq_kv_lens_present:
-            raise ValueError(f"{flavor}: THD/varlen requires SEQ_KV_LENS_PRESENT")
+    if k.window_left is not None and k.window_left < 0:
+        raise ValueError(f"{flavor}: window_left must be >= 0 (or None for unbounded); got {k.window_left}")
+    if k.window_right is not None and k.window_right < 0:
+        raise ValueError(f"{flavor}: window_right must be >= 0 (or None for unbounded); got {k.window_right}")
+    if k.bottom_right:
+        if k.window_right is None:
+            raise ValueError(f"{flavor}: bottom_right anchors the band's diagonal and requires a right bound (window_right)")
+        if k.window_left is not None:
+            raise ValueError(f"{flavor}: bottom_right + window_left (SWA) is not supported")
+    if k.thd_varlen and not k.seq_kv_lens_present:
+        raise ValueError(f"{flavor}: THD/varlen requires SEQ_KV_LENS_PRESENT (per-sequence padded masking)")
     if k.seq_q_lens_present:
         if k.thd_varlen:
             raise ValueError(f"{flavor}: SEQ_Q_LENS_PRESENT is dense-only (THD carries per-sequence Q lengths via cu_seqlens)")
@@ -116,6 +122,20 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
             raise ValueError(f"{flavor}: SEQ_Q_LENS_PRESENT requires SEQ_KV_LENS_PRESENT (padding mask)")
     if k.sched_policy not in (SCHED_NATURAL, SCHED_LPT):
         raise ValueError(f"{flavor}: only SCHED_NATURAL (0) / SCHED_LPT (1) are wired up; got {k.sched_policy}")
+
+
+def _mask_flags_from(params: TemplateParams) -> int:
+    """Kernel-facing MASK bits, derived from the band + padding: the kernels
+    fold trace-time branches on these bits; the band VALUES ride the CFG's
+    WINDOW_LEFT / WINDOW_RIGHT fields (0 when the corresponding bit is unset)."""
+    flags = MASK_NONE
+    if params.window_right is not None:
+        flags |= MASK_CAUSAL
+    if params.window_left is not None:
+        flags |= MASK_SWA
+    if params.thd_varlen or params.seq_kv_lens_present:
+        flags |= MASK_PADDED
+    return flags
 
 
 # ---------------------------------------------------------------------------
@@ -234,11 +254,11 @@ class CfgD256:
 
     RESCALE_THRESHOLD: float = 8.0
 
-    MASK_FLAGS: int = MASK_NONE
-    SWA_WINDOW: int = 0
-    BAND_RIGHT: int = 0
+    MASK_FLAGS: int = MASK_NONE  # derived from the band by make_cfg (see _mask_flags_from)
+    WINDOW_LEFT: int = 0  # band left offset W (valid when MASK_SWA is set)
+    WINDOW_RIGHT: int = 0  # band right offset R (valid when MASK_CAUSAL is set; 0 = plain causal)
     HAS_SINK: int = 0
-    CAUSAL_BOTTOM_RIGHT: int = 0
+    BOTTOM_RIGHT: int = 0  # band diagonal anchored bottom-right
 
     L2_SIZE_MIB: int = 60
     SCHEDULER_POLICY: int = SCHED_NATURAL
@@ -307,11 +327,11 @@ def make_cfg_d256(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
         RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
         TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
         TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
-        MASK_FLAGS=params.mask_flags,
-        SWA_WINDOW=params.swa_window,
-        BAND_RIGHT=params.band_right,
+        MASK_FLAGS=_mask_flags_from(params),
+        WINDOW_LEFT=params.window_left or 0,
+        WINDOW_RIGHT=params.window_right or 0,
         HAS_SINK=int(params.has_sink),
-        CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
+        BOTTOM_RIGHT=int(params.bottom_right),
         SCHEDULER_POLICY=params.sched_policy,
         SEQ_KV_LENS_PRESENT=1 if (params.thd_varlen or params.seq_kv_lens_present) else 0,
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
@@ -370,11 +390,11 @@ class CfgD512:
 
     RESCALE_THRESHOLD: float = 8.0
 
-    MASK_FLAGS: int = MASK_NONE
-    SWA_WINDOW: int = 0
-    BAND_RIGHT: int = 0
+    MASK_FLAGS: int = MASK_NONE  # derived from the band by make_cfg (see _mask_flags_from)
+    WINDOW_LEFT: int = 0  # band left offset W (valid when MASK_SWA is set)
+    WINDOW_RIGHT: int = 0  # band right offset R (valid when MASK_CAUSAL is set; 0 = plain causal)
     HAS_SINK: int = 0
-    CAUSAL_BOTTOM_RIGHT: int = 0
+    BOTTOM_RIGHT: int = 0  # band diagonal anchored bottom-right
 
     L2_SIZE_MIB: int = 60
     SCHEDULER_POLICY: int = SCHED_NATURAL
@@ -450,11 +470,11 @@ def make_cfg_d512(params: TemplateParams) -> Tuple[CfgD512, TmaIters]:
         RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
         TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
         TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
-        MASK_FLAGS=params.mask_flags,
-        SWA_WINDOW=params.swa_window,
-        BAND_RIGHT=params.band_right,
+        MASK_FLAGS=_mask_flags_from(params),
+        WINDOW_LEFT=params.window_left or 0,
+        WINDOW_RIGHT=params.window_right or 0,
         HAS_SINK=int(params.has_sink),
-        CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
+        BOTTOM_RIGHT=int(params.bottom_right),
         SCHEDULER_POLICY=params.sched_policy,
         SEQ_KV_LENS_PRESENT=1 if (params.thd_varlen or params.seq_kv_lens_present) else 0,
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
@@ -515,11 +535,11 @@ class CfgD128:
 
     RESCALE_THRESHOLD: float = 8.0
 
-    MASK_FLAGS: int = MASK_NONE
-    SWA_WINDOW: int = 0
-    BAND_RIGHT: int = 0
+    MASK_FLAGS: int = MASK_NONE  # derived from the band by make_cfg (see _mask_flags_from)
+    WINDOW_LEFT: int = 0  # band left offset W (valid when MASK_SWA is set)
+    WINDOW_RIGHT: int = 0  # band right offset R (valid when MASK_CAUSAL is set; 0 = plain causal)
     HAS_SINK: int = 0
-    CAUSAL_BOTTOM_RIGHT: int = 0
+    BOTTOM_RIGHT: int = 0  # band diagonal anchored bottom-right
 
     L2_SIZE_MIB: int = 60
     SCHEDULER_POLICY: int = SCHED_NATURAL
@@ -610,11 +630,11 @@ def make_cfg_d128(params: TemplateParams) -> Tuple[CfgD128, TmaIters]:
         TILE_K_HW_BMM1=tile_k_hw_fp8,
         TILE_K_HW_BMM2=tile_k_hw_fp8,
         STAGES_KV=4 if fp8 else 2,
-        MASK_FLAGS=params.mask_flags,
-        SWA_WINDOW=params.swa_window,
-        BAND_RIGHT=params.band_right,
+        MASK_FLAGS=_mask_flags_from(params),
+        WINDOW_LEFT=params.window_left or 0,
+        WINDOW_RIGHT=params.window_right or 0,
         HAS_SINK=int(params.has_sink),
-        CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
+        BOTTOM_RIGHT=int(params.bottom_right),
         SCHEDULER_POLICY=params.sched_policy,
         SEQ_KV_LENS_PRESENT=1 if (params.thd_varlen or params.seq_kv_lens_present) else 0,
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
@@ -679,14 +699,14 @@ def make_cfg_d192(params: TemplateParams) -> Tuple[CfgD192, TmaIters]:
         RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
         TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
         TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
-        MASK_FLAGS=params.mask_flags,
-        SWA_WINDOW=params.swa_window,
-        BAND_RIGHT=params.band_right,
+        MASK_FLAGS=_mask_flags_from(params),
+        WINDOW_LEFT=params.window_left or 0,
+        WINDOW_RIGHT=params.window_right or 0,
         HAS_SINK=int(params.has_sink),
-        CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
+        BOTTOM_RIGHT=int(params.bottom_right),
         SCHEDULER_POLICY=1,
-        SOFTMAX_REGS=216 if params.mask_flags == MASK_NONE else 192,
-        CORRECTION_REGS=40 if params.mask_flags == MASK_NONE else 88,
+        SOFTMAX_REGS=216 if _mask_flags_from(params) == MASK_NONE else 192,
+        CORRECTION_REGS=40 if _mask_flags_from(params) == MASK_NONE else 88,
         SEQ_KV_LENS_PRESENT=1 if (params.thd_varlen or params.seq_kv_lens_present) else 0,
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
         THD_VARLEN=int(params.thd_varlen),

--- a/python/cudnn/sdpa/fwd/config_sm120.py
+++ b/python/cudnn/sdpa/fwd/config_sm120.py
@@ -25,9 +25,14 @@ class TemplateParams:
     """
 
     dtype_qkv: int = DTYPE_FP16
-    is_causal: bool = False
-    causal_bottom_right: bool = False
-    window_size_left: int | None = None
+    # The mask is ONE diagonal band (same model as config_sm100 / the analyzer
+    # facts): per-side offsets from the diagonal, None = unbounded on that
+    # side. This kernel serves window_right in {None, 0} only (plain causal;
+    # right-band widening is not plumbed here). bottom_right anchors the
+    # band's diagonal at the bottom-right corner.
+    window_left: int | None = None
+    window_right: int | None = None
+    bottom_right: bool = False
     seq_q_lens_present: bool = False
     seq_kv_lens_present: bool = False
     has_sink: bool = False
@@ -46,10 +51,12 @@ def validate_params(params: TemplateParams) -> None:
 
     if params.dtype_qkv not in (DTYPE_BF16, DTYPE_FP16):
         raise ValueError(f"SM120 SDPA: dtype_qkv must be DTYPE_BF16 ({DTYPE_BF16}) or DTYPE_FP16 ({DTYPE_FP16}); got {params.dtype_qkv}")
-    if params.causal_bottom_right and not params.is_causal:
-        raise ValueError("SM120 SDPA: causal_bottom_right requires is_causal=True")
-    if params.window_size_left is not None and params.window_size_left < 0:
-        raise ValueError(f"SM120 SDPA: window_size_left must be non-negative; got {params.window_size_left}")
+    if params.window_right not in (None, 0):
+        raise ValueError(f"SM120 SDPA: window_right must be None (unbounded) or 0 (causal) — right-band widening is not plumbed; got {params.window_right}")
+    if params.bottom_right and params.window_right is None:
+        raise ValueError("SM120 SDPA: bottom_right anchors the band's diagonal and requires a right bound (window_right)")
+    if params.window_left is not None and params.window_left < 0:
+        raise ValueError(f"SM120 SDPA: window_left must be non-negative; got {params.window_left}")
     if params.q_tile not in SEQ_Q_TILES:
         raise ValueError(f"SM120 SDPA: q_tile must be one of {SEQ_Q_TILES}; got {params.q_tile}")
     if params.kv_tile not in SEQ_KV_TILES:

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -134,7 +134,7 @@ class Capabilities:
     causal: bool = False
     bottom_right: bool = False
     bottom_right_with_swa: bool = False  # kernel gap: BR diagonal excludes SWA
-    # Kernel gap (pre-existing, sibling of thd_bottom_right): the BR diagonal is
+    # Kernel gap (pre-existing): for a DENSE padded graph the BR diagonal is
     # computed as seq_len_kv[b] - GLOBAL S_q, but cuDNN semantics for a dense
     # padded graph carrying per-batch seq_len_q anchor it at
     # (seq_len_q[b], seq_len_kv[b]) — any batch with seq_len_q[b] < S_q gets a
@@ -152,11 +152,6 @@ class Capabilities:
     lse_optional: bool = False
     thd: bool = False
     cu_seq_len: bool = False  # cu_seq_len_q / cu_seq_len_kv prefix sums (no row serves these yet)
-    # True = the kernel anchors the THD bottom-right diagonal at each sequence's
-    # own (seq_len_q[b], seq_len_kv[b]). Rows that keep False (the SM100 flavors)
-    # compute it from the GLOBAL S_q — the THD variant of the
-    # bottom_right_padded_seq_q gap above.
-    thd_bottom_right: bool = False
     # Dense padded + stats needs the per-batch seq_len_q LSE trim (padded
     # q-rows write LSE=-inf / O=0, cuDNN >= 9.14). Plumbed for the half
     # kernels via SEQ_Q_LENS_PRESENT; the FP8/MXFP8 kernels lack the epilogue
@@ -199,6 +194,20 @@ class Capabilities:
     tile_ms: frozenset[int] = frozenset()
     tile_ns: frozenset[int] = frozenset()
     cgas: frozenset[int] = frozenset()
+
+
+def _band_covers_kv_tail(facts: "ga.SdpaGraphFacts") -> bool:
+    """True when the causal band (plain or right-widened) provably masks every
+    KV column >= S_kv, so a ragged KV tail cannot leak into the softmax.
+
+    The last unmasked column is (S_q - 1) + R top-left or (S_kv - 1) + R
+    bottom-right (R = the right-band bound, 0 for plain causal)."""
+    if not (facts.causal or facts.right_band_widening):
+        return False
+    r = facts.right_bound or 0
+    if facts.bottom_right:
+        return r == 0
+    return facts.s_q + r <= facts.s_kv
 
 
 def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Optional[SdpaFwdKnobs] = None) -> Optional[str]:
@@ -300,14 +309,12 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
             return f"graph uses {label}, which this engine does not support"
 
     if facts.bottom_right:
-        if not facts.causal:
-            return "bottom-right alignment requires a causal upper bound"
+        if not (facts.causal or facts.right_band_widening):
+            return "bottom-right alignment requires a causal upper bound (plain or right-widened)"
         if not capabilities.bottom_right:
             return "graph uses bottom-right causal, which this kernel does not support"
         if facts.window_left is not None and not capabilities.bottom_right_with_swa:
             return "bottom-right causal combined with a sliding window is not supported"
-        if facts.thd and not capabilities.thd_bottom_right:
-            return "THD with bottom-right causal is not supported (per-sequence diagonal gap)"
         if facts.padded and not facts.thd and facts.seq_q_t is not None and not capabilities.bottom_right_padded_seq_q:
             return (
                 "bottom-right causal with a dense padding mask carrying per-batch seq_len_q is not "
@@ -329,8 +336,7 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
             )
 
     if capabilities.skv_tile and facts.s_kv % capabilities.skv_tile != 0 and not capabilities.skv_tail_via_padding:
-        causal_covers_tail = facts.causal and (facts.bottom_right or facts.s_q <= facts.s_kv)
-        if not (facts.padded or causal_covers_tail):
+        if not (facts.padded or _band_covers_kv_tail(facts)):
             return f"S_kv ({facts.s_kv}) must be a multiple of {capabilities.skv_tile} unless a padding mask is given or the causal mask covers the KV tail"
     return None
 
@@ -360,6 +366,7 @@ def _sm100_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
             dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
             causal=True,
             bottom_right=True,
+            right_band_widening=True,
             swa=True,
             padded=True,
             sink=True,
@@ -400,6 +407,7 @@ def _sm100_mxfp8_spec(d: int) -> EngineSpec:
             is_mxfp8=True,
             causal=True,
             bottom_right=True,
+            right_band_widening=True,
             swa=True,
             padded=True,
             sink=True,
@@ -435,6 +443,7 @@ def _sm100_fp8_spec(d: int) -> EngineSpec:
             is_fp8=True,
             causal=True,
             bottom_right=True,
+            right_band_widening=True,
             swa=True,
             padded=True,
             sink=True,
@@ -481,7 +490,6 @@ def _sm120_spec() -> EngineSpec:
             lse_optional=True,
             padded_stats=True,
             thd=True,
-            thd_bottom_right=True,
             layouts=frozenset({"bshd", "dense_flex"}),
             sched_policies=frozenset({SCHED_NATURAL}),
             tile_ms=frozenset({64, 128}),
@@ -545,8 +553,9 @@ def lower_dsl_prefill(
     # a ragged S_kv with no mask covering the tail is served through the
     # kernel's padded path with per-batch lengths pinned to the full S_kv.
     skv_tile = spec.capabilities.skv_tile or 128
-    causal_covers_tail = facts.causal and (facts.bottom_right or facts.s_q <= facts.s_kv)
-    synth_kv_padding = spec.capabilities.skv_tail_via_padding and not facts.padded and not facts.thd and facts.s_kv % skv_tile != 0 and not causal_covers_tail
+    synth_kv_padding = (
+        spec.capabilities.skv_tail_via_padding and not facts.padded and not facts.thd and facts.s_kv % skv_tile != 0 and not _band_covers_kv_tail(facts)
+    )
 
     seq_q_t = facts.seq_q_t if facts.padded else None
     seq_kv_t = facts.seq_kv_t if facts.padded else None
@@ -563,9 +572,12 @@ def lower_dsl_prefill(
         sample_v=ga.tensor_desc_from_ir(facts.v_t, name="v"),
         sample_o=ga.tensor_desc_from_ir(facts.o_t, name="o"),
         sample_lse=ga.tensor_desc_from_ir(facts.stats_t, "lse") if facts.stats_t is not None else None,
-        is_causal=facts.causal,
+        # A right-widened band lowers as the causal mask with a BAND_RIGHT
+        # diagonal offset (facts.causal is False when right_bound > 0).
+        is_causal=facts.causal or facts.right_band_widening,
         causal_bottom_right=facts.bottom_right,
         window_size_left=facts.window_left,
+        window_size_right=(facts.right_bound if facts.right_band_widening else None),
         scale_softmax=facts.scale,
         seq_kv_lens_present=facts.padded or synth_kv_padding,
         # Dense padded-Q trim (q rows >= seq_len_q[b] -> O := 0, LSE := -inf):

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -203,31 +203,31 @@ def compute_kv_loop_bounds(
     q_row_coord,
     seqlen_q,
     seq_kv_len,
-    swa_window: int,
+    window_left: int,
     mask_flags: int,
     tile_n: int,
     cga_tile_m: int,
-    causal_bottom_right: bool = False,
-    band_right: int = 0,
+    bottom_right: bool = False,
+    window_right: int = 0,
 ) -> KvLoopBounds:
-    # band_right: compile-time diagonal-band right bound (cuDNN
+    # window_right: compile-time diagonal-band right bound (cuDNN
     # diagonal_band_right_bound) — the causal upper limit is widened by
-    # band_right columns. 0 = plain causal; folds out entirely.
+    # window_right columns. 0 = plain causal; folds out entirely.
     left = cutlass.Int32(0)
     right = _div_up(seq_kv_len, tile_n)
 
-    if cutlass.const_expr(causal_bottom_right):
+    if cutlass.const_expr(bottom_right):
         causal_diag = seq_kv_len - seqlen_q
     else:
         causal_diag = cutlass.Int32(0)
 
     if cutlass.const_expr(mask_flags & MASK_CAUSAL):
-        kv_hi_caus = _div_up(q_row_coord + cutlass.Int32(cga_tile_m + band_right) + causal_diag, tile_n)
+        kv_hi_caus = _div_up(q_row_coord + cutlass.Int32(cga_tile_m + window_right) + causal_diag, tile_n)
         right = cute.math.min(right, kv_hi_caus)
 
     if cutlass.const_expr(mask_flags & MASK_SWA):
-        cond = q_row_coord > cutlass.Int32(swa_window)
-        delta = q_row_coord - cutlass.Int32(swa_window)
+        cond = q_row_coord > cutlass.Int32(window_left)
+        delta = q_row_coord - cutlass.Int32(window_left)
         kv_lo_swa = cutlass.Int32(
             arith.select(
                 cond.ir_value(),
@@ -249,13 +249,13 @@ def compute_kv_loop_bounds(
         )
         unmasked_hi = cute.math.min(unmasked_hi, lo_pad)
     if cutlass.const_expr(mask_flags & MASK_CAUSAL):
-        lo_caus = (q_row_coord + cutlass.Int32(band_right) + causal_diag) // cutlass.Int32(tile_n)
+        lo_caus = (q_row_coord + cutlass.Int32(window_right) + causal_diag) // cutlass.Int32(tile_n)
         unmasked_hi = cute.math.min(unmasked_hi, lo_caus)
     unmasked_hi = cute.math.max(unmasked_hi, left)
 
     unmasked_lo = left
     if cutlass.const_expr(mask_flags & MASK_SWA):
-        anchor = q_row_coord + cutlass.Int32(cga_tile_m - 1 - swa_window)
+        anchor = q_row_coord + cutlass.Int32(cga_tile_m - 1 - window_left)
         swa_unmasked_lo = _div_up(anchor, tile_n)
         cond = anchor > cutlass.Int32(0)
         swa_unmasked_lo = cutlass.Int32(
@@ -356,12 +356,12 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             q_row_coord,
             seqlen_q,
             seqlen_kv,
-            CFG.SWA_WINDOW,
+            CFG.WINDOW_LEFT,
             CFG.MASK_FLAGS,
             CFG.TILE_N,
             cga_tile_m,
-            causal_bottom_right=bool(CFG.CAUSAL_BOTTOM_RIGHT),
-            band_right=int(getattr(CFG, "BAND_RIGHT", 0)),
+            bottom_right=bool(CFG.BOTTOM_RIGHT),
+            window_right=int(CFG.WINDOW_RIGHT),
         )
 
     @cute.jit
@@ -415,7 +415,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
         every non-BR mask, where seqlen_q only feeds the unused diagonal)
         keep the scalar S_q, so this folds out unless THD_VARLEN and
         CAUSAL_BOTTOM_RIGHT are both set."""
-        if cutlass.const_expr(int(getattr(CFG, "THD_VARLEN", 0)) == 1 and int(CFG.CAUSAL_BOTTOM_RIGHT) == 1):
+        if cutlass.const_expr(int(getattr(CFG, "THD_VARLEN", 0)) == 1 and int(CFG.BOTTOM_RIGHT) == 1):
             cu = cutlass.make_array_view(seq_kv_lens_tensor)
             q0 = n_batch
             return cutlass.Int32(cu[q0 + batch_idx + cutlass.Int32(1)]) - cutlass.Int32(cu[q0 + batch_idx])

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -208,7 +208,11 @@ def compute_kv_loop_bounds(
     tile_n: int,
     cga_tile_m: int,
     causal_bottom_right: bool = False,
+    band_right: int = 0,
 ) -> KvLoopBounds:
+    # band_right: compile-time diagonal-band right bound (cuDNN
+    # diagonal_band_right_bound) — the causal upper limit is widened by
+    # band_right columns. 0 = plain causal; folds out entirely.
     left = cutlass.Int32(0)
     right = _div_up(seq_kv_len, tile_n)
 
@@ -218,7 +222,7 @@ def compute_kv_loop_bounds(
         causal_diag = cutlass.Int32(0)
 
     if cutlass.const_expr(mask_flags & MASK_CAUSAL):
-        kv_hi_caus = _div_up(q_row_coord + cutlass.Int32(cga_tile_m) + causal_diag, tile_n)
+        kv_hi_caus = _div_up(q_row_coord + cutlass.Int32(cga_tile_m + band_right) + causal_diag, tile_n)
         right = cute.math.min(right, kv_hi_caus)
 
     if cutlass.const_expr(mask_flags & MASK_SWA):
@@ -245,7 +249,7 @@ def compute_kv_loop_bounds(
         )
         unmasked_hi = cute.math.min(unmasked_hi, lo_pad)
     if cutlass.const_expr(mask_flags & MASK_CAUSAL):
-        lo_caus = (q_row_coord + causal_diag) // cutlass.Int32(tile_n)
+        lo_caus = (q_row_coord + cutlass.Int32(band_right) + causal_diag) // cutlass.Int32(tile_n)
         unmasked_hi = cute.math.min(unmasked_hi, lo_caus)
     unmasked_hi = cute.math.max(unmasked_hi, left)
 
@@ -290,6 +294,7 @@ class SdpaHelpers(NamedTuple):
     bounds_for_tile: object
     bounds_for_tile_qtrim: object
     resolve_seqlen_kv: object
+    resolve_seqlen_q: object
     thd_decode: object
     dispatch_decode_initial: object
     dispatch_decode_payload: object
@@ -356,6 +361,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             CFG.TILE_N,
             cga_tile_m,
             causal_bottom_right=bool(CFG.CAUSAL_BOTTOM_RIGHT),
+            band_right=int(getattr(CFG, "BAND_RIGHT", 0)),
         )
 
     @cute.jit
@@ -397,6 +403,23 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             arr = cutlass.make_array_view(seq_kv_lens_tensor)
             return cutlass.Int32(arr[batch_idx])
         return scalar_seqlen_kv
+
+    @cute.jit
+    def _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, scalar_seqlen_q, n_batch):
+        """Per-sequence Q length for the bottom-right causal diagonal.
+
+        THD anchors the BR diagonal at the per-sequence corner
+        (seq_len_q[b], seq_len_kv[b]): the actual Q length is the cu_seqlen_q
+        difference from the packed [kv_lens | cu_q | cu_kv] metadata buffer
+        (same layout _thd_decode / _thd_tma_offsets read). Dense graphs (and
+        every non-BR mask, where seqlen_q only feeds the unused diagonal)
+        keep the scalar S_q, so this folds out unless THD_VARLEN and
+        CAUSAL_BOTTOM_RIGHT are both set."""
+        if cutlass.const_expr(int(getattr(CFG, "THD_VARLEN", 0)) == 1 and int(CFG.CAUSAL_BOTTOM_RIGHT) == 1):
+            cu = cutlass.make_array_view(seq_kv_lens_tensor)
+            q0 = n_batch
+            return cutlass.Int32(cu[q0 + batch_idx + cutlass.Int32(1)]) - cutlass.Int32(cu[q0 + batch_idx])
+        return scalar_seqlen_q
 
     _thd_on = int(getattr(CFG, "THD_VARLEN", 0))
 
@@ -467,6 +490,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
         bounds_for_tile=_bounds_for_tile,
         bounds_for_tile_qtrim=_bounds_for_tile_qtrim,
         resolve_seqlen_kv=_resolve_seqlen_kv,
+        resolve_seqlen_q=_resolve_seqlen_q,
         thd_decode=_thd_decode,
         dispatch_decode_initial=_dispatch_decode_initial,
         dispatch_decode_payload=_dispatch_decode_payload,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
@@ -1292,21 +1292,21 @@ def _softmax_kv_body(
             for c in range(N_CHUNKS)
         ]
         # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
-        # CFG.CAUSAL_BOTTOM_RIGHT is 0 — top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
         chunks_S = [
             apply_mask_chunk(
                 raw_chunks[c],
                 q_abs,
                 kv_col_base + cutlass.Int32(c * CHUNK),
                 eff_seqlen_kv,
-                CFG.SWA_WINDOW,
+                CFG.WINDOW_LEFT,
                 CFG.MASK_FLAGS,
                 N=CHUNK,
-                causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+                bottom_right=CFG.BOTTOM_RIGHT,
                 causal_diag=causal_diag,
                 mask_value=float("-inf"),
-                band_right=CFG.BAND_RIGHT,
+                window_right=CFG.WINDOW_RIGHT,
             )
             for c in range(N_CHUNKS)
         ]

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
@@ -181,6 +181,7 @@ _decode_payload = _sdpa_h.decode_payload
 # per-batch actual Q length (SEQ_Q_LENS_PRESENT; folds to plain bounds otherwise).
 _bounds_for_tile = _sdpa_h.bounds_for_tile_qtrim
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
@@ -626,7 +627,8 @@ def _tmaldg_warp_group(
         kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -764,7 +766,8 @@ def _tmaldg_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -1010,7 +1013,8 @@ def _mma_warp_group(
             seq_kv_lens_tensor,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1212,7 +1216,8 @@ def _mma_warp_group(
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1230,7 +1235,7 @@ def _softmax_kv_body(
     bars,
     q_abs,
     eff_seqlen_kv,
-    seqlen_q,
+    eff_seqlen_q,
     scale_log2,
     total_max,
     total_max_safe,
@@ -1288,7 +1293,7 @@ def _softmax_kv_body(
         ]
         # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
         # CFG.CAUSAL_BOTTOM_RIGHT is 0 — top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
         chunks_S = [
             apply_mask_chunk(
                 raw_chunks[c],
@@ -1301,6 +1306,7 @@ def _softmax_kv_body(
                 causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
                 causal_diag=causal_diag,
                 mask_value=float("-inf"),
+                band_right=CFG.BAND_RIGHT,
             )
             for c in range(N_CHUNKS)
         ]
@@ -1488,7 +1494,9 @@ def _softmax_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1525,7 +1533,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_max_safe,
@@ -1544,7 +1552,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_max_safe,
@@ -1562,7 +1570,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_max_safe,
@@ -1580,7 +1588,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_max_safe,
@@ -1617,7 +1625,8 @@ def _softmax_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
 
 @cute.jit
@@ -1684,7 +1693,9 @@ def _correction_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1894,7 +1905,8 @@ def _correction_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     # End-of-warp tmem_dealloc: under cga2 each corr lane ALSO DSMEM-arrives
     # on the peer so the peer's local mbar accumulates the full CGA-total count.

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -170,6 +170,7 @@ _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
 # THD / varlen — shared helpers (FP8 element-addressed like f16, per-tensor
 # dequant scalars, no block-scale SF).  Gated by CFG.THD_VARLEN (folds out).
@@ -571,7 +572,8 @@ def _tmaldg_warp_group(
         kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -704,7 +706,8 @@ def _tmaldg_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -934,7 +937,8 @@ def _mma_warp_group(
             seq_kv_lens_tensor,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1129,7 +1133,8 @@ def _mma_warp_group(
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1147,7 +1152,7 @@ def _softmax_kv_body(
     bars,
     q_abs,
     eff_seqlen_kv,
-    seqlen_q,
+    eff_seqlen_q,
     scale_log2,
     total_max,
     total_sum,
@@ -1194,7 +1199,7 @@ def _softmax_kv_body(
         ]
         # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
         # CFG.CAUSAL_BOTTOM_RIGHT is 0 — top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
         chunks_S = [
             apply_mask_chunk(
                 raw_chunks[c],
@@ -1206,6 +1211,7 @@ def _softmax_kv_body(
                 N=CHUNK,
                 causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
                 causal_diag=causal_diag,
+                band_right=CFG.BAND_RIGHT,
             )
             for c in range(N_CHUNKS)
         ]
@@ -1372,7 +1378,9 @@ def _softmax_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1408,7 +1416,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_sum,
@@ -1428,7 +1436,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_sum,
@@ -1447,7 +1455,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_sum,
@@ -1466,7 +1474,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_sum,
@@ -1501,7 +1509,8 @@ def _softmax_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
 
 @cute.jit
@@ -1569,7 +1578,9 @@ def _correction_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1828,7 +1839,8 @@ def _correction_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
     # tmem_dealloc fan-out: fire one arrive per lane; cga2 also DSMEM-arrives
     # on the peer so peer's local mbar accumulates the full CGA count.

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -1198,20 +1198,20 @@ def _softmax_kv_body(
             for c in range(N_CHUNKS)
         ]
         # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
-        # CFG.CAUSAL_BOTTOM_RIGHT is 0 — top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
         chunks_S = [
             apply_mask_chunk(
                 raw_chunks[c],
                 q_abs,
                 kv_col_base + cutlass.Int32(c * CHUNK),
                 eff_seqlen_kv,
-                CFG.SWA_WINDOW,
+                CFG.WINDOW_LEFT,
                 CFG.MASK_FLAGS,
                 N=CHUNK,
-                causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+                bottom_right=CFG.BOTTOM_RIGHT,
                 causal_diag=causal_diag,
-                band_right=CFG.BAND_RIGHT,
+                window_right=CFG.WINDOW_RIGHT,
             )
             for c in range(N_CHUNKS)
         ]

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -219,6 +219,7 @@ _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
@@ -787,7 +788,8 @@ def _tmaldg_warp_group(
         kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -981,7 +983,8 @@ def _tmaldg_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -1258,7 +1261,8 @@ def _mma_warp_group(
             seq_kv_lens_tensor,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1555,7 +1559,8 @@ def _mma_warp_group(
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1574,7 +1579,7 @@ def _softmax_kv_body(
     mb_softmax_ldtm,
     q_abs,
     eff_seqlen_kv,
-    seqlen_q,
+    eff_seqlen_q,
     scale_log2,
     total_max,
     total_sum,
@@ -1636,7 +1641,7 @@ def _softmax_kv_body(
         kv_col_base_b = kv_col_base_a + cutlass.Int32(CHUNK)
         # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
         # CFG.CAUSAL_BOTTOM_RIGHT is 0 — top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
         reg_S_a = apply_mask_chunk(
             reg_S_a,
             q_abs,
@@ -1647,6 +1652,7 @@ def _softmax_kv_body(
             N=CHUNK,
             causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
             causal_diag=causal_diag,
+            band_right=CFG.BAND_RIGHT,
         )
         reg_S_b = apply_mask_chunk(
             reg_S_b,
@@ -1658,6 +1664,7 @@ def _softmax_kv_body(
             N=CHUNK,
             causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
             causal_diag=causal_diag,
+            band_right=CFG.BAND_RIGHT,
         )
 
         max_a = row_max_reduction_64(reg_S_a)
@@ -1829,7 +1836,9 @@ def _softmax_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1865,7 +1874,7 @@ def _softmax_warp_group(
                     mb_softmax_ldtm,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_sum,
@@ -1884,7 +1893,7 @@ def _softmax_warp_group(
                     mb_softmax_ldtm,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_sum,
@@ -1902,7 +1911,7 @@ def _softmax_warp_group(
                     mb_softmax_ldtm,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_sum,
@@ -1922,7 +1931,7 @@ def _softmax_warp_group(
                     mb_softmax_ldtm,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_sum,
@@ -1957,7 +1966,8 @@ def _softmax_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
 
 @cute.jit
@@ -2018,7 +2028,9 @@ def _correction_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -2200,7 +2212,8 @@ def _correction_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
     # mb_tmem_dealloc fan-out — all-lanes arrive + DSMEM-arrive on cross-pair peer under cga2.
     if cutlass.const_expr(CFG.CTA_MMA == 2):

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -1640,31 +1640,31 @@ def _softmax_kv_body(
         kv_col_base_a = kv_loop * cutlass.Int32(CFG.TILE_N)
         kv_col_base_b = kv_col_base_a + cutlass.Int32(CHUNK)
         # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
-        # CFG.CAUSAL_BOTTOM_RIGHT is 0 — top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
         reg_S_a = apply_mask_chunk(
             reg_S_a,
             q_abs,
             kv_col_base_a,
             eff_seqlen_kv,
-            CFG.SWA_WINDOW,
+            CFG.WINDOW_LEFT,
             CFG.MASK_FLAGS,
             N=CHUNK,
-            causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+            bottom_right=CFG.BOTTOM_RIGHT,
             causal_diag=causal_diag,
-            band_right=CFG.BAND_RIGHT,
+            window_right=CFG.WINDOW_RIGHT,
         )
         reg_S_b = apply_mask_chunk(
             reg_S_b,
             q_abs,
             kv_col_base_b,
             eff_seqlen_kv,
-            CFG.SWA_WINDOW,
+            CFG.WINDOW_LEFT,
             CFG.MASK_FLAGS,
             N=CHUNK,
-            causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+            bottom_right=CFG.BOTTOM_RIGHT,
             causal_diag=causal_diag,
-            band_right=CFG.BAND_RIGHT,
+            window_right=CFG.WINDOW_RIGHT,
         )
 
         max_a = row_max_reduction_64(reg_S_a)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -192,7 +192,7 @@ def _bounds_for_tile(
 
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
-CAN_HAVE_EMPTY_KV = (CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.CAUSAL_BOTTOM_RIGHT
+CAN_HAVE_EMPTY_KV = (CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.BOTTOM_RIGHT
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
 # factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
@@ -212,10 +212,10 @@ _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 def _apply_top_left_causal_mask_chunk(reg_S, q_abs, kv_col_base, N: int = 64):
     neg_inf = cutlass.Float32(float("-inf"))
     last_live = q_abs - kv_col_base
-    if cutlass.const_expr(CFG.BAND_RIGHT != 0):
+    if cutlass.const_expr(CFG.WINDOW_RIGHT != 0):
         # Right-band widening: the causal upper limit sits BAND_RIGHT columns
         # right of the diagonal (cuDNN diagonal_band_right_bound).
-        last_live = last_live + cutlass.Int32(CFG.BAND_RIGHT)
+        last_live = last_live + cutlass.Int32(CFG.WINDOW_RIGHT)
     elems = [
         cutlass.Float32(
             arith.select(
@@ -233,8 +233,8 @@ def _apply_top_left_causal_mask_chunk(reg_S, q_abs, kv_col_base, N: int = 64):
 def _apply_bottom_right_causal_mask_chunk(reg_S, q_abs, kv_col_base, causal_diag, N: int = 64):
     neg_inf = cutlass.Float32(float("-inf"))
     last_live = q_abs + causal_diag - kv_col_base
-    if cutlass.const_expr(CFG.BAND_RIGHT != 0):
-        last_live = last_live + cutlass.Int32(CFG.BAND_RIGHT)
+    if cutlass.const_expr(CFG.WINDOW_RIGHT != 0):
+        last_live = last_live + cutlass.Int32(CFG.WINDOW_RIGHT)
     elems = [
         cutlass.Float32(
             arith.select(
@@ -1327,8 +1327,8 @@ def _softmax_kv_body(
     if cutlass.const_expr(apply_mask):
         kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
         # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
-        # CFG.CAUSAL_BOTTOM_RIGHT is 0 - top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        # CFG.BOTTOM_RIGHT is 0 - top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
 
     _wait_mbarrier(bars.mb_bmm1_done[sub_tile_id], bmm1_phase)
     bmm1_phase = bmm1_phase ^ 1
@@ -1346,7 +1346,7 @@ def _softmax_kv_body(
             )
             for c in range(N_CHUNKS)
         ]
-        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.CAUSAL_BOTTOM_RIGHT == 0):
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0):
             chunks_S = [
                 _apply_top_left_causal_mask_chunk(
                     raw_chunks[c],
@@ -1356,7 +1356,7 @@ def _softmax_kv_body(
                 )
                 for c in range(N_CHUNKS)
             ]
-        elif cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.CAUSAL_BOTTOM_RIGHT != 0):
+        elif cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT != 0):
             chunks_S = [
                 _apply_bottom_right_causal_mask_chunk(
                     raw_chunks[c],
@@ -1374,13 +1374,13 @@ def _softmax_kv_body(
                     q_abs,
                     kv_col_base + cutlass.Int32(c * CHUNK),
                     eff_seqlen_kv,
-                    CFG.SWA_WINDOW,
+                    CFG.WINDOW_LEFT,
                     CFG.MASK_FLAGS,
                     N=CHUNK,
-                    causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+                    bottom_right=CFG.BOTTOM_RIGHT,
                     causal_diag=causal_diag,
                     mask_value=float("-inf"),
-                    band_right=CFG.BAND_RIGHT,
+                    window_right=CFG.WINDOW_RIGHT,
                 )
                 for c in range(N_CHUNKS)
             ]
@@ -1892,7 +1892,7 @@ def _correction_warp_group(
                 # Dead row (no valid KV column at all): O := 0, LSE := -inf.
                 # Top-left causal and no-mask dense tiles always have at least
                 # one valid KV per live row, so fold this select out there.
-                if cutlass.const_expr((CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.CAUSAL_BOTTOM_RIGHT):
+                if cutlass.const_expr((CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.BOTTOM_RIGHT):
                     row_dead = total_sum <= cutlass.Float32(0.0)
                     neg_inf_lse = cutlass.Float32(float("-inf"))
                     lse_val = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse_val.ir_value()))

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -191,6 +191,7 @@ def _bounds_for_tile(
 
 
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 CAN_HAVE_EMPTY_KV = (CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.CAUSAL_BOTTOM_RIGHT
 
 # THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
@@ -211,6 +212,10 @@ _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 def _apply_top_left_causal_mask_chunk(reg_S, q_abs, kv_col_base, N: int = 64):
     neg_inf = cutlass.Float32(float("-inf"))
     last_live = q_abs - kv_col_base
+    if cutlass.const_expr(CFG.BAND_RIGHT != 0):
+        # Right-band widening: the causal upper limit sits BAND_RIGHT columns
+        # right of the diagonal (cuDNN diagonal_band_right_bound).
+        last_live = last_live + cutlass.Int32(CFG.BAND_RIGHT)
     elems = [
         cutlass.Float32(
             arith.select(
@@ -228,6 +233,8 @@ def _apply_top_left_causal_mask_chunk(reg_S, q_abs, kv_col_base, N: int = 64):
 def _apply_bottom_right_causal_mask_chunk(reg_S, q_abs, kv_col_base, causal_diag, N: int = 64):
     neg_inf = cutlass.Float32(float("-inf"))
     last_live = q_abs + causal_diag - kv_col_base
+    if cutlass.const_expr(CFG.BAND_RIGHT != 0):
+        last_live = last_live + cutlass.Int32(CFG.BAND_RIGHT)
     elems = [
         cutlass.Float32(
             arith.select(
@@ -673,7 +680,8 @@ def _tmaldg_warp_group(
         kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -816,7 +824,8 @@ def _tmaldg_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -1062,7 +1071,8 @@ def _mma_warp_group(
             seq_kv_lens_tensor,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1263,7 +1273,8 @@ def _mma_warp_group(
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -1284,7 +1295,7 @@ def _softmax_kv_body(
     bars,
     q_abs,
     eff_seqlen_kv,
-    seqlen_q,
+    eff_seqlen_q,
     scale_log2,
     total_max,
     total_max_safe,
@@ -1317,7 +1328,7 @@ def _softmax_kv_body(
         kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
         # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
         # CFG.CAUSAL_BOTTOM_RIGHT is 0 - top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
 
     _wait_mbarrier(bars.mb_bmm1_done[sub_tile_id], bmm1_phase)
     bmm1_phase = bmm1_phase ^ 1
@@ -1369,6 +1380,7 @@ def _softmax_kv_body(
                     causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
                     causal_diag=causal_diag,
                     mask_value=float("-inf"),
+                    band_right=CFG.BAND_RIGHT,
                 )
                 for c in range(N_CHUNKS)
             ]
@@ -1564,7 +1576,9 @@ def _softmax_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1598,7 +1612,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_max_safe,
@@ -1619,7 +1633,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_max_safe,
@@ -1639,7 +1653,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_max_safe,
@@ -1659,7 +1673,7 @@ def _softmax_warp_group(
                     bars,
                     q_abs,
                     eff_seqlen_kv,
-                    seqlen_q,
+                    eff_seqlen_q,
                     scale_log2,
                     total_max,
                     total_max_safe,
@@ -1696,7 +1710,8 @@ def _softmax_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
 
 @cute.jit
@@ -1763,7 +1778,9 @@ def _correction_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1983,7 +2000,8 @@ def _correction_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     # End-of-warp tmem_dealloc: under cga2 each corr lane ALSO DSMEM-arrives
     # on the peer so the peer's local mbar accumulates the full CGA-total count.

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
@@ -117,6 +117,7 @@ _decode_payload = _sdpa_h.decode_payload
 # per-batch actual Q length (SEQ_Q_LENS_PRESENT; folds to plain bounds otherwise).
 _bounds_for_tile = _sdpa_h.bounds_for_tile_qtrim
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
 
 from cudnn.sdpa.fwd.kernels.thd_sm100 import build_o_descs_kernel as _build_o_descs_kernel, TENSOR_MAP_QWORDS
@@ -489,7 +490,8 @@ def _tmaldg_warp_group(
         kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -575,7 +577,8 @@ def _tmaldg_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -759,7 +762,8 @@ def _mma_warp_group(
             seq_kv_lens_tensor,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -901,7 +905,8 @@ def _mma_warp_group(
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -950,7 +955,9 @@ def _softmax_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(CFG.SOFTMAX_WG0_BASE * 32)
 
@@ -1069,7 +1076,7 @@ def _softmax_warp_group(
                 raw_chunks = [
                     nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
                 ]
-                causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+                causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
                 chunks_S = [
                     apply_mask_chunk(
                         raw_chunks[c],
@@ -1081,6 +1088,7 @@ def _softmax_warp_group(
                         N=CHUNK,
                         causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
                         causal_diag=causal_diag,
+                        band_right=CFG.BAND_RIGHT,
                         mask_value=float("-inf"),
                     )
                     for c in range(N_CHUNKS)
@@ -1221,7 +1229,7 @@ def _softmax_warp_group(
                 raw_chunks = [
                     nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
                 ]
-                causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+                causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
                 chunks_S = [
                     apply_mask_chunk(
                         raw_chunks[c],
@@ -1233,6 +1241,7 @@ def _softmax_warp_group(
                         N=CHUNK,
                         causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
                         causal_diag=causal_diag,
+                        band_right=CFG.BAND_RIGHT,
                         mask_value=float("-inf"),
                     )
                     for c in range(N_CHUNKS)
@@ -1310,7 +1319,8 @@ def _softmax_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
 
 @cute.jit
@@ -1356,7 +1366,9 @@ def _correction_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     O_CHUNK = 16
     N_CHUNKS_O = CFG.TILE_O // O_CHUNK
@@ -1566,7 +1578,8 @@ def _correction_warp_group(
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
 
     if cutlass.const_expr(CFG.CTA_MMA == 2):
         peer_cta = cta_id_x ^ cutlass.Int32(1)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
@@ -1076,19 +1076,19 @@ def _softmax_warp_group(
                 raw_chunks = [
                     nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
                 ]
-                causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+                causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
                 chunks_S = [
                     apply_mask_chunk(
                         raw_chunks[c],
                         q_abs,
                         kv_col_base + cutlass.Int32(c * CHUNK),
                         eff_seqlen_kv,
-                        CFG.SWA_WINDOW,
+                        CFG.WINDOW_LEFT,
                         CFG.MASK_FLAGS,
                         N=CHUNK,
-                        causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+                        bottom_right=CFG.BOTTOM_RIGHT,
                         causal_diag=causal_diag,
-                        band_right=CFG.BAND_RIGHT,
+                        window_right=CFG.WINDOW_RIGHT,
                         mask_value=float("-inf"),
                     )
                     for c in range(N_CHUNKS)
@@ -1229,19 +1229,19 @@ def _softmax_warp_group(
                 raw_chunks = [
                     nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
                 ]
-                causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+                causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
                 chunks_S = [
                     apply_mask_chunk(
                         raw_chunks[c],
                         q_abs,
                         kv_col_base + cutlass.Int32(c * CHUNK),
                         eff_seqlen_kv,
-                        CFG.SWA_WINDOW,
+                        CFG.WINDOW_LEFT,
                         CFG.MASK_FLAGS,
                         N=CHUNK,
-                        causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+                        bottom_right=CFG.BOTTOM_RIGHT,
                         causal_diag=causal_diag,
-                        band_right=CFG.BAND_RIGHT,
+                        window_right=CFG.WINDOW_RIGHT,
                         mask_value=float("-inf"),
                     )
                     for c in range(N_CHUNKS)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
@@ -660,19 +660,19 @@ def _sg0_softmax_kv_iter(
             )
             for c in range(SOFTMAX_N_CHUNKS_LOAD)
         ]
-        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
         chunks_S = [
             apply_mask_chunk(
                 raw_chunks[c],
                 q_abs,
                 kv_col_base + cutlass.Int32(c * SOFTMAX_CHUNK),
                 eff_seqlen_kv,
-                CFG.SWA_WINDOW,
+                CFG.WINDOW_LEFT,
                 CFG.MASK_FLAGS,
                 N=SOFTMAX_CHUNK,
-                causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+                bottom_right=CFG.BOTTOM_RIGHT,
                 causal_diag=causal_diag,
-                band_right=CFG.BAND_RIGHT,
+                window_right=CFG.WINDOW_RIGHT,
                 mask_value=float("-inf"),
             )
             for c in range(SOFTMAX_N_CHUNKS_LOAD)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
@@ -304,6 +304,7 @@ _sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
 # per-batch actual Q length (SEQ_Q_LENS_PRESENT; folds to plain bounds otherwise).
 _bounds_for_tile = _sdpa_h.bounds_for_tile_qtrim
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
 
 _decode_initial = _sdpa_h.decode_initial
@@ -634,7 +635,7 @@ def _sg0_softmax_kv_iter(
     sAlpha_xfer_raw,
     q_abs,
     eff_seqlen_kv,
-    seqlen_q,
+    eff_seqlen_q,
     scale_log2,
     tid_in_wg,
     is_lead_warp,
@@ -659,7 +660,7 @@ def _sg0_softmax_kv_iter(
             )
             for c in range(SOFTMAX_N_CHUNKS_LOAD)
         ]
-        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
         chunks_S = [
             apply_mask_chunk(
                 raw_chunks[c],
@@ -671,6 +672,7 @@ def _sg0_softmax_kv_iter(
                 N=SOFTMAX_CHUNK,
                 causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
                 causal_diag=causal_diag,
+                band_right=CFG.BAND_RIGHT,
                 mask_value=float("-inf"),
             )
             for c in range(SOFTMAX_N_CHUNKS_LOAD)
@@ -817,7 +819,8 @@ def _compute_warp_group(
         eff_seqlen_kv = seqlen_kv
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_unmasked_lo = bounds_init.unmasked_lo
         kv_unmasked_hi = bounds_init.unmasked_hi
@@ -880,7 +883,7 @@ def _compute_warp_group(
                             sAlpha_xfer_raw,
                             q_abs,
                             eff_seqlen_kv,
-                            seqlen_q,
+                            eff_seqlen_q,
                             scale_log2,
                             tid_in_wg,
                             is_lead_warp,
@@ -903,7 +906,7 @@ def _compute_warp_group(
                             sAlpha_xfer_raw,
                             q_abs,
                             eff_seqlen_kv,
-                            seqlen_q,
+                            eff_seqlen_q,
                             scale_log2,
                             tid_in_wg,
                             is_lead_warp,
@@ -925,7 +928,7 @@ def _compute_warp_group(
                             sAlpha_xfer_raw,
                             q_abs,
                             eff_seqlen_kv,
-                            seqlen_q,
+                            eff_seqlen_q,
                             scale_log2,
                             tid_in_wg,
                             is_lead_warp,
@@ -947,7 +950,7 @@ def _compute_warp_group(
                             sAlpha_xfer_raw,
                             q_abs,
                             eff_seqlen_kv,
-                            seqlen_q,
+                            eff_seqlen_q,
                             scale_log2,
                             tid_in_wg,
                             is_lead_warp,
@@ -1184,7 +1187,8 @@ def _compute_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_unmasked_lo = bounds_next.unmasked_lo
             kv_unmasked_hi = bounds_next.unmasked_hi
@@ -1293,7 +1297,8 @@ def _mma_warp_group(
         kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1439,7 +1444,8 @@ def _mma_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -1496,7 +1502,8 @@ def _mma_warp_non_leader(
             kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
         else:
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_init.left
             kv_right = bounds_init.right
 
@@ -1535,7 +1542,8 @@ def _mma_warp_non_leader(
             sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
             if cutlass.const_expr(CFG.MASK_FLAGS != 0):
                 eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-                bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+                eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+                bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
                 kv_left = bounds_next.left
                 kv_right = bounds_next.right
     bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
@@ -1594,7 +1602,8 @@ def _tmaldg_warp_group(
         kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1687,7 +1696,8 @@ def _tmaldg_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -171,7 +171,7 @@ class SM120FusedMultiHeadAttentionForward:
         in_dtype: Type[cutlass.Numeric] = cutlass.Float16,
         out_dtype: Type[cutlass.Numeric] = cutlass.Float16,
         is_causal: bool = False,
-        causal_bottom_right: bool = False,
+        bottom_right: bool = False,
         window_size_left: int | None = None,
         seq_q_lens_present: bool = False,
         seq_kv_lens_present: bool = False,
@@ -190,7 +190,7 @@ class SM120FusedMultiHeadAttentionForward:
         :param in_dtype: Q/K/V element type (Float16 or BFloat16).
         :param out_dtype: O element type. Must match ``in_dtype``.
         :param is_causal: Apply an upper causal bound to QK.
-        :param causal_bottom_right: Shift the causal diagonal by ``Skv - Sq``.
+        :param bottom_right: Shift the causal diagonal by ``Skv - Sq``.
         :param window_size_left: Inclusive left-window offset, or ``None``.
         :param seq_q_lens_present: Read per-batch query lengths at runtime.
         :param seq_kv_lens_present: Read per-batch key/value lengths at runtime.
@@ -222,7 +222,7 @@ class SM120FusedMultiHeadAttentionForward:
         self.in_dtype = in_dtype
         self.out_dtype = in_dtype
         self.is_causal = is_causal
-        self.causal_bottom_right = causal_bottom_right
+        self.bottom_right = bottom_right
         self.window_size_left = window_size_left
         self.seq_q_lens_present = seq_q_lens_present
         self.seq_kv_lens_present = seq_kv_lens_present
@@ -489,7 +489,7 @@ class SM120FusedMultiHeadAttentionForward:
             # exclusive upper bound; ``first_valid_col`` is inclusive.
             q_position = basic_params.q_seq_idx + q_row_in_cta
             diagonal_offset = cutlass.Int32(0)
-            if cutlass.const_expr(self.causal_bottom_right):
+            if cutlass.const_expr(self.bottom_right):
                 diagonal_offset = basic_params.seqlen_k - basic_params.seqlen_q
             diagonal_position = q_position + diagonal_offset
 
@@ -815,7 +815,7 @@ class SM120FusedMultiHeadAttentionForward:
                 num_kv_tiles = cutlass.Int32(0)
         if cutlass.const_expr(self.is_causal):
             causal_k_end = q_seq_idx + self.q_tile
-            if cutlass.const_expr(self.causal_bottom_right):
+            if cutlass.const_expr(self.bottom_right):
                 causal_k_end += seqlen_k - seqlen_q
             causal_k_end = cute.math.max(cutlass.Int32(0), cute.math.min(causal_k_end, seqlen_k))
             num_kv_tiles_causal = ceil_div(causal_k_end, self.kv_tile)
@@ -824,7 +824,7 @@ class SM120FusedMultiHeadAttentionForward:
         min_kv_tile = cutlass.Int32(0)
         if cutlass.const_expr(self.window_size_left is not None):
             first_q_position = q_seq_idx
-            if cutlass.const_expr(self.causal_bottom_right):
+            if cutlass.const_expr(self.bottom_right):
                 first_q_position += seqlen_k - seqlen_q
             first_valid_col = cute.math.max(cutlass.Int32(0), first_q_position - self.window_size_left)
             min_kv_tile = first_valid_col // self.kv_tile
@@ -990,7 +990,7 @@ class SM120FusedMultiHeadAttentionForward:
             mask_steps = 1
             if cutlass.const_expr(self.is_causal):
                 mask_steps = ceil_div(self.q_tile, self.kv_tile)
-                if cutlass.const_expr(self.causal_bottom_right):
+                if cutlass.const_expr(self.bottom_right):
                     # The shifted diagonal can straddle one additional KV tile.
                     mask_steps = ceil_div(self.q_tile + self.kv_tile - 1, self.kv_tile)
             left_mask_steps = 1
@@ -1391,9 +1391,9 @@ def compile(  # noqa: A001
     kernel = SM120FusedMultiHeadAttentionForward(
         in_dtype=STORAGE_DTYPE,
         out_dtype=STORAGE_DTYPE,
-        is_causal=PARAMS.is_causal,
-        causal_bottom_right=PARAMS.causal_bottom_right,
-        window_size_left=PARAMS.window_size_left,
+        is_causal=PARAMS.window_right is not None,
+        bottom_right=PARAMS.bottom_right,
+        window_size_left=PARAMS.window_left,
         seq_q_lens_present=PARAMS.seq_q_lens_present,
         seq_kv_lens_present=PARAMS.seq_kv_lens_present,
         has_sink=PARAMS.has_sink,

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -453,6 +453,8 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
         # would make every engine reject an effectively-unmasked graph.
         has_band = resolved_right is not None or left_bound is not None
         align_is_br = has_band and rec.get("diagonal_alignment") == cudnn.diagonal_alignment.BOTTOM_RIGHT
+    if resolved_right is not None and resolved_right < 0:
+        return _invalid(f"diagonal-band right bound must be >= 0; got {resolved_right}")
     right_widening = resolved_right not in (0, None)
     causal = (resolved_right is not None) and not right_widening
     if left_bound is not None and left_bound < 1:

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -116,7 +116,7 @@ _DTYPE_IDS = ["fp16", "bf16"]
 _THD_SENTINEL = 2048.0
 
 
-def _ref_sdpa_full(q, k, v, *, scale, is_causal=False, bottom_right=False, swa_window=None, seq_kv_lens=None, sinks=None, return_stats=False):
+def _ref_sdpa_full(q, k, v, *, scale, is_causal=False, bottom_right=False, band_right=0, swa_window=None, seq_kv_lens=None, sinks=None, return_stats=False):
     """fp32 reference matching the SM100 DSL kernel's mask + sink semantics.
     q/k/v are BHSD; GQA (h_q > h_kv) is handled by expanding K/V. With
     ``return_stats`` also returns the (B, H_q, S_q) LSE — logsumexp over the
@@ -134,7 +134,7 @@ def _ref_sdpa_full(q, k, v, *, scale, is_causal=False, bottom_right=False, swa_w
     j = torch.arange(s_kv, device=dev).view(1, 1, 1, s_kv)
     masked = torch.zeros(b, 1, s_q, s_kv, dtype=torch.bool, device=dev)
     if is_causal:
-        lim = i + (s_kv - s_q) if bottom_right else i
+        lim = (i + (s_kv - s_q) if bottom_right else i) + band_right
         masked = masked | (j > lim)
     if swa_window is not None:
         masked = masked | (j < i - swa_window)
@@ -585,15 +585,21 @@ def test_dsl_sm100_thd_cross(dtype, d):
 # forces padding internally, so its mask axis is on top of that (no standalone
 # "padded" entry); dense carries the explicit "padded" case.
 _COMBO_SWA_W = 64
+_COMBO_BAND_R = 40  # right-band widening bound (diagonal_band_right_bound)
 
 
 def _mask_graph_kwargs(mask):
     """graph.sdpa kwargs for the causal-family masks (padded handled separately)."""
+    import cudnn
+
     return {
         "none": {},
         "causal": dict(use_causal_mask=True),
         "causal_br": dict(use_causal_mask_bottom_right=True),
         "swa": dict(use_causal_mask=True, sliding_window_length=_COMBO_SWA_W + 1),
+        "band": dict(diagonal_band_right_bound=_COMBO_BAND_R),
+        "band_br": dict(diagonal_band_right_bound=_COMBO_BAND_R, diagonal_alignment=cudnn.diagonal_alignment.BOTTOM_RIGHT),
+        "band_swa": dict(diagonal_band_right_bound=_COMBO_BAND_R, diagonal_band_left_bound=_COMBO_SWA_W + 1),
     }[mask]
 
 
@@ -604,6 +610,9 @@ def _mask_ref_kwargs(mask):
         "causal": dict(is_causal=True),
         "causal_br": dict(is_causal=True, bottom_right=True),
         "swa": dict(is_causal=True, swa_window=_COMBO_SWA_W),
+        "band": dict(is_causal=True, band_right=_COMBO_BAND_R),
+        "band_br": dict(is_causal=True, bottom_right=True, band_right=_COMBO_BAND_R),
+        "band_swa": dict(is_causal=True, band_right=_COMBO_BAND_R, swa_window=_COMBO_SWA_W),
     }[mask]
 
 
@@ -723,7 +732,7 @@ def _run_dsl_thd_graph(
 
 def _combo_dense(d, dtype, H_q, H_kv, scale, sink_t, mask):
     b = 2
-    s_q, s_kv = (128, 256) if mask == "causal_br" else (256, 256)
+    s_q, s_kv = (128, 256) if mask in ("causal_br", "band_br") else (256, 256)
     q = _bhsd(b, H_q, s_q, d, dtype)
     k = _bhsd(b, H_kv, s_kv, d, dtype)
     v = _bhsd(b, H_kv, s_kv, d, dtype)
@@ -746,6 +755,11 @@ def _combo_thd(d, dtype, H_q, H_kv, scale, sink_t, mask):
     dev = "cuda"
     seq_lens_q = [200, 150]
     seq_lens_kv = [180, 120]
+    if mask in ("causal_br", "band_br"):
+        # Bottom-right masks: keep seq_len_kv[b] >= seq_len_q[b] so no sequence
+        # has fully-masked rows (the torch softmax reference NaNs on those).
+        seq_lens_q = [150, 90]
+        seq_lens_kv = [180, 120]
     B = len(seq_lens_q)
 
     def _cu(sl):
@@ -919,10 +933,12 @@ def test_dsl_sm100_thd_all_q_zero_stats(stats_layout):
 
 
 _COMBO_MASKS = {
-    "dense": ["none", "causal", "causal_br", "swa", "padded"],
-    # THD forces padding internally; bottom-right causal is a kernel gap (BR
-    # diagonal needs global, not per-sequence, Q length), so it is excluded.
-    "thd": ["none", "causal", "swa"],
+    "dense": ["none", "causal", "causal_br", "swa", "padded", "band", "band_br", "band_swa"],
+    # THD forces padding internally, so its mask axis rides on top of that.
+    # causal_br: the kernels anchor the BR diagonal at each sequence's own
+    # (seq_len_q[b], seq_len_kv[b]) from the cu_seqlen metadata.
+    # band/band_br: diagonal-band right-bound widening (BAND_RIGHT).
+    "thd": ["none", "causal", "swa", "causal_br", "band", "band_br"],
 }
 
 

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -269,6 +269,72 @@ def test_dsl_sm100_causal_bottom_right(dtype, d):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d,d_v", [(128, 128), (192, 128), (256, 256), (512, 512)], ids=["llama", "dsv3", "qwen", "dsv4"])
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_band_right_partial_kv_tile(d, d_v):
+    """Right-widened band over a PARTIAL final KV tile, tail covered by the band.
+
+    S_kv % 128 != 0 with no padding mask is only admitted when the widened band
+    provably masks the garbage tail columns (s_q + R <= s_kv — see
+    engines._band_covers_kv_tail); this pins that the fast causal mask paths
+    (which never consult eff_seqlen_kv) really do keep the tail masked."""
+    _require_dsl()
+    dtype = torch.bfloat16
+    b, h, s_q, s_kv, R = 2, 4, 192, 328, 40  # s_q + R = 232 <= 328; 328 % 128 = 72
+    scale = 1.0 / math.sqrt(d)
+    q = _bhsd(b, h, s_q, d, dtype)
+    k = _bhsd(b, h, s_kv, d, dtype)
+    v = _bhsd(b, h, s_kv, d_v, dtype)
+    o = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(diagonal_band_right_bound=R))
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True, band_right=R)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("d", _FLAVORS, ids=_FLAVOR_IDS)
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_band_right_multi_cluster(d):
+    """Right-widened band across MULTIPLE Q-tile clusters: the widened columns
+    of a cluster's bottom rows spill past the cluster's plain-causal KV-tile
+    bound, so this fails if the widening reaches the per-element mask but not
+    compute_kv_loop_bounds (the two must widen together — regression for the
+    CFG.WINDOW_RIGHT bounds feed)."""
+    _require_dsl()
+    dtype = torch.bfloat16
+    b, h, s, R = 1, 2, 1280, 40
+    scale = 1.0 / math.sqrt(d)
+    q, k, v = (_bhsd(b, h, s, d, dtype) for _ in range(3))
+    o = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(diagonal_band_right_bound=R))
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True, band_right=R)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+def test_dsl_sm100_band_right_uncovered_tail_rejected():
+    """The complement: a widened band whose last unmasked column reaches past
+    S_kv (s_q + R > s_kv) must NOT be admitted without a padding mask — the
+    fast causal paths would unmask the garbage tail columns."""
+    _require_dsl()
+    import cudnn
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.fwd import engines as fwd_engines
+
+    b, h, s_q, s_kv, d, R = 2, 4, 192, 200, 128, 40  # s_q + R = 232 > 200; 200 % 128 != 0
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    dims_q, str_q = (b, h, s_q, d), (s_q * h * d, d, h * d, 1)
+    dims_kv, str_kv = (b, h, s_kv, d), (s_kv * h * d, d, h * d, 1)
+    tq = g.tensor(dim=dims_q, stride=str_q, data_type=cudnn.data_type.BFLOAT16, name="q")
+    tk = g.tensor(dim=dims_kv, stride=str_kv, data_type=cudnn.data_type.BFLOAT16, name="k")
+    tv = g.tensor(dim=dims_kv, stride=str_kv, data_type=cudnn.data_type.BFLOAT16, name="v")
+    o, _ = g.sdpa(name="s", q=tq, k=tk, v=tv, attn_scale=0.1, generate_stats=False, diagonal_band_right_bound=R)
+    o.set_output(True).set_dim(dims_q).set_stride(str_q)
+    o.set_data_type(cudnn.data_type.BFLOAT16)
+    facts = ga.analyze(g)
+    assert facts is not None and facts.invalid is None
+    assert not any(fwd_engines.probe(spec, g) for spec in fwd_engines.ENGINE_SPECS)
+
+
+@pytest.mark.L0
 @pytest.mark.parametrize("d", _FLAVORS, ids=_FLAVOR_IDS)
 @pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
 @torch_fork_set_rng(seed=0)

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -317,11 +317,12 @@ def test_probe_accepts_thd_top_left_causal():
     assert engines.engine_name(512) in _eligible(g)
 
 
-def test_probe_rejects_thd_bottom_right():
-    # THD + bottom-right causal is a kernel gap (BR diagonal needs global, not per-sequence, Q length).
+def test_probe_accepts_thd_bottom_right():
+    # The SM100 kernels anchor the THD bottom-right diagonal at each sequence's
+    # own (seq_len_q[b], seq_len_kv[b]) via the cu_seqlen metadata.
     g = _mk_graph()
     _mk_thd_qkvo(g, mask_kwargs=dict(use_causal_mask_bottom_right=True))
-    assert not _eligible(g)
+    assert engines.engine_name(512) in _eligible(g)
 
 
 def test_probe_accepts_thd_stats():
@@ -361,10 +362,25 @@ def test_probe_accepts_thd_stats():
     assert engines.engine_name(512) in _eligible(g)
 
 
-def test_probe_rejects_right_band_widening():
+def test_probe_accepts_right_band_widening():
+    # diagonal_band_right_bound > 0 lowers as MASK_CAUSAL with a compile-time
+    # BAND_RIGHT diagonal offset.
     g = _mk_graph()
     q, k, v, dims, strides = _mk_qkv(g)
     o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, diagonal_band_right_bound=16)
+    _finish_output(o, dims, strides)
+    assert engines.engine_name(512) in _eligible(g)
+    facts = ga.analyze(g)
+    assert facts.right_band_widening and facts.right_bound == 16 and not facts.causal
+
+
+def test_probe_rejects_negative_right_band():
+    g = _mk_graph()
+    q, k, v, dims, strides = _mk_qkv(g)
+    try:
+        o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, diagonal_band_right_bound=-4)
+    except (RuntimeError, ValueError):
+        return  # the pygraph binding may reject it before the probe ever runs
     _finish_output(o, dims, strides)
     assert not _eligible(g)
 


### PR DESCRIPTION
Two mask-machinery features for the SM100 FROST SDPA fwd engines, closing the two biggest single-reason routing gaps after bwd (per a test_mhas_v2 mismatch census on SM100: right-band widening solely blocked 220 graphs, THD bottom-right 31+). Supersedes GitLab MR !2308 (closed).

**Causal right-band widening** (`diagonal_band_right_bound > 0`)
- Lowers as `MASK_CAUSAL` with a compile-time `BAND_RIGHT` offset on the diagonal, applied in both `compute_kv_loop_bounds` (hi/lo tile limits) and `apply_mask_chunk` (per-element), so all five SM100 rows — f16 d128/d256/d512, fp8, mxfp8 — serve it (caps flipped).
- The analyzer records the bound as `facts.window_right`; a new `_band_covers_kv_tail` helper accounts for the widened band in the S_kv%128 tail rule (top-left: covered iff `s_q + R <= s_kv`; bottom-right: iff `R == 0`).
- The DSL adapter grows `window_size_right` (validated `>= 0`, requires the causal band); SM120 rejects it explicitly (not plumbed there).

**THD bottom-right per-sequence diagonal**
- New `resolve_seqlen_q` helper reads each sequence's actual Q length from the packed cu_seqlen metadata (the same buffer `_thd_decode` reads) and feeds both the KV-loop bounds and the mask diagonal; it folds out entirely unless `THD_VARLEN && CAUSAL_BOTTOM_RIGHT`.
- The `thd_bottom_right` capability gap flag and its gate are deleted (SM120 already anchored per sequence).

**Validation (B200, cuDNN 9.23, cutlass-dsl internal)**
- `test_mhas_v2` full run: **1951 pass / 0 fail**, routing **526/2874 graphs on FROST (18.3%)**, up from 244/2753 (8.9%) — d128 103→221, d256 86→224, fp8 55→81.
- frost sm100 suites: 447 pass pre-rebase, 390/390 post-rebase. Combo sweep extended with `band`, `band_br`, `band_swa` (dense) and `causal_br`, `band`, `band_br` (THD); analyzer probe tests flipped to accept, plus a negative-bound rejection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for right-side widening in causal attention windows on supported SM100 configurations.
  * Improved bottom-right and variable-length attention handling with per-sequence query lengths.

* **Bug Fixes**
  * Improved masking and KV-bound calculations for causal, sliding-window, and variable-length attention.
  * Added validation for invalid window values and unsupported configurations.

* **Tests**
  * Expanded coverage for right-banded masks, bottom-right alignment, variable-length sequences, and validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->