### PR TITLE
Add native SM100 d192/d128 SDPA fprop kernel for DSv3 MLA

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -36,11 +36,17 @@ from cudnn.sdpa.fwd.config_sm120 import (
     TemplateParams as Sm120TemplateParams,
 )
 
-_SM100_FLAVOR_DIMS = {512: (512, 512), 256: (256, 256), 128: (128, 128)}  # template key -> (max D_QK, max D_V) envelope
+_SM100_FLAVORS = (
+    (128, 128),
+    (192, 128),
+    (256, 256),
+    (512, 512),
+)  # ordered smallest-first: (max D_QK, max D_V) envelope
 _SM100_KERNEL_FILES = {
-    512: "prefill_d512_f16_sm100.py",
-    256: "prefill_d256_f16_sm100.py",
-    128: "prefill_d128_f16_sm100.py",
+    (512, 512): "prefill_d512_f16_sm100.py",
+    (256, 256): "prefill_d256_f16_sm100.py",
+    (192, 128): "prefill_d192_d128_f16_sm100.py",
+    (128, 128): "prefill_d128_f16_sm100.py",
 }
 # DTYPE_* codes: E4M3=0, E5M2=1, BF16=2, FP16=3. FP8 inputs (0/1) route to the
 # block-scale MXFP8 kernel (d128 only); the output dtype is encoded the same way.
@@ -129,11 +135,16 @@ class WorkspaceCarver:
         return self._flat[self._off :]
 
 
-def _pick_flavor(d_qk: int, d_v: int) -> int:
+def _flavor_tag(flavor: tuple[int, int]) -> str:
+    d_qk, d_v = flavor
+    return f"d{d_qk}" if d_qk == d_v else f"d{d_qk}_d{d_v}"
+
+
+def _pick_flavor(d_qk: int, d_v: int) -> tuple[int, int]:
     """Smallest flavor whose envelope covers ``(d_qk, d_v)`` (f16/bf16 only).
 
-    ENVELOPE (zero-padding) semantics: one flavor D >= max(d_qk, d_v) serves
-    both head dims jointly — e.g. (192, 128) runs on the d256 kernel. The
+    ENVELOPE (zero-padding) semantics: one flavor covers ``d_qk`` and ``d_v``
+    with its own max extents — e.g. (192, 128) runs on the d192/d128 kernel. The
     kernel's TMA descriptors are built from the ACTUAL tensor extents while
     the tile box stays the compile-time D, so loads past d_qk / d_v hardware
     zero-fill (adding exact zero terms to every QK^T dot product — S, softmax
@@ -142,13 +153,13 @@ def _pick_flavor(d_qk: int, d_v: int) -> int:
     check_support); alignment (d % 8, the TMA 16-byte global-stride rule at
     2 bytes/elem) is also gated in check_support / engines.mismatch.
     """
-    for flavor in sorted(_SM100_FLAVOR_DIMS):
-        fdqk, fdv = _SM100_FLAVOR_DIMS[flavor]
+    for flavor in _SM100_FLAVORS:
+        fdqk, fdv = flavor
         if d_qk <= fdqk and d_v <= fdv:
             return flavor
     raise ValueError(
         f"Frost SM100 DSL SDPA: no flavor envelope covers (D_QK={d_qk}, D_V={d_v}); "
-        f"largest supported: {_SM100_FLAVOR_DIMS[max(_SM100_FLAVOR_DIMS)]} (d128/d256/d512 envelopes)."
+        f"largest supported: {_SM100_FLAVORS[-1]} (d128/d192-d128/d256/d512 envelopes)."
     )
 
 
@@ -159,15 +170,16 @@ def _load_kernel_template(filename: str, params: Hashable, tag: str):
     return load_template(path, params, tag=tag)
 
 
-def _load_sm100_kernel_module(flavor: int, params: Sm100TemplateParams, fp8: bool = False, pertensor: bool = False):
+def _load_sm100_kernel_module(flavor: tuple[int, int], params: Sm100TemplateParams, fp8: bool = False, pertensor: bool = False):
     """Load one SM100 module for the selected flavor and quantization path."""
 
+    tag = _flavor_tag(flavor)
     if fp8:
         filename = _SM100_FP8_KERNEL_FILE if pertensor else _SM100_MXFP8_KERNEL_FILE
-        tag = f"sdpa_fwd_sm100_{'fp8' if pertensor else 'mxfp8'}_d{flavor}"
+        tag = f"sdpa_fwd_sm100_{'fp8' if pertensor else 'mxfp8'}_{tag}"
     else:
         filename = _SM100_KERNEL_FILES[flavor]
-        tag = f"sdpa_fwd_sm100_d{flavor}"
+        tag = f"sdpa_fwd_sm100_{tag}"
     return _load_kernel_template(filename, params, tag)
 
 
@@ -327,7 +339,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
     """SM100 (Blackwell) SDPA forward via the FROST DSL template kernels."""
 
     def _initialize_implementation(self) -> None:
-        self.flavor: Optional[int] = None
+        self.flavor: Optional[tuple[int, int]] = None
         self.mask_flags = 0
         self.swa_window_runtime = 0
         self._k_mod = None

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -612,4 +612,74 @@ def make_cfg_d128(params: TemplateParams) -> Tuple[CfgD128, TmaIters]:
     return cfg, _tma_iters(cfg)
 
 
-MAKE_CFG = {128: make_cfg_d128, 256: make_cfg_d256, 512: make_cfg_d512}
+# ---------------------------------------------------------------------------
+# d192/d128 flavor — DSv3 MLA logical d_qk = 192, d_v = 128, SM100, cga2
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CfgD192(CfgD128):
+    TILE_K: int = 192
+    TILE_O: int = 128
+    QO_ALIAS: int = 1
+    SOFTMAX_REGS: int = 192
+    CORRECTION_REGS: int = 88
+
+
+def _validate_cfg_d192(cfg: CfgD192) -> None:
+    """Consistency checks on the native DSv3 d192/d128 geometry."""
+    checks = (
+        (cfg.DTYPE_QKV in (DTYPE_BF16, DTYPE_FP16), "d192: only BF16/FP16 inputs are supported"),
+        (cfg.DTYPE_O == cfg.DTYPE_QKV, "d192: DTYPE_O must equal DTYPE_QKV"),
+        (cfg.MMA_REGS == cfg.TMALDG_REGS == cfg.TMASTG_REGS == cfg.SCHEDULER_REGS, "d192: MMA/TMALDG/TMASTG/SCHEDULER regs must match"),
+        (cfg.MMA_REGS + cfg.CORRECTION_REGS + cfg.SOFTMAX_WARPGROUPS * cfg.SOFTMAX_REGS <= 512, "d192: register budget over 512"),
+        (cfg.MMA_REGS % 8 == 0 and cfg.CORRECTION_REGS % 8 == 0 and cfg.SOFTMAX_REGS % 8 == 0, "d192: per-role regs must be multiples of 8"),
+        (cfg.CGA_M == 2 and cfg.CTA_MMA == 2, "d192 SM100 is cga2-only (CGA_M == CTA_MMA == 2)"),
+        (cfg.TILE_K == 192 and cfg.TILE_O == 128, "d192: expected D_QK tile 192 and D_V tile 128"),
+        (cfg.QO_ALIAS == 1, "d192: Q/O SMEM alias is required to stay within SM100 SMEM budget"),
+        (cfg.TILES_Q == 2, "d192: TILES_Q must be 2"),
+        (cfg.SOFTMAX_WARPGROUPS == 2, "d192: SOFTMAX_WARPGROUPS must be 2"),
+        (cfg.CORRECTION_WARPS == 4, "d192: CORRECTION_WARPS must be 4"),
+        (cfg.TOTAL_WARPS == 16 and cfg.THREADS_PER_CTA == 512, "d192: 16 warps / 512 threads"),
+        (cfg.READ_TILE_ARRIVERS == 15, f"d192: expected READ_TILE_ARRIVERS=15, got {cfg.READ_TILE_ARRIVERS}"),
+        (cfg.STAGES_KV == 2, "d192 SM100: STAGES_KV must be 2 for BF16/FP16"),
+        (cfg.TILE_K_HW_BMM1 == 16 and cfg.TILE_K_HW_BMM2 == 16, "d192: TILE_K_HW must be 16 for BF16/FP16 on SM10x"),
+        (cfg.Q_SWZ_BYTES == 128 and cfg.K_SWZ_BYTES == 128, "d192: Q/K swizzle must be 128B"),
+        (cfg.V_SWZ_BYTES == 128 and cfg.O_SWZ_BYTES == 128, "d192: V/O swizzle must be 128B"),
+    )
+    for ok, msg in checks:
+        if not ok:
+            raise ValueError(msg)
+
+
+def make_cfg_d192(params: TemplateParams) -> Tuple[CfgD192, TmaIters]:
+    _validate_params("d192", params)
+    b = bpe(params.dtype_qkv)
+    cfg = CfgD192(
+        DTYPE_QKV=params.dtype_qkv,
+        DTYPE_O=params.dtype_qkv,
+        BPE=b,
+        BPE_O=b,
+        Q_SWZ_BYTES=q_swz_bytes(192, b),
+        K_SWZ_BYTES=q_swz_bytes(192, b),
+        V_SWZ_BYTES=v_swz_bytes(128, 2, b),
+        O_SWZ_BYTES=o_swz_bytes(128, b),
+        RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
+        TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
+        TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
+        MASK_FLAGS=params.mask_flags,
+        SWA_WINDOW=params.swa_window,
+        HAS_SINK=int(params.has_sink),
+        CAUSAL_BOTTOM_RIGHT=int(params.causal_bottom_right),
+        SCHEDULER_POLICY=1,
+        SOFTMAX_REGS=216 if params.mask_flags == MASK_NONE else 192,
+        CORRECTION_REGS=40 if params.mask_flags == MASK_NONE else 88,
+        SEQ_KV_LENS_PRESENT=1 if (params.thd_varlen or params.seq_kv_lens_present) else 0,
+        SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
+        THD_VARLEN=int(params.thd_varlen),
+    )
+    _validate_cfg_d192(cfg)
+    return cfg, _tma_iters(cfg)
+
+
+MAKE_CFG = {128: make_cfg_d128, 192: make_cfg_d192, 256: make_cfg_d256, 512: make_cfg_d512}

--- a/python/cudnn/sdpa/fwd/engine.py
+++ b/python/cudnn/sdpa/fwd/engine.py
@@ -134,6 +134,7 @@ _ID_OFFSETS = {
     "sdpa_fwd_prefill_sm100_d128_mxfp8": 3,
     "sdpa_fwd_prefill_sm100_d128_fp8": 4,
     "sdpa_fwd_prefill_sm120": 5,
+    "sdpa_fwd_prefill_sm100_d192_d128": 6,
 }
 
 

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -300,14 +300,16 @@ class EngineSpec:
     lower: "Callable[[EngineSpec, ga.SdpaGraphFacts, Optional[SdpaFwdKnobs]], Any]"
 
 
-def _sm100_spec(d: int) -> EngineSpec:
+def _sm100_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
+    d_v = d if d_v is None else d_v
+    suffix = f"d{d}" if d_v == d else f"d{d}_d{d_v}"
     return EngineSpec(
-        name=f"sdpa_fwd_prefill_sm100_d{d}",
+        name=f"sdpa_fwd_prefill_sm100_{suffix}",
         capabilities=Capabilities(
             arches=_BLACKWELL_ARCHES,
             phase="prefill",
             d_qk=frozenset({d}),
-            d_v=frozenset({d}),
+            d_v=frozenset({d_v}),
             d_envelope=True,  # native tile box d; smaller dims via TMA zero-padding
             dtypes=frozenset({torch.float16, torch.bfloat16}),
             causal=True,
@@ -661,12 +663,16 @@ def engine_name(
     arch: str = "sm100",
     mxfp8: bool = False,
     fp8: bool = False,
+    d_v: Optional[int] = None,
 ) -> str:
     """The registered engine name for a coverage cell (test/user convenience)."""
 
     name = f"sdpa_fwd_{phase}_{arch}"
     if d is not None:
-        name += f"_d{d}"
+        if d_v is None or d_v == d:
+            name += f"_d{d}"
+        else:
+            name += f"_d{d}_d{d_v}"
     suffix = "_mxfp8" if mxfp8 else "_fp8" if fp8 else ""
     return name + suffix
 
@@ -684,6 +690,7 @@ def engine_name(
 # engine._ID_OFFSETS and never move.
 ENGINE_SPECS = (
     _sm100_spec(128),
+    _sm100_spec(192, d_v=128),
     _sm100_spec(256),
     _sm100_spec(512),
     _sm100_mxfp8_spec(128),

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -1,0 +1,2216 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+DSL prefill SDPA kernel — DSv3 MLA flavor, d_qk = 192, d_v = 128, FP16/BF16, SM100.
+
+SM100 (Blackwell GB200) DSv3-class prefill kernel.  Pipeline shape:
+TILES_Q=2, two softmax warpgroups, four correction warps, 16 warps / 512
+threads, persistent try_cancel scheduler, Q∪O alias.
+
+SM100 resource layout:
+  1. **cga2-only, STAGES_KV=2**: per-CTA K/V halved by the collective MMA →
+     SMEM 192 KiB (sQ 64 + sK 32 + sV 32 + sO 64), under the Blackwell
+     ~228 KiB cap.
+  2. **TMEM stats** (512-col Blackwell cap): S_acc 0/128 + O 256..511 fill
+     all 512 cols, so stats ride the FREE HEAD of each sub-tile's S_acc
+     slot — sub-tile 0 → col 0, sub-tile 1 → col 128 (P only aliases the
+     tails at 64 / 192).  This matches the C++ SM100 reference layout
+     (tmem_Stats = base + softmax_gid*128).  Safe under the existing
+     mb_stat_full / mb_stat_empty handshake: correction reads alpha before
+     releasing MMA to overwrite that S_acc head next iter.
+  3. **Manual row-max** on the MASK_NONE fast path — ``tcgen05_ld`` +
+     ``row_max_reduction`` (the masked path's pattern) instead of
+     ``tmem_load_max_reduction_tile`` (LDTM.STAT).
+  4. SM100 launch: ``cluster=(CTA_MMA, 1, 1)``; compile retains
+     ``--ptxas-options -uumn`` so the ``sched_res_busy_xu64`` region around
+     the P exp2/store sequence is honored by the backend.
+
+Supported: FP16 / BF16 (``DTYPE_QKV in {2, 3}``); masks none / causal / SWA /
+padded and all pairwise combos (causal+swa, causal+padded, swa+padded);
+attention sink (per-head logit in the softmax denominator); cga2; fixed LPT
+scheduler.  Validated on Blackwell (cc 10.0) vs a torch fp32 reference.
+
+THD / varlen (``CFG.THD_VARLEN=1``): packed ``[1,T,H,D]`` Q/K/V + ``cu_seqlens``
+coord offset (applied to BOTH Q slabs under TILES_Q=2), per-batch O
+TMA-descriptor array (shared ``thd_sm100.py``), packed ``[1,QH,T]`` LSE — via
+the shared ``_common_sm100`` / ``thd_sm100`` mechanism (same as the SM100 qwen
+/ dsv4 kernels).  The dense ``[B,S,H,D]`` path is byte-identical (folds out at
+``THD_VARLEN=0``).
+
+"""
+
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass.experimental.cuda import tensor_map as tmap
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls cuda)
+
+from dataclasses import dataclass
+
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d192
+
+# The template loader (api_dsl._load_kernel_module) injects FROST_TEMPLATE_PARAMS
+# as a module global before this body executes; a plain import falls back to
+# the default TemplateParams so the file stays importable on its own.
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d192(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# O TMA box / store params follow O's swizzle, not V's (under cga2 V may drop to a narrower swizzle while O stays Swz128B).
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE) // CFG.O_SWZ_BYTES
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    WAIT_TIMEOUT,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    # SM100: no LDTM.STAT — the MASK_NONE fast path uses manual tcgen05_ld +
+    # row_max_reduction (see _softmax_kv_body), so tmem_load_max_reduction_tile
+    # is not imported.
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+
+
+@cute.jit
+def _wait_ptr(mb, phase):
+    phase = cutlass.Int32(phase)
+    while not nvvm.mbarrier_wait_parity(mb, phase, nvvm.MBarrierWait.TRY):
+        pass
+
+
+@cute.jit
+def _wait_mbarrier(mb, phase):
+    _wait_ptr(mb.smem_ptr, phase)
+
+
+# Storage dtype + MMA kind dispatch — folded at trace time on CFG.DTYPE_QKV.
+if CFG.DTYPE_QKV == 2:
+    STORAGE_DTYPE = cutlass.BFloat16
+    P_STORAGE_DTYPE = cutlass.BFloat16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+elif CFG.DTYPE_QKV == 3:
+    STORAGE_DTYPE = cutlass.Float16
+    P_STORAGE_DTYPE = cutlass.Float16
+    MMA_KIND = nvvm.Tcgen05MMAKind.F16
+    IS_TF32 = False
+else:
+    # SM100 d192/d128: f16/bf16 only. The config already asserts
+    # DTYPE_QKV in {2, 3}.
+    raise ValueError(f"prefill_sdpa_d192_d128_f16_sm100: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16 or 3=FP16)")
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    make_classic_bars,
+    row_max_for_exp2,
+    make_sdpa_helpers,
+)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+# Per-CTA buffer element counts + collective TMA transaction byte counts.
+# K (seq rows) and V (d_v cols) shrink by CTA_MMA; Q / O are per-CTA full.
+# At cga2 leader's expect_tx = per-CTA elems * BPE * CTA_MMA (collective bytes).
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+
+# Q∪O alias (dsv3 TF32): O reuses Q's SMEM slab once BMM1 has consumed Q.
+# Each of the TILES_Q slabs is sized to max(Q,O) so sQ[qs] and sO[qs] coincide;
+# for the classic flavors d_qk >= d_v so the slab is qBufferElems.  TMA-STG
+# arrives mb_q_o_alias after O drains; TMA-LDG waits it before reloading Q.
+IS_QO_ALIAS = bool(CFG.QO_ALIAS)
+QO_SLAB_ELEMS = max(qBufferElems, oBufferElems)
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+
+# This flavor is cga2-only (CTA_MMA=2), so its LPT q-tile accounting in the
+# shared helper stays in CGA-tile units.
+_sdpa_h = make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units=True)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+
+
+@cute.jit
+def _bounds_for_tile(
+    q_super_idx,
+    seqlen_q,
+    seqlen_kv,
+    cta_in_pair,
+    seq_q_lens_tensor,
+    batch_idx,
+):
+    # Keep the KV pipeline active for padded-Q tail tiles; the epilogue trims
+    # rows beyond the per-batch Q length before storing O and LSE.
+    return _sdpa_h.bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair)
+
+
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+CAN_HAVE_EMPTY_KV = (CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.CAUSAL_BOTTOM_RIGHT
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/dsl/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_o_descs_kernel as _build_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+
+@cute.jit
+def _apply_top_left_causal_mask_chunk(reg_S, q_abs, kv_col_base, N: int = 64):
+    neg_inf = cutlass.Float32(float("-inf"))
+    last_live = q_abs - kv_col_base
+    elems = [
+        cutlass.Float32(
+            arith.select(
+                (cutlass.Int32(i) > last_live).ir_value(),
+                neg_inf.ir_value(),
+                reg_S[i].ir_value(),
+            )
+        )
+        for i in range(N)
+    ]
+    return cutlass.Vector.from_elements(tuple(elems), cutlass.Float32)
+
+
+@cute.jit
+def _apply_bottom_right_causal_mask_chunk(reg_S, q_abs, kv_col_base, causal_diag, N: int = 64):
+    neg_inf = cutlass.Float32(float("-inf"))
+    last_live = q_abs + causal_diag - kv_col_base
+    elems = [
+        cutlass.Float32(
+            arith.select(
+                (cutlass.Int32(i) > last_live).ir_value(),
+                neg_inf.ir_value(),
+                reg_S[i].ir_value(),
+            )
+        )
+        for i in range(N)
+    ]
+    return cutlass.Vector.from_elements(tuple(elems), cutlass.Float32)
+
+
+# P (BMM2 operand) aliases the TAIL of each 128-col S_acc slot since BMM1
+# finishes (and softmax loads S into registers) before P is written.
+# fp16/bf16 pack 2 probs per FP32 cell → P width = TILE_N/2 ≤ 64 cols → P
+# sits at slot offset 64.  TF32 is 1:1 → P width = TILE_N, so P aliases the
+# FULL slot (offset 0 / 128).  Mirrors C++ S_bmm2_0 = S_acc_cols - S_bmm2_cols.
+_P0_OFF = 0 if IS_TF32 else 64
+_P1_OFF = 128 if IS_TF32 else 192
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """Column offsets for the classic 2-sub-tile SDPA pipeline.
+
+    SM100 512-col TMEM cap.  S_acc[0]=0..127,
+    S_acc[1]=128..255, O=256..511 fill all 512 cols, so stats cannot live
+    at a dedicated col 544 (off the Blackwell cap).  Instead each sub-tile's
+    stats ride the FREE HEAD of its own S_acc slot (col 0 / 128) — P only
+    aliases the tails at 64 / 192, and softmax has already read S into
+    registers before writing stats.  Matches the C++ SM100 reference layout
+    (tmem_Stats = base + softmax_gid*128).  Safe under the existing
+    mb_stat_full / mb_stat_empty handshake: correction reads that iter's
+    alpha before releasing MMA to overwrite the S_acc head next iter.
+    """
+
+    # Blackwell SM10.0 cap; requires is_exclusive=True on tcgen05_alloc.
+    TOTAL_COLS: int = 512
+
+    S0_OFF: int = 0
+    S1_OFF: int = 128
+
+    O0_OFF: int = 256
+    O1_OFF: int = 384
+
+    P0_OFF: int = _P0_OFF
+    P1_OFF: int = _P1_OFF
+
+    # SM100: stats ride the head of sub-tile qs's S_acc slot (== S{qs}_OFF):
+    # sub-tile 0 → col 0, sub-tile 1 → col 128.  Use STATS_OFF + qs*STATS_STRIDE.
+    STATS_OFF: int = 0
+    STATS_STRIDE: int = 128
+
+
+LAYOUT = KernelTmemLayout()
+
+
+# === Kernel ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+    # Dense padded-Q trim: separate (B,)-int32 per-batch Q lengths (mirrors
+    # cuDNN's SEQLEN_Q pointer / FA's seqused_q). None unless
+    # CFG.SEQ_Q_LENS_PRESENT — the DSL specializes on None, so the flag-off
+    # ABI is unchanged.
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+) -> None:
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # SMEM allocations in natural Q/K/V/O order — Tcgen05SmemDesc.build truncates
+    # start_address past ~256 KiB so this order keeps the data buffers in low SMEM.
+    # QO_ALIAS: one Q∪O slab (TILES_Q × max(Q,O) elems); sO points into it and
+    # strides by QO_SLAB_ELEMS so sO[qs] coincides with sQ[qs].  Else: separate
+    # Q and O buffers (the classic layout).
+    if cutlass.const_expr(IS_QO_ALIAS):
+        sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * QO_SLAB_ELEMS, alignment=1024, space=cutlass.AddressSpace.smem)
+        sO_raw = sQ_raw
+        _SO_STAGE_ELEMS = QO_SLAB_ELEMS
+    else:
+        sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * qBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+        sO_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * oBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+        _SO_STAGE_ELEMS = oBufferElems
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    # Keep V on a distinct SMEM address region from K; this avoids an unfavorable
+    # K/V placement for the BMM2 handoff without changing occupancy.
+    _kv_smem_pad = cutlass.Array(cutlass.Int8, 8192, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        # V is split along d_v under cga2 → tma_loads_per_tile = TMA_VO_ITERS / CTA_MMA.
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=_SO_STAGE_ELEMS,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    bars = make_classic_bars(CFG)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    # tile_id_smem stride 8 Int32/stage (32 B) = 16 B try_cancel payload + 16 B padding.
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # Scheduler mbar arrive count — stays kernel-local (sched is NOT in Bars).
+    READ_TILE_ARRIVERS_TOTAL = ((CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS) + CFG.CORRECTION_WARPS + 1 + 1) * CGA_SIZE + (CFG.CGA_M // CFG.CTA_MMA)
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # range_constexpr → Python-int loop variable so bars.mb_X[qs].init()
+            # can index the per-stage init_count tuple (mb_bmm2_ready) at trace
+            # time.  Loop bounds are small (TILES_Q=2, STAGES_KV=2-4) — unroll
+            # is free.
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_q_full[qs].init()
+                bars.mb_q_empty[qs].init()
+                bars.mb_bmm1_done[qs].init()
+                bars.mb_bmm2_done[qs].init()
+                bars.mb_stat_full[qs].init()
+                bars.mb_stat_empty[qs].init()
+                bars.mb_stats_read[qs].init()
+                bars.mb_o_full[qs].init()
+                bars.mb_o_empty[qs].init()
+                if cutlass.const_expr(IS_QO_ALIAS):
+                    bars.mb_q_o_alias[qs].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + c].init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+            bars.mb_tmem_dealloc.init()
+            bars.mb_empty_mainloop.init()
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4: cluster fence gates cga2 cross-CTA arrive_on_peer on peer init.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    # The DSL's @cute.kernel stages if/else — use Python ternaries so the chosen
+    # expression flows into the trace (variables in branches aren't visible outside).
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    # TMA-load self-bit mask: each peer's cta_group::2 TMA targets its own bit;
+    # cga2 routing strips bit-24 so bytes land on leader's mbar.
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    # === Per-warp role dispatch ===
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=0,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        # Under cga2 the non-leader CTA runs the quiet body (alloc + dealloc only).
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    seq_q_lens_tensor=seq_q_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(tmem_ptr_i32, bars)
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                seq_q_lens_tensor=seq_q_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            seq_q_lens_tensor=seq_q_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        # try_cancel.multicast::cluster::all — only (0,0,0) CTA issues; at cga1
+        # cta_id_x == 0 always, so flag is 1 unconditionally.
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# === TMA-LDG warp ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+    """Unified TMA-LDG warp — cga1 / cga2 x MASK_NONE / PADDED / CAUSAL / SWA.
+
+    Spill-free in CFG.OTHER_REGS via q_row_base pre-multiplied after each
+    scheduler decode (gives ptxas a live use of nxt_q before the loop
+    back-edge, keeping the LDS.128 result in uniform registers).
+    """
+    q_empty_phase = cutlass.Int32(1)
+    kv_state = PipelineState.start(phase=1)
+
+    # Q-reload gate: under QO_ALIAS the next tile's Q-load must wait for the
+    # prior tile's O (sharing the slab) to drain — TMA-STG fires mb_q_o_alias
+    # (strictly after MMA consumed Q).  Else gate on mb_q_empty (MMA commit).
+    # Both bootstrap consumer-side via q_empty_phase=1.
+    mb_q_reload = bars.mb_q_o_alias if cutlass.const_expr(IS_QO_ALIAS) else bars.mb_q_empty
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    # GQA: K/V are indexed by kv-head, not Q-head.
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # The DSL TMA descriptor is element-typed; contiguous coord is in ELEMENTS not bytes.
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            if cutlass.const_expr(CAN_HAVE_EMPTY_KV and IS_QO_ALIAS):
+                # TMA-STG advances the Q/O alias gate for every tile, including
+                # empty ones. Consume that transaction even though no Q reload
+                # is needed, or the next nonempty tile observes stale parity.
+                _wait_mbarrier(mb_q_reload[0], q_empty_phase)
+                _wait_mbarrier(mb_q_reload[1], q_empty_phase)
+                q_empty_phase = q_empty_phase ^ 1
+        else:
+            # Prologue interleave Q[0] -> K[first] -> Q[1] -> V[first] -> mainloop —
+            # K load starts before Q[1] is issued and V before kv mainloop.
+            kv_row_base = kv_left * CFG.TILE_N
+
+            _wait_mbarrier(mb_q_reload[0], q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[0].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            _wait_mbarrier(bars.mb_k_empty[kv_state.idx], kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sK[kv_state.idx],
+                # THD: the prologue K load MUST apply the per-sequence kv offset
+                # (kv_seq_off = cu_k[batch]) and use the packed batch coord
+                # (tma_batch), exactly like the mainloop K load below and the V
+                # loads.  The old form (`+ K_ROW_OFFSET_PEER, batch_idx`) is
+                # byte-identical for the dense path (kv_seq_off=0,
+                # tma_batch==batch_idx) but reads the WRONG packed location for
+                # THD batch>=1 — corrupting the first (diagonal) KV tile and, via
+                # the online-softmax running max/sum, the whole batch>=1 output.
+                # (Ported from VibeTile 7ac72cb "fix THD".)
+                tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            _wait_mbarrier(mb_q_reload[1], q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[1],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[1].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            q_empty_phase = q_empty_phase ^ 1
+
+            _wait_mbarrier(bars.mb_v_empty[kv_state.idx], kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sV[kv_state.idx],
+                tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=6):
+                kv_row_base = kv_loop * CFG.TILE_N
+
+                _wait_mbarrier(bars.mb_k_empty[kv_state.idx], kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                _wait_mbarrier(bars.mb_v_empty[kv_state.idx], kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        # Raw scheduler payload loads avoid extra uniformization on this back-edge.
+        _wait_ptr(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        # q_row_base compute right after decode drives ptxas R2UR.
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2: drain trailing empty mbar arrives so SMEM isn't torn down while
+    # leader's multicast commits are still in-flight.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _qs in cutlass.range_constexpr(CFG.TILES_Q):
+            _wait_mbarrier(mb_q_reload[_qs], q_empty_phase)
+        q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            _wait_mbarrier(bars.mb_k_empty[kv_state.idx], kv_state.phase)
+            _wait_mbarrier(bars.mb_v_empty[kv_state.idx], kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# === TMA-STG warp ===
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """Persistent O-store warp.  First tile from blockIdx; subsequent tiles
+    via scheduler warp's clusterlaunchcontrol.try_cancel.async.
+    """
+    o_full_phase = cutlass.Int32(0)  # consumer waits — first-arrive flips 0 → 1
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            _wait_mbarrier(bars.mb_o_full[qs], o_full_phase)
+
+            # O TMA params follow O's swizzle (NOT V's) — under gptoss cga2 V drops to Swz64B while O stays Swz128B.
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (base at the sequence's packed row, seq extent = S_q_b → a box
+                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                # batch coord collapses to 0.  Both slabs share one descriptor.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                )
+
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_o_empty[qs].arrive()
+            # QO_ALIAS: O[qs] has drained to GMEM → the shared Q∪O slab is free
+            # for TMA-LDG to clobber with the next tile's Q[qs].
+            if cutlass.const_expr(IS_QO_ALIAS):
+                bars.mb_q_o_alias[qs].arrive()
+
+        o_full_phase = o_full_phase ^ 1
+
+        _wait_ptr(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# === BMM1 / BMM2 SMEM + idesc constants ===
+
+# Per-tensor swizzle layout enum: SWIZZLE_128B_ATOM_32B=1, Swz128B=2,
+# Swz64B=4, Swz32B=6.
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+_SWZ_ATOM_32B = 1  # required on the transposed BMM2 operand (V) under kind::tf32
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+# V is the B-transposed BMM2 operand → TF32 needs SWIZZLE_128B_ATOM_32B.
+# Q/K (BMM1, non-transposed) and O keep standard swizzle for all dtypes.
+SMEM_LAYOUT_V = _SWZ_ATOM_32B if IS_TF32 else _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+# O SMEM swizzle: third param is the XOR shift offset (=3 across all widths), NOT the B value.
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+
+LEADING_BYTE_OFFSET_QK = 0
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES
+# TF32 ATOM32 override (mirrors C++ prefill_sdpa_f16.cu:803-806): the
+# SWIZZLE_128B_ATOM_32B mode pins leading = TILE_N*128, stride = 512 (NOT
+# the standard 8*V_SWZ).  Standard formulas with kind::tf32 silently zero C.
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+_LEADING_PV_STD = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+LEADING_BYTE_OFFSET_PV = (CFG.TILE_N * 128) if IS_TF32 else _LEADING_PV_STD
+STRIDE_BYTE_OFFSET_PV = 512 if IS_TF32 else (8 * CFG.V_SWZ_BYTES)
+
+NUM_KPHASES_PV = CFG.TILE_N // CFG.TILE_K_HW_BMM2
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+@cute.jit
+def _mma_warp_quiet(tmem_ptr_i32, bars):
+    """Minimal quiet body for the non-leader CTA's MMA-warp slot under cga2.
+
+    Non-leader still participates in TMEM alloc / release lock (warp-collective
+    .sync.aligned ops) and TMEM-publish named barriers — leader's MMA reads
+    through the cluster crossbar from peer's TMEM during cga2 collective MMA.
+    """
+    # All-lanes warp-collective ops — NO elect_sync gating.
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    # Match lead MMA's named-barrier arrive count (lead is +1 on both publish barriers).
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    _wait_mbarrier(bars.mb_tmem_dealloc, cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Unified MMA warp — cga1 / cga2-leader x MASK_NONE / PADDED / CAUSAL / SWA,
+    spill-free in CFG.OTHER_REGS (40).  Non-leader under cga2 uses _mma_warp_quiet.
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    # idesc M is COLLECTIVE (per-CTA M * CTA_MMA): cga2 tcgen05.mma.cta_group::2
+    # reads both peers' A and produces 2*LOCAL_M output rows.
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+    )
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    # BMM2 V uses non-default K_SUBTILE = V_SWZ_BYTES/BPE (cga2 V Swz64B on dsv3/gptoss).
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    desc_Q0 = sQ[0].desc()
+    desc_Q1 = sQ[1].desc()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=0)
+    bmm2_ready_phase = cutlass.Int32(0)
+    # Only specializations that retain the legacy empty handshake use this.
+    empty_mainloop_phase = cutlass.Int32(0)
+    # Stats-consumed gate (one flip per tile per sub-tile): the prologue BMM1
+    # overwrites the S_acc HEAD where the PREVIOUS tile's final
+    # (total_max, total_sum) stats live until the correction epilogue has read
+    # them.  q_full/k_full alone do NOT order that read before the BMM1 (Q/K
+    # can be resident well before correction finishes its epilogue — the
+    # window widens by ~a gmem latency under HAS_SINK, corrupting the second
+    # sub-tile's LSE/O on causal multi-wave shapes).  Bootstrap phase 1: the
+    # first tile has no prior stats to protect, so the wait passes immediately.
+    stats_read_phase = cutlass.Int32(1)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            if cutlass.const_expr(not CAN_HAVE_EMPTY_KV):
+                _wait_mbarrier(bars.mb_empty_mainloop, empty_mainloop_phase)
+                empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+                _wait_mbarrier(bars.mb_stats_read[0], stats_read_phase)
+                _wait_mbarrier(bars.mb_stats_read[1], stats_read_phase)
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            # Prologue: BMM1[sub0], BMM1[sub1] for kv=kv_left.
+            # mb_stats_read[qs] gates each BMM1 on the correction epilogue
+            # having READ the previous tile's final stats from the S_acc head
+            # this BMM1 is about to overwrite (q_full/k_full don't order that).
+            _wait_mbarrier(bars.mb_q_full[0], q_full_phase)
+            _wait_mbarrier(bars.mb_k_full[kv_state.idx], kv_state.phase)
+            _wait_mbarrier(bars.mb_stats_read[0], stats_read_phase)
+            desc_K = sK[kv_state.idx].desc()
+            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)))
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            _wait_mbarrier(bars.mb_q_full[1], q_full_phase)
+            _wait_mbarrier(bars.mb_stats_read[1], stats_read_phase)
+            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)))
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            q_full_phase = q_full_phase ^ 1
+
+            # Mainloop kv = kv_left+1 .. kv_right-1 (empty when n_kv == 1)
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                old_state = kv_state
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+                _wait_mbarrier(bars.mb_v_full[old_state.idx], old_state.phase)
+                desc_V = sV[old_state.idx].desc()
+                is_not_first_bmm2 = cutlass.Boolean(kv_loop != (kv_left + cutlass.Int32(1)))
+
+                # BMM2 sub-tile 0
+                _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2)
+                    accum_b2 = cutlass.Boolean(True)
+                if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                    _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
+                    for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                        mma_ts_step(
+                            bmm2_desc,
+                            (tmem_raw.subview(LAYOUT.P0_OFF)),
+                            desc_V,
+                            (tmem_raw.subview(LAYOUT.O0_OFF)),
+                            NUM_KPHASES_PV_PER_CHUNK + local_k,
+                            cutlass.Boolean(True),
+                        )
+                elect_p = nvvm.elect_sync()
+                cute.arch.inline_ptx('.pragma "next knob FenceCode";')
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM1 sub 0 for next kv
+                _wait_mbarrier(bars.mb_k_full[kv_state.idx], kv_state.phase)
+                desc_K = sK[kv_state.idx].desc()
+                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)))
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM2 sub-tile 1
+                _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2)
+                    accum_b2 = cutlass.Boolean(True)
+                if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                    _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
+                    for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                        mma_ts_step(
+                            bmm2_desc,
+                            (tmem_raw.subview(LAYOUT.P1_OFF)),
+                            desc_V,
+                            (tmem_raw.subview(LAYOUT.O1_OFF)),
+                            NUM_KPHASES_PV_PER_CHUNK + local_k,
+                            cutlass.Boolean(True),
+                        )
+                elect_p = nvvm.elect_sync()
+                cute.arch.inline_ptx('.pragma "next knob FenceCode";')
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_v_empty[old_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                # BMM1 sub 1 for next kv
+                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)))
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                bmm2_ready_phase = bmm2_ready_phase ^ 1
+
+            # Epilogue: BMM2 for last kv (always runs — n_kv >= 1).
+            # Under QO_ALIAS the TMA-LDG Q-reload gate is mb_q_o_alias (fired by
+            # TMA-STG after O drains), so MMA does NOT fire mb_q_empty.
+            if cutlass.const_expr(not IS_QO_ALIAS):
+                elect_p = nvvm.elect_sync()
+                for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                    bars.mb_q_empty[qs].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            _wait_mbarrier(bars.mb_v_full[kv_state.idx], kv_state.phase)
+            desc_V = sV[kv_state.idx].desc()
+            is_not_first_bmm2_epi = cutlass.Boolean((kv_right - kv_left) != cutlass.Int32(1))
+
+            _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2)
+                accum_b2 = cutlass.Boolean(True)
+            if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                    )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2)
+                accum_b2 = cutlass.Boolean(True)
+            if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P1_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O1_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                    )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_v_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bmm2_ready_phase = bmm2_ready_phase ^ 1
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (kv_right > kv_left):
+            stats_read_phase = stats_read_phase ^ 1
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        _wait_ptr(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+            nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    _wait_mbarrier(bars.mb_tmem_dealloc, cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _softmax_kv_body(
+    apply_mask: bool,
+    sub_tile_id: int,
+    kv_loop,
+    s_addr_base,
+    p_addr_base,
+    stats_addr,
+    bars,
+    q_abs,
+    eff_seqlen_kv,
+    seqlen_q,
+    scale_log2,
+    total_max,
+    total_max_safe,
+    total_sum,
+    bmm1_phase,
+    stat_empty_phase,
+    leader_cta_id,
+):
+    """Per-iter kv body for the softmax warp group.
+
+    Compile-time apply_mask (Python bool) picks the load+max strategy:
+    apply_mask=False uses manual tcgen05.ld + software row-max;
+    apply_mask=True uses tcgen05.ld + apply_mask_chunk + software row-max
+    (HW max can't observe NEG_INFINITY written after the load).
+
+    total_max runs in scaled (log2) units and starts at -inf; total_max_safe
+    is its 0-substituted companion (see row_max_for_exp2), carried so alpha
+    can be exp2(prev_safe - new_safe) with the substitution on both operands.
+
+    Returns updated (total_max, total_max_safe, total_sum, bmm1_phase,
+    stat_empty_phase).
+    """
+    CHUNK = 64
+    # fp16/bf16 pack 2 probs per FP32 TMEM cell (CHUNK//2); TF32 is 1:1 (CHUNK).
+    P_COLS_PER_CHUNK = CHUNK if IS_TF32 else CHUNK // 2
+    N_CHUNKS = CFG.N_BMM2_CHUNKS
+    RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+    if cutlass.const_expr(apply_mask):
+        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.CAUSAL_BOTTOM_RIGHT is 0 - top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.CAUSAL_BOTTOM_RIGHT) else None
+
+    _wait_mbarrier(bars.mb_bmm1_done[sub_tile_id], bmm1_phase)
+    bmm1_phase = bmm1_phase ^ 1
+
+    # apply_mask is a Python bool — wrap in cutlass.const_expr so the DSL folds
+    # at trace time instead of staging cf.if (the two arms produce Vectors
+    # built via different MLIR op sequences and the tracer would error).
+    if cutlass.const_expr(apply_mask):
+        # Python comprehensions (not for+append) so the tracer sees fully-formed lists.
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
+                num=CHUNK,
+            )
+            for c in range(N_CHUNKS)
+        ]
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.CAUSAL_BOTTOM_RIGHT == 0):
+            chunks_S = [
+                _apply_top_left_causal_mask_chunk(
+                    raw_chunks[c],
+                    q_abs,
+                    kv_col_base + cutlass.Int32(c * CHUNK),
+                    N=CHUNK,
+                )
+                for c in range(N_CHUNKS)
+            ]
+        elif cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.CAUSAL_BOTTOM_RIGHT != 0):
+            chunks_S = [
+                _apply_bottom_right_causal_mask_chunk(
+                    raw_chunks[c],
+                    q_abs,
+                    kv_col_base + cutlass.Int32(c * CHUNK),
+                    causal_diag,
+                    N=CHUNK,
+                )
+                for c in range(N_CHUNKS)
+            ]
+        else:
+            chunks_S = [
+                apply_mask_chunk(
+                    raw_chunks[c],
+                    q_abs,
+                    kv_col_base + cutlass.Int32(c * CHUNK),
+                    eff_seqlen_kv,
+                    CFG.SWA_WINDOW,
+                    CFG.MASK_FLAGS,
+                    N=CHUNK,
+                    causal_bottom_right=CFG.CAUSAL_BOTTOM_RIGHT,
+                    causal_diag=causal_diag,
+                    mask_value=float("-inf"),
+                )
+                for c in range(N_CHUNKS)
+            ]
+        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
+        from cudnn.frost.tile_dsl.regtile import vec_concat
+
+        # vec_concat handles single-element lists too; keeps tracer Vector type uniform across N_CHUNKS.
+        reg_S_vec = vec_concat(chunks_S)
+        current_max_unscaled = chunks_max[0]
+        for m in chunks_max[1:]:
+            current_max_unscaled = cute.math.max(current_max_unscaled, m)
+    else:
+        # SM100: manual row-max (no LDTM.STAT / tmem_load_max_reduction_tile).
+        # Pure MASK_NONE avoids the x32 lowering, which spills under DSL 4.7.
+        # Causal kernels retain x32 for their unmasked middle segment.
+        from cudnn.frost.tile_dsl.regtile import vec_concat
+
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            raw_chunks = [
+                nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
+                    num=CHUNK,
+                )
+                for c in range(N_CHUNKS)
+            ]
+        else:
+            LOAD_CHUNK = 32
+            raw_chunks = [
+                nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * LOAD_CHUNK), cutlass.Float32),
+                    num=LOAD_CHUNK,
+                )
+                for c in range(CFG.TILE_N // LOAD_CHUNK)
+            ]
+        reg_S_vec = vec_concat(raw_chunks)
+        current_max_unscaled = row_max_reduction(reg_S_vec)
+
+    # Pass size=CFG.TILE_N explicitly — Vector.shape[0] is an MLIR value
+    # (not Python int) for vec_concat-built vectors, so auto-detect can't recover the length.
+    reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+    current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+
+    cute.arch.inline_ptx('.pragma "set knob SchedResBusyXU64=1";')
+
+    # Online softmax with RESCALE_THRESHOLD skip.  total_max starts at -inf,
+    # so the first live iteration always clears the threshold
+    # (real - (-inf) = +inf) while a fully-masked one never does
+    # (-inf - x = -inf or NaN; ordered > is false for both) — dead
+    # iterations can never move the max.
+    update_cond = (current_max - total_max) > RESCALE_THRESHOLD
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    # Canonical 0-substitution at point of use, on BOTH alpha operands:
+    # no-update iters give alpha == exp2(0) == 1 exactly (ballot keeps
+    # firing); min(., 0) guards the dead->alive transition (safe max drops
+    # 0 -> real*scale < 0) where total_sum is still 0 so alpha must merely
+    # stay finite.  total_max_safe starts at -inf so iter 0 keeps alpha = 0.
+    new_total_max_safe = row_max_for_exp2(total_max)
+    alpha = cute.math.exp2(
+        cute.math.min(total_max_safe - new_total_max_safe, cutlass.Float32(0.0)),
+        fastmath=True,
+    )
+    total_max_safe = new_total_max_safe
+
+    alpha_vec = cutlass.Vector.from_elements((alpha,), cutlass.Float32)
+    _wait_mbarrier(bars.mb_stat_empty[sub_tile_id], stat_empty_phase)
+    stat_empty_phase = stat_empty_phase ^ 1
+    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_stat_full[sub_tile_id].arrive()
+
+    # Rescale full reg_S in one vector op — emits same FFMA2 sequence as explicit half-tile rescales.
+    reg_S = reg_S * scale_log2 - total_max_safe
+
+    # Chunk 0 manual unroll — the DSL's @cute.jit tracer makes the loop iter an
+    # MLIR value, breaking Python slice.indices() math inside RegTile[].
+    chunk_S_0 = reg_S[0:CHUNK].vec
+    chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+    # Hoist chunk 0's sum before the cast to overlap with the cast's FFMA chain.
+    hoisted_sum = row_reduction_pair(chunk_P_0)
+    chunk_P_0_fp16 = chunk_P_0.to(STORAGE_DTYPE)
+    nvvm.tcgen05_st(
+        "32x32b",
+        nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32),
+        chunk_P_0_fp16,
+    )
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    cute.arch.inline_ptx('.pragma "next knob FenceInterference";')
+    bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    # Chunk 1 folds out at TILE_N=64 (N_CHUNKS=1).
+    deferred_P_1 = None
+    p1_sum_pair = None
+    if cutlass.const_expr(N_CHUNKS == 2):
+        chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+        deferred_P_1 = cute.math.exp2(chunk_S_1, fastmath=True)
+        p1_sum_pair = row_reduction_pair(deferred_P_1)
+        chunk_P_1_fp16 = deferred_P_1.to(STORAGE_DTYPE)
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(
+                p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK),
+                cutlass.Float32,
+            ),
+            chunk_P_1_fp16,
+        )
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        cute.arch.inline_ptx('.pragma "next knob FenceCode";')
+        bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 1].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    cute.arch.inline_ptx('.pragma "reset knob SchedResBusyXU64=1";')
+
+    new_p_sum_pair = hoisted_sum
+    if cutlass.const_expr(N_CHUNKS == 2):
+        new_p_sum_pair = new_p_sum_pair + p1_sum_pair
+    sum_lo, sum_hi = cute.arch.fma_packed_f32x2(
+        (total_sum[0], total_sum[1]),
+        (alpha, alpha),
+        (new_p_sum_pair[0], new_p_sum_pair[1]),
+    )
+    total_sum = cutlass.Vector.from_elements((sum_lo, sum_hi), cutlass.Float32)
+
+    return total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase
+
+
+@cute.jit
+def _softmax_warp_group(
+    sub_tile_id: int,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    sQ,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Softmax warp group (one of two): online softmax per kv iter.
+
+    Each lane owns one row of the 128 x 128 S_acc tile, loads its 128 fp32
+    cols with a single tcgen05.ld.red.max, runs online softmax (total_max +
+    total_sum tracking with RESCALE_THRESHOLD skip), publishes alpha to
+    corr, writes P to TMEM cols at S_acc tail, fires bmm2_ready[sub][chunk].
+    """
+    # Wait on MMA's TMEM-publish named barrier BEFORE any tmem_ptr_i32.load() —
+    # without it softmax can race MMA's tcgen05_alloc and read a stale base.
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+
+    NEG_INF = cutlass.Float32(float("-inf"))
+
+    CHUNK = 64
+    P_COLS_PER_CHUNK = CHUNK // 2
+    stats_off = LAYOUT.STATS_OFF + sub_tile_id * LAYOUT.STATS_STRIDE
+
+    # Phase trackers persist across tile boundaries (barriers don't reset).
+    bmm1_phase = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+    # total_sum kept as Vector[Float32, 2] (even/odd partials) so per-iter update lowers to packed FMUL2 + FADD2.
+    total_max = NEG_INF
+    total_max_safe = NEG_INF
+    total_sum = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
+    tmem_base_softmax = tmem_ptr_i32.load()
+    s_addr_base_softmax = tmem_base_softmax + cutlass.Int32(tmem_S_off)
+    p_addr_base_softmax = tmem_base_softmax + cutlass.Int32(tmem_P_off)
+    stats_addr_softmax = tmem_base_softmax + cutlass.Int32(stats_off)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        total_max = NEG_INF
+        total_max_safe = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # 3-segment kv loop: LEFT-masked / fully-unmasked / RIGHT-masked.
+        # At MASK_NONE bounds collapse so the two masked sub-loops have empty range and fold out.
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    s_addr_base_softmax,
+                    p_addr_base_softmax,
+                    stats_addr_softmax,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_max_safe,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+        else:
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    s_addr_base_softmax,
+                    p_addr_base_softmax,
+                    stats_addr_softmax,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_max_safe,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    s_addr_base_softmax,
+                    p_addr_base_softmax,
+                    stats_addr_softmax,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_max_safe,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    s_addr_base_softmax,
+                    p_addr_base_softmax,
+                    stats_addr_softmax,
+                    bars,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_max_safe,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+
+        if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
+            # Only real mainloops own a stats transaction. Empty tiles bypass
+            # this phase entirely and are materialized by the correction warp.
+            total_sum_scalar = total_sum[0] + total_sum[1]
+            stats_vec_epi = cutlass.Vector.from_elements((total_max_safe, total_sum_scalar), cutlass.Float32)
+            _wait_mbarrier(bars.mb_stat_empty[sub_tile_id], stat_empty_phase)
+            stat_empty_phase = stat_empty_phase ^ 1
+            nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr_softmax, cutlass.Float32), stats_vec_epi)
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+            bars.mb_stat_full[sub_tile_id].arrive()
+
+        _wait_ptr(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    seq_q_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Correction warp group: 4 warps x 32 lanes = 128 lanes, 1 lane per O row.
+
+    Per kv iter rescales O by alpha (skipped when all_alpha_one warp ballot
+    fires); per-tile epilogue normalizes O by 1/total_sum, casts to fp16,
+    swizzled-stores to sO, fires o_full for TMA-STG.  Holds the P14
+    end-of-tile catch-up flip on bmm2_done_phase (needed at n_kv=1 multi-wave).
+    """
+    # Wait on MMA's TMEM-publish named barrier BEFORE any tmem_ptr_i32.load() —
+    # without it correction can race MMA's tcgen05_alloc and read a stale base.
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    # O_CHUNK=16 (halved from 32) shortens the alpha-rescale live range —
+    # at 32, DSL regalloc spilled correction-warp regs to the stack.
+    O_CHUNK = 8
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    # Use O_SWZ_B (NOT V_SWZ_B): under cga2 V is split along d_v and may drop
+    # to a narrower swizzle while O is full-row.  V-based stride here silently
+    # produces correct TMEM but garbled SMEM → wrong O after TMA-STG.
+    TMA_O_ITERS = (CFG.TILE_O * CFG.BPE) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS
+    TMA_O_GRANU_ELEMS = CFG.TILE_M * D_BLOCK_SIZE
+
+    stat_full_phase = cutlass.Int32(0)
+    # bmm2_done starts at phase=0; iter 0 is skipped, first wait at kv_loop=1.
+    bmm2_done_phase = cutlass.Int32(0)
+    o_empty_phase = cutlass.Int32(1)  # bootstrap
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        # Iter-0 lifted out of kv loop: MMA's iter-0 BMM2 uses init_d=False
+        # to overwrite O garbage, so alpha-rescale is unnecessary in iter 0.
+        if bounds.right > bounds.left:
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                _wait_mbarrier(bars.mb_stat_full[qs], stat_full_phase)
+                bars.mb_stat_empty[qs].arrive()
+            stat_full_phase = stat_full_phase ^ 1
+        else:
+            if cutlass.const_expr(not CAN_HAVE_EMPTY_KV):
+                bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            tmem_base_iter = tmem_ptr_i32.load()
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                stats_off = LAYOUT.STATS_OFF + qs * LAYOUT.STATS_STRIDE
+                tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+                stats_addr = tmem_base_iter + cutlass.Int32(stats_off)
+
+                _wait_mbarrier(bars.mb_stat_full[qs], stat_full_phase)
+
+                stats_vec = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                    num=2,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                alpha = stats_vec[0]
+
+                # all_alpha_one ballot: when every lane has alpha==1.0 the entire rescale loop skips.
+                alpha_is_one = alpha == cutlass.Float32(1.0)
+                all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                bars.mb_stat_empty[qs].arrive()
+
+                _wait_mbarrier(bars.mb_bmm2_done[qs], bmm2_done_phase)
+
+                # vec_scale_pair emits nvvm.mul_packed_f32x2 → FMUL2.  Without it
+                # plain o_chunk*alpha lowers to scalar FMUL inside the runtime-if
+                # (downstream fp32 tcgen05_st doesn't force packed regs).
+                if ~all_alpha_one:
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_iter + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_full_phase = stat_full_phase ^ 1
+            bmm2_done_phase = bmm2_done_phase ^ 1
+
+        # === End-of-kv epilogue ===
+        tmem_base_epi = tmem_ptr_i32.load()
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            stats_off = LAYOUT.STATS_OFF + qs * LAYOUT.STATS_STRIDE
+            tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+            stats_addr = tmem_base_epi + cutlass.Int32(stats_off)
+
+            total_max_scaled = cutlass.Float32(float("-inf"))
+            total_sum = cutlass.Float32(0.0)
+            if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
+                # Wait the (total_max, total_sum_final) publish from softmax's epilogue.
+                _wait_mbarrier(bars.mb_stat_full[qs], stat_full_phase)
+
+                stats_vec = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(stats_addr, cutlass.Float32),
+                    num=2,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                total_max_scaled = stats_vec[0]  # log2-units (softmax stores it scaled)
+                total_sum = stats_vec[1]
+
+                # Fire stat_empty so softmax's NEXT-tile iter 0 wait can pass.
+                bars.mb_stat_empty[qs].arrive()
+                # Release MMA's NEXT-tile prologue BMM1 into this S_acc slot: the
+                # final stats ride the slot HEAD and are now safely in registers
+                # (tcgen05_wait LOAD above).  Cross-CTA arrive on the leader under
+                # cga2 — the collective BMM1 writes both peers' TMEM.
+                bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
+            lse_val = cutlass.Float32(0.0)
+            # With sinks: fold the lift-the-max rescale into threshold_beta so O is scaled by scale/new_sum in one FMUL.
+            LN2 = cutlass.Float32(0.6931471805599453)
+            total_max_nat = total_max_scaled * LN2
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                new_max = cute.math.max(total_max_nat, sink_logit)
+                scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+                new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+                lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+                inv_sum = scale / new_sum
+            else:
+                lse_val = total_max_nat + cute.math.log(cute.math.max(total_sum, cutlass.Float32(1e-30)), fastmath=True)
+                # Safe inverse: avoid div by 0 on fully-masked rows.
+                inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+                # Dead row (no valid KV column at all): O := 0, LSE := -inf.
+                # Top-left causal and no-mask dense tiles always have at least
+                # one valid KV per live row, so fold this select out there.
+                if cutlass.const_expr((CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.CAUSAL_BOTTOM_RIGHT):
+                    row_dead = total_sum <= cutlass.Float32(0.0)
+                    neg_inf_lse = cutlass.Float32(float("-inf"))
+                    lse_val = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse_val.ir_value()))
+                    inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
+
+            # OOB-row guard: under cga2 the cluster's Q rows can exceed seqlen_q;
+            # without the guard the write aliases the next head's LSE slot.
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
+            if cutlass.const_expr(CFG.SEQ_Q_LENS_PRESENT):
+                # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b]
+                # write O := 0 / LSE := -inf.  Applied AFTER the sink branch on
+                # purpose — a trimmed row is dead even with a sink.  Per-batch
+                # q lens come in via the dedicated seq_q_lens_tensor parameter.
+                _sq_arr = cutlass.make_array_view(seq_q_lens_tensor)
+                _q_len_b = cutlass.Int32(_sq_arr[batch_idx])
+                row_trim = q_row_global >= _q_len_b
+                neg_inf_trim = cutlass.Float32(float("-inf"))
+                lse_val = cutlass.Float32(arith.select(row_trim.ir_value(), neg_inf_trim.ir_value(), lse_val.ir_value()))
+                inv_sum = cutlass.Float32(arith.select(row_trim.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
+                # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                if q_row_global < _s_q_b:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                    lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                if q_row_global < seqlen_q:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[batch_idx, head_idx, :]
+                    lse_row[q_row_global] = lse_val
+
+            sO_sub_base = sO[qs].base
+
+            if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
+                # The final stats live in the S_acc slot and can be consumed
+                # before BMM2 retires. Only the O TMEM loads need this wait.
+                _wait_mbarrier(bars.mb_bmm2_done[qs], bmm2_done_phase)
+
+            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                o_fp16 = cutlass.Vector.from_elements(
+                    tuple(STORAGE_DTYPE(0.0) for _ in range(O_CHUNK)),
+                    STORAGE_DTYPE,
+                )
+                if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
+                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    o_scaled = vec_scale_pair(o_chunk, inv_sum, O_CHUNK)
+                    o_fp16 = o_scaled.to(STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+
+                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                # mb_o_empty[qs] wait gates the FIRST SMEM store (not the
+                # earlier TMEM-load loop), keeping TMEM-load/FFMA/cast overlapped
+                # with TMA-STG draining the prior persistent tile.
+                if chunk_idx == 0:
+                    _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
+                smem_ptr.store_swizzled(o_fp16, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            # fence_proxy needed before TMA reads SMEM written by tcgen05_st (via store_swizzled).
+            nvvm.fence_proxy("async.shared", space="cta")
+
+            bars.mb_o_full[qs].arrive()
+
+        if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
+            stat_full_phase = stat_full_phase ^ 1
+            bmm2_done_phase = bmm2_done_phase ^ 1
+        o_empty_phase = o_empty_phase ^ 1
+
+        _wait_ptr(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+
+    # End-of-warp tmem_dealloc: under cga2 each corr lane ALSO DSMEM-arrives
+    # on the peer so the peer's local mbar accumulates the full CGA-total count.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # Dense padded-Q trim: separate (B,)-int32 per-batch Q lengths; None
+    # (and absent from the compiled ABI) unless CFG.SEQ_Q_LENS_PRESENT.
+    seq_q_lens_tensor: Optional[cute.Tensor] = None,
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    # Tensors are [B, S, H, D] with stride_order=(3, 2, 1, 0); D is fastest.
+    # K is split along seq under cga2 — box rows are per-CTA.  V is split along d_v
+    # (plumbed via num_iters//CTA_MMA).  O's TMA box inner dim follows O's swizzle, NOT V's.
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    # Per-tensor TMA swizzle tracks per-CTA inner bytes (derived from CFG.*_SWZ_BYTES).
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_tensor,
+        box_dims=qk_box_k,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    # V TMA: TF32 needs SWIZZLE_128B_ATOM_32B (transposed BMM2 operand) — same
+    # 128-B swizzle line / box geometry as standard Swz128B, just the atom mode.
+    # Standard Swz128B with kind::tf32 + b_trans silently returns all-zero O.
+    _v_tma_swz = tmap.TensorMapSwizzle.s128b_atom_32b if IS_TF32 else _tma_swz(CFG.V_SWZ_BYTES)
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_v_tma_swz,
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # Each cluster pair (CTA_MMA CTAs) collectively covers TILE_M*TILES_Q*CTA_MMA Q rows;
+    # without the cluster-wide divisor cga2 over-launches and OOB clusters collide in GMEM.
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units = Σ_b ceil(S_q_b/CGA_TILE_M)*QH,
+        # host-computed); grid_x = n_thd_units * CGA_M.  Works at cga1 (CGA_M=1).
+        # ENVELOPE: the packed-O row stride is QH * ACTUAL d_v (o_tensor's
+        # static inner extent), not QH * TILE_O — the per-batch descriptor
+        # bases must step in real rows or every batch >= 1 lands OOB.
+        _build_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(o_tensor.shape[3]),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        # Grid Python-folds on Cfg constant (avoids DSL if staging).
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+        seq_q_lens_tensor,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128, d_qk: int = CFG.TILE_K, d_v: int = CFG.TILE_O) -> Callable:  # noqa: A001
+    """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
+
+    THD/varlen: q/k/v/o/lse are PACKED with batch dim 1 ([1,T,H,D]); ``b`` is the
+    LOGICAL batch (sequence count) driving n_batch / metadata + O-desc sizes.
+
+    ENVELOPE: ``d_qk`` / ``d_v`` are the ACTUAL head dims (defaults = the
+    flavor's full TILE_K / TILE_O). The Q/K/V/O TMA descriptors are built from
+    these extents while the tile box stays the compile-time TILE geometry, so
+    box columns past d_qk / d_v hardware zero-fill on load (exact zero terms in
+    every QK^T / P·V dot product) and O box columns past d_v are OOB-clipped on
+    store — the kernel body is unchanged. Constraint: every non-innermost TMA
+    global stride must be a 16-byte multiple; the compact BSHD H-stride is
+    d * BPE, so d must be a multiple of 8 at 2 bytes/elem."""
+    if not (0 < d_qk <= CFG.TILE_K and 0 < d_v <= CFG.TILE_O):
+        raise ValueError(f"d192 envelope: need 0 < d_qk <= {CFG.TILE_K} and 0 < d_v <= {CFG.TILE_O}; got ({d_qk}, {d_v})")
+    if (d_qk * CFG.BPE) % 16 != 0 or (d_v * CFG.BPE_O) % 16 != 0:
+        raise ValueError(f"d192 envelope: d_qk*BPE and d_v*BPE must be 16-byte multiples (TMA global-stride rule); got ({d_qk}, {d_v}) at BPE={CFG.BPE}")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_qk),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, d_v),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_lse = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (_fake_batch, qh, sq),
+        stride_order=(2, 1, 0),
+        assumed_align=16,
+    )
+    # Sinks tensor always part of the ABI; read only when CFG.HAS_SINK == 1 (compile-time fold).
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # seq_kv_lens always part of the ABI; read only when CFG.SEQ_KV_LENS_PRESENT == 1
+    # (compile-time fold).  THD overloads it as the [seq_kv_lens(B)|cu_q(B+1)|
+    # cu_k(B+1)] metadata buffer (length 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Dense padded-Q trim: SEPARATE (B,)-int32 per-batch Q lengths parameter
+    # (cuDNN SEQLEN_Q / FA seqused_q style); None folds it out of the ABI when
+    # the flag is off.  assumed_align=4 — the caller's tensor is bound
+    # directly (no repack), so only natural int32 alignment is required.
+    fake_seq_q_lens = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Int32,
+            (b,),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+        if CFG.SEQ_Q_LENS_PRESENT
+        else None
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
+    # dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        fake_seq_q_lens,
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        # Keep -uumn so the P exp2/store sched_res_busy_xu64 region affects
+        # backend scheduling.
+        options="--enable-tvm-ffi --ptxas-options -uumn",
+    )

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -47,7 +47,7 @@ pytestmark = pytest.mark.skipif(
 
 
 def _ref_sdpa(q, k, v, *, is_causal, scale):
-    """Reference SDPA in fp32 (DSv4 v1 scope: dense, top-left causal or none)."""
+    """Reference SDPA in fp32 (dense, top-left causal or none)."""
     q_ref, k_ref, v_ref = q.to(torch.float32), k.to(torch.float32), v.to(torch.float32)
     scores = torch.matmul(q_ref, k_ref.transpose(-1, -2)) * scale
     if is_causal:
@@ -214,13 +214,32 @@ def _run_dsl_graph(q_gpu, k_gpu, v_gpu, *, scale, dtype, sdpa_kwargs, seq_len_kv
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(q_gpu.shape[-1]))
+    _select_engine(g, engine_name(q_gpu.shape[-1], d_v=d_v))
     g.check_support()
     g.build_plans()
     vp[o] = o_gpu
     g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8))
     torch.cuda.synchronize()
     return o_gpu
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@pytest.mark.parametrize("is_causal", [False, True], ids=["dense", "causal"])
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_d192_d128(dtype, is_causal):
+    """Native DSv3 MLA shape: Q/K use d_qk=192 while V/O use d_v=128."""
+    _require_dsl()
+    b, h, s = 2, 8, 256
+    d_qk, d_v = 192, 128
+    scale = 1.0 / math.sqrt(d_qk)
+    q = _bhsd(b, h, s, d_qk, dtype)
+    k = _bhsd(b, h, s, d_qk, dtype)
+    v = _bhsd(b, h, s, d_v, dtype)
+
+    o = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=is_causal))
+    o_ref = _ref_sdpa(q, k, v, is_causal=is_causal, scale=scale)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -149,8 +149,8 @@ def test_probe_envelope_covers_small_head_dim():
 
 
 def test_probe_envelope_mixed_dims_pick_covering_flavor():
-    # (d_qk=192, d_v=128) needs one flavor covering BOTH dims: d256 (and d512),
-    # never d128; registration order auto-selects d256.
+    # (d_qk=192, d_v=128) uses the native d192/d128 flavor; larger envelopes
+    # remain eligible for explicit A/B selection.
     g = _mk_graph()
     d_qk, d_v = 192, 128
     q = g.tensor(dim=(B, H, S, d_qk), stride=(S * H * d_qk, d_qk, H * d_qk, 1), data_type=DTYPE, name="q")
@@ -160,9 +160,9 @@ def test_probe_envelope_mixed_dims_pick_covering_flavor():
     _finish_output(o, (B, H, S, d_v), (S * H * d_v, d_v, H * d_v, 1))
     elig = _eligible(g)
     assert engines.engine_name(128) not in elig
-    assert {engines.engine_name(256), engines.engine_name(512)} <= elig
+    assert {engines.engine_name(192, d_v=128), engines.engine_name(256), engines.engine_name(512)} <= elig
     ordered = [s.name for s in engines.ENGINE_SPECS if s.name in elig]
-    assert ordered[0] == engines.engine_name(256)
+    assert ordered[0] == engines.engine_name(192, d_v=128)
 
 
 def test_probe_rejects_wrong_device_family(monkeypatch):


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

This PR adds a native SM100/Blackwell FROST DSL SDPA forward kernel for the DSv3 MLA logical shape:

- `D_QK = 192`
- `D_V = 128`
- BF16 and FP16 input/output
- Dense prefill path using the CGA2 classic pipeline

The implementation extends the existing SM100 `d=128` classic forward pipeline for the logical `192/128` shape instead of selecting a padded `d=256` flavor.

The change:

- Adds `prefill_d192_d128_f16_sm100.py`.
- Adds `CfgD192` and `make_cfg_d192`.
- Adds a `d192/d128` engine capability row and API flavor route.
- Adds d192/d128 correctness and graph-analyzer coverage.
- Allocates a stable engine-ID offset for the d192/d128 route.
- Keeps the existing d128, d256, and d512 kernels unchanged.
- Keeps d192/d128 wait and scheduling tuning local to the new kernel.

## Why

DSv3 MLA uses Q/K head dimension 192 and V/O head dimension 128. Selecting the existing d256 envelope performs unnecessary padded work. A native logical-shape kernel reduces duration while preserving high compute utilization.

For top-left causal `S=8192`, the native kernel reaches 87.09% Compute SOL and 820.0 useful TFLOPS. Against an exact d256 padded-work proxy, it is approximately 1.50x faster by both duration and useful TFLOPS.

## Related issues

None.

## API and compatibility impact

- No new public Python or C++ API.
- Adds a new internal FROST engine flavor for `D_QK=192, D_V=128` on SM100.
- Existing d128, d256, and d512 routing and kernel implementations are unchanged.
- Unsupported graph shapes continue to fall through to existing eligible engines.
- Requires the existing CuTeDSL optional dependency path. Performance measurements below used CUTLASS DSL `4.7.0a0`.

## Testing

Formatting and syntax:

```bash
pre-commit run --files \
  python/cudnn/sdpa/fwd/api_dsl.py \
  python/cudnn/sdpa/fwd/config_sm100.py \
  python/cudnn/sdpa/fwd/engine.py \
  python/cudnn/sdpa/fwd/engines.py \
  python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py \
  test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py \
  test/python/sdpa/frost/test_sdpa_graph_analyzer.py
```

Result: passed. The new kernel was also checked with `python3 -m py_compile`.

Targeted test coverage:

```bash
pytest test/python/sdpa/frost/test_sdpa_graph_analyzer.py::test_probe_envelope_mixed_dims_pick_covering_flavor
pytest test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py -k d192_d128
```

Local SM100 validation results:

- Graph analyzer plus FP16/BF16 dense/causal execution: 5/5 passed.
- Expanded BF16/FP16 top-left, bottom-right, and no-mask matrix: 18/18 passed.
- The expanded matrix includes non-tile-aligned sequence lengths.
- The selected execution flavor was `[192, 128]`.
- GQA/MQA, SWA/padding/sinks, and THD/varlen were not part of the expanded performance audit and continue to use existing routing constraints.

Post-port verification from a clean editable build of this GitHub branch:

- The two targeted commands above passed: 5/5.
- The Blackwell FROST gate scope was also run locally with four pytest workers: `test/python/sdpa/frost test/python/test_mhas_v2.py`.
- FROST SDPA result: 357 passed, 36 skipped, 0 failed. The d192/d128 FROST route executed 54 graphs.
- `test_mhas_v2.py` result on the local cuDNN 9.21.1 backend: 1862 passed, 907 skipped, 116 failed. All failures were native FP8/MXFP8 backward cases outside this forward-kernel diff. Validation against the current development backend is pending the repository CI bot run.

## Performance methodology

- GPU: NVIDIA GB100, SM100.
- CUTLASS DSL: `4.7.0a0`.
- Data type: BF16.
- Shape: `B=2`, `Hq=128`, `Hkv=128`, `D_QK=192`, `D_V=128`.
- Nsight Compute: base clock control, launch skip 3, five measured launches per row.
- Observed SM clock: approximately `0.842-0.846 GHz`.
- Absolute durations should not be compared with measurements taken at higher SM clocks.
- All 12 native rows were rerun from the final executable source. The 8192 rows also received independent 15-launch confirmations.

### Native d192/d128 SOL by mask and size

| mask | S_q x S_kv | NCU duration (us) | Compute SOL % | useful TFLOPS | Memory SOL % | observed SM clock (GHz) |
|---|---:|---:|---:|---:|---:|---:|
| top_left | 2048x2048 | 605.89 | 71.63 | 567.4 | 24.88 | 0.842494 |
| top_left | 4096x4096 | 1914.39 | 81.04 | 718.1 | 25.13 | 0.844062 |
| top_left | 4096x8192 | 1912.75 | 81.05 | 718.7 | 25.05 | 0.844523 |
| top_left | 8192x8192 | 6705.18 | 87.09 | 820.0 | 24.78 | 0.844778 |
| bottom_right | 2048x2048 | 610.30 | 71.27 | 563.3 | 24.95 | 0.841870 |
| bottom_right | 4096x4096 | 1921.86 | 80.72 | 715.3 | 26.46 | 0.844645 |
| bottom_right | 4096x8192 | 4863.84 | 88.22 | 847.8 | 24.34 | 0.845300 |
| bottom_right | 8192x8192 | 6731.40 | 86.86 | 816.8 | 24.69 | 0.844461 |
| no_mask | 2048x2048 | 844.88 | 81.60 | 813.4 | 26.78 | 0.842525 |
| no_mask | 4096x4096 | 3140.58 | 87.43 | 875.2 | 25.90 | 0.845509 |
| no_mask | 4096x8192 | 6096.22 | 90.02 | 901.8 | 24.45 | 0.845652 |
| no_mask | 8192x8192 | 12168.19 | 90.24 | 903.6 | 24.45 | 0.845123 |

### Comparison against an exact d256 proxy

Before this change, logical `192/128` used a d256 envelope. The controlled reference below is a separate exact `256/256` run used as a padded-work proxy, not a direct logical `192/128` fallback execution. For DSv3 useful work, `(192 + 128) / (256 + 256) = 0.625` of the proxy work is useful.

For top-left causal `S=8192`:

| implementation | selected flavor | NCU duration (us) | raw Compute SOL % | useful SOL % | useful TFLOPS |
|---|---:|---:|---:|---:|---:|
| exact d256 proxy | `256` | 10054.18 | 88.27 | 55.17 | 546.9 |
| native d192/d128 | `192` | 6705.18 | 87.09 | 87.09 | 820.0 |

The native d192/d128 path is approximately 1.50x faster for this case by both duration and useful TFLOPS. This is a proxy estimate rather than a direct fallback A/B measurement.

### Existing exact-shape kernel reference

These rows are not direct apples-to-apples comparisons because the logical head dimensions differ. They provide context for current SM100 FROST forward SOL at `S=8192`.

| kernel | logical D_QK/D_V | mask | S | NCU duration (us) | Compute SOL % | Memory SOL % | observed SM clock (GHz) |
|---|---:|---|---:|---:|---:|---:|---:|
| d128 existing | 128/128 | top_left | 8192 | 7107.26 | 70.81 | 16.31 | 0.845617 |
| d128 existing | 128/128 | bottom_right | 8192 | 7152.97 | 70.47 | 16.24 | 0.845366 |
| d128 existing | 128/128 | no_mask | 8192 | 12454.32 | 75.81 | 17.37 | 0.845729 |
| d256 existing | 256/256 | top_left | 8192 | 10054.18 | 88.27 | 26.74 | 0.846004 |
| d256 existing | 256/256 | bottom_right | 8192 | 9985.62 | 88.80 | 26.71 | 0.846018 |
| d256 existing | 256/256 | no_mask | 8192 | 18153.50 | 94.73 | 26.36 | 0.845069 |
| d512 existing | 512/512 | top_left | 8192 | 26346.53 | 69.66 | 37.68 | 0.844959 |
| d512 existing | 512/512 | bottom_right | 8192 | 26306.23 | 69.78 | 37.75 | 0.844902 |
| d512 existing | 512/512 | no_mask | 8192 | 48453.82 | 73.00 | 38.43 | 0.844599 |

## Optimization notes

The final 15-launch `8192x8192` confirmations were:

- Top-left: **87.097443% Compute SOL / 6.705419 ms**.
- Bottom-right: **86.861660% Compute SOL / 6.729591 ms**.
- No-mask: **90.255379% Compute SOL / 12.165702 ms**.

Deep profiling reported zero local/shared spills for all three mask paths, 128 registers per thread, and approximately 25% achieved occupancy. The gains below are context-dependent and are not additive.

| Applied optimization | Compute SOL evidence | Retained gain |
|---|---:|---:|
| Replace the local inline-PTX wait with generic CuTeDSL wait lowering | 75.6858% -> 80.2006% | **+4.5148 pt** |
| Use the no-time `mbarrier_wait_parity(..., TRY)` loop instead of the timed generic wait | 84.484424% -> 85.747026% | **+1.2626 pt** |
| Pass the phase directly instead of warp-uniformizing it | 85.055622% -> 85.747026% | **+0.6914 pt** |
| Force the D192 scheduler to LPT instead of NATURAL | 82.275626% -> 85.747026% | **+3.4714 pt** |
| Use the D128-derived causal register split `192/88` instead of `200/72` | 85.179120% -> 85.741305% | **+0.5622 pt** |
| Increase the TMA-LDG producer-loop unroll from 3 to 6 | 85.449759% -> 85.741305% | **+0.2915 pt** |
| Add the `sched_res_busy_xu64` region together with `--ptxas-options -uumn` | 84.008995% -> 84.402966% | **+0.3940 pt (coupled pair)** |
| Extend the XU region from P-only work to online max/alpha/stat plus P exp2/store | 85.468947% -> 85.880816% | **+0.4119 pt** |
| Use 4x LDTM.x32 for causal unmasked segments while retaining 2x LDTM.x64 for pure no-mask | causal: 84.868992% -> 85.880816%; no-mask x32/x64: 41.750872% -> 86.205275% | **+1.0118 pt causal; avoids 470M no-mask spill requests** |
| Run one full-row max tree after concatenation instead of four chunk-local max trees | 85.279139% -> 85.880816% | **+0.6017 pt** |
| Use `FenceInterference` rather than `FenceCode` for P chunk-0 publication | 86.881162% -> 87.094033% | **+0.2129 pt; 0.338% faster** |
| Keep `FenceCode` on P chunk-1 publication | no-mask: 89.811894% -> 89.850968%; bottom-right: 86.760661% -> 86.859571% | **+0.0391 / +0.0989 pt** |
| Fence both steady-state BMM2-done publications | 86.195711% -> 87.097443% | **+0.9017 pt; 1.195% faster** |
| Specialize pure no-mask softmax/correction registers from `192/88` to `216/40` | 89.150040% -> 90.255379% | **+1.1053 pt; 1.235% faster** |

Final-context leave-one-out checks confirmed the dual BMM2-done fences and the no-mask `216/40` register split. A previously promising BMM1-done fence was removed after the BMM2 fences subsumed its gain, and no-mask producer unroll 7 was removed after the `216/40` split made unroll 6 faster again. The no-mask route retains the x64 zero-spill lowering and uses `216/40`; causal paths use `192/88`.
