### PR TITLE
docs: add label guidance to PR template and AGENTS.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,7 @@
 
 - [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
 - [ ] I ran `pre-commit run` and committed any formatting changes.
+- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
 
 ## Affected area
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,10 @@ Reusable task recipes live in `skills/` (auto-discovered by Claude Code via `.cl
 - Published documentation: <https://docs.nvidia.com/deeplearning/cudnn/latest/developer/overview.html>
 - In-repo docs index: [llms.txt](llms.txt) · operation reference in [docs/operations/](docs/operations/) · OSS kernel APIs in [docs/fe-oss-apis/overview.md](docs/fe-oss-apis/overview.md)
 - PyPI: <https://pypi.org/project/nvidia-cudnn-frontend/>
+
+
+## PR labels
+
+When opening a pull request, apply **at minimum one label from each group**: one `cat-*` (change type), one or more `mod-*` (affected module), and one `orig-*` (originator). See the full label list at <https://github.com/NVIDIA/cudnn-frontend/labels>.
+
+Leave `closed-*` and `open-*` labels for maintainers.


### PR DESCRIPTION
## Summary

Add a checklist item to the PR template and a short section to AGENTS.md reminding contributors (and agents) to apply GitHub labels before marking a PR ready for review.

## Why

PRs were being opened without labels, making triage and filtering harder. The guidance links to the live labels page rather than embedding a static table.

## API and compatibility impact

None.

## Testing

Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request guidance to require category, modification, and origin labels.
  * Clarified that closure and status labels are reserved for maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->