### PR TITLE
fix-bs-quantize-output-alignment-issue

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -42,6 +42,7 @@ from .dtypes import (
     DTYPE_BYTES,
     DTYPE_TO_CUTLASS,
     DTYPE_TO_MMA_KIND,
+    MAX_EPI_CHUNK_ELEMS,
     _allowed_vsize,
     _aux_align_reqs,
     _compute_output_vec_bytes,
@@ -2127,12 +2128,16 @@ def _check_cta_group_geometry(config: TileConfig, cta_group: int) -> None:
         # Empirically (B200): tcgen05.mma cta_group::2 with n_dim not a
         # multiple of 16 raises an illegal-instruction fault (n_dim=8/24/40
         # fault, 16/32/48/240 run); 1-CTA MMA accepts any multiple of 8.
-        raise NotImplementedError(f"2-CTA MMA needs mma_inst_n % 16 == 0 (pair MMA instruction n_dim); " f"config {config.name!r} has mma_inst_n={config.mma_inst_n}")
+        raise NotImplementedError(
+            f"2-CTA MMA needs mma_inst_n % 16 == 0 (pair MMA instruction n_dim); " f"config {config.name!r} has mma_inst_n={config.mma_inst_n}"
+        )
     if config.cta_tile_n % 16 != 0:
         # The pair splits B's N across the two CTAs: per-CTA SMEM/TMA N is
         # cta_tile_n // 2, which must stay a multiple of 8 (the 8-row tcgen05
         # core-matrix chunk / TileConfig's N granularity).
-        raise NotImplementedError(f"2-CTA MMA needs cta_tile_n % 16 == 0 (pair splits B's N in SMEM); " f"config {config.name!r} has cta_tile_n={config.cta_tile_n}")
+        raise NotImplementedError(
+            f"2-CTA MMA needs cta_tile_n % 16 == 0 (pair splits B's N in SMEM); " f"config {config.name!r} has cta_tile_n={config.cta_tile_n}"
+        )
 
 
 def _check_dtype_config_compat(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
@@ -2405,6 +2410,7 @@ def _use_tma_store_epi(chain, cfg, vec_bytes_epi: int, cta_group: int) -> bool:
         return chain.matmul.M % m_align == 0
     return True
 
+
 def _check_block_quant_supported(
     chain: FusionChain,
     vec_bytes_epi: int,
@@ -2420,7 +2426,36 @@ def _check_block_quant_supported(
     elem_bytes = DTYPE_BYTES[chain.output_dtype]
     vsize = vec_bytes_epi // elem_bytes
     cols_per_acc_stage = _epi_tile_cols(config, cta_group)
+    # A quant pins the chunk to its block size, so — unlike every other chain,
+    # where the chunk is derived from the outputs' own layouts — the two
+    # divisibility properties the epilogue relies on have to be asserted here:
+    # the drain walks whole chunks (`for j in range(subtile_w // vsize)`) and
+    # stores only whole chunks (`if col_j + vsize <= N`).
+    subtile_w = _pow2_floor(cols_per_acc_stage, MAX_EPI_CHUNK_ELEMS)
+    if subtile_w % vsize != 0:
+        raise NotImplementedError(
+            f"block_scale_quantize epilogue chunk ({vsize} elements, from block sizes "
+            f"{sorted({q.block_size for q in chain.quants})}) must divide the {subtile_w}-column "
+            f"drain subtile of cols_per_acc_stage={cols_per_acc_stage} "
+            f"(config={config.name}, cta_group={cta_group})"
+        )
+    if chain.matmul.N % vsize != 0:
+        raise NotImplementedError(
+            f"block_scale_quantize requires N % chunk == 0 — the epilogue stores whole "
+            f"chunks only, so a partial trailing chunk is dropped; got N={chain.matmul.N}, "
+            f"chunk={vsize} elements"
+        )
     for q in chain.quants:
+        # Applies to col quants too: `_emit_block_quant_col` maps chunk column
+        # i to lane i % block_size, so a chunk narrower than the block leaves
+        # the upper lanes storing a scale they never computed.
+        if vsize % q.block_size != 0:
+            raise NotImplementedError(
+                "block_scale_quantize requires block_size to divide the epilogue chunk "
+                f"width (= the largest quant block, clamped to the lowest set bit of "
+                f"cols_per_acc_stage={cols_per_acc_stage} and to {MAX_EPI_CHUNK_ELEMS} "
+                f"elements); got block_size={q.block_size}, vsize={vsize}"
+            )
         if q.axis == 1:
             # Col quant: a warp (block 32) or half-warp (block 16) of rows is
             # one M block; the redux needs every row guard uniform across the
@@ -2454,11 +2489,6 @@ def _check_block_quant_supported(
                         "F8_128x4 col block_scale_quantize scale output currently requires " f"scale_dim={expected_scale_dim}; got {q.scale_dim}"
                     )
             continue
-        if vsize % q.block_size != 0:
-            raise NotImplementedError(
-                "block_scale_quantize requires block_size to divide the epilogue "
-                f"chunk width (= the largest quant block); got block_size={q.block_size}, vsize={vsize}"
-            )
         if cols_per_acc_stage < q.block_size or cols_per_acc_stage % q.block_size != 0:
             raise NotImplementedError(
                 "block_scale_quantize epilogue requires each CTA epilogue drain to "

--- a/python/cudnn/gemm/frost/dtypes.py
+++ b/python/cudnn/gemm/frost/dtypes.py
@@ -83,6 +83,13 @@ CUDNN_FROM_DTYPE: dict[Dtype, Any] = {v: k for k, v in DTYPE_FROM_CUDNN.items()}
 
 MAX_MEM_ACCESS_BYTES = 32
 
+# Widest epilogue chunk in ELEMENTS (not bytes). The epilogue drains the
+# accumulator in <= 32-column subtiles (tcgen05_ld SHAPE_32X32B, num <= 32) and
+# the codegen walks a chunk with `range(32)` + `const_expr(i < vsize)` guards,
+# so a chunk can never hold more elements than this. It CAN span more than
+# MAX_MEM_ACCESS_BYTES: a wide dtype splits its chunk into several stores.
+MAX_EPI_CHUNK_ELEMS = 32
+
 
 def _pow2_floor(x: int, cap: int = MAX_MEM_ACCESS_BYTES) -> int:
     """Largest power of 2 (<= cap) dividing ``x``; ``cap`` when ``x`` is 0 (no
@@ -175,6 +182,12 @@ def _compute_output_vec_bytes(chain: FusionChain, tile_cols: "int | None" = None
     block size; otherwise vsize = the min over every dense output's widest
     allowed store. M-major output → elem_bytes (scalar / TMA store).
 
+    The chunk is a shared ELEMENT count, not one memory access — every output
+    reads/writes the same columns but splits the chunk into its own
+    ``MAX_MEM_ACCESS_BYTES``-wide accesses (``epilogue_codegen._tap_store_elems``).
+    So a 2-byte output co-materialized with a 32-element block quant keeps the
+    32-element chunk the quant needs and stores it as 2 x 32 B.
+
     ``tile_cols`` (the per-CTA epilogue drain width in accumulator columns, when
     the tile config is known) additionally clamps the chunk so it divides every
     power-of-2 subtile span the epilogue decomposes the tile into — i.e. vsize
@@ -190,10 +203,10 @@ def _compute_output_vec_bytes(chain: FusionChain, tile_cols: "int | None" = None
             (_allowed_vsize(chain, spec.dtype, spec.dim, spec.stride) for spec in chain.output_specs if spec.dtype != "fp4_e2m1"),
             default=_allowed_vsize(chain, chain.output_dtype),
         )
-    vec_bytes = vsize * elem_bytes
+    vsize = min(vsize, MAX_EPI_CHUNK_ELEMS)
     if tile_cols is not None:
-        vec_bytes = min(vec_bytes, _pow2_floor(tile_cols * elem_bytes))
-    return vec_bytes
+        vsize = min(vsize, _pow2_floor(tile_cols, cap=MAX_EPI_CHUNK_ELEMS))
+    return vsize * elem_bytes
 
 
 def _aux_align_reqs(chain: FusionChain, vec_bytes: "int | None" = None) -> dict:

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .dtypes import DTYPE_BYTES, DTYPE_TO_CUTLASS, _output_align_reqs, allowed_store_vsize, dense_output_layout, tensor_alignment
+from .dtypes import DTYPE_BYTES, DTYPE_TO_CUTLASS, MAX_EPI_CHUNK_ELEMS, _output_align_reqs, allowed_store_vsize, dense_output_layout, tensor_alignment
 from .fusion_ir import (
     BlockQuantizeSpec,
     Dtype,
@@ -851,9 +851,13 @@ def _emit_block_quant_col(
     p = f"_q{quant_idx}"
     scale_dtype = DTYPE_TO_CUTLASS[quant.scale_dtype]
     G = 16 if quant.block_size == 16 else 32
-    if vsize % G != 0 and vsize >= G:
-        raise NotImplementedError(f"col block-quantize: store vector {vsize} must be a multiple of the {G}-lane block group (or smaller than it)")
-    n_groups = max(vsize // G, 1)
+    if vsize % G != 0:
+        raise NotImplementedError(
+            f"col block-quantize: store vector {vsize} must be a multiple of the {G}-lane "
+            f"block group — every lane stores column `col_j + lane % {G}`, so a narrower "
+            f"chunk would store scales for columns it never computed"
+        )
+    n_groups = vsize // G
     lines: list[str] = [
         f"{p}_lane = tidx % 32",
         f"{p}_src = ({source_var}).to(cutlass.Float32)",
@@ -1159,15 +1163,20 @@ def generate(
     all per-tap plumbing. ``vec_bytes_epi`` / ``output_elem_bytes`` (from the
     compiler) fix the inner-loop chunk size: each tap stores
     ``vsize = vec_bytes_epi // output_elem_bytes`` elements per chunk."""
+    vsize = vec_bytes_epi // output_elem_bytes
+    if vsize > MAX_EPI_CHUNK_ELEMS:
+        raise NotImplementedError(
+            f"epilogue chunk of {vsize} elements exceeds the {MAX_EPI_CHUNK_ELEMS}-element "
+            f"drain subtile (vec_bytes_epi={vec_bytes_epi}, output_elem_bytes={output_elem_bytes})"
+        )
     # aux_views snippet. `row` is defined by the template just before this hook
     # (M-aware: differs for MMA_M=64 vs MMA_M>=128) — we just consume it.
     aux_lines: list[str] = []
     for aux in chain.aux_tensors:
-        if aux.grouped_by_moe and aux.bcast_mode == "per_col" and (aux.stride[0] * DTYPE_BYTES[aux.dtype]) % vec_bytes_epi != 0:
+        if aux.grouped_by_moe and aux.bcast_mode == "per_col" and aux.stride[0] % vsize != 0:
             raise NotImplementedError(
-                f"per-group per-col aux {aux.name!r}: group stride "
-                f"{aux.stride[0]} x {DTYPE_BYTES[aux.dtype]} B must be a multiple of the "
-                f"epilogue vector width ({vec_bytes_epi} B) for aligned vector loads"
+                f"per-group per-col aux {aux.name!r}: group stride {aux.stride[0]} must be "
+                f"a multiple of the epilogue chunk ({vsize} elements) for aligned vector loads"
             )
         aux_lines.append(f"{_aux_ptr_var(aux.name)} = {aux.name}.iterator.raw_ptr()")
         if aux.bcast_mode == "scalar":
@@ -1243,7 +1252,6 @@ def generate(
     def _scale_tap_idx(qi: int) -> int:
         return n_dense_taps + len(chain.reductions) + qi
 
-    vsize = vec_bytes_epi // output_elem_bytes
     for si, spec in enumerate(specs):
         src = _parent_value(spec.source_ref)
         if use_tma_store and si == 0:

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -31,7 +31,7 @@ pytestmark = [pytest.mark.L0, requires_sm100]
 
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  — installs the cudnn.pygraph recorder hook
-from cudnn.gemm.frost.compiler import _current_arch
+from cudnn.gemm.frost.compiler import _current_arch, _epi_vec_bytes
 from cudnn.gemm.frost.tile_config import CATALOG
 
 # INT8 matmul runs only on SM 100 or SM 110 (disjoint range).
@@ -1392,6 +1392,86 @@ def test_dense_block_scale_quant_with_dense_tap() -> None:
     torch.testing.assert_close(tap.float(), ref_sw, atol=0, rtol=0)
     torch.testing.assert_close(q_scale.float(), scale_ref.float(), atol=0, rtol=0)
     torch.testing.assert_close(q.float(), q_ref.float(), atol=0, rtol=0)
+
+
+def test_dense_block_scale_quant_with_fp32_dense_tap() -> None:
+    """The chunk stays pinned to the quant block even when the widest dense
+    output is 4 bytes: 32 elements x 4 B = 128 B, split into four 32 B stores."""
+    cfg, cta_group, scheduler = _resolve("CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma")
+    M = N = K = 128
+    block_size = 32
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    A = g.tensor(name="A", dim=[1, M, K], stride=_a_stride_batched(M, K, "k"))
+    B = g.tensor(name="B", dim=[1, K, N], stride=_b_stride_batched(N, K, "k"))
+    C = g.matmul(A=A, B=B, name="mm")
+    C.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    Q, QS = g.block_scale_quantize(input=C, block_size=block_size, name="q")
+    Q.set_output(True).set_data_type(cudnn.data_type.FP8_E4M3)
+    QS.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+
+    compiled = _plan(g, config=cfg, cta_group=cta_group, scheduler=scheduler)
+    assert _epi_vec_bytes(compiled.chain, cfg, cta_group) == block_size * 4
+
+    a, b, _ = _mkdata(M, N, K, "bf16", "bf16")
+    tap = torch.empty(1, M, N, dtype=torch.float32, device="cuda")
+    q = torch.empty(1, M, N, dtype=torch.float8_e4m3fn, device="cuda")
+    q_scale = torch.empty(1, M, N // block_size, dtype=torch.float8_e8m0fnu, device="cuda")
+    compiled(_vp(compiled, a, b, [tap, q, q_scale]))
+    torch.cuda.synchronize()
+
+    ref = torch.einsum("bmk,bnk->bmn", a.to(torch.float32), b.to(torch.float32))
+    q_ref, scale_ref = _block_quant_reference(ref, block_size, torch.float8_e4m3fn, torch.float8_e8m0fnu)
+    torch.testing.assert_close(tap, ref, atol=0, rtol=0)
+    torch.testing.assert_close(q_scale.float(), scale_ref.float(), atol=0, rtol=0)
+    torch.testing.assert_close(q.float(), q_ref.float(), atol=0, rtol=0)
+
+
+def test_dense_col_block_scale_quant_with_dense_tap() -> None:
+    """Col quant behind a 2-byte dense tap. The chunk must stay as wide as the
+    32-lane block group: a narrower one has the upper lanes store a scale they
+    never computed, to columns past the chunk (and past the scale tensor on the
+    last chunk of a row block)."""
+    cfg, cta_group, scheduler = _resolve("CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma")
+    M, N, K, bs = 256, 128, 128, 32
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    A = g.tensor(name="A", dim=[1, M, K], stride=_a_stride_batched(M, K, "k"))
+    B = g.tensor(name="B", dim=[1, K, N], stride=_b_stride_batched(N, K, "k"))
+    C = g.matmul(A=A, B=B, name="mm")
+    S = g.swish(input=C, name="sw")
+    S.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+    Q, QS = g.block_scale_quantize(input=S, block_size=bs, axis=1, name="q")
+    Q.set_output(True).set_data_type(cudnn.data_type.FP8_E4M3)
+    QS.set_dim([1, M // bs, N]).set_stride([M // bs * N, N, 1])
+    QS.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+
+    compiled = _plan(g, config=cfg, cta_group=cta_group, scheduler=scheduler)
+    assert _epi_vec_bytes(compiled.chain, cfg, cta_group) == bs * 2
+
+    a, b, _ = _mkdata(M, N, K, "bf16", "bf16")
+    tap = torch.empty(1, M, N, dtype=torch.bfloat16, device="cuda")
+    q = torch.empty(1, M, N, dtype=torch.float8_e4m3fn, device="cuda")
+    # One guard row past the scale tensor catches an over-wide scale store.
+    n_scale = (M // bs) * N
+    scale_buf = torch.full((n_scale + N,), 0x7F, dtype=torch.uint8, device="cuda")
+    q_scale = scale_buf.view(torch.float8_e8m0fnu)[:n_scale].view(1, M // bs, N)
+    compiled(_vp(compiled, a, b, [tap, q, q_scale]))
+    torch.cuda.synchronize()
+
+    ref_mm = torch.einsum("bmk,bnk->bmn", a.to(torch.float32), b.to(torch.float32))
+    ref_sw = (ref_mm * torch.sigmoid(ref_mm)).to(torch.bfloat16).float()
+    q_ref, scale_ref = _col_quant_reference(ref_sw, bs, torch.float8_e4m3fn, torch.float8_e8m0fnu)
+    torch.testing.assert_close(tap.float(), ref_sw, atol=0, rtol=0)
+    torch.testing.assert_close(q_scale.float(), scale_ref.float(), atol=0, rtol=0)
+    torch.testing.assert_close(q.float(), q_ref.float(), atol=0, rtol=0)
+    assert (scale_buf[n_scale:] == 0x7F).all()
 
 
 def test_dense_dual_block_scale_quant() -> None:


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Fix the FROST engine quantize operation blocked by fixed vector size in epilogue

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for block-scale quantization configurations.
  * Prevented epilogue processing from exceeding supported vector widths.
  * Added safeguards against invalid scale-store alignment and oversized accesses.
  * Improved compatibility for dense outputs combined with quantized results.

* **Tests**
  * Added regression coverage for FP32 and BF16 dense-output quantization scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->