### PR TITLE
Pin apache-tvm-ffi to 0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ cutedsl = [
     "nvidia-cutlass-dsl[cu13]>=4.5.0",
     "cuda-python",
     "torch",
-    "apache-tvm-ffi>=0.1.11",
+    "apache-tvm-ffi==0.1.11",
     "torch-c-dlpack-ext",
 ]
 


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

Build, packaging, or installation

## Summary

Pin `apache-tvm-ffi` to exactly `0.1.11` in the `cutedsl` optional-dependency group:

```diff
-    "apache-tvm-ffi>=0.1.11",
+    "apache-tvm-ffi==0.1.11",
```

One line in `pyproject.toml`; no code changes.

## Why

The constraint was `>=0.1.11`, so a fresh `pip install ".[cutedsl]"` currently pulls **0.1.13.post2** (the latest release). Pinning exactly means the OSS CuTeDSL kernels build and run against a known-good FFI version instead of whatever happens to be newest at install time.

This is consistent with how the `dev` dependency group already pins its toolchain (`black==26.3.1`, `clang-format==21.1.6`).

## Related issues

None.

## API and compatibility impact

**This is an effective downgrade for new installs** — from 0.1.13.post2 to 0.1.11 — so it is a behavioural change, not a no-op. Existing environments that already have a newer `apache-tvm-ffi` will be downgraded on their next install of the `cutedsl` extra.

An exact pin also means any dependency that requires a newer `apache-tvm-ffi` will now conflict rather than resolve. If the intent is only to establish a floor plus a compatibility ceiling, `>=0.1.11,<0.2` would be less restrictive — happy to switch if that is preferred.

No public API, GPU, cuDNN, or CUDA version impact.

## Testing

- `pyproject.toml` parses and the extra resolves as expected:
  `['nvidia-cutlass-dsl[cu13]>=4.5.0', 'cuda-python', 'torch', 'apache-tvm-ffi==0.1.11', 'torch-c-dlpack-ext']`
- Confirmed the pinned version is installable: `pip install --dry-run --no-deps "apache-tvm-ffi==0.1.11"` → `Would install apache-tvm-ffi-0.1.11`.
- `apache-tvm-ffi` appears in exactly one place in the repo, so no other manifest, CI file, or doc needed updating.

The CuTeDSL kernels were not exercised against the pinned version here — that needs a GPU runner.
