### PR TITLE
remove-occupancy-nvrtc-dependency

### DIFF
--- a/python/cudnn/frost/device.py
+++ b/python/cudnn/frost/device.py
@@ -105,6 +105,13 @@ def compute_capability(device: int) -> tuple[int, int]:
 
 
 @functools.lru_cache(maxsize=None)
+def multiprocessor_count(device: int) -> int:
+    drv = _driver()
+    handle = _device_handle(device)
+    return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, handle)))
+
+
+@functools.lru_cache(maxsize=None)
 def shared_memory_per_block_optin(device: int) -> int:
     drv = _driver()
     handle = _device_handle(device)

--- a/python/cudnn/frost/occupancy.py
+++ b/python/cudnn/frost/occupancy.py
@@ -5,19 +5,35 @@
 
 from __future__ import annotations
 
-from .device import compute_capability, device_context, device_name, is_available, resolve_device, shared_memory_per_block_optin
+from .device import compute_capability, device_context, device_name, is_available, multiprocessor_count, resolve_device, shared_memory_per_block_optin
 
 MAX_CLUSTER_SIZE = 16
+
+MIN_CLUSTER_CAPABILITY = (9, 0)
 
 # {device index: table}. Per device — the count depends on the GPU's SM/GPC
 # geometry, so a process driving two different models needs two tables.
 _OCCUPANCY_MAPS: dict[int, list[int]] = {}
 
-_PROBE_SRC = b"""
-extern "C" __global__ void frost_occupancy_probe(float *out) {
-    extern __shared__ char smem[];
-    smem[threadIdx.x] = (char)threadIdx.x;
-    if (out != nullptr) out[0] = (float)smem[0];
+
+_PROBE_PTX = b"""
+.version 7.8
+.target sm_90
+.address_size 64
+
+.extern .shared .align 16 .b8 frost_probe_smem[];
+
+.visible .entry frost_occupancy_probe(
+    .param .u64 frost_occupancy_probe_param_0
+)
+{
+    .reg .b32 %r<4>;
+
+    mov.u32      %r1, %tid.x;
+    mov.u32      %r2, frost_probe_smem;
+    add.s32      %r3, %r2, %r1;
+    st.shared.u8 [%r3], %r1;
+    ret;
 }
 """
 
@@ -26,7 +42,6 @@ def _build_occupancy_map(device: int) -> list[int]:
     """Query sizes 1..:data:`MAX_CLUSTER_SIZE` against a proxy kernel pinned to
     1 CTA/SM (dynamic SMEM = the device's full opt-in budget)."""
     import cuda.bindings.driver as drv
-    import cuda.bindings.nvrtc as nvrtc
 
     def _ck(err, *rest):
         if int(err) != 0:
@@ -35,22 +50,17 @@ def _build_occupancy_map(device: int) -> list[int]:
 
     if not is_available():
         raise RuntimeError("cudnn.frost.occupancy: no CUDA device visible")
-    major, minor = compute_capability(device)
+    if compute_capability(device) < MIN_CLUSTER_CAPABILITY:
+        # No clusters below sm_90: a size-1 "cluster" is a CTA, one per SM under
+        # the same full-opt-in-SMEM pinning the probe uses, and nothing wider is
+        # launchable — the zeros are what max_active_clusters rejects on.
+        return [multiprocessor_count(device)] + [0] * (MAX_CLUSTER_SIZE - 1)
     smem_bytes = shared_memory_per_block_optin(device)
-
-    prog = _ck(*nvrtc.nvrtcCreateProgram(_PROBE_SRC, b"frost_occupancy_probe.cu", 0, [], []))
-    try:
-        opts = [f"--gpu-architecture=compute_{major}{minor}".encode()]
-        _ck(*nvrtc.nvrtcCompileProgram(prog, len(opts), opts), None)
-        ptx = b" " * _ck(*nvrtc.nvrtcGetPTXSize(prog))
-        _ck(*nvrtc.nvrtcGetPTX(prog, ptx), None)
-    finally:
-        nvrtc.nvrtcDestroyProgram(prog)
 
     # The driver calls below answer for the CURRENT context, so the query has to
     # run on `device` — importing a FROST engine deliberately creates none.
     with device_context(device):
-        mod = _ck(*drv.cuModuleLoadData(ptx))
+        mod = _ck(*drv.cuModuleLoadData(_PROBE_PTX))
         try:
             fn = _ck(*drv.cuModuleGetFunction(mod, b"frost_occupancy_probe"))
             _ck(*drv.cuFuncSetAttribute(fn, drv.CUfunction_attribute.CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, smem_bytes), None)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Remove nvrtc dependency when calculating the occupancy map, to fix the ci issue

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved GPU occupancy detection for newer SM90-class devices by using precompiled resources, reducing runtime compilation overhead.
  * Added cached detection of each device’s multiprocessor count for faster repeated queries.

* **Compatibility**
  * Added reliable fallback occupancy behavior for older GPU architectures, including support for single-cluster workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->