### PR TITLE
frost(sdpa): filter arch-specific tests correctly to fix sm120 pipeline failures

### DIFF
--- a/test/python/gemm/frost/conftest.py
+++ b/test/python/gemm/frost/conftest.py
@@ -33,3 +33,20 @@ def _frost_opt_in(monkeypatch):
     the same pytest process, quietly turning a default-path run into an opt-in
     one."""
     monkeypatch.setenv("CUDNN_FRONTEND_ENABLE_FROST_ENGINES", "1")
+
+
+@pytest.fixture
+def _pretend_sm100(monkeypatch):
+    """Supply the SM100 target profile used while rendering or compiling."""
+    from cudnn.gemm.frost import compiler
+
+    monkeypatch.setattr(compiler, "_current_arch", lambda: 100)
+
+
+@pytest.fixture
+def _pretend_sm103(monkeypatch):
+    """Supply the SM103 target profile used while rendering or compiling."""
+    from cudnn.gemm.frost import compiler, tile_config
+
+    monkeypatch.setattr(compiler, "_current_arch", lambda: 103)
+    monkeypatch.setattr(tile_config, "_sm_smem_budget_bytes", lambda device=None: 227 * 1024)

--- a/test/python/gemm/frost/test_block_scale_matmul.py
+++ b/test/python/gemm/frost/test_block_scale_matmul.py
@@ -1213,7 +1213,7 @@ def test_mxfp8_m_major_a_n_major_b(config_name, M, N, K):
     torch.testing.assert_close(c[0], ref, atol=2e-1, rtol=2e-2)
 
 
-def test_fp4_rejects_non_k_major():
+def test_fp4_rejects_non_k_major(_pretend_sm100):
     """FP4 must be K-major — sub-byte packing mis-strides an M/N-major
     descriptor, so the compiler rejects it at JIT time."""
     M = N = K = 256
@@ -1249,11 +1249,6 @@ requires_sm103 = pytest.mark.skipif(
 
 def _sm103_kw(config_name, cta_group=1):
     return dict(config=by_name(config_name), cta_group=cta_group, scheduler="clc")
-
-
-@pytest.fixture
-def _pretend_sm103(monkeypatch):
-    monkeypatch.setattr(C, "_current_arch", lambda: 103)
 
 
 # Config catalog / geometry guards
@@ -1409,7 +1404,7 @@ def _const(src, name):
     return eval(line.split(" = ", 1)[1])
 
 
-def test_render_nvfp4_k_walk_tables():
+def test_render_nvfp4_k_walk_tables(_pretend_sm103):
     src = _render("nvfp4", _CFG_128)
     compile(src, "generated_kernel.py", "exec")
     assert "cudnn_frost_sm103_block_scale_matmul_1ctamma_128x128x384_128x128x48_cluster1x1" in src
@@ -1438,7 +1433,7 @@ def test_render_nvfp4_k_walk_tables():
     assert _const(src, "sf_k") == 48
 
 
-def test_render_mxfp4_k_walk_tables():
+def test_render_mxfp4_k_walk_tables(_pretend_sm103):
     src = _render("mxfp4", _CFG_128)
     compile(src, "generated_kernel.py", "exec")
     # mxfp4: 3 SF bytes per MMA — the sf_id cycles all four byte offsets.
@@ -1451,7 +1446,7 @@ def test_render_mxfp4_k_walk_tables():
     assert _const(src, "sf_atoms_per_group") == 3
 
 
-def test_render_n256_interleaves_sfb_blocks():
+def test_render_n256_interleaves_sfb_blocks(_pretend_sm103):
     src = _render("nvfp4", _CFG_256)
     compile(src, "generated_kernel.py", "exec")
     # Two 128-col SFB blocks interleave at word granularity: the MMA walk
@@ -1641,7 +1636,7 @@ def test_sm103_block_scale_matmul_clusters(cluster, M, N):
 
 
 @pytest.mark.parametrize("M,N", [(64, 4096), (4096, 64), (128, 128), (4096, 4096)])
-def test_auto_config_is_accepted_by_the_registry(M, N):
+def test_auto_config_is_accepted_by_the_registry(_pretend_sm100, M, N):
     """``select_config`` is a second decision path that does not consult the
     registry funnel, so its pick can be one the funnel rejects — the graph then
     fails to build and falls back to native cuDNN with only an INFO log. Block

--- a/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_block_scale_matmul_fwd.py
@@ -738,7 +738,7 @@ def test_e2e_nonpacked_tensors(combo, config_name, cta_group, mode) -> None:
 
 
 @pytest.mark.parametrize("S,N", [(64, 4096), (4096, 64), (4096, 4096)])
-def test_auto_config_is_accepted_by_the_registry(S, N):
+def test_auto_config_is_accepted_by_the_registry(_pretend_sm100, S, N):
     """Same invariant as the dense block-scale case: the grouped path shares the
     BlockScaleSpec machinery, so its 128-multiple tile constraint applies too and
     ``select_config`` must not pick a geometry the registry rejects."""

--- a/test/python/gemm/frost/test_multi_gemm.py
+++ b/test/python/gemm/frost/test_multi_gemm.py
@@ -24,6 +24,8 @@ from cudnn.gemm.frost.tile_config import CATALOG, DEFAULT_CONFIG, by_name
 
 pytestmark = pytest.mark.L0
 
+_GPU = requires_sm100
+
 
 def _graph(io=cudnn.data_type.BFLOAT16):
     return cudnn.pygraph(
@@ -174,6 +176,7 @@ _N256_C2_CFG = next(
 )
 
 
+@_GPU
 def test_multi_gemm_2ctamma_compiles() -> None:
     """The 2-CTA-MMA CLC template (cluster2x1) compiles a dual-GEMM graph."""
     M, N, K = 256, 256, 128
@@ -207,8 +210,6 @@ def test_multi_gemm_mainloop_template_rejected() -> None:
 
 
 # --- End-to-end correctness (GPU) ---
-
-_GPU = requires_sm100
 
 
 def _rand(M, N, K, scale=1.0):

--- a/test/python/linear_attention/frost/test_gdn_bprop_kernel.py
+++ b/test/python/linear_attention/frost/test_gdn_bprop_kernel.py
@@ -363,6 +363,7 @@ def test_bprop_kernel_zero_length_sequence(num_q_heads, num_k_heads, num_v_heads
 # ---------------------------------------------------------------------------
 
 
+@requires_runtime
 def test_frost_gdn_bwd_engine_no_h(seq_lens=(128, 256), H=2, D=128):
     """GDN_BWD without the h input: the engine reruns the forward with H
     dumping and must match the explicit-h path bit for bit."""


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- CI or test infrastructure

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

Filter architecture-specific tests correctly to fix SM120 pipeline failures.

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

Currently some tests are intended to run in an SM100 environment (either real or mocked), but are currently executed in the SM120 pipeline and fail as a result. This PR filters out those cases accordingly.

## Related issues

Related to https://github.com/NVIDIA/cudnn-frontend/issues/381

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

N/A.

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->

```
pytest \
    gemm/frost \
    sdpa/frost \
    linear_attention/frost \
    test_mhas_v2.py \
    -n 4 \
    --tb=short

========= 1507 passed, 8341 skipped, 413 warnings in 222.41s (0:03:42) =========
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved GPU architecture coverage by standardizing simulated SM100 and SM103 test environments.
  * Updated matrix multiplication and grouped matrix multiplication tests to use shared architecture fixtures.
  * Restricted specialized compilation and backward-engine tests to environments with the required GPU and runtime support.
  * Consolidated GPU availability checks for dual-GEMM tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->