### PR TITLE
Full causal-mask support for FROST SM120 SDPA backward engine

### DIFF
--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -236,20 +236,6 @@ class SdpaBwdDslSm120(SdpaBwdDsl):
             self.causal_bottom_right and not self.is_causal,
             "causal_bottom_right requires is_causal=True",
         )
-        # The kernel's diagonal is bottom-right (FA2). Top-left causal is
-        # identical when S_q == S_kv, which is what the engine gates on.
-        self._value_error_if(
-            self.is_causal and not self.causal_bottom_right and s_q != s_kv,
-            "top-left causal with S_q != S_kv is not supported (the kernel diagonal is bottom-right)",
-        )
-        # Bottom-right causal with S_q > S_kv produces fully-masked query
-        # rows whose forward stats are -inf; the backward exp2 replay is not
-        # specified for those rows. Conservatively rejected (engine gates on
-        # this too).
-        self._value_error_if(
-            self.is_causal and s_q > s_kv,
-            "causal with S_q > S_kv is not supported (fully-masked query rows)",
-        )
 
         self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
         self.compute_capability = torch.cuda.get_device_capability(self.q_desc.device)
@@ -284,6 +270,7 @@ class SdpaBwdDslSm120(SdpaBwdDsl):
         params = Sm120TemplateParams(
             dtype_qkv=_SM120_DTYPE_QKV_CODE[self.dtype],
             is_causal=self.is_causal,
+            causal_top_left=self.is_causal and not self.causal_bottom_right,
             q_tile=self.q_tile,
             kv_tile=self.kv_tile,
         )

--- a/python/cudnn/sdpa/bwd/config_sm120.py
+++ b/python/cudnn/sdpa/bwd/config_sm120.py
@@ -26,6 +26,7 @@ class TemplateParams:
 
     dtype_qkv: int = DTYPE_FP16
     is_causal: bool = False
+    causal_top_left: bool = False
     use_pdl: bool = True
     q_tile: int = 0
     kv_tile: int = 0
@@ -41,6 +42,8 @@ def validate_params(params: TemplateParams) -> None:
 
     if params.dtype_qkv not in (DTYPE_BF16, DTYPE_FP16):
         raise ValueError(f"SM120 SDPA bwd: dtype_qkv must be DTYPE_BF16 ({DTYPE_BF16}) or DTYPE_FP16 ({DTYPE_FP16}); got {params.dtype_qkv}")
+    if params.causal_top_left and not params.is_causal:
+        raise ValueError("SM120 SDPA bwd: causal_top_left requires is_causal=True")
     if params.q_tile not in (0,) + SEQ_Q_TILES:
         raise ValueError(f"SM120 SDPA bwd: q_tile must be one of {(0,) + SEQ_Q_TILES} (0 = per-head-dim default); got {params.q_tile}")
     if params.kv_tile not in (0,) + SEQ_KV_TILES:

--- a/python/cudnn/sdpa/bwd/engines.py
+++ b/python/cudnn/sdpa/bwd/engines.py
@@ -157,19 +157,8 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", requested: 
 
     if facts.bottom_right and not facts.causal:
         return "bottom-right alignment requires a causal upper bound"
-    if facts.causal:
-        # The kernel's diagonal is bottom-right-aligned (FA2 convention:
-        # masked iff k > q + S_kv - S_q). Top-left causal is identical when
-        # S_q == S_kv.
-        if facts.bottom_right and not capabilities.bottom_right:
-            return "graph uses bottom-right causal, which this engine does not support"
-        if not facts.bottom_right and facts.s_q != facts.s_kv:
-            return "top-left causal with S_q != S_kv is not supported (the kernel diagonal is bottom-right)"
-        # Bottom-right causal with S_q > S_kv produces fully-masked query
-        # rows whose forward stats are -inf; the backward exp2 replay is not
-        # specified for those rows. Conservatively rejected.
-        if facts.s_q > facts.s_kv:
-            return "causal with S_q > S_kv is not supported (fully-masked query rows)"
+    if facts.causal and facts.bottom_right and not capabilities.bottom_right:
+        return "graph uses bottom-right causal, which this engine does not support"
 
     # The kernel consumes the forward stats as a contiguous natural-log LSE
     # (fp32 (B, H_q, S_q, 1)); a strided stats view has no zero-copy reshape.

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm120.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm120.py
@@ -293,6 +293,7 @@ class SM120FusedMultiHeadAttentionFP16Backward:
         self,
         in_dtype: Type[cutlass.Numeric] = cutlass.Float16,
         is_causal: bool = False,
+        causal_top_left: bool = False,
         head_dim: int = 128,
         use_pdl: bool = True,
         q_tile: int = 0,
@@ -300,6 +301,7 @@ class SM120FusedMultiHeadAttentionFP16Backward:
     ):
         self.in_dtype = in_dtype
         self.is_causal = is_causal
+        self.causal_top_left = bool(causal_top_left)
         self.d = head_dim
         self.use_pdl = bool(use_pdl)
         self.q_tile, self.kv_tile = self.DEFAULT_TILES[head_dim]
@@ -435,10 +437,14 @@ class SM120FusedMultiHeadAttentionFP16Backward:
 
         m_block_max = (SQ + M - 1) // M
         if cutlass.const_expr(self.is_causal):
-            m_block_min = cute.math.max(kv_base + SQ - SKV, cutlass.Int32(0)) // M
+            if cutlass.const_expr(self.causal_top_left):
+                diag_off = cutlass.Int32(0)
+            else:
+                diag_off = SKV - SQ
+            m_block_min = cute.math.max(kv_base - diag_off, cutlass.Int32(0)) // M
         else:
             m_block_min = cutlass.Int32(0)
-        n_iters = m_block_max - m_block_min
+        n_iters = cute.math.max(m_block_max - m_block_min, cutlass.Int32(0))
 
         smem = cutlass.Array(io_dtype, self.smem_elems, space=cutlass.AddressSpace.smem, alignment=128)
         sQ = smem  # 2 * M * d (double buffer)
@@ -561,10 +567,14 @@ class SM120FusedMultiHeadAttentionFP16Backward:
                         )
                         if ok32 == 0:
                             val = inf
-                        lse_r[rep * 2 + hf] = val * cutlass.Float32(_LOG2E)
                     else:
                         val = (lse_ptr + lse_base + r_abs).load()
-                        lse_r[rep * 2 + hf] = val * cutlass.Float32(_LOG2E)
+                    if cutlass.const_expr(self.is_causal and not self.causal_top_left):
+                        # Fully-masked row (bottom-right, S_q > S_kv) has stats = -inf;
+                        # +inf zeroes the row's P / grads and avoids NaN propagation.
+                        if val == cutlass.Float32(float("-inf")):
+                            val = cutlass.Float32(float("inf"))
+                    lse_r[rep * 2 + hf] = val * cutlass.Float32(_LOG2E)
 
             while not prims.mbarrier_try_wait_parity(v_mbar, cutlass.Int32(0)):
                 pass
@@ -657,7 +667,8 @@ class SM120FusedMultiHeadAttentionFP16Backward:
 
                 # Mask + softmax (scores -> P, unscaled by attn_scale) and the
                 # P store to smem.
-                do_mask_causal = (m_block * M) < (kv_base + N + SQ - SKV)
+                if cutlass.const_expr(self.is_causal):
+                    do_mask_causal = (m_block * M) < (kv_base + N - diag_off)
                 neg_inf = cutlass.Float32(float("-inf"))
                 for rep in cutlass.range_constexpr(SDP_REPS):
                     for nf in cutlass.range_constexpr(SDP_NF):
@@ -673,13 +684,13 @@ class SM120FusedMultiHeadAttentionFP16Backward:
                         s3 = acc_s[off + 3]
                         if cutlass.const_expr(self.is_causal):
                             if do_mask_causal:
-                                if kv_a0 > r0 + SKV - SQ:
+                                if kv_a0 > r0 + diag_off:
                                     s0 = neg_inf
-                                if kv_a1 > r0 + SKV - SQ:
+                                if kv_a1 > r0 + diag_off:
                                     s1 = neg_inf
-                                if kv_a0 > r8 + SKV - SQ:
+                                if kv_a0 > r8 + diag_off:
                                     s2 = neg_inf
-                                if kv_a1 > r8 + SKV - SQ:
+                                if kv_a1 > r8 + diag_off:
                                     s3 = neg_inf
                         if cutlass.const_expr(PARTIAL_KV):
                             if kv_a0 >= SKV:
@@ -823,7 +834,13 @@ class SM120FusedMultiHeadAttentionFP16Backward:
                     for rep in cutlass.range_constexpr(SDP_REPS):
                         for hf in cutlass.range_constexpr(2):
                             r_loc = wm_s * 16 + rep * 16 * WM_SDP + g_lane + hf * 8
-                            lse_r[rep * 2 + hf] = (lse_ptr + lse_base + nq0 + r_loc).load() * cutlass.Float32(_LOG2E)
+                            val = (lse_ptr + lse_base + nq0 + r_loc).load()
+                            if cutlass.const_expr(self.is_causal and not self.causal_top_left):
+                                # Fully-masked row (bottom-right, S_q > S_kv) has stats = -inf;
+                                # +inf zeroes the row's P / grads and avoids NaN propagation.
+                                if val == cutlass.Float32(float("-inf")):
+                                    val = cutlass.Float32(float("inf"))
+                            lse_r[rep * 2 + hf] = val * cutlass.Float32(_LOG2E)
 
                 # dQ accumulate into the scrambled dq_accum.
                 t_r = math_tidx // 32
@@ -1188,6 +1205,7 @@ def compile(  # noqa: A001
     bwd = SM120FusedMultiHeadAttentionFP16Backward(
         in_dtype=STORAGE_DTYPE,
         is_causal=PARAMS.is_causal,
+        causal_top_left=PARAMS.causal_top_left,
         head_dim=d,
         use_pdl=PARAMS.use_pdl,
         q_tile=PARAMS.q_tile,

--- a/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_bwd_dsl_sm120.py
@@ -80,27 +80,16 @@ def _ref_bwd(
     is_causal: bool = False,
     causal_bottom_right: bool = False,
 ):
-    """FP32 autograd reference: returns (o, stats, dq, dk, dv).
+    """Reference via the canonical refs (sdpa/fp16_ref.py)."""
 
-    ``stats`` is the natural-log LSE reshaped to the graph's (B, H, S_q, 1)
-    layout — exactly what the forward pass would have produced.
-    """
+    import cudnn
+    from sdpa.fp16_ref import compute_ref, compute_ref_backward
 
-    s_q, s_kv = q.shape[2], k.shape[2]
-    q32 = q.detach().float().requires_grad_()
-    k32 = k.detach().float().requires_grad_()
-    v32 = v.detach().float().requires_grad_()
-    scores = torch.matmul(q32, k32.transpose(-1, -2)) * scale
-    if is_causal:
-        diagonal = s_kv - s_q if causal_bottom_right else 0
-        mask = torch.ones(s_q, s_kv, device="cuda", dtype=torch.bool).tril(diagonal=diagonal)
-        scores = scores.masked_fill(~mask, float("-inf"))
-    stats = torch.logsumexp(scores, dim=-1, keepdim=True).contiguous()  # (B, H, S_q, 1)
-    p32 = torch.softmax(scores, dim=-1)
-    o32 = torch.matmul(p32, v32)
-    o32.backward(do.float())
-    o = o32.detach().to(q.dtype)
-    return o, stats, q32.grad.to(q.dtype), k32.grad.to(q.dtype), v32.grad.to(q.dtype)
+    diag_align = cudnn.diagonal_alignment.BOTTOM_RIGHT if causal_bottom_right else cudnn.diagonal_alignment.TOP_LEFT
+    right_bound = 0 if is_causal else None
+    o_ref, stats_ref, _, _ = compute_ref(q, k, v, attn_scale=scale, diag_align=diag_align, right_bound=right_bound, torch_type=q.dtype)
+    dq, dk, dv, _, _ = compute_ref_backward(q, k, v, o_ref, do, attn_scale=scale, diag_align=diag_align, right_bound=right_bound, torch_type=q.dtype)
+    return o_ref.to(q.dtype), stats_ref.contiguous(), dq.to(q.dtype), dk.to(q.dtype), dv.to(q.dtype)
 
 
 def _expected_workspace_bytes(batch: int, heads: int, s_q: int, head_dim: int) -> int:
@@ -288,17 +277,64 @@ def test_sdpa_bwd_dsl_sm120_cross_seqlen_causal_br():
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("is_causal", [False, True], ids=["dense", "causal_br"])
+@pytest.mark.parametrize(("s_q", "s_kv"), [(1024, 384), (193, 64)], ids=["sq_gt_skv", "sq_gt_skv_tails"])
+@torch_fork_set_rng(seed=6)
+def test_sdpa_bwd_dsl_sm120_causal_br_sq_gt_skv(s_q: int, s_kv: int):
+    """Bottom-right causal with S_q > S_kv"""
+
+    _require_dsl()
+    import cudnn
+
+    # Bottom right causal mask does not support max_s_q > max_s_kv in graph api.
+    try:
+        _run_case(s_q=s_q, s_kv=s_kv, head_dim=64, is_causal=True, causal_bottom_right=True)
+        return
+    except cudnn.cudnnGraphNotSupportedError as exc:
+        assert "max_s_q > max_s_kv" in str(exc), f"unexpected graph rejection: {exc}"
+
+    from cudnn.sdpa.bwd.api_dsl import sdpa_bwd_wrapper_dsl_sm120
+
+    batch, heads, head_dim, dtype = 2, 4, 64, torch.float16
+    scale = 1.0 / math.sqrt(head_dim)
+    q = _bhsd(batch, heads, s_q, head_dim, dtype)
+    k = _bhsd(batch, heads, s_kv, head_dim, dtype)
+    v = _bhsd(batch, heads, s_kv, head_dim, dtype)
+    do = _bhsd(batch, heads, s_q, head_dim, dtype)
+    o, stats, dq_ref, dk_ref, dv_ref = _ref_bwd(q, k, v, do, scale=scale, is_causal=True, causal_bottom_right=True)
+    o = _bhsd(batch, heads, s_q, head_dim, dtype, empty=True).copy_(o)
+    out = sdpa_bwd_wrapper_dsl_sm120(q, k, v, o, do, stats, is_causal=True, causal_bottom_right=True, scale_softmax=scale)
+    tol = _tolerances(dtype)
+    torch.testing.assert_close(out["dq_tensor"].float(), dq_ref.float(), **tol)
+    torch.testing.assert_close(out["dk_tensor"].float(), dk_ref.float(), **tol)
+    torch.testing.assert_close(out["dv_tensor"].float(), dv_ref.float(), **tol)
+    assert out["dq_tensor"][:, :, : s_q - s_kv, :].abs().max().item() == 0.0, "fully-masked rows must have exactly zero dQ"
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("s_q", "s_kv"),
+    [(384, 1024), (1024, 384), (64, 512)],
+    ids=["sq_lt_skv", "sq_gt_skv", "empty_kv_tiles"],
+)
+@torch_fork_set_rng(seed=3)
+def test_sdpa_bwd_dsl_sm120_cross_seqlen_causal_top_left(s_q: int, s_kv: int):
+    """Top-left causal with S_q != S_kv."""
+
+    _run_case(s_q=s_q, s_kv=s_kv, head_dim=64, is_causal=True)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mask", ["dense", "causal_br", "causal_tl"])
 @torch_fork_set_rng(seed=4)
-def test_sdpa_bwd_dsl_sm120_sequence_tails(is_causal: bool):
+def test_sdpa_bwd_dsl_sm120_sequence_tails(mask: str):
     """Non-tile-multiple sequence tails exercise the partial-Q/KV predicates."""
 
     _run_case(
         s_q=193,
         s_kv=257,
         head_dim=128,
-        is_causal=is_causal,
-        causal_bottom_right=is_causal,
+        is_causal=mask != "dense",
+        causal_bottom_right=mask == "causal_br",
     )
 
 

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -846,10 +846,9 @@ def test_bwd_probe_rejects_unsupported_head_dim(monkeypatch):
 
 def test_bwd_probe_causal_notches(monkeypatch):
     monkeypatch.setattr(ga, "_device_cc", lambda: (12, 0))
-    # Top-left causal requires S_q == S_kv (the kernel diagonal is bottom-right).
-    assert not _bwd_eligible(_mk_bwd_graph(s_q=S // 2, use_causal_mask=True))
-    # Causal with S_q > S_kv has fully-masked query rows (stats = -inf).
-    assert not _bwd_eligible(_mk_bwd_graph(s_q=2 * S, use_causal_mask_bottom_right=True))
+    assert _BWD_ENGINE in _bwd_eligible(_mk_bwd_graph(s_q=S // 2, use_causal_mask=True))
+    assert _BWD_ENGINE in _bwd_eligible(_mk_bwd_graph(s_q=2 * S, use_causal_mask=True))
+    assert _BWD_ENGINE in _bwd_eligible(_mk_bwd_graph(s_q=2 * S, use_causal_mask_bottom_right=True))
     # Sliding window is not supported.
     assert not _bwd_eligible(_mk_bwd_graph(use_causal_mask=True, sliding_window_length=64))
 
@@ -904,8 +903,8 @@ def test_bwd_mismatch_reason_strings(monkeypatch):
     assert reason is not None and "GQA" in reason
     reason = bwd_engines.mismatch(caps, _facts(_mk_bwd_graph(d=96)))
     assert reason is not None and "96" in reason
-    reason = bwd_engines.mismatch(caps, _facts(_mk_bwd_graph(s_q=S // 2, use_causal_mask=True)))
-    assert reason is not None and "top-left" in reason
+    reason = bwd_engines.mismatch(caps, _facts(_mk_bwd_graph(use_causal_mask=True, sliding_window_length=64)))
+    assert reason is not None and "sliding window" in reason
     reason = bwd_engines.mismatch(caps, _facts(_mk_bwd_graph(use_deterministic_algorithm=True)))
     assert reason is not None and "deterministic" in reason
     reason = bwd_engines.mismatch(caps, _facts(_mk_bwd_graph()), engines.SdpaFwdKnobs(tile_m=64))


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area
- FE OSS kernels or CuTeDSL
<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

- Add top left causal mask
- Bottom-right with S_q > S_kv
- Reuse reference functions in `sm120_sdpa_bwd/test/python/sdpa/fp16_ref.py`

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->
#381 

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->
```
pytest test/python/sdpa/frost/test_sdpa_graph_analyzer.py -q -n 4
66 passed, 8 warnings in 5.23s

pytest test/python/sdpa/frost/test_sdpa_bwd_dsl_sm120.py -q -n 4
20 passed, 27 warnings in 12.76s

CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1 pytest test/python/sdpa/frost -q -n 4
118 passed, 318 skipped, 100 warnings in 28.11s

CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1 pytest "test/python/test_mhas_v2.py::test_sdpa_random_bwd_L0" -q -n 4
=========================================== FROST routing =============================================
graphs on FROST engines: 134/554 (24.2%) -- transition goal is all-FROST
  frost:sdpa_fwd_prefill_sm120: 134
  native:fp16-bwd: 176
  native:fp16-fwd: 244
176 passed, 208 skipped, 309 warnings in 88.75s (0:01:28)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for top-left causal attention with differing query and key/value sequence lengths.
  * Expanded support for bottom-right causal attention when query sequences exceed key/value sequences.
  * Added configuration for selecting causal diagonal alignment.

* **Bug Fixes**
  * Prevented invalid gradient propagation for fully masked query rows.
  * Improved handling of sequence tails and causal masking across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->