### PR TITLE
AOT kernel export/import for cuDNN frontend graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,13 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# AOT sample build output
+samples/aot*/flow2_import_execute
+samples/aot*/bench_cpu_costs
+samples/aot*/*.so
+samples/aot*/*.o
+samples/aot*/*.cubin
+samples/aot*/*.cudnn
+samples/aot*/*.cudnn.*
+samples/aot/bench_sdpa_cpu_costs

--- a/include/cudnn_frontend/experimental/cutedsl_engine_interface.h
+++ b/include/cudnn_frontend/experimental/cutedsl_engine_interface.h
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+// Payload description and abstract engine for AOT-exported CuTeDSL-family
+// kernels. Deliberately free of any tvm-ffi dependency: graph_interface.h and
+// plans.h include this header, so cuDNN FE core must stay buildable without
+// the tvm-ffi headers on the include path. The concrete engine that actually
+// loads a module and calls into it lives in cutedsl_ffi_engine.h, which is
+// pulled in only by kernel_library.h (the opt-in AOT surface).
+
+#include "../graph_helpers.h"
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace cudnn_frontend {
+namespace experimental {
+
+// One positional argument of the exported kernel's C entry point, in call
+// order. The graph blob knows the sorted-uid order of the variant pack; it does
+// not know the kernel's signature, which is what this describes.
+enum class CuteDslArgKind {
+    TENSOR,      // a variant-pack tensor, addressed by uid
+    WORKSPACE,   // a slice of the engine workspace at workspace_offset
+    SCALAR_I64,  // a compile-time-frozen integer baked into the artifact
+    SCALAR_F64,  // a compile-time-frozen double baked into the artifact
+    ARRAY_I64,   // a tuple of integers the kernel takes as ONE argument
+    ENV_STREAM,  // the kernel takes the tvm-ffi environment stream (no argument)
+    STREAM,      // the execution stream, passed positionally as an opaque handle
+    NONE  // an optional port the kernel was compiled without; still a positional slot
+};
+
+struct CuteDslArgSpec {
+    CuteDslArgKind kind = CuteDslArgKind::TENSOR;
+
+    int64_t uid              = -1;  // TENSOR
+    int64_t workspace_offset = 0;   // WORKSPACE
+
+    // Shape / stride / dtype as the KERNEL sees the buffer. Carried explicitly
+    // rather than read back off the graph's tensor list so that a plan-only
+    // blob (serialize_structure=false) round-trips, and so a mismatch against
+    // the graph is detectable at load instead of at launch.
+    DataType_t data_type = DataType_t::NOT_SET;
+    std::vector<int64_t> shape;
+    std::vector<int64_t> stride;
+
+    int64_t scalar_i64 = 0;
+    double scalar_f64  = 0.0;
+    std::vector<int64_t> values;  // ARRAY_I64
+
+    // Index into VariantPackTemplate::all_uids, resolved by bind_slots().
+    // Mirrors how Execution_plan_list::set_oss_slot_indices() gives the -2/-3
+    // engines O(1) access to the finished pointer array.
+    int slot = -1;
+};
+
+enum class CuteDslStepKind {
+    CALL,        // invoke an exported kernel through its tvm-ffi entry point
+    MEMSET_ZERO  // zero a workspace region, stream-ordered, before the next step
+};
+
+// One entry in the launch sequence.
+//
+// A single exported symbol is enough for a kernel that is one launch, which is
+// what the elementwise-add vehicle is. Real families are not: the FROST GDN
+// forward partitions its work on the device, builds its TMA descriptors, and
+// only then runs the chunked kernel -- three kernels plus a zeroed counter,
+// with the intermediates living in the caller's workspace. The host code that
+// sequences them is Python, and Python is exactly what an AOT artifact must not
+// need, so the sequence itself becomes part of the payload.
+//
+// Every step launches on the same stream in order, so device-side ordering is
+// the stream's and no host synchronization appears anywhere in execute().
+struct CuteDslStep {
+    CuteDslStepKind kind = CuteDslStepKind::CALL;
+
+    // CALL: resolved inside the payload's module, or -- for flow 3, where
+    // nothing was ever serialised -- in the tvm-ffi global table.
+    std::string function_name;
+    std::string global_symbol;
+    std::vector<CuteDslArgSpec> args;
+
+    // MEMSET_ZERO
+    int64_t workspace_offset = 0;
+    int64_t nbytes           = 0;
+};
+
+// Everything needed to reconstitute and call one exported kernel. Written to
+// the container under the "cutedsl_data" key, next to "cudnn_backend_data".
+struct CuteDslPayload {
+    std::string abi = "tvm-ffi";
+    int abi_version = 1;
+
+    // The linked shared object. The cubin is embedded inside it by the CuTeDSL
+    // exporter, so there is no separate device-code blob and FE never calls
+    // cuModuleLoad: the exported host shim does that on first call.
+    std::vector<uint8_t> module_bytes;
+    // Integrity, not authenticity: catches a truncated or garbled container
+    // before the bytes are handed to dlopen. FNV-1a/64 rather than a digest so
+    // FE does not grow a crypto implementation; both sides compute it the same
+    // way and the value doubles as the content-addressed cache-file name.
+    uint64_t module_hash = 0;
+
+    // Checked at load, loudly, so a wrong-arch artifact is an error and not an
+    // illegal memory access.
+    std::string sm_arch;
+
+    // dlopen'd before the module itself, so a deployment missing
+    // libcute_dsl_runtime.so gets a named error rather than an unresolved
+    // symbol abort out of the dynamic loader.
+    std::vector<std::string> runtime_deps;
+
+    int64_t engine_workspace_size = 0;
+
+    // What execute() runs, in order. A one-launch kernel is a one-element list.
+    std::vector<CuteDslStep> steps;
+};
+
+// The per-engine half of the plugin interface. One implementation per ABI; the
+// only one today is tvm-ffi (CuteDslFfiEngine).
+class ICuteDslEngine {
+   public:
+    virtual ~ICuteDslEngine() = default;
+
+    virtual int64_t
+    get_workspace_size() const = 0;
+
+    // Resolve every TENSOR arg's uid to its slot in the finished pointer array.
+    // Called once, from prepare_variant_pack_template().
+    virtual error_t
+    bind_slots(std::function<int(int64_t)> const &slot_for) = 0;
+
+    // Hot path. const, and must not mutate the engine: any number of threads
+    // may execute one graph concurrently.
+    virtual error_t
+    execute(void *const *ptrs, void *engine_workspace, cudaStream_t stream) const = 0;
+};
+
+// Constructing an engine needs the tvm-ffi headers, which core FE does not
+// include. cutedsl_ffi_engine.h installs itself here on include; a graph that
+// deserializes a cutedsl payload without that header available fails with a
+// clear message instead of dereferencing null.
+using CuteDslEngineFactory = error_t (*)(CuteDslPayload const &, std::shared_ptr<ICuteDslEngine> &);
+
+inline CuteDslEngineFactory &
+cutedsl_engine_factory() {
+    static CuteDslEngineFactory factory = nullptr;
+    return factory;
+}
+
+inline error_t
+make_cutedsl_engine(CuteDslPayload const &payload, std::shared_ptr<ICuteDslEngine> &engine) {
+    RETURN_CUDNN_FRONTEND_ERROR_IF(cutedsl_engine_factory() == nullptr,
+                                   error_code_t::GRAPH_NOT_SUPPORTED,
+                                   "This graph carries a CuTeDSL (" + payload.abi +
+                                       ") payload, but AOT support is not available in this build. Include "
+                                       "cudnn_frontend/kernel_library.h and build against the tvm-ffi headers.");
+    return cutedsl_engine_factory()(payload, engine);
+}
+
+#ifndef CUDNN_FRONTEND_SKIP_JSON_LIB
+
+NLOHMANN_JSON_SERIALIZE_ENUM(CuteDslArgKind,
+                             {
+                                 {CuteDslArgKind::TENSOR, "TENSOR"},
+                                 {CuteDslArgKind::WORKSPACE, "WORKSPACE"},
+                                 {CuteDslArgKind::SCALAR_I64, "SCALAR_I64"},
+                                 {CuteDslArgKind::SCALAR_F64, "SCALAR_F64"},
+                                 {CuteDslArgKind::ARRAY_I64, "ARRAY_I64"},
+                                 {CuteDslArgKind::ENV_STREAM, "ENV_STREAM"},
+                                 {CuteDslArgKind::STREAM, "STREAM"},
+                                 {CuteDslArgKind::NONE, "NONE"},
+                             })
+
+NLOHMANN_JSON_SERIALIZE_ENUM(CuteDslStepKind,
+                             {
+                                 {CuteDslStepKind::CALL, "CALL"},
+                                 {CuteDslStepKind::MEMSET_ZERO, "MEMSET_ZERO"},
+                             })
+
+inline void
+to_json(json &j, CuteDslArgSpec const &a) {
+    j         = json::object();
+    j["kind"] = a.kind;
+    switch (a.kind) {
+        case CuteDslArgKind::TENSOR:
+            j["uid"] = a.uid;
+            break;
+        case CuteDslArgKind::WORKSPACE:
+            j["workspace_offset"] = a.workspace_offset;
+            break;
+        case CuteDslArgKind::SCALAR_I64:
+            j["value"] = a.scalar_i64;
+            break;
+        case CuteDslArgKind::ARRAY_I64:
+            j["values"] = a.values;
+            break;
+        case CuteDslArgKind::SCALAR_F64:
+            j["value"] = a.scalar_f64;
+            break;
+        case CuteDslArgKind::ENV_STREAM:
+        case CuteDslArgKind::STREAM:
+        case CuteDslArgKind::NONE:
+            return;
+    }
+    j["data_type"] = a.data_type;
+    j["shape"]     = a.shape;
+    j["stride"]    = a.stride;
+}
+
+inline void
+from_json(json const &j, CuteDslArgSpec &a) {
+    a.kind = j.at("kind").get<CuteDslArgKind>();
+    if (a.kind == CuteDslArgKind::ENV_STREAM || a.kind == CuteDslArgKind::STREAM ||
+        a.kind == CuteDslArgKind::NONE) {
+        return;
+    }
+    if (a.kind == CuteDslArgKind::ARRAY_I64) {
+        if (j.contains("values")) a.values = j.at("values").get<std::vector<int64_t>>();
+        return;  // carries no shape/stride: it is not a buffer
+    }
+    if (j.contains("uid")) a.uid = j.at("uid").get<int64_t>();
+    if (j.contains("workspace_offset")) a.workspace_offset = j.at("workspace_offset").get<int64_t>();
+    if (a.kind == CuteDslArgKind::SCALAR_I64 && j.contains("value")) a.scalar_i64 = j.at("value").get<int64_t>();
+    if (a.kind == CuteDslArgKind::SCALAR_F64 && j.contains("value")) a.scalar_f64 = j.at("value").get<double>();
+    if (j.contains("data_type")) a.data_type = j.at("data_type").get<DataType_t>();
+    if (j.contains("shape")) a.shape = j.at("shape").get<std::vector<int64_t>>();
+    if (j.contains("stride")) a.stride = j.at("stride").get<std::vector<int64_t>>();
+}
+
+inline void
+to_json(json &j, CuteDslStep const &s) {
+    j         = json::object();
+    j["kind"] = s.kind;
+    if (s.kind == CuteDslStepKind::MEMSET_ZERO) {
+        j["workspace_offset"] = s.workspace_offset;
+        j["nbytes"]           = s.nbytes;
+        return;
+    }
+    j["function_name"] = s.function_name;
+    j["global_symbol"] = s.global_symbol;
+    j["args"]          = s.args;
+}
+
+inline void
+from_json(json const &j, CuteDslStep &s) {
+    s.kind = j.value("kind", CuteDslStepKind::CALL);
+    if (s.kind == CuteDslStepKind::MEMSET_ZERO) {
+        s.workspace_offset = j.value("workspace_offset", static_cast<int64_t>(0));
+        s.nbytes           = j.value("nbytes", static_cast<int64_t>(0));
+        return;
+    }
+    s.function_name = j.value("function_name", std::string{});
+    s.global_symbol = j.value("global_symbol", std::string{});
+    if (j.contains("args")) s.args = j.at("args").get<std::vector<CuteDslArgSpec>>();
+}
+
+inline void
+to_json(json &j, CuteDslPayload const &p) {
+    j                          = json::object();
+    j["abi"]                   = p.abi;
+    j["abi_version"]           = p.abi_version;
+    j["module"]                = json::object();
+    j["module"]["format"]      = "elf-so";
+    j["module"]["hash_algo"]   = "fnv1a64";
+    j["module"]["hash"]        = p.module_hash;
+    j["module"]["size"]        = static_cast<int64_t>(p.module_bytes.size());
+    j["module"]["bytes"]       = json::binary(p.module_bytes);
+    j["sm_arch"]               = p.sm_arch;
+    j["runtime_deps"]          = p.runtime_deps;
+    j["engine_workspace_size"] = p.engine_workspace_size;
+    j["steps"]                 = p.steps;
+}
+
+inline void
+from_json(json const &j, CuteDslPayload &p) {
+    p.abi         = j.value("abi", std::string("tvm-ffi"));
+    p.abi_version = j.value("abi_version", 1);
+    if (j.contains("module")) {
+        auto const &m = j.at("module");
+        if (m.contains("hash")) p.module_hash = m.at("hash").get<uint64_t>();
+        if (m.contains("bytes")) {
+            auto const &b = m.at("bytes");
+            if (b.is_binary()) {
+                auto const &bin = b.get_binary();
+                p.module_bytes.assign(bin.begin(), bin.end());
+            } else {
+                p.module_bytes = b.get<std::vector<uint8_t>>();
+            }
+        }
+    }
+    p.sm_arch = j.value("sm_arch", std::string{});
+    if (j.contains("runtime_deps")) p.runtime_deps = j.at("runtime_deps").get<std::vector<std::string>>();
+    p.engine_workspace_size = j.value("engine_workspace_size", static_cast<int64_t>(0));
+    if (j.contains("steps")) p.steps = j.at("steps").get<std::vector<CuteDslStep>>();
+}
+
+#endif
+
+}  // namespace experimental
+}  // namespace cudnn_frontend

--- a/include/cudnn_frontend/experimental/cutedsl_ffi_engine.h
+++ b/include/cudnn_frontend/experimental/cutedsl_ffi_engine.h
@@ -1,0 +1,622 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+// The tvm-ffi implementation of ICuteDslEngine. This is the only FE header
+// that includes the tvm-ffi headers; it is reached through kernel_library.h,
+// never through cudnn_frontend.h, so a consumer that does not use AOT keeps
+// building with no tvm-ffi on the include path.
+
+#include "cutedsl_engine_interface.h"
+
+#include <tvm/ffi/any.h>
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/extra/module.h>
+
+// <tvm/ffi/extra/c_env_api.h> is not included on purpose. It declares an
+// allocator hook whose type comes from a newer DLPack than the one cudnn-frontend
+// vendors, and whichever dlpack.h is first on the include path wins for the whole
+// translation unit. Only the stream hook is needed here, and it is a stable C ABI
+// entry point, so it is declared directly rather than dragging in a second DLPack.
+extern "C" {
+TVM_FFI_DLL int
+TVMFFIEnvSetStream(int32_t device_type, int32_t device_id, void *stream, void **opt_out_original_stream);
+}
+
+#include "../../cudnn_frontend_shim.h"
+
+#include <cuda_runtime.h>
+#include <dlfcn.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace cudnn_frontend {
+namespace experimental {
+
+namespace cutedsl_detail {
+
+inline uint64_t
+fnv1a64(void const *data, size_t n) {
+    auto const *p            = static_cast<unsigned char const *>(data);
+    uint64_t hash            = 1469598103934665603ull;
+    constexpr uint64_t prime = 1099511628211ull;
+    for (size_t i = 0; i < n; i++) {
+        hash ^= static_cast<uint64_t>(p[i]);
+        hash *= prime;
+    }
+    return hash;
+}
+
+inline std::string
+cache_dir() {
+    if (char const *env = std::getenv("CUDNN_FRONTEND_AOT_CACHE_DIR")) {
+        return std::string(env);
+    }
+    char const *tmp = std::getenv("TMPDIR");
+    return std::string(tmp ? tmp : "/tmp") + "/cudnn_fe_aot_cache";
+}
+
+// Materialise the module bytes as a file so the dynamic loader can map them.
+// Content-addressed: the same artifact loaded twice, or by two processes,
+// resolves to one file, and a partially written file is never observed under
+// its final name because the write goes to a pid-unique temporary first.
+inline error_t
+write_module_file(CuteDslPayload const &payload, std::string &out_path) {
+    std::string const dir = cache_dir();
+    // mkdir -p, one level: the parent is /tmp or a user-supplied directory.
+    ::mkdir(dir.c_str(), 0700);
+
+    char name[64];
+    std::snprintf(name, sizeof(name), "/cudnn_fe_%016llx.so", static_cast<unsigned long long>(payload.module_hash));
+    out_path = dir + name;
+
+    {
+        std::ifstream probe(out_path, std::ios::binary | std::ios::ate);
+        if (probe.good() && static_cast<size_t>(probe.tellg()) == payload.module_bytes.size()) {
+            return {error_code_t::OK, ""};
+        }
+    }
+
+    char tmp_name[96];
+    std::snprintf(tmp_name,
+                  sizeof(tmp_name),
+                  "/cudnn_fe_%016llx.so.%d.tmp",
+                  static_cast<unsigned long long>(payload.module_hash),
+                  static_cast<int>(::getpid()));
+    std::string const tmp_path = dir + tmp_name;
+
+    {
+        std::ofstream f(tmp_path, std::ios::binary | std::ios::trunc);
+        RETURN_CUDNN_FRONTEND_ERROR_IF(!f.good(),
+                                       error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                                       "Could not open " + tmp_path +
+                                           " to materialise the AOT module: " + std::strerror(errno) +
+                                           ". Set CUDNN_FRONTEND_AOT_CACHE_DIR to a writable directory.");
+        f.write(reinterpret_cast<char const *>(payload.module_bytes.data()),
+                static_cast<std::streamsize>(payload.module_bytes.size()));
+        RETURN_CUDNN_FRONTEND_ERROR_IF(!f.good(),
+                                       error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                                       "Short write materialising the AOT module to " + tmp_path);
+    }
+
+    RETURN_CUDNN_FRONTEND_ERROR_IF(::rename(tmp_path.c_str(), out_path.c_str()) != 0,
+                                   error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                                   "Could not publish the AOT module as " + out_path + ": " + std::strerror(errno));
+    return {error_code_t::OK, ""};
+}
+
+// A missing libcute_dsl_runtime.so otherwise surfaces as an unresolved-symbol
+// failure from inside dlopen of the artifact, which names the artifact and not
+// the thing that is actually absent. Load the declared dependencies first so
+// the error says what to install.
+inline error_t
+preload_runtime_deps(CuteDslPayload const &payload) {
+    for (auto const &dep : payload.runtime_deps) {
+        ::dlerror();
+        if (::dlopen(dep.c_str(), RTLD_NOW | RTLD_GLOBAL) == nullptr) {
+            char const *why = ::dlerror();
+            return {error_code_t::GRAPH_NOT_SUPPORTED,
+                    "This artifact needs the runtime dependency '" + dep +
+                        "', which could not be loaded: " + std::string(why ? why : "unknown error") +
+                        ". Install it, or put its directory on LD_LIBRARY_PATH."};
+        }
+    }
+    return {error_code_t::OK, ""};
+}
+
+// Two graphs exported from one build usually share nothing, but re-importing
+// the same container, or importing one that holds several graphs against the
+// same module, should dlopen once.
+inline error_t
+load_module_cached(CuteDslPayload const &payload, std::optional<tvm::ffi::Module> &out) {
+    static std::mutex mu;
+    static std::map<uint64_t, tvm::ffi::Module> cache;
+
+    std::lock_guard<std::mutex> lk(mu);
+    auto it = cache.find(payload.module_hash);
+    if (it != cache.end()) {
+        out = it->second;
+        return {error_code_t::OK, ""};
+    }
+
+    CHECK_CUDNN_FRONTEND_ERROR(preload_runtime_deps(payload));
+
+    std::string path;
+    CHECK_CUDNN_FRONTEND_ERROR(write_module_file(payload, path));
+
+    // tvm-ffi reports failure by throwing; FE never lets an exception escape.
+    try {
+        tvm::ffi::Module module = tvm::ffi::Module::LoadFromFile(path);
+        cache.emplace(payload.module_hash, module);
+        out = std::move(module);
+    } catch (std::exception const &e) {
+        return {error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                "Failed to load the AOT module written to " + path + ": " + e.what()};
+    }
+    return {error_code_t::OK, ""};
+}
+
+inline error_t
+to_dl_data_type(DataType_t dt, DLDataType &out) {
+    out.lanes = 1;
+    switch (dt) {
+        case DataType_t::FLOAT:
+            out.code = kDLFloat, out.bits = 32;
+            break;
+        case DataType_t::DOUBLE:
+            out.code = kDLFloat, out.bits = 64;
+            break;
+        case DataType_t::HALF:
+            out.code = kDLFloat, out.bits = 16;
+            break;
+        case DataType_t::BFLOAT16:
+            out.code = kDLBfloat, out.bits = 16;
+            break;
+        case DataType_t::INT8:
+            out.code = kDLInt, out.bits = 8;
+            break;
+        case DataType_t::INT32:
+            out.code = kDLInt, out.bits = 32;
+            break;
+        case DataType_t::INT64:
+            out.code = kDLInt, out.bits = 64;
+            break;
+        case DataType_t::UINT8:
+            out.code = kDLUInt, out.bits = 8;
+            break;
+        case DataType_t::BOOLEAN:
+        case DataType_t::BYTE_BOOLEAN:
+            out.code = kDLBool, out.bits = 8;
+            break;
+        case DataType_t::FP8_E4M3:
+            out.code = kDLFloat8_e4m3fn, out.bits = 8;
+            break;
+        case DataType_t::FP8_E5M2:
+            out.code = kDLFloat8_e5m2, out.bits = 8;
+            break;
+        default:
+            return {error_code_t::GRAPH_NOT_SUPPORTED,
+                    "No DLPack encoding for cuDNN data type " + std::to_string(static_cast<int>(dt)) +
+                        " in a CuTeDSL argument"};
+    }
+    return {error_code_t::OK, ""};
+}
+
+}  // namespace cutedsl_detail
+
+// Calls an AOT-exported CuTeDSL kernel through its tvm-ffi entry point.
+//
+// Everything that can be prepared once is prepared at load: the module is
+// dlopen'd, every step's function is resolved, and one DLTensor per tensor
+// argument is built with its shape/stride storage owned by this object. The hot
+// path copies that array to the stack, patches the data pointers out of FE's
+// finished pointer array, and calls. Nothing on the engine is mutated, so
+// concurrent execute() of one graph is safe.
+//
+// A payload with a launch sequence (see CuteDslStep) runs its steps in order on
+// one stream. All of them come out of the same module, so a sequence costs the
+// same single dlopen as a one-launch kernel.
+class CuteDslFfiEngine : public ICuteDslEngine {
+   public:
+    static error_t
+    create(CuteDslPayload const &payload, std::shared_ptr<ICuteDslEngine> &out) {
+        auto engine = std::shared_ptr<CuteDslFfiEngine>(new CuteDslFfiEngine());
+        CHECK_CUDNN_FRONTEND_ERROR(engine->initialize(payload));
+        out = std::move(engine);
+        return {error_code_t::OK, ""};
+    }
+
+    int64_t
+    get_workspace_size() const override {
+        return payload_.engine_workspace_size;
+    }
+
+    error_t
+    bind_slots(std::function<int(int64_t)> const &slot_for) override {
+        for (auto &step : steps_) {
+            for (size_t i = 0; i < step.args.size(); i++) {
+                if (step.args[i].kind != CuteDslArgKind::TENSOR) continue;
+                int const slot = slot_for(step.args[i].uid);
+                RETURN_CUDNN_FRONTEND_ERROR_IF(
+                    slot < 0,
+                    error_code_t::INVALID_VARIANT_PACK,
+                    "CuTeDSL step '" + step.label + "' argument " + std::to_string(i) + " refers to uid " +
+                        std::to_string(step.args[i].uid) +
+                        ", which is not part of this graph's variant pack. The artifact does not match the graph.");
+                step.args[i].slot = slot;
+            }
+        }
+        slots_bound_ = true;
+        return {error_code_t::OK, ""};
+    }
+
+    error_t
+    execute(void *const *ptrs, void *engine_workspace, cudaStream_t stream) const override {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(!slots_bound_,
+                                       error_code_t::GRAPH_EXECUTION_FAILED,
+                                       "CuTeDSL argument slots are not bound; prepare_variant_pack_template() must "
+                                       "run before execute().");
+
+        // Steps that take the stream as an explicit argument do not need this,
+        // but a payload may mix both conventions, and it is one thread-local
+        // store per execute() rather than per step. Thread-local, so setting it
+        // does not disturb another thread executing another graph; restored so
+        // we do not leak our stream into whatever the caller does next.
+        void *original   = nullptr;
+        int const set_rc = TVMFFIEnvSetStream(kDLCUDA, device_ordinal_, static_cast<void *>(stream), &original);
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            set_rc != 0, error_code_t::GRAPH_EXECUTION_FAILED, "TVMFFIEnvSetStream failed for the CuTeDSL engine");
+
+        error_t status = {error_code_t::OK, ""};
+        for (auto const &step : steps_) {
+            status = run_step(step, ptrs, engine_workspace, stream);
+            if (status.is_bad()) break;
+        }
+
+        TVMFFIEnvSetStream(kDLCUDA, device_ordinal_, original, nullptr);
+        return status;
+    }
+
+   private:
+    CuteDslFfiEngine() = default;
+
+    // One step of the launch sequence, with everything resolvable resolved.
+    struct BoundStep {
+        CuteDslStepKind kind = CuteDslStepKind::CALL;
+        std::string label;  // for diagnostics: the symbol, or "memset"
+
+        std::optional<tvm::ffi::Function> function;
+        std::vector<CuteDslArgSpec> args;
+        std::vector<DLTensor> prototypes;
+        std::vector<std::vector<int64_t>> shape_storage;
+        std::vector<std::vector<int64_t>> stride_storage;
+        // ARRAY_I64 arguments, built ONCE here rather than per call: the values
+        // are frozen into the artifact, and allocating a container on every
+        // launch would put host cost back into the path this exists to keep cheap.
+        std::vector<tvm::ffi::Array<int64_t>> arrays;
+
+        int64_t workspace_offset = 0;
+        int64_t nbytes           = 0;
+    };
+
+    error_t
+    run_step(BoundStep const &step, void *const *ptrs, void *engine_workspace, cudaStream_t stream) const {
+        if (step.kind == CuteDslStepKind::MEMSET_ZERO) {
+            // Stream-ordered: the kernel that reads this counter is the next
+            // step on the same stream, so no host synchronization is implied.
+            _CUDNN_CHECK_CUDA_ERROR(detail::cuda_mem_set_async(
+                static_cast<char *>(engine_workspace) + step.workspace_offset, 0, step.nbytes, stream));
+            return {error_code_t::OK, ""};
+        }
+
+        int const n             = static_cast<int>(step.args.size());
+        constexpr int STACK_MAX = 32;
+        DLTensor stack_tensors[STACK_MAX];
+        tvm::ffi::AnyView stack_views[STACK_MAX];
+        std::vector<DLTensor> heap_tensors;
+        std::vector<tvm::ffi::AnyView> heap_views;
+
+        DLTensor *tensors        = stack_tensors;
+        tvm::ffi::AnyView *views = stack_views;
+        if (n > STACK_MAX) {
+            heap_tensors.resize(n);
+            heap_views.resize(n);
+            tensors = heap_tensors.data();
+            views   = heap_views.data();
+        }
+
+        int n_view = 0;
+        for (int i = 0; i < n; i++) {
+            auto const &a = step.args[i];
+            switch (a.kind) {
+                case CuteDslArgKind::ENV_STREAM:
+                    continue;  // carried by the environment stream, not an argument
+                case CuteDslArgKind::STREAM:
+                    views[n_view++] = static_cast<void *>(stream);
+                    continue;
+                case CuteDslArgKind::NONE:
+                    // An optional port the kernel was compiled without. CuTeDSL
+                    // keeps it as a positional parameter typed None, so the slot
+                    // has to be filled -- with nullptr, not skipped.
+                    views[n_view++] = nullptr;
+                    continue;
+                case CuteDslArgKind::SCALAR_I64:
+                    views[n_view++] = a.scalar_i64;
+                    continue;
+                case CuteDslArgKind::SCALAR_F64:
+                    views[n_view++] = a.scalar_f64;
+                    continue;
+                case CuteDslArgKind::ARRAY_I64:
+                    // built at bind time; a tuple parameter the kernel takes whole
+                    views[n_view++] = step.arrays[i];
+                    continue;
+                case CuteDslArgKind::TENSOR:
+                    tensors[n_view]      = step.prototypes[i];
+                    tensors[n_view].data = ptrs[a.slot];
+                    views[n_view]        = &tensors[n_view];
+                    n_view++;
+                    continue;
+                case CuteDslArgKind::WORKSPACE:
+                    tensors[n_view]      = step.prototypes[i];
+                    tensors[n_view].data = static_cast<char *>(engine_workspace) + a.workspace_offset;
+                    views[n_view]        = &tensors[n_view];
+                    n_view++;
+                    continue;
+            }
+        }
+
+        try {
+            tvm::ffi::Any result;
+            step.function->CallPacked(views, n_view, &result);
+        } catch (std::exception const &e) {
+            return {error_code_t::GRAPH_EXECUTION_FAILED, "CuTeDSL kernel '" + step.label + "' failed: " + e.what()};
+        }
+        return {error_code_t::OK, ""};
+    }
+
+    error_t
+    initialize(CuteDslPayload const &payload) {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(payload.abi != "tvm-ffi",
+                                       error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                       "Unknown CuTeDSL ABI '" + payload.abi + "'; this build understands 'tvm-ffi'.");
+        RETURN_CUDNN_FRONTEND_ERROR_IF(payload.abi_version != 1,
+                                       error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                       "CuTeDSL tvm-ffi ABI version " + std::to_string(payload.abi_version) +
+                                           " is newer than this build understands (1).");
+        auto const &sequence = payload.steps;
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            sequence.empty(), error_code_t::UNSUPPORTED_GRAPH_FORMAT, "CuTeDSL payload describes no launch sequence.");
+
+        // A step resolved from the global table needs nothing on disk; any step
+        // resolved from the module means the module must be there.
+        bool needs_module = false;
+        for (auto const &step : sequence) {
+            if (step.kind != CuteDslStepKind::CALL) continue;
+            RETURN_CUDNN_FRONTEND_ERROR_IF(step.function_name.empty() && step.global_symbol.empty(),
+                                           error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                           "A CuTeDSL step names no entry point.");
+            if (step.global_symbol.empty()) needs_module = true;
+        }
+        RETURN_CUDNN_FRONTEND_ERROR_IF(needs_module && payload.module_bytes.empty(),
+                                       error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                       "CuTeDSL payload carries neither module bytes nor a global symbol.");
+
+        CHECK_CUDNN_FRONTEND_ERROR(check_target(payload));
+
+        payload_ = payload;
+
+        if (needs_module) {
+            uint64_t const actual = cutedsl_detail::fnv1a64(payload.module_bytes.data(), payload.module_bytes.size());
+            RETURN_CUDNN_FRONTEND_ERROR_IF(actual != payload.module_hash,
+                                           error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                           "The AOT module in this artifact is corrupt: content hash is " +
+                                               std::to_string(actual) + ", the container says " +
+                                               std::to_string(payload.module_hash) + ".");
+            CHECK_CUDNN_FRONTEND_ERROR(cutedsl_detail::load_module_cached(payload_, module_));
+        }
+
+        int device = 0;
+        _CUDNN_CHECK_CUDA_ERROR(detail::cuda_get_device(&device));
+        device_ordinal_ = device;
+
+        steps_.reserve(sequence.size());
+        for (auto const &step : sequence) {
+            BoundStep bound;
+            bound.kind = step.kind;
+            if (step.kind == CuteDslStepKind::MEMSET_ZERO) {
+                bound.label            = "memset";
+                bound.workspace_offset = step.workspace_offset;
+                bound.nbytes           = step.nbytes;
+                RETURN_CUDNN_FRONTEND_ERROR_IF(
+                    bound.nbytes < 0 || bound.workspace_offset < 0 ||
+                        bound.workspace_offset + bound.nbytes > payload.engine_workspace_size,
+                    error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                    "A CuTeDSL MEMSET_ZERO step falls outside the declared engine workspace.");
+                steps_.push_back(std::move(bound));
+                continue;
+            }
+
+            bound.args  = step.args;
+            bound.label = step.global_symbol.empty() ? step.function_name : step.global_symbol;
+            CHECK_CUDNN_FRONTEND_ERROR(resolve_function(step, bound));
+            CHECK_CUDNN_FRONTEND_ERROR(build_prototypes(bound));
+            steps_.push_back(std::move(bound));
+        }
+        return {error_code_t::OK, ""};
+    }
+
+    error_t
+    resolve_function(CuteDslStep const &step, BoundStep &bound) const {
+        tvm::ffi::Optional<tvm::ffi::Function> fn;
+        if (!step.global_symbol.empty()) {
+            // Flow 3: the kernel was compiled in this process and published
+            // under a name. Nothing was written out, so there is nothing to
+            // hash or dlopen.
+            try {
+                fn = tvm::ffi::Function::GetGlobal(step.global_symbol);
+            } catch (std::exception const &e) {
+                return {error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                        "Looking up '" + step.global_symbol + "' in the global function table failed: " + e.what()};
+            }
+            RETURN_CUDNN_FRONTEND_ERROR_IF(!fn.has_value(),
+                                           error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                                           "Nothing is registered under '" + step.global_symbol + "'.");
+        } else {
+            try {
+                fn = (*module_)->GetFunction(step.function_name);
+            } catch (std::exception const &e) {
+                return {error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                        "Looking up '" + step.function_name + "' in the AOT module failed: " + e.what()};
+            }
+            RETURN_CUDNN_FRONTEND_ERROR_IF(!fn.has_value(),
+                                           error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                                           "The AOT module does not export '" + step.function_name + "'.");
+        }
+        bound.function = fn.value();
+        return {error_code_t::OK, ""};
+    }
+
+    // An artifact built for another architecture must be a clean error at load.
+    // Executing it would be an illegal memory access at best.
+    error_t
+    check_target(CuteDslPayload const &payload) const {
+        if (payload.sm_arch.empty()) {
+            return {error_code_t::OK, ""};
+        }
+        int device = 0;
+        _CUDNN_CHECK_CUDA_ERROR(detail::cuda_get_device(&device));
+        cudaDeviceProp prop{};
+        _CUDNN_CHECK_CUDA_ERROR(detail::cuda_get_device_properties(&prop, device));
+
+        std::string const running = "sm_" + std::to_string(prop.major) + std::to_string(prop.minor);
+        // Artifacts are tagged sm_100a / sm_100f / sm_100; compare the numeric
+        // part and let the family suffix through.
+        std::string tagged = payload.sm_arch;
+        while (!tagged.empty() && (tagged.back() == 'a' || tagged.back() == 'f')) {
+            tagged.pop_back();
+        }
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            tagged != running,
+            error_code_t::GRAPH_NOT_SUPPORTED,
+            "This artifact was built for " + payload.sm_arch + " but this device is " + running + ".");
+        return {error_code_t::OK, ""};
+    }
+
+    error_t
+    build_prototypes(BoundStep &bound) const {
+        size_t const n = bound.args.size();
+        bound.prototypes.assign(n, DLTensor{});
+        bound.shape_storage.resize(n);
+        bound.stride_storage.resize(n);
+        bound.arrays.assign(n, tvm::ffi::Array<int64_t>{});
+
+        int n_view = 0;
+        for (size_t i = 0; i < n; i++) {
+            auto const &a = bound.args[i];
+            if (a.kind == CuteDslArgKind::ENV_STREAM) continue;
+            n_view++;
+            if (a.kind == CuteDslArgKind::ARRAY_I64) {
+                // built once, here: the values are frozen into the artifact
+                bound.arrays[i] = tvm::ffi::Array<int64_t>(a.values.begin(), a.values.end());
+                continue;
+            }
+            if (a.kind != CuteDslArgKind::TENSOR && a.kind != CuteDslArgKind::WORKSPACE) continue;
+
+            RETURN_CUDNN_FRONTEND_ERROR_IF(a.shape.size() != a.stride.size(),
+                                           error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                           "CuTeDSL step '" + bound.label + "' argument " + std::to_string(i) +
+                                               " has " + std::to_string(a.shape.size()) + " dims but " +
+                                               std::to_string(a.stride.size()) + " strides.");
+
+            bound.shape_storage[i]  = a.shape;
+            bound.stride_storage[i] = a.stride;
+
+            DLTensor &t = bound.prototypes[i];
+            t.data      = nullptr;
+            t.device    = DLDevice{kDLCUDA, device_ordinal_};
+            t.ndim      = static_cast<int32_t>(a.shape.size());
+            CHECK_CUDNN_FRONTEND_ERROR(cutedsl_detail::to_dl_data_type(a.data_type, t.dtype));
+            t.shape       = bound.shape_storage[i].data();
+            t.strides     = bound.stride_storage[i].data();
+            t.byte_offset = 0;
+        }
+        RETURN_CUDNN_FRONTEND_ERROR_IF(n_view > 2047,
+                                       error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                       "A tvm-ffi signature is limited to 2047 arguments; step '" + bound.label +
+                                           "' has " + std::to_string(n_view) + ".");
+        return {error_code_t::OK, ""};
+    }
+
+    CuteDslPayload payload_;
+
+    // ffi::Module is a non-nullable object ref, so it is held in an optional
+    // rather than default-constructed. Every step comes out of this one module,
+    // unless the payload resolves them from the global table instead.
+    std::optional<tvm::ffi::Module> module_;
+
+    std::vector<BoundStep> steps_;
+
+    int device_ordinal_ = 0;
+    bool slots_bound_   = false;
+};
+
+namespace cutedsl_detail {
+
+inline error_t
+ffi_engine_factory(CuteDslPayload const &payload, std::shared_ptr<ICuteDslEngine> &out) {
+    return CuteDslFfiEngine::create(payload, out);
+}
+
+// Installing on include is what makes the AOT surface opt-in: core FE holds a
+// null factory and says so; including kernel_library.h fills it in.
+struct FactoryInstaller {
+    FactoryInstaller() { cutedsl_engine_factory() = &ffi_engine_factory; }
+};
+
+inline FactoryInstaller const &
+install_factory() {
+    static FactoryInstaller const installer;
+    return installer;
+}
+
+namespace {
+[[maybe_unused]] auto const &cutedsl_factory_installed = install_factory();
+}
+
+}  // namespace cutedsl_detail
+
+}  // namespace experimental
+}  // namespace cudnn_frontend

--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -81,6 +81,15 @@ class Graph : public ICudnn, public INode {
     // char: 'x'=hex, 'd'=decimal, 'b'=base64
     std::vector<std::pair<std::shared_ptr<Tensor_attributes>, char>> tensors_to_dump;
 
+    // AOT: what this graph's plan actually is, when the plan is not a cuDNN
+    // backend execution plan. Empty for a classic graph.
+    std::optional<experimental::CuteDslPayload> cutedsl_payload;
+
+    // Set by deserialize(). A graph that arrived from an artifact has its plan
+    // already chosen and compiled; re-running the build lifecycle on it would
+    // either silently do nothing or corrupt the loaded state, so it is refused.
+    bool built_from_artifact = false;
+
     error_t
     collect_assigned_uid(std::shared_ptr<Tensor_attributes> const &tensor,
                          std::unordered_set<Tensor_attributes::uid_t> &used_uids,
@@ -979,8 +988,29 @@ class Graph : public ICudnn, public INode {
         return {error_code_t::OK, ""};
     }
 
+    // A graph handed back by deserialize() / import_from_disk() / get_global()
+    // already has its one plan chosen and compiled. Re-entering the build
+    // lifecycle on it would at best do nothing and at worst overwrite the
+    // loaded plan, so every build-time entry point refuses instead.
+    error_t
+    reject_if_from_artifact(char const *what) const {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            built_from_artifact,
+            error_code_t::GRAPH_NOT_SUPPORTED,
+            std::string(what) +
+                " cannot be called on a graph that was deserialized: its plan was selected and compiled when the "
+                "artifact was built, and this graph carries only that plan. Build a new graph to plan again.");
+        return {error_code_t::OK, ""};
+    }
+
+    bool
+    is_built_from_artifact() const {
+        return built_from_artifact;
+    }
+
     error_t
     validate() {
+        CHECK_CUDNN_FRONTEND_ERROR(reject_if_from_artifact("validate()"));
         CUDNN_FE_LOG_BANNER("  VALIDATING GRAPH  ");
         CHECK_CUDNN_FRONTEND_ERROR(assign_uids());
         CUDNN_FE_LOG(*this << std::endl;);
@@ -1016,6 +1046,7 @@ class Graph : public ICudnn, public INode {
 
     error_t
     build_operation_graph(cudnnHandle_t handle) {
+        CHECK_CUDNN_FRONTEND_ERROR(reject_if_from_artifact("build_operation_graph()"));
         CUDNN_FE_LOG_BANNER("  BUILD OP GRAPH  ");
 
         CUDNN_FE_LOG_BANNER("  1/4 INFER PROPERTIES OF NODES  ");
@@ -1129,6 +1160,13 @@ class Graph : public ICudnn, public INode {
             return {error_code_t::OK, ""};
         }
 
+        // AOT CuTeDSL engine workspace: whatever the artifact declared.
+        if (plan_index == graph::Execution_plan_list::CUTEDSL_ENGINE_CANDIDATE) {
+            cudnn_workspace_size = fe_workspace_size + plans.get_cutedsl_workspace_size();
+            CUDNN_FE_LOG_LABEL_ENDL("INFO: get_workspace_size() is " << cudnn_workspace_size << " (CuTeDSL engine)");
+            return {error_code_t::OK, ""};
+        }
+
         // There are two workspaces:
         // - cudnn execution plan workspace
         // - FE node workspace (example: alibiSlope for fmha)
@@ -1159,7 +1197,8 @@ class Graph : public ICudnn, public INode {
 
         // OSS engines are not backed by cuDNN execution plans, so their workspace stays frontend-owned.
         if (plan_index == graph::Execution_plan_list::OSS_SDPA_ENGINE_CANDIDATE ||
-            plan_index == graph::Execution_plan_list::OSS_RMS_NORM_SILU_ENGINE_CANDIDATE) {
+            plan_index == graph::Execution_plan_list::OSS_RMS_NORM_SILU_ENGINE_CANDIDATE ||
+            plan_index == graph::Execution_plan_list::CUTEDSL_ENGINE_CANDIDATE) {
             return get_workspace_size_plan_at_index(plan_index, cudnn_workspace_size);
         }
 
@@ -1547,6 +1586,18 @@ class Graph : public ICudnn, public INode {
             return {error_code_t::OK, ""};
         }
 
+        // AOT CuTeDSL-family engine: the artifact is the plan.
+        if (plan_index == graph::Execution_plan_list::CUTEDSL_ENGINE_CANDIDATE) {
+            RETURN_CUDNN_FRONTEND_ERROR_IF(!override_uids.empty(),
+                                           error_code_t::GRAPH_NOT_SUPPORTED,
+                                           "Dynamic shape overrides are not supported for an AOT CuTeDSL graph: the "
+                                           "artifact is compiled for one fully specialized shape.");
+            cudaStream_t stream = nullptr;
+            _CUDNN_CHECK_CUDNN_ERROR(detail::get_stream(handle, &stream));
+            CHECK_CUDNN_FRONTEND_ERROR(plans.execute_cutedsl_engine(ptrs, engine_workspace, stream));
+            return {error_code_t::OK, ""};
+        }
+
         // Backend path
         if (override_uids.empty()) {
             CHECK_CUDNN_FRONTEND_ERROR(detail::execute(
@@ -1673,27 +1724,73 @@ class Graph : public ICudnn, public INode {
      */
     error_t
     serialize(std::vector<uint8_t> &data, bool serialize_structure = true) const {
-        CUDNN_FE_LOG_BANNER(" SERIALIZE PLAN  ");
 #ifndef CUDNN_FRONTEND_SKIP_JSON_LIB
-        CHECK_CUDNN_FRONTEND_ERROR(assign_uids());
         json j;
+        CHECK_CUDNN_FRONTEND_ERROR(serialize_plan(j, serialize_structure));
+        data = json::to_ubjson(j);
+        return {error_code_t::OK, ""};
+#else
+        CUDNN_FRONTEND_UNUSED(data);
+        CUDNN_FRONTEND_UNUSED(serialize_structure);
+        return {error_code_t::GRAPH_NOT_SUPPORTED, "unavailable when compiled with CUDNN_FRONTEND_SKIP_JSON_LIB"};
+#endif
+    }
+
+#ifndef CUDNN_FRONTEND_SKIP_JSON_LIB
+    /**
+     * @brief serialize() without the final UBJSON encoding.
+     *
+     * The multi-graph container nests one of these per name, so it must not pay
+     * for a byte encoding per graph and a decode per graph on the way back.
+     */
+    error_t
+    serialize_plan(json &j, bool serialize_structure = true) const {
+        CUDNN_FE_LOG_BANNER(" SERIALIZE PLAN  ");
+        CHECK_CUDNN_FRONTEND_ERROR(assign_uids());
+        j                 = json::object();
         j["json_version"] = GRAPH_JSON_VERSION;
         // Optionally serialize the graph structure (nodes/tensors).
         if (serialize_structure) {
             serialize(j);
         }
 
-        auto const candidate = plans.candidate;
-        auto execution_plan  = plans.execution_plans[candidate];
-        if (execution_plan != nullptr) {
-            auto serialized_plan    = execution_plan->getJsonRepresentation();
-            j["cudnn_backend_data"] = serialized_plan;
-            j["variant_pack_uids"]  = variant_pack_uids;
-        }
+        // The uid order the variant pack is addressed in. Needed by every
+        // engine, so it is written unconditionally; it used to be nested under
+        // the backend-plan branch, where an engine with no cuDNN execution plan
+        // could never reach it.
+        j["variant_pack_uids"] = variant_pack_uids;
 
-        std::vector<BehaviorNote_t> selected_behavior_notes;
-        CHECK_CUDNN_FRONTEND_ERROR(plans.get_behavior_notes_at_index(candidate, selected_behavior_notes));
-        j["behavior_notes"] = std::vector<std::vector<BehaviorNote_t>>{std::move(selected_behavior_notes)};
+        // The name is the kernel's identity for AOT lookup, so it has to
+        // survive a plan-only round trip too. The structural blob writes it
+        // under "context", which the plan deserialize path never reads.
+        j["kernel_name"] = context.get_name();
+
+        auto const candidate = plans.candidate;
+
+        if (cutedsl_payload.has_value()) {
+            // A CuTeDSL graph carries its own artifact instead of a cuDNN plan.
+            // The two keys are siblings and mutually exclusive; engine_kind is
+            // what the loader branches on.
+            j["engine_kind"]    = "cutedsl";
+            j["cutedsl_data"]   = cutedsl_payload.value();
+            j["behavior_notes"] = std::vector<std::vector<BehaviorNote_t>>{{}};
+        } else {
+            RETURN_CUDNN_FRONTEND_ERROR_IF(
+                candidate < 0 || candidate >= static_cast<int64_t>(plans.execution_plans.size()),
+                error_code_t::GRAPH_NOT_SUPPORTED,
+                "This graph's selected plan (" + std::to_string(candidate) +
+                    ") is not a cuDNN backend execution plan and carries no exportable payload. Only the CuTeDSL "
+                    "family engine supports AOT export today.");
+            auto execution_plan = plans.execution_plans[candidate];
+            if (execution_plan != nullptr) {
+                auto serialized_plan    = execution_plan->getJsonRepresentation();
+                j["cudnn_backend_data"] = serialized_plan;
+            }
+
+            std::vector<BehaviorNote_t> selected_behavior_notes;
+            CHECK_CUDNN_FRONTEND_ERROR(plans.get_behavior_notes_at_index(candidate, selected_behavior_notes));
+            j["behavior_notes"] = std::vector<std::vector<BehaviorNote_t>>{std::move(selected_behavior_notes)};
+        }
 
         std::unordered_map<uid_t, pass_by_values_t> tensor_to_pass_by_value;
         // Pass-by-value data lives in the cached member restored on deserialize.
@@ -1743,15 +1840,10 @@ class Graph : public ICudnn, public INode {
         }
         j["tensors_to_dump"] = tensors_to_dump_uids;
 
-        data = json::to_ubjson(j);
         CUDNN_FE_LOG_BANNER(" SERIALIZE PLAN (ALL OK) ");
         return {error_code_t::OK, ""};
-#else
-        CUDNN_FRONTEND_UNUSED(data);
-        CUDNN_FRONTEND_UNUSED(serialize_structure);
-        return {error_code_t::GRAPH_NOT_SUPPORTED, "unavailable when compiled with CUDNN_FRONTEND_SKIP_JSON_LIB"};
-#endif
     }
+#endif
 
     /**
      * @brief Deserialize an execution plan from a serialized byte blob.
@@ -1867,16 +1959,41 @@ class Graph : public ICudnn, public INode {
             }
         }
 
-        RETURN_CUDNN_FRONTEND_ERROR_IF(
-            enforce_precompiled && !j.contains("cudnn_backend_data"),
-            error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
-            "enforce_precompiled requested, but serialized graph has no precompiled execution plan");
+        if (j.contains("kernel_name") && j["kernel_name"].is_string()) {
+            context.set_name(j["kernel_name"].get<std::string>());
+        }
 
-        auto serialized_plan = j["cudnn_backend_data"];
-        if (device_prop != nullptr) {
-            CHECK_CUDNN_FRONTEND_ERROR(plans.build_plans(device_prop, serialized_plan));
+        std::string const engine_kind = j.value("engine_kind", std::string("cudnn_backend"));
+        bool const is_cutedsl         = (engine_kind == "cutedsl");
+
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            engine_kind != "cudnn_backend" && !is_cutedsl,
+            error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+            "This artifact was produced by engine '" + engine_kind + "', which this build does not know how to load.");
+
+        if (is_cutedsl) {
+            // The artifact IS the plan: no cuDNN execution plan to rebuild, and
+            // nothing for the backend to be asked about.
+            RETURN_CUDNN_FRONTEND_ERROR_IF(!j.contains("cutedsl_data"),
+                                           error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                           "Artifact declares engine_kind 'cutedsl' but carries no cutedsl_data.");
+            experimental::CuteDslPayload payload = j["cutedsl_data"].get<experimental::CuteDslPayload>();
+            std::shared_ptr<experimental::ICuteDslEngine> engine;
+            CHECK_CUDNN_FRONTEND_ERROR(experimental::make_cutedsl_engine(payload, engine));
+            cutedsl_payload = std::move(payload);
+            plans.set_cutedsl_engine(std::move(engine));
         } else {
-            CHECK_CUDNN_FRONTEND_ERROR(plans.build_plans(handle, serialized_plan));
+            RETURN_CUDNN_FRONTEND_ERROR_IF(
+                enforce_precompiled && !j.contains("cudnn_backend_data"),
+                error_code_t::GRAPH_EXECUTION_PLAN_CREATION_FAILED,
+                "enforce_precompiled requested, but serialized graph has no precompiled execution plan");
+
+            auto serialized_plan = j["cudnn_backend_data"];
+            if (device_prop != nullptr) {
+                CHECK_CUDNN_FRONTEND_ERROR(plans.build_plans(device_prop, serialized_plan));
+            } else {
+                CHECK_CUDNN_FRONTEND_ERROR(plans.build_plans(handle, serialized_plan));
+            }
         }
 
         plans.behavior_notes = j["behavior_notes"].get<std::vector<std::vector<BehaviorNote_t>>>();
@@ -1934,9 +2051,13 @@ class Graph : public ICudnn, public INode {
             }
         }
 
-        if (run_warmup && handle != nullptr) {
+        // warmup() fake-captures a cudnnBackendExecute; there is no backend plan
+        // on the CuTeDSL path, and the artifact needs no warming.
+        if (run_warmup && handle != nullptr && !is_cutedsl) {
             CHECK_CUDNN_FRONTEND_ERROR(warmup(handle));
         }
+
+        built_from_artifact = true;
 
         CUDNN_FE_LOG_BANNER(" DESERIALIZE PLAN (ALL OK) ");
 
@@ -1974,6 +2095,78 @@ class Graph : public ICudnn, public INode {
     set_name(std::string const &name) {
         context.set_name(name);
         return *this;
+    }
+
+    std::string
+    get_name() const {
+        return context.get_name();
+    }
+
+    // Attach the artifact this graph's chosen plan lowered to. Called on the
+    // build box, by the engine that produced it, before serialize(). Does not
+    // load anything: exporting must work without a device able to run the
+    // kernel.
+    error_t
+    set_cutedsl_payload(experimental::CuteDslPayload payload) {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(payload.steps.empty(),
+                                       error_code_t::INVALID_VALUE,
+                                       "A CuTeDSL payload must name at least one entry point.");
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            payload.module_bytes.empty(), error_code_t::INVALID_VALUE, "A CuTeDSL payload must carry module bytes.");
+        cutedsl_payload = std::move(payload);
+        return {error_code_t::OK, ""};
+    }
+
+    // Declare the variant pack directly, with no cuDNN operation graph behind
+    // it.
+    //
+    // The elementwise-add vehicle is also a valid cuDNN graph, so its uid set
+    // falls out of the ordinary lowering. A Python-engine family need not be:
+    // the FROST linear-attention kernels have no backend lowering at all, and
+    // build_operation_graph() on one of them fails with "no cuDNN backend
+    // lowering" rather than producing a uid set. For those the engine is the
+    // only thing that knows which buffers the kernel wants, so it says so here.
+    //
+    // Everything downstream -- serialize_plan(), the variant-pack template,
+    // execute() -- reads variant_pack_uids and does not care where it came
+    // from, which is why this is a setter and not a second code path.
+    error_t
+    declare_variant_pack(std::vector<uid_t> const &uids) {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            uids.empty(), error_code_t::INVALID_VALUE, "A declared variant pack must name at least one tensor.");
+        variant_pack_uids.clear();
+        variant_pack_uids.insert(uids.begin(), uids.end());
+        varpack_prep_state->prepared.store(false, std::memory_order_release);
+        varpack_template = {};
+        return {error_code_t::OK, ""};
+    }
+
+    bool
+    has_cutedsl_payload() const {
+        return cutedsl_payload.has_value();
+    }
+
+    // Attach the payload AND make it executable now, without a round trip
+    // through a container. This is what register_global() uses: the kernel is
+    // already compiled and resident, so the only thing missing is the binding
+    // between its arguments and this graph's variant pack.
+    error_t
+    activate_cutedsl_payload(experimental::CuteDslPayload payload) {
+        std::shared_ptr<experimental::ICuteDslEngine> engine;
+        CHECK_CUDNN_FRONTEND_ERROR(experimental::make_cutedsl_engine(payload, engine));
+        cutedsl_payload = std::move(payload);
+        plans.set_cutedsl_engine(std::move(engine));
+
+        // The template may already have been prepared against the previous
+        // candidate; rebuild it so the engine's slots get bound.
+        varpack_prep_state->prepared.store(false, std::memory_order_release);
+        varpack_template = {};
+        CHECK_CUDNN_FRONTEND_ERROR(prepare_variant_pack_template());
+
+        // From here this graph carries one fixed compiled plan, exactly like a
+        // graph that came off disk.
+        built_from_artifact = true;
+        return {error_code_t::OK, ""};
     }
 
     error_t
@@ -2241,6 +2434,7 @@ class Graph : public ICudnn, public INode {
     // overload for deviceless AoT compilation
     error_t
     check_support() {
+        CHECK_CUDNN_FRONTEND_ERROR(reject_if_from_artifact("check_support()"));
         // Check OSS engine first if registered
 
         CHECK_CUDNN_FRONTEND_ERROR(context.populate_sm_version_from_device());
@@ -2428,6 +2622,12 @@ class Graph : public ICudnn, public INode {
         // Apply OSS slot indices before the release-store so a reader that
         // observes prepared=true also sees the slot writes.
         apply_oss_slot_indices_to_plans();
+        CHECK_CUDNN_FRONTEND_ERROR(plans.bind_cutedsl_slot_indices([this](int64_t uid) -> int {
+            for (size_t i = 0; i < varpack_template.all_uids.size(); ++i) {
+                if (varpack_template.all_uids[i] == uid) return static_cast<int>(i);
+            }
+            return -1;
+        }));
         varpack_prep_state->prepared.store(true, std::memory_order_release);
 
         return {error_code_t::OK, ""};
@@ -2931,6 +3131,7 @@ Graph::get_knobs_for_engine(int64_t const engine, std::vector<Knob> &knobs) {
 
 inline error_t
 Graph::create_execution_plans(std::vector<HeurMode_t> const &mode) {
+    CHECK_CUDNN_FRONTEND_ERROR(reject_if_from_artifact("create_execution_plans()"));
     CUDNN_FE_LOG_BANNER("  CREATE EXECUTION PLANS  (HEURISTICS QUERY)  ");
 
     // CHECK IF NEED TO OVERRIDE HEURISTICS QUERY
@@ -3026,12 +3227,14 @@ Graph::create_execution_plan(int64_t const engine_id, std::unordered_map<KnobTyp
 
 inline error_t
 Graph::build_plan_at_index(int64_t plan_index) {
+    CHECK_CUDNN_FRONTEND_ERROR(reject_if_from_artifact("build_plan_at_index()"));
     CHECK_CUDNN_FRONTEND_ERROR(plans.build_plan_at_index(plan_index));
     return {error_code_t::OK, ""};
 }
 
 inline error_t
 Graph::build_plans(BuildPlanPolicy_t const policy, bool const do_multithreaded_builds) {
+    CHECK_CUDNN_FRONTEND_ERROR(reject_if_from_artifact("build_plans()"));
 #ifndef CUDNN_FRONTEND_SKIP_JSON_LIB
     CUDNN_FE_LOG_BANNER("  BUILD PLANS  for policy " << nlohmann::json(policy).dump() << "  ");
 #else

--- a/include/cudnn_frontend/kernel_library.h
+++ b/include/cudnn_frontend/kernel_library.h
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+// The AOT surface: export a set of built graphs to one container, import them
+// back by name, or publish them into the process-global table.
+//
+// This header is NOT included by cudnn_frontend.h. Including it is what opts a
+// translation unit into the tvm-ffi dependency; a consumer that never exports
+// or imports an artifact needs none of it.
+//
+//     cudnn_frontend::KernelLibrary lib;
+//     CHECK(cudnn_frontend::import_from_disk("mykernels.cudnn", &lib));
+//     cudnn_frontend::graph::Graph graph_ln;
+//     CHECK(lib.get("ln_fwd_bf16", &graph_ln));
+//     CHECK(graph_ln.execute(handle, ptrs.data(), (int)ptrs.size(), workspace));
+
+#include "../cudnn_frontend.h"
+#include "experimental/cutedsl_ffi_engine.h"
+
+#include <fstream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace cudnn_frontend {
+
+// Re-exported so callers say cudnn_frontend::CuteDslPayload.
+using experimental::CuteDslArgKind;
+using experimental::CuteDslArgSpec;
+using experimental::CuteDslPayload;
+
+// Bumped when the container layout changes in a way an older reader cannot
+// cope with. The per-graph blobs carry their own json_version independently.
+static constexpr int KERNEL_LIBRARY_CONTAINER_VERSION = 1;
+
+/**
+ * @brief A set of AOT kernels, addressed by name.
+ *
+ * Lookup is by name and never by position, so adding a kernel to a container
+ * cannot change what an existing caller resolves.
+ */
+class KernelLibrary {
+   public:
+    /**
+     * @brief Fetch the graph published under @p name.
+     *
+     * @param name Name given to set_name() when the graph was exported.
+     * @param out  Receives a graph that is ready to execute. A snapshot: it
+     *             keeps a reference to the compiled kernel it was fetched with.
+     * @return error_t OK, or an error naming the keys that do exist.
+     */
+    error_t
+    get(std::string const &name, graph::Graph *out) const {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(out == nullptr, error_code_t::INVALID_VALUE, "get() needs an out graph.");
+        auto it = graphs_.find(name);
+        if (it == graphs_.end()) {
+            std::string known;
+            for (auto const &[k, v] : graphs_) {
+                (void)v;
+                known += (known.empty() ? "" : ", ") + k;
+            }
+            return {
+                error_code_t::INVALID_VALUE,
+                "No kernel named '" + name + "' in this library. It holds: " + (known.empty() ? "(nothing)" : known)};
+        }
+        *out = *it->second;
+        return {error_code_t::OK, ""};
+    }
+
+    std::vector<std::string>
+    keys() const {
+        std::vector<std::string> names;
+        names.reserve(graphs_.size());
+        for (auto const &[k, v] : graphs_) {
+            (void)v;
+            names.push_back(k);
+        }
+        return names;
+    }
+
+    size_t
+    size() const {
+        return graphs_.size();
+    }
+
+    // Populated by import_from_disk(); public so the Python bindings can hand
+    // the same shared graphs out without a second copy.
+    std::map<std::string, std::shared_ptr<graph::Graph>> graphs_;
+};
+
+#ifndef CUDNN_FRONTEND_SKIP_JSON_LIB
+
+namespace detail {
+
+inline error_t
+build_container(std::vector<std::shared_ptr<graph::Graph>> const &graphs, json &container) {
+    RETURN_CUDNN_FRONTEND_ERROR_IF(
+        graphs.empty(), error_code_t::INVALID_VALUE, "export_to_disk() needs at least one graph.");
+
+    container                      = json::object();
+    container["container_version"] = KERNEL_LIBRARY_CONTAINER_VERSION;
+    container["fe_version"]        = std::to_string(CUDNN_FRONTEND_MAJOR_VERSION) + "." +
+                              std::to_string(CUDNN_FRONTEND_MINOR_VERSION) + "." +
+                              std::to_string(CUDNN_FRONTEND_PATCH_VERSION);
+    container["cudnn_backend_version"] = static_cast<int64_t>(detail::get_backend_version());
+    container["graphs"]                = json::object();
+
+    for (auto const &g : graphs) {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(g == nullptr, error_code_t::INVALID_VALUE, "export_to_disk() got a null graph.");
+        std::string const name = g->get_name();
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            name.empty(),
+            error_code_t::INVALID_VALUE,
+            "Every graph must be named with set_name() before export: the name is the lookup key.");
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            container["graphs"].contains(name),
+            error_code_t::INVALID_VALUE,
+            "Two graphs in this call are both named '" + name + "'; names must be unique within one container.");
+
+        json graph_json;
+        CHECK_CUDNN_FRONTEND_ERROR(g->serialize_plan(graph_json));
+        container["graphs"][name] = std::move(graph_json);
+    }
+    return {error_code_t::OK, ""};
+}
+
+inline error_t
+load_container(json const &container, cudnnHandle_t handle, KernelLibrary &lib) {
+    RETURN_CUDNN_FRONTEND_ERROR_IF(!container.contains("container_version"),
+                                   error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                   "This file is not a cuDNN kernel library (no container_version).");
+    int const version = container["container_version"].get<int>();
+    RETURN_CUDNN_FRONTEND_ERROR_IF(version > KERNEL_LIBRARY_CONTAINER_VERSION,
+                                   error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                   "This container is version " + std::to_string(version) +
+                                       ", newer than this build understands (" +
+                                       std::to_string(KERNEL_LIBRARY_CONTAINER_VERSION) + ").");
+    RETURN_CUDNN_FRONTEND_ERROR_IF(!container.contains("graphs") || !container["graphs"].is_object(),
+                                   error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                                   "Container has no graphs section.");
+
+    for (auto it = container["graphs"].begin(); it != container["graphs"].end(); ++it) {
+        auto g = std::make_shared<graph::Graph>();
+        // Every mismatch a graph can have — json version, engine kind,
+        // architecture, missing runtime dependency, corrupt module — is raised
+        // here, before anything is executable.
+        auto status = g->deserialize(handle, it.value(), false, false);
+        if (status.is_bad()) {
+            return {status.get_code(), "Loading kernel '" + it.key() + "': " + status.get_message()};
+        }
+        lib.graphs_[it.key()] = std::move(g);
+    }
+    return {error_code_t::OK, ""};
+}
+
+}  // namespace detail
+
+/**
+ * @brief Pack a set of built graphs into one container file.
+ *
+ * The whole set goes in and one container comes out; adding a kernel later
+ * means calling this again with the full set.
+ */
+inline error_t
+export_to_disk(std::vector<std::shared_ptr<graph::Graph>> const &graphs, std::string const &path) {
+    json container;
+    CHECK_CUDNN_FRONTEND_ERROR(detail::build_container(graphs, container));
+
+    std::vector<uint8_t> const data = json::to_ubjson(container);
+
+    // Written to a sibling temporary and renamed, so a reader never sees a
+    // half-written container under the real name.
+    std::string const tmp_path = path + ".tmp";
+    {
+        std::ofstream f(tmp_path, std::ios::binary | std::ios::trunc);
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            !f.good(), error_code_t::INVALID_VALUE, "Could not open " + tmp_path + " for writing.");
+        f.write(reinterpret_cast<char const *>(data.data()), static_cast<std::streamsize>(data.size()));
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            !f.good(), error_code_t::INVALID_VALUE, "Short write producing " + tmp_path + ".");
+    }
+    RETURN_CUDNN_FRONTEND_ERROR_IF(std::rename(tmp_path.c_str(), path.c_str()) != 0,
+                                   error_code_t::INVALID_VALUE,
+                                   "Could not publish the container as " + path + ".");
+    return {error_code_t::OK, ""};
+}
+
+/**
+ * @brief Read a container back. Every graph in it is executable on return.
+ *
+ * @param path   Container written by export_to_disk().
+ * @param lib    Receives the name -> graph mapping.
+ * @param handle Only used by graphs whose plan is a cuDNN backend plan; a
+ *               container of CuTeDSL kernels loads without one.
+ */
+inline error_t
+import_from_disk(std::string const &path, KernelLibrary *lib, cudnnHandle_t handle = nullptr) {
+    RETURN_CUDNN_FRONTEND_ERROR_IF(lib == nullptr, error_code_t::INVALID_VALUE, "import_from_disk() needs a library.");
+
+    std::ifstream f(path, std::ios::binary | std::ios::ate);
+    RETURN_CUDNN_FRONTEND_ERROR_IF(!f.good(), error_code_t::INVALID_VALUE, "Could not open " + path + " for reading.");
+    std::streamsize const size = f.tellg();
+    f.seekg(0, std::ios::beg);
+    std::vector<uint8_t> data(static_cast<size_t>(size));
+    RETURN_CUDNN_FRONTEND_ERROR_IF(!f.read(reinterpret_cast<char *>(data.data()), size),
+                                   error_code_t::INVALID_VALUE,
+                                   "Short read loading " + path + ".");
+
+    json container;
+    try {
+        container = json::from_ubjson(data);
+    } catch (std::exception const &e) {
+        return {error_code_t::UNSUPPORTED_GRAPH_FORMAT,
+                "Could not parse " + path + " as a cuDNN kernel library: " + e.what()};
+    }
+    return detail::load_container(container, handle, *lib);
+}
+
+#endif  // CUDNN_FRONTEND_SKIP_JSON_LIB
+
+// ---------------------------------------------------------------------------
+// Flow 3: publish into the process, no file.
+//
+// A kernel compiled mid-run — by an autotuner, or a dynamic specialisation — is
+// immediately reachable from the C++ executor under a name. The registry owns a
+// reference, so the compiled object cannot be collected out from under a live
+// handle. On the wire the tvm-ffi name is "cudnn.<name>"; that prefix is applied
+// and stripped here and never appears in user code.
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+struct GlobalRegistry {
+    std::mutex mu;
+    std::map<std::string, std::shared_ptr<graph::Graph>> graphs;
+};
+
+// The registry must be ONE instance per process, not one per shared object.
+// Flow 3's whole point is that a kernel registered from Python is reachable
+// from a C++ extension in the same process -- and that extension is a separate
+// .so. cuDNN FE's own python module is built with -fvisibility=hidden, which
+// would give each .so a private copy of this function-local static and leave
+// the extension looking at an empty registry. Marking it default-visibility
+// makes the dynamic linker bind every DSO to the first definition loaded.
+#if defined(_WIN32)
+// Windows has no equivalent interposition: each DLL would still get its own
+// copy, so flow 3 across DLL boundaries needs the registry to live in one
+// owning DLL with dllexport/dllimport. Not needed for this proof of concept.
+#define CUDNN_FRONTEND_SHARED_ACROSS_DSO
+#else
+#define CUDNN_FRONTEND_SHARED_ACROSS_DSO __attribute__((visibility("default")))
+#endif
+
+CUDNN_FRONTEND_SHARED_ACROSS_DSO inline GlobalRegistry &
+global_registry() {
+    static GlobalRegistry registry;
+    return registry;
+}
+
+}  // namespace detail
+
+// The one place the wire prefix is spelled.
+inline std::string
+global_symbol_for(std::string const &name) {
+    return "cudnn." + name;
+}
+
+/**
+ * @brief Publish a built graph under its set_name() name.
+ *
+ * @param graph    The graph. The registry keeps a reference to it.
+ * @param override Replace an existing registration instead of failing. Callers
+ *                 holding a handle from get_global() must re-fetch afterwards.
+ */
+inline error_t
+register_global(std::shared_ptr<graph::Graph> const &graph, bool override = false) {
+    RETURN_CUDNN_FRONTEND_ERROR_IF(graph == nullptr, error_code_t::INVALID_VALUE, "register_global() needs a graph.");
+    std::string const name = graph->get_name();
+    RETURN_CUDNN_FRONTEND_ERROR_IF(
+        name.empty(),
+        error_code_t::INVALID_VALUE,
+        "register_global() needs a name: call set_name() first, it is the lookup key in both AOT flows.");
+
+    auto &registry = detail::global_registry();
+    std::lock_guard<std::mutex> lk(registry.mu);
+    RETURN_CUDNN_FRONTEND_ERROR_IF(!override && registry.graphs.count(name) != 0,
+                                   error_code_t::INVALID_VALUE,
+                                   "'" + name + "' is already registered. Pass override=true to replace it.");
+    registry.graphs[name] = graph;
+    return {error_code_t::OK, ""};
+}
+
+/**
+ * @brief Fetch a graph published by register_global().
+ *
+ * The result is a snapshot: after an override=true re-registration, an existing
+ * handle keeps running the kernel it was fetched with, and a caller that wants
+ * the new one must call get_global() again.
+ */
+inline error_t
+get_global(std::string const &name, graph::Graph *out) {
+    RETURN_CUDNN_FRONTEND_ERROR_IF(out == nullptr, error_code_t::INVALID_VALUE, "get_global() needs an out graph.");
+    auto &registry = detail::global_registry();
+    std::lock_guard<std::mutex> lk(registry.mu);
+    auto it = registry.graphs.find(name);
+    if (it == registry.graphs.end()) {
+        std::string known;
+        for (auto const &[k, v] : registry.graphs) {
+            (void)v;
+            known += (known.empty() ? "" : ", ") + k;
+        }
+        return {error_code_t::INVALID_VALUE,
+                "Nothing is registered under '" + name + "'. Registered: " + (known.empty() ? "(nothing)" : known)};
+    }
+    *out = *it->second;
+    return {error_code_t::OK, ""};
+}
+
+/// @brief Drop a registration. Snapshots already handed out keep working.
+inline error_t
+unregister_global(std::string const &name) {
+    auto &registry = detail::global_registry();
+    std::lock_guard<std::mutex> lk(registry.mu);
+    RETURN_CUDNN_FRONTEND_ERROR_IF(
+        registry.graphs.erase(name) == 0, error_code_t::INVALID_VALUE, "Nothing is registered under '" + name + "'.");
+    return {error_code_t::OK, ""};
+}
+
+inline std::vector<std::string>
+registered_global_names() {
+    auto &registry = detail::global_registry();
+    std::lock_guard<std::mutex> lk(registry.mu);
+    std::vector<std::string> names;
+    names.reserve(registry.graphs.size());
+    for (auto const &[k, v] : registry.graphs) {
+        (void)v;
+        names.push_back(k);
+    }
+    return names;
+}
+
+}  // namespace cudnn_frontend

--- a/include/cudnn_frontend/plans.h
+++ b/include/cudnn_frontend/plans.h
@@ -21,6 +21,7 @@
 #include "experimental/sm90_sdpa_prefill_engine.h"
 #include "experimental/sm100_sdpa_prefill_engine.h"
 #include "experimental/sm100_rms_norm_silu_engine.h"
+#include "experimental/cutedsl_engine_interface.h"
 
 namespace cudnn_frontend {
 
@@ -820,6 +821,13 @@ class Execution_plan_list {
             return {error_code_t::OK, ""};
         }
 
+        // AOT CuTeDSL engine path
+        if (index == CUTEDSL_ENGINE_CANDIDATE) {
+            RETURN_CUDNN_FRONTEND_ERROR_IF(
+                !cutedsl_engine_, error_code_t::GRAPH_EXECUTION_FAILED, "CuTeDSL engine not loaded.");
+            return {error_code_t::OK, ""};
+        }
+
         RETURN_CUDNN_FRONTEND_ERROR_IF((index < 0) || (static_cast<int64_t>(execution_plans.size()) <= index),
                                        error_code_t::GRAPH_EXECUTION_FAILED,
                                        "Plan index " + std::to_string(index) + " is invalid.");
@@ -1159,6 +1167,17 @@ class Execution_plan_list {
         }
     }
 
+    // Same hook as set_oss_slot_indices(), but the CuTeDSL engine can report a
+    // uid that is not in this graph's variant pack (an artifact/graph mismatch),
+    // so it returns a status instead of writing -1 and failing later.
+    error_t
+    bind_cutedsl_slot_indices(std::function<int(int64_t)> const& slot_for) {
+        if (!cutedsl_engine_) {
+            return {error_code_t::OK, ""};
+        }
+        return cutedsl_engine_->bind_slots(slot_for);
+    }
+
     // Flat-array overload for RmsNorm+SiLU
     error_t
     execute_oss_rms_norm_silu_engine(void* const* ptrs, void* workspace, int device, cudaStream_t stream) const {
@@ -1205,7 +1224,48 @@ class Execution_plan_list {
                                                   extra);
     }
 
+    // ================================================================
+    // AOT CuTeDSL-family engine support
+    //
+    // The fourth dispatch target. Unlike the two above, this engine is never
+    // selected by heuristics: it exists only on a graph that came back from
+    // import_from_disk() / get_global(), where the artifact IS the plan.
+    // ================================================================
+
+    static constexpr int64_t CUTEDSL_ENGINE_CANDIDATE = -4;
+
+    void
+    set_cutedsl_engine(std::shared_ptr<experimental::ICuteDslEngine> engine) {
+        cutedsl_engine_ = std::move(engine);
+        candidate       = CUTEDSL_ENGINE_CANDIDATE;
+    }
+
+    bool
+    has_cutedsl_engine() const {
+        return cutedsl_engine_ != nullptr;
+    }
+
+    bool
+    is_cutedsl_candidate() const {
+        return candidate == CUTEDSL_ENGINE_CANDIDATE;
+    }
+
+    int64_t
+    get_cutedsl_workspace_size() const {
+        if (!cutedsl_engine_) return 0;
+        return cutedsl_engine_->get_workspace_size();
+    }
+
+    error_t
+    execute_cutedsl_engine(void* const* ptrs, void* workspace, cudaStream_t stream) const {
+        RETURN_CUDNN_FRONTEND_ERROR_IF(
+            !cutedsl_engine_, error_code_t::GRAPH_EXECUTION_FAILED, "CuTeDSL engine not loaded");
+        return cutedsl_engine_->execute(ptrs, workspace, stream);
+    }
+
    private:
+    std::shared_ptr<experimental::ICuteDslEngine> cutedsl_engine_;
+
     std::shared_ptr<experimental::IOssSdpaEngine> oss_sdpa_engine_;
     bool oss_sdpa_engine_supported_ = false;
     bool oss_sdpa_engine_built_     = false;

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -98,6 +98,44 @@ target_include_directories(
 
 target_compile_definitions(_compiled_module PRIVATE NV_CUDNN_FRONTEND_USE_DYNAMIC_LOADING)
 
+# ---------------------------------------------------------------------------
+# AOT kernel export/import (cudnn.export_to_disk / import_from_disk / ...).
+#
+# Needs the tvm-ffi headers and libtvm_ffi, which arrive with the optional
+# `cutedsl` extra (apache-tvm-ffi). When the extra is absent the bindings build
+# exactly as before and the AOT entry points raise a clear "not available in
+# this build" error.
+# ---------------------------------------------------------------------------
+option(CUDNN_FRONTEND_ENABLE_AOT "Build the AOT kernel export/import entry points." ON)
+
+if(CUDNN_FRONTEND_ENABLE_AOT)
+    execute_process(
+        COMMAND ${Python_EXECUTABLE} -c
+            "import os,tvm_ffi,tvm_ffi.libinfo as l;d=os.path.dirname(tvm_ffi.__file__);print(os.path.join(d,'include'));print(os.path.join(d,'3rdparty','dlpack','include'));print(l.find_libtvm_ffi())"
+        OUTPUT_VARIABLE TVM_FFI_PATHS
+        RESULT_VARIABLE TVM_FFI_PROBE_RESULT
+        ERROR_QUIET
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(TVM_FFI_PROBE_RESULT EQUAL 0)
+        string(REPLACE "\n" ";" TVM_FFI_PATHS "${TVM_FFI_PATHS}")
+        list(GET TVM_FFI_PATHS 0 TVM_FFI_INCLUDE_DIR)
+        list(GET TVM_FFI_PATHS 1 TVM_FFI_DLPACK_INCLUDE_DIR)
+        list(GET TVM_FFI_PATHS 2 TVM_FFI_LIBRARY)
+        message(STATUS "AOT export enabled: tvm-ffi at ${TVM_FFI_LIBRARY}")
+        # SYSTEM: the tvm-ffi headers do not survive FE's -Wall -Wextra -Werror.
+        target_include_directories(
+            _compiled_module SYSTEM
+            PRIVATE ${TVM_FFI_INCLUDE_DIR}
+            PRIVATE ${TVM_FFI_DLPACK_INCLUDE_DIR}
+        )
+        target_link_libraries(_compiled_module PRIVATE ${TVM_FFI_LIBRARY})
+        target_compile_definitions(_compiled_module PRIVATE CUDNN_FRONTEND_ENABLE_AOT)
+    else()
+        message(STATUS "AOT export disabled: apache-tvm-ffi not importable (install the 'cutedsl' extra)")
+    endif()
+endif()
+
 if(CUDNN_FRONTEND_USE_SYSTEM_DLPACK)
     target_link_libraries(
         _compiled_module

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -268,6 +268,11 @@ from .nodes import Node
 
 from .graph import graph, jit, graph_cache
 
+# AOT kernel export/import. Imported eagerly (it pulls in nothing heavy; the
+# cutlass / tvm-ffi imports live inside the engine that needs them).
+from . import aot
+from .aot import export_to_disk, import_from_disk, KernelLibrary, register_global, get_global, unregister_global
+
 from typing import Any
 
 _EAGER_PUBLIC_NAMES = (

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -1757,6 +1757,13 @@ class pygraph:
                     ``set_stream`` semantics, both python engines and backend)
             override_uids/shapes/strides: dynamic-shape overrides (backend path)
         """
+        # AOT form: a flat pointer array already gathered in
+        # variant_pack_uids_sorted() order. Both AOT flows hand back a graph, so
+        # this is the one call shape a caller off an artifact uses. It returns
+        # before the build below, which an artifact has already had done for it.
+        if isinstance(tensor_dict, (list, tuple)):
+            return self.execute_ptrs(tensor_dict, workspace, handle=handle)
+
         if not self._is_built:
             # A JIT engine must compile for the device/stream it will run on, so
             # build the caller context here. Only here: a steady-state execute()
@@ -2073,6 +2080,70 @@ class pygraph:
         import json
 
         return json.dumps(self.inspect(), default=str, indent=2)
+
+    @property
+    def engine(self) -> Optional["BaseEngine"]:
+        """The python engine for the selected plan, or None for the backend path.
+        Populated after create_execution_plans()."""
+        return self.selected_engine
+
+    # =========================================================================
+    # AOT: naming, the uid order a caller needs to gather pointers, and the
+    # pointer-array execute both AOT flows hand back.
+    # =========================================================================
+
+    def set_name(self, name: str) -> "pygraph":
+        """Name this graph. Mandatory before AOT export: the name is the kernel's
+        identity and the lookup key in both AOT flows."""
+        if not name:
+            raise ValueError("set_name() needs a non-empty name")
+        self._cpp_graph_kwargs["name"] = name
+        if self._lowered_graph is not None:
+            self._lowered_graph.set_name(name)
+        return self
+
+    def get_name(self) -> str:
+        return self._cpp_graph_kwargs.get("name", "")
+
+    def variant_pack_uids_sorted(self) -> List[int]:
+        """The uids execute(ptrs, ...) expects pointers for, in order.
+
+        Resolved once at startup by an AOT caller, then used to gather a flat
+        pointer array on every call.
+        """
+        if self._lowered_graph is None:
+            raise RuntimeError("variant_pack_uids_sorted() needs a built or imported graph")
+        return list(self._lowered_graph._get_variant_pack_uids_sorted())
+
+    def execute_ptrs(self, ptrs, workspace, handle=None) -> None:
+        """Execute from a flat pointer array gathered in variant_pack_uids_sorted() order.
+
+        The hot path of both AOT flows. ``ptrs`` may hold ints or anything with
+        ``.data_ptr()``; nothing about the graph is mutated, so concurrent calls
+        on one graph are safe -- which is why the void*[] is built per call
+        rather than kept on the graph and refilled.
+        """
+        if self._lowered_graph is None:
+            raise RuntimeError("execute_ptrs() needs a built or imported graph")
+
+        def _ptr(d):
+            if type(d) is int:
+                return d
+            if hasattr(d, "data_ptr"):
+                return d.data_ptr()
+            import cudnn
+
+            return cudnn._pybind_module._get_data_ptr(d)
+
+        n = len(ptrs)
+        array = (ctypes.c_void_p * n)(*[_ptr(p) for p in ptrs])
+        self._lowered_graph._execute_with_raw_ptrs(
+            ctypes.addressof(array),
+            n,
+            _ptr(workspace) if workspace is not None else 0,
+            to_backend_handle(handle if handle is not None else self._handle) or 0,
+            -1,
+        )
 
     def serialize(self):
         """Serialize the graph (classic passthrough).

--- a/python/cudnn/aot.py
+++ b/python/cudnn/aot.py
@@ -1,0 +1,333 @@
+"""Ahead-of-time kernel export and import.
+
+Build a graph once, on a build box, and get the compiled kernel back in another
+process — or another language — with no JIT, no cutlass and no compiler at the
+other end.
+
+Two destinations share one build path and one call machinery, and differ only in
+where the compiled kernel lands:
+
+* ``export_to_disk(graphs, path)`` packs the set into one container file;
+* ``register_global(graph)`` writes nothing and publishes into the process table.
+
+Both hand back a ``pygraph``, so every line below the lookup is the ordinary
+execute API.
+
+Only the CuTeDSL family engine can be exported today. A graph whose selected plan
+belongs to the cuDNN backend, or to the cuda-python / CUDA C++ engines, raises a
+clear "not implemented" — the retrofit is real work and is not done here.
+"""
+
+import json
+from typing import Any, Dict, Iterable, List, Optional
+
+from ._handle import to_backend_handle
+
+__all__ = [
+    "export_to_disk",
+    "import_from_disk",
+    "KernelLibrary",
+    "register_global",
+    "get_global",
+    "unregister_global",
+    "registered_global_names",
+    "serialize_graph",
+    "deserialize_graph",
+]
+
+
+def _compiled_plan_of(graph) -> Any:
+    """The CompiledPlan that would run if this graph were executed."""
+    engine = graph.selected_engine
+    if engine is None:
+        raise NotImplementedError(
+            f"Graph {graph.get_name()!r} runs on the cuDNN backend engine, which does not support AOT export yet. "
+            "Only the CuTeDSL family engine implements it today."
+        )
+    plan_index = graph._plan_index
+    if plan_index not in graph._compiled_plans:
+        raise RuntimeError(f"Graph {graph.get_name()!r} has not been built. Call build_plans() before exporting: the artifact is " "the compiled plan.")
+    return graph._compiled_plans[plan_index]
+
+
+def _graph_io_uids(graph) -> List[int]:
+    """Every uid a caller has to supply a pointer for, from the Python graph.
+
+    The fallback for a family with no cuDNN lowering: the non-virtual tensors
+    wired to the graph's nodes ARE the variant pack.
+    """
+    consumed = set()
+    for node in graph.nodes:
+        for tensor in node.inputs.values():
+            if tensor is not None:
+                consumed.add(tensor.uid)
+
+    uids = []
+    for node in graph.nodes:
+        for direction, ports in (("in", node.inputs), ("out", node.outputs)):
+            for tensor in ports.values():
+                if tensor is None:
+                    continue
+                # A terminal output has to land somewhere even if it was never
+                # marked with set_output(): nothing downstream will produce a
+                # buffer for it, so the caller must.
+                terminal = direction == "out" and tensor.uid not in consumed
+                if tensor.is_virtual and not terminal:
+                    continue
+                if tensor.uid not in uids:
+                    uids.append(tensor.uid)
+    return uids
+
+
+def _lower_for_export(graph) -> Any:
+    """Bring the C++ graph up to the point where its variant pack is known.
+
+    Export needs what only the cuDNN lowering knows: the uid set the variant
+    pack is addressed by, the pass-by-value scalars, the workspace layout and
+    the frontend workspace size. That is exactly what build_operation_graph()
+    computes, and it is computed the same way for every engine — which is why
+    the artifact can reuse the existing serialize() blob instead of inventing a
+    second description of the same graph.
+
+    Not every exportable graph HAS a cuDNN lowering, though. The FROST
+    linear-attention nodes are Python-engine-only: ``build_operation_graph()``
+    on one of them fails outright, because there is no backend operation to
+    build. For those the engine is the only thing that knows the buffer set, so
+    the uid list is declared straight onto the C++ graph and everything
+    downstream — serialize, the variant-pack template, execute — proceeds
+    identically.
+    """
+    if graph._lowered_graph is None:
+        if not graph._is_validated:
+            graph.validate()
+        import cudnn
+
+        try:
+            graph._lowered_graph = graph._lower_to_cpp()
+            graph._lowered_graph.validate()
+            graph._verify_uid_ownership()
+        except cudnn.cudnnGraphNotSupportedError:
+            # No backend lowering for these nodes. That is not an error here:
+            # the plan being exported belongs to a python engine, which is the
+            # only thing that was ever going to run them.
+            lowered = cudnn._pybind_module.backend_graph()
+            lowered._declare_variant_pack(_graph_io_uids(graph))
+            graph._lowered_graph = lowered
+            graph._cpp_bog_done = True
+            return lowered
+    if not graph._cpp_bog_done:
+        graph._lowered_graph.build_operation_graph()
+        graph._cpp_bog_done = True
+        graph._sync_ir_shapes_from_backend()
+    return graph._lowered_graph
+
+
+def _attach_payload(graph) -> Any:
+    """Ask this graph's engine for its artifact and hand it to the C++ graph."""
+    name = graph.get_name()
+    if not name or name == "test_graph":
+        raise ValueError("set_name() is mandatory before AOT export: the name is the kernel's identity and the lookup key.")
+
+    compiled = _compiled_plan_of(graph)
+    payload, module_bytes = compiled.export_aot_payload(graph)
+
+    lowered = _lower_for_export(graph)
+    lowered.set_name(name)
+    lowered._set_cutedsl_payload(json.dumps(payload), module_bytes)
+    return lowered
+
+
+def serialize_graph(graph) -> bytes:
+    """One built CuTeDSL graph as a self-contained artifact.
+
+    The bytes carry the graph's variant-pack description (the existing cuDNN
+    serialization) plus the compiled module, and are accepted back by
+    ``deserialize_graph``.
+    """
+    lowered = _attach_payload(graph)
+    return bytes(lowered.serialize())
+
+
+def deserialize_graph(data: bytes, handle: Optional[int] = None):
+    """Rebuild an executable graph from ``serialize_graph`` bytes.
+
+    Version, architecture and missing-runtime-dependency mismatches are all
+    detected here, not at the first launch.
+    """
+    import cudnn
+
+    graph = cudnn.pygraph()
+    graph._lowered_graph = cudnn._pybind_module.backend_graph()
+    backend_handle = to_backend_handle(handle)
+    if backend_handle is not None:
+        graph._lowered_graph.deserialize(backend_handle, list(data))
+    else:
+        graph._lowered_graph.deserialize(list(data))
+    graph._is_built = True
+    graph._cpp_graph_kwargs["name"] = graph._lowered_graph.get_name()
+    return graph
+
+
+def _wrap_lowered(lowered, handle: Optional[int] = None):
+    """Present an imported C++ graph as the pygraph the caller executes."""
+    import cudnn
+
+    graph = cudnn.pygraph(handle=handle)
+    graph._lowered_graph = lowered
+    graph._is_built = True
+    graph._cpp_graph_kwargs["name"] = lowered.get_name()
+    return graph
+
+
+class KernelLibrary:
+    """The kernels in one container, addressed by name.
+
+    Lookup is by name and never by position, so adding a kernel to a container
+    cannot change what an existing caller resolves.
+    """
+
+    def __init__(self, graphs: Dict[str, Any]):
+        self._graphs = dict(graphs)
+
+    def __getitem__(self, name: str):
+        try:
+            return self._graphs[name]
+        except KeyError:
+            raise KeyError(f"no kernel named {name!r} in this library; it holds {sorted(self._graphs)}") from None
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._graphs
+
+    def __len__(self) -> int:
+        return len(self._graphs)
+
+    def __iter__(self):
+        return iter(self._graphs)
+
+    def keys(self):
+        return self._graphs.keys()
+
+    def items(self):
+        return self._graphs.items()
+
+    def values(self):
+        return self._graphs.values()
+
+    def __repr__(self) -> str:
+        return f"KernelLibrary({sorted(self._graphs)})"
+
+
+def export_to_disk(graphs: Iterable[Any], path: str) -> None:
+    """Pack a set of built graphs into one container.
+
+    The whole set goes in and one container comes out, so adding a kernel later
+    means calling this again with the full set. Every graph must have been named
+    with ``set_name()``; a duplicate name within one call is an error.
+
+    Nothing about the serialization reaches the caller: the container is opaque,
+    and each engine stores itself inside it its own way.
+    """
+    import cudnn
+
+    graphs = list(graphs)
+    if not graphs:
+        raise ValueError("export_to_disk() needs at least one graph")
+
+    seen: Dict[str, int] = {}
+    lowered: List[Any] = []
+    for i, g in enumerate(graphs):
+        name = g.get_name()
+        if not name or name == "test_graph":
+            raise ValueError(f"graph at position {i} has no name; set_name() is mandatory before AOT export")
+        if name in seen:
+            raise ValueError(f"graphs at positions {seen[name]} and {i} are both named {name!r}; names must be unique within one call")
+        seen[name] = i
+        lowered.append(_attach_payload(g))
+
+    cudnn._pybind_module._aot_export_to_disk(lowered, path)
+
+
+def import_from_disk(path: str, handle: Optional[int] = None) -> KernelLibrary:
+    """Read a container back as name -> graph.
+
+    Every graph in it is executable on return: version, architecture and
+    missing-runtime-dependency mismatches are all raised here rather than at the
+    first launch.
+    """
+    import cudnn
+
+    pairs = cudnn._pybind_module._aot_import_from_disk(path, to_backend_handle(handle))
+    return KernelLibrary({name: _wrap_lowered(lowered, handle) for name, lowered in pairs})
+
+
+# ---------------------------------------------------------------------------
+# Flow 3: register to memory. Same build path as flow 2 with the last two lines
+# deleted — nothing is written out, so there is nothing to pack.
+# ---------------------------------------------------------------------------
+
+
+def register_global(graph, override: bool = False) -> None:
+    """Publish a built graph under its ``set_name()`` name. No file is written.
+
+    The kernel was compiled in this process and its cubin is already in the CUDA
+    context, so a name is all a C++ executor in the same process needs. The
+    registry holds a reference, so the compiled object cannot be collected out
+    from under a live handle.
+
+    A duplicate name is an error unless ``override=True`` (the autotuner case);
+    callers holding a handle from ``get_global`` must re-fetch after an override.
+    """
+    import cudnn
+
+    name = graph.get_name()
+    if not name or name == "test_graph":
+        raise ValueError("set_name() is mandatory before register_global(): the name is the kernel's identity.")
+
+    compiled = _compiled_plan_of(graph)
+    # The tvm-ffi table is flat and process-wide, so FE namespaces its entries.
+    # The prefix is applied here and stripped in get_global; it never appears in
+    # user code.
+    symbol = cudnn._pybind_module._aot_global_symbol_for(name)
+    payload = compiled.aot_global_payload(graph, symbol)
+
+    lowered = _lower_for_export(graph)
+    lowered.set_name(name)
+    cudnn._pybind_module._aot_register_global(lowered, json.dumps(payload), override)
+
+
+def get_global(name: str, handle: Optional[int] = None):
+    """Fetch a graph published by ``register_global``, as a snapshot.
+
+    The returned graph keeps running the kernel it was fetched with: after an
+    ``override=True`` re-registration a caller that wants the new one must call
+    ``get_global`` again.
+    """
+    import cudnn
+
+    return _wrap_lowered(cudnn._pybind_module._aot_get_global(name, to_backend_handle(handle)), handle)
+
+
+def unregister_global(name: str) -> None:
+    """Drop a registration. Snapshots already handed out keep working.
+
+    The tvm-ffi entries go too, or the compiled kernel they hold stays alive for
+    the life of the process. A kernel registers one entry per launch step, named
+    ``<prefix>.<i>``, so they are walked until one is missing.
+    """
+    import tvm_ffi
+
+    import cudnn
+
+    cudnn._pybind_module._aot_unregister_global(name)
+    prefix = cudnn._pybind_module._aot_global_symbol_for(name)
+    i = 0
+    while tvm_ffi.get_global_func(f"{prefix}.{i}", allow_missing=True) is not None:
+        tvm_ffi.remove_global_func(f"{prefix}.{i}")
+        i += 1
+
+
+def registered_global_names() -> List[str]:
+    """Names currently published in this process."""
+    import cudnn
+
+    return list(cudnn._pybind_module._aot_registered_global_names())

--- a/python/cudnn/engines/base.py
+++ b/python/cudnn/engines/base.py
@@ -324,6 +324,45 @@ class CompiledPlan:
     def execute(self, graph: "pygraph", variant_pack: "VariantPack", ctx: ExecutionContext) -> None:
         raise NotImplementedError
 
+    def _launch_sequence(self):
+        """``(steps, workspace_bytes)`` — the launches this plan issues.
+
+        The entire per-engine half of the AOT plugin interface. A plan that
+        implements it can be handed to ``cudnn.export_to_disk()`` or
+        ``cudnn.register_global()``; the container, both loaders and both
+        executors are shared and need nothing further.
+
+        Most plans do not write the list by hand. ``record_launch_sequence()``
+        derives it by running the plan once on throwaway buffers and watching
+        which compiled kernels it issues, over which of its own tensors — so a
+        retrofit is usually a few lines saying how to run the plan, not a
+        transcription of every kernel's signature.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support AOT export yet. It needs a _launch_sequence(); the cuDNN "
+            "backend, cuda-python and CUDA C++ engines are not retrofitted."
+        )
+
+    def export_aot_payload(self, graph: "pygraph") -> Any:
+        """Flow 2: ``(payload, module_bytes)`` — the steps written to one linked .so."""
+        from cudnn.engines.cutedsl_aot import base_payload, link_steps
+
+        steps, workspace_size = self._launch_sequence()
+        payload_steps, module_bytes, runtime_deps = link_steps(steps, graph.get_name())
+        payload = base_payload(workspace_size)
+        payload["steps"] = payload_steps
+        payload["runtime_deps"] = runtime_deps
+        return payload, module_bytes
+
+    def aot_global_payload(self, graph: "pygraph", symbol: str) -> Any:
+        """Flow 3: the same steps, published into the tvm-ffi table. Nothing is written."""
+        from cudnn.engines.cutedsl_aot import base_payload, register_steps
+
+        steps, workspace_size = self._launch_sequence()
+        payload = base_payload(workspace_size)
+        payload["steps"] = register_steps(steps, symbol)
+        return payload
+
 
 class _EagerPlan(CompiledPlan):
     """Default CompiledPlan for simple eager engines (delegates to engine.execute)."""

--- a/python/cudnn/engines/cutedsl_aot.py
+++ b/python/cudnn/engines/cutedsl_aot.py
@@ -1,0 +1,446 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+"""AOT export shared by every CuTeDSL-family engine.
+
+An engine describes its kernel as a list of ``Step``s and calls ``link_steps``
+(flow 2, writes one linked shared object) or ``register_steps`` (flow 3,
+publishes into the tvm-ffi global table). A one-launch kernel is a one-element
+list; the FROST GDN forward is four. Both end up as the payload's ``steps``,
+which is what ``CuteDslStep`` in ``cutedsl_engine_interface.h`` reads.
+
+Several exported kernels link into ONE shared object and stay individually
+resolvable by name, so a sequence costs the same single dlopen as one launch.
+
+The argument lists are the engine's business, not the graph's: only the engine
+knows the kernel's signature, and CuTeDSL's rules for what survives into the
+runtime signature are not guessable from the graph. A plain Python
+``int``/``bool``/dataclass argument at ``cute.compile`` time is frozen as a
+constant and disappears, while a ``cutlass.Int32`` / ``cutlass.Float32`` /
+annotated parameter stays; and an optional port passed as ``None`` at compile
+time stays as a positional slot that must still be filled with null (hence
+``NONE`` among the argument kinds, rather than simply omitting it).
+
+Small kernels state their steps outright, which is worth reading once as the
+plain form of the thing. A plan of several launches over a carved workspace can
+instead hand ``record_launch_sequence`` a probe run and let it watch: same
+result, but the signatures stay in the one place that already knows them.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from typing import Any, Dict, List, Tuple
+
+
+def _cudnn_dtype_name(dt: Any) -> str:
+    return getattr(dt, "name", str(dt)).upper().replace("DATA_TYPE.", "")
+
+
+def _contiguous_stride(shape) -> List[int]:
+    stride = [1] * len(shape)
+    for i in range(len(shape) - 2, -1, -1):
+        stride[i] = stride[i + 1] * int(shape[i + 1])
+    return stride
+
+
+def tensor_arg(uid: int, data_type: Any, shape) -> Dict[str, Any]:
+    """A variant-pack tensor, addressed by uid."""
+    name = _cudnn_dtype_name(data_type)
+    if data_type is None or name == "NOT_SET":
+        raise ValueError(
+            f"the tensor with uid {uid} has no data type, so the artifact cannot describe it. "
+            "Call set_data_type() on it before exporting: an inferred dtype is fine at JIT time, "
+            "but an AOT artifact has to state what the kernel was compiled for."
+        )
+    shape = [int(s) for s in shape]
+    return {
+        "kind": "TENSOR",
+        "uid": int(uid),
+        "data_type": _cudnn_dtype_name(data_type),
+        "shape": shape,
+        "stride": _contiguous_stride(shape),
+    }
+
+
+def workspace_arg(offset: int, data_type: str, shape) -> Dict[str, Any]:
+    """A slice of the engine workspace. ``data_type`` is a cuDNN type name."""
+    shape = [int(s) for s in shape]
+    return {
+        "kind": "WORKSPACE",
+        "workspace_offset": int(offset),
+        "data_type": data_type,
+        "shape": shape,
+        "stride": _contiguous_stride(shape),
+    }
+
+
+def i64_arg(value: int) -> Dict[str, Any]:
+    return {"kind": "SCALAR_I64", "value": int(value)}
+
+
+def f64_arg(value: float) -> Dict[str, Any]:
+    return {"kind": "SCALAR_F64", "value": float(value)}
+
+
+class Step:
+    """One entry of the launch sequence, before it is lowered to a payload.
+
+    ``fn`` is the object ``cute.compile`` handed back. It is kept here rather
+    than a symbol name because export and register_global need different things
+    out of it: export writes it to an object file, register_global publishes the
+    live tvm-ffi function it already holds.
+    """
+
+    def __init__(self, name: str, fn: Any, args: List[Dict[str, Any]]):
+        self.name = name
+        self.fn = fn
+        self.args = args
+
+
+class MemsetZero:
+    """Zero a workspace region, stream-ordered, before the next step reads it."""
+
+    def __init__(self, offset: int, nbytes: int):
+        self.offset = int(offset)
+        self.nbytes = int(nbytes)
+
+
+def gpu_arch() -> str:
+    from cuda.bindings import runtime as rt
+
+    err, dev = rt.cudaGetDevice()
+    if int(err) != 0:
+        raise RuntimeError(f"cudaGetDevice failed: {err}")
+    err, major = rt.cudaDeviceGetAttribute(rt.cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, dev)
+    if int(err) != 0:
+        raise RuntimeError(f"cudaDeviceGetAttribute failed: {err}")
+    err, minor = rt.cudaDeviceGetAttribute(rt.cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, dev)
+    if int(err) != 0:
+        raise RuntimeError(f"cudaDeviceGetAttribute failed: {err}")
+    # 'a' selects the architecture-specific feature set, which is what the
+    # FROST kernels are compiled against.
+    return f"sm_{major}{minor}a"
+
+
+def link_steps(steps, graph_name: str) -> Tuple[List[Dict[str, Any]], bytes, List[str]]:
+    """Export every CALL step to an object file and link the set into one .so.
+
+    Returns the payload's step list, the module bytes, and the runtime
+    dependencies the deploy box needs on its library path. Loading the result
+    needs neither a compiler nor cutlass.
+    """
+    import cutlass.cute as cute
+    import tvm_ffi  # importable-at-export check: the loader will need it too
+
+    _ = tvm_ffi
+
+    payload_steps: List[Dict[str, Any]] = []
+    with tempfile.TemporaryDirectory(prefix="cudnn_fe_aot_") as tmp:
+        objects = []
+        for index, step in enumerate(steps):
+            if isinstance(step, MemsetZero):
+                payload_steps.append({"kind": "MEMSET_ZERO", "workspace_offset": step.offset, "nbytes": step.nbytes})
+                continue
+            # Distinct per step: several kernels share one object file, and
+            # CuTeDSL derives its internal symbol prefix from this name.
+            symbol = f"cudnn_aot_{graph_name}_{index}_{step.name}"
+            obj = os.path.join(tmp, f"step{index}.o")
+            step.fn.export_to_c(obj, symbol)
+            objects.append(obj)
+            payload_steps.append({"kind": "CALL", "function_name": symbol, "args": step.args})
+
+        so = os.path.join(tmp, "kernels.so")
+        runtime_libs = cute.runtime.find_runtime_libraries(enable_tvm_ffi=True)
+        link = [os.environ.get("CC", "gcc"), "-shared", "-o", so, *objects, *runtime_libs]
+        proc = subprocess.run(link, capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise RuntimeError(f"Linking the AOT module failed:\n{' '.join(link)}\n{proc.stderr}")
+        with open(so, "rb") as f:
+            module_bytes = f.read()
+
+    # The SONAMEs, not the build-box paths: the deploy box resolves them
+    # however it resolves libraries.
+    runtime_deps = [os.path.basename(p) for p in cute.runtime.find_runtime_libraries(enable_tvm_ffi=True)]
+    return payload_steps, module_bytes, runtime_deps
+
+
+def register_steps(steps, symbol_prefix: str) -> List[Dict[str, Any]]:
+    """Publish every CALL step in the tvm-ffi global table; nothing is written.
+
+    ``cute.compile`` with ``--enable-tvm-ffi`` hands back an object that already
+    holds a live tvm-ffi function whose cubin is in this CUDA context, so flow 3
+    is a handful of table insertions and an argument description.
+    """
+    import tvm_ffi
+
+    payload_steps: List[Dict[str, Any]] = []
+    for index, step in enumerate(steps):
+        if isinstance(step, MemsetZero):
+            payload_steps.append({"kind": "MEMSET_ZERO", "workspace_offset": step.offset, "nbytes": step.nbytes})
+            continue
+        fn = getattr(step.fn, "_tvm_ffi_function", None)
+        if fn is None:
+            fn = step.fn if isinstance(step.fn, tvm_ffi.Function) else None
+        if fn is None:
+            raise RuntimeError(f"the compiled kernel for step '{step.name}' exposes no tvm-ffi function; was --enable-tvm-ffi set?")
+        symbol = f"{symbol_prefix}.{index}"
+        tvm_ffi.register_global_func(symbol, fn, override=True)
+        payload_steps.append({"kind": "CALL", "global_symbol": symbol, "args": step.args})
+    return payload_steps
+
+
+def base_payload(workspace_size: int) -> Dict[str, Any]:
+    return {
+        "abi": "tvm-ffi",
+        "abi_version": 1,
+        "sm_arch": gpu_arch(),
+        "runtime_deps": [],
+        "engine_workspace_size": int(workspace_size),
+    }
+
+
+# cuDNN type name <- the name torch and DeviceView both spell their dtypes with
+_DTYPE_NAMES = {
+    "bfloat16": "BFLOAT16",
+    "float16": "HALF",
+    "float32": "FLOAT",
+    "int32": "INT32",
+    "int64": "INT64",
+    "uint8": "UINT8",
+}
+
+
+def _torch_dtype(data_type, port: str):
+    import torch
+
+    import cudnn
+
+    dt = {
+        cudnn.data_type.HALF: torch.float16,
+        cudnn.data_type.BFLOAT16: torch.bfloat16,
+        cudnn.data_type.FLOAT: torch.float32,
+        cudnn.data_type.INT32: torch.int32,
+    }.get(data_type)
+    if dt is None:
+        raise ValueError(
+            f"the graph tensor for '{port}' has data type {data_type}, which the artifact cannot describe. "
+            "Call set_data_type() on it before exporting: an inferred dtype is fine at JIT time, but an AOT "
+            "artifact has to state what the kernel was compiled for."
+        )
+    return dt
+
+
+def _positional(fn, args, kwargs):
+    """The call's arguments as the exported symbol will receive them.
+
+    A CuTeDSL entry point with keyword-only parameters or defaults is called
+    through a generated wrapper, but the symbol underneath is positional-only.
+    The wrapper carries the real signature, so binding against it turns any
+    call shape into the one order the payload can describe.
+    """
+    if not kwargs:
+        return args
+    import inspect
+
+    wrapper = getattr(fn, "_kwargs_wrapper", None)
+    if wrapper is None:
+        raise RuntimeError(f"a kernel was called with keyword arguments {list(kwargs)} but exposes no signature to resolve them against")
+    signature = inspect.signature(wrapper)
+    bound = signature.bind(*args, **kwargs)
+    bound.apply_defaults()
+    return tuple(bound.arguments[name] for name in signature.parameters)
+
+
+def _recording():
+    """Patch in a recorder over every compiled-kernel call and workspace memset.
+
+    Returns (calls, restore). ``calls`` fills with ``(fn, args)`` for a launch
+    and ``(None, (ptr, nbytes))`` for a memset, in issue order.
+    """
+    from cutlass.cutlass_dsl import tvm_ffi_provider as provider
+
+    from cudnn.frost import buffers
+
+    classes = [provider.TVMFFIJitCompiledFunctionWithKwargs, provider.TVMFFIJitCompiledFunctionBase]
+    saved = [(c, c.__call__) for c in classes] + [(buffers, buffers.memset_zero_async)]
+    calls, depth = [], [0]
+
+    def wrap_call(original):
+        def recording(self, *args, **kwargs):
+            # The subclass __call__ delegates to the base's, so only the
+            # outermost frame is a launch.
+            if depth[0] == 0:
+                calls.append((self, _positional(self, args, kwargs)))
+            depth[0] += 1
+            try:
+                return original(self, *args, **kwargs)
+            finally:
+                depth[0] -= 1
+
+        return recording
+
+    def recording_memset(ptr, nbytes, stream):
+        calls.append((None, (int(ptr), int(nbytes))))
+        return saved[-1][1](ptr, nbytes, stream)
+
+    for c in classes:
+        c.__call__ = wrap_call(c.__call__)
+    buffers.memset_zero_async = recording_memset
+
+    def restore():
+        for owner, original in saved:
+            if owner is buffers:
+                buffers.memset_zero_async = original
+            else:
+                owner.__call__ = original
+
+    return calls, restore
+
+
+def record_launch_sequence(run, tensors, workspace_bytes: int):
+    """``(steps, workspace_bytes)`` for a plan, by running it and watching.
+
+    A real kernel family's launch sequence lives in host Python: which kernels
+    run, in what order, over which buffers. Transcribing that into an artifact
+    by hand costs a second copy of every kernel's runtime signature and its
+    compile-cache key -- free to drift from the first copy, and growing with
+    every kernel in the family. Running the plan and watching keeps one copy:
+    the kernel's own call site.
+
+    ``tensors`` are the graph tensors the plan touches; ``run(buffers,
+    workspace, stream)`` issues its launches over throwaway copies of them,
+    keyed by uid. A plan retrofits by supplying those two, which is why the
+    same recorder serves plans whose buffers are keyed by node port and plans
+    whose buffers are keyed by tensor object.
+
+    Two runs over two distinct buffer sets. The first compiles, since these
+    kernels compile on first execute when the real buffers are known. The
+    second is recorded, and its fresh addresses defeat the pointer-keyed
+    descriptor memo the kernels hold, so the descriptor builds appear in the
+    sequence. They have to: execute() may not mutate the graph, so an artifact
+    rebuilds descriptors on every call rather than remembering last call's
+    pointers.
+
+    Export already requires the target GPU -- the cubin is architecture
+    specific -- so running the kernel to describe it asks for nothing new.
+    """
+    import torch
+
+    stream = torch.cuda.current_stream().cuda_stream
+
+    def fresh():
+        out = {}
+        for t in tensors:
+            name = t.get_name() or f"uid {t.get_uid()}"
+            dtype = _torch_dtype(t.get_data_type(), name)
+            # as_strided, not zeros: a plan's tensors carry the graph's own
+            # strides, which need not be row-major contiguous (an SDPA q/k/v is
+            # BHSD over BSHD storage). The kernel is compiled for that layout.
+            dim, stride = [int(d) for d in t.get_dim()], [int(v) for v in t.get_stride()]
+            span = 1 + sum((d - 1) * v for d, v in zip(dim, stride))
+            out[t.get_uid()] = torch.zeros(span, dtype=dtype, device="cuda").as_strided(dim, stride)
+        return out
+
+    def workspace():
+        return torch.zeros(max(workspace_bytes, 1), dtype=torch.uint8, device="cuda")
+
+    # Held past the second run so the caching allocator cannot hand the same
+    # addresses back and quietly re-arm the descriptor memo.
+    warmup, warmup_ws = fresh(), workspace()
+    run(warmup, warmup_ws, stream)
+    torch.cuda.synchronize()
+
+    bufs, ws = fresh(), workspace()
+    calls, restore = _recording()
+    try:
+        run(bufs, ws, stream)
+        torch.cuda.synchronize()
+    finally:
+        restore()
+    del warmup, warmup_ws
+    if not calls:
+        raise RuntimeError("the AOT probe recorded no launches, so there is nothing to export")
+
+    uid_of_ptr = {b.data_ptr(): uid for uid, b in bufs.items()}
+    ws_ptr = ws.data_ptr()
+
+    # Buffers the plan allocated for itself, which are neither variant-pack
+    # tensors nor workspace slices -- the zero-filled stand-ins a kernel takes
+    # for optional ports the graph did not ask for. An artifact can only
+    # address the pack and the workspace, so they are appended to the workspace
+    # and zeroed by a step. That is sound only because they ARE zero, so that
+    # is checked rather than assumed: a plan-allocated buffer carrying real
+    # content is a genuinely un-exportable argument and says so.
+    carved, extra = {}, workspace_bytes
+    for fn, payload in calls:
+        if fn is None:
+            continue
+        for a in payload:
+            ptr = getattr(a, "data_ptr", None)
+            if ptr is None or not callable(ptr):
+                continue
+            ptr = ptr()
+            if ptr in uid_of_ptr or 0 <= ptr - ws_ptr < max(workspace_bytes, 1) or ptr in carved:
+                continue
+            if a.count_nonzero().item():
+                raise RuntimeError(
+                    f"the plan reached a kernel with a {list(a.shape)} {a.dtype} buffer of its own that is not "
+                    "all zeros, so the artifact cannot reproduce it: it is neither a variant-pack tensor nor a "
+                    "workspace slice, and its contents are not recoverable from the graph."
+                )
+            nbytes = a.numel() * a.element_size()
+            extra = (extra + 127) & ~127
+            carved[ptr] = (extra, nbytes)
+            extra += nbytes
+    workspace_bytes = extra
+
+    def spec(a, index=None, step=None):
+        if a is None:
+            return {"kind": "NONE"}
+        if isinstance(a, (tuple, list)):
+            # ONE parameter carrying a tuple of ints (a problem-size descriptor),
+            # not one slot per element -- the kernel's arity says so. The loader
+            # builds the container once, so this costs nothing per call.
+            return {"kind": "ARRAY_I64", "values": [int(getattr(x, "value", x)) for x in a]}
+        if type(a).__name__ == "CUstream":
+            return {"kind": "STREAM"}
+        # cutlass.Float32 / cutlass.Int32 and friends survive into the runtime
+        # signature as scalars, unlike a plain Python int frozen at compile time
+        kind = type(a).__name__
+        # a cutlass scalar wraps its python value; plain int/float go as-is
+        value = a.value if hasattr(a, "value") and not hasattr(a, "data_ptr") else a
+        if isinstance(value, float) or kind.startswith(("Float", "Double")):
+            return f64_arg(value)
+        if isinstance(value, int) or kind.startswith(("Int", "Uint", "Bool")):  # bool included, deliberately
+            return i64_arg(value)
+        name = _DTYPE_NAMES[str(a.dtype).split(".")[-1]]
+        shape = [int(s) for s in a.shape]
+        # the recorded object's own strides; only fall back to row-major for a
+        # view that does not carry them (a workspace slice)
+        get = getattr(a, "stride", None)
+        stride = [int(v) for v in get()] if callable(get) else _contiguous_stride(shape)
+        ptr = a.data_ptr()
+        if ptr in uid_of_ptr:
+            return {"kind": "TENSOR", "uid": uid_of_ptr[ptr], "data_type": name, "shape": shape, "stride": stride}
+        offset = ptr - ws_ptr
+        if 0 <= offset < max(workspace_bytes, 1):
+            return {"kind": "WORKSPACE", "workspace_offset": offset, "data_type": name, "shape": shape, "stride": stride}
+        if ptr in carved:
+            return {"kind": "WORKSPACE", "workspace_offset": carved[ptr][0], "data_type": name, "shape": shape, "stride": stride}
+        raise RuntimeError(
+            f"step {step} argument {index} (shape {shape}, {name}) points at neither a graph tensor nor the "
+            "engine workspace. Every buffer an exported plan touches must come from the variant pack or the "
+            "workspace, since those are the only two the artifact can address."
+        )
+
+    # zeroed once, ahead of every launch that reads them
+    steps = [MemsetZero(off, nbytes) for off, nbytes in sorted(carved.values())]
+    for index, (fn, payload) in enumerate(calls):
+        if fn is None:
+            ptr, nbytes = payload
+            steps.append(MemsetZero(ptr - ws_ptr, nbytes))
+        else:
+            steps.append(Step(f"step{index}", fn, [spec(a, i, index) for i, a in enumerate(payload)]))
+    return steps, workspace_bytes

--- a/python/cudnn/engines/cutedsl_demo.py
+++ b/python/cudnn/engines/cutedsl_demo.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The AOT export reference family: two small CuTeDSL elementwise-add engines.
+
+They exist to be exported, not to be fast. The samples under ``samples/aot``
+and ``test/python/test_aot_export.py`` build against them because a kernel
+small enough to read end-to-end is what makes the export path reviewable; the
+family is opt_in so it never competes for a real pointwise graph.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def CuteDslDemoEngines(ids: Dict[str, int]) -> List:
+    """The demo engines the manifest asked for. ``ids`` is ``{name: engine_id}``."""
+    from .cutedsl_pointwise_engine import CuteDslPointwiseAddEngine
+    from .cutedsl_tma_add_engine import CuteDslTmaAddEngine
+
+    classes = {
+        "cutedsl_pointwise_add": CuteDslPointwiseAddEngine,
+        "cutedsl_tma_add": CuteDslTmaAddEngine,
+    }
+    return [classes[name](engine_id) for name, engine_id in ids.items() if name in classes]

--- a/python/cudnn/engines/cutedsl_pointwise_engine.py
+++ b/python/cudnn/engines/cutedsl_pointwise_engine.py
@@ -1,0 +1,196 @@
+"""A CuTeDSL engine for elementwise-add graphs, and the AOT export vehicle.
+
+This is deliberately the smallest real CuTeDSL engine that can exist: it takes a
+single-node POINTWISE ADD graph, JITs one CuTe kernel for it, and knows how to
+turn that compiled kernel into an artifact the C++ side can load with no Python
+and no compiler.
+
+It exists for two reasons. It is the reference implementation of the AOT half of
+the engine contract (``CompiledPlan.export_aot_payload``), which is the whole
+per-engine plugin interface; and it is the vehicle the AOT round-trip tests run
+on, since the graph it accepts is also one the cuDNN backend can run, so every
+result has an oracle.
+
+Real CuTeDSL engines (frost's GEMM family, the SDPA/grouped-GEMM kernels behind
+``cudnn.experimental.ops``) plug into the same two methods.
+"""
+
+import sys
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+
+from .base import BaseEngine, CompiledPlan, ExecutionContext, PlanConfig
+from .cutedsl_aot import Step, base_payload, link_steps, register_steps, tensor_arg
+from ..graph_types import NodeType
+
+if TYPE_CHECKING:
+    from .._pygraph import pygraph
+
+THREADS_PER_BLOCK = 256
+
+# cuDNN data_type -> (cute dtype attribute name, torch dtype name). Kept to the
+# types this toy kernel is meaningful for; the payload schema itself is not
+# limited to these.
+_SUPPORTED_DTYPES = {
+    "FLOAT": "Float32",
+    "HALF": "Float16",
+    "BFLOAT16": "BFloat16",
+}
+
+
+def _dtype_name(dt: Any) -> str:
+    return getattr(dt, "name", str(dt)).upper().replace("DATA_TYPE.", "")
+
+
+def _is_contiguous(dim: List[int], stride: List[int]) -> bool:
+    expected = 1
+    for d, s in zip(reversed(dim), reversed(stride)):
+        if s != expected:
+            return False
+        expected *= d
+    return True
+
+
+def _num_elements(dim: List[int]) -> int:
+    n = 1
+    for d in dim:
+        n *= d
+    return n
+
+
+def _build_kernel(cute, dtype):
+    """The kernel and its host wrapper, built against a cute dtype."""
+
+    @cute.kernel
+    def add_kernel(a: cute.Tensor, b: cute.Tensor, c: cute.Tensor):
+        bidx, _, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+        tid = bidx * THREADS_PER_BLOCK + tidx
+        if tid < a.shape[0]:
+            c[tid] = a[tid] + b[tid]
+
+    @cute.jit
+    def add(a: cute.Tensor, b: cute.Tensor, c: cute.Tensor):
+        n = a.shape[0]
+        blocks = (n + THREADS_PER_BLOCK - 1) // THREADS_PER_BLOCK
+        add_kernel(a, b, c).launch(grid=(blocks, 1, 1), block=(THREADS_PER_BLOCK, 1, 1))
+
+    _ = dtype  # the dtype is carried by the fake tensors passed to cute.compile
+    return add
+
+
+class CuteDslPointwiseAddCompiledPlan(CompiledPlan):
+    """One JIT-compiled elementwise add, plus its AOT artifact."""
+
+    def __init__(self, engine, plan, uids: Tuple[int, int, int], n: int, cute_dtype_name: str, cudnn_dtype: Any):
+        self.engine = engine
+        self.plan = plan
+        self.a_uid, self.b_uid, self.c_uid = uids
+        self.n = n
+        self.cute_dtype_name = cute_dtype_name
+        self.cudnn_dtype = cudnn_dtype
+        self._compiled = None
+
+    def _compile(self):
+        if self._compiled is not None:
+            return self._compiled
+        import cutlass
+        import cutlass.cute as cute
+
+        dtype = getattr(cutlass, self.cute_dtype_name)
+        fn = _build_kernel(cute, dtype)
+        fakes = [cute.runtime.make_fake_compact_tensor(dtype, (self.n,)) for _ in range(3)]
+        # --enable-tvm-ffi is what makes the compiled object callable across the
+        # C ABI, and what export_to_c will emit an entry point for.
+        self._compiled = cute.compile(fn, *fakes, options="--enable-tvm-ffi")
+        return self._compiled
+
+    def get_workspace_size(self) -> int:
+        return 0
+
+    def execute(self, graph, tensor_data: Dict[int, Any], ctx: ExecutionContext) -> None:
+        compiled = self._compile()
+        a = tensor_data[self.a_uid]
+        b = tensor_data[self.b_uid]
+        c = tensor_data[self.c_uid]
+        compiled(a.reshape(-1), b.reshape(-1), c.reshape(-1))
+
+    # ---------------------------------------------------------------- AOT ----
+
+    def _steps(self):
+        """One launch. The kernel was compiled against a flat 1-D view, so that
+        is the shape the artifact hands it whatever rank the graph tensor has:
+        the graph knows the uid order, only the engine knows the signature."""
+        return [
+            Step(
+                "add",
+                self._compile(),
+                [tensor_arg(uid, self.cudnn_dtype, (self.n,)) for uid in (self.a_uid, self.b_uid, self.c_uid)],
+            )
+        ]
+
+    def export_aot_payload(self, graph: "pygraph") -> Tuple[Dict[str, Any], bytes]:
+        steps, module_bytes, runtime_deps = link_steps(self._steps(), graph.get_name())
+        payload = base_payload(self.get_workspace_size())
+        payload["steps"] = steps
+        payload["runtime_deps"] = runtime_deps
+        return payload, module_bytes
+
+    def aot_global_payload(self, graph: "pygraph", symbol: str):
+        payload = base_payload(self.get_workspace_size())
+        payload["steps"] = register_steps(self._steps(), symbol)
+        return payload
+
+
+class CuteDslPointwiseAddEngine(BaseEngine):
+    """CuTeDSL elementwise add: one POINTWISE ADD node, contiguous, on CUDA."""
+
+    name = "cutedsl_pointwise_add"
+
+    def __init__(self, engine_id: int):
+        super().__init__()
+        self.engine_id = engine_id
+
+    def check_support(self, graph: "pygraph") -> None:
+        if "cutlass" not in sys.modules:
+            try:
+                import cutlass  # noqa: F401
+            except ImportError as e:
+                raise NotImplementedError(f"CuteDslPointwiseAddEngine needs nvidia-cutlass-dsl: {e}")
+
+        nodes = graph.nodes
+        if len(nodes) != 1:
+            raise NotImplementedError(f"CuteDslPointwiseAddEngine handles a single-node graph, got {len(nodes)}")
+        node = nodes[0]
+        if node.node_type != NodeType.POINTWISE or node.params.get("mode") != "add":
+            raise NotImplementedError("CuteDslPointwiseAddEngine handles POINTWISE add only")
+        if len(node.inputs) != 2:
+            raise NotImplementedError("CuteDslPointwiseAddEngine needs exactly two inputs")
+
+        tensors = [node.inputs["IN_0"], node.inputs["IN_1"], node.outputs["OUT_0"]]
+        dtypes = {_dtype_name(t.data_type) for t in tensors}
+        if len(dtypes) != 1 or next(iter(dtypes)) not in _SUPPORTED_DTYPES:
+            raise NotImplementedError(f"CuteDslPointwiseAddEngine: unsupported/mixed data types {dtypes}")
+        shapes = {tuple(t.dim) for t in tensors}
+        if len(shapes) != 1:
+            raise NotImplementedError(f"CuteDslPointwiseAddEngine needs identical shapes, got {shapes}")
+        for t in tensors:
+            if not _is_contiguous(list(t.dim), list(t.stride)):
+                raise NotImplementedError(f"CuteDslPointwiseAddEngine needs contiguous tensors, {t.name} is not")
+
+
+    def build_plan(self, graph: "pygraph", plan: PlanConfig, ctx: ExecutionContext = None) -> CompiledPlan:
+        self.check_support(graph)
+        node = graph.nodes[0]
+        a, b = node.inputs["IN_0"], node.inputs["IN_1"]
+        c = node.outputs["OUT_0"]
+        cudnn_dtype = a.data_type
+        compiled = CuteDslPointwiseAddCompiledPlan(
+            self,
+            plan,
+            (a.uid, b.uid, c.uid),
+            _num_elements(list(a.dim)),
+            _SUPPORTED_DTYPES[_dtype_name(cudnn_dtype)],
+            cudnn_dtype,
+        )
+        compiled._compile()  # build_plans() is where the JIT cost belongs
+        return compiled

--- a/python/cudnn/engines/cutedsl_tma_add_engine.py
+++ b/python/cudnn/engines/cutedsl_tma_add_engine.py
@@ -1,0 +1,227 @@
+"""A CuTeDSL engine for 2-D elementwise add whose operands arrive by TMA.
+
+The vehicle behind ``samples/aot``: the smallest engine that is still
+representative. A flat vector add builds no TMA descriptors, so it understates
+what a call costs and teaches nothing about the part that grows with a real
+kernel. This one is the same arithmetic over 2-D tiles with the operands loaded
+through TMA, which is enough to exercise descriptor construction, shared memory,
+an mbarrier and an explicit stream argument, and still fit on a screen.
+
+Descriptors are built by ``cpasync.make_tiled_tma_atom`` in the HOST half of the
+jit function, so once per call, against the pointers that actually arrived --
+not once at compile time. ``samples/aot/bench_cpu_costs`` prices that against
+``cutedsl_pointwise_engine``, which is the same add with the descriptors taken
+away.
+
+Four things here compile clean and fail at runtime. They are commented inline
+next to the code that avoids them, because each one cost real debugging time:
+the TMA copy must not be predicated, ``tma_partition`` wants a CTA-tiled gmem
+tensor, a host-built layout cannot enter the kernel region, and the fake tensors
+used at compile time must carry the caller's stride order.
+"""
+
+import sys
+from typing import TYPE_CHECKING, Any, Dict, Tuple
+
+from .base import BaseEngine, CompiledPlan, ExecutionContext, PlanConfig
+from .cutedsl_aot import Step, base_payload, link_steps, register_steps, tensor_arg
+from ..graph_types import NodeType
+
+if TYPE_CHECKING:
+    from .._pygraph import pygraph
+
+BM, BN = 128, 64
+THREADS = 128
+
+
+def dtype_name(dt: Any) -> str:
+    return getattr(dt, "name", str(dt)).upper().replace("DATA_TYPE.", "")
+
+
+def build_kernel():
+    """The kernel and its host wrapper. Imports live here so the engine module
+    stays importable without cutlass."""
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.nvgpu import cpasync
+
+    @cute.kernel
+    def tma_add_kernel(tma_a, tma_b, gA: cute.Tensor, gB: cute.Tensor, mC: cute.Tensor):
+        smem_layout = cute.make_ordered_layout((BM, BN), order=(1, 0))
+        bidx, bidy, _ = cute.arch.block_idx()
+        tidx, _, _ = cute.arch.thread_idx()
+
+        smem = cutlass.utils.SmemAllocator()
+        sA = smem.allocate_tensor(cutlass.Float32, smem_layout, byte_alignment=1024)
+        sB = smem.allocate_tensor(cutlass.Float32, smem_layout, byte_alignment=1024)
+        mbar = smem.allocate_array(cutlass.Int64, 1)
+
+        if tidx == 0:
+            cute.arch.mbarrier_init(mbar, 1)
+        cute.arch.mbarrier_init_fence()
+        cute.arch.barrier()
+
+        # Partitioned outside any conditional: a value produced inside a region
+        # cannot be consumed outside it.
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_a, 0, cute.make_layout(1),
+            cute.group_modes(sA, 0, 2),
+            cute.group_modes(cute.local_tile(gA, (BM, BN), (bidx, bidy)), 0, 2),
+        )
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_b, 0, cute.make_layout(1),
+            cute.group_modes(sB, 0, 2),
+            cute.group_modes(cute.local_tile(gB, (BM, BN), (bidx, bidy)), 0, 2),
+        )
+
+        # One warp issues. expect_tx is elected to a single lane; the copies are
+        # NOT inside the elect -- a TMA copy is warp-uniform and the DSL emits
+        # the single issue itself. A copy inside elect_one deadlocks, because
+        # the transaction count never reaches what was expected.
+        warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        if warp == 0:
+            with cute.arch.elect_one():
+                cute.arch.mbarrier_arrive_and_expect_tx(mbar, BM * BN * 4 * 2)
+            cute.copy(tma_a, tAgA, tAsA, tma_bar_ptr=mbar)
+            cute.copy(tma_b, tBgB, tBsB, tma_bar_ptr=mbar)
+        cute.arch.mbarrier_wait(mbar, 0)
+
+        for e in cutlass.range_constexpr(BM * BN // THREADS):
+            flat = e * THREADS + tidx
+            r = flat // BN
+            c = flat % BN
+            mC[(bidx * BM + r, bidy * BN + c)] = sA[(r, c)] + sB[(r, c)]
+
+    @cute.jit
+    def tma_add(mA: cute.Tensor, mB: cute.Tensor, mC: cute.Tensor, stream: cuda.CUstream):
+        smem_layout = cute.make_ordered_layout((BM, BN), order=(1, 0))
+        op = cpasync.CopyBulkTensorTileG2SOp()
+        # The cost under test: one host-side descriptor encode per operand, on
+        # every call.
+        tma_a, gA = cpasync.make_tiled_tma_atom(op, mA, smem_layout, (BM, BN))
+        tma_b, gB = cpasync.make_tiled_tma_atom(op, mB, smem_layout, (BM, BN))
+        m, n = mC.shape
+        tma_add_kernel(tma_a, tma_b, gA, gB, mC).launch(
+            grid=(m // BM, n // BN, 1), block=(THREADS, 1, 1), stream=stream
+        )
+
+    return tma_add
+
+
+class CuteDslTmaAddCompiledPlan(CompiledPlan):
+    """One JIT-compiled TMA tile add, plus its AOT artifact."""
+
+    def __init__(self, engine, plan, uids, shape, cudnn_dtype):
+        self.engine = engine
+        self.plan = plan
+        self.a_uid, self.b_uid, self.c_uid = uids
+        self.shape = tuple(int(s) for s in shape)
+        self.cudnn_dtype = cudnn_dtype
+        self._compiled = None
+
+    def _compile(self):
+        if self._compiled is not None:
+            return self._compiled
+        import cuda.bindings.driver as cuda
+        import cutlass
+        import cutlass.cute as cute
+
+        fn = build_kernel()
+        # stride_order (1, 0) = row-major, matching the contiguous stride the
+        # graph declares. The default is the other order, which compiles fine
+        # and then rejects a row-major caller at the ABI boundary.
+        fakes = [
+            cute.runtime.make_fake_compact_tensor(cutlass.Float32, self.shape, stride_order=(1, 0))
+            for _ in range(3)
+        ]
+        self._compiled = cute.compile(fn, *fakes, cuda.CUstream(0), options="--enable-tvm-ffi")
+        return self._compiled
+
+    def get_workspace_size(self) -> int:
+        return 0
+
+    def execute(self, graph, tensor_data: Dict[int, Any], ctx: ExecutionContext) -> None:
+        import cuda.bindings.driver as cuda
+
+        compiled = self._compile()
+        stream = getattr(ctx, "stream", None) or 0
+        compiled(tensor_data[self.a_uid], tensor_data[self.b_uid], tensor_data[self.c_uid], cuda.CUstream(int(stream)))
+
+    # ---------------------------------------------------------------- AOT ----
+
+    def _steps(self):
+        """This kernel is one launch; the shared exporter takes a list."""
+        return [
+            Step(
+                "tile_add",
+                self._compile(),
+                [
+                    tensor_arg(self.a_uid, self.cudnn_dtype, self.shape),
+                    tensor_arg(self.b_uid, self.cudnn_dtype, self.shape),
+                    tensor_arg(self.c_uid, self.cudnn_dtype, self.shape),
+                    # A positional handle, not the tvm-ffi environment stream:
+                    # the jit function takes a CUstream.
+                    {"kind": "STREAM"},
+                ],
+            )
+        ]
+
+    def export_aot_payload(self, graph: "pygraph") -> Tuple[Dict[str, Any], bytes]:
+        steps, module_bytes, runtime_deps = link_steps(self._steps(), graph.get_name())
+        payload = base_payload(self.get_workspace_size())
+        payload["steps"] = steps
+        payload["runtime_deps"] = runtime_deps
+        return payload, module_bytes
+
+    def aot_global_payload(self, graph: "pygraph", symbol: str):
+        payload = base_payload(self.get_workspace_size())
+        payload["steps"] = register_steps(self._steps(), symbol)
+        return payload
+
+
+class CuteDslTmaAddEngine(BaseEngine):
+    """CuTeDSL 2-D elementwise add with TMA-loaded operands."""
+
+    name = "cutedsl_tma_add"
+
+    def __init__(self, engine_id: int):
+        super().__init__()
+        self.engine_id = engine_id
+
+    def check_support(self, graph: "pygraph") -> None:
+        if "cutlass" not in sys.modules:
+            try:
+                import cutlass  # noqa: F401
+            except ImportError as e:
+                raise NotImplementedError(f"CuteDslTmaAddEngine needs nvidia-cutlass-dsl: {e}")
+
+        nodes = graph.nodes
+        if len(nodes) != 1:
+            raise NotImplementedError(f"CuteDslTmaAddEngine handles a single-node graph, got {len(nodes)}")
+        node = nodes[0]
+        if node.node_type != NodeType.POINTWISE or node.params.get("mode") != "add":
+            raise NotImplementedError("CuteDslTmaAddEngine handles POINTWISE add only")
+
+        tensors = [node.inputs["IN_0"], node.inputs["IN_1"], node.outputs["OUT_0"]]
+        for t in tensors:
+            if dtype_name(t.data_type) != "FLOAT":
+                raise NotImplementedError(f"CuteDslTmaAddEngine is fp32 only, {t.name} is {t.data_type}")
+            if len(t.dim) != 2:
+                raise NotImplementedError(f"CuteDslTmaAddEngine needs rank-2 tensors, {t.name} has rank {len(t.dim)}")
+        shapes = {tuple(t.dim) for t in tensors}
+        if len(shapes) != 1:
+            raise NotImplementedError(f"CuteDslTmaAddEngine needs identical shapes, got {shapes}")
+        m, n = next(iter(shapes))
+        if m % BM or n % BN:
+            raise NotImplementedError(f"CuteDslTmaAddEngine needs shapes divisible by the {BM}x{BN} tile, got {m}x{n}")
+
+
+    def build_plan(self, graph: "pygraph", plan: PlanConfig, ctx: ExecutionContext = None) -> CompiledPlan:
+        self.check_support(graph)
+        node = graph.nodes[0]
+        a, b = node.inputs["IN_0"], node.inputs["IN_1"]
+        c = node.outputs["OUT_0"]
+        compiled = CuteDslTmaAddCompiledPlan(self, plan, (a.uid, b.uid, c.uid), a.dim, a.data_type)
+        compiled._compile()  # build_plans() is where the JIT cost belongs
+        return compiled

--- a/python/cudnn/engines/engine_ids.py
+++ b/python/cudnn/engines/engine_ids.py
@@ -39,6 +39,7 @@ GDN2_ID_BASE = PYTHON_ENGINE_ID_BASE + 300  # 20_300..20_399
 FROST_GEMM_ID_BASE = PYTHON_ENGINE_ID_BASE + 400  # 20_400..20_499
 FROST_SDPA_FWD_ID_BASE = PYTHON_ENGINE_ID_BASE + 500  # 20_500..20_599
 FROST_SDPA_BWD_ID_BASE = PYTHON_ENGINE_ID_BASE + 600  # 20_600..20_699
+CUTEDSL_DEMO_ID_BASE = PYTHON_ENGINE_ID_BASE + 700  # 20_700..20_799
 
 # The delegating entry: the backend picks among candidates it holds but does not
 # expose as plans (heur_mode.OPENSOURCE). It has no C++ plan index and no

--- a/python/cudnn/engines/manifest.py
+++ b/python/cudnn/engines/manifest.py
@@ -35,7 +35,16 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, Mapping, Optional, Tuple
 
-from .engine_ids import FAMILY_BLOCK, FROST_GEMM_ID_BASE, FROST_SDPA_BWD_ID_BASE, FROST_SDPA_FWD_ID_BASE, GDN2_ID_BASE, GDN_ID_BASE, KDA_ID_BASE
+from .engine_ids import (
+    CUTEDSL_DEMO_ID_BASE,
+    FAMILY_BLOCK,
+    FROST_GEMM_ID_BASE,
+    FROST_SDPA_BWD_ID_BASE,
+    FROST_SDPA_FWD_ID_BASE,
+    GDN2_ID_BASE,
+    GDN_ID_BASE,
+    KDA_ID_BASE,
+)
 
 _LOG = logging.getLogger("cudnn.engines.manifest")
 
@@ -131,6 +140,15 @@ _ANCHOR_NODE_TO_FAMILY = {
     "GDN2_BWD": "gdn2",
 }
 
+# Consulted only when the anchors above name NOTHING. POINTWISE cannot be a
+# primary anchor -- family_for() returns None the moment two families are named,
+# so anchoring on it would knock every `matmul + pointwise` graph off the gemm
+# family. As a fallback it is safe by construction: a primary anchor always
+# wins, and this is reached only by a graph no shipping family claims.
+_FALLBACK_NODE_TO_FAMILY = {
+    "POINTWISE": "cutedsl_demo",
+}
+
 # ---------------------------------------------------------------------------
 # The manifest, one entry per family. Ids are pre-release (engine_ids.py), so
 # blocks may still be re-cut; once shipped, a slot is fixed forever because an
@@ -202,6 +220,23 @@ MANIFEST: Tuple[EngineFamily, ...] = (
         },
         analyzer=("cudnn.sdpa.graph_analyzer", "analyze"),
     ),
+    # The AOT export reference: two deliberately small CuTeDSL engines the
+    # samples and tests build against. opt_in, because a demo has no business
+    # competing for real pointwise graphs.
+    EngineFamily(
+        CUTEDSL_DEMO_ID_BASE,
+        "cutedsl_demo",
+        "cudnn.engines.cutedsl_demo",
+        "CuteDslDemoEngines",
+        # TMA first: both engines claim a contiguous fp32 add, and with no
+        # heuristics hook the first accepting engine wins. The TMA one declines
+        # anything not divisible by its 128x64 tile, so the plain engine still
+        # takes the shapes it is the sample's control for.
+        slots={
+            "cutedsl_tma_add": EngineSlot(0, opt_in=True),
+            "cutedsl_pointwise_add": EngineSlot(1, opt_in=True),
+        },
+    ),
 )
 
 
@@ -224,7 +259,10 @@ def family_for(graph) -> Optional[EngineFamily]:
     Does NOT decide coverage: an unlisted node type is ignored, so
     ``matmul -> reshape`` still classifies as gemm and the analyzer declines it.
     """
-    named = {_ANCHOR_NODE_TO_FAMILY[n] for n in graph_node_types(graph) if n in _ANCHOR_NODE_TO_FAMILY}
+    types = graph_node_types(graph)
+    named = {_ANCHOR_NODE_TO_FAMILY[n] for n in types if n in _ANCHOR_NODE_TO_FAMILY}
+    if not named:
+        named = {_FALLBACK_NODE_TO_FAMILY[n] for n in types if n in _FALLBACK_NODE_TO_FAMILY}
     if len(named) != 1:
         return None
     name = named.pop()  # once: a generator would re-pop on every iteration

--- a/python/cudnn/sdpa/fwd/engine.py
+++ b/python/cudnn/sdpa/fwd/engine.py
@@ -71,6 +71,38 @@ class _FrostSdpaFwdPlan(CompiledPlan):
         else:
             self._compiled(pack, stream=ctx.stream)
 
+    def _launch_sequence(self):
+        """Run the kernel over probe buffers and record what it launches.
+
+        The executor wants a pack keyed by the binding's own tensor objects, so
+        that is all this supplies; export itself is shared (CompiledPlan). The
+        probe buffers carry each tensor's graph strides, which for SDPA are a
+        BHSD view over BSHD storage rather than anything row-major.
+
+        INCOMPLETE, and it will say so rather than write a bad artifact. One
+        parameter is left: ``problem_size``, a tuple of six int32 passed as a
+        SINGLE argument, which the payload has no kind for. Adding one means a
+        tvm-ffi container built once at load -- building it per call would add
+        host cost to the path whose cheapness is the point.
+
+        Everything else about this plan does export: the recorder carves the
+        ``sinks`` / ``seq_kv`` / ``o_desc`` dummies (zero-filled stand-ins for
+        optional ports the graph did not ask for) out of the engine workspace,
+        and binds the keyword-called kernel positionally.
+        """
+        from cudnn.engines.cutedsl_aot import record_launch_sequence
+
+        required = self.get_workspace_size()
+
+        def run(buffers, workspace, stream):
+            pack = {t: buffers[t.get_uid()] for t in self._tensors}
+            if required:
+                self._compiled(pack, workspace, stream=stream)
+            else:
+                self._compiled(pack, stream=stream)
+
+        return record_launch_sequence(run, self._tensors, required)
+
 
 class FrostSdpaFwdEngine(BaseEngine):
     """One SDPA-forward capability cell (arch x phase x geometry x quantization).

--- a/python/pygraph/pygraph.cpp
+++ b/python/pygraph/pygraph.cpp
@@ -19,6 +19,11 @@
 #include "pybind11/stl.h"
 
 #include "cudnn_frontend.h"
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+// Pulls in the tvm-ffi engine and installs the factory that deserialize() uses
+// to reconstitute a CuTeDSL artifact.
+#include "cudnn_frontend/kernel_library.h"
+#endif
 #include "pygraph.h"
 
 namespace py = pybind11;
@@ -625,6 +630,43 @@ PyGraph::serialize() const {
 }
 
 void
+PyGraph::set_cutedsl_payload(std::string const& payload_json, py::bytes const& module_bytes) {
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+    cudnn_frontend::experimental::CuteDslPayload payload;
+    try {
+        json j  = json::parse(payload_json);
+        payload = j.get<cudnn_frontend::experimental::CuteDslPayload>();
+    } catch (std::exception const& e) {
+        throw_if(
+            true, cudnn_frontend::error_code_t::INVALID_VALUE, std::string("Malformed CuTeDSL payload: ") + e.what());
+    }
+
+    std::string_view const bytes = static_cast<std::string_view>(module_bytes);
+    payload.module_bytes.assign(bytes.begin(), bytes.end());
+    // Hashed here rather than in Python so the writer and the loader can never
+    // disagree about the algorithm.
+    payload.module_hash =
+        cudnn_frontend::experimental::cutedsl_detail::fnv1a64(payload.module_bytes.data(), payload.module_bytes.size());
+
+    auto status = graph->set_cutedsl_payload(std::move(payload));
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
+#else
+    (void)payload_json;
+    (void)module_bytes;
+    throw_if(true,
+             cudnn_frontend::error_code_t::GRAPH_NOT_SUPPORTED,
+             "AOT kernel export is not available in this build. Reinstall cudnn-frontend with the 'cutedsl' extra "
+             "(pip install nvidia-cudnn-frontend[cutedsl]) so apache-tvm-ffi is present at build time.");
+#endif
+}
+
+void
+PyGraph::declare_variant_pack(std::vector<int64_t> const& uids) {
+    auto status = graph->declare_variant_pack(uids);
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
+}
+
+void
 PyGraph::deserialize(std::optional<std::intptr_t> handle_, py::object const& pyobj, bool const enforce_precompiled) {
     if (py::isinstance<py::str>(pyobj)) {
         json j = json::parse(pyobj.cast<std::string>());
@@ -828,8 +870,151 @@ default_vector(void) {
     return {};
 }
 
+// ---------------------------------------------------------------------------
+// AOT container: the set of graphs goes in, one container comes out, and it
+// comes back as name -> graph. The format is written and read entirely in C++
+// so a C++ consumer reads the same file with no Python in the picture.
+// ---------------------------------------------------------------------------
+
+static void
+aot_export_to_disk(std::vector<PyGraph*> const& graphs, std::string const& path) {
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+    std::vector<std::shared_ptr<cudnn_frontend::graph::Graph>> raw;
+    raw.reserve(graphs.size());
+    for (auto* g : graphs) {
+        throw_if(g == nullptr, error_code_t::INVALID_VALUE, "export_to_disk() got a null graph.");
+        raw.push_back(g->graph);
+    }
+    auto status = cudnn_frontend::export_to_disk(raw, path);
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
+#else
+    (void)graphs;
+    (void)path;
+    throw_if(true,
+             error_code_t::GRAPH_NOT_SUPPORTED,
+             "AOT kernel export is not available in this build. Reinstall cudnn-frontend with apache-tvm-ffi "
+             "importable at build time (pip install -e . --no-build-isolation, with the 'cutedsl' extra).");
+#endif
+}
+
+static void
+aot_register_global(PyGraph* graph, std::string const& payload_json, bool override_existing) {
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+    throw_if(graph == nullptr, error_code_t::INVALID_VALUE, "register_global() got a null graph.");
+
+    cudnn_frontend::experimental::CuteDslPayload payload;
+    try {
+        json j  = json::parse(payload_json);
+        payload = j.get<cudnn_frontend::experimental::CuteDslPayload>();
+    } catch (std::exception const& e) {
+        throw_if(true, error_code_t::INVALID_VALUE, std::string("Malformed CuTeDSL payload: ") + e.what());
+    }
+
+    auto status = graph->graph->activate_cutedsl_payload(std::move(payload));
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
+
+    status = cudnn_frontend::register_global(graph->graph, override_existing);
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
+#else
+    (void)graph;
+    (void)payload_json;
+    (void)override_existing;
+    throw_if(true, error_code_t::GRAPH_NOT_SUPPORTED, "AOT kernel registration is not available in this build.");
+#endif
+}
+
+static PyGraph*
+aot_get_global(std::string const& name, std::optional<std::intptr_t> handle_) {
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+    // A snapshot, per the flow-3 contract: the copy keeps a reference to the
+    // engine it was fetched with, so an override=True re-registration does not
+    // change what this handle runs.
+    auto snapshot = std::make_shared<cudnn_frontend::graph::Graph>();
+    auto status   = cudnn_frontend::get_global(name, snapshot.get());
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
+
+    auto* py_graph   = new PyGraph(snapshot);
+    py_graph->handle = handle_.has_value() ? static_cast<cudnnHandle_t>((void*)(handle_.value())) : nullptr;
+    return py_graph;
+#else
+    (void)name;
+    (void)handle_;
+    throw_if(true, error_code_t::GRAPH_NOT_SUPPORTED, "AOT kernel registration is not available in this build.");
+    return nullptr;
+#endif
+}
+
+static void
+aot_unregister_global(std::string const& name) {
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+    auto status = cudnn_frontend::unregister_global(name);
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
+#else
+    (void)name;
+    throw_if(true, error_code_t::GRAPH_NOT_SUPPORTED, "AOT kernel registration is not available in this build.");
+#endif
+}
+
+static std::vector<std::string>
+aot_registered_global_names() {
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+    return cudnn_frontend::registered_global_names();
+#else
+    return {};
+#endif
+}
+
+static std::string
+aot_global_symbol_for(std::string const& name) {
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+    return cudnn_frontend::global_symbol_for(name);
+#else
+    return "cudnn." + name;
+#endif
+}
+
+static std::vector<std::pair<std::string, PyGraph*>>
+aot_import_from_disk(std::string const& path, std::optional<std::intptr_t> handle_) {
+#ifdef CUDNN_FRONTEND_ENABLE_AOT
+    cudnn_frontend::KernelLibrary lib;
+    cudnnHandle_t handle = handle_.has_value() ? static_cast<cudnnHandle_t>((void*)(handle_.value())) : nullptr;
+
+    auto status = cudnn_frontend::import_from_disk(path, &lib, handle);
+    throw_if(status.is_bad(), status.get_code(), status.get_message());
+
+    std::vector<std::pair<std::string, PyGraph*>> out;
+    out.reserve(lib.graphs_.size());
+    for (auto const& [name, graph] : lib.graphs_) {
+        auto* py_graph   = new PyGraph(graph);
+        py_graph->handle = handle;
+        out.emplace_back(name, py_graph);
+    }
+    return out;
+#else
+    (void)path;
+    (void)handle_;
+    throw_if(true,
+             error_code_t::GRAPH_NOT_SUPPORTED,
+             "AOT kernel import is not available in this build. Reinstall cudnn-frontend with apache-tvm-ffi "
+             "importable at build time (pip install -e . --no-build-isolation, with the 'cutedsl' extra).");
+    return {};
+#endif
+}
+
 void
 init_pygraph_submodule(py::module_& m) {
+    m.def("_aot_export_to_disk", &aot_export_to_disk, py::arg("graphs"), py::arg("path"));
+    m.def("_aot_import_from_disk", &aot_import_from_disk, py::arg("path"), py::arg("handle") = py::none());
+    m.def("_aot_register_global",
+          &aot_register_global,
+          py::arg("graph"),
+          py::arg("payload_json"),
+          py::arg("override_existing"));
+    m.def("_aot_get_global", &aot_get_global, py::arg("name"), py::arg("handle") = py::none());
+    m.def("_aot_unregister_global", &aot_unregister_global, py::arg("name"));
+    m.def("_aot_registered_global_names", &aot_registered_global_names);
+    m.def("_aot_global_symbol_for", &aot_global_symbol_for, py::arg("name"));
+
     py::class_<PyGraph> pygraph_(m, "backend_graph");
     pygraph_
         .def(py::init<std::string const&,
@@ -1374,6 +1559,12 @@ init_pygraph_submodule(py::module_& m) {
         .def("populate_cuda_graph", &PyGraph::populate_cuda_graph)
         .def("update_cuda_graph", &PyGraph::update_cuda_graph)
         .def("serialize", &PyGraph::serialize)
+        .def("set_name", &PyGraph::set_name, py::arg("name"))
+        .def("get_name", &PyGraph::get_name)
+        .def("_is_built_from_artifact", &PyGraph::is_built_from_artifact)
+        .def("_has_cutedsl_payload", &PyGraph::has_cutedsl_payload)
+        .def("_set_cutedsl_payload", &PyGraph::set_cutedsl_payload, py::arg("payload_json"), py::arg("module_bytes"))
+        .def("_declare_variant_pack", &PyGraph::declare_variant_pack, py::arg("uids"))
         .def("deserialize",
              (void (PyGraph::*)(std::optional<std::intptr_t>, py::object const&, bool const))&PyGraph::deserialize,
              py::arg("handle_"),

--- a/python/pygraph/pygraph.h
+++ b/python/pygraph/pygraph.h
@@ -803,6 +803,39 @@ class PyGraph {
     serialize() const;
 
     void
+    set_name(std::string const& name) {
+        graph->set_name(name);
+    }
+
+    std::string
+    get_name() const {
+        return graph->get_name();
+    }
+
+    bool
+    is_built_from_artifact() const {
+        return graph->is_built_from_artifact();
+    }
+
+    // True when this graph's plan is an AOT CuTeDSL artifact rather than a
+    // cuDNN backend execution plan.
+    bool
+    has_cutedsl_payload() const {
+        return graph->has_cutedsl_payload();
+    }
+
+    // Attach the AOT artifact produced for this graph's selected plan.
+    // `payload_json` carries everything but the module bytes, which arrive
+    // separately so they never pass through a JSON text encoding.
+    void
+    set_cutedsl_payload(std::string const& payload_json, py::bytes const& module_bytes);
+
+    // Name the variant pack directly, for a graph with no cuDNN backend
+    // lowering. See Graph::declare_variant_pack().
+    void
+    declare_variant_pack(std::vector<int64_t> const& uids);
+
+    void
     deserialize(std::optional<std::intptr_t> handle_, py::object const& pyobj, bool const enforce_precompiled = false);
 
     void

--- a/samples/aot/README.md
+++ b/samples/aot/README.md
@@ -1,0 +1,176 @@
+# AOT kernel export/import — one file per step
+
+Three ways a kernel reaches a caller, in increasing order of commitment. Flow 1
+is what ships today. Flows 2 and 3 are the AOT track: they share one build path
+and one call machinery, and differ only in whether the compiled kernel becomes a
+file or stays resident in the process.
+
+Each flow is split into the steps a real deployment splits into, so a reader can
+see exactly which half needs a compiler and which half does not.
+
+**The kernel is a TMA tile add** — `c = a + b` over 2-D `fp32` tiles, operands
+loaded through TMA, written in CuTeDSL. Small enough that the samples stay about
+the flows, but not a toy in the way a flat vector add is: it builds TMA
+descriptors on every call, which is what a real kernel does and what dominates
+per-call host cost once a kernel has many operands. All three flows run the same
+kernel, so they differ in how it is reached and in nothing else.
+
+A production kernel is exported the same way: [`bench_sdpa_export.py`](bench_sdpa_export.py)
+puts a FROST SDPA forward graph through the identical lifecycle. It needs
+`CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1`, which is how the FROST engines opt in.
+
+## Flow 1 — imperative (today, experimental)
+
+| file | step |
+|---|---|
+| [`flow1_imperative.py`](flow1_imperative.py) | build *and* execute, same process, every process |
+
+Compile the kernel in this process and call it. No graph, no artifact, no ABI —
+which is what the shipped per-family entry points do underneath. It JITs on
+first use and caches in a module-level dict that dies with the process; the
+sample prints the cold and warm call times, and the gap between them is the cost
+flows 2 and 3 exist to remove.
+
+## Flow 2 — AOT, export to file
+
+| file | step | needs a compiler? |
+|---|---|---|
+| [`flow2_export.py`](flow2_export.py) | build box: compile the set, write one container | yes |
+| [`flow2_import_execute.py`](flow2_import_execute.py) | deploy box, Python: open it, execute by name | **no** |
+| [`flow2_import_execute.cpp`](flow2_import_execute.cpp) | deploy box, C++: same, no Python in the process | **no** |
+
+The export step is the only one that needs a GPU toolchain or cutlass. The two
+consumers are interchangeable — same container, same uid order, same results.
+`flow2_import_execute.py` asserts that no kernel toolchain was loaded in its
+process, which is the property the whole flow exists for.
+
+## Flow 3 — AOT, register to memory
+
+| file | step |
+|---|---|
+| [`flow3_register_global.py`](flow3_register_global.py) | compile and publish under a name — **nothing is written to disk** |
+| [`flow3_global_execute.py`](flow3_global_execute.py) | fetch by name and execute, from Python |
+| [`flow3_global_execute_nanobind.cpp`](flow3_global_execute_nanobind.cpp) | fetch by name and execute, from a C++ extension in the same process |
+| [`flow3_orchestrator.py`](flow3_orchestrator.py) | drives both consumers against one registration |
+
+`flow3_orchestrator.py` is the interesting one:
+
+```
+A)  register_global (Python)  ->  execute (Python)
+B)  register_global (Python)  ->  execute (C++, nanobind extension)
+```
+
+Case B is the half a pure-Python sample cannot show. The kernel is compiled by
+Python and never serialised; the C++ executor is a *separate shared object* in
+the same process and reaches the same graph by name. It prints what the
+extension sees in the registry, which is how you can tell it shares the real one
+rather than holding a private copy — the failure mode that
+`kernel_library.h`'s default-visibility annotation exists to prevent.
+
+## Shared
+
+| file | what |
+|---|---|
+| [`common.py`](common.py) | the graph every sample builds, and the per-call pointer gather |
+| [`build.sh`](build.sh) | compiles the two C++ pieces |
+| [`bench_cpu_costs.cpp`](bench_cpu_costs.cpp) / [`.py`](bench_cpu_costs.py) | every way of reaching one kernel, priced against each other |
+| [`bench_native_add.cu`](bench_native_add.cu) | the hand-written kernel the two floor rows launch |
+| [`bench_sdpa_export.py`](bench_sdpa_export.py) / [`bench_sdpa_cpu_costs.cpp`](bench_sdpa_cpu_costs.cpp) | the same pricing on a FROST SDPA forward graph |
+| [`tile_add_primitives.py`](tile_add_primitives.py) | the same kernel one level down, in `cutlass.experimental.primitives` |
+
+`bench_cpu_costs` is the one to run for a table. Every arm ends in the *same*
+CuTeDSL kernel out of the *same* container — flow 2, flow 3, a direct tvm-ffi
+call, the tvm-ffi global table, and (as a floor) a hand-written kernel through
+both the runtime and driver APIs. Because the arms differ only in the call path,
+`fe_* − ffi_*` is the frontend's front door over an OSS-engine plan, which is
+otherwise easy to overstate by differencing two measurements that ran different
+dispatch stacks over different kernels.
+
+### Pricing TMA
+
+`--plain` exports the same arithmetic with a flat 1-D load and no descriptors.
+It is not a flow — it exists so the two can be differenced:
+
+```bash
+python flow2_export.py --bench            # the TMA tile add
+python flow2_export.py --plain --bench    # the same add, no TMA
+./bench_cpu_costs mykernels.cudnn
+./bench_cpu_costs plainkernels.cudnn
+```
+
+| call path | plain add | TMA tile add | delta |
+|---|---|---|---|
+| `ffi_module` (C++, TVM FFI) | 1.86 | 2.04 | +0.18 |
+| `fe_container` (FE `graph.execute`) | 2.09 | 2.35 | +0.26 |
+
+Two descriptors per call, so roughly 0.09 µs each — an order of magnitude below
+FROST's ~1.5 µs per operand. TMA descriptors are cheap; FROST's `_build_descs`
+is the outlier.
+
+The front door does not move with TMA: +0.22 µs on the plain add, +0.31 µs on
+the TMA one, against a ±0.02 µs noise floor. It is a property of the caller, not
+of what the kernel does.
+
+## Running
+
+```bash
+export CUDA_PATH=/path/to/cuda CUDNN_PATH=/path/to/cudnn
+
+python flow1_imperative.py                  # flow 1
+
+python flow2_export.py                      # flow 2, build box
+python flow2_import_execute.py              #         deploy box, Python
+./build.sh && ./flow2_import_execute        #         deploy box, C++
+
+python flow3_register_global.py             # flow 3, publish
+python flow3_global_execute.py              #         fetch + execute, Python
+./build.sh && python flow3_orchestrator.py  #         both consumers, one registration
+```
+
+`build.sh` also builds `bench_cpu_costs`, which needs the extra artifacts from
+`python flow2_export.py --bench`.
+
+## Requirements
+
+A Blackwell GPU, CUDA 13.x, and cuDNN frontend built with the AOT entry points —
+which compile in only when `apache-tvm-ffi` is importable at CMake configure
+time:
+
+```bash
+pip install -e ".[cutedsl]" --no-build-isolation
+pip install nanobind          # flow 3's C++ consumer only
+```
+
+`--no-build-isolation` matters: under PEP 517 isolation `tvm_ffi` is not
+importable when CMake configures, so the AOT entry points are left out and
+report that cleanly at runtime. `nanobind` is needed only to build
+`flow3_global_execute_nanobind`; without it `flow3_orchestrator.py` skips case B
+and still runs case A.
+
+## Scope
+
+The engine behind flows 2 and 3 is `CuteDslTmaAddEngine`, written as the
+vehicle, so these samples exercise no workspace slots, no pass-by-value scalars
+and no replacement slots. `bench_sdpa_export.py` covers a kernel that does.
+The cuDNN backend engine and the cuda-python / CUDA C++ engines report "not
+implemented" from the AOT entry points; retrofitting them is real work and is
+not done here.
+
+[`tile_add_primitives.py`](tile_add_primitives.py) is the same kernel written
+against the raw primitives instead of `cpasync.make_tiled_tma_atom` — the
+descriptor built by hand, the PTX bulk-tensor copy issued by hand, the mbarrier
+driven by hand. It is not a fourth flow and nothing imports it; it is there
+because that is the level FROST works at, so it is the level you end up
+debugging at. Its own four gotchas are listed in its docstring, the sharpest
+being that the descriptor parameter must be `cutlass.GridConstant[TensorMap]`.
+The canonical form for these is the DKG tutorial at
+`examples/CuTeDSL/experimental/primitives/tutorial/04_tma_load.py`.
+
+Writing the TMA kernel turned up four things that compile clean and fail at
+runtime, recorded in `cutedsl_tma_add_engine.py` next to the code that avoids
+them: `cute.copy` must not be inside `elect_one` (the kernel deadlocks in
+`mbarrier_wait`, which retries forever rather than erroring); `tma_partition`
+wants the gmem tensor already tiled to the CTA; a layout built on the host
+cannot cross into the kernel region; and `make_fake_compact_tensor` defaults to
+a stride order that is not row-major, so the artifact compiles and then rejects
+a row-major caller at the ABI boundary.

--- a/samples/aot/bench_cpu_costs.cpp
+++ b/samples/aot/bench_cpu_costs.cpp
@@ -1,0 +1,378 @@
+// What does each way of reaching one kernel cost per launch, on the CPU?
+//
+// Every arm below ends in the SAME compiled CuTeDSL elementwise add, out of the
+// same container, except the two floor arms, which are a hand-written kernel
+// launched with no FFI at all (bench_native_add.cu). So the numbers compare
+// CALL PATHS, not kernels -- which is the property the earlier front-door
+// measurement lacked: it compared an FE call over a cuDNN backend plan against
+// a tvm-ffi call over a cutlass kernel, two different dispatch stacks over two
+// different kernels, and the two could not honestly be differenced.
+//
+//   ffi_module     ffi::Function out of the AOT .so, called directly
+//   ffi_global     the same function resolved from the tvm-ffi global table
+//   fe_container   fe::Graph from import_from_disk() -> graph.execute()
+//   fe_global      fe::Graph from get_global()       -> graph.execute()
+//   native_launch  hand-written kernel, cudaLaunchKernel
+//   raw_cubin      the same kernel as a cubin, cuModuleLoad + cuLaunchKernel
+//   graph_replay   cudaGraph capture of ffi_module, replayed
+//
+// fe_* minus ffi_* is the frontend's front door over an OSS-engine plan, which
+// is the number this whole design turns on and which was previously estimated
+// rather than measured.
+//
+// Method: submit time, so no synchronization inside a burst. Arms run
+// round-robin within each burst so drift hits all of them equally, and the
+// reported figure is the median over bursts. The queue is drained BETWEEN
+// bursts, outside the timed region: without that it fills, every arm becomes
+// bound by launch backpressure, and the host-side differences vanish into it.
+// A repeated arm ("control") is reported to show what the noise floor is.
+//
+//     ./bench_cpu_costs [mykernels.cudnn]
+
+#include <cudnn_frontend/kernel_library.h>
+
+#include <tvm/ffi/any.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/extra/module.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace fe  = cudnn_frontend;
+namespace ffi = tvm::ffi;
+
+extern "C" void native_add_launch(void const *a, void const *b, void *c, int n, cudaStream_t stream);
+
+#define CHECK_FE(expr)                                                                        \
+    do {                                                                                      \
+        auto _status = (expr);                                                                \
+        if (_status.is_bad()) {                                                               \
+            std::fprintf(stderr, "FAILED: %s\n  %s\n", #expr, _status.get_message().c_str()); \
+            return 1;                                                                         \
+        }                                                                                     \
+    } while (0)
+
+#define CHECK_CUDA(expr)                                                                      \
+    do {                                                                                      \
+        cudaError_t _err = (expr);                                                            \
+        if (_err != cudaSuccess) {                                                            \
+            std::fprintf(stderr, "CUDA FAILED: %s\n  %s\n", #expr, cudaGetErrorString(_err)); \
+            return 1;                                                                         \
+        }                                                                                     \
+    } while (0)
+
+#define CHECK_CU(expr)                                                              \
+    do {                                                                            \
+        CUresult _err = (expr);                                                     \
+        if (_err != CUDA_SUCCESS) {                                                 \
+            char const *_msg = nullptr;                                             \
+            cuGetErrorString(_err, &_msg);                                          \
+            std::fprintf(stderr, "CU FAILED: %s\n  %s\n", #expr, _msg ? _msg : ""); \
+            return 1;                                                               \
+        }                                                                           \
+    } while (0)
+
+namespace {
+
+std::string
+manifest_string(std::string const &text, std::string const &key) {
+    auto const at = text.find("\"" + key + "\"");
+    if (at == std::string::npos) return {};
+    auto const open  = text.find('"', text.find(':', at));
+    auto const close = text.find('"', open + 1);
+    if (open == std::string::npos || close == std::string::npos) return {};
+    return text.substr(open + 1, close - open - 1);
+}
+
+double
+median(std::vector<double> v) {
+    if (v.empty()) return 0.0;
+    std::sort(v.begin(), v.end());
+    return v[v.size() / 2];
+}
+
+struct Arm {
+    char const *label;
+    std::function<void()> call;
+    std::vector<double> samples;
+};
+
+}  // namespace
+
+int
+main(int argc, char **argv) {
+    std::string const container = (argc > 1) ? argv[1] : "mykernels.cudnn";
+
+    std::ifstream mf(container + ".bench.json");
+    if (!mf.good()) {
+        std::fprintf(stderr, "cannot read %s.bench.json -- run flow2_export.py --bench first\n", container.c_str());
+        return 1;
+    }
+    std::string const bench((std::istreambuf_iterator<char>(mf)), std::istreambuf_iterator<char>());
+    std::string const kernel = manifest_string(bench, "kernel");
+    std::string const symbol = manifest_string(bench, "symbol");
+    // Some kernels take the stream as a positional handle rather than reading
+    // the tvm-ffi environment stream, so the direct-FFI arms have to match the
+    // signature the artifact actually exports.
+    bool const stream_arg = bench.find("\"stream_arg\": true") != std::string::npos;
+
+    cudnnHandle_t handle;
+    if (cudnnCreate(&handle) != CUDNN_STATUS_SUCCESS) {
+        std::fprintf(stderr, "could not create a cuDNN handle\n");
+        return 1;
+    }
+    cudaStream_t stream = nullptr;
+    cudnnGetStream(handle, &stream);
+
+    int device = 0;
+    CHECK_CUDA(cudaGetDevice(&device));
+
+    // ---------------------------------------------------------------- data --
+    // Shape comes from the artifact, not from this file: the plain add is a
+    // flat 1-D view, the TMA tile add is rank 2, and the direct-FFI arms must
+    // hand the kernel exactly what it was compiled for.
+    std::vector<int64_t> shape;
+    {
+        auto const at   = bench.find("\"shape\"");
+        auto const open = bench.find('[', at);
+        char const *p   = bench.c_str() + open + 1;
+        while (true) {
+            char *end       = nullptr;
+            long long const v = std::strtoll(p, &end, 10);
+            if (end == p) break;
+            shape.push_back(v);
+            p = end;
+            while (*p == ' ' || *p == ',' || *p == '\n') p++;
+            if (*p == ']') break;
+        }
+    }
+    if (shape.empty()) {
+        std::fprintf(stderr, "no shape in %s.bench.json -- re-run flow2_export.py --bench\n", container.c_str());
+        return 1;
+    }
+    int64_t n = 1;
+    for (auto d : shape) n *= d;
+
+    float *da, *db, *dc;
+    CHECK_CUDA(cudaMalloc(&da, n * sizeof(float)));
+    CHECK_CUDA(cudaMalloc(&db, n * sizeof(float)));
+    CHECK_CUDA(cudaMalloc(&dc, n * sizeof(float)));
+
+    // -------------------------------------------------- FE: from container --
+    fe::KernelLibrary lib;
+    CHECK_FE(fe::import_from_disk(container, &lib, handle));
+    fe::graph::Graph from_container;
+    CHECK_FE(lib.get(kernel, &from_container));
+
+    auto const uid_order   = from_container.get_variant_pack_uids_sorted();
+    int64_t workspace_size = 0;
+    CHECK_FE(from_container.get_workspace_size(workspace_size));
+    void *workspace = nullptr;
+    if (workspace_size > 0) CHECK_CUDA(cudaMalloc(&workspace, workspace_size));
+
+    std::vector<void *> ptrs(uid_order.size());
+    for (size_t i = 0; i < uid_order.size(); i++) {
+        ptrs[i] = (i == 0) ? static_cast<void *>(da) : (i == 1) ? static_cast<void *>(db) : static_cast<void *>(dc);
+    }
+
+    // ----------------------------------------------- FE: from the registry --
+    // Same graph, published under its name and fetched back, so the only
+    // difference from fe_container is where the Graph came from.
+    auto shared = std::make_shared<fe::graph::Graph>(from_container);
+    CHECK_FE(fe::register_global(shared, true));
+    fe::graph::Graph from_registry;
+    CHECK_FE(fe::get_global(kernel, &from_registry));
+
+    // ------------------------------------------------- tvm-ffi, no FE at all --
+    ffi::Module module = ffi::Module::LoadFromFile(container + ".bench.so");
+    auto module_fn     = module->GetFunction(symbol);
+    if (!module_fn.has_value()) {
+        std::fprintf(stderr, "the benchmark module does not export %s\n", symbol.c_str());
+        return 1;
+    }
+    ffi::Function fn_from_module = module_fn.value();
+
+    // Publish it under a name and resolve it back, which is what a C++ caller
+    // does in the register-to-memory flow when it skips FE entirely.
+    ffi::Function::SetGlobal("bench_cpu_costs_add", fn_from_module, true);
+    auto global_fn = ffi::Function::GetGlobal("bench_cpu_costs_add");
+    if (!global_fn.has_value()) {
+        std::fprintf(stderr, "could not resolve the function back out of the global table\n");
+        return 1;
+    }
+    ffi::Function fn_from_global = global_fn.value();
+
+    std::vector<int64_t> strides(shape.size(), 1);
+    for (int i = static_cast<int>(shape.size()) - 2; i >= 0; i--) strides[i] = strides[i + 1] * shape[i + 1];
+    DLDataType const f32{kDLFloat, 32, 1};
+    DLDevice const gpu{kDLCUDA, device};
+    int32_t const ndim = static_cast<int32_t>(shape.size());
+    DLTensor const proto_a{da, gpu, ndim, f32, shape.data(), strides.data(), 0};
+    DLTensor const proto_b{db, gpu, ndim, f32, shape.data(), strides.data(), 0};
+    DLTensor const proto_c{dc, gpu, ndim, f32, shape.data(), strides.data(), 0};
+
+    // The kernel takes the tvm-ffi environment stream, so a direct caller has
+    // to put its stream there -- exactly as FE's dispatch target does. Setting
+    // it is part of the arm, not excluded from it.
+    auto call_ffi = [&](ffi::Function const &f) {
+        DLTensor t[3] = {proto_a, proto_b, proto_c};
+        ffi::AnyView args[4];
+        args[0] = &t[0];
+        args[1] = &t[1];
+        args[2] = &t[2];
+        int n_args = 3;
+        if (stream_arg) {
+            args[3] = static_cast<void *>(stream);
+            n_args  = 4;
+        }
+        // Set regardless: a kernel taking the stream positionally ignores this,
+        // and one reading the environment stream needs it. Keeping both makes
+        // the two arms comparable.
+        void *original = nullptr;
+        TVMFFIEnvSetStream(kDLCUDA, device, static_cast<void *>(stream), &original);
+        ffi::Any result;
+        f.CallPacked(args, n_args, &result);
+        TVMFFIEnvSetStream(kDLCUDA, device, original, nullptr);
+    };
+
+    // ------------------------------------------------ driver API, no FFI --
+    CUmodule cu_module;
+    CUfunction cu_add;
+    CHECK_CU(cuModuleLoad(&cu_module, "bench_native_add.cubin"));
+    CHECK_CU(cuModuleGetFunction(&cu_add, cu_module, "native_add"));
+    int const n32    = static_cast<int>(n);
+    int const blocks = (n32 + 255) / 256;
+
+    // ---------------------------------------------------- CUDA graph replay --
+    // Capture on a non-default stream, which capture requires. Deferred until
+    // after the warmup below: the exported host shim loads its cubin lazily on
+    // first call, and doing that inside a capture touches the legacy default
+    // stream and fails with STREAM_CAPTURE_IMPLICIT.
+    cudaStream_t capture_stream;
+    CHECK_CUDA(cudaStreamCreate(&capture_stream));
+    cudaGraph_t captured;
+    cudaGraphExec_t replay = nullptr;
+    // NOTE: what gets captured here is the NATIVE kernel, not the CuTeDSL one.
+    // Capturing the exported host shim fails with cudaErrorStreamCaptureImplicit
+    // (906) in every capture mode -- it touches the legacy default stream
+    // somewhere inside. That is worth knowing on its own (a CuTeDSL kernel is
+    // not capturable as shipped), but it does not change this row: replay cost
+    // is a property of the graph launch, not of which kernel is in the graph.
+    // One node either way.
+    auto capture_native_call = [&](int nodes, cudaGraphExec_t *out) -> cudaError_t {
+        cudaError_t rc = cudaStreamBeginCapture(capture_stream, cudaStreamCaptureModeThreadLocal);
+        if (rc != cudaSuccess) return rc;
+        for (int i = 0; i < nodes; i++) native_add_launch(da, db, dc, static_cast<int>(n), capture_stream);
+        rc = cudaStreamEndCapture(capture_stream, &captured);
+        if (rc != cudaSuccess) return rc;
+        return cudaGraphInstantiate(out, captured, nullptr, nullptr, 0);
+    };
+
+    // Replaying a ONE-node graph saves almost nothing: the per-launch cost is
+    // mostly the submit itself, and a graph still has to be submitted. The
+    // often-quoted ~0.1 µs is a per-KERNEL figure from a graph holding many of
+    // them, so both are measured -- a 1-node replay, and a 32-node replay
+    // divided by 32.
+    constexpr int GRAPH_NODES = 32;
+    cudaGraphExec_t replay_many = nullptr;
+
+    // ----------------------------------------------------------------- arms --
+    std::vector<Arm> arms;
+    arms.push_back({"ffi_module    (cutlass AOT .so, C++, TVM FFI)", [&] { call_ffi(fn_from_module); }, {}});
+    arms.push_back({"ffi_global    (cutlass AOT, C++, global table)", [&] { call_ffi(fn_from_global); }, {}});
+    arms.push_back({"fe_container  (FE graph.execute, from container)",
+                    [&] { (void)from_container.execute(handle, ptrs.data(), (int)ptrs.size(), workspace); },
+                    {}});
+    arms.push_back({"fe_global     (FE graph.execute, from registry)",
+                    [&] { (void)from_registry.execute(handle, ptrs.data(), (int)ptrs.size(), workspace); },
+                    {}});
+    arms.push_back({"native_launch (hand-written, cudaLaunchKernel)",
+                    [&] { native_add_launch(da, db, dc, n32, stream); },
+                    {}});
+    arms.push_back({"raw_cubin     (cuLaunchKernel, no FFI)",
+                    [&] {
+                        void *params[] = {&da, &db, &dc, (void *)&n32};
+                        cuLaunchKernel(cu_add, blocks, 1, 1, 256, 1, 1, 0, (CUstream)stream, params, nullptr);
+                    },
+                    {}});
+    arms.push_back({"graph_replay  (cudaGraph replay, 1 node)",
+                    [&] {
+                        if (replay) (void)cudaGraphLaunch(replay, capture_stream);
+                    },
+                    {}});
+    arms.push_back({"graph_replay32(cudaGraph replay, 32 nodes)",
+                    [&] {
+                        if (replay_many) (void)cudaGraphLaunch(replay_many, capture_stream);
+                    },
+                    {}});
+    // Repeat of arm 0. Its difference from arm 0 is the noise floor: any gap
+    // between other arms smaller than this is not a measurement.
+    arms.push_back({"control       (= ffi_module, repeated)", [&] { call_ffi(fn_from_module); }, {}});
+
+    constexpr int WARMUP = 300;
+    constexpr int BURSTS = 41;  // longer runs get queue-throttled and stop measuring host cost
+    constexpr int CALLS  = 100;
+
+    for (int i = 0; i < WARMUP; i++) {
+        for (auto &arm : arms) arm.call();
+    }
+    CHECK_CUDA(cudaDeviceSynchronize());
+
+    // Everything is loaded now, so the capture sees only the launch.
+    CHECK_CUDA(capture_native_call(1, &replay));
+    CHECK_CUDA(capture_native_call(GRAPH_NODES, &replay_many));
+    for (int i = 0; i < WARMUP; i++) {
+        arms[6].call();  // warm the replay arms too
+        arms[7].call();
+    }
+    CHECK_CUDA(cudaDeviceSynchronize());
+
+    auto burst = [&](Arm &arm) {
+        auto const t0 = std::chrono::steady_clock::now();
+        for (int i = 0; i < CALLS; i++) arm.call();
+        auto const t1 = std::chrono::steady_clock::now();
+        cudaDeviceSynchronize();  // drain BETWEEN bursts, outside the timing
+        return std::chrono::duration<double, std::micro>(t1 - t0).count() / CALLS;
+    };
+
+    for (int b = 0; b < BURSTS; b++) {
+        for (auto &arm : arms) arm.samples.push_back(burst(arm));
+    }
+
+    std::printf("kernel %s, n=%lld, %d bursts x %d calls, round-robin, medians\n\n",
+                kernel.c_str(),
+                static_cast<long long>(n),
+                BURSTS,
+                CALLS);
+    std::printf("  %-46s %10s\n", "call path", "us/call");
+    double const floor_us = median(arms[4].samples);
+    for (auto &arm : arms) {
+        double const us = median(arm.samples);
+        std::printf("  %-46s %10.3f", arm.label, us);
+        if (&arm != &arms[4]) std::printf("   (%+.3f vs native_launch)", us - floor_us);
+        std::printf("\n");
+    }
+    std::printf("  %-46s %10.3f   (32-node replay / 32)\n",
+                "  ^ per kernel in the 32-node graph",
+                median(arms[7].samples) / GRAPH_NODES);
+    std::printf("\n  front door over an OSS-engine plan: fe_container - ffi_module = %+.3f us\n",
+                median(arms[2].samples) - median(arms[0].samples));
+
+    CHECK_CUDA(cudaDeviceSynchronize());
+    cudaFree(da);
+    cudaFree(db);
+    cudaFree(dc);
+    if (workspace) cudaFree(workspace);
+    cudnnDestroy(handle);
+    return 0;
+}

--- a/samples/aot/bench_cpu_costs.py
+++ b/samples/aot/bench_cpu_costs.py
@@ -1,0 +1,122 @@
+"""The Python half of the CPU-cost table.
+
+Same kernel as bench_cpu_costs.cpp -- the CuTeDSL TMA tile add out of the same
+container -- so the C++ and Python rows are directly comparable and the table
+measures call paths rather than kernels.
+
+    python bench_cpu_costs.py [mykernels.cudnn]
+
+Method matches the C++ half: submit time with no synchronization inside a burst,
+arms round-robin within each burst so drift hits all of them equally, the queue
+drained BETWEEN bursts outside the timed region, and the median reported. A
+repeated arm gives the noise floor.
+"""
+
+import json
+import statistics
+import sys
+import time
+
+import torch
+
+import cudnn
+
+BURSTS = 41
+CALLS = 100
+WARMUP = 300
+
+
+def burst(fn):
+    t0 = time.perf_counter()
+    for _ in range(CALLS):
+        fn()
+    t1 = time.perf_counter()
+    torch.cuda.synchronize()  # drain between bursts, outside the timing
+    return (t1 - t0) * 1e6 / CALLS
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise SystemExit("needs a CUDA device")
+    path = sys.argv[1] if len(sys.argv) > 1 else "mykernels.cudnn"
+
+    with open(path + ".bench.json") as f:
+        bench = json.load(f)
+    kernel, symbol = bench["kernel"], bench["symbol"]
+    shape = tuple(bench["shape"])
+    # The TMA kernel takes the stream positionally; the plain add reads the
+    # tvm-ffi environment stream and takes three arguments.
+    stream_arg = bench.get("stream_arg", False)
+
+    handle = cudnn.create_handle()
+    cudnn.set_stream(handle=handle, stream=torch.cuda.current_stream().cuda_stream)
+
+    a = torch.randn(*shape, device="cuda", dtype=torch.float32)
+    b = torch.randn(*shape, device="cuda", dtype=torch.float32)
+    c = torch.zeros(*shape, device="cuda", dtype=torch.float32)
+
+    arms = []
+
+    # --- flow 2: the frontend front door, from a container -------------------
+    lib = cudnn.import_from_disk(path, handle=handle)
+    graph = lib[kernel]
+    ws = torch.empty(max(graph.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+    ptrs = [a.data_ptr(), b.data_ptr(), c.data_ptr()]
+    assert len(graph.variant_pack_uids_sorted()) == 3
+    arms.append(("fe_python     (FE graph.execute, from container)", lambda: graph.execute(ptrs, ws, handle=handle)))
+
+    # --- the same kernel with no frontend in the call ------------------------
+    # Imported here rather than at module scope: this is the toolchain the
+    # deploy box does not have, and only the benchmark needs it.
+    import cuda.bindings.driver as cuda
+    import tvm_ffi
+
+    module = tvm_ffi.load_module(path + ".bench.so")
+    fn = module[symbol]
+    raw_stream = torch.cuda.current_stream().cuda_stream
+    if stream_arg:
+        arms.append(("ffi_python    (cutlass AOT .so, torch tensors)", lambda: fn(a, b, c, raw_stream)))
+    else:
+        arms.append(("ffi_python    (cutlass AOT .so, torch tensors)", lambda: fn(a, b, c)))
+
+    # --- flow 1: the imperative path, JIT-compiled in this process -----------
+    # Same device code; the difference is entirely in how the call gets there.
+    import cutlass
+    import cutlass.cute as cute
+
+    from cudnn.engines.cutedsl_tma_add_engine import build_kernel
+
+    compiled = cute.compile(
+        build_kernel(),
+        *[cute.runtime.make_fake_compact_tensor(cutlass.Float32, shape, stride_order=(1, 0)) for _ in range(3)],
+        cuda.CUstream(0),
+        options="--enable-tvm-ffi",
+    )
+    cu_stream = cuda.CUstream(raw_stream)
+    arms.append(("py_imperative (CuTeDSL JIT object, torch tensors)", lambda: compiled(a, b, c, cu_stream)))
+
+    # Noise floor: a repeat of the first arm.
+    arms.append(("control       (= fe_python, repeated)", lambda: graph.execute(ptrs, ws, handle=handle)))
+
+    for _ in range(WARMUP):
+        for _label, fn_ in arms:
+            fn_()
+    torch.cuda.synchronize()
+
+    samples = {label: [] for label, _ in arms}
+    for _ in range(BURSTS):
+        for label, fn_ in arms:
+            samples[label].append(burst(fn_))
+
+    print(f"kernel {kernel}, shape={shape}, {BURSTS} bursts x {CALLS} calls, round-robin, medians\n")
+    print(f"  {'call path':<46} {'us/call':>10}")
+    for label, _ in arms:
+        print(f"  {label:<46} {statistics.median(samples[label]):>10.3f}")
+
+    fe = statistics.median(samples[arms[0][0]])
+    ffi_ = statistics.median(samples[arms[1][0]])
+    print(f"\n  front door from Python: fe_python - ffi_python = {fe - ffi_:+.3f} us")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/aot/bench_native_add.cu
+++ b/samples/aot/bench_native_add.cu
@@ -1,0 +1,34 @@
+// The driver floor for the CPU-cost table: the same elementwise add, written by
+// hand, with no FFI and no frontend anywhere in the call.
+//
+// Separate from bench_cpu_costs.cpp because it needs nvcc, and the rest of the
+// benchmark is g++ over the FE and tvm-ffi headers. build.sh compiles this
+// twice: once to an object linked into the benchmark (the cudaLaunchKernel
+// arm), and once to a .cubin loaded through cuModuleLoad at runtime (the
+// driver-API arm).
+//
+// The block size matches the CuTeDSL kernel's so the two launches configure the
+// same grid. This is the one arm whose device code is NOT the cutlass-authored
+// kernel; it is here to answer "what does a launch cost at all", not to compare
+// device performance.
+
+#include <cuda_runtime.h>
+
+#define THREADS_PER_BLOCK 256
+
+extern "C" __global__ void
+native_add(float const *a, float const *b, float *c, int n) {
+    int const tid = blockIdx.x * THREADS_PER_BLOCK + threadIdx.x;
+    if (tid < n) {
+        c[tid] = a[tid] + b[tid];
+    }
+}
+
+// Launched from here rather than from the benchmark so the whole arm stays in
+// the translation unit nvcc owns.
+extern "C" void
+native_add_launch(void const *a, void const *b, void *c, int n, cudaStream_t stream) {
+    int const blocks = (n + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK;
+    native_add<<<blocks, THREADS_PER_BLOCK, 0, stream>>>(
+        static_cast<float const *>(a), static_cast<float const *>(b), static_cast<float *>(c), n);
+}

--- a/samples/aot/bench_sdpa_cpu_costs.cpp
+++ b/samples/aot/bench_sdpa_cpu_costs.cpp
@@ -1,0 +1,285 @@
+// Host cost of an SDPA forward launch, two call paths, one process.
+//
+//   backend   the cuDNN backend engine, graph built and executed in C++
+//   aot       the FROST SDPA kernel, compiled in Python, executed from a
+//             container this process opened -- no Python, no cutlass, no JIT
+//
+// The two are NOT the same kernel: the backend engine has no AOT export, so the
+// artifact necessarily carries the other SDPA implementation. Same problem,
+// same buffers, same clock -- what is being compared is the CALL PATH, which is
+// what host overhead is.
+//
+// Method follows bench_cpu_costs.cpp: submit time, no synchronization inside a
+// burst, arms round-robin within each burst so drift hits both equally, median
+// over bursts, and the queue drained BETWEEN bursts outside the timed region.
+// A repeated arm gives the noise floor.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <dlfcn.h>
+
+#include <cudnn_frontend.h>
+#include <cudnn_frontend/kernel_library.h>
+
+namespace fe = cudnn_frontend;
+
+// FE is built here in dynamic-loading mode (as its own python module is), so
+// one translation unit has to own the handle and open libcudnn.
+namespace cudnn_frontend {
+void *cudnn_dlhandle = nullptr;
+}
+
+namespace {
+
+#define CHECK_CUDA(expr)                                                                                    \
+    do {                                                                                                    \
+        cudaError_t const _e = (expr);                                                                      \
+        if (_e != cudaSuccess) {                                                                            \
+            std::fprintf(stderr, "%s:%d %s -> %s\n", __FILE__, __LINE__, #expr, cudaGetErrorString(_e));    \
+            std::exit(1);                                                                                   \
+        }                                                                                                   \
+    } while (0)
+
+#define CHECK_FE(expr)                                                                    \
+    do {                                                                                  \
+        auto _s = (expr);                                                           \
+        if (_s.is_bad()) {                                                                \
+            std::fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, _s.get_message().c_str()); \
+            std::exit(1);                                                                 \
+        }                                                                                 \
+    } while (0)
+
+double
+median(std::vector<double> v) {
+    if (v.empty()) return 0.0;
+    std::sort(v.begin(), v.end());
+    return v[v.size() / 2];
+}
+
+// Minimal scrape of the bench manifest; the container carries the real contract.
+int64_t
+manifest_int(std::string const &text, char const *key) {
+    std::string const pat = std::string("\"") + key + "\":";
+    size_t p              = text.find(pat);
+    if (p == std::string::npos) return -1;
+    return std::strtoll(text.c_str() + p + pat.size(), nullptr, 10);
+}
+
+struct Arm {
+    char const *label;
+    std::function<void()> call;
+    std::vector<double> samples;
+};
+
+constexpr int64_t Q_UID = 101, K_UID = 102, V_UID = 103, O_UID = 104;
+
+}  // namespace
+
+int
+main(int argc, char **argv) {
+    std::string const container = (argc > 1) ? argv[1] : "sdpa.cudnn";
+
+    std::ifstream mf(container + ".bench.json");
+    if (!mf.good()) {
+        std::fprintf(stderr, "cannot read %s.bench.json -- run bench_sdpa_export.py first\n", container.c_str());
+        return 1;
+    }
+    std::string const bench((std::istreambuf_iterator<char>(mf)), std::istreambuf_iterator<char>());
+    int64_t const B = manifest_int(bench, "dims");  // first element of dims
+    (void)B;
+
+    // Must match bench_sdpa_export.py.
+    int64_t const b = 2, h = 8, s = 1024, d = 128;
+    std::vector<int64_t> const dim{b, h, s, d};
+    std::vector<int64_t> const stride{s * h * d, d, h * d, 1};
+    int64_t const elems = b * h * s * d;
+
+    fe::cudnn_dlhandle = ::dlopen("libcudnn.so", RTLD_NOW | RTLD_GLOBAL);
+    if (fe::cudnn_dlhandle == nullptr) {
+        std::fprintf(stderr, "dlopen(libcudnn.so): %s\n", ::dlerror());
+        return 1;
+    }
+
+    cudnnHandle_t handle;
+    if (cudnnCreate(&handle) != CUDNN_STATUS_SUCCESS) {
+        std::fprintf(stderr, "could not create a cuDNN handle\n");
+        return 1;
+    }
+    cudaStream_t stream = nullptr;
+    cudnnGetStream(handle, &stream);
+
+    void *dq = nullptr, *dk = nullptr, *dv = nullptr, *dout = nullptr;
+    CHECK_CUDA(cudaMalloc(&dq, elems * 2));
+    CHECK_CUDA(cudaMalloc(&dk, elems * 2));
+    CHECK_CUDA(cudaMalloc(&dv, elems * 2));
+    CHECK_CUDA(cudaMalloc(&dout, elems * 2));
+    CHECK_CUDA(cudaMemset(dq, 0, elems * 2));
+    CHECK_CUDA(cudaMemset(dk, 0, elems * 2));
+    CHECK_CUDA(cudaMemset(dv, 0, elems * 2));
+
+    // ------------------------------------------------------- backend arm --
+    // The ordinary C++ lifecycle: build here, execute here. This is the path a
+    // C++ integration takes today.
+    fe::graph::Graph backend;
+    backend.set_io_data_type(fe::DataType_t::HALF)
+        .set_intermediate_data_type(fe::DataType_t::FLOAT)
+        .set_compute_data_type(fe::DataType_t::FLOAT);
+
+    auto Q = backend.tensor(fe::graph::Tensor_attributes().set_name("q").set_uid(Q_UID).set_dim(dim).set_stride(stride));
+    auto K = backend.tensor(fe::graph::Tensor_attributes().set_name("k").set_uid(K_UID).set_dim(dim).set_stride(stride));
+    auto V = backend.tensor(fe::graph::Tensor_attributes().set_name("v").set_uid(V_UID).set_dim(dim).set_stride(stride));
+
+    auto opts = fe::graph::SDPA_attributes()
+                    .set_name("sdpa")
+                    .set_generate_stats(false)
+                    .set_attn_scale(1.0f / 11.313708f)  // 1/sqrt(128)
+                    .set_diagonal_alignment(fe::DiagonalAlignment_t::TOP_LEFT)
+                    .set_diagonal_band_right_bound(0);
+
+    auto [O, Stats] = backend.sdpa(Q, K, V, opts);
+    (void)Stats;
+    O->set_output(true).set_dim(dim).set_stride(stride).set_uid(O_UID);
+
+    CHECK_FE(backend.validate());
+    CHECK_FE(backend.build_operation_graph(handle));
+    CHECK_FE(backend.create_execution_plans({fe::HeurMode_t::A}));
+    CHECK_FE(backend.check_support(handle));
+    CHECK_FE(backend.build_plans(handle));
+
+    int64_t backend_ws = 0;
+    CHECK_FE(backend.get_workspace_size(backend_ws));
+    void *backend_workspace = nullptr;
+    if (backend_ws > 0) CHECK_CUDA(cudaMalloc(&backend_workspace, backend_ws));
+
+    std::unordered_map<int64_t, void *> pack{{Q_UID, dq}, {K_UID, dk}, {V_UID, dv}, {O_UID, dout}};
+
+    // ----------------------------------------------------------- aot arm --
+    fe::KernelLibrary lib;
+    CHECK_FE(fe::import_from_disk(container, &lib, handle));
+    fe::graph::Graph aot;
+    CHECK_FE(lib.get("sdpa_fwd_causal_f16", &aot));
+
+    std::vector<int64_t> const order = aot.get_variant_pack_uids_sorted();
+    std::vector<void *> ptrs(order.size());
+    {
+        // The gather a caller does per call; the ORDER is resolved once, here.
+        std::unordered_map<int64_t, void *> by_uid;
+        // uids come from the exporter's manifest, which lists them by role.
+        std::string const uids = bench.substr(bench.find("\"uids\""));
+        int64_t const uq = manifest_int(uids, "q"), uk = manifest_int(uids, "k");
+        int64_t const uv = manifest_int(uids, "v"), uo = manifest_int(uids, "o");
+        by_uid[uq] = dq;
+        by_uid[uk] = dk;
+        by_uid[uv] = dv;
+        by_uid[uo] = dout;
+        for (size_t i = 0; i < order.size(); i++) {
+            auto it = by_uid.find(order[i]);
+            if (it == by_uid.end()) {
+                std::fprintf(stderr, "manifest has no buffer for uid %lld\n", (long long)order[i]);
+                return 1;
+            }
+            ptrs[i] = it->second;
+        }
+    }
+
+    int64_t aot_ws = 0;
+    CHECK_FE(aot.get_workspace_size(aot_ws));
+    void *aot_workspace = nullptr;
+    if (aot_ws > 0) CHECK_CUDA(cudaMalloc(&aot_workspace, aot_ws));
+
+    // ---------------------------------------------------------------- arms --
+    std::vector<Arm> arms;
+    arms.push_back({"backend  (cuDNN backend engine, C++ build+execute)",
+                    [&] { (void)backend.execute(handle, pack, backend_workspace); },
+                    {}});
+    arms.push_back({"aot      (python compile, C++ execute from container)",
+                    [&] { (void)aot.execute(handle, ptrs.data(), (int)ptrs.size(), aot_workspace); },
+                    {}});
+    // Diagnostic: the three cudaMemsetAsync the artifact issues to zero the
+    // dummy buffers it carved into the workspace. Not a call path -- it isolates
+    // how much of the aot arm is those memsets rather than the launch.
+    arms.push_back({"  (diag) 3x cudaMemsetAsync only",
+                    [&] {
+                        cudaMemsetAsync(static_cast<char *>(aot_workspace) + 65536, 0, 32, stream);
+                        cudaMemsetAsync(static_cast<char *>(aot_workspace) + 65664, 0, 8, stream);
+                        cudaMemsetAsync(static_cast<char *>(aot_workspace) + 65792, 0, 8, stream);
+                    },
+                    {}});
+    // Repeat of arm 0: its gap from arm 0 is the noise floor. Any difference
+    // between the two paths smaller than this is not a measurement.
+    arms.push_back({"control  (= backend, repeated)",
+                    [&] { (void)backend.execute(handle, pack, backend_workspace); },
+                    {}});
+
+    constexpr int WARMUP = 300;
+    constexpr int BURSTS = 41;
+    constexpr int CALLS  = 100;
+
+    for (int i = 0; i < WARMUP; i++)
+        for (auto &arm : arms) arm.call();
+    CHECK_CUDA(cudaDeviceSynchronize());
+
+    auto burst = [&](Arm &arm) {
+        auto const t0 = std::chrono::steady_clock::now();
+        for (int i = 0; i < CALLS; i++) arm.call();
+        auto const t1 = std::chrono::steady_clock::now();
+        cudaDeviceSynchronize();  // drained BETWEEN bursts, outside the timing
+        return std::chrono::duration<double, std::micro>(t1 - t0).count() / CALLS;
+    };
+
+    for (int burst_i = 0; burst_i < BURSTS; burst_i++)
+        for (auto &arm : arms) arm.samples.push_back(burst(arm));
+
+    std::printf("SDPA forward, causal, B=%lld H=%lld S=%lld D=%lld, fp16\n", (long long)b, (long long)h, (long long)s, (long long)d);
+    std::printf("%d bursts x %d calls, round-robin, medians\n\n", BURSTS, CALLS);
+    std::printf("  %-52s %10s\n", "call path", "us/call");
+    for (auto &arm : arms) std::printf("  %-52s %10.3f\n", arm.label, median(arm.samples));
+
+    // Submit time only measures the HOST while the queue has room. If the GPU
+    // is slower than the submit loop the queue fills and submit time decays
+    // into device time, which is a throughput number wearing a latency costume.
+    // So measure the device side too and say which clock is binding.
+    std::printf("\n  %-52s %10s %10s\n", "", "submit", "wall/sync");
+    for (size_t ai = 0; ai < 2; ai++) {
+        std::vector<double> wall;
+        for (int b_i = 0; b_i < 11; b_i++) {
+            CHECK_CUDA(cudaDeviceSynchronize());
+            auto const t0 = std::chrono::steady_clock::now();
+            for (int i = 0; i < CALLS; i++) arms[ai].call();
+            CHECK_CUDA(cudaDeviceSynchronize());  // INSIDE the timed region
+            auto const t1 = std::chrono::steady_clock::now();
+            wall.push_back(std::chrono::duration<double, std::micro>(t1 - t0).count() / CALLS);
+        }
+        double const sub = median(arms[ai].samples), w = median(wall);
+        std::printf("  %-52s %10.3f %10.3f   %s\n",
+                    arms[ai].label,
+                    sub,
+                    w,
+                    (w > sub * 1.15) ? "host-bound" : "DEVICE-BOUND: submit is not host cost");
+    }
+
+    double const noise = median(arms[3].samples) - median(arms[0].samples);
+    std::printf("\n  noise floor (control - backend)      %+.3f us\n", noise);
+    std::printf("  aot - backend                        %+.3f us\n", median(arms[1].samples) - median(arms[0].samples));
+    std::printf("  workspace: backend %lld B, aot %lld B\n", (long long)backend_ws, (long long)aot_ws);
+
+    CHECK_CUDA(cudaDeviceSynchronize());
+    cudaFree(dq);
+    cudaFree(dk);
+    cudaFree(dv);
+    cudaFree(dout);
+    if (backend_workspace) cudaFree(backend_workspace);
+    if (aot_workspace) cudaFree(aot_workspace);
+    cudnnDestroy(handle);
+    return 0;
+}

--- a/samples/aot/bench_sdpa_export.py
+++ b/samples/aot/bench_sdpa_export.py
@@ -1,0 +1,84 @@
+"""Export one FROST SDPA forward graph, for bench_sdpa_cpu_costs.cpp to execute.
+
+The C++ side builds the SAME problem on the cuDNN backend engine and times both
+call paths against each other. This half only has to produce the artifact, so it
+is the ordinary lifecycle plus set_name() and export_to_disk().
+
+    python bench_sdpa_export.py [sdpa.cudnn]
+"""
+
+import json
+import sys
+
+import torch
+
+import cudnn
+
+B, H, S, D = 2, 8, 1024, 128
+DIMS = (B, H, S, D)
+# BHSD logical view over BSHD storage -- what an attention stack actually hands
+# a kernel, and not row-major contiguous.
+STRIDES = (S * H * D, D, H * D, 1)
+NAME = "sdpa_fwd_causal_f16"
+
+
+def build(name=NAME):
+    dt = cudnn.data_type.HALF
+    graph = cudnn.pygraph(
+        io_data_type=dt,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    ports = {p: graph.tensor(dim=DIMS, stride=STRIDES, data_type=dt, name=p) for p in ("q", "k", "v")}
+    o, _stats = graph.sdpa(
+        name="sdpa",
+        q=ports["q"],
+        k=ports["k"],
+        v=ports["v"],
+        attn_scale=1.0 / (D**0.5),
+        is_inference=True,
+        use_causal_mask=True,
+    )
+    o.set_output(True).set_dim(DIMS).set_stride(STRIDES).set_data_type(dt)
+    ports["o"] = o
+
+    graph.validate()
+    graph.build_operation_graph()
+    graph.create_execution_plans()
+    graph.build_plans()
+    graph.set_name(name)
+    return graph, ports
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise SystemExit("needs a CUDA device")
+    path = sys.argv[1] if len(sys.argv) > 1 else "sdpa.cudnn"
+
+    graph, ports = build()
+    engine = getattr(graph.selected_engine, "name", graph.selected_engine)
+    cudnn.export_to_disk([graph], path=path)
+
+    # Shapes and uid roles for the C++ side. Not part of the contract -- the
+    # container already carries the uid ORDER, which is what execute() needs.
+    with open(path + ".bench.json", "w") as f:
+        json.dump(
+            {
+                "kernel": NAME,
+                "engine": engine,
+                "dims": list(DIMS),
+                "strides": list(STRIDES),
+                "uids": {p: t.get_uid() for p, t in ports.items()},
+                "workspace": graph.get_workspace_size(),
+            },
+            f,
+            indent=2,
+        )
+
+    print(f"wrote {path}")
+    print(f"  {NAME}  B={B} H={H} S={S} D={D}  engine={engine}")
+    print(f"  workspace {graph.get_workspace_size()} bytes")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/aot/build.sh
+++ b/samples/aot/build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Build the two C++ pieces:
+#   flow2_import_execute            standalone binary, no Python in the process
+#   flow3_global_execute_nanobind   python extension, loaded into the process that registers
+#
+#   CUDA_PATH=... CUDNN_PATH=... ./build.sh
+set -e
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FE_ROOT="$(cd "$HERE/../.." && pwd)"
+
+: "${CUDA_PATH:?set CUDA_PATH to the CUDA toolkit}"
+: "${CUDNN_PATH:?set CUDNN_PATH to the cuDNN install}"
+PYTHON="${PYTHON:-python3}"
+
+read -r TVM_INC TVM_DLPACK TVM_LIB NB_DIR NB_INC PY_INC <<EOF
+$($PYTHON - <<'PY'
+import os, sysconfig, nanobind, tvm_ffi, tvm_ffi.libinfo as libinfo
+
+tvm = os.path.dirname(tvm_ffi.__file__)
+nb = os.path.dirname(nanobind.__file__)
+print(
+    os.path.join(tvm, "include"),
+    os.path.join(tvm, "3rdparty", "dlpack", "include"),
+    libinfo.find_libtvm_ffi(),
+    nb,
+    nanobind.include_dir(),
+    sysconfig.get_paths()["include"],
+)
+PY
+)
+EOF
+
+COMMON=(-std=c++17 -O2 -Wall -Wextra
+        -I"$FE_ROOT/include" -isystem "$TVM_INC" -isystem "$TVM_DLPACK"
+        -I"$CUDNN_PATH/include" -I"$CUDA_PATH/include"
+        -L"$CUDNN_PATH/lib64" -L"$CUDNN_PATH/lib" -L"$CUDA_PATH/lib64")
+
+echo "== flow2_import_execute (standalone) =="
+g++ "${COMMON[@]}" "$HERE/flow2_import_execute.cpp" -o "$HERE/flow2_import_execute" \
+    "$TVM_LIB" -lcudnn -lcudart
+
+echo "== bench_cpu_costs (standalone) =="
+# The floor arms need nvcc. Compiled twice: an object for the cudaLaunchKernel
+# arm, and a cubin the driver-API arm loads at runtime.
+SM_ARCH="${SM_ARCH:-$($PYTHON -c 'import torch;a,b=torch.cuda.get_device_capability();print(f"sm_{a}{b}a")' 2>/dev/null || echo sm_100a)}"
+"$CUDA_PATH/bin/nvcc" -O2 -std=c++17 -arch="$SM_ARCH" -c "$HERE/bench_native_add.cu" -o "$HERE/bench_native_add.o"
+"$CUDA_PATH/bin/nvcc" -O2 -std=c++17 -arch="$SM_ARCH" -cubin "$HERE/bench_native_add.cu" -o "$HERE/bench_native_add.cubin"
+g++ "${COMMON[@]}" "$HERE/bench_cpu_costs.cpp" "$HERE/bench_native_add.o" -o "$HERE/bench_cpu_costs" \
+    "$TVM_LIB" -lcudnn -lcudart -lcuda
+
+echo "== bench_sdpa_cpu_costs (standalone) =="
+g++ "${COMMON[@]}" "$HERE/bench_sdpa_cpu_costs.cpp" -o "$HERE/bench_sdpa_cpu_costs" \
+    "$TVM_LIB" -lcudnn -lcudart -lcuda -lnvrtc
+
+echo "== flow3_global_execute_nanobind (python extension) =="
+EXT_SUFFIX=$($PYTHON -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
+# -fvisibility=hidden on purpose: this is exactly how FE's own bindings are
+# built, so the extension proves the registry really is shared across shared
+# objects rather than accidentally working because everything is exported.
+g++ "${COMMON[@]}" -shared -fPIC -fvisibility=hidden \
+    "$HERE/flow3_global_execute_nanobind.cpp" "$NB_DIR/src/nb_combined.cpp" \
+    -I"$NB_INC" -I"$NB_DIR/src" -I"$NB_DIR/ext/robin_map/include" -I"$PY_INC" \
+    -o "$HERE/flow3_global_execute_nanobind${EXT_SUFFIX}" \
+    "$TVM_LIB" -lcudnn -lcudart
+
+echo
+echo "built:"
+ls -1 "$HERE/flow2_import_execute" "$HERE/bench_cpu_costs" "$HERE/bench_sdpa_cpu_costs" "$HERE"/flow3_global_execute_nanobind*.so

--- a/samples/aot/common.py
+++ b/samples/aot/common.py
@@ -1,0 +1,97 @@
+"""The graph every AOT sample builds, in one place.
+
+A 2-D elementwise tile add whose operands arrive by TMA, routed to the CuTeDSL
+engine. Small enough that the samples stay about the three flows rather than
+about the kernel, but not a toy in the way a flat vector add is: it builds TMA
+descriptors on every call, which is what a real kernel does and what dominates
+the per-call host cost once a kernel has many operands.
+
+Shapes must be a multiple of the 128x64 tile.
+
+The plain 1-D add is kept below as ``build_plain``. It is not part of any flow
+sample; it exists so bench_cpu_costs can price the SAME arithmetic with and
+without TMA, which is the only way to attribute a cost to the descriptors
+rather than to the kernel.
+"""
+
+import os
+
+# The demo engines are opt_in in engines/manifest.py, so a graph only reaches
+# them once this is set. Engines cannot be injected -- the manifest is the only
+# way one exists -- so the gate is the sample's whole engine selection.
+os.environ.setdefault("CUDNN_FRONTEND_ENABLE_FROST_ENGINES", "1")
+
+import cudnn  # noqa: E402 -- must follow the opt-in gate above
+
+# One entry per kernel the flow-2 samples ship in a container.
+CONTAINER_KERNELS = {
+    "tile_add_small_f32": (128, 64),
+    "tile_add_large_f32": (1024, 512),
+}
+
+# The no-TMA control, for the benchmark only.
+PLAIN_KERNELS = {
+    "add_small_f32": (4, 1024),
+    "add_large_f32": (8, 4096),
+}
+
+
+def contiguous_stride(shape):
+    stride, acc = [], 1
+    for extent in reversed(shape):
+        stride.append(acc)
+        acc *= extent
+    return list(reversed(stride))
+
+
+def build(name, shape=(128, 64)):
+    """Build and compile one named graph. The ordinary lifecycle, nothing AOT.
+
+    Returns (graph, (a, b, c)) — the tensors come back so callers can key a
+    variant pack by uid without looking them up by name.
+    """
+    graph = cudnn.pygraph(
+        io_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    a = graph.tensor(dim=list(shape), stride=contiguous_stride(shape), data_type=cudnn.data_type.FLOAT, name="A")
+    b = graph.tensor(dim=list(shape), stride=contiguous_stride(shape), data_type=cudnn.data_type.FLOAT, name="B")
+    c = graph.add(a, b, name="sum")
+    c.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+
+    # create_execution_plans -> check_support -> build_plans. The router picks
+    # the engine; build_plans() is where the kernel materialises. (A plain
+    # build() would try the cuDNN backend lowering first, which this graph does
+    # not need.)
+    graph.create_execution_plans()
+    graph.build_plans()
+
+    # Mandatory before either AOT flow: the name is the kernel's identity and
+    # the lookup key in both.
+    graph.set_name(name)
+    return graph, (a, b, c)
+
+
+def build_plain(name, shape=(4, 1024)):
+    """The same add with a plain 1-D load: the benchmark's no-TMA control."""
+
+    graph = cudnn.pygraph(
+        io_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    a = graph.tensor(dim=list(shape), stride=contiguous_stride(shape), data_type=cudnn.data_type.FLOAT, name="A")
+    b = graph.tensor(dim=list(shape), stride=contiguous_stride(shape), data_type=cudnn.data_type.FLOAT, name="B")
+    c = graph.add(a, b, name="sum")
+    c.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    graph.build([cudnn.heur_mode.A])
+    graph.set_name(name)
+    return graph, (a, b, c)
+
+
+def gather(graph, uid_to_buffer):
+    """Pointers in the order execute() wants them.
+
+    variant_pack_uids_sorted() is resolved once at startup; this gather is the
+    only per-call work a caller does.
+    """
+    return [uid_to_buffer[uid] for uid in graph.variant_pack_uids_sorted()]

--- a/samples/aot/flow1_imperative.py
+++ b/samples/aot/flow1_imperative.py
@@ -1,0 +1,76 @@
+"""Flow 1 — imperative, experimental. What ships today.
+
+No graph, no artifact, no ABI: compile the kernel in this process and call it.
+That is what the shipped per-family entry points do underneath — JIT on first
+use, cache in a module-level dict — and that cache dies with the process, so the
+JIT cost is paid again in every process. Which is what flows 2 and 3 exist to
+remove.
+
+Deliberately the same kernel as flows 2 and 3, so the three flows differ in how
+the kernel is reached and in nothing else.
+
+This layer is EXPERIMENTAL: the API is not fixed and is free to change shape as
+the kernels evolve.
+
+    python flow1_imperative.py
+"""
+
+import time
+
+import torch
+
+from common import CONTAINER_KERNELS
+
+NAME = "tile_add_large_f32"
+SHAPE = CONTAINER_KERNELS[NAME]
+
+# A module-level cache, exactly like the shipped imperative APIs keep. It is the
+# thing that does not survive to the next process.
+_CACHE = {}
+
+
+def tile_add(a, b, c):
+    """Compile on first use for this shape, then replay."""
+    import cuda.bindings.driver as cuda
+    import cutlass
+    import cutlass.cute as cute
+
+    from cudnn.engines.cutedsl_tma_add_engine import build_kernel
+
+    key = tuple(a.shape)
+    if key not in _CACHE:
+        fn = build_kernel()
+        fakes = [cute.runtime.make_fake_compact_tensor(cutlass.Float32, key, stride_order=(1, 0)) for _ in range(3)]
+        _CACHE[key] = cute.compile(fn, *fakes, cuda.CUstream(0), options="--enable-tvm-ffi")
+    _CACHE[key](a, b, c, cuda.CUstream(torch.cuda.current_stream().cuda_stream))
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise SystemExit("needs a CUDA device")
+
+    a = torch.randn(*SHAPE, device="cuda", dtype=torch.float32)
+    b = torch.randn(*SHAPE, device="cuda", dtype=torch.float32)
+    c = torch.zeros(*SHAPE, device="cuda", dtype=torch.float32)
+
+    # First call JITs: seconds, not microseconds.
+    t0 = time.perf_counter()
+    tile_add(a, b, c)
+    torch.cuda.synchronize()
+    cold = time.perf_counter() - t0
+
+    # Every later call in THIS process hits the cache above.
+    t0 = time.perf_counter()
+    tile_add(a, b, c)
+    torch.cuda.synchronize()
+    warm = time.perf_counter() - t0
+
+    print(f"first call (JIT): {cold * 1e3:9.1f} ms")
+    print(f"second call:      {warm * 1e3:9.3f} ms   <- the cache flows 2 and 3 make durable")
+    err = (c - (a + b)).abs().max().item()
+    print(f"max |err| = {err}")
+    return 0 if err == 0.0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/samples/aot/flow2_export.py
+++ b/samples/aot/flow2_export.py
@@ -1,0 +1,109 @@
+"""Flow 2, build box: compile a set of graphs and ship one container.
+
+Nothing here runs at launch time. This is the only step that needs a GPU
+toolchain, cutlass, or Python at all — everything downstream just opens the file
+this writes.
+
+    python flow2_export.py [mykernels.cudnn]
+
+Writes:
+    mykernels.cudnn                 the container: name -> kernel
+    mykernels.cudnn.manifest.json   shapes and uid order, for the samples only
+"""
+
+import json
+import sys
+
+import cudnn
+
+from common import CONTAINER_KERNELS, PLAIN_KERNELS, build, build_plain
+
+BENCH_KERNEL = "tile_add_large_f32"
+PLAIN_BENCH_KERNEL = "add_small_f32"
+
+
+def dump_bench_module(path, graph, bench_kernel=BENCH_KERNEL):
+    """Drop the same kernel out as a plain .so, for the benchmarks.
+
+    Only the benchmark needs this: its baseline arm calls the exported symbol
+    directly, with no cuDNN in the picture, and both arms must provably run the
+    same code. Not part of either flow.
+    """
+    plan = graph._compiled_plans[graph._plan_index]
+    payload, module_bytes = plan.export_aot_payload(graph)
+    with open(path + ".bench.so", "wb") as f:
+        f.write(module_bytes)
+    with open(path + ".bench.json", "w") as f:
+        # These kernels are one launch, so the artifact has one step.
+        (step,) = payload["steps"]
+        args = step["args"]
+        json.dump(
+            {
+                "kernel": bench_kernel,
+                "symbol": step["function_name"],
+                # Whether the entry point takes the stream POSITIONALLY. The
+                # plain add reads the tvm-ffi environment stream and takes 3
+                # args; the TMA kernel takes a CUstream and takes 4.
+                "stream_arg": any(a.get("kind") == "STREAM" for a in args),
+                # The shape the kernel was compiled for. The direct-FFI arms
+                # build their own DLTensors and must match it exactly.
+                "shape": [a["shape"] for a in args if a.get("kind") == "TENSOR"][0],
+            },
+            f,
+            indent=2,
+        )
+
+
+def main():
+    argv = [a for a in sys.argv[1:] if not a.startswith("--")]
+    want_bench = "--bench" in sys.argv
+    # --plain swaps the TMA tile add for the flat 1-D add. Not a flow: it is
+    # the benchmark's no-TMA control, the same arithmetic with the descriptors
+    # taken away, which is the only way to attribute a cost to them.
+    want_plain = "--plain" in sys.argv
+    path = argv[0] if argv else ("plainkernels.cudnn" if want_plain else "mykernels.cudnn")
+
+    kernels = PLAIN_KERNELS if want_plain else CONTAINER_KERNELS
+    builder = build_plain if want_plain else build
+    bench_kernel = PLAIN_BENCH_KERNEL if want_plain else BENCH_KERNEL
+
+    graphs, tensors = [], {}
+    for name, shape in kernels.items():
+        graph, (a, b, c) = builder(name, shape)
+        graphs.append(graph)
+        tensors[name] = (a, b, c)
+
+    # The SET goes in, ONE container comes out. Adding a kernel later means
+    # calling this again with the full set. Serialization is internal: no blob,
+    # envelope or format detail reaches the caller.
+    cudnn.export_to_disk(graphs, path=path)
+
+    # NOT part of the contract. The container already carries the uid order, and
+    # flow2_import_execute.{py,cpp} read it from there via
+    # variant_pack_uids_sorted(). This file only tells the samples which buffer
+    # shapes to allocate and which uid is A / B / C, which a real caller knows
+    # from its own model.
+    manifest = {
+        name: {
+            "shape": list(shape),
+            "a_uid": tensors[name][0].uid,
+            "b_uid": tensors[name][1].uid,
+            "c_uid": tensors[name][2].uid,
+        }
+        for name, shape in kernels.items()
+    }
+    with open(path + ".manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    if want_bench:
+        dump_bench_module(path, graphs[list(kernels).index(bench_kernel)], bench_kernel)
+
+    print(f"wrote {path}")
+    for name in sorted(kernels):
+        print(f"  {name}  shape={tuple(kernels[name])}")
+    if want_bench:
+        print(f"  + {path}.bench.so for bench_cpu_costs")
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/aot/flow2_import_execute.cpp
+++ b/samples/aot/flow2_import_execute.cpp
@@ -1,0 +1,155 @@
+// Flow 2, deploy box (C++): open the container and run every kernel in it.
+//
+// The same job as flow2_import_execute.py, with no Python in the process at
+// all. This binary links cudnn-frontend and libtvm_ffi and nothing else -- no
+// cutlass, no NVRTC, no kernel toolchain.
+//
+//     ./flow2_import_execute [mykernels.cudnn]
+
+#include <cudnn_frontend/kernel_library.h>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fe = cudnn_frontend;
+
+#define CHECK_FE(expr)                                                                        \
+    do {                                                                                      \
+        auto _status = (expr);                                                                \
+        if (_status.is_bad()) {                                                               \
+            std::fprintf(stderr, "FAILED: %s\n  %s\n", #expr, _status.get_message().c_str()); \
+            return 1;                                                                         \
+        }                                                                                     \
+    } while (0)
+
+#define CHECK_CUDA(expr)                                                                      \
+    do {                                                                                      \
+        cudaError_t _err = (expr);                                                            \
+        if (_err != cudaSuccess) {                                                            \
+            std::fprintf(stderr, "CUDA FAILED: %s\n  %s\n", #expr, cudaGetErrorString(_err)); \
+            return 1;                                                                         \
+        }                                                                                     \
+    } while (0)
+
+namespace {
+
+// The manifest is a convenience for the samples, not part of the contract: the
+// uid ORDER comes from the container via get_variant_pack_uids_sorted(); this
+// only says which uid is A / B / C and how big the buffers are, which a real
+// caller knows from its own model. Scanned by hand so the sample grows no JSON
+// dependency of its own.
+long long
+manifest_int(std::string const &text, size_t from, char const *key) {
+    auto const at = text.find(std::string("\"") + key + "\"", from);
+    if (at == std::string::npos) return -1;
+    return std::strtoll(text.c_str() + text.find(':', at) + 1, nullptr, 10);
+}
+
+long long
+manifest_elems(std::string const &text, size_t from) {
+    auto const open  = text.find('[', text.find("\"shape\"", from));
+    auto const close = text.find(']', open);
+    long long n      = 1;
+    for (size_t i = open + 1; i < close; i++) {
+        if (std::isdigit(static_cast<unsigned char>(text[i]))) {
+            n *= std::strtoll(text.c_str() + i, nullptr, 10);
+            while (i < close && std::isdigit(static_cast<unsigned char>(text[i]))) i++;
+        }
+    }
+    return n;
+}
+
+}  // namespace
+
+int
+main(int argc, char **argv) {
+    std::string const container = (argc > 1) ? argv[1] : "mykernels.cudnn";
+
+    std::ifstream mf(container + ".manifest.json");
+    if (!mf.good()) {
+        std::fprintf(stderr, "cannot read %s.manifest.json -- run flow2_export.py first\n", container.c_str());
+        return 1;
+    }
+    std::string const manifest((std::istreambuf_iterator<char>(mf)), std::istreambuf_iterator<char>());
+
+    cudnnHandle_t handle;
+    if (cudnnCreate(&handle) != CUDNN_STATUS_SUCCESS) {
+        std::fprintf(stderr, "could not create a cuDNN handle\n");
+        return 1;
+    }
+
+    // Version, architecture and missing-runtime-dependency mismatches are all
+    // rejected HERE, loudly. A misread artifact is never an illegal access.
+    fe::KernelLibrary lib;
+    CHECK_FE(fe::import_from_disk(container, &lib, handle));
+
+    std::printf("opened %s holding %zu kernel(s):", container.c_str(), lib.size());
+    for (auto const &name : lib.keys()) std::printf(" %s", name.c_str());
+    std::printf("\n");
+
+    int failures = 0;
+    for (auto const &name : lib.keys()) {
+        fe::graph::Graph graph;
+        CHECK_FE(lib.get(name, &graph));  // BY NAME, never by position
+
+        // Resolved once, at startup.
+        auto const uid_order   = graph.get_variant_pack_uids_sorted();
+        int64_t workspace_size = 0;
+        CHECK_FE(graph.get_workspace_size(workspace_size));
+
+        auto const at         = manifest.find("\"" + name + "\"");
+        long long const n     = manifest_elems(manifest, at);
+        long long const a_uid = manifest_int(manifest, at, "a_uid");
+        long long const b_uid = manifest_int(manifest, at, "b_uid");
+
+        float *da, *db, *dc;
+        CHECK_CUDA(cudaMalloc(&da, n * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&db, n * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&dc, n * sizeof(float)));
+        void *workspace = nullptr;
+        if (workspace_size > 0) CHECK_CUDA(cudaMalloc(&workspace, workspace_size));
+
+        std::vector<float> ha(n), hb(n), hc(n);
+        for (long long i = 0; i < n; i++) {
+            ha[i] = static_cast<float>(i % 97) * 0.5f;
+            hb[i] = static_cast<float>(i % 31) * 0.25f;
+        }
+        CHECK_CUDA(cudaMemcpy(da, ha.data(), n * sizeof(float), cudaMemcpyHostToDevice));
+        CHECK_CUDA(cudaMemcpy(db, hb.data(), n * sizeof(float), cudaMemcpyHostToDevice));
+        CHECK_CUDA(cudaMemset(dc, 0xff, n * sizeof(float)));  // poison, so a no-op is visible
+
+        // Hot path: gather in uid_order, then execute.
+        std::vector<void *> ptrs(uid_order.size());
+        for (size_t i = 0; i < uid_order.size(); i++) {
+            ptrs[i] = (uid_order[i] == a_uid)   ? static_cast<void *>(da)
+                      : (uid_order[i] == b_uid) ? static_cast<void *>(db)
+                                                : static_cast<void *>(dc);
+        }
+        CHECK_FE(graph.execute(handle, ptrs.data(), static_cast<int>(ptrs.size()), workspace));
+        CHECK_CUDA(cudaDeviceSynchronize());
+        CHECK_CUDA(cudaMemcpy(hc.data(), dc, n * sizeof(float), cudaMemcpyDeviceToHost));
+
+        double max_err = 0.0;
+        for (long long i = 0; i < n; i++) {
+            max_err = std::max(max_err, static_cast<double>(std::fabs(hc[i] - (ha[i] + hb[i]))));
+        }
+        std::printf(
+            "  %-16s n=%-8lld max |err| = %g%s\n", name.c_str(), n, max_err, max_err == 0.0 ? "" : "   <-- MISMATCH");
+        if (max_err != 0.0) failures++;
+
+        cudaFree(da);
+        cudaFree(db);
+        cudaFree(dc);
+        if (workspace) cudaFree(workspace);
+    }
+
+    cudnnDestroy(handle);
+    return failures ? 1 : 0;
+}

--- a/samples/aot/flow2_import_execute.py
+++ b/samples/aot/flow2_import_execute.py
@@ -1,0 +1,65 @@
+"""Flow 2, deploy box (Python): open the container and run every kernel in it.
+
+Nothing here compiles. Run it in a fresh interpreter — with no cutlass and no
+kernel toolchain installed, if you want to see the point — against a container
+flow2_export.py wrote earlier, possibly on another machine.
+
+    python flow2_import_execute.py [mykernels.cudnn]
+"""
+
+import json
+import sys
+
+import torch
+
+import cudnn
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else "mykernels.cudnn"
+    if not torch.cuda.is_available():
+        raise SystemExit("needs a CUDA device")
+
+    with open(path + ".manifest.json") as f:
+        manifest = json.load(f)
+
+    handle = cudnn.create_handle()
+
+    # Version, architecture and missing-runtime-dependency mismatches are all
+    # rejected HERE, loudly. A misread artifact is never an illegal access.
+    lib = cudnn.import_from_disk(path, handle)
+    print(f"opened {path} holding {len(lib)} kernel(s): {sorted(lib.keys())}")
+
+    failures = 0
+    for name in sorted(lib.keys()):
+        graph = lib[name]  # BY NAME, never by position
+        entry = manifest[name]
+        shape = tuple(entry["shape"])
+
+        # Resolved once, at startup.
+        uid_order = graph.variant_pack_uids_sorted()
+        workspace = torch.empty(max(graph.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+
+        a = torch.randn(shape, device="cuda")
+        b = torch.randn(shape, device="cuda")
+        out = torch.full(shape, float("nan"), device="cuda")
+        by_uid = {entry["a_uid"]: a, entry["b_uid"]: b, entry["c_uid"]: out}
+
+        # Hot path: gather in uid_order, then execute.
+        graph.execute([by_uid[uid] for uid in uid_order], workspace, handle=handle)
+        torch.cuda.synchronize()
+
+        err = (out - (a + b)).abs().max().item()
+        print(f"  {name:<16} shape={shape} max |err| = {err}{'' if err == 0 else '   <-- MISMATCH'}")
+        failures += err != 0
+
+    cudnn.destroy_handle(handle)
+
+    # The claim this sample exists to demonstrate.
+    compiled = any(m in sys.modules for m in ("cutlass", "cutlass.cute"))
+    print(f"kernel toolchain loaded in this process: {compiled}")
+    raise SystemExit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/aot/flow3_global_execute.py
+++ b/samples/aot/flow3_global_execute.py
@@ -1,0 +1,49 @@
+"""Flow 3, execute step (Python): fetch a published kernel by name and run it.
+
+Below the lookup line this is byte-identical to flow 2 — both flows hand back a
+graph, so execution is one API. The only difference is where the graph came
+from: get_global() instead of a container.
+
+Importable (flow3_orchestrator.py case A drives it) and runnable on its own:
+
+    python flow3_global_execute.py
+"""
+
+import torch
+
+import cudnn
+
+from common import gather
+from flow3_register_global import NAME, SHAPE, register
+
+
+def execute_from_global(name, uids, shape, handle):
+    """Fetch by name and execute. Returns max |err| against a + b."""
+    # A snapshot: it keeps running the kernel it was fetched with, so after an
+    # override=True re-registration a caller that wants the new one re-fetches.
+    graph = cudnn.get_global(name, handle)
+
+    a = torch.randn(shape, device="cuda")
+    b = torch.randn(shape, device="cuda")
+    out = torch.full(shape, float("nan"), device="cuda")  # poison: a no-op is visible
+    workspace = torch.empty(max(graph.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+
+    graph.execute(gather(graph, {uids["a"]: a, uids["b"]: b, uids["c"]: out}), workspace, handle=handle)
+    torch.cuda.synchronize()
+
+    return (out - (a + b)).abs().max().item()
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise SystemExit("needs a CUDA device")
+
+    handle = cudnn.create_handle()
+    uids = register()
+    print("max |err|:", execute_from_global(NAME, uids, SHAPE, handle))
+    cudnn.unregister_global(NAME)
+    cudnn.destroy_handle(handle)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/aot/flow3_global_execute_nanobind.cpp
+++ b/samples/aot/flow3_global_execute_nanobind.cpp
@@ -1,0 +1,99 @@
+// Flow 3, execute step (C++): fetch a published kernel by name and run it,
+// from a nanobind extension loaded into the SAME process that registered it.
+//
+// This is the half of flow 3 that a pure-Python sample cannot show. The kernel
+// is compiled by Python; this is a separate shared object, and it reaches the
+// same graph through the process-global registry with no file, no container and
+// no serialisation anywhere.
+//
+// That only works because cudnn_frontend::detail::global_registry() is exported
+// with default visibility. It is a function-local static in a header, and FE's
+// own Python bindings are built with -fvisibility=hidden, so without that this
+// module would get a private, empty registry and get_global() would report
+// nothing registered. See kernel_library.h.
+//
+// Built by build.sh into flow3_global_execute_nanobind*.so.
+
+#include <cudnn_frontend/kernel_library.h>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace nb = nanobind;
+namespace fe = cudnn_frontend;
+
+namespace {
+
+// FE returns error_t and never throws; the Python half of the boundary wants an
+// exception, so this is where the two conventions meet. Taken by value because
+// error_object::is_bad() / get_message() are non-const.
+void
+check(fe::error_t status, char const *what) {
+    if (status.is_bad()) {
+        throw std::runtime_error(std::string(what) + ": " + status.get_message());
+    }
+}
+
+}  // namespace
+
+NB_MODULE(flow3_global_execute_nanobind, m) {
+    m.doc() = "C++ executor for a kernel published by cudnn.register_global() in this process";
+
+    m.def(
+        "registered_names",
+        [] { return fe::registered_global_names(); },
+        "What this shared object can see in the process-global registry. Proves it is the same "
+        "registry Python wrote to, not a private copy.");
+
+    m.def(
+        "variant_pack_uids_sorted",
+        [](std::string const &name) {
+            fe::graph::Graph graph;
+            check(fe::get_global(name, &graph), "get_global");
+            return graph.get_variant_pack_uids_sorted();
+        },
+        nb::arg("name"),
+        "The uid order execute() wants pointers in. Resolved once, at startup.");
+
+    m.def(
+        "workspace_size",
+        [](std::string const &name) {
+            fe::graph::Graph graph;
+            check(fe::get_global(name, &graph), "get_global");
+            int64_t size = 0;
+            check(graph.get_workspace_size(size), "get_workspace_size");
+            return size;
+        },
+        nb::arg("name"));
+
+    m.def(
+        "execute",
+        [](std::string const &name, std::vector<uintptr_t> const &ptrs, uintptr_t workspace, uintptr_t handle) {
+            // A snapshot, exactly as in Python: this keeps a reference to the
+            // compiled kernel it was fetched with.
+            fe::graph::Graph graph;
+            check(fe::get_global(name, &graph), "get_global");
+
+            std::vector<void *> raw(ptrs.size());
+            for (size_t i = 0; i < ptrs.size(); i++) {
+                raw[i] = reinterpret_cast<void *>(ptrs[i]);
+            }
+
+            // Identical to the flow-2 C++ executor from here down.
+            check(graph.execute(reinterpret_cast<cudnnHandle_t>(handle),
+                                raw.data(),
+                                static_cast<int>(raw.size()),
+                                reinterpret_cast<void *>(workspace)),
+                  "execute");
+        },
+        nb::arg("name"),
+        nb::arg("ptrs"),
+        nb::arg("workspace"),
+        nb::arg("handle"),
+        "Execute the named kernel from a pointer array gathered in variant_pack_uids_sorted() order.");
+}

--- a/samples/aot/flow3_orchestrator.py
+++ b/samples/aot/flow3_orchestrator.py
@@ -1,0 +1,89 @@
+"""Flow 3, both consumers, in one process.
+
+    A)  register_global (Python)  ->  execute (Python)
+    B)  register_global (Python)  ->  execute (C++, a nanobind extension)
+
+Case B is the one that matters. The kernel is compiled by Python and never
+serialised; the C++ executor is a separate shared object in the same process and
+reaches the same graph through the process-global registry, by name. Nothing is
+written to disk in either case.
+
+Run build.sh first so the nanobind module exists; without it case B is skipped
+and case A still runs.
+
+    python flow3_orchestrator.py
+"""
+
+import sys
+
+import torch
+
+import cudnn
+from cudnn._handle import to_backend_handle
+
+from common import gather
+from flow3_global_execute import execute_from_global
+from flow3_register_global import NAME, SHAPE, register
+
+
+def case_a(handle, uids):
+    """register_global (Python) -> execute (Python)."""
+    err = execute_from_global(NAME, uids, SHAPE, handle)
+    print(f"  A  python register -> python execute      max |err| = {err}")
+    return err == 0
+
+
+def case_b(handle, uids):
+    """register_global (Python) -> execute (C++ nanobind extension)."""
+    try:
+        import flow3_global_execute_nanobind as cpp
+    except ImportError as e:
+        print(f"  B  SKIPPED: {e}. Run ./build.sh to compile the extension.")
+        return None
+
+    # The proof that the extension shares the registry rather than holding a
+    # private copy: it is a different .so and it sees what Python registered.
+    seen = cpp.registered_names()
+    print(f"     the C++ .so sees the registry as: {seen}")
+    assert NAME in seen, "the extension has its own registry -- see kernel_library.h"
+
+    # Resolved once, through the C++ side this time.
+    uid_order = cpp.variant_pack_uids_sorted(NAME)
+    workspace = torch.empty(max(cpp.workspace_size(NAME), 1), dtype=torch.uint8, device="cuda")
+
+    a = torch.randn(SHAPE, device="cuda")
+    b = torch.randn(SHAPE, device="cuda")
+    out = torch.full(SHAPE, float("nan"), device="cuda")
+    by_uid = {uids["a"]: a, uids["b"]: b, uids["c"]: out}
+
+    # The hot path crosses into C++ with a flat pointer array and nothing else.
+    cpp.execute(NAME, [by_uid[uid].data_ptr() for uid in uid_order], workspace.data_ptr(), to_backend_handle(handle))
+    torch.cuda.synchronize()
+
+    err = (out - (a + b)).abs().max().item()
+    print(f"  B  python register -> C++ execute         max |err| = {err}")
+    return err == 0
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise SystemExit("needs a CUDA device")
+
+    handle = cudnn.create_handle()
+
+    # One registration, both consumers. This is the whole point: the kernel is
+    # published once and whoever is in the process can reach it by name.
+    uids = register()
+    print(f"registered {NAME!r}; nothing written to disk")
+
+    results = [case_a(handle, uids), case_b(handle, uids)]
+
+    cudnn.unregister_global(NAME)
+    cudnn.destroy_handle(handle)
+
+    ran = [r for r in results if r is not None]
+    raise SystemExit(0 if ran and all(ran) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/aot/flow3_register_global.py
+++ b/samples/aot/flow3_register_global.py
@@ -1,0 +1,43 @@
+"""Flow 3, publish step: compile a kernel and publish it under a name.
+
+The same build as flow 2 with the last two lines deleted. Nothing is written
+out, so there is nothing to pack — the name in the process table is the entire
+contract. The registry holds a reference, so the compiled object cannot be
+collected out from under a live handle.
+
+Importable (flow3_orchestrator.py drives it) and runnable on its own:
+
+    python flow3_register_global.py
+"""
+
+import cudnn
+
+from common import build
+
+NAME = "tile_add_f32"
+SHAPE = (1024, 512)
+
+
+def register(name=NAME, shape=SHAPE, override=False):
+    """Compile and publish. Returns the tensor uids the caller binds buffers to."""
+    graph, (a, b, c) = build(name, shape)
+
+    # No file. The kernel was compiled in this process and its cubin is already
+    # in the CUDA context, so a name is all a C++ executor in this same process
+    # needs. Duplicate name is an error unless override=True (the autotuner
+    # case); callers holding a get_global handle must re-fetch afterwards.
+    cudnn.register_global(graph, override=override)
+
+    return {"a": a.uid, "b": b.uid, "c": c.uid}
+
+
+def main():
+    uids = register()
+    print("registered:", cudnn.aot.registered_global_names())
+    print("uids:", uids)
+    cudnn.unregister_global(NAME)
+    print("after unregister:", cudnn.aot.registered_global_names())
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/aot/tile_add_primitives.py
+++ b/samples/aot/tile_add_primitives.py
@@ -1,0 +1,143 @@
+"""The same TMA tile add, one level down: cutlass.experimental.primitives.
+
+``cutedsl_tma_add_engine`` writes this kernel with ``cpasync.make_tiled_tma_atom``
+and ``cute.copy``, which wrap the descriptor and the copy instruction in an
+"atom" and hide where the descriptor lives. This file is the explicit spelling
+of the identical kernel: build the TMA descriptor yourself, issue the PTX
+bulk-tensor copy yourself, drive the mbarrier yourself.
+
+It is here because the two are worth reading side by side. The atom version is
+what you want to write; this one is what it lowers to, and it is the level FROST
+works at, so it is the level you end up debugging at.
+
+Same arithmetic, same tile, same result:
+
+    c = a + b     fp32, 2-D, 128x64 tiles, operands loaded by TMA
+
+The canonical form for these primitives is the DKG tutorial at
+``examples/CuTeDSL/experimental/primitives/tutorial/04_tma_load.py``. Four things
+in it are load-bearing and none of them fail at compile time:
+
+* the descriptor parameter must be ``cutlass.GridConstant[cuda.TensorMap]``. A
+  TMA descriptor read from kernel parameter space has to be grid-constant; pass
+  a bare ``TensorMap`` and the copy faults with a misaligned address, nowhere
+  near the actual mistake.
+* ``elect_sync()`` elects one lane PER WARP, so a block wider than a warp needs
+  its own warp guard on top. Without it every warp issues the copies and
+  quadruples the transaction count.
+* ``mbarrier_arrive_expect_tx`` must precede the copies, and its byte count
+  covers every copy that signals the same barrier -- hence the sum of both
+  descriptors' ``global_tx_bytes()``.
+* the wait spins on the timelimit variant, which retries on a tick-timeout and
+  carries ``.acquire.cta`` ordering, so the TMA writes are visible once it
+  returns.
+
+    python tile_add_primitives.py
+"""
+
+import cuda.bindings.driver as drv
+import cutlass
+import cutlass.cute as cute
+import cutlass.experimental.cuda as cuda
+import torch
+from cutlass.cute.runtime import from_dlpack
+from cutlass.experimental import primitives as prims
+
+BM, BN = 128, 64
+THREADS = 128
+
+
+@cute.kernel
+def tile_add_kernel(
+    desc_a: cutlass.GridConstant[cuda.TensorMap],
+    desc_b: cutlass.GridConstant[cuda.TensorMap],
+    mC: cute.Tensor,
+):
+    bidx, bidy, _ = cute.arch.block_idx()
+    tidx, _, _ = cute.arch.thread_idx()
+
+    sA = cutlass.Array(cutlass.Float32, (BM, BN), space=cutlass.AddressSpace.smem)
+    sB = cutlass.Array(cutlass.Float32, (BM, BN), space=cutlass.AddressSpace.smem)
+    mbar = cutlass.Array(cutlass.Int64, 1, space=cutlass.AddressSpace.smem)
+
+    # One warp, then one lane within it. elect_sync() alone would leave one
+    # lane per warp, i.e. four issuers in a 128-thread block.
+    warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    if warp == 0:
+        if prims.elect_sync():
+            prims.prefetch_tensormap(desc_a.get_ptr())
+            prims.prefetch_tensormap(desc_b.get_ptr())
+            prims.mbarrier_init(mbar, 1)
+    prims.fence_mbarrier_init()
+    prims.barrier_cta_sync(0)
+
+    if warp == 0:
+        if prims.elect_sync():
+            # Both copies signal this barrier, so the promised byte count is
+            # the sum. Promised BEFORE the copies, or TMA can decrement a
+            # counter that is not set yet.
+            prims.mbarrier_arrive_expect_tx(
+                mbar, desc_a.global_tx_bytes() + desc_b.global_tx_bytes()
+            )
+            # Coordinates are element indices in the DESCRIPTOR's dimension
+            # order -- innermost (N) first, the reverse of box_dims below.
+            prims.cp_async_bulk_tensor_shared_cta_global(
+                sA, desc_a.get_ptr(), (bidy * BN, bidx * BM), mbar
+            )
+            prims.cp_async_bulk_tensor_shared_cta_global(
+                sB, desc_b.get_ptr(), (bidy * BN, bidx * BM), mbar
+            )
+
+    while not prims.mbarrier_try_wait_parity(mbar, 0, time_limit=10_000_000):
+        pass
+
+    for e in cutlass.range_constexpr(BM * BN // THREADS):
+        flat = e * THREADS + tidx
+        r = flat // BN
+        c = flat % BN
+        mC[(bidx * BM + r, bidy * BN + c)] = sA[(r, c)] + sB[(r, c)]
+
+
+@cute.jit
+def tile_add(mA: cute.Tensor, mB: cute.Tensor, mC: cute.Tensor, stream: drv.CUstream):
+    # Host side, once per call, against the pointers that actually arrived.
+    # box_dims is in the TENSOR's mode order; swizzle none means the tile lands
+    # linearly in shared memory, which is what the plain 2-D Array above is.
+    descs = [
+        cuda.create_tensor_map_tiled_from_view(
+            t, box_dims=(BM, BN), stride_order=(1, 0), swizzle=cuda.TensorMapSwizzle.none
+        )
+        for t in (mA, mB)
+    ]
+    m, n = mC.shape
+    tile_add_kernel(descs[0], descs[1], mC).launch(
+        grid=(m // BM, n // BN, 1), block=(THREADS, 1, 1), stream=stream
+    )
+
+
+def main():
+    if not torch.cuda.is_available():
+        raise SystemExit("needs a CUDA device")
+
+    M, N = 1024, 512
+    a = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    b = torch.randn(M, N, device="cuda", dtype=torch.float32)
+    c = torch.zeros(M, N, device="cuda", dtype=torch.float32)
+    stream = drv.CUstream(torch.cuda.current_stream().cuda_stream)
+
+    compiled = cute.compile(
+        tile_add,
+        *[from_dlpack(t, assumed_align=16) for t in (a, b, c)],
+        stream,
+        options="--enable-tvm-ffi",
+    )
+    compiled(a, b, c, stream)
+    torch.cuda.synchronize()
+
+    err = (c - (a + b)).abs().max().item()
+    print(f"tile_add via primitives  {M}x{N}  max |err| = {err}")
+    return 0 if err == 0.0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/python/test_aot_export.py
+++ b/test/python/test_aot_export.py
@@ -1,0 +1,552 @@
+"""AOT kernel export/import.
+
+Covers the two AOT flows end to end: a container written on a build box and
+executed in a process that never compiles anything, and the same graphs
+published into the process-global table with no file at all.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+
+import cudnn
+
+pytestmark = pytest.mark.L0
+
+cutlass = pytest.importorskip("cutlass", reason="AOT export needs nvidia-cutlass-dsl")
+tvm_ffi = pytest.importorskip("tvm_ffi", reason="AOT export needs apache-tvm-ffi")
+
+
+@pytest.fixture(autouse=True)
+def enable_demo_engines(monkeypatch):
+    """The CuTeDSL demo family is opt_in, and engines are not injectable."""
+    monkeypatch.setenv("CUDNN_FRONTEND_ENABLE_FROST_ENGINES", "1")
+
+
+def _requires_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("needs a CUDA device")
+
+
+def build_add_graph(name, shape=(4, 1024), dtype=torch.float32):
+    """A single-node elementwise-add graph routed to the CuTeDSL engine."""
+    graph = cudnn.pygraph(
+        io_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    a = graph.tensor(dim=list(shape), stride=_contig_stride(shape), data_type=cudnn.data_type.FLOAT, name="A")
+    b = graph.tensor(dim=list(shape), stride=_contig_stride(shape), data_type=cudnn.data_type.FLOAT, name="B")
+    c = graph.add(a, b, name="sum")
+    c.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+
+    graph.validate()
+    graph.build_operation_graph()
+    graph.create_execution_plans([cudnn.heur_mode.A])
+    graph.check_support()
+    graph.build_plans()
+    graph.set_name(name)
+    return graph, a, b, c
+
+
+def _contig_stride(shape):
+    stride, acc = [], 1
+    for d in reversed(shape):
+        stride.append(acc)
+        acc *= d
+    return list(reversed(stride))
+
+
+def test_cutedsl_engine_is_selected():
+    """The vehicle must actually route to the CuTeDSL engine, not to cuDNN."""
+    _requires_cuda()
+    graph, *_ = build_add_graph("add_f32_selected")
+    assert graph.selected_engine is not None
+    assert graph.selected_engine.name == "cutedsl_pointwise_add"
+
+
+def test_round_trip_matches_direct_execution():
+    """serialize -> deserialize -> execute is numerically identical to executing
+    the same graph directly."""
+    _requires_cuda()
+    shape = (4, 1024)
+    handle = cudnn.create_handle()
+
+    graph, a, b, c = build_add_graph("add_fwd_f32", shape)
+
+    a_gpu = torch.randn(shape, device="cuda", dtype=torch.float32)
+    b_gpu = torch.randn(shape, device="cuda", dtype=torch.float32)
+    direct = torch.zeros(shape, device="cuda", dtype=torch.float32)
+
+    graph.execute({a: a_gpu, b: b_gpu, c: direct}, None, handle=handle)
+    torch.cuda.synchronize()
+
+    data = cudnn.aot.serialize_graph(graph)
+    assert len(data) > 0
+
+    loaded = cudnn.aot.deserialize_graph(data, handle)
+    assert loaded.get_name() == "add_fwd_f32"
+    # The loaded graph must dispatch to the artifact, not to a cuDNN plan.
+    assert loaded._lowered_graph._has_cutedsl_payload()
+
+    uid_order = loaded.variant_pack_uids_sorted()
+    assert sorted(uid_order) == sorted([a.uid, b.uid, c.uid])
+
+    by_uid = {a.uid: a_gpu, b.uid: b_gpu}
+    round_tripped = torch.zeros(shape, device="cuda", dtype=torch.float32)
+    by_uid[c.uid] = round_tripped
+
+    ws_size = loaded.get_workspace_size()
+    ws = torch.empty(max(ws_size, 1), dtype=torch.uint8, device="cuda")
+
+    # The doc's spelling: execute() takes the gathered pointer array directly.
+    loaded.execute([by_uid[u] for u in uid_order], ws, handle=handle)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(round_tripped, a_gpu + b_gpu, rtol=0, atol=0)
+    torch.testing.assert_close(round_tripped, direct, rtol=0, atol=0)
+
+    cudnn.destroy_handle(handle)
+
+
+def test_concurrent_execute_of_one_imported_graph():
+    """execute() does not mutate the graph, so one graph may be executed from
+    any number of threads."""
+    _requires_cuda()
+    import threading
+
+    shape = (4, 1024)
+    handle = cudnn.create_handle()
+    graph, a, b, c = build_add_graph("add_threads_f32", shape)
+    loaded = cudnn.aot.deserialize_graph(cudnn.aot.serialize_graph(graph), handle)
+    uid_order = loaded.variant_pack_uids_sorted()
+
+    a_gpu = torch.randn(shape, device="cuda")
+    b_gpu = torch.randn(shape, device="cuda")
+    expected = a_gpu + b_gpu
+    failures = []
+
+    def run(i):
+        out = torch.zeros(shape, device="cuda")
+        by_uid = {a.uid: a_gpu, b.uid: b_gpu, c.uid: out}
+        ws = torch.empty(1, dtype=torch.uint8, device="cuda")
+        try:
+            loaded.execute_ptrs([by_uid[u] for u in uid_order], ws, handle=handle)
+            torch.cuda.synchronize()
+            if not torch.equal(out, expected):
+                failures.append(f"thread {i}: numerical mismatch")
+        except Exception as e:  # noqa: BLE001 — reported, not swallowed
+            failures.append(f"thread {i}: {e}")
+
+    threads = [threading.Thread(target=run, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not failures, failures
+
+    cudnn.destroy_handle(handle)
+
+
+def test_wrong_architecture_is_rejected_at_load():
+    """A misread artifact must be a clean error, never an illegal access."""
+    _requires_cuda()
+    handle = cudnn.create_handle()
+    graph, *_ = build_add_graph("add_arch_f32")
+    data = cudnn.aot.serialize_graph(graph)
+
+    tag = data.find(b"sm_100a")
+    assert tag > 0, "expected the artifact to record its target architecture"
+    tampered = bytearray(data)
+    tampered[tag : tag + 7] = b"sm_90aa"
+
+    with pytest.raises(Exception, match="but this device is"):
+        cudnn.aot.deserialize_graph(bytes(tampered), handle)
+
+    cudnn.destroy_handle(handle)
+
+
+def test_deserialized_graph_refuses_to_be_rebuilt():
+    """Build-time calls on a graph that came from an artifact must be a clear
+    error, not undefined behaviour."""
+    _requires_cuda()
+    handle = cudnn.create_handle()
+    graph, *_ = build_add_graph("add_guard_f32")
+    loaded = cudnn.aot.deserialize_graph(cudnn.aot.serialize_graph(graph), handle)
+
+    for call in (
+        lambda: loaded._lowered_graph.validate(),
+        lambda: loaded._lowered_graph.build_operation_graph(),
+        lambda: loaded._lowered_graph.create_execution_plans([cudnn.heur_mode.A]),
+        lambda: loaded._lowered_graph.check_support(),
+        lambda: loaded._lowered_graph.build_plans(),
+    ):
+        with pytest.raises(Exception, match="deserialized"):
+            call()
+
+    cudnn.destroy_handle(handle)
+
+
+def test_export_requires_a_name():
+    _requires_cuda()
+    graph = cudnn.pygraph(
+        io_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    shape = (2, 256)
+    a = graph.tensor(dim=list(shape), stride=_contig_stride(shape), data_type=cudnn.data_type.FLOAT, name="A")
+    b = graph.tensor(dim=list(shape), stride=_contig_stride(shape), data_type=cudnn.data_type.FLOAT, name="B")
+    c = graph.add(a, b, name="sum")
+    c.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    graph.build([cudnn.heur_mode.A])
+
+    with pytest.raises(ValueError, match="set_name"):
+        cudnn.aot.serialize_graph(graph)
+
+
+def test_backend_engine_export_is_not_implemented(monkeypatch):
+    """A cuDNN-backend graph must say so, not produce a broken artifact."""
+    _requires_cuda()
+    # Off, or the demo pointwise engine claims this graph and it never reaches
+    # the backend.
+    monkeypatch.delenv("CUDNN_FRONTEND_ENABLE_FROST_ENGINES", raising=False)
+    graph = cudnn.pygraph(
+        io_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    shape = (2, 256)
+    a = graph.tensor(dim=list(shape), stride=_contig_stride(shape), data_type=cudnn.data_type.FLOAT, name="A")
+    b = graph.tensor(dim=list(shape), stride=_contig_stride(shape), data_type=cudnn.data_type.FLOAT, name="B")
+    c = graph.add(a, b, name="sum")
+    c.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    graph.build([cudnn.heur_mode.A])
+    graph.set_name("add_backend_f32")
+
+    with pytest.raises(NotImplementedError, match="cuDNN backend"):
+        cudnn.aot.serialize_graph(graph)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: a container of N graphs, executed in a process that never compiled
+# anything.
+# ---------------------------------------------------------------------------
+
+# Runs in the fresh process: import the container, execute every kernel in it
+# from the pointer array, and report the results as JSON on stdout.
+_CONSUMER = r"""
+import json, sys
+import torch
+import cudnn
+
+path, spec_json = sys.argv[1], sys.argv[2]
+spec = json.loads(spec_json)
+handle = cudnn.create_handle()
+
+lib = cudnn.import_from_disk(path, handle)
+result = {"keys": sorted(lib.keys()), "outputs": {}}
+
+for name, entry in spec.items():
+    graph = lib[name]
+    shape = tuple(entry["shape"])
+    torch.manual_seed(entry["seed"])
+    a = torch.randn(shape, device="cuda")
+    b = torch.randn(shape, device="cuda")
+    out = torch.full(shape, float("nan"), device="cuda")
+
+    uid_order = graph.variant_pack_uids_sorted()
+    by_uid = {entry["a_uid"]: a, entry["b_uid"]: b, entry["c_uid"]: out}
+    ws = torch.empty(max(graph.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+    graph.execute([by_uid[u] for u in uid_order], ws, handle=handle)
+    torch.cuda.synchronize()
+
+    result["outputs"][name] = {
+        "exact": bool(torch.equal(out, a + b)),
+        "uid_order": list(uid_order),
+        "checksum": float(out.double().sum().item()),
+    }
+
+cudnn.destroy_handle(handle)
+# The point of flow 2: no kernel toolchain ran in this process.
+# nvidia_cutlass_dsl lands in sys.modules from the wheel's path hook alone;
+# "cutlass" is the import that actually brings in the JIT.
+result["compiler_loaded"] = any(m in sys.modules for m in ("cutlass", "cutlass.cute"))
+print("RESULT " + json.dumps(result))
+"""
+
+
+def _run_consumer(path, spec):
+    """Run the consumer in a genuinely fresh interpreter."""
+    proc = subprocess.run(
+        [sys.executable, "-c", _CONSUMER, path, json.dumps(spec)],
+        capture_output=True,
+        text=True,
+        env=dict(os.environ),
+    )
+    assert proc.returncode == 0, f"consumer failed:\n{proc.stdout}\n{proc.stderr}"
+    line = next((l for l in proc.stdout.splitlines() if l.startswith("RESULT ")), None)
+    assert line is not None, f"no result from consumer:\n{proc.stdout}\n{proc.stderr}"
+    return json.loads(line[len("RESULT ") :])
+
+
+def test_container_of_n_graphs_runs_in_a_fresh_process(tmp_path):
+    """The whole point of flow 2: build here, execute over there, no compiler."""
+    _requires_cuda()
+    path = str(tmp_path / "mykernels.cudnn")
+
+    specs = {"add_small_f32": (2, 512), "add_medium_f32": (4, 1024), "add_large_f32": (8, 2048)}
+    graphs, spec = [], {}
+    for name, shape in specs.items():
+        graph, a, b, c = build_add_graph(name, shape)
+        graphs.append(graph)
+        spec[name] = {
+            "shape": list(shape),
+            "seed": len(name),
+            "a_uid": a.uid,
+            "b_uid": b.uid,
+            "c_uid": c.uid,
+        }
+
+    cudnn.export_to_disk(graphs, path=path)
+    assert os.path.getsize(path) > 0
+
+    result = _run_consumer(path, spec)
+    assert result["keys"] == sorted(specs)
+    assert not result["compiler_loaded"], "the consuming process should never load a kernel toolchain"
+
+    for name in specs:
+        got = result["outputs"][name]
+        assert got["exact"], f"{name} did not match a+b in the fresh process"
+        # And the same expectation reproduced here, from the same seed.
+        torch.manual_seed(spec[name]["seed"])
+        shape = tuple(spec[name]["shape"])
+        a_gpu = torch.randn(shape, device="cuda")
+        b_gpu = torch.randn(shape, device="cuda")
+        assert got["checksum"] == pytest.approx((a_gpu + b_gpu).double().sum().item(), rel=0, abs=0)
+
+
+def test_container_lookup_is_by_name(tmp_path):
+    """Adding a kernel must not change what an existing caller resolves."""
+    _requires_cuda()
+    handle = cudnn.create_handle()
+
+    small = str(tmp_path / "small.cudnn")
+    big = str(tmp_path / "big.cudnn")
+
+    g1, *_ = build_add_graph("kernel_one")
+    cudnn.export_to_disk([g1], path=small)
+
+    # A second container with an extra kernel sorted BEFORE the first one.
+    g1b, *_ = build_add_graph("kernel_one")
+    g0, *_ = build_add_graph("aaa_kernel_zero")
+    cudnn.export_to_disk([g0, g1b], path=big)
+
+    lib_small = cudnn.import_from_disk(small, handle)
+    lib_big = cudnn.import_from_disk(big, handle)
+
+    assert sorted(lib_small.keys()) == ["kernel_one"]
+    assert sorted(lib_big.keys()) == ["aaa_kernel_zero", "kernel_one"]
+    assert lib_big["kernel_one"].get_name() == "kernel_one"
+
+    with pytest.raises(KeyError, match="no kernel named"):
+        lib_big["nope"]
+
+    cudnn.destroy_handle(handle)
+
+
+def test_duplicate_names_in_one_call_are_rejected(tmp_path):
+    _requires_cuda()
+    g1, *_ = build_add_graph("same_name")
+    g2, *_ = build_add_graph("same_name")
+    with pytest.raises(ValueError, match="both named"):
+        cudnn.export_to_disk([g1, g2], path=str(tmp_path / "dup.cudnn"))
+
+
+def test_unnamed_graph_is_rejected(tmp_path):
+    _requires_cuda()
+    graph = cudnn.pygraph(
+        io_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    shape = (2, 256)
+    a = graph.tensor(dim=list(shape), stride=_contig_stride(shape), data_type=cudnn.data_type.FLOAT, name="A")
+    b = graph.tensor(dim=list(shape), stride=_contig_stride(shape), data_type=cudnn.data_type.FLOAT, name="B")
+    c = graph.add(a, b, name="sum")
+    c.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    graph.build([cudnn.heur_mode.A])
+    with pytest.raises(ValueError, match="set_name"):
+        cudnn.export_to_disk([graph], path=str(tmp_path / "unnamed.cudnn"))
+
+
+def test_not_a_container_is_a_clean_error(tmp_path):
+    _requires_cuda()
+    junk = tmp_path / "junk.cudnn"
+    junk.write_bytes(b"this is not a cudnn kernel library")
+    with pytest.raises(Exception, match="cuDNN kernel library"):
+        cudnn.import_from_disk(str(junk))
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: register to memory. No file, same process, same execute API.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_registry():
+    """Leave the process table as we found it, whatever the test does."""
+    before = set(cudnn.aot.registered_global_names())
+    yield
+    for name in set(cudnn.aot.registered_global_names()) - before:
+        cudnn.aot.unregister_global(name)
+
+
+def test_register_global_then_execute(clean_registry):
+    """Flow 3 end to end: publish under a name, fetch it back, execute."""
+    _requires_cuda()
+    shape = (4, 1024)
+    handle = cudnn.create_handle()
+
+    graph, a, b, c = build_add_graph("ln_resident_f32", shape)
+    cudnn.register_global(graph)
+    assert "ln_resident_f32" in cudnn.aot.registered_global_names()
+
+    fetched = cudnn.get_global("ln_resident_f32", handle)
+    assert fetched.get_name() == "ln_resident_f32"
+
+    a_gpu = torch.randn(shape, device="cuda")
+    b_gpu = torch.randn(shape, device="cuda")
+    out = torch.full(shape, float("nan"), device="cuda")
+
+    uid_order = fetched.variant_pack_uids_sorted()
+    by_uid = {a.uid: a_gpu, b.uid: b_gpu, c.uid: out}
+    ws = torch.empty(max(fetched.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+
+    # Identical to flow 2 from the lookup down.
+    fetched.execute([by_uid[u] for u in uid_order], ws, handle=handle)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out, a_gpu + b_gpu, rtol=0, atol=0)
+
+    cudnn.unregister_global("ln_resident_f32")
+    assert "ln_resident_f32" not in cudnn.aot.registered_global_names()
+
+    cudnn.destroy_handle(handle)
+
+
+def test_register_global_writes_no_file(tmp_path, clean_registry):
+    """Flow 3's whole point: nothing is serialised."""
+    _requires_cuda()
+    cache = tmp_path / "aot_cache"
+    old = os.environ.get("CUDNN_FRONTEND_AOT_CACHE_DIR")
+    os.environ["CUDNN_FRONTEND_AOT_CACHE_DIR"] = str(cache)
+    try:
+        graph, *_ = build_add_graph("ln_nofile_f32")
+        cudnn.register_global(graph)
+        cudnn.get_global("ln_nofile_f32")
+        assert not cache.exists(), "register_global() materialised a module file"
+    finally:
+        if old is None:
+            os.environ.pop("CUDNN_FRONTEND_AOT_CACHE_DIR", None)
+        else:
+            os.environ["CUDNN_FRONTEND_AOT_CACHE_DIR"] = old
+
+
+def test_duplicate_registration_needs_override(clean_registry):
+    _requires_cuda()
+    g1, *_ = build_add_graph("ln_dup_f32")
+    cudnn.register_global(g1)
+
+    g2, *_ = build_add_graph("ln_dup_f32", (8, 256))
+    with pytest.raises(Exception, match="already registered"):
+        cudnn.register_global(g2)
+
+    cudnn.register_global(g2, override=True)
+
+
+def test_override_and_refetch(clean_registry):
+    """A handle from get_global is a snapshot: it keeps running the kernel it was
+    fetched with, and a caller that wants the new one re-fetches."""
+    _requires_cuda()
+    handle = cudnn.create_handle()
+
+    first_shape, second_shape = (4, 1024), (2, 64)
+    g1, a1, b1, c1 = build_add_graph("ln_override_f32", first_shape)
+    cudnn.register_global(g1)
+    stale = cudnn.get_global("ln_override_f32", handle)
+    stale_order = stale.variant_pack_uids_sorted()
+
+    g2, a2, b2, c2 = build_add_graph("ln_override_f32", second_shape)
+    cudnn.register_global(g2, override=True)
+
+    fresh = cudnn.get_global("ln_override_f32", handle)
+
+    def run(graph, shape, uids, order):
+        a_gpu = torch.randn(shape, device="cuda")
+        b_gpu = torch.randn(shape, device="cuda")
+        out = torch.full(shape, float("nan"), device="cuda")
+        by_uid = dict(zip(uids, (a_gpu, b_gpu, out)))
+        ws = torch.empty(max(graph.get_workspace_size(), 1), dtype=torch.uint8, device="cuda")
+        graph.execute([by_uid[u] for u in order], ws, handle=handle)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(out, a_gpu + b_gpu, rtol=0, atol=0)
+
+    # The stale snapshot still runs the kernel it was fetched with...
+    run(stale, first_shape, (a1.uid, b1.uid, c1.uid), stale_order)
+    # ...and the re-fetched handle runs the new one.
+    run(fresh, second_shape, (a2.uid, b2.uid, c2.uid), fresh.variant_pack_uids_sorted())
+
+    cudnn.destroy_handle(handle)
+
+
+def test_get_unknown_global_is_a_clean_error(clean_registry):
+    _requires_cuda()
+    with pytest.raises(Exception, match="Nothing is registered under"):
+        cudnn.get_global("no_such_kernel")
+    with pytest.raises(Exception, match="Nothing is registered under"):
+        cudnn.unregister_global("no_such_kernel")
+
+
+def test_registry_holds_a_reference(clean_registry):
+    """The compiled object must survive the builder dropping every reference."""
+    _requires_cuda()
+    import gc
+
+    handle = cudnn.create_handle()
+    graph, a, b, c = build_add_graph("ln_lifetime_f32", (2, 512))
+    uids = (a.uid, b.uid, c.uid)
+    cudnn.register_global(graph)
+
+    del graph, a, b, c
+    gc.collect()
+
+    fetched = cudnn.get_global("ln_lifetime_f32", handle)
+    shape = (2, 512)
+    a_gpu = torch.randn(shape, device="cuda")
+    b_gpu = torch.randn(shape, device="cuda")
+    out = torch.zeros(shape, device="cuda")
+    by_uid = dict(zip(uids, (a_gpu, b_gpu, out)))
+    ws = torch.empty(1, dtype=torch.uint8, device="cuda")
+    fetched.execute([by_uid[u] for u in fetched.variant_pack_uids_sorted()], ws, handle=handle)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, a_gpu + b_gpu, rtol=0, atol=0)
+
+    cudnn.destroy_handle(handle)
+
+
+def test_wire_prefix_never_appears_in_user_code(clean_registry):
+    """FE namespaces its entries as cudnn.<name>; the user says <name>."""
+    _requires_cuda()
+    import tvm_ffi
+
+    graph, *_ = build_add_graph("ln_prefix_f32")
+    cudnn.register_global(graph)
+
+    assert cudnn.aot.registered_global_names() == ["ln_prefix_f32"] or "ln_prefix_f32" in cudnn.aot.registered_global_names()
+    # One entry per launch step, named <prefix>.<i>; this kernel is one launch.
+    assert tvm_ffi.get_global_func("cudnn.ln_prefix_f32.0", allow_missing=True) is not None
+    assert tvm_ffi.get_global_func("ln_prefix_f32.0", allow_missing=True) is None
+
+    cudnn.unregister_global("ln_prefix_f32")
+    assert tvm_ffi.get_global_func("cudnn.ln_prefix_f32.0", allow_missing=True) is None


### PR DESCRIPTION
AOT kernel export/import for cuDNN frontend graphs.

Build a graph once, on a build box, and get the compiled kernel back in another
process — or another language — with no JIT, no cutlass and no compiler at the
other end.

This is the **core** PR. The FROST linear-attention retrofit (`samples/aot_linear`,
`test_aot_family.py`, a `_launch_sequence()` for `FrostLaPlan`) follows separately.

## Two destinations, one build path

Both take a built graph and hand back a `pygraph`, so every line below the lookup
is the ordinary execute API.

```python
graph.set_name("ln_fwd_bf16")             # mandatory: the name IS the identity

cudnn.export_to_disk([graph, ...], path="mykernels.cudnn")   # flow 2: one container
cudnn.register_global(graph)                                  # flow 3: no file at all
```

```python
lib   = cudnn.import_from_disk("mykernels.cudnn")   # or cudnn.get_global(name)
graph = lib["ln_fwd_bf16"]                          # by name, never by position

order = graph.variant_pack_uids_sorted()            # once, at startup
graph.execute([t[u].data_ptr() for u in order], workspace, handle=handle)
```

Same thing from C++ with no Python in the process, via `kernel_library.h`:

```cpp
cudnn::KernelLibrary lib;
CHECK(cudnn::import_from_disk("mykernels.cudnn", &lib));
cudnn::Graph g;  CHECK(lib.get("ln_fwd_bf16", &g));
CHECK(g.execute(handle, ptrs.data(), (int)ptrs.size(), workspace));
```

Version, architecture and missing-runtime-dependency mismatches are rejected at
load, not at first launch. Build-time calls on a graph that arrived off disk
fail with a clear "this graph was deserialized" error.

## The engine plugin interface

One method per engine:

```python
class CompiledPlan:
    def _launch_sequence(self): ...   # (steps, workspace_bytes)
```

Everything else — the container, both loaders, both executors, the
deserialized-graph guard — is shared. A plan's launches are exported as an
ordered list of steps (a call or a stream-ordered workspace clear), so a
multi-launch plan needs no second representation and costs the same single
`dlopen` as a one-launch one.

Most plans don't write the list by hand: `record_launch_sequence()` runs the
plan once on throwaway buffers and watches which kernels it issues over which
tensors, so a retrofit is a few lines saying how to run the plan.

## Coverage

| engine | AOT export |
|---|---|
| CuTeDSL demo family (`cutedsl_tma_add`, `cutedsl_pointwise_add`) | yes |
| FROST SDPA forward (`sdpa/fwd/engine.py`) | yes |
| cuDNN backend, cuda-python, CUDA C++ | raises `NotImplementedError` at export |

Retrofitting the backend engine is the eventual target and is deliberately not in
either PR. An unretrofitted engine fails loudly at **export** time rather than
producing a broken artifact that fails at load.

## What's new

- **Python** — `cudnn.export_to_disk` / `import_from_disk` / `KernelLibrary` /
  `register_global` / `get_global` / `unregister_global`, plus
  `serialize_graph` / `deserialize_graph` for the single-graph case
  (`python/cudnn/aot.py`).
- **pygraph** — `set_name()` / `get_name()`, `variant_pack_uids_sorted()`, and
  `execute()` accepting a flat pointer array in that order.
- **C++** — `cudnn_frontend/kernel_library.h` (the AOT surface, its own header;
  core `cudnn_frontend.h` is untouched) and
  `cudnn_frontend/experimental/cutedsl_{engine_interface,ffi_engine}.h`.
- **Build** — `apache-tvm-ffi` joins the optional `cutedsl` extra. The AOT entry
  points are compiled only when it is importable at configure time
  (`CUDNN_FRONTEND_ENABLE_AOT`, ON by default) and otherwise report that
  cleanly at the call.
- **Demo engines** — a `cutedsl_demo` manifest family (id block 20_700), opt_in
  behind `CUDNN_FRONTEND_ENABLE_FROST_ENGINES=1` so it never competes for a real
  pointwise graph. Small on purpose: the export path is only reviewable if the
  kernel under it can be read end to end.
- **Samples** — `samples/aot`, one runnable file per flow, indexed in its README,
  plus the benchmarks that produced the numbers below.
- **Tests** — `test/python/test_aot_export.py`, 19 tests: round trip, the
  N-graph container executed in a fresh interpreter that never imports cutlass,
  the global registry, lifetime/override semantics, arch and version rejection,
  concurrent execute, and the backend-engine refusal.

## CPU cost, measured (B200, this branch)

Every row ends in the *same* CuTeDSL fp32 TMA tile add (1024×512, 128×64 tiles)
out of the *same* container, so this compares call paths, not kernels. Submit
time, arms round-robin within each burst, medians of 41×100-call bursts.
Reproduce with `samples/aot/bench_cpu_costs.{py,cpp}`.

| call path | µs/launch |
|---|---|
| Python — flow 2, `graph.execute()` on an imported graph | 4.01 |
| Python — flow 1, imperative CuTeDSL call | 3.09 |
| Python — CUTLASS native AOT `.so` called directly | 2.76 |
| C++ — flow 2, `graph.execute()` from `import_from_disk()` | 2.23 |
| C++ — flow 3, `graph.execute()` from `get_global()` | 2.23 |
| C++ — CUTLASS native AOT (TVM FFI) | 1.96 |
| C++ — CUTLASS native AOT (global table) | 1.96 |
| C++ — `cudaLaunchKernel`, hand-written kernel | 1.68 |
| C++ — raw cubin, `cuLaunchKernel`, no FFI | 1.51 |
| CUDA graph replay — 1 node / per kernel in a 32-node graph | 1.28 / 0.04 |

The frontend's front door over an OSS-engine plan is **+0.27 µs** in C++
(2.23 − 1.96) and **+1.25 µs** from Python (4.01 − 2.76); the Python gap is the
pybind11 boundary and per-call list marshalling on top of the same C++ path, not
the frontend. Flows 2 and 3 are identical to within noise (±0.02 µs): where a
kernel came from is settled once, at load.

### On a real kernel — SDPA fwd, causal, B=2 H=8 S=1024 D=128 fp16

`samples/aot/bench_sdpa_export.py` then `bench_sdpa_cpu_costs`.

| call path | submit µs | wall µs |
|---|---|---|
| C++ — cuDNN backend engine, built and executed in C++ | 3.68 | 31.1 |
| C++ — AOT, Python compile → execute from a container | 5.50 | 44.0 |

Not the same kernel — the backend engine has no AOT export, so the artifact
necessarily carries the CuTeDSL SDPA. Of the AOT arm's 5.50 µs, **2.49 µs is
three `cudaMemsetAsync` calls zeroing 48 bytes**: three optional ports (sink
logits, per-batch KV lengths, a paged-descriptor array) are non-optional
parameters the kernel never reads, so a caller must pass zero-filled stand-ins
every launch. Folding them out of the ABI is a change to the kernels, not to
this design, and is not landed here. Both arms are host-bound during the burst.

## Verified

- `test/python/test_aot_export.py` — 19 passed (B200, SM100).
- Every `samples/aot` flow sample, both C++ samples (`flow2_import_execute`, the
  nanobind extension), and both benchmarks.

@coderabbitai ignore
