### PR TITLE
Tell DLPack we are only reading, so probe() survives a graph capture

### DIFF
--- a/python/cudnn/frost/buffers.py
+++ b/python/cudnn/frost/buffers.py
@@ -235,7 +235,14 @@ def probe(buf):
     dl = getattr(buf, "__dlpack__", None)
     if dl is None:
         raise TypeError(f"buffer of type {type(buf).__name__} exposes neither __cuda_array_interface__ nor __dlpack__")
-    capsule = dl()
+    # stream=-1 is DLPack's "the caller handles synchronisation; do no
+    # bookkeeping". probe() only reads metadata, so it never needed any --
+    # and the default makes torch call record_stream, which is illegal inside
+    # a CUDA graph capture.
+    try:
+        capsule = dl(stream=-1)
+    except TypeError:  # a producer whose __dlpack__ predates the stream kwarg
+        capsule = dl()
     raw = _PyCapsule_GetPointer(capsule, b"dltensor")
     mt = ctypes.cast(raw, ctypes.POINTER(_DLManagedTensor)).contents
     t = mt.dl_tensor

--- a/test/python/test_buffer_probe.py
+++ b/test/python/test_buffer_probe.py
@@ -24,13 +24,20 @@ from cudnn.frost import buffers
 pytestmark = pytest.mark.L0
 
 requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+# bfloat16 needs SM80+. Reported per dtype so float16/float32 still run on older
+# cards -- they take the CAI path, which is the control for the DLPack one.
+_BF16_OK = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8
 
 # float16/float32 resolve through __cuda_array_interface__; bfloat16 has no
 # numpy typestr (torch reports raw "<V2"), so it is the dtype that reaches the
 # DLPack path -- the one that has to stay capture-safe. fp8 is absent because
 # probe() does not map it at all ("unsupported buffer dtype (code=10, bits=8)"),
 # which is a separate gap and not this fix's business.
-_DTYPES = [torch.float16, torch.float32, torch.bfloat16]
+_DTYPES = [
+    torch.float16,
+    torch.float32,
+    pytest.param(torch.bfloat16, marks=pytest.mark.skipif(not _BF16_OK, reason="bfloat16 needs SM80+")),
+]
 
 
 @requires_cuda
@@ -57,6 +64,7 @@ def test_probe_is_capture_safe(dtype):
     """
     t = torch.zeros(64, dtype=dtype, device="cuda")
     side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())  # order the zeros before the write
     with torch.cuda.stream(side):  # warm up allocation off the capture stream
         t.add_(1)
     torch.cuda.synchronize()

--- a/test/python/test_buffer_probe.py
+++ b/test/python/test_buffer_probe.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``cudnn.frost.buffers.probe`` reads a buffer; it must not touch streams.
+
+probe() is the boundary where a caller's framework buffer becomes
+(pointer, shape, strides, dtype, device) for a kernel launch. It reads metadata
+and nothing else, so it has no business synchronising -- and a producer that
+does bookkeeping on its behalf breaks CUDA graph capture.
+
+That is not hypothetical: the DLPack fallback called ``__dlpack__()`` with the
+default stream argument, which makes torch call ``record_stream``, which is
+illegal during capture. It took out every GDN and KDA capture test (286 of
+them) while reporting only "operation failed due to a previous error during
+capture" -- an error that names neither this function nor this file.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from cudnn.frost import buffers
+
+pytestmark = pytest.mark.L0
+
+requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA device")
+
+# float16/float32 resolve through __cuda_array_interface__; bfloat16 has no
+# numpy typestr (torch reports raw "<V2"), so it is the dtype that reaches the
+# DLPack path -- the one that has to stay capture-safe. fp8 is absent because
+# probe() does not map it at all ("unsupported buffer dtype (code=10, bits=8)"),
+# which is a separate gap and not this fix's business.
+_DTYPES = [torch.float16, torch.float32, torch.bfloat16]
+
+
+@requires_cuda
+@pytest.mark.parametrize("dtype", _DTYPES, ids=lambda d: str(d).split(".")[-1])
+def test_probe_reports_the_buffer(dtype):
+    t = torch.zeros((4, 8), dtype=dtype, device="cuda")
+    ptr, shape, strides, name, device = buffers.probe(t)
+
+    assert ptr == t.data_ptr()
+    assert shape == (4, 8)
+    assert strides in (None, (8, 1))  # None == densely packed
+    assert name == str(dtype).split(".")[-1]
+    assert device == t.device.index
+
+
+@requires_cuda
+@pytest.mark.parametrize("dtype", _DTYPES, ids=lambda d: str(d).split(".")[-1])
+def test_probe_is_capture_safe(dtype):
+    """Probing inside a capture must not abort it.
+
+    Guarding here rather than trusting the linear-attention suites to notice:
+    they do, but only after a hundred lines of unrelated setup and with an
+    error that points at torch's stream bookkeeping.
+    """
+    t = torch.zeros(64, dtype=dtype, device="cuda")
+    side = torch.cuda.Stream()
+    with torch.cuda.stream(side):  # warm up allocation off the capture stream
+        t.add_(1)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=torch.cuda.Stream()):
+        buffers.probe(t)
+        t.add_(1)
+    graph.replay()
+    torch.cuda.synchronize()


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: `cat-bug`, `mod-frost`, `mod-cutedsl`, `orig-nv-eng`.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

`buffers.probe()` turns a caller's buffer into `(pointer, shape, strides, dtype, device)` for a kernel launch. It reads metadata and does nothing else — so it never needed synchronisation. Its DLPack fallback called `__dlpack__()` with the default stream argument, which torch reads as *prepare this tensor for a consumer on another stream* and answers with `record_stream`. That is illegal inside a CUDA graph capture.

```python
-    capsule = dl()
+    try:
+        capsule = dl(stream=-1)   # DLPack: caller handles sync, do no bookkeeping
+    except TypeError:             # producer predating the stream kwarg
+        capsule = dl()
```

## Why it looked like a GDN/KDA bug

`probe()` prefers `__cuda_array_interface__`, whose `typestr` is numpy-flavoured. `float16` is `"<f2"` and resolves there; **bfloat16 has no numpy spelling**, so torch reports raw `"<V2"`, the lookup misses, and it falls through to DLPack.

So the failure needed three things at once — bf16 buffers, a capture, and `probe()` on the execute path — and only the linear-attention suites have all three:

```
286 failed  test_gdn_bprop_kernel.py (118), test_gdn_prefill_kernel.py (97),
            test_kda_prefill_kernel.py (63), test_gdn2_*, ops/test_gdn2_op.py
```

every one reporting `operation failed due to a previous error during capture` — an error naming neither this file nor this function. SDPA and GEMM use fp16/fp8 and take the CAI path; **a bf16 SDPA capture would have hit the same thing.**

Minimal reproduction, no cudnn involved:

```
dl()               -> capture fails
dl(stream=None)    -> capture fails
dl(stream=-1)      -> capture OK
__cuda_array_interface__ -> capture OK
```

## Why

`probe()` reads metadata and launches nothing, so it has no business asking a producer to synchronise. Passing the default stream argument made torch do bookkeeping on its behalf — correct for a cross-stream handoff, illegal inside a capture, and unnecessary either way.

## Related issues

Found while working on #502 (python engine dispatch cleanup); independent of it and based on current `develop`.

## API and compatibility impact

**None.** `buffers.probe()` is internal and its return value is unchanged. `stream=-1` is the DLPack-specified way to request no synchronisation; the `TypeError` fallback keeps producers whose `__dlpack__` predates the argument working.

## Testing

`test/python/test_buffer_probe.py` pins it on `probe()` directly rather than leaving the linear-attention suites to notice again — they do notice, but a hundred lines into unrelated setup and pointing at torch's stream bookkeeping. **Reverting the fix turns `test_probe_is_capture_safe[bfloat16]` red; that was checked.**

On sm100:

```
test/python/linear_attention          353 passed, 1769 skipped
                                      (286 failed / 67 passed on this same tree before)
+ sdpa/frost + gemm/frost + new test  4859 passed, 3892 skipped
```

## Not addressed here

`probe()` has no mapping for fp8 at all — `TypeError: unsupported buffer dtype (code=10, bits=8, lanes=1)` — so fp8 is absent from the test. Separate gap, and I have no fp8-under-capture case to verify a fix against.

Worth knowing for anyone weighing the two protocols: CAI is *not* strictly cheaper-and-better. It cannot express bf16 or fp8 (fp8 raises outright), it is CUDA-only (CPU tensors and JAX arrays expose only DLPack), it carries no ownership or lifetime semantics, and torch reports version 2, which has no `stream` field at all. Its capture-safety here comes precisely from knowing nothing about streams. The existing CAI-first-then-DLPack order is right; only the DLPack call was under-specified.

/cc @Anerudhan


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA buffer inspection to avoid unnecessary synchronization.
  * Added compatibility for data producers that do not support stream options.
  * Ensured buffer inspection works safely during CUDA graph capture.

* **Tests**
  * Added coverage for float16, float32, and bfloat16 buffers.
  * Verified pointer, shape, strides, data type, and device reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->