### PR TITLE
frost(sdpa): add mixed head-dim support for SM120 frost sdpa_fwd engine

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1468,7 +1468,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         self.q_tile = _SM120_Q_TILES[0] if self.tile_m is None else self.tile_m
         self.kv_tile = _SM120_KV_TILES[0] if self.tile_n is None else self.tile_n
         self.compute_capability: Optional[tuple[int, int]] = None
-        self.head_dim: Optional[int] = None
+        self.head_dim_qk: Optional[int] = None
+        self.head_dim_v: Optional[int] = None
         self._k_mod = None
 
     def check_support(self) -> bool:
@@ -1517,9 +1518,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
 
         b, h_q, s_q, d_q = self.q_desc.shape
         _, h_kv, s_kv, _ = self.k_desc.shape
+        d_v = self.v_desc.shape[3]
         self._check_tensor_shape(self.k_desc, (b, h_kv, s_kv, d_q), name="K")
-        self._check_tensor_shape(self.v_desc, (b, h_kv, s_kv, d_q), name="V")
-        self._check_tensor_shape(self.o_desc, (b, h_q, s_q, d_q), name="O")
+        self._check_tensor_shape(self.v_desc, (b, h_kv, s_kv, d_v), name="V")
+        self._check_tensor_shape(self.o_desc, (b, h_q, s_q, d_v), name="O")
         if self.lse_desc is not None:
             # THD stats are not plumbed (the kernel's packed (1, H, T) LSE does
             # not match cuDNN's ragged Stats contract) — reject the request
@@ -1535,7 +1537,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             ("H_kv", h_kv),
             ("S_q", s_q),
             ("S_kv", s_kv),
-            ("D", d_q),
+            ("D_QK", d_q),
+            ("D_V", d_v),
         ):
             self._value_error_if(int(val) <= 0, f"{label} must be > 0; got {val}")
         self._value_error_if(
@@ -1544,7 +1547,11 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         )
         self._value_error_if(
             d_q not in _SM120_SUPPORTED_HEAD_TILES,
-            f"D ({d_q}) must be one of {_SM120_SUPPORTED_HEAD_TILES}",
+            f"D_QK ({d_q}) must be one of {_SM120_SUPPORTED_HEAD_TILES}",
+        )
+        self._value_error_if(
+            d_v not in _SM120_SUPPORTED_HEAD_TILES,
+            f"D_V ({d_v}) must be one of {_SM120_SUPPORTED_HEAD_TILES}",
         )
 
         self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16], name="Q")
@@ -1598,8 +1605,9 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         smem_capacity_bytes = cutlass.utils.get_smem_capacity_in_bytes(arch)
 
         def _smem_bytes(kv_tile: int) -> int:
-            # K/V double buffer, aliased with the q_tile x D output staging tile.
-            return max(2 * kv_tile * d_q * self.dtype.itemsize, self.q_tile * d_q * self.dtype.itemsize) + 16
+            # One K tile (D_QK wide) + one V tile (D_V wide), aliased with the
+            # q_tile x D_V output staging tile.
+            return max(kv_tile * (d_q + d_v) * self.dtype.itemsize, self.q_tile * d_v * self.dtype.itemsize) + 16
 
         if self.tile_n is None:
             # Pick the largest KV tile that fits this device.
@@ -1621,8 +1629,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         self.h_q = int(h_q)
         self.h_kv = int(h_kv)
         self.head_dim_qk = int(d_q)
-        self.head_dim_v = int(d_q)
-        self.head_dim = int(d_q)
+        self.head_dim_v = int(d_v)
         self._is_supported = True
 
         self._logger.debug("check_support completed successfully")
@@ -1662,7 +1669,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             kh=self.h_kv,
             sq=self.s_q_max,
             skv=self.s_k_max,
-            d=self.head_dim,
+            d_qk=self.head_dim_qk,
+            d_v=self.head_dim_v,
             # No sample_lse -> the LSE store is compiled out; execute() then
             # binds no LSE buffer at all (no dummy, no allocation).
             has_lse=self.lse_desc is not None,
@@ -1780,7 +1788,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         per-execute compile and grid.
         """
 
-        b, qh, kh, d = self.batch_size, self.h_q, self.h_kv, self.head_dim
+        b, qh, kh = self.batch_size, self.h_q, self.h_kv
+        d_qk, d_v = self.head_dim_qk, self.head_dim_v
         dev = q_buf.device
         carver = WorkspaceCarver(workspace, self.scratch_workspace_bytes(), "SdpaFwdDslSm120 (THD)") if workspace is not None else None
 
@@ -1816,7 +1825,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         if t_kv == 0:
             # Every row is dead: O := 0 (THD stats are not plumbed). A
             # zero-token K/V view cannot back a TMA descriptor, so short-cut.
-            o_buf.as_strided((t_q * qh * d,), (1,), o_buf.storage_offset()).zero_()
+            o_buf.as_strided((t_q * qh * d_v,), (1,), o_buf.storage_offset()).zero_()
             return
 
         # THD stats are not plumbed: the kernel compiles with has_lse=False, so
@@ -1831,6 +1840,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
 
         def _packed(buf, tokens):
             heads = qh if buf is q_buf or buf is o_buf else kh
+            d = d_qk if buf is q_buf or buf is k_buf else d_v
             return buf.as_strided((1, tokens, heads, d), (tokens * heads * d, heads * d, d, 1), buf.storage_offset())
 
         if current_stream is None:
@@ -1845,7 +1855,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             kh=kh,
             sq=t_q,
             skv=t_kv,
-            d=d,
+            d_qk=d_qk,
+            d_v=d_v,
             max_sq=max_sq,
             has_lse=False,
         )
@@ -1900,12 +1911,13 @@ def sdpa_fwd_wrapper_dsl_sm120(
         )
     if q_tensor.ndim != 4 or k_tensor.ndim != 4 or v_tensor.ndim != 4:
         raise ValueError(f"Q, K, and V must be rank-4 BHSD; got Q={q_tensor.ndim}D K={k_tensor.ndim}D V={v_tensor.ndim}D")
-    o_tensor = torch.empty_strided(
-        q_tensor.shape,
-        q_tensor.stride(),
+    b, h_q, s_q, _ = q_tensor.shape
+    d_v = v_tensor.shape[-1]
+    o_tensor = torch.empty(
+        (b, s_q, h_q, d_v),
         dtype=q_tensor.dtype,
         device=q_tensor.device,
-    )
+    ).transpose(1, 2)
     lse_tensor = _allocate_lse_tensor(q_tensor)
     cache_key = _make_cache_key(
         SdpaFwdDslSm120,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -179,7 +179,8 @@ class SM120FusedMultiHeadAttentionForward:
         thd_varlen: bool = False,
         thd_batch: int = 1,
         thd_max_sq: int = 0,
-        head_tile: int = 128,
+        head_tile_qk: int = 128,
+        head_tile_v: int = 128,
         kv_tile: int = SEQ_KV_TILES[0],
         q_tile: int = SEQ_Q_TILES[0],
     ):
@@ -201,8 +202,10 @@ class SM120FusedMultiHeadAttentionForward:
             grid covers ``ceil(thd_max_sq / q_tile)`` tiles per sequence.
         :param thd_batch: THD only: the real sequence count B.
         :param thd_max_sq: THD only: the longest sequence's Q length.
-        :param head_tile: Head dimension tile. Must be a multiple of 16 between
-            16 and 256, inclusive.
+        :param head_tile_qk: Q/K head dimension (the QK^T contraction width).
+            Must be a multiple of 16 between 16 and 256, inclusive.
+        :param head_tile_v: V/O head dimension (the P@V output width). Same
+            constraint as ``head_tile_qk``.
         :param q_tile: Query sequence tile size.
         :param kv_tile: Key/value sequence tile size.
         """
@@ -223,7 +226,8 @@ class SM120FusedMultiHeadAttentionForward:
         self.thd_batch = thd_batch
         self.thd_max_sq = thd_max_sq
 
-        self.head_tile = head_tile
+        self.head_tile_qk = head_tile_qk
+        self.head_tile_v = head_tile_v
         self.q_tile = q_tile
         self.kv_tile = kv_tile
 
@@ -256,30 +260,30 @@ class SM120FusedMultiHeadAttentionForward:
         """Compute derived tile, MMA, and TMA constants from the configuration."""
 
         # Tiling
-        self.qo_tile_elems = self.q_tile * self.head_tile
-        self.kv_tile_elems = self.kv_tile * self.head_tile
+        self.k_tile_elems = self.kv_tile * self.head_tile_qk
+        self.v_tile_elems = self.kv_tile * self.head_tile_v
+        self.o_tile_elems = self.q_tile * self.head_tile_v
 
         # MMA
         self.qk_k_frags = self.kv_tile // self.MMA_TILER[1]
-        self.qk_d_frags = self.head_tile // self.MMA_TILER[2]
+        self.qk_d_frags = self.head_tile_qk // self.MMA_TILER[2]
         self.pv_v_frags = self.kv_tile // self.MMA_TILER[2]
-        self.pv_d_frags = self.head_tile // self.MMA_TILER[1]
+        self.pv_d_frags = self.head_tile_v // self.MMA_TILER[1]
 
         # TMA
-        tma_copy_head_bytes = self.head_tile * self.in_dtype.bytes
-        if tma_copy_head_bytes % 128 == 0:
-            self.tma_swizzle = cuda.TensorMapSwizzle.s128b
-            self.tma_swizzle_chunks = tma_copy_head_bytes // 128
-        elif tma_copy_head_bytes % 64 == 0:
-            self.tma_swizzle = cuda.TensorMapSwizzle.s64b
-            self.tma_swizzle_chunks = tma_copy_head_bytes // 64
-        elif tma_copy_head_bytes % 32 == 0:
-            self.tma_swizzle = cuda.TensorMapSwizzle.s32b
-            self.tma_swizzle_chunks = tma_copy_head_bytes // 32
-        else:
-            raise ValueError(f"Unsupported TMA inner dimension: {tma_copy_head_bytes} B")
+        def get_swizzle(head_tile: int):
+            head_bytes = head_tile * self.in_dtype.bytes
+            for swizzle, span in (
+                (cuda.TensorMapSwizzle.s128b, 128),
+                (cuda.TensorMapSwizzle.s64b, 64),
+                (cuda.TensorMapSwizzle.s32b, 32),
+            ):
+                if head_bytes % span == 0:
+                    return swizzle, head_bytes // span, head_tile // (head_bytes // span)
+            raise ValueError(f"Unsupported TMA inner dimension: {head_bytes} B")
 
-        self.tma_swizzle_chunk_elems = self.head_tile // self.tma_swizzle_chunks
+        self.k_tma_swizzle, self.k_tma_swizzle_chunks, self.k_swizzle_chunk_elems = get_swizzle(self.head_tile_qk)
+        self.v_tma_swizzle, self.v_tma_swizzle_chunks, self.v_swizzle_chunk_elems = get_swizzle(self.head_tile_v)
 
     @cute.jit
     def load_one_kv_tile(
@@ -349,7 +353,7 @@ class SM120FusedMultiHeadAttentionForward:
                 row_in_cta, col_in_cta = mma_offsets_in_cta[i]
                 cur_q_seq_idx = basic_params.q_seq_idx + row_in_cta
                 q_packed = cutlass.Int32(0)
-                if cur_q_seq_idx < basic_params.seqlen_q and col_in_cta < basic_params.head_dim:
+                if cur_q_seq_idx < basic_params.seqlen_q and col_in_cta < basic_params.head_dim_qk:
                     q_pair = (basic_params.q_ptr + basic_params.q_head_off + cur_q_seq_idx * basic_params.q_seq_stride + col_in_cta).load(count=2, alignment=4)
                     q_packed = q_pair.bitcast(cutlass.Int32)[0]
                 q_regs[q_regs_offset + i] = q_packed
@@ -390,16 +394,16 @@ class SM120FusedMultiHeadAttentionForward:
         def load_k_frag_pair(k_frag_pair: cutlass.Constexpr[int], d_frag: cutlass.Constexpr[int]):
             k_row_in_cta = k_frag_pair * 16 + k_row_in_frag_pair
             k_col_in_cta = d_frag * 16 + k_col_in_frag_pair
-            k_chunk = k_col_in_cta // self.tma_swizzle_chunk_elems
-            k_col_in_chunk = k_col_in_cta % self.tma_swizzle_chunk_elems
+            k_chunk = k_col_in_cta // self.k_swizzle_chunk_elems
+            k_col_in_chunk = k_col_in_cta % self.k_swizzle_chunk_elems
             k_physical_row = k_chunk * self.kv_tile + k_row_in_cta
             k_smem_ptr = (
                 mma_params.sK.data_ptr()
-                + k_physical_row * self.tma_swizzle_chunk_elems
+                + k_physical_row * self.k_swizzle_chunk_elems
                 + swizzle_xor(
                     k_physical_row,
                     k_col_in_chunk,
-                    self.tma_swizzle_chunk_elems,
+                    self.k_swizzle_chunk_elems,
                     self.in_dtype.bytes,
                 )
             )
@@ -604,16 +608,16 @@ class SM120FusedMultiHeadAttentionForward:
         def load_v_frag_pair(v_frag: cutlass.Constexpr[int], d_frag_pair: cutlass.Constexpr[int]):
             v_row_in_cta = v_frag * 16 + v_row_in_frag_pair
             v_col_in_cta = d_frag_pair * 16 + v_col_in_frag_pair
-            v_chunk = v_col_in_cta // self.tma_swizzle_chunk_elems
-            v_col_in_chunk = v_col_in_cta % self.tma_swizzle_chunk_elems
+            v_chunk = v_col_in_cta // self.v_swizzle_chunk_elems
+            v_col_in_chunk = v_col_in_cta % self.v_swizzle_chunk_elems
             v_physical_row = v_chunk * self.kv_tile + v_row_in_cta
             sV_ptr = (
                 mma_params.sV.data_ptr()
-                + v_physical_row * self.tma_swizzle_chunk_elems
+                + v_physical_row * self.v_swizzle_chunk_elems
                 + swizzle_xor(
                     v_physical_row,
                     v_col_in_chunk,
-                    self.tma_swizzle_chunk_elems,
+                    self.v_swizzle_chunk_elems,
                     self.in_dtype.bytes,
                 )
             )
@@ -775,7 +779,8 @@ class SM120FusedMultiHeadAttentionForward:
 
         num_heads_q = q.shape[2]
         num_heads_kv = k.shape[2]
-        head_dim = q.shape[3]
+        head_dim_qk = q.shape[3]
+        head_dim_v = v.shape[3]
         q_ptr = q.iterator.raw_ptr()
         o_ptr = o.iterator.raw_ptr()
 
@@ -818,18 +823,19 @@ class SM120FusedMultiHeadAttentionForward:
         has_kv_work = num_kv_tiles > 0 and (num_kv_tiles - 1) >= min_kv_tile
 
         # Shared-memory layout:
-        #   sK: one kv_tile x head_tile K tile
-        #   sV: one kv_tile x head_tile V tile
-        # The epilogue later aliases this storage as sO after compute warps
-        # finish consuming the final K/V tile.
+        #   sK: one kv_tile x head_tile_qk K tile
+        #   sV: one kv_tile x head_tile_v V tile
+        # The epilogue later aliases this storage as the q_tile x head_tile_v
+        # sO staging tile after compute warps finish consuming the final K/V
+        # tile.
         sKV = cutlass.Array(
             k.dtype,
-            max(self.kv_tile_elems * 2, self.qo_tile_elems),
+            max(self.k_tile_elems + self.v_tile_elems, self.o_tile_elems),
             space=cutlass.AddressSpace.smem,
             alignment=128,
         )
         sK = sKV
-        sV = sKV.subview(self.kv_tile_elems)
+        sV = sKV.subview(self.k_tile_elems)
         tma_mbar = cutlass.Array(cutlass.Int64, 2, space=cutlass.AddressSpace.smem, alignment=8)
         k_tma_mbar = tma_mbar
         v_tma_mbar = tma_mbar.subview(1)
@@ -941,7 +947,7 @@ class SM120FusedMultiHeadAttentionForward:
             basic_params = SimpleNamespace(
                 seqlen_q=seqlen_q,
                 seqlen_k=seqlen_k,
-                head_dim=head_dim,
+                head_dim_qk=head_dim_qk,
                 q_ptr=q_ptr,
                 batch_idx=batch_idx,
                 head_idx=head_idx,
@@ -1139,12 +1145,12 @@ class SM120FusedMultiHeadAttentionForward:
                     # Packed storage: rows past this sequence's Q length are
                     # the NEXT sequence's tokens — no store, and never the
                     # dense path's zero-fill.
-                    if store_q_seq_idx < seqlen_q and store_col_in_cta < head_dim:
+                    if store_q_seq_idx < seqlen_q and store_col_in_cta < head_dim_v:
                         gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
                         sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * (16 * 16) + lane * 8
                         gO_ptr.store(sO_ptr.load(count=8, alignment=16), alignment=16)
                 else:
-                    if store_q_seq_idx < q.shape[1] and store_col_in_cta < head_dim:
+                    if store_q_seq_idx < q.shape[1] and store_col_in_cta < head_dim_v:
                         gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
                         if store_q_seq_idx < seqlen_q:
                             sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * (16 * 16) + lane * 8
@@ -1200,12 +1206,15 @@ class SM120FusedMultiHeadAttentionForward:
         :param softmax_scale_log2: ``softmax_scale * log2(e)``.
         :param stream: CUDA stream used for the launch.
         """
-        head_dim = q.shape[3]
-        if cutlass.const_expr(head_dim != k.shape[3] or head_dim != v.shape[3] or head_dim != o.shape[3] or head_dim != self.head_tile):
-            raise ValueError("runtime tensor head dimensions must match the kernel head_tile")
+        head_dim_qk = q.shape[3]
+        head_dim_v = v.shape[3]
+        if cutlass.const_expr(head_dim_qk != k.shape[3] or head_dim_qk != self.head_tile_qk):
+            raise ValueError("runtime Q/K head dimensions must match the kernel head_tile_qk")
+        if cutlass.const_expr(head_dim_v != o.shape[3] or head_dim_v != self.head_tile_v):
+            raise ValueError("runtime V/O head dimensions must match the kernel head_tile_v")
         if cutlass.const_expr(
             q.shape[0] != k.shape[0]
-            or k.shape != v.shape
+            or k.shape[:3] != v.shape[:3]
             or q.shape[0] != o.shape[0]
             or q.shape[1] != o.shape[1]
             or q.shape[2] != o.shape[2]
@@ -1233,40 +1242,63 @@ class SM120FusedMultiHeadAttentionForward:
         # Split D into I contiguous C-element chunks while preserving the
         # compact (B, S, H, D) global-memory address calculation. TMA order
         # (C, S, I, H, B) linearizes the SMEM destination as [I][kv_tile][C].
-        kv_tma_layout = cute.make_layout(
+        k_tma_layout = cute.make_layout(
             (
                 k.shape[0],
                 k.shape[2],
-                self.tma_swizzle_chunks,
+                self.k_tma_swizzle_chunks,
                 k.shape[1],
-                self.tma_swizzle_chunk_elems,
+                self.k_swizzle_chunk_elems,
             ),
             stride=(
-                k.shape[1] * k.shape[2] * head_dim,
-                head_dim,
-                self.tma_swizzle_chunk_elems,
-                k.shape[2] * head_dim,
+                k.shape[1] * k.shape[2] * head_dim_qk,
+                head_dim_qk,
+                self.k_swizzle_chunk_elems,
+                k.shape[2] * head_dim_qk,
                 1,
             ),
         )
-        kv_tma_box = (
+        k_tma_box = (
             1,
             1,
-            self.tma_swizzle_chunks,
+            self.k_tma_swizzle_chunks,
             self.kv_tile,
-            self.tma_swizzle_chunk_elems,
+            self.k_swizzle_chunk_elems,
         )
         tma_k_desc = cuda.create_tensor_map_tiled_from_view(
-            cute.make_tensor(k.iterator, kv_tma_layout),
-            box_dims=kv_tma_box,
+            cute.make_tensor(k.iterator, k_tma_layout),
+            box_dims=k_tma_box,
             stride_order=(4, 3, 2, 1, 0),
-            swizzle=self.tma_swizzle,
+            swizzle=self.k_tma_swizzle,
+        )
+        v_tma_layout = cute.make_layout(
+            (
+                v.shape[0],
+                v.shape[2],
+                self.v_tma_swizzle_chunks,
+                v.shape[1],
+                self.v_swizzle_chunk_elems,
+            ),
+            stride=(
+                v.shape[1] * v.shape[2] * head_dim_v,
+                head_dim_v,
+                self.v_swizzle_chunk_elems,
+                v.shape[2] * head_dim_v,
+                1,
+            ),
+        )
+        v_tma_box = (
+            1,
+            1,
+            self.v_tma_swizzle_chunks,
+            self.kv_tile,
+            self.v_swizzle_chunk_elems,
         )
         tma_v_desc = cuda.create_tensor_map_tiled_from_view(
-            cute.make_tensor(v.iterator, kv_tma_layout),
-            box_dims=kv_tma_box,
+            cute.make_tensor(v.iterator, v_tma_layout),
+            box_dims=v_tma_box,
             stride_order=(4, 3, 2, 1, 0),
-            swizzle=self.tma_swizzle,
+            swizzle=self.v_tma_swizzle,
         )
         self.kernel(
             q,
@@ -1303,11 +1335,15 @@ def compile(  # noqa: A001
     kh: int = 1,
     sq: int = 128,
     skv: int = 128,
-    d: int = 128,
+    d_qk: int = 128,
+    d_v: int = 128,
     max_sq: int = 0,
     has_lse: bool = True,
 ) -> Callable:
     """Compile and cache one architecture-specific compact BSHD shape.
+
+    ``d_qk`` is the Q/K head dim (QK^T contraction width) and ``d_v`` the V/O
+    head dim (P@V output width); they are independent, e.g. (192, 128).
 
     THD specializations pack the batch: ``b`` is the real sequence count,
     ``sq``/``skv`` are the packed token totals, and ``max_sq`` (the longest
@@ -1330,32 +1366,33 @@ def compile(  # noqa: A001
         thd_varlen=PARAMS.thd_varlen,
         thd_batch=b,
         thd_max_sq=max_sq,
-        head_tile=d,
+        head_tile_qk=d_qk,
+        head_tile_v=d_v,
         q_tile=PARAMS.q_tile,
         kv_tile=PARAMS.kv_tile,
     )
     fake_batch = 1 if PARAMS.thd_varlen else b
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (fake_batch, sq, qh, d),
+        (fake_batch, sq, qh, d_qk),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_k = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (fake_batch, skv, kh, d),
+        (fake_batch, skv, kh, d_qk),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_v = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (fake_batch, skv, kh, d),
+        (fake_batch, skv, kh, d_v),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (fake_batch, sq, qh, d),
+        (fake_batch, sq, qh, d_v),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
@@ -160,6 +160,7 @@ def _run_case(
     s_q: int = 128,
     s_kv: int = 128,
     head_dim: int = 128,
+    head_dim_v: int | None = None,
     dtype: torch.dtype = torch.float16,
     q_tile: int | None = None,
     kv_tile: int | None = None,
@@ -174,7 +175,7 @@ def _run_case(
 ) -> None:
     q = _bhsd(batch, h_q, s_q, head_dim, dtype)
     k = _bhsd(batch, h_kv, s_kv, head_dim, dtype)
-    v = _bhsd(batch, h_kv, s_kv, head_dim, dtype)
+    v = _bhsd(batch, h_kv, s_kv, head_dim if head_dim_v is None else head_dim_v, dtype)
     scale = 1.0 / math.sqrt(head_dim) if scale is None else scale
     sinks = torch.randn(1, h_q, 1, 1, dtype=torch.float32, device="cuda") if with_sink else None
     mask_kwargs = dict(
@@ -237,8 +238,9 @@ def _run_dsl_graph(
     dtype = q_gpu.dtype
     io_dtype = cudnn.data_type.HALF if dtype == torch.float16 else cudnn.data_type.BFLOAT16
     if o_gpu is None:
-        batch, heads, sequence, head_dim = q_gpu.shape
-        o_gpu = torch.empty(batch, sequence, heads, head_dim, dtype=dtype, device="cuda").transpose(1, 2)
+        batch, heads, sequence, _ = q_gpu.shape
+        head_dim_v = v_gpu.shape[3]
+        o_gpu = torch.empty(batch, sequence, heads, head_dim_v, dtype=dtype, device="cuda").transpose(1, 2)
 
     graph = cudnn.pygraph(
         io_data_type=io_dtype,
@@ -347,6 +349,7 @@ def _run_thd_case(
     h_q: int = 8,
     h_kv: int = 8,
     head_dim: int = 64,
+    head_dim_v: int | None = None,
     dtype: torch.dtype = torch.float16,
     is_causal: bool = False,
     causal_bottom_right: bool = False,
@@ -363,14 +366,15 @@ def _run_thd_case(
     batch = len(seq_q_lens)
     s_q_max = max(max(seq_q_lens), 1)
     s_kv_max = max(max(seq_kv_lens), 1)
+    d_v = head_dim if head_dim_v is None else head_dim_v
     scale = 1.0 / math.sqrt(head_dim)
     q_seqs = [_bhsd(1, h_q, max(n, 1), head_dim, dtype)[:, :, :n] for n in seq_q_lens]
     k_seqs = [_bhsd(1, h_kv, max(n, 1), head_dim, dtype)[:, :, :n] for n in seq_kv_lens]
-    v_seqs = [_bhsd(1, h_kv, max(n, 1), head_dim, dtype)[:, :, :n] for n in seq_kv_lens]
+    v_seqs = [_bhsd(1, h_kv, max(n, 1), d_v, dtype)[:, :, :n] for n in seq_kv_lens]
     q_view, _, q_ro = _pack_thd([s.contiguous() for s in q_seqs], s_q_max)
     k_view, _, k_ro = _pack_thd([s.contiguous() for s in k_seqs], s_kv_max)
     v_view, _, v_ro = _pack_thd([s.contiguous() for s in v_seqs], s_kv_max)
-    o_view, o_storage, o_ro = _pack_thd([torch.zeros(1, h_q, max(n, 1), head_dim, dtype=dtype, device="cuda")[:, :, :n] for n in seq_q_lens], s_q_max)
+    o_view, o_storage, o_ro = _pack_thd([torch.zeros(1, h_q, max(n, 1), d_v, dtype=dtype, device="cuda")[:, :, :n] for n in seq_q_lens], s_q_max)
     sq_t = torch.tensor(seq_q_lens, dtype=torch.int32, device="cuda").view(batch, 1, 1, 1)
     skv_t = torch.tensor(seq_kv_lens, dtype=torch.int32, device="cuda").view(batch, 1, 1, 1)
     sinks = torch.randn(1, h_q, 1, 1, dtype=torch.float32, device="cuda") if with_sink else None
@@ -429,7 +433,7 @@ def _run_thd_case(
     cu = [0]
     for n in seq_q_lens:
         cu.append(cu[-1] + n)
-    packed_o = o_storage[: cu[-1] * h_q * head_dim].view(max(cu[-1], 1), h_q, head_dim)
+    packed_o = o_storage[: cu[-1] * h_q * d_v].view(max(cu[-1], 1), h_q, d_v)
     for i, (nq, nkv) in enumerate(zip(seq_q_lens, seq_kv_lens)):
         if nq == 0:
             continue
@@ -834,6 +838,129 @@ def test_dsl_sm120_dense_flex_bhsd_contiguous():
 @torch_fork_set_rng(seed=2)
 def test_dsl_sm120_representative_head_dimensions(head_dim: int, kv_tile: int | None):
     _run_case(head_dim=head_dim, kv_tile=kv_tile)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("head_dim", "head_dim_v"),
+    [(192, 128), (128, 192), (96, 32), (128, 48)],
+    ids=["mla192x128", "v_wider", "small_mixed", "cross_swizzle"],
+)
+@torch_fork_set_rng(seed=23)
+def test_dsl_sm120_mixed_head_dims(head_dim: int, head_dim_v: int):
+    """D_QK != D_V: independent QK^T contraction and P@V output widths.
+
+    (192, 128) is the MLA-style shape; the K and V SMEM tiles and TMA swizzle
+    configurations differ, so a reversed pair and a small mixed pair guard the
+    per-tensor address math in both directions, and (128, 48) pins K and V on
+    DIFFERENT swizzle modes (s128b vs s32b)."""
+    _run_case(batch=2, h_q=4, h_kv=4, s_q=256, s_kv=384, head_dim=head_dim, head_dim_v=head_dim_v)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=24)
+def test_dsl_sm120_mixed_head_dims_causal_gqa_stats():
+    """MLA shape under bottom-right causal + GQA, with the LSE checked (the
+    stats path depends only on D_QK; this pins that it survives the split)."""
+    _run_case(
+        batch=2,
+        h_q=8,
+        h_kv=2,
+        s_q=192,
+        s_kv=320,
+        head_dim=192,
+        head_dim_v=128,
+        is_causal=True,
+        causal_bottom_right=True,
+        check_stats=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=25)
+def test_dsl_sm120_thd_mixed_head_dims():
+    """THD packed views carry per-tensor head dims (Q/K at 192, V/O at 128)."""
+    _run_thd_case(
+        seq_q_lens=[33, 128, 7],
+        seq_kv_lens=[65, 128, 190],
+        h_q=4,
+        h_kv=2,
+        head_dim=192,
+        head_dim_v=128,
+        is_causal=True,
+        causal_bottom_right=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=26)
+def test_dsl_sm120_mixed_head_dims_masks():
+    """MLA shape under the remaining mask family: top-left causal, and causal
+    with a left sliding window (the mask math lives on the QK^T side, so this
+    pins that it stays anchored to D_QK after the split)."""
+    _run_case(batch=2, h_q=4, h_kv=4, s_q=256, s_kv=256, head_dim=192, head_dim_v=128, is_causal=True)
+    _run_case(batch=2, h_q=4, h_kv=4, s_q=256, s_kv=256, head_dim=192, head_dim_v=128, is_causal=True, window_size_left=96)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=27)
+def test_dsl_sm120_mixed_head_dims_padded_stats():
+    """MLA shape + per-batch Q/KV lengths with the LSE checked: rows past
+    seq_len_q[b] zero-fill O through the epilogue's D_V-guarded store and trim
+    the LSE to -inf, so the changed store guard and the stats trim are
+    exercised together."""
+    seq_q_lens = torch.tensor([230, 120], dtype=torch.int32, device="cuda")
+    seq_kv_lens = torch.tensor([180, 240], dtype=torch.int32, device="cuda")
+    _run_case(
+        batch=2,
+        h_q=4,
+        h_kv=4,
+        s_q=256,
+        s_kv=256,
+        head_dim=192,
+        head_dim_v=128,
+        seq_q_lens=seq_q_lens,
+        seq_kv_lens=seq_kv_lens,
+        check_stats=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=28)
+def test_dsl_sm120_mixed_head_dims_sink_bf16():
+    """MLA shape + attention sink with the LSE checked (the sink logit rides
+    the softmax denominator, which depends only on D_QK), on bf16 to cover the
+    second dtype."""
+    _run_case(
+        batch=2,
+        h_q=8,
+        h_kv=2,
+        s_q=256,
+        s_kv=256,
+        head_dim=192,
+        head_dim_v=128,
+        dtype=torch.bfloat16,
+        is_causal=True,
+        with_sink=True,
+        check_stats=True,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=29)
+def test_dsl_sm120_thd_mixed_head_dims_sink():
+    """THD + mixed head dims + sink: the packed per-tensor D views and the
+    sink denominator together, without a mask (the THD mixed-dim causal case
+    is covered above)."""
+    _run_thd_case(
+        seq_q_lens=[130, 70, 9],
+        seq_kv_lens=[130, 70, 190],
+        h_q=8,
+        h_kv=2,
+        head_dim=192,
+        head_dim_v=128,
+        with_sink=True,
+    )
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -571,6 +571,18 @@ def test_sm120_probe_rejects_head_dim_not_multiple_of_16(monkeypatch):
     assert not _eligible(_mk_sm120_graph(d=136))  # multiple of 8, not of 16
 
 
+def test_sm120_probe_accepts_mixed_head_dims(monkeypatch):
+    monkeypatch.setattr(ga, "_device_cc", lambda: (12, 0))
+    d_qk, d_v = 192, 128
+    g = _mk_graph()
+    q = g.tensor(dim=(B, H, S, d_qk), stride=(S * H * d_qk, d_qk, H * d_qk, 1), data_type=DTYPE, name="q")
+    k = g.tensor(dim=(B, H, S, d_qk), stride=(S * H * d_qk, d_qk, H * d_qk, 1), data_type=DTYPE, name="k")
+    v = g.tensor(dim=(B, H, S, d_v), stride=(S * H * d_v, d_v, H * d_v, 1), data_type=DTYPE, name="v")
+    o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, use_causal_mask=True)
+    _finish_output(o, (B, H, S, d_v), (S * H * d_v, d_v, H * d_v, 1))
+    assert _SM120 in _eligible(g)
+
+
 def test_sm120_probe_accepts_stats_output(monkeypatch):
     monkeypatch.setattr(ga, "_device_cc", lambda: (12, 0))
     g = _mk_graph()


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- FE OSS kernels or CuTeDSL

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

Add mixed head-dim support (d_qk != d_v) to the SM120 FROST SDPA forward engine, serving MLA-style shapes such as (d_qk=192, d_v=128).

  * Kernel (prefill_f16_sm120.py): split the single head_tile into head_tile_qk (QK^T contraction width) and head_tile_v (P@V output width). K and V carry independent SMEM tile extents (sK: `kv_tile x d_qk`, sV: `kv_tile x d_v`, epilogue aliases the storage as the `q_tile x d_v` O staging tile), independent TMA swizzle configurations, and per-tensor TMA descriptors
  * Adapter (api_dsl.py, `SdpaFwdDslSm120`): check_support validates V/O against d_v, gates both dims independently, and sizes SMEM as `max(kv_tile*(d_qk+d_v), q_tile*d_v)*itemsize + 16`; the THD path builds per-tensor packed views
  * Tests: 10 mixed-dim cases for reference and an analyzer probe test

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

To support mixed head-dim (d_qk != d_v) for the SM120 FROST SDPA forward engine.

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

Related to #381.

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

`SdpaFwdDslSm120` now accepts V/O head dims different from Q/K; previously rejected shapes build and run.

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->

Test command: `test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py -m "L0 or L1"`
Test result: 39 passed, 0 failed (8 skips are the pre-existing knobs gate) — all existing same-dim cases plus the new mixed-dim family.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using different head dimensions for queries/keys and values in SM120 scaled dot-product attention.
  * Supports mixed dimensions across dense, causal, sliding-window, padded, grouped-query, statistics, sink, BF16, and THD scenarios.
  * Output tensors now use the value head dimension where applicable.

* **Bug Fixes**
  * Improved handling of zero-length outputs, memory sizing, validation, and runtime kernel execution for mixed head dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->