### PR TITLE
Multi utcmma opt

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -490,7 +490,6 @@ def _render_tile_constants(cfg: TileConfig, chain: FusionChain, cta_group: int, 
         f"multicast_b = {cfg.multicast_b(cta_group)}",
         f"ab_smem_swizzle = cutlass.experimental.primitives.Tcgen05SmemSwizzle.{smem_swizzle_name}",
         f"ab_smem_swizzle_bytes = {smem_swizzle_bytes}",
-        f"ab_smem_desc_stride_byte_offset = {smem_desc_stride_byte_offset}",
         f"a_smem_desc_leading_byte_offset = {a_lbo}",
         f"a_smem_desc_stride_byte_offset = {a_sbo}",
         f"a_smem_k_step_bytes = {a_k_step}",
@@ -534,15 +533,16 @@ def _render_tile_constants(cfg: TileConfig, chain: FusionChain, cta_group: int, 
     total_tmem = _tmem_cols_for_arch()
     lines.append(f"num_tmem_alloc_cols = {total_tmem}")
     if chain.is_multi_gemm:
-        region = chain.num_gemms * cfg.cta_tile_n
+        cols_per_acc = cfg.cta_tile_n // 2 if (cta_group == 2 and cfg.cta_tile_m == 64) else cfg.cta_tile_n
+        region = chain.num_gemms * cols_per_acc
         if region > total_tmem:
             raise NotImplementedError(
-                f"multi-GEMM: {chain.num_gemms} GEMMs × cta_tile_n={cfg.cta_tile_n} "
-                f"= {region} acc cols exceed {total_tmem} TMEM (single stage). "
+                f"multi-GEMM: {chain.num_gemms} GEMMs × {cols_per_acc} acc cols "
+                f"= {region} exceed {total_tmem} TMEM (single stage). "
                 f"Pick a smaller cta_tile_n or fewer GEMMs."
             )
         acc_stages_mg = 2 if 2 * region <= total_tmem else 1
-        lines.append(f"acc_stages = {acc_stages_mg}  # multi-GEMM: {chain.num_gemms}×{cfg.cta_tile_n} cols/stage")
+        lines.append(f"acc_stages = {acc_stages_mg}  # multi-GEMM: {chain.num_gemms}×{cols_per_acc} cols/stage")
         # ab_stages: one SMEM buffer per DISTINCT operand (num_a A + num_b B per
         # stage), not the single A+B that smem_max_ab_stages assumes.
         from .tile_config import _sm_smem_ab_budget_bytes, _AB_STAGES_CAP
@@ -797,7 +797,7 @@ def _render_block_scale_tile_constants(
     _REGISTERS_PER_ATOM = 4  # cols per 128×4 utccp atom
     scales_per_inst = mma_inst_k_elems // bs.block_size
     word_scales = max(_REGISTERS_PER_ATOM, scales_per_inst)  # cols per block-word
-    word_atoms = word_scales // _REGISTERS_PER_ATOM  # atoms copied per word
+    word_atoms = -(-word_scales // _REGISTERS_PER_ATOM)  # atoms copied per word (ceil: a partial atom still costs one)
     insts_per_word = max(_REGISTERS_PER_ATOM // scales_per_inst, 1)
     num_sf_words = max(num_kblocks // insts_per_word, 1)  # utccp refreshes / k-tile
     _REGISTERS_PER_BLOCK = word_scales  # SF word width per block
@@ -891,14 +891,20 @@ def _render_block_scale_tile_constants(
 
     mma_m = cta_m * cta_group
     half_m = cta_group == 2 and mma_m == 128  # unreachable while block-scale pins cta_m=128
-    if is_sm103:  # enhanced OMMA: nvfp4 (block 16) -> 6X, mxfp4 (block 32) -> 3X
-        vec_6x = bs.block_size == 16
-        sf_ids = [scales_per_inst * j % 4 for j in range(num_kblocks)]
-        sfb_extra = 4 if cta_n <= 128 else 8
-        sfa_spans = [(scales_per_inst * j // 4 * 4 * nb_m, 4 if (not vec_6x and sf_ids[j] < 2) else 8) for j in range(num_kblocks)]
-        sfb_spans = [
-            (scales_per_inst * j // 4 * 4 * nb_n, 2 * ((cta_n + 63) // 64) + (sfb_extra if (vec_6x or sf_ids[j] >= 2) else 0)) for j in range(num_kblocks)
-        ]
+    omma_k = mma_inst_k_elems if is_fp4 else 0
+    sf_ids = [scales_per_inst * j % 4 for j in range(num_kblocks)]
+    sfb_extra = 4 if cta_n <= 128 else 8
+    sfa_off = [scales_per_inst * j // 4 * 4 * nb_m for j in range(num_kblocks)]
+    sfb_off = [scales_per_inst * j // 4 * 4 * nb_n for j in range(num_kblocks)]
+    if omma_k in (96, 128):
+        # 96 -> 3X (block 32) / 6X (block 16); 128 -> 4X (block 32) / 8X (block 16).
+        wide_vec = bs.block_size == 16  # the 6X / 8X arm
+        if omma_k == 128:  # extra-enhanced: the extra term is 8X-only
+            extra = [sfb_extra if wide_vec else 0] * num_kblocks
+        else:  # enhanced: 6X, or 3X with sfb_id >= 2
+            extra = [sfb_extra if (wide_vec or sf_ids[j] >= 2) else 0 for j in range(num_kblocks)]
+        sfa_spans = [(sfa_off[j], 4 if (not wide_vec and omma_k == 96 and sf_ids[j] < 2) else 8) for j in range(num_kblocks)]
+        sfb_spans = [(sfb_off[j], 2 * ((cta_n + 63) // 64) + extra[j]) for j in range(num_kblocks)]
     else:
         sfa_spans = [(0, 2 if half_m else 4)]
         sfb_spans = [(0, 2 * ((cta_n + 127) // 128) if half_m else 2 * ((cta_n + 63) // 64))]

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -2140,6 +2140,19 @@ def _check_cta_group_geometry(config: TileConfig, cta_group: int) -> None:
         )
 
 
+def _check_mma_n_dim(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
+    """MMA n_dim rules that depend on the MMA kind, not just geometry (int8/UTCIMMA)."""
+    if DTYPE_TO_MMA_KIND.get(_mma_a_dtype(chain)) != "nvvm.Tcgen05MMAKind.INT8":
+        return
+    for label, n in (("mma_inst_n", config.mma_inst_n), ("cta_tile_n", config.cta_tile_n)):
+        if n >= 40 and (n // 8) % 2 != 0:
+            raise NotImplementedError(
+                f"int8 MMA (UTCIMMA) needs N ≤ 32 or a multiple of 16; "
+                f'config {config.name!r} has {label}={n} (ISA: "UTCIMMA only '
+                f'supports 16 step increments for N > 32 for non-.WS mode")'
+            )
+
+
 def _check_dtype_config_compat(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
     """Reject (chain, config) where the config K_BYTES isn't a multiple of the
     MMA dtype's element width. ``cta_group`` sets per-CTA SMEM N for the
@@ -2567,6 +2580,7 @@ def jit_from_cudnn_graph(
     """
     chain, binding = analyze_with_binding(graph)
     _check_cta_group_geometry(config, cta_group)
+    _check_mma_n_dim(chain, config, cta_group)
     # MoE grouped block-scale = both matches at once (dequant + moe_grouped);
     # check BEFORE the single-feature gates.
     if chain.has_moe and chain.has_block_scale:

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -889,6 +889,28 @@ def _render_block_scale_tile_constants(
             f"block-scale {cfg.name!r}: the accumulator + SF regions need {used_cols} TMEM columns but only {num_tmem_alloc_cols} are allocated"
         )
 
+    mma_m = cta_m * cta_group
+    half_m = cta_group == 2 and mma_m == 128  # unreachable while block-scale pins cta_m=128
+    if is_sm103:  # enhanced OMMA: nvfp4 (block 16) -> 6X, mxfp4 (block 32) -> 3X
+        vec_6x = bs.block_size == 16
+        sf_ids = [scales_per_inst * j % 4 for j in range(num_kblocks)]
+        sfb_extra = 4 if cta_n <= 128 else 8
+        sfa_spans = [(scales_per_inst * j // 4 * 4 * nb_m, 4 if (not vec_6x and sf_ids[j] < 2) else 8) for j in range(num_kblocks)]
+        sfb_spans = [
+            (scales_per_inst * j // 4 * 4 * nb_n, 2 * ((cta_n + 63) // 64) + (sfb_extra if (vec_6x or sf_ids[j] >= 2) else 0)) for j in range(num_kblocks)
+        ]
+    else:
+        sfa_spans = [(0, 2 if half_m else 4)]
+        sfb_spans = [(0, 2 * ((cta_n + 127) // 128) if half_m else 2 * ((cta_n + 63) // 64))]
+    for _label, _bases, _spans in (("SFA", sfa_col_bases, sfa_spans), ("SFB", sfb_col_bases, sfb_spans)):
+        _end = max(b + off + cols for b in _bases for off, cols in _spans)
+        if _end > num_tmem_alloc_cols:
+            raise NotImplementedError(
+                f"block-scale {cfg.name!r}: the hardware {_label} TMEM span reaches "
+                f"column {_end} but only {num_tmem_alloc_cols} are allocated "
+                f"(ISA 'Load {_label[-1]} scale factors'" + ("; SM Errata 160 means the hardware will NOT report OOR_ADDR here)" if _label == "SFB" else ")")
+            )
+
     # --- AB SMEM pipeline depth ----------------------------------------------
     # Per-stage SMEM = (packed data + SF) per DISTINCT operand + 2 mbar.
     per_stage = na * (sA_packed_elems + sfa_smem_bytes) + nb * (sB_packed_elems + sfb_smem_bytes) + 2 * 8
@@ -2141,16 +2163,37 @@ def _check_cta_group_geometry(config: TileConfig, cta_group: int) -> None:
 
 
 def _check_mma_n_dim(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
-    """MMA n_dim rules that depend on the MMA kind, not just geometry (int8/UTCIMMA)."""
-    if DTYPE_TO_MMA_KIND.get(_mma_a_dtype(chain)) != "nvvm.Tcgen05MMAKind.INT8":
-        return
-    for label, n in (("mma_inst_n", config.mma_inst_n), ("cta_tile_n", config.cta_tile_n)):
-        if n >= 40 and (n // 8) % 2 != 0:
-            raise NotImplementedError(
-                f"int8 MMA (UTCIMMA) needs N ≤ 32 or a multiple of 16; "
-                f'config {config.name!r} has {label}={n} (ISA: "UTCIMMA only '
-                f'supports 16 step increments for N > 32 for non-.WS mode")'
-            )
+    """MMA n_dim rules that depend on the dtype / operand layout, not just geometry.
+
+    Both come from ISA table2 + the SPA model and are invisible in the geometry
+    guards; ``config.mma_inst_n`` and ``cta_tile_n`` are checked because 1ctamma
+    encodes the latter and 2ctamma the former (equal for every catalog entry).
+    """
+    ns = (("mma_inst_n", config.mma_inst_n), ("cta_tile_n", config.cta_tile_n))
+
+    # UTCIMMA is narrower than the other kinds above N=32.
+    if DTYPE_TO_MMA_KIND.get(_mma_a_dtype(chain)) == "nvvm.Tcgen05MMAKind.INT8":
+        for label, n in ns:
+            if n >= 40 and (n // 8) % 2 != 0:
+                raise NotImplementedError(
+                    f"int8 MMA (UTCIMMA) needs N ≤ 32 or a multiple of 16; "
+                    f'config {config.name!r} has {label}={n} (ISA: "UTCIMMA only '
+                    f'supports 16 step increments for N > 32 for non-.WS mode")'
+                )
+
+    # table2's "8bit-transpose B" rows tighten N for every non-HMMA kind:
+    # 1CTA 16..256 step 16, 2CTA 32..256 step 32. B is transposed iff N-major.
+    bs = chain.block_scale
+    b_dt = bs.b_dtype if bs is not None else chain.matmul.b_dtype
+    if _dtype_bits(b_dt) == 8 and chain.matmul.b_major == "n":
+        step = 32 if cta_group == 2 else 16
+        for label, n in ns:
+            if n < step or n % step != 0:
+                raise NotImplementedError(
+                    f"8-bit transposed (N-major) B needs N ≥ {step} and a multiple "
+                    f"of {step} under cta_group={cta_group}; config {config.name!r} "
+                    f"has {label}={n} (ISA table2, the '8bit-transpose B = Yes' rows)"
+                )
 
 
 def _check_dtype_config_compat(chain: FusionChain, config: TileConfig, cta_group: int) -> None:

--- a/python/cudnn/gemm/frost/kernel_registry.py
+++ b/python/cudnn/gemm/frost/kernel_registry.py
@@ -310,6 +310,7 @@ class KernelTemplate:
         # cta_group constraints (the template's, not the config's).
         try:
             C._check_cta_group_geometry(config, self.cta_group)
+            C._check_mma_n_dim(chain, config, self.cta_group)
         except NotImplementedError as e:
             return str(e)
         try:

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
@@ -825,7 +825,12 @@ def _kernel(
 
         subtile_cnt = cute.ceil_div(cta_tile_mnk[1], 32)
         t2r_inst_repx = epi_tile_mn[1]
-        shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+        if cutlass.const_expr(cta_tile_mnk[0] == 64):
+            shape = nvvm.Tcgen05LdStShape.SHAPE_16X32BX2
+            ld_half_off = 0
+        else:
+            shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+            ld_half_off = None
         lane = tidx % 32
 
         # @@TMA_STORE_ONLY:BEGIN@@
@@ -874,10 +879,11 @@ def _kernel(
                             6,
                             cutlass.Float32,
                         )
-                        c_rmem_vecs.append(nvvm.tcgen05_ld(shape, tmem, num=t2r_inst_repx))
+                        c_rmem_vecs.append(nvvm.tcgen05_ld(shape, tmem, num=t2r_inst_repx, offset=ld_half_off))
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if use_acc_overlap and (not cd_out_is_m_major) and subtile_idx == acc_overlap_subtiles - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -971,6 +977,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr((not use_acc_overlap) or cd_out_is_m_major):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -1003,6 +1010,7 @@ def _kernel(
             tile_iter += 1
 
         if cutlass.const_expr(use_acc_overlap):
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
             if elect_one:
                 nvvm.mbarrier_arrive(tmem_dealloc_mbar_ptr)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
@@ -253,17 +253,23 @@ def _kernel(
     num_consumer_warps_per_cta = 7
     clc_empty_count = num_consumer_warps_per_cta * cluster_size
     if warp_idx == 0:
-        if elect_one:
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), num_epilogue_warps)
-            if cutlass.const_expr(use_acc_overlap):
+        if cutlass.const_expr(use_acc_overlap):
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, num_epilogue_warps)
-            for i in range(CLC_SCHED_STAGES):
+        for i in range(CLC_SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(clc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(clc_empty_mbar_ptr.subview(i), clc_empty_count)
     nvvm.fence_mbarrier_init()
     if cutlass.const_expr(cluster_shape_mnk[0] * cluster_shape_mnk[1] > 1):
@@ -391,9 +397,9 @@ def _kernel(
                     sfa_m_block = coord_m_per_cta // 128
                     if cutlass.const_expr(multicast_a):
                         if n_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(a_is_m_major):
-                                    for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if cutlass.const_expr(a_is_m_major):
+                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sA_stage.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                             tma_a_desc.get_ptr(),
@@ -407,7 +413,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_a,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
@@ -418,9 +425,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -434,7 +441,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
@@ -476,9 +484,9 @@ def _kernel(
                     sfb_n_block = coord_n_per_cta // 128
                     if cutlass.const_expr(multicast_b):
                         if m_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                             tma_b_desc.get_ptr(),
@@ -492,7 +500,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
@@ -503,9 +512,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -519,7 +528,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
@@ -941,20 +951,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma_static.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma_static.py
@@ -237,14 +237,18 @@ def _kernel(
 
     ab_empty_count = cluster_m + cluster_n - 1
     if warp_idx == 0:
-        if elect_one:
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), num_epilogue_warps)
-            if cutlass.const_expr(use_acc_overlap):
+        if cutlass.const_expr(use_acc_overlap):
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, num_epilogue_warps)
     nvvm.fence_mbarrier_init()
 
@@ -321,9 +325,9 @@ def _kernel(
                     sfa_m_block = coord_m_per_cta // 128
                     if cutlass.const_expr(multicast_a):
                         if n_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(a_is_m_major):
-                                    for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if cutlass.const_expr(a_is_m_major):
+                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sA_stage.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                             tma_a_desc.get_ptr(),
@@ -337,7 +341,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_a,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
@@ -348,9 +353,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -364,7 +369,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
@@ -406,9 +412,9 @@ def _kernel(
                     sfb_n_block = coord_n_per_cta // 128
                     if cutlass.const_expr(multicast_b):
                         if m_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                             tma_b_desc.get_ptr(),
@@ -422,7 +428,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
@@ -433,9 +440,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -449,7 +456,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
@@ -835,20 +843,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma_static.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma_static.py
@@ -718,7 +718,12 @@ def _kernel(
 
         subtile_cnt = cute.ceil_div(cta_tile_mnk[1], 32)
         t2r_inst_repx = epi_tile_mn[1]
-        shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+        if cutlass.const_expr(cta_tile_mnk[0] == 64):
+            shape = nvvm.Tcgen05LdStShape.SHAPE_16X32BX2
+            ld_half_off = 0
+        else:
+            shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+            ld_half_off = None
         lane = tidx % 32
 
         # @@TMA_STORE_ONLY:BEGIN@@
@@ -768,10 +773,11 @@ def _kernel(
                             6,
                             cutlass.Float32,
                         )
-                        c_rmem_vecs.append(nvvm.tcgen05_ld(shape, tmem, num=t2r_inst_repx))
+                        c_rmem_vecs.append(nvvm.tcgen05_ld(shape, tmem, num=t2r_inst_repx, offset=ld_half_off))
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if use_acc_overlap and (not cd_out_is_m_major) and subtile_idx == acc_overlap_subtiles - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -865,6 +871,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr((not use_acc_overlap) or cd_out_is_m_major):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -874,6 +881,7 @@ def _kernel(
             tile_iter += 1
 
         if cutlass.const_expr(use_acc_overlap):
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
             if elect_one:
                 nvvm.mbarrier_arrive(tmem_dealloc_mbar_ptr)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
@@ -956,6 +956,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if use_acc_overlap and (not cd_out_is_m_major) and subtile_idx == acc_overlap_subtiles - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
@@ -1050,6 +1051,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr((not use_acc_overlap) or cd_out_is_m_major):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
@@ -1083,6 +1085,7 @@ def _kernel(
             tile_iter += 1
 
         if cutlass.const_expr(use_acc_overlap):
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
             if elect_one:
                 nvvm.mbarrier_arrive(tmem_dealloc_mbar_ptr)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
@@ -255,19 +255,26 @@ def _kernel(
     num_consumer_warps_per_cta = 7
     clc_empty_count = num_consumer_warps_per_cta * cluster_size
     if warp_idx == 0:
-        if elect_one:
-            if cutlass.const_expr(use_acc_overlap):
+        if cutlass.const_expr(use_acc_overlap):
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, num_epilogue_warps)
-            else:
+        else:
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, 32)
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), acc_empty_count)
-            for i in range(CLC_SCHED_STAGES):
+        for i in range(CLC_SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(clc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(clc_empty_mbar_ptr.subview(i), clc_empty_count)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
@@ -403,9 +410,9 @@ def _kernel(
                     sfa_m_block = coord_m_per_cta // 128
                     if cutlass.const_expr(multicast_a):
                         if n_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(a_is_m_major):
-                                    for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if cutlass.const_expr(a_is_m_major):
+                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sA_stage.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_a_desc.get_ptr(),
@@ -419,7 +426,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_a,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
@@ -430,9 +438,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -446,7 +454,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
@@ -487,9 +496,9 @@ def _kernel(
                     tma_sfb_desc = tma_sfb_descs[_bj]
                     if cutlass.const_expr(multicast_b):
                         if pair_m_idx == 0:
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_b_desc.get_ptr(),
@@ -503,7 +512,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
@@ -514,9 +524,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -530,7 +540,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
@@ -1015,20 +1026,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma_static.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma_static.py
@@ -819,6 +819,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if use_acc_overlap and (not cd_out_is_m_major) and subtile_idx == acc_overlap_subtiles - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
@@ -913,6 +914,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr((not use_acc_overlap) or cd_out_is_m_major):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
@@ -923,6 +925,7 @@ def _kernel(
             tile_iter += 1
 
         if cutlass.const_expr(use_acc_overlap):
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
             if elect_one:
                 nvvm.mbarrier_arrive(tmem_dealloc_mbar_ptr)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma_static.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma_static.py
@@ -236,16 +236,21 @@ def _kernel(
     cta_group = 2
     ab_empty_count = (cluster_m // cta_group) + cluster_n - 1
     if warp_idx == 0:
-        if elect_one:
-            if cutlass.const_expr(use_acc_overlap):
+        if cutlass.const_expr(use_acc_overlap):
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, num_epilogue_warps)
-            else:
+        else:
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, 32)
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), acc_empty_count)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
@@ -328,9 +333,9 @@ def _kernel(
                     sfa_m_block = coord_m_per_cta // 128
                     if cutlass.const_expr(multicast_a):
                         if n_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(a_is_m_major):
-                                    for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if cutlass.const_expr(a_is_m_major):
+                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sA_stage.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_a_desc.get_ptr(),
@@ -344,7 +349,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_a,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
@@ -355,9 +361,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -371,7 +377,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
@@ -412,9 +419,9 @@ def _kernel(
                     tma_sfb_desc = tma_sfb_descs[_bj]
                     if cutlass.const_expr(multicast_b):
                         if pair_m_idx == 0:
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_b_desc.get_ptr(),
@@ -428,7 +435,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
@@ -439,9 +447,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -455,7 +463,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
@@ -878,20 +887,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
@@ -692,7 +692,12 @@ def _kernel(
 
         epi_spans = _epi_subtile_spans(cols_per_acc_stage)
         subtile_cnt = len(epi_spans)
-        shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+        if cutlass.const_expr(cta_tile_mnk[0] == 64):
+            shape = nvvm.Tcgen05LdStShape.SHAPE_16X32BX2
+            ld_half_off = 0
+        else:
+            shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+            ld_half_off = None
         lane = tidx % 32
 
         # @@TMA_STORE_ONLY:BEGIN@@
@@ -729,7 +734,7 @@ def _kernel(
                     for g in cutlass.range_constexpr(num_gemms):
                         subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
                         tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w, offset=ld_half_off)
                         # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
                         if cutlass.const_expr(acc_widen_to_fp32):
                             _accf = _cv.to(cutlass.Float32)
@@ -739,6 +744,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if (not use_tma_store_epi) and subtile_idx == subtile_cnt - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -835,6 +841,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr(use_tma_store_epi):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
@@ -241,15 +241,20 @@ def _kernel(
     num_consumer_warps_per_cta = 7
     clc_empty_count = num_consumer_warps_per_cta * cluster_size
     if warp_idx == 0:
-        if elect_one:
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), num_epilogue_warps)
-            for i in range(CLC_SCHED_STAGES):
+        for i in range(CLC_SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(clc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(clc_empty_mbar_ptr.subview(i), clc_empty_count)
     nvvm.fence_mbarrier_init()
 
@@ -387,9 +392,9 @@ def _kernel(
                     tma_a_desc = tma_a_descs[_ai]
                     if cutlass.const_expr(multicast_a):
                         if n_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(a_is_m_major):
-                                    for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if cutlass.const_expr(a_is_m_major):
+                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sA_stage.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                             tma_a_desc.get_ptr(),
@@ -403,7 +408,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_a,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
@@ -414,9 +420,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -430,7 +436,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
@@ -446,9 +453,9 @@ def _kernel(
                     tma_b_desc = tma_b_descs[_bj]
                     if cutlass.const_expr(multicast_b):
                         if m_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                             tma_b_desc.get_ptr(),
@@ -462,7 +469,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
@@ -473,9 +481,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -489,7 +497,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
@@ -805,20 +814,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma_static.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma_static.py
@@ -576,7 +576,12 @@ def _kernel(
 
         epi_spans = _epi_subtile_spans(cols_per_acc_stage)
         subtile_cnt = len(epi_spans)
-        shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+        if cutlass.const_expr(cta_tile_mnk[0] == 64):
+            shape = nvvm.Tcgen05LdStShape.SHAPE_16X32BX2
+            ld_half_off = 0
+        else:
+            shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+            ld_half_off = None
         lane = tidx % 32
 
         # @@TMA_STORE_ONLY:BEGIN@@
@@ -614,7 +619,7 @@ def _kernel(
                     for g in cutlass.range_constexpr(num_gemms):
                         subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
                         tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w, offset=ld_half_off)
                         # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
                         if cutlass.const_expr(acc_widen_to_fp32):
                             _accf = _cv.to(cutlass.Float32)
@@ -624,6 +629,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if (not use_tma_store_epi) and subtile_idx == subtile_cnt - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -720,6 +726,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr(use_tma_store_epi):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma_static.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma_static.py
@@ -227,12 +227,15 @@ def _kernel(
 
     ab_empty_count = cluster_m + cluster_n - 1
     if warp_idx == 0:
-        if elect_one:
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), num_epilogue_warps)
     nvvm.fence_mbarrier_init()
 
@@ -316,9 +319,9 @@ def _kernel(
                     tma_a_desc = tma_a_descs[_ai]
                     if cutlass.const_expr(multicast_a):
                         if n_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(a_is_m_major):
-                                    for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if cutlass.const_expr(a_is_m_major):
+                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sA_stage.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                             tma_a_desc.get_ptr(),
@@ -332,7 +335,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_a,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
@@ -343,9 +347,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -359,7 +363,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
@@ -375,9 +380,9 @@ def _kernel(
                     tma_b_desc = tma_b_descs[_bj]
                     if cutlass.const_expr(multicast_b):
                         if m_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                             tma_b_desc.get_ptr(),
@@ -391,7 +396,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
@@ -402,9 +408,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -418,7 +424,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
@@ -690,20 +697,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
@@ -250,14 +250,20 @@ def _kernel(
     if warp_idx == 0:
         if elect_one:
             nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, 32)
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), acc_empty_count)
-            for i in range(CLC_SCHED_STAGES):
+        for i in range(CLC_SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(clc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(clc_empty_mbar_ptr.subview(i), clc_empty_count)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
@@ -399,9 +405,9 @@ def _kernel(
                     tma_a_desc = tma_a_descs[_ai]
                     if cutlass.const_expr(multicast_a):
                         if n_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(a_is_m_major):
-                                    for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if cutlass.const_expr(a_is_m_major):
+                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sA_stage.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_a_desc.get_ptr(),
@@ -415,7 +421,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_a,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
@@ -426,9 +433,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -442,7 +449,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
@@ -458,9 +466,9 @@ def _kernel(
                     tma_b_desc = tma_b_descs[_bj]
                     if cutlass.const_expr(multicast_b):
                         if pair_m_idx == 0:
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_b_desc.get_ptr(),
@@ -474,7 +482,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
@@ -485,9 +494,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -501,7 +510,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
@@ -872,20 +882,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
@@ -807,6 +807,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if (not use_tma_store_epi) and subtile_idx == subtile_cnt - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(
@@ -907,6 +908,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr(use_tma_store_epi):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma_static.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma_static.py
@@ -230,11 +230,15 @@ def _kernel(
     if warp_idx == 0:
         if elect_one:
             nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, 32)
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), acc_empty_count)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
@@ -322,9 +326,9 @@ def _kernel(
                     tma_a_desc = tma_a_descs[_ai]
                     if cutlass.const_expr(multicast_a):
                         if n_rank == 0:
-                            if elect_one:
-                                if cutlass.const_expr(a_is_m_major):
-                                    for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if cutlass.const_expr(a_is_m_major):
+                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sA_stage.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_a_desc.get_ptr(),
@@ -338,7 +342,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_a,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage,
                                         tma_a_desc.get_ptr(),
@@ -349,9 +354,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_stage.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -365,7 +370,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_stage,
                                     tma_a_desc.get_ptr(),
@@ -381,9 +387,9 @@ def _kernel(
                     tma_b_desc = tma_b_descs[_bj]
                     if cutlass.const_expr(multicast_b):
                         if pair_m_idx == 0:
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_b_desc.get_ptr(),
@@ -397,7 +403,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_desc.get_ptr(),
@@ -408,9 +415,9 @@ def _kernel(
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
                     else:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -424,7 +431,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_stage,
                                     tma_b_desc.get_ptr(),
@@ -736,20 +744,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma_static.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma_static.py
@@ -671,6 +671,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if (not use_tma_store_epi) and subtile_idx == subtile_cnt - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(
@@ -771,6 +772,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr(use_tma_store_epi):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
@@ -245,17 +245,24 @@ def _kernel(
     num_consumer_warps_per_cta = 7 + num_mainloop_warps
     clc_empty_count = num_consumer_warps_per_cta * cluster_size
     if warp_idx == 0:
-        if elect_one:
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(a_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(b_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(mainloop_full_mbar_ptr.subview(i), num_mainloop_warps)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), num_epilogue_warps)
-            for i in range(CLC_SCHED_STAGES):
+        for i in range(CLC_SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(clc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(clc_empty_mbar_ptr.subview(i), clc_empty_count)
     nvvm.fence_mbarrier_init()
 
@@ -405,13 +412,14 @@ def _kernel(
                     sB_tma_dst = sB_stage
                 if elect_one:
                     nvvm.mbarrier_arrive_expect_tx(a_full_mbar_ptr.subview(stage), sA_tma_bytes)
+                if elect_one:
                     nvvm.mbarrier_arrive_expect_tx(b_full_mbar_ptr.subview(stage), sB_tma_bytes)
 
                 if cutlass.const_expr(multicast_a):
                     if n_rank == 0:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_tma_dst.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -425,7 +433,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_tma_dst,
                                     tma_a_desc.get_ptr(),
@@ -436,9 +445,9 @@ def _kernel(
                                     group=nvvm.CTAGroup.CTA_1,
                                 )
                 else:
-                    if elect_one:
-                        if cutlass.const_expr(a_is_m_major):
-                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                    if cutlass.const_expr(a_is_m_major):
+                        for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_tma_dst.subview(m_group * a_tma_group_elems * cta_tile_mnk[2]),
                                     tma_a_desc.get_ptr(),
@@ -452,7 +461,8 @@ def _kernel(
                                     multicast_mask=tma_mcast_mask_a,
                                     group=nvvm.CTAGroup.CTA_1,
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                 sA_tma_dst,
                                 tma_a_desc.get_ptr(),
@@ -465,9 +475,9 @@ def _kernel(
 
                 if cutlass.const_expr(multicast_b):
                     if m_rank == 0:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_tma_dst.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -481,7 +491,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_1,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_tma_dst,
                                     tma_b_desc.get_ptr(),
@@ -492,9 +503,9 @@ def _kernel(
                                     group=nvvm.CTAGroup.CTA_1,
                                 )
                 else:
-                    if elect_one:
-                        if cutlass.const_expr(b_is_n_major):
-                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                    if cutlass.const_expr(b_is_n_major):
+                        for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_tma_dst.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                     tma_b_desc.get_ptr(),
@@ -508,7 +519,8 @@ def _kernel(
                                     multicast_mask=tma_mcast_mask_b,
                                     group=nvvm.CTAGroup.CTA_1,
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                 sB_tma_dst,
                                 tma_b_desc.get_ptr(),
@@ -1032,20 +1044,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
@@ -919,7 +919,12 @@ def _kernel(
 
         epi_spans = _epi_subtile_spans(cols_per_acc_stage)
         subtile_cnt = len(epi_spans)
-        shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+        if cutlass.const_expr(cta_tile_mnk[0] == 64):
+            shape = nvvm.Tcgen05LdStShape.SHAPE_16X32BX2
+            ld_half_off = 0
+        else:
+            shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+            ld_half_off = None
         lane = tidx % 32
 
         # @@TMA_STORE_ONLY:BEGIN@@
@@ -956,7 +961,7 @@ def _kernel(
                     for g in cutlass.range_constexpr(num_gemms):
                         subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
                         tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w, offset=ld_half_off)
                         # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
                         if cutlass.const_expr(acc_widen_to_fp32):
                             _accf = _cv.to(cutlass.Float32)
@@ -966,6 +971,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if (not use_tma_store_epi) and subtile_idx == subtile_cnt - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -1062,6 +1068,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr(use_tma_store_epi):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
@@ -1102,6 +1102,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if (not use_tma_store_epi) and subtile_idx == subtile_cnt - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(
@@ -1202,6 +1203,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr(use_tma_store_epi):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
@@ -253,16 +253,24 @@ def _kernel(
     if warp_idx == 0:
         if elect_one:
             nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, 32)
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(a_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(b_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(mainloop_full_mbar_ptr.subview(i), mainloop_full_count)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), acc_empty_count)
-            for i in range(CLC_SCHED_STAGES):
+        for i in range(CLC_SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(clc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(clc_empty_mbar_ptr.subview(i), clc_empty_count)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
@@ -431,9 +439,9 @@ def _kernel(
                             nvvm.mbarrier_arrive_expect_tx(b_full_mbar_ptr.subview(stage), sB_tma_bytes * 2)
                 if cutlass.const_expr(mainloop_fuse_a):
                     a_self_mask = cutlass.Int16(1) << cta_rank_in_cluster
-                    if elect_one:
-                        if cutlass.const_expr(a_is_m_major):
-                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                    if cutlass.const_expr(a_is_m_major):
+                        for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_tma_dst.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                     tma_a_desc.get_ptr(),
@@ -447,7 +455,8 @@ def _kernel(
                                     multicast_mask=a_self_mask,
                                     group=nvvm.CTAGroup.CTA_1,
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                 sA_tma_dst,
                                 tma_a_desc.get_ptr(),
@@ -459,9 +468,9 @@ def _kernel(
                             )
                 elif cutlass.const_expr(multicast_a):
                     if n_rank == 0:
-                        if elect_one:
-                            if cutlass.const_expr(a_is_m_major):
-                                for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                        if cutlass.const_expr(a_is_m_major):
+                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sA_tma_dst.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_a_desc.get_ptr(),
@@ -475,7 +484,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_a,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_tma_dst,
                                     tma_a_desc.get_ptr(),
@@ -486,9 +496,9 @@ def _kernel(
                                     group=nvvm.CTAGroup.CTA_2,
                                 )
                 else:
-                    if elect_one:
-                        if cutlass.const_expr(a_is_m_major):
-                            for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                    if cutlass.const_expr(a_is_m_major):
+                        for m_group in cutlass.range_constexpr(cta_tile_mnk[0] // a_tma_group_elems):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sA_tma_dst.subview(m_group * a_tma_group_elems * cgrp_tile_mnk[2]),
                                     tma_a_desc.get_ptr(),
@@ -502,7 +512,8 @@ def _kernel(
                                     multicast_mask=tma_mcast_mask_a,
                                     group=nvvm.CTAGroup.CTA_2,
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                 sA_tma_dst,
                                 tma_a_desc.get_ptr(),
@@ -515,9 +526,9 @@ def _kernel(
 
                 if cutlass.const_expr(mainloop_fuse_b):
                     b_self_mask = cutlass.Int16(1) << cta_rank_in_cluster
-                    if elect_one:
-                        if cutlass.const_expr(b_is_n_major):
-                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                    if cutlass.const_expr(b_is_n_major):
+                        for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_tma_dst.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                     tma_b_desc.get_ptr(),
@@ -531,7 +542,8 @@ def _kernel(
                                     multicast_mask=b_self_mask,
                                     group=nvvm.CTAGroup.CTA_1,
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                 sB_tma_dst,
                                 tma_b_desc.get_ptr(),
@@ -543,9 +555,9 @@ def _kernel(
                             )
                 elif cutlass.const_expr(multicast_b):
                     if pair_m_idx == 0:
-                        if elect_one:
-                            if cutlass.const_expr(b_is_n_major):
-                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                        if cutlass.const_expr(b_is_n_major):
+                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_tma_dst.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                         tma_b_desc.get_ptr(),
@@ -559,7 +571,8 @@ def _kernel(
                                         multicast_mask=tma_mcast_mask_b,
                                         group=nvvm.CTAGroup.CTA_2,
                                     )
-                            else:
+                        else:
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_tma_dst,
                                     tma_b_desc.get_ptr(),
@@ -570,9 +583,9 @@ def _kernel(
                                     group=nvvm.CTAGroup.CTA_2,
                                 )
                 else:
-                    if elect_one:
-                        if cutlass.const_expr(b_is_n_major):
-                            for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                    if cutlass.const_expr(b_is_n_major):
+                        for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                     sB_tma_dst.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                     tma_b_desc.get_ptr(),
@@ -586,7 +599,8 @@ def _kernel(
                                     multicast_mask=tma_mcast_mask_b,
                                     group=nvvm.CTAGroup.CTA_2,
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                 sB_tma_dst,
                                 tma_b_desc.get_ptr(),
@@ -1167,20 +1181,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -931,7 +931,12 @@ def _kernel(
 
         subtile_cnt = cute.ceil_div(cta_tile_mnk[1], 32)
         t2r_inst_repx = epi_tile_mn[1]
-        shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+        if cutlass.const_expr(cta_tile_mnk[0] == 64):
+            shape = nvvm.Tcgen05LdStShape.SHAPE_16X32BX2
+            ld_half_off = 0
+        else:
+            shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+            ld_half_off = None
         lane = tidx % 32
 
         while is_valid != 0:
@@ -1000,10 +1005,11 @@ def _kernel(
                             6,
                             cutlass.Float32,
                         )
-                        c_rmem_vecs.append(nvvm.tcgen05_ld(shape, tmem, num=t2r_inst_repx))
+                        c_rmem_vecs.append(nvvm.tcgen05_ld(shape, tmem, num=t2r_inst_repx, offset=ld_half_off))
                     c_rmem_vec = c_rmem_vecs[0]
 
                     if cutlass.const_expr(use_acc_overlap and subtile_idx == acc_overlap_subtiles - 1):
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
                             nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -1023,12 +1029,14 @@ def _kernel(
                     # @@STG_ONLY:END@@
 
                 if cutlass.const_expr(not use_acc_overlap):
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
                 tile_iter += 1
 
         if cutlass.const_expr(use_acc_overlap):
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
             if elect_one:
                 nvvm.mbarrier_arrive(tmem_dealloc_mbar_ptr)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -269,17 +269,23 @@ def _kernel(
     ab_empty_count = cluster_m + cluster_n - 1
     sched_empty_count = 1 + 1 + num_epilogue_warps
     if warp_idx == 0:
-        if elect_one:
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), num_epilogue_warps)
-            if cutlass.const_expr(use_acc_overlap):
+        if cutlass.const_expr(use_acc_overlap):
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, num_epilogue_warps)
-            for i in range(SCHED_STAGES):
+        for i in range(SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
     nvvm.fence_mbarrier_init()
 
@@ -637,9 +643,9 @@ def _kernel(
                     if b_issue:
                         for _bj in cutlass.range_constexpr(num_b_operands):
                             sB_stage = smem_b_list[_bj].subview(sB_elems * stage)
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                             tma_b_descs[_bj].get_ptr(),
@@ -653,7 +659,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_descs[_bj].get_ptr(),

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -1062,6 +1062,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                     if use_acc_overlap and subtile_idx == acc_overlap_subtiles - 1:
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
                             mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
@@ -1084,6 +1085,7 @@ def _kernel(
                     # @@STG_ONLY:END@@
 
                 if cutlass.const_expr(not use_acc_overlap):
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
@@ -1091,6 +1093,7 @@ def _kernel(
                 tile_iter += 1
 
         if cutlass.const_expr(use_acc_overlap):
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
             if elect_one:
                 nvvm.mbarrier_arrive(tmem_dealloc_mbar_ptr)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -274,19 +274,26 @@ def _kernel(
     ab_empty_count = (cluster_m // cta_group) + cluster_n - 1
     sched_empty_count = 1 + 1 + num_epilogue_warps
     if warp_idx == 0:
-        if elect_one:
-            if cutlass.const_expr(use_acc_overlap):
+        if cutlass.const_expr(use_acc_overlap):
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, num_epilogue_warps)
-            else:
+        else:
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, 32)
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), acc_empty_count)
-            for i in range(SCHED_STAGES):
+        for i in range(SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
@@ -649,9 +656,9 @@ def _kernel(
                     if b_issue:
                         for _bj in cutlass.range_constexpr(num_b_operands):
                             sB_stage = smem_b_list[_bj].subview(sB_elems * stage)
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_b_descs[_bj].get_ptr(),
@@ -665,7 +672,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_descs[_bj].get_ptr(),

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
@@ -739,7 +739,12 @@ def _kernel(
 
         epi_spans = _epi_subtile_spans(cols_per_acc_stage)
         subtile_cnt = len(epi_spans)
-        shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+        if cutlass.const_expr(cta_tile_mnk[0] == 64):
+            shape = nvvm.Tcgen05LdStShape.SHAPE_16X32BX2
+            ld_half_off = 0
+        else:
+            shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+            ld_half_off = None
         lane = tidx % 32
 
         while not nvvm.mbarrier_try_wait_parity(sched_full_mbar_ptr.subview(sched_stage), sched_full_phase, time_limit=10_000_000):
@@ -787,7 +792,7 @@ def _kernel(
                 for g in cutlass.range_constexpr(num_gemms):
                     subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
                     tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                    _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                    _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w, offset=ld_half_off)
                     if cutlass.const_expr(acc_widen_to_fp32):
                         _accf = _cv.to(cutlass.Float32)
                         _cv = _accf + cutlass.full_like(_accf, 0.0)
@@ -795,6 +800,7 @@ def _kernel(
                 c_rmem_vec = c_rmem_vecs[0]
 
                 if subtile_idx == subtile_cnt - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
@@ -283,15 +283,20 @@ def _kernel(
     ab_empty_count = cluster_m + cluster_n - 1
     sched_empty_count = 1 + 1 + num_epilogue_warps
     if warp_idx == 0:
-        if elect_one:
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), num_epilogue_warps)
-            for i in range(SCHED_STAGES):
+        for i in range(SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
     nvvm.fence_mbarrier_init()
     if cutlass.const_expr(cluster_shape_mnk[0] * cluster_shape_mnk[1] > 1):
@@ -543,9 +548,9 @@ def _kernel(
                     if b_issue:
                         for _bj in cutlass.range_constexpr(num_b_operands):
                             sB_stage = smem_b_list[_bj].subview(sB_elems * stage)
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cta_tile_mnk[2]),
                                             tma_b_descs[_bj].get_ptr(),
@@ -559,7 +564,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_1,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_descs[_bj].get_ptr(),

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
@@ -867,6 +867,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                     if subtile_idx == subtile_cnt - 1:
+                        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
                             nvvm.mbarrier_arrive(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
@@ -296,14 +296,20 @@ def _kernel(
     if warp_idx == 0:
         if elect_one:
             nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, 32)
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), acc_empty_count)
-            for i in range(SCHED_STAGES):
+        for i in range(SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
@@ -560,9 +566,9 @@ def _kernel(
                     if b_issue:
                         for _bj in cutlass.range_constexpr(num_b_operands):
                             sB_stage = smem_b_list[_bj].subview(sB_elems * stage)
-                            if elect_one:
-                                if cutlass.const_expr(b_is_n_major):
-                                    for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                            if cutlass.const_expr(b_is_n_major):
+                                for n_group in cutlass.range_constexpr(cta_tile_mnk[1] // b_tma_group_elems):
+                                    if elect_one:
                                         nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                             sB_stage.subview(n_group * b_tma_group_elems * cgrp_tile_mnk[2]),
                                             tma_b_descs[_bj].get_ptr(),
@@ -576,7 +582,8 @@ def _kernel(
                                             multicast_mask=tma_mcast_mask_b,
                                             group=nvvm.CTAGroup.CTA_2,
                                         )
-                                else:
+                            else:
+                                if elect_one:
                                     nvvm.cp_async_bulk_tensor_shared_cluster_global(
                                         sB_stage,
                                         tma_b_descs[_bj].get_ptr(),

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
@@ -1014,7 +1014,12 @@ def _kernel(
 
         subtile_cnt = cute.ceil_div(cta_tile_mnk[1], 32)
         t2r_inst_repx = epi_tile_mn[1]
-        shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+        if cutlass.const_expr(cta_tile_mnk[0] == 64):
+            shape = nvvm.Tcgen05LdStShape.SHAPE_16X32BX2
+            ld_half_off = 0
+        else:
+            shape = nvvm.Tcgen05LdStShape.SHAPE_32X32B
+            ld_half_off = None
         lane = tidx % 32
 
         # @@TMA_STORE_ONLY:BEGIN@@
@@ -1063,10 +1068,11 @@ def _kernel(
                             6,
                             cutlass.Float32,
                         )
-                        c_rmem_vecs.append(nvvm.tcgen05_ld(shape, tmem, num=t2r_inst_repx))
+                        c_rmem_vecs.append(nvvm.tcgen05_ld(shape, tmem, num=t2r_inst_repx, offset=ld_half_off))
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if use_acc_overlap and (not cd_out_is_m_major) and subtile_idx == acc_overlap_subtiles - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -1160,6 +1166,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr((not use_acc_overlap) or cd_out_is_m_major):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
@@ -1192,6 +1199,7 @@ def _kernel(
             tile_iter += 1
 
         if cutlass.const_expr(use_acc_overlap):
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
             if elect_one:
                 nvvm.mbarrier_arrive(tmem_dealloc_mbar_ptr)

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
@@ -319,20 +319,28 @@ def _kernel(
     num_consumer_warps_per_cta = 8
     clc_empty_count = num_consumer_warps_per_cta * cluster_size
     if warp_idx == 0:
-        if elect_one:
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(sf_stages):
+        for i in range(sf_stages):
+            if elect_one:
                 nvvm.mbarrier_init(sf_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(sf_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), num_epilogue_warps)
-            if cutlass.const_expr(use_acc_overlap):
+        if cutlass.const_expr(use_acc_overlap):
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, num_epilogue_warps)
-            for i in range(CLC_SCHED_STAGES):
+        for i in range(CLC_SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(clc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(clc_empty_mbar_ptr.subview(i), clc_empty_count)
     nvvm.fence_mbarrier_init()
     if cutlass.const_expr(cluster_shape_mnk[0] * cluster_shape_mnk[1] > 1):
@@ -1130,20 +1138,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
@@ -1138,6 +1138,7 @@ def _kernel(
                     c_rmem_vec = c_rmem_vecs[0]
 
                 if use_acc_overlap and (not cd_out_is_m_major) and subtile_idx == acc_overlap_subtiles - 1:
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                     if elect_one:
                         mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
@@ -1232,6 +1233,7 @@ def _kernel(
                 # @@STG_ONLY:END@@
 
             if cutlass.const_expr((not use_acc_overlap) or cd_out_is_m_major):
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                 if elect_one:
                     mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
@@ -1265,6 +1267,7 @@ def _kernel(
             tile_iter += 1
 
         if cutlass.const_expr(use_acc_overlap):
+            nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
             if elect_one:
                 nvvm.mbarrier_arrive(tmem_dealloc_mbar_ptr)

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
@@ -321,22 +321,31 @@ def _kernel(
     num_consumer_warps_per_cta = 8
     clc_empty_count = num_consumer_warps_per_cta * cluster_size
     if warp_idx == 0:
-        if elect_one:
-            if cutlass.const_expr(use_acc_overlap):
+        if cutlass.const_expr(use_acc_overlap):
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, num_epilogue_warps)
-            else:
+        else:
+            if elect_one:
                 nvvm.mbarrier_init(tmem_dealloc_mbar_ptr, 32)
-            for i in range(ab_stages):
+        for i in range(ab_stages):
+            if elect_one:
                 nvvm.mbarrier_init(ab_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(ab_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(sf_stages):
+        for i in range(sf_stages):
+            if elect_one:
                 nvvm.mbarrier_init(sf_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(sf_empty_mbar_ptr.subview(i), ab_empty_count)
-            for i in range(acc_stages):
+        for i in range(acc_stages):
+            if elect_one:
                 nvvm.mbarrier_init(acc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(acc_empty_mbar_ptr.subview(i), acc_empty_count)
-            for i in range(CLC_SCHED_STAGES):
+        for i in range(CLC_SCHED_STAGES):
+            if elect_one:
                 nvvm.mbarrier_init(clc_full_mbar_ptr.subview(i), 1)
+            if elect_one:
                 nvvm.mbarrier_init(clc_empty_mbar_ptr.subview(i), clc_empty_count)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
@@ -1197,20 +1206,22 @@ def _kernel(
                 )
 
                 if warp_idx == 0:
-                    if elect_one:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                    if cutlass.const_expr(cd_out_is_m_major):
+                        for _mb in cutlass.range_constexpr(cta_tile_mnk[0] // cd_mmajor_atom_m):
+                            if elect_one:
                                 nvvm.cp_async_bulk_tensor_global_shared_cta(
                                     tma_c_desc.get_ptr(),
                                     smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
                                     (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
                                 )
-                        else:
+                    else:
+                        if elect_one:
                             nvvm.cp_async_bulk_tensor_global_shared_cta(
                                 tma_c_desc.get_ptr(),
                                 smem_subtile_ptr,
                                 (col, coord_m, tile_l),
                             )
+                    if elect_one:
                         nvvm.cp_async_bulk_commit_group()
                     nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
 


### PR DESCRIPTION
## Before submitting

- [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [ ] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Fix a series of potential issue during a throughout audit of tcgen.05/config

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GEMM reliability for multi-tile and block-scaled workloads.
  - Corrected handling of partial scale-factor data and tensor-memory sizing.
  - Added validation for unsupported matrix dimensions and hardware access ranges, with clearer error messages.
  - Improved synchronization during matrix multiplication output processing to prevent incomplete or inconsistent results.
  - Enhanced support for 64-row tile configurations across standard and grouped matrix multiplication workloads.
  - Improved reliability across additional matrix multiplication and mixture-of-experts workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->