### PR TITLE
python: FlashAttention-style window_size=(left, right) on sdpa / sdpa_backward

### DIFF
--- a/docs/operations/Attention.md
+++ b/docs/operations/Attention.md
@@ -300,6 +300,7 @@ graph.sdpa(
     diagonal_alignment=TOP_LEFT,          # Diagonal alignment: TOP_LEFT or BOTTOM_RIGHT
     diagonal_band_left_bound=None,        # Left bound for sliding window (None = no bound)
     diagonal_band_right_bound=None,       # Right bound for causal mask (0 = causal, None = no bound)
+    window_size=None,                     # FlashAttention-style (left, right) offset window (alias for the two bounds)
     dropout=None,                         # Dropout config: (prob, seed, offset) or (mask, scale)
     rng_dump=None,                        # Debug: output tensor for RNG dropout mask
     paged_attention_k_table=None,         # Page table for K container
@@ -328,6 +329,7 @@ graph.sdpa(
 - `cu_seq_len_kv` (Optional[cudnn_tensor]): Cumulative key/value sequence lengths; same shape, type, and constraints as `cu_seq_len_q`.
 - `diagonal_alignment` (Optional[cudnn.diagonal_alignment]): Alignment for diagonal masking. `TOP_LEFT` for standard causal, `BOTTOM_RIGHT` for prefix-LM style.
 - `diagonal_band_left_bound` (Optional[int]): Left bound for sliding window attention. Masks columns at or before `row_idx - left_bound`.
+- `window_size` (Optional[Tuple[int, int]]): FlashAttention-convention `(left, right)` attention window: per-side **offsets** from the (aligned) diagonal, with `-1` or `None` meaning unbounded on that side. `(-1, 0)` is plain causal, `(W, 0)` is causal with a sliding window of `W` past tokens, `(-1, R)` widens the causal bound by `R` future tokens. Equivalent to `diagonal_band_left_bound = left + 1` and `diagonal_band_right_bound = right`; anchoring still comes from `diagonal_alignment` (pass `BOTTOM_RIGHT` for FlashAttention parity). Mutually exclusive with `diagonal_band_left_bound`, `diagonal_band_right_bound`, `sliding_window_length`, `use_causal_mask`, and `use_causal_mask_bottom_right`.
 - `diagonal_band_right_bound` (Optional[int]): Right bound for causal masking. Set to 0 for causal mask. Masks columns beyond `row_idx + right_bound`.
 - `dropout` (Optional[tuple]): Dropout configuration. Either `(probability, seed, offset)` for Philox RNG or `(mask, scale)` for custom mask.
 - `rng_dump` (Optional[cudnn_tensor]): Debug tensor to capture the Philox RNG dropout mask.

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -367,21 +367,46 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
     # Masks: resolve cuDNN's several spellings to (causal, bottom_right, window_left).
     use_causal = bool(rec.get("use_causal_mask", False))
     use_causal_br = bool(rec.get("use_causal_mask_bottom_right", False))
+    # FlashAttention-convention window_size=(left, right): per-side OFFSETS
+    # from the diagonal, -1/None = unbounded. Another spelling of the diagonal
+    # band (the pygraph binding enforces mutual exclusivity): the left OFFSET
+    # is the band left LENGTH - 1, the right OFFSET is the band right bound.
+    window_size = rec.get("window_size")
+    ws_left = ws_right = None
+    if window_size is not None:
+        others = _first_not_none(
+            rec.get("sliding_window_length"),
+            rec.get("diagonal_band_left_bound"),
+            rec.get("left_bound"),
+            rec.get("sliding_window"),
+            rec.get("diagonal_band_right_bound"),
+            rec.get("right_bound"),
+        )
+        if others is not None or use_causal or use_causal_br:
+            return _invalid("window_size cannot be combined with any other masking arg (it is an alias for the diagonal band)")
+        try:
+            ws_l, ws_r = window_size
+        except (TypeError, ValueError):
+            return _invalid(f"window_size must be a (left, right) pair; got {window_size!r}")
+        ws_left = (int(ws_l) + 1) if ws_l not in (None, -1) else None
+        ws_right = int(ws_r) if ws_r not in (None, -1) else None
     # Left window (== length; window offset is length-1). The op family uses several
-    # spellings for the same knob: sdpa → sliding_window_length; sdpa_mxfp8 →
-    # diagonal_band_left_bound; sdpa_fp8 → left_bound / sliding_window.
+    # spellings for the same knob: sdpa → sliding_window_length / window_size[0];
+    # sdpa_mxfp8 → diagonal_band_left_bound; sdpa_fp8 → left_bound / sliding_window.
     left_bound = _first_not_none(
         rec.get("sliding_window_length"),
         rec.get("diagonal_band_left_bound"),
         rec.get("left_bound"),
         rec.get("sliding_window"),
+        ws_left,
     )
     if use_causal or use_causal_br:
         resolved_right = 0
         align_is_br = use_causal_br
     else:
-        # Right band: diagonal_band_right_bound (sdpa/mxfp8) or right_bound (fp8).
-        resolved_right = _first_not_none(rec.get("diagonal_band_right_bound"), rec.get("right_bound"))
+        # Right band: diagonal_band_right_bound (sdpa/mxfp8), right_bound (fp8),
+        # or window_size[1].
+        resolved_right = _first_not_none(rec.get("diagonal_band_right_bound"), rec.get("right_bound"), ws_right)
         # Alignment is a property OF the diagonal band; with no band bound at all
         # there is no diagonal, so BOTTOM_RIGHT is inert — recording it as a fact
         # would make every engine reject an effectively-unmasked graph.

--- a/python/pygraph/pygraph.h
+++ b/python/pygraph/pygraph.h
@@ -57,7 +57,7 @@ class PyGraph {
     std::optional<PyCallback> callback_fn;
     std::optional<PyCallback> callback_fn_bprop;
 
-    PyGraph(Graph_t graph_) : graph(graph_) {};
+    PyGraph(Graph_t graph_) : graph(graph_){};
 
     PyGraph(std::string const&,
             cudnn_frontend::DataType_t io_data_type,
@@ -457,7 +457,8 @@ class PyGraph {
          std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> sink_token,
          bool const unfuse_fma,
          std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_q,
-         std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_kv);
+         std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_kv,
+         py::object const& window_size);
 
     // return [dQ, dK, dV]
     std::array<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, 3>
@@ -490,7 +491,8 @@ class PyGraph {
                   std::optional<PyCallback> fn,
                   std::optional<PyCallback> fn_bprop,
                   std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> sink_token,
-                  std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> dSink_token);
+                  std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> dSink_token,
+                  py::object const& window_size);
 
     // return [o, stats, amax_s, amax_o]
     std::array<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, 4>

--- a/python/pygraph/sdpa.cpp
+++ b/python/pygraph/sdpa.cpp
@@ -224,6 +224,60 @@ PyGraph::sdpa_internal(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>
     }
 }
 
+// FlashAttention-convention attention window: a (left, right) pair of per-side
+// OFFSETS from the (aligned) diagonal, where -1 or None means "unbounded on
+// that side" — window_size=(-1, 0) is plain causal, (W, 0) adds a sliding
+// window of W past tokens, (-1, R) widens the causal bound by R future tokens.
+// Maps onto the cuDNN diagonal band: the left OFFSET W keeps k >= q - W, i.e.
+// diagonal_band_left_bound (a LENGTH) = W + 1; the right OFFSET R keeps
+// k <= q + R, i.e. diagonal_band_right_bound = R. Anchoring stays the
+// orthogonal diagonal_alignment argument (FlashAttention parity: BOTTOM_RIGHT).
+static std::pair<py::object, py::object>
+window_size_to_band_bounds(py::object const& window_size) {
+    if (!py::isinstance<py::tuple>(window_size) && !py::isinstance<py::list>(window_size)) {
+        throw std::runtime_error("window_size must be a (left, right) tuple or list of per-side offsets");
+    }
+    auto const seq = window_size.cast<py::sequence>();
+    if (seq.size() != 2) {
+        throw std::runtime_error("window_size must have exactly two entries: (left, right)");
+    }
+    auto side_to_bound = [](py::handle side, int64_t length_offset, char const* name) -> py::object {
+        if (side.is_none()) {
+            return py::none();
+        }
+        if (!py::isinstance<py::int_>(side)) {
+            throw std::runtime_error(std::string("window_size ") + name + " must be an int or None");
+        }
+        auto const offset = side.cast<int64_t>();
+        if (offset == -1) {
+            return py::none();  // -1 == unbounded, FlashAttention convention
+        }
+        if (offset < 0) {
+            throw std::runtime_error(std::string("window_size ") + name + " must be >= 0, or -1/None for unbounded");
+        }
+        return py::int_(offset + length_offset);
+    };
+    return {side_to_bound(seq[0], /*length_offset=*/1, "left"), side_to_bound(seq[1], /*length_offset=*/0, "right")};
+}
+
+static void
+throw_if_window_size_combined(bool use_causal_mask,
+                              bool use_causal_mask_bottom_right,
+                              py::object const& sliding_window,
+                              py::object const& left_bound,
+                              py::object const& right_bound) {
+    if (!sliding_window.is_none() || !left_bound.is_none() || !right_bound.is_none()) {
+        throw std::runtime_error(
+            "window_size is an alias for the diagonal band and cannot be combined with "
+            "sliding_window_length / diagonal_band_left_bound / diagonal_band_right_bound");
+    }
+    if (use_causal_mask || use_causal_mask_bottom_right) {
+        throw std::runtime_error(
+            "window_size cannot be combined with use_causal_mask / use_causal_mask_bottom_right — express causal "
+            "as window_size=(-1, 0) (with diagonal_alignment for the bottom-right variant)");
+    }
+}
+
 std::array<std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>, 2>
 PyGraph::sdpa(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& q,
               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& k,
@@ -257,7 +311,8 @@ PyGraph::sdpa(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& q,
               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> sink_token,
               bool const unfuse_fma,
               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_q,
-              std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_kv) {
+              std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_kv,
+              py::object const& window_size) {
     cudnn_frontend::DataType_t mma_core_mode                            = cudnn_frontend::DataType_t::HALF;
     std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> descale_q = nullptr;
     std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> descale_k = nullptr;
@@ -313,6 +368,14 @@ PyGraph::sdpa(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& q,
     if (use_causal_mask_bottom_right) {
         actual_diagonal_alignment = cudnn_frontend::DiagonalAlignment_t::BOTTOM_RIGHT;
         actual_right_bound        = py::int_(0);
+    }
+
+    // FlashAttention-convention (left, right) offset window (see
+    // window_size_to_band_bounds); exclusive with every other band spelling.
+    if (!window_size.is_none()) {
+        throw_if_window_size_combined(
+            use_causal_mask, use_causal_mask_bottom_right, sliding_window, left_bound, right_bound);
+        std::tie(actual_left_bound, actual_right_bound) = window_size_to_band_bounds(window_size);
     }
 
     auto internal_result = sdpa_internal(q,
@@ -386,7 +449,8 @@ PyGraph::sdpa_backward(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>
                        std::optional<PyCallback> fn,
                        std::optional<PyCallback> fn_bprop,
                        std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> sink_token,
-                       std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> dSink_token) {
+                       std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> dSink_token,
+                       py::object const& window_size) {
     auto attributes =
         cudnn_frontend::graph::SDPA_backward_attributes()
             .set_bias(bias)
@@ -445,6 +509,16 @@ PyGraph::sdpa_backward(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>
         attributes.set_max_total_seq_len_kv(max_total_seq_len_kv_value);
     }
 
+    // FlashAttention-convention (left, right) offset window (see
+    // window_size_to_band_bounds); exclusive with every other band spelling.
+    py::object actual_left_bound  = left_bound;
+    py::object actual_right_bound = right_bound;
+    if (!window_size.is_none()) {
+        throw_if_window_size_combined(
+            use_causal_mask, use_causal_mask_bottom_right, sliding_window, left_bound, right_bound);
+        std::tie(actual_left_bound, actual_right_bound) = window_size_to_band_bounds(window_size);
+    }
+
     if (!sliding_window.is_none()) {
         if (py::isinstance<py::int_>(sliding_window)) {
             int sliding_window_value = sliding_window.cast<int64_t>();
@@ -454,17 +528,17 @@ PyGraph::sdpa_backward(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>
         }
     }
 
-    if (!left_bound.is_none()) {
-        if (py::isinstance<py::int_>(left_bound)) {
-            attributes.set_diagonal_band_left_bound(left_bound.cast<int64_t>());
+    if (!actual_left_bound.is_none()) {
+        if (py::isinstance<py::int_>(actual_left_bound)) {
+            attributes.set_diagonal_band_left_bound(actual_left_bound.cast<int64_t>());
         } else {
             throw std::runtime_error("diagonal_band_left_bound must be an int (or None)");
         }
     }
 
-    if (!right_bound.is_none()) {
-        if (py::isinstance<py::int_>(right_bound)) {
-            attributes.set_diagonal_band_right_bound(right_bound.cast<int64_t>());
+    if (!actual_right_bound.is_none()) {
+        if (py::isinstance<py::int_>(actual_right_bound)) {
+            attributes.set_diagonal_band_right_bound(actual_right_bound.cast<int64_t>());
         } else {
             throw std::runtime_error("diagonal_band_right_bound must be an int (or None)");
         }
@@ -1117,6 +1191,7 @@ init_pygraph_sdpa_submodule(py::class_<PyGraph>& m) {
           py::arg_v("unfuse_fma", false),
           py::arg_v("cu_seq_len_q", nullptr),
           py::arg_v("cu_seq_len_kv", nullptr),
+          py::arg_v("window_size", py::none()),
           R"pbdoc(
                 Perform scaled dot product attention.
 
@@ -1147,6 +1222,7 @@ init_pygraph_sdpa_submodule(py::class_<PyGraph>& m) {
                     cu_seq_len_kv (Optional[cudnn_tensor]): Cumulative sequence length of the key, shape (b+1, 1, 1, 1) or 1-D (b+1,) (promoted automatically), int32 or int64. Mutually exclusive with seq_len_kv; pair with a Q-side tensor (seq_len_q or cu_seq_len_q) and set use_padding_mask=True. Requires cuDNN 9.24+ and UNIFIED (9.25+ if the two sides use different forms).
                 Preferred masking Args:
                     diagonal_alignment (Optional[cudnn.diagonal_alignment]): One of {"TOP_LEFT", "BOTTOM_RIGHT"}. E.g., causal masking can be performed by setting diagonal_alignment=TOP_LEFT, and diagonal_band_right_bound=0. Default is TOP_LEFT.
+                    window_size (Optional[Tuple[int, int]]): FlashAttention-convention (left, right) attention window: per-side OFFSETS from the diagonal, -1 or None = unbounded on that side. (-1, 0) is causal, (W, 0) causal + sliding window of W past tokens, (-1, R) causal widened by R future tokens. Maps to diagonal_band_left_bound = left + 1 / diagonal_band_right_bound = right; anchoring still comes from diagonal_alignment (FlashAttention parity: BOTTOM_RIGHT). Mutually exclusive with every other masking arg.
                     diagonal_band_left_bound (Optional[int]): An integer >= 1 specifying the offset to the left of the main diagonal to attend to. Default is None, implying +Inf.
                     diagonal_band_right_bound (Optional[int]): An integer >= 0 specifying the offset to the right of the main diagonal to attend to. Default is None, implying +Inf.
                 Deprecated masking Args (can cause undetermined behavior when combined with the Preferred masking args):
@@ -1194,6 +1270,7 @@ init_pygraph_sdpa_submodule(py::class_<PyGraph>& m) {
           py::arg_v("score_mod_bprop", std::nullopt),
           py::arg_v("sink_token", nullptr),
           py::arg_v("dSink_token", nullptr),
+          py::arg_v("window_size", py::none()),
           R"pbdoc(
                 Compute the key, query, value gradients of scaled dot product attention.
 
@@ -1224,6 +1301,7 @@ init_pygraph_sdpa_submodule(py::class_<PyGraph>& m) {
                     dSink_token (Optional[cudnn_tensor]): The sink attention token gradient tensor. Shape is (1, h_q, 1, 1), type is float32.
                 Preferred masking Args:
                     diagonal_alignment (Optional[cudnn.diagonal_alignment]): One of {"TOP_LEFT", "BOTTOM_RIGHT"}. E.g., causal masking can be performed by setting diagonal_alignment=TOP_LEFT, and diagonal_band_right_bound=0. Default is TOP_LEFT.
+                    window_size (Optional[Tuple[int, int]]): FlashAttention-convention (left, right) attention window: per-side OFFSETS from the diagonal, -1 or None = unbounded on that side. (-1, 0) is causal, (W, 0) causal + sliding window of W past tokens, (-1, R) causal widened by R future tokens. Maps to diagonal_band_left_bound = left + 1 / diagonal_band_right_bound = right; anchoring still comes from diagonal_alignment (FlashAttention parity: BOTTOM_RIGHT). Mutually exclusive with every other masking arg.
                     diagonal_band_left_bround (Optional[int]): An integer >= 1 specifying the offset to the left of the main diagonal to attend to. Default is None, implying +Inf.
                     diagonal_band_right_bound (Optional[int]): An integer >= 0 specifying the offset to the right of the main diagonal to attend to. Default is None, implying +Inf.
                 Deprecated masking Args (can cause undetermined behavior when combined with the Preferred masking args):

--- a/test/python/test_sdpa_window_size.py
+++ b/test/python/test_sdpa_window_size.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""window_size=(left, right): the FlashAttention-convention alias for the SDPA
+diagonal band. Each side is an OFFSET from the (aligned) diagonal, -1 or None =
+unbounded; equivalent to diagonal_band_left_bound = left + 1 and
+diagonal_band_right_bound = right. These tests pin the alias to the explicit
+band spellings: same facts at the analyzer, bit-identical O at execute, and a
+lowering-time error for every disallowed combination."""
+
+import math
+
+import cudnn
+import pytest
+import torch
+
+pytestmark = pytest.mark.L0
+
+B, H, S, D = 2, 4, 256, 128
+
+
+def _build_graph(**kw):
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    dims, strides = (B, H, S, D), (S * H * D, D, H * D, 1)
+    q = g.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.HALF, name="q")
+    k = g.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.HALF, name="k")
+    v = g.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.HALF, name="v")
+    o, _ = g.sdpa(name="sdpa", q=q, k=k, v=v, attn_scale=0.1, generate_stats=False, **kw)
+    o.set_output(True).set_dim(dims).set_stride(strides)
+    o.set_data_type(cudnn.data_type.HALF)
+    return g
+
+
+def _band_facts(**kw):
+    """(causal, bottom_right, window_left, right_bound) facts the FROST analyzer resolves."""
+    from cudnn.sdpa import graph_analyzer as ga
+
+    f = ga.analyze(_build_graph(**kw))
+    assert f is not None and f.invalid is None, getattr(f, "invalid", "no sdpa node")
+    return (f.causal, f.bottom_right, f.window_left, f.right_bound)
+
+
+_EQUIVALENT_SPELLINGS = [
+    (dict(window_size=(63, 0)), dict(sliding_window_length=64, use_causal_mask=True)),
+    (dict(window_size=(-1, 0)), dict(use_causal_mask=True)),
+    (dict(window_size=(-1, 40)), dict(diagonal_band_right_bound=40)),
+    (dict(window_size=(31, 78)), dict(diagonal_band_left_bound=32, diagonal_band_right_bound=78)),
+    (dict(window_size=(31, -1)), dict(diagonal_band_left_bound=32)),
+    (dict(window_size=(None, 0), diagonal_alignment=cudnn.diagonal_alignment.BOTTOM_RIGHT), dict(use_causal_mask_bottom_right=True)),
+]
+_EQUIVALENT_IDS = ["swa-causal", "causal", "right-widen", "band", "swa-only", "causal-br"]
+
+
+@pytest.mark.parametrize("kw_window,kw_explicit", _EQUIVALENT_SPELLINGS, ids=_EQUIVALENT_IDS)
+def test_window_size_facts_match_explicit_band(kw_window, kw_explicit):
+    assert _band_facts(**kw_window) == _band_facts(**kw_explicit)
+
+
+def test_window_size_list_form():
+    assert _band_facts(window_size=[31, 78]) == _band_facts(window_size=(31, 78))
+
+
+def _run_gpu(**kw):
+    torch.manual_seed(0)
+    q = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16).transpose(1, 2)
+    k = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16).transpose(1, 2)
+    v = torch.randn(B, S, H, D, device="cuda", dtype=torch.float16).transpose(1, 2)
+    o = torch.empty(B, S, H, D, device="cuda", dtype=torch.float16).transpose(1, 2)
+    scale = 1.0 / math.sqrt(D)
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    tq, tk, tv = g.tensor_like(q), g.tensor_like(k), g.tensor_like(v)
+    to, _ = g.sdpa(name="sdpa", q=tq, k=tk, v=tv, generate_stats=False, attn_scale=scale, **kw)
+    to.set_output(True).set_dim(o.shape).set_stride(o.stride())
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    g.check_support()
+    g.build_plans()
+    g.execute({tq: q, tk: k, tv: v, to: o}, torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8))
+    torch.cuda.synchronize()
+    return o
+
+
+@pytest.mark.parametrize("kw_window,kw_explicit", _EQUIVALENT_SPELLINGS, ids=_EQUIVALENT_IDS)
+def test_window_size_execute_matches_explicit_band(cudnn_handle, kw_window, kw_explicit):
+    assert torch.equal(_run_gpu(**kw_window), _run_gpu(**kw_explicit))
+
+
+@pytest.mark.parametrize(
+    "kw,fragment",
+    [
+        (dict(window_size=(1, 0), use_causal_mask=True), "cannot be combined"),
+        (dict(window_size=(1, 0), use_causal_mask_bottom_right=True), "cannot be combined"),
+        (dict(window_size=(1, 0), sliding_window_length=2), "cannot be combined"),
+        (dict(window_size=(1, 0), diagonal_band_left_bound=2), "cannot be combined"),
+        (dict(window_size=(1, 0), diagonal_band_right_bound=0), "cannot be combined"),
+        (dict(window_size=(1, 2, 3)), "exactly two"),
+        (dict(window_size=(-2, 0)), ">= 0"),
+        (dict(window_size=(0, -3)), ">= 0"),
+        (dict(window_size=5), "tuple or list"),
+        (dict(window_size=(0.5, 0)), "int or None"),
+    ],
+    ids=[
+        "with-causal",
+        "with-causal-br",
+        "with-sliding-window",
+        "with-left-bound",
+        "with-right-bound",
+        "three-entries",
+        "negative-left",
+        "negative-right",
+        "not-a-pair",
+        "float-entry",
+    ],
+)
+def test_window_size_rejects_bad_usage(kw, fragment):
+    """The pybind layer validates at lowering (build_operation_graph)."""
+    g = _build_graph(**kw)
+    with pytest.raises(Exception, match=fragment):
+        g.validate()
+        g.build_operation_graph()


### PR DESCRIPTION
Adds the attention-window spelling every OSS attention API uses (FlashAttention v2-v4, CUTLASS FMHA, FlashInfer, TransformerEngine) to the cuDNN python graph API:

```python
graph.sdpa(q, k, v, window_size=(left, right), ...)          # and sdpa_backward
```

`(left, right)` are per-side **offsets** from the (aligned) diagonal, `-1` or `None` = unbounded on that side: `(-1, 0)` is plain causal, `(W, 0)` is causal + a sliding window of `W` past tokens, `(-1, R)` widens the causal bound by `R` future tokens.

**Semantics** — a pure alias for the existing diagonal band: `diagonal_band_left_bound = left + 1` (cuDNN's left bound is a length, the FA offset is length−1) and `diagonal_band_right_bound = right`. This is the exact conversion every cuDNN integrator hand-writes today (e.g. TransformerEngine's `set_diagonal_band_left_bound(window_size_left + 1)` in `fused_attn_f16_arbitrary_seqlen.cu`). Anchoring still comes from `diagonal_alignment` — pass `BOTTOM_RIGHT` for exact FlashAttention parity (FA is always bottom-right anchored). Mutually exclusive with `diagonal_band_*`, `sliding_window_length`, and `use_causal_mask*`, enforced in the pybind layer.

**Changes**
- `python/pygraph/sdpa.cpp` / `pygraph.h`: `window_size` kwarg on `sdpa` and `sdpa_backward` (appended last — no positional break), a shared `window_size_to_band_bounds` resolver + exclusivity check.
- `python/cudnn/sdpa/graph_analyzer.py`: the FROST analyzer resolves the new spelling into the same `window_left` / `right_bound` facts (and marks mixed spellings invalid).
- `docs/operations/Attention.md`: documented.
- `test/python/test_sdpa_window_size.py`: six band shapes pinned to their explicit-spelling equivalents — equal analyzer facts and **bit-identical O** on GPU (B200) — plus ten rejected-misuse cases. 23/23 pass.

fp8/mxfp8 sdpa variants keep their existing `left_bound`/`right_bound` args (follow-up if wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
