### PR TITLE
Fix CausalConv1d sample links and backends architecture fence

### DIFF
--- a/docs/operations/CausalConv1d.md
+++ b/docs/operations/CausalConv1d.md
@@ -62,7 +62,7 @@ Where:
 - $L$ is the sequence length
 - $K$ is the kernel size
 
-See the [NHW forward notebook](../../samples/python/60_causal_conv1d_forward.ipynb) and [NHW backward notebook](../../samples/python/61_causal_conv1d_backward.ipynb) for PyTorch references and numerical comparisons.
+See the [NHW forward notebook](https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/python/60_causal_conv1d_forward.ipynb) and [NHW backward notebook](https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/python/61_causal_conv1d_backward.ipynb) for PyTorch references and numerical comparisons.
 
 ### `cudnn.ops.causal_conv1d_nwh`
 
@@ -108,7 +108,7 @@ y = cudnn.ops.causal_conv1d_nwh(x, weight, bias=None, activation="identity")
 
 The API supports `torch.autograd` and `torch.compile` for forward and backward execution. Backward computes `dx` with shape $(B, L, D)$, `dweight` with shape $(K, D)$, and `dbias` with shape $(D,)$. The supported kernel-size range remains 2–128 for both directions.
 
-See the [NWH forward notebook](../../samples/python/62_causal_conv1d_nwh_forward.ipynb) and [NWH backward notebook](../../samples/python/63_causal_conv1d_nwh_backward.ipynb) for PyTorch references and numerical comparisons.
+See the [NWH forward notebook](https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/python/62_causal_conv1d_nwh_forward.ipynb) and [NWH backward notebook](https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/python/63_causal_conv1d_nwh_backward.ipynb) for PyTorch references and numerical comparisons.
 
 ### `cudnn.ops.b2b_causal_conv1d`
 
@@ -147,7 +147,7 @@ y_gated = cudnn.ops.b2b_causal_conv1d(x, weights_proj, weights_mixer, skip_bias)
 
 The API supports `torch.autograd` and `torch.compile` for forward and backward execution. Backward computes `dx` with shape $(B, 3D, L)$, `dweights_proj` with shape $(3D, K_{proj})$, `dweights_mixer` with shape $(D, K_{mixer})$, and `dskip_bias` with shape $(D,)$. The projection and mixer kernel-size ranges are unchanged for backward.
 
-See the [B2B forward notebook](../../samples/python/64_b2b_causal_conv1d_forward.ipynb) and [B2B backward notebook](../../samples/python/65_b2b_causal_conv1d_backward.ipynb) for decomposed PyTorch references and numerical comparisons.
+See the [B2B forward notebook](https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/python/64_b2b_causal_conv1d_forward.ipynb) and [B2B backward notebook](https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/python/65_b2b_causal_conv1d_backward.ipynb) for decomposed PyTorch references and numerical comparisons.
 
 ### Low-level bindings
 

--- a/docs/python_graph_and_execution_backends.md
+++ b/docs/python_graph_and_execution_backends.md
@@ -9,7 +9,7 @@ backend. The C++ graph builder is internal
 (`cudnn._pybind_module.backend_graph`) and is reached exclusively through
 lowering.
 
-```
+```text
 cudnn.pygraph (Python IR)  →  create_execution_plans()  →  Router  →  routed plan list
   nodes / tensors / params        (route here,               PlanConfig(engine_id, knobs):
   fully introspectable            lazy lowering)             python engines + one backend entry


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- Documentation or samples

## Summary

- Replace broken relative `../../samples/python/*.ipynb` links in `docs/operations/CausalConv1d.md` with GitHub absolute URLs.
- Mark the architecture diagram code block in `docs/python_graph_and_execution_backends.md` as `text`.

## Why

- Relative sample notebook links do not resolve when these docs are consumed outside this repository (samples are not present in the docs publishing context).
- The untyped architecture fence can be misinterpreted by syntax highlighters because of Unicode arrows.

## Related issues

N/A

## API and compatibility impact

None

## Testing

- Docs-only change; verified link targets match existing `samples/python/` notebooks and followed the same absolute-URL pattern used elsewhere in `docs/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated notebook references with direct GitHub links for forward and backward examples.
  * Clarified the architecture diagram’s code block language annotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->