### PR TITLE
Experimental JAX bindings for CuteDSL kernels (MVP: gemm_amax)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,13 @@ cutedsl = [
     "apache-tvm-ffi>=0.1.11",
     "torch-c-dlpack-ext",
 ]
+# Experimental (draft): call CuteDSL kernels from JAX as real primitives.
+# Keep the apache-tvm-ffi pin in sync with _bridge.py (header-only ABI dep).
+jax = [
+    "jax",
+    "jax-tvm-ffi",
+    "apache-tvm-ffi>=0.1.11,<0.2",
+]
 
 [dependency-groups]
 dev = [

--- a/python/cudnn/experimental/jax/README.md
+++ b/python/cudnn/experimental/jax/README.md
@@ -1,0 +1,76 @@
+# cuDNN-FE CuteDSL kernels from JAX (MVP / draft)
+
+**Purpose of this MVP:** show the *actual per-kernel cost* of exposing a CuteDSL
+kernel to JAX as a **real primitive** (composes with `@jax.jit`, no host callback),
+so the FE / TE-JAX folks can feel the shape before we commit to it. `gemm_amax`
+is the first kernel because its output shapes come entirely from input shapes —
+no data-dependent shape, so it isolates the pure bridge boilerplate.
+
+> Status: **unverified end-to-end.** Needs SM100 + `jax` + `jax-tvm-ffi`, plus the
+> two GOTCHAs below resolved on hardware. This is a direction preview (draft MR).
+
+## Architecture — FE owns a stable API, tvm-ffi is internal transport
+
+```
+JAX user / TE-JAX
+   |  cudnn.experimental.jax.gemm_amax(...)      <-- STABLE, FE-owned contract
+   v
+_bridge.py  (register_ffi_target + version guard)   <-- written ONCE
+   v
+jax-tvm-ffi  ->  XLA custom call                     <-- swappable transport
+   v
+CuteDSL kernel compiled with --enable-tvm-ffi        <-- SAME binary torch calls
+```
+
+Why this split (not "hand TE the raw kernel"):
+- The kernel's tvm-ffi ABI is **not** a stable contract — it drifts. Keeping it
+  behind an FE-owned op means a drift is a one-file pin bump here, invisible to
+  callers. If TE built on the raw kernel, every drift would break TE directly and
+  FE couldn't see it.
+- The transport is replaceable: the public op signature is the contract, so
+  `jax-tvm-ffi` could later be swapped for a hand-written XLA FFI handler with
+  zero caller impact.
+
+## What is / isn't in scope here
+
+- **In:** the JAX bridge boilerplate — abstract-eval (static output shapes),
+  ffi_call, output/stream/init handling, the reusable registration helper.
+- **Out (orthogonal):** de-torching the kernels (the separate "remove torch"
+  effort). Until that lands, the op takes a `_sample_torch` shim to drive the
+  kernel's existing `check_support()/compile()`. That collapses to plain
+  shape/dtype descriptors once de-torching is done.
+- **Out:** autograd. Forward-only, but a complete forward boundary.
+
+## Per-kernel boilerplate (the number people asked for)
+
+Everything framework-neutral is in `_bridge.py` (~90 lines, written once). Adding
+a kernel = one file like `gemm_amax.py`: a wrapper that reorders `(rets, args)`
+into the kernel's parameter order (~3 lines), one `register_once`, and a JAX-facing
+op with shape inference + `ffi_call` (~30 lines). For a dense, shape-from-inputs
+kernel that is **~40–60 lines and no C++**. Kernels with data-dependent output
+shapes (grouped / MoE / sparse) additionally need a padded/offsets abstract-eval —
+a real per-kernel design item, not boilerplate.
+
+## Open GOTCHAs (hardware, not boilerplate — the PoC must nail these)
+
+1. **stream** — the kernel compiles with `use_tvm_ffi_env_stream=False`; the JAX
+   path needs `True` so the CUDA stream comes from the tvm-ffi env stream that
+   jax-tvm-ffi sets from XLA. One flag in the kernel's `compile()` — the only
+   kernel-side edit this MVP needs.
+2. **amax init** — XLA output buffers are uninitialized; the kernel atomicMax-es
+   into amax and needs it pre-filled with `-inf`. Handled here via a donated input
+   `input_output_alias`ed onto the output.
+3. **layout** — the compiled kernel is specialized to the sample's strides; XLA
+   hands row-major buffers by default. Declare operand/result layouts on
+   `ffi_call`, or match input layout. Left for the PoC.
+
+## Run
+
+```bash
+pip install 'jax[cuda13]' jax-tvm-ffi                 # apache-tvm-ffi pinned in _bridge.py
+export PYTHONPATH=build
+pytest test/python/experimental/jax/test_gemm_amax_jax.py -q   # skips if no SM100 / no jax
+```
+
+<sub>note to self: claude design session — "cudnn-FE CuteDSL kernels -> JAX (tvm-ffi) MVP".
+cwd /home/scratch.yanxu_libs/cudnn_frontend</sub>

--- a/python/cudnn/experimental/jax/__init__.py
+++ b/python/cudnn/experimental/jax/__init__.py
@@ -1,0 +1,10 @@
+"""Experimental JAX bindings for cuDNN-FE CuteDSL kernels.
+
+MVP / draft. Exposes CuteDSL kernels as real JAX primitives (compose with
+@jax.jit) via an internal jax-tvm-ffi transport, behind a stable FE-owned API.
+See README.md for the architecture and the open GOTCHAs.
+"""
+
+from .gemm_amax import gemm_amax
+
+__all__ = ["gemm_amax"]

--- a/python/cudnn/experimental/jax/_bridge.py
+++ b/python/cudnn/experimental/jax/_bridge.py
@@ -1,0 +1,93 @@
+"""Shared JAX <- CuteDSL bridge (written ONCE; every kernel binding reuses it).
+
+Architecture (the deliberate choice — see README.md):
+  - FE owns a STABLE public JAX op. tvm-ffi is an INTERNAL transport, never the
+    external contract. If tvm-ffi's ABI drifts, only this file moves; callers and
+    the per-kernel `*_jax` signatures are unaffected.
+  - The CuteDSL kernels are already compiled with `--enable-tvm-ffi`, so their
+    entrypoint speaks the tvm-ffi ABI. jax-tvm-ffi adapts that to an XLA custom
+    call; nothing new is needed on the kernel side.
+
+Mitigations baked in here (from the observed flashinfer tvm-ffi/DSL breakages):
+  - Tight version guard on apache-tvm-ffi with a HUMAN error, so a dependency
+    mismatch does not surface downstream as an opaque `CONFIG_MISSING_TVM_FFI`
+    that reads like a kernel bug.
+  - register-once memoization keyed by target name.
+
+Status: MVP / draft. Unverified end-to-end (needs SM100 + jax + jax-tvm-ffi).
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata as _md
+
+# apache-tvm-ffi is a header-only ABI dependency; pin like flashinfer does.
+_TVM_FFI_MIN = (0, 1, 11)
+_TVM_FFI_MAX_EXCL = (0, 2)
+
+_registered: set[str] = set()
+_checked = False
+
+
+def _parse_ver(v: str) -> tuple:
+    out = []
+    for part in v.split(".")[:3]:
+        num = "".join(ch for ch in part if ch.isdigit())
+        out.append(int(num) if num else 0)
+    return tuple(out)
+
+
+def ensure_available() -> None:
+    """Raise a clear, human error if the JAX transport stack is missing/mismatched.
+
+    Deliberately explicit so a packaging problem is not mistaken for a kernel bug.
+    """
+    global _checked
+    if _checked:
+        return
+    missing = []
+    for pkg in ("jax", "jax_tvm_ffi"):
+        if importlib.util.find_spec(pkg) is None:
+            missing.append(pkg.replace("_", "-"))
+    if missing:
+        raise ImportError("cudnn.experimental.jax requires " f"{', '.join(missing)}. Install with: pip install 'jax[cuda13]' jax-tvm-ffi")
+    try:
+        ver = _md.version("apache-tvm-ffi")
+    except _md.PackageNotFoundError:
+        raise ImportError(
+            "cudnn.experimental.jax requires apache-tvm-ffi "
+            f">={'.'.join(map(str, _TVM_FFI_MIN))},<{'.'.join(map(str, _TVM_FFI_MAX_EXCL))} "
+            "(header-only ABI dep). Install: pip install apache-tvm-ffi"
+        )
+    pv = _parse_ver(ver)
+    if not (_TVM_FFI_MIN <= pv < _TVM_FFI_MAX_EXCL):
+        raise ImportError(
+            f"apache-tvm-ffi {ver} is outside the supported ABI window "
+            f"[{'.'.join(map(str, _TVM_FFI_MIN))}, {'.'.join(map(str, _TVM_FFI_MAX_EXCL))}). "
+            "Pin it inside that range; the CuteDSL kernels are compiled against it."
+        )
+    _checked = True
+
+
+def register_once(name: str, wrapper, arg_spec) -> str:
+    """Register a tvm-ffi wrapper as an XLA FFI target with FE's standard flags.
+
+    `wrapper(*rets, *args, **attrs)` reorders JAX's (outputs, inputs, scalars) into
+    the compiled kernel's own parameter order and calls it. Returns `name`.
+    """
+    ensure_available()
+    if name in _registered:
+        return name
+    import jax_tvm_ffi
+
+    jax_tvm_ffi.register_ffi_target(
+        name,
+        wrapper,
+        arg_spec=arg_spec,
+        platform="gpu",
+        allow_cuda_graph=True,
+        pass_owned_tensor=True,  # wrapper receives tvm_ffi.Tensor (DLPack-backed)
+    )
+    _registered.add(name)
+    return name

--- a/python/cudnn/experimental/jax/gemm_amax.py
+++ b/python/cudnn/experimental/jax/gemm_amax.py
@@ -1,0 +1,140 @@
+"""JAX binding for the SM100 blockscaled GEMM + fused amax CuteDSL kernel.
+
+This is the *entire* per-kernel cost of exposing a CuteDSL kernel to JAX as a real
+primitive (composes with @jax.jit; no host callback). Everything framework-neutral
+lives in _bridge.py; below is only what is specific to gemm_amax.
+
+Assumes torch-removal (the separate de-torching effort) is orthogonal and done;
+here we only count the JAX boilerplate. The kernel is reused verbatim — same
+compiled binary the torch path calls.
+
+Status: MVP / draft — UNVERIFIED end-to-end. Needs SM100 + jax + jax-tvm-ffi and
+the two GOTCHAs below resolved on hardware.
+"""
+
+from __future__ import annotations
+
+from . import _bridge
+
+# The CuteDSL kernel, reused as-is. Prefer the top-level re-export (stable across
+# the #459 gemm-fusion reorg); fall back to the module paths on older trees.
+try:
+    from cudnn import GemmAmaxSm100
+except ImportError:  # pragma: no cover
+    try:
+        from cudnn.gemm.cutedsl.dense.amax.api import GemmAmaxSm100  # post-#459
+    except ImportError:
+        from cudnn.gemm_amax.api import GemmAmaxSm100  # pre-reorg
+
+
+_compiled_cache: dict = {}
+
+
+def _get_compiled(spec, sample_torch):
+    """Compile the CuteDSL kernel once per specialization; return the tvm-ffi callable.
+
+    GOTCHA (stream): the kernel currently compiles with
+        make_fake_stream(use_tvm_ffi_env_stream=False)   # amax/api.py
+    For the JAX path it must be True so the CUDA stream is taken from the tvm-ffi
+    env stream that jax-tvm-ffi sets from XLA's stream. That is a 1-flag change in
+    the kernel's compile(); tracked as the only kernel-side edit this MVP needs.
+    """
+    if spec in _compiled_cache:
+        return _compiled_cache[spec]
+    a, b, sfa, sfb, c, amax = sample_torch
+    k = GemmAmaxSm100(
+        sample_a=a,
+        sample_b=b,
+        sample_sfa=sfa,
+        sample_sfb=sfb,
+        sample_c=c,
+        sample_amax=amax,
+        acc_dtype=spec.acc_dtype,
+        mma_tiler_mn=spec.mma_tiler_mn,
+        cluster_shape_mn=spec.cluster_shape_mn,
+        sf_vec_size=spec.sf_vec_size,
+    )
+    assert k.check_support()
+    k.compile()
+    _compiled_cache[spec] = k._compiled_kernel
+    return _compiled_cache[spec]
+
+
+class _Spec:
+    __slots__ = ("c_dtype", "c_major", "acc_dtype", "mma_tiler_mn", "cluster_shape_mn", "sf_vec_size")
+
+    def __init__(self, c_dtype, c_major, acc_dtype, mma, cluster, sfv):
+        self.c_dtype, self.c_major, self.acc_dtype = c_dtype, c_major, acc_dtype
+        self.mma_tiler_mn, self.cluster_shape_mn, self.sf_vec_size = mma, cluster, sfv
+
+    def key(self):
+        return f"{self.c_dtype}|{self.c_major}|{self.mma_tiler_mn}|{self.cluster_shape_mn}|{self.sf_vec_size}"
+
+    def __hash__(self):
+        return hash(self.key())
+
+    def __eq__(self, o):
+        return isinstance(o, _Spec) and self.key() == o.key()
+
+
+_targets: dict = {}
+
+
+def _ensure_target(spec, sample_torch):
+    name = f"cudnn.gemm_amax.{spec.key()}"
+    if name in _targets:
+        return name
+    compiled = _get_compiled(spec, sample_torch)
+
+    # Reorder JAX's (rets, args) into the kernel's own order.
+    # kernel: compiled(a, b, sfa, sfb, c, amax)   [+ env stream]
+    # JAX:    (c, amax) then (a, b, sfa, sfb, amax_init)
+    def _wrapper(c, amax, a, b, sfa, sfb, amax_init):
+        compiled(a, b, sfa, sfb, c, amax)  # env stream injected by the bridge
+
+    _bridge.register_once(name, _wrapper, arg_spec=["rets", "args"])
+    _targets[name] = True
+    return name
+
+
+def gemm_amax(a, b, sfa, sfb, *, c_dtype, c_major="n", acc_dtype=None, mma_tiler_mn=(128, 128), cluster_shape_mn=(1, 1), sf_vec_size=32, _sample_torch):
+    """Blockscaled GEMM with fused amax, callable from JAX under @jax.jit.
+
+    a: [m, k, l]   b: [n, k, l]   sfa/sfb: atom-reshaped scale factors
+    Returns (c: [m, n, l], amax: [1, 1, 1]). Pure JAX in / pure JAX out.
+
+    `_sample_torch` is a temporary MVP shim: representative torch tensors used to
+    drive the kernel's existing check_support()/compile(). Once torch-removal lands
+    this collapses to plain shape/dtype descriptors (orthogonal effort).
+    """
+    import jax
+    import jax.numpy as jnp
+
+    m, _, l = a.shape
+    n, _, _ = b.shape
+
+    # abstract-eval: outputs are fully determined by INPUT shapes (no data-dependent
+    # shape — this is why gemm_amax is the easy case, unlike grouped/MoE/sparse).
+    out_specs = (
+        jax.ShapeDtypeStruct((m, n, l), c_dtype),
+        jax.ShapeDtypeStruct((1, 1, 1), jnp.float32),
+    )
+
+    spec = _Spec(c_dtype, c_major, acc_dtype, mma_tiler_mn, cluster_shape_mn, sf_vec_size)
+    name = _ensure_target(spec, _sample_torch)
+
+    # GOTCHA (amax init): XLA output buffers are uninitialized, but the kernel does
+    # atomicMax into amax and needs it pre-filled with -inf (torch path: torch.full).
+    # So amax enters as a donated input filled with -inf, input_output_aliased to
+    # output #1 — the XLA-native way to express an in-out accumulator.
+    amax_init = jnp.full((1, 1, 1), -jnp.inf, dtype=jnp.float32)
+
+    # GOTCHA (layout): the compiled kernel is specialized to the sample's strides
+    # (c_major); XLA hands row-major buffers by default. On hardware, declare
+    # operand/result layouts on ffi_call or match input layout. Left for the PoC.
+    c, amax = jax.ffi.ffi_call(
+        name,
+        out_specs,
+        input_output_aliases={4: 1},  # arg #4 (amax_init) -> output #1 (amax)
+    )(a, b, sfa, sfb, amax_init)
+    return c, amax

--- a/test/python/experimental/jax/test_gemm_amax_jax.py
+++ b/test/python/experimental/jax/test_gemm_amax_jax.py
@@ -1,0 +1,77 @@
+"""End-to-end smoke test for the JAX binding of gemm_amax (MVP / draft).
+
+Skips unless the full stack is present: jax, jax-tvm-ffi, torch, and an SM100 GPU.
+It reuses the existing torch test's input builder + reference so the JAX path is
+checked against the exact same kernel the torch path runs.
+
+Run:  pytest test/python/experimental/jax/test_gemm_amax_jax.py -q
+"""
+
+import pytest
+
+jax = pytest.importorskip("jax")
+pytest.importorskip("jax_tvm_ffi")
+torch = pytest.importorskip("torch")
+import jax.numpy as jnp
+
+
+def _is_sm100() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability(torch.cuda.current_device())
+    return major >= 10
+
+
+pytestmark = pytest.mark.skipif(not _is_sm100(), reason="gemm_amax needs SM100+")
+
+
+def _to_jax(t: "torch.Tensor"):
+    # zero-copy torch -> jax via DLPack (the framework-neutral handoff).
+    return jax.dlpack.from_dlpack(t.detach().contiguous())
+
+
+def test_gemm_amax_jax_matches_torch():
+    from cudnn import gemm_amax_wrapper_sm100
+    from cudnn.experimental.jax import gemm_amax as gemm_amax_jax
+    from fe_api.gemm.test_gemm_amax_utils import allocate_input_tensors
+
+    m, n, k, l = 256, 256, 256, 1
+    ab_dtype, sf_dtype, sf_vec_size = torch.float8_e4m3fn, torch.float8_e8m0fnu, 32
+    a_major, b_major, c_major = "k", "k", "n"
+    c_dtype = torch.bfloat16
+
+    a, b, sfa, sfb = allocate_input_tensors(m, n, k, l, ab_dtype, sf_dtype, sf_vec_size, a_major, b_major)
+
+    # torch reference (same compiled kernel)
+    c_ref, amax_ref = gemm_amax_wrapper_sm100(a, b, sfa, sfb, c_major=c_major, c_dtype=c_dtype, sf_vec_size=sf_vec_size).values()
+
+    # JAX path, under jit, calling the identical kernel via the tvm-ffi bridge
+    @jax.jit
+    def run(a_j, b_j, sfa_j, sfb_j):
+        return gemm_amax_jax(
+            a_j,
+            b_j,
+            sfa_j,
+            sfb_j,
+            c_dtype=jnp.bfloat16,
+            c_major=c_major,
+            sf_vec_size=sf_vec_size,
+            _sample_torch=(a, b, sfa, sfb, c_ref, amax_ref),
+        )
+
+    c_jax, amax_jax = run(_to_jax(a), _to_jax(b), _to_jax(sfa), _to_jax(sfb))
+
+    import numpy as np
+
+    np.testing.assert_allclose(
+        np.asarray(c_jax.astype(jnp.float32)),
+        c_ref.float().cpu().numpy(),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    np.testing.assert_allclose(
+        np.asarray(amax_jax).reshape(()),
+        float(amax_ref.reshape(()).cpu()),
+        rtol=2e-2,
+        atol=2e-2,
+    )


### PR DESCRIPTION
## Summary (draft / direction preview)

MVP for calling **CuteDSL kernels from JAX as real primitives** (compose with `@jax.jit`, no host callback), so FE / TE-JAX folks can feel the per-kernel cost before we commit to a shape. `gemm_amax` is the first kernel because its output shapes come only from input shapes — it isolates the pure bridge boilerplate.

> **Status: unverified end-to-end.** Needs SM100 + `jax` + `jax-tvm-ffi`, plus the GOTCHAs below resolved on hardware. This is a preview, not a merge candidate.

### Architecture — FE owns a stable API; tvm-ffi is internal transport
```
JAX user / TE-JAX
   |  cudnn.experimental.jax.gemm_amax(...)     <- STABLE, FE-owned contract
   v
_bridge.py  (register + version guard)          <- written ONCE
   v
jax-tvm-ffi -> XLA custom call                   <- swappable transport
   v
CuteDSL kernel compiled with --enable-tvm-ffi    <- SAME binary the torch path calls
```
The kernel's tvm-ffi ABI is **not** a stable contract (it drifts). Keeping it behind an FE-owned op means a drift is a one-file pin bump here, invisible to callers — instead of breaking a downstream consumer directly. The transport is replaceable: the public op signature is the contract, so `jax-tvm-ffi` could later be swapped for a hand-written XLA FFI handler with zero caller impact.

### Per-kernel boilerplate (the number people asked for)
Everything framework-neutral is in `_bridge.py` (written once). Adding a **dense, shape-from-inputs** kernel = one file like `gemm_amax.py`: a ~3-line reorder wrapper, one `register_once`, and a JAX-facing op with shape inference + `ffi_call` — **~40–60 lines, no C++**. Kernels with data-dependent output shapes (grouped / MoE / sparse) additionally need a padded/offsets abstract-eval — a real per-kernel design item, not boilerplate.

### Scope
- **In:** the JAX bridge boilerplate (abstract-eval, `ffi_call`, output/stream/init handling, the reusable registration helper).
- **Out (orthogonal):** de-torching the kernels. Until that lands, the op takes a `_sample_torch` shim to drive the kernel's existing `check_support()/compile()`; it collapses to plain shape/dtype descriptors once de-torching is done.
- **Out:** autograd. Forward-only, but a complete forward boundary.

### Open GOTCHAs (hardware, not boilerplate)
1. **stream** — kernel compiles with `use_tvm_ffi_env_stream=False`; JAX path needs `True` (stream from the tvm-ffi env stream XLA sets). One flag in the kernel's `compile()` — the only kernel-side edit.
2. **amax init** — XLA output buffers are uninitialized; the kernel atomicMax-es into amax and needs `-inf`. Handled via a donated input `input_output_alias`ed onto the output.
3. **layout** — compiled kernel is specialized to the sample's strides; XLA hands row-major by default. Declare `ffi_call` layouts or match input layout. Left for the PoC.

### Files
- `python/cudnn/experimental/jax/_bridge.py` — reusable tvm-ffi→JAX registration + tvm-ffi version guard (human error, not opaque `CONFIG_MISSING_TVM_FFI`).
- `python/cudnn/experimental/jax/gemm_amax.py` — the per-kernel binding.
- `test/python/experimental/jax/test_gemm_amax_jax.py` — end-to-end smoke vs the torch path (skips without SM100 / jax).
- `python/cudnn/experimental/jax/README.md` — architecture + gotchas.
- `pyproject.toml` — `jax` optional-dependency extra.

### Test plan
- `pytest test/python/experimental/jax/test_gemm_amax_jax.py` on SM100 with `jax`+`jax-tvm-ffi` (currently skips). Compares c/amax against `gemm_amax_wrapper_sm100` (the identical kernel).
- Resolve the three GOTCHAs on hardware.

---
<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code) · note to self: claude design session — "cudnn-FE CuteDSL kernels -> JAX (tvm-ffi) MVP" · cwd /home/scratch.yanxu_libs/cudnn_frontend</sub>
