### PR TITLE
feat(determinism): grouped gemm dsrelu deterministic dprob

### DIFF
--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
@@ -238,7 +238,11 @@ op.execute(
   - Layout: must match `D_row`
   - Dtype: must match `D_row`
 - Output tensor **dprob**: `result["dprob_tensor"]` (wrapper) or `sample_dprob` / `dprob_tensor` (class)
-  - Shape: `(valid_m, 1, 1)`
+  - Shape (wrapper): `(valid_m, 1, 1)`, whether or not `deterministic` is set — the per-N-tile
+    workspace and the reduction into it are internal
+  - Shape (class API): `(valid_m, 1, 1)` normally, but `(valid_m, grid_n, 1)` under
+    `deterministic=True`, and the caller reduces over dim 1 after `execute()`.
+    See [Deterministic dprob](#deterministic-dprob) for `grid_n`
   - Dtype: `float32`
 - Output tensors **SFD_row** / **SFD_col**
   - Dtypes: must match `SFA`
@@ -322,9 +326,8 @@ Tuple unpacking order is: `(d_row_tensor, d_col_tensor, dprob_tensor, dbias_tens
 
 ## Deterministic dprob
 
-`dprob` is the only output of this kernel that is not reproducible run to run by default.
-Every other output writes each element exactly once; `dprob` is a float reduction, and it is
-non-deterministic at two levels:
+`dprob` is a float reduction rather than a single write per element, and by default it is not
+reproducible run to run. It is non-deterministic at two levels:
 
 1. **Within a CTA.** The N-subtile loop is traversed forward or reversed depending on the
    accumulator pipeline phase, which varies between runs. A running fp32 sum over a flipping
@@ -362,6 +365,11 @@ non-deterministic configurations compile and cache separately.
 `grid_n` is the number of N-tiles the scheduler can emit, `ceil_div(n, TILE_N × cluster_n) ×
 cluster_n` — which is *not* `ceil_div(n, TILE_N)` unless `cluster_n` is 1, because the
 scheduler counts whole clusters and then expands to CTAs.
+
+**The flag covers `dprob` only.** With `generate_dbias=True` the kernel also accumulates
+`dbias` across CTA tiles with atomics, so that output remains scheduling-dependent. Every
+other output — `d_row`, `d_col`, `d_srelu`, the scale factors — is a single write per element
+and is reproducible either way. A run needing bit-exact `dbias` cannot get it here yet.
 
 ---
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
@@ -274,7 +274,7 @@ op.execute(
   - Enables the discrete column-scale-factor path used by grouped FP8
 - `deterministic: bool | None`
   - Makes `dprob` bit-exact run to run — see [Deterministic dprob](#deterministic-dprob)
-  - Wrapper: `None` (default) reads `CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC`, off unless set
+  - Wrapper: `None` (default) follows `torch.use_deterministic_algorithms`
   - Class API: plain `bool`, default `False`
 - CUDA stream (`current_stream` in class API, `current_stream` in wrapper)
 
@@ -340,25 +340,28 @@ cross-CTA atomic still leaves a divergent result.
 2. `dprob` is given one slot per N-tile, so each `(token, tile_n)` pair has exactly one
    writer, and those slots are reduced with `torch.sum` in fixed order.
 
-This flag is the only control over the behaviour: the reduction happens inside the kernel, so
-no process-level determinism setting affects it.
+Left unset, the flag follows torch:
 
 ```python
-# Explicit, per call site:
-result = cudnn.grouped_gemm_dsrelu_wrapper_sm100(..., deterministic=True)
+# Process-wide, along with every other deterministic algorithm:
+torch.use_deterministic_algorithms(True)
 
-# Or process-wide, when the call site is not yours to edit:
-#   export CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC=1
+# Or explicitly, per call site, independent of the torch setting:
+result = cudnn.grouped_gemm_dsrelu_wrapper_sm100(..., deterministic=True)
 ```
 
 `dprob_tensor` keeps its `(valid_m, 1, 1)` shape either way — the per-N-tile workspace and
 the reduction into it are internal to the wrapper. The class API is lower level: pass
-`sample_dprob` / `dprob_tensor` shaped `(valid_m, ceil_div(n, mma_tiler_mn[1]), 1)` and reduce
-over dim 1 yourself.
+`sample_dprob` / `dprob_tensor` carrying one slot per N-tile and reduce over dim 1 yourself.
 
-**Cost.** `grid_n ×` the `dprob` workspace (`grid_n = ceil_div(n, mma_tiler_mn[1])`), one
-reduction kernel, and `subtile_cnt` extra registers per epilogue thread. Deterministic and
+**Cost.** `grid_n ×` the `dprob` workspace, one reduction kernel, and `subtile_cnt` extra
+registers per epilogue thread — and the last of those only for tile shapes that overlap the
+accumulator, since that is what reverses the subtile loop. Deterministic and
 non-deterministic configurations compile and cache separately.
+
+`grid_n` is the number of N-tiles the scheduler can emit, `ceil_div(n, TILE_N × cluster_n) ×
+cluster_n` — which is *not* `ceil_div(n, TILE_N)` unless `cluster_n` is 1, because the
+scheduler counts whole clusters and then expands to CTAs.
 
 ---
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
@@ -400,9 +400,9 @@ element and is reproducible either way.
 
 **Streams.** `dprob`, `dbias` and `amax` are accumulated into, so the wrapper initialises them
 on `current_stream` rather than on torch's current stream; otherwise the memset is unordered
-against the kernel and the guarantee is void whenever the caller runs on its own stream. The
-buffers themselves are allocated on torch's stream and `record_stream`-ed onto
-`current_stream`, which keeps all outputs in one allocator pool. A caller driving the class
+against the kernel and the guarantee is void whenever the caller runs on its own stream. Those
+buffers are therefore allocated on `current_stream` too; the write-only outputs still come from
+torch's stream and are `record_stream`-ed onto `current_stream` instead. A caller driving the class
 API directly owns both of these itself.
 
 ---

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
@@ -272,6 +272,10 @@ op.execute(
   - Only `"n"` (n-major layout) is supported
 - `discrete_col_sfd: bool`
   - Enables the discrete column-scale-factor path used by grouped FP8
+- `deterministic: bool | None`
+  - Makes `dprob` bit-exact run to run — see [Deterministic dprob](#deterministic-dprob)
+  - Wrapper: `None` (default) reads `CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC`, off unless set
+  - Class API: plain `bool`, default `False`
 - CUDA stream (`current_stream` in class API, `current_stream` in wrapper)
 
 ### Wrapper return values
@@ -313,6 +317,48 @@ Tuple unpacking order is: `(d_row_tensor, d_col_tensor, dprob_tensor, dbias_tens
 
 - `m_aligned` must be `256`
 - Requires CUDA with SM100+ compute capability
+
+---
+
+## Deterministic dprob
+
+`dprob` is the only output of this kernel that is not reproducible run to run by default.
+Every other output writes each element exactly once; `dprob` is a float reduction, and it is
+non-deterministic at two levels:
+
+1. **Within a CTA.** The N-subtile loop is traversed forward or reversed depending on the
+   accumulator pipeline phase, which varies between runs. A running fp32 sum over a flipping
+   order is not reproducible, because float addition is not associative.
+2. **Across CTAs.** Every N-tile atomically accumulates into the same `dprob[token]`, so the
+   summation order follows tile scheduling.
+
+`deterministic=True` fixes both. **Neither fix is sufficient on its own** — fixing only the
+cross-CTA atomic still leaves a divergent result.
+
+1. Each subtile's partial goes into a slot indexed by the actual subtile, then the slots are
+   summed in canonical order after the loop.
+2. `dprob` is given one slot per N-tile, so each `(token, tile_n)` pair has exactly one
+   writer, and those slots are reduced with `torch.sum` in fixed order.
+
+This flag is the only control over the behaviour: the reduction happens inside the kernel, so
+no process-level determinism setting affects it.
+
+```python
+# Explicit, per call site:
+result = cudnn.grouped_gemm_dsrelu_wrapper_sm100(..., deterministic=True)
+
+# Or process-wide, when the call site is not yours to edit:
+#   export CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC=1
+```
+
+`dprob_tensor` keeps its `(valid_m, 1, 1)` shape either way — the per-N-tile workspace and
+the reduction into it are internal to the wrapper. The class API is lower level: pass
+`sample_dprob` / `dprob_tensor` shaped `(valid_m, ceil_div(n, mma_tiler_mn[1]), 1)` and reduce
+over dim 1 yourself.
+
+**Cost.** `grid_n ×` the `dprob` workspace (`grid_n = ceil_div(n, mma_tiler_mn[1])`), one
+reduction kernel, and `subtile_cnt` extra registers per epilogue thread. Deterministic and
+non-deterministic configurations compile and cache separately.
 
 ---
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
@@ -366,10 +366,44 @@ non-deterministic configurations compile and cache separately.
 cluster_n` — which is *not* `ceil_div(n, TILE_N)` unless `cluster_n` is 1, because the
 scheduler counts whole clusters and then expands to CTAs.
 
-**The flag covers `dprob` only.** With `generate_dbias=True` the kernel also accumulates
-`dbias` across CTA tiles with atomics, so that output remains scheduling-dependent. Every
-other output — `d_row`, `d_col`, `d_srelu`, the scale factors — is a single write per element
-and is reproducible either way. A run needing bit-exact `dbias` cannot get it here yet.
+**`dbias` is covered too, by a different mechanism.** By default the kernel accumulates it
+across *M*-tiles with bf16 atomics (`red.global.add.noftz.bf16x2`) in an order set by tile
+scheduling — a separate contention axis from `dprob`'s, since every N column is owned outright
+by one `(tile_n, subtile)` pair.
+
+Under `deterministic=True` the kernel instead writes one **fp32** slot per
+`(absolute M-block, n)`, which has exactly one writer, and the wrapper reduces those per
+expert. Groups are padded to a multiple of `m_aligned`, so no M-block straddles two experts and
+each expert owns a contiguous block range `[padded_offsets[e-1] / cta_tile_m,
+padded_offsets[e] / cta_tile_m)`. The workspace is `ceil_div(valid_m, cta_tile_m) × n_out` fp32
+— 4 MiB at `valid_m=64k`, `n=2048`, the same order as `dprob`'s.
+
+The segment sum is a one-hot matmul rather than `index_add_`/`scatter_add_`, which are
+themselves non-deterministic on CUDA, and rather than a per-expert slice, which would need
+`padded_offsets` on the host — a sync in the training loop. Keeping fp32 partials and narrowing
+to bf16 once at the end also makes this path **more accurate** than the default, which rounds
+on every M-tile.
+
+`dbias_tensor` keeps its `(expert_cnt, n_out, 1)` bf16 shape either way. The class API is lower
+level: under `deterministic=True`, `sample_dbias` / `dbias_tensor` must be the
+`(ceil_div(valid_m, cta_tile_m), n_out, 1)` **float32** workspace, and the caller does the
+per-expert reduction itself.
+
+`check_support()` rejects `deterministic=True` with `m_aligned % (cta_tile_m × cluster_m) != 0`:
+the slot index is only single-writer if the scheduler emits no M-tile past an expert's range,
+which needs that division to be exact. Every supported shape satisfies it — `m_aligned` is
+pinned to 256 and `cta_tile_m × cluster_m` is 128 or 256 — but a wider cluster would alias one
+expert's phantom tiles onto the next expert's slots.
+
+Every other output — `d_row`, `d_col`, `d_srelu`, the scale factors — is a single write per
+element and is reproducible either way.
+
+**Streams.** `dprob`, `dbias` and `amax` are accumulated into, so the wrapper initialises them
+on `current_stream` rather than on torch's current stream; otherwise the memset is unordered
+against the kernel and the guarantee is void whenever the caller runs on its own stream. The
+buffers themselves are allocated on torch's stream and `record_stream`-ed onto
+`current_stream`, which keeps all outputs in one allocator pool. A caller driving the class
+API directly owns both of these itself.
 
 ---
 

--- a/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md
@@ -240,9 +240,9 @@ op.execute(
 - Output tensor **dprob**: `result["dprob_tensor"]` (wrapper) or `sample_dprob` / `dprob_tensor` (class)
   - Shape (wrapper): `(valid_m, 1, 1)`, whether or not `deterministic` is set — the per-N-tile
     workspace and the reduction into it are internal
-  - Shape (class API): `(valid_m, 1, 1)` normally, but `(valid_m, grid_n, 1)` under
-    `deterministic=True`, and the caller reduces over dim 1 after `execute()`.
-    See [Deterministic dprob](#deterministic-dprob) for `grid_n`
+  - Shape: `(valid_m, 1, 1)` in both modes. Under `deterministic=True` the class API also takes
+    `sample_dprob_workspace` / `dprob_workspace_tensor` (`dprob_workspace_shape(valid_m, n)`,
+    float32) and the caller calls `reduce_dprob_workspace` after `execute()`
   - Dtype: `float32`
 - Output tensors **SFD_row** / **SFD_col**
   - Dtypes: must match `SFA`
@@ -371,23 +371,29 @@ across *M*-tiles with bf16 atomics (`red.global.add.noftz.bf16x2`) in an order s
 scheduling — a separate contention axis from `dprob`'s, since every N column is owned outright
 by one `(tile_n, subtile)` pair.
 
-Under `deterministic=True` the kernel instead writes one **fp32** slot per
-`(absolute M-block, n)`, which has exactly one writer, and the wrapper reduces those per
-expert. Groups are padded to a multiple of `m_aligned`, so no M-block straddles two experts and
-each expert owns a contiguous block range `[padded_offsets[e-1] / cta_tile_m,
-padded_offsets[e] / cta_tile_m)`. The workspace is `ceil_div(valid_m, cta_tile_m) × n_out` fp32
-— 4 MiB at `valid_m=64k`, `n=2048`, the same order as `dprob`'s.
+Under `deterministic=True` the kernel instead writes one slot per `(absolute M-block, n)`,
+which has exactly one writer, and the reduction sums those per expert. Groups are padded to a
+multiple of `m_aligned`, so no M-block straddles two experts and each expert owns a contiguous
+block range `[padded_offsets[e-1] / cta_tile_m, padded_offsets[e] / cta_tile_m)`. The workspace
+is `ceil_div(valid_m, cta_tile_m) × n_out` **bf16** — 2 MiB at `valid_m=64k`, `n=2048`.
 
-The segment sum is a one-hot matmul rather than `index_add_`/`scatter_add_`, which are
+The slots stay bf16 deliberately. Reproducibility comes from the single writer and the
+fixed-order reduction, not from a wider accumulator, so fp32 slots would double the memory and
+split one packed `bf16x2` store into two scalar ones for no determinism benefit. Accuracy still
+improves over the default: there each M-tile's atomic rounds the *running* sum, here each slot
+rounds once and the segment matmul accumulates them in fp32.
+
+That segment sum is a one-hot matmul rather than `index_add_`/`scatter_add_`, which are
 themselves non-deterministic on CUDA, and rather than a per-expert slice, which would need
-`padded_offsets` on the host — a sync in the training loop. Keeping fp32 partials and narrowing
-to bf16 once at the end also makes this path **more accurate** than the default, which rounds
-on every M-tile.
+`padded_offsets` on the host — a sync in the training loop.
 
-`dbias_tensor` keeps its `(expert_cnt, n_out, 1)` bf16 shape either way. The class API is lower
-level: under `deterministic=True`, `sample_dbias` / `dbias_tensor` must be the
-`(ceil_div(valid_m, cta_tile_m), n_out, 1)` **float32** workspace, and the caller does the
-per-expert reduction itself.
+**The output arguments are identical in both modes.** `dprob` is `(valid_m, 1, 1)` float32 and
+`dbias` is `(expert_cnt, n_out, 1)` bf16 whether or not the flag is set. What the flag adds is
+scratch, and only for the class API: `sample_dprob_workspace` / `dprob_workspace_tensor` and
+`sample_dbias_workspace` / `dbias_workspace_tensor`, sized by `dprob_workspace_shape(valid_m, n)`
+and `dbias_workspace_shape(valid_m, n)`, reduced afterwards by `reduce_dprob_workspace` and
+`reduce_dbias_workspace`. Use those rather than reducing by hand — a plain sum over dim 0 of the
+dbias slots is wrong, and wrong quietly. The wrapper allocates and reduces both for you.
 
 `check_support()` rejects `deterministic=True` with `m_aligned % (cta_tile_m × cluster_m) != 0`:
 the slot index is only single-writer if the scheduler emits no M-tile past an expert's range,

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -124,6 +124,15 @@ Methods:
   - The cuda stream to use for operation kernel execution.
   - Default: None (uses default stream)
 
+- Determinism
+  - Several kernels reduce with cross-CTA atomics, so those outputs are not bit-exact run to
+    run. Kernels react to `torch.use_deterministic_algorithms(True)`: they switch to a
+    deterministic path where one exists, and otherwise raise (or warn, under
+    `warn_only`) rather than silently return a non-reproducible result.
+  - Where a deterministic path exists it can also be selected per call with
+    `deterministic=True`, independent of the torch setting. See
+    [Grouped GEMM + dsReLU](gemm_fusions/grouped_gemm_dsrelu.md#deterministic-dprob).
+
 
 ## File structure and examples
 

--- a/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
+++ b/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
@@ -15,23 +15,6 @@ class GroupedGemmBackend(str, Enum):
     BLOCK_SCALED = "block_scaled"
 
 
-def _resolve_torch_stream(handle: int, device: torch.device):
-    """The torch stream object for a raw CUDA stream handle.
-
-    Prefers torch's own current/default stream objects when the handle matches one of them, so
-    the common case does not mint an ExternalStream per call.
-    """
-    import torch
-
-    torch_current = torch.cuda.current_stream(device)
-    if handle == torch_current.cuda_stream:
-        return torch_current
-    torch_default = torch.cuda.default_stream(device)
-    if handle == torch_default.cuda_stream:
-        return torch_default
-    return torch.cuda.ExternalStream(handle, device=device)
-
-
 @contextmanager
 def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch.device) -> Iterator[None]:
     """Run PyTorch work on the CUDA stream used for the kernel launch.
@@ -44,7 +27,16 @@ def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch
     if current_stream is None:
         yield
         return
-    with torch.cuda.stream(_resolve_torch_stream(int(current_stream), device)):
+    handle = int(current_stream)
+    torch_current = torch.cuda.current_stream(device)
+    torch_default = torch.cuda.default_stream(device)
+    if handle == torch_current.cuda_stream:
+        launch_stream = torch_current
+    elif handle == torch_default.cuda_stream:
+        launch_stream = torch_default
+    else:
+        launch_stream = torch.cuda.ExternalStream(handle, device=device)
+    with torch.cuda.stream(launch_stream):
         yield
 
 
@@ -64,9 +56,11 @@ def _record_streams(current_stream: Optional[cuda.CUstream], device: torch.devic
     import torch
 
     handle = int(current_stream)
-    if handle == torch.cuda.current_stream(device).cuda_stream:
+    torch_current = torch.cuda.current_stream(device)
+    if handle == torch_current.cuda_stream:
         return
-    consumer = _resolve_torch_stream(handle, device)
+    torch_default = torch.cuda.default_stream(device)
+    consumer = torch_default if handle == torch_default.cuda_stream else torch.cuda.ExternalStream(handle, device=device)
     for tensor in tensors:
         if tensor is not None:
             tensor.record_stream(consumer)

--- a/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
+++ b/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
@@ -15,6 +15,23 @@ class GroupedGemmBackend(str, Enum):
     BLOCK_SCALED = "block_scaled"
 
 
+def _resolve_torch_stream(handle: int, device: torch.device):
+    """The torch stream object for a raw CUDA stream handle.
+
+    Prefers torch's own current/default stream objects when the handle matches one of them, so
+    the common case does not mint an ExternalStream per call.
+    """
+    import torch
+
+    torch_current = torch.cuda.current_stream(device)
+    if handle == torch_current.cuda_stream:
+        return torch_current
+    torch_default = torch.cuda.default_stream(device)
+    if handle == torch_default.cuda_stream:
+        return torch_default
+    return torch.cuda.ExternalStream(handle, device=device)
+
+
 @contextmanager
 def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch.device) -> Iterator[None]:
     """Run PyTorch work on the CUDA stream used for the kernel launch.
@@ -27,17 +44,32 @@ def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch
     if current_stream is None:
         yield
         return
-    handle = int(current_stream)
-    torch_current = torch.cuda.current_stream(device)
-    torch_default = torch.cuda.default_stream(device)
-    if handle == torch_current.cuda_stream:
-        launch_stream = torch_current
-    elif handle == torch_default.cuda_stream:
-        launch_stream = torch_default
-    else:
-        launch_stream = torch.cuda.ExternalStream(handle, device=device)
-    with torch.cuda.stream(launch_stream):
+    with torch.cuda.stream(_resolve_torch_stream(int(current_stream), device)):
         yield
+
+
+def _record_streams(current_stream: Optional[cuda.CUstream], device: torch.device, *tensors) -> None:
+    """Keep torch's allocator from recycling buffers the kernel is still writing.
+
+    A wrapper that allocates its outputs on torch's stream but launches on the caller's has torch
+    tag each block to the allocation stream, so it can hand the block to the next allocation there
+    as soon as the tensor is freed -- without waiting for the kernel. Recording the consumer stream
+    is what defers that reuse. No-op when the two are the same stream, which is the common case and
+    where record_stream would only add the block to the allocator's event-polled path for nothing.
+
+    torch-only, like _torch_stream_context: guard the call on the framework.
+    """
+    if current_stream is None:
+        return
+    import torch
+
+    handle = int(current_stream)
+    if handle == torch.cuda.current_stream(device).cuda_stream:
+        return
+    consumer = _resolve_torch_stream(handle, device)
+    for tensor in tensors:
+        if tensor is not None:
+            tensor.record_stream(consumer)
 
 
 def select_grouped_gemm_backend(

--- a/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
+++ b/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
@@ -40,32 +40,6 @@ def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch
         yield
 
 
-def _record_streams(current_stream: Optional[cuda.CUstream], device: torch.device, *tensors) -> None:
-    """Keep torch's allocator from recycling buffers the kernel is still writing.
-
-    A wrapper that allocates its outputs on torch's stream but launches on the caller's has torch
-    tag each block to the allocation stream, so it can hand the block to the next allocation there
-    as soon as the tensor is freed -- without waiting for the kernel. Recording the consumer stream
-    is what defers that reuse. No-op when the two are the same stream, which is the common case and
-    where record_stream would only add the block to the allocator's event-polled path for nothing.
-
-    torch-only, like _torch_stream_context: guard the call on the framework.
-    """
-    if current_stream is None:
-        return
-    import torch
-
-    handle = int(current_stream)
-    torch_current = torch.cuda.current_stream(device)
-    if handle == torch_current.cuda_stream:
-        return
-    torch_default = torch.cuda.default_stream(device)
-    consumer = torch_default if handle == torch_default.cuda_stream else torch.cuda.ExternalStream(handle, device=device)
-    for tensor in tensors:
-        if tensor is not None:
-            tensor.record_stream(consumer)
-
-
 def select_grouped_gemm_backend(
     *,
     operation,

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -52,11 +52,21 @@ from cudnn.tensor_adapter import (
 )
 
 
+def _uses_2cta_instrs(mma_tiler_mn: Tuple[int, int]) -> bool:
+    """An M tile of 256 is the 2-CTA MMA shape -- tcgen05 pairs two CTAs to cover it.
+
+    check_support enforces the pairing: M must be 256 with 2-CTA instructions and 128
+    without, so the tile size and the instruction form carry the same information.
+    """
+    return mma_tiler_mn[0] == 256
+
+
 def _resolve_cluster_shape_mn(mma_tiler_mn: Tuple[int, int], cluster_shape_mn: Optional[Tuple[int, int]]) -> Tuple[int, int]:
     """The cluster shape the kernel will actually run with, defaults applied."""
     if cluster_shape_mn is not None:
         return cluster_shape_mn
-    return (2, 1) if mma_tiler_mn[0] == 256 else (1, 1)
+    # 2-CTA MMA needs both CTAs of the pair in the same cluster along M.
+    return (2, 1) if _uses_2cta_instrs(mma_tiler_mn) else (1, 1)
 
 
 def _dprob_n_slots(n_out: int, mma_tiler_mn: Tuple[int, int], cluster_shape_mn: Optional[Tuple[int, int]], deterministic: bool) -> int:
@@ -299,7 +309,7 @@ class GroupedGemmDsreluSm100(APIBase):
         # ---- Configuration ----
         self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
-        self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        self.use_2cta_instrs = _uses_2cta_instrs(mma_tiler_mn)
         self.cluster_shape_mn = _resolve_cluster_shape_mn(mma_tiler_mn, cluster_shape_mn)
         self.sf_vec_size = sf_vec_size
         self.vector_f32 = vector_f32

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -23,12 +23,12 @@ from .moe_blockscaled_grouped_gemm_dsrelu_quant import (
     BlockScaledMoEGroupedGemmQuantBwdKernel,
     EpilogueType,
 )
+from ..backend_utils import _torch_stream_context
 from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
-from contextlib import contextmanager
 import logging
 import os
-from typing import Iterator, Tuple, Optional
+from typing import Tuple, Optional
 
 import cutlass
 import cutlass.cute as cute
@@ -89,20 +89,14 @@ def _dprob_n_slots(n_out: int, mma_tiler_mn: Tuple[int, int], cluster_shape_mn: 
     return ceil_div(n_out, mma_tiler_mn[1] * cluster_n) * cluster_n
 
 
-@contextmanager
-def _torch_stream_context(current_stream: Optional[cuda.CUstream]) -> Iterator[None]:
-    """Run torch work on ``current_stream`` when the caller supplied one.
+def _cta_tile_m(mma_tiler_mn: Tuple[int, int]) -> int:
+    """Rows one CTA's epilogue owns, and so the granularity of a deterministic dbias slot.
 
-    Same shape as the helpers in csa/compressor and deepseek_sparse_attention/utils; kept
-    local rather than imported so a GEMM kernel does not depend on an attention module.
+    Mirrors the kernel's ``cta_tile_shape_mnk[0] = mma_tiler[0] // thr_id_size``. Shared with
+    ``GroupedGemmDsreluSm100.__init__`` for the same reason ``_resolve_cluster_shape_mn`` is:
+    the wrapper must not derive a different value than the class it is about to construct.
     """
-    if current_stream is None:
-        yield
-        return
-    import torch
-
-    with torch.cuda.stream(torch.cuda.get_stream_from_external(int(current_stream))):
-        yield
+    return mma_tiler_mn[0] // (2 if mma_tiler_mn[0] == 256 else 1)
 
 
 def _reduce_dprob_slots(
@@ -113,22 +107,71 @@ def _reduce_dprob_slots(
 ) -> torch.Tensor:
     """Collapse the per-N-tile dprob slots back to the caller's ``(valid_m, 1, 1)`` shape.
 
-    A no-op unless deterministic, where the sum is what makes the result reproducible: it
-    runs in a fixed order, unlike the kernel's cross-CTA atomics. Accumulates onto a
-    caller-supplied buffer, matching what the atomic does on the non-deterministic path;
-    when we allocated the buffer ourselves there is nothing to add onto.
+    A no-op unless deterministic, where the fixed summation order is what makes the result
+    reproducible, unlike the kernel's cross-CTA atomics. Every token owns the same number of
+    slots, so this is a plain sum over dim 1 -- no segment structure, unlike dbias. Accumulates
+    onto a caller-supplied buffer, matching what the atomic does on the non-deterministic path.
 
-    Issued on ``current_stream``, the same stream execute() ran the kernel on. On torch's
-    current stream instead, a caller who passes a different stream would have the reduction
-    read dprob_tensor before the kernel finished writing it.
+    Issued on ``current_stream``, the stream execute() ran the kernel on. On torch's current
+    stream instead, a caller who passes a different stream would have the reduction read
+    dprob_tensor before the kernel finished writing it.
     """
     if not deterministic:
         return dprob_tensor
     import torch
 
-    with _torch_stream_context(current_stream):
+    with _torch_stream_context(current_stream, dprob_tensor.device):
         reduced = torch.sum(dprob_tensor, dim=1, keepdim=True)
         return reduced if caller_dprob_tensor is None else caller_dprob_tensor.add_(reduced)
+
+
+def _reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_offsets, cta_tile_m):
+    """Segment-sum the per-M-block dbias slots into a per-expert ``(expert, n, 1)`` bf16 tensor.
+
+    ``dbias_workspace`` is None whenever the kernel wrote dbias directly -- no dbias at all, or
+    the non-deterministic path -- and then there is nothing to collapse.
+
+    Expert ``e`` owns the contiguous block range whose first token falls in
+    ``[padded_offsets[e-1], padded_offsets[e])``. Done as a one-hot matmul because ``index_add_``
+    and ``scatter_add_`` are themselves non-deterministic on CUDA, and slicing per expert would
+    need ``padded_offsets`` on the host -- a sync in the training loop. A cumsum-and-subtract
+    would be deterministic too but cancels catastrophically across experts of different
+    magnitude. Comparing in token space rather than block space saves the division.
+
+    fp32 throughout, narrowed once at the end: strictly more accurate than the default path,
+    which rounds to bf16 on every M-tile.
+    """
+    if dbias_workspace is None:
+        return dbias_tensor
+    import torch
+
+    m_blocks, n_out = dbias_workspace.shape[0], dbias_workspace.shape[1]
+    with _torch_stream_context(current_stream, dbias_workspace.device):
+        block_tok = torch.arange(0, m_blocks * cta_tile_m, cta_tile_m, device=dbias_workspace.device, dtype=padded_offsets.dtype).unsqueeze(0)
+        starts = torch.cat((padded_offsets.new_zeros(1), padded_offsets[:-1])).unsqueeze(1)
+        onehot = ((block_tok >= starts) & (block_tok < padded_offsets.unsqueeze(1))).to(torch.float32)
+        return (onehot @ dbias_workspace.reshape(m_blocks, n_out)).reshape(-1, n_out, 1).to(torch.bfloat16)
+
+
+def _record_streams(current_stream: Optional[cuda.CUstream], device, *tensors) -> None:
+    """Keep torch's allocator from recycling buffers the kernel is still writing.
+
+    These come from torch's current stream, so torch tags the block to that stream and hands it
+    to the next allocation there as soon as the tensor is freed -- without waiting for work
+    queued on ``current_stream``. Same reason ``csa/compressor/api.py`` and the sibling
+    grouped-GEMM APIs call ``record_stream``.
+    """
+    if current_stream is None:
+        return
+    import torch
+
+    handle = int(current_stream)
+    if handle == torch.cuda.current_stream(device).cuda_stream:
+        return  # same stream the blocks were allocated on; nothing to guard against
+    consumer = torch.cuda.ExternalStream(handle, device=device)
+    for tensor in tensors:
+        if tensor is not None:
+            tensor.record_stream(consumer)
 
 
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -336,6 +379,9 @@ class GroupedGemmDsreluSm100(APIBase):
         self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        # Rows one CTA's epilogue owns, and so the granularity of a deterministic dbias slot.
+        # Mirrors the kernel's cta_tile_shape_mnk[0] = mma_tiler[0] // thr_id_size.
+        self.cta_tile_m = _cta_tile_m(mma_tiler_mn)
         self.cluster_shape_mn = _resolve_cluster_shape_mn(mma_tiler_mn, cluster_shape_mn)
         self.sf_vec_size = sf_vec_size
         self.vector_f32 = vector_f32
@@ -409,6 +455,23 @@ class GroupedGemmDsreluSm100(APIBase):
             extra_error_msg=f"{name} in the physical (L, MN', K', 32, 4, 4) form must be C-contiguous",
         )
 
+    def _make_dbias_fake(self):
+        """Fake dbias tensor for compilation.
+
+        Deterministic dbias is indexed by M-block, so dim 0 scales with the token count and has
+        to stay symbolic -- baked static it would bind the compiled kernel to one valid_m and
+        silently reuse it for another, the trap _dprob_n_slots documents for dprob's slot extent.
+        Divisibility 2 because valid_m is a multiple of m_aligned (256) and a block is
+        cta_tile_m (128) rows. The default (expert, n, 1) layout has no token-dependent extent.
+        """
+        if self.dbias_desc is None or not self.deterministic:
+            return self._make_fake_cute_tensor_from_desc(self.dbias_desc, assumed_align=16)
+        return self._make_fake_cute_compact_tensor(
+            dtype=self.dbias_desc.dtype,
+            shape=(cute.sym_int(divisibility=2), *self.dbias_desc.shape[1:]),
+            stride_order=self.dbias_desc.stride_order,
+        )
+
     def check_support(self) -> bool:
         """Check if the kernel configuration is supported.
 
@@ -465,7 +528,11 @@ class GroupedGemmDsreluSm100(APIBase):
         self._check_tensor_shape(self.prob_desc, (tensor_m, 1, 1), "prob")
         dprob_slots = _dprob_n_slots(n_out, self.mma_tiler_mn, self.cluster_shape_mn, self.deterministic)
         self._check_tensor_shape(self.dprob_desc, (tensor_m, dprob_slots, 1), "dprob")
-        self._check_tensor_shape(self.dbias_desc, (self.expert_cnt, n_out, 1), "dbias")
+        # Deterministic dbias is a different tensor, not an extra dimension on the same one --
+        # dprob could keep its shape because its slot axis is orthogonal to its output axis,
+        # dbias's is not. One fp32 slot per (CTA M-tile, n), reduced per expert after execute().
+        dbias_rows = ceil_div(tensor_m, self.cta_tile_m) if self.deterministic else self.expert_cnt
+        self._check_tensor_shape(self.dbias_desc, (dbias_rows, n_out, 1), "dbias")
         self._check_tensor_shape(self.amax_desc, (self.expert_cnt, 1), "amax")
         self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
         self._check_tensor_shape(self.padded_offsets_desc, (self.expert_cnt,), "padded_offsets")
@@ -588,9 +655,9 @@ class GroupedGemmDsreluSm100(APIBase):
         )
         self._check_dtype(
             self.dbias_desc,
-            dtype=cutlass.BFloat16,
+            dtype=cutlass.Float32 if self.deterministic else cutlass.BFloat16,
             name="Dbias",
-            extra_error_msg="dbias must be bfloat16",
+            extra_error_msg="dbias must be float32 when deterministic=True" if self.deterministic else "dbias must be bfloat16",
         )
         self.c_dtype = self._check_dtype(
             self.c_desc,
@@ -746,6 +813,20 @@ class GroupedGemmDsreluSm100(APIBase):
         )
 
         # ---- Disabled configurations ----
+        # Deterministic dbias keys its workspace by absolute M-block,
+        # token_offset // cta_tile_m + tile_m_idx, which is single-writer only if the scheduler
+        # emits no tile past an expert's range. It emits
+        # ceil_div(tokens_e, cta_tile_m * cluster_m) * cluster_m tiles per expert, so that ceil
+        # must be exact: m_aligned, which every tokens_e is a multiple of, has to divide by the
+        # cluster's M footprint. True for every supported shape (m_aligned is pinned to 256,
+        # cta_tile_m * cluster_m is 128 or 256), but a wider cluster would alias one expert's
+        # phantom tiles onto the next expert's slots.
+        self._not_implemented_error_if(
+            self.deterministic and self.dbias_desc is not None and self.m_aligned % (self.cta_tile_m * self.cluster_shape_mn[0]) != 0,
+            f"Invalid configuration: deterministic dbias needs m_aligned ({self.m_aligned}) to be a multiple of "
+            f"cta_tile_m * cluster_m ({self.cta_tile_m} * {self.cluster_shape_mn[0]}).",
+        )
+
         self._not_implemented_error_if(
             self.dbias_desc is None and self._is_fp4x2(self.ab_dtype) and self.sf_vec_size == 16 and self.d_dtype is cutlass.Float32,
             "Invalid configuration: fp4 ab_dtype, sf_vec_size 16, d_dtype float32 is not supported. " "Please use sf_vec_size 32 or d_dtype bf16 instead",
@@ -1024,7 +1105,7 @@ class GroupedGemmDsreluSm100(APIBase):
                         stride=(16, 4, stride_sfd_rest_m, 1, 512, stride_sfd_n_out),
                     )
 
-        dbias_fake = self._make_fake_cute_tensor_from_desc(self.dbias_desc, assumed_align=16)
+        dbias_fake = self._make_dbias_fake()
 
         _compiled_kernel = cute.compile(
             gemm_dsrelu,
@@ -1248,7 +1329,7 @@ class GroupedGemmDsreluSm100(APIBase):
             stride=self.dprob_desc.stride,
             assumed_align=16,
         )
-        dbias_tensor = self._make_fake_cute_tensor_from_desc(self.dbias_desc, assumed_align=16)
+        dbias_tensor = self._make_dbias_fake()
 
         # Compile-time placeholders for the pointer-array arguments: real device bytes
         # (fake tensors have dummy iterators) allocated in the caller's framework,
@@ -1659,13 +1740,19 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         # Follows torch's process-wide flag. jax has no equivalent global, so there the opt-in
         # has to be explicit rather than inherited -- and `torch` is not even bound on that path.
         deterministic = framework == "torch" and torch.are_deterministic_algorithms_enabled()
+    if deterministic and framework != "torch":
+        # The slot reductions below are torch ops on torch streams. Rather than half-support it,
+        # say so: a caller who asked for reproducibility should not get it silently unenforced.
+        raise NotImplementedError(f"deterministic=True is only implemented for the torch framework, got {framework}")
     dprob_n_slots = _dprob_n_slots(n_out, mma_tiler_mn, cluster_shape_mn, deterministic)
+    cta_tile_m = _cta_tile_m(mma_tiler_mn)
     # None when we allocate it ourselves, in which case the reduction can write the result
     # straight out instead of adding it onto a buffer we just zeroed.
     caller_dprob_tensor = dprob_tensor
     if dprob_tensor is None or deterministic:
         if framework == "torch":
-            dprob_tensor = torch.zeros((valid_m, dprob_n_slots, 1), dtype=torch.float32, device=a_tensor.device)
+            with _torch_stream_context(current_stream, a_tensor.device):
+                dprob_tensor = torch.zeros((valid_m, dprob_n_slots, 1), dtype=torch.float32, device=a_tensor.device)
         else:
             dprob_tensor = _jax_alloc(lambda: jnp.zeros((valid_m, dprob_n_slots, 1), dtype=jnp.float32, device=a_tensor.device))
 
@@ -1698,14 +1785,33 @@ def grouped_gemm_dsrelu_wrapper_sm100(
     if d_dtype in (cutlass.BFloat16, cutlass.Float16):
         _logger.debug("grouped_gemm_dsrelu_wrapper_sm100: Constructing amax_tensor")
         if framework == "torch":
-            amax_tensor = torch.full((l, 1), float("-inf"), dtype=torch.float32, device=a_tensor.device)
+            with _torch_stream_context(current_stream, a_tensor.device):
+                amax_tensor = torch.full((l, 1), float("-inf"), dtype=torch.float32, device=a_tensor.device)
         else:
             amax_tensor = _jax_alloc(lambda: jnp.full((l, 1), float("-inf"), dtype=jnp.float32, device=a_tensor.device))
+    # Deterministic dbias is a separate buffer, not a reshaped one: the kernel writes fp32
+    # per-(M-block, n) slots and _reduce_dbias_slots turns those into the bf16 (expert, n)
+    # output. The default path instead has the kernel atomic-accumulate straight into that
+    # output, so there it has to exist and be zeroed up front. dbias_kernel_tensor is what
+    # execute() writes; dbias_tensor is what comes back.
+    dbias_workspace = None
     if generate_dbias:
-        if framework == "torch":
-            dbias_tensor = torch.zeros((l, n_out, 1), dtype=torch.bfloat16, device=a_tensor.device)
+        if deterministic:  # torch-only, rejected for jax above
+            with _torch_stream_context(current_stream, a_tensor.device):
+                dbias_workspace = torch.zeros((ceil_div(valid_m, cta_tile_m), n_out, 1), dtype=torch.float32, device=a_tensor.device)
+        elif framework == "torch":
+            with _torch_stream_context(current_stream, a_tensor.device):
+                dbias_tensor = torch.zeros((l, n_out, 1), dtype=torch.bfloat16, device=a_tensor.device)
         else:
             dbias_tensor = _jax_alloc(lambda: jnp.zeros((l, n_out, 1), dtype=framework_dtype(cutlass.BFloat16, "jax"), device=a_tensor.device))
+    dbias_kernel_tensor = dbias_workspace if dbias_workspace is not None else dbias_tensor
+
+    # The write-only outputs need no ordered init, but they still come from torch's stream while
+    # the kernel writes them on the caller's, so torch could recycle the block early. The
+    # accumulators above are allocated on the caller's stream and need no such record. No-op
+    # under jax, which does not use torch's allocator.
+    if framework == "torch":
+        _record_streams(current_stream, a_tensor.device, d_row_tensor, d_col_tensor, d_srelu_tensor, sfd_row_tensor, sfd_col_tensor, sfd_col_d_srelu_tensor)
 
     if valid_m == 0:
         _logger.debug("grouped_gemm_dsrelu_wrapper_sm100: valid_m is zero, skipping kernel execution")
@@ -1716,7 +1822,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             # Reduced here too, so a zero-token call returns the documented (valid_m, 1, 1)
             # shape rather than leaking the slot dimension.
             dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic, current_stream),
-            dbias_tensor=dbias_tensor,
+            dbias_tensor=_reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_offsets, cta_tile_m),
             amax_tensor=amax_tensor,
             sfd_row_tensor=sfd_row_tensor,
             sfd_col_tensor=sfd_col_tensor,
@@ -1801,7 +1907,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             # stride order, so without this the second call would reuse a kernel built for
             # the wrong dprob extent.
             dprob_n_slots,
-            *(dynamic_tensor_signature(dbias_tensor) if use_full_dynamic else tensor_signature(dbias_tensor)),
+            *(dynamic_tensor_signature(dbias_kernel_tensor) if use_full_dynamic else tensor_signature(dbias_kernel_tensor)),
             *(dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1)) if not use_full_dynamic else dynamic_tensor_signature(d_srelu_tensor)),
             *(dynamic_tensor_signature(sfb_tensor) if use_full_dynamic else tensor_signature(sfb_tensor)),
             *(dynamic_tensor_signature(sfd_col_d_srelu_tensor) if use_full_dynamic else tensor_signature(sfd_col_d_srelu_tensor)),
@@ -1835,7 +1941,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             *tensor_signature(alpha_tensor),
             *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
             *dynamic_m_tensor_signature(dprob_tensor, tuple(dprob_tensor.shape[1:])),
-            *tensor_signature(dbias_tensor),
+            *tensor_signature(dbias_kernel_tensor),
             *dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1), dynamic_stride_dims=(2,)),
             *dynamic_sfd_col_tensor_signature(sfd_col_d_srelu_tensor),
             *tensor_signature(norm_const_tensor),
@@ -1876,7 +1982,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
                 sample_alpha=alpha_tensor,
                 sample_prob=prob_tensor,
                 sample_dprob=dprob_tensor,
-                sample_dbias=dbias_tensor,
+                sample_dbias=dbias_kernel_tensor,
                 sample_b=b_tensor,
                 sample_sfb=sfb_tensor,
                 sample_sfd_row=sfd_row_tensor,
@@ -1907,7 +2013,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
                 sample_alpha=alpha_tensor,
                 sample_prob=prob_tensor,
                 sample_dprob=dprob_tensor,
-                sample_dbias=dbias_tensor,
+                sample_dbias=dbias_kernel_tensor,
                 num_experts=num_experts,
                 b_shape=b_shape,
                 b_dtype=b_dtype,
@@ -1947,7 +2053,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             alpha_tensor=alpha_tensor,
             prob_tensor=prob_tensor,
             dprob_tensor=dprob_tensor,
-            dbias_tensor=dbias_tensor,
+            dbias_tensor=dbias_kernel_tensor,
             b_tensor=b_tensor,
             sfb_tensor=sfb_tensor,
             sfd_row_tensor=sfd_row_tensor,
@@ -1969,7 +2075,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             alpha_tensor=alpha_tensor,
             prob_tensor=prob_tensor,
             dprob_tensor=dprob_tensor,
-            dbias_tensor=dbias_tensor,
+            dbias_tensor=dbias_kernel_tensor,
             b_ptrs=b_ptrs,
             sfb_ptrs=sfb_ptrs,
             sfd_row_tensor=sfd_row_tensor,
@@ -1985,7 +2091,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         d_col_tensor=d_col_tensor,
         d_srelu_tensor=d_srelu_tensor,
         dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic, current_stream),
-        dbias_tensor=dbias_tensor,
+        dbias_tensor=_reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_offsets, cta_tile_m),
         amax_tensor=amax_tensor,
         sfd_row_tensor=sfd_row_tensor,
         sfd_col_tensor=sfd_col_tensor,

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -52,6 +52,19 @@ from cudnn.tensor_adapter import (
 )
 
 
+def _dprob_n_slots(n_out: int, mma_tiler_mn: Tuple[int, int], deterministic: bool) -> int:
+    """Extent of dprob's dim 1.
+
+    Non-deterministic (default): 1 -- every N-tile atomically accumulates into the same
+    ``dprob[token]``, so the fp32 summation order follows tile scheduling.
+
+    Deterministic: one slot per N-tile, so each ``(token, tile_n)`` pair has exactly one
+    writer and the caller can reduce over dim 1 in a fixed order. ``tile_n_idx`` counts in
+    units of ``mma_tiler_mn[1]``.
+    """
+    return ceil_div(n_out, mma_tiler_mn[1]) if deterministic else 1
+
+
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
     if _convert_to_cutlass_data_type_or_none(tensor.dtype) is cutlass.Uint8:
         cute_tensor = from_dlpack(tensor, assumed_align=16, enable_tvm_ffi=True).mark_layout_dynamic(leading_dim=1)
@@ -137,6 +150,7 @@ class GroupedGemmDsreluSm100(APIBase):
         b_major: str = "k",
         use_dynamic_sched: bool = False,
         use_dsrelu_reuse: bool = False,
+        deterministic: bool = False,
     ):
         """Initialize the GroupedGemmDsreluSm100 API.
 
@@ -169,6 +183,9 @@ class GroupedGemmDsreluSm100(APIBase):
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
+        :param deterministic: Compute dprob run-to-run bit-exactly. sample_dprob must then be
+            shaped (valid_m, ceil_div(n, mma_tiler_mn[1]), 1) and the caller must reduce over
+            dim 1 after execute(); grouped_gemm_dsrelu_wrapper_sm100 does both for you
         """
         framework = detect_framework(sample_a)
         if sample_a is not None and framework not in ("torch", "jax"):
@@ -266,6 +283,7 @@ class GroupedGemmDsreluSm100(APIBase):
 
         self.use_dynamic_sched = use_dynamic_sched
         self.use_dsrelu_reuse = use_dsrelu_reuse
+        self.deterministic = deterministic
 
         self._interpret_uint8_as_fp4x2 = True
         self._has_dbias = self.dbias_desc is not None
@@ -382,7 +400,9 @@ class GroupedGemmDsreluSm100(APIBase):
 
         self._check_tensor_shape(self.alpha_desc, (self.expert_cnt,), "alpha")
         self._check_tensor_shape(self.prob_desc, (tensor_m, 1, 1), "prob")
-        self._check_tensor_shape(self.dprob_desc, (tensor_m, 1, 1), "dprob")
+        # Under deterministic=True, dprob carries one slot per N-tile so that each
+        # (token, tile_n) pair has a single writer; the caller reduces over that dimension.
+        self._check_tensor_shape(self.dprob_desc, (tensor_m, _dprob_n_slots(n_out, self.mma_tiler_mn, self.deterministic), 1), "dprob")
         self._check_tensor_shape(self.dbias_desc, (self.expert_cnt, n_out, 1), "dbias")
         self._check_tensor_shape(self.amax_desc, (self.expert_cnt, 1), "amax")
         self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
@@ -708,6 +728,7 @@ class GroupedGemmDsreluSm100(APIBase):
             generate_dbias=self._has_dbias,
             generate_d_srelu=self._generate_d_srelu,
             use_dsrelu_reuse=self.use_dsrelu_reuse,
+            deterministic=self.deterministic,
         )
 
         hardware_info = cutlass.utils.HardwareInfo()
@@ -792,7 +813,7 @@ class GroupedGemmDsreluSm100(APIBase):
             )
             dprob_cute_fake = self._make_fake_cute_compact_tensor(
                 dtype=self.dprob_desc.dtype,
-                shape=(valid_m, 1, 1),
+                shape=(valid_m, *self.dprob_desc.shape[1:]),
                 stride_order=self.dprob_desc.stride_order,
             )
 
@@ -1435,6 +1456,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
     discrete_col_sfd: bool = False,
     use_dynamic_sched: bool = False,
     use_dsrelu_reuse: bool = False,
+    deterministic: Optional[bool] = None,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Convenience wrapper for grouped GEMM dSReLU backward operation.
@@ -1475,6 +1497,11 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         discrete_col_sfd: Generate discrete col-major scale factor tensor
         use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
+        deterministic: Make dprob bit-exact run to run. ``dprob_tensor`` keeps its
+            ``(valid_m, 1, 1)`` shape either way -- the extra per-N-tile workspace and the
+            fixed-order reduction into it are internal. ``None`` (default) reads
+            ``CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC``, which is off unless set, so
+            callers that cannot pass the argument can still opt in from the environment.
         current_stream: CUDA stream
 
     Returns:
@@ -1621,6 +1648,17 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             sfd_col_d_srelu_tensor=sfd_col_d_srelu_tensor,
         )
 
+    # ---- Deterministic dprob ----
+    # Give the kernel one dprob slot per N-tile so each (token, tile_n) pair has a single
+    # writer, then reduce over the tile dimension below in a fixed order. Keeping the
+    # workspace internal means dprob_tensor's shape and contract are unchanged for callers.
+    if deterministic is None:
+        deterministic = os.environ.get("CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC", "0") != "0"
+    caller_dprob_tensor = dprob_tensor
+    dprob_n_slots = _dprob_n_slots(n_out, mma_tiler_mn, deterministic)
+    if deterministic:
+        dprob_tensor = torch.zeros((valid_m, dprob_n_slots, 1), dtype=torch.float32, device=a_tensor.device)
+
     # ---- Build cache key ----
     def stride_order(tensor: torch.Tensor) -> Tuple[int, ...]:
         return tuple(i for i, s in sorted(enumerate(get_strides(tensor)), key=lambda x: x[1]))
@@ -1692,7 +1730,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             ),
             *tensor_signature(alpha_tensor),
             *(dynamic_m_tensor_signature(prob_tensor, (1, 1)) if not use_full_dynamic else dynamic_tensor_signature(prob_tensor)),
-            *(dynamic_m_tensor_signature(dprob_tensor, (1, 1)) if not use_full_dynamic else dynamic_tensor_signature(dprob_tensor)),
+            *(dynamic_m_tensor_signature(dprob_tensor, (dprob_n_slots, 1)) if not use_full_dynamic else dynamic_tensor_signature(dprob_tensor)),
             *(dynamic_tensor_signature(dbias_tensor) if use_full_dynamic else tensor_signature(dbias_tensor)),
             *(dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1)) if not use_full_dynamic else dynamic_tensor_signature(d_srelu_tensor)),
             *(dynamic_tensor_signature(sfb_tensor) if use_full_dynamic else tensor_signature(sfb_tensor)),
@@ -1714,6 +1752,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             discrete_col_sfd,
             use_dynamic_sched,
             use_dsrelu_reuse,
+            deterministic,
         )
     else:
         cache_key = (
@@ -1725,7 +1764,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             *dynamic_m_sf_signature(sfa_tensor),
             *tensor_signature(alpha_tensor),
             *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
-            *dynamic_m_tensor_signature(dprob_tensor, (1, 1)),
+            *dynamic_m_tensor_signature(dprob_tensor, (dprob_n_slots, 1)),
             *tensor_signature(dbias_tensor),
             *dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1), dynamic_stride_dims=(2,)),
             *dynamic_sfd_col_tensor_signature(sfd_col_d_srelu_tensor),
@@ -1744,6 +1783,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             discrete_col_sfd,
             use_dynamic_sched,
             use_dsrelu_reuse,
+            deterministic,
             b_major,
             num_experts,
         )
@@ -1783,6 +1823,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
                 discrete_col_sfd=discrete_col_sfd,
                 use_dynamic_sched=use_dynamic_sched,
                 use_dsrelu_reuse=use_dsrelu_reuse,
+                deterministic=deterministic,
             )
         else:
             api = GroupedGemmDsreluSm100(
@@ -1815,6 +1856,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
                 b_major=b_major,
                 use_dynamic_sched=use_dynamic_sched,
                 use_dsrelu_reuse=use_dsrelu_reuse,
+                deterministic=deterministic,
             )
 
         if not api.check_support():
@@ -1867,6 +1909,14 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             norm_const_tensor=norm_const_tensor,
             current_stream=current_stream,
         )
+
+    if deterministic:
+        # Fixed-order reduction of the per-N-tile partials into the caller's (M, 1, 1) dprob.
+        # Accumulate rather than assign: the kernel's atomic adds into whatever dprob_tensor
+        # already held, so this path has to as well or the two modes would disagree for a
+        # caller that passes a non-zeroed buffer.
+        caller_dprob_tensor += torch.sum(dprob_tensor, dim=1, keepdim=True)
+        dprob_tensor = caller_dprob_tensor
 
     return TupleDict(
         d_row_tensor=d_row_tensor,

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -99,30 +99,25 @@ def _cta_tile_m(mma_tiler_mn: Tuple[int, int]) -> int:
     return mma_tiler_mn[0] // (2 if mma_tiler_mn[0] == 256 else 1)
 
 
-def _reduce_dprob_slots(
-    dprob_tensor: torch.Tensor,
-    caller_dprob_tensor: Optional[torch.Tensor],
-    deterministic: bool,
-    current_stream: Optional[cuda.CUstream],
-) -> torch.Tensor:
-    """Collapse the per-N-tile dprob slots back to the caller's ``(valid_m, 1, 1)`` shape.
+def _reduce_dprob_slots(dprob_workspace, dprob_tensor, current_stream):
+    """Collapse the per-N-tile dprob slots into the caller's ``(valid_m, 1, 1)`` output.
 
-    A no-op unless deterministic, where the fixed summation order is what makes the result
-    reproducible, unlike the kernel's cross-CTA atomics. Every token owns the same number of
-    slots, so this is a plain sum over dim 1 -- no segment structure, unlike dbias. Accumulates
-    onto a caller-supplied buffer, matching what the atomic does on the non-deterministic path.
+    ``dprob_workspace`` is None whenever the kernel wrote dprob directly -- the non-deterministic
+    path -- and then there is nothing to collapse. Every token owns the same number of slots, so
+    this is a plain sum over dim 1; dbias needs a segment sum instead. Accumulates onto the
+    output, matching what the atomic does on the non-deterministic path.
 
     Issued on ``current_stream``, the stream execute() ran the kernel on. On torch's current
-    stream instead, a caller who passes a different stream would have the reduction read
-    dprob_tensor before the kernel finished writing it.
+    stream instead, a caller who passes a different stream would have the reduction read the
+    workspace before the kernel finished writing it.
     """
-    if not deterministic:
+    if dprob_workspace is None:
         return dprob_tensor
     import torch
 
-    with _torch_stream_context(current_stream, dprob_tensor.device):
-        reduced = torch.sum(dprob_tensor, dim=1, keepdim=True)
-        return reduced if caller_dprob_tensor is None else caller_dprob_tensor.add_(reduced)
+    with _torch_stream_context(current_stream, dprob_workspace.device):
+        reduced = torch.sum(dprob_workspace, dim=1, keepdim=True)
+        return reduced if dprob_tensor is None else dprob_tensor.add_(reduced)
 
 
 def _reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_offsets, cta_tile_m):
@@ -137,9 +132,6 @@ def _reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_of
     need ``padded_offsets`` on the host -- a sync in the training loop. A cumsum-and-subtract
     would be deterministic too but cancels catastrophically across experts of different
     magnitude. Comparing in token space rather than block space saves the division.
-
-    fp32 throughout, narrowed once at the end: strictly more accurate than the default path,
-    which rounds to bf16 on every M-tile.
     """
     if dbias_workspace is None:
         return dbias_tensor
@@ -149,8 +141,11 @@ def _reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_of
     with _torch_stream_context(current_stream, dbias_workspace.device):
         block_tok = torch.arange(0, m_blocks * cta_tile_m, cta_tile_m, device=dbias_workspace.device, dtype=padded_offsets.dtype).unsqueeze(0)
         starts = torch.cat((padded_offsets.new_zeros(1), padded_offsets[:-1])).unsqueeze(1)
-        onehot = ((block_tok >= starts) & (block_tok < padded_offsets.unsqueeze(1))).to(torch.float32)
-        return (onehot @ dbias_workspace.reshape(m_blocks, n_out)).reshape(-1, n_out, 1).to(torch.bfloat16)
+        # Built in the workspace dtype so the matmul is a straight bf16 GEMM: cuBLAS accumulates
+        # it in fp32 internally and rounds once, which is still better than the default path
+        # rounding on every M-tile, at half the memory and one store instead of two.
+        onehot = ((block_tok >= starts) & (block_tok < padded_offsets.unsqueeze(1))).to(dbias_workspace.dtype)
+        return (onehot @ dbias_workspace.reshape(m_blocks, n_out)).reshape(-1, n_out, 1)
 
 
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -217,6 +212,8 @@ class GroupedGemmDsreluSm100(APIBase):
         sample_prob: Optional[torch.Tensor] = None,
         sample_dprob: Optional[torch.Tensor] = None,
         sample_dbias: Optional[torch.Tensor] = None,
+        sample_dprob_workspace: Optional[torch.Tensor] = None,
+        sample_dbias_workspace: Optional[torch.Tensor] = None,
         # Discrete mode -- provide these instead:
         num_experts: Optional[int] = None,
         b_shape: Optional[Tuple[int, ...]] = None,
@@ -253,9 +250,11 @@ class GroupedGemmDsreluSm100(APIBase):
         :param sample_dprob: Gradient of probability tensor (valid_m, 1, 1), must be zero-initialized
         :param sample_b: (Dense) Sample B tensor (n, k, l)
         :param sample_sfb: (Dense) Sample scale factor B tensor
-        :param sample_dbias: Optional dbias output tensor (expert_cnt, n, 1) bfloat16 -- but under
-            ``deterministic`` the kernel writes one fp32 slot per (CTA M-tile, n) instead, so pass
-            ``(ceil_div(valid_m, cta_tile_m), n, 1)`` float32 and reduce it per expert yourself
+        :param sample_dbias: Optional dbias output tensor (expert_cnt, n, 1) bfloat16, in both modes
+        :param sample_dprob_workspace: Determinism scratch, required iff ``deterministic``:
+            ``dprob_workspace_shape(valid_m)``, float32
+        :param sample_dbias_workspace: Determinism scratch, required iff ``deterministic`` and
+            ``sample_dbias``: ``dbias_workspace_shape(valid_m, n)``, bfloat16
         :param num_experts: (Discrete) Number of experts
         :param b_shape: (Discrete) Shape of a single expert B tensor, e.g. (n, k)
         :param b_dtype: (Discrete) Data type of B tensors
@@ -273,12 +272,11 @@ class GroupedGemmDsreluSm100(APIBase):
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
-        :param deterministic: Compute dprob and dbias run-to-run bit-exactly. Both outputs then
-            arrive as slot workspaces the caller reduces after execute(): sample_dprob carries one
-            slot per N-tile (see _dprob_n_slots) and reduces over dim 1, sample_dbias one fp32 slot
-            per absolute M-block and reduces per expert over the ranges padded_offsets marks off (a
-            plain sum will not do -- see the segment sum in _reduce_dbias_slots).
-            grouped_gemm_dsrelu_wrapper_sm100 does all of this for you and returns the usual shapes
+        :param deterministic: Compute dprob and dbias run-to-run bit-exactly. dprob and dbias keep
+            their shapes and dtypes; what the flag adds is the two scratch tensors above, which the
+            kernel writes instead, and a reduction the caller runs after execute():
+            ``reduce_dprob_workspace`` and ``reduce_dbias_workspace``.
+            grouped_gemm_dsrelu_wrapper_sm100 allocates and reduces both for you
         """
         framework = detect_framework(sample_a)
         if sample_a is not None and framework not in ("torch", "jax"):
@@ -332,6 +330,10 @@ class GroupedGemmDsreluSm100(APIBase):
         self.prob_desc = self._make_tensor_desc(sample_prob, name="sample_prob", canonical=True)
         self.dprob_desc = self._make_tensor_desc(sample_dprob, name="sample_dprob", canonical=True)
         self.dbias_desc = self._make_tensor_desc(sample_dbias, name="sample_dbias", canonical=True)
+        # Determinism scratch, kept out of the output descriptors so dprob/dbias mean the same
+        # thing in both modes. The kernel writes whichever of the pair is active.
+        self.dprob_workspace_desc = self._make_tensor_desc(sample_dprob_workspace, name="sample_dprob_workspace", canonical=True)
+        self.dbias_workspace_desc = self._make_tensor_desc(sample_dbias_workspace, name="sample_dbias_workspace", canonical=True)
 
         self.sfd_row_desc = self._make_tensor_desc(sample_sfd_row, name="sample_sfd_row", canonical=True)
         self.sfd_col_desc = self._make_tensor_desc(sample_sfd_col, name="sample_sfd_col", canonical=True)
@@ -437,21 +439,56 @@ class GroupedGemmDsreluSm100(APIBase):
             extra_error_msg=f"{name} in the physical (L, MN', K', 32, 4, 4) form must be C-contiguous",
         )
 
+    @staticmethod
+    def dprob_workspace_shape(valid_m: int, n: int, mma_tiler_mn: Tuple[int, int] = (256, 256), cluster_shape_mn: Optional[Tuple[int, int]] = None):
+        """Shape of ``sample_dprob_workspace`` -- one fp32 slot per (token, N-tile)."""
+        return (valid_m, _dprob_n_slots(n, mma_tiler_mn, cluster_shape_mn, True), 1)
+
+    @staticmethod
+    def dbias_workspace_shape(valid_m: int, n: int, mma_tiler_mn: Tuple[int, int] = (256, 256)):
+        """Shape of ``sample_dbias_workspace`` -- one bf16 slot per (CTA M-block, n)."""
+        return (ceil_div(valid_m, _cta_tile_m(mma_tiler_mn)), n, 1)
+
+    @staticmethod
+    def reduce_dprob_workspace(dprob_workspace, dprob_tensor=None, current_stream=None):
+        """Collapse the dprob slots into ``(valid_m, 1, 1)``; accumulates onto dprob_tensor if given."""
+        return _reduce_dprob_slots(dprob_workspace, dprob_tensor, current_stream)
+
+    @staticmethod
+    def reduce_dbias_workspace(dbias_workspace, padded_offsets, mma_tiler_mn: Tuple[int, int] = (256, 256), current_stream=None):
+        """Segment-sum the dbias slots per expert into ``(expert_cnt, n, 1)``.
+
+        Public because a plain sum over dim 0 is wrong here and gets it wrong quietly: the slots
+        have to be grouped by the expert ranges ``padded_offsets`` marks off.
+        """
+        return _reduce_dbias_slots(dbias_workspace, None, current_stream, padded_offsets, _cta_tile_m(mma_tiler_mn))
+
+    @property
+    def _kernel_dprob_desc(self):
+        """The dprob descriptor the kernel writes: the per-N-tile scratch under determinism."""
+        return self.dprob_workspace_desc if self.deterministic else self.dprob_desc
+
+    @property
+    def _kernel_dbias_desc(self):
+        """The dbias descriptor the kernel writes: the M-block scratch under determinism."""
+        return self.dbias_workspace_desc if self.deterministic and self.dbias_desc is not None else self.dbias_desc
+
     def _make_dbias_fake(self):
         """Fake dbias tensor for compilation.
 
-        Deterministic dbias is indexed by M-block, so dim 0 scales with the token count and has
-        to stay symbolic -- baked static it would bind the compiled kernel to one valid_m and
-        silently reuse it for another, the trap _dprob_n_slots documents for dprob's slot extent.
+        The determinism scratch is indexed by M-block, so its dim 0 scales with the token count
+        and has to stay symbolic -- baked static it would bind the compiled kernel to one valid_m
+        and silently reuse it for another, the trap _dprob_n_slots documents for dprob's slots.
         Divisibility 2 because valid_m is a multiple of m_aligned (256) and a block is
-        cta_tile_m (128) rows. The default (expert, n, 1) layout has no token-dependent extent.
+        cta_tile_m (128) rows. The (expert, n, 1) output has no token-dependent extent.
         """
-        if self.dbias_desc is None or not self.deterministic:
-            return self._make_fake_cute_tensor_from_desc(self.dbias_desc, assumed_align=16)
+        desc = self._kernel_dbias_desc
+        if desc is None or not self.deterministic:
+            return self._make_fake_cute_tensor_from_desc(desc, assumed_align=16)
         return self._make_fake_cute_compact_tensor(
-            dtype=self.dbias_desc.dtype,
-            shape=self.dbias_desc.shape,
-            stride_order=self.dbias_desc.stride_order,
+            dtype=desc.dtype,
+            shape=desc.shape,
+            stride_order=desc.stride_order,
             dynamic_mode=0,
             divisibility=2,
         )
@@ -510,13 +547,14 @@ class GroupedGemmDsreluSm100(APIBase):
 
         self._check_tensor_shape(self.alpha_desc, (self.expert_cnt,), "alpha")
         self._check_tensor_shape(self.prob_desc, (tensor_m, 1, 1), "prob")
-        dprob_slots = _dprob_n_slots(n_out, self.mma_tiler_mn, self.cluster_shape_mn, self.deterministic)
-        self._check_tensor_shape(self.dprob_desc, (tensor_m, dprob_slots, 1), "dprob")
-        # Deterministic dbias is a different tensor, not an extra dimension on the same one --
-        # dprob could keep its shape because its slot axis is orthogonal to its output axis,
-        # dbias's is not. One fp32 slot per (CTA M-tile, n), reduced per expert after execute().
-        dbias_rows = ceil_div(tensor_m, self.cta_tile_m) if self.deterministic else self.expert_cnt
-        self._check_tensor_shape(self.dbias_desc, (dbias_rows, n_out, 1), "dbias")
+        self._check_tensor_shape(self.dprob_desc, (tensor_m, 1, 1), "dprob")
+        self._check_tensor_shape(self.dbias_desc, (self.expert_cnt, n_out, 1), "dbias")
+        # The determinism scratch. Separate tensors rather than a reshaped dprob/dbias, so the
+        # output contract does not depend on the flag; the kernel writes these instead.
+        self._check_tensor_shape(
+            self.dprob_workspace_desc, (tensor_m, _dprob_n_slots(n_out, self.mma_tiler_mn, self.cluster_shape_mn, True), 1), "dprob_workspace"
+        )
+        self._check_tensor_shape(self.dbias_workspace_desc, (ceil_div(tensor_m, self.cta_tile_m), n_out, 1), "dbias_workspace")
         self._check_tensor_shape(self.amax_desc, (self.expert_cnt, 1), "amax")
         self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
         self._check_tensor_shape(self.padded_offsets_desc, (self.expert_cnt,), "padded_offsets")
@@ -637,12 +675,11 @@ class GroupedGemmDsreluSm100(APIBase):
             name="Dprob",
             extra_error_msg="Dprob must be float32",
         )
-        self._check_dtype(
-            self.dbias_desc,
-            dtype=cutlass.Float32 if self.deterministic else cutlass.BFloat16,
-            name="Dbias",
-            extra_error_msg="dbias must be float32 when deterministic=True" if self.deterministic else "dbias must be bfloat16",
-        )
+        self._check_dtype(self.dbias_desc, dtype=cutlass.BFloat16, name="Dbias", extra_error_msg="dbias must be bfloat16")
+        # Scratch matches the output it stands in for: the slots only need a single writer and a
+        # fixed-order reduction to be reproducible, not a wider accumulator.
+        self._check_dtype(self.dprob_workspace_desc, dtype=cutlass.Float32, name="Dprob workspace", extra_error_msg="dprob workspace must be float32")
+        self._check_dtype(self.dbias_workspace_desc, dtype=cutlass.BFloat16, name="Dbias workspace", extra_error_msg="dbias workspace must be bfloat16")
         self.c_dtype = self._check_dtype(
             self.c_desc,
             dtype=[cutlass.Float32, cutlass.Float16, cutlass.BFloat16, cutlass.Float8E4M3FN, cutlass.Float8E5M2],
@@ -796,6 +833,20 @@ class GroupedGemmDsreluSm100(APIBase):
             f"expert_cnt must be <= 1024, got {self.expert_cnt}",
         )
 
+        # ---- Determinism scratch must be present exactly when the flag is on ----
+        self._value_error_if(
+            self.deterministic and self.dprob_workspace_desc is None,
+            "deterministic=True requires sample_dprob_workspace of shape dprob_workspace_shape(valid_m, n), float32",
+        )
+        self._value_error_if(
+            self.deterministic and self.dbias_desc is not None and self.dbias_workspace_desc is None,
+            "deterministic=True with dbias requires sample_dbias_workspace of shape dbias_workspace_shape(valid_m, n), bfloat16",
+        )
+        self._value_error_if(
+            not self.deterministic and (self.dprob_workspace_desc is not None or self.dbias_workspace_desc is not None),
+            "the determinism workspaces are only used when deterministic=True",
+        )
+
         # ---- Disabled configurations ----
         # Deterministic dbias keys its workspace by absolute M-block,
         # token_offset // cta_tile_m + tile_m_idx, which is single-writer only if the scheduler
@@ -939,9 +990,9 @@ class GroupedGemmDsreluSm100(APIBase):
                 stride_order=self.prob_desc.stride_order,
             )
             dprob_cute_fake = self._make_fake_cute_compact_tensor(
-                dtype=self.dprob_desc.dtype,
-                shape=(valid_m, *self.dprob_desc.shape[1:]),
-                stride_order=self.dprob_desc.stride_order,
+                dtype=self._kernel_dprob_desc.dtype,
+                shape=(valid_m, *self._kernel_dprob_desc.shape[1:]),
+                stride_order=self._kernel_dprob_desc.stride_order,
             )
 
             sfd_row_fake = None
@@ -1055,9 +1106,9 @@ class GroupedGemmDsreluSm100(APIBase):
                 stride=self.prob_desc.stride,
             )
             dprob_cute_fake = self._make_fake_cute_tensor(
-                dtype=self.dprob_desc.dtype,
-                shape=(valid_m, *self.dprob_desc.shape[1:]),
-                stride=self.dprob_desc.stride,
+                dtype=self._kernel_dprob_desc.dtype,
+                shape=(valid_m, *self._kernel_dprob_desc.shape[1:]),
+                stride=self._kernel_dprob_desc.stride,
             )
 
             sfd_row_fake = None
@@ -1308,9 +1359,9 @@ class GroupedGemmDsreluSm100(APIBase):
             assumed_align=16,
         )
         dprob_tensor = self._make_fake_cute_tensor(
-            dtype=self.dprob_desc.dtype,
-            shape=(valid_m, *self.dprob_desc.shape[1:]),
-            stride=self.dprob_desc.stride,
+            dtype=self._kernel_dprob_desc.dtype,
+            shape=(valid_m, *self._kernel_dprob_desc.shape[1:]),
+            stride=self._kernel_dprob_desc.stride,
             assumed_align=16,
         )
         dbias_tensor = self._make_dbias_fake()
@@ -1437,6 +1488,9 @@ class GroupedGemmDsreluSm100(APIBase):
         b_tensor: Optional[torch.Tensor] = None,
         sfb_tensor: Optional[torch.Tensor] = None,
         dbias_tensor: Optional[torch.Tensor] = None,
+        # Determinism scratch, required iff the op was built with deterministic=True:
+        dprob_workspace_tensor: Optional[torch.Tensor] = None,
+        dbias_workspace_tensor: Optional[torch.Tensor] = None,
         # Discrete mode:
         b_ptrs: Optional[torch.Tensor] = None,
         sfb_ptrs: Optional[torch.Tensor] = None,
@@ -1466,6 +1520,8 @@ class GroupedGemmDsreluSm100(APIBase):
         :param b_tensor: (Dense) Input B tensor (weights)
         :param sfb_tensor: (Dense) Scale factor B
         :param dbias_tensor: Optional dbias output tensor.
+        :param dprob_workspace_tensor: Determinism scratch, required iff deterministic=True
+        :param dbias_workspace_tensor: Determinism scratch, required iff deterministic=True and dbias
         :param b_ptrs: (Discrete) 1-D int64 device tensor of per-expert B data pointers
         :param sfb_ptrs: (Discrete) 1-D int64 device tensor of per-expert SFB data pointers
         :param sfd_row_tensor: Optional row scale factor D
@@ -1494,6 +1550,19 @@ class GroupedGemmDsreluSm100(APIBase):
                 dbias_tensor is None,
                 "dbias_tensor is required when GroupedGemmDsreluSm100 is configured with sample_dbias",
             )
+        # Under determinism the kernel fills the scratch and the caller reduces it into
+        # dprob/dbias afterwards; dprob_tensor/dbias_tensor are otherwise written directly.
+        if self.deterministic:
+            self._value_error_if(
+                dprob_workspace_tensor is None,
+                "dprob_workspace_tensor is required when the op was built with deterministic=True",
+            )
+            self._value_error_if(
+                self._has_dbias and dbias_workspace_tensor is None,
+                "dbias_workspace_tensor is required when the op was built with deterministic=True and sample_dbias",
+            )
+            dprob_tensor = dprob_workspace_tensor
+            dbias_tensor = dbias_workspace_tensor if self._has_dbias else dbias_tensor
 
         if self.weight_mode == MoEWeightMode.DENSE:
             self._compiled_kernel(
@@ -1625,11 +1694,10 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
         deterministic: Make dprob and dbias bit-exact run to run; raises NotImplementedError
-            for any framework other than torch. ``dprob_tensor`` keeps its
-            ``(valid_m, 1, 1)`` shape either way -- the extra per-N-tile workspace and the
-            fixed-order reduction into it are internal. ``None`` (default) follows
-            ``torch.use_deterministic_algorithms``. See docs/fe-oss-apis/gemm_fusions/
-            grouped_gemm_dsrelu.md#deterministic-dprob.
+            for any framework other than torch. Every returned tensor keeps its usual shape and
+            dtype -- the slot workspaces and the fixed-order reductions into them are internal to
+            this wrapper. ``None`` (default) follows ``torch.use_deterministic_algorithms``.
+            See docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md#deterministic-dprob.
         current_stream: CUDA stream
 
     Returns:
@@ -1722,24 +1790,31 @@ def grouped_gemm_dsrelu_wrapper_sm100(
     # single writer; the reduction back to (valid_m, 1, 1) happens after execute(). Resolved
     # here, with the other arguments, so `deterministic` is a plain bool from this point on.
     if deterministic is None:
-        # Follows torch's process-wide flag. jax has no equivalent global, so there the opt-in
-        # has to be explicit rather than inherited -- and `torch` is not even bound on that path.
-        deterministic = framework == "torch" and torch.are_deterministic_algorithms_enabled()
+        # Follows torch's process-wide flag. jax has no equivalent global, so there the opt-in has
+        # to be explicit rather than inherited. Written as a nested branch, not
+        # `framework == "torch" and torch...`: `torch` is only bound by the conditional import
+        # above, so that form is one operand-reorder away from a NameError under jax.
+        deterministic = False
+        if framework == "torch":
+            deterministic = torch.are_deterministic_algorithms_enabled()
     if deterministic and framework != "torch":
         # The slot reductions below are torch ops on torch streams. Rather than half-support it,
         # say so: a caller who asked for reproducibility should not get it silently unenforced.
         raise NotImplementedError(f"deterministic=True is only implemented for the torch framework, got {framework}")
     dprob_n_slots = _dprob_n_slots(n_out, mma_tiler_mn, cluster_shape_mn, deterministic)
     cta_tile_m = _cta_tile_m(mma_tiler_mn)
-    # None when we allocate it ourselves, in which case the reduction can write the result
-    # straight out instead of adding it onto a buffer we just zeroed.
-    caller_dprob_tensor = dprob_tensor
-    if dprob_tensor is None or deterministic:
+    if dprob_tensor is None:
         if framework == "torch":
             with _torch_stream_context(current_stream, a_tensor.device):
-                dprob_tensor = torch.zeros((valid_m, dprob_n_slots, 1), dtype=torch.float32, device=a_tensor.device)
+                dprob_tensor = torch.zeros((valid_m, 1, 1), dtype=torch.float32, device=a_tensor.device)
         else:
-            dprob_tensor = _jax_alloc(lambda: jnp.zeros((valid_m, dprob_n_slots, 1), dtype=jnp.float32, device=a_tensor.device))
+            dprob_tensor = _jax_alloc(lambda: jnp.zeros((valid_m, 1, 1), dtype=jnp.float32, device=a_tensor.device))
+    # Determinism scratch, allocated here so the wrapper's own signature does not change with
+    # the flag. torch-only, rejected for jax above.
+    dprob_workspace = None
+    if deterministic:
+        with _torch_stream_context(current_stream, a_tensor.device):
+            dprob_workspace = torch.zeros((valid_m, dprob_n_slots, 1), dtype=torch.float32, device=a_tensor.device)
 
     if _convert_to_cutlass_data_type(a_tensor.dtype) in (
         cutlass.Float8E4M3FN,
@@ -1775,18 +1850,15 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         else:
             amax_tensor = _jax_alloc(lambda: jnp.full((l, 1), float("-inf"), dtype=jnp.float32, device=a_tensor.device))
     # Deterministic dbias is a separate buffer, not a reshaped one: the kernel writes fp32
-    # per-(M-block, n) slots and _reduce_dbias_slots turns those into the bf16 (expert, n)
-    # output. The default path instead has the kernel atomic-accumulate straight into that
-    # output, so there it has to exist and be zeroed up front. dbias_kernel_tensor is what
-    # execute() writes; dbias_tensor is what comes back.
+    # dbias keeps its (expert, n, 1) bf16 shape in both modes; under determinism the kernel fills
+    # the M-block scratch instead and _reduce_dbias_slots segment-sums it into this tensor.
     dbias_workspace = None
     if generate_dbias:
-        if deterministic:  # torch-only, rejected for jax above
-            with _torch_stream_context(current_stream, a_tensor.device):
-                dbias_workspace = torch.zeros((ceil_div(valid_m, cta_tile_m), n_out, 1), dtype=torch.float32, device=a_tensor.device)
-        elif framework == "torch":
+        if framework == "torch":
             with _torch_stream_context(current_stream, a_tensor.device):
                 dbias_tensor = torch.zeros((l, n_out, 1), dtype=torch.bfloat16, device=a_tensor.device)
+                if deterministic:
+                    dbias_workspace = torch.zeros((ceil_div(valid_m, cta_tile_m), n_out, 1), dtype=torch.bfloat16, device=a_tensor.device)
         else:
             dbias_tensor = _jax_alloc(lambda: jnp.zeros((l, n_out, 1), dtype=framework_dtype(cutlass.BFloat16, "jax"), device=a_tensor.device))
     dbias_kernel_tensor = dbias_workspace if dbias_workspace is not None else dbias_tensor
@@ -1806,7 +1878,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             d_srelu_tensor=d_srelu_tensor,
             # Reduced here too, so a zero-token call returns the documented (valid_m, 1, 1)
             # shape rather than leaking the slot dimension.
-            dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic, current_stream),
+            dprob_tensor=_reduce_dprob_slots(dprob_workspace, dprob_tensor, current_stream),
             dbias_tensor=_reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_offsets, cta_tile_m),
             amax_tensor=amax_tensor,
             sfd_row_tensor=sfd_row_tensor,
@@ -1873,6 +1945,8 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         if deterministic and dbias_kernel_tensor is not None
         else tensor_signature(dbias_kernel_tensor)
     )
+    # The kernel writes the scratch under determinism, so that is what the key has to describe.
+    dprob_kernel_tensor = dprob_workspace if dprob_workspace is not None else dprob_tensor
 
     use_full_dynamic = is_dense and os.environ.get("CUDNN_FE_GROUPED_GEMM_DYNAMIC_MNKL", "1") != "0"
 
@@ -1896,7 +1970,11 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             ),
             *tensor_signature(alpha_tensor),
             *(dynamic_m_tensor_signature(prob_tensor, (1, 1)) if not use_full_dynamic else dynamic_tensor_signature(prob_tensor)),
-            *(dynamic_m_tensor_signature(dprob_tensor, tuple(dprob_tensor.shape[1:])) if not use_full_dynamic else dynamic_tensor_signature(dprob_tensor)),
+            *(
+                dynamic_m_tensor_signature(dprob_kernel_tensor, tuple(dprob_kernel_tensor.shape[1:]))
+                if not use_full_dynamic
+                else dynamic_tensor_signature(dprob_kernel_tensor)
+            ),
             # Explicit, because the signature above does not carry it under use_full_dynamic:
             # that path drops the shape entirely, yet the slot count is baked into the
             # compiled descriptor. n_out=512 and n_out=513 give 2 and 3 slots with identical
@@ -1936,7 +2014,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             *dynamic_m_sf_signature(sfa_tensor),
             *tensor_signature(alpha_tensor),
             *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
-            *dynamic_m_tensor_signature(dprob_tensor, tuple(dprob_tensor.shape[1:])),
+            *dynamic_m_tensor_signature(dprob_kernel_tensor, tuple(dprob_kernel_tensor.shape[1:])),
             *dbias_signature,
             *dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1), dynamic_stride_dims=(2,)),
             *dynamic_sfd_col_tensor_signature(sfd_col_d_srelu_tensor),
@@ -1978,7 +2056,9 @@ def grouped_gemm_dsrelu_wrapper_sm100(
                 sample_alpha=alpha_tensor,
                 sample_prob=prob_tensor,
                 sample_dprob=dprob_tensor,
-                sample_dbias=dbias_kernel_tensor,
+                sample_dbias=dbias_tensor,
+                sample_dprob_workspace=dprob_workspace,
+                sample_dbias_workspace=dbias_workspace,
                 sample_b=b_tensor,
                 sample_sfb=sfb_tensor,
                 sample_sfd_row=sfd_row_tensor,
@@ -2009,7 +2089,9 @@ def grouped_gemm_dsrelu_wrapper_sm100(
                 sample_alpha=alpha_tensor,
                 sample_prob=prob_tensor,
                 sample_dprob=dprob_tensor,
-                sample_dbias=dbias_kernel_tensor,
+                sample_dbias=dbias_tensor,
+                sample_dprob_workspace=dprob_workspace,
+                sample_dbias_workspace=dbias_workspace,
                 num_experts=num_experts,
                 b_shape=b_shape,
                 b_dtype=b_dtype,
@@ -2049,7 +2131,9 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             alpha_tensor=alpha_tensor,
             prob_tensor=prob_tensor,
             dprob_tensor=dprob_tensor,
-            dbias_tensor=dbias_kernel_tensor,
+            dbias_tensor=dbias_tensor,
+            dprob_workspace_tensor=dprob_workspace,
+            dbias_workspace_tensor=dbias_workspace,
             b_tensor=b_tensor,
             sfb_tensor=sfb_tensor,
             sfd_row_tensor=sfd_row_tensor,
@@ -2071,7 +2155,9 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             alpha_tensor=alpha_tensor,
             prob_tensor=prob_tensor,
             dprob_tensor=dprob_tensor,
-            dbias_tensor=dbias_kernel_tensor,
+            dbias_tensor=dbias_tensor,
+            dprob_workspace_tensor=dprob_workspace,
+            dbias_workspace_tensor=dbias_workspace,
             b_ptrs=b_ptrs,
             sfb_ptrs=sfb_ptrs,
             sfd_row_tensor=sfd_row_tensor,
@@ -2086,7 +2172,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         d_row_tensor=d_row_tensor,
         d_col_tensor=d_col_tensor,
         d_srelu_tensor=d_srelu_tensor,
-        dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic, current_stream),
+        dprob_tensor=_reduce_dprob_slots(dprob_workspace, dprob_tensor, current_stream),
         dbias_tensor=_reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_offsets, cta_tile_m),
         amax_tensor=amax_tensor,
         sfd_row_tensor=sfd_row_tensor,

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -53,28 +53,18 @@ from cudnn.tensor_adapter import (
 )
 
 
-def _uses_2cta_instrs(mma_tiler_mn: Tuple[int, int]) -> bool:
-    """Whether this M tile selects the 2-SM tcgen05 MMA atom.
-
-    Not a tuning choice: tcgen05 offers exactly two MMA forms, 1-SM (``CtaGroup.ONE``,
-    M=128) and 2-SM (``CtaGroup.TWO``, M=256, where two CTAs of a cluster cooperate on one
-    MMA), so the M tile and the CTA group are the same fact -- see the kernel's
-    ``self.cta_group``. check_support asserts the pairing in both directions, and requires
-    an even ``cluster_shape_mn[0]`` so the CTA pair lands in one cluster.
-
-    The other 128s and 256s nearby are unrelated constants that happen to collide: the N
-    tile, the scale-factor layout atom, FIX_PAD_SIZE, and byte alignments are all free to
-    move independently of this one.
-    """
-    return mma_tiler_mn[0] == 256
-
-
 def _resolve_cluster_shape_mn(mma_tiler_mn: Tuple[int, int], cluster_shape_mn: Optional[Tuple[int, int]]) -> Tuple[int, int]:
-    """The cluster shape the kernel will actually run with, defaults applied."""
+    """The cluster shape the kernel will actually run with, defaults applied.
+
+    Shared with ``GroupedGemmDsreluSm100.__init__`` so the wrapper cannot resolve a
+    different default than the class it is about to construct. M=256 selects the 2-SM
+    tcgen05 MMA atom (M=128 is 1-SM), and that CTA pair has to share a cluster along M --
+    hence (2, 1). check_support asserts both halves of the pairing.
+    """
     if cluster_shape_mn is not None:
         return cluster_shape_mn
-    # 2-CTA MMA needs both CTAs of the pair in the same cluster along M.
-    return (2, 1) if _uses_2cta_instrs(mma_tiler_mn) else (1, 1)
+    use_2cta_instrs = mma_tiler_mn[0] == 256
+    return (2, 1) if use_2cta_instrs else (1, 1)
 
 
 def _dprob_n_slots(n_out: int, mma_tiler_mn: Tuple[int, int], cluster_shape_mn: Optional[Tuple[int, int]], deterministic: bool) -> int:
@@ -345,7 +335,7 @@ class GroupedGemmDsreluSm100(APIBase):
         # ---- Configuration ----
         self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
-        self.use_2cta_instrs = _uses_2cta_instrs(mma_tiler_mn)
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256
         self.cluster_shape_mn = _resolve_cluster_shape_mn(mma_tiler_mn, cluster_shape_mn)
         self.sf_vec_size = sf_vec_size
         self.vector_f32 = vector_f32

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -52,17 +52,47 @@ from cudnn.tensor_adapter import (
 )
 
 
-def _dprob_n_slots(n_out: int, mma_tiler_mn: Tuple[int, int], deterministic: bool) -> int:
+def _resolve_cluster_shape_mn(mma_tiler_mn: Tuple[int, int], cluster_shape_mn: Optional[Tuple[int, int]]) -> Tuple[int, int]:
+    """The cluster shape the kernel will actually run with, defaults applied."""
+    if cluster_shape_mn is not None:
+        return cluster_shape_mn
+    return (2, 1) if mma_tiler_mn[0] == 256 else (1, 1)
+
+
+def _dprob_n_slots(n_out: int, mma_tiler_mn: Tuple[int, int], cluster_shape_mn: Optional[Tuple[int, int]], deterministic: bool) -> int:
     """Extent of dprob's dim 1.
 
     Non-deterministic (default): 1 -- every N-tile atomically accumulates into the same
     ``dprob[token]``, so the fp32 summation order follows tile scheduling.
 
     Deterministic: one slot per N-tile, so each ``(token, tile_n)`` pair has exactly one
-    writer and the caller can reduce over dim 1 in a fixed order. ``tile_n_idx`` counts in
-    units of ``mma_tiler_mn[1]``.
+    writer and the caller can reduce over dim 1 in a fixed order.
+
+    The extent must cover every ``tile_n_idx`` the scheduler can emit, which is *not*
+    ``ceil_div(n_out, tile_n)``: MoEPersistentTileScheduler counts whole clusters and then
+    expands to CTAs (``cta_tile_n_idx = cluster_tile_n_idx * cluster_n + cta_id_in_cluster``,
+    over ``ceil_div(n_out, tile_n * cluster_n)`` clusters), so the bound rounds up to a
+    multiple of ``cluster_n``. The two agree only at ``cluster_n == 1``; using the narrower
+    form would index past the end of the workspace for any wider cluster.
     """
-    return ceil_div(n_out, mma_tiler_mn[1]) if deterministic else 1
+    if not deterministic:
+        return 1
+    cluster_n = _resolve_cluster_shape_mn(mma_tiler_mn, cluster_shape_mn)[1]
+    return ceil_div(n_out, mma_tiler_mn[1] * cluster_n) * cluster_n
+
+
+def _reduce_dprob_slots(dprob_tensor: torch.Tensor, caller_dprob_tensor: Optional[torch.Tensor], deterministic: bool) -> torch.Tensor:
+    """Collapse the per-N-tile dprob slots back to the caller's ``(valid_m, 1, 1)`` shape.
+
+    A no-op unless deterministic, where the sum is what makes the result reproducible: it
+    runs in a fixed order, unlike the kernel's cross-CTA atomics. Accumulates onto a
+    caller-supplied buffer, matching what the atomic does on the non-deterministic path;
+    when we allocated the buffer ourselves there is nothing to add onto.
+    """
+    if not deterministic:
+        return dprob_tensor
+    reduced = torch.sum(dprob_tensor, dim=1, keepdim=True)
+    return reduced if caller_dprob_tensor is None else caller_dprob_tensor.add_(reduced)
 
 
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -183,8 +213,8 @@ class GroupedGemmDsreluSm100(APIBase):
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
-        :param deterministic: Compute dprob run-to-run bit-exactly. sample_dprob must then be
-            shaped (valid_m, ceil_div(n, mma_tiler_mn[1]), 1) and the caller must reduce over
+        :param deterministic: Compute dprob run-to-run bit-exactly. sample_dprob must then
+            carry one slot per N-tile (see _dprob_n_slots) and the caller must reduce over
             dim 1 after execute(); grouped_gemm_dsrelu_wrapper_sm100 does both for you
         """
         framework = detect_framework(sample_a)
@@ -270,10 +300,7 @@ class GroupedGemmDsreluSm100(APIBase):
         self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
-        if cluster_shape_mn is None:
-            self.cluster_shape_mn = (2, 1) if self.use_2cta_instrs else (1, 1)
-        else:
-            self.cluster_shape_mn = cluster_shape_mn
+        self.cluster_shape_mn = _resolve_cluster_shape_mn(mma_tiler_mn, cluster_shape_mn)
         self.sf_vec_size = sf_vec_size
         self.vector_f32 = vector_f32
         self.m_aligned = m_aligned
@@ -400,9 +427,8 @@ class GroupedGemmDsreluSm100(APIBase):
 
         self._check_tensor_shape(self.alpha_desc, (self.expert_cnt,), "alpha")
         self._check_tensor_shape(self.prob_desc, (tensor_m, 1, 1), "prob")
-        # Under deterministic=True, dprob carries one slot per N-tile so that each
-        # (token, tile_n) pair has a single writer; the caller reduces over that dimension.
-        self._check_tensor_shape(self.dprob_desc, (tensor_m, _dprob_n_slots(n_out, self.mma_tiler_mn, self.deterministic), 1), "dprob")
+        dprob_slots = _dprob_n_slots(n_out, self.mma_tiler_mn, self.cluster_shape_mn, self.deterministic)
+        self._check_tensor_shape(self.dprob_desc, (tensor_m, dprob_slots, 1), "dprob")
         self._check_tensor_shape(self.dbias_desc, (self.expert_cnt, n_out, 1), "dbias")
         self._check_tensor_shape(self.amax_desc, (self.expert_cnt, 1), "amax")
         self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
@@ -1499,9 +1525,9 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
         deterministic: Make dprob bit-exact run to run. ``dprob_tensor`` keeps its
             ``(valid_m, 1, 1)`` shape either way -- the extra per-N-tile workspace and the
-            fixed-order reduction into it are internal. ``None`` (default) reads
-            ``CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC``, which is off unless set, so
-            callers that cannot pass the argument can still opt in from the environment.
+            fixed-order reduction into it are internal. ``None`` (default) follows
+            ``torch.use_deterministic_algorithms``. See docs/fe-oss-apis/gemm_fusions/
+            grouped_gemm_dsrelu.md#deterministic-dprob.
         current_stream: CUDA stream
 
     Returns:
@@ -1590,11 +1616,22 @@ def grouped_gemm_dsrelu_wrapper_sm100(
     amax_tensor = None
     dbias_tensor = None
 
-    if dprob_tensor is None:
+    # Deterministic mode gives dprob one slot per N-tile so each (token, tile_n) pair has a
+    # single writer; the reduction back to (valid_m, 1, 1) happens after execute(). Resolved
+    # here, with the other arguments, so `deterministic` is a plain bool from this point on.
+    if deterministic is None:
+        # Follows torch's process-wide flag. jax has no equivalent global, so there the opt-in
+        # has to be explicit rather than inherited -- and `torch` is not even bound on that path.
+        deterministic = framework == "torch" and torch.are_deterministic_algorithms_enabled()
+    dprob_n_slots = _dprob_n_slots(n_out, mma_tiler_mn, cluster_shape_mn, deterministic)
+    # None when we allocate it ourselves, in which case the reduction can write the result
+    # straight out instead of adding it onto a buffer we just zeroed.
+    caller_dprob_tensor = dprob_tensor
+    if dprob_tensor is None or deterministic:
         if framework == "torch":
-            dprob_tensor = torch.zeros((valid_m, 1, 1), dtype=torch.float32, device=a_tensor.device)
+            dprob_tensor = torch.zeros((valid_m, dprob_n_slots, 1), dtype=torch.float32, device=a_tensor.device)
         else:
-            dprob_tensor = _jax_alloc(lambda: jnp.zeros((valid_m, 1, 1), dtype=jnp.float32, device=a_tensor.device))
+            dprob_tensor = _jax_alloc(lambda: jnp.zeros((valid_m, dprob_n_slots, 1), dtype=jnp.float32, device=a_tensor.device))
 
     if _convert_to_cutlass_data_type(a_tensor.dtype) in (
         cutlass.Float8E4M3FN,
@@ -1640,24 +1677,15 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             d_row_tensor=d_row_tensor,
             d_col_tensor=d_col_tensor,
             d_srelu_tensor=d_srelu_tensor,
-            dprob_tensor=dprob_tensor,
+            # Reduced here too, so a zero-token call returns the documented (valid_m, 1, 1)
+            # shape rather than leaking the slot dimension.
+            dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic),
             dbias_tensor=dbias_tensor,
             amax_tensor=amax_tensor,
             sfd_row_tensor=sfd_row_tensor,
             sfd_col_tensor=sfd_col_tensor,
             sfd_col_d_srelu_tensor=sfd_col_d_srelu_tensor,
         )
-
-    # ---- Deterministic dprob ----
-    # Give the kernel one dprob slot per N-tile so each (token, tile_n) pair has a single
-    # writer, then reduce over the tile dimension below in a fixed order. Keeping the
-    # workspace internal means dprob_tensor's shape and contract are unchanged for callers.
-    if deterministic is None:
-        deterministic = os.environ.get("CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC", "0") != "0"
-    caller_dprob_tensor = dprob_tensor
-    dprob_n_slots = _dprob_n_slots(n_out, mma_tiler_mn, deterministic)
-    if deterministic:
-        dprob_tensor = torch.zeros((valid_m, dprob_n_slots, 1), dtype=torch.float32, device=a_tensor.device)
 
     # ---- Build cache key ----
     def stride_order(tensor: torch.Tensor) -> Tuple[int, ...]:
@@ -1730,7 +1758,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             ),
             *tensor_signature(alpha_tensor),
             *(dynamic_m_tensor_signature(prob_tensor, (1, 1)) if not use_full_dynamic else dynamic_tensor_signature(prob_tensor)),
-            *(dynamic_m_tensor_signature(dprob_tensor, (dprob_n_slots, 1)) if not use_full_dynamic else dynamic_tensor_signature(dprob_tensor)),
+            *(dynamic_m_tensor_signature(dprob_tensor, tuple(dprob_tensor.shape[1:])) if not use_full_dynamic else dynamic_tensor_signature(dprob_tensor)),
             *(dynamic_tensor_signature(dbias_tensor) if use_full_dynamic else tensor_signature(dbias_tensor)),
             *(dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1)) if not use_full_dynamic else dynamic_tensor_signature(d_srelu_tensor)),
             *(dynamic_tensor_signature(sfb_tensor) if use_full_dynamic else tensor_signature(sfb_tensor)),
@@ -1764,7 +1792,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             *dynamic_m_sf_signature(sfa_tensor),
             *tensor_signature(alpha_tensor),
             *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
-            *dynamic_m_tensor_signature(dprob_tensor, (dprob_n_slots, 1)),
+            *dynamic_m_tensor_signature(dprob_tensor, tuple(dprob_tensor.shape[1:])),
             *tensor_signature(dbias_tensor),
             *dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1), dynamic_stride_dims=(2,)),
             *dynamic_sfd_col_tensor_signature(sfd_col_d_srelu_tensor),
@@ -1910,19 +1938,11 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             current_stream=current_stream,
         )
 
-    if deterministic:
-        # Fixed-order reduction of the per-N-tile partials into the caller's (M, 1, 1) dprob.
-        # Accumulate rather than assign: the kernel's atomic adds into whatever dprob_tensor
-        # already held, so this path has to as well or the two modes would disagree for a
-        # caller that passes a non-zeroed buffer.
-        caller_dprob_tensor += torch.sum(dprob_tensor, dim=1, keepdim=True)
-        dprob_tensor = caller_dprob_tensor
-
     return TupleDict(
         d_row_tensor=d_row_tensor,
         d_col_tensor=d_col_tensor,
         d_srelu_tensor=d_srelu_tensor,
-        dprob_tensor=dprob_tensor,
+        dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic),
         dbias_tensor=dbias_tensor,
         amax_tensor=amax_tensor,
         sfd_row_tensor=sfd_row_tensor,

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -23,7 +23,7 @@ from .moe_blockscaled_grouped_gemm_dsrelu_quant import (
     BlockScaledMoEGroupedGemmQuantBwdKernel,
     EpilogueType,
 )
-from ..backend_utils import _record_streams, _torch_stream_context
+from ..backend_utils import _torch_stream_context
 from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
 import logging
@@ -145,7 +145,11 @@ def _reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_of
         # it in fp32 internally and rounds once, which is still better than the default path
         # rounding on every M-tile, at half the memory and one store instead of two.
         onehot = ((block_tok >= starts) & (block_tok < padded_offsets.unsqueeze(1))).to(dbias_workspace.dtype)
-        return (onehot @ dbias_workspace.reshape(m_blocks, n_out)).reshape(-1, n_out, 1)
+        reduced = (onehot @ dbias_workspace.reshape(m_blocks, n_out)).reshape(-1, n_out, 1)
+        # Accumulate, like dprob and like the atomic on the non-deterministic path: a caller
+        # summing dbias across micro-batches into one buffer must not get overwrite semantics
+        # from the flag alone.
+        return reduced if dbias_tensor is None else dbias_tensor.add_(reduced)
 
 
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -455,13 +459,15 @@ class GroupedGemmDsreluSm100(APIBase):
         return _reduce_dprob_slots(dprob_workspace, dprob_tensor, current_stream)
 
     @staticmethod
-    def reduce_dbias_workspace(dbias_workspace, padded_offsets, mma_tiler_mn: Tuple[int, int] = (256, 256), current_stream=None):
-        """Segment-sum the dbias slots per expert into ``(expert_cnt, n, 1)``.
+    def reduce_dbias_workspace(dbias_workspace, padded_offsets, dbias_tensor=None, mma_tiler_mn: Tuple[int, int] = (256, 256), current_stream=None):
+        """Segment-sum the dbias slots per expert; accumulates onto dbias_tensor if given.
 
         Public because a plain sum over dim 0 is wrong here and gets it wrong quietly: the slots
-        have to be grouped by the expert ranges ``padded_offsets`` marks off.
+        have to be grouped by the expert ranges ``padded_offsets`` marks off. Accumulates rather
+        than overwrites, matching both reduce_dprob_workspace and the atomic the kernel uses when
+        the flag is off.
         """
-        return _reduce_dbias_slots(dbias_workspace, None, current_stream, padded_offsets, _cta_tile_m(mma_tiler_mn))
+        return _reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_offsets, _cta_tile_m(mma_tiler_mn))
 
     @property
     def _kernel_dprob_desc(self):
@@ -1770,9 +1776,14 @@ def grouped_gemm_dsrelu_wrapper_sm100(
 
     if framework == "torch":
         d_torch_dtype = framework_dtype(d_dtype, "torch")
-        d_row_tensor = torch.empty_strided((valid_m, n_out, 1), (n_out, 1, valid_m * n_out), dtype=d_torch_dtype, device=a_tensor.device)
-        d_col_tensor = torch.empty_strided((valid_m, n_out, 1), (n_out, 1, valid_m * n_out), dtype=d_torch_dtype, device=a_tensor.device)
-        d_srelu_tensor = torch.empty_strided((valid_m, n_out, 1), (n_out, 1, valid_m * n_out), dtype=d_torch_dtype, device=a_tensor.device)
+        # Inside the context, like the accumulators: torch's allocator reuses a block freed on the
+        # allocating stream on the strength of that stream's ordering, which says nothing about a
+        # kernel writing the block on current_stream. record_stream cannot fix this direction --
+        # it defers reuse after *this* tensor is freed, not the handout of an already-freed block.
+        with _torch_stream_context(current_stream, a_tensor.device):
+            d_row_tensor = torch.empty_strided((valid_m, n_out, 1), (n_out, 1, valid_m * n_out), dtype=d_torch_dtype, device=a_tensor.device)
+            d_col_tensor = torch.empty_strided((valid_m, n_out, 1), (n_out, 1, valid_m * n_out), dtype=d_torch_dtype, device=a_tensor.device)
+            d_srelu_tensor = torch.empty_strided((valid_m, n_out, 1), (n_out, 1, valid_m * n_out), dtype=d_torch_dtype, device=a_tensor.device)
     else:
         # n-major C-contiguous; the extent-1 batch dim's stride is unobservable by the kernel.
         d_jax_dtype = framework_dtype(d_dtype, "jax")
@@ -1831,9 +1842,10 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         mma_shape_col = (1, ceil_div(n_out, 128), ceil_div(sf_k_col, 4), 32, 4, 4)
         if framework == "torch":
             mma_permute_order = (3, 4, 1, 5, 2, 0)
-            sfd_row_tensor = torch.empty(mma_shape_row, dtype=sf_dtype, device=a_tensor.device).permute(mma_permute_order)
-            sfd_col_tensor = torch.empty(mma_shape_col, dtype=sf_dtype, device=a_tensor.device).permute(mma_permute_order)
-            sfd_col_d_srelu_tensor = torch.empty(mma_shape_col, dtype=sf_dtype, device=a_tensor.device).permute(mma_permute_order)
+            with _torch_stream_context(current_stream, a_tensor.device):
+                sfd_row_tensor = torch.empty(mma_shape_row, dtype=sf_dtype, device=a_tensor.device).permute(mma_permute_order)
+                sfd_col_tensor = torch.empty(mma_shape_col, dtype=sf_dtype, device=a_tensor.device).permute(mma_permute_order)
+                sfd_col_d_srelu_tensor = torch.empty(mma_shape_col, dtype=sf_dtype, device=a_tensor.device).permute(mma_permute_order)
         else:
             # Physical C-contiguous atom allocations: JAX cannot express the permuted view;
             # the kernel rebuilds the SF layout from the GEMM shapes and consumes only the
@@ -1862,13 +1874,6 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         else:
             dbias_tensor = _jax_alloc(lambda: jnp.zeros((l, n_out, 1), dtype=framework_dtype(cutlass.BFloat16, "jax"), device=a_tensor.device))
     dbias_kernel_tensor = dbias_workspace if dbias_workspace is not None else dbias_tensor
-
-    # The write-only outputs need no ordered init, but they still come from torch's stream while
-    # the kernel writes them on the caller's, so torch could recycle the block early. The
-    # accumulators above are allocated on the caller's stream and need no such record. No-op
-    # under jax, which does not use torch's allocator.
-    if framework == "torch":
-        _record_streams(current_stream, a_tensor.device, d_row_tensor, d_col_tensor, d_srelu_tensor, sfd_row_tensor, sfd_col_tensor, sfd_col_d_srelu_tensor)
 
     if valid_m == 0:
         _logger.debug("grouped_gemm_dsrelu_wrapper_sm100: valid_m is zero, skipping kernel execution")
@@ -1945,6 +1950,12 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         if deterministic and dbias_kernel_tensor is not None
         else tensor_signature(dbias_kernel_tensor)
     )
+    # Used on both arms, not just the non-full-dynamic one. Every other tensor may drop its shape
+    # under full dynamic because the kernel compiles with symbolic extents, but _make_dbias_fake
+    # frees only dim 0 -- dbias's n stays baked -- and nothing else in the dense key carries n
+    # (b_tensor.shape[2] is l, and dprob_n_slots is too coarse: n=384 and n=512 both give 2).
+    # Verified: with the shape dropped, n=384 then n=512 reuses the first kernel and CuTeDSL
+    # rejects the call with "Mismatched dbias_tensor.shape[1] ... expected to be 384" (job 469460).
     # The kernel writes the scratch under determinism, so that is what the key has to describe.
     dprob_kernel_tensor = dprob_workspace if dprob_workspace is not None else dprob_tensor
 
@@ -1981,7 +1992,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             # stride order, so without this the second call would reuse a kernel built for
             # the wrong dprob extent.
             dprob_n_slots,
-            *(dynamic_tensor_signature(dbias_kernel_tensor) if use_full_dynamic else dbias_signature),
+            *dbias_signature,
             *(dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1)) if not use_full_dynamic else dynamic_tensor_signature(d_srelu_tensor)),
             *(dynamic_tensor_signature(sfb_tensor) if use_full_dynamic else tensor_signature(sfb_tensor)),
             *(dynamic_tensor_signature(sfd_col_d_srelu_tensor) if use_full_dynamic else tensor_signature(sfd_col_d_srelu_tensor)),

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -23,7 +23,7 @@ from .moe_blockscaled_grouped_gemm_dsrelu_quant import (
     BlockScaledMoEGroupedGemmQuantBwdKernel,
     EpilogueType,
 )
-from ..backend_utils import _torch_stream_context
+from ..backend_utils import _record_streams, _torch_stream_context
 from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
 import logging
@@ -153,27 +153,6 @@ def _reduce_dbias_slots(dbias_workspace, dbias_tensor, current_stream, padded_of
         return (onehot @ dbias_workspace.reshape(m_blocks, n_out)).reshape(-1, n_out, 1).to(torch.bfloat16)
 
 
-def _record_streams(current_stream: Optional[cuda.CUstream], device, *tensors) -> None:
-    """Keep torch's allocator from recycling buffers the kernel is still writing.
-
-    These come from torch's current stream, so torch tags the block to that stream and hands it
-    to the next allocation there as soon as the tensor is freed -- without waiting for work
-    queued on ``current_stream``. Same reason ``csa/compressor/api.py`` and the sibling
-    grouped-GEMM APIs call ``record_stream``.
-    """
-    if current_stream is None:
-        return
-    import torch
-
-    handle = int(current_stream)
-    if handle == torch.cuda.current_stream(device).cuda_stream:
-        return  # same stream the blocks were allocated on; nothing to guard against
-    consumer = torch.cuda.ExternalStream(handle, device=device)
-    for tensor in tensors:
-        if tensor is not None:
-            tensor.record_stream(consumer)
-
-
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
     if _convert_to_cutlass_data_type_or_none(tensor.dtype) is cutlass.Uint8:
         cute_tensor = from_dlpack(tensor, assumed_align=16, enable_tvm_ffi=True).mark_layout_dynamic(leading_dim=1)
@@ -274,7 +253,9 @@ class GroupedGemmDsreluSm100(APIBase):
         :param sample_dprob: Gradient of probability tensor (valid_m, 1, 1), must be zero-initialized
         :param sample_b: (Dense) Sample B tensor (n, k, l)
         :param sample_sfb: (Dense) Sample scale factor B tensor
-        :param sample_dbias: Optional dbias output tensor (expert_cnt, n, 1)
+        :param sample_dbias: Optional dbias output tensor (expert_cnt, n, 1) bfloat16 -- but under
+            ``deterministic`` the kernel writes one fp32 slot per (CTA M-tile, n) instead, so pass
+            ``(ceil_div(valid_m, cta_tile_m), n, 1)`` float32 and reduce it per expert yourself
         :param num_experts: (Discrete) Number of experts
         :param b_shape: (Discrete) Shape of a single expert B tensor, e.g. (n, k)
         :param b_dtype: (Discrete) Data type of B tensors
@@ -292,9 +273,12 @@ class GroupedGemmDsreluSm100(APIBase):
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
-        :param deterministic: Compute dprob run-to-run bit-exactly. sample_dprob must then
-            carry one slot per N-tile (see _dprob_n_slots) and the caller must reduce over
-            dim 1 after execute(); grouped_gemm_dsrelu_wrapper_sm100 does both for you
+        :param deterministic: Compute dprob and dbias run-to-run bit-exactly. Both outputs then
+            arrive as slot workspaces the caller reduces after execute(): sample_dprob carries one
+            slot per N-tile (see _dprob_n_slots) and reduces over dim 1, sample_dbias one fp32 slot
+            per absolute M-block and reduces per expert over the ranges padded_offsets marks off (a
+            plain sum will not do -- see the segment sum in _reduce_dbias_slots).
+            grouped_gemm_dsrelu_wrapper_sm100 does all of this for you and returns the usual shapes
         """
         framework = detect_framework(sample_a)
         if sample_a is not None and framework not in ("torch", "jax"):
@@ -379,8 +363,6 @@ class GroupedGemmDsreluSm100(APIBase):
         self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
-        # Rows one CTA's epilogue owns, and so the granularity of a deterministic dbias slot.
-        # Mirrors the kernel's cta_tile_shape_mnk[0] = mma_tiler[0] // thr_id_size.
         self.cta_tile_m = _cta_tile_m(mma_tiler_mn)
         self.cluster_shape_mn = _resolve_cluster_shape_mn(mma_tiler_mn, cluster_shape_mn)
         self.sf_vec_size = sf_vec_size
@@ -468,8 +450,10 @@ class GroupedGemmDsreluSm100(APIBase):
             return self._make_fake_cute_tensor_from_desc(self.dbias_desc, assumed_align=16)
         return self._make_fake_cute_compact_tensor(
             dtype=self.dbias_desc.dtype,
-            shape=(cute.sym_int(divisibility=2), *self.dbias_desc.shape[1:]),
+            shape=self.dbias_desc.shape,
             stride_order=self.dbias_desc.stride_order,
+            dynamic_mode=0,
+            divisibility=2,
         )
 
     def check_support(self) -> bool:
@@ -1640,7 +1624,8 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         discrete_col_sfd: Generate discrete col-major scale factor tensor
         use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
-        deterministic: Make dprob bit-exact run to run. ``dprob_tensor`` keeps its
+        deterministic: Make dprob and dbias bit-exact run to run; raises NotImplementedError
+            for any framework other than torch. ``dprob_tensor`` keeps its
             ``(valid_m, 1, 1)`` shape either way -- the extra per-N-tile workspace and the
             fixed-order reduction into it are internal. ``None`` (default) follows
             ``torch.use_deterministic_algorithms``. See docs/fe-oss-apis/gemm_fusions/
@@ -1878,6 +1863,17 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         static_shape = (shape[0], shape[1], None, *shape[3:])
         return dynamic_m_tensor_signature(tensor, static_shape, dynamic_stride_dims=(0, 1))
 
+    # Deterministic dbias indexes by M-block, so its dim 0 follows valid_m and keying on the full
+    # shape would recompile for every distinct token count -- the trap _dprob_n_slots documents
+    # for dprob's slot extent, and _make_dbias_fake already keeps that extent symbolic. Key it
+    # the way dprob is keyed: M dynamic, the rest static. Strides are (n_out, 1, 1) either way,
+    # so they carry no M. Non-deterministic dbias is (expert_cnt, n_out, 1) and static already.
+    dbias_signature = (
+        dynamic_m_tensor_signature(dbias_kernel_tensor, tuple(get_shape(dbias_kernel_tensor)[1:]))
+        if deterministic and dbias_kernel_tensor is not None
+        else tensor_signature(dbias_kernel_tensor)
+    )
+
     use_full_dynamic = is_dense and os.environ.get("CUDNN_FE_GROUPED_GEMM_DYNAMIC_MNKL", "1") != "0"
 
     if is_dense:
@@ -1907,7 +1903,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             # stride order, so without this the second call would reuse a kernel built for
             # the wrong dprob extent.
             dprob_n_slots,
-            *(dynamic_tensor_signature(dbias_kernel_tensor) if use_full_dynamic else tensor_signature(dbias_kernel_tensor)),
+            *(dynamic_tensor_signature(dbias_kernel_tensor) if use_full_dynamic else dbias_signature),
             *(dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1)) if not use_full_dynamic else dynamic_tensor_signature(d_srelu_tensor)),
             *(dynamic_tensor_signature(sfb_tensor) if use_full_dynamic else tensor_signature(sfb_tensor)),
             *(dynamic_tensor_signature(sfd_col_d_srelu_tensor) if use_full_dynamic else tensor_signature(sfd_col_d_srelu_tensor)),
@@ -1941,7 +1937,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             *tensor_signature(alpha_tensor),
             *dynamic_m_tensor_signature(prob_tensor, (1, 1)),
             *dynamic_m_tensor_signature(dprob_tensor, tuple(dprob_tensor.shape[1:])),
-            *tensor_signature(dbias_kernel_tensor),
+            *dbias_signature,
             *dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1), dynamic_stride_dims=(2,)),
             *dynamic_sfd_col_tensor_signature(sfd_col_d_srelu_tensor),
             *tensor_signature(norm_const_tensor),

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -53,10 +53,17 @@ from cudnn.tensor_adapter import (
 
 
 def _uses_2cta_instrs(mma_tiler_mn: Tuple[int, int]) -> bool:
-    """An M tile of 256 is the 2-CTA MMA shape -- tcgen05 pairs two CTAs to cover it.
+    """Whether this M tile selects the 2-SM tcgen05 MMA atom.
 
-    check_support enforces the pairing: M must be 256 with 2-CTA instructions and 128
-    without, so the tile size and the instruction form carry the same information.
+    Not a tuning choice: tcgen05 offers exactly two MMA forms, 1-SM (``CtaGroup.ONE``,
+    M=128) and 2-SM (``CtaGroup.TWO``, M=256, where two CTAs of a cluster cooperate on one
+    MMA), so the M tile and the CTA group are the same fact -- see the kernel's
+    ``self.cta_group``. check_support asserts the pairing in both directions, and requires
+    an even ``cluster_shape_mn[0]`` so the CTA pair lands in one cluster.
+
+    The other 128s and 256s nearby are unrelated constants that happen to collide: the N
+    tile, the scale-factor layout atom, FIX_PAD_SIZE, and byte alignments are all free to
+    move independently of this one.
     """
     return mma_tiler_mn[0] == 256
 

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -25,9 +25,10 @@ from .moe_blockscaled_grouped_gemm_dsrelu_quant import (
 )
 from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
+from contextlib import contextmanager
 import logging
 import os
-from typing import Tuple, Optional
+from typing import Iterator, Tuple, Optional
 
 import cutlass
 import cutlass.cute as cute
@@ -98,18 +99,46 @@ def _dprob_n_slots(n_out: int, mma_tiler_mn: Tuple[int, int], cluster_shape_mn: 
     return ceil_div(n_out, mma_tiler_mn[1] * cluster_n) * cluster_n
 
 
-def _reduce_dprob_slots(dprob_tensor: torch.Tensor, caller_dprob_tensor: Optional[torch.Tensor], deterministic: bool) -> torch.Tensor:
+@contextmanager
+def _torch_stream_context(current_stream: Optional[cuda.CUstream]) -> Iterator[None]:
+    """Run torch work on ``current_stream`` when the caller supplied one.
+
+    Same shape as the helpers in csa/compressor and deepseek_sparse_attention/utils; kept
+    local rather than imported so a GEMM kernel does not depend on an attention module.
+    """
+    if current_stream is None:
+        yield
+        return
+    import torch
+
+    with torch.cuda.stream(torch.cuda.get_stream_from_external(int(current_stream))):
+        yield
+
+
+def _reduce_dprob_slots(
+    dprob_tensor: torch.Tensor,
+    caller_dprob_tensor: Optional[torch.Tensor],
+    deterministic: bool,
+    current_stream: Optional[cuda.CUstream],
+) -> torch.Tensor:
     """Collapse the per-N-tile dprob slots back to the caller's ``(valid_m, 1, 1)`` shape.
 
     A no-op unless deterministic, where the sum is what makes the result reproducible: it
     runs in a fixed order, unlike the kernel's cross-CTA atomics. Accumulates onto a
     caller-supplied buffer, matching what the atomic does on the non-deterministic path;
     when we allocated the buffer ourselves there is nothing to add onto.
+
+    Issued on ``current_stream``, the same stream execute() ran the kernel on. On torch's
+    current stream instead, a caller who passes a different stream would have the reduction
+    read dprob_tensor before the kernel finished writing it.
     """
     if not deterministic:
         return dprob_tensor
-    reduced = torch.sum(dprob_tensor, dim=1, keepdim=True)
-    return reduced if caller_dprob_tensor is None else caller_dprob_tensor.add_(reduced)
+    import torch
+
+    with _torch_stream_context(current_stream):
+        reduced = torch.sum(dprob_tensor, dim=1, keepdim=True)
+        return reduced if caller_dprob_tensor is None else caller_dprob_tensor.add_(reduced)
 
 
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
@@ -1696,7 +1725,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             d_srelu_tensor=d_srelu_tensor,
             # Reduced here too, so a zero-token call returns the documented (valid_m, 1, 1)
             # shape rather than leaking the slot dimension.
-            dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic),
+            dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic, current_stream),
             dbias_tensor=dbias_tensor,
             amax_tensor=amax_tensor,
             sfd_row_tensor=sfd_row_tensor,
@@ -1776,6 +1805,12 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             *tensor_signature(alpha_tensor),
             *(dynamic_m_tensor_signature(prob_tensor, (1, 1)) if not use_full_dynamic else dynamic_tensor_signature(prob_tensor)),
             *(dynamic_m_tensor_signature(dprob_tensor, tuple(dprob_tensor.shape[1:])) if not use_full_dynamic else dynamic_tensor_signature(dprob_tensor)),
+            # Explicit, because the signature above does not carry it under use_full_dynamic:
+            # that path drops the shape entirely, yet the slot count is baked into the
+            # compiled descriptor. n_out=512 and n_out=513 give 2 and 3 slots with identical
+            # stride order, so without this the second call would reuse a kernel built for
+            # the wrong dprob extent.
+            dprob_n_slots,
             *(dynamic_tensor_signature(dbias_tensor) if use_full_dynamic else tensor_signature(dbias_tensor)),
             *(dynamic_m_tensor_signature(d_srelu_tensor, (n_out, 1)) if not use_full_dynamic else dynamic_tensor_signature(d_srelu_tensor)),
             *(dynamic_tensor_signature(sfb_tensor) if use_full_dynamic else tensor_signature(sfb_tensor)),
@@ -1959,7 +1994,7 @@ def grouped_gemm_dsrelu_wrapper_sm100(
         d_row_tensor=d_row_tensor,
         d_col_tensor=d_col_tensor,
         d_srelu_tensor=d_srelu_tensor,
-        dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic),
+        dprob_tensor=_reduce_dprob_slots(dprob_tensor, caller_dprob_tensor, deterministic, current_stream),
         dbias_tensor=dbias_tensor,
         amax_tensor=amax_tensor,
         sfd_row_tensor=sfd_row_tensor,

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -116,6 +116,28 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
     :param use_dynamic_sched: Enable dynamic tile scheduling.
     :param epilogue_type: Epilogue type (``EpilogueType.NONE`` or ``EpilogueType.DSRELU``).
     :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob.
+    :param deterministic: Compute ``dprob`` run-to-run bit-exactly. ``dprob`` must then be
+        shaped ``(M, grid_n, 1)`` with ``grid_n = ceil_div(n, mma_tiler_mn[1])``; the caller
+        reduces over dim 1 afterwards. See below.
+
+    **Deterministic dprob.** Only ``dprob`` is non-deterministic by default -- every other
+    output is a single write per element -- and it is so at two levels:
+
+    1. Within a CTA, the N-subtile loop runs forward or reversed depending on
+       ``reverse_subtile``, which follows the accumulator pipeline phase and so varies run to
+       run. A running fp32 sum over a flipping order is not reproducible.
+    2. Across CTAs, every N-tile atomically accumulates into the same ``dprob[token]``, so the
+       summation order follows tile scheduling.
+
+    ``deterministic=True`` fixes both, and neither fix is sufficient alone:
+
+    1. Each subtile's partial is parked in a slot indexed by the *actual* subtile, then summed
+       in canonical ``0..subtile_cnt-1`` order after the loop.
+    2. ``dprob`` carries an extra N-tile dimension so each ``(token, tile_n)`` slot has exactly
+       one writer. The caller reduces over that dimension in fixed order.
+
+    Cost is ``grid_n x`` the dprob workspace plus one reduction, and ``subtile_cnt`` registers
+    per epilogue thread.
     """
 
     FIX_PAD_SIZE = 256
@@ -176,6 +198,7 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         generate_dbias: bool = False,
         generate_d_srelu: bool = False,
         use_dsrelu_reuse: bool = False,
+        deterministic: bool = False,
     ):
         mma_tile_m = mma_tiler_mn[0]
         if self.FIX_PAD_SIZE % mma_tile_m != 0:
@@ -245,6 +268,7 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         self.generate_dbias = generate_dbias
         self.generate_d_srelu = generate_d_srelu
         self.use_dsrelu_reuse = use_dsrelu_reuse
+        self.deterministic = deterministic
         self.dbias_cross_warp_reduce = generate_dbias
 
         self.weight_mode = weight_mode
@@ -617,7 +641,7 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         padded_offsets: cute.Tensor,
         alpha: cute.Tensor,
         prob: cute.Tensor,
-        dprob: Optional[cute.Tensor],  # OUTPUT: dL/d(prob), shape (M,1,1), Float32
+        dprob: Optional[cute.Tensor],  # OUTPUT: dL/d(prob), shape (M,1,1) -- (M,grid_n,1) if deterministic, Float32
         dbias_tensor: Optional[cute.Tensor],  # OUTPUT: dL/d(bias), shape (L,N), BF16 (accumulated via atomic)
         d_srelu: Optional[cute.Tensor],  # OUTPUT: recomputed SReLU activation, shape (M,N,1)
         sfd_col_d_srelu_tensor: Optional[cute.Tensor],  # OUTPUT: column SF for d_srelu when FP8-quantized
@@ -1332,7 +1356,7 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         padded_offsets: cute.Tensor,
         alpha: cute.Tensor,
         prob: cute.Tensor,
-        dprob: Optional[cute.Tensor],  # dL/d(prob) output, shape (M,1,1), Float32
+        dprob: Optional[cute.Tensor],  # dL/d(prob) output, shape (M,1,1) -- (M,grid_n,1) if deterministic, Float32
         mDbias_tensor: Optional[cute.Tensor],  # dL/d(bias) output, shape (L,N), BF16
         workspace_ptr,
         cluster_layout_vmnk: cute.Layout,
@@ -2118,6 +2142,13 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
 
                 subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
 
+                # Deterministic dprob, level 1: one slot per subtile instead of a running sum
+                # over the pipeline-flipped traversal order. Summed canonically after the loop.
+                if cutlass.const_expr(self.deterministic and dprob is not None):
+                    dProbParts = cute.make_rmem_tensor(cute.make_layout((subtile_cnt,)), cutlass.Float32)
+                    for part_idx in cutlass.range_constexpr(subtile_cnt):
+                        dProbParts[part_idx] = cutlass.Float32(0.0)
+
                 for subtile_idx in cutlass.range(0, subtile_cnt, 1, unroll=1):
                     real_subtile_idx = subtile_idx
                     if cutlass.const_expr(self.overlapping_accum):
@@ -2177,11 +2208,15 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                         if cutlass.const_expr(self.use_dsrelu_reuse):
                             tRelu2 = self.compute_relu2(tTR_rAcc, tRelu)
                             if cutlass.const_expr(dprob is not None):
-                                dProbVal = dProbVal + self.compute_dprob_from_relu2(
+                                dprob_partial = self.compute_dprob_from_relu2(
                                     tTR_rAcc,
                                     acc_vec,
                                     tRelu2,
                                 )
+                                if cutlass.const_expr(self.deterministic):
+                                    dProbParts[real_subtile_idx] = dprob_partial
+                                else:
+                                    dProbVal = dProbVal + dprob_partial
                             if cutlass.const_expr(self.generate_d_srelu):
                                 tComputeSrelu = self.scale_srelu_from_relu2(
                                     tTR_rAcc,
@@ -2230,7 +2265,11 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                             else:
                                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                                     tDprob[i] = tRelu[i] * tRelu[i] * acc_vec[i]
-                            dProbVal = dProbVal + tDprob.load().reduce(cute.ReductionOp.ADD, cutlass.Float32(0.0), 0)
+                            dprob_partial = tDprob.load().reduce(cute.ReductionOp.ADD, cutlass.Float32(0.0), 0)
+                            if cutlass.const_expr(self.deterministic):
+                                dProbParts[real_subtile_idx] = dprob_partial
+                            else:
+                                dProbVal = dProbVal + dprob_partial
                     else:
                         # NONE epilogue: dA = acc * prob (identity, no SReLU gate)
                         if cutlass.const_expr(self.vectorized_f32):
@@ -2356,8 +2395,20 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                 if cutlass.const_expr(self.epilogue_type == EpilogueType.DSRELU.value):
                     if cutlass.const_expr(dprob is not None):
                         real_dprob, _ = epi_ext.get_gmem_tensor("dprob", dprob, padded_offsets, epi_work_tile_info)
+                        if cutlass.const_expr(self.deterministic):
+                            # Level 1: canonical fixed-order sum over the per-subtile slots.
+                            dProbVal = cutlass.Float32(0.0)
+                            for part_idx in cutlass.range_constexpr(subtile_cnt):
+                                dProbVal = dProbVal + dProbParts[part_idx]
+                            # Level 2: this tile owns the (token, tile_n) slot outright -- one CTA
+                            # per (tile_m, tile_n), one thread per token within it -- so no other
+                            # N-tile's partial lands here. The add is therefore uncontended; the
+                            # atomic is redundant but kept so both modes share one store path.
+                            dprob_slot = real_dprob[(mPosition, epi_work_tile_info.tile_n_idx, None)]
+                        else:
+                            dprob_slot = real_dprob[(mPosition, None, None)]
                         _ = atomic_add_float32(
-                            ptr=real_dprob[(mPosition, None, None)].iterator.llvm_ptr,
+                            ptr=dprob_slot.iterator.llvm_ptr,
                             value=dProbVal,
                         )
 

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -1037,11 +1037,17 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         warp_idx,
         sDbias,
         dbias_gmem_2d,
-        expert_idx,
         n_base,
         dbias_n_total,
+        dbias_row_idx,
     ) -> None:
         """Sum dA across M within this subtile and atomic-add to dbias[expert, n].
+
+        ``dbias_row_idx`` selects the destination row: ``expert_idx`` normally, or -- under
+        ``deterministic`` -- the absolute M-block, which gives every ``(M-block, n)`` pair a
+        single writer so the caller can reduce them per expert in a fixed order. The store
+        below is otherwise identical, except that the deterministic workspace is fp32, so it
+        takes two scalar atomics where the bf16 output takes one packed bf16x2.
 
         Adapted from moe_blockscaled_grouped_gemm_dglu_dbias.py's dbias_reduction,
         which handled two interleaved vectors (d1, d2). Here we have a single
@@ -1119,12 +1125,29 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                     cta_sum_a = cta_sum_a + rDst_w[0]
                     cta_sum_b = cta_sum_b + rDst_w[1]
                 if n_offset < dbias_n_total:
-                    gmem_ptr = dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr
-                    atomic_add_bf16x2(gmem_ptr, cta_sum_a, cta_sum_b)
+                    self.dbias_store(dbias_gmem_2d, dbias_row_idx, n_offset, cta_sum_a, cta_sum_b)
         else:
             if lane_idx < 16 and n_offset < dbias_n_total:
-                gmem_ptr = dbias_gmem_2d[(expert_idx, n_offset, None)].iterator.llvm_ptr
-                atomic_add_bf16x2(gmem_ptr, sum_a, sum_b)
+                self.dbias_store(dbias_gmem_2d, dbias_row_idx, n_offset, sum_a, sum_b)
+
+    @cute.jit
+    def dbias_store(self, dbias_gmem_2d, row_idx, n_offset, val_a, val_b) -> None:
+        """Commit one thread's two N columns of dbias.
+
+        Deterministic: the row is this CTA's own M-block, so the slot has exactly one writer and
+        the adds are uncontended. fp32 rather than bf16 because narrowing once after the
+        per-expert reduction loses less than rounding on every tile; that costs two scalar
+        atomics here where the default packs both columns into one. A plain vector store would
+        do -- the atomic buys nothing once the slot is single-writer -- but that is left for a
+        change that can be measured on hardware.
+
+        Default: every M-tile of the expert accumulates into the same address.
+        """
+        if cutlass.const_expr(self.deterministic):
+            _ = atomic_add_float32(ptr=dbias_gmem_2d[(row_idx, n_offset, None)].iterator.llvm_ptr, value=val_a)
+            _ = atomic_add_float32(ptr=dbias_gmem_2d[(row_idx, n_offset + 1, None)].iterator.llvm_ptr, value=val_b)
+        else:
+            atomic_add_bf16x2(dbias_gmem_2d[(row_idx, n_offset, None)].iterator.llvm_ptr, val_a, val_b)
 
     @cute.jit
     def quant_sfd_row(self, tile_idx, tiled_copy_r2s, src, pvscale, norm_const, rcp_limit, tRSrD):
@@ -2280,14 +2303,21 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                         dA_vec = tCompute.load()
                         n_base = epi_work_tile_info.tile_n_idx * self.mma_tiler[1] + real_subtile_idx * self.epi_tile[1]
                         dbias_n_total = cute.size(mDbias_tensor, mode=[1])
+                        # Deterministic dbias is keyed by the absolute M-block instead of the
+                        # expert, so each (M-block, n) has one writer. token_offset is the
+                        # expert's start and a multiple of cta_tile_m, so the division is exact.
+                        # Same index global_sfd_m rebuilds for the SFD-col path further down.
+                        dbias_row_idx = expert_idx
+                        if cutlass.const_expr(self.deterministic):
+                            dbias_row_idx = epi_work_tile_info.tile_m_idx + epi_ext.token_offset // self.cta_tile_shape_mnk[0]
                         self.dbias_reduction(
                             dA_vec,
                             warp_idx,
                             sDbias,
                             mDbias_tensor,
-                            expert_idx,
                             n_base,
                             dbias_n_total,
+                            dbias_row_idx,
                         )
 
                     if cutlass.const_expr(self.generate_amax):

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -116,28 +116,10 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
     :param use_dynamic_sched: Enable dynamic tile scheduling.
     :param epilogue_type: Epilogue type (``EpilogueType.NONE`` or ``EpilogueType.DSRELU``).
     :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob.
-    :param deterministic: Compute ``dprob`` run-to-run bit-exactly. ``dprob`` must then be
-        shaped ``(M, grid_n, 1)`` with ``grid_n = ceil_div(n, mma_tiler_mn[1])``; the caller
-        reduces over dim 1 afterwards. See below.
-
-    **Deterministic dprob.** Only ``dprob`` is non-deterministic by default -- every other
-    output is a single write per element -- and it is so at two levels:
-
-    1. Within a CTA, the N-subtile loop runs forward or reversed depending on
-       ``reverse_subtile``, which follows the accumulator pipeline phase and so varies run to
-       run. A running fp32 sum over a flipping order is not reproducible.
-    2. Across CTAs, every N-tile atomically accumulates into the same ``dprob[token]``, so the
-       summation order follows tile scheduling.
-
-    ``deterministic=True`` fixes both, and neither fix is sufficient alone:
-
-    1. Each subtile's partial is parked in a slot indexed by the *actual* subtile, then summed
-       in canonical ``0..subtile_cnt-1`` order after the loop.
-    2. ``dprob`` carries an extra N-tile dimension so each ``(token, tile_n)`` slot has exactly
-       one writer. The caller reduces over that dimension in fixed order.
-
-    Cost is ``grid_n x`` the dprob workspace plus one reduction, and ``subtile_cnt`` registers
-    per epilogue thread.
+    :param deterministic: Compute ``dprob`` run-to-run bit-exactly. ``dprob`` must then carry
+        one slot per N-tile so that each ``(token, tile_n)`` pair has a single writer, and the
+        caller reduces over that dimension afterwards. Rationale and cost:
+        docs/fe-oss-apis/gemm_fusions/grouped_gemm_dsrelu.md#deterministic-dprob.
     """
 
     FIX_PAD_SIZE = 256
@@ -427,6 +409,9 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         )
 
         self.overlapping_accum = self.num_acc_stage == 1 and self.mma_tiler[1] == 256
+        # Level 1 of the deterministic dprob fix. overlapping_accum is what reverses the
+        # subtile loop, so it is the only case where a running sum sees a varying order.
+        self.dprob_slot_parking = self.deterministic and self.overlapping_accum
         self.epilogue_prefetch_more = False
         self.use_fp8_ptx_cvt = True
 
@@ -2142,9 +2127,15 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
 
                 subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
 
-                # Deterministic dprob, level 1: one slot per subtile instead of a running sum
-                # over the pipeline-flipped traversal order. Summed canonically after the loop.
-                if cutlass.const_expr(self.deterministic and dprob is not None):
+                # Deterministic dprob, level 1: park each subtile's partial in its own slot and
+                # sum canonically after the loop, instead of a running sum over a traversal
+                # order that flips with the pipeline phase.
+                #
+                # Only needed when overlapping_accum is on, because that is the only thing that
+                # reverses the loop; otherwise real_subtile_idx == subtile_idx and the running
+                # sum already runs 0..subtile_cnt-1. Skipping the array there keeps the
+                # dynamically-indexed local-memory allocation out of those configurations.
+                if cutlass.const_expr(self.dprob_slot_parking and dprob is not None):
                     dProbParts = cute.make_rmem_tensor(cute.make_layout((subtile_cnt,)), cutlass.Float32)
                     for part_idx in cutlass.range_constexpr(subtile_cnt):
                         dProbParts[part_idx] = cutlass.Float32(0.0)
@@ -2213,10 +2204,6 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                                     acc_vec,
                                     tRelu2,
                                 )
-                                if cutlass.const_expr(self.deterministic):
-                                    dProbParts[real_subtile_idx] = dprob_partial
-                                else:
-                                    dProbVal = dProbVal + dprob_partial
                             if cutlass.const_expr(self.generate_d_srelu):
                                 tComputeSrelu = self.scale_srelu_from_relu2(
                                     tTR_rAcc,
@@ -2266,7 +2253,11 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                                     tDprob[i] = tRelu[i] * tRelu[i] * acc_vec[i]
                             dprob_partial = tDprob.load().reduce(cute.ReductionOp.ADD, cutlass.Float32(0.0), 0)
-                            if cutlass.const_expr(self.deterministic):
+
+                        # Single home for both producers above -- their guards are mutually
+                        # exclusive on use_dsrelu_reuse, so exactly one has run.
+                        if cutlass.const_expr(dprob is not None):
+                            if cutlass.const_expr(self.dprob_slot_parking):
                                 dProbParts[real_subtile_idx] = dprob_partial
                             else:
                                 dProbVal = dProbVal + dprob_partial
@@ -2395,11 +2386,12 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                 if cutlass.const_expr(self.epilogue_type == EpilogueType.DSRELU.value):
                     if cutlass.const_expr(dprob is not None):
                         real_dprob, _ = epi_ext.get_gmem_tensor("dprob", dprob, padded_offsets, epi_work_tile_info)
-                        if cutlass.const_expr(self.deterministic):
-                            # Level 1: canonical fixed-order sum over the per-subtile slots.
+                        if cutlass.const_expr(self.dprob_slot_parking):
+                            # Canonical fixed-order sum over the per-subtile slots.
                             dProbVal = cutlass.Float32(0.0)
                             for part_idx in cutlass.range_constexpr(subtile_cnt):
                                 dProbVal = dProbVal + dProbParts[part_idx]
+                        if cutlass.const_expr(self.deterministic):
                             # Level 2: this tile owns the (token, tile_n) slot outright -- one CTA
                             # per (tile_m, tile_n), one thread per token within it -- so no other
                             # N-tile's partial lands here. The add is therefore uncontended; the

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -1043,6 +1043,12 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
     ) -> None:
         """Sum dA across M within this subtile and atomic-add to dbias[dbias_row_idx, n].
 
+        ``dbias_row_idx`` is the expert normally, or -- under ``deterministic`` -- this CTA's
+        absolute M-block, which gives every ``(M-block, n)`` pair a single writer so the caller
+        can reduce per expert in a fixed order afterwards. Only the row differs: the slots stay
+        bf16, so both modes issue the same packed store. Determinism comes from the single writer
+        and the fixed-order reduction, not from a wider accumulator.
+
         Adapted from moe_blockscaled_grouped_gemm_dglu_dbias.py's dbias_reduction,
         which handled two interleaved vectors (d1, d2). Here we have a single
         vector dA, so 16 lanes handle the 32 N columns (2 cols each via bf16x2).
@@ -1119,29 +1125,10 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                     cta_sum_a = cta_sum_a + rDst_w[0]
                     cta_sum_b = cta_sum_b + rDst_w[1]
                 if n_offset < dbias_n_total:
-                    self.dbias_store(dbias_gmem_2d, dbias_row_idx, n_offset, cta_sum_a, cta_sum_b)
+                    atomic_add_bf16x2(dbias_gmem_2d[(dbias_row_idx, n_offset, None)].iterator.llvm_ptr, cta_sum_a, cta_sum_b)
         else:
             if lane_idx < 16 and n_offset < dbias_n_total:
-                self.dbias_store(dbias_gmem_2d, dbias_row_idx, n_offset, sum_a, sum_b)
-
-    @cute.jit
-    def dbias_store(self, dbias_gmem_2d, row_idx, n_offset, val_a, val_b) -> None:
-        """Commit one thread's two N columns of dbias.
-
-        Deterministic: the row is this CTA's own M-block, so the slot has exactly one writer and
-        the adds are uncontended. fp32 rather than bf16 because narrowing once after the
-        per-expert reduction loses less than rounding on every tile; that costs two scalar
-        atomics here where the default packs both columns into one. A plain vector store would
-        do -- the atomic buys nothing once the slot is single-writer -- but that is left for a
-        change that can be measured on hardware.
-
-        Default: every M-tile of the expert accumulates into the same address.
-        """
-        if cutlass.const_expr(self.deterministic):
-            _ = atomic_add_float32(ptr=dbias_gmem_2d[(row_idx, n_offset, None)].iterator.llvm_ptr, value=val_a)
-            _ = atomic_add_float32(ptr=dbias_gmem_2d[(row_idx, n_offset + 1, None)].iterator.llvm_ptr, value=val_b)
-        else:
-            atomic_add_bf16x2(dbias_gmem_2d[(row_idx, n_offset, None)].iterator.llvm_ptr, val_a, val_b)
+                atomic_add_bf16x2(dbias_gmem_2d[(dbias_row_idx, n_offset, None)].iterator.llvm_ptr, sum_a, sum_b)
 
     @cute.jit
     def quant_sfd_row(self, tile_idx, tiled_copy_r2s, src, pvscale, norm_const, rcp_limit, tRSrD):

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -1041,13 +1041,7 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
         dbias_n_total,
         dbias_row_idx,
     ) -> None:
-        """Sum dA across M within this subtile and atomic-add to dbias[expert, n].
-
-        ``dbias_row_idx`` selects the destination row: ``expert_idx`` normally, or -- under
-        ``deterministic`` -- the absolute M-block, which gives every ``(M-block, n)`` pair a
-        single writer so the caller can reduce them per expert in a fixed order. The store
-        below is otherwise identical, except that the deterministic workspace is fp32, so it
-        takes two scalar atomics where the bf16 output takes one packed bf16x2.
+        """Sum dA across M within this subtile and atomic-add to dbias[dbias_row_idx, n].
 
         Adapted from moe_blockscaled_grouped_gemm_dglu_dbias.py's dbias_reduction,
         which handled two interleaved vectors (d1, d2). Here we have a single
@@ -2298,18 +2292,20 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                             for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                                 tCompute[i] = acc_vec[i] * mProb
 
-                    # dbias reduction: sum dA across M for each N, atomic-add to dbias[expert, n]
+                    # This tile's row in any M-block-indexed output. token_offset is the expert's
+                    # start and a multiple of cta_tile_m, so the division is exact.
+                    global_m_block = epi_work_tile_info.tile_m_idx + epi_ext.token_offset // self.cta_tile_shape_mnk[0]
+
+                    # dbias reduction: sum dA across M for each N, atomic-add to dbias[row, n]
                     if cutlass.const_expr(self.generate_dbias):
                         dA_vec = tCompute.load()
                         n_base = epi_work_tile_info.tile_n_idx * self.mma_tiler[1] + real_subtile_idx * self.epi_tile[1]
                         dbias_n_total = cute.size(mDbias_tensor, mode=[1])
                         # Deterministic dbias is keyed by the absolute M-block instead of the
-                        # expert, so each (M-block, n) has one writer. token_offset is the
-                        # expert's start and a multiple of cta_tile_m, so the division is exact.
-                        # Same index global_sfd_m rebuilds for the SFD-col path further down.
+                        # expert, so each (M-block, n) has one writer.
                         dbias_row_idx = expert_idx
                         if cutlass.const_expr(self.deterministic):
-                            dbias_row_idx = epi_work_tile_info.tile_m_idx + epi_ext.token_offset // self.cta_tile_shape_mnk[0]
+                            dbias_row_idx = global_m_block
                         self.dbias_reduction(
                             dA_vec,
                             warp_idx,
@@ -2354,12 +2350,11 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                                 d_rcp_limits,
                                 tRS_rD_srelu,
                             )
-                        global_sfd_m = epi_work_tile_info.tile_m_idx + epi_ext.token_offset // self.cta_tile_shape_mnk[0]
                         if cutlass.const_expr(self.mma_tiler[1] == 256):
                             sfd_n = epi_work_tile_info.tile_n_idx * 2 + (real_subtile_idx >> 2)
                         else:
                             sfd_n = epi_work_tile_info.tile_n_idx
-                        sfd_row_idx_mn = (global_sfd_m, sfd_n)
+                        sfd_row_idx_mn = (global_m_block, sfd_n)
                         sfd_col_idx_mn = sfd_row_idx_mn
                         if cutlass.const_expr(self.discrete_col_sfd):
                             sfd_col_idx_mn = (

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -8,9 +8,11 @@ This module tests the contiguous grouped block-scaled GEMM backward pass
 with dSReLU activation gradient for MoE (Mixture of Experts) workloads.
 """
 
+import contextlib
+
 import torch
 import pytest
-from test_utils import torch_fork_set_rng
+from test_utils import torch_fork_set_rng, assert_bitwise_runs, bitwise_bits
 from fe_api.grouped_gemm.test_grouped_gemm_dsrelu_utils import (
     with_grouped_gemm_dsrelu_params_fp4,
     with_grouped_gemm_dsrelu_params_fp8,
@@ -388,7 +390,7 @@ def test_grouped_gemm_dsrelu_wrapper_uint8_raw_fp4_smoke(request):
     assert torch.count_nonzero(outputs["d_row_tensor"]).item() > 0
 
 
-def _run_dsrelu_deterministic_case(case, **wrapper_kwargs):
+def _run_dsrelu_case(case, **wrapper_kwargs):
     """Run the wrapper once over an already-built case, so repeats share identical inputs.
 
     ``dprob_tensor`` is deliberately not passed: the wrapper then allocates and zeroes a
@@ -424,7 +426,7 @@ def _run_dsrelu_deterministic_case(case, **wrapper_kwargs):
     )
 
 
-def _build_dsrelu_deterministic_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd):
+def _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd):
     cfg = grouped_gemm_dsrelu_init(
         request=request,
         ab_dtype=ab_dtype,
@@ -466,6 +468,57 @@ def _build_dsrelu_deterministic_case(request, ab_dtype, c_dtype, d_dtype, sf_vec
     return inputs, cfg
 
 
+@contextlib.contextmanager
+def _torch_deterministic_algorithms():
+    """Scope torch's global determinism flag, restoring whatever the session had."""
+    previous = torch.are_deterministic_algorithms_enabled()
+    torch.use_deterministic_algorithms(True, warn_only=True)
+    try:
+        yield
+    finally:
+        torch.use_deterministic_algorithms(previous, warn_only=True)
+
+
+def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inputs=None):
+    """The three properties deterministic=True has to hold, shared by dense and discrete.
+
+    ``relaunch`` produces another deterministic run; it is called repeatedly, because a
+    reduction-order race is timing-dependent and one repeat proves little.
+    """
+    torch.cuda.synchronize()
+    inputs, cfg = case
+
+    # The caller-visible shape is unchanged -- the per-N-tile workspace is internal.
+    assert deterministic["dprob_tensor"].shape == baseline["dprob_tensor"].shape
+    assert torch.count_nonzero(deterministic["dprob_tensor"]).item() > 0
+
+    # 1. Repeated runs agree to the last bit, not merely to a tolerance.
+    assert_bitwise_runs(lambda: (relaunch()["dprob_tensor"],), label="dprob")
+
+    # 2. Reordering a float sum must not change what is being summed: a partial dropped by a
+    # gap in the per-subtile slots, or double-counted by a second writer to an N-tile slot,
+    # would show up here and nowhere else.
+    scale = baseline["dprob_tensor"].abs().max().item()
+    torch.testing.assert_close(deterministic["dprob_tensor"], baseline["dprob_tensor"], rtol=1e-4, atol=1e-4 * max(scale, 1.0))
+
+    # dprob is the only output the flag touches; dA and friends are single-write per element
+    # and must come back untouched. d_col only joins that list when the fp8 scale-factor path
+    # is active -- otherwise the kernel leaves it at whatever its torch.empty_strided
+    # allocation happened to contain, which differs between two independent calls for reasons
+    # that have nothing to do with determinism. (The reference check skips it for the same
+    # reason: run_grouped_gemm_dsrelu_ref only builds d_col_ref under generate_sfd.)
+    unchanged = ["d_row_tensor", "d_srelu_tensor"]
+    if deterministic.get("sfd_col_tensor") is not None:
+        unchanged.append("d_col_tensor")
+    for key in unchanged:
+        assert torch.equal(deterministic[key], baseline[key]), f"{key} changed under deterministic=True"
+
+    # 3. The deterministic path clears the same bar as the default one, not merely agrees
+    # with it: the reference the non-deterministic wrapper tests run, over the whole backward
+    # output set (dprob, dA row/col, d_srelu, amax, scale factors).
+    check_ref_grouped_gemm_dsrelu(inputs if ref_inputs is None else ref_inputs, deterministic, cfg, skip_ref=cfg["skip_ref"])
+
+
 # n defaults to 512 against an mma_tiler_mn[1] of 256, so grid_n is 2 and the cross-N-tile
 # reduction -- level 2 of the fix -- is actually exercised. A config with n <= 256 would
 # only cover level 1.
@@ -489,76 +542,30 @@ def test_grouped_gemm_dsrelu_deterministic_dprob(request, ab_dtype, c_dtype, d_d
     except ImportError:
         pytest.skip("Environment not supported: cudnn optional dependencies not installed")
 
-    case = _build_dsrelu_deterministic_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd)
+    case = _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd)
 
     try:
-        baseline = _run_dsrelu_deterministic_case(case, deterministic=False)
-        first = _run_dsrelu_deterministic_case(case, deterministic=True)
-        second = _run_dsrelu_deterministic_case(case, deterministic=True)
+        baseline = _run_dsrelu_case(case, deterministic=False)
+        deterministic = _run_dsrelu_case(case, deterministic=True)
     except (ValueError, NotImplementedError) as e:
         pytest.skip(f"Unsupported testcase: {e}")
+    _assert_dprob_deterministic(case, baseline, deterministic, lambda: _run_dsrelu_case(case, deterministic=True))
+
+    # Unset, the flag follows torch -- the path most callers will actually take.
+    with _torch_deterministic_algorithms():
+        from_torch = _run_dsrelu_case(case)
     torch.cuda.synchronize()
-
-    # The caller-visible shape is unchanged -- the per-N-tile workspace is internal.
-    assert first["dprob_tensor"].shape == baseline["dprob_tensor"].shape
-    assert torch.isfinite(first["dprob_tensor"]).all()
-    assert torch.count_nonzero(first["dprob_tensor"]).item() > 0
-
-    # The property under test. Two runs of the same kernel on the same inputs must agree
-    # to the last bit, not merely to a tolerance.
-    assert torch.equal(first["dprob_tensor"], second["dprob_tensor"])
-
-    # Reordering a float sum must not change what is being summed: a partial dropped by a
-    # gap in the per-subtile slots, or double-counted by a second writer to an N-tile slot,
-    # would show up here and nowhere else.
-    scale = baseline["dprob_tensor"].abs().max().item()
-    torch.testing.assert_close(
-        first["dprob_tensor"],
-        baseline["dprob_tensor"],
-        rtol=1e-4,
-        atol=1e-4 * max(scale, 1.0),
-    )
-
-    # dprob is the only output the flag touches; dA and friends are single-write per
-    # element and must come back untouched.
-    for key in ("d_row_tensor", "d_col_tensor", "d_srelu_tensor"):
-        assert torch.equal(first[key], baseline[key]), f"{key} changed under deterministic=True"
-
-    # The deterministic path has to clear the same bar as the default one, not merely agree
-    # with it: this is the reference check the non-deterministic wrapper tests run, over the
-    # whole backward output set (dprob, dA row/col, d_srelu, amax, scale factors).
-    inputs, cfg = case
-    check_ref_grouped_gemm_dsrelu(inputs, first, cfg, skip_ref=cfg["skip_ref"])
+    assert torch.equal(bitwise_bits(from_torch["dprob_tensor"]), bitwise_bits(deterministic["dprob_tensor"]))
 
 
-@pytest.mark.L0
-@torch_fork_set_rng(seed=19)
-def test_grouped_gemm_dsrelu_deterministic_dprob_env_var(request, monkeypatch):
-    """The env var is the opt-in when the call site is not the caller's to edit."""
-    try:
-        import cudnn  # noqa: F401
-        from cuda.bindings import driver as cuda  # noqa: F401
-    except ImportError:
-        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
-
-    # fp8 rather than the uint8 raw-FP4 config: the latter needs a CUTLASS the shared
-    # allocators cannot always provide, and a test that skips is a test that guards nothing.
-    case = _build_dsrelu_deterministic_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
-
-    try:
-        explicit = _run_dsrelu_deterministic_case(case, deterministic=True)
-        monkeypatch.setenv("CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC", "1")
-        from_env = _run_dsrelu_deterministic_case(case)
-    except (ValueError, NotImplementedError) as e:
-        pytest.skip(f"Unsupported testcase: {e}")
-    torch.cuda.synchronize()
-
-    assert torch.equal(explicit["dprob_tensor"], from_env["dprob_tensor"])
+# b_major does not reach the dprob path, so the n-major config would only re-prove what
+# fp8-k-major already does; the two dtypes are kept because they compile different kernels.
+DISCRETE_DETERMINISTIC_CONFIGS = [c for c in DISCRETE_GROUPED_GEMM_DSRELU_SUPPORTED_CONFIGS if c.id != "fp8-n-major"]
 
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=23)
-@pytest.mark.parametrize("ab_dtype,c_dtype,d_dtype,b_major", DISCRETE_GROUPED_GEMM_DSRELU_SUPPORTED_CONFIGS)
+@pytest.mark.parametrize("ab_dtype,c_dtype,d_dtype,b_major", DISCRETE_DETERMINISTIC_CONFIGS)
 def test_grouped_gemm_dsrelu_deterministic_dprob_discrete(request, ab_dtype, c_dtype, d_dtype, b_major):
     """Same guarantee in discrete-weight mode, which builds its cache key on its own branch."""
     try:
@@ -637,21 +644,13 @@ def test_grouped_gemm_dsrelu_deterministic_dprob_discrete(request, ab_dtype, c_d
         )
 
     baseline = run(deterministic=False)
-    first = run(deterministic=True)
-    second = run(deterministic=True)
-    torch.cuda.synchronize()
-
-    assert first["dprob_tensor"].shape == baseline["dprob_tensor"].shape
-    assert torch.equal(first["dprob_tensor"], second["dprob_tensor"])
-
-    scale = baseline["dprob_tensor"].abs().max().item()
-    torch.testing.assert_close(first["dprob_tensor"], baseline["dprob_tensor"], rtol=1e-4, atol=1e-4 * max(scale, 1.0))
-
-    check_ref_grouped_gemm_dsrelu(
-        _dense_ref_inputs_from_discrete(inputs),
-        first,
-        cfg,
-        skip_ref=cfg["skip_ref"],
+    deterministic = run(deterministic=True)
+    _assert_dprob_deterministic(
+        (inputs, cfg),
+        baseline,
+        deterministic,
+        lambda: run(deterministic=True),
+        ref_inputs=_dense_ref_inputs_from_discrete(inputs),
     )
 
 

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -506,21 +506,10 @@ def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inp
 
     # 2. Reordering a float sum must not change what is being summed: a partial dropped by a
     # gap in the per-subtile slots, or double-counted by a second writer to an N-tile slot,
-    # would show up here and nowhere else.
-    #
-    # The two modes sum the same n terms in a different order, so the gap between them is
-    # reordering error and nothing else. Summing n floats in a different order moves the
-    # result by at most (n-1) * u, u = 2**-24 being the fp32 unit roundoff; take 4x that as
-    # the bound so the test is not tuned to the exact schedule. Derived from n rather than
-    # hardcoded because n is settable (--grouped-gemm-nkl), and a fixed tolerance would
-    # false-fail on a wider problem.
-    #
-    # atol is separate because rtol alone is meaningless for an entry that cancelled to near
-    # zero: its absolute error is bounded by the size of the summands, not of the result. So
-    # scale atol by the largest dprob, with a floor of 1 for an all-tiny tensor.
-    reorder_rtol = 4 * (cfg["n"] - 1) * 2**-24
-    scale = baseline["dprob_tensor"].abs().max().item()
-    torch.testing.assert_close(deterministic["dprob_tensor"], baseline["dprob_tensor"], rtol=reorder_rtol, atol=reorder_rtol * max(scale, 1.0))
+    # would show up here and nowhere else. The tolerance is not delicate -- both modes sum
+    # the same terms, so the honest difference is fp32 reordering (~1e-5 here), while a
+    # dropped or duplicated partial moves dprob by tens of percent.
+    torch.testing.assert_close(deterministic["dprob_tensor"], baseline["dprob_tensor"], rtol=1e-4, atol=1e-4)
 
     # dprob is the only output the flag touches; dA and friends are single-write per element
     # and must come back untouched. d_col only joins that list when the fp8 scale-factor path

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -708,11 +708,13 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
 
     assert_bitwise_runs(_relaunch, label="dbias+dprob")
 
-    # Both paths sum the same terms, so the honest gap is reordering plus the fact that the
-    # deterministic path keeps fp32 partials where the default rounds to bf16 on every M-tile
-    # -- which makes it the *more* accurate of the two. A dropped or double-counted M-block
-    # would move dbias far beyond this.
-    torch.testing.assert_close(deterministic["dbias_tensor"].float(), baseline["dbias_tensor"].float(), rtol=2e-2, atol=2e-2)
+    # The two paths sum the same terms but not the same way: the default rounds to bf16 on every
+    # M-tile, the deterministic one keeps fp32 partials and narrows once, which makes it the more
+    # accurate of the pair. So they agree only to bf16 resolution at dbias's magnitude, and the
+    # bound is scaled accordingly -- job 459169 failed a flat 2e-2 on a 16.0 difference that is
+    # ~2 ULP of bf16 there. Correctness against the reference is check_ref's job, below.
+    det_dbias, base_dbias = deterministic["dbias_tensor"].float(), baseline["dbias_tensor"].float()
+    torch.testing.assert_close(det_dbias, base_dbias, rtol=5e-2, atol=max(base_dbias.abs().max().item(), 1.0) * 5e-2)
 
     check_ref_grouped_gemm_dsrelu(inputs, deterministic, cfg, skip_ref=cfg["skip_ref"])
 
@@ -723,9 +725,10 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
 def test_grouped_gemm_dsrelu_deterministic_dbias_segments(request, n):
     """The per-expert segment sum must follow the real expert boundaries.
 
-    A one-hot built off the wrong offsets still produces plausible finite numbers, so agreeing
-    with the non-deterministic path is not enough. Two n values, because the block count per
-    expert differs between them.
+    A one-hot built off the wrong offsets still produces plausible finite numbers and still
+    agrees with the non-deterministic path to a loose tolerance, so only the reference catches
+    it -- check_ref_grouped_gemm_dsrelu compares against a dbias summed per expert from the
+    unquantized dA. Two n values, because the block count per expert differs between them.
     """
     try:
         import cudnn  # noqa: F401
@@ -741,14 +744,8 @@ def test_grouped_gemm_dsrelu_deterministic_dbias_segments(request, n):
         pytest.skip(f"Unsupported testcase: {e}")
     torch.cuda.synchronize()
 
-    # dbias[e] is the column sum of dA over exactly the rows of expert e. Taken from the kernel's
-    # own d_row rather than a second reference implementation, so a failure points at the segment
-    # mapping and not at the GEMM. Stacked into one comparison to keep this to a single sync.
-    offsets = inputs["padded_offsets_tensor"].tolist()
-    d_row = outputs["d_row_tensor"].float()
-    bounds = list(zip([0] + offsets[:-1], offsets))
-    expected = torch.stack([d_row[start:end].sum(dim=0).reshape(-1) for start, end in bounds])
-    torch.testing.assert_close(outputs["dbias_tensor"].float().reshape(len(offsets), -1), expected, rtol=5e-2, atol=5e-2)
+    assert outputs["dbias_tensor"].shape == (cfg["l"], n, 1)
+    check_ref_grouped_gemm_dsrelu(inputs, outputs, cfg, skip_ref=cfg["skip_ref"])
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -609,6 +609,149 @@ def test_grouped_gemm_dsrelu_deterministic_dprob_side_stream(request):
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=37)
+def test_grouped_gemm_dsrelu_deterministic_dprob_side_stream_unordered_init(request):
+    """The dprob workspace must be zeroed on the caller's stream, not on torch's.
+
+    The kernel *accumulates* into dprob, so the zeroing has to be visible to it. Allocating
+    with torch.zeros puts that memset on torch's current stream, which is unordered against a
+    caller-supplied one -- the kernel is then free to atomic-add onto whatever the allocator
+    handed back, and deterministic=True silently stops being deterministic.
+
+    Where the plain side-stream test above is only opportunistic, this one forces the failure:
+    a same-sized block is poisoned and freed so torch's allocator hands those exact bytes to
+    the wrapper, and torch's stream is occupied so a memset queued there lands well after the
+    kernel has run. Against the buggy ordering dprob comes back carrying the poison; against
+    the fixed ordering it is bit-identical to the same case run on torch's own stream.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    # White-box on purpose: the poison block only gets reused if it matches the workspace byte
+    # for byte, and the slot count is exactly what this test must not hardcode.
+    from cudnn.gemm.cutedsl.grouped.dsrelu.api import _dprob_n_slots
+
+    case = _build_dsrelu_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    inputs, cfg = case
+
+    try:
+        expected = _run_dsrelu_case(case, deterministic=True)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    valid_m = inputs["a_tensor"].shape[0]
+    slots = _dprob_n_slots(cfg["n"], cfg["mma_tiler_mn"], cfg["cluster_shape_mn"], True)
+    assert slots > 1, "config must have more than one N-tile for this to exercise the slot workspace"
+
+    side = torch.cuda.Stream()
+    # Freed, not held: the bytes stay in the allocator's pool for torch's current stream, so
+    # the wrapper's next same-shaped allocation gets them back still carrying the poison.
+    poison = torch.full((valid_m, slots, 1), 1e30, dtype=torch.float32, device=inputs["a_tensor"].device)
+    del poison
+    # ~100 ms of occupancy on torch's stream. A memset mistakenly queued there cannot reach the
+    # buffer until after the kernel on `side` has already accumulated into it.
+    torch.cuda._sleep(200_000_000)
+
+    on_side = _run_dsrelu_case(case, deterministic=True, current_stream=cuda.CUstream(side.cuda_stream))
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(on_side["dprob_tensor"]).all(), "dprob picked up the poisoned block -- workspace zeroed on the wrong stream"
+    assert torch.equal(
+        bitwise_bits(on_side["dprob_tensor"]), bitwise_bits(expected["dprob_tensor"])
+    ), "deterministic dprob differs between torch's stream and a caller-supplied stream"
+    check_ref_grouped_gemm_dsrelu(inputs, on_side, cfg, skip_ref=cfg["skip_ref"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=41)
+def test_grouped_gemm_dsrelu_deterministic_dbias(request):
+    """deterministic=True makes dbias bit-exact without changing what it computes.
+
+    dbias contends across M-tiles, not N-tiles like dprob, so it gets its own fp32 workspace
+    indexed by absolute M-block plus a per-expert segment sum. The three properties are the
+    same ones dprob has to hold: repeatable to the bit, agreeing with the default path, and
+    with the flag's other outputs untouched.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    inputs, cfg = case
+
+    try:
+        baseline = _run_dsrelu_case(case, deterministic=False, generate_dbias=True)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    deterministic = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
+    torch.cuda.synchronize()
+
+    # The caller-visible dbias keeps its (expert, n, 1) bf16 shape -- the fp32 M-block
+    # workspace and the segment sum are internal to the wrapper.
+    assert deterministic["dbias_tensor"].shape == baseline["dbias_tensor"].shape
+    assert deterministic["dbias_tensor"].dtype == torch.bfloat16
+    assert torch.count_nonzero(deterministic["dbias_tensor"]).item() > 0
+
+    def _relaunch():
+        out = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
+        # dprob rides along rather than getting its own run: both reductions are issued on the
+        # same stream, and only checking them together catches an ordering regression there.
+        return out["dbias_tensor"], out["dprob_tensor"]
+
+    assert_bitwise_runs(_relaunch, label="dbias+dprob")
+
+    # Both paths sum the same terms, so the honest gap is reordering plus the fact that the
+    # deterministic path keeps fp32 partials where the default rounds to bf16 on every M-tile
+    # -- which makes it the *more* accurate of the two. A dropped or double-counted M-block
+    # would move dbias far beyond this.
+    torch.testing.assert_close(deterministic["dbias_tensor"].float(), baseline["dbias_tensor"].float(), rtol=2e-2, atol=2e-2)
+
+    check_ref_grouped_gemm_dsrelu(inputs, deterministic, cfg, skip_ref=cfg["skip_ref"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=43)
+@pytest.mark.parametrize("n", [512, 768])
+def test_grouped_gemm_dsrelu_deterministic_dbias_segments(request, n):
+    """The per-expert segment sum must follow the real expert boundaries.
+
+    A one-hot built off the wrong offsets still produces plausible finite numbers, so agreeing
+    with the non-deterministic path is not enough. Two n values, because the block count per
+    expert differs between them.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True, n_override=n)
+    inputs, cfg = case
+    try:
+        outputs = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    # dbias[e] is the column sum of dA over exactly the rows of expert e. Taken from the kernel's
+    # own d_row rather than a second reference implementation, so a failure points at the segment
+    # mapping and not at the GEMM. Stacked into one comparison to keep this to a single sync.
+    offsets = inputs["padded_offsets_tensor"].tolist()
+    d_row = outputs["d_row_tensor"].float()
+    bounds = list(zip([0] + offsets[:-1], offsets))
+    expected = torch.stack([d_row[start:end].sum(dim=0).reshape(-1) for start, end in bounds])
+    torch.testing.assert_close(outputs["dbias_tensor"].float().reshape(len(offsets), -1), expected, rtol=5e-2, atol=5e-2)
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=31)
 def test_grouped_gemm_dsrelu_deterministic_dprob_slot_count_cache(request):
     """Two N values with different slot counts must not share a compiled kernel.

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -407,6 +407,9 @@ def _run_dsrelu_deterministic_case(case, **wrapper_kwargs):
         padded_offsets=inputs["padded_offsets_tensor"],
         alpha_tensor=inputs["alpha_tensor"],
         prob_tensor=inputs["prob_tensor"],
+        # Required whenever the fp8 path allocates sfd_row/sfd_col: the API rejects a
+        # descriptor set where these three are not all-None or all-present.
+        norm_const_tensor=inputs.get("norm_const_tensor"),
         acc_dtype=cfg["acc_dtype"],
         d_dtype=cfg["d_dtype"],
         cd_major=cfg["cd_major"],
@@ -538,7 +541,9 @@ def test_grouped_gemm_dsrelu_deterministic_dprob_env_var(request, monkeypatch):
     except ImportError:
         pytest.skip("Environment not supported: cudnn optional dependencies not installed")
 
-    case = _build_dsrelu_deterministic_case(request, torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, True, False)
+    # fp8 rather than the uint8 raw-FP4 config: the latter needs a CUTLASS the shared
+    # allocators cannot always provide, and a test that skips is a test that guards nothing.
+    case = _build_dsrelu_deterministic_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
 
     try:
         explicit = _run_dsrelu_deterministic_case(case, deterministic=True)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -737,6 +737,39 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=71)
+@pytest.mark.parametrize("deterministic", [False, True], ids=["default", "deterministic"])
+def test_grouped_gemm_dsrelu_dbias_cache_keys_on_n(request, deterministic, monkeypatch):
+    """Two n values that share a dprob slot count must not share a dbias kernel.
+
+    Under the default full-dynamic key every tensor drops its shape, because the kernel compiles
+    with symbolic extents -- but _make_dbias_fake frees only dim 0, so dbias's n stays baked, and
+    nothing else in the dense key carries n (b_tensor.shape[2] is l; dprob_n_slots is too coarse,
+    n=384 and n=512 both give 2). Before the fix the second call reused the first kernel and
+    CuTeDSL rejected it: "Mismatched dbias_tensor.shape[1] ... expected to be 384" (job 469460).
+    Pre-existing on the default path, which is why this is parametrized over both modes.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+        from cudnn.gemm.cutedsl.grouped.dsrelu import api as dsrelu_api
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    monkeypatch.setattr(dsrelu_api, "_cache_of_GroupedGemmDsreluSm100Objects", {})
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    for n in (384, 512):
+        case = _build_dsrelu_case(request, *args, n_override=n)
+        try:
+            outputs = _run_dsrelu_case(case, deterministic=deterministic, generate_dbias=True)
+        except (ValueError, NotImplementedError) as e:
+            pytest.skip(f"Unsupported testcase: {e}")
+        torch.cuda.synchronize()
+        assert outputs["dbias_tensor"].shape == (case[1]["l"], n, 1)
+        check_ref_grouped_gemm_dsrelu(case[0], outputs, case[1], skip_ref=case[1]["skip_ref"])
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=67)
 def test_grouped_gemm_dsrelu_deterministic_class_api(request):
     """The class API under determinism: same output args as the default, plus explicit scratch.
@@ -831,8 +864,10 @@ def test_grouped_gemm_dsrelu_deterministic_class_api(request):
         norm_const_tensor=inputs.get("norm_const_tensor"),
         current_stream=stream,
     )
+    # Both accumulate onto the output, so the zeroed buffers above end up holding the result --
+    # no copy_ needed, and the same semantics the kernel has when the flag is off.
     GroupedGemmDsreluSm100.reduce_dprob_workspace(dprob_ws, dprob, stream)
-    dbias.copy_(GroupedGemmDsreluSm100.reduce_dbias_workspace(dbias_ws, inputs["padded_offsets_tensor"], cfg["mma_tiler_mn"], stream))
+    GroupedGemmDsreluSm100.reduce_dbias_workspace(dbias_ws, inputs["padded_offsets_tensor"], dbias, cfg["mma_tiler_mn"], stream)
     torch.cuda.synchronize()
 
     assert torch.equal(bitwise_bits(dprob), bitwise_bits(expected["dprob_tensor"])), "class API dprob differs from the wrapper"

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -400,6 +400,7 @@ def _run_dsrelu_case(case, **wrapper_kwargs):
     from cuda.bindings import driver as cuda
 
     inputs, cfg = case
+    wrapper_kwargs.setdefault("current_stream", cuda.CUstream(torch.cuda.current_stream().cuda_stream))
     return grouped_gemm_dsrelu_wrapper_sm100(
         a_tensor=inputs["a_tensor"],
         b_tensor=inputs["b_tensor"],
@@ -421,12 +422,11 @@ def _run_dsrelu_case(case, **wrapper_kwargs):
         vector_f32=cfg["vector_f32"],
         m_aligned=cfg["m_aligned"],
         discrete_col_sfd=cfg["discrete_col_sfd"],
-        current_stream=cuda.CUstream(torch.cuda.current_stream().cuda_stream),
         **wrapper_kwargs,
     )
 
 
-def _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd):
+def _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd, n_override=None):
     cfg = grouped_gemm_dsrelu_init(
         request=request,
         ab_dtype=ab_dtype,
@@ -442,6 +442,10 @@ def _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtyp
         discrete_col_sfd=discrete_col_sfd,
         b_major="k",
     )
+    if n_override is not None:
+        # Everything downstream reads cfg["n"], so overriding it here keeps the allocators,
+        # the wrapper call and the reference in agreement.
+        cfg["n"] = n_override
     inputs = allocate_grouped_gemm_input_tensors(
         n=cfg["n"],
         k=cfg["k"],
@@ -470,13 +474,18 @@ def _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtyp
 
 @contextlib.contextmanager
 def _torch_deterministic_algorithms():
-    """Scope torch's global determinism flag, restoring whatever the session had."""
+    """Scope torch's global determinism flag, restoring whatever the session had.
+
+    warn_only is captured and restored too: hardcoding it on the way out would downgrade a
+    session running under strict determinism into warning-only for every later test.
+    """
     previous = torch.are_deterministic_algorithms_enabled()
+    previous_warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
     torch.use_deterministic_algorithms(True, warn_only=True)
     try:
         yield
     finally:
-        torch.use_deterministic_algorithms(previous, warn_only=True)
+        torch.use_deterministic_algorithms(previous, warn_only=previous_warn_only)
 
 
 def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inputs=None):
@@ -556,11 +565,14 @@ def test_grouped_gemm_dsrelu_deterministic_dprob(request, ab_dtype, c_dtype, d_d
 
     case = _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd)
 
+    # Only the baseline probe may skip. Once it has run, the config is supported, so a
+    # failure from the deterministic run is a real failure -- catching it here would turn
+    # exactly the regression this test exists to find into a green skip.
     try:
         baseline = _run_dsrelu_case(case, deterministic=False)
-        deterministic = _run_dsrelu_case(case, deterministic=True)
     except (ValueError, NotImplementedError) as e:
         pytest.skip(f"Unsupported testcase: {e}")
+    deterministic = _run_dsrelu_case(case, deterministic=True)
     _assert_dprob_deterministic(case, baseline, deterministic, lambda: _run_dsrelu_case(case, deterministic=True))
 
     # Unset, the flag follows torch -- the path most callers will actually take.
@@ -573,6 +585,65 @@ def test_grouped_gemm_dsrelu_deterministic_dprob(request, ab_dtype, c_dtype, d_d
 # b_major does not reach the dprob path, so the n-major config would only re-prove what
 # fp8-k-major already does; the two dtypes are kept because they compile different kernels.
 DISCRETE_DETERMINISTIC_CONFIGS = [c for c in DISCRETE_GROUPED_GEMM_DSRELU_SUPPORTED_CONFIGS if c.id != "fp8-n-major"]
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=29)
+def test_grouped_gemm_dsrelu_deterministic_dprob_side_stream(request):
+    """The slot reduction must be ordered against the kernel on the caller's stream.
+
+    Issued on torch's current stream instead, it would read dprob before the kernel that
+    writes it had finished. The race is timing-dependent, so a green run here is not proof
+    of correct ordering -- but it does exercise the non-current-stream path, which every
+    other test misses by passing torch's own stream.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    inputs, cfg = case
+
+    # Deliberately NOT entering torch.cuda.stream(side): the divergence between the wrapper's
+    # stream and torch's current stream is the whole point. Inside that context the two would
+    # be the same stream and the ordering bug could not appear.
+    side = torch.cuda.Stream()
+    try:
+        on_side = _run_dsrelu_case(case, deterministic=True, current_stream=cuda.CUstream(side.cuda_stream))
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    check_ref_grouped_gemm_dsrelu(inputs, on_side, cfg, skip_ref=cfg["skip_ref"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=31)
+def test_grouped_gemm_dsrelu_deterministic_dprob_slot_count_cache(request):
+    """Two N values with different slot counts must not share a compiled kernel.
+
+    Under CUDNN_FE_GROUPED_GEMM_DYNAMIC_MNKL the cache key drops tensor shapes, but the
+    dprob slot extent is static in the compiled descriptor. n=512 and n=768 give 2 and 3
+    slots; if the second reuses the first's kernel, its dprob comes back wrong.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    for n in (512, 768):
+        case = _build_dsrelu_case(request, *args, n_override=n)
+        inputs, cfg = case
+        try:
+            outputs = _run_dsrelu_case(case, deterministic=True)
+        except (ValueError, NotImplementedError) as e:
+            pytest.skip(f"Unsupported testcase: {e}")
+        torch.cuda.synchronize()
+        check_ref_grouped_gemm_dsrelu(inputs, outputs, cfg, skip_ref=cfg["skip_ref"])
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -388,6 +388,163 @@ def test_grouped_gemm_dsrelu_wrapper_uint8_raw_fp4_smoke(request):
     assert torch.count_nonzero(outputs["d_row_tensor"]).item() > 0
 
 
+def _run_dsrelu_deterministic_case(case, **wrapper_kwargs):
+    """Run the wrapper once over an already-built case, so repeats share identical inputs.
+
+    ``dprob_tensor`` is deliberately not passed: the wrapper then allocates and zeroes a
+    fresh one per call, which is what lets two runs be compared against each other.
+    """
+    from cudnn import grouped_gemm_dsrelu_wrapper_sm100
+    from cuda.bindings import driver as cuda
+
+    inputs, cfg = case
+    return grouped_gemm_dsrelu_wrapper_sm100(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        c_tensor=inputs["c_tensor"],
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        prob_tensor=inputs["prob_tensor"],
+        acc_dtype=cfg["acc_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        current_stream=cuda.CUstream(torch.cuda.current_stream().cuda_stream),
+        **wrapper_kwargs,
+    )
+
+
+def _build_dsrelu_deterministic_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd):
+    cfg = grouped_gemm_dsrelu_init(
+        request=request,
+        ab_dtype=ab_dtype,
+        c_dtype=c_dtype,
+        d_dtype=d_dtype,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=sf_vec_size,
+        sf_dtype=sf_dtype,
+        vector_f32=vector_f32,
+        discrete_col_sfd=discrete_col_sfd,
+        b_major="k",
+    )
+    inputs = allocate_grouped_gemm_input_tensors(
+        n=cfg["n"],
+        k=cfg["k"],
+        l=cfg["l"],
+        group_m_list=cfg["group_m_list"],
+        ab_dtype=cfg["ab_dtype"],
+        b_major=cfg["b_major"],
+        sf_dtype=cfg["sf_dtype"],
+        sf_vec_size=cfg["sf_vec_size"],
+        m_aligned=cfg["m_aligned"],
+    )
+    inputs, _ = allocate_grouped_gemm_dsrelu_tensors(
+        tensor_m=inputs["tensor_m"],
+        n=cfg["n"],
+        l=cfg["l"],
+        ab_dtype=cfg["ab_dtype"],
+        c_dtype=cfg["c_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        sf_dtype=cfg["sf_dtype"],
+        sf_vec_size=cfg["sf_vec_size"],
+        input_tensors=inputs,
+    )
+    return inputs, cfg
+
+
+# n defaults to 512 against an mma_tiler_mn[1] of 256, so grid_n is 2 and the cross-N-tile
+# reduction -- level 2 of the fix -- is actually exercised. A config with n <= 256 would
+# only cover level 1.
+GROUPED_GEMM_DSRELU_DETERMINISTIC_CONFIGS = [
+    pytest.param(torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, True, False, id="fp4"),
+    pytest.param(torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True, id="fp8"),
+]
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=17)
+@pytest.mark.parametrize(
+    "ab_dtype,c_dtype,d_dtype,sf_vec_size,sf_dtype,vector_f32,discrete_col_sfd",
+    GROUPED_GEMM_DSRELU_DETERMINISTIC_CONFIGS,
+)
+def test_grouped_gemm_dsrelu_deterministic_dprob(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd):
+    """deterministic=True makes dprob bit-exact without changing what it computes."""
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_deterministic_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd)
+
+    try:
+        baseline = _run_dsrelu_deterministic_case(case, deterministic=False)
+        first = _run_dsrelu_deterministic_case(case, deterministic=True)
+        second = _run_dsrelu_deterministic_case(case, deterministic=True)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    # The caller-visible shape is unchanged -- the per-N-tile workspace is internal.
+    assert first["dprob_tensor"].shape == baseline["dprob_tensor"].shape
+    assert torch.isfinite(first["dprob_tensor"]).all()
+    assert torch.count_nonzero(first["dprob_tensor"]).item() > 0
+
+    # The property under test. Two runs of the same kernel on the same inputs must agree
+    # to the last bit, not merely to a tolerance.
+    assert torch.equal(first["dprob_tensor"], second["dprob_tensor"])
+
+    # Reordering a float sum must not change what is being summed: a partial dropped by a
+    # gap in the per-subtile slots, or double-counted by a second writer to an N-tile slot,
+    # would show up here and nowhere else.
+    scale = baseline["dprob_tensor"].abs().max().item()
+    torch.testing.assert_close(
+        first["dprob_tensor"],
+        baseline["dprob_tensor"],
+        rtol=1e-4,
+        atol=1e-4 * max(scale, 1.0),
+    )
+
+    # dprob is the only output the flag touches; dA and friends are single-write per
+    # element and must come back untouched.
+    for key in ("d_row_tensor", "d_col_tensor", "d_srelu_tensor"):
+        assert torch.equal(first[key], baseline[key]), f"{key} changed under deterministic=True"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=19)
+def test_grouped_gemm_dsrelu_deterministic_dprob_env_var(request, monkeypatch):
+    """The env var is the opt-in when the call site is not the caller's to edit."""
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_deterministic_case(request, torch.uint8, torch.bfloat16, torch.bfloat16, 16, torch.float8_e8m0fnu, True, False)
+
+    try:
+        explicit = _run_dsrelu_deterministic_case(case, deterministic=True)
+        monkeypatch.setenv("CUDNN_FE_GROUPED_GEMM_DSRELU_DETERMINISTIC", "1")
+        from_env = _run_dsrelu_deterministic_case(case)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    assert torch.equal(explicit["dprob_tensor"], from_env["dprob_tensor"])
+
+
 @pytest.mark.L0
 @torch_fork_set_rng(seed=13)
 @pytest.mark.parametrize("ab_dtype,c_dtype,d_dtype,b_major", DISCRETE_GROUPED_GEMM_DSRELU_SUPPORTED_CONFIGS)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -521,6 +521,12 @@ def test_grouped_gemm_dsrelu_deterministic_dprob(request, ab_dtype, c_dtype, d_d
     for key in ("d_row_tensor", "d_col_tensor", "d_srelu_tensor"):
         assert torch.equal(first[key], baseline[key]), f"{key} changed under deterministic=True"
 
+    # The deterministic path has to clear the same bar as the default one, not merely agree
+    # with it: this is the reference check the non-deterministic wrapper tests run, over the
+    # whole backward output set (dprob, dA row/col, d_srelu, amax, scale factors).
+    inputs, cfg = case
+    check_ref_grouped_gemm_dsrelu(inputs, first, cfg, skip_ref=cfg["skip_ref"])
+
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=19)
@@ -543,6 +549,105 @@ def test_grouped_gemm_dsrelu_deterministic_dprob_env_var(request, monkeypatch):
     torch.cuda.synchronize()
 
     assert torch.equal(explicit["dprob_tensor"], from_env["dprob_tensor"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=23)
+@pytest.mark.parametrize("ab_dtype,c_dtype,d_dtype,b_major", DISCRETE_GROUPED_GEMM_DSRELU_SUPPORTED_CONFIGS)
+def test_grouped_gemm_dsrelu_deterministic_dprob_discrete(request, ab_dtype, c_dtype, d_dtype, b_major):
+    """Same guarantee in discrete-weight mode, which builds its cache key on its own branch."""
+    try:
+        from cudnn import grouped_gemm_dsrelu_wrapper_sm100
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    cfg = discrete_grouped_gemm_init(
+        request=request,
+        ab_dtype=ab_dtype,
+        c_dtype=c_dtype,
+        d_dtype=d_dtype,
+        cd_major="n",
+        acc_dtype=torch.float32,
+        mma_tiler_mn=(256, 256),
+        cluster_shape_mn=(2, 1),
+        sf_vec_size=32,
+        sf_dtype=torch.float8_e8m0fnu,
+        vector_f32=False,
+        discrete_col_sfd=False,
+        b_major=b_major,
+    )
+
+    inputs = _prepare_discrete_dsrelu_inputs(
+        allocate_discrete_input_tensors(
+            n=cfg["n"],
+            k=cfg["k"],
+            num_experts=cfg["l"],
+            group_m_list=cfg["group_m_list"],
+            ab_dtype=cfg["ab_dtype"],
+            sf_dtype=cfg["sf_dtype"],
+            sf_vec_size=cfg["sf_vec_size"],
+            m_aligned=cfg["m_aligned"],
+            b_major=cfg["b_major"],
+        )
+    )
+    inputs, _ = allocate_grouped_gemm_dsrelu_tensors(
+        tensor_m=inputs["tensor_m"],
+        n=cfg["n"],
+        l=cfg["l"],
+        ab_dtype=cfg["ab_dtype"],
+        c_dtype=cfg["c_dtype"],
+        d_dtype=cfg["d_dtype"],
+        cd_major=cfg["cd_major"],
+        sf_dtype=cfg["sf_dtype"],
+        sf_vec_size=cfg["sf_vec_size"],
+        input_tensors=inputs,
+    )
+
+    def run(**kwargs):
+        return grouped_gemm_dsrelu_wrapper_sm100(
+            a_tensor=inputs["a_tensor"],
+            c_tensor=inputs["c_tensor"],
+            sfa_tensor=inputs["sfa_tensor"],
+            padded_offsets=inputs["padded_offsets_tensor"],
+            alpha_tensor=inputs["alpha_tensor"],
+            prob_tensor=inputs["prob_tensor"],
+            b_ptrs=inputs["b_ptrs_tensor"],
+            sfb_ptrs=inputs["sfb_ptrs_tensor"],
+            n=cfg["n"],
+            b_dtype=inputs["b_list"][0].dtype,
+            b_major=cfg["b_major"],
+            norm_const_tensor=inputs.get("norm_const_tensor"),
+            acc_dtype=cfg["acc_dtype"],
+            d_dtype=cfg["d_dtype"],
+            cd_major=cfg["cd_major"],
+            mma_tiler_mn=cfg["mma_tiler_mn"],
+            cluster_shape_mn=cfg["cluster_shape_mn"],
+            sf_vec_size=cfg["sf_vec_size"],
+            vector_f32=cfg["vector_f32"],
+            m_aligned=cfg["m_aligned"],
+            discrete_col_sfd=cfg["discrete_col_sfd"],
+            current_stream=cuda.CUstream(torch.cuda.current_stream().cuda_stream),
+            **kwargs,
+        )
+
+    baseline = run(deterministic=False)
+    first = run(deterministic=True)
+    second = run(deterministic=True)
+    torch.cuda.synchronize()
+
+    assert first["dprob_tensor"].shape == baseline["dprob_tensor"].shape
+    assert torch.equal(first["dprob_tensor"], second["dprob_tensor"])
+
+    scale = baseline["dprob_tensor"].abs().max().item()
+    torch.testing.assert_close(first["dprob_tensor"], baseline["dprob_tensor"], rtol=1e-4, atol=1e-4 * max(scale, 1.0))
+
+    check_ref_grouped_gemm_dsrelu(
+        _dense_ref_inputs_from_discrete(inputs),
+        first,
+        cfg,
+        skip_ref=cfg["skip_ref"],
+    )
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -737,6 +737,109 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=67)
+def test_grouped_gemm_dsrelu_deterministic_class_api(request):
+    """The class API under determinism: same output args as the default, plus explicit scratch.
+
+    Every other determinism test drives the wrapper, which hides the workspaces. This is the only
+    coverage of the contract a direct GroupedGemmDsreluSm100 caller sees -- that dprob and dbias
+    keep their shapes and dtypes, that the scratch is a separate argument sized by the public
+    helpers, and that the public reductions turn it into the documented outputs.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda
+        from cudnn import GroupedGemmDsreluSm100
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    case = _build_dsrelu_case(request, *args, group_m_override=[256, 512, 256, 1024])
+    inputs, cfg = case
+
+    # The wrapper run is the oracle: same inputs, so the class must reproduce it exactly.
+    try:
+        expected = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    valid_m, n, l = inputs["a_tensor"].shape[0], cfg["n"], cfg["l"]
+    dev = inputs["a_tensor"].device
+    dprob = torch.zeros((valid_m, 1, 1), dtype=torch.float32, device=dev)
+    dbias = torch.zeros((l, n, 1), dtype=torch.bfloat16, device=dev)
+    dprob_ws = torch.zeros(GroupedGemmDsreluSm100.dprob_workspace_shape(valid_m, n), dtype=torch.float32, device=dev)
+    dbias_ws = torch.zeros(GroupedGemmDsreluSm100.dbias_workspace_shape(valid_m, n), dtype=torch.bfloat16, device=dev)
+
+    # The output args are byte-for-byte the ones the non-deterministic path takes.
+    assert dprob.shape == expected["dprob_tensor"].shape and dprob.dtype == expected["dprob_tensor"].dtype
+    assert dbias.shape == expected["dbias_tensor"].shape and dbias.dtype == expected["dbias_tensor"].dtype
+
+    d_row = torch.empty_strided((valid_m, n, 1), (n, 1, valid_m * n), dtype=cfg["d_dtype"], device=dev)
+    d_col = torch.empty_strided((valid_m, n, 1), (n, 1, valid_m * n), dtype=cfg["d_dtype"], device=dev)
+    op = GroupedGemmDsreluSm100(
+        sample_a=inputs["a_tensor"],
+        sample_b=inputs["b_tensor"],
+        sample_c=inputs["c_tensor"],
+        sample_d_row=d_row,
+        sample_d_col=d_col,
+        sample_sfa=inputs["sfa_tensor"],
+        sample_sfb=inputs["sfb_tensor"],
+        sample_padded_offsets=inputs["padded_offsets_tensor"],
+        sample_alpha=inputs["alpha_tensor"],
+        sample_prob=inputs["prob_tensor"],
+        sample_dprob=dprob,
+        sample_dbias=dbias,
+        sample_dprob_workspace=dprob_ws,
+        sample_dbias_workspace=dbias_ws,
+        sample_sfd_row=expected["sfd_row_tensor"],
+        sample_sfd_col=expected["sfd_col_tensor"],
+        sample_norm_const=inputs.get("norm_const_tensor"),
+        acc_dtype=cfg["acc_dtype"],
+        mma_tiler_mn=cfg["mma_tiler_mn"],
+        cluster_shape_mn=cfg["cluster_shape_mn"],
+        sf_vec_size=cfg["sf_vec_size"],
+        vector_f32=cfg["vector_f32"],
+        m_aligned=cfg["m_aligned"],
+        discrete_col_sfd=cfg["discrete_col_sfd"],
+        deterministic=True,
+    )
+    try:
+        assert op.check_support()
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    op.compile()
+
+    stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    op.execute(
+        a_tensor=inputs["a_tensor"],
+        b_tensor=inputs["b_tensor"],
+        c_tensor=inputs["c_tensor"],
+        d_row_tensor=d_row,
+        d_col_tensor=d_col,
+        sfa_tensor=inputs["sfa_tensor"],
+        sfb_tensor=inputs["sfb_tensor"],
+        padded_offsets=inputs["padded_offsets_tensor"],
+        alpha_tensor=inputs["alpha_tensor"],
+        prob_tensor=inputs["prob_tensor"],
+        dprob_tensor=dprob,
+        dbias_tensor=dbias,
+        dprob_workspace_tensor=dprob_ws,
+        dbias_workspace_tensor=dbias_ws,
+        sfd_row_tensor=expected["sfd_row_tensor"],
+        sfd_col_tensor=expected["sfd_col_tensor"],
+        norm_const_tensor=inputs.get("norm_const_tensor"),
+        current_stream=stream,
+    )
+    GroupedGemmDsreluSm100.reduce_dprob_workspace(dprob_ws, dprob, stream)
+    dbias.copy_(GroupedGemmDsreluSm100.reduce_dbias_workspace(dbias_ws, inputs["padded_offsets_tensor"], cfg["mma_tiler_mn"], stream))
+    torch.cuda.synchronize()
+
+    assert torch.equal(bitwise_bits(dprob), bitwise_bits(expected["dprob_tensor"])), "class API dprob differs from the wrapper"
+    assert torch.equal(bitwise_bits(dbias), bitwise_bits(expected["dbias_tensor"])), "class API dbias differs from the wrapper"
+
+
+@pytest.mark.L0
 @torch_fork_set_rng(seed=59)
 def test_grouped_gemm_dsrelu_deterministic_dbias_cache_is_m_dynamic(request, monkeypatch):
     """Deterministic dbias must not add token-count dependence to the compile cache key.

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -672,9 +672,8 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
     """deterministic=True makes dbias bit-exact without changing what it computes.
 
     dbias contends across M-tiles, not N-tiles like dprob, so it gets its own fp32 workspace
-    indexed by absolute M-block plus a per-expert segment sum. The three properties are the
-    same ones dprob has to hold: repeatable to the bit, agreeing with the default path, and
-    with the flag's other outputs untouched.
+    indexed by absolute M-block plus a per-expert segment sum. The properties it has to hold are
+    the same ones dprob does, so this reuses that checklist and adds the dbias-specific parts.
     """
     try:
         import cudnn  # noqa: F401
@@ -694,41 +693,35 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
     deterministic = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
     torch.cuda.synchronize()
 
-    # The caller-visible dbias keeps its (expert, n, 1) bf16 shape -- the fp32 M-block
-    # workspace and the segment sum are internal to the wrapper.
-    assert deterministic["dbias_tensor"].shape == baseline["dbias_tensor"].shape
+    # Everything dprob has to hold, dbias holds too -- including that the flag leaves the other
+    # outputs untouched -- so the dprob checklist covers it. check_ref now asserts dbias against
+    # the reference as well, which is what actually pins the per-expert segment mapping.
+    _assert_dprob_deterministic(case, baseline, deterministic, lambda: _run_dsrelu_case(case, deterministic=True, generate_dbias=True))
+
+    # The caller-visible dbias keeps its (expert, n, 1) bf16 shape; the fp32 M-block workspace and
+    # the segment sum are internal to the wrapper.
     assert deterministic["dbias_tensor"].dtype == torch.bfloat16
     assert torch.count_nonzero(deterministic["dbias_tensor"]).item() > 0
-
-    def _relaunch():
-        out = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
-        # dprob rides along rather than getting its own run: both reductions are issued on the
-        # same stream, and only checking them together catches an ordering regression there.
-        return out["dbias_tensor"], out["dprob_tensor"]
-
-    assert_bitwise_runs(_relaunch, label="dbias+dprob")
 
     # The two paths sum the same terms but not the same way: the default rounds to bf16 on every
     # M-tile, the deterministic one keeps fp32 partials and narrows once, which makes it the more
     # accurate of the pair. So they agree only to bf16 resolution at dbias's magnitude, and the
     # bound is scaled accordingly -- job 459169 failed a flat 2e-2 on a 16.0 difference that is
-    # ~2 ULP of bf16 there. Correctness against the reference is check_ref's job, below.
+    # ~2 ULP of bf16 there.
     det_dbias, base_dbias = deterministic["dbias_tensor"].float(), baseline["dbias_tensor"].float()
     torch.testing.assert_close(det_dbias, base_dbias, rtol=5e-2, atol=max(base_dbias.abs().max().item(), 1.0) * 5e-2)
-
-    check_ref_grouped_gemm_dsrelu(inputs, deterministic, cfg, skip_ref=cfg["skip_ref"])
 
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=43)
-@pytest.mark.parametrize("n", [512, 768])
-def test_grouped_gemm_dsrelu_deterministic_dbias_segments(request, n):
-    """The per-expert segment sum must follow the real expert boundaries.
+def test_grouped_gemm_dsrelu_deterministic_dbias_segments(request):
+    """The per-expert segment sum must follow the real expert boundaries at a second N.
 
     A one-hot built off the wrong offsets still produces plausible finite numbers and still
     agrees with the non-deterministic path to a loose tolerance, so only the reference catches
     it -- check_ref_grouped_gemm_dsrelu compares against a dbias summed per expert from the
-    unquantized dA. Two n values, because the block count per expert differs between them.
+    unquantized dA. n=768 rather than the default 512, so the segment sum is exercised against
+    a workspace whose row stride differs from the one the test above already covers.
     """
     try:
         import cudnn  # noqa: F401
@@ -736,7 +729,7 @@ def test_grouped_gemm_dsrelu_deterministic_dbias_segments(request, n):
     except ImportError:
         pytest.skip("Environment not supported: cudnn optional dependencies not installed")
 
-    case = _build_dsrelu_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True, n_override=n)
+    case = _build_dsrelu_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True, n_override=768)
     inputs, cfg = case
     try:
         outputs = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
@@ -744,7 +737,7 @@ def test_grouped_gemm_dsrelu_deterministic_dbias_segments(request, n):
         pytest.skip(f"Unsupported testcase: {e}")
     torch.cuda.synchronize()
 
-    assert outputs["dbias_tensor"].shape == (cfg["l"], n, 1)
+    assert outputs["dbias_tensor"].shape == (cfg["l"], 768, 1)
     check_ref_grouped_gemm_dsrelu(inputs, outputs, cfg, skip_ref=cfg["skip_ref"])
 
 

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -426,7 +426,7 @@ def _run_dsrelu_case(case, **wrapper_kwargs):
     )
 
 
-def _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd, n_override=None):
+def _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtype, vector_f32, discrete_col_sfd, n_override=None, group_m_override=None):
     cfg = grouped_gemm_dsrelu_init(
         request=request,
         ab_dtype=ab_dtype,
@@ -446,6 +446,12 @@ def _build_dsrelu_case(request, ab_dtype, c_dtype, d_dtype, sf_vec_size, sf_dtyp
         # Everything downstream reads cfg["n"], so overriding it here keeps the allocators,
         # the wrapper call and the reference in agreement.
         cfg["n"] = n_override
+    if group_m_override is not None:
+        # The default is [256] * l -- every expert the same size, so every expert owns the same
+        # number of M-blocks. Anything that assumes a uniform stride between experts survives
+        # that; only a ragged distribution tells a real segment mapping from a fake one.
+        cfg["group_m_list"] = group_m_override
+        cfg["l"] = len(group_m_override)
     inputs = allocate_grouped_gemm_input_tensors(
         n=cfg["n"],
         k=cfg["k"],
@@ -488,7 +494,7 @@ def _torch_deterministic_algorithms():
         torch.use_deterministic_algorithms(previous, warn_only=previous_warn_only)
 
 
-def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inputs=None):
+def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inputs=None, dprob_rtol=1e-4, dprob_atol=1e-4):
     """The three properties deterministic=True has to hold, shared by dense and discrete.
 
     ``relaunch`` produces another deterministic run; it is called repeatedly, because a
@@ -508,8 +514,9 @@ def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inp
     # gap in the per-subtile slots, or double-counted by a second writer to an N-tile slot,
     # would show up here and nowhere else. The tolerance is not delicate -- both modes sum
     # the same terms, so the honest difference is fp32 reordering (~1e-5 here), while a
-    # dropped or duplicated partial moves dprob by tens of percent.
-    torch.testing.assert_close(deterministic["dprob_tensor"], baseline["dprob_tensor"], rtol=1e-4, atol=1e-4)
+    # dropped or duplicated partial moves dprob by tens of percent. It does not transfer across
+    # n, though -- dprob sums n terms -- so callers at a larger n pass a looser pair.
+    torch.testing.assert_close(deterministic["dprob_tensor"], baseline["dprob_tensor"], rtol=dprob_rtol, atol=dprob_atol)
 
     # dprob is the only output the flag touches; dA and friends are single-write per element
     # and must come back untouched. d_col only joins that list when the fp8 scale-factor path
@@ -674,6 +681,9 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
     dbias contends across M-tiles, not N-tiles like dprob, so it gets its own fp32 workspace
     indexed by absolute M-block plus a per-expert segment sum. The properties it has to hold are
     the same ones dprob does, so this reuses that checklist and adds the dbias-specific parts.
+
+    Run on a ragged expert distribution -- see the comment on the case below; the default one
+    cannot fail this test.
     """
     try:
         import cudnn  # noqa: F401
@@ -681,7 +691,21 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
     except ImportError:
         pytest.skip("Environment not supported: cudnn optional dependencies not installed")
 
-    case = _build_dsrelu_case(request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    # Ragged on purpose. Measured (job 466159, 16 launches per config): at the default
+    # [256] * 4 the NON-deterministic dbias is already bit-stable, so assert_bitwise_runs below
+    # would pass whether or not the fix works. At this distribution it varies 15/15, which is
+    # what makes the assertion mean something.
+    case = _build_dsrelu_case(
+        request,
+        torch.float8_e4m3fn,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        32,
+        torch.float8_e8m0fnu,
+        False,
+        True,
+        group_m_override=[256, 512, 256, 1024],
+    )
     inputs, cfg = case
 
     try:
@@ -710,6 +734,165 @@ def test_grouped_gemm_dsrelu_deterministic_dbias(request):
     # ~2 ULP of bf16 there.
     det_dbias, base_dbias = deterministic["dbias_tensor"].float(), baseline["dbias_tensor"].float()
     torch.testing.assert_close(det_dbias, base_dbias, rtol=5e-2, atol=max(base_dbias.abs().max().item(), 1.0) * 5e-2)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=59)
+def test_grouped_gemm_dsrelu_deterministic_dbias_cache_is_m_dynamic(request, monkeypatch):
+    """Deterministic dbias must not add token-count dependence to the compile cache key.
+
+    The workspace has one row per CTA M-tile, so its dim 0 follows valid_m; keyed on the full
+    shape it would recompile for most steps of an MoE loop. Asserted as "no more entries than
+    the default path produces" rather than "exactly one": measured (job 466362) this config
+    already recompiles per valid_m without dbias at all -- elements 28/33/34 of the key are the
+    d_col batch stride and the sfd_col shape/strides, all of which carry M. That is pre-existing
+    and orthogonal; what this pins is that the flag adds nothing on top.
+
+    Only reachable with CUDNN_FE_GROUPED_GEMM_DYNAMIC_MNKL=0 -- the default path drops tensor
+    shapes from the key entirely, which is why the other dbias tests cannot see this.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+        from cudnn.gemm.cutedsl.grouped.dsrelu import api as dsrelu_api
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    monkeypatch.setenv("CUDNN_FE_GROUPED_GEMM_DYNAMIC_MNKL", "0")
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+
+    def entries_for(deterministic):
+        monkeypatch.setattr(dsrelu_api, "_cache_of_GroupedGemmDsreluSm100Objects", {})
+        for group_m_list in ([256] * 4, [256, 512, 256, 512]):
+            case = _build_dsrelu_case(request, *args, group_m_override=group_m_list)
+            outputs = _run_dsrelu_case(case, deterministic=deterministic, generate_dbias=True)
+            torch.cuda.synchronize()
+            check_ref_grouped_gemm_dsrelu(case[0], outputs, case[1], skip_ref=case[1]["skip_ref"])
+        return len(dsrelu_api._cache_of_GroupedGemmDsreluSm100Objects)
+
+    try:
+        baseline_entries = entries_for(False)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+
+    assert entries_for(True) == baseline_entries, "deterministic dbias added a token-count-dependent cache key"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=61)
+def test_grouped_gemm_dsrelu_deterministic_dbias_zero_tokens(request):
+    """A zero-token call must still return the documented dbias, not the slot workspace.
+
+    valid_m == 0 skips the kernel entirely, so the reduction runs on an empty workspace: the
+    one-hot is (expert_cnt, 0) and the matmul has an empty contraction. It has to come back
+    (expert_cnt, n, 1) bf16 and zeroed, the same as the non-deterministic path.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    args = (torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True)
+    case = _build_dsrelu_case(request, *args)
+    inputs, cfg = case
+    # Zero every group: valid_m becomes 0 while the descriptors stay well-formed.
+    inputs = dict(inputs)
+    inputs["padded_offsets_tensor"] = torch.zeros_like(inputs["padded_offsets_tensor"])
+    try:
+        outputs = _run_dsrelu_case((inputs, cfg), deterministic=True, generate_dbias=True)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    assert outputs["dbias_tensor"].shape == (cfg["l"], cfg["n"], 1)
+    assert outputs["dbias_tensor"].dtype == torch.bfloat16
+    assert torch.count_nonzero(outputs["dbias_tensor"]).item() == 0
+    assert outputs["dprob_tensor"].shape[1:] == (1, 1)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=53)
+def test_grouped_gemm_dsrelu_deterministic_at_scale(request):
+    """The one config in this file where the default path is non-deterministic in *both* outputs.
+
+    Measured (job 466159, 16 launches per config): at l=4 / [256] * 4 / n=512 -- what every other
+    determinism test here uses -- the non-deterministic dprob AND dbias are both already bit-stable,
+    so those tests cannot distinguish a working fix from a broken one. At l=8 / [1024] * 8 / n=2048
+    both vary 15/15. This is the case that actually demonstrates the flag does something.
+
+    L1 rather than L0: it is roughly 16x the work of the smoke configs.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_case(
+        request,
+        torch.float8_e4m3fn,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        32,
+        torch.float8_e8m0fnu,
+        False,
+        True,
+        n_override=2048,
+        group_m_override=[1024] * 8,
+    )
+    inputs, cfg = case
+    try:
+        baseline = _run_dsrelu_case(case, deterministic=False, generate_dbias=True)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    deterministic = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
+    # dprob sums n terms, so fp32 reassociation grows with n: the helper's 1e-4 is calibrated at
+    # the default n=512, and 1 element in 8192 lands at 1.8e-4 relative here (job 466172). That is
+    # reordering, not a dropped partial -- those move dprob by tens of percent, not by 5e-4.
+    _assert_dprob_deterministic(
+        case,
+        baseline,
+        deterministic,
+        lambda: _run_dsrelu_case(case, deterministic=True, generate_dbias=True),
+        dprob_rtol=1e-3,
+        dprob_atol=1e-3,
+    )
+    check_ref_grouped_gemm_dsrelu(inputs, deterministic, cfg, skip_ref=cfg["skip_ref"])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=47)
+@pytest.mark.parametrize("group_m_list", [[256, 512, 256, 1024], [512, 256, 1024, 256]], ids=["ragged", "ragged-reordered"])
+def test_grouped_gemm_dsrelu_deterministic_dbias_ragged_experts(request, group_m_list):
+    """Experts of different sizes own different numbers of M-blocks.
+
+    The default config is [256] * 4 -- every expert exactly two M-blocks -- so a segment sum
+    that simply assumed a fixed stride between experts would pass every other dbias test here.
+    These distributions give 2/4/2/8 and 4/2/8/2 blocks, so a fixed-stride or off-by-one
+    mapping lands one expert's rows in another and the reference check fails.
+    """
+    try:
+        import cudnn  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn optional dependencies not installed")
+
+    case = _build_dsrelu_case(
+        request, torch.float8_e4m3fn, torch.bfloat16, torch.float8_e4m3fn, 32, torch.float8_e8m0fnu, False, True, group_m_override=group_m_list
+    )
+    inputs, cfg = case
+    try:
+        outputs = _run_dsrelu_case(case, deterministic=True, generate_dbias=True)
+    except (ValueError, NotImplementedError) as e:
+        pytest.skip(f"Unsupported testcase: {e}")
+    torch.cuda.synchronize()
+
+    # Each expert's row must be non-trivial, or a mapping that collapsed everything into one
+    # expert could still satisfy the reference check on the rows it happened to fill.
+    per_expert_nonzero = (outputs["dbias_tensor"].float().abs().sum(dim=(1, 2)) > 0).tolist()
+    assert all(per_expert_nonzero), f"empty dbias rows: {per_expert_nonzero}"
+    check_ref_grouped_gemm_dsrelu(inputs, outputs, cfg, skip_ref=cfg["skip_ref"])
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu.py
@@ -498,8 +498,20 @@ def _assert_dprob_deterministic(case, baseline, deterministic, relaunch, ref_inp
     # 2. Reordering a float sum must not change what is being summed: a partial dropped by a
     # gap in the per-subtile slots, or double-counted by a second writer to an N-tile slot,
     # would show up here and nowhere else.
+    #
+    # The two modes sum the same n terms in a different order, so the gap between them is
+    # reordering error and nothing else. Summing n floats in a different order moves the
+    # result by at most (n-1) * u, u = 2**-24 being the fp32 unit roundoff; take 4x that as
+    # the bound so the test is not tuned to the exact schedule. Derived from n rather than
+    # hardcoded because n is settable (--grouped-gemm-nkl), and a fixed tolerance would
+    # false-fail on a wider problem.
+    #
+    # atol is separate because rtol alone is meaningless for an entry that cancelled to near
+    # zero: its absolute error is bounded by the size of the summands, not of the result. So
+    # scale atol by the largest dprob, with a floor of 1 for an all-tiny tensor.
+    reorder_rtol = 4 * (cfg["n"] - 1) * 2**-24
     scale = baseline["dprob_tensor"].abs().max().item()
-    torch.testing.assert_close(deterministic["dprob_tensor"], baseline["dprob_tensor"], rtol=1e-4, atol=1e-4 * max(scale, 1.0))
+    torch.testing.assert_close(deterministic["dprob_tensor"], baseline["dprob_tensor"], rtol=reorder_rtol, atol=reorder_rtol * max(scale, 1.0))
 
     # dprob is the only output the flag touches; dA and friends are single-write per element
     # and must come back untouched. d_col only joins that list when the fp8 scale-factor path

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu_utils.py
@@ -493,6 +493,14 @@ def check_ref_grouped_gemm_dsrelu(
     )
 
     torch.testing.assert_close(outputs["dprob_tensor"].float(), ref_tensors["dprob_ref"].float(), atol=atol, rtol=rtol)
+
+    if outputs.get("dbias_tensor") is not None and "dbias_ref" in ref_tensors:
+        # dbias sums dA down a whole expert, so its magnitude is ~group_m times d_row's and the
+        # shared atol does not transfer. Scaled by the largest reference value instead, which is
+        # loose enough for the default path -- it atomic-accumulates in bf16, one rounding per
+        # M-tile -- while still catching a dropped or misattributed expert segment.
+        dbias_scale = max(ref_tensors["dbias_ref"].float().abs().max().item(), 1.0)
+        torch.testing.assert_close(outputs["dbias_tensor"].float(), ref_tensors["dbias_ref"].float(), atol=dbias_scale * 5e-2, rtol=5e-2)
     torch.testing.assert_close(outputs["d_row_tensor"].float(), ref_tensors["d_ref"].float(), atol=atol, rtol=rtol)
 
     if "d_col_ref" in ref_tensors:

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu_utils.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_dsrelu_utils.py
@@ -494,7 +494,7 @@ def check_ref_grouped_gemm_dsrelu(
 
     torch.testing.assert_close(outputs["dprob_tensor"].float(), ref_tensors["dprob_ref"].float(), atol=atol, rtol=rtol)
 
-    if outputs.get("dbias_tensor") is not None and "dbias_ref" in ref_tensors:
+    if outputs.get("dbias_tensor") is not None:
         # dbias sums dA down a whole expert, so its magnitude is ~group_m times d_row's and the
         # shared atol does not transfer. Scaled by the largest reference value instead, which is
         # loose enough for the default path -- it atomic-accumulates in bf16, one rounding per

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -24,6 +24,9 @@ def assert_bitwise_runs(launch, repeats=DETERMINISM_REPEATS, label=""):
     ``repeats`` times back to back (single sync at the end) and require every
     run to match run 0 bit for bit (barrier/fence races are timing-dependent;
     any mismatching bit is a failure, there is no tolerance)."""
+    # DETERMINISM_REPEATS is settable, and below 2 there is nothing to compare run 0
+    # against -- the loop below would be empty and the assertion would pass vacuously.
+    assert repeats >= 2, f"{label}: assert_bitwise_runs needs repeats >= 2, got {repeats}"
     runs = [launch() for _ in range(repeats)]
     torch.cuda.synchronize()
     for out in runs[0]:

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -1,8 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import torch
 import functools
+
+# Repeats for bitwise-determinism checks. A reduction-order race is timing-dependent, so a
+# single repeat proves little; overridable for bisecting a flaky one.
+DETERMINISM_REPEATS = int(os.environ.get("DETERMINISM_REPEATS", "8"))
+
+
+def bitwise_bits(t: torch.Tensor) -> torch.Tensor:
+    """View a tensor as raw bytes, so comparisons are bitwise rather than by value.
+
+    torch.equal on floats would call +0.0 and -0.0 equal -- a difference a change in
+    reduction order can produce.
+    """
+    return t.contiguous().view(torch.uint8)
+
+
+def assert_bitwise_runs(launch, repeats=DETERMINISM_REPEATS, label=""):
+    """``launch()`` returns a tuple of freshly-written output tensors.  Launch
+    ``repeats`` times back to back (single sync at the end) and require every
+    run to match run 0 bit for bit (barrier/fence races are timing-dependent;
+    any mismatching bit is a failure, there is no tolerance)."""
+    runs = [launch() for _ in range(repeats)]
+    torch.cuda.synchronize()
+    for out in runs[0]:
+        assert torch.isfinite(out.float()).all(), f"{label}: non-finite output in run 0"
+    for r, outs in enumerate(runs[1:], start=1):
+        for i, (a, b) in enumerate(zip(runs[0], outs)):
+            assert torch.equal(bitwise_bits(a), bitwise_bits(b)), f"{label}: output {i} differs between run 0 and run {r}"
 
 
 # decorator function to fork the RNG and set the seed for each tests


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
   - I don't have access to add GitHub labels 

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic execution support for grouped GEMM + dsReLU operations.
  - Deterministic mode provides bitwise-stable `dprob` results across repeated runs.
  - The wrapper can inherit PyTorch deterministic settings, with per-call overrides available.
  - Added deterministic output-shape and reduction handling, including per-tile intermediate results.
  - `dbias` results remain nondeterministic.

- **Documentation**
  - Documented determinism options, output differences, resource costs, and usage details.

- **Tests**
  - Added coverage for repeatability, output preservation, alternate streams, and reference correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->