### PR TITLE
Type-erase the gemm/cutedsl APIs for torch + JAX, with eager and jax.jit entry points

### DIFF
--- a/docs/fe-oss-apis/gemm_fusions/gemm_amax.md
+++ b/docs/fe-oss-apis/gemm_fusions/gemm_amax.md
@@ -63,6 +63,8 @@ A (MxKxL), SFA                   B (NxKxL), SFB
 
 ## API Usage
 
+The tensor parameters are type-erased: torch tensors and JAX arrays are both accepted. torch is only imported when torch tensors/dtypes are passed, and jax only when JAX arrays are passed. Dtype parameters (`c_dtype`, `acc_dtype`) accept torch dtypes, numpy/ml_dtypes dtypes, dtype name strings, or `cutlass` types.
+
 ### High-level wrapper
 ```python
 result = gemm_amax_wrapper_sm100(
@@ -101,6 +103,53 @@ op = GemmAmaxSm100(
 assert op.check_support()
 op.compile()
 op.execute(a, b, sfa, sfb, c, amax, current_stream=None)
+```
+
+### Using JAX arrays
+
+Two integration levels are available:
+
+1. **`gemm_amax_jax_sm100`** (recommended for jitted programs) — an XLA custom call via [jax-tvm-ffi]. The kernel runs on XLA's compute stream (correctly ordered with surrounding ops), outputs are XLA-managed fresh arrays, and the call composes with `jax.jit`. No manual synchronization is needed. Requires the `jax` dependency group (`pip install --group jax`, which brings `jax-tvm-ffi`; Python >= 3.11).
+
+```python
+from cudnn import gemm_amax_jax_sm100
+
+@jax.jit
+def quantized_matmul(a, b, sfa, sfb):
+    c, amax = gemm_amax_jax_sm100(a, b, sfa, sfb, c_dtype=jnp.float32, sf_vec_size=32)
+    return c, amax
+```
+
+Calling it eagerly works but re-traces the `ffi_call` on every invocation; call it from inside a jitted function in hot loops.
+
+2. **The eager entry points below** (`gemm_amax_wrapper_sm100`, `GemmAmaxSm100`) also accept JAX arrays via DLPack. In hot loops prefer the **class API with pre-allocated output buffers** (~15 µs CPU per launch) over the wrapper — per-call `jnp` output allocation in the wrapper costs hundreds of µs of XLA dispatch.
+
+JAX arrays are always row-major (C-contiguous) and immutable-by-contract, so the JAX contract differs from torch in a few ways (all entry points):
+
+- `A`/`B` must be k-major `(M, K, 1)` / `(N, K, 1)` C-contiguous arrays, and the batch dim must be `L == 1` (batch-outermost layouts are not expressible as JAX arrays).
+- `C` supports `c_major="n"` only (the wrapper raises for `"m"`).
+- `SFA`/`SFB` are passed in the **physical C-contiguous atom shape** `(L, ceil_div(MN, 128), ceil_div(K, 4·sf_vec_size), 32, 4, 4)` — byte-identical in memory to the torch-style logical view above (which is this allocation permuted by `(3, 4, 1, 5, 2, 0)`). Both forms are accepted for either framework.
+- Packed fp4 has no JAX dtype; the intended vehicle is a `uint8` container tensor (`(M, K // 2, 1)`), but that container path is currently disabled kernel-side for torch and JAX alike. FP8 flavors (`float8_e4m3fn`, `float8_e5m2`, `float8_e8m0fnu` via ml_dtypes) are fully supported.
+- Eager entry points only: with no explicit stream, the kernel launches on the **CUDA legacy default stream**, which XLA does not track. `jax.block_until_ready(...)` your inputs before calling, and synchronize the device (or the stream you passed) before reading the outputs. (`gemm_amax_jax_sm100` has neither caveat — XLA orders it on its own stream.)
+- The eager wrapper allocates outputs with `jnp.empty`/`jnp.full` and the kernel writes into them via DLPack. This is outside JAX's functional model: eager use only — do not call the wrapper under `jax.jit` or with donated buffers. Use `gemm_amax_jax_sm100` under `jit`.
+
+```python
+import jax, jax.numpy as jnp
+import ml_dtypes
+import numpy as np
+from cudnn import gemm_amax_wrapper_sm100
+
+m, n, k, sf_vec_size = 512, 256, 256, 32
+a = jax.device_put(np.random.randn(m, k, 1).astype(ml_dtypes.float8_e5m2))
+b = jax.device_put(np.random.randn(n, k, 1).astype(ml_dtypes.float8_e5m2))
+sfa = jax.device_put(np.ones((1, m // 128, k // (4 * sf_vec_size), 32, 4, 4), dtype=ml_dtypes.float8_e8m0fnu))
+sfb = jax.device_put(np.ones((1, n // 128, k // (4 * sf_vec_size), 32, 4, 4), dtype=ml_dtypes.float8_e8m0fnu))
+jax.block_until_ready((a, b, sfa, sfb))
+
+c, amax = gemm_amax_wrapper_sm100(a, b, sfa, sfb, c_dtype=jnp.float32, sf_vec_size=sf_vec_size)
+
+from cuda.bindings import runtime as cudart
+cudart.cudaDeviceSynchronize()  # kernel ran on the legacy stream, outside XLA's tracking
 ```
 
 ---
@@ -199,9 +248,16 @@ Tuple unpacking order is: `(c_tensor, amax_tensor)`.
 ### Environment
 
 - Requires CUDA with SM100+ compute capability
+- All tensors must reside on the same CUDA device
+
+### JAX-specific constraints
+
+- `L == 1`; `A`/`B` k-major; `C` n-major only
+- `SFA`/`SFB` in the physical atom shape `(L, MN', K', 32, 4, 4)` (see "Using JAX arrays")
+- Eager use only (no `jax.jit` over these entry points); synchronize before reading outputs
 
 ---
 
 ## Usage examples
 
-For usage examples, see test cases in `test/python/fe_api/gemm/test_gemm_amax.py`
+For usage examples, see test cases in `test/python/fe_api/gemm/test_gemm_amax.py` (torch) and `test/python/fe_api/gemm/test_gemm_amax_jax.py` (JAX)

--- a/docs/fe-oss-apis/gemm_fusions/gemm_dsrelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/gemm_dsrelu.md
@@ -73,6 +73,8 @@ A (MxKxL), SFA                   B (NxKxL), SFB
 
 ## API Usage
 
+The tensor parameters are type-erased: torch tensors and JAX arrays are both accepted (torch is only imported when torch tensors/dtypes are passed, jax only when JAX arrays are passed). Dtype parameters accept torch dtypes, numpy/ml_dtypes dtypes, dtype name strings, or `cutlass` types. The JAX contract matches gemm_amax (see `gemm_amax.md` "Using JAX arrays"): A/B k-major `(M, K, 1)`/`(N, K, 1)`, outputs n-major only, batch `L == 1`, scale-factor tensors accepted in the physical C-contiguous atom shape `(L, MN', K', 32, 4, 4)`; the eager entry points run on the CUDA legacy default stream (synchronize before reading outputs). A `jax.jit`-compatible XLA custom-call entry point is not yet available for this kernel (its signature carries optional None-typed parameters that the jax-tvm-ffi bridge cannot supply).
+
 ### High-level wrapper
 
 ```python

--- a/docs/fe-oss-apis/gemm_fusions/gemm_srelu.md
+++ b/docs/fe-oss-apis/gemm_fusions/gemm_srelu.md
@@ -66,6 +66,8 @@ A (MxKxL), SFA                   B (NxKxL), SFB
 
 ## API Usage
 
+The tensor parameters are type-erased: torch tensors and JAX arrays are both accepted (torch is only imported when torch tensors/dtypes are passed, jax only when JAX arrays are passed). Dtype parameters accept torch dtypes, numpy/ml_dtypes dtypes, dtype name strings, or `cutlass` types. The JAX contract matches gemm_amax (see `gemm_amax.md` "Using JAX arrays"): A/B k-major `(M, K, 1)`/`(N, K, 1)`, outputs n-major only, batch `L == 1`, scale-factor tensors accepted in the physical C-contiguous atom shape `(L, MN', K', 32, 4, 4)`; the eager entry points run on the CUDA legacy default stream (synchronize before reading outputs). A `jax.jit`-compatible XLA custom-call entry point is not yet available for this kernel (its signature carries optional None-typed parameters that the jax-tvm-ffi bridge cannot supply).
+
 ### High-level wrapper
 
 ```python

--- a/docs/fe-oss-apis/gemm_fusions/gemm_swiglu.md
+++ b/docs/fe-oss-apis/gemm_fusions/gemm_swiglu.md
@@ -66,6 +66,19 @@ Notes:
 
 ## API Usage
 
+The tensor parameters are type-erased: torch tensors and JAX arrays are both accepted (torch is only imported when torch tensors/dtypes are passed, jax only when JAX arrays are passed). Dtype parameters accept torch dtypes, numpy/ml_dtypes dtypes, dtype name strings, or `cutlass` types. The JAX contract matches gemm_amax (see `gemm_amax.md` "Using JAX arrays"): A/B k-major `(M, K, 1)`/`(N, K, 1)`, outputs n-major only, batch `L == 1`, SF tensors accepted in the physical C-contiguous atom shape `(L, MN', K', 32, 4, 4)`; the eager entry points run on the CUDA legacy default stream (synchronize before reading outputs).
+
+For jitted JAX programs, use **`gemm_swiglu_jax_sm100`** — an XLA custom call (via jax-tvm-ffi, `jax` dependency group) that runs on XLA's compute stream, returns fresh `(ab12, c)` arrays, and composes with `jax.jit`. It currently supports the standard (non-quantized) kernel only; use the eager wrapper for blockscaled MXFP8 inputs from JAX. `alpha` is a static (trace-time) parameter.
+
+```python
+from cudnn import gemm_swiglu_jax_sm100
+
+@jax.jit
+def swiglu_mlp(a, b):
+    ab12, c = gemm_swiglu_jax_sm100(a, b, alpha=1.0, ab12_dtype=jnp.float32, c_dtype=jnp.bfloat16)
+    return c
+```
+
 ### High-level wrapper (Standard Mode)
 
 ```python

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -2,6 +2,8 @@
 
 **FE-OSS APIs are experimental and subject to change.**
 
+The GEMM CuTeDSL APIs are type-erased and torch-lazy: torch is imported only when torch tensors are passed. The dense GEMM fusions (amax, swiglu, srelu, dsrelu) additionally accept JAX arrays (see `gemm_amax.md` "Using JAX arrays" for the JAX contract), with `jax.jit`-compatible XLA custom-call entry points for amax and swiglu; the grouped / discrete-grouped / proj_rope APIs currently support torch tensors only and reject other frameworks with a clear error.
+
 This folder documents the Python FE APIs implemented under `python/cudnn`. For details on currently implemented operations, see:
 - [GEMM + Amax](gemm_fusions/gemm_amax.md)
 - [GEMM + RoPE + MXFP8 Projection](gemm_fusions/gemm_proj_rope_mxfp8.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,20 @@ dev = [
     "black==26.3.1",
     "clang-format==21.1.6",
 ]
+# Per-framework groups for the type-erased CuTeDSL APIs (currently
+# gemm.cutedsl.dense.amax): install with `pip install --group torch` /
+# `pip install --group jax`. GPU wheels (torch cuXX, jax[cuda12]/[cuda13])
+# are left to the user.
+torch = [
+    "torch",
+    "torch-c-dlpack-ext",
+]
+# jax-tvm-ffi provides the jax.jit-compatible XLA custom-call entry points
+# (e.g. gemm_amax_jax_sm100) and requires Python >= 3.11.
+jax = [
+    "jax>=0.4.35",
+    "jax-tvm-ffi>=0.1.3",
+]
 
 [build-system]
 requires = ["setuptools>=64", "cmake>=3.18", "ninja==1.11.1.1", "pybind11[global]>=2.13,<3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,10 @@ dev = [
     "black==26.3.1",
     "clang-format==21.1.6",
 ]
-# Per-framework groups for the type-erased CuTeDSL APIs (currently
-# gemm.cutedsl.dense.amax): install with `pip install --group torch` /
-# `pip install --group jax`. GPU wheels (torch cuXX, jax[cuda12]/[cuda13])
-# are left to the user.
+# Per-framework groups for the type-erased CuTeDSL GEMM APIs (JAX is supported
+# by the dense fusions: amax, swiglu, srelu, dsrelu): install with
+# `pip install --group torch` / `pip install --group jax`. GPU wheels
+# (torch cuXX, jax[cuda12]/[cuda13]) are left to the user.
 torch = [
     "torch",
     "torch-c-dlpack-ext",

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -318,6 +318,7 @@ _LAZY_OPTIONAL_IMPORTS = {
     "NSA": (".native_sparse_attention", "NSA"),
     "GemmSwigluSm100": (".gemm.cutedsl.dense.swiglu", "GemmSwigluSm100"),
     "gemm_swiglu_wrapper_sm100": (".gemm.cutedsl.dense.swiglu", "gemm_swiglu_wrapper_sm100"),
+    "gemm_swiglu_jax_sm100": (".gemm.cutedsl.dense.swiglu", "gemm_swiglu_jax_sm100"),
     "GemmSreluSm100": (".gemm.cutedsl.dense.srelu", "GemmSreluSm100"),
     "gemm_srelu_wrapper_sm100": (".gemm.cutedsl.dense.srelu", "gemm_srelu_wrapper_sm100"),
     "GemmDsreluSm100": (".gemm.cutedsl.dense.dsrelu", "GemmDsreluSm100"),

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -324,6 +324,7 @@ _LAZY_OPTIONAL_IMPORTS = {
     "gemm_dsrelu_wrapper_sm100": (".gemm.cutedsl.dense.dsrelu", "gemm_dsrelu_wrapper_sm100"),
     "GemmAmaxSm100": (".gemm.cutedsl.dense.amax", "GemmAmaxSm100"),
     "gemm_amax_wrapper_sm100": (".gemm.cutedsl.dense.amax", "gemm_amax_wrapper_sm100"),
+    "gemm_amax_jax_sm100": (".gemm.cutedsl.dense.amax", "gemm_amax_jax_sm100"),
     "GemmProjRopeMxfp8Bf16InSm100": (".gemm.cutedsl.dense.proj_rope_mxfp8", "GemmProjRopeMxfp8Bf16InSm100"),
     "GemmProjRopeMxfp8Mxfp8InSm100": (".gemm.cutedsl.dense.proj_rope_mxfp8", "GemmProjRopeMxfp8Mxfp8InSm100"),
     "gemm_proj_rope_mxfp8_wrapper_sm100": (".gemm.cutedsl.dense.proj_rope_mxfp8", "gemm_proj_rope_mxfp8_wrapper_sm100"),

--- a/python/cudnn/api_base.py
+++ b/python/cudnn/api_base.py
@@ -14,14 +14,36 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, List, Tuple, Optional
 import logging
+import sys
 import threading
 import cuda.bindings.driver as cuda
 import cutlass
-import torch
 
 import cutlass.cute as cute
 from cudnn._experimental_warnings import warn_experimental_api_once
-from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.datatypes import _convert_to_cutlass_data_type, _convert_to_cutlass_data_type_or_none
+from cudnn.tensor_adapter import (
+    Device,
+    canonicalize_unit_dim_strides,
+    cuda_is_available,
+    get_compute_capability,
+    get_device,
+    get_shape,
+    get_strides,
+)
+
+# torch stays a lazy dependency: a torch tensor/dtype can only reach these APIs if torch
+# is already imported, so probing sys.modules never imports torch on behalf of other
+# frameworks (e.g. JAX).
+
+
+def _torch():
+    return sys.modules.get("torch")
+
+
+def _is_framework_tensor(obj: Any) -> bool:
+    """True for framework tensors (torch/jax/numpy/...) as opposed to dtypes or shape/stride tuples."""
+    return hasattr(obj, "__dlpack__")
 
 
 def ceil_div(a: int, b: int) -> int:
@@ -35,7 +57,7 @@ def is_power_of_2(n: int) -> bool:
 
 def is_sm107_device() -> bool:
     """Return True when the current CUDA device is Rubin (SM107)."""
-    return torch.cuda.is_available() and torch.cuda.get_device_capability(torch.cuda.current_device()) == (10, 7)
+    return cuda_is_available() and get_compute_capability() == (10, 7)
 
 
 def get_device_type() -> str:
@@ -67,11 +89,11 @@ def _reset_experimental_api_warning_registry() -> None:
 class TensorDesc:
     """Metadata needed to validate/compile tensor signatures without storage."""
 
-    dtype: torch.dtype
+    dtype: Any
     shape: Tuple[int, ...]
     stride: Tuple[int, ...]
     stride_order: Tuple[int, ...]
-    device: torch.device
+    device: Any
     interpret_uint8_as_fp4x2: bool = False
     ndim: int = field(init=False)
     name: str = ""
@@ -81,7 +103,8 @@ class TensorDesc:
         stride = tuple(self.stride)
         stride_order = tuple(self.stride_order)
         device = self.device
-        if not isinstance(device, torch.device):
+        torch = _torch()
+        if torch is not None and not isinstance(device, (torch.device, Device)):
             try:
                 device = torch.device(device)
             except (TypeError, ValueError, RuntimeError) as exc:
@@ -198,9 +221,10 @@ class TensorDesc:
             raise TypeError("len() of a 0-d tensor")
         return self.shape[0]
 
-    def size(self, dim: Optional[int] = None) -> torch.Size | int:
+    def size(self, dim: Optional[int] = None) -> Tuple[int, ...] | int:
         if dim is None:
-            return torch.Size(self.shape)
+            torch = _torch()
+            return torch.Size(self.shape) if torch is not None else self.shape
         dim = self._normalize_dim(int(dim), self.ndim)
         return self.shape[dim]
 
@@ -260,16 +284,18 @@ class TensorDesc:
         new_stride = self.stride[:dim] + (inserted_stride,) + self.stride[dim:]
         return self._with_layout(new_shape, new_stride)
 
-    def is_contiguous(self, memory_format: torch.memory_format = torch.contiguous_format) -> bool:
-        if memory_format in {torch.contiguous_format, torch.preserve_format}:
+    def is_contiguous(self, memory_format: Any = None) -> bool:
+        """Row-major contiguity check; ``memory_format=None`` means torch.contiguous_format semantics."""
+        torch = _torch()
+        if memory_format is None or (torch is not None and memory_format in {torch.contiguous_format, torch.preserve_format}):
             if self._numel(self.shape) == 0:
                 return True
             return self._is_contiguous_with_order(self.shape, self.stride, tuple(range(self.ndim - 1, -1, -1)))
-        if memory_format == torch.channels_last:
+        if torch is not None and memory_format == torch.channels_last:
             if self.ndim != 4:
                 return False
             return self._is_contiguous_with_order(self.shape, self.stride, (1, 3, 2, 0))
-        if memory_format == torch.channels_last_3d:
+        if torch is not None and memory_format == torch.channels_last_3d:
             if self.ndim != 5:
                 return False
             return self._is_contiguous_with_order(self.shape, self.stride, (1, 4, 3, 2, 0))
@@ -541,8 +567,12 @@ class APIBase(ABC):
             ...     # Now current_stream is guaranteed to be a valid stream
         """
         if stream is None:
-            self._logger.debug(f"{self.__class__.__name__}: No CUDA stream provided, using torch current stream")
-            return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+            torch = _torch()
+            if torch is not None:
+                self._logger.debug(f"{self.__class__.__name__}: No CUDA stream provided, using torch current stream")
+                return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+            self._logger.debug(f"{self.__class__.__name__}: No CUDA stream provided and torch not imported, using CUDA legacy default stream")
+            return cuda.CUstream(0)
         return stream
 
     def _pad_tensor_to_ndim(
@@ -567,8 +597,12 @@ class APIBase(ABC):
 
         if tensor.ndim < ndim:
             self._logger.info(f"Padding {name} to {ndim}D from {tensor.shape}")
-            for _ in range(ndim - tensor.ndim):
-                tensor = tensor.unsqueeze(-1)
+            if hasattr(tensor, "unsqueeze"):
+                for _ in range(ndim - tensor.ndim):
+                    tensor = tensor.unsqueeze(-1)
+            else:
+                # e.g. JAX arrays have no unsqueeze; appending unit dims via reshape is equivalent
+                tensor = tensor.reshape(tuple(tensor.shape) + (1,) * (ndim - tensor.ndim))
         return tensor
 
     def _unpad_tensor_to_ndim(
@@ -616,13 +650,16 @@ class APIBase(ABC):
         if isinstance(tensor_or_dtype, TensorDesc):
             dtype = tensor_or_dtype.dtype
             interpret_uint8_as_fp4x2 = tensor_or_dtype.interpret_uint8_as_fp4x2
-        elif isinstance(tensor_or_dtype, torch.Tensor):
+        elif _is_framework_tensor(tensor_or_dtype):
             dtype = tensor_or_dtype.dtype
             interpret_uint8_as_fp4x2 = self._interpret_uint8_as_fp4x2
         else:
             dtype = tensor_or_dtype
             interpret_uint8_as_fp4x2 = self._interpret_uint8_as_fp4x2
-        return (dtype == torch.float4_e2m1fn_x2) or (interpret_uint8_as_fp4x2 and dtype == torch.uint8)
+        # Compare in canonical (cutlass) dtype space so torch/jax/numpy dtypes all resolve;
+        # dtypes with no cutlass mapping compare False, as before.
+        dtype = _convert_to_cutlass_data_type_or_none(dtype)
+        return (dtype is cutlass.Float4E2M1FN) or (interpret_uint8_as_fp4x2 and dtype is cutlass.Uint8)
 
     def _is_fp8(self, tensor_or_dtype: torch.Tensor | torch.dtype | TensorDesc) -> bool:
         """Check if tensor or dtype is an FP8 datatype.
@@ -634,8 +671,8 @@ class APIBase(ABC):
         """
         if tensor_or_dtype is None:
             return False
-        dtype = tensor_or_dtype.dtype if isinstance(tensor_or_dtype, (torch.Tensor, TensorDesc)) else tensor_or_dtype
-        return dtype in {torch.float8_e5m2, torch.float8_e4m3fn}
+        dtype = tensor_or_dtype.dtype if isinstance(tensor_or_dtype, TensorDesc) or _is_framework_tensor(tensor_or_dtype) else tensor_or_dtype
+        return _convert_to_cutlass_data_type_or_none(dtype) in {cutlass.Float8E5M2, cutlass.Float8E4M3FN}
 
     def _is_f16(self, tensor_or_dtype: torch.Tensor | torch.dtype | TensorDesc) -> bool:
         """Check if tensor or dtype is an fp16 or bf16 datatype.
@@ -647,20 +684,19 @@ class APIBase(ABC):
         """
         if tensor_or_dtype is None:
             return False
-        dtype = tensor_or_dtype.dtype if isinstance(tensor_or_dtype, (torch.Tensor, TensorDesc)) else tensor_or_dtype
-        return dtype in {torch.float16, torch.bfloat16}
+        dtype = tensor_or_dtype.dtype if isinstance(tensor_or_dtype, TensorDesc) or _is_framework_tensor(tensor_or_dtype) else tensor_or_dtype
+        return _convert_to_cutlass_data_type_or_none(dtype) in {cutlass.Float16, cutlass.BFloat16}
 
     def _get_innermost_stride_dim(self, tensor: torch.Tensor, name: str = "") -> int:
         """Return index of innermost contiguous dimension (stride == 1).
 
         :raises RuntimeError: If no dimension with stride 1 is found.
         """
-        idx = next((i for i, s in enumerate(tensor.stride()) if s == 1), None)
+        tensor_stride = get_strides(tensor)
+        idx = next((i for i, s in enumerate(tensor_stride) if s == 1), None)
         if idx is None:
-            self._logger.critical(
-                f"tensor {name} has shape: {tensor.shape} stride {tensor.stride()} – innermost contiguous (stride == 1) dimension not found. "
-            )
-            raise RuntimeError(f"tensor {name} has shape: {tensor.shape} stride {tensor.stride()} – innermost contiguous (stride == 1) dimension not found. ")
+            self._logger.critical(f"tensor {name} has shape: {tensor.shape} stride {tensor_stride} – innermost contiguous (stride == 1) dimension not found. ")
+            raise RuntimeError(f"tensor {name} has shape: {tensor.shape} stride {tensor_stride} – innermost contiguous (stride == 1) dimension not found. ")
         return idx
 
     def _tensor_shape(
@@ -688,11 +724,11 @@ class APIBase(ABC):
 
         if self._is_fp4x2(tensor):
             innermost_dim_index = self._get_innermost_stride_dim(tensor, name=name)
-            shape = tuple(dim * 2 if i == innermost_dim_index else dim for i, dim in enumerate(tensor.shape))
+            shape = tuple(dim * 2 if i == innermost_dim_index else dim for i, dim in enumerate(get_shape(tensor)))
             self._logger.debug(f"FP4x2 tensor {name}: physical shape {tensor.shape} -> logical shape {shape}")
             return shape
         else:
-            return tensor.shape
+            return get_shape(tensor)
 
     def _tensor_stride(
         self,
@@ -719,11 +755,12 @@ class APIBase(ABC):
 
         if self._is_fp4x2(tensor):
             innermost_dim_index = self._get_innermost_stride_dim(tensor, name=name)
-            strides = tuple(s * 2 if i != innermost_dim_index else s for i, s in enumerate(tensor.stride()))
-            self._logger.debug(f"FP4x2 tensor {name}: physical stride {tensor.stride()} -> logical stride {strides}")
+            tensor_stride = get_strides(tensor)
+            strides = tuple(s * 2 if i != innermost_dim_index else s for i, s in enumerate(tensor_stride))
+            self._logger.debug(f"FP4x2 tensor {name}: physical stride {tensor_stride} -> logical stride {strides}")
             return strides
         else:
-            return tensor.stride()
+            return get_strides(tensor)
 
     def _check_tensor_shape(
         self,
@@ -745,7 +782,11 @@ class APIBase(ABC):
         """
         if tensor_or_shape is None:
             return None
-        tensor_shape = self._tensor_shape(tensor_or_shape, name=name) if isinstance(tensor_or_shape, (torch.Tensor, TensorDesc)) else tensor_or_shape
+        tensor_shape = (
+            self._tensor_shape(tensor_or_shape, name=name)
+            if isinstance(tensor_or_shape, TensorDesc) or _is_framework_tensor(tensor_or_shape)
+            else tensor_or_shape
+        )
         if isinstance(shape, tuple):
             if tensor_shape != shape:
                 raise ValueError(f"{name} tensor shape mismatch: expected {shape}, got {tensor_shape}")
@@ -785,7 +826,7 @@ class APIBase(ABC):
         if isinstance(tensor_or_stride, TensorDesc):
             tensor_stride = tensor_or_stride.stride
             tensor_stride_order = tensor_or_stride.stride_order
-        elif isinstance(tensor_or_stride, torch.Tensor):
+        elif _is_framework_tensor(tensor_or_stride):
             tensor_stride = self._tensor_stride(tensor_or_stride, name=name)
             tensor_stride_order = tuple(i for i, s in sorted(enumerate(tensor_stride), key=lambda x: x[1]))
         else:
@@ -851,8 +892,10 @@ class APIBase(ABC):
         """
         if tensor_or_dtype is None:
             return None
-        tensor_dtype = tensor_or_dtype.dtype if isinstance(tensor_or_dtype, (torch.Tensor, TensorDesc)) else tensor_or_dtype
-        if isinstance(dtype, torch.dtype):
+        tensor_dtype = tensor_or_dtype.dtype if isinstance(tensor_or_dtype, TensorDesc) or _is_framework_tensor(tensor_or_dtype) else tensor_or_dtype
+        torch = _torch()
+        is_scalar_dtype = (torch is not None and isinstance(dtype, torch.dtype)) or (isinstance(dtype, type) and issubclass(dtype, cutlass.Numeric))
+        if is_scalar_dtype:
             if tensor_dtype != dtype:
                 error_msg = f"{name} dtype mismatch: expected {dtype}, got {tensor_dtype}"
                 if extra_error_msg:
@@ -927,11 +970,18 @@ class APIBase(ABC):
 
     def _make_tensor_desc(
         self,
-        tensor: Optional[torch.Tensor],
+        tensor: Optional[Any],
         name: str = "",
         interpret_uint8_as_fp4x2: Optional[bool] = None,
+        canonical: bool = False,
     ) -> Optional[TensorDesc]:
-        """Capture logical tensor metadata that is sufficient for validation/compile."""
+        """Capture logical tensor metadata that is sufficient for validation/compile.
+
+        With ``canonical=True`` the descriptor is framework-neutral: the dtype is converted
+        to its cutlass type, the device is read via the tensor adapter (torch tensors keep
+        torch.device), and extent-1 dims get canonicalized strides so layouts that differ
+        only in unit-dim strides -- unobservable by the kernels -- compare and compile equal.
+        """
         if tensor is None:
             return None
         if interpret_uint8_as_fp4x2 is None:
@@ -943,13 +993,20 @@ class APIBase(ABC):
             tensor_stride = self._tensor_stride(tensor, name=name)
         finally:
             self._interpret_uint8_as_fp4x2 = prev_interpret
+        if canonical:
+            dtype = _convert_to_cutlass_data_type(tensor.dtype)
+            device = get_device(tensor)
+            tensor_stride = canonicalize_unit_dim_strides(tensor_shape, tensor_stride)
+        else:
+            dtype = tensor.dtype
+            device = tensor.device
         tensor_stride_order = tuple(i for i, s in sorted(enumerate(tensor_stride), key=lambda x: (x[1], tensor_shape[x[0]])))
         return TensorDesc(
-            dtype=tensor.dtype,
+            dtype=dtype,
             shape=tensor_shape,
             stride=tensor_stride,
             stride_order=tensor_stride_order,
-            device=tensor.device,
+            device=device,
             interpret_uint8_as_fp4x2=interpret_uint8_as_fp4x2,
             name=name,
         )

--- a/python/cudnn/datatypes.py
+++ b/python/cudnn/datatypes.py
@@ -65,13 +65,24 @@ def is_torch_available():
 
 
 def is_cutlass_available():
-    global cutlass_available, _torch_to_cutlass_data_type_dict
+    global cutlass_available
     if cutlass_available is None:
+        try:
+            import cutlass
+
+            cutlass_available = True
+        except ImportError:
+            cutlass_available = False
+    return cutlass_available
+
+
+def _is_torch_to_cutlass_available():
+    global _torch_to_cutlass_data_type_dict
+    if _torch_to_cutlass_data_type_dict is None:
         try:
             import torch
             import cutlass
 
-            cutlass_available = True
             mapping = {
                 torch.half: getattr(cutlass, "Float16", None),
                 getattr(torch, "float16", torch.half): getattr(cutlass, "Float16", None),
@@ -92,9 +103,60 @@ def is_cutlass_available():
             }
             _torch_to_cutlass_data_type_dict = {t: c for t, c in mapping.items() if t is not None and c is not None}
         except ImportError:
-            cutlass_available = False
             _torch_to_cutlass_data_type_dict = {}
-    return cutlass_available
+    return bool(_torch_to_cutlass_data_type_dict)
+
+
+# Framework-neutral dtype-name -> cutlass mapping. Keyed on np.dtype(x).name so
+# numpy, ml_dtypes, and string dtypes all resolve without importing torch or ml_dtypes.
+_dtype_name_to_cutlass_data_type_dict = None
+
+
+def _get_dtype_name_to_cutlass_dict():
+    global _dtype_name_to_cutlass_data_type_dict
+    if _dtype_name_to_cutlass_data_type_dict is None:
+        import cutlass
+
+        names = {
+            "float16": "Float16",
+            "bfloat16": "BFloat16",
+            "float32": "Float32",
+            "float64": "Float64",
+            "uint8": "Uint8",
+            "int8": "Int8",
+            "int32": "Int32",
+            "int64": "Int64",
+            "bool": "Boolean",
+            "float8_e4m3fn": "Float8E4M3FN",
+            "float8_e5m2": "Float8E5M2",
+            "float8_e8m0fnu": "Float8E8M0FNU",
+            "float4_e2m1fn": "Float4E2M1FN",
+        }
+        _dtype_name_to_cutlass_data_type_dict = {name: getattr(cutlass, attr) for name, attr in names.items() if getattr(cutlass, attr, None) is not None}
+    return _dtype_name_to_cutlass_data_type_dict
+
+
+def _dtype_name_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2: bool = False):
+    """Map a numpy/ml_dtypes dtype (or dtype name string) to a cutlass type, or None."""
+    try:
+        import numpy as np
+
+        name = np.dtype(data_type).name
+    except Exception:
+        try:
+            # dtype names like "bfloat16"/"float8_e4m3fn" only resolve once
+            # ml_dtypes has registered its numpy extension types.
+            import ml_dtypes
+            import numpy as np
+
+            name = np.dtype(data_type).name
+        except Exception:
+            return None
+    if interpret_uint8_as_fp4x2 and name == "uint8":
+        import cutlass
+
+        return getattr(cutlass, "Float4E2M1FN", None)
+    return _get_dtype_name_to_cutlass_dict().get(name, None)
 
 
 # Returns None in case mapping is not available
@@ -106,9 +168,12 @@ def _torch_to_cudnn_data_type(torch_data_type) -> cudnn_data_type:
 
 
 def _torch_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2: bool = False):
-    if is_cutlass_available() and is_torch_available():
-        import torch
-
+    # A torch dtype can only be passed in if torch is already imported, so probing
+    # sys.modules avoids importing torch on behalf of other frameworks' dtypes.
+    torch = sys.modules.get("torch")
+    if torch is None or not isinstance(data_type, torch.dtype):
+        return None
+    if is_cutlass_available() and _is_torch_to_cutlass_available():
         if interpret_uint8_as_fp4x2 and data_type == torch.uint8:
             import cutlass
 
@@ -123,15 +188,29 @@ def _convert_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2: bool = Fa
         import cutlass
 
         if isinstance(data_type, type) and issubclass(data_type, cutlass.Numeric):
+            if interpret_uint8_as_fp4x2 and data_type is cutlass.Uint8:
+                return cutlass.Float4E2M1FN
             return data_type
         elif data_type is not None:
             cutlass_data_type = _torch_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2=interpret_uint8_as_fp4x2)
+            if cutlass_data_type is None:
+                cutlass_data_type = _dtype_name_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2=interpret_uint8_as_fp4x2)
             if cutlass_data_type is None:
                 raise ValueError("Unsupported tensor data type.")
             return cutlass_data_type
         else:
             raise ValueError("None is not a valid tensor data type.")
     return None
+
+
+def _convert_to_cutlass_data_type_or_none(data_type, interpret_uint8_as_fp4x2: bool = False):
+    """Like _convert_to_cutlass_data_type but returns None for unmappable dtypes instead of raising."""
+    if data_type is None or not is_cutlass_available():
+        return None
+    try:
+        return _convert_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2=interpret_uint8_as_fp4x2)
+    except ValueError:
+        return None
 
 
 def _cudnn_to_torch_data_type(cudnn_data_type):
@@ -177,3 +256,12 @@ def _is_torch_tensor(input_tensor) -> bool:
 
         return isinstance(input_tensor, torch.Tensor)
     return False
+
+
+def _is_jax_array(input_tensor) -> bool:
+    # A jax array can only exist if jax is already imported, so probing
+    # sys.modules never triggers a jax import.
+    jax = sys.modules.get("jax")
+    if jax is not None and isinstance(input_tensor, getattr(jax, "Array", ())):
+        return True
+    return type(input_tensor).__module__.startswith(("jax", "jaxlib"))

--- a/python/cudnn/gemm/cutedsl/_jax_ffi.py
+++ b/python/cudnn/gemm/cutedsl/_jax_ffi.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the jax.jit-compatible entry points of the CuTeDSL GEMM APIs.
+
+These entry points integrate with XLA via jax-tvm-ffi: the kernel variant is compiled
+with the TVM-FFI environment stream (so it runs on XLA's compute stream), all outputs
+are donated pre-initialized operands (input_output_aliases + arg_spec=["args"]) matching
+the kernels' destination-passing signatures, and calls compose with jax.jit.
+
+This module imports jax/jax_tvm_ffi at import time; it is only loaded from the
+per-API jax_api modules, which are lazily exported.
+"""
+
+from typing import Any, Callable, Tuple
+
+import jax_tvm_ffi
+
+from cudnn.api_base import TensorDesc
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import Device
+
+
+def c_contiguous_strides(shape: Tuple[int, ...]) -> Tuple[int, ...]:
+    strides, acc = [1] * len(shape), 1
+    for i in range(len(shape) - 1, -1, -1):
+        strides[i] = acc
+        acc *= shape[i]
+    return tuple(strides)
+
+
+def make_row_major_desc(shape: Tuple[int, ...], dtype: Any, name: str) -> TensorDesc:
+    """Descriptor for a C-contiguous (row-major) JAX buffer, from shape/dtype only.
+
+    Built from aval metadata so this works for jax.jit tracers as well as concrete
+    arrays (tracers expose .shape/.dtype but no device or DLPack).
+    """
+    shape = tuple(shape)
+    stride = c_contiguous_strides(shape)
+    return TensorDesc(
+        dtype=_convert_to_cutlass_data_type(dtype),
+        shape=shape,
+        stride=stride,
+        stride_order=TensorDesc._compute_stride_order(shape, stride),
+        device=Device("cuda", 0),
+        name=name,
+    )
+
+
+def get_or_register_env_stream_target(
+    registry: dict,
+    cache_key: Any,
+    make_gemm: Callable[[], Any],
+    target_prefix: str,
+    arg_spec: Tuple[str, ...] = ("args",),
+) -> str:
+    """Compile the env-stream kernel variant for cache_key (once) and register it as an
+    XLA FFI target; return the registered target name.
+
+    The registry keeps (target, gemm, compiled) so the compiled kernel stays alive
+    alongside the global registration.
+    """
+    entry = registry.get(cache_key)
+    if entry is None:
+        gemm = make_gemm()
+        assert gemm.check_support()
+        compiled = gemm._compile_kernel(use_tvm_ffi_env_stream=True)
+        target = f"{target_prefix}.{len(registry)}"
+        jax_tvm_ffi.register_ffi_target(target, compiled, arg_spec=list(arg_spec), platform="gpu", allow_cuda_graph=True)
+        registry[cache_key] = (target, gemm, compiled)
+        entry = registry[cache_key]
+    return entry[0]

--- a/python/cudnn/gemm/cutedsl/dense/amax/__init__.py
+++ b/python/cudnn/gemm/cutedsl/dense/amax/__init__.py
@@ -9,4 +9,15 @@ from .api import (
 __all__ = [
     "GemmAmaxSm100",
     "gemm_amax_wrapper_sm100",
+    "gemm_amax_jax_sm100",
 ]
+
+
+def __getattr__(name):
+    # Lazy: the jax entry point imports jax/jax_tvm_ffi, which must not be pulled in
+    # for torch-only users.
+    if name == "gemm_amax_jax_sm100":
+        from .jax_api import gemm_amax_jax_sm100
+
+        return gemm_amax_jax_sm100
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/cudnn/gemm/cutedsl/dense/amax/api.py
+++ b/python/cudnn/gemm/cutedsl/dense/amax/api.py
@@ -7,8 +7,7 @@ from .dense_blockscaled_gemm_persistent_amax import (
 
 from cuda.bindings import driver as cuda
 import os
-import torch
-from typing import Tuple, Optional
+from typing import Any, Tuple, Optional
 
 import cutlass
 import cutlass.cute as cute
@@ -16,18 +15,36 @@ from cutlass.cute.runtime import make_fake_stream
 
 from cudnn.datatypes import _convert_to_cutlass_data_type
 from cudnn.api_base import APIBase, TensorDesc, TupleDict, is_power_of_2, ceil_div
+from cudnn.tensor_adapter import (
+    canonicalize_unit_dim_strides,
+    cuda_is_available,
+    default_stream,
+    detect_framework,
+    framework_dtype,
+    get_compute_capability,
+    get_shape,
+    get_strides,
+)
 
 
 class GemmAmaxSm100(APIBase):
+    """Blockscaled GEMM with amax epilogue for SM100.
+
+    Tensor parameters are type-erased: torch tensors and JAX arrays are both accepted
+    (any DLPack-capable tensor with .shape/.dtype works for metadata). torch is only
+    imported when torch tensors/dtypes are passed; likewise for JAX. Dtype parameters
+    accept torch dtypes, numpy/ml_dtypes dtypes, or cutlass types.
+    """
+
     def __init__(
         self,
-        sample_a: torch.Tensor,
-        sample_b: torch.Tensor,
-        sample_sfa: torch.Tensor,
-        sample_sfb: torch.Tensor,
-        sample_c: torch.Tensor,
-        sample_amax: torch.Tensor,
-        acc_dtype: torch.dtype = torch.float32,
+        sample_a: Any,
+        sample_b: Any,
+        sample_sfa: Any,
+        sample_sfb: Any,
+        sample_c: Any,
+        sample_amax: Any,
+        acc_dtype: Any = cutlass.Float32,
         mma_tiler_mn: Tuple[int, int] = (128, 128),
         cluster_shape_mn: Tuple[int, int] = (1, 1),
         sf_vec_size: int = 32,
@@ -37,14 +54,14 @@ class GemmAmaxSm100(APIBase):
         self._warn_experimental_api()
         self._logger.debug("Entering __init__")
 
-        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a")
-        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b")
-        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa")
-        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb")
-        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c")
-        self.amax_desc = self._make_tensor_desc(sample_amax, name="sample_amax")
+        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
+        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b", canonical=True)
+        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa", canonical=True)
+        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb", canonical=True)
+        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c", canonical=True)
+        self.amax_desc = self._make_tensor_desc(sample_amax, name="sample_amax", canonical=True)
 
-        self.acc_dtype = acc_dtype
+        self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
         self.cluster_shape_mn = cluster_shape_mn
         self.sf_vec_size = sf_vec_size
@@ -61,13 +78,45 @@ class GemmAmaxSm100(APIBase):
             f"__init__ completed with args: sample_a {self.a_desc.shape}, sample_b {self.b_desc.shape}, sample_sfa {self.sfa_desc.shape}, sample_sfb {self.sfb_desc.shape}, sample_c {self.c_desc.shape}, sample_amax {self.amax_desc.shape}, acc_dtype {acc_dtype}, mma_tiler_mn {mma_tiler_mn}, cluster_shape_mn {cluster_shape_mn}, sf_vec_size {sf_vec_size}"
         )
 
+    def _check_sf_shape(self, sf_desc: TensorDesc, l: int, name: str) -> Tuple[int, int]:
+        """Validate a scale-factor tensor shape and return (mn_div_atom_m0_m1, sf_k_div_atom_k).
+
+        SF tensors are accepted in either of two equivalent forms (byte-identical memory):
+        - the torch-style logical atom view (Atom_M0, Atom_M1, MN', Atom_K, K', L), i.e. a
+          C-contiguous (L, MN', K', Atom_M0, Atom_M1, Atom_K) allocation permuted by
+          (3, 4, 1, 5, 2, 0), or
+        - that physical C-contiguous shape (L, MN', K', Atom_M0, Atom_M1, Atom_K) directly,
+          for frameworks such as JAX that cannot express the permuted (strided) view.
+
+        The kernel rebuilds the SF layout from the A/B shapes and consumes only the SF base
+        pointer, so only the element count and memory order matter.
+        """
+        shape = sf_desc.shape
+        self._value_error_if(len(shape) != 6, f"{name} tensor must be 6-D, got shape {shape}")
+        if shape[0] == self.atom_m[0] and shape[1] == self.atom_m[1] and shape[3] == self.atom_k:
+            mn_div_atom_m0_m1, sf_k_div_atom_k = shape[2], shape[4]
+            self._check_tensor_shape(
+                sf_desc,
+                (self.atom_m[0], self.atom_m[1], mn_div_atom_m0_m1, self.atom_k, sf_k_div_atom_k, l),
+                name,
+            )
+        else:
+            mn_div_atom_m0_m1, sf_k_div_atom_k = shape[1], shape[2]
+            self._check_tensor_shape(
+                sf_desc,
+                (l, mn_div_atom_m0_m1, sf_k_div_atom_k, self.atom_m[0], self.atom_m[1], self.atom_k),
+                name,
+            )
+        return mn_div_atom_m0_m1, sf_k_div_atom_k
+
     def check_support(self) -> bool:
         self._logger.debug("Entering check_support")
 
         self._logger.debug("Checking dtypes and sf_vec_size")
+        # Tensor descriptors are canonical (cutlass dtypes), so validation is framework-neutral.
         ab_dtype = self._check_dtype(
             self.a_desc,
-            dtype=[torch.float4_e2m1fn_x2, torch.uint8, torch.float8_e5m2, torch.float8_e4m3fn],
+            dtype=[cutlass.Float4E2M1FN, cutlass.Uint8, cutlass.Float8E5M2, cutlass.Float8E4M3FN],
             name="A",
         )
         self._check_dtype(
@@ -76,7 +125,7 @@ class GemmAmaxSm100(APIBase):
             name="B",
             extra_error_msg="A and B tensor dtypes must match",
         )
-        if ab_dtype == torch.uint8:
+        if ab_dtype is cutlass.Uint8:
             self._logger.warning("Uint8 ab_dtype will be interpreted as packed fp4, not as native uint8")
 
         self._value_error_if(
@@ -86,7 +135,7 @@ class GemmAmaxSm100(APIBase):
 
         sf_dtype = self._check_dtype(
             self.sfa_desc,
-            dtype=[torch.float8_e8m0fnu, torch.float8_e4m3fn, torch.int8],
+            dtype=[cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN, cutlass.Int8],
             name="sfa",
         )
         self._check_dtype(
@@ -95,21 +144,21 @@ class GemmAmaxSm100(APIBase):
             name="sfb",
             extra_error_msg="sfa and sfb tensor dtypes must match",
         )
-        if sf_dtype == torch.int8:
+        if sf_dtype is cutlass.Int8:
             self._logger.warning("Int8 sf_dtype will be interpreted as float8_e8m0fnu, not as native int8")
 
         self._value_error_if(
-            sf_dtype == torch.float8_e4m3fn and self.sf_vec_size == 32,
+            sf_dtype is cutlass.Float8E4M3FN and self.sf_vec_size == 32,
             "Unsupported sf_dtype and sf_vec_size combination: float8_e4m3fn and 32 is not supported",
         )
         self._value_error_if(
-            ab_dtype in {torch.float8_e5m2, torch.float8_e4m3fn} and self.sf_vec_size == 16,
+            ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and self.sf_vec_size == 16,
             f"Unsupported ab_dtype and sf_vec_size combination: {{float8_e5m2, float8_e4m3fn}} and 16 is not supported",
         )
 
         c_dtype = self._check_dtype(
             self.c_desc,
-            dtype=[torch.float32, torch.float16, torch.bfloat16, torch.float8_e5m2, torch.float8_e4m3fn, torch.float4_e2m1fn_x2, torch.uint8],
+            dtype=[cutlass.Float32, cutlass.Float16, cutlass.BFloat16, cutlass.Float8E5M2, cutlass.Float8E4M3FN, cutlass.Float4E2M1FN, cutlass.Uint8],
             name="C",
         )
         self._value_error_if(
@@ -122,7 +171,7 @@ class GemmAmaxSm100(APIBase):
         )
         self._check_dtype(
             self.acc_dtype,
-            dtype=torch.float32,
+            dtype=cutlass.Float32,
             name="Accumulator",
             extra_error_msg="Accumulator must be float32",
         )
@@ -133,21 +182,15 @@ class GemmAmaxSm100(APIBase):
         self._logger.debug("Checking tensor layout")
         m, k, l = self.a_desc.shape
         n, _, _ = self.b_desc.shape
-        _, _, m_div_atom_m0_m1, _, sf_k_div_atom_k, _ = self.sfa_desc.shape
-        _, _, n_div_atom_m0_m1, _, sf_k_div_atom_k, _ = self.sfb_desc.shape
 
         self._check_tensor_shape(self.a_desc, (m, k, l), "A")
         self._check_tensor_shape(self.b_desc, (n, k, l), "B")
         self._check_tensor_shape(self.c_desc, (m, n, l), "C")
-        self._check_tensor_shape(
-            self.sfa_desc,
-            (self.atom_m[0], self.atom_m[1], m_div_atom_m0_m1, self.atom_k, sf_k_div_atom_k, l),
-            "sfa",
-        )
-        self._check_tensor_shape(
-            self.sfb_desc,
-            (self.atom_m[0], self.atom_m[1], n_div_atom_m0_m1, self.atom_k, sf_k_div_atom_k, l),
-            "sfb",
+        m_div_atom_m0_m1, sf_k_div_atom_k = self._check_sf_shape(self.sfa_desc, l, "sfa")
+        n_div_atom_m0_m1, sfb_k_div_atom_k = self._check_sf_shape(self.sfb_desc, l, "sfb")
+        self._value_error_if(
+            sf_k_div_atom_k != sfb_k_div_atom_k,
+            f"sfa and sfb tensor K' mismatch: got {sf_k_div_atom_k} and {sfb_k_div_atom_k}",
         )
         self.amax_desc = self._pad_tensor_to_ndim(self.amax_desc, 3, "amax")
         self._check_tensor_shape(self.amax_desc, (1, 1, 1), "amax")
@@ -216,8 +259,8 @@ class GemmAmaxSm100(APIBase):
             "Illegal cluster shape",
         )
         self._not_implemented_error_if(
-            self.mma_tiler_mn == (128, 256) and self.sf_vec_size == 16 and c_dtype in {torch.float32, torch.float16, torch.bfloat16},
-            "mma_tiler_mn (128, 256), sf_vec_size 16, c_dtype {torch.float32, torch.float16, torch.bfloat16} fails to launch",
+            self.mma_tiler_mn == (128, 256) and self.sf_vec_size == 16 and c_dtype in {cutlass.Float32, cutlass.Float16, cutlass.BFloat16},
+            "mma_tiler_mn (128, 256), sf_vec_size 16, c_dtype {float32, float16, bfloat16} fails to launch",
         )
 
         # Special cluster shape check for scale factor multicasts.
@@ -252,13 +295,12 @@ class GemmAmaxSm100(APIBase):
         )
 
         self._logger.debug("Checking environment")
-        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
-        device = torch.cuda.current_device()
-        major, minor = torch.cuda.get_device_capability(device)
+        self._runtime_error_if(not cuda_is_available(), "CUDA is not available")
+        major, minor = get_compute_capability()
         compute_capability = major * 10 + minor
         self._runtime_error_if(
             compute_capability < 100,
-            f"GemmAmax requires SM100+ compute capability, but found SM{compute_capability} on device {device}",
+            f"GemmAmax requires SM100+ compute capability, but found SM{compute_capability} on the current device",
         )
 
         self._kernel = Sm100BlockScaledPersistentDenseGemmKernel
@@ -267,12 +309,14 @@ class GemmAmaxSm100(APIBase):
         self._logger.debug("check_support completed successfully")
         return True
 
-    def compile(self) -> None:
-        self._logger.debug("Entering compile")
+    def _compile_kernel(self, use_tvm_ffi_env_stream: bool = False):
+        """Compile the kernel and return the raw TVM-FFI callable.
+
+        With ``use_tvm_ffi_env_stream=True`` the stream argument is bound to the
+        TVM-FFI environment stream and dropped from the callable's signature --
+        the variant used for XLA custom-call (jax.ffi) integration.
+        """
         self._ensure_support_checked()
-        if self._compiled_kernel is not None:
-            self._logger.debug("Kernel already compiled; skipping recompilation")
-            return
 
         gemm_amax = self._kernel(
             sf_vec_size=self.sf_vec_size,
@@ -294,9 +338,9 @@ class GemmAmaxSm100(APIBase):
         sfb_cute = self._make_fake_cute_tensor_from_desc(self.sfb_desc, assumed_align=16)
         c_cute = self._make_fake_cute_tensor_from_desc(self.c_desc, assumed_align=16)
         amax_cute = self._make_fake_cute_tensor_from_desc(self.amax_desc, assumed_align=16)
-        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=use_tvm_ffi_env_stream)
 
-        _compiled_kernel = cute.compile(
+        return cute.compile(
             gemm_amax,
             a_tensor=a_cute,
             b_tensor=b_cute,
@@ -309,17 +353,28 @@ class GemmAmaxSm100(APIBase):
             options="--enable-tvm-ffi",
         )
 
+    def compile(self) -> None:
+        self._logger.debug("Entering compile")
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            self._logger.debug("Kernel already compiled; skipping recompilation")
+            return
+
+        _compiled_kernel = self._compile_kernel(use_tvm_ffi_env_stream=False)
+
         def tensor_api(
-            a_tensor: torch.Tensor,
-            b_tensor: torch.Tensor,
-            sfa_tensor: torch.Tensor,
-            sfb_tensor: torch.Tensor,
-            c_tensor: torch.Tensor,
-            amax_tensor: torch.Tensor,
+            a_tensor: Any,
+            b_tensor: Any,
+            sfa_tensor: Any,
+            sfb_tensor: Any,
+            c_tensor: Any,
+            amax_tensor: Any,
             stream: cuda.CUstream,
         ):
             amax_tensor = self._pad_tensor_to_ndim(amax_tensor, 3, "amax")
 
+            # The TVM-FFI callable converts any DLPack-capable tensor itself
+            # (C fast path for torch, __dlpack__ protocol otherwise).
             return _compiled_kernel(
                 a_tensor,
                 b_tensor,
@@ -340,16 +395,19 @@ class GemmAmaxSm100(APIBase):
 
     def execute(
         self,
-        a_tensor: torch.Tensor,
-        b_tensor: torch.Tensor,
-        sfa_tensor: torch.Tensor,
-        sfb_tensor: torch.Tensor,
-        c_tensor: torch.Tensor,
-        amax_tensor: torch.Tensor,
+        a_tensor: Any,
+        b_tensor: Any,
+        sfa_tensor: Any,
+        sfb_tensor: Any,
+        c_tensor: Any,
+        amax_tensor: Any,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         self._logger.debug("Entering execute")
-        current_stream = self._get_default_stream(current_stream)
+        if current_stream is None:
+            # torch inputs stay ordered with the caller's current torch stream;
+            # other frameworks (e.g. JAX) default to the CUDA legacy default stream.
+            current_stream = default_stream(detect_framework(a_tensor))
 
         self._runtime_error_if(
             self._compiled_kernel is None,
@@ -376,13 +434,13 @@ _cache_of_GemmAmaxSm100Objects = {}
 
 
 def gemm_amax_wrapper_sm100(
-    a_tensor: torch.Tensor,
-    b_tensor: torch.Tensor,
-    sfa_tensor: torch.Tensor,
-    sfb_tensor: torch.Tensor,
+    a_tensor: Any,
+    b_tensor: Any,
+    sfa_tensor: Any,
+    sfb_tensor: Any,
     c_major: str = "n",
-    c_dtype: torch.dtype = torch.float32,
-    acc_dtype: torch.dtype = torch.float32,
+    c_dtype: Any = cutlass.Float32,
+    acc_dtype: Any = cutlass.Float32,
     mma_tiler_mn: Tuple[int, int] = (128, 128),
     cluster_shape_mn: Tuple[int, int] = (1, 1),
     sf_vec_size: int = 32,
@@ -391,30 +449,53 @@ def gemm_amax_wrapper_sm100(
 
     _logger.debug("gemm_amax_wrapper_sm100: Creating empty output tensors c and amax")
 
-    m, _, l = a_tensor.shape
-    n, _, l = b_tensor.shape
-    c_tensor = None
-    if c_major == "m":
-        c_tensor = torch.empty_strided((m, n, l), (1, m, m * n), dtype=c_dtype, device=a_tensor.device)
-    elif c_major == "n":
-        c_tensor = torch.empty_strided((m, n, l), (n, 1, m * n), dtype=c_dtype, device=a_tensor.device)
-    else:
+    framework = detect_framework(a_tensor)
+    c_dtype = _convert_to_cutlass_data_type(c_dtype)
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
+
+    m, _, l = get_shape(a_tensor)
+    n, _, l = get_shape(b_tensor)
+    if c_major not in ("m", "n"):
         raise ValueError(f"c_major must be either 'm' or 'n', got {c_major}")
-    amax_tensor = torch.full((1, 1, 1), -float("inf"), device=a_tensor.device, dtype=torch.float32)
+
+    if framework == "torch":
+        import torch
+
+        if c_major == "m":
+            c_tensor = torch.empty_strided((m, n, l), (1, m, m * n), dtype=framework_dtype(c_dtype, "torch"), device=a_tensor.device)
+        else:
+            c_tensor = torch.empty_strided((m, n, l), (n, 1, m * n), dtype=framework_dtype(c_dtype, "torch"), device=a_tensor.device)
+        amax_tensor = torch.full((1, 1, 1), -float("inf"), device=a_tensor.device, dtype=torch.float32)
+    elif framework == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        if c_major == "m":
+            raise ValueError("JAX arrays are row-major; only c_major='n' is supported for JAX inputs")
+        if l != 1:
+            raise ValueError("JAX inputs must have batch dim L == 1; batch-outermost (L-major) layouts are not expressible as JAX arrays")
+        device = a_tensor.device
+        c_tensor = jnp.empty((m, n, l), dtype=framework_dtype(c_dtype, "jax"), device=device)
+        amax_tensor = jnp.full((1, 1, 1), -float("inf"), dtype=jnp.float32, device=device)
+        # The kernel writes into these buffers on the launch stream; make sure XLA has
+        # finished materializing them before the kernel runs.
+        jax.block_until_ready((c_tensor, amax_tensor))
+    else:
+        raise ValueError(f"Unsupported tensor framework '{framework}' for gemm_amax_wrapper_sm100; pass torch tensors or JAX arrays")
 
     cache_key = (
-        a_tensor.shape,
-        b_tensor.shape,
-        sfa_tensor.shape,
-        sfb_tensor.shape,
-        a_tensor.dtype,
-        b_tensor.dtype,
-        sfa_tensor.dtype,
-        sfb_tensor.dtype,
-        a_tensor.stride(),
-        b_tensor.stride(),
-        sfa_tensor.stride(),
-        sfb_tensor.stride(),
+        get_shape(a_tensor),
+        get_shape(b_tensor),
+        get_shape(sfa_tensor),
+        get_shape(sfb_tensor),
+        _convert_to_cutlass_data_type(a_tensor.dtype),
+        _convert_to_cutlass_data_type(b_tensor.dtype),
+        _convert_to_cutlass_data_type(sfa_tensor.dtype),
+        _convert_to_cutlass_data_type(sfb_tensor.dtype),
+        canonicalize_unit_dim_strides(get_shape(a_tensor), get_strides(a_tensor)),
+        canonicalize_unit_dim_strides(get_shape(b_tensor), get_strides(b_tensor)),
+        canonicalize_unit_dim_strides(get_shape(sfa_tensor), get_strides(sfa_tensor)),
+        canonicalize_unit_dim_strides(get_shape(sfb_tensor), get_strides(sfb_tensor)),
         c_major,
         c_dtype,
         acc_dtype,

--- a/python/cudnn/gemm/cutedsl/dense/amax/jax_api.py
+++ b/python/cudnn/gemm/cutedsl/dense/amax/jax_api.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""JAX-native (XLA custom call) entry point for the blockscaled GEMM + amax kernel.
+
+Unlike the eager path (``gemm_amax_wrapper_sm100`` with JAX arrays), this entry point
+integrates with XLA via jax-tvm-ffi: the kernel is compiled with the TVM-FFI environment
+stream (so it runs on XLA's compute stream, correctly ordered with surrounding ops), the
+output buffers are managed by XLA through donation, and the call is ``jax.jit``-compatible.
+No manual synchronization or block_until_ready is needed around it.
+
+This module imports jax/jax_tvm_ffi at import time; it is only loaded when the
+``gemm_amax_jax_sm100`` symbol is requested.
+"""
+
+from typing import Any, Tuple
+
+import jax
+import jax.numpy as jnp
+import jax_tvm_ffi
+
+import cutlass
+
+from cudnn.api_base import TensorDesc
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import Device, framework_dtype
+from .api import GemmAmaxSm100
+
+# cache_key -> (registered XLA target name, GemmAmaxSm100, compiled tvm-ffi callable).
+# The object references keep the compiled kernel alive alongside the global registration.
+_registered_targets = {}
+
+
+def _c_contiguous_strides(shape: Tuple[int, ...]) -> Tuple[int, ...]:
+    strides, acc = [1] * len(shape), 1
+    for i in range(len(shape) - 1, -1, -1):
+        strides[i] = acc
+        acc *= shape[i]
+    return tuple(strides)
+
+
+def _make_desc(shape: Tuple[int, ...], dtype: Any, name: str) -> TensorDesc:
+    """Descriptor for a C-contiguous (row-major) JAX buffer, from shape/dtype only.
+
+    Built directly from aval metadata so this works for jax.jit tracers as well as
+    concrete arrays (tracers expose .shape/.dtype but no device or DLPack).
+    """
+    stride = _c_contiguous_strides(shape)
+    return TensorDesc(
+        dtype=_convert_to_cutlass_data_type(dtype),
+        shape=shape,
+        stride=stride,
+        stride_order=TensorDesc._compute_stride_order(shape, stride),
+        device=Device("cuda", 0),
+        name=name,
+    )
+
+
+def gemm_amax_jax_sm100(
+    a_tensor: Any,
+    b_tensor: Any,
+    sfa_tensor: Any,
+    sfb_tensor: Any,
+    c_dtype: Any = cutlass.Float32,
+    acc_dtype: Any = cutlass.Float32,
+    mma_tiler_mn: Tuple[int, int] = (128, 128),
+    cluster_shape_mn: Tuple[int, int] = (1, 1),
+    sf_vec_size: int = 32,
+) -> Tuple[Any, Any]:
+    """Blockscaled GEMM + amax as an XLA custom call; usable eagerly or under jax.jit.
+
+    Arguments are JAX arrays (or tracers): A (M, K, 1) and B (N, K, 1) k-major
+    C-contiguous, SFA/SFB in the physical atom shape (1, MN', K', 32, 4, 4).
+    Returns a plain ``(c_tensor, amax_tensor)`` tuple of fresh JAX arrays (a plain
+    tuple, not a TupleDict, so the result is a valid JAX pytree under jit); C is n-major.
+
+    Note: calling this eagerly re-traces the ffi_call each time -- prefer calling it
+    from inside a jitted function in hot loops.
+    """
+    c_dtype = _convert_to_cutlass_data_type(c_dtype)
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
+
+    m, _, l = a_tensor.shape
+    n, _, _ = b_tensor.shape
+    if l != 1:
+        raise ValueError("JAX inputs must have batch dim L == 1; batch-outermost (L-major) layouts are not expressible as JAX arrays")
+
+    cache_key = (
+        tuple(a_tensor.shape),
+        tuple(b_tensor.shape),
+        tuple(sfa_tensor.shape),
+        tuple(sfb_tensor.shape),
+        _convert_to_cutlass_data_type(a_tensor.dtype),
+        _convert_to_cutlass_data_type(b_tensor.dtype),
+        _convert_to_cutlass_data_type(sfa_tensor.dtype),
+        _convert_to_cutlass_data_type(sfb_tensor.dtype),
+        c_dtype,
+        acc_dtype,
+        mma_tiler_mn,
+        cluster_shape_mn,
+        sf_vec_size,
+    )
+
+    entry = _registered_targets.get(cache_key)
+    if entry is None:
+        gemm = GemmAmaxSm100(
+            sample_a=_make_desc(tuple(a_tensor.shape), a_tensor.dtype, "sample_a"),
+            sample_b=_make_desc(tuple(b_tensor.shape), b_tensor.dtype, "sample_b"),
+            sample_sfa=_make_desc(tuple(sfa_tensor.shape), sfa_tensor.dtype, "sample_sfa"),
+            sample_sfb=_make_desc(tuple(sfb_tensor.shape), sfb_tensor.dtype, "sample_sfb"),
+            sample_c=_make_desc((m, n, l), c_dtype, "sample_c"),
+            sample_amax=_make_desc((1, 1, 1), cutlass.Float32, "sample_amax"),
+            acc_dtype=acc_dtype,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            sf_vec_size=sf_vec_size,
+        )
+        assert gemm.check_support()
+        compiled = gemm._compile_kernel(use_tvm_ffi_env_stream=True)
+        target = f"cudnn.gemm_amax_sm100.{len(_registered_targets)}"
+        # arg_spec=["args"]: only the operands are passed to the kernel; the result
+        # buffers arrive as the two donated trailing operands (input_output_aliases below),
+        # matching the kernel's destination-passing signature (a, b, sfa, sfb, c, amax).
+        jax_tvm_ffi.register_ffi_target(target, compiled, arg_spec=["args"], platform="gpu", allow_cuda_graph=True)
+        entry = (target, gemm, compiled)
+        _registered_targets[cache_key] = entry
+    target = entry[0]
+
+    c_jax_dtype = framework_dtype(c_dtype, "jax")
+    c_buf = jnp.zeros((m, n, l), dtype=c_jax_dtype)
+    # Zero-init is a valid amax identity: the kernel accumulates max(|c|) >= 0 via a
+    # signed-integer atomic max of non-negative float bit patterns.
+    amax_buf = jnp.zeros((1, 1, 1), dtype=jnp.float32)
+
+    c_tensor, amax_tensor = jax.ffi.ffi_call(
+        target,
+        (
+            jax.ShapeDtypeStruct((m, n, l), c_jax_dtype),
+            jax.ShapeDtypeStruct((1, 1, 1), jnp.float32),
+        ),
+        input_output_aliases={4: 0, 5: 1},
+    )(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_buf, amax_buf)
+
+    return c_tensor, amax_tensor

--- a/python/cudnn/gemm/cutedsl/dense/amax/jax_api.py
+++ b/python/cudnn/gemm/cutedsl/dense/amax/jax_api.py
@@ -17,43 +17,17 @@ from typing import Any, Tuple
 
 import jax
 import jax.numpy as jnp
-import jax_tvm_ffi
 
 import cutlass
 
-from cudnn.api_base import TensorDesc
 from cudnn.datatypes import _convert_to_cutlass_data_type
-from cudnn.tensor_adapter import Device, framework_dtype
+from cudnn.tensor_adapter import framework_dtype
+from cudnn.gemm.cutedsl._jax_ffi import get_or_register_env_stream_target, make_row_major_desc as _make_desc
 from .api import GemmAmaxSm100
 
 # cache_key -> (registered XLA target name, GemmAmaxSm100, compiled tvm-ffi callable).
 # The object references keep the compiled kernel alive alongside the global registration.
 _registered_targets = {}
-
-
-def _c_contiguous_strides(shape: Tuple[int, ...]) -> Tuple[int, ...]:
-    strides, acc = [1] * len(shape), 1
-    for i in range(len(shape) - 1, -1, -1):
-        strides[i] = acc
-        acc *= shape[i]
-    return tuple(strides)
-
-
-def _make_desc(shape: Tuple[int, ...], dtype: Any, name: str) -> TensorDesc:
-    """Descriptor for a C-contiguous (row-major) JAX buffer, from shape/dtype only.
-
-    Built directly from aval metadata so this works for jax.jit tracers as well as
-    concrete arrays (tracers expose .shape/.dtype but no device or DLPack).
-    """
-    stride = _c_contiguous_strides(shape)
-    return TensorDesc(
-        dtype=_convert_to_cutlass_data_type(dtype),
-        shape=shape,
-        stride=stride,
-        stride_order=TensorDesc._compute_stride_order(shape, stride),
-        device=Device("cuda", 0),
-        name=name,
-    )
 
 
 def gemm_amax_jax_sm100(
@@ -101,9 +75,8 @@ def gemm_amax_jax_sm100(
         sf_vec_size,
     )
 
-    entry = _registered_targets.get(cache_key)
-    if entry is None:
-        gemm = GemmAmaxSm100(
+    def make_gemm():
+        return GemmAmaxSm100(
             sample_a=_make_desc(tuple(a_tensor.shape), a_tensor.dtype, "sample_a"),
             sample_b=_make_desc(tuple(b_tensor.shape), b_tensor.dtype, "sample_b"),
             sample_sfa=_make_desc(tuple(sfa_tensor.shape), sfa_tensor.dtype, "sample_sfa"),
@@ -115,16 +88,11 @@ def gemm_amax_jax_sm100(
             cluster_shape_mn=cluster_shape_mn,
             sf_vec_size=sf_vec_size,
         )
-        assert gemm.check_support()
-        compiled = gemm._compile_kernel(use_tvm_ffi_env_stream=True)
-        target = f"cudnn.gemm_amax_sm100.{len(_registered_targets)}"
-        # arg_spec=["args"]: only the operands are passed to the kernel; the result
-        # buffers arrive as the two donated trailing operands (input_output_aliases below),
-        # matching the kernel's destination-passing signature (a, b, sfa, sfb, c, amax).
-        jax_tvm_ffi.register_ffi_target(target, compiled, arg_spec=["args"], platform="gpu", allow_cuda_graph=True)
-        entry = (target, gemm, compiled)
-        _registered_targets[cache_key] = entry
-    target = entry[0]
+
+    # arg_spec=["args"]: only the operands are passed to the kernel; the result
+    # buffers arrive as the two donated trailing operands (input_output_aliases below),
+    # matching the kernel's destination-passing signature (a, b, sfa, sfb, c, amax).
+    target = get_or_register_env_stream_target(_registered_targets, cache_key, make_gemm, "cudnn.gemm_amax_sm100")
 
     c_jax_dtype = framework_dtype(c_dtype, "jax")
     c_buf = jnp.zeros((m, n, l), dtype=c_jax_dtype)

--- a/python/cudnn/gemm/cutedsl/dense/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/dense/dsrelu/api.py
@@ -5,16 +5,25 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import cutlass
 import cutlass.cute as cute
-import torch
 from cuda.bindings import driver as cuda
 from cutlass.cute.runtime import make_fake_stream
 
 from cudnn.api_base import APIBase, TupleDict, ceil_div, is_power_of_2
 from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import (
+    canonicalize_unit_dim_strides,
+    cuda_is_available,
+    default_stream,
+    detect_framework,
+    framework_dtype,
+    get_compute_capability,
+    get_shape,
+    get_strides,
+)
 
 from .dense_blockscaled_gemm_persistent_dsrelu_quant import (
     Sm100BlockScaledPersistentDenseGemmKernel,
@@ -30,21 +39,29 @@ def _major_from_stride_order(stride_order: Tuple[int, ...], mode0_label: str, mo
 
 
 class GemmDsreluSm100(APIBase):
+    """Blockscaled GEMM + dsReLU (sReLU backward) for SM100.
+
+    Tensor parameters are type-erased: torch tensors and JAX arrays are both accepted
+    (the compiled kernels consume tensors via DLPack). torch is only imported when
+    torch tensors/dtypes are passed; likewise for JAX. Dtype parameters accept torch
+    dtypes, numpy/ml_dtypes dtypes, dtype name strings, or cutlass types.
+    """
+
     def __init__(
         self,
-        sample_a: torch.Tensor,
-        sample_b: torch.Tensor,
-        sample_c: torch.Tensor,
-        sample_d: torch.Tensor,
-        sample_dprob: torch.Tensor,
-        sample_sfa: torch.Tensor,
-        sample_sfb: torch.Tensor,
-        sample_prob: torch.Tensor,
-        sample_sfd: Optional[torch.Tensor] = None,
-        sample_amax: Optional[torch.Tensor] = None,
-        sample_norm_const: Optional[torch.Tensor] = None,
+        sample_a: Any,
+        sample_b: Any,
+        sample_c: Any,
+        sample_d: Any,
+        sample_dprob: Any,
+        sample_sfa: Any,
+        sample_sfb: Any,
+        sample_prob: Any,
+        sample_sfd: Optional[Any] = None,
+        sample_amax: Optional[Any] = None,
+        sample_norm_const: Optional[Any] = None,
         alpha: float = 1.0,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Any = cutlass.Float32,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -54,24 +71,24 @@ class GemmDsreluSm100(APIBase):
 
         self._warn_experimental_api()
 
-        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a")
-        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b")
-        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c")
-        self.d_desc = self._make_tensor_desc(sample_d, name="sample_d")
-        self.dprob_desc = self._make_tensor_desc(sample_dprob, name="sample_dprob")
-        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa")
-        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb")
-        self.prob_desc = self._make_tensor_desc(sample_prob, name="sample_prob")
-        self.sfd_desc = self._make_tensor_desc(sample_sfd, name="sample_sfd")
-        self.amax_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_amax, name="sample_amax"), 1, "amax")
+        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
+        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b", canonical=True)
+        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c", canonical=True)
+        self.d_desc = self._make_tensor_desc(sample_d, name="sample_d", canonical=True)
+        self.dprob_desc = self._make_tensor_desc(sample_dprob, name="sample_dprob", canonical=True)
+        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa", canonical=True)
+        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb", canonical=True)
+        self.prob_desc = self._make_tensor_desc(sample_prob, name="sample_prob", canonical=True)
+        self.sfd_desc = self._make_tensor_desc(sample_sfd, name="sample_sfd", canonical=True)
+        self.amax_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_amax, name="sample_amax", canonical=True), 1, "amax")
         self.norm_const_desc = self._unpad_tensor_to_ndim(
-            self._make_tensor_desc(sample_norm_const, name="sample_norm_const"),
+            self._make_tensor_desc(sample_norm_const, name="sample_norm_const", canonical=True),
             1,
             "norm_const",
         )
 
         self.alpha = alpha
-        self.acc_dtype = acc_dtype
+        self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
         self.cluster_shape_mn = cluster_shape_mn if cluster_shape_mn is not None else ((2, 1) if mma_tiler_mn[0] == 256 else (1, 1))
         self.sf_vec_size = sf_vec_size
@@ -91,48 +108,55 @@ class GemmDsreluSm100(APIBase):
         self._check_tensor_shape(self.prob_desc, (m, 1, l), "prob")
         self._check_tensor_shape(self.dprob_desc, (m, 1, l), "dprob")
 
+        # SF tensors are accepted in the torch-style logical atom view or the
+        # byte-identical physical C-contiguous shape (L, MN', K', 32, 4, 4) --
+        # frameworks with row-major-only layouts (e.g. JAX) cannot express the
+        # permuted logical view.
+        def sf_shapes(mn_div, k_div):
+            return [(32, 4, mn_div, 4, k_div, l), (l, mn_div, k_div, 32, 4, 4)]
+
         rest_k = ceil_div(ceil_div(k, self.sf_vec_size), 4)
-        self._check_tensor_shape(self.sfa_desc, (32, 4, ceil_div(m, 128), 4, rest_k, l), "SFA")
-        self._check_tensor_shape(self.sfb_desc, (32, 4, ceil_div(n, 128), 4, rest_k, l), "SFB")
+        self._check_tensor_shape(self.sfa_desc, sf_shapes(ceil_div(m, 128), rest_k), "SFA")
+        self._check_tensor_shape(self.sfb_desc, sf_shapes(ceil_div(n, 128), rest_k), "SFB")
 
         if self.sfd_desc is not None:
             rest_n = ceil_div(ceil_div(n, self.sf_vec_size), 4)
-            self._check_tensor_shape(self.sfd_desc, (32, 4, ceil_div(m, 128), 4, rest_n, l), "SFD")
+            self._check_tensor_shape(self.sfd_desc, sf_shapes(ceil_div(m, 128), rest_n), "SFD")
 
         self._check_tensor_shape(self.amax_desc, (1,), "amax")
         self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
 
         self.ab_dtype = self._check_dtype(
             self.a_desc,
-            dtype=[torch.float4_e2m1fn_x2, torch.uint8, torch.float8_e4m3fn, torch.float8_e5m2],
+            dtype=[cutlass.Float4E2M1FN, cutlass.Uint8, cutlass.Float8E4M3FN, cutlass.Float8E5M2],
             name="A",
         )
         self._check_dtype(self.b_desc, dtype=self.ab_dtype, name="B", extra_error_msg="A and B must have the same dtype")
         self.c_dtype = self._check_dtype(
             self.c_desc,
-            dtype=[torch.float16, torch.bfloat16, torch.float32],
+            dtype=[cutlass.Float16, cutlass.BFloat16, cutlass.Float32],
             name="C",
         )
         self.d_dtype = self._check_dtype(
             self.d_desc,
-            dtype=[torch.float16, torch.bfloat16, torch.float32, torch.float8_e4m3fn, torch.float8_e5m2],
+            dtype=[cutlass.Float16, cutlass.BFloat16, cutlass.Float32, cutlass.Float8E4M3FN, cutlass.Float8E5M2],
             name="D",
         )
-        self._check_dtype(self.prob_desc, dtype=torch.float32, name="prob")
-        self._check_dtype(self.dprob_desc, dtype=torch.float32, name="dprob")
+        self._check_dtype(self.prob_desc, dtype=cutlass.Float32, name="prob")
+        self._check_dtype(self.dprob_desc, dtype=cutlass.Float32, name="dprob")
 
-        self.sf_dtype = self._check_dtype(self.sfa_desc, dtype=[torch.float8_e8m0fnu, torch.float8_e4m3fn], name="SFA")
+        self.sf_dtype = self._check_dtype(self.sfa_desc, dtype=[cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN], name="SFA")
         self._check_dtype(self.sfb_desc, dtype=self.sf_dtype, name="SFB", extra_error_msg="SFB must have the same dtype as SFA")
         self._check_dtype(self.sfd_desc, dtype=self.sf_dtype, name="SFD", extra_error_msg="SFD must have the same dtype as SFA")
 
-        self._check_dtype(self.acc_dtype, dtype=torch.float32, name="Accumulator")
+        self._check_dtype(self.acc_dtype, dtype=cutlass.Float32, name="Accumulator")
 
         self._value_error_if(self.sf_vec_size not in {16, 32}, f"sf_vec_size must be 16 or 32, got {self.sf_vec_size}")
         self._value_error_if(
             self._is_fp8(self.d_desc) and (self.sfd_desc is None or self.norm_const_desc is None), "sfd and norm_const are required when D is FP8"
         )
         self._value_error_if(
-            self._is_fp4x2(self.ab_dtype) and self.d_dtype in {torch.float8_e4m3fn, torch.float8_e5m2}, "FP4 input with FP8 output is not supported"
+            self._is_fp4x2(self.ab_dtype) and self.d_dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}, "FP4 input with FP8 output is not supported"
         )
 
         a_major = _major_from_stride_order(self.a_desc.stride_order, "m", "k")
@@ -156,8 +180,8 @@ class GemmDsreluSm100(APIBase):
             f"Invalid cluster shape {self.cluster_shape_mn}",
         )
 
-        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
-        major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+        self._runtime_error_if(not cuda_is_available(), "CUDA is not available")
+        major, minor = get_compute_capability()
         self._runtime_error_if(major * 10 + minor < 100, f"GemmDsreluSm100 requires SM100+, found SM{major}{minor}")
 
         self._value_error_if(
@@ -371,17 +395,17 @@ class GemmDsreluSm100(APIBase):
         )
 
         def tensor_api(
-            a_tensor: torch.Tensor,
-            b_tensor: torch.Tensor,
-            sfa_tensor: torch.Tensor,
-            sfb_tensor: torch.Tensor,
-            c_tensor: torch.Tensor,
-            d_tensor: torch.Tensor,
-            prob_tensor: torch.Tensor,
-            dprob_tensor: torch.Tensor,
-            amax_tensor: Optional[torch.Tensor],
-            sfd_tensor: Optional[torch.Tensor],
-            norm_const_tensor: Optional[torch.Tensor],
+            a_tensor: Any,
+            b_tensor: Any,
+            sfa_tensor: Any,
+            sfb_tensor: Any,
+            c_tensor: Any,
+            d_tensor: Any,
+            prob_tensor: Any,
+            dprob_tensor: Any,
+            amax_tensor: Optional[Any],
+            sfd_tensor: Optional[Any],
+            norm_const_tensor: Optional[Any],
             alpha: float,
             stream: cuda.CUstream,
         ) -> None:
@@ -405,22 +429,25 @@ class GemmDsreluSm100(APIBase):
 
     def execute(
         self,
-        a_tensor: torch.Tensor,
-        b_tensor: torch.Tensor,
-        c_tensor: torch.Tensor,
-        d_tensor: torch.Tensor,
-        dprob_tensor: torch.Tensor,
-        sfa_tensor: torch.Tensor,
-        sfb_tensor: torch.Tensor,
-        prob_tensor: torch.Tensor,
-        sfd_tensor: Optional[torch.Tensor] = None,
-        amax_tensor: Optional[torch.Tensor] = None,
-        norm_const_tensor: Optional[torch.Tensor] = None,
+        a_tensor: Any,
+        b_tensor: Any,
+        c_tensor: Any,
+        d_tensor: Any,
+        dprob_tensor: Any,
+        sfa_tensor: Any,
+        sfb_tensor: Any,
+        prob_tensor: Any,
+        sfd_tensor: Optional[Any] = None,
+        amax_tensor: Optional[Any] = None,
+        norm_const_tensor: Optional[Any] = None,
         alpha: Optional[float] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         self._runtime_error_if(self._compiled_kernel is None, "GemmDsreluSm100 kernel not compiled; call compile() first")
-        current_stream = self._get_default_stream(current_stream)
+        if current_stream is None:
+            # torch inputs stay ordered with the caller's current torch stream;
+            # other frameworks (e.g. JAX) default to the CUDA legacy default stream.
+            current_stream = default_stream(detect_framework(a_tensor))
         self._compiled_kernel(
             a_tensor=a_tensor,
             b_tensor=b_tensor,
@@ -444,7 +471,9 @@ _DENSE_GEMM_DYNAMIC_M_ENV = "CUDNN_FE_GEMM_DYNAMIC_M"
 _DENSE_GEMM_DYNAMIC_MNKL_ENV = "CUDNN_FE_GEMM_DYNAMIC_MNKL"
 
 
-def _allocate_dense_output(shape: Tuple[int, int, int], major: str, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+def _allocate_dense_output(shape: Tuple[int, int, int], major: str, dtype: Any, device: Any) -> Any:
+    import torch
+
     m, n, l = shape
     if major == "m":
         return torch.empty_strided((m, n, l), (1, m, m * n), dtype=dtype, device=device)
@@ -454,74 +483,118 @@ def _allocate_dense_output(shape: Tuple[int, int, int], major: str, dtype: torch
 
 
 def gemm_dsrelu_wrapper_sm100(
-    a_tensor: torch.Tensor,
-    b_tensor: torch.Tensor,
-    c_tensor: torch.Tensor,
-    sfa_tensor: torch.Tensor,
-    sfb_tensor: torch.Tensor,
-    prob_tensor: torch.Tensor,
+    a_tensor: Any,
+    b_tensor: Any,
+    c_tensor: Any,
+    sfa_tensor: Any,
+    sfb_tensor: Any,
+    prob_tensor: Any,
     alpha: float = 1.0,
     d_major: str = "n",
-    d_dtype: torch.dtype = torch.bfloat16,
-    acc_dtype: torch.dtype = torch.float32,
+    d_dtype: Any = cutlass.BFloat16,
+    acc_dtype: Any = cutlass.Float32,
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
-    norm_const_tensor: Optional[torch.Tensor] = None,
+    norm_const_tensor: Optional[Any] = None,
     sf_vec_size: int = 16,
     vector_f32: bool = False,
     stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
-    m, k, l = a_tensor.shape
-    n, _, _ = b_tensor.shape
+    framework = detect_framework(a_tensor)
+    d_dtype = _convert_to_cutlass_data_type(d_dtype)
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
+    ab_cutlass_dtype = _convert_to_cutlass_data_type(a_tensor.dtype)
 
-    d_tensor = _allocate_dense_output((m, n, l), d_major, d_dtype, a_tensor.device)
-    dprob_tensor = torch.zeros((m, 1, l), dtype=torch.float32, device=a_tensor.device)
+    m, k, l = get_shape(a_tensor)
+    n, _, _ = get_shape(b_tensor)
 
-    sfd_tensor = None
-    if d_dtype in {torch.float8_e4m3fn, torch.float8_e5m2}:
-        sf_k = ceil_div(n, sf_vec_size)
-        mma_shape = (
-            l,
-            ceil_div(m, 128),
-            ceil_div(sf_k, 4),
-            32,
-            4,
-            4,
-        )
-        sfd_tensor = torch.empty(mma_shape, dtype=sfa_tensor.dtype, device=a_tensor.device).permute(3, 4, 1, 5, 2, 0)
+    if framework == "torch":
+        import torch
 
-    amax_tensor = None
-    if a_tensor.dtype in {torch.float4_e2m1fn_x2, torch.uint8} and d_dtype in {torch.bfloat16, torch.float16, torch.float32}:
-        amax_tensor = torch.full((1,), float("-inf"), dtype=torch.float32, device=a_tensor.device)
+        d_tensor = _allocate_dense_output((m, n, l), d_major, framework_dtype(d_dtype, "torch"), a_tensor.device)
+        dprob_tensor = torch.zeros((m, 1, l), dtype=torch.float32, device=a_tensor.device)
+
+        sfd_tensor = None
+        if d_dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}:
+            sf_k = ceil_div(n, sf_vec_size)
+            mma_shape = (
+                l,
+                ceil_div(m, 128),
+                ceil_div(sf_k, 4),
+                32,
+                4,
+                4,
+            )
+            sfd_tensor = torch.empty(mma_shape, dtype=sfa_tensor.dtype, device=a_tensor.device).permute(3, 4, 1, 5, 2, 0)
+
+        amax_tensor = None
+        if ab_cutlass_dtype in {cutlass.Float4E2M1FN, cutlass.Uint8} and d_dtype in {cutlass.BFloat16, cutlass.Float16, cutlass.Float32}:
+            amax_tensor = torch.full((1,), float("-inf"), dtype=torch.float32, device=a_tensor.device)
+    elif framework == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        if d_major == "m":
+            raise ValueError("JAX arrays are row-major; only d_major='n' is supported for JAX inputs")
+        if d_major != "n":
+            raise ValueError(f"major must be 'm' or 'n', got {d_major}")
+        if l != 1:
+            raise ValueError("JAX inputs must have batch dim L == 1; batch-outermost (L-major) layouts are not expressible as JAX arrays")
+        device = a_tensor.device
+        d_tensor = jnp.empty((m, n, l), dtype=framework_dtype(d_dtype, "jax"), device=device)
+        dprob_tensor = jnp.zeros((m, 1, l), dtype=jnp.float32, device=device)
+        outputs_to_sync = [d_tensor, dprob_tensor]
+
+        sfd_tensor = None
+        if d_dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}:
+            # SFD in the physical C-contiguous atom shape; the torch path's permuted
+            # logical view is byte-identical in memory
+            sf_k = ceil_div(n, sf_vec_size)
+            sfd_tensor = jnp.empty(
+                (l, ceil_div(m, 128), ceil_div(sf_k, 4), 32, 4, 4),
+                dtype=framework_dtype(_convert_to_cutlass_data_type(sfa_tensor.dtype), "jax"),
+                device=device,
+            )
+            outputs_to_sync.append(sfd_tensor)
+
+        amax_tensor = None
+        if ab_cutlass_dtype in {cutlass.Float4E2M1FN, cutlass.Uint8} and d_dtype in {cutlass.BFloat16, cutlass.Float16, cutlass.Float32}:
+            amax_tensor = jnp.full((1,), -float("inf"), dtype=jnp.float32, device=device)
+            outputs_to_sync.append(amax_tensor)
+        # The kernel writes into these buffers on the launch stream; make sure XLA has
+        # finished materializing them before the kernel runs.
+        jax.block_until_ready(outputs_to_sync)
+    else:
+        raise ValueError(f"Unsupported tensor framework '{framework}' for gemm_dsrelu_wrapper_sm100; pass torch tensors or JAX arrays")
 
     use_full_dynamic = os.environ.get(_DENSE_GEMM_DYNAMIC_MNKL_ENV) is not None
     use_dynamic_m = not use_full_dynamic and os.environ.get(_DENSE_GEMM_DYNAMIC_M_ENV) is not None
 
-    def stride_order(tensor: torch.Tensor) -> Tuple[int, ...]:
-        return tuple(i for i, s in sorted(enumerate(tensor.stride()), key=lambda x: x[1]))
+    def stride_order(tensor: Any) -> Tuple[int, ...]:
+        return tuple(i for i, s in sorted(enumerate(get_strides(tensor)), key=lambda x: x[1]))
 
-    def tensor_signature(tensor: Optional[torch.Tensor]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+    def tensor_signature(tensor: Optional[Any]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[Any]]:
         if tensor is None:
             return None, None, None
-        return tuple(tensor.shape), tuple(tensor.stride()), tensor.dtype
+        return get_shape(tensor), canonicalize_unit_dim_strides(get_shape(tensor), get_strides(tensor)), _convert_to_cutlass_data_type(tensor.dtype)
 
-    def dynamic_compact_signature(tensor: Optional[torch.Tensor]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+    def dynamic_compact_signature(tensor: Optional[Any]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[Any]]:
         if tensor is None:
             return None, None, None
-        return tuple(tensor.shape[1:]), stride_order(tensor), tensor.dtype
+        return get_shape(tensor)[1:], stride_order(tensor), _convert_to_cutlass_data_type(tensor.dtype)
 
-    def dynamic_tensor_signature(tensor: Optional[torch.Tensor]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+    def dynamic_tensor_signature(tensor: Optional[Any]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[Any]]:
         if tensor is None:
             return None, None, None
-        return None, stride_order(tensor), tensor.dtype
+        return None, stride_order(tensor), _convert_to_cutlass_data_type(tensor.dtype)
 
     def dynamic_m_tensor_signature(
-        tensor: Optional[torch.Tensor], static_shape_suffix: Optional[Tuple[int, ...]], dynamic_stride_dims: Tuple[int, ...] = ()
-    ) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+        tensor: Optional[Any], static_shape_suffix: Optional[Tuple[int, ...]], dynamic_stride_dims: Tuple[int, ...] = ()
+    ) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[Any]]:
         if tensor is None:
             return None, None, None
-        stride_signature = tuple(None if i in dynamic_stride_dims else s for i, s in enumerate(tensor.stride()))
-        return static_shape_suffix, stride_signature, tensor.dtype
+        stride_signature = tuple(None if i in dynamic_stride_dims else s for i, s in enumerate(get_strides(tensor)))
+        return static_shape_suffix, stride_signature, _convert_to_cutlass_data_type(tensor.dtype)
 
     cache_key = (
         use_full_dynamic,
@@ -540,7 +613,7 @@ def gemm_dsrelu_wrapper_sm100(
             dynamic_tensor_signature(sfa_tensor)
             if use_full_dynamic
             else (
-                dynamic_m_tensor_signature(sfa_tensor, (sfa_tensor.shape[4], sfa_tensor.shape[5]), dynamic_stride_dims=(5,))
+                dynamic_m_tensor_signature(sfa_tensor, (get_shape(sfa_tensor)[4], get_shape(sfa_tensor)[5]), dynamic_stride_dims=(5,))
                 if use_dynamic_m
                 else tensor_signature(sfa_tensor)
             )
@@ -551,9 +624,9 @@ def gemm_dsrelu_wrapper_sm100(
             if use_full_dynamic
             else dynamic_compact_signature(prob_tensor) if use_dynamic_m else tensor_signature(prob_tensor)
         ),
-        norm_const_tensor.shape if norm_const_tensor is not None else None,
-        norm_const_tensor.stride() if norm_const_tensor is not None else None,
-        norm_const_tensor.dtype if norm_const_tensor is not None else None,
+        get_shape(norm_const_tensor) if norm_const_tensor is not None else None,
+        canonicalize_unit_dim_strides(get_shape(norm_const_tensor), get_strides(norm_const_tensor)) if norm_const_tensor is not None else None,
+        _convert_to_cutlass_data_type(norm_const_tensor.dtype) if norm_const_tensor is not None else None,
         alpha,
         acc_dtype,
         mma_tiler_mn,

--- a/python/cudnn/gemm/cutedsl/dense/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/dense/dsrelu/dense_blockscaled_gemm_persistent_dsrelu_quant.py
@@ -3,7 +3,6 @@
 from typing import Type, Tuple, Union, Optional
 
 import cuda.bindings.driver as cuda
-import torch
 
 import cutlass
 import cutlass.cute as cute

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/api.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/api.py
@@ -13,6 +13,8 @@ kernels that differ only in the GEMM *input* precision, exposed as sibling APIBa
 match), allocates outputs, drives the class lifecycle, and returns a ``TupleDict``.
 """
 
+from __future__ import annotations
+
 from .gemm_proj_rope_mxfp8_bf16in import (
     gemm_proj_rope_mxfp8_host as _bf16in_host,
     HEAD_DIM,
@@ -27,7 +29,6 @@ from .gemm_proj_rope_mxfp8_mxfp8in import (
 
 from cuda.bindings import driver as cuda
 import logging
-import torch
 from typing import Optional
 
 import cutlass.utils
@@ -55,6 +56,10 @@ class GemmProjRopeMxfp8Bf16InSm100(APIBase):
         sample_out_scales_col: torch.Tensor,
         w_out_in: bool = False,
     ):
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_x is not None and not is_torch_tensor(sample_x):
+            raise ValueError("GemmProjRopeMxfp8Bf16InSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
         super().__init__()
         self._warn_experimental_api()
         self._logger.debug("Entering __init__")
@@ -86,6 +91,8 @@ class GemmProjRopeMxfp8Bf16InSm100(APIBase):
         self._logger.debug(f"__init__ completed: x {self.x_desc.shape}, w {self.w_desc.shape}, w_out_in {self.w_out_in}")
 
     def check_support(self) -> bool:
+        import torch
+
         self._logger.debug("Entering check_support")
 
         self._check_dtype(self.x_desc, dtype=torch.bfloat16, name="x")
@@ -179,6 +186,8 @@ class GemmProjRopeMxfp8Bf16InSm100(APIBase):
         return mA, mB, mCos, mSin, mQrow, mSrow, mQcol, mScol
 
     def compile(self) -> None:
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -245,6 +254,10 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         sample_out_fp8_col: torch.Tensor,
         sample_out_scales_col: torch.Tensor,
     ):
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_x_code is not None and not is_torch_tensor(sample_x_code):
+            raise ValueError("GemmProjRopeMxfp8Mxfp8InSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
         super().__init__()
         self._warn_experimental_api()
         self._logger.debug("Entering __init__")
@@ -280,6 +293,8 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         self._logger.debug(f"__init__ completed: x_code {self.x_code_desc.shape}, w_code {self.w_code_desc.shape}")
 
     def check_support(self) -> bool:
+        import torch
+
         self._logger.debug("Entering check_support")
 
         self._check_dtype(self.x_code_desc, dtype=torch.float8_e4m3fn, name="x_code")
@@ -399,6 +414,8 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         return mA, mSFA, mB, mSFB, mCos, mSin, mQrow, mSrow, mQcol, mScol
 
     def compile(self) -> None:
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -479,6 +496,8 @@ def _check_contiguous(api, **named_descs):
 
 
 def _check_sm100(api):
+    import torch
+
     api._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
     device = torch.cuda.current_device()
     major, minor = torch.cuda.get_device_capability(device)
@@ -522,6 +541,12 @@ def gemm_proj_rope_mxfp8_wrapper_sm100(
     Returns:
         ``TupleDict(out_fp8_row, out_scales_row, out_fp8_col, out_scales_col)``.
     """
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if x is not None and not is_torch_tensor(x):
+        raise ValueError("gemm_proj_rope_mxfp8_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
     assert x.dtype == w.dtype, f"x and w must share a dtype (both bfloat16 or both float8_e4m3fn); got x {x.dtype}, w {w.dtype}"
 
     tokens = x.shape[0]

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fused projection GEMM + per-head YARN RoPE + dual-direction MXFP8 quantize (Blackwell / SM100)."""
 
-import torch
-
 import cutlass
 import cutlass.cute as cute
 import cutlass.utils as utils
@@ -514,6 +512,8 @@ def gemm_proj_rope_mxfp8_host(
 # PyTorch reference (oracle) for the fused kernel above.
 # ---------------------------------------------------------------------------
 def gemm_proj_rope_mxfp8_reference(x, w, cos, sin, w_out_in=False):
+    import torch
+
     E8M0_BIAS = 127
     tokens = x.shape[0]
     # Heads derived from the weight's projected dimension (matches the kernel's Constexpr).

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_bf16in.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fused projection GEMM + per-head YARN RoPE + dual-direction MXFP8 quantize (Blackwell / SM100)."""
 
-import torch
-
 import cutlass
 import cutlass.cute as cute
 import cutlass.utils as utils
@@ -514,6 +512,8 @@ def gemm_proj_rope_mxfp8_host(
 # PyTorch reference (oracle) for the fused kernel above.
 # ---------------------------------------------------------------------------
 def gemm_proj_rope_mxfp8_reference(x, w, cos, sin, w_out_in=False):
+    import torch
+
     E8M0_BIAS = 127
     tokens = x.shape[0]
     # Heads derived from the weight's projected dimension (matches the kernel's Constexpr).

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fused projection GEMM + per-head YARN RoPE + dual-direction MXFP8 quantize (Blackwell / SM100)."""
 
-import torch
-
 import cutlass
 import cutlass.cute as cute
 import cutlass.utils as utils

--- a/python/cudnn/gemm/cutedsl/dense/srelu/api.py
+++ b/python/cudnn/gemm/cutedsl/dense/srelu/api.py
@@ -5,16 +5,25 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import cutlass
 import cutlass.cute as cute
-import torch
 from cuda.bindings import driver as cuda
 from cutlass.cute.runtime import make_fake_stream
 
 from cudnn.api_base import APIBase, TupleDict, ceil_div, is_power_of_2
 from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import (
+    canonicalize_unit_dim_strides,
+    cuda_is_available,
+    default_stream,
+    detect_framework,
+    framework_dtype,
+    get_compute_capability,
+    get_shape,
+    get_strides,
+)
 
 from .dense_blockscaled_gemm_persistent_srelu_quant import (
     Sm100BlockScaledPersistentDenseGemmKernel,
@@ -30,20 +39,28 @@ def _major_from_stride_order(stride_order: Tuple[int, ...], mode0_label: str, mo
 
 
 class GemmSreluSm100(APIBase):
+    """Blockscaled GEMM + sReLU for SM100.
+
+    Tensor parameters are type-erased: torch tensors and JAX arrays are both accepted
+    (the compiled kernels consume tensors via DLPack). torch is only imported when
+    torch tensors/dtypes are passed; likewise for JAX. Dtype parameters accept torch
+    dtypes, numpy/ml_dtypes dtypes, dtype name strings, or cutlass types.
+    """
+
     def __init__(
         self,
-        sample_a: torch.Tensor,
-        sample_b: torch.Tensor,
-        sample_c: torch.Tensor,
-        sample_d: torch.Tensor,
-        sample_sfa: torch.Tensor,
-        sample_sfb: torch.Tensor,
-        sample_prob: torch.Tensor,
-        sample_sfd: Optional[torch.Tensor] = None,
-        sample_amax: Optional[torch.Tensor] = None,
-        sample_norm_const: Optional[torch.Tensor] = None,
+        sample_a: Any,
+        sample_b: Any,
+        sample_c: Any,
+        sample_d: Any,
+        sample_sfa: Any,
+        sample_sfb: Any,
+        sample_prob: Any,
+        sample_sfd: Optional[Any] = None,
+        sample_amax: Optional[Any] = None,
+        sample_norm_const: Optional[Any] = None,
         alpha: float = 1.0,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Any = cutlass.Float32,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -53,23 +70,23 @@ class GemmSreluSm100(APIBase):
 
         self._warn_experimental_api()
 
-        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a")
-        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b")
-        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c")
-        self.d_desc = self._make_tensor_desc(sample_d, name="sample_d")
-        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa")
-        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb")
-        self.prob_desc = self._make_tensor_desc(sample_prob, name="sample_prob")
-        self.sfd_desc = self._make_tensor_desc(sample_sfd, name="sample_sfd")
-        self.amax_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_amax, name="sample_amax"), 1, "amax")
+        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
+        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b", canonical=True)
+        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c", canonical=True)
+        self.d_desc = self._make_tensor_desc(sample_d, name="sample_d", canonical=True)
+        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa", canonical=True)
+        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb", canonical=True)
+        self.prob_desc = self._make_tensor_desc(sample_prob, name="sample_prob", canonical=True)
+        self.sfd_desc = self._make_tensor_desc(sample_sfd, name="sample_sfd", canonical=True)
+        self.amax_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_amax, name="sample_amax", canonical=True), 1, "amax")
         self.norm_const_desc = self._unpad_tensor_to_ndim(
-            self._make_tensor_desc(sample_norm_const, name="sample_norm_const"),
+            self._make_tensor_desc(sample_norm_const, name="sample_norm_const", canonical=True),
             1,
             "norm_const",
         )
 
         self.alpha = alpha
-        self.acc_dtype = acc_dtype
+        self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
         self.cluster_shape_mn = cluster_shape_mn if cluster_shape_mn is not None else ((2, 1) if mma_tiler_mn[0] == 256 else (1, 1))
         self.sf_vec_size = sf_vec_size
@@ -90,47 +107,54 @@ class GemmSreluSm100(APIBase):
         self._check_tensor_shape(self.d_desc, (m, n, l), "D")
         self._check_tensor_shape(self.prob_desc, (m, 1, l), "prob")
 
+        # SF tensors are accepted in the torch-style logical atom view or the
+        # byte-identical physical C-contiguous shape (L, MN', K', 32, 4, 4) --
+        # frameworks with row-major-only layouts (e.g. JAX) cannot express the
+        # permuted logical view.
+        def sf_shapes(mn_div, k_div):
+            return [(32, 4, mn_div, 4, k_div, l), (l, mn_div, k_div, 32, 4, 4)]
+
         rest_k = ceil_div(ceil_div(k, self.sf_vec_size), 4)
-        self._check_tensor_shape(self.sfa_desc, (32, 4, ceil_div(m, 128), 4, rest_k, l), "SFA")
-        self._check_tensor_shape(self.sfb_desc, (32, 4, ceil_div(n, 128), 4, rest_k, l), "SFB")
+        self._check_tensor_shape(self.sfa_desc, sf_shapes(ceil_div(m, 128), rest_k), "SFA")
+        self._check_tensor_shape(self.sfb_desc, sf_shapes(ceil_div(n, 128), rest_k), "SFB")
 
         if self.sfd_desc is not None:
             rest_n = ceil_div(ceil_div(n, self.sf_vec_size), 4)
-            self._check_tensor_shape(self.sfd_desc, (32, 4, ceil_div(m, 128), 4, rest_n, l), "SFD")
+            self._check_tensor_shape(self.sfd_desc, sf_shapes(ceil_div(m, 128), rest_n), "SFD")
 
         self._check_tensor_shape(self.amax_desc, (1,), "amax")
         self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
 
         self.ab_dtype = self._check_dtype(
             self.a_desc,
-            dtype=[torch.float4_e2m1fn_x2, torch.uint8, torch.float8_e4m3fn, torch.float8_e5m2],
+            dtype=[cutlass.Float4E2M1FN, cutlass.Uint8, cutlass.Float8E4M3FN, cutlass.Float8E5M2],
             name="A",
         )
         self._check_dtype(self.b_desc, dtype=self.ab_dtype, name="B", extra_error_msg="A and B must have the same dtype")
         self.c_dtype = self._check_dtype(
             self.c_desc,
-            dtype=[torch.float16, torch.bfloat16, torch.float32, torch.float8_e4m3fn, torch.float8_e5m2],
+            dtype=[cutlass.Float16, cutlass.BFloat16, cutlass.Float32, cutlass.Float8E4M3FN, cutlass.Float8E5M2],
             name="C",
         )
         self.d_dtype = self._check_dtype(
             self.d_desc,
-            dtype=[torch.float16, torch.bfloat16, torch.float32, torch.float8_e4m3fn, torch.float8_e5m2],
+            dtype=[cutlass.Float16, cutlass.BFloat16, cutlass.Float32, cutlass.Float8E4M3FN, cutlass.Float8E5M2],
             name="D",
         )
-        self._check_dtype(self.prob_desc, dtype=torch.float32, name="prob")
+        self._check_dtype(self.prob_desc, dtype=cutlass.Float32, name="prob")
 
-        self.sf_dtype = self._check_dtype(self.sfa_desc, dtype=[torch.float8_e8m0fnu, torch.float8_e4m3fn], name="SFA")
+        self.sf_dtype = self._check_dtype(self.sfa_desc, dtype=[cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN], name="SFA")
         self._check_dtype(self.sfb_desc, dtype=self.sf_dtype, name="SFB", extra_error_msg="SFB must have the same dtype as SFA")
         self._check_dtype(self.sfd_desc, dtype=self.sf_dtype, name="SFD", extra_error_msg="SFD must have the same dtype as SFA")
 
-        self._check_dtype(self.acc_dtype, dtype=torch.float32, name="Accumulator")
+        self._check_dtype(self.acc_dtype, dtype=cutlass.Float32, name="Accumulator")
 
         self._value_error_if(self.sf_vec_size not in {16, 32}, f"sf_vec_size must be 16 or 32, got {self.sf_vec_size}")
         self._value_error_if(
             self._is_fp8(self.d_desc) and (self.sfd_desc is None or self.norm_const_desc is None), "sfd and norm_const are required when D is FP8"
         )
         self._value_error_if(
-            self._is_fp4x2(self.ab_dtype) and self.d_dtype in {torch.float8_e4m3fn, torch.float8_e5m2}, "FP4 input with FP8 output is not supported"
+            self._is_fp4x2(self.ab_dtype) and self.d_dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}, "FP4 input with FP8 output is not supported"
         )
 
         a_major = _major_from_stride_order(self.a_desc.stride_order, "m", "k")
@@ -154,8 +178,8 @@ class GemmSreluSm100(APIBase):
             f"Invalid cluster shape {self.cluster_shape_mn}",
         )
 
-        self._runtime_error_if(not torch.cuda.is_available(), "CUDA is not available")
-        major, minor = torch.cuda.get_device_capability(torch.cuda.current_device())
+        self._runtime_error_if(not cuda_is_available(), "CUDA is not available")
+        major, minor = get_compute_capability()
         self._runtime_error_if(major * 10 + minor < 100, f"GemmSreluSm100 requires SM100+, found SM{major}{minor}")
 
         self._value_error_if(
@@ -357,16 +381,16 @@ class GemmSreluSm100(APIBase):
         )
 
         def tensor_api(
-            a_tensor: torch.Tensor,
-            b_tensor: torch.Tensor,
-            sfa_tensor: torch.Tensor,
-            sfb_tensor: torch.Tensor,
-            c_tensor: torch.Tensor,
-            d_tensor: torch.Tensor,
-            prob_tensor: torch.Tensor,
-            amax_tensor: Optional[torch.Tensor],
-            sfd_tensor: Optional[torch.Tensor],
-            norm_const_tensor: Optional[torch.Tensor],
+            a_tensor: Any,
+            b_tensor: Any,
+            sfa_tensor: Any,
+            sfb_tensor: Any,
+            c_tensor: Any,
+            d_tensor: Any,
+            prob_tensor: Any,
+            amax_tensor: Optional[Any],
+            sfd_tensor: Optional[Any],
+            norm_const_tensor: Optional[Any],
             alpha: float,
             stream: cuda.CUstream,
         ) -> None:
@@ -389,21 +413,24 @@ class GemmSreluSm100(APIBase):
 
     def execute(
         self,
-        a_tensor: torch.Tensor,
-        b_tensor: torch.Tensor,
-        c_tensor: torch.Tensor,
-        d_tensor: torch.Tensor,
-        sfa_tensor: torch.Tensor,
-        sfb_tensor: torch.Tensor,
-        prob_tensor: torch.Tensor,
-        sfd_tensor: Optional[torch.Tensor] = None,
-        amax_tensor: Optional[torch.Tensor] = None,
-        norm_const_tensor: Optional[torch.Tensor] = None,
+        a_tensor: Any,
+        b_tensor: Any,
+        c_tensor: Any,
+        d_tensor: Any,
+        sfa_tensor: Any,
+        sfb_tensor: Any,
+        prob_tensor: Any,
+        sfd_tensor: Optional[Any] = None,
+        amax_tensor: Optional[Any] = None,
+        norm_const_tensor: Optional[Any] = None,
         alpha: Optional[float] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         self._runtime_error_if(self._compiled_kernel is None, "GemmSreluSm100 kernel not compiled; call compile() first")
-        current_stream = self._get_default_stream(current_stream)
+        if current_stream is None:
+            # torch inputs stay ordered with the caller's current torch stream;
+            # other frameworks (e.g. JAX) default to the CUDA legacy default stream.
+            current_stream = default_stream(detect_framework(a_tensor))
         self._compiled_kernel(
             a_tensor=a_tensor,
             b_tensor=b_tensor,
@@ -426,7 +453,9 @@ _DENSE_GEMM_DYNAMIC_M_ENV = "CUDNN_FE_GEMM_DYNAMIC_M"
 _DENSE_GEMM_DYNAMIC_MNKL_ENV = "CUDNN_FE_GEMM_DYNAMIC_MNKL"
 
 
-def _allocate_dense_output(shape: Tuple[int, int, int], major: str, dtype: torch.dtype, device: torch.device) -> torch.Tensor:
+def _allocate_dense_output(shape: Tuple[int, int, int], major: str, dtype: Any, device: Any) -> Any:
+    import torch
+
     m, n, l = shape
     if major == "m":
         return torch.empty_strided((m, n, l), (1, m, m * n), dtype=dtype, device=device)
@@ -436,74 +465,119 @@ def _allocate_dense_output(shape: Tuple[int, int, int], major: str, dtype: torch
 
 
 def gemm_srelu_wrapper_sm100(
-    a_tensor: torch.Tensor,
-    b_tensor: torch.Tensor,
-    sfa_tensor: torch.Tensor,
-    sfb_tensor: torch.Tensor,
-    prob_tensor: torch.Tensor,
+    a_tensor: Any,
+    b_tensor: Any,
+    sfa_tensor: Any,
+    sfb_tensor: Any,
+    prob_tensor: Any,
     alpha: float = 1.0,
     c_major: str = "n",
-    c_dtype: torch.dtype = torch.bfloat16,
-    d_dtype: torch.dtype = torch.bfloat16,
-    acc_dtype: torch.dtype = torch.float32,
+    c_dtype: Any = cutlass.BFloat16,
+    d_dtype: Any = cutlass.BFloat16,
+    acc_dtype: Any = cutlass.Float32,
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
-    norm_const_tensor: Optional[torch.Tensor] = None,
+    norm_const_tensor: Optional[Any] = None,
     sf_vec_size: int = 16,
     vector_f32: bool = False,
     stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
-    m, k, l = a_tensor.shape
-    n, _, _ = b_tensor.shape
+    framework = detect_framework(a_tensor)
+    c_dtype = _convert_to_cutlass_data_type(c_dtype)
+    d_dtype = _convert_to_cutlass_data_type(d_dtype)
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
+    ab_cutlass_dtype = _convert_to_cutlass_data_type(a_tensor.dtype)
 
-    c_tensor = _allocate_dense_output((m, n, l), c_major, c_dtype, a_tensor.device)
-    d_tensor = _allocate_dense_output((m, n, l), c_major, d_dtype, a_tensor.device)
+    m, k, l = get_shape(a_tensor)
+    n, _, _ = get_shape(b_tensor)
 
-    sfd_tensor = None
-    if d_dtype in {torch.float8_e4m3fn, torch.float8_e5m2}:
-        sf_k = ceil_div(n, sf_vec_size)
-        mma_shape = (
-            l,
-            ceil_div(m, 128),
-            ceil_div(sf_k, 4),
-            32,
-            4,
-            4,
-        )
-        sfd_tensor = torch.empty(mma_shape, dtype=sfa_tensor.dtype, device=a_tensor.device).permute(3, 4, 1, 5, 2, 0)
+    if framework == "torch":
+        import torch
 
-    amax_tensor = None
-    if a_tensor.dtype in {torch.float4_e2m1fn_x2, torch.uint8} and d_dtype in {torch.bfloat16, torch.float16, torch.float32}:
-        amax_tensor = torch.full((1,), float("-inf"), dtype=torch.float32, device=a_tensor.device)
+        c_tensor = _allocate_dense_output((m, n, l), c_major, framework_dtype(c_dtype, "torch"), a_tensor.device)
+        d_tensor = _allocate_dense_output((m, n, l), c_major, framework_dtype(d_dtype, "torch"), a_tensor.device)
+
+        sfd_tensor = None
+        if d_dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}:
+            sf_k = ceil_div(n, sf_vec_size)
+            mma_shape = (
+                l,
+                ceil_div(m, 128),
+                ceil_div(sf_k, 4),
+                32,
+                4,
+                4,
+            )
+            sfd_tensor = torch.empty(mma_shape, dtype=sfa_tensor.dtype, device=a_tensor.device).permute(3, 4, 1, 5, 2, 0)
+
+        amax_tensor = None
+        if ab_cutlass_dtype in {cutlass.Float4E2M1FN, cutlass.Uint8} and d_dtype in {cutlass.BFloat16, cutlass.Float16, cutlass.Float32}:
+            amax_tensor = torch.full((1,), float("-inf"), dtype=torch.float32, device=a_tensor.device)
+    elif framework == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        if c_major == "m":
+            raise ValueError("JAX arrays are row-major; only c_major='n' is supported for JAX inputs")
+        if c_major != "n":
+            raise ValueError(f"major must be 'm' or 'n', got {c_major}")
+        if l != 1:
+            raise ValueError("JAX inputs must have batch dim L == 1; batch-outermost (L-major) layouts are not expressible as JAX arrays")
+        device = a_tensor.device
+        c_tensor = jnp.empty((m, n, l), dtype=framework_dtype(c_dtype, "jax"), device=device)
+        d_tensor = jnp.empty((m, n, l), dtype=framework_dtype(d_dtype, "jax"), device=device)
+        outputs_to_sync = [c_tensor, d_tensor]
+
+        sfd_tensor = None
+        if d_dtype in {cutlass.Float8E4M3FN, cutlass.Float8E5M2}:
+            # SFD in the physical C-contiguous atom shape; the torch path's permuted
+            # logical view is byte-identical in memory
+            sf_k = ceil_div(n, sf_vec_size)
+            sfd_tensor = jnp.empty(
+                (l, ceil_div(m, 128), ceil_div(sf_k, 4), 32, 4, 4),
+                dtype=framework_dtype(_convert_to_cutlass_data_type(sfa_tensor.dtype), "jax"),
+                device=device,
+            )
+            outputs_to_sync.append(sfd_tensor)
+
+        amax_tensor = None
+        if ab_cutlass_dtype in {cutlass.Float4E2M1FN, cutlass.Uint8} and d_dtype in {cutlass.BFloat16, cutlass.Float16, cutlass.Float32}:
+            amax_tensor = jnp.full((1,), -float("inf"), dtype=jnp.float32, device=device)
+            outputs_to_sync.append(amax_tensor)
+        # The kernel writes into these buffers on the launch stream; make sure XLA has
+        # finished materializing them before the kernel runs.
+        jax.block_until_ready(outputs_to_sync)
+    else:
+        raise ValueError(f"Unsupported tensor framework '{framework}' for gemm_srelu_wrapper_sm100; pass torch tensors or JAX arrays")
 
     use_full_dynamic = os.environ.get(_DENSE_GEMM_DYNAMIC_MNKL_ENV) is not None
     use_dynamic_m = not use_full_dynamic and os.environ.get(_DENSE_GEMM_DYNAMIC_M_ENV) is not None
 
-    def stride_order(tensor: torch.Tensor) -> Tuple[int, ...]:
-        return tuple(i for i, s in sorted(enumerate(tensor.stride()), key=lambda x: x[1]))
+    def stride_order(tensor: Any) -> Tuple[int, ...]:
+        return tuple(i for i, s in sorted(enumerate(get_strides(tensor)), key=lambda x: x[1]))
 
-    def tensor_signature(tensor: Optional[torch.Tensor]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+    def tensor_signature(tensor: Optional[Any]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[Any]]:
         if tensor is None:
             return None, None, None
-        return tuple(tensor.shape), tuple(tensor.stride()), tensor.dtype
+        return get_shape(tensor), canonicalize_unit_dim_strides(get_shape(tensor), get_strides(tensor)), _convert_to_cutlass_data_type(tensor.dtype)
 
-    def dynamic_compact_signature(tensor: Optional[torch.Tensor]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+    def dynamic_compact_signature(tensor: Optional[Any]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[Any]]:
         if tensor is None:
             return None, None, None
-        return tuple(tensor.shape[1:]), stride_order(tensor), tensor.dtype
+        return get_shape(tensor)[1:], stride_order(tensor), _convert_to_cutlass_data_type(tensor.dtype)
 
-    def dynamic_tensor_signature(tensor: Optional[torch.Tensor]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+    def dynamic_tensor_signature(tensor: Optional[Any]) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[Any]]:
         if tensor is None:
             return None, None, None
-        return None, stride_order(tensor), tensor.dtype
+        return None, stride_order(tensor), _convert_to_cutlass_data_type(tensor.dtype)
 
     def dynamic_m_tensor_signature(
-        tensor: Optional[torch.Tensor], static_shape_suffix: Optional[Tuple[int, ...]], dynamic_stride_dims: Tuple[int, ...] = ()
-    ) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[torch.dtype]]:
+        tensor: Optional[Any], static_shape_suffix: Optional[Tuple[int, ...]], dynamic_stride_dims: Tuple[int, ...] = ()
+    ) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]], Optional[Any]]:
         if tensor is None:
             return None, None, None
-        stride_signature = tuple(None if i in dynamic_stride_dims else s for i, s in enumerate(tensor.stride()))
-        return static_shape_suffix, stride_signature, tensor.dtype
+        stride_signature = tuple(None if i in dynamic_stride_dims else s for i, s in enumerate(get_strides(tensor)))
+        return static_shape_suffix, stride_signature, _convert_to_cutlass_data_type(tensor.dtype)
 
     cache_key = (
         use_full_dynamic,
@@ -517,7 +591,7 @@ def gemm_srelu_wrapper_sm100(
             dynamic_tensor_signature(sfa_tensor)
             if use_full_dynamic
             else (
-                dynamic_m_tensor_signature(sfa_tensor, (sfa_tensor.shape[4], sfa_tensor.shape[5]), dynamic_stride_dims=(5,))
+                dynamic_m_tensor_signature(sfa_tensor, (get_shape(sfa_tensor)[4], get_shape(sfa_tensor)[5]), dynamic_stride_dims=(5,))
                 if use_dynamic_m
                 else tensor_signature(sfa_tensor)
             )
@@ -528,9 +602,9 @@ def gemm_srelu_wrapper_sm100(
             if use_full_dynamic
             else dynamic_compact_signature(prob_tensor) if use_dynamic_m else tensor_signature(prob_tensor)
         ),
-        norm_const_tensor.shape if norm_const_tensor is not None else None,
-        norm_const_tensor.stride() if norm_const_tensor is not None else None,
-        norm_const_tensor.dtype if norm_const_tensor is not None else None,
+        get_shape(norm_const_tensor) if norm_const_tensor is not None else None,
+        canonicalize_unit_dim_strides(get_shape(norm_const_tensor), get_strides(norm_const_tensor)) if norm_const_tensor is not None else None,
+        _convert_to_cutlass_data_type(norm_const_tensor.dtype) if norm_const_tensor is not None else None,
         alpha,
         acc_dtype,
         mma_tiler_mn,

--- a/python/cudnn/gemm/cutedsl/dense/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/dense/srelu/dense_blockscaled_gemm_persistent_srelu_quant.py
@@ -3,7 +3,6 @@
 from typing import Type, Tuple, Union, Optional
 
 import cuda.bindings.driver as cuda
-import torch
 
 import cutlass
 import cutlass.cute as cute

--- a/python/cudnn/gemm/cutedsl/dense/swiglu/__init__.py
+++ b/python/cudnn/gemm/cutedsl/dense/swiglu/__init__.py
@@ -9,4 +9,15 @@ from .api import (
 __all__ = [
     "GemmSwigluSm100",
     "gemm_swiglu_wrapper_sm100",
+    "gemm_swiglu_jax_sm100",
 ]
+
+
+def __getattr__(name):
+    # Lazy: the jax entry point imports jax/jax_tvm_ffi, which must not be pulled in
+    # for torch-only users.
+    if name == "gemm_swiglu_jax_sm100":
+        from .jax_api import gemm_swiglu_jax_sm100
+
+        return gemm_swiglu_jax_sm100
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/cudnn/gemm/cutedsl/dense/swiglu/api.py
+++ b/python/cudnn/gemm/cutedsl/dense/swiglu/api.py
@@ -7,8 +7,7 @@ from .dense_blockscaled_gemm_persistent_swiglu_interleaved_quant import (
     Sm100BlockScaledPersistentDenseGemmKernel,
 )
 from cuda.bindings import driver as cuda
-import torch
-from typing import Tuple, Optional
+from typing import Any, Tuple, Optional
 
 import cutlass
 import cutlass.cute as cute
@@ -16,26 +15,44 @@ from cutlass.cute.runtime import make_fake_stream
 
 from cudnn.datatypes import _convert_to_cutlass_data_type
 from cudnn.api_base import APIBase, TupleDict, ceil_div, is_power_of_2
+from cudnn.tensor_adapter import (
+    canonicalize_unit_dim_strides,
+    cuda_is_available,
+    default_stream,
+    detect_framework,
+    framework_dtype,
+    get_compute_capability,
+    get_shape,
+    get_strides,
+)
 import os
 
 
 class GemmSwigluSm100(APIBase):
+    """Persistent GEMM + SwiGLU for SM100.
+
+    Tensor parameters are type-erased: torch tensors and JAX arrays are both accepted
+    (the compiled kernels consume tensors via DLPack). torch is only imported when
+    torch tensors/dtypes are passed; likewise for JAX. Dtype parameters accept torch
+    dtypes, numpy/ml_dtypes dtypes, dtype name strings, or cutlass types.
+    """
+
     def __init__(
         self,
-        sample_a: torch.Tensor,
-        sample_b: torch.Tensor,
-        sample_ab12: torch.Tensor,
-        sample_c: torch.Tensor,
+        sample_a: Any,
+        sample_b: Any,
+        sample_ab12: Any,
+        sample_c: Any,
         alpha: float = 1.0,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Any = cutlass.Float32,
         mma_tiler_mn: Tuple[int, int] = (128, 128),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         ### Quantize only arguments
-        sample_sfa: Optional[torch.Tensor] = None,
-        sample_sfb: Optional[torch.Tensor] = None,
-        sample_amax: Optional[torch.Tensor] = None,
-        sample_sfc: Optional[torch.Tensor] = None,
-        sample_norm_const: Optional[torch.Tensor] = None,
+        sample_sfa: Optional[Any] = None,
+        sample_sfb: Optional[Any] = None,
+        sample_amax: Optional[Any] = None,
+        sample_sfc: Optional[Any] = None,
+        sample_norm_const: Optional[Any] = None,
         sf_vec_size: int = 16,
         vector_f32: bool = False,
         ab12_stages: int = 4,
@@ -45,12 +62,12 @@ class GemmSwigluSm100(APIBase):
         self._warn_experimental_api()
         self._logger.debug("Entering __init__")
 
-        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a")
-        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b")
-        self.ab12_desc = self._make_tensor_desc(sample_ab12, name="sample_ab12")
-        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c")
+        self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
+        self.b_desc = self._make_tensor_desc(sample_b, name="sample_b", canonical=True)
+        self.ab12_desc = self._make_tensor_desc(sample_ab12, name="sample_ab12", canonical=True)
+        self.c_desc = self._make_tensor_desc(sample_c, name="sample_c", canonical=True)
         self.alpha = alpha
-        self.acc_dtype = acc_dtype
+        self.acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
         self.mma_tiler_mn = mma_tiler_mn
         if cluster_shape_mn is None:
             self.cluster_shape_mn = (1, 1) if not self.mma_tiler_mn[0] == 256 else (2, 2)
@@ -58,11 +75,11 @@ class GemmSwigluSm100(APIBase):
             self.cluster_shape_mn = cluster_shape_mn
 
         ### Quantize only arguments
-        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa")
-        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb")
-        self.sfc_desc = self._make_tensor_desc(sample_sfc, name="sample_sfc")
-        self.amax_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_amax, name="sample_amax"), 1, "amax")
-        self.norm_const_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_norm_const, name="sample_norm_const"), 1, "norm_const")
+        self.sfa_desc = self._make_tensor_desc(sample_sfa, name="sample_sfa", canonical=True)
+        self.sfb_desc = self._make_tensor_desc(sample_sfb, name="sample_sfb", canonical=True)
+        self.sfc_desc = self._make_tensor_desc(sample_sfc, name="sample_sfc", canonical=True)
+        self.amax_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_amax, name="sample_amax", canonical=True), 1, "amax")
+        self.norm_const_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_norm_const, name="sample_norm_const", canonical=True), 1, "norm_const")
         self.sf_vec_size = sf_vec_size
         self.vector_f32 = vector_f32
         self.ab12_stages = ab12_stages
@@ -98,12 +115,19 @@ class GemmSwigluSm100(APIBase):
         self._check_tensor_shape(self.c_desc, (m, n // 2, l), "C")
 
         if self._kernel is Sm100BlockScaledPersistentDenseGemmKernel:
+            # SF tensors are accepted in the torch-style logical atom view or the
+            # byte-identical physical C-contiguous shape (L, MN', K', 32, 4, 4) --
+            # frameworks with row-major-only layouts (e.g. JAX) cannot express the
+            # permuted logical view.
+            def sf_shapes(mn_div, k_div):
+                return [(32, 4, mn_div, 4, k_div, l), (l, mn_div, k_div, 32, 4, 4)]
+
             rest_k = ceil_div(ceil_div(k, self.sf_vec_size), 4)
-            self._check_tensor_shape(self.sfa_desc, (32, 4, ceil_div(m, 128), 4, rest_k, l), "SFA")
-            self._check_tensor_shape(self.sfb_desc, (32, 4, ceil_div(n, 128), 4, rest_k, l), "SFB")
+            self._check_tensor_shape(self.sfa_desc, sf_shapes(ceil_div(m, 128), rest_k), "SFA")
+            self._check_tensor_shape(self.sfb_desc, sf_shapes(ceil_div(n, 128), rest_k), "SFB")
             self._check_tensor_shape(self.amax_desc, (1,), "amax")
             rest_n2 = ceil_div(ceil_div(n // 2, self.sf_vec_size), 4)
-            self._check_tensor_shape(self.sfc_desc, (32, 4, ceil_div(m, 128), 4, rest_n2, l), "SFC")
+            self._check_tensor_shape(self.sfc_desc, sf_shapes(ceil_div(m, 128), rest_n2), "SFC")
             self._check_tensor_shape(self.norm_const_desc, (1,), "norm_const")
 
         _ = self._check_tensor_stride(self.a_desc, stride=[(1, m, m * k), (k, 1, m * k)])
@@ -120,45 +144,44 @@ class GemmSwigluSm100(APIBase):
             self.ab_dtype = self._check_dtype(
                 self.a_desc,
                 dtype=[
-                    torch.float16,
-                    torch.bfloat16,
-                    torch.float32,
-                    torch.float8_e4m3fn,
-                    torch.float8_e5m2,
+                    cutlass.Float16,
+                    cutlass.BFloat16,
+                    cutlass.Float32,
+                    cutlass.Float8E4M3FN,
+                    cutlass.Float8E5M2,
                 ],
                 name="A",
             )
-            match self.acc_dtype:
-                case torch.float32:
-                    self.ab12_dtype = self._check_dtype(
-                        self.ab12_desc,
-                        dtype=[
-                            torch.float32,
-                            torch.float16,
-                            torch.bfloat16,
-                            torch.float8_e4m3fn,
-                            torch.float8_e5m2,
-                        ],
-                        name="AB12 (for float32 acc_dtype)",
-                    )
-                    self._not_implemented_error_if(
-                        self._is_fp8(self.ab12_dtype),
-                        f"ab12_dtype {{torch.float8_e5m2, torch.float8_e4m3fn}} is currently disabled",
-                    )
-                case torch.float16:
-                    self.ab12_dtype = self._check_dtype(
-                        self.ab12_desc,
-                        dtype=[torch.float16, torch.bfloat16],
-                        name="AB12 (for float16 acc_dtype)",
-                    )
-                    self._check_dtype(
-                        self.a_desc,
-                        dtype=[torch.float16, torch.float8_e4m3fn, torch.float8_e5m2],
-                        name="A/B (for float16 acc_dtype)",
-                    )
-                case _:
-                    raise ValueError(f"Unsupported acc_dtype: expected one of {{torch.float32, torch.float16}}, got {self.acc_dtype}")
-            self.c_dtype = self._check_dtype(self.c_desc, dtype=[torch.float16, torch.bfloat16], name="C")
+            if self.acc_dtype is cutlass.Float32:
+                self.ab12_dtype = self._check_dtype(
+                    self.ab12_desc,
+                    dtype=[
+                        cutlass.Float32,
+                        cutlass.Float16,
+                        cutlass.BFloat16,
+                        cutlass.Float8E4M3FN,
+                        cutlass.Float8E5M2,
+                    ],
+                    name="AB12 (for float32 acc_dtype)",
+                )
+                self._not_implemented_error_if(
+                    self._is_fp8(self.ab12_dtype),
+                    f"ab12_dtype {{torch.float8_e5m2, torch.float8_e4m3fn}} is currently disabled",
+                )
+            elif self.acc_dtype is cutlass.Float16:
+                self.ab12_dtype = self._check_dtype(
+                    self.ab12_desc,
+                    dtype=[cutlass.Float16, cutlass.BFloat16],
+                    name="AB12 (for float16 acc_dtype)",
+                )
+                self._check_dtype(
+                    self.a_desc,
+                    dtype=[cutlass.Float16, cutlass.Float8E4M3FN, cutlass.Float8E5M2],
+                    name="A/B (for float16 acc_dtype)",
+                )
+            else:
+                raise ValueError(f"Unsupported acc_dtype: expected one of {{torch.float32, torch.float16}}, got {self.acc_dtype}")
+            self.c_dtype = self._check_dtype(self.c_desc, dtype=[cutlass.Float16, cutlass.BFloat16], name="C")
         elif self._kernel is Sm100BlockScaledPersistentDenseGemmKernel:
             self._value_error_if(
                 self.sfa_desc is None or self.sfb_desc is None,
@@ -168,37 +191,37 @@ class GemmSwigluSm100(APIBase):
             self.ab_dtype = self._check_dtype(
                 self.a_desc,
                 dtype=[
-                    torch.float4_e2m1fn_x2,
-                    torch.uint8,
-                    torch.float8_e5m2,
-                    torch.float8_e4m3fn,
+                    cutlass.Float4E2M1FN,
+                    cutlass.Uint8,
+                    cutlass.Float8E5M2,
+                    cutlass.Float8E4M3FN,
                 ],
                 name="A (for quantized GEMM swiglu kernel)",
             )
             self.acc_dtype = self._check_dtype(
                 self.acc_dtype,
-                dtype=torch.float32,
+                dtype=cutlass.Float32,
                 name="Accumulator (for quantized GEMM swiglu kernel)",
             )
             self.ab12_dtype = self._check_dtype(
                 self.ab12_desc,
                 dtype=[
-                    torch.float32,
-                    torch.float16,
-                    torch.bfloat16,
-                    torch.float8_e4m3fn,
-                    torch.float8_e5m2,
+                    cutlass.Float32,
+                    cutlass.Float16,
+                    cutlass.BFloat16,
+                    cutlass.Float8E4M3FN,
+                    cutlass.Float8E5M2,
                 ],
                 name="AB12 (for quantized GEMM swiglu kernel)",
             )
             self.c_dtype = self._check_dtype(
                 self.c_desc,
                 dtype=[
-                    torch.float32,
-                    torch.float16,
-                    torch.bfloat16,
-                    torch.float8_e4m3fn,
-                    torch.float8_e5m2,
+                    cutlass.Float32,
+                    cutlass.Float16,
+                    cutlass.BFloat16,
+                    cutlass.Float8E4M3FN,
+                    cutlass.Float8E5M2,
                 ],
                 name="C (for quantized GEMM swiglu kernel)",
             )
@@ -213,12 +236,12 @@ class GemmSwigluSm100(APIBase):
                 "sfc and norm_const must be provided when c_dtype is fp8",
             )
             self._value_error_if(
-                (self._is_fp4x2(self.ab_dtype) and self.c_dtype == torch.bfloat16) and (self.amax_desc is None),
+                (self._is_fp4x2(self.ab_dtype) and self.c_dtype is cutlass.BFloat16) and (self.amax_desc is None),
                 "amax must be provided when ab_dtype is fp4 and c_dtype is bf16",
             )
 
             self._not_implemented_error_if(
-                self.c_dtype == torch.float32 and self.ab12_dtype == torch.float32,
+                self.c_dtype is cutlass.Float32 and self.ab12_dtype is cutlass.Float32,
                 "float32 c_dtype and float32 ab12_dtype currently disabled due to kernel bug",
             )
 
@@ -228,7 +251,7 @@ class GemmSwigluSm100(APIBase):
             )
             self.sf_dtype = self._check_dtype(
                 self.sfa_desc,
-                dtype=[torch.float8_e8m0fnu, torch.float8_e4m3fn],
+                dtype=[cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN],
                 name="SFA",
             )
             self._check_dtype(
@@ -245,12 +268,12 @@ class GemmSwigluSm100(APIBase):
             )
             if self._is_fp8(self.ab_dtype):
                 self._value_error_if(
-                    not (self.sf_dtype == torch.float8_e8m0fnu and self.sf_vec_size == 32),
+                    not (self.sf_dtype is cutlass.Float8E8M0FNU and self.sf_vec_size == 32),
                     "Invalid ab_dtype and sf_dtype/sf_vec_size combination: fp8 ab_dtype requires float8_e8m0fnu sf_dtype and 32 sf_vec_size",
                 )
             elif self._is_fp4x2(self.ab_dtype):
                 self._value_error_if(
-                    self.sf_dtype == torch.float8_e4m3fn and self.sf_vec_size == 32,
+                    self.sf_dtype is cutlass.Float8E4M3FN and self.sf_vec_size == 32,
                     "Invalid ab_dtype and sf_dtype/sf_vec_size combination: fp4 ab_dtype not supported with float8_e4m3fn sf_dtype and 32 sf_vec_size",
                 )
 
@@ -291,7 +314,7 @@ class GemmSwigluSm100(APIBase):
             else:
                 if self._is_fp8(self.ab_dtype):
                     self._value_error_if(
-                        self._is_fp8(self.c_dtype) or self._is_fp8(self.ab12_dtype) or self.ab12_dtype == torch.float32,
+                        self._is_fp8(self.c_dtype) or self._is_fp8(self.ab12_dtype) or self.ab12_dtype is cutlass.Float32,
                         "For MXFP8 inputs for blockscaled quantized GEMM swiglu kernel, ab12_dtype and c_dtype cannot be FP8. ab12_dtype also cannot be float32",
                     )
 
@@ -347,24 +370,25 @@ class GemmSwigluSm100(APIBase):
             )
 
         self._logger.debug("Checking environment")
-        if not torch.cuda.is_available():
+        if not cuda_is_available():
             raise RuntimeError("CUDA is not available")
-        device = torch.cuda.current_device()
-        major, minor = torch.cuda.get_device_capability(device)
+        major, minor = get_compute_capability()
         compute_capability = major * 10 + minor
         if compute_capability < 100:
-            raise RuntimeError(f"GemmSwiglu requires SM100+ compute capability, but found SM{compute_capability} on device {device}")
+            raise RuntimeError(f"GemmSwiglu requires SM100+ compute capability, but found SM{compute_capability} on the current device")
 
         self._is_supported = True
         self._logger.debug("check_support completed successfully")
         return True
 
-    def compile(self) -> None:
-        self._logger.debug("Entering compile")
+    def _compile_kernel(self, use_tvm_ffi_env_stream: bool = False):
+        """Compile the kernel and return the raw TVM-FFI callable.
+
+        With ``use_tvm_ffi_env_stream=True`` the stream argument is bound to the
+        TVM-FFI environment stream and dropped from the callable's signature --
+        the variant used for XLA custom-call (jax.ffi) integration.
+        """
         self._ensure_support_checked()
-        if self._compiled_kernel is not None:
-            self._logger.debug("Kernel already compiled; skipping recompilation")
-            return
 
         if self._kernel is PersistentDenseGemmKernel:
             gemm_swiglu = self._kernel(
@@ -392,11 +416,11 @@ class GemmSwigluSm100(APIBase):
             "max_active_clusters must be > 0 after applying overlap margin; reduce CUDNNFE_CLUSTER_OVERLAP_MARGIN",
         )
 
-        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=False)
+        fake_stream = make_fake_stream(use_tvm_ffi_env_stream=use_tvm_ffi_env_stream)
 
         if self._kernel is PersistentDenseGemmKernel:
             self._logger.debug("Compiling gemm_swiglu")
-            _compiled_kernel = cute.compile(
+            return cute.compile(
                 gemm_swiglu,
                 a=self._make_fake_cute_tensor_from_desc(self.a_desc),
                 b=self._make_fake_cute_tensor_from_desc(self.b_desc),
@@ -407,12 +431,40 @@ class GemmSwigluSm100(APIBase):
                 stream=fake_stream,
                 options="--enable-tvm-ffi",
             )
+        self._logger.debug("Compiling gemm_swiglu_blockscaled_quantized")
+        return cute.compile(
+            gemm_swiglu,
+            a_tensor=self._make_fake_cute_tensor_from_desc(self.a_desc, assumed_align=16),
+            b_tensor=self._make_fake_cute_tensor_from_desc(self.b_desc, assumed_align=16),
+            sfa_tensor=self._make_fake_cute_tensor_from_desc(self.sfa_desc, assumed_align=16),
+            sfb_tensor=self._make_fake_cute_tensor_from_desc(self.sfb_desc, assumed_align=16),
+            c_tensor=self._make_fake_cute_tensor_from_desc(self.c_desc, assumed_align=16),
+            ab12_tensor=self._make_fake_cute_tensor_from_desc(self.ab12_desc, assumed_align=8),
+            amax_tensor=self._make_fake_cute_tensor_from_desc(self.amax_desc, assumed_align=16),
+            sfc_tensor=self._make_fake_cute_tensor_from_desc(self.sfc_desc, assumed_align=16),
+            norm_const_tensor=self._make_fake_cute_tensor_from_desc(self.norm_const_desc, assumed_align=16),
+            alpha=self.alpha,
+            max_active_clusters=max_active_clusters,
+            stream=fake_stream,
+            options="--enable-tvm-ffi",
+        )
+
+    def compile(self) -> None:
+        self._logger.debug("Entering compile")
+        self._ensure_support_checked()
+        if self._compiled_kernel is not None:
+            self._logger.debug("Kernel already compiled; skipping recompilation")
+            return
+
+        _compiled_kernel = self._compile_kernel(use_tvm_ffi_env_stream=False)
+
+        if self._kernel is PersistentDenseGemmKernel:
 
             def tensor_api(
-                a_tensor: torch.Tensor,
-                b_tensor: torch.Tensor,
-                ab12_tensor: torch.Tensor,
-                c_tensor: torch.Tensor,
+                a_tensor: Any,
+                b_tensor: Any,
+                ab12_tensor: Any,
+                c_tensor: Any,
                 alpha: float,
                 stream: cuda.CUstream,
             ) -> None:
@@ -427,34 +479,17 @@ class GemmSwigluSm100(APIBase):
 
             self._compiled_kernel = tensor_api
         elif self._kernel is Sm100BlockScaledPersistentDenseGemmKernel:
-            self._logger.debug("Compiling gemm_swiglu_blockscaled_quantized")
-            _compiled_kernel = cute.compile(
-                gemm_swiglu,
-                a_tensor=self._make_fake_cute_tensor_from_desc(self.a_desc, assumed_align=16),
-                b_tensor=self._make_fake_cute_tensor_from_desc(self.b_desc, assumed_align=16),
-                sfa_tensor=self._make_fake_cute_tensor_from_desc(self.sfa_desc, assumed_align=16),
-                sfb_tensor=self._make_fake_cute_tensor_from_desc(self.sfb_desc, assumed_align=16),
-                c_tensor=self._make_fake_cute_tensor_from_desc(self.c_desc, assumed_align=16),
-                ab12_tensor=self._make_fake_cute_tensor_from_desc(self.ab12_desc, assumed_align=8),
-                amax_tensor=self._make_fake_cute_tensor_from_desc(self.amax_desc, assumed_align=16),
-                sfc_tensor=self._make_fake_cute_tensor_from_desc(self.sfc_desc, assumed_align=16),
-                norm_const_tensor=self._make_fake_cute_tensor_from_desc(self.norm_const_desc, assumed_align=16),
-                alpha=self.alpha,
-                max_active_clusters=max_active_clusters,
-                stream=fake_stream,
-                options="--enable-tvm-ffi",
-            )
 
             def tensor_api(
-                a_tensor: torch.Tensor,
-                b_tensor: torch.Tensor,
-                ab12_tensor: torch.Tensor,
-                c_tensor: torch.Tensor,
-                sfa_tensor: Optional[torch.Tensor],
-                sfb_tensor: Optional[torch.Tensor],
-                amax_tensor: Optional[torch.Tensor],
-                sfc_tensor: Optional[torch.Tensor],
-                norm_const_tensor: Optional[torch.Tensor],
+                a_tensor: Any,
+                b_tensor: Any,
+                ab12_tensor: Any,
+                c_tensor: Any,
+                sfa_tensor: Optional[Any],
+                sfb_tensor: Optional[Any],
+                amax_tensor: Optional[Any],
+                sfc_tensor: Optional[Any],
+                norm_const_tensor: Optional[Any],
                 alpha: float,
                 stream: cuda.CUstream,
             ) -> None:
@@ -480,20 +515,23 @@ class GemmSwigluSm100(APIBase):
 
     def execute(
         self,
-        a_tensor: torch.Tensor,
-        b_tensor: torch.Tensor,
-        ab12_tensor: torch.Tensor,
-        c_tensor: torch.Tensor,
-        sfa_tensor: Optional[torch.Tensor] = None,
-        sfb_tensor: Optional[torch.Tensor] = None,
-        amax_tensor: Optional[torch.Tensor] = None,
-        sfc_tensor: Optional[torch.Tensor] = None,
-        norm_const_tensor: Optional[torch.Tensor] = None,
+        a_tensor: Any,
+        b_tensor: Any,
+        ab12_tensor: Any,
+        c_tensor: Any,
+        sfa_tensor: Optional[Any] = None,
+        sfb_tensor: Optional[Any] = None,
+        amax_tensor: Optional[Any] = None,
+        sfc_tensor: Optional[Any] = None,
+        norm_const_tensor: Optional[Any] = None,
         alpha: float = 1.0,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         self._logger.debug("Entering execute")
-        current_stream = self._get_default_stream(current_stream)
+        if current_stream is None:
+            # torch inputs stay ordered with the caller's current torch stream;
+            # other frameworks (e.g. JAX) default to the CUDA legacy default stream.
+            current_stream = default_stream(detect_framework(a_tensor))
 
         self._runtime_error_if(
             self._compiled_kernel is None,
@@ -537,19 +575,19 @@ _cache_of_GemmSwigluSm100Objects = {}
 
 
 def gemm_swiglu_wrapper_sm100(
-    a_tensor: torch.Tensor,
-    b_tensor: torch.Tensor,
+    a_tensor: Any,
+    b_tensor: Any,
     alpha: float = 1.0,
     c_major: str = "n",
-    ab12_dtype: torch.dtype = torch.float32,
-    c_dtype: torch.dtype = torch.float16,
-    acc_dtype: torch.dtype = torch.float32,
+    ab12_dtype: Any = cutlass.Float32,
+    c_dtype: Any = cutlass.Float16,
+    acc_dtype: Any = cutlass.Float32,
     mma_tiler_mn: Tuple[int, int] = (128, 128),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
     ### Quantize only arguments
-    sfa_tensor: Optional[torch.Tensor] = None,
-    sfb_tensor: Optional[torch.Tensor] = None,
-    norm_const_tensor: Optional[torch.Tensor] = None,
+    sfa_tensor: Optional[Any] = None,
+    sfb_tensor: Optional[Any] = None,
+    norm_const_tensor: Optional[Any] = None,
     sf_vec_size: int = 16,
     vector_f32: bool = False,
     ab12_stages: int = 4,
@@ -557,55 +595,96 @@ def gemm_swiglu_wrapper_sm100(
 ) -> TupleDict:
 
     _logger.debug("gemm_swiglu_wrapper_sm100: Creating empty output tensors ab12 and c")
-    m, k, l = a_tensor.shape
-    n, k, l = b_tensor.shape
-    ab12_tensor, c_tensor = None, None
-    if c_major == "m":
-        ab12_tensor = torch.empty_strided((m, n, l), (1, m, m * n), dtype=ab12_dtype, device=a_tensor.device)
-        c_tensor = torch.empty_strided((m, n // 2, l), (1, m, m * n // 2), dtype=c_dtype, device=a_tensor.device)
-    elif c_major == "n":
-        ab12_tensor = torch.empty_strided((m, n, l), (n, 1, m * n), dtype=ab12_dtype, device=a_tensor.device)
-        c_tensor = torch.empty_strided(
-            (m, n // 2, l),
-            (n // 2, 1, m * n // 2),
-            dtype=c_dtype,
-            device=a_tensor.device,
-        )
-    else:
+    framework = detect_framework(a_tensor)
+    ab12_dtype = _convert_to_cutlass_data_type(ab12_dtype)
+    c_dtype = _convert_to_cutlass_data_type(c_dtype)
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
+    is_quantized = sfa_tensor is not None and sfb_tensor is not None
+    ab_cutlass_dtype = _convert_to_cutlass_data_type(a_tensor.dtype)
+
+    m, k, l = get_shape(a_tensor)
+    n, k, l = get_shape(b_tensor)
+    if c_major not in ("m", "n"):
         raise ValueError(f"c_major must be either 'm' or 'n', got {c_major}")
 
     sfc_tensor, amax_tensor = None, None
-    if sfa_tensor is not None and sfb_tensor is not None:
-        _logger.debug("gemm_swiglu_wrapper_sm100: Detected sfa_tensor and sfb_tensor, constructing quantized output tensors")
-        if c_dtype in {torch.float8_e5m2, torch.float8_e4m3fn}:
-            _logger.debug("gemm_swiglu_wrapper_sm100: Detected fp8 c_dtype, constructing sfc_tensor")
+    if framework == "torch":
+        import torch
 
-            sf_k = ceil_div(n // 2, sf_vec_size)
-            mma_shape = (
-                l,
-                ceil_div(m, 128),
-                ceil_div(sf_k, 4),
-                32,
-                4,
-                4,
-            )
-            mma_permute_order = (3, 4, 1, 5, 2, 0)
-            sfc_tensor = torch.empty(
-                mma_shape,
-                dtype=torch.float8_e8m0fnu,
+        if c_major == "m":
+            ab12_tensor = torch.empty_strided((m, n, l), (1, m, m * n), dtype=framework_dtype(ab12_dtype, "torch"), device=a_tensor.device)
+            c_tensor = torch.empty_strided((m, n // 2, l), (1, m, m * n // 2), dtype=framework_dtype(c_dtype, "torch"), device=a_tensor.device)
+        else:
+            ab12_tensor = torch.empty_strided((m, n, l), (n, 1, m * n), dtype=framework_dtype(ab12_dtype, "torch"), device=a_tensor.device)
+            c_tensor = torch.empty_strided(
+                (m, n // 2, l),
+                (n // 2, 1, m * n // 2),
+                dtype=framework_dtype(c_dtype, "torch"),
                 device=a_tensor.device,
-            ).permute(mma_permute_order)
-        if a_tensor.dtype in {torch.float4_e2m1fn_x2, torch.uint8} and c_dtype == torch.bfloat16:
-            _logger.debug("gemm_swiglu_wrapper_sm100: Detected fp4 ab_dtype and bf16 c_dtype, constructing amax_tensor")
-            amax_tensor = torch.full((1, 1, 1), -float("inf"), device=a_tensor.device, dtype=torch.float32)
+            )
+
+        if is_quantized:
+            _logger.debug("gemm_swiglu_wrapper_sm100: Detected sfa_tensor and sfb_tensor, constructing quantized output tensors")
+            if c_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN}:
+                _logger.debug("gemm_swiglu_wrapper_sm100: Detected fp8 c_dtype, constructing sfc_tensor")
+
+                sf_k = ceil_div(n // 2, sf_vec_size)
+                mma_shape = (
+                    l,
+                    ceil_div(m, 128),
+                    ceil_div(sf_k, 4),
+                    32,
+                    4,
+                    4,
+                )
+                mma_permute_order = (3, 4, 1, 5, 2, 0)
+                sfc_tensor = torch.empty(
+                    mma_shape,
+                    dtype=torch.float8_e8m0fnu,
+                    device=a_tensor.device,
+                ).permute(mma_permute_order)
+            if ab_cutlass_dtype in {cutlass.Float4E2M1FN, cutlass.Uint8} and c_dtype is cutlass.BFloat16:
+                _logger.debug("gemm_swiglu_wrapper_sm100: Detected fp4 ab_dtype and bf16 c_dtype, constructing amax_tensor")
+                amax_tensor = torch.full((1, 1, 1), -float("inf"), device=a_tensor.device, dtype=torch.float32)
+    elif framework == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        if c_major == "m":
+            raise ValueError("JAX arrays are row-major; only c_major='n' is supported for JAX inputs")
+        if l != 1:
+            raise ValueError("JAX inputs must have batch dim L == 1; batch-outermost (L-major) layouts are not expressible as JAX arrays")
+        device = a_tensor.device
+        ab12_tensor = jnp.empty((m, n, l), dtype=framework_dtype(ab12_dtype, "jax"), device=device)
+        c_tensor = jnp.empty((m, n // 2, l), dtype=framework_dtype(c_dtype, "jax"), device=device)
+        outputs_to_sync = [ab12_tensor, c_tensor]
+        if is_quantized:
+            if c_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN}:
+                # SFC in the physical C-contiguous atom shape; the torch path's permuted
+                # logical view is byte-identical in memory
+                sf_k = ceil_div(n // 2, sf_vec_size)
+                sfc_tensor = jnp.empty(
+                    (l, ceil_div(m, 128), ceil_div(sf_k, 4), 32, 4, 4),
+                    dtype=framework_dtype(cutlass.Float8E8M0FNU, "jax"),
+                    device=device,
+                )
+                outputs_to_sync.append(sfc_tensor)
+            if ab_cutlass_dtype in {cutlass.Float4E2M1FN, cutlass.Uint8} and c_dtype is cutlass.BFloat16:
+                amax_tensor = jnp.full((1, 1, 1), -float("inf"), dtype=jnp.float32, device=device)
+                outputs_to_sync.append(amax_tensor)
+        # The kernel writes into these buffers on the launch stream; make sure XLA has
+        # finished materializing them before the kernel runs.
+        jax.block_until_ready(outputs_to_sync)
+    else:
+        raise ValueError(f"Unsupported tensor framework '{framework}' for gemm_swiglu_wrapper_sm100; pass torch tensors or JAX arrays")
 
     cache_key = (
-        a_tensor.shape,
-        b_tensor.shape,
-        a_tensor.dtype,
-        b_tensor.dtype,
-        a_tensor.stride(),
-        b_tensor.stride(),
+        get_shape(a_tensor),
+        get_shape(b_tensor),
+        ab_cutlass_dtype,
+        _convert_to_cutlass_data_type(b_tensor.dtype),
+        canonicalize_unit_dim_strides(get_shape(a_tensor), get_strides(a_tensor)),
+        canonicalize_unit_dim_strides(get_shape(b_tensor), get_strides(b_tensor)),
         alpha,
         c_major,
         ab12_dtype,
@@ -613,15 +692,15 @@ def gemm_swiglu_wrapper_sm100(
         acc_dtype,
         mma_tiler_mn,
         cluster_shape_mn,
-        sfa_tensor.shape if sfa_tensor is not None else None,
-        sfb_tensor.shape if sfb_tensor is not None else None,
-        sfa_tensor.stride() if sfa_tensor is not None else None,
-        sfb_tensor.stride() if sfb_tensor is not None else None,
-        sfa_tensor.dtype if sfa_tensor is not None else None,
-        sfb_tensor.dtype if sfb_tensor is not None else None,
-        norm_const_tensor.shape if norm_const_tensor is not None else None,
-        norm_const_tensor.stride() if norm_const_tensor is not None else None,
-        norm_const_tensor.dtype if norm_const_tensor is not None else None,
+        get_shape(sfa_tensor) if sfa_tensor is not None else None,
+        get_shape(sfb_tensor) if sfb_tensor is not None else None,
+        canonicalize_unit_dim_strides(get_shape(sfa_tensor), get_strides(sfa_tensor)) if sfa_tensor is not None else None,
+        canonicalize_unit_dim_strides(get_shape(sfb_tensor), get_strides(sfb_tensor)) if sfb_tensor is not None else None,
+        _convert_to_cutlass_data_type(sfa_tensor.dtype) if sfa_tensor is not None else None,
+        _convert_to_cutlass_data_type(sfb_tensor.dtype) if sfb_tensor is not None else None,
+        get_shape(norm_const_tensor) if norm_const_tensor is not None else None,
+        canonicalize_unit_dim_strides(get_shape(norm_const_tensor), get_strides(norm_const_tensor)) if norm_const_tensor is not None else None,
+        _convert_to_cutlass_data_type(norm_const_tensor.dtype) if norm_const_tensor is not None else None,
         sf_vec_size,
         vector_f32,
         ab12_stages,

--- a/python/cudnn/gemm/cutedsl/dense/swiglu/jax_api.py
+++ b/python/cudnn/gemm/cutedsl/dense/swiglu/jax_api.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""JAX-native (XLA custom call) entry point for the GEMM + SwiGLU kernels.
+
+See dense/amax/jax_api.py for the integration pattern: the kernel variant is compiled
+with the TVM-FFI environment stream (runs on XLA's compute stream), all outputs are
+donated pre-initialized operands, and the call composes with jax.jit.
+"""
+
+from typing import Any, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+
+import cutlass
+
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import framework_dtype
+from cudnn.gemm.cutedsl._jax_ffi import get_or_register_env_stream_target, make_row_major_desc as _make_desc
+from .api import GemmSwigluSm100
+
+_registered_targets = {}
+
+
+def gemm_swiglu_jax_sm100(
+    a_tensor: Any,
+    b_tensor: Any,
+    alpha: float = 1.0,
+    ab12_dtype: Any = cutlass.Float32,
+    c_dtype: Any = cutlass.Float16,
+    acc_dtype: Any = cutlass.Float32,
+    mma_tiler_mn: Tuple[int, int] = (128, 128),
+    cluster_shape_mn: Optional[Tuple[int, int]] = None,
+    ### Quantize only arguments
+    sfa_tensor: Optional[Any] = None,
+    sfb_tensor: Optional[Any] = None,
+    sf_vec_size: int = 16,
+    vector_f32: bool = False,
+    ab12_stages: int = 4,
+) -> Tuple[Any, Any]:
+    """GEMM + SwiGLU as an XLA custom call; usable eagerly or under jax.jit.
+
+    A (M, K, 1) and B (N, K, 1) are k-major C-contiguous JAX arrays (or tracers).
+    Returns a plain ``(ab12_tensor, c_tensor)`` tuple of fresh n-major JAX arrays.
+    ``alpha`` is a static (trace-time) parameter.
+
+    Supports the non-quantized kernel only: the quantized kernel's compiled signature
+    carries None-typed parameters the XLA FFI bridge cannot supply -- use
+    ``gemm_swiglu_wrapper_sm100`` (eager) for blockscaled MXFP8 inputs from JAX.
+    """
+    ab12_dtype = _convert_to_cutlass_data_type(ab12_dtype)
+    c_dtype = _convert_to_cutlass_data_type(c_dtype)
+    acc_dtype = _convert_to_cutlass_data_type(acc_dtype)
+
+    m, _, l = a_tensor.shape
+    n, _, _ = b_tensor.shape
+    if l != 1:
+        raise ValueError("JAX inputs must have batch dim L == 1; batch-outermost (L-major) layouts are not expressible as JAX arrays")
+
+    if sfa_tensor is not None or sfb_tensor is not None:
+        # The quantized kernel's compiled signature carries explicit None-typed
+        # parameters (amax/sfc/norm_const) that the XLA FFI bridge cannot supply.
+        raise NotImplementedError(
+            "gemm_swiglu_jax_sm100 currently supports the non-quantized kernel only; "
+            "use gemm_swiglu_wrapper_sm100 (eager) for blockscaled MXFP8 inputs from JAX"
+        )
+
+    cache_key = (
+        tuple(a_tensor.shape),
+        tuple(b_tensor.shape),
+        _convert_to_cutlass_data_type(a_tensor.dtype),
+        _convert_to_cutlass_data_type(b_tensor.dtype),
+        alpha,
+        ab12_dtype,
+        c_dtype,
+        acc_dtype,
+        mma_tiler_mn,
+        cluster_shape_mn,
+    )
+
+    def make_gemm():
+        return GemmSwigluSm100(
+            sample_a=_make_desc(tuple(a_tensor.shape), a_tensor.dtype, "sample_a"),
+            sample_b=_make_desc(tuple(b_tensor.shape), b_tensor.dtype, "sample_b"),
+            sample_ab12=_make_desc((m, n, l), ab12_dtype, "sample_ab12"),
+            sample_c=_make_desc((m, n // 2, l), c_dtype, "sample_c"),
+            alpha=alpha,
+            acc_dtype=acc_dtype,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+        )
+
+    # arg_spec: operands first (the donated output buffers land in the kernel's
+    # destination-passing slots), then alpha as an XLA call attribute.
+    target = get_or_register_env_stream_target(
+        _registered_targets,
+        cache_key,
+        make_gemm,
+        "cudnn.gemm_swiglu_sm100",
+        arg_spec=("args", "attrs.alpha"),
+    )
+
+    ab12_jax_dtype = framework_dtype(ab12_dtype, "jax")
+    c_jax_dtype = framework_dtype(c_dtype, "jax")
+    ab12_buf = jnp.zeros((m, n, l), dtype=ab12_jax_dtype)
+    c_buf = jnp.zeros((m, n // 2, l), dtype=c_jax_dtype)
+    out_types = (
+        jax.ShapeDtypeStruct((m, n, l), ab12_jax_dtype),
+        jax.ShapeDtypeStruct((m, n // 2, l), c_jax_dtype),
+    )
+
+    # Kernel signature: (a, b, ab12, c, alpha[, stream from the TVM-FFI environment]).
+    ab12_tensor, c_tensor = jax.ffi.ffi_call(
+        target,
+        out_types,
+        input_output_aliases={2: 0, 3: 1},
+    )(a_tensor, b_tensor, ab12_buf, c_buf, alpha=float(alpha))
+
+    return ab12_tensor, c_tensor

--- a/python/cudnn/gemm/cutedsl/discrete_grouped/discrete_kernel_utils.py
+++ b/python/cudnn/gemm/cutedsl/discrete_grouped/discrete_kernel_utils.py
@@ -12,9 +12,9 @@ This module contains:
 - Kernel helper functions that don't depend on kernel instance state
 """
 
-from typing import Type, Tuple, Union
+from __future__ import annotations
 
-import torch
+from typing import Type, Tuple, Union
 
 import cutlass
 import cutlass.cute as cute
@@ -44,6 +44,8 @@ FIX_PAD_SIZE = 256
 
 
 def _require_pointer_tensor(ptrs: torch.Tensor, name: str, expected_len: int | None = None) -> None:
+    import torch
+
     if ptrs.dtype != torch.int64:
         raise ValueError(f"{name} must be int64, got {ptrs.dtype}")
     if ptrs.ndim != 1:
@@ -345,6 +347,8 @@ def silu_f32_geglu_scaled(a: Union[float, Float32], fastmath: bool = False) -> U
 
 def sigmoid(x):
     """PyTorch reference sigmoid using exp2 for numerical consistency."""
+    import torch
+
     LOG2_E = 1.4426950408889634
     exp_x = torch.exp2(x * (-LOG2_E))
     ret = 1.0 / (exp_x + 1.0)
@@ -361,6 +365,8 @@ def compute_reference_amax(output_tensor: torch.Tensor) -> float:
     Returns:
         float: reference amax value
     """
+    import torch
+
     if output_tensor.dtype != torch.float32:
         output_fp32 = output_tensor.float()
     else:
@@ -390,6 +396,8 @@ def compare_and_report_mismatches(
         rtol: Relative tolerance
         max_mismatches: Maximum number of mismatches to report
     """
+    import torch
+
     if gpu_tensor.is_cuda:
         gpu_data = gpu_tensor.cpu()
     else:

--- a/python/cudnn/gemm/cutedsl/discrete_grouped/dswiglu/api.py
+++ b/python/cudnn/gemm/cutedsl/discrete_grouped/dswiglu/api.py
@@ -7,13 +7,14 @@ This module provides the API class for discrete-weight block-scaled grouped GEMM
 backward pass with dGLU (dSwiGLU/dGeGLU) activation gradient for MoE workloads.
 """
 
+from __future__ import annotations
+
 from .discrete_B_blockscaled_grouped_gemm_dglu_dbias import (
     BlockScaledDiscreteWeightDgluDbiasGroupedGemmKernel,
 )
 from cuda.bindings import driver as cuda
 import logging
 import os
-import torch
 from typing import Tuple, Optional
 
 import cutlass
@@ -61,7 +62,7 @@ class DiscreteGroupedGemmDswigluSm100(APIBase):
         sample_sfd_col: Optional[torch.Tensor] = None,
         sample_amax: Optional[torch.Tensor] = None,
         sample_norm_const: Optional[torch.Tensor] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -93,7 +94,7 @@ class DiscreteGroupedGemmDswigluSm100(APIBase):
         :param sample_sfd_col: Optional column scale factor for D
         :param sample_amax: Optional amax tensor, shape (expert_cnt, 2, 1)
         :param sample_norm_const: Optional normalization constant
-        :param acc_dtype: Accumulator data type
+        :param acc_dtype: Accumulator data type (default: torch.float32)
         :param mma_tiler_mn: MMA tiler shape (M, N)
         :param cluster_shape_mn: Cluster shape (M, N)
         :param sf_vec_size: Scale factor vector size
@@ -105,6 +106,16 @@ class DiscreteGroupedGemmDswigluSm100(APIBase):
         :param epilogue_op: Optional epilogue operation ("relu", "srelu", or None)
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         """
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("DiscreteGroupedGemmDswigluSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
+
         super().__init__()
 
         self._warn_experimental_api()
@@ -177,6 +188,8 @@ class DiscreteGroupedGemmDswigluSm100(APIBase):
 
     def check_support(self) -> bool:
         """Check if the kernel configuration is supported."""
+        import torch
+
         self._logger.debug("Entering check_support")
 
         all_none = all(x is None for x in [self.sfd_row_desc, self.sfd_col_desc, self.norm_const_desc])
@@ -437,6 +450,8 @@ class DiscreteGroupedGemmDswigluSm100(APIBase):
 
     def compile(self) -> None:
         """Compile the backward kernel from tensor descriptors captured in __init__."""
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -788,8 +803,8 @@ def discrete_grouped_gemm_dswiglu_wrapper_sm100(
     b_dtype: torch.dtype,
     generate_dbias: bool = False,
     norm_const_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -847,6 +862,18 @@ def discrete_grouped_gemm_dswiglu_wrapper_sm100(
         TupleDict with keys: d_row_tensor, d_col_tensor, dprob_tensor,
             amax_tensor, sfd_row_tensor, sfd_col_tensor
     """
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("discrete_grouped_gemm_dswiglu_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
+
     # Resolve linear_offset default: None means "use the activation-derived legacy
     # default" (1.0 for dgeglu, 0.0 for dswiglu) for backwards compatibility.
     if linear_offset is None:

--- a/python/cudnn/gemm/cutedsl/discrete_grouped/swiglu/api.py
+++ b/python/cudnn/gemm/cutedsl/discrete_grouped/swiglu/api.py
@@ -12,13 +12,14 @@ weight pointers -- avoiding the need to copy/reshape weights from independent
 parameter allocations.
 """
 
+from __future__ import annotations
+
 from .discrete_B_blockscaled_grouped_gemm_glu_bias import (
     BlockScaledDiscreteWeightGroupedGemmBiasKernel,
 )
 from cuda.bindings import driver as cuda
 import logging
 import os
-import torch
 from typing import Tuple, Optional
 
 import cutlass
@@ -73,7 +74,7 @@ class DiscreteGroupedGemmSwigluSm100(APIBase):
         sample_amax: Optional[torch.Tensor] = None,
         sample_norm_const: Optional[torch.Tensor] = None,
         sample_prob: Optional[torch.Tensor] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -102,7 +103,7 @@ class DiscreteGroupedGemmSwigluSm100(APIBase):
         :param sample_amax: Optional amax tensor for quantization
         :param sample_norm_const: Optional normalization constant
         :param sample_prob: Optional probability tensor for gating
-        :param acc_dtype: Accumulator data type
+        :param acc_dtype: Accumulator data type (default: torch.float32)
         :param mma_tiler_mn: MMA tiler shape (M, N)
         :param cluster_shape_mn: Cluster shape (M, N)
         :param sf_vec_size: Scale factor vector size
@@ -113,6 +114,16 @@ class DiscreteGroupedGemmSwigluSm100(APIBase):
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         """
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("DiscreteGroupedGemmSwigluSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
+
         super().__init__()
 
         self._warn_experimental_api()
@@ -179,6 +190,8 @@ class DiscreteGroupedGemmSwigluSm100(APIBase):
 
         :return: True if supported, raises exception otherwise
         """
+        import torch
+
         self._logger.debug("Entering check_support")
 
         all_none = all(x is None for x in [self.sfd_row_desc, self.sfd_col_desc, self.norm_const_desc])
@@ -462,6 +475,8 @@ class DiscreteGroupedGemmSwigluSm100(APIBase):
 
     def compile(self) -> None:
         """Compile the kernel from tensor descriptors captured in __init__."""
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -810,9 +825,9 @@ def discrete_grouped_gemm_swiglu_wrapper_sm100(
     bias_tensor: Optional[torch.Tensor] = None,
     norm_const_tensor: Optional[torch.Tensor] = None,
     prob_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    c_dtype: torch.dtype = torch.bfloat16,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    c_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -847,9 +862,9 @@ def discrete_grouped_gemm_swiglu_wrapper_sm100(
         bias_tensor: Optional bias tensor with shape (n, expert_cnt) and stride (1, n)
         norm_const_tensor: Optional normalization constant
         prob_tensor: Optional probability tensor for gating
-        acc_dtype: Accumulator data type
-        c_dtype: Intermediate C tensor data type
-        d_dtype: Output D tensor data type
+        acc_dtype: Accumulator data type (default: torch.float32)
+        c_dtype: Intermediate C tensor data type (default: torch.bfloat16)
+        d_dtype: Output D tensor data type (default: torch.bfloat16)
         cd_major: CD major dimension (only "n" supported)
         mma_tiler_mn: MMA tiler shape
         cluster_shape_mn: Cluster shape
@@ -882,6 +897,20 @@ def discrete_grouped_gemm_swiglu_wrapper_sm100(
         TupleDict with keys: c_tensor, d_tensor, d_col_tensor, amax_tensor,
             sfd_row_tensor, sfd_col_tensor
     """
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("discrete_grouped_gemm_swiglu_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if c_dtype is None:
+        c_dtype = torch.bfloat16
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
+
     # Resolve linear_offset default: None means "use the activation-derived legacy
     # default" (1.0 for geglu, 0.0 for swiglu) for backwards compatibility.
     if linear_offset is None:

--- a/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
+++ b/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 from enum import Enum
 from typing import Iterator, Optional
 
-import torch
 from cuda.bindings import driver as cuda
 
 
@@ -17,6 +18,8 @@ class GroupedGemmBackend(str, Enum):
 @contextmanager
 def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch.device) -> Iterator[None]:
     """Run PyTorch work on the CUDA stream used for the kernel launch."""
+    import torch
+
     if current_stream is None:
         yield
         return
@@ -41,6 +44,8 @@ def select_grouped_gemm_backend(
     scale_controls,
     block_scaled_dtype_pairs,
 ):
+    import torch
+
     bf16_operands = (a_dtype == torch.bfloat16, b_dtype == torch.bfloat16)
     if any(bf16_operands):
         if not all(bf16_operands):

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/_bf16_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/_bf16_api.py
@@ -3,6 +3,8 @@
 
 """Private descriptor-first BF16 API for SM100 grouped GEMM dGLU."""
 
+from __future__ import annotations
+
 import os
 import weakref
 from typing import Optional, Tuple
@@ -12,7 +14,6 @@ import cutlass.cute as cute
 from cuda.bindings import driver as cuda
 from cutlass.cute.nvgpu import OperandMajorMode
 from cutlass.cute.runtime import from_dlpack, make_fake_stream
-import torch
 
 from cudnn.api_base import APIBase, TensorDesc
 from cudnn.datatypes import _convert_to_cutlass_data_type
@@ -21,7 +22,16 @@ from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_p
 from ..moe_utils import MoEWeightMode
 from .moe_grouped_gemm_dglu_dbias import MoEGroupedGemmDgluDbiasBf16Kernel
 
-_OUTPUT_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+_OUTPUT_DTYPES = None
+
+
+def _output_dtypes():
+    global _OUTPUT_DTYPES
+    if _OUTPUT_DTYPES is None:
+        import torch
+
+        _OUTPUT_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+    return _OUTPUT_DTYPES
 
 
 class GroupedGemmDgluBf16API(APIBase):
@@ -42,7 +52,7 @@ class GroupedGemmDgluBf16API(APIBase):
         num_experts: Optional[int] = None,
         b_shape: Optional[Tuple[int, ...]] = None,
         b_dtype: Optional[torch.dtype] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         vector_f32: bool = False,
@@ -51,6 +61,10 @@ class GroupedGemmDgluBf16API(APIBase):
         b_major: str = "k",
         use_dynamic_sched: bool = False,
     ) -> None:
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
         super().__init__()
         self._warn_experimental_api()
 
@@ -189,6 +203,8 @@ class GroupedGemmDgluBf16API(APIBase):
 
     @staticmethod
     def _record_pointer_stream(b_ptrs: torch.Tensor, stream: cuda.CUstream) -> None:
+        import torch
+
         handle = int(stream)
         torch_current = torch.cuda.current_stream(b_ptrs.device)
         torch_default = torch.cuda.default_stream(b_ptrs.device)
@@ -201,6 +217,8 @@ class GroupedGemmDgluBf16API(APIBase):
         b_ptrs.record_stream(launch_stream)
 
     def check_support(self) -> bool:
+        import torch
+
         if self.a_desc.ndim != 3:
             raise ValueError(f"sample_a must be rank-3, got {self.a_desc.shape}")
         tensor_m, k, one = self.a_desc.shape
@@ -249,8 +267,8 @@ class GroupedGemmDgluBf16API(APIBase):
         if self.b_desc is not None:
             self._check_dtype(self.b_desc, torch.bfloat16, "sample_b")
         self._check_dtype(self.b_dtype, torch.bfloat16, "b_dtype")
-        self._check_dtype(self.c_desc, _OUTPUT_DTYPES, "sample_c")
-        self._check_dtype(self.d_row_desc, _OUTPUT_DTYPES, "sample_d_row")
+        self._check_dtype(self.c_desc, _output_dtypes(), "sample_c")
+        self._check_dtype(self.d_row_desc, _output_dtypes(), "sample_d_row")
         self._check_dtype(self.padded_offsets_desc, torch.int32, "sample_padded_offsets")
         self._check_dtype(self.alpha_desc, torch.float32, "sample_alpha")
         self._check_dtype(self.beta_desc, torch.float32, "sample_beta")
@@ -331,6 +349,8 @@ class GroupedGemmDgluBf16API(APIBase):
         return True
 
     def compile(self) -> None:
+        import torch
+
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
             return

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/_blockscaled_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/_blockscaled_api.py
@@ -17,12 +17,13 @@ Discrete mode
     at execution time.
 """
 
+from __future__ import annotations
+
 from .moe_blockscaled_grouped_gemm_dglu_dbias import BlockScaledMoEGroupedGemmDgluDbiasKernel
 from ..moe_utils import MoEWeightMode
 from ..backend_utils import rubin_single_group_offsets_kwarg
 from cuda.bindings import driver as cuda
 import os
-import torch
 from typing import Tuple, Optional
 
 import cutlass
@@ -123,7 +124,7 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
         sample_amax: Optional[torch.Tensor] = None,
         sample_norm_const: Optional[torch.Tensor] = None,
         # Configuration
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -183,6 +184,10 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
         :param glu_clamp_min: Compile-time dGeGLU lower clamp. Ignored when
             ``act_func == "dswiglu"``.
         """
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
         super().__init__()
 
         self._warn_experimental_api()
@@ -297,6 +302,8 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
 
     @staticmethod
     def _record_pointer_stream(pointers: torch.Tensor, current_stream: cuda.CUstream) -> None:
+        import torch
+
         handle = int(current_stream)
         torch_current = torch.cuda.current_stream(pointers.device)
         torch_default = torch.cuda.default_stream(pointers.device)
@@ -317,6 +324,8 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
 
         :return: True if supported, raises exception otherwise
         """
+        import torch
+
         self._logger.debug("Entering check_support")
 
         # ---- SFD group validation ----
@@ -670,6 +679,8 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
 
     def compile(self) -> None:
         """Compile the kernel."""
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -1003,6 +1014,8 @@ class GroupedGemmDgluBlockScaledAPI(APIBase):
 
     def _compile_discrete(self, gemm_dglu, max_active_clusters, fake_stream) -> None:
         """Compile for discrete (per-expert pointer) weight mode."""
+        import torch
+
         if len(self.b_shape) == 2:
             n, k = self.b_shape
         else:

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/api.py
@@ -17,6 +17,8 @@ Discrete mode
     at execution time.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, replace
 
 from ..backend_utils import (
@@ -29,20 +31,28 @@ from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
 import logging
 import os
-import torch
 from typing import Any, Tuple, Optional, overload
 
 from cudnn.api_base import APIBase, TupleDict, ceil_div, get_device_type
 
-_BLOCK_SCALED_DTYPE_PAIRS = {
-    (dtype, dtype)
-    for dtype in (
-        torch.float4_e2m1fn_x2,
-        torch.uint8,
-        torch.float8_e5m2,
-        torch.float8_e4m3fn,
-    )
-}
+_BLOCK_SCALED_DTYPE_PAIRS = None
+
+
+def _block_scaled_dtype_pairs():
+    global _BLOCK_SCALED_DTYPE_PAIRS
+    if _BLOCK_SCALED_DTYPE_PAIRS is None:
+        import torch
+
+        _BLOCK_SCALED_DTYPE_PAIRS = {
+            (dtype, dtype)
+            for dtype in (
+                torch.float4_e2m1fn_x2,
+                torch.uint8,
+                torch.float8_e5m2,
+                torch.float8_e4m3fn,
+            )
+        }
+    return _BLOCK_SCALED_DTYPE_PAIRS
 
 
 from ._bf16_api import GroupedGemmDgluBf16API
@@ -73,8 +83,8 @@ class DgluCall:
     b_dtype: Optional[torch.dtype] = None
     b_major: str = "k"
     norm_const_tensor: Optional[torch.Tensor] = None
-    acc_dtype: torch.dtype = torch.float32
-    d_dtype: torch.dtype = torch.bfloat16
+    acc_dtype: Optional[torch.dtype] = None
+    d_dtype: Optional[torch.dtype] = None
     cd_major: str = "n"
     mma_tiler_mn: Tuple[int, int] = (256, 256)
     cluster_shape_mn: Optional[Tuple[int, int]] = None
@@ -157,7 +167,7 @@ class GroupedGemmDgluSm100(APIBase):
         sample_sfd_col: Optional[torch.Tensor] = None,
         sample_amax: Optional[torch.Tensor] = None,
         sample_norm_const: Optional[torch.Tensor] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -178,6 +188,14 @@ class GroupedGemmDgluSm100(APIBase):
         self._pending_init_kwargs = dict(locals())
         self._pending_init_kwargs.pop("self")
         self._pending_init_kwargs.pop("__class__", None)
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmDgluSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            self._pending_init_kwargs["acc_dtype"] = torch.float32
         self._implementation = None
 
     def check_support(self) -> bool:
@@ -203,7 +221,7 @@ class GroupedGemmDgluSm100(APIBase):
                     ("glu_clamp_min", kwargs["glu_clamp_min"] if kwargs["glu_clamp_min"] != -7.0 else None),
                     ("epilogue_op", kwargs["epilogue_op"] if kwargs["epilogue_op"] not in (None, "none", "identity") else None),
                 ),
-                block_scaled_dtype_pairs=_BLOCK_SCALED_DTYPE_PAIRS,
+                block_scaled_dtype_pairs=_block_scaled_dtype_pairs(),
             )
             self.backend = backend
             self.linear_offset = kwargs["linear_offset"]
@@ -456,6 +474,8 @@ def _grouped_gemm_dglu_block_scaled_call(call: DgluCall) -> TupleDict:
         TupleDict with keys: d_row_tensor, d_col_tensor, dprob_tensor,
             dbias_tensor, amax_tensor, sfd_row_tensor, sfd_col_tensor
     """
+    import torch
+
     from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_pointer_tensor
 
     a_tensor = call.a_tensor
@@ -844,7 +864,16 @@ def _grouped_gemm_dglu_block_scaled_call(call: DgluCall) -> TupleDict:
 def _normalize_dglu_call(
     call: DgluCall,
 ) -> tuple[DgluCall, GroupedGemmBackend]:
+    import torch
+
     from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_pointer_tensor
+
+    if call.acc_dtype is None or call.d_dtype is None:
+        call = replace(
+            call,
+            acc_dtype=call.acc_dtype if call.acc_dtype is not None else torch.float32,
+            d_dtype=call.d_dtype if call.d_dtype is not None else torch.bfloat16,
+        )
 
     is_dense = call.b_tensor is not None
     is_discrete = call.b_ptrs is not None
@@ -905,7 +934,7 @@ def _normalize_dglu_call(
                 call.epilogue_op if call.epilogue_op not in (None, "none", "identity") else None,
             ),
         ),
-        block_scaled_dtype_pairs=_BLOCK_SCALED_DTYPE_PAIRS,
+        block_scaled_dtype_pairs=_block_scaled_dtype_pairs(),
     )
     linear_offset = call.linear_offset
     if linear_offset is None:
@@ -991,6 +1020,8 @@ def _dglu_tensor_signature(tensor: Optional[torch.Tensor], *, dynamic_m: bool = 
 
 
 def _grouped_gemm_dglu_bf16_call(call: DgluCall) -> TupleDict:
+    import torch
+
     valid_m = call.a_tensor.shape[0]
     n_weight = call.b_tensor.shape[0] if call.b_tensor is not None else call.n
     two_n = 2 * n_weight
@@ -1141,8 +1172,8 @@ def grouped_gemm_dglu_wrapper_sm100(
     b_dtype: Optional[torch.dtype] = None,
     b_major: str = "k",
     norm_const_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -1161,6 +1192,16 @@ def grouped_gemm_dglu_wrapper_sm100(
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Dispatch grouped GEMM dGLU once from an immutable normalized call."""
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_dglu_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
     call = DgluCall(
         a_tensor=a_tensor,
         c_tensor=c_tensor,

--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/api.py
@@ -17,6 +17,8 @@ Discrete mode
     at execution time.
 """
 
+from __future__ import annotations
+
 from .moe_blockscaled_grouped_gemm_dsrelu_quant import (
     BlockScaledMoEGroupedGemmQuantBwdKernel,
     EpilogueType,
@@ -25,7 +27,6 @@ from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
 import logging
 import os
-import torch
 from typing import Tuple, Optional
 
 import cutlass
@@ -38,6 +39,8 @@ from cudnn.api_base import APIBase, TupleDict, ceil_div, is_power_of_2
 
 
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    import torch
+
     if tensor.dtype == torch.uint8:
         cute_tensor = from_dlpack(tensor, assumed_align=16, enable_tvm_ffi=True).mark_layout_dynamic(leading_dim=1)
         cute_tensor.element_type = cutlass.Float4E2M1FN
@@ -112,7 +115,7 @@ class GroupedGemmDsreluSm100(APIBase):
         sample_amax: Optional[torch.Tensor] = None,
         sample_norm_const: Optional[torch.Tensor] = None,
         # Configuration
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -155,6 +158,14 @@ class GroupedGemmDsreluSm100(APIBase):
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         :param use_dsrelu_reuse: Reuse relu(C)^2 between d_srelu and dprob
         """
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmDsreluSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            acc_dtype = torch.float32
         super().__init__()
 
         self._warn_experimental_api()
@@ -249,6 +260,8 @@ class GroupedGemmDsreluSm100(APIBase):
 
         :return: True if supported, raises exception otherwise
         """
+        import torch
+
         self._logger.debug("Entering check_support")
 
         # ---- SFD group validation ----
@@ -604,6 +617,8 @@ class GroupedGemmDsreluSm100(APIBase):
 
     def compile(self) -> None:
         """Compile the kernel."""
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -654,6 +669,8 @@ class GroupedGemmDsreluSm100(APIBase):
 
     def _compile_dense(self, gemm_dsrelu, max_active_clusters, fake_stream) -> None:
         """Compile for dense (contiguous) weight mode."""
+        import torch
+
         self._logger.debug("Compiling grouped_gemm_dsrelu kernel")
         use_full_dynamic = self._use_full_dynamic_mnkl
 
@@ -946,6 +963,8 @@ class GroupedGemmDsreluSm100(APIBase):
 
     def _compile_discrete(self, gemm_dsrelu, max_active_clusters, fake_stream) -> None:
         """Compile for discrete (per-expert pointer) weight mode."""
+        import torch
+
         if len(self.b_shape) == 2:
             n, k = self.b_shape
         else:
@@ -1290,8 +1309,8 @@ def grouped_gemm_dsrelu_wrapper_sm100(
     b_major: str = "k",
     # Common:
     norm_const_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -1348,6 +1367,16 @@ def grouped_gemm_dsrelu_wrapper_sm100(
             dbias_tensor, amax_tensor, sfd_row_tensor, sfd_col_tensor
     """
     from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_pointer_tensor
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_dsrelu_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
 
     is_dense = b_tensor is not None
     is_discrete = b_ptrs is not None

--- a/python/cudnn/gemm/cutedsl/grouped/dswiglu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dswiglu/api.py
@@ -7,11 +7,12 @@ This module provides the API class for contiguous grouped block-scaled GEMM
 backward pass with dSwiGLU activation gradient for MoE (Mixture of Experts) workloads.
 """
 
+from __future__ import annotations
+
 from .grouped_gemm_dswiglu_quant import (
     BlockScaledContiguousGroupedGemmKernel,
 )
 from cuda.bindings import driver as cuda
-import torch
 from typing import Tuple, Optional
 
 import cutlass
@@ -64,7 +65,7 @@ class GroupedGemmDswigluSm100(APIBase):
         sample_amax: Optional[torch.Tensor] = None,
         sample_norm_const: Optional[torch.Tensor] = None,
         # Configuration
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -100,6 +101,14 @@ class GroupedGemmDswigluSm100(APIBase):
         :param discrete_col_sfd: Boolean, True to generate discrete col-major scale factor tensor
         :param epilogue_op: Optional epilogue operation. Valid values: None, "none", "identity", "relu", "srelu"
         """
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmDswigluSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            acc_dtype = torch.float32
         super().__init__()
 
         self._warn_experimental_api()
@@ -162,6 +171,8 @@ class GroupedGemmDswigluSm100(APIBase):
 
         :return: True if supported, raises exception otherwise
         """
+        import torch
+
         self._logger.debug("Entering check_support")
 
         all_none = all(x is None for x in [self.sfd_row_desc, self.sfd_col_desc, self.norm_const_desc])
@@ -679,8 +690,8 @@ def grouped_gemm_dswiglu_wrapper_sm100(
     beta_tensor: Optional[torch.Tensor],
     prob_tensor: torch.Tensor,
     norm_const_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -731,6 +742,16 @@ def grouped_gemm_dswiglu_wrapper_sm100(
             - **sfd_row_tensor** (torch.Tensor or None): Row-wise scale factors for D
             - **sfd_col_tensor** (torch.Tensor or None): Column-wise scale factors for D
     """
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_dswiglu_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
     valid_m = a_tensor.shape[0]
     n, _, l = b_tensor.shape
 

--- a/python/cudnn/gemm/cutedsl/grouped/glu/_bf16_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/_bf16_api.py
@@ -3,6 +3,8 @@
 
 """Private BF16 API for the SM100 grouped GEMM GLU kernel."""
 
+from __future__ import annotations
+
 import os
 import weakref
 from typing import Optional, Tuple
@@ -12,7 +14,6 @@ import cutlass.cute as cute
 from cuda.bindings import driver as cuda
 from cutlass.cute.nvgpu import OperandMajorMode
 from cutlass.cute.runtime import from_dlpack, make_fake_stream
-import torch
 
 from cudnn.api_base import APIBase, TensorDesc
 from cudnn.datatypes import _convert_to_cutlass_data_type
@@ -21,7 +22,16 @@ from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_p
 from ..moe_utils import MoEWeightMode
 from .moe_grouped_gemm_glu_bias import MoEGroupedGemmGluBiasBf16Kernel
 
-_OUTPUT_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+_OUTPUT_DTYPES = None
+
+
+def _output_dtypes():
+    global _OUTPUT_DTYPES
+    if _OUTPUT_DTYPES is None:
+        import torch
+
+        _OUTPUT_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+    return _OUTPUT_DTYPES
 
 
 class GroupedGemmGluBf16API(APIBase):
@@ -40,7 +50,7 @@ class GroupedGemmGluBf16API(APIBase):
         num_experts: Optional[int] = None,
         b_shape: Optional[Tuple[int, ...]] = None,
         b_dtype: Optional[torch.dtype] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         vector_f32: bool = False,
@@ -50,6 +60,10 @@ class GroupedGemmGluBf16API(APIBase):
         b_major: str = "k",
         use_dynamic_sched: bool = False,
     ) -> None:
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
         super().__init__()
         self._warn_experimental_api()
 
@@ -185,6 +199,8 @@ class GroupedGemmGluBf16API(APIBase):
 
     @staticmethod
     def _record_pointer_stream(b_ptrs: torch.Tensor, current_stream: cuda.CUstream) -> None:
+        import torch
+
         handle = int(current_stream)
         torch_current = torch.cuda.current_stream(b_ptrs.device)
         torch_default = torch.cuda.default_stream(b_ptrs.device)
@@ -197,6 +213,8 @@ class GroupedGemmGluBf16API(APIBase):
         b_ptrs.record_stream(launch_stream)
 
     def check_support(self) -> bool:
+        import torch
+
         if self.a_desc.ndim != 3:
             raise ValueError(f"sample_a must be rank-3, got {self.a_desc.shape}")
         tensor_m, k, one = self.a_desc.shape
@@ -243,8 +261,8 @@ class GroupedGemmGluBf16API(APIBase):
         if self.weight_mode == MoEWeightMode.DENSE:
             self._check_dtype(self.b_desc, torch.bfloat16, "sample_b")
         self._check_dtype(self.b_dtype, torch.bfloat16, "b_dtype")
-        self._check_dtype(self.c_desc, _OUTPUT_DTYPES, "sample_c")
-        self._check_dtype(self.d_desc, _OUTPUT_DTYPES, "sample_d")
+        self._check_dtype(self.c_desc, _output_dtypes(), "sample_c")
+        self._check_dtype(self.d_desc, _output_dtypes(), "sample_d")
         self._check_dtype(self.padded_offsets_desc, torch.int32, "sample_padded_offsets")
         self._check_dtype(self.alpha_desc, torch.float32, "sample_alpha")
         self._check_dtype(self.prob_desc, torch.float32, "sample_prob")
@@ -264,7 +282,7 @@ class GroupedGemmGluBf16API(APIBase):
         if self.bias_desc is not None:
             self._expect_shape(self.bias_desc, (n, self.expert_cnt), "sample_bias")
             self._expect_stride(self.bias_desc, (1, n), "sample_bias")
-            self._check_dtype(self.bias_desc, _OUTPUT_DTYPES, "sample_bias")
+            self._check_dtype(self.bias_desc, _output_dtypes(), "sample_bias")
             self._expect_device(self.bias_desc, device, "sample_bias")
 
         for name, data_ptr in self._sample_data_ptrs.items():
@@ -329,6 +347,8 @@ class GroupedGemmGluBf16API(APIBase):
         return True
 
     def compile(self) -> None:
+        import torch
+
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
             return

--- a/python/cudnn/gemm/cutedsl/grouped/glu/_blockscaled_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/_blockscaled_api.py
@@ -17,12 +17,13 @@ Discrete mode
     at execution time.
 """
 
+from __future__ import annotations
+
 from .moe_blockscaled_grouped_gemm_glu_bias import BlockScaledMoEGroupedGemmGluBiasKernel
 from ..backend_utils import _torch_stream_context, rubin_single_group_offsets_kwarg
 from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
 import os
-import torch
 from typing import Tuple, Optional
 
 import cutlass
@@ -117,7 +118,7 @@ class GroupedGemmGluBlockScaledAPI(APIBase):
         sample_norm_const: Optional[torch.Tensor] = None,
         sample_prob: Optional[torch.Tensor] = None,
         # Configuration
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -161,6 +162,10 @@ class GroupedGemmGluBlockScaledAPI(APIBase):
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         """
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
         super().__init__()
 
         self._warn_experimental_api()
@@ -257,6 +262,8 @@ class GroupedGemmGluBlockScaledAPI(APIBase):
 
         :return: True if supported, raises exception otherwise
         """
+        import torch
+
         self._logger.debug("Entering check_support")
 
         # ---- SFD group validation ----
@@ -601,6 +608,8 @@ class GroupedGemmGluBlockScaledAPI(APIBase):
 
     def compile(self) -> None:
         """Compile the kernel."""
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -931,6 +940,8 @@ class GroupedGemmGluBlockScaledAPI(APIBase):
 
     def _compile_discrete(self, gemm_glu, max_active_clusters, fake_stream) -> None:
         """Compile for discrete (per-expert pointer) weight mode."""
+        import torch
+
         if len(self.b_shape) == 2:
             n, k = self.b_shape
         else:

--- a/python/cudnn/gemm/cutedsl/grouped/glu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/api.py
@@ -17,6 +17,8 @@ Discrete mode
     at execution time.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, replace
 
 from ..backend_utils import (
@@ -28,20 +30,28 @@ from ..moe_utils import MoEWeightMode
 from cuda.bindings import driver as cuda
 import logging
 import os
-import torch
 from typing import Any, Tuple, Optional, overload
 
 from cudnn.api_base import APIBase, TupleDict, ceil_div, get_device_type
 
-_BLOCK_SCALED_DTYPE_PAIRS = {
-    (dtype, dtype)
-    for dtype in (
-        torch.float4_e2m1fn_x2,
-        torch.uint8,
-        torch.float8_e5m2,
-        torch.float8_e4m3fn,
-    )
-}
+_BLOCK_SCALED_DTYPE_PAIRS = None
+
+
+def _block_scaled_dtype_pairs():
+    global _BLOCK_SCALED_DTYPE_PAIRS
+    if _BLOCK_SCALED_DTYPE_PAIRS is None:
+        import torch
+
+        _BLOCK_SCALED_DTYPE_PAIRS = {
+            (dtype, dtype)
+            for dtype in (
+                torch.float4_e2m1fn_x2,
+                torch.uint8,
+                torch.float8_e5m2,
+                torch.float8_e4m3fn,
+            )
+        }
+    return _BLOCK_SCALED_DTYPE_PAIRS
 
 
 from ._bf16_api import GroupedGemmGluBf16API
@@ -69,9 +79,9 @@ class GluCall:
     b_major: str = "k"
     norm_const_tensor: Optional[torch.Tensor] = None
     prob_tensor: Optional[torch.Tensor] = None
-    acc_dtype: torch.dtype = torch.float32
-    c_dtype: torch.dtype = torch.bfloat16
-    d_dtype: torch.dtype = torch.bfloat16
+    acc_dtype: Optional[torch.dtype] = None
+    c_dtype: Optional[torch.dtype] = None
+    d_dtype: Optional[torch.dtype] = None
     cd_major: str = "n"
     mma_tiler_mn: Tuple[int, int] = (256, 256)
     cluster_shape_mn: Optional[Tuple[int, int]] = None
@@ -146,7 +156,7 @@ class GroupedGemmGluSm100(APIBase):
         sample_amax: Optional[torch.Tensor] = None,
         sample_norm_const: Optional[torch.Tensor] = None,
         sample_prob: Optional[torch.Tensor] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -163,6 +173,14 @@ class GroupedGemmGluSm100(APIBase):
         self._pending_init_kwargs = dict(locals())
         self._pending_init_kwargs.pop("self")
         self._pending_init_kwargs.pop("__class__", None)
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmGluSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            self._pending_init_kwargs["acc_dtype"] = torch.float32
         self._implementation = None
 
     def check_support(self) -> bool:
@@ -184,7 +202,7 @@ class GroupedGemmGluSm100(APIBase):
                     ("sf_vec_size", kwargs["sf_vec_size"] if kwargs["sf_vec_size"] != 16 else None),
                     ("discrete_col_sfd", kwargs["discrete_col_sfd"] if kwargs["discrete_col_sfd"] else None),
                 ),
-                block_scaled_dtype_pairs=_BLOCK_SCALED_DTYPE_PAIRS,
+                block_scaled_dtype_pairs=_block_scaled_dtype_pairs(),
             )
             self.backend = backend
             if backend is GroupedGemmBackend.BF16:
@@ -446,6 +464,8 @@ def _grouped_gemm_glu_block_scaled_call(call: GluCall) -> TupleDict:
         TupleDict with keys: c_tensor, d_tensor, d_col_tensor, amax_tensor,
             sfd_row_tensor, sfd_col_tensor
     """
+    import torch
+
     from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_pointer_tensor
 
     a_tensor = call.a_tensor
@@ -807,7 +827,17 @@ def _grouped_gemm_glu_block_scaled_call(call: GluCall) -> TupleDict:
 
 
 def _normalize_glu_call(call: GluCall) -> tuple[GluCall, GroupedGemmBackend]:
+    import torch
+
     from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_pointer_tensor
+
+    if call.acc_dtype is None or call.c_dtype is None or call.d_dtype is None:
+        call = replace(
+            call,
+            acc_dtype=call.acc_dtype if call.acc_dtype is not None else torch.float32,
+            c_dtype=call.c_dtype if call.c_dtype is not None else torch.bfloat16,
+            d_dtype=call.d_dtype if call.d_dtype is not None else torch.bfloat16,
+        )
 
     is_dense = call.b_tensor is not None
     is_discrete = call.b_ptrs is not None
@@ -867,7 +897,7 @@ def _normalize_glu_call(call: GluCall) -> tuple[GluCall, GroupedGemmBackend]:
                 call.glu_clamp_min if call.glu_clamp_min != -7.0 else None,
             ),
         ),
-        block_scaled_dtype_pairs=_BLOCK_SCALED_DTYPE_PAIRS,
+        block_scaled_dtype_pairs=_block_scaled_dtype_pairs(),
     )
 
     linear_offset = call.linear_offset
@@ -946,6 +976,8 @@ def _glu_tensor_signature(tensor: Optional[torch.Tensor], *, dynamic_m: bool = F
 
 
 def _grouped_gemm_glu_bf16_call(call: GluCall) -> TupleDict:
+    import torch
+
     valid_m, k, _ = call.a_tensor.shape
     if call.weight_mode == MoEWeightMode.DENSE:
         n_full = call.b_tensor.shape[0]
@@ -1095,9 +1127,9 @@ def grouped_gemm_glu_wrapper_sm100(
     b_major: str = "k",
     norm_const_tensor: Optional[torch.Tensor] = None,
     prob_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    c_dtype: torch.dtype = torch.bfloat16,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    c_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -1116,6 +1148,18 @@ def grouped_gemm_glu_wrapper_sm100(
     generate_c: bool = False,
 ) -> TupleDict:
     """Dispatch grouped GEMM GLU once from an immutable normalized call."""
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_glu_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if c_dtype is None:
+        c_dtype = torch.bfloat16
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
     _reject_unsupported_rubin_glu_tune_params(
         get_device_type() == "rubin",
         geglu_alpha,

--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/api.py
@@ -3,6 +3,8 @@
 
 """FE API for grouped GEMM GLU + Hadamard forward fusion."""
 
+from __future__ import annotations
+
 import logging
 import os
 from typing import Optional, Tuple
@@ -10,7 +12,6 @@ from typing import Optional, Tuple
 from cuda.bindings import driver as cuda
 import cutlass
 import cutlass.cute as cute
-import torch
 from cutlass.cute.nvgpu import OperandMajorMode
 from cutlass.cute.runtime import from_dlpack, make_fake_stream
 
@@ -23,6 +24,8 @@ from .moe_blockscaled_grouped_gemm_glu_hadamard import BlockScaledMoEGroupedGemm
 
 
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    import torch
+
     if tensor.dtype == torch.uint8:
         cute_tensor = from_dlpack(tensor, assumed_align=16, enable_tvm_ffi=True).mark_layout_dynamic(leading_dim=1)
         cute_tensor.element_type = cutlass.Float4E2M1FN
@@ -52,7 +55,7 @@ class GroupedGemmGluHadamardSm100(APIBase):
         sample_post_rht_amax: Optional[torch.Tensor] = None,
         sample_bias: Optional[torch.Tensor] = None,
         sample_hadamard: Optional[torch.Tensor] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -62,6 +65,14 @@ class GroupedGemmGluHadamardSm100(APIBase):
         use_dynamic_sched: bool = False,
         use_tmem_post_rht_amax: bool = False,
     ):
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmGluHadamardSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
         super().__init__()
 
         self._warn_experimental_api()
@@ -137,6 +148,8 @@ class GroupedGemmGluHadamardSm100(APIBase):
 
     @staticmethod
     def _make_hadamard_tensor(device: torch.device) -> torch.Tensor:
+        import torch
+
         return hadamard_matrix(HADAMARD_SIZE, dtype=torch.bfloat16, device=device).t().contiguous()
 
     @classmethod
@@ -147,6 +160,8 @@ class GroupedGemmGluHadamardSm100(APIBase):
         device: torch.device,
         name: str,
     ) -> torch.Tensor:
+        import torch
+
         expected_shape = (HADAMARD_SIZE, HADAMARD_SIZE)
         if tuple(hadamard_tensor.shape) != expected_shape:
             raise ValueError(f"{name} tensor shape mismatch: expected {expected_shape}, got {tuple(hadamard_tensor.shape)}")
@@ -157,6 +172,8 @@ class GroupedGemmGluHadamardSm100(APIBase):
         return hadamard_tensor
 
     def check_support(self) -> bool:
+        import torch
+
         tensor_m, k, _ = self._tensor_shape(self.a_desc, name="sample_a")
         if self.weight_mode == MoEWeightMode.DENSE:
             n, _, l = self._tensor_shape(self.b_desc, name="sample_b")
@@ -280,6 +297,8 @@ class GroupedGemmGluHadamardSm100(APIBase):
         return True
 
     def compile(self) -> None:
+        import torch
+
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
             return
@@ -514,6 +533,8 @@ class GroupedGemmGluHadamardSm100(APIBase):
         bias_tensor: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
+        import torch
+
         self._ensure_support_checked()
         if self._compiled_kernel is None:
             raise RuntimeError("Kernel has not been compiled")
@@ -588,9 +609,9 @@ def grouped_gemm_glu_hadamard_wrapper_sm100(
     b_dtype: Optional[torch.dtype] = None,
     b_major: str = "k",
     bias_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    c_dtype: torch.dtype = torch.bfloat16,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    c_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -604,6 +625,18 @@ def grouped_gemm_glu_hadamard_wrapper_sm100(
 ) -> TupleDict:
     """High-level wrapper for grouped GEMM GLU + Hadamard forward fusion."""
     from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_pointer_tensor
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_glu_hadamard_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if c_dtype is None:
+        c_dtype = torch.bfloat16
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
 
     valid_m = a_tensor.shape[0]
     is_dense = b_tensor is not None

--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/hadamard_utils.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/hadamard_utils.py
@@ -10,7 +10,6 @@ import cutlass.utils.blackwell_helpers as sm100_utils
 from cutlass.cute.nvgpu import tcgen05
 from cutlass.cute.nvgpu import OperandMajorMode
 from cutlass.cute.nvgpu.tcgen05 import OperandSource
-import torch
 
 HADAMARD_SIZE = 16
 TMEM_ROW_STRIDE = 1 << 16
@@ -235,6 +234,8 @@ def hadamard_smem_transpose_fwht_amax(sD, d_buffer, feature_offset: cutlass.Cons
 
 
 def hadamard_matrix(n, dtype=None, device=None):
+    import torch
+
     if dtype is None:
         dtype = torch.float32
     if n < 1:

--- a/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
+++ b/python/cudnn/gemm/cutedsl/grouped/moe_kernel_helpers.py
@@ -12,9 +12,9 @@ This module contains:
 - Kernel helper functions that don't depend on kernel instance state
 """
 
-from typing import Type, Tuple, Union
+from __future__ import annotations
 
-import torch
+from typing import Type, Tuple, Union
 
 import cutlass
 import cutlass.cute as cute
@@ -401,6 +401,8 @@ def silu_f32_geglu_scaled(a: Union[float, Float32], fastmath: bool = False) -> U
 
 def sigmoid(x):
     """PyTorch reference sigmoid using exp2 for numerical consistency."""
+    import torch
+
     LOG2_E = 1.4426950408889634
     exp_x = torch.exp2(x * (-LOG2_E))
     ret = 1.0 / (exp_x + 1.0)
@@ -417,6 +419,8 @@ def compute_reference_amax(output_tensor: torch.Tensor) -> float:
     Returns:
         float: reference amax value
     """
+    import torch
+
     if output_tensor.dtype != torch.float32:
         output_fp32 = output_tensor.float()
     else:
@@ -446,6 +450,8 @@ def compare_and_report_mismatches(
         rtol: Relative tolerance
         max_mismatches: Maximum number of mismatches to report
     """
+    import torch
+
     if gpu_tensor.is_cuda:
         gpu_data = gpu_tensor.cpu()
     else:

--- a/python/cudnn/gemm/cutedsl/grouped/quant/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/quant/api.py
@@ -8,12 +8,13 @@ and discrete weight modes for grouped block-scaled GEMM with output
 quantization in MoE (Mixture of Experts) workloads.
 """
 
+from __future__ import annotations
+
 import os
 from typing import Optional, Tuple
 
 import cutlass
 import cutlass.cute as cute
-import torch
 from cuda.bindings import driver as cuda
 from cutlass.cute.runtime import make_fake_stream
 
@@ -75,7 +76,7 @@ class GroupedGemmQuantSm100(APIBase):
         sample_prob: Optional[torch.Tensor] = None,
         sample_row_scale: Optional[torch.Tensor] = None,
         # Configuration
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -119,6 +120,14 @@ class GroupedGemmQuantSm100(APIBase):
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         """
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmQuantSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            acc_dtype = torch.float32
         super().__init__()
 
         self._warn_experimental_api()
@@ -219,6 +228,8 @@ class GroupedGemmQuantSm100(APIBase):
 
         :return: True if supported, raises exception otherwise
         """
+        import torch
+
         self._logger.debug("Entering check_support")
 
         all_none = all(x is None for x in [self.sfd_row_desc, self.sfd_col_desc, self.norm_const_desc])
@@ -535,6 +546,8 @@ class GroupedGemmQuantSm100(APIBase):
 
     def compile(self) -> None:
         """Compile the kernel."""
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -873,6 +886,8 @@ class GroupedGemmQuantSm100(APIBase):
 
     def _compile_discrete(self, gemm_quant, max_active_clusters, fake_stream) -> None:
         """Compile for discrete (per-expert pointer) weight mode."""
+        import torch
+
         if len(self.b_shape) == 2:
             n, k = self.b_shape
         else:
@@ -1227,8 +1242,8 @@ def grouped_gemm_quant_wrapper_sm100(
     norm_const_tensor: Optional[torch.Tensor] = None,
     prob_tensor: Optional[torch.Tensor] = None,
     row_scale_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     d_tensor: Optional[torch.Tensor] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
@@ -1306,6 +1321,16 @@ def grouped_gemm_quant_wrapper_sm100(
                 d = result[0]  # d_tensor
     """
     from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_pointer_tensor
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_quant_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
 
     is_dense = b_tensor is not None
     is_discrete = b_ptrs is not None

--- a/python/cudnn/gemm/cutedsl/grouped/srelu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/srelu/api.py
@@ -8,12 +8,13 @@ and discrete weight modes for grouped block-scaled GEMM with output
 SReLU output quantization in MoE (Mixture of Experts) workloads.
 """
 
+from __future__ import annotations
+
 import os
 from typing import Optional, Tuple
 
 import cutlass
 import cutlass.cute as cute
-import torch
 from cuda.bindings import driver as cuda
 from cutlass.cute.runtime import make_fake_stream
 
@@ -30,6 +31,8 @@ from cutlass.cute.runtime import from_dlpack
 
 
 def _reinterpret_raw_grouped_fp4_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    import torch
+
     if tensor.dtype == torch.uint8:
         cute_tensor = from_dlpack(tensor, assumed_align=16, enable_tvm_ffi=True).mark_layout_dynamic(leading_dim=1)
         cute_tensor.element_type = cutlass.Float4E2M1FN
@@ -75,7 +78,7 @@ class GroupedGemmSreluSm100(APIBase):
         sample_norm_const: Optional[torch.Tensor] = None,
         sample_prob: Optional[torch.Tensor] = None,
         # Configuration
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -116,6 +119,14 @@ class GroupedGemmSreluSm100(APIBase):
         :param b_major: Major dimension for B tensor, one of "k" or "n"
         :param use_dynamic_sched: Enable dynamic tile scheduling for load balancing
         """
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmSreluSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            acc_dtype = torch.float32
         super().__init__()
 
         self._warn_experimental_api()
@@ -210,6 +221,8 @@ class GroupedGemmSreluSm100(APIBase):
 
         :return: True if supported, raises exception otherwise
         """
+        import torch
+
         self._logger.debug("Entering check_support")
 
         all_none = all(x is None for x in [self.sfd_row_desc, self.sfd_col_desc, self.norm_const_desc])
@@ -528,6 +541,8 @@ class GroupedGemmSreluSm100(APIBase):
 
     def compile(self) -> None:
         """Compile the kernel."""
+        import torch
+
         self._logger.debug("Entering compile")
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
@@ -577,6 +592,8 @@ class GroupedGemmSreluSm100(APIBase):
 
     def _compile_dense(self, gemm_srelu, max_active_clusters, fake_stream) -> None:
         """Compile for dense (contiguous) weight mode."""
+        import torch
+
         fake_workspace_ptr = cute.runtime.nullptr(
             dtype=cutlass.Uint8,
             assumed_align=128,
@@ -831,6 +848,8 @@ class GroupedGemmSreluSm100(APIBase):
 
     def _compile_discrete(self, gemm_srelu, max_active_clusters, fake_stream) -> None:
         """Compile for discrete (per-expert pointer) weight mode."""
+        import torch
+
         if len(self.b_shape) == 2:
             n, k = self.b_shape
         else:
@@ -1138,9 +1157,9 @@ def grouped_gemm_srelu_wrapper_sm100(
     b_major: str = "k",
     norm_const_tensor: Optional[torch.Tensor] = None,
     prob_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    c_dtype: torch.dtype = torch.bfloat16,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    c_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -1212,6 +1231,18 @@ def grouped_gemm_srelu_wrapper_sm100(
                 d = result[1]  # d_tensor
     """
     from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_pointer_tensor
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_srelu_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if c_dtype is None:
+        c_dtype = torch.bfloat16
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
 
     is_dense = b_tensor is not None
     is_discrete = b_ptrs is not None

--- a/python/cudnn/gemm/cutedsl/grouped/swiglu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/swiglu/api.py
@@ -7,12 +7,13 @@ This module provides the API class for contiguous grouped block-scaled GEMM
 with SwiGLU activation for MoE (Mixture of Experts) workloads.
 """
 
+from __future__ import annotations
+
 from .grouped_gemm_swiglu_quant import (
     BlockScaledContiguousGroupedGemmKernel,
 )
 from cuda.bindings import driver as cuda
 import os
-import torch
 from typing import Tuple, Optional
 
 import cutlass
@@ -63,7 +64,7 @@ class GroupedGemmSwigluSm100(APIBase):
         sample_norm_const: Optional[torch.Tensor] = None,
         sample_prob: Optional[torch.Tensor] = None,
         # Configuration
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -95,6 +96,14 @@ class GroupedGemmSwigluSm100(APIBase):
         :param m_aligned: Alignment for group M dimension
         :param discrete_col_sfd: Boolean, True to generate discrete col-major scale factor tensor. Only applies when already output scale factor tensors are provided.
         """
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmSwigluSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            acc_dtype = torch.float32
         super().__init__()
 
         self._warn_experimental_api()
@@ -150,6 +159,8 @@ class GroupedGemmSwigluSm100(APIBase):
 
         :return: True if supported, raises exception otherwise
         """
+        import torch
+
         self._logger.debug("Entering check_support")
 
         all_none = all(x is None for x in [self.sfd_row_desc, self.sfd_col_desc, self.norm_const_desc])
@@ -760,9 +771,9 @@ def grouped_gemm_swiglu_wrapper_sm100(
     alpha_tensor: torch.Tensor,
     norm_const_tensor: Optional[torch.Tensor] = None,
     prob_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    c_dtype: torch.dtype = torch.bfloat16,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    c_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     cd_major: str = "n",
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
@@ -823,6 +834,18 @@ def grouped_gemm_swiglu_wrapper_sm100(
                 # Integer indexing
                 c = result[0]  # c_tensor
     """
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_swiglu_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if c_dtype is None:
+        c_dtype = torch.bfloat16
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
     valid_m, k, _ = a_tensor.shape
     n, _, l = b_tensor.shape
     n_out = n // 2  # After SwiGLU

--- a/python/cudnn/gemm/cutedsl/grouped/unfused/_bf16_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused/_bf16_api.py
@@ -3,11 +3,12 @@
 
 """Private APIBase API for the source-close unfused BF16 MoE kernel."""
 
+from __future__ import annotations
+
 import os
 import weakref
 from typing import Optional, Tuple
 
-import torch
 import cutlass
 import cutlass.cute as cute
 from cuda.bindings import driver as cuda
@@ -21,7 +22,16 @@ from cudnn.gemm.cutedsl.discrete_grouped.discrete_kernel_utils import _require_p
 from ..moe_utils import MoEWeightMode
 from .moe_grouped_gemm import MoEGroupedGemmBf16Kernel
 
-_OUTPUT_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+_OUTPUT_DTYPES = None
+
+
+def _output_dtypes():
+    global _OUTPUT_DTYPES
+    if _OUTPUT_DTYPES is None:
+        import torch
+
+        _OUTPUT_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+    return _OUTPUT_DTYPES
 
 
 class GroupedGemmBf16API(APIBase):
@@ -40,7 +50,7 @@ class GroupedGemmBf16API(APIBase):
         num_experts: Optional[int] = None,
         b_shape: Optional[Tuple[int, ...]] = None,
         b_dtype: Optional[torch.dtype] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         vector_f32: bool = False,
@@ -49,6 +59,10 @@ class GroupedGemmBf16API(APIBase):
         b_major: str = "k",
         use_dynamic_sched: bool = False,
     ) -> None:
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
         super().__init__()
         self._warn_experimental_api()
 
@@ -186,6 +200,8 @@ class GroupedGemmBf16API(APIBase):
 
     @staticmethod
     def _record_pointer_stream(b_ptrs: torch.Tensor, current_stream: cuda.CUstream) -> None:
+        import torch
+
         handle = int(current_stream)
         torch_current = torch.cuda.current_stream(b_ptrs.device)
         torch_default = torch.cuda.default_stream(b_ptrs.device)
@@ -198,6 +214,8 @@ class GroupedGemmBf16API(APIBase):
         b_ptrs.record_stream(launch_stream)
 
     def check_support(self) -> bool:
+        import torch
+
         if self.a_desc.ndim != 3:
             raise ValueError(f"sample_a must be rank-3, got {self.a_desc.shape}")
         tensor_m, k, one = self.a_desc.shape
@@ -241,8 +259,8 @@ class GroupedGemmBf16API(APIBase):
         if self.weight_mode == MoEWeightMode.DENSE:
             self._check_dtype(self.b_desc, torch.bfloat16, "sample_b")
         self._check_dtype(self.b_dtype, torch.bfloat16, "b_dtype")
-        self._check_dtype(self.c_desc, _OUTPUT_DTYPES, "sample_c")
-        self._check_dtype(self.d_desc, _OUTPUT_DTYPES, "sample_d")
+        self._check_dtype(self.c_desc, _output_dtypes(), "sample_c")
+        self._check_dtype(self.d_desc, _output_dtypes(), "sample_d")
         self._check_dtype(self.padded_offsets_desc, torch.int32, "sample_padded_offsets")
         self._check_dtype(self.alpha_desc, torch.float32, "sample_alpha")
         self._check_dtype(self.prob_desc, torch.float32, "sample_prob")
@@ -262,7 +280,7 @@ class GroupedGemmBf16API(APIBase):
         if self.bias_desc is not None:
             self._expect_shape(self.bias_desc, (n, self.expert_cnt), "sample_bias")
             self._expect_stride(self.bias_desc, (1, n), "sample_bias")
-            self._check_dtype(self.bias_desc, _OUTPUT_DTYPES, "sample_bias")
+            self._check_dtype(self.bias_desc, _output_dtypes(), "sample_bias")
             self._expect_device(self.bias_desc, device, "sample_bias")
 
         for name, data_ptr in self._sample_data_ptrs.items():
@@ -325,6 +343,8 @@ class GroupedGemmBf16API(APIBase):
         return True
 
     def compile(self) -> None:
+        import torch
+
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
             return

--- a/python/cudnn/gemm/cutedsl/grouped/unfused/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused/api.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import os
 from typing import Optional, Tuple
 
-import torch
 from cuda.bindings import driver as cuda
 
 from cudnn.api_base import APIBase, TupleDict
@@ -37,7 +36,7 @@ class GroupedGemmSm100(APIBase):
         num_experts: Optional[int] = None,
         b_shape: Optional[Tuple[int, ...]] = None,
         b_dtype: Optional[torch.dtype] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         vector_f32: bool = False,
@@ -50,6 +49,14 @@ class GroupedGemmSm100(APIBase):
         self._pending_init_kwargs = dict(locals())
         self._pending_init_kwargs.pop("self")
         self._pending_init_kwargs.pop("__class__", None)
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            self._pending_init_kwargs["acc_dtype"] = torch.float32
         self._implementation = None
 
     def check_support(self) -> bool:
@@ -157,6 +164,8 @@ def _normalize_call(
     cd_major: str,
     m_aligned: int,
 ) -> tuple[bool, int, int, int]:
+    import torch
+
     is_dense = b_tensor is not None
     is_discrete = b_ptrs is not None
     if is_dense and is_discrete:
@@ -234,9 +243,9 @@ def grouped_gemm_wrapper_sm100(
     b_dtype: Optional[torch.dtype] = None,
     b_major: str = "k",
     prob_tensor: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    c_dtype: torch.dtype = torch.bfloat16,
-    d_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    c_dtype: Optional[torch.dtype] = None,
+    d_dtype: Optional[torch.dtype] = None,
     c_tensor: Optional[torch.Tensor] = None,
     d_tensor: Optional[torch.Tensor] = None,
     cd_major: str = "n",
@@ -248,6 +257,18 @@ def grouped_gemm_wrapper_sm100(
     use_dynamic_sched: bool = False,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if c_dtype is None:
+        c_dtype = torch.bfloat16
+    if d_dtype is None:
+        d_dtype = torch.bfloat16
     is_dense, tensor_m, n_out, expert_cnt = _normalize_call(
         a_tensor,
         padded_offsets,

--- a/python/cudnn/gemm/cutedsl/grouped/utils.py
+++ b/python/cudnn/gemm/cutedsl/grouped/utils.py
@@ -7,6 +7,8 @@ This module contains the tile scheduler classes and helper functions used by bot
 the forward (grouped_gemm_swiglu) and backward (grouped_gemm_dswiglu) kernels.
 """
 
+from __future__ import annotations
+
 from typing import Tuple, Union
 
 from cutlass.cutlass_dsl import (
@@ -26,7 +28,6 @@ from cutlass.cutlass_dsl import T
 from cutlass.cute.typing import Float32, Int32
 import cutlass.cute as cute
 import cutlass
-import torch
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import (
     Agent,
@@ -177,6 +178,8 @@ def fmax(a: Union[float, Float32], b: Union[float, Float32], *, loc=None, ip=Non
 
 def logical_shape_fp4x2_aware(tensor: torch.Tensor) -> Tuple[int, ...]:
     """Return correct shapes for NVFP4 tensor."""
+    import torch
+
     if tensor.dtype == torch.float4_e2m1fn_x2:
         innermost_dim_index = next((i for i, s in enumerate(tensor.stride()) if s == 1), None)
         if innermost_dim_index is None:

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/_bf16_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/_bf16_api.py
@@ -3,6 +3,8 @@
 
 """Private descriptor-first BF16 API for SM100 grouped GEMM wgrad."""
 
+from __future__ import annotations
+
 import os
 import weakref
 from typing import Optional, Tuple, Union
@@ -11,7 +13,6 @@ import cutlass
 import cutlass.cute as cute
 from cuda.bindings import driver as cuda
 from cutlass.cute.runtime import from_dlpack, make_fake_stream
-import torch
 
 from cudnn.api_base import APIBase, TensorDesc
 from cudnn.datatypes import _convert_to_cutlass_data_type
@@ -21,7 +22,16 @@ from ..backend_utils import _torch_stream_context
 from ..moe_utils import MoEWeightMode, WGradInputOrder
 from .moe_grouped_gemm_wgrad import MoEGroupedGemmWgradBF16Kernel
 
-_OUTPUT_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+_OUTPUT_DTYPES = None
+
+
+def _output_dtypes():
+    global _OUTPUT_DTYPES
+    if _OUTPUT_DTYPES is None:
+        import torch
+
+        _OUTPUT_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+    return _OUTPUT_DTYPES
 
 
 class GroupedGemmWgradBf16API(APIBase):
@@ -41,13 +51,17 @@ class GroupedGemmWgradBf16API(APIBase):
         wgrad_dtype: Optional[torch.dtype] = None,
         sample_global_scale_a: Optional[torch.Tensor] = None,
         sample_global_scale_b: Optional[torch.Tensor] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
         accumulate_on_output: bool = False,
         input_order: Union[WGradInputOrder, str] = WGradInputOrder.Tensor2D,
     ) -> None:
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
         super().__init__()
         self._warn_experimental_api()
         self.input_order = WGradInputOrder(input_order)
@@ -178,6 +192,8 @@ class GroupedGemmWgradBf16API(APIBase):
 
     @staticmethod
     def _record_pointer_stream(pointers: torch.Tensor, current_stream: cuda.CUstream) -> None:
+        import torch
+
         handle = int(current_stream)
         torch_current = torch.cuda.current_stream(pointers.device)
         torch_default = torch.cuda.default_stream(pointers.device)
@@ -213,6 +229,8 @@ class GroupedGemmWgradBf16API(APIBase):
             raise ValueError(f"{name} must be on {device}, got {desc.device}")
 
     def check_support(self) -> bool:
+        import torch
+
         if self.a_desc.ndim != 2:
             raise ValueError(f"sample_a must be rank-2, got {self.a_desc.shape}")
         if self.b_desc.ndim != 2:
@@ -226,7 +244,7 @@ class GroupedGemmWgradBf16API(APIBase):
         self._check_dtype(self.a_desc, torch.bfloat16, "sample_a")
         self._check_dtype(self.b_desc, torch.bfloat16, "sample_b")
         self._check_dtype(self.offsets_desc, torch.int32, "sample_offsets")
-        self._check_dtype(self.wgrad_dtype, _OUTPUT_DTYPES, "wgrad_dtype")
+        self._check_dtype(self.wgrad_dtype, _output_dtypes(), "wgrad_dtype")
         if self.acc_dtype != torch.float32:
             raise ValueError(f"acc_dtype must be torch.float32, got {self.acc_dtype}")
         if any(control is not None for control in self._scale_controls):
@@ -311,6 +329,8 @@ class GroupedGemmWgradBf16API(APIBase):
         return True
 
     def compile(self) -> None:
+        import torch
+
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
             return
@@ -455,6 +475,8 @@ class GroupedGemmWgradBf16API(APIBase):
         global_scale_b: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
+        import torch
+
         current_stream = self._get_default_stream(current_stream)
         if self._compiled_kernel is None:
             raise RuntimeError("Kernel not compiled; call compile() first")

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/_blockscaled_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/_blockscaled_api.py
@@ -3,9 +3,10 @@
 
 """Unified FE API for grouped GEMM wgrad on SM100+."""
 
+from __future__ import annotations
+
 from typing import Optional, Tuple, Union
 
-import torch
 import cutlass
 import cutlass.cute as cute
 from cuda.bindings import driver as cuda
@@ -28,6 +29,8 @@ def _get_rubin_kernel():
 
 
 def _is_supported_rubin_quantization(ab_dtype: torch.dtype, sf_dtype: torch.dtype, sf_vec_size: int) -> bool:
+    import torch
+
     is_fp4 = ab_dtype in (torch.float4_e2m1fn_x2, torch.uint8)
     if is_fp4:
         return (sf_dtype == torch.float8_e4m3fn and sf_vec_size == 16) or (sf_dtype == torch.float8_e8m0fnu and sf_vec_size == 32)
@@ -55,13 +58,17 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
         wgrad_dtype: Optional[torch.dtype] = None,
         sample_global_scale_a: Optional[torch.Tensor] = None,
         sample_global_scale_b: Optional[torch.Tensor] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
         accumulate_on_output: bool = False,
         input_order: Union[WGradInputOrder, str] = WGradInputOrder.Tensor2D,
     ):
+        import torch
+
+        if acc_dtype is None:
+            acc_dtype = torch.float32
         super().__init__()
         self._warn_experimental_api()
         self.input_order = WGradInputOrder(input_order)
@@ -159,6 +166,8 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
         return offset_values
 
     def _check_rubin_quantization_support(self) -> None:
+        import torch
+
         if not self._is_rubin_kernel:
             return
 
@@ -179,6 +188,8 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
             )
 
     def check_support(self) -> bool:
+        import torch
+
         m, tokens_sum = self._tensor_shape(self.a_desc, name="sample_a")
         _, n = self._tensor_shape(self.b_desc, name="sample_b")
 
@@ -266,6 +277,8 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
         return True
 
     def compile(self) -> None:
+        import torch
+
         self._ensure_support_checked()
         if self._compiled_kernel is not None:
             return
@@ -399,6 +412,8 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
         self._compiled_kernel = tensor_api
 
     def _compile_discrete(self, kernel, max_active_clusters, fake_stream) -> None:
+        import torch
+
         a_fake = (
             from_dlpack(self.sample_a_tensor, assumed_align=16, enable_tvm_ffi=True).mark_compact_shape_dynamic(
                 mode=1,
@@ -530,6 +545,8 @@ class GroupedGemmWgradBlockScaledAPI(APIBase):
         global_scale_b: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
+        import torch
+
         current_stream = self._get_default_stream(current_stream)
         self._runtime_error_if(self._compiled_kernel is None, "Kernel not compiled; call compile() first")
 

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/api.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import Any, Optional, Tuple, overload
 import os
 
-import torch
 from cuda.bindings import driver as cuda
 
 from cudnn.api_base import APIBase, TupleDict, get_device_type
@@ -22,15 +21,25 @@ from ..backend_utils import (
 )
 from ..moe_utils import WGradInputOrder
 
-_BLOCK_SCALED_DTYPE_PAIRS = {
-    (dtype, dtype)
-    for dtype in (
-        torch.float4_e2m1fn_x2,
-        torch.uint8,
-        torch.float8_e5m2,
-        torch.float8_e4m3fn,
-    )
-}
+_BLOCK_SCALED_DTYPE_PAIRS = None
+
+
+def _block_scaled_dtype_pairs():
+    global _BLOCK_SCALED_DTYPE_PAIRS
+    if _BLOCK_SCALED_DTYPE_PAIRS is None:
+        import torch
+
+        _BLOCK_SCALED_DTYPE_PAIRS = {
+            (dtype, dtype)
+            for dtype in (
+                torch.float4_e2m1fn_x2,
+                torch.uint8,
+                torch.float8_e5m2,
+                torch.float8_e4m3fn,
+            )
+        }
+    return _BLOCK_SCALED_DTYPE_PAIRS
+
 
 _cache_of_GroupedGemmWgradSm100Objects = {}
 
@@ -86,7 +95,7 @@ class GroupedGemmWgradSm100(APIBase):
         wgrad_dtype: Optional[torch.dtype] = None,
         sample_global_scale_a: Optional[torch.Tensor] = None,
         sample_global_scale_b: Optional[torch.Tensor] = None,
-        acc_dtype: torch.dtype = torch.float32,
+        acc_dtype: Optional[torch.dtype] = None,
         mma_tiler_mn: Tuple[int, int] = (256, 256),
         cluster_shape_mn: Optional[Tuple[int, int]] = None,
         sf_vec_size: int = 16,
@@ -97,6 +106,14 @@ class GroupedGemmWgradSm100(APIBase):
         self._pending_init_kwargs = dict(locals())
         self._pending_init_kwargs.pop("self")
         self._pending_init_kwargs.pop("__class__", None)
+        from cudnn.tensor_adapter import is_torch_tensor
+
+        if sample_a is not None and not is_torch_tensor(sample_a):
+            raise ValueError("GroupedGemmWgradSm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+        if acc_dtype is None:
+            import torch
+
+            self._pending_init_kwargs["acc_dtype"] = torch.float32
         self._implementation = None
 
     def check_support(self) -> bool:
@@ -113,7 +130,7 @@ class GroupedGemmWgradSm100(APIBase):
                     ("sample_global_scale_b", kwargs["sample_global_scale_b"]),
                     ("sf_vec_size", kwargs["sf_vec_size"] if kwargs["sf_vec_size"] != 16 else None),
                 ),
-                block_scaled_dtype_pairs=_BLOCK_SCALED_DTYPE_PAIRS,
+                block_scaled_dtype_pairs=_block_scaled_dtype_pairs(),
             )
             self.backend = backend
             if backend is GroupedGemmBackend.BF16:
@@ -218,8 +235,8 @@ def grouped_gemm_wgrad_wrapper_sm100(
     wgrad_ptrs: Optional[torch.Tensor] = None,
     global_scale_a: Optional[torch.Tensor] = None,
     global_scale_b: Optional[torch.Tensor] = None,
-    acc_dtype: torch.dtype = torch.float32,
-    wgrad_dtype: torch.dtype = torch.bfloat16,
+    acc_dtype: Optional[torch.dtype] = None,
+    wgrad_dtype: Optional[torch.dtype] = None,
     mma_tiler_mn: Tuple[int, int] = (256, 256),
     cluster_shape_mn: Optional[Tuple[int, int]] = None,
     sf_vec_size: int = 16,
@@ -228,6 +245,16 @@ def grouped_gemm_wgrad_wrapper_sm100(
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Compile and execute grouped GEMM wgrad through the selected backend API."""
+    from cudnn.tensor_adapter import is_torch_tensor
+
+    if a_tensor is not None and not is_torch_tensor(a_tensor):
+        raise ValueError("grouped_gemm_wgrad_wrapper_sm100 currently supports torch tensors only; JAX support is not yet implemented for this API")
+    import torch
+
+    if acc_dtype is None:
+        acc_dtype = torch.float32
+    if wgrad_dtype is None:
+        wgrad_dtype = torch.bfloat16
     if output_mode not in ("dense", "discrete"):
         raise ValueError(f'output_mode must be "dense" or "discrete", got {output_mode}')
     if a_tensor.ndim != 2 or b_tensor.ndim != 2:
@@ -255,7 +282,7 @@ def grouped_gemm_wgrad_wrapper_sm100(
             ("global_scale_b", global_scale_b),
             ("sf_vec_size", sf_vec_size if sf_vec_size != 16 else None),
         ),
-        block_scaled_dtype_pairs=_BLOCK_SCALED_DTYPE_PAIRS,
+        block_scaled_dtype_pairs=_block_scaled_dtype_pairs(),
     )
     if wgrad_tensor is None and wgrad_ptrs is None:
         allocator = torch.zeros if accumulate_on_output else torch.empty

--- a/python/cudnn/tensor_adapter.py
+++ b/python/cudnn/tensor_adapter.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Framework-neutral tensor helpers.
+
+The frontend-only CuTeDSL APIs only need tensor *metadata* (shape/stride/dtype/device)
+plus a CUDA stream at launch time -- the data handoff to the compiled kernels is DLPack.
+This module reads that metadata from torch tensors, JAX arrays, or numpy arrays without
+eagerly importing any of those frameworks: a tensor of framework X can only exist if X is
+already in sys.modules, so probing sys.modules never triggers an import.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+import cuda.bindings.driver as cuda
+
+from cudnn.datatypes import _convert_to_cutlass_data_type
+
+
+@dataclass(frozen=True)
+class Device:
+    """Minimal stand-in for torch.device with the same .type/.index/str() surface."""
+
+    type: str
+    index: Optional[int] = None
+
+    def __str__(self):
+        return self.type if self.index is None else f"{self.type}:{self.index}"
+
+
+def is_torch_tensor(tensor: Any) -> bool:
+    torch = sys.modules.get("torch")
+    return torch is not None and isinstance(tensor, torch.Tensor)
+
+
+def is_jax_array(tensor: Any) -> bool:
+    jax = sys.modules.get("jax")
+    if jax is not None and isinstance(tensor, getattr(jax, "Array", ())):
+        return True
+    return type(tensor).__module__.startswith(("jax", "jaxlib"))
+
+
+def is_numpy_array(tensor: Any) -> bool:
+    numpy = sys.modules.get("numpy")
+    return numpy is not None and isinstance(tensor, numpy.ndarray)
+
+
+def detect_framework(tensor: Any) -> str:
+    """Return "torch", "jax", "numpy", or "unknown" for the given tensor."""
+    if is_torch_tensor(tensor):
+        return "torch"
+    if is_jax_array(tensor):
+        return "jax"
+    if is_numpy_array(tensor):
+        return "numpy"
+    return "unknown"
+
+
+def get_shape(tensor: Any) -> Tuple[int, ...]:
+    return tuple(tensor.shape)
+
+
+def _c_contiguous_strides(shape: Tuple[int, ...]) -> Tuple[int, ...]:
+    strides = [1] * len(shape)
+    acc = 1
+    for i in range(len(shape) - 1, -1, -1):
+        strides[i] = acc
+        acc *= shape[i]
+    return tuple(strides)
+
+
+def get_strides(tensor: Any) -> Tuple[int, ...]:
+    """Strides in elements. JAX arrays don't expose strides; their default layout is C-contiguous."""
+    if is_torch_tensor(tensor):
+        return tuple(tensor.stride())
+    if is_jax_array(tensor):
+        return _c_contiguous_strides(get_shape(tensor))
+    if is_numpy_array(tensor):
+        return tuple(s // tensor.itemsize for s in tensor.strides)
+    stride = getattr(tensor, "stride", None)
+    if callable(stride):
+        return tuple(stride())
+    strides = getattr(tensor, "strides", None)
+    if strides is not None:
+        return tuple(strides)
+    return _c_contiguous_strides(get_shape(tensor))
+
+
+def get_device(tensor: Any) -> Any:
+    """Device of the tensor: torch tensors keep their native torch.device; others map to Device."""
+    if is_torch_tensor(tensor):
+        return tensor.device
+    if is_jax_array(tensor):
+        jax_device = getattr(tensor, "device", None)
+        if jax_device is None or callable(jax_device):
+            jax_device = next(iter(tensor.devices()))
+        platform = jax_device.platform
+        return Device("cuda" if platform == "gpu" else platform, jax_device.id)
+    if is_numpy_array(tensor):
+        return Device("cpu")
+    device = getattr(tensor, "device", None)
+    if device is not None:
+        return device
+    return Device("unknown")
+
+
+def default_stream(framework: str) -> cuda.CUstream:
+    """Stream to launch on when the caller did not pass one.
+
+    torch has a per-thread "current stream" notion; other frameworks don't expose one,
+    so they get the CUDA legacy default stream (callers doing stream overlap should
+    pass an explicit cuda.CUstream).
+    """
+    if framework == "torch":
+        import torch
+
+        return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    return cuda.CUstream(0)
+
+
+def cuda_is_available() -> bool:
+    torch = sys.modules.get("torch")
+    if torch is not None:
+        return torch.cuda.is_available()
+    from cuda.bindings import runtime as cudart
+
+    err, count = cudart.cudaGetDeviceCount()
+    return err == cudart.cudaError_t.cudaSuccess and count > 0
+
+
+def get_compute_capability() -> Tuple[int, int]:
+    """(major, minor) of the current CUDA device, without requiring torch."""
+    torch = sys.modules.get("torch")
+    if torch is not None and torch.cuda.is_available():
+        return torch.cuda.get_device_capability(torch.cuda.current_device())
+    from cuda.bindings import runtime as cudart
+
+    def _check(result):
+        err, *values = result
+        if err != cudart.cudaError_t.cudaSuccess:
+            raise RuntimeError(f"CUDA runtime error: {err}")
+        return values[0] if len(values) == 1 else values
+
+    device = _check(cudart.cudaGetDevice())
+    major = _check(cudart.cudaDeviceGetAttribute(cudart.cudaDeviceAttr.cudaDevAttrComputeCapabilityMajor, device))
+    minor = _check(cudart.cudaDeviceGetAttribute(cudart.cudaDeviceAttr.cudaDevAttrComputeCapabilityMinor, device))
+    return major, minor
+
+
+def canonicalize_unit_dim_strides(shape: Tuple[int, ...], stride: Tuple[int, ...]) -> Tuple[int, ...]:
+    """Give extent-1 dims the dense "outermost" stride (numel) so that layouts that differ
+    only in unit-dim strides -- which the kernels cannot observe -- compare and compile equal."""
+    numel = 1
+    for dim in shape:
+        numel *= dim
+    return tuple(numel if dim == 1 else s for dim, s in zip(shape, stride))
+
+
+def pad_to_ndim(tensor: Any, ndim: int) -> Any:
+    """Append size-1 dims up to ndim; works for any framework tensor exposing reshape."""
+    shape = get_shape(tensor)
+    if len(shape) >= ndim:
+        return tensor
+    unsqueeze = getattr(tensor, "unsqueeze", None)
+    if callable(unsqueeze):
+        while len(get_shape(tensor)) < ndim:
+            tensor = tensor.unsqueeze(-1)
+        return tensor
+    return tensor.reshape(shape + (1,) * (ndim - len(shape)))
+
+
+# cutlass type -> framework-neutral dtype name; built lazily to keep cutlass import lazy.
+_cutlass_to_name_dict = None
+
+
+def _cutlass_to_dtype_name(cutlass_dtype: Any) -> str:
+    global _cutlass_to_name_dict
+    if _cutlass_to_name_dict is None:
+        import cutlass
+
+        names = {
+            "Float16": "float16",
+            "BFloat16": "bfloat16",
+            "Float32": "float32",
+            "Float64": "float64",
+            "Uint8": "uint8",
+            "Int8": "int8",
+            "Int32": "int32",
+            "Int64": "int64",
+            "Boolean": "bool",
+            "Float8E4M3FN": "float8_e4m3fn",
+            "Float8E5M2": "float8_e5m2",
+            "Float8E8M0FNU": "float8_e8m0fnu",
+            "Float4E2M1FN": "float4_e2m1fn",
+        }
+        _cutlass_to_name_dict = {getattr(cutlass, attr): name for attr, name in names.items() if getattr(cutlass, attr, None) is not None}
+    name = _cutlass_to_name_dict.get(cutlass_dtype)
+    if name is None:
+        raise ValueError(f"No dtype name known for cutlass type {cutlass_dtype}.")
+    return name
+
+
+def framework_dtype(dtype: Any, framework: str) -> Any:
+    """Convert a dtype (cutlass/torch/numpy/ml_dtypes/str) to the given framework's dtype object.
+
+    Used when the wrapper APIs allocate output tensors in the caller's framework.
+    """
+    canonical = _convert_to_cutlass_data_type(dtype)
+    name = _cutlass_to_dtype_name(canonical)
+    if framework == "torch":
+        import torch
+
+        if name == "float4_e2m1fn":
+            return torch.float4_e2m1fn_x2
+        return getattr(torch, name)
+    if framework == "jax":
+        if name == "float4_e2m1fn":
+            raise ValueError("JAX has no packed fp4 dtype; use a uint8 container tensor instead.")
+        import numpy as np
+
+        try:
+            return np.dtype(name)
+        except TypeError:
+            import ml_dtypes
+
+            return np.dtype(getattr(ml_dtypes, name))
+    raise ValueError(f"Cannot materialize dtype {dtype} for framework '{framework}'.")

--- a/test/python/fe_api/gemm/test_cutedsl_jax_guards.py
+++ b/test/python/fe_api/gemm/test_cutedsl_jax_guards.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+The grouped/discrete-grouped/proj_rope CuTeDSL APIs are torch-only for now: they must
+reject JAX arrays with a clear error at the public entry points (instead of failing
+deep inside pointer-array/workspace machinery), and their modules must import without
+torch. Real JAX support for these APIs is future work.
+"""
+
+import inspect
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp
+
+TORCH_ONLY_WRAPPERS = [
+    "grouped_gemm_wrapper_sm100",
+    "grouped_gemm_swiglu_wrapper_sm100",
+    "grouped_gemm_dswiglu_wrapper_sm100",
+    "grouped_gemm_srelu_wrapper_sm100",
+    "grouped_gemm_dsrelu_wrapper_sm100",
+    "grouped_gemm_glu_wrapper_sm100",
+    "grouped_gemm_dglu_wrapper_sm100",
+    "grouped_gemm_glu_hadamard_wrapper_sm100",
+    "grouped_gemm_quant_wrapper_sm100",
+    "grouped_gemm_wgrad_wrapper_sm100",
+    "discrete_grouped_gemm_swiglu_wrapper_sm100",
+    "discrete_grouped_gemm_dswiglu_wrapper_sm100",
+    "gemm_proj_rope_mxfp8_wrapper_sm100",
+]
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("wrapper_name", TORCH_ONLY_WRAPPERS)
+def test_torch_only_wrapper_rejects_jax(wrapper_name):
+    import cudnn
+
+    try:
+        wrapper = getattr(cudnn, wrapper_name)
+    except (AttributeError, ImportError):
+        pytest.skip(f"{wrapper_name} is not exported in this build")
+
+    dummy = jnp.asarray(np.zeros((16, 16, 1), dtype=np.float32))
+    # Fill every required parameter with the dummy JAX array; the framework guard
+    # runs on the first tensor argument before any validation.
+    kwargs = {}
+    for name, param in inspect.signature(wrapper).parameters.items():
+        if param.default is inspect.Parameter.empty and param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            kwargs[name] = dummy
+
+    with pytest.raises(ValueError, match="torch tensors only"):
+        wrapper(**kwargs)

--- a/test/python/fe_api/gemm/test_gemm_amax_jax.py
+++ b/test/python/fe_api/gemm/test_gemm_amax_jax.py
@@ -1,0 +1,295 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+JAX tests for the type-erased GemmAmaxSm100 / gemm_amax_wrapper_sm100 API.
+
+JAX arrays are always row-major, so the JAX contract differs from torch in a few
+documented ways: A/B are k-major (mn, k, 1), C is n-major only, batch dim L == 1,
+scale factors are passed in the physical C-contiguous atom shape
+(L, MN', K', 32, 4, 4), and packed fp4 uses a uint8 container tensor.
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+ml_dtypes = pytest.importorskip("ml_dtypes")
+import jax.numpy as jnp
+
+ATOM_M = (32, 4)
+ATOM_K = 4
+
+
+def ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def skip_unless_sm100():
+    if not any(d.platform == "gpu" for d in jax.devices()):
+        pytest.skip("JAX has no CUDA device")
+    from cudnn.tensor_adapter import get_compute_capability
+
+    major, _ = get_compute_capability()
+    if major < 10:
+        pytest.skip(f"Environment not supported: requires compute capability >= 10, found {major}")
+
+
+def make_sf_physical(mn, k, sf_vec_size, sf_dtype, rng):
+    """Build a scale-factor tensor in the physical C-contiguous atom shape
+    (1, MN', K', 32, 4, 4), plus its (mn, k) f32 expansion for the reference.
+
+    The logical torch-style view is this allocation permuted by (3, 4, 1, 5, 2, 0),
+    with mn = a0 + 32*a1 + 128*rm and sf_k = ak + 4*rk.
+    """
+    sf_k = ceil_div(k, sf_vec_size)
+    mn_div = ceil_div(mn, ATOM_M[0] * ATOM_M[1])
+    k_div = ceil_div(sf_k, ATOM_K)
+
+    exponents = rng.integers(-2, 3, size=(1, mn_div, k_div, ATOM_M[0], ATOM_M[1], ATOM_K))
+    sf_np = (2.0**exponents).astype(sf_dtype)
+    sf_f32 = sf_np.astype(np.float32)
+
+    # (rm, rk, a0, a1, ak) -> (rm, a1, a0, rk, ak) -> (mn_padded, sf_k_padded)
+    sf_2d = np.transpose(sf_f32[0], (0, 3, 2, 1, 4)).reshape(mn_div * ATOM_M[0] * ATOM_M[1], k_div * ATOM_K)
+    sf_expanded = np.repeat(sf_2d[:mn, :sf_k], sf_vec_size, axis=1)[:, :k]
+    return sf_np, sf_expanded
+
+
+def make_ab_fp8(mn, k, ab_dtype, rng):
+    """(mn, k, 1) C-contiguous fp8 tensor with values exactly representable in fp8."""
+    values = (rng.integers(-4, 5, size=(mn, k, 1)) * 0.25).astype(np.float32)
+    quantized = values.astype(ab_dtype)
+    return quantized, quantized.astype(np.float32)[:, :, 0]
+
+
+FP4_E2M1_VALUES = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=np.float32)
+
+
+def make_ab_fp4_uint8(mn, k, rng):
+    """(mn, k // 2, 1) C-contiguous uint8 tensor holding packed fp4 (e2m1) pairs,
+    element 0 in the low nibble, plus the (mn, k) f32 decode for the reference."""
+    codes = rng.integers(0, 16, size=(mn, k)).astype(np.uint8)
+    decoded = FP4_E2M1_VALUES[codes & 0x7] * np.where(codes & 0x8, -1.0, 1.0).astype(np.float32)
+    packed = (codes[:, 0::2] | (codes[:, 1::2] << 4)).astype(np.uint8)[:, :, None]
+    return packed, decoded
+
+
+def reference_gemm_amax(a_f32, b_f32, sfa_expanded, sfb_expanded):
+    c_ref = (a_f32 * sfa_expanded) @ (b_f32 * sfb_expanded).T
+    amax_ref = np.max(np.abs(c_ref))
+    return c_ref, amax_ref
+
+
+def device_sync():
+    from cuda.bindings import runtime as cudart
+
+    (err,) = cudart.cudaDeviceSynchronize()
+    assert err == cudart.cudaError_t.cudaSuccess
+
+
+def run_wrapper_and_check(a_np, a_ref, b_np, b_ref, sfa_np, sfa_expanded, sfb_np, sfb_expanded, c_dtype, sf_vec_size, m, n):
+    from cudnn import gemm_amax_wrapper_sm100
+
+    a_dev = jax.device_put(a_np)
+    b_dev = jax.device_put(b_np)
+    sfa_dev = jax.device_put(sfa_np)
+    sfb_dev = jax.device_put(sfb_np)
+    jax.block_until_ready((a_dev, b_dev, sfa_dev, sfb_dev))
+
+    c_ref, amax_ref = reference_gemm_amax(a_ref, b_ref, sfa_expanded, sfb_expanded)
+
+    # Run twice to exercise the compile cache path
+    for _ in range(2):
+        c_dev, amax_dev = gemm_amax_wrapper_sm100(
+            a_tensor=a_dev,
+            b_tensor=b_dev,
+            sfa_tensor=sfa_dev,
+            sfb_tensor=sfb_dev,
+            c_major="n",
+            c_dtype=c_dtype,
+            sf_vec_size=sf_vec_size,
+        )
+        # The kernel runs on the CUDA legacy default stream, outside XLA's tracking
+        device_sync()
+
+        assert c_dev.shape == (m, n, 1)
+        c_out = np.asarray(c_dev).astype(np.float32)[:, :, 0]
+        amax_out = float(np.asarray(amax_dev).reshape(()))
+        np.testing.assert_allclose(c_out, c_ref.astype(np.asarray(c_dev).dtype).astype(np.float32), atol=0.01, rtol=0.01)
+        np.testing.assert_allclose(amax_out, amax_ref, atol=1e-1, rtol=1e-1)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("c_dtype", [np.float32, ml_dtypes.bfloat16])
+def test_gemm_amax_jax_wrapper_fp8(c_dtype):
+    skip_unless_sm100()
+    m, n, k = 512, 256, 256
+    sf_vec_size = 32
+    rng = np.random.default_rng(0)
+
+    a_np, a_ref = make_ab_fp8(m, k, ml_dtypes.float8_e5m2, rng)
+    b_np, b_ref = make_ab_fp8(n, k, ml_dtypes.float8_e5m2, rng)
+    sfa_np, sfa_expanded = make_sf_physical(m, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    sfb_np, sfb_expanded = make_sf_physical(n, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+
+    run_wrapper_and_check(a_np, a_ref, b_np, b_ref, sfa_np, sfa_expanded, sfb_np, sfb_expanded, c_dtype, sf_vec_size, m, n)
+
+
+@pytest.mark.L0
+@pytest.mark.xfail(
+    raises=TypeError,
+    strict=False,
+    reason="The uint8 packed-fp4 container path fails at kernel construction for torch and JAX alike "
+    "(TensorDescs are built before _interpret_uint8_as_fp4x2 is set, so the kernel sees Uint8); "
+    "torch.uint8 is likewise disabled in test_gemm_amax_utils.py. Remove this marker when the container path is fixed.",
+)
+@pytest.mark.parametrize("sf_vec_size", [16, 32])
+def test_gemm_amax_jax_wrapper_fp4_uint8(sf_vec_size):
+    skip_unless_sm100()
+    m, n, k = 512, 256, 256
+    rng = np.random.default_rng(0)
+
+    a_np, a_ref = make_ab_fp4_uint8(m, k, rng)
+    b_np, b_ref = make_ab_fp4_uint8(n, k, rng)
+    sf_dtype = ml_dtypes.float8_e8m0fnu if sf_vec_size == 32 else ml_dtypes.float8_e4m3fn
+    sfa_np, sfa_expanded = make_sf_physical(m, k, sf_vec_size, sf_dtype, rng)
+    sfb_np, sfb_expanded = make_sf_physical(n, k, sf_vec_size, sf_dtype, rng)
+
+    run_wrapper_and_check(a_np, a_ref, b_np, b_ref, sfa_np, sfa_expanded, sfb_np, sfb_expanded, np.float32, sf_vec_size, m, n)
+
+
+@pytest.mark.L0
+def test_gemm_amax_jax_compile_execute_fp8():
+    """Class API with caller-allocated JAX output buffers and an explicit stream."""
+    skip_unless_sm100()
+    from cuda.bindings import driver as cuda
+    from cudnn import GemmAmaxSm100
+
+    m, n, k = 512, 256, 256
+    sf_vec_size = 32
+    rng = np.random.default_rng(1)
+
+    a_np, a_ref = make_ab_fp8(m, k, ml_dtypes.float8_e5m2, rng)
+    b_np, b_ref = make_ab_fp8(n, k, ml_dtypes.float8_e5m2, rng)
+    sfa_np, sfa_expanded = make_sf_physical(m, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    sfb_np, sfb_expanded = make_sf_physical(n, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+
+    a_dev = jax.device_put(a_np)
+    b_dev = jax.device_put(b_np)
+    sfa_dev = jax.device_put(sfa_np)
+    sfb_dev = jax.device_put(sfb_np)
+    c_dev = jnp.zeros((m, n, 1), dtype=jnp.float32)
+    amax_dev = jnp.full((1, 1, 1), -float("inf"), dtype=jnp.float32)
+    jax.block_until_ready((a_dev, b_dev, sfa_dev, sfb_dev, c_dev, amax_dev))
+
+    gemm = GemmAmaxSm100(
+        sample_a=a_dev,
+        sample_b=b_dev,
+        sample_sfa=sfa_dev,
+        sample_sfb=sfb_dev,
+        sample_c=c_dev,
+        sample_amax=amax_dev,
+        sf_vec_size=sf_vec_size,
+    )
+    assert gemm.check_support()
+    gemm.compile()
+    gemm.execute(
+        a_tensor=a_dev,
+        b_tensor=b_dev,
+        sfa_tensor=sfa_dev,
+        sfb_tensor=sfb_dev,
+        c_tensor=c_dev,
+        amax_tensor=amax_dev,
+        current_stream=cuda.CUstream(0),
+    )
+    device_sync()
+
+    c_ref, amax_ref = reference_gemm_amax(a_ref, b_ref, sfa_expanded, sfb_expanded)
+    np.testing.assert_allclose(np.asarray(c_dev)[:, :, 0], c_ref, atol=0.01, rtol=0.01)
+    np.testing.assert_allclose(float(np.asarray(amax_dev).reshape(())), amax_ref, atol=1e-1, rtol=1e-1)
+
+
+@pytest.mark.L0
+def test_gemm_amax_jax_wrapper_errors():
+    skip_unless_sm100()
+    from cudnn import gemm_amax_wrapper_sm100
+
+    m, n, k = 512, 256, 256
+    sf_vec_size = 32
+    rng = np.random.default_rng(2)
+
+    a_np, _ = make_ab_fp8(m, k, ml_dtypes.float8_e5m2, rng)
+    b_np, _ = make_ab_fp8(n, k, ml_dtypes.float8_e5m2, rng)
+    sfa_np, _ = make_sf_physical(m, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    sfb_np, _ = make_sf_physical(n, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+
+    a_dev = jax.device_put(a_np)
+    b_dev = jax.device_put(b_np)
+    sfa_dev = jax.device_put(sfa_np)
+    sfb_dev = jax.device_put(sfb_np)
+
+    with pytest.raises(ValueError, match="row-major"):
+        gemm_amax_wrapper_sm100(a_dev, b_dev, sfa_dev, sfb_dev, c_major="m")
+
+    a_batched = jax.device_put(np.repeat(a_np, 2, axis=2))
+    b_batched = jax.device_put(np.repeat(b_np, 2, axis=2))
+    with pytest.raises(ValueError, match="batch dim L == 1"):
+        gemm_amax_wrapper_sm100(a_batched, b_batched, sfa_dev, sfb_dev)
+
+    with pytest.raises(ValueError, match="Unsupported tensor framework"):
+        gemm_amax_wrapper_sm100(a_np, b_np, sfa_np, sfb_np)
+
+
+@pytest.mark.L0
+def test_gemm_amax_jax_ffi_sm100():
+    """XLA custom-call entry point (jax-tvm-ffi): eager, jitted, cached, and composed."""
+    pytest.importorskip("jax_tvm_ffi")
+    skip_unless_sm100()
+    from cudnn import gemm_amax_jax_sm100
+
+    m, n, k = 512, 256, 256
+    sf_vec_size = 32
+    rng = np.random.default_rng(3)
+
+    a_np, a_ref = make_ab_fp8(m, k, ml_dtypes.float8_e5m2, rng)
+    b_np, b_ref = make_ab_fp8(n, k, ml_dtypes.float8_e5m2, rng)
+    sfa_np, sfa_expanded = make_sf_physical(m, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    sfb_np, sfb_expanded = make_sf_physical(n, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    c_ref, amax_ref = reference_gemm_amax(a_ref, b_ref, sfa_expanded, sfb_expanded)
+
+    a_dev, b_dev, sfa_dev, sfb_dev = (jax.device_put(x) for x in (a_np, b_np, sfa_np, sfb_np))
+
+    def check(c_dev, amax_dev):
+        # XLA orders the custom call on its own stream; block_until_ready is sufficient
+        jax.block_until_ready((c_dev, amax_dev))
+        np.testing.assert_allclose(np.asarray(c_dev)[:, :, 0], c_ref, atol=0.01, rtol=0.01)
+        np.testing.assert_allclose(float(np.asarray(amax_dev).reshape(())), amax_ref, atol=1e-1, rtol=1e-1)
+
+    # Eager
+    check(*gemm_amax_jax_sm100(a_dev, b_dev, sfa_dev, sfb_dev, sf_vec_size=sf_vec_size))
+
+    # Under jax.jit, twice (donation safety + compiled-kernel/registration cache)
+    jitted = jax.jit(lambda a, b, sfa, sfb: gemm_amax_jax_sm100(a, b, sfa, sfb, sf_vec_size=sf_vec_size))
+    check(*jitted(a_dev, b_dev, sfa_dev, sfb_dev))
+    check(*jitted(a_dev, b_dev, sfa_dev, sfb_dev))
+
+    # Composed with surrounding jnp ops in one jitted graph
+    @jax.jit
+    def composed(a, b, sfa, sfb):
+        c, amax = gemm_amax_jax_sm100(a, b, sfa, sfb, sf_vec_size=sf_vec_size)
+        return jnp.sum(c) / amax[0, 0, 0]
+
+    ratio = composed(a_dev, b_dev, sfa_dev, sfb_dev)
+    jax.block_until_ready(ratio)
+    np.testing.assert_allclose(float(ratio), c_ref.sum() / amax_ref, rtol=0.02)
+
+    # Batch dim restriction
+    with pytest.raises(ValueError, match="batch dim L == 1"):
+        gemm_amax_jax_sm100(
+            jax.device_put(np.repeat(a_np, 2, axis=2)),
+            jax.device_put(np.repeat(b_np, 2, axis=2)),
+            sfa_dev,
+            sfb_dev,
+            sf_vec_size=sf_vec_size,
+        )

--- a/test/python/fe_api/gemm/test_gemm_srelu_dsrelu_jax.py
+++ b/test/python/fe_api/gemm/test_gemm_srelu_dsrelu_jax.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+JAX tests for the type-erased GemmSreluSm100 / GemmDsreluSm100 APIs.
+
+Strategy: run each wrapper once with torch tensors and once with JAX arrays built
+from the same bytes, and require bit-identical outputs — the two framework paths
+share one compiled kernel, so any divergence is a metadata/layout bug.
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+ml_dtypes = pytest.importorskip("ml_dtypes")
+torch = pytest.importorskip("torch")
+import jax.numpy as jnp
+
+from fe_api.gemm.test_gemm_amax_jax import device_sync, skip_unless_sm100
+
+from cudnn.api_base import ceil_div
+
+
+def make_inputs(m, n, k, l, sf_vec_size, rng):
+    rest_k = ceil_div(ceil_div(k, sf_vec_size), 4)
+    a_np = rng.standard_normal((m, k, l), dtype=np.float32).astype(ml_dtypes.float8_e4m3fn)
+    b_np = rng.standard_normal((n, k, l), dtype=np.float32).astype(ml_dtypes.float8_e4m3fn)
+    # e8m0 value 1.0 == byte 127; physical C-contiguous atom shape (L, MN', K', 32, 4, 4)
+    sfa_np = np.full((l, ceil_div(m, 128), rest_k, 32, 4, 4), 127, dtype=np.uint8).view(ml_dtypes.float8_e8m0fnu)
+    sfb_np = np.full((l, ceil_div(n, 128), rest_k, 32, 4, 4), 127, dtype=np.uint8).view(ml_dtypes.float8_e8m0fnu)
+    prob_np = rng.random((m, 1, l), dtype=np.float32)
+    return a_np, b_np, sfa_np, sfb_np, prob_np
+
+
+def to_torch(x, dtype):
+    return torch.from_numpy(np.ascontiguousarray(x).view(np.uint8)).view(dtype).reshape(x.shape).cuda()
+
+
+@pytest.mark.L0
+def test_gemm_srelu_jax_matches_torch():
+    skip_unless_sm100()
+    import cudnn
+
+    m, n, k, l = 256, 256, 512, 1
+    sf_vec_size = 32
+    rng = np.random.default_rng(0)
+    a_np, b_np, sfa_np, sfb_np, prob_np = make_inputs(m, n, k, l, sf_vec_size, rng)
+
+    kwargs = dict(c_dtype="bfloat16", d_dtype="bfloat16", sf_vec_size=sf_vec_size)
+    res_t = cudnn.gemm_srelu_wrapper_sm100(
+        a_tensor=to_torch(a_np, torch.float8_e4m3fn),
+        b_tensor=to_torch(b_np, torch.float8_e4m3fn),
+        sfa_tensor=to_torch(sfa_np, torch.float8_e8m0fnu),
+        sfb_tensor=to_torch(sfb_np, torch.float8_e8m0fnu),
+        prob_tensor=torch.from_numpy(prob_np).cuda(),
+        **kwargs,
+    )
+    torch.cuda.synchronize()
+
+    a_j, b_j, sfa_j, sfb_j, prob_j = (jnp.asarray(x) for x in (a_np, b_np, sfa_np, sfb_np, prob_np))
+    jax.block_until_ready((a_j, b_j, sfa_j, sfb_j, prob_j))
+    res_j = cudnn.gemm_srelu_wrapper_sm100(
+        a_tensor=a_j,
+        b_tensor=b_j,
+        sfa_tensor=sfa_j,
+        sfb_tensor=sfb_j,
+        prob_tensor=prob_j,
+        **kwargs,
+    )
+    device_sync()  # eager JAX path runs on the CUDA legacy default stream
+
+    for key in ("c_tensor", "d_tensor"):
+        np.testing.assert_array_equal(
+            np.asarray(res_j[key]).astype(np.float32),
+            res_t[key].float().cpu().numpy(),
+            err_msg=f"srelu {key}: JAX output differs from torch output on identical input bytes",
+        )
+
+
+@pytest.mark.L0
+def test_gemm_dsrelu_jax_matches_torch():
+    skip_unless_sm100()
+    import cudnn
+
+    m, n, k, l = 256, 256, 512, 1
+    sf_vec_size = 32
+    rng = np.random.default_rng(1)
+    a_np, b_np, sfa_np, sfb_np, prob_np = make_inputs(m, n, k, l, sf_vec_size, rng)
+    c_in_np = rng.standard_normal((m, n, l), dtype=np.float32).astype(ml_dtypes.bfloat16)
+
+    kwargs = dict(d_dtype="bfloat16", sf_vec_size=sf_vec_size)
+    res_t = cudnn.gemm_dsrelu_wrapper_sm100(
+        a_tensor=to_torch(a_np, torch.float8_e4m3fn),
+        b_tensor=to_torch(b_np, torch.float8_e4m3fn),
+        c_tensor=to_torch(c_in_np, torch.bfloat16),
+        sfa_tensor=to_torch(sfa_np, torch.float8_e8m0fnu),
+        sfb_tensor=to_torch(sfb_np, torch.float8_e8m0fnu),
+        prob_tensor=torch.from_numpy(prob_np).cuda(),
+        **kwargs,
+    )
+    torch.cuda.synchronize()
+
+    a_j, b_j, c_j, sfa_j, sfb_j, prob_j = (jnp.asarray(x) for x in (a_np, b_np, c_in_np, sfa_np, sfb_np, prob_np))
+    jax.block_until_ready((a_j, b_j, c_j, sfa_j, sfb_j, prob_j))
+    res_j = cudnn.gemm_dsrelu_wrapper_sm100(
+        a_tensor=a_j,
+        b_tensor=b_j,
+        c_tensor=c_j,
+        sfa_tensor=sfa_j,
+        sfb_tensor=sfb_j,
+        prob_tensor=prob_j,
+        **kwargs,
+    )
+    device_sync()
+
+    for key in ("d_tensor", "dprob_tensor"):
+        np.testing.assert_array_equal(
+            np.asarray(res_j[key]).astype(np.float32),
+            res_t[key].float().cpu().numpy(),
+            err_msg=f"dsrelu {key}: JAX output differs from torch output on identical input bytes",
+        )
+
+
+@pytest.mark.L0
+def test_gemm_srelu_dsrelu_jax_errors():
+    skip_unless_sm100()
+    import cudnn
+
+    m, n, k, l = 256, 256, 512, 1
+    rng = np.random.default_rng(2)
+    a_np, b_np, sfa_np, sfb_np, prob_np = make_inputs(m, n, k, l, 32, rng)
+    a_j, b_j, sfa_j, sfb_j, prob_j = (jnp.asarray(x) for x in (a_np, b_np, sfa_np, sfb_np, prob_np))
+
+    with pytest.raises(ValueError, match="row-major"):
+        cudnn.gemm_srelu_wrapper_sm100(a_j, b_j, sfa_j, sfb_j, prob_j, c_major="m", sf_vec_size=32)
+
+    with pytest.raises(ValueError, match="Unsupported tensor framework"):
+        cudnn.gemm_srelu_wrapper_sm100(a_np, b_np, sfa_np, sfb_np, prob_np, sf_vec_size=32)

--- a/test/python/fe_api/gemm/test_gemm_swiglu_jax.py
+++ b/test/python/fe_api/gemm/test_gemm_swiglu_jax.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+JAX tests for the type-erased GemmSwigluSm100 API and the gemm_swiglu_jax_sm100
+XLA custom-call entry point. Same JAX contract as gemm_amax (see
+test_gemm_amax_jax.py): k-major (mn, k, 1) A/B, n-major outputs, L == 1, SF tensors
+in the physical C-contiguous atom shape.
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+ml_dtypes = pytest.importorskip("ml_dtypes")
+import jax.numpy as jnp
+
+from fe_api.gemm.test_gemm_amax_jax import (
+    device_sync,
+    make_ab_fp8,
+    make_sf_physical,
+    skip_unless_sm100,
+)
+
+
+def swiglu_block_ref(ab12_ref, n):
+    """c = input * silu(gate) with 32-column block interleaving (even blocks input, odd gate)."""
+    cols = np.arange(n).reshape(n // 32, 32)
+    input_idx, gate_idx = cols[0::2].reshape(-1), cols[1::2].reshape(-1)
+    gate = ab12_ref[:, gate_idx]
+    return ab12_ref[:, input_idx] * (gate / (1 + np.exp(-gate)))
+
+
+def make_ab_bf16(mn, k, rng):
+    values = (rng.integers(-4, 5, size=(mn, k, 1)) * 0.25).astype(ml_dtypes.bfloat16)
+    return values, values.astype(np.float32)[:, :, 0]
+
+
+@pytest.mark.L0
+def test_gemm_swiglu_jax_wrapper_bf16():
+    """Eager wrapper, non-quantized kernel, bf16 inputs."""
+    skip_unless_sm100()
+    from cudnn import gemm_swiglu_wrapper_sm100
+
+    m, n, k = 256, 256, 256
+    alpha = 1.0
+    rng = np.random.default_rng(0)
+    a_np, a_ref = make_ab_bf16(m, k, rng)
+    b_np, b_ref = make_ab_bf16(n, k, rng)
+    a_dev, b_dev = jax.device_put(a_np), jax.device_put(b_np)
+    jax.block_until_ready((a_dev, b_dev))
+
+    ab12_ref = alpha * (a_ref @ b_ref.T)
+    c_ref = swiglu_block_ref(ab12_ref, n)
+
+    for _ in range(2):  # exercise the compile cache path
+        ab12, c, sfc, amax = gemm_swiglu_wrapper_sm100(
+            a_tensor=a_dev,
+            b_tensor=b_dev,
+            alpha=alpha,
+            c_major="n",
+            ab12_dtype=np.float32,
+            c_dtype=ml_dtypes.bfloat16,
+        )
+        device_sync()  # eager path runs on the CUDA legacy default stream
+        assert sfc is None and amax is None
+        np.testing.assert_allclose(np.asarray(ab12)[:, :, 0], ab12_ref, atol=0.02, rtol=0.02)
+        np.testing.assert_allclose(np.asarray(c).astype(np.float32)[:, :, 0], c_ref, atol=0.05, rtol=0.05)
+
+
+@pytest.mark.L0
+def test_gemm_swiglu_jax_wrapper_quant_fp8():
+    """Eager wrapper, blockscaled quantized kernel, MXFP8 inputs."""
+    skip_unless_sm100()
+    from cudnn import gemm_swiglu_wrapper_sm100
+
+    m, n, k = 256, 256, 256
+    sf_vec_size = 32
+    rng = np.random.default_rng(1)
+    a_np, a_ref = make_ab_fp8(m, k, ml_dtypes.float8_e4m3fn, rng)
+    b_np, b_ref = make_ab_fp8(n, k, ml_dtypes.float8_e4m3fn, rng)
+    sfa_np, sfa_expanded = make_sf_physical(m, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    sfb_np, sfb_expanded = make_sf_physical(n, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    a_dev, b_dev, sfa_dev, sfb_dev = (jax.device_put(x) for x in (a_np, b_np, sfa_np, sfb_np))
+    jax.block_until_ready((a_dev, b_dev, sfa_dev, sfb_dev))
+
+    ab12_ref = (a_ref * sfa_expanded) @ (b_ref * sfb_expanded).T
+    c_ref = swiglu_block_ref(ab12_ref, n)
+
+    ab12, c, sfc, amax = gemm_swiglu_wrapper_sm100(
+        a_tensor=a_dev,
+        b_tensor=b_dev,
+        c_major="n",
+        ab12_dtype=ml_dtypes.bfloat16,
+        c_dtype=ml_dtypes.bfloat16,
+        sfa_tensor=sfa_dev,
+        sfb_tensor=sfb_dev,
+        sf_vec_size=sf_vec_size,
+    )
+    device_sync()
+    assert sfc is None and amax is None
+    np.testing.assert_allclose(np.asarray(ab12).astype(np.float32)[:, :, 0], ab12_ref, atol=0.5, rtol=0.05)
+    np.testing.assert_allclose(np.asarray(c).astype(np.float32)[:, :, 0], c_ref, atol=1.0, rtol=0.05)
+
+
+@pytest.mark.L0
+def test_gemm_swiglu_jax_ffi_sm100():
+    """XLA custom-call entry point: jitted, repeated (donation safety), and alpha attr."""
+    pytest.importorskip("jax_tvm_ffi")
+    skip_unless_sm100()
+    from cudnn import gemm_swiglu_jax_sm100
+
+    m, n, k = 256, 256, 256
+    alpha = 2.0
+    rng = np.random.default_rng(2)
+    a_np, a_ref = make_ab_bf16(m, k, rng)
+    b_np, b_ref = make_ab_bf16(n, k, rng)
+    a_dev, b_dev = jax.device_put(a_np), jax.device_put(b_np)
+
+    ab12_ref = alpha * (a_ref @ b_ref.T)
+    c_ref = swiglu_block_ref(ab12_ref, n)
+
+    jitted = jax.jit(lambda a, b: gemm_swiglu_jax_sm100(a, b, alpha=alpha, ab12_dtype=jnp.float32, c_dtype=jnp.bfloat16))
+    for _ in range(2):
+        ab12, c = jitted(a_dev, b_dev)
+        jax.block_until_ready((ab12, c))  # XLA-stream ordered; no manual device sync needed
+        np.testing.assert_allclose(np.asarray(ab12)[:, :, 0], ab12_ref, atol=0.02, rtol=0.02)
+        np.testing.assert_allclose(np.asarray(c).astype(np.float32)[:, :, 0], c_ref, atol=0.05, rtol=0.05)
+
+    # The quantized (blockscaled) config is eager-wrapper-only for now
+    sf_vec_size = 32
+    a2_np, _ = make_ab_fp8(m, k, ml_dtypes.float8_e4m3fn, rng)
+    b2_np, _ = make_ab_fp8(n, k, ml_dtypes.float8_e4m3fn, rng)
+    sfa_np, _ = make_sf_physical(m, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    sfb_np, _ = make_sf_physical(n, k, sf_vec_size, ml_dtypes.float8_e8m0fnu, rng)
+    a2, b2, sfa, sfb = (jax.device_put(x) for x in (a2_np, b2_np, sfa_np, sfb_np))
+    with pytest.raises(NotImplementedError, match="non-quantized kernel only"):
+        gemm_swiglu_jax_sm100(a2, b2, sfa_tensor=sfa, sfb_tensor=sfb, sf_vec_size=sf_vec_size)
+
+
+@pytest.mark.L0
+def test_gemm_swiglu_jax_wrapper_errors():
+    skip_unless_sm100()
+    from cudnn import gemm_swiglu_wrapper_sm100
+
+    m, n, k = 256, 256, 256
+    rng = np.random.default_rng(3)
+    a_np, _ = make_ab_bf16(m, k, rng)
+    b_np, _ = make_ab_bf16(n, k, rng)
+    a_dev, b_dev = jax.device_put(a_np), jax.device_put(b_np)
+
+    with pytest.raises(ValueError, match="row-major"):
+        gemm_swiglu_wrapper_sm100(a_dev, b_dev, c_major="m")
+
+    a_batched = jax.device_put(np.repeat(a_np, 2, axis=2))
+    b_batched = jax.device_put(np.repeat(b_np, 2, axis=2))
+    with pytest.raises(ValueError, match="batch dim L == 1"):
+        gemm_swiglu_wrapper_sm100(a_batched, b_batched)
+
+    with pytest.raises(ValueError, match="Unsupported tensor framework"):
+        gemm_swiglu_wrapper_sm100(a_np, b_np)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

FE OSS kernels or CuTeDSL (Python API)

## Summary

Two commits:

**Commit 1** type-erases the `gemm_amax` API so it accepts **JAX arrays alongside torch tensors** (torch imported only when torch tensors/dtypes are passed, jax only when JAX arrays are passed), and adds a **`jax.jit`-compatible XLA custom-call entry point** (`gemm_amax_jax_sm100`, via jax-tvm-ffi).

**Commit 2** extends this to **all APIs under `python/cudnn/gemm/cutedsl/`** (~35 files). Every API is now torch-lazy (modules import and public symbols resolve without torch installed); JAX support depends on each kernel's data path:

### Per-API JAX support matrix

| API | torch eager | JAX eager | `jax.jit` (XLA custom call) |
|---|---|---|---|
| `gemm_amax` | ✅ | ✅ | ✅ `gemm_amax_jax_sm100` |
| `gemm_swiglu` | ✅ | ✅ (incl. blockscaled MXFP8) | ✅ `gemm_swiglu_jax_sm100` (non-quantized kernel only¹) |
| `gemm_srelu` | ✅ | ✅ | —¹ |
| `gemm_dsrelu` | ✅ | ✅ | —¹ |
| `gemm_proj_rope_mxfp8` | ✅ | ✖ clear error² | — |
| `grouped_gemm` (unfused) | ✅ | ✖ clear error² | — |
| `grouped_gemm_{swiglu, dswiglu, srelu, dsrelu, glu, dglu, glu_hadamard, quant, wgrad}` | ✅ | ✖ clear error² | — |
| `discrete_grouped_gemm_{swiglu, dswiglu}` | ✅ | ✖ clear error² | — |

¹ Kernels whose compiled signature carries optional None-typed parameters (srelu/dsrelu, quantized swiglu) cannot cross the jax-tvm-ffi bridge yet — it has no way to supply `None` (a missing-attr probe hard-crashes). These raise `NotImplementedError` pointing at the eager wrappers; unlocking them is an upstream jax-tvm-ffi feature request.
² Torch-only data paths (device pointer arrays from `.data_ptr()`, torch workspaces, torch stream contexts; proj_rope additionally uses `from_dlpack(x.detach())`). Their public entry points reject non-torch tensors up front with `ValueError("... currently supports torch tensors only; JAX support is not yet implemented for this API")` instead of failing deep inside pointer/workspace machinery. Real JAX support there requires redesigning that machinery (framework-neutral workspace allocation, a pointer-extraction story for JAX buffers) and is future work.

JAX dtype note (dense fusions): fp8 flavors (`float8_e4m3fn/e5m2/e8m0fnu` via ml_dtypes) are fully supported; packed fp4 is not reachable from JAX (no packed-fp4 JAX dtype, and the `uint8` container path fails at kernel construction for torch and JAX alike — xfailed tests document it).

### Eager vs jit trade-off (JAX-supported APIs)

| | Eager (type-erased wrappers/classes) | `gemm_amax_jax_sm100` / `gemm_swiglu_jax_sm100` (XLA custom call) |
|---|---|---|
| Model | imperative, destination-passing: caller owns buffers and stream | functional: XLA owns buffers/stream, returns fresh arrays |
| Stream | CUDA legacy default stream (XLA does not track it) → sync before reading outputs | XLA's compute stream — correctly ordered, no manual sync |
| Under `jax.jit` | not usable (tracers have no buffers) | designed for it; registered `allow_cuda_graph=True` |
| CPU cost/launch (SM100, fp8 512×256×256, GPU kernel ~5.7 µs) | **15 µs** JAX / 4.9 µs torch | ~48 µs standalone (XLA dispatch dominated); **~5.3 µs/kernel e2e amortized** in a jitted graph |
| Best for | eager hot loops, benchmarking, interop | jitted programs, composing with other XLA ops |

Shared infrastructure: `cudnn/tensor_adapter.py` (framework detection via `sys.modules` probing — never imports a framework on another's behalf; shape/stride/device readers; torch-free compute-capability query) and `cudnn/gemm/cutedsl/_jax_ffi.py` (row-major descriptors from tracer avals, env-stream compile + XLA target registry; scalar params like swiglu's `alpha` pass as XLA call attributes via `arg_spec=["args", "attrs.alpha"]`).

## Why

The CuTeDSL data path is already framework-neutral: kernels compile with `--enable-tvm-ffi` against fake cute tensors built from metadata, and real tensors reach the compiled callable via DLPack. Only metadata reading, the dtype vocabulary, stream defaulting, and output allocation were torch-bound. Removing that coupling lets JAX users call the same kernels without importing torch, and the jax.ffi entry points give jitted programs correct XLA stream ordering and buffer management. Where real JAX support isn't feasible yet (grouped pointer-array/workspace machinery), failing fast with a clear error beats failing deep inside `.data_ptr()` calls.

## Related issues

None.

## API and compatibility impact

- **torch users: zero behavior change** across all APIs (verified suite-wide, see Testing). Two deliberate strictly-wider acceptances on the dense fusions: (1) unit-dim stride canonicalization means C-contiguous `l=1` torch tensors that previously failed stride checks now pass (the tvm-ffi ABI ignores strides of extent-1 dims); (2) `check_support` error messages on dense fusions spell dtypes as cutlass types — accept/reject behavior unchanged.
- **New public symbols**: `gemm_amax_jax_sm100`, `gemm_swiglu_jax_sm100` (lazy exports; require jax + jax-tvm-ffi, Python ≥ 3.11). Dense-fusion dtype parameters accept torch dtypes, numpy/ml_dtypes dtypes, dtype name strings, or cutlass types.
- **JAX contract** (dense fusions; JAX arrays are row-major, immutable-by-contract): A/B k-major `(M, K, 1)`/`(N, K, 1)`; outputs n-major only; batch `L == 1` only; SF tensors accepted in the torch logical atom view *or* the byte-identical physical C-contiguous `(L, MN', K', 32, 4, 4)` shape (both forms, either framework — safe because the kernels rebuild SF layouts from A/B shapes and use only base pointers).
- Grouped/discrete/proj_rope entry points raise `ValueError("... currently supports torch tensors only ...")` for non-torch tensors — previously they would fail with framework-specific attribute errors deep in the call.
- Packaging: `torch` and `jax` PEP 735 dependency groups (`pip install --group jax`); the `cutedsl` extra is unchanged.
- GPU/CUDA requirements unchanged (SM100+); no C++ or backend changes.

## Testing

On a B200-class SM100 (CC 10.0), Python 3.12, torch 2.13+cu130, jax 0.11 + jax-tvm-ffi 0.1.3, nvidia-cutlass-dsl 4.6. All comparisons are against a pristine baseline worktree at the parent commit, same environment:

```bash
cd test/python
# Dense suite: failure list byte-identical to baseline (64 known env-numerics failures);
# 783 passed (+20 = exactly the new JAX/guard tests), 518 skipped, 2 xfailed:
pytest fe_api/gemm/ -q
# Grouped/discrete suite: identical counts both trees --
# 634 passed, 509 skipped, 2 pre-existing collection errors
# (test_grouped_gemm_{glu,dglu}.py import util modules that do not exist upstream):
pytest fe_api/grouped_gemm/ -q --continue-on-collection-errors
# New JAX tests: 25 passed, 2 xfailed
pytest fe_api/gemm/test_gemm_amax_jax.py fe_api/gemm/test_gemm_swiglu_jax.py \
       fe_api/gemm/test_gemm_srelu_dsrelu_jax.py fe_api/gemm/test_cutedsl_jax_guards.py -q
```

New test coverage: swiglu eager bf16 + blockscaled MXFP8 wrapper paths and the jitted entry point (donation safety, static alpha); srelu/dsrelu **bit-identical cross-framework runs** (JAX and torch wrappers on identical input bytes must agree exactly — they share one compiled kernel); all 13 torch-only public wrappers reject JAX arrays with the clear error (one guard test per API). Import hygiene: all 39 `gemm.cutedsl` lazy exports resolve with torch poisoned out of `sys.modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)