### PR TITLE
dsa(indexer_backward): restore `range_constexpr` in 8 `kernel_gemm` epilogue loops

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py
@@ -1074,7 +1074,7 @@ class IndexerBackwardSm100:
         s_full_1_phase = Int32(0)
 
         dw_accum = cute.make_rmem_tensor(tSrS_shape, Float32)
-        for ei in cutlass.range(cute.size(dw_accum), unroll_full=True):
+        for ei in cutlass.range_constexpr(cute.size(dw_accum)):
             dw_accum[ei] = Float32(0.0)
 
         tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
@@ -1129,16 +1129,16 @@ class IndexerBackwardSm100:
 
             # Phase 2: Convert dS f32→bf16, write to sdS via coordinate mapping.
             tSrS_f16 = cute.make_rmem_tensor(tSrS.shape, self.q_dtype)
-            for ei in cutlass.range(cute.size(tSrS), unroll_full=True):
+            for ei in cutlass.range_constexpr(cute.size(tSrS)):
                 tSrS_f16[ei] = self.q_dtype(tSrS[ei])
 
             if bi % 2 == 0:
-                for ei in cutlass.range(cute.size(tSrS_f16), unroll_full=True):
+                for ei in cutlass.range_constexpr(cute.size(tSrS_f16)):
                     h = cute.get(tCcS[ei], mode=[0, 0])
                     n = cute.get(tCcS[ei], mode=[0, 1])
                     sdS_gemm_view_0[h, n] = tSrS_f16[ei]
             else:
-                for ei in cutlass.range(cute.size(tSrS_f16), unroll_full=True):
+                for ei in cutlass.range_constexpr(cute.size(tSrS_f16)):
                     h = cute.get(tCcS[ei], mode=[0, 0])
                     n = cute.get(tCcS[ei], mode=[0, 1])
                     sdS_gemm_view_1[h, n] = tSrS_f16[ei]
@@ -1159,7 +1159,7 @@ class IndexerBackwardSm100:
         cute.copy(tiled_tmem_load_dq, tDqDq_t2r, tDQrDQ)
 
         tDQrDQ_bf16 = cute.make_rmem_tensor(tDQrDQ.shape, self.q_dtype)
-        for ei in cutlass.range(cute.size(tDQrDQ), unroll_full=True):
+        for ei in cutlass.range_constexpr(cute.size(tDQrDQ)):
             tDQrDQ_bf16[ei] = self.q_dtype(tDQrDQ[ei] * Float32(sm_scale))
 
         cute.arch.fence_view_async_tmem_load()
@@ -1169,7 +1169,7 @@ class IndexerBackwardSm100:
             sdQ_epi_slice,
             cute.make_layout((self.heads_padded, self.head_dim_padded)),
         )
-        for ei in cutlass.range(cute.size(tDQrDQ_bf16), unroll_full=True):
+        for ei in cutlass.range_constexpr(cute.size(tDQrDQ_bf16)):
             h = cute.get(tCcDQ[ei], mode=[0, 0])
             d = cute.get(tCcDQ[ei], mode=[0, 1])
             sdQ_gemm_view[h, d] = tDQrDQ_bf16[ei]
@@ -1188,7 +1188,7 @@ class IndexerBackwardSm100:
         for h_local in cutlass.range_constexpr(HEADS_PER_WARP):
             h = warp_base_h + h_local
             my_partial = Float32(0.0)
-            for ei in cutlass.range(cute.size(dw_accum), unroll_full=True):
+            for ei in cutlass.range_constexpr(cute.size(dw_accum)):
                 if cute.get(tCcS[ei], mode=[0, 0]) == h:
                     my_partial = my_partial + dw_accum[ei]
             total = cute.arch.warp_reduction_sum(my_partial)
@@ -1257,7 +1257,7 @@ class IndexerBackwardSm100:
             # local→global when topk_indices_global=False); gmem fallback
             # mirrors that conversion via const_expr branch.
             batch_offset_l2g = Int32(0) if const_expr(self.topk_indices_global) else batch_idx * (seqlen_k // batch_size)
-            for pair in cutlass.range(cute.size(tDKrDK) // 2, unroll_full=True):
+            for pair in cutlass.range_constexpr(cute.size(tDKrDK) // 2):
                 ei = pair * 2
                 n = cute.get(tCcDK[ei], mode=[0, 0])
                 d = cute.get(tCcDK[ei], mode=[0, 1])


### PR DESCRIPTION
Fixes #548 (SM100 DSA indexer backward: `kernel_gemm`
pure-kernel latency regressed 17.5-25.4% after the `range_constexpr` ->
`range(..., unroll_full=True)` migration).

## What

Reverts exactly 8 loops in the `kernel_gemm` compute/reduce epilogues of
`python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py`
from `cutlass.range(..., unroll_full=True)` back to
`cutlass.range_constexpr(...)`. No other changes; the one-shot barrier fix
from #426 is untouched. An analogous ninth migration site in
`kernel_score_grad` was measured separately and shows no runtime difference
(49.70 us vs 49.73 us at the anchor shape), so it is intentionally left
unchanged - see the issue.

Both forms fully unroll the loop body: `range_constexpr` unrolls at trace
time, while `range(..., unroll_full=True)` lowers through the DSL
structured-control-flow path. In this configuration the migrated form
produced the higher latencies in the issue; this PR restores the
pre-migration form for exactly these 8 loops. See the issue for the full
isolation trail (grad-signal-recipe insensitivity, 1.26.0 wheel anchor, and a
single-migration revert probe on the public commit 3fcee36).

## Verification (B200 sm_100a, driver 590.48.01, CUDA 13.3, cutlass-dsl 4.6.1)

Performance - canonical seeded harness (B=1, H=64, D=128, S_k=4096), nsys
pure-kernel median, N=60 per variant, both variants interleaved per-iteration
in one profiling session; anchor shape S_q=8192/topk=1024:

| build | kernel_gemm med | develop / build |
|---|---|---|
| develop @ 11c16ff | 2056.9 us | 1.000 |
| this PR | 1688.8 us | **1.218** |
| 1.26.0 wheel (reference anchor, isolated session) | 1691.8 us | - |

Stated in both directions: develop has **21.8% higher latency** than this PR;
this PR has **17.9% lower latency** than develop. Across S_q {4096, 8192} x
topk {512, 1024, 1536, 2048} the same harness measures develop 17.5-25.4%
higher at every shape (full table with standard deviations in the issue).

Compile-time tradeoff (disclosed): `range_constexpr` raises time-to-first-call
with a cold DSL JIT cache from ~3.5 s to ~5.2 s at the anchor shape (one-time
per compiled shape); at 368 us saved per call it amortizes after ~4600 calls.

Numerics - no numerical regression observed:

- `d_index_q`, `d_weights` (kernel_gemm): **bitwise identical** to develop on
  the canonical harness at both S_q=8192/topk=1024 and S_q=4096/topk=512.
- `d_index_k` uses fp32 atomicAdd and is nondeterministic run-to-run: the
  develop-vs-PR difference (max_abs 6.7e-08, rms_rel 3.9e-07 at the anchor
  shape) is comparable in scale to same-build rerun differences
  (develop-develop max_abs 6.7e-08 / rms_rel 3.1e-07; PR-PR 6.0e-08 /
  3.3e-07).

Tests / lint:

- `test/python/fe_api/dsa/test_DSA_indexer_backward.py` and
  `test_DSA_dense_indexer_backward.py`: 3 passed.
- Full `fe_api/dsa/`: 81 passed, 7 skipped, 2 pre-existing failures in
  `test_DSA_indexer_top_k.py` that reproduce identically on unmodified develop
  (unrelated module).
- `pre-commit run` (pinned config: black 26.3.1, line-length 160): passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved compile-time loop handling for sparse attention indexing operations.
  * Preserved existing computation, memory access, synchronization, and reduction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->