### PR TITLE
Add JAX support to block_sparse_attention (SM100/SM110 blk128 paths, stacked on #553)

### DIFF
--- a/docs/fe-oss-apis/bsa.md
+++ b/docs/fe-oss-apis/bsa.md
@@ -2,6 +2,25 @@
 
 **This is an experimental API and subject to change.**
 
+## JAX support
+
+The tensor parameters are type-erased: torch tensors and JAX arrays are both
+accepted (torch is imported only when torch tensors are passed, jax only when
+JAX arrays are passed). JAX arrays are supported on the **SM100/SM110 blk128
+forward and backward paths** in both `bhsd` and `bshd` layouts; the SM90/SM120
+and blk64 backends (and their `kv_splits`/`use_clc` options) reject JAX inputs
+with clear errors.
+
+- Outputs (`o`/`lse`, `dq`/`dk`/`dv`) are allocated as C-contiguous `jnp`
+  arrays in the caller's layout; pre-allocated JAX output buffers are also
+  accepted.
+- The backward's internal transposed tensor views travel as zero-copy permuted
+  DLPack wrappers (JAX has no strided views; see
+  `cudnn.tensor_adapter.permuted_view`) — no extra copies relative to torch.
+- Eager only, on the **CUDA legacy default stream** (XLA does not track it):
+  `jax.block_until_ready(...)` your inputs before calling, and synchronize the
+  device before reading outputs.
+
 ## Overview
 
 Block Sparse Attention computes non-causal scaled dot-product attention over a

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -7,6 +7,7 @@ The GEMM CuTeDSL APIs are type-erased and torch-lazy: torch is imported only whe
 - **Dense fusions** (amax, swiglu, srelu, dsrelu): full JAX eager support, plus `jax.jit`-compatible XLA custom-call entry points for all four (built on `cudnn.jax.call` / CuTeDSL's native `cutlass.jax` bridge; see `gemm_amax.md` "Using JAX arrays").
 - **Grouped / discrete-grouped**: JAX eager support in discrete (pointer-array) weight modes — unfused grouped GEMM, glu/dglu (BF16), dsrelu (FP8), wgrad (BF16), and discrete-grouped swiglu/dswiglu (FP8) — plus a `jax.jit`-compatible `*_jax_sm100` entry point for each of those same families (built on `cudnn.jax.call`; each API page documents its exact jit contract). Dense weight mode, column-major bias layouts, and kernels whose scale factors are MMA-permuted tensor arguments (grouped swiglu/srelu/quant/dswiglu, glu_hadamard, block-scaled glu/dglu/wgrad backends) reject JAX with clear errors.
 - **proj_rope_mxfp8**: JAX eager support on both input paths with `w_out_in=True` (the transposed [in, out] weight view is torch-only), plus the `jax.jit`-compatible `gemm_proj_rope_mxfp8_jax_sm100` entry point.
+- **Block Sparse Attention (BSA)**: JAX eager support on the SM100/SM110 blk128 forward and backward paths, both layouts (see `bsa.md` "JAX support"); the SM90/SM120 and blk64 backends reject JAX with clear errors.
 
 This folder documents the Python FE APIs implemented under `python/cudnn`. For details on currently implemented operations, see:
 - [GEMM + Amax](gemm_fusions/gemm_amax.md)

--- a/python/cudnn/block_sparse_attention/_interface.py
+++ b/python/cudnn/block_sparse_attention/_interface.py
@@ -2,11 +2,18 @@
 # SPDX-License-Identifier: MIT
 # BSA attention interface for SM90/SM100 block-sparse kernels.
 
+from __future__ import annotations
+
 import math
 from functools import lru_cache
 from typing import Optional, Tuple
 
-import torch
+try:
+    # torch is optional: only the torch tensor paths need it. JAX callers (the
+    # SM100/SM110 blk128 paths) must be able to import this module without it.
+    import torch
+except ImportError:  # pragma: no cover - exercised by torch-free JAX installs
+    torch = None
 
 import cuda.bindings.driver as cuda
 
@@ -14,6 +21,18 @@ import cutlass
 import cutlass.cute as cute
 from cutlass import Int32, Float32
 from cutlass.cute.runtime import from_dlpack
+
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import (
+    allocate_tensor,
+    default_stream,
+    detect_framework,
+    get_compute_capability,
+    get_shape,
+    get_strides,
+    is_torch_tensor,
+    permuted_view,
+)
 
 from cudnn.block_sparse_attention.csrc.fwd.sm100_blk128.bsa_fwd_sm100 import (
     BlockSparseAttnForwardSm100Blk128,
@@ -77,27 +96,57 @@ from cudnn.block_sparse_attention.csrc.bwd.bucketed_k2q_csr import build_buckete
 
 @lru_cache(maxsize=None)
 def _get_device_arch_for_device(device_index: int):
-    major, minor = torch.cuda.get_device_capability(device_index)
+    if torch is not None and torch.cuda.is_available():
+        major, minor = torch.cuda.get_device_capability(device_index)
+    else:
+        major, minor = get_compute_capability()
     return major * 10 + int(minor)
 
 
 def _get_device_arch():
-    return _get_device_arch_for_device(torch.cuda.current_device())
+    device_index = torch.cuda.current_device() if torch is not None and torch.cuda.is_available() else 0
+    return _get_device_arch_for_device(device_index)
+
+
+def _maybe_detach(t):
+    """Detach torch autograd-tracked tensors before DLPack export; no-op otherwise."""
+    detach = getattr(t, "detach", None)
+    return detach() if callable(detach) else t
+
+
+def _nvtx_range(is_torch: bool, name: str):
+    if is_torch:
+        return torch.cuda.nvtx.range(name)
+    import contextlib
+
+    return contextlib.nullcontext()
+
+
+def _dim_order(t) -> tuple[int, ...]:
+    """torch.Tensor.dim_order() semantics for any framework tensor (outermost first)."""
+    dim_order = getattr(t, "dim_order", None)
+    if callable(dim_order):
+        return tuple(dim_order())
+    shape, strides = get_shape(t), get_strides(t)
+    return tuple(reversed(sorted(range(len(shape)), key=lambda i: (strides[i], shape[i]))))
 
 
 def maybe_contiguous(x):
-    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
+    if x is None or not is_torch_tensor(x):
+        # JAX arrays are always compact in their axis order; nothing to do.
+        return x
+    return x.contiguous() if x.stride(-1) != 1 else x
 
 
 def _to_cute_tensor(
-    t: torch.Tensor,
+    t,
     assumed_align: Optional[int] = 16,
     leading_dim: int = -1,
     fully_dynamic: bool = False,
     enable_tvm_ffi: bool = True,
 ) -> cute.Tensor:
     tensor = from_dlpack(
-        t.detach(),
+        _maybe_detach(t),
         assumed_align=assumed_align,
         enable_tvm_ffi=enable_tvm_ffi,
     )
@@ -109,7 +158,7 @@ def _to_cute_tensor(
 
 
 def _to_cute_tensor_dynamic_compact_shape(
-    t: torch.Tensor,
+    t,
     mode: int | tuple[int, ...],
     assumed_align: int = 16,
     leading_dim: int = -1,
@@ -119,7 +168,7 @@ def _to_cute_tensor_dynamic_compact_shape(
     tensor = _to_cute_tensor(t, assumed_align=assumed_align, leading_dim=leading_dim)
     if isinstance(mode, int):
         mode = (mode,)
-    stride_order = t.dim_order() if stride_order is None else stride_order
+    stride_order = _dim_order(t) if stride_order is None else stride_order
     for mode_i in mode:
         tensor = tensor.mark_compact_shape_dynamic(
             mode=mode_i,
@@ -137,13 +186,7 @@ def _to_sm90_bwd_cute_tensor(t: torch.Tensor, assumed_align: int = 16, enable_tv
     )
 
 
-torch2cute_dtype_map = {
-    torch.float16: cutlass.Float16,
-    torch.bfloat16: cutlass.BFloat16,
-    torch.float32: cutlass.Float32,
-}
-
-_SM100_BLK64_INT32_MAX = torch.iinfo(torch.int32).max
+_SM100_BLK64_INT32_MAX = 2**31 - 1
 
 
 def _sm100_blk64_require_int32(name: str, value: int) -> int:
@@ -225,32 +268,33 @@ def _sm100_blk64_requires_int64_kv_strides(
     return False
 
 
-def _tensor_layout_compile_key(t: torch.Tensor):
-    return (tuple(t.dim_order()), tuple(s == 0 for s in t.stride()))
+def _tensor_layout_compile_key(t):
+    return (_dim_order(t), tuple(s == 0 for s in get_strides(t)))
 
 
-def _tensor_static_compile_key(t: torch.Tensor):
+def _tensor_static_compile_key(t):
     """Capture the static tensor type used by unmarked CuTe DLPack tensors."""
-    return (t.dtype, tuple(t.shape), tuple(t.stride()))
+    return (_convert_to_cutlass_data_type(t.dtype), get_shape(t), get_strides(t))
 
 
-def _tensor_dynamic_layout_compile_key(t: torch.Tensor, leading_dim: int = -1):
+def _tensor_dynamic_layout_compile_key(t, leading_dim: int = -1):
     """Match the static rank/dtype/broadcast parts of mark_layout_dynamic()."""
+    strides = get_strides(t)
     if leading_dim == -1:
-        leading_dim = t.ndim - 1
+        leading_dim = len(strides) - 1
     return (
-        t.dtype,
-        t.ndim,
+        _convert_to_cutlass_data_type(t.dtype),
+        len(strides),
         int(leading_dim),
-        int(t.stride(leading_dim)),
-        tuple(s == 0 for s in t.stride()),
+        int(strides[leading_dim]),
+        tuple(s == 0 for s in strides),
     )
 
 
 def _dynamic_tensors_compile_key(
     namespace: str,
     config: tuple,
-    tensors: tuple[Optional[torch.Tensor], ...],
+    tensors: tuple,
     leading_dims: Optional[tuple[int, ...]] = None,
 ):
     if leading_dims is None:
@@ -672,7 +716,7 @@ def _bsa_attn_fwd_sm90_blk64(
         value_dim=v.shape[-1],
         blocksparse_blocksize_q=SM90_FWD_BLOCK_SIZE,
         blocksparse_blocksize_k=SM90_FWD_BLOCK_SIZE,
-        dtype=torch2cute_dtype_map[q.dtype],
+        dtype=_convert_to_cutlass_data_type(q.dtype),
         acc_dtype=cutlass.Float32,
         has_block_sizes=has_block_sizes,
         num_splits=kv_splits,
@@ -826,7 +870,7 @@ def _bsa_attn_fwd_sm120_blk64(
         value_dim=v.shape[-1],
         blocksparse_blocksize_q=SM120_FWD_BLOCK_SIZE,
         blocksparse_blocksize_k=SM120_FWD_BLOCK_SIZE,
-        dtype=torch2cute_dtype_map[q.dtype],
+        dtype=_convert_to_cutlass_data_type(q.dtype),
         acc_dtype=cutlass.Float32,
         has_block_sizes=has_block_sizes,
         has_block_nums=has_block_nums,
@@ -926,7 +970,7 @@ def _combine_blk64_kv_bucketed_partials(
         dtype=torch.float32,
         device=q.device,
     )
-    dtype = torch2cute_dtype_map[q.dtype]
+    dtype = _convert_to_cutlass_data_type(q.dtype)
     log_max_splits = _ceil_log2_int(kv_splits)
     # Baseline combine geometry; a single configuration is easier to maintain.
     combine_tile_m = 16
@@ -1073,6 +1117,8 @@ def bsa_attn_fwd_blk64_cutedsl(
     kv_splits: int | str = 1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """BSA forward attention through an independent blk64 CuTeDSL kernel class."""
+    if not is_torch_tensor(q):
+        raise ValueError("JAX arrays are supported only on the SM100/SM110 blk128 forward path; the blk64 path requires torch tensors")
     assert q.dtype == torch.bfloat16, "blk64 CuTeDSL requires bf16"
     assert q.is_cuda and k.is_cuda and v.is_cuda
     assert q.dim() == 4 and k.dim() == 4 and v.dim() == 4
@@ -1145,7 +1191,7 @@ def bsa_attn_fwd_blk64_cutedsl(
     if softmax_scale is None:
         softmax_scale = head_dim**-0.5
 
-    dtype = torch2cute_dtype_map[q_bhsd.dtype]
+    dtype = _convert_to_cutlass_data_type(q_bhsd.dtype)
     arch = _get_device_arch()
     allow_empty_block_nums = has_variable_block_nums and allow_empty_block_nums
     sparse_block_size = 64
@@ -1374,6 +1420,8 @@ def bsa_attn_fwd(
         layout: "bhsd" (default) or "bshd". Output follows the same layout as input.
     """
     assert layout in ("bhsd", "bshd"), f"layout must be 'bhsd' or 'bshd', got {layout!r}"
+    framework = detect_framework(q)
+    is_torch = framework == "torch"
     q, k, v = [maybe_contiguous(t) for t in (q, k, v)]
     if layout == "bhsd":
         batch_size, num_head, seqlen_q, head_dim = q.shape
@@ -1387,25 +1435,29 @@ def bsa_attn_fwd(
     assert batch_k == batch_size and batch_v == batch_size
     assert seqlen_k_v == seqlen_k and num_head_kv_v == num_head_kv
     assert head_dim_k == head_dim
-    assert q.dtype in [torch.float16, torch.bfloat16], "inputs must be float16 or bfloat16"
-    assert q.dtype == k.dtype == v.dtype, "inputs must have the same dtype"
+    q_cutlass_dtype = _convert_to_cutlass_data_type(q.dtype)
+    assert q_cutlass_dtype in (cutlass.Float16, cutlass.BFloat16), "inputs must be float16 or bfloat16"
+    assert q_cutlass_dtype == _convert_to_cutlass_data_type(k.dtype) == _convert_to_cutlass_data_type(v.dtype), "inputs must have the same dtype"
 
-    assert all(t.is_cuda for t in (q, k, v)), "inputs must be on CUDA device"
+    if is_torch:
+        assert all(t.is_cuda for t in (q, k, v)), "inputs must be on CUDA device"
 
     arch = _get_device_arch()
     assert arch // 10 in [9, 10, 11, 12], "BSA only supports SM90/SM100/SM110/SM120"
     assert num_head % num_head_kv == 0
+    if not is_torch and arch // 10 not in (10, 11):
+        raise ValueError("JAX arrays are supported only on the SM100/SM110 blk128 forward path; pass torch tensors for the other backends")
 
     # Block-sparse parameter validation
-    assert q2k_block_index.dtype == torch.int32, "q2k_block_index must be int32"
+    assert _convert_to_cutlass_data_type(q2k_block_index.dtype) == cutlass.Int32, "q2k_block_index must be int32"
     q2k_block_index = maybe_contiguous(q2k_block_index)
     has_block_sizes = block_sizes is not None
     if has_block_sizes:
-        assert block_sizes.dtype == torch.int32, "block_sizes must be int32"
+        assert _convert_to_cutlass_data_type(block_sizes.dtype) == cutlass.Int32, "block_sizes must be int32"
         block_sizes = maybe_contiguous(block_sizes)
     if q2k_block_nums is not None:
         q2k_block_nums = maybe_contiguous(q2k_block_nums)
-        assert q2k_block_nums.dtype == torch.int32, "q2k_block_nums must be int32"
+        assert _convert_to_cutlass_data_type(q2k_block_nums.dtype) == cutlass.Int32, "q2k_block_nums must be int32"
         assert q2k_block_nums.ndim == 3, f"q2k_block_nums must be 3D (batch, num_heads, num_q_blocks), got {q2k_block_nums.ndim}D"
     else:
         if arch // 10 in (9, 12):
@@ -1527,34 +1579,37 @@ def bsa_attn_fwd(
 
     qhead_per_kvhead = num_head // num_head_kv
 
-    out_torch_dtype = q.dtype
     device = q.device
     lse_shape = (batch_size, num_head, seqlen_q)
-    requires_grad = q.requires_grad or k.requires_grad or v.requires_grad
+    requires_grad = is_torch and (q.requires_grad or k.requires_grad or v.requires_grad)
 
     if out is None:
         out_shape = (batch_size, num_head, seqlen_q, head_dim_v) if layout == "bhsd" else (batch_size, seqlen_q, num_head, head_dim_v)
-        out = torch.empty(out_shape, dtype=out_torch_dtype, device=device)
+        out = allocate_tensor(framework, out_shape, q.dtype, device)
     else:
         expected_out_shape = (batch_size, num_head, seqlen_q, head_dim_v) if layout == "bhsd" else (batch_size, seqlen_q, num_head, head_dim_v)
         assert out.shape == expected_out_shape
 
     if lse is None:
-        lse = torch.empty(lse_shape, dtype=torch.float32, device=device) if requires_grad or return_lse else None
+        lse = allocate_tensor(framework, lse_shape, cutlass.Float32, device) if requires_grad or return_lse else None
 
-    dtype = torch2cute_dtype_map[q.dtype]
+    dtype = _convert_to_cutlass_data_type(q.dtype)
 
-    current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    if is_torch:
+        current_stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
+    else:
+        # JAX arrays carry no stream; launch on the CUDA legacy default stream.
+        current_stream = default_stream(framework)
 
     has_variable_block_nums = q2k_block_nums is not None
     if layout == "bhsd":
         q_kernel, k_kernel, v_kernel, out_kernel = q, k, v, out
     else:
         q_kernel, k_kernel, v_kernel, out_kernel = (
-            q.transpose(1, 2),
-            k.transpose(1, 2),
-            v.transpose(1, 2),
-            out.transpose(1, 2),
+            permuted_view(q, (0, 2, 1, 3)),
+            permuted_view(k, (0, 2, 1, 3)),
+            permuted_view(v, (0, 2, 1, 3)),
+            permuted_view(out, (0, 2, 1, 3)),
         )
     bsa_fwd_kernel = BlockSparseAttnForwardSm100Blk128(
         head_dim,
@@ -1632,18 +1687,18 @@ def bsa_attn_fwd(
             options="--enable-tvm-ffi",
         )
 
-    with torch.cuda.nvtx.range("bsa_attn_fwd_kernel"):
+    with _nvtx_range(is_torch, "bsa_attn_fwd_kernel"):
         bsa_attn_fwd.compile_cache[compile_key](
-            q_kernel.detach(),
-            k_kernel.detach(),
-            v_kernel.detach(),
-            out_kernel.detach(),
+            _maybe_detach(q_kernel),
+            _maybe_detach(k_kernel),
+            _maybe_detach(v_kernel),
+            _maybe_detach(out_kernel),
             lse,
             softmax_scale,
-            q2k_block_index.detach(),
-            block_sizes.detach() if has_block_sizes else None,
+            _maybe_detach(q2k_block_index),
+            _maybe_detach(block_sizes) if has_block_sizes else None,
             block_sparse_num,
-            q2k_block_nums.detach() if has_variable_block_nums else None,
+            _maybe_detach(q2k_block_nums) if has_variable_block_nums else None,
             current_stream,
         )
 
@@ -1713,13 +1768,16 @@ def bsa_attn_bwd(
           to FA4's SM100 128x128 backward kernel with BSA block-sparse metadata.
     """
     assert layout in ("bhsd", "bshd"), f"layout must be 'bhsd' or 'bshd', got {layout!r}"
+    framework = detect_framework(q)
+    is_torch = framework == "torch"
     q, k, v, out, dout = [maybe_contiguous(t) for t in (q, k, v, out, dout)]
     lse = maybe_contiguous(lse)
 
-    assert q.dtype == torch.bfloat16, "bwd only supports bfloat16"
-    assert q.dtype == k.dtype == v.dtype == out.dtype == dout.dtype
-    assert lse.dtype == torch.float32
-    assert all(t.is_cuda for t in (q, k, v, out, dout, lse))
+    assert _convert_to_cutlass_data_type(q.dtype) == cutlass.BFloat16, "bwd only supports bfloat16"
+    assert all(_convert_to_cutlass_data_type(t.dtype) == cutlass.BFloat16 for t in (k, v, out, dout))
+    assert _convert_to_cutlass_data_type(lse.dtype) == cutlass.Float32
+    if is_torch:
+        assert all(t.is_cuda for t in (q, k, v, out, dout, lse))
 
     if layout == "bhsd":
         batch_size, num_heads, seqlen_q, head_dim = q.shape
@@ -1731,19 +1789,28 @@ def bsa_attn_bwd(
         batch_size, seqlen_q, num_heads, head_dim = q.shape
         batch_k, seqlen_k, num_heads_kv, head_dim_k = k.shape
         batch_v, seqlen_v, num_heads_v, head_dim_v = v.shape
+        if not is_torch:
+            # JAX has no strided views; allocate the gradients in the caller's
+            # layout up front so the kernel writes through permuted views of the
+            # arrays that are returned (the views below are DLPack wrappers).
+            dq = allocate_tensor(framework, q.shape, q.dtype, q.device) if dq is None else dq
+            dk = allocate_tensor(framework, k.shape, k.dtype, q.device) if dk is None else dk
+            dv = allocate_tensor(framework, v.shape, v.dtype, q.device) if dv is None else dv
         q_bwd, k_bwd, v_bwd, out_bwd, dout_bwd = (
-            q.transpose(1, 2),
-            k.transpose(1, 2),
-            v.transpose(1, 2),
-            out.transpose(1, 2),
-            dout.transpose(1, 2),
+            permuted_view(q, (0, 2, 1, 3)),
+            permuted_view(k, (0, 2, 1, 3)),
+            permuted_view(v, (0, 2, 1, 3)),
+            permuted_view(out, (0, 2, 1, 3)),
+            permuted_view(dout, (0, 2, 1, 3)),
         )
-        dq_bwd = dq.transpose(1, 2) if dq is not None else None
-        dk_bwd = dk.transpose(1, 2) if dk is not None else None
-        dv_bwd = dv.transpose(1, 2) if dv is not None else None
+        dq_bwd = permuted_view(dq, (0, 2, 1, 3)) if dq is not None else None
+        dk_bwd = permuted_view(dk, (0, 2, 1, 3)) if dk is not None else None
+        dv_bwd = permuted_view(dv, (0, 2, 1, 3)) if dv is not None else None
 
     arch = _get_device_arch()
     assert arch // 10 in [9, 10, 11], "BSA bwd only supports SM90/SM100/SM110"
+    if not is_torch and arch // 10 not in (10, 11):
+        raise ValueError("JAX arrays are supported only on the SM100/SM110 blk128 backward path; pass torch tensors for the other backends")
     if arch // 10 == 9:
         bwd_head_dim = SM90_BWD_HEAD_DIM
         if sparse_block_size is None:
@@ -1784,25 +1851,25 @@ def bsa_attn_bwd(
     assert q.shape == out.shape == dout.shape == expected_q_shape
     assert k.shape == v.shape == expected_kv_shape
     if dq is not None:
-        assert dq.shape == expected_q_shape and dq.dtype == q.dtype
-        assert dq.is_cuda
+        assert tuple(dq.shape) == expected_q_shape and _convert_to_cutlass_data_type(dq.dtype) == _convert_to_cutlass_data_type(q.dtype)
+        assert not is_torch or dq.is_cuda
     if dk is not None:
-        assert dk.shape == expected_kv_shape and dk.dtype == k.dtype
-        assert dk.is_cuda
+        assert tuple(dk.shape) == expected_kv_shape and _convert_to_cutlass_data_type(dk.dtype) == _convert_to_cutlass_data_type(k.dtype)
+        assert not is_torch or dk.is_cuda
     if dv is not None:
-        assert dv.shape == expected_kv_shape and dv.dtype == v.dtype
-        assert dv.is_cuda
+        assert tuple(dv.shape) == expected_kv_shape and _convert_to_cutlass_data_type(dv.dtype) == _convert_to_cutlass_data_type(v.dtype)
+        assert not is_torch or dv.is_cuda
     assert lse.shape == (batch_size, num_heads, seqlen_q)
 
     num_q_blocks = (seqlen_q + sparse_block_size - 1) // sparse_block_size
     num_kv_blocks = (seqlen_k + sparse_block_size - 1) // sparse_block_size
 
-    assert q2k_block_index.dtype == torch.int32
+    assert _convert_to_cutlass_data_type(q2k_block_index.dtype) == cutlass.Int32
     assert q2k_block_index.shape[:3] == (batch_size, num_heads, num_q_blocks), (
         f"q2k_block_index has shape {tuple(q2k_block_index.shape)}, expected " f"(b={batch_size}, h={num_heads}, num_q_blocks={num_q_blocks}, max_kv_blocks)"
     )
     if q2k_block_nums is not None:
-        assert q2k_block_nums.dtype == torch.int32
+        assert _convert_to_cutlass_data_type(q2k_block_nums.dtype) == cutlass.Int32
         assert q2k_block_nums.shape == (batch_size, num_heads, num_q_blocks)
     else:
         assert q2k_block_index.shape[-1] >= block_sparse_num, (
@@ -1840,12 +1907,19 @@ def bsa_attn_bwd(
             dv=dv_bwd,
         )
         if layout == "bshd":
+            if not is_torch:
+                # The kernel wrote through permuted DLPack views of the caller-layout
+                # arrays pre-allocated above; return the real arrays.
+                return dq, dk, dv
             return (
                 dq_out.transpose(1, 2),
                 dk_out.transpose(1, 2),
                 dv_out.transpose(1, 2),
             )
         return dq_out, dk_out, dv_out
+
+    if not is_torch:
+        raise ValueError("JAX arrays are supported only on the SM100/SM110 blk128 backward path; pass torch tensors for the blk64 backends")
 
     if bucket_size_blocks is None:
         bucket_size_blocks = sm90_bwd_auto_bucketed_k2q_size_blocks(num_q_blocks) if arch // 10 == 9 else sm100_bwd_auto_bucketed_k2q_size_blocks(num_q_blocks)
@@ -1996,7 +2070,7 @@ def _bsa_attn_bwd_bucketed_k2q_csr(
 
         block_sizes_sm90 = variable_block_sizes if has_block_sizes else None
 
-        dtype = torch2cute_dtype_map[q.dtype]
+        dtype = _convert_to_cutlass_data_type(q.dtype)
         workspace = _empty_bwd_workspace_with_zeroed_accum(
             batch_size=batch_size,
             num_heads=num_heads,

--- a/python/cudnn/block_sparse_attention/api.py
+++ b/python/cudnn/block_sparse_attention/api.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 from typing import Optional
 
-import torch
+import cutlass
 
 from cudnn.api_base import TupleDict
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import detect_framework, get_device, get_shape, get_strides, is_torch_tensor
 
 
 def _validate_layout(layout: str) -> None:
@@ -17,18 +19,32 @@ def _validate_layout(layout: str) -> None:
         raise ValueError(f"layout must be 'bhsd' or 'bshd', got {layout!r}")
 
 
-def _canonical_shapes(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, layout: str):
+def _is_cuda(tensor) -> bool:
+    return get_device(tensor).type == "cuda"
+
+
+def _same_device(a, b) -> bool:
+    return get_device(a) == get_device(b)
+
+
+def _validate_framework(framework: str, name: str = "block sparse attention") -> None:
+    if framework not in ("torch", "jax"):
+        raise ValueError(f"Unsupported tensor framework '{framework}' for {name}; pass torch tensors or JAX arrays")
+
+
+def _canonical_shapes(q, k, v, layout: str):
     _validate_layout(layout)
-    if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+    q_shape, k_shape, v_shape = get_shape(q), get_shape(k), get_shape(v)
+    if len(q_shape) != 4 or len(k_shape) != 4 or len(v_shape) != 4:
         raise ValueError("q, k, and v must all be rank-4 tensors")
     if layout == "bhsd":
-        b, h_q, s_q, d_qk = q.shape
-        b_k, h_kv, s_k, d_k = k.shape
-        b_v, h_v, s_v, d_v = v.shape
+        b, h_q, s_q, d_qk = q_shape
+        b_k, h_kv, s_k, d_k = k_shape
+        b_v, h_v, s_v, d_v = v_shape
     else:
-        b, s_q, h_q, d_qk = q.shape
-        b_k, s_k, h_kv, d_k = k.shape
-        b_v, s_v, h_v, d_v = v.shape
+        b, s_q, h_q, d_qk = q_shape
+        b_k, s_k, h_kv, d_k = k_shape
+        b_v, s_v, h_v, d_v = v_shape
     if min(b, h_q, h_kv, s_q, s_k, d_qk, d_v) < 1:
         raise ValueError("q, k, and v dimensions must all be positive")
     if (b_k, b_v) != (b, b):
@@ -39,60 +55,82 @@ def _canonical_shapes(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, layout:
         raise ValueError("q and k head dimensions must match")
     if h_q % h_kv != 0:
         raise ValueError("the number of query heads must be divisible by the number of KV heads")
-    if q.dtype not in {torch.float16, torch.bfloat16} or q.dtype != k.dtype or q.dtype != v.dtype:
+    q_dtype = _convert_to_cutlass_data_type(q.dtype)
+    if q_dtype not in (cutlass.Float16, cutlass.BFloat16) or any(_convert_to_cutlass_data_type(t.dtype) != q_dtype for t in (k, v)):
         raise ValueError("q, k, and v must have the same float16 or bfloat16 dtype")
-    if any(t.stride(-1) != 1 for t in (q, k, v)):
+    if any(get_strides(t)[-1] != 1 for t in (q, k, v)):
         raise ValueError("q, k, and v must have a contiguous head dimension")
-    if not all(t.is_cuda for t in (q, k, v)):
+    if not all(_is_cuda(t) for t in (q, k, v)):
         raise RuntimeError("block sparse attention requires CUDA tensors")
-    if any(t.device != q.device for t in (k, v)):
+    if any(not _same_device(t, q) for t in (k, v)):
         raise ValueError("q, k, and v must be on the same CUDA device")
     return b, h_q, h_kv, s_q, s_k, d_qk, d_v
 
 
 def _validate_sparse_metadata(
-    q2k_block_index: torch.Tensor,
-    q2k_block_nums: Optional[torch.Tensor],
-    block_sizes: Optional[torch.Tensor],
+    q2k_block_index,
+    q2k_block_nums,
+    block_sizes,
     *,
     expected_prefix: tuple[int, int, int],
     num_kv_blocks: int,
-    device: torch.device,
+    reference,
     allowed_block_size_ranks: tuple[int, ...],
 ) -> None:
-    if q2k_block_index.ndim != 4 or q2k_block_index.dtype != torch.int32:
+    index_shape = get_shape(q2k_block_index)
+    if len(index_shape) != 4 or _convert_to_cutlass_data_type(q2k_block_index.dtype) != cutlass.Int32:
         raise ValueError("q2k_block_index must be a rank-4 int32 tensor")
-    if tuple(q2k_block_index.shape[:3]) != expected_prefix:
-        raise ValueError("q2k_block_index shape prefix must be " f"{expected_prefix}, got {tuple(q2k_block_index.shape[:3])}")
-    if q2k_block_index.shape[-1] < 1:
+    if index_shape[:3] != expected_prefix:
+        raise ValueError("q2k_block_index shape prefix must be " f"{expected_prefix}, got {index_shape[:3]}")
+    if index_shape[-1] < 1:
         raise ValueError("q2k_block_index must have a non-empty KV-block capacity")
-    if not q2k_block_index.is_cuda or q2k_block_index.device != device:
+    if not _is_cuda(q2k_block_index) or not _same_device(q2k_block_index, reference):
         raise ValueError("q2k_block_index must be on the same CUDA device as q")
     if q2k_block_nums is not None:
-        if q2k_block_nums.ndim != 3 or q2k_block_nums.dtype != torch.int32:
+        nums_shape = get_shape(q2k_block_nums)
+        if len(nums_shape) != 3 or _convert_to_cutlass_data_type(q2k_block_nums.dtype) != cutlass.Int32:
             raise ValueError("q2k_block_nums must be a rank-3 int32 tensor")
-        if tuple(q2k_block_nums.shape) != expected_prefix:
-            raise ValueError(f"q2k_block_nums shape must be {expected_prefix}, got {tuple(q2k_block_nums.shape)}")
-        if not q2k_block_nums.is_cuda or q2k_block_nums.device != device:
+        if nums_shape != expected_prefix:
+            raise ValueError(f"q2k_block_nums shape must be {expected_prefix}, got {nums_shape}")
+        if not _is_cuda(q2k_block_nums) or not _same_device(q2k_block_nums, reference):
             raise ValueError("q2k_block_nums must be on the same CUDA device as q")
     if block_sizes is not None:
-        if block_sizes.dtype != torch.int32:
+        sizes_shape = get_shape(block_sizes)
+        if _convert_to_cutlass_data_type(block_sizes.dtype) != cutlass.Int32:
             raise ValueError("block_sizes must have dtype int32")
-        if block_sizes.ndim not in allowed_block_size_ranks:
-            raise ValueError(f"block_sizes rank must be one of {allowed_block_size_ranks}, got {block_sizes.ndim}")
+        if len(sizes_shape) not in allowed_block_size_ranks:
+            raise ValueError(f"block_sizes rank must be one of {allowed_block_size_ranks}, got {len(sizes_shape)}")
         expected_shapes = {
             1: (num_kv_blocks,),
             2: (expected_prefix[0], num_kv_blocks),
             3: (expected_prefix[0], expected_prefix[1], num_kv_blocks),
         }
-        if tuple(block_sizes.shape) != expected_shapes[block_sizes.ndim]:
-            raise ValueError(f"block_sizes shape must be {expected_shapes[block_sizes.ndim]}, " f"got {tuple(block_sizes.shape)}")
-        if not block_sizes.is_cuda or block_sizes.device != device:
+        if sizes_shape != expected_shapes[len(sizes_shape)]:
+            raise ValueError(f"block_sizes shape must be {expected_shapes[len(sizes_shape)]}, " f"got {sizes_shape}")
+        if not _is_cuda(block_sizes) or not _same_device(block_sizes, reference):
             raise ValueError("block_sizes must be on the same CUDA device as q")
 
 
-def _device_arch(tensor: torch.Tensor) -> int:
-    major, minor = torch.cuda.get_device_capability(tensor.device)
+def _device_context(tensor):
+    """torch: bind the CUDA device of ``tensor`` for the call; JAX: no-op (single-context)."""
+    if is_torch_tensor(tensor):
+        import torch
+
+        return torch.cuda.device(tensor.device)
+    import contextlib
+
+    return contextlib.nullcontext()
+
+
+def _device_arch(tensor) -> int:
+    if is_torch_tensor(tensor):
+        import torch
+
+        major, minor = torch.cuda.get_device_capability(tensor.device)
+    else:
+        from cudnn.tensor_adapter import get_compute_capability
+
+        major, minor = get_compute_capability()
     return major * 10 + minor
 
 
@@ -110,26 +148,27 @@ def _validate_fixed_block_count(
 
 
 def _validate_backward_tensors(
-    do_tensor: torch.Tensor,
-    q_tensor: torch.Tensor,
-    o_tensor: torch.Tensor,
-    lse_tensor: torch.Tensor,
-    dq_tensor: Optional[torch.Tensor],
-    dk_tensor: Optional[torch.Tensor],
-    dv_tensor: Optional[torch.Tensor],
-    k_tensor: torch.Tensor,
-    v_tensor: torch.Tensor,
+    do_tensor,
+    q_tensor,
+    o_tensor,
+    lse_tensor,
+    dq_tensor,
+    dk_tensor,
+    dv_tensor,
+    k_tensor,
+    v_tensor,
 ) -> None:
-    if do_tensor.shape != o_tensor.shape or o_tensor.shape != q_tensor.shape:
+    if get_shape(do_tensor) != get_shape(o_tensor) or get_shape(o_tensor) != get_shape(q_tensor):
         raise ValueError("do_tensor, o_tensor, and q_tensor must have identical shapes")
-    if do_tensor.dtype != q_tensor.dtype or o_tensor.dtype != q_tensor.dtype:
+    q_dtype = _convert_to_cutlass_data_type(q_tensor.dtype)
+    if _convert_to_cutlass_data_type(do_tensor.dtype) != q_dtype or _convert_to_cutlass_data_type(o_tensor.dtype) != q_dtype:
         raise ValueError("do_tensor and o_tensor must have the same dtype as q_tensor")
-    if lse_tensor.dtype != torch.float32:
+    if _convert_to_cutlass_data_type(lse_tensor.dtype) != cutlass.Float32:
         raise ValueError("lse_tensor must have dtype float32")
     tensors = (do_tensor, o_tensor, lse_tensor)
-    if not all(t.is_cuda and t.device == q_tensor.device for t in tensors):
+    if not all(_is_cuda(t) and _same_device(t, q_tensor) for t in tensors):
         raise ValueError("do_tensor, o_tensor, and lse_tensor must be on the same CUDA device as q")
-    if do_tensor.stride(-1) != 1 or o_tensor.stride(-1) != 1:
+    if get_strides(do_tensor)[-1] != 1 or get_strides(o_tensor)[-1] != 1:
         raise ValueError("do_tensor and o_tensor must have a contiguous head dimension")
     expected_outputs = (
         (dq_tensor, q_tensor, "dq_tensor"),
@@ -139,20 +178,20 @@ def _validate_backward_tensors(
     for output, reference, name in expected_outputs:
         if output is None:
             continue
-        if output.shape != reference.shape or output.dtype != reference.dtype:
+        if get_shape(output) != get_shape(reference) or _convert_to_cutlass_data_type(output.dtype) != _convert_to_cutlass_data_type(reference.dtype):
             raise ValueError(f"{name} must match the corresponding input shape and dtype")
-        if not output.is_cuda or output.device != q_tensor.device or output.stride(-1) != 1:
+        if not _is_cuda(output) or not _same_device(output, q_tensor) or get_strides(output)[-1] != 1:
             raise ValueError(f"{name} must be on the same CUDA device as q with a contiguous head dimension")
 
 
 def block_sparse_attention_forward(
-    q_tensor: torch.Tensor,
-    k_tensor: torch.Tensor,
-    v_tensor: torch.Tensor,
-    q2k_block_index: torch.Tensor,
+    q_tensor,
+    k_tensor,
+    v_tensor,
+    q2k_block_index,
     block_sparse_num: Optional[int] = None,
-    block_sizes: Optional[torch.Tensor] = None,
-    q2k_block_nums: Optional[torch.Tensor] = None,
+    block_sizes=None,
+    q2k_block_nums=None,
     *,
     sparse_block_size: Optional[int] = None,
     allow_empty_block_nums: bool = False,
@@ -170,8 +209,15 @@ def block_sparse_attention_forward(
 
     Sparse metadata values are a caller contract; see the "Sparse metadata"
     section of ``docs/fe-oss-apis/bsa.md`` for the required value ranges.
+
+    Tensor parameters are type-erased: torch tensors and JAX arrays are both
+    accepted (torch is imported only for torch tensors). JAX arrays are
+    supported on the SM100/SM110 blk128 path only; see the "JAX support"
+    section of ``docs/fe-oss-apis/bsa.md``.
     """
 
+    framework = detect_framework(q_tensor)
+    _validate_framework(framework, "block_sparse_attention_forward")
     batch, num_q_heads, num_kv_heads, seqlen_q, seqlen_k, head_dim, value_dim = _canonical_shapes(q_tensor, k_tensor, v_tensor, layout)
     arch = _device_arch(q_tensor)
     arch_family = arch // 10
@@ -182,6 +228,11 @@ def block_sparse_attention_forward(
         sparse_block_size = 64 if arch_family in {9, 12} else 128
     if sparse_block_size not in {64, 128}:
         raise ValueError("sparse_block_size must be 64 or 128")
+    if framework == "jax" and not (arch_family in {10, 11} and sparse_block_size == 128):
+        raise ValueError(
+            "JAX arrays are supported only on the SM100/SM110 blk128 forward path "
+            f"(got SM{arch}, sparse_block_size={sparse_block_size}); pass torch tensors for the other backends"
+        )
     if arch_family == 9:
         if isinstance(kv_splits, str) or not 1 <= int(kv_splits) <= 256:
             raise ValueError("SM90 kv_splits must be an integer in [1, 256]")
@@ -197,7 +248,7 @@ def block_sparse_attention_forward(
         if head_dim != 128 or value_dim != 128:
             raise NotImplementedError("SM120 forward requires QK and V dimensions of 128")
     elif sparse_block_size == 64:
-        if q_tensor.dtype != torch.bfloat16 or head_dim != 128 or value_dim != 128:
+        if _convert_to_cutlass_data_type(q_tensor.dtype) != cutlass.BFloat16 or head_dim != 128 or value_dim != 128:
             raise NotImplementedError("SM100/SM110 blk64 forward requires BF16 and QK=V=128")
         if num_q_heads != num_kv_heads:
             raise NotImplementedError("SM100/SM110 blk64 forward supports MHA only")
@@ -227,21 +278,21 @@ def block_sparse_attention_forward(
         block_sizes,
         expected_prefix=expected_prefix,
         num_kv_blocks=num_kv_blocks,
-        device=q_tensor.device,
+        reference=q_tensor,
         allowed_block_size_ranks=allowed_block_size_ranks,
     )
 
     if block_sparse_num is None:
-        block_sparse_num = int(q2k_block_index.shape[-1])
+        block_sparse_num = int(get_shape(q2k_block_index)[-1])
     if q2k_block_nums is None:
         require_even = arch_family in {10, 11} and sparse_block_size == 128
         _validate_fixed_block_count(
             block_sparse_num,
-            q2k_block_index.shape[-1],
+            get_shape(q2k_block_index)[-1],
             require_even=require_even,
         )
 
-    with torch.cuda.device(q_tensor.device):
+    with _device_context(q_tensor):
         from . import _interface
 
         if sparse_block_size == 64 and arch_family in {10, 11}:
@@ -284,21 +335,21 @@ def block_sparse_attention_forward(
 
 
 def block_sparse_attention_backward(
-    do_tensor: torch.Tensor,
-    q_tensor: torch.Tensor,
-    k_tensor: torch.Tensor,
-    v_tensor: torch.Tensor,
-    o_tensor: torch.Tensor,
-    lse_tensor: torch.Tensor,
-    q2k_block_index: torch.Tensor,
+    do_tensor,
+    q_tensor,
+    k_tensor,
+    v_tensor,
+    o_tensor,
+    lse_tensor,
+    q2k_block_index,
     block_sparse_num: Optional[int] = None,
-    block_sizes: Optional[torch.Tensor] = None,
-    q2k_block_nums: Optional[torch.Tensor] = None,
+    block_sizes=None,
+    q2k_block_nums=None,
     *,
     softmax_scale: Optional[float] = None,
-    dq_tensor: Optional[torch.Tensor] = None,
-    dk_tensor: Optional[torch.Tensor] = None,
-    dv_tensor: Optional[torch.Tensor] = None,
+    dq_tensor=None,
+    dk_tensor=None,
+    dv_tensor=None,
     bucket_size_blocks: Optional[int] = None,
     sparse_block_size: Optional[int] = None,
     layout: str = "bhsd",
@@ -307,14 +358,21 @@ def block_sparse_attention_backward(
 
     Sparse metadata values are a caller contract; see the "Sparse metadata"
     section of ``docs/fe-oss-apis/bsa.md`` for the required value ranges.
+
+    Tensor parameters are type-erased: torch tensors and JAX arrays are both
+    accepted (torch is imported only for torch tensors). JAX arrays are
+    supported on the SM100/SM110 blk128 path only; see the "JAX support"
+    section of ``docs/fe-oss-apis/bsa.md``.
     """
 
+    framework = detect_framework(q_tensor)
+    _validate_framework(framework, "block_sparse_attention_backward")
     batch, num_q_heads, num_kv_heads, seqlen_q, seqlen_k, head_dim, value_dim = _canonical_shapes(q_tensor, k_tensor, v_tensor, layout)
     arch = _device_arch(q_tensor)
     arch_family = arch // 10
     if arch_family not in {9, 10, 11}:
         raise RuntimeError(f"block sparse attention backward requires SM90-SM110, found SM{arch}")
-    if q_tensor.dtype != torch.bfloat16:
+    if _convert_to_cutlass_data_type(q_tensor.dtype) != cutlass.BFloat16:
         raise NotImplementedError("block sparse attention backward requires BF16")
     if num_q_heads != num_kv_heads:
         raise NotImplementedError("block sparse attention backward supports MHA only")
@@ -325,6 +383,11 @@ def block_sparse_attention_backward(
         sparse_block_size = 64 if arch_family == 9 else 128
     if sparse_block_size not in {64, 128}:
         raise ValueError("sparse_block_size must be 64 or 128")
+    if framework == "jax" and not (arch_family in {10, 11} and sparse_block_size == 128):
+        raise ValueError(
+            "JAX arrays are supported only on the SM100/SM110 blk128 backward path "
+            f"(got SM{arch}, sparse_block_size={sparse_block_size}); pass torch tensors for the other backends"
+        )
     if arch_family == 9 and sparse_block_size != 64:
         raise NotImplementedError("SM90 backward only provides a blk64 path")
     if sparse_block_size == 64 and head_dim != 128:
@@ -345,21 +408,21 @@ def block_sparse_attention_backward(
         block_sizes,
         expected_prefix=expected_prefix,
         num_kv_blocks=(seqlen_k + sparse_block_size - 1) // sparse_block_size,
-        device=q_tensor.device,
+        reference=q_tensor,
         allowed_block_size_ranks=(1, 2),
     )
     if block_sparse_num is None:
-        block_sparse_num = int(q2k_block_index.shape[-1])
+        block_sparse_num = int(get_shape(q2k_block_index)[-1])
     if q2k_block_nums is None:
         _validate_fixed_block_count(
             block_sparse_num,
-            q2k_block_index.shape[-1],
+            get_shape(q2k_block_index)[-1],
             require_even=sparse_block_size == 128,
         )
 
     expected_lse_shape = (batch, num_q_heads, seqlen_q)
-    if tuple(lse_tensor.shape) != expected_lse_shape:
-        raise ValueError(f"lse_tensor shape must be {expected_lse_shape}, got {tuple(lse_tensor.shape)}")
+    if get_shape(lse_tensor) != expected_lse_shape:
+        raise ValueError(f"lse_tensor shape must be {expected_lse_shape}, got {get_shape(lse_tensor)}")
     _validate_backward_tensors(
         do_tensor,
         q_tensor,
@@ -372,7 +435,7 @@ def block_sparse_attention_backward(
         v_tensor,
     )
 
-    with torch.cuda.device(q_tensor.device):
+    with _device_context(q_tensor):
         from . import _interface
 
         dq, dk, dv = _interface.bsa_attn_bwd(

--- a/python/cudnn/block_sparse_attention/csrc/bwd/bsa_bwd_prepost.py
+++ b/python/cudnn/block_sparse_attention/csrc/bwd/bsa_bwd_prepost.py
@@ -5,7 +5,12 @@ import os
 import re
 from functools import lru_cache
 
-import torch
+try:
+    # torch is optional: only the torch tensor paths need it. JAX callers must
+    # be able to import this module without it.
+    import torch
+except ImportError:  # pragma: no cover - exercised by torch-free JAX installs
+    torch = None
 
 import cutlass.cute as cute
 from cutlass import Float32, Int32
@@ -29,13 +34,19 @@ def _parse_arch_str(arch_str: str) -> int:
 def _get_device_arch_for_device(device_index: int, arch_override: str | None):
     if arch_override is not None:
         return _parse_arch_str(arch_override)
-    major, minor = torch.cuda.get_device_capability(device_index)
+    if torch is not None and torch.cuda.is_available():
+        major, minor = torch.cuda.get_device_capability(device_index)
+    else:
+        from cudnn.tensor_adapter import get_compute_capability
+
+        major, minor = get_compute_capability()
     return major * 10 + int(minor)
 
 
 def _get_device_arch():
+    device_index = torch.cuda.current_device() if torch is not None and torch.cuda.is_available() else 0
     return _get_device_arch_for_device(
-        torch.cuda.current_device(),
+        device_index,
         os.environ.get("CUDNN_BSA_ARCH", None),
     )
 

--- a/python/cudnn/block_sparse_attention/csrc/bwd/bucketed_k2q_csr.py
+++ b/python/cudnn/block_sparse_attention/csrc/bwd/bucketed_k2q_csr.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from typing import Optional, Tuple
 
 import cutlass
@@ -8,7 +10,11 @@ import cutlass.cute as cute
 from cutlass import Int32, const_expr
 from cutlass.cute.runtime import from_dlpack
 import cuda.bindings.driver as cuda
-import torch
+
+from cudnn.datatypes import _convert_to_cutlass_data_type
+from cudnn.tensor_adapter import allocate_tensor, default_stream, detect_framework, get_shape, is_torch_tensor
+
+_INT32_MAX = 2**31 - 1
 
 
 class BucketedK2QCsrUniversal:
@@ -242,74 +248,75 @@ def _bucketed_k2q_csr_compile_key(
     )
 
 
-def _to_cute_tensor(tensor: torch.Tensor) -> cute.Tensor:
+def _maybe_detach(t):
+    detach = getattr(t, "detach", None)
+    return detach() if callable(detach) else t
+
+
+def _to_cute_tensor(tensor) -> cute.Tensor:
     return from_dlpack(
-        tensor.detach(),
+        _maybe_detach(tensor),
         assumed_align=4,
         enable_tvm_ffi=True,
     ).mark_layout_dynamic(leading_dim=tensor.ndim - 1)
 
 
 def build_bucketed_k2q_csr_cutedsl(
-    q2k_block_index: torch.Tensor,
+    q2k_block_index,
     block_sparse_num: int,
     num_kv_blocks: int,
     *,
     bucket_size_blocks: int,
-    q2k_block_nums: Optional[torch.Tensor] = None,
-) -> Tuple[torch.Tensor, torch.Tensor, int, int]:
+    q2k_block_nums=None,
+) -> Tuple:
     """Build bucketed K-to-Q CSR metadata with CuTe DSL kernels."""
-    assert q2k_block_index.dtype == torch.int32
-    assert q2k_block_index.is_cuda
+    framework = detect_framework(q2k_block_index)
+    is_torch = framework == "torch"
+    assert _convert_to_cutlass_data_type(q2k_block_index.dtype) == cutlass.Int32
+    assert not is_torch or q2k_block_index.is_cuda
     assert q2k_block_index.ndim == 4
     assert bucket_size_blocks > 0
     assert num_kv_blocks > 0
 
     batch_size, num_heads, num_q_blocks, max_kv_blocks = q2k_block_index.shape
     assert num_q_blocks > 0
-    q2k_block_index = q2k_block_index.contiguous()
+    if is_torch:
+        q2k_block_index = q2k_block_index.contiguous()
     has_variable_block_nums = q2k_block_nums is not None
     if has_variable_block_nums:
         assert q2k_block_nums is not None
-        assert q2k_block_nums.dtype == torch.int32
-        assert q2k_block_nums.shape == (batch_size, num_heads, num_q_blocks)
-        assert q2k_block_nums.is_cuda
-        assert q2k_block_nums.device == q2k_block_index.device
-        q2k_block_nums = q2k_block_nums.contiguous()
+        assert _convert_to_cutlass_data_type(q2k_block_nums.dtype) == cutlass.Int32
+        assert get_shape(q2k_block_nums) == (batch_size, num_heads, num_q_blocks)
+        assert not is_torch or (q2k_block_nums.is_cuda and q2k_block_nums.device == q2k_block_index.device)
+        if is_torch:
+            q2k_block_nums = q2k_block_nums.contiguous()
         max_edges = num_q_blocks * max_kv_blocks
     else:
         assert 0 <= block_sparse_num <= max_kv_blocks
         q2k_block_nums = q2k_block_index
         max_edges = num_q_blocks * int(block_sparse_num)
 
-    assert max_edges <= torch.iinfo(torch.int32).max
+    assert max_edges <= _INT32_MAX
     max_edges = max(1, max_edges)
     num_q_groups = (num_q_blocks + bucket_size_blocks - 1) // bucket_size_blocks
     device = q2k_block_index.device
-    counts = torch.zeros(
-        (batch_size, num_heads, num_q_groups, num_kv_blocks),
-        dtype=torch.int32,
-        device=device,
-    )
-    local_offsets = torch.empty(
-        (batch_size, num_heads, num_q_groups, num_kv_blocks + 1),
-        dtype=torch.int32,
-        device=device,
-    )
-    group_totals = torch.empty(
-        (batch_size, num_heads, num_q_groups),
-        dtype=torch.int32,
-        device=device,
-    )
-    bucketed_k2q_offsets = torch.empty_like(local_offsets)
-    cursors = torch.empty_like(counts)
-    bucketed_k2q_indices = torch.empty(
-        (batch_size, num_heads, max_edges),
-        dtype=torch.int32,
-        device=device,
-    )
+    counts = allocate_tensor(framework, (batch_size, num_heads, num_q_groups, num_kv_blocks), cutlass.Int32, device, zero=True)
+    local_offsets = allocate_tensor(framework, (batch_size, num_heads, num_q_groups, num_kv_blocks + 1), cutlass.Int32, device)
+    group_totals = allocate_tensor(framework, (batch_size, num_heads, num_q_groups), cutlass.Int32, device)
+    bucketed_k2q_offsets = allocate_tensor(framework, (batch_size, num_heads, num_q_groups, num_kv_blocks + 1), cutlass.Int32, device)
+    cursors = allocate_tensor(framework, (batch_size, num_heads, num_q_groups, num_kv_blocks), cutlass.Int32, device)
+    bucketed_k2q_indices = allocate_tensor(framework, (batch_size, num_heads, max_edges), cutlass.Int32, device)
 
-    current_stream = cuda.CUstream(torch.cuda.current_stream(q2k_block_index.device).cuda_stream)
+    if is_torch:
+        import torch
+
+        current_stream = cuda.CUstream(torch.cuda.current_stream(q2k_block_index.device).cuda_stream)
+        device_capability = torch.cuda.get_device_capability(q2k_block_index.device)
+    else:
+        from cudnn.tensor_adapter import get_compute_capability
+
+        current_stream = default_stream(framework)
+        device_capability = get_compute_capability()
     tensors = (
         counts,
         local_offsets,
@@ -320,7 +327,6 @@ def build_bucketed_k2q_csr_cutedsl(
         q2k_block_index,
         q2k_block_nums,
     )
-    device_capability = torch.cuda.get_device_capability(q2k_block_index.device)
     compile_key = _bucketed_k2q_csr_compile_key(
         device_capability,
         block_sparse_num,

--- a/python/cudnn/block_sparse_attention/csrc/bwd/sm100_blk128/bsa_bwd_sm100.py
+++ b/python/cudnn/block_sparse_attention/csrc/bwd/sm100_blk128/bsa_bwd_sm100.py
@@ -1,12 +1,19 @@
 # Copyright (c) 2025, Ted Zadouri, Markus Hoehnerbach, Jay Shah, Tri Dao.
 # SPDX-License-Identifier: MIT
+from __future__ import annotations
+
 import math
 from typing import Callable, NamedTuple, Optional, Tuple
 from functools import partial
 
 import cuda.bindings.driver as cuda
 
-import torch
+try:
+    # torch is optional: only the torch tensor paths need it. JAX callers must
+    # be able to import this module without it.
+    import torch
+except ImportError:  # pragma: no cover - exercised by torch-free JAX installs
+    torch = None
 
 import cutlass
 import cutlass.cute as cute
@@ -22,7 +29,6 @@ from cudnn.block_sparse_attention.csrc.utils.cute_dsl_utils import (
     assume_tensor_aligned,
     get_broadcast_dims,
     to_cute_tensor,
-    torch2cute_dtype_map,
 )
 from cudnn.block_sparse_attention.csrc.utils import copy_utils
 from cudnn.block_sparse_attention.csrc.utils import pipeline
@@ -2194,12 +2200,16 @@ def bsa_sm100_blk128_bwd_bucketed_k2q_csr(
     dv: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """SM100/SM110 blk128 bwd entry receiving BSA bucketed k2q CSR."""
-    assert q.dtype == torch.bfloat16, "SM100 blk128 bwd only supports bfloat16"
-    assert q.dtype == k.dtype == v.dtype == out.dtype == dout.dtype
-    assert lse.dtype == torch.float32
+    from cudnn.datatypes import _convert_to_cutlass_data_type
+    from cudnn.tensor_adapter import allocate_tensor, detect_framework, get_shape, permuted_view
+
+    framework = detect_framework(q) if not hasattr(q, "_array") else detect_framework(q._array)
+    assert _convert_to_cutlass_data_type(q.dtype) == cutlass.BFloat16, "SM100 blk128 bwd only supports bfloat16"
+    assert all(_convert_to_cutlass_data_type(t.dtype) == cutlass.BFloat16 for t in (k, v, out, dout))
+    assert _convert_to_cutlass_data_type(lse.dtype) == cutlass.Float32
     assert _get_device_arch() // 10 in [10, 11]
-    assert bucketed_k2q_offsets.dtype == torch.int32
-    assert bucketed_k2q_indices.dtype == torch.int32
+    assert _convert_to_cutlass_data_type(bucketed_k2q_offsets.dtype) == cutlass.Int32
+    assert _convert_to_cutlass_data_type(bucketed_k2q_indices.dtype) == cutlass.Int32
 
     batch_size, num_heads, seqlen_q, head_dim = q.shape
     seqlen_k = k.shape[2]
@@ -2220,60 +2230,43 @@ def bsa_sm100_blk128_bwd_bucketed_k2q_csr(
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)
 
-    if dq is None:
-        dq = torch.empty_like(q)
-    if dk is None:
-        dk = torch.empty_like(k)
-    if dv is None:
-        dv = torch.empty_like(v)
+    if framework == "torch":
+        # empty_like preserves the (possibly permuted-view) stride pattern so the
+        # returned gradients match the caller's memory layout.
+        dq = torch.empty_like(q) if dq is None else dq
+        dk = torch.empty_like(k) if dk is None else dk
+        dv = torch.empty_like(v) if dv is None else dv
+    else:
+        # JAX gradients in the kernel-logical (bhsd) layout; the bshd caller
+        # layout pre-allocates in _interface before permuting.
+        dq = allocate_tensor(framework, get_shape(q), q.dtype, q.device) if dq is None else dq
+        dk = allocate_tensor(framework, get_shape(k), k.dtype, q.device) if dk is None else dk
+        dv = allocate_tensor(framework, get_shape(v), v.dtype, q.device) if dv is None else dv
 
-    q_bshd = q.transpose(1, 2)
-    k_bshd = k.transpose(1, 2)
-    v_bshd = v.transpose(1, 2)
-    out_bshd = out.transpose(1, 2)
-    dout_bshd = dout.transpose(1, 2)
-    dq_bshd = dq.transpose(1, 2)
-    dk_bshd = dk.transpose(1, 2)
-    dv_bshd = dv.transpose(1, 2)
+    bshd = (0, 2, 1, 3)
+    q_bshd = permuted_view(q, bshd)
+    k_bshd = permuted_view(k, bshd)
+    v_bshd = permuted_view(v, bshd)
+    out_bshd = permuted_view(out, bshd)
+    dout_bshd = permuted_view(dout, bshd)
+    dq_bshd = permuted_view(dq, bshd)
+    dk_bshd = permuted_view(dk, bshd)
+    dv_bshd = permuted_view(dv, bshd)
 
     seqlen_q_rounded = num_q_blocks * SM100_BLK128_BWD_SPARSE_BLOCK_SIZE
     seqlen_k_rounded = num_kv_blocks * SM100_BLK128_BWD_SPARSE_BLOCK_SIZE
     head_dim_rounded = _ceil_div(head_dim, 32) * 32
-    dq_accum = torch.empty(
-        batch_size,
-        num_heads,
-        seqlen_q_rounded * head_dim_rounded,
-        dtype=torch.float32,
-        device=q.device,
-    )
-    dpsum = torch.empty(
-        batch_size,
-        num_heads,
-        seqlen_q_rounded,
-        dtype=torch.float32,
-        device=q.device,
-    )
-    lse_log2 = torch.empty_like(dpsum)
+    dq_accum = allocate_tensor(framework, (batch_size, num_heads, seqlen_q_rounded * head_dim_rounded), cutlass.Float32, q.device)
+    dpsum = allocate_tensor(framework, (batch_size, num_heads, seqlen_q_rounded), cutlass.Float32, q.device)
+    lse_log2 = allocate_tensor(framework, (batch_size, num_heads, seqlen_q_rounded), cutlass.Float32, q.device)
     if use_dkv_postprocess:
-        dk_accum = torch.zeros(
-            batch_size,
-            num_heads,
-            seqlen_k_rounded * head_dim_rounded,
-            dtype=torch.float32,
-            device=q.device,
-        )
-        dv_accum = torch.zeros(
-            batch_size,
-            num_heads,
-            seqlen_k_rounded * head_dim_rounded,
-            dtype=torch.float32,
-            device=q.device,
-        )
+        dk_accum = allocate_tensor(framework, (batch_size, num_heads, seqlen_k_rounded * head_dim_rounded), cutlass.Float32, q.device, zero=True)
+        dv_accum = allocate_tensor(framework, (batch_size, num_heads, seqlen_k_rounded * head_dim_rounded), cutlass.Float32, q.device, zero=True)
     else:
         dk_accum = None
         dv_accum = None
 
-    dtype = torch2cute_dtype_map[q.dtype]
+    dtype = _convert_to_cutlass_data_type(q.dtype)
     _bwd_preprocess(
         out_bshd,
         dout_bshd,

--- a/python/cudnn/block_sparse_attention/csrc/utils/cute_dsl_utils.py
+++ b/python/cudnn/block_sparse_attention/csrc/utils/cute_dsl_utils.py
@@ -10,7 +10,12 @@ from dataclasses import dataclass, fields
 from functools import partial
 from typing import Tuple, get_origin
 
-import torch
+try:
+    # torch is optional: only the torch tensor paths need it. JAX callers must
+    # be able to import this module without it.
+    import torch
+except ImportError:  # pragma: no cover - exercised by torch-free JAX installs
+    torch = None
 
 import cutlass
 import cutlass.cute as cute
@@ -52,13 +57,17 @@ def _install_constexpr_tvm_ffi_converter() -> None:
 
 _install_constexpr_tvm_ffi_converter()
 
-torch2cute_dtype_map = {
-    torch.float16: cutlass.Float16,
-    torch.bfloat16: cutlass.BFloat16,
-    torch.float32: cutlass.Float32,
-    torch.float8_e4m3fn: cutlass.Float8E4M3FN,
-    torch.float8_e5m2: cutlass.Float8E5M2,
-}
+torch2cute_dtype_map = (
+    {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+        torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+        torch.float8_e5m2: cutlass.Float8E5M2,
+    }
+    if torch is not None
+    else {}
+)
 
 
 def _partition_param_fields(obj):
@@ -138,12 +147,18 @@ def assume_tensor_aligned(t):
     return cute.make_tensor(t.iterator, cute.make_layout(t.shape, stride=assume_strides_aligned(t)))
 
 
+def _maybe_detach(t):
+    """Detach torch autograd-tracked tensors before DLPack export; no-op otherwise."""
+    detach = getattr(t, "detach", None)
+    return detach() if callable(detach) else t
+
+
 def to_cute_tensor(t, assumed_align=16, leading_dim=-1, fully_dynamic=False, enable_tvm_ffi=True):
-    """Convert torch tensor to cute tensor for TVM FFI. leading_dim=-1 defaults to t.ndim-1."""
+    """Convert a framework tensor to a cute tensor for TVM FFI. leading_dim=-1 defaults to t.ndim-1."""
     # NOTE: torch 2.9.1 doesn't support fp8 via DLPack but 2.11.0 nightly does
     # currently export raw bytes as uint8 and tell cutlass correct type
     # can directly export as fp8 when torch supports it
-    if t.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+    if torch is not None and isinstance(t, torch.Tensor) and t.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
         tensor = from_dlpack(
             t.view(torch.uint8).detach(),
             assumed_align=assumed_align,
@@ -151,7 +166,7 @@ def to_cute_tensor(t, assumed_align=16, leading_dim=-1, fully_dynamic=False, ena
         )
         tensor.element_type = cutlass.Float8E4M3FN if t.dtype == torch.float8_e4m3fn else cutlass.Float8E5M2
     else:
-        tensor = from_dlpack(t.detach(), assumed_align=assumed_align, enable_tvm_ffi=enable_tvm_ffi)
+        tensor = from_dlpack(_maybe_detach(t), assumed_align=assumed_align, enable_tvm_ffi=enable_tvm_ffi)
     if fully_dynamic:
         return tensor.mark_layout_dynamic()
     if leading_dim == -1:
@@ -159,11 +174,13 @@ def to_cute_tensor(t, assumed_align=16, leading_dim=-1, fully_dynamic=False, ena
     return tensor.mark_layout_dynamic(leading_dim=leading_dim)
 
 
-def get_broadcast_dims(tensor: torch.Tensor) -> Tuple[bool, ...]:
+def get_broadcast_dims(tensor) -> Tuple[bool, ...]:
     """Return tuple of bools indicating which dims have stride=0 (broadcast).
 
     This is useful for compile keys since CuTe's mark_layout_dynamic() keeps
     stride=0 as static, meaning kernels compiled with different broadcast
     patterns are not interchangeable.
     """
-    return tuple(s == 0 for s in tensor.stride())
+    from cudnn.tensor_adapter import get_strides
+
+    return tuple(s == 0 for s in get_strides(tensor))

--- a/python/cudnn/tensor_adapter.py
+++ b/python/cudnn/tensor_adapter.py
@@ -216,6 +216,139 @@ def allocate_byte_workspace(framework: str, nbytes: int, device: Any) -> Any:
     raise ValueError(f"Cannot allocate a workspace for framework '{framework}'")
 
 
+def allocate_tensor(framework: str, shape: Tuple[int, ...], dtype: Any, device: Any, zero: bool = False) -> Any:
+    """Allocate an output/scratch tensor in the caller's framework allocator.
+
+    ``dtype`` accepts anything :func:`framework_dtype` does (cutlass/torch/numpy/str).
+    For JAX the buffer is materialized (``block_until_ready``) before returning so
+    kernels may immediately write into it on the launch stream; JAX buffers are
+    always zero-filled (``jnp.empty`` is an alias of ``zeros`` and uninitialized
+    memory is not observable anyway through XLA's functional model).
+    """
+    fw_dtype = framework_dtype(dtype, framework)
+    if framework == "torch":
+        import torch
+
+        factory = torch.zeros if zero else torch.empty
+        return factory(shape, dtype=fw_dtype, device=device)
+    if framework == "jax":
+        import jax
+        import jax.numpy as jnp
+
+        return jax.block_until_ready(jnp.zeros(shape, dtype=fw_dtype, device=device))
+    raise ValueError(f"Cannot allocate a tensor for framework '{framework}'")
+
+
+class _JaxPermutedDLPackView:
+    """Zero-copy permuted (transposed) view of a JAX array for DLPack consumers.
+
+    JAX cannot express strided views, but the CuTeDSL/TVM-FFI kernel ABI only
+    consumes DLPack metadata. ``tvm_ffi.from_dlpack`` materializes explicit
+    strides even for compact arrays, so this wrapper re-exports the underlying
+    array through a fresh tvm-ffi capsule whose shape/strides arrays are
+    permuted in place — the data pointer is untouched. Each ``__dlpack__`` call
+    builds a fresh capsule, so a view can be consumed multiple times.
+    """
+
+    def __init__(self, array: Any, perm: Tuple[int, ...]):
+        base_shape = get_shape(array)
+        if sorted(perm) != list(range(len(base_shape))):
+            raise ValueError(f"perm {perm} is not a permutation of {len(base_shape)} dims")
+        self._array = array
+        self._perm = tuple(int(p) for p in perm)
+        self.shape = tuple(base_shape[p] for p in self._perm)
+        base_strides = get_strides(array)
+        self.strides = tuple(base_strides[p] for p in self._perm)
+        self.ndim = len(self.shape)
+        self.dtype = array.dtype
+        self.device = array.device
+
+    def detach(self):
+        return self
+
+    def stride(self, dim: Optional[int] = None):
+        return self.strides if dim is None else self.strides[dim]
+
+    def dim_order(self) -> Tuple[int, ...]:
+        order = sorted(range(self.ndim), key=lambda i: (self.strides[i], self.shape[i]))
+        return tuple(reversed(order))
+
+    def __dlpack_device__(self):
+        return self._array.__dlpack_device__()
+
+    def __dlpack__(self, **kwargs):
+        import ctypes
+
+        import tvm_ffi
+
+        # A fresh tvm-ffi export per call: its capsule owns freshly materialized
+        # shape/strides arrays, so the in-place permutation below can never
+        # double-apply or corrupt another consumer's view.
+        capsule = tvm_ffi.from_dlpack(self._array).__dlpack__(**kwargs)
+
+        get_name = ctypes.pythonapi.PyCapsule_GetName
+        get_name.restype = ctypes.c_char_p
+        get_name.argtypes = [ctypes.py_object]
+        get_pointer = ctypes.pythonapi.PyCapsule_GetPointer
+        get_pointer.restype = ctypes.c_void_p
+        get_pointer.argtypes = [ctypes.py_object, ctypes.c_char_p]
+
+        class _DLDevice(ctypes.Structure):
+            _fields_ = [("device_type", ctypes.c_int32), ("device_id", ctypes.c_int32)]
+
+        class _DLDataType(ctypes.Structure):
+            _fields_ = [("code", ctypes.c_uint8), ("bits", ctypes.c_uint8), ("lanes", ctypes.c_uint16)]
+
+        class _DLTensor(ctypes.Structure):
+            _fields_ = [
+                ("data", ctypes.c_void_p),
+                ("device", _DLDevice),
+                ("ndim", ctypes.c_int32),
+                ("dtype", _DLDataType),
+                ("shape", ctypes.POINTER(ctypes.c_int64)),
+                ("strides", ctypes.POINTER(ctypes.c_int64)),
+                ("byte_offset", ctypes.c_uint64),
+            ]
+
+        name = get_name(capsule)
+        pointer = get_pointer(capsule, name)
+        if name == b"dltensor_versioned":
+            # DLManagedTensorVersioned: version (2x uint32), manager_ctx, deleter, flags, dl_tensor
+            offset = ctypes.sizeof(ctypes.c_uint32) * 2 + ctypes.sizeof(ctypes.c_void_p) * 2 + ctypes.sizeof(ctypes.c_uint64)
+        elif name == b"dltensor":
+            # DLManagedTensor: dl_tensor first
+            offset = 0
+        else:
+            raise RuntimeError(f"Unrecognized DLPack capsule {name!r}")
+        dl_tensor = ctypes.cast(pointer + offset, ctypes.POINTER(_DLTensor)).contents
+        if dl_tensor.ndim != self.ndim:
+            raise RuntimeError(f"DLPack rank mismatch: capsule has {dl_tensor.ndim}, view expects {self.ndim}")
+        if not dl_tensor.strides:
+            raise RuntimeError("DLPack capsule has no explicit strides; cannot permute in place")
+        shape = [dl_tensor.shape[i] for i in range(dl_tensor.ndim)]
+        strides = [dl_tensor.strides[i] for i in range(dl_tensor.ndim)]
+        for i, p in enumerate(self._perm):
+            dl_tensor.shape[i] = shape[p]
+            dl_tensor.strides[i] = strides[p]
+        return capsule
+
+
+def permuted_view(tensor: Any, perm: Tuple[int, ...]) -> Any:
+    """Zero-copy dimension-permuted view of a tensor, for any supported framework.
+
+    torch returns a regular strided view; JAX (which has no strided views)
+    returns a DLPack-exporting wrapper accepted by the TVM-FFI kernel ABI and
+    ``cute.runtime.from_dlpack``. Applying it to an existing view composes the
+    permutations on the original array.
+    """
+    if is_torch_tensor(tensor):
+        return tensor.permute(*perm)
+    if isinstance(tensor, _JaxPermutedDLPackView):
+        composed = tuple(tensor._perm[p] for p in perm)
+        return _JaxPermutedDLPackView(tensor._array, composed)
+    return _JaxPermutedDLPackView(tensor, perm)
+
+
 def pad_to_ndim(tensor: Any, ndim: int) -> Any:
     """Append size-1 dims up to ndim; works for any framework tensor exposing reshape."""
     shape = get_shape(tensor)

--- a/test/python/fe_api/bsa/test_BSA_attention_jax.py
+++ b/test/python/fe_api/bsa/test_BSA_attention_jax.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+JAX coverage for block-sparse attention (SM100/SM110 blk128 paths).
+
+JAX contract: forward and backward on the SM100/SM110 blk128 kernels only
+(SM90/SM120 and the blk64 paths reject JAX arrays with clear errors). The
+backward's internal transposed tensor views travel as zero-copy permuted
+DLPack wrappers (`cudnn.tensor_adapter.permuted_view`). Outputs are checked
+bit-identical against the torch wrapper run on identical input bytes (both
+paths share one compiled kernel per stride pattern).
+"""
+
+import importlib
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+ml_dtypes = pytest.importorskip("ml_dtypes")
+torch = pytest.importorskip("torch")
+import jax.numpy as jnp
+
+from test_utils import torch_fork_set_rng
+from fe_api.bsa.bsa_utils import make_fixed_metadata, supported_block_size
+
+pytestmark = [pytest.mark.gpu_exclusive, pytest.mark.xdist_group(name="gpu_exclusive")]
+
+
+def _import_bsa():
+    try:
+        from cudnn import BSA
+
+        importlib.import_module("cudnn.block_sparse_attention._interface")
+
+        return BSA
+    except (ImportError, OSError) as error:
+        pytest.skip(f"block sparse attention optional dependencies are unavailable: {error}")
+
+
+def _skip_unless_blk128():
+    if not torch.cuda.is_available():
+        pytest.skip("block sparse attention tests require CUDA")
+    major, _ = torch.cuda.get_device_capability()
+    if major not in {10, 11}:
+        pytest.skip("the BSA JAX contract covers the SM100/SM110 blk128 paths only")
+
+
+def _device_sync():
+    # The eager JAX path runs on the CUDA legacy default stream, which XLA does
+    # not track; synchronize before reading outputs.
+    torch.cuda.synchronize()
+
+
+def _to_jax(t: torch.Tensor):
+    np_dtype = {torch.bfloat16: ml_dtypes.bfloat16, torch.float32: np.float32, torch.int32: np.int32}[t.dtype]
+    return jnp.asarray(t.view(torch.uint8).cpu().numpy().view(np_dtype).reshape(t.shape) if t.dtype == torch.bfloat16 else t.cpu().numpy())
+
+
+def _bits(x) -> np.ndarray:
+    return np.asarray(x).view(np.uint8)
+
+
+def _make_problem(seed: int):
+    block_size = supported_block_size(backward=True)
+    assert block_size == 128
+    batch, heads, seqlen_q, seqlen_k, dim = 1, 2, 2 * block_size, 4 * block_size, 128
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    q = torch.randn((batch, heads, seqlen_q, dim), device="cuda", dtype=torch.bfloat16, generator=generator)
+    k = torch.randn((batch, heads, seqlen_k, dim), device="cuda", dtype=torch.bfloat16, generator=generator)
+    v = torch.randn((batch, heads, seqlen_k, dim), device="cuda", dtype=torch.bfloat16, generator=generator)
+    do = torch.randn((batch, heads, seqlen_q, dim), device="cuda", dtype=torch.bfloat16, generator=generator)
+    q2k, block_sparse_num, block_sizes = make_fixed_metadata(batch, heads, seqlen_q, seqlen_k, block_size)
+    return block_size, q, k, v, do, q2k, block_sparse_num, block_sizes
+
+
+@pytest.mark.L0
+def test_bsa_attention_forward_jax_matches_torch():
+    _skip_unless_blk128()
+    BSA = _import_bsa()
+    block_size, q, k, v, _, q2k, block_sparse_num, block_sizes = _make_problem(seed=0)
+
+    result_t = BSA.block_sparse_attention_forward(q, k, v, q2k, block_sparse_num, block_sizes, sparse_block_size=block_size)
+    torch.cuda.synchronize()
+
+    q_j, k_j, v_j, q2k_j, sizes_j = (_to_jax(t) for t in (q, k, v, q2k, block_sizes))
+    jax.block_until_ready((q_j, k_j, v_j, q2k_j, sizes_j))
+    result_j = BSA.block_sparse_attention_forward(q_j, k_j, v_j, q2k_j, block_sparse_num, sizes_j, sparse_block_size=block_size)
+    _device_sync()
+
+    np.testing.assert_array_equal(
+        _bits(result_j["o_tensor"]),
+        result_t["o_tensor"].view(torch.uint8).cpu().numpy(),
+        err_msg="BSA forward o: JAX output differs from torch output on identical input bytes",
+    )
+    np.testing.assert_array_equal(
+        _bits(result_j["lse_tensor"]),
+        result_t["lse_tensor"].view(torch.uint8).cpu().numpy(),
+        err_msg="BSA forward lse: JAX output differs from torch output on identical input bytes",
+    )
+
+
+@pytest.mark.L0
+def test_bsa_attention_forward_jax_bshd_layout():
+    _skip_unless_blk128()
+    BSA = _import_bsa()
+    block_size, q, k, v, _, q2k, block_sparse_num, block_sizes = _make_problem(seed=1)
+    # bshd-contiguous buffers for both frameworks (same bytes, same strides)
+    q_s, k_s, v_s = (t.transpose(1, 2).contiguous() for t in (q, k, v))
+
+    result_t = BSA.block_sparse_attention_forward(q_s, k_s, v_s, q2k, block_sparse_num, block_sizes, sparse_block_size=block_size, layout="bshd")
+    torch.cuda.synchronize()
+
+    q_j, k_j, v_j, q2k_j, sizes_j = (_to_jax(t) for t in (q_s, k_s, v_s, q2k, block_sizes))
+    jax.block_until_ready((q_j, k_j, v_j, q2k_j, sizes_j))
+    result_j = BSA.block_sparse_attention_forward(q_j, k_j, v_j, q2k_j, block_sparse_num, sizes_j, sparse_block_size=block_size, layout="bshd")
+    _device_sync()
+
+    for key in ("o_tensor", "lse_tensor"):
+        np.testing.assert_array_equal(
+            _bits(result_j[key]),
+            result_t[key].view(torch.uint8).cpu().numpy(),
+            err_msg=f"BSA forward bshd {key}: JAX output differs from torch output on identical input bytes",
+        )
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("layout", ["bhsd", "bshd"])
+def test_bsa_attention_backward_jax_matches_torch(layout):
+    _skip_unless_blk128()
+    BSA = _import_bsa()
+    block_size, q, k, v, do, q2k, block_sparse_num, _ = _make_problem(seed=2)
+    if layout == "bshd":
+        q, k, v, do = (t.transpose(1, 2).contiguous() for t in (q, k, v, do))
+
+    forward_t = BSA.block_sparse_attention_forward(q, k, v, q2k, block_sparse_num, None, sparse_block_size=block_size, layout=layout)
+    backward_t = BSA.block_sparse_attention_backward(
+        do,
+        q,
+        k,
+        v,
+        forward_t["o_tensor"],
+        forward_t["lse_tensor"],
+        q2k,
+        block_sparse_num,
+        None,
+        sparse_block_size=block_size,
+        layout=layout,
+    )
+    torch.cuda.synchronize()
+
+    do_j, q_j, k_j, v_j, q2k_j = (_to_jax(t) for t in (do, q, k, v, q2k))
+    o_j, lse_j = _to_jax(forward_t["o_tensor"]), _to_jax(forward_t["lse_tensor"])
+    jax.block_until_ready((do_j, q_j, k_j, v_j, q2k_j, o_j, lse_j))
+    backward_j = BSA.block_sparse_attention_backward(
+        do_j,
+        q_j,
+        k_j,
+        v_j,
+        o_j,
+        lse_j,
+        q2k_j,
+        block_sparse_num,
+        None,
+        sparse_block_size=block_size,
+        layout=layout,
+    )
+    _device_sync()
+
+    # dq is bit-deterministic; dk/dv accumulate across Q blocks in a
+    # scheduling-dependent order (bit-nondeterministic run to run even within
+    # one framework), so they compare at a 1-ulp-scale bf16 tolerance.
+    for key, bitwise in (("dq_tensor", True), ("dk_tensor", False), ("dv_tensor", False)):
+        got = backward_j[key]
+        assert not hasattr(got, "_array"), f"{key} must be a real JAX array, not an internal view wrapper"
+        expected = backward_t[key].contiguous()
+        if bitwise:
+            np.testing.assert_array_equal(
+                _bits(got),
+                expected.view(torch.uint8).cpu().numpy(),
+                err_msg=f"BSA backward {layout} {key}: JAX output differs from torch output on identical input bytes",
+            )
+        else:
+            np.testing.assert_allclose(
+                np.asarray(got).astype(np.float32),
+                expected.float().cpu().numpy(),
+                rtol=1e-2,
+                atol=1e-2,
+                err_msg=f"BSA backward {layout} {key}: JAX output differs from torch output beyond accumulation-order noise",
+            )
+
+
+@pytest.mark.L0
+def test_bsa_attention_jax_errors():
+    _skip_unless_blk128()
+    BSA = _import_bsa()
+    block_size, q, k, v, do, q2k, block_sparse_num, block_sizes = _make_problem(seed=3)
+    q_j, k_j, v_j, q2k_j = (_to_jax(t) for t in (q, k, v, q2k))
+
+    with pytest.raises(ValueError, match="blk128"):
+        BSA.block_sparse_attention_forward(q_j, k_j, v_j, q2k_j, block_sparse_num, sparse_block_size=64)
+
+    with pytest.raises(ValueError, match="blk128"):
+        BSA.block_sparse_attention_backward(
+            _to_jax(do),
+            q_j,
+            k_j,
+            v_j,
+            q_j,
+            jnp.zeros(q.shape[:3], dtype=jnp.float32),
+            q2k_j,
+            block_sparse_num,
+            None,
+            sparse_block_size=64,
+        )
+
+    with pytest.raises(ValueError, match="Unsupported tensor framework"):
+        BSA.block_sparse_attention_forward(np.asarray(q_j), np.asarray(k_j), np.asarray(v_j), np.asarray(q2k_j), block_sparse_num)


### PR DESCRIPTION
> **Stacked on #553** (→ #534 → #530) — this branch contains those PRs' commits plus one new commit (`3457f56a9`). **Review only the top commit.** Will be rebased as the base PRs merge.

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

FE OSS kernels or CuTeDSL (Python API)

## Summary

Extends the type-erased torch+JAX tensor contract from the GEMM CuTeDSL APIs (#529/#530/#553) to **`python/cudnn/block_sparse_attention`**: `cudnn.BSA.block_sparse_attention_forward/backward` now accept JAX arrays alongside torch tensors, with torch imported only when torch tensors are passed.

### Per-path status

| Path | torch | JAX |
|---|---|---|
| SM100/SM110 blk128 forward (`bhsd` and `bshd`) | ✅ unchanged | ✅ **new**, eager |
| SM100/SM110 blk128 backward (`bhsd` and `bshd`, incl. pre-allocated dq/dk/dv) | ✅ unchanged | ✅ **new**, eager |
| SM90 / SM120 forward, SM90 backward | ✅ unchanged | ✖ clear `ValueError` (arch-specific torch code paths) |
| SM100/SM110 blk64 forward/backward (`kv_splits`, `use_clc`) | ✅ unchanged | ✖ clear `ValueError` |

### The key new mechanism: zero-copy permuted views for JAX

The blk128 kernels consume **transposed strided views** at every kernel boundary (the backward's logical layout is `bshd`, reached from `bhsd` buffers via `transpose(1, 2)` views). JAX has no strided views — but the TVM-FFI kernel ABI only consumes DLPack metadata, and `tvm_ffi.from_dlpack` **materializes explicit strides** even for compact arrays. The new **`cudnn.tensor_adapter.permuted_view(tensor, perm)`** exploits this:

- torch → a regular `permute` view (unchanged semantics);
- JAX → a small DLPack-exporting wrapper that re-exports the array through a fresh tvm-ffi capsule whose shape/strides arrays are **permuted in place** over the same data pointer (each `__dlpack__` call builds a fresh capsule, so views are multi-consumable and composable).

Result: the JAX paths run the **same compiled kernels with the same stride patterns** as torch, with zero extra copies. Both layouts work for forward and backward.

### Implementation notes

- `api.py` + `_interface.py` + the blk128 csrc host functions (`bsa_bwd_sm100.py`, `bucketed_k2q_csr.py`, `bsa_bwd_prepost.py`, `cute_dsl_utils.py`) are torch-lazy (`try: import torch` + `from __future__ import annotations`); the whole BSA import chain — including the optional blk128 backward, whose `try/except ImportError` guard previously masked the torch dependency — now imports with torch **and** jax absent.
- Framework-branched allocation via a new `cudnn.tensor_adapter.allocate_tensor` (torch `empty/zeros` preserving `empty_like` stride semantics on the torch path; materialized `jnp` buffers for JAX); validation via cutlass dtypes and adapter metadata helpers; JAX launches on the CUDA legacy default stream (the backward's pre/main/post kernel chain uses the tvm-ffi environment stream, which resolves to the default stream without torch).
- For `layout="bshd"` JAX backward, dq/dk/dv are pre-allocated in the caller's layout and the kernel writes through permuted views, so callers always receive real JAX arrays.

## Why

BSA is used from JAX-based training stacks; the CuTeDSL data path was already framework-neutral (tvm-ffi/DLPack) and only host-side metadata, allocation, and stream handling were torch-bound — the same situation the GEMM stack was in before #529. `permuted_view` closes the one genuinely new gap (strided views), and is reusable for future JAX enablement of the other attention APIs.

## Related issues

Stacked on #553 (→ #534 → #530).

## API and compatibility impact

- Public API signatures unchanged; torch behavior and numerics untouched (torch BSA suite passes unchanged). JAX arrays gain eager support on the blk128 paths; unsupported backends raise `ValueError` naming the supported path.
- New public helpers `cudnn.tensor_adapter.permuted_view` and `cudnn.tensor_adapter.allocate_tensor`.
- Eager-only for JAX (legacy default stream contract, same as the GEMM eager paths); a `jax.jit` entry point via `cudnn.jax.call` is a natural follow-up.

## Testing

On a B200-class SM100 (CC 10.0), Python 3.12, torch 2.13, jax 0.11, nvidia-cutlass-dsl 4.6:

```bash
cd test/python
pytest fe_api/bsa/ -q -m "L0 or L1"   # 22 passed (13 fwd + 4 bwd torch, unchanged; 5 new JAX)
```

- New `test_BSA_attention_jax.py`: forward (`bhsd` + `bshd`) **bit-identical** to torch on identical input bytes; backward (`bhsd` + `bshd`) with dq bit-identical and dk/dv at 1-ulp-scale bf16 tolerance (their cross-Q-block accumulation is scheduling-order nondeterministic run-to-run *within* either framework — verified jax-vs-jax); error-path coverage (blk64 rejection fwd+bwd, non-torch/JAX frameworks).
- GEMM JAX suites re-run green after the `tensor_adapter` additions (`test_gemm_amax_jax.py`, `test_grouped_gemm_jax.py`: 8 passed, 2 xfailed).
- Import hygiene: `cudnn.BSA.*` resolves with torch and jax both absent (`sys.modules` nulled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added broad JAX support for grouped GEMM, fused GEMM, discrete grouped GEMM, and Block Sparse Attention.
  - Added `jax.jit`-compatible entry points for supported SM100/SM110 workflows.
  - Added eager execution, framework-aware tensor handling, output allocation, and zero-copy integration.

- **Documentation**
  - Expanded guidance for supported layouts, synchronization, limitations, and installation.

- **Bug Fixes**
  - Added clearer errors for unsupported layouts, data types, architectures, and tensor frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->