### PR TITLE
DSA: support per-token causal offsets in indexer forward

### DIFF
--- a/docs/fe-oss-apis/dsa.md
+++ b/docs/fe-oss-apis/dsa.md
@@ -140,15 +140,19 @@ dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
 Computes dense indexer scores:
 ``S[b, q, k] = sum_h ReLU(Q_h · K_h^T) · W_h`` with a ratio-causal mask.
 For local query row `q_local`, valid KV columns satisfy
-`k_local < clamp((q_causal_offsets[b] + q_local + 1) // ratio, 0, seqlen_k_b)`.
-When `q_causal_offsets` is omitted, all offsets are zero.
+`k_local < clamp((q_position + 1) // ratio, 0, seqlen_k_b)`. When
+`q_causal_offsets` is omitted, `q_position = q_local`. A `(batch,)` tensor uses
+`q_position = q_local + q_causal_offsets[b]`. THD input also accepts a
+`(total_q,)` tensor and uses
+`q_position = q_local + q_causal_offsets[cu_seqlens_q[b] + q_local]`.
 
-`q_causal_offsets[b]` is the global uncompressed token index corresponding to
-local `q[0]` for batch or THD segment `b`. It is not the packed storage offset
-from `cu_seqlens_q`: `cu_seqlens_q` locates where a local Q segment is stored,
-while `q_causal_offsets` locates that segment in the global causal timeline.
+The offset values are position deltas, not packed-storage indices:
+`cu_seqlens_q` locates a local Q segment in storage, while
+`q_causal_offsets` locates each row in the causal timeline. Negative deltas are
+allowed, and the visible-K count is clamped to the sequence's valid K range.
 The K columns are assumed to be a compressed-KV prefix starting at global
-compressed column 0.
+compressed column 0. Offset values are runtime data: after CUDA Graph capture,
+the same tensor may be updated in place before replay without recompilation.
 
 - **Inputs**
   - `q`: `(B, S_q, H_q, D)` BF16, or the architecture-specific FP8 format
@@ -157,8 +161,8 @@ compressed column 0.
     described below.
   - `w`: `(B, S_q, H_q)` BF16. The SM90 FP8 path also accepts FP32 when
     weights have already been pre-scaled by `q_scale * sm_scale`.
-  - `q_causal_offsets` (optional): CUDA INT32 tensor with one entry per
-    batch/THD segment, on the same device as `q`.
+  - `q_causal_offsets` (optional): CUDA INT32 tensor of shape `(batch,)`, or
+    `(total_q,)` for BF16 THD input, on the same device as `q`.
 - **Output** — `scores`: `(B, S_q, S_k)` FP32.
 - **Precision paths**
   - SM90 `precision="fp8"`: Q/K use E4M3 and `q_scale`/`k_scale` are FP32
@@ -180,7 +184,9 @@ compressed column 0.
   `qhead_per_kv_head ∈ {16, 32, 64}` and currently requires `H_kv == 1`;
   SM100 BF16 dense and combined Top-K paths support
   `qhead_per_kv_head ∈ {32, 64}`, as do their MXFP8 paths. All currently
-  require `H_kv == 1` (MQA).
+  require `H_kv == 1` (MQA). Per-token offsets are BF16-forward-only and
+  THD-only; BSHD, MXFP8/FP8, combined Top-K, score recompute, and backward
+  continue to accept only per-sequence offsets.
 
 ```python
 result = DSA.indexer_forward_wrapper(
@@ -284,7 +290,8 @@ L1-normalised head-summed softmax over top-K entries:
 Full-KV (no top-K) analogues of §5 and §6. Each returns `{'out', 'denom'}`.
 They apply the same ratio-causal mask as Indexer Forward; masked positions are
 written as `-inf` and excluded from `denom`. Pass the same `q_causal_offsets` to
-all dense score tensors that feed the same loss path.
+all dense score tensors that feed the same loss path. These dense APIs accept
+only the per-sequence `(batch,)` form, including for THD inputs.
 
 On SM100, Indexer Forward and Dense Indexer Score Recompute use the same
 unified kernel implementation: forward runs it with `compute_lse=False`, while

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface.py
@@ -216,8 +216,10 @@ def indexer_fwd(
             sequence and be a multiple of 128 tokens. Any span satisfying those
             requirements is valid. Both scale prefixes must be ``None`` for BSHD.
         sf_vec_size: scale vector size for MXFP8, currently must be 32.
-        q_causal_offsets: optional int32 CUDA tensor of shape ``(batch,)``.
-            Each entry is the global uncompressed token index for local q[0].
+        q_causal_offsets: optional int32 CUDA tensor of shape ``(batch,)``, or
+            ``(total_q,)`` for BF16 THD inputs. A batch entry is added to every
+            local Q position in that sequence; a THD entry is added only to
+            its corresponding Q token.
 
     Returns:
         S_sum: BSHD ``(bs, seqlen_q, seqlen_k)`` or THD
@@ -372,7 +374,6 @@ def indexer_fwd(
             raise ValueError(f"seqlen_q ({seqlen_q_dim}) must be <= seqlen_k * ratio " f"({seqlen_k_dim * ratio})")
         out_shape = (bs, seqlen_q_dim, seqlen_k_dim)
         out_buf_shape = None
-
     if n_heads_kv != 1:
         raise ValueError("SM100 indexer forward currently requires n_heads_kv=1 (MQA); " f"got n_heads_kv={n_heads_kv}")
     expected_qhead_per_kv_head = n_heads_q // n_heads_kv
@@ -382,7 +383,23 @@ def indexer_fwd(
         raise ValueError(f"qhead_per_kv_head ({qhead_per_kv_head}) must equal " f"n_heads_q // n_heads_kv ({expected_qhead_per_kv_head})")
     _validate_indexer_qhead_per_kv_head(qhead_per_kv_head, precision)
 
-    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(bs), q.device, stream=current_stream)
+    q_causal_offsets = validate_q_causal_offsets(
+        q_causal_offsets,
+        int(bs),
+        q.device,
+        stream=current_stream,
+        total_q=int(total_q) if is_varlen else None,
+    )
+    if q_causal_offsets is None:
+        q_causal_offset_mode = "none"
+    elif is_varlen and q_causal_offsets.shape[0] != int(bs):
+        q_causal_offset_mode = "token"
+    else:
+        q_causal_offset_mode = "sequence"
+    if q_causal_offset_mode == "token" and precision != "bf16":
+        raise ValueError("THD per-token q_causal_offsets currently require precision='bf16'")
+    if q_causal_offset_mode == "token" and is_compressed_logits:
+        raise ValueError("THD per-token q_causal_offsets are not supported by indexer forward Top-K")
 
     if precision == "bf16" and m_block_size // qhead_per_kv_head > 2:
         if m_block_size == 128:
@@ -482,7 +499,7 @@ def indexer_fwd(
             cu_k_cute = _to_cute_tensor(cu_seqlens_k, leading_dim=0) if is_varlen else None
             cu_q_scale_cute = _to_cute_tensor(cu_seqlens_q_scale_padded, leading_dim=0) if is_varlen else None
             cu_k_scale_cute = _to_cute_tensor(cu_seqlens_k_scale_padded, leading_dim=0) if is_varlen else None
-            q_offsets_cute = _to_cute_tensor(q_causal_offsets, leading_dim=0) if q_causal_offsets is not None else None
+            q_offsets_cute = _to_cute_tensor(q_causal_offsets, assumed_align=4, leading_dim=0) if q_causal_offsets is not None else None
 
             kernel_obj = IndexerForwardSm100Mxfp8(
                 head_dim=head_dim,
@@ -565,7 +582,7 @@ def indexer_fwd(
         kv_stage,
         num_threads,
         is_varlen,
-        q_causal_offsets is not None,
+        q_causal_offset_mode,
     )
 
     if compile_key not in _compile_cache:
@@ -576,7 +593,7 @@ def indexer_fwd(
         denom_cute = _to_cute_tensor(denom_tmp)
         cu_q_cute = _to_cute_tensor(cu_seqlens_q, leading_dim=0) if is_varlen else None
         cu_k_cute = _to_cute_tensor(cu_seqlens_k, leading_dim=0) if is_varlen else None
-        q_offsets_cute = _to_cute_tensor(q_causal_offsets, leading_dim=0) if q_causal_offsets is not None else None
+        q_offsets_cute = _to_cute_tensor(q_causal_offsets, assumed_align=4, leading_dim=0) if q_causal_offsets is not None else None
 
         kernel_obj = IndexerForwardSm100(
             head_dim=head_dim,
@@ -589,6 +606,7 @@ def indexer_fwd(
             is_varlen=is_varlen,
             compute_lse=False,
             is_compressed_logits=False,
+            q_causal_offset_mode=q_causal_offset_mode,
         )
 
         scale_arg = cutlass.Float32(sm_scale)

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/_interface_sm90.py
@@ -180,7 +180,21 @@ def indexer_fwd(
     assert qhead_per_kv_head == n_heads_q // n_heads_kv
     supported_qhpkv = _SUPPORTED_FP8_QHPKV if use_fp8_scales else _SUPPORTED_QHPKV
     assert qhead_per_kv_head in supported_qhpkv, f"qhead_per_kv_head must be one of {supported_qhpkv}, got {qhead_per_kv_head}"
-    q_causal_offsets = validate_q_causal_offsets(q_causal_offsets, int(batch_size), q.device, stream=current_stream)
+    q_causal_offsets = validate_q_causal_offsets(
+        q_causal_offsets,
+        int(batch_size),
+        q.device,
+        stream=current_stream,
+        total_q=int(total_q) if is_varlen else None,
+    )
+    if q_causal_offsets is None:
+        q_causal_offset_mode = "none"
+    elif is_varlen and q_causal_offsets.shape[0] != int(batch_size):
+        q_causal_offset_mode = "token"
+    else:
+        q_causal_offset_mode = "sequence"
+    if q_causal_offset_mode == "token" and precision != "bf16":
+        raise ValueError("THD per-token q_causal_offsets currently require precision='bf16'")
 
     if out is None:
         with _torch_stream_context(current_stream):
@@ -222,7 +236,7 @@ def indexer_fwd(
         get_broadcast_dims(w),
         get_broadcast_dims(q_scale) if q_scale is not None else None,
         get_broadcast_dims(k_scale) if k_scale is not None else None,
-        q_causal_offsets is not None,
+        q_causal_offset_mode,
     )
     if compile_key not in _compile_cache:
         q_cute = _to_cute_tensor(q)
@@ -234,7 +248,7 @@ def indexer_fwd(
         lse_cute = _to_cute_tensor(lse_out) if compute_lse else None
         cu_q_cute = _to_cute_tensor(cu_seqlens_q, leading_dim=0) if is_varlen else None
         cu_k_cute = _to_cute_tensor(cu_seqlens_k, leading_dim=0) if is_varlen else None
-        q_offsets_cute = _to_cute_tensor(q_causal_offsets, leading_dim=0) if q_causal_offsets is not None else None
+        q_offsets_cute = _to_cute_tensor(q_causal_offsets, assumed_align=4, leading_dim=0) if q_causal_offsets is not None else None
         kernel_obj = IndexerForwardSm90(
             torch2cute_dtype_map[q.dtype],
             torch2cute_dtype_map[w.dtype],
@@ -245,6 +259,7 @@ def indexer_fwd(
             use_unchecked_qh64=use_unchecked_qh64,
             use_unchecked_qh64_masked=use_unchecked_qh64_masked,
             compute_lse=compute_lse,
+            q_causal_offset_mode=q_causal_offset_mode,
         )
         _compile_cache[compile_key] = cute.compile(
             kernel_obj,

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/api.py
@@ -216,8 +216,9 @@ def indexer_forward_wrapper(
 
     Returns ``{'scores': (B, S_q, S_k) FP32}``. The ratio causal mask marks
     positions outside the valid KV range with -inf. ``q_causal_offsets`` may
-    specify the global uncompressed token index for each batch/THD segment's
-    local q[0].
+    contain one position delta per batch/THD segment, or one delta per packed
+    Q token for THD input. Offset values are read at execution time, so a
+    captured CUDA Graph can replay after the tensor is updated in place.
     """
     if device_major() == 9:
         if cu_seqlens_q_scale_padded is not None or cu_seqlens_k_scale_padded is not None:

--- a/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_forward/indexer_fwd_sm90.py
@@ -65,11 +65,14 @@ class IndexerForwardSm90:
         use_unchecked_qh64: bool = False,
         use_unchecked_qh64_masked: bool = False,
         compute_lse: bool = False,
+        q_causal_offset_mode: str = "none",
     ):
         assert head_dim == 128, f"SM90 direct forward supports head_dim=128, got {head_dim}"
         supported_qhpkv = (32, 64) if qk_dtype == cutlass.Float8E4M3FN else (16, 32, 64)
         assert qhead_per_kvhead in supported_qhpkv, f"SM90 direct forward supports qhpkv in {supported_qhpkv}, got {qhead_per_kvhead}"
         assert ratio >= 1, f"ratio must be >=1, got {ratio}"
+        assert q_causal_offset_mode in ("none", "sequence", "token")
+        assert q_causal_offset_mode != "token" or is_varlen
         self.qk_dtype = qk_dtype
         self.w_dtype = w_dtype
         self.use_fp8_scales = qk_dtype == cutlass.Float8E4M3FN
@@ -80,6 +83,7 @@ class IndexerForwardSm90:
         self.is_varlen = is_varlen
         self.use_split_q_wg = self.use_fp8_scales
         self.use_fp8_prescaled_w = self.use_fp8_scales and w_dtype == Float32
+        self.q_causal_offset_mode = q_causal_offset_mode
 
         self.tile_m = 128
         self.mma_tile_n = 64
@@ -253,6 +257,32 @@ class IndexerForwardSm90:
         return cute.ceil_div(kv_limit, self.tile_n)
 
     @cute.jit
+    def _compute_per_token_k_limits(
+        self,
+        m_block: Int32,
+        seqlen_q: Int32,
+        seqlen_k: Int32,
+        q_batch_offset: Int32,
+        mQCausalOffsets: cute.Tensor,
+    ):
+        q_token_base = m_block * Int32(self.q_tokens_per_tile)
+        r_kv_limits = cute.make_rmem_tensor((self.q_tokens_per_tile,), Int32)
+        r_kv_limits.fill(Int32(0))
+        kv_limit_min = seqlen_k
+        kv_limit_max = Int32(0)
+        for qi in cutlass.range_constexpr(self.q_tokens_per_tile):
+            q_local = q_token_base + Int32(qi)
+            if q_local < seqlen_q:
+                q_causal_offset = mQCausalOffsets[q_batch_offset + q_local]
+                kv_limit = (q_causal_offset + q_local + Int32(1)) // Int32(self.ratio)
+                kv_limit = kv_limit if kv_limit < seqlen_k else seqlen_k
+                kv_limit = kv_limit if kv_limit > Int32(0) else Int32(0)
+                r_kv_limits[qi] = kv_limit
+                kv_limit_min = kv_limit if kv_limit < kv_limit_min else kv_limit_min
+                kv_limit_max = kv_limit if kv_limit > kv_limit_max else kv_limit_max
+        return r_kv_limits, kv_limit_min, kv_limit_max
+
+    @cute.jit
     def _iter_n_block(self, iter_idx: Int32, n_block_max: Int32) -> Int32:
         if const_expr(self.use_fp8_scales):
             return n_block_max - Int32(1) - iter_idx
@@ -345,6 +375,7 @@ class IndexerForwardSm90:
         q_batch_offset: Int32,
         batch_idx: Int32,
         q_causal_offset: Int32,
+        kv_limits,
         sm_scale: Float32,
         kv_group_offset: Int32,
         lse_max: cute.Tensor = None,
@@ -389,10 +420,17 @@ class IndexerForwardSm90:
                     should_store = Boolean(True)
                     should_accum_lse = Boolean(True)
                     if apply_causal_mask:
-                        col_lim = (q_causal_offset + q_local + Int32(1)) // Int32(self.ratio)
-                        if k_local >= seqlen_k or k_local >= col_lim:
-                            should_store = Boolean(False)
-                            should_accum_lse = Boolean(False)
+                        if const_expr(self.q_causal_offset_mode == "token"):
+                            if q_local < seqlen_q:
+                                q_idx = q_stage_idx * self.q_tokens_per_stage + qi
+                                if k_local >= kv_limits[q_idx]:
+                                    should_store = Boolean(False)
+                                    should_accum_lse = Boolean(False)
+                        else:
+                            col_lim = (q_causal_offset + q_local + Int32(1)) // Int32(self.ratio)
+                            if k_local >= seqlen_k or k_local >= col_lim:
+                                should_store = Boolean(False)
+                                should_accum_lse = Boolean(False)
                     elif k_local >= seqlen_k:
                         should_store = Boolean(False)
                         should_accum_lse = Boolean(False)
@@ -594,11 +632,21 @@ class IndexerForwardSm90:
             tile_m=self.tile_m,
             tile_n=self.tile_n,
         )
-        q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
+        q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None or self.q_causal_offset_mode == "token") else mQCausalOffsets[batch_idx]
         num_m_blocks = cute.ceil_div(seqlen.seqlen_q * self.qhead_per_kvhead, self.tile_m)
         if block_x < num_m_blocks:
             m_block = num_m_blocks - Int32(1) - block_x
-            n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset)
+            if const_expr(self.q_causal_offset_mode == "token"):
+                _, _, kv_limit_max = self._compute_per_token_k_limits(
+                    m_block,
+                    seqlen.seqlen_q,
+                    seqlen.seqlen_k,
+                    seqlen.offset_q,
+                    mQCausalOffsets,
+                )
+                n_block_max = cute.ceil_div(kv_limit_max, self.tile_n)
+            else:
+                n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset)
 
             mQ_cur = seqlen.offset_batch_Q(mQ, batch_idx, dim=3)[None, None, head_idx]
             mK_cur = seqlen.offset_batch_K(mK, batch_idx, dim=3)[None, None, head_idx]
@@ -645,7 +693,10 @@ class IndexerForwardSm90:
                 else:
                     while iter_idx < n_block_max:
                         stage = iter_idx & Int32(1)
-                        n_block = self._iter_n_block(iter_idx, n_block_max)
+                        if const_expr(self.q_causal_offset_mode == "token"):
+                            n_block = n_block_max - Int32(1) - iter_idx
+                        else:
+                            n_block = self._iter_n_block(iter_idx, n_block_max)
                         if iter_idx >= Int32(2):
                             if stage == Int32(0):
                                 cute.arch.mbarrier_wait(mbar_KVEmpty0_ptr, kve0_phase)
@@ -727,11 +778,25 @@ class IndexerForwardSm90:
             tile_m=self.tile_m,
             tile_n=self.tile_n,
         )
-        q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
+        q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None or self.q_causal_offset_mode == "token") else mQCausalOffsets[batch_idx]
         num_m_blocks = cute.ceil_div(seqlen.seqlen_q * self.qhead_per_kvhead, self.tile_m)
         if block_x < num_m_blocks:
             m_block = num_m_blocks - Int32(1) - block_x
-            n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset)
+            if const_expr(self.q_causal_offset_mode == "token"):
+                r_kv_limits, kv_limit_min, kv_limit_max = self._compute_per_token_k_limits(
+                    m_block,
+                    seqlen.seqlen_q,
+                    seqlen.seqlen_k,
+                    seqlen.offset_q,
+                    mQCausalOffsets,
+                )
+                n_block_max = cute.ceil_div(kv_limit_max, self.tile_n)
+                masked_block_count = n_block_max - kv_limit_min // Int32(self.tile_n)
+            else:
+                r_kv_limits = mQCausalOffsets
+                kv_limit_min = Int32(0)
+                n_block_max = self._compute_n_blocks(m_block, seqlen.seqlen_q, seqlen.seqlen_k, q_causal_offset)
+                masked_block_count = Int32(0)
 
             thr_mma = tiled_mma_QK.get_slice(wg_tidx)
             tSrQ0, tSrK = _mma_partition_fragment_AB(thr_mma, sQ_0, sKV_staged, self.swap_AB)
@@ -775,7 +840,10 @@ class IndexerForwardSm90:
             iter_idx = Int32(0)
             while iter_idx < n_block_max:
                 stage = iter_idx & Int32(1)
-                n_block = self._iter_n_block(iter_idx, n_block_max)
+                if const_expr(self.q_causal_offset_mode == "token"):
+                    n_block = n_block_max - Int32(1) - iter_idx
+                else:
+                    n_block = self._iter_n_block(iter_idx, n_block_max)
                 if stage == Int32(0):
                     cute.arch.mbarrier_wait(mbar_KV0_ptr, kv0_phase)
                     kv0_phase = kv0_phase ^ Int32(1)
@@ -819,7 +887,10 @@ class IndexerForwardSm90:
                             with cute.arch.elect_one():
                                 cute.arch.mbarrier_arrive(mbar_KVEmpty1_ptr, arrive_count=128)
 
-                apply_causal_mask = Boolean(iter_idx < Int32(2)) if const_expr(self.mask_two_rightmost_nblocks) else Boolean(iter_idx == Int32(0))
+                if const_expr(self.q_causal_offset_mode == "token"):
+                    apply_causal_mask = Boolean(iter_idx < masked_block_count)
+                else:
+                    apply_causal_mask = Boolean(iter_idx < Int32(2)) if const_expr(self.mask_two_rightmost_nblocks) else Boolean(iter_idx == Int32(0))
                 if const_expr(self.use_fp8_scales):
                     self._epilogue_store_to_gmem(
                         0,
@@ -836,6 +907,7 @@ class IndexerForwardSm90:
                         seqlen.offset_q,
                         batch_idx,
                         q_causal_offset,
+                        r_kv_limits,
                         sm_scale,
                         Int32(0),
                         lse_max0 if const_expr(self.compute_lse) else None,
@@ -856,6 +928,7 @@ class IndexerForwardSm90:
                         seqlen.offset_q,
                         batch_idx,
                         q_causal_offset,
+                        r_kv_limits,
                         sm_scale,
                         Int32(0),
                         lse_max1 if const_expr(self.compute_lse) else None,
@@ -877,6 +950,7 @@ class IndexerForwardSm90:
                         seqlen.offset_q,
                         batch_idx,
                         q_causal_offset,
+                        r_kv_limits,
                         sm_scale,
                         Int32(0),
                         lse_max0 if const_expr(self.compute_lse) else None,
@@ -897,6 +971,7 @@ class IndexerForwardSm90:
                         seqlen.offset_q,
                         batch_idx,
                         q_causal_offset,
+                        r_kv_limits,
                         sm_scale,
                         Int32(0),
                         lse_max1 if const_expr(self.compute_lse) else None,
@@ -1110,6 +1185,7 @@ class IndexerForwardSm90:
                         seqlen.offset_q,
                         batch_idx,
                         q_causal_offset,
+                        mQCausalOffsets,
                         sm_scale,
                         Int32(0),
                         lse_max if const_expr(self.compute_lse) else None,

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
@@ -879,8 +879,8 @@ class DenseScoreRecomputeSm100:
         seqlen_q,
         seqlen_k,
         q_causal_offset,
-        q_batch_offset,
-        mQCausalOffsets,
+        q_batch_offset=None,
+        mQCausalOffsets=None,
     ):
         """Return dense K blocks that can contain at least one valid KV column."""
         ratio = Int32(self.ratio)

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/dense_score_recompute_sm100.py
@@ -109,9 +109,12 @@ class DenseScoreRecomputeSm100:
         k_block_size: int | None = None,
         ratio: int = 1,
         is_varlen: bool = False,
+        q_causal_offset_mode: str = "sequence",
     ):
         assert score_type in ("indexer", "attention")
         assert ratio >= 1, f"ratio must be >= 1, got {ratio}"
+        assert q_causal_offset_mode in ("none", "sequence", "token")
+        assert q_causal_offset_mode != "token" or is_varlen
         self.score_type = score_type
         self.head_dim = head_dim
         self.qhead_per_kvhead = qhead_per_kvhead
@@ -120,6 +123,7 @@ class DenseScoreRecomputeSm100:
         self.kv_stage = kv_stage
         self.ratio = ratio
         self.is_varlen = is_varlen
+        self.q_causal_offset_mode = q_causal_offset_mode
         # Unified forward specializations opt in to compact output. The base
         # dense score kernel always retains its dense output contract.
         self.is_compressed_logits = False
@@ -554,7 +558,7 @@ class DenseScoreRecomputeSm100:
                     m_block_sched = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
-                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
+                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None or self.q_causal_offset_mode == "token") else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
                         seqlen.seqlen_q * self.qhead_per_kvhead,
                         self.m_block_size,
@@ -568,6 +572,8 @@ class DenseScoreRecomputeSm100:
                             seqlen.seqlen_q,
                             seqlen.seqlen_k,
                             q_causal_offset,
+                            seqlen.offset_q,
+                            mQCausalOffsets,
                         )
                         # PerHead data load (double-buffered)
                         per_head_buf_off = (tile_count % 2) * self.m_block_size
@@ -656,7 +662,7 @@ class DenseScoreRecomputeSm100:
                     m_block_sched = work_tile.tile_idx[0]
                     batch_idx = work_tile.tile_idx[2]
                     seqlen = SeqlenInfoCls(batch_idx)
-                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
+                    q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None or self.q_causal_offset_mode == "token") else mQCausalOffsets[batch_idx]
                     num_m_blocks_cur = cute.ceil_div(
                         seqlen.seqlen_q * self.qhead_per_kvhead,
                         self.m_block_size,
@@ -670,6 +676,8 @@ class DenseScoreRecomputeSm100:
                             seqlen.seqlen_q,
                             seqlen.seqlen_k,
                             q_causal_offset,
+                            seqlen.offset_q,
+                            mQCausalOffsets,
                         )
                         Q_consumer.reset()
                         handle_Q = Q_consumer.wait_and_advance()
@@ -759,7 +767,7 @@ class DenseScoreRecomputeSm100:
                 m_block_sched = work_tile.tile_idx[0]
                 batch_idx = work_tile.tile_idx[2]
                 seqlen = SeqlenInfoCls(batch_idx)
-                q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None) else mQCausalOffsets[batch_idx]
+                q_causal_offset = Int32(0) if const_expr(mQCausalOffsets is None or self.q_causal_offset_mode == "token") else mQCausalOffsets[batch_idx]
                 num_m_blocks_cur = cute.ceil_div(
                     seqlen.seqlen_q * self.qhead_per_kvhead,
                     self.m_block_size,
@@ -773,6 +781,8 @@ class DenseScoreRecomputeSm100:
                         seqlen.seqlen_q,
                         seqlen.seqlen_k,
                         q_causal_offset,
+                        seqlen.offset_q,
+                        mQCausalOffsets,
                     )
                     per_head_offset = (tile_count % 2) * self.m_block_size
                     mDenom_cur = seqlen.offset_batch_Q(mDenom, batch_idx, dim=1)
@@ -823,6 +833,8 @@ class DenseScoreRecomputeSm100:
                             reduce_phase,
                             softmax_scale,
                             per_head_offset=per_head_offset,
+                            q_batch_offset=seqlen.offset_q,
+                            q_causal_offsets=mQCausalOffsets,
                             batch_idx=batch_idx,
                             cand_batch_offsets=mCandBatchOffsets,
                         )
@@ -848,6 +860,8 @@ class DenseScoreRecomputeSm100:
                             reduce_phase,
                             softmax_scale,
                             per_head_offset=per_head_offset,
+                            q_batch_offset=seqlen.offset_q,
+                            q_causal_offsets=mQCausalOffsets,
                         )
                     tile_count = tile_count + 1
                 clc_pipeline.consumer_wait(clc_consumer_state)
@@ -859,14 +873,31 @@ class DenseScoreRecomputeSm100:
                     cute.arch.mbarrier_arrive(tmem_dealloc_mbar_ptr)
 
     @cute.jit
-    def _dense_compute_n_blocks(self, m_block, seqlen_q, seqlen_k, q_causal_offset):
+    def _dense_compute_n_blocks(
+        self,
+        m_block,
+        seqlen_q,
+        seqlen_k,
+        q_causal_offset,
+        q_batch_offset,
+        mQCausalOffsets,
+    ):
         """Return dense K blocks that can contain at least one valid KV column."""
         ratio = Int32(self.ratio)
         q_token_base = m_block * self.q_tokens_per_tile
-        q_token_last = q_token_base + Int32(self.q_tokens_per_tile - 1)
-        q_token_last = q_token_last if q_token_last < seqlen_q else seqlen_q - Int32(1)
-
-        max_kv_needed = (q_causal_offset + q_token_last + Int32(1)) // ratio
+        if const_expr(self.q_causal_offset_mode == "token"):
+            max_kv_needed = Int32(0)
+            for qi in cutlass.range_constexpr(self.q_tokens_per_tile):
+                q_token = q_token_base + Int32(qi)
+                if q_token < seqlen_q:
+                    kv_needed = (mQCausalOffsets[q_batch_offset + q_token] + q_token + Int32(1)) // ratio
+                    kv_needed = kv_needed if kv_needed > Int32(0) else Int32(0)
+                    kv_needed = kv_needed if kv_needed < seqlen_k else seqlen_k
+                    max_kv_needed = kv_needed if kv_needed > max_kv_needed else max_kv_needed
+        else:
+            q_token_last = q_token_base + Int32(self.q_tokens_per_tile - 1)
+            q_token_last = q_token_last if q_token_last < seqlen_q else seqlen_q - Int32(1)
+            max_kv_needed = (q_causal_offset + q_token_last + Int32(1)) // ratio
         max_kv_needed = max_kv_needed if max_kv_needed > Int32(0) else Int32(0)
         max_kv_needed = max_kv_needed if max_kv_needed < seqlen_k else seqlen_k
         return cute.ceil_div(max_kv_needed, self.n_block_size)
@@ -979,6 +1010,8 @@ class DenseScoreRecomputeSm100:
         reduce_phase,
         softmax_scale,
         per_head_offset=None,
+        q_batch_offset=None,
+        q_causal_offsets=None,
     ):
         """Dense indexer epilogue: TMEM->RF, ReLU, *W, head reduce.
 

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/indexer_score_unified_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/indexer_score_unified_sm100.py
@@ -18,7 +18,7 @@ import math
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Float32, Int32, Int64
+from cutlass import Boolean, Float32, Int32, Int64
 import cutlass.cute.nvgpu.tcgen05 as tcgen05
 
 from .dense_score_recompute_sm100 import (
@@ -46,6 +46,7 @@ class IndexerScoreUnifiedSm100(DenseScoreRecomputeSm100):
         # Dense FE entry points remain the default. The compressed forward path
         # opts in and writes only ratio-causal candidates into a compact buffer.
         self.is_compressed_logits = is_compressed_logits
+        assert self.q_causal_offset_mode != "token" or not self.is_compressed_logits
         # BSHD BF16 may expose that compact buffer as (batch, per_batch_floats)
         # so the hot epilogue carries an Int32 column offset instead of a flat
         # Int64 address. Varlen and non-uniform batches retain the flat path.
@@ -88,6 +89,8 @@ class IndexerScoreUnifiedSm100(DenseScoreRecomputeSm100):
         reduce_phase,
         softmax_scale,
         per_head_offset=None,
+        q_batch_offset=None,
+        q_causal_offsets=None,
         batch_idx=None,
         cand_batch_offsets=None,
     ):
@@ -114,7 +117,22 @@ class IndexerScoreUnifiedSm100(DenseScoreRecomputeSm100):
 
         q_token_base = m_block * q_tokens_per_tile
         q_token_idxs = [q_token_base + Int32(qi) for qi in range(q_tokens_per_tile)]
-        col_limits = [(q_causal_offset + q_token_idxs[qi] + Int32(1)) // ratio for qi in range(q_tokens_per_tile)]
+        if cutlass.const_expr(self.q_causal_offset_mode == "token"):
+            col_limits = cute.make_rmem_tensor((q_tokens_per_tile,), Int32)
+            col_limits.fill(Int32(0))
+            col_limit_min = seqlen_k
+            for qi in cutlass.range_constexpr(q_tokens_per_tile):
+                q_token_idx = q_token_idxs[qi]
+                if q_token_idx < seqlen_q:
+                    col_limit = (q_causal_offsets[q_batch_offset + q_token_idx] + q_token_idx + Int32(1)) // ratio
+                    col_limit = col_limit if col_limit > Int32(0) else Int32(0)
+                    col_limit = col_limit if col_limit < seqlen_k else seqlen_k
+                    col_limits[qi] = col_limit
+                    col_limit_min = col_limit if col_limit < col_limit_min else col_limit_min
+            first_masked_n_block = col_limit_min // Int32(self.n_block_size)
+        else:
+            col_limits = [(q_causal_offset + q_token_idxs[qi] + Int32(1)) // ratio for qi in range(q_tokens_per_tile)]
+            first_masked_n_block = Int32(0)
 
         if cutlass.const_expr(self.is_compressed_logits and self.cand_2d):
             q_global_start = Int64(q_causal_offset)
@@ -183,7 +201,11 @@ class IndexerScoreUnifiedSm100(DenseScoreRecomputeSm100):
             for qi in cutlass.range_constexpr(q_tokens_per_tile):
                 q_token_idx = q_token_idxs[qi]
                 col_limit = col_limits[qi]
-                if q_token_idx < seqlen_q and pos < col_limit and pos < seqlen_k:
+                if cutlass.const_expr(self.q_causal_offset_mode == "token"):
+                    is_visible = Boolean(True) if n_blk < first_masked_n_block else pos < col_limit
+                else:
+                    is_visible = pos < col_limit and pos < seqlen_k
+                if q_token_idx < seqlen_q and is_visible:
                     local_sum_0 = (Float32(0.0), Float32(0.0))
                     local_sum_1 = (Float32(0.0), Float32(0.0))
                     local_sum_2 = (Float32(0.0), Float32(0.0))

--- a/python/cudnn/deepseek_sparse_attention/score_recompute/indexer_score_unified_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/score_recompute/indexer_score_unified_sm100.py
@@ -122,13 +122,13 @@ class IndexerScoreUnifiedSm100(DenseScoreRecomputeSm100):
             col_limits.fill(Int32(0))
             col_limit_min = seqlen_k
             for qi in cutlass.range_constexpr(q_tokens_per_tile):
-                q_token_idx = q_token_idxs[qi]
-                if q_token_idx < seqlen_q:
-                    col_limit = (q_causal_offsets[q_batch_offset + q_token_idx] + q_token_idx + Int32(1)) // ratio
-                    col_limit = col_limit if col_limit > Int32(0) else Int32(0)
-                    col_limit = col_limit if col_limit < seqlen_k else seqlen_k
-                    col_limits[qi] = col_limit
-                    col_limit_min = col_limit if col_limit < col_limit_min else col_limit_min
+                q_token_idx_for_limit = q_token_idxs[qi]
+                if q_token_idx_for_limit < seqlen_q:
+                    q_col_limit = (q_causal_offsets[q_batch_offset + q_token_idx_for_limit] + q_token_idx_for_limit + Int32(1)) // ratio
+                    q_col_limit = q_col_limit if q_col_limit > Int32(0) else Int32(0)
+                    q_col_limit = q_col_limit if q_col_limit < seqlen_k else seqlen_k
+                    col_limits[qi] = q_col_limit
+                    col_limit_min = q_col_limit if q_col_limit < col_limit_min else col_limit_min
             first_masked_n_block = col_limit_min // Int32(self.n_block_size)
         else:
             col_limits = [(q_causal_offset + q_token_idxs[qi] + Int32(1)) // ratio for qi in range(q_tokens_per_tile)]

--- a/python/cudnn/deepseek_sparse_attention/utils/runtime.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/runtime.py
@@ -35,13 +35,16 @@ def validate_q_causal_offsets(
     batch: int,
     device: torch.device,
     stream: Optional[cuda.CUstream] = None,
+    total_q: Optional[int] = None,
 ) -> torch.Tensor | None:
     if q_causal_offsets is None:
         return None
     if q_causal_offsets.dtype != torch.int32:
         raise ValueError("q_causal_offsets must be int32")
-    if q_causal_offsets.ndim != 1 or q_causal_offsets.shape[0] != batch:
-        raise ValueError(f"q_causal_offsets must have shape ({batch},), got {tuple(q_causal_offsets.shape)}")
+    valid_lengths = (batch,) if total_q is None or total_q == batch else (batch, total_q)
+    if q_causal_offsets.ndim != 1 or q_causal_offsets.shape[0] not in valid_lengths:
+        expected = f"({batch},)" if len(valid_lengths) == 1 else f"({batch},) or ({total_q},)"
+        raise ValueError(f"q_causal_offsets must have shape {expected}, got {tuple(q_causal_offsets.shape)}")
     if not q_causal_offsets.is_cuda:
         raise ValueError("q_causal_offsets must be a CUDA tensor")
     if q_causal_offsets.device != device:

--- a/test/python/fe_api/dsa/dsa_reference.py
+++ b/test/python/fe_api/dsa/dsa_reference.py
@@ -239,6 +239,84 @@ def check_ref_compressed_topk(
         )
 
 
+def ref_indexer_forward_thd(
+    q: torch.Tensor,  # (total_q, H_q, D)
+    k: torch.Tensor,  # (total_k, H_kv, D)
+    w: torch.Tensor,  # (total_q, H_q)
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_k: int,
+    ratio: int,
+    q_causal_offsets: torch.Tensor,  # (total_q,)
+) -> torch.Tensor:
+    """Independent PyTorch reference for THD per-token causal offsets."""
+    out = torch.full(
+        (q.shape[0], max_seqlen_k),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    cu_q = cu_seqlens_q.cpu().tolist()
+    cu_k = cu_seqlens_k.cpu().tolist()
+    offsets = q_causal_offsets.to(dtype=torch.int64)
+
+    for batch in range(len(cu_q) - 1):
+        q0, q1 = cu_q[batch : batch + 2]
+        k0, k1 = cu_k[batch : batch + 2]
+        q_b = q[q0:q1].to(torch.float32)
+        k_b = k[k0:k1].to(torch.float32)
+        w_b = w[q0:q1].to(torch.float32)
+        qhpkv = q_b.shape[1] // k_b.shape[1]
+        k_b = k_b.repeat_interleave(qhpkv, dim=1)
+        scores = torch.einsum("qhd,khd->qhk", q_b, k_b).relu()
+        scores = (scores * w_b.unsqueeze(-1)).sum(dim=1)
+
+        q_local = torch.arange(q1 - q0, dtype=torch.int64, device=q.device)
+        visible_k = torch.div(
+            q_local + offsets[q0:q1] + 1,
+            ratio,
+            rounding_mode="floor",
+        ).clamp(0, k1 - k0)
+        k_local = torch.arange(k1 - k0, dtype=torch.int64, device=q.device)
+        valid = k_local.unsqueeze(0) < visible_k.unsqueeze(1)
+        out[q0:q1, : k1 - k0] = scores.masked_fill(~valid, float("-inf"))
+
+    return out
+
+
+def check_ref_indexer_forward_thd(
+    q,
+    k,
+    w,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    max_seqlen_k,
+    out_actual,
+    ratio,
+    q_causal_offsets,
+    atol: float = 1e-4,
+    rtol: float = 1e-4,
+):
+    out_ref = ref_indexer_forward_thd(
+        q,
+        k,
+        w,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_k,
+        ratio,
+        q_causal_offsets,
+    )
+    finite = torch.isfinite(out_ref)
+    assert torch.equal(torch.isneginf(out_actual), torch.isneginf(out_ref))
+    torch.testing.assert_close(
+        out_actual[finite],
+        out_ref[finite],
+        atol=atol,
+        rtol=rtol,
+    )
+
+
 def ref_indexer_top_k(
     input_values: torch.Tensor,  # (n_rows, num_cols)
     seq_lens: torch.Tensor,  # (batch_size,)

--- a/test/python/fe_api/dsa/test_DSA_indexer_forward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_forward.py
@@ -21,6 +21,7 @@ from fe_api.dsa.dsa_utils import (
 from fe_api.dsa.dsa_reference import (
     check_ref_compressed_topk,
     check_ref_indexer_forward,
+    check_ref_indexer_forward_thd,
     ref_indexer_forward,
 )
 
@@ -710,3 +711,251 @@ def test_DSA_indexer_forward_wrapper_fp8_sm90_thd_matches_dequant_reference():
         )
         if s_k < max(k_lengths):
             assert bool(torch.isneginf(result["scores"][q0:q1, s_k:]).all())
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=15)
+def test_DSA_indexer_forward_wrapper_thd_per_token_offsets_nonmonotonic():
+    major = torch.cuda.get_device_capability()[0]
+    if major not in (9, 10):
+        pytest.skip("DSA indexer forward requires SM90 or SM100")
+
+    from cudnn import DSA
+
+    device = torch.device("cuda")
+    ratio, h_q, h_kv, d = 4, 32, 1, 128
+    q_lengths = [7, 11]
+    k_lengths = [650, 533]
+    max_seqlen_k = max(k_lengths)
+    cu_seqlens_q = torch.tensor([0, 7, 18], dtype=torch.int32, device=device)
+    cu_seqlens_k = torch.tensor([0, 650, 1183], dtype=torch.int32, device=device)
+    total_q, total_k = sum(q_lengths), sum(k_lengths)
+    q = torch.randn(total_q, h_q, d, dtype=torch.bfloat16, device=device)
+    k = torch.randn(total_k, h_kv, d, dtype=torch.bfloat16, device=device)
+    w = torch.randn(total_q, h_q, dtype=torch.bfloat16, device=device)
+
+    # Each sequence begins with non-monotonic source positions in one CTA.
+    # The late row requires K blocks that the last row does not, while the
+    # early rows must remain masked in intermediate K blocks. Negative deltas
+    # and ragged CTA tails are present in both sequences.
+    q_causal_offsets = torch.tensor(
+        [
+            3,
+            2558,
+            -1,
+            252,
+            507,
+            2,
+            1017,
+            1279,
+            14,
+            2117,
+            60,
+            507,
+            -5,
+            1694,
+            24,
+            1015,
+            -7,
+            1790,
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    scores = DSA.indexer_forward_wrapper(
+        q,
+        k,
+        w,
+        ratio=ratio,
+        qhead_per_kv_head=h_q,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max(q_lengths),
+        max_seqlen_k=max_seqlen_k,
+        q_causal_offsets=q_causal_offsets,
+    )["scores"]
+    torch.cuda.synchronize()
+
+    assert scores.shape == (total_q, max_seqlen_k)
+    assert bool(torch.isfinite(scores[0, 0]))
+    assert bool(torch.isneginf(scores[0, 1]))
+    assert bool(torch.isfinite(scores[1, 639]))
+    assert bool(torch.isneginf(scores[1, 640]))
+    assert bool(torch.isneginf(scores[0, 128]))
+    assert bool(torch.isfinite(scores[9, 529]))
+    assert bool(torch.isneginf(scores[9, 530]))
+    assert bool(torch.isneginf(scores[7:, k_lengths[1] :]).all())
+    check_ref_indexer_forward_thd(
+        q,
+        k,
+        w,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_k,
+        scores,
+        ratio,
+        q_causal_offsets,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=16)
+def test_DSA_indexer_forward_wrapper_thd_offset_modes_and_compile_cache():
+    major = torch.cuda.get_device_capability()[0]
+    if major not in (9, 10):
+        pytest.skip("DSA indexer forward requires SM90 or SM100")
+
+    from cudnn import DSA
+
+    device = torch.device("cuda")
+    ratio, h_q, h_kv, d = 4, 32, 1, 128
+    q_lengths = [5, 9]
+    k_lengths = [36, 41]
+    cu_seqlens_q = torch.tensor([0, 5, 14], dtype=torch.int32, device=device)
+    cu_seqlens_k = torch.tensor([0, 36, 77], dtype=torch.int32, device=device)
+    total_q, total_k = sum(q_lengths), sum(k_lengths)
+    max_seqlen_k = max(k_lengths)
+    q = torch.randn(total_q, h_q, d, dtype=torch.bfloat16, device=device)
+    k = torch.randn(total_k, h_kv, d, dtype=torch.bfloat16, device=device)
+    w = torch.randn(total_q, h_q, dtype=torch.bfloat16, device=device)
+    sequence_offsets = torch.tensor([140, -4], dtype=torch.int32, device=device)
+    token_offsets = torch.tensor(
+        [140] * q_lengths[0] + [-4] * q_lengths[1],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    def run(offsets):
+        return DSA.indexer_forward_wrapper(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            qhead_per_kv_head=h_q,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max(q_lengths),
+            max_seqlen_k=max_seqlen_k,
+            q_causal_offsets=offsets,
+        )["scores"]
+
+    # Keep this order: it catches compile-cache keys that distinguish only
+    # offset-present versus offset-absent instead of sequence versus token.
+    scores_sequence_first = run(sequence_offsets)
+    scores_token = run(token_offsets)
+    scores_sequence_again = run(sequence_offsets)
+    scores_none = run(None)
+    torch.cuda.synchronize()
+
+    check_ref_indexer_forward_thd(
+        q,
+        k,
+        w,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_k,
+        scores_token,
+        ratio,
+        token_offsets,
+    )
+    check_ref_indexer_forward_thd(
+        q,
+        k,
+        w,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_k,
+        scores_none,
+        ratio,
+        torch.zeros_like(token_offsets),
+    )
+    torch.testing.assert_close(scores_sequence_first, scores_token)
+    torch.testing.assert_close(scores_sequence_again, scores_token)
+    assert bool(torch.isneginf(scores_token[: q_lengths[0], k_lengths[0] :]).all())
+
+    q_bshd = torch.randn(2, 4, h_q, d, dtype=torch.bfloat16, device=device)
+    k_bshd = torch.randn(2, 8, h_kv, d, dtype=torch.bfloat16, device=device)
+    w_bshd = torch.randn(2, 4, h_q, dtype=torch.bfloat16, device=device)
+    with pytest.raises(ValueError, match=r"must have shape \(2,\)"):
+        DSA.indexer_forward_wrapper(
+            q_bshd,
+            k_bshd,
+            w_bshd,
+            ratio=ratio,
+            qhead_per_kv_head=h_q,
+            q_causal_offsets=torch.zeros(8, dtype=torch.int32, device=device),
+        )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=17)
+def test_DSA_indexer_forward_wrapper_thd_per_token_offsets_cuda_graph_replay():
+    major = torch.cuda.get_device_capability()[0]
+    if major not in (9, 10):
+        pytest.skip("DSA indexer forward requires SM90 or SM100")
+
+    from cudnn import DSA
+
+    device = torch.device("cuda")
+    ratio, h_q, h_kv, d = 4, 32, 1, 128
+    q_lengths = [6, 10]
+    k_lengths = [132, 140]
+    cu_seqlens_q = torch.tensor([0, 6, 16], dtype=torch.int32, device=device)
+    cu_seqlens_k = torch.tensor([0, 132, 272], dtype=torch.int32, device=device)
+    total_q, total_k = sum(q_lengths), sum(k_lengths)
+    max_seqlen_k = max(k_lengths)
+    q = torch.randn(total_q, h_q, d, dtype=torch.bfloat16, device=device)
+    k = torch.randn(total_k, h_kv, d, dtype=torch.bfloat16, device=device)
+    w = torch.randn(total_q, h_q, dtype=torch.bfloat16, device=device)
+    q_causal_offset_storage = torch.empty(total_q + 1, dtype=torch.int32, device=device)
+    q_causal_offsets = q_causal_offset_storage[1:]
+    q_causal_offsets.fill_(508)
+    assert q_causal_offsets.is_contiguous()
+    assert q_causal_offsets.data_ptr() % 16 == 4
+    updated_offsets = torch.tensor(
+        [3, 522, -2, 252, 387, 6, 551, 2, 507, -4, 379, 14, 531, -8, 260, 19],
+        dtype=torch.int32,
+        device=device,
+    )
+    scores = torch.empty(total_q, max_seqlen_k, dtype=torch.float32, device=device)
+
+    def run():
+        return DSA.indexer_forward_wrapper(
+            q,
+            k,
+            w,
+            ratio=ratio,
+            qhead_per_kv_head=h_q,
+            out=scores,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max(q_lengths),
+            max_seqlen_k=max_seqlen_k,
+            q_causal_offsets=q_causal_offsets,
+        )["scores"]
+
+    run()  # JIT compilation is intentionally outside capture.
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_scores = run()
+    torch.cuda.synchronize()
+    initial_mask = torch.isneginf(captured_scores).clone()
+
+    q_causal_offsets.copy_(updated_offsets)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert not torch.equal(initial_mask, torch.isneginf(captured_scores))
+    check_ref_indexer_forward_thd(
+        q,
+        k,
+        w,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_k,
+        captured_scores,
+        ratio,
+        updated_offsets,
+    )


### PR DESCRIPTION
DRAFT!
This PR is intended to be used in conjunction with a feature under development in MCore. We are currently reviewing and modifying that MCore feature, so not yet certain whether there is a corresponding need to modify this PR. I will remove the draft flag once the MCore side feature is finalized.

## Before submitting

- [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)). The submitter account cannot add labels to the upstream repository.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Extend the existing `q_causal_offsets` input for BF16 THD indexer forward to accept one runtime offset delta per packed Q token. The existing no-offset and per-sequence paths remain separate compile-time specializations and retain their existing behavior.

For a token, visibility is:

```
q_position = q_local + q_causal_offsets[token]
visible_k = clamp((q_position + 1) // ratio, 0, seqlen_k)
```

SM90 and SM100 derive each CTA's K traversal bound from the maximum visible-K over valid Q rows, retain the minimum-visible-K all-row fast path, and apply exact per-row masks to the remaining blocks.

## Why

Context-parallel zigzag layouts can mix early, late, and non-monotonic source Q positions in one local THD tile. A single per-sequence offset cannot describe those positions and forces every rank to traverse the same large K prefix. Per-token runtime deltas preserve exact causal semantics while reducing load imbalance, without adding a new public parameter or introducing host/device synchronization.

## Related issues

None.

## API and compatibility impact

- No new public parameter.
- `q_causal_offsets=None` and shape `(batch,)` are unchanged.
- BF16 THD indexer forward additionally accepts shape `(total_q,)`.
- BSHD, FP8/MXFP8, combined Top-K, dense score recompute, and backward remain per-sequence-only.
- Offset values remain runtime data and are not part of the compile key, so CUDA Graph replay can update the tensor in place.
- INT32 offset tensors use 4-byte assumed alignment.

## Testing

Current branch (`5667dc23681c26eec2c020c64483054199f96fad`, based on `NVIDIA/develop@66efedfe806ca2f86c28d123e974204660526ef7`):

- `pre-commit run --files <10 changed files>`: passed (black and black-jupyter; clang-format skipped because no applicable files).
- `python3.11 -m py_compile <9 changed Python files>`: passed.
- `git diff --check`: passed.
- H100 full `test_DSA_indexer_forward.py`: 11 passed, 6 SM100-only skips, 9.05 s; all three new per-token tests executed and passed.
- H100 full DSA L0: 49 passed, 2 pre-existing Top-K failures, 42 architecture-specific skips, 48.67 s.
- H100 CUDA-event performance (5 warmups, 20 samples, JIT excluded), CP32/512K: sequence -0.006%, equivalent token +0.567%, zigzag slowest-rank latency -48.873%, max/min 1.029x.
- GB200 full `test_DSA_indexer_forward.py`: 12 passed, 5 SM90-only skips, 14.30 s; all three new per-token tests executed and passed.
- GB200 full DSA L0: 84 passed, 2 pre-existing Top-K failures, 7 architecture-specific skips, 86.29 s.
- GB200 CUDA-event performance (5 warmups, 20 samples, JIT excluded), CP32/512K: sequence -0.211%, equivalent token -0.636%, zigzag slowest-rank latency -49.746%, max/min 1.054x.

GB200 execution also caught and fixed two SM100 compile regressions before publication: a CuTe DSL dynamic-loop type join caused by reusing a token-index local across compile-time specializations, and missing optional arguments for inherited MXFP8 sequence-only callers. The final full-file result above is from the exact formatted source tree. The ephemeral test container removed its optional `flash-attn-4` package because that package is incompatible with CUTLASS DSL 4.6.1 during unrelated `conftest.py` Transformer Engine import; product sources were not changed for that environment issue.

Pre-rebase implementation with the same semantics, validated on `develop@b7ddaae668a1e44efd823d684b3987d5137290ec`:

- New test before product changes: failed on H100 with `q_causal_offsets must have shape (2,), got (18,)`.
- H100 full `test_DSA_indexer_forward.py`: 7 passed, 0 skipped, 5.89 s.
- GB200 full `test_DSA_indexer_forward.py`: 5 passed, 2 SM90-only skips, 6.23 s; all new per-token tests executed.
- H100 full DSA L0: 35 passed, 2 pre-existing Top-K failures, 11 skipped, 45.62 s.
- GB200 full DSA L0: 42 passed, 2 pre-existing Top-K failures, 4 architecture-specific skips, 46.64 s.
- CUDA-event performance (5 warmups, 20 samples, JIT excluded):
  - H100 CP32/512K: sequence +0.003%, equivalent token +1.499%, zigzag slowest-rank latency -48.375%, max/min 1.038x.
  - GB200 CP32/512K: sequence +0.006%, equivalent token -1.017%, zigzag slowest-rank latency -48.696%, max/min 1.029x.
