### PR TITLE
fix : serialize Tensor_attributes::alignment

### DIFF
--- a/include/cudnn_frontend/graph_properties.h
+++ b/include/cudnn_frontend/graph_properties.h
@@ -131,7 +131,7 @@ class Tensor_attributes {
 
     std::shared_ptr<Tensor_attributes> ragged_offset;
     int64_t ragged_offset_multiplier = 1;
-    int64_t alignment                = 16;  // Default to 16 bytes
+    int64_t alignment                = default_alignment;
     int64_t vector_count             = 1;   // Default to 1 (no vectorization)
     int64_t vector_dimension         = -1;  // Default to -1 (not set)
 
@@ -412,6 +412,9 @@ class Tensor_attributes {
         reordering_type = value;
         return *this;
     }
+
+    // Pointer alignment assumed by the backend when selecting engines, in bytes.
+    static constexpr int64_t default_alignment = 16;
 
     int64_t
     get_alignment() const {

--- a/include/cudnn_frontend/utils/serialize.h
+++ b/include/cudnn_frontend/utils/serialize.h
@@ -617,6 +617,11 @@ to_json(nlohmann::json& j, const Tensor_attributes& ta) {
     if (ta.has_ragged_offset_multiplier()) {
         j["ragged_offset_multiplier"] = ta.ragged_offset_multiplier;
     }
+    // Emitted only when non-default so that graphs which never call set_alignment keep a
+    // byte-identical payload (and therefore an unchanged Graph::key()) across this change.
+    if (ta.alignment != Tensor_attributes::default_alignment) {
+        j["alignment"] = ta.alignment;
+    }
 }
 
 inline void
@@ -644,6 +649,9 @@ from_json(const nlohmann::json& j, Tensor_attributes& ta) {
     if (j.contains("ragged_offset_multiplier")) {
         ta.ragged_offset_multiplier = j.at("ragged_offset_multiplier").get<int64_t>();
     }
+    // Read tolerantly: payloads produced before alignment was serialized carry no such key,
+    // and they must keep deserializing to the default rather than throwing.
+    ta.alignment = j.value("alignment", Tensor_attributes::default_alignment);
 }
 
 NLOHMANN_JSON_SERIALIZE_ENUM(KnobType_t,

--- a/include/cudnn_frontend/utils/serialize.h
+++ b/include/cudnn_frontend/utils/serialize.h
@@ -649,8 +649,7 @@ from_json(const nlohmann::json& j, Tensor_attributes& ta) {
     if (j.contains("ragged_offset_multiplier")) {
         ta.ragged_offset_multiplier = j.at("ragged_offset_multiplier").get<int64_t>();
     }
-    // Read tolerantly: payloads produced before alignment was serialized carry no such key,
-    // and they must keep deserializing to the default rather than throwing.
+    // Optional read, for backward compatibility with payloads that predate this key.
     ta.alignment = j.value("alignment", Tensor_attributes::default_alignment);
 }
 

--- a/test/cpp/serialize.cpp
+++ b/test/cpp/serialize.cpp
@@ -26,6 +26,101 @@ TEST_CASE("Tensor attributes", "[tensor][serialize]") {
     REQUIRE(tensor_attributes_deserialized == tensor_attributes);
 }
 
+TEST_CASE("Tensor attributes alignment", "[tensor][serialize]") {
+    namespace fe = cudnn_frontend;
+
+    auto make_tensor = []() -> fe::graph::Tensor_attributes {
+        return fe::graph::Tensor_attributes()
+            .set_name("image")
+            .set_dim({4, 32, 16, 16})
+            .set_stride({32 * 16 * 16, 1, 32 * 16, 32})
+            .set_uid(12312)
+            .set_data_type(fe::DataType_t::HALF);
+    };
+
+    SECTION("a non-default alignment survives the round trip") {
+        auto tensor_attributes = make_tensor().set_alignment(4);
+
+        json j = tensor_attributes;
+        REQUIRE(j.contains("alignment"));
+        REQUIRE(j["alignment"].get<int64_t>() == 4);
+
+        auto deserialized = j.get<fe::graph::Tensor_attributes>();
+        REQUIRE(deserialized.get_alignment() == 4);
+    }
+
+    SECTION("the default alignment is not emitted") {
+        auto tensor_attributes = make_tensor();
+        REQUIRE(tensor_attributes.get_alignment() == fe::graph::Tensor_attributes::default_alignment);
+
+        json j = tensor_attributes;
+        REQUIRE_FALSE(j.contains("alignment"));
+
+        auto deserialized = j.get<fe::graph::Tensor_attributes>();
+        REQUIRE(deserialized.get_alignment() == fe::graph::Tensor_attributes::default_alignment);
+    }
+
+    SECTION("a payload with no alignment key deserializes to the default") {
+        json j = make_tensor().set_alignment(4);
+        REQUIRE(j.erase("alignment") == 1);
+
+        fe::graph::Tensor_attributes deserialized;
+        REQUIRE_NOTHROW(deserialized = j.get<fe::graph::Tensor_attributes>());
+        REQUIRE(deserialized.get_alignment() == fe::graph::Tensor_attributes::default_alignment);
+    }
+}
+
+TEST_CASE("conv graph serialization preserves alignment", "[graph][serialize]") {
+    namespace fe = cudnn_frontend;
+
+    fe::graph::Graph graph;
+
+    auto x = graph.tensor(fe::graph::Tensor_attributes());
+    x->set_name("image")
+        .set_dim({4, 32, 16, 16})
+        .set_stride({32 * 16 * 16, 1, 32 * 16, 32})
+        .set_data_type(fe::DataType_t::HALF)
+        .set_alignment(4);
+
+    auto w = graph.tensor(fe::graph::Tensor_attributes());
+    w->set_name("weight")
+        .set_dim({64, 32, 3, 3})
+        .set_stride({32 * 3 * 3, 1, 32 * 3, 32})
+        .set_data_type(fe::DataType_t::HALF);
+
+    auto conv_fprop_attributes = fe::graph::Conv_fprop_attributes()
+                                     .set_name("conv_fprop")
+                                     .set_padding({1, 1})
+                                     .set_stride({1, 1})
+                                     .set_dilation({1, 1})
+                                     .set_compute_data_type(fe::DataType_t::FLOAT);
+
+    auto y = graph.conv_fprop(x, w, conv_fprop_attributes);
+    y->set_name("output").set_output(true).set_data_type(fe::DataType_t::HALF);
+
+    auto alignment_of = [](json const& serialized, std::string const& name) -> int64_t {
+        for (auto const& tensor : serialized["tensors"]) {
+            if (tensor.contains("name") && tensor["name"].get<std::string>() == name) {
+                return tensor.value("alignment", fe::graph::Tensor_attributes::default_alignment);
+            }
+        }
+        return -1;
+    };
+
+    json j = graph;
+
+    REQUIRE(alignment_of(j, "image") == 4);
+    REQUIRE(alignment_of(j, "weight") == fe::graph::Tensor_attributes::default_alignment);
+
+    fe::graph::Graph graph_deserialized;
+    REQUIRE(graph_deserialized.deserialize(j).is_good());
+
+    json j2 = graph_deserialized;
+
+    REQUIRE(alignment_of(j2, "image") == 4);
+    REQUIRE(j == j2);
+}
+
 TEST_CASE("Context serialization", "[context][serialize]") {
     namespace fe = cudnn_frontend;
 


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

C++ frontend API or graph construction

## Summary

`Tensor_attributes::alignment` is serialized by neither `to_json` nor `from_json`, so `set_alignment(n)` is lost across any JSON round trip.

- `to_json` now emits `"alignment"`, and only when it differs from the default.
- `from_json` reads it with `json::value()`, falling back to the default.
- New `Tensor_attributes::default_alignment` replaces the literal `16` that was duplicated in the member initializer.
- New round-trip and graph-payload cases in `test/cpp/serialize.cpp`.

## Why

Alignment is part of what makes a tensor selectable by a given engine, so a graph rebuilt from a payload can pick a kernel that assumes more alignment than the pointer actually has. The omission also reaches `j["tensors"]` in the structural payload — embedded in the plan blob when `serialize_structure` is true, and what `Graph::deserialize` rebuilds tensors from.

## Related issues

None.

## API and compatibility impact

- **New public constant:** `Tensor_attributes::default_alignment` (`static constexpr int64_t`, 16). No existing declarations change.
- **Wire format:** `"alignment"` is a new *optional* key. Older payloads carry no such key and must not throw, hence `json::value()` rather than `j.at()`; newer payloads are ignored by older frontends. `GRAPH_JSON_VERSION` is unchanged, since the key is optional in both directions.
- **`Graph::key()`** hashes the serialized graph. Emitting only when non-default keeps it byte-identical for every graph that never calls `set_alignment`. Graphs that do call it now hash distinctly, which is the intent — they previously collided with their differently-aligned counterparts.
- No performance impact.

## Testing

Release build, x86_64 Ubuntu 24.04, CUDA 13.4, cuDNN 9.20, A100.

- Full build (library, `tests`, `samples`, `legacy_samples`) clean under `-Werror -Wall -Wextra -Wpedantic`.
- `./build/bin/tests "[serialize]"` → `All tests passed (72 assertions in 13 test cases)`.
- Reverting only `utils/serialize.h` and rebuilding → `13 | 11 passed | 2 failed`, with `REQUIRE( alignment_of(j, "image") == 4 )` expanding to `16 == 4`, confirming the new cases cover the defect.
- Python suite not run; no Python or binding code is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tensor alignment now has a documented default of 16 bytes.
  * Serialization omits default alignment values while preserving custom alignment settings.
  * Older serialized data remains compatible by restoring the default alignment when unspecified.

* **Bug Fixes**
  * Preserved tensor and convolution graph alignment through serialization and deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->