### PR TITLE
build: default to a parallel extension build in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,12 @@ class CMakeBuild(build_ext):
             if hasattr(self, "parallel") and self.parallel:
                 # CMake 3.12+ only.
                 build_args += [f"-j{self.parallel}"]
+            else:
+                # Without an explicit -j, `cmake --build` compiles one TU at a
+                # time, so pip installs built the extension serially. Cap at 8:
+                # the extension has ~6 TUs, each peaking at 1-2 GB of compiler
+                # memory, so higher values buy nothing and only add pressure.
+                build_args += [f"-j{min(os.cpu_count() or 1, 8)}"]
 
         build_temp = Path(self.build_temp) / ext.name
         if not build_temp.exists():


### PR DESCRIPTION
## Problem

`CMakeBuild.build_extension` only passes `-j` to `cmake --build` when `self.parallel` is set. Neither `pip` nor PyPA-build sets it, so unless the user exports `CMAKE_BUILD_PARALLEL_LEVEL`, the default `pip install .` / `pip install -e .` path builds the pybind11 extension one translation unit at a time.

## Fix

Fall back to `-j min(os.cpu_count(), 8)` when neither `CMAKE_BUILD_PARALLEL_LEVEL` nor `self.parallel` is set.

The cap is deliberate: the extension is ~6 TUs and each peaks at 1-2 GB of compiler memory, so a larger `-j` buys no additional throughput and only raises peak memory on many-core machines.

Precedence is unchanged — `CMAKE_BUILD_PARALLEL_LEVEL` still short-circuits the whole block, and an explicit `build_ext -j` still wins over the new default.

## Test

- `pip install -e .` now compiles the extension in parallel instead of serially.
- `CMAKE_BUILD_PARALLEL_LEVEL=2 pip install -e .` and `python setup.py build_ext -j4` behave as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Builds now automatically use available CPU resources for parallel compilation when no parallelism setting is specified.
  * Parallel build jobs are capped at eight to help maintain consistent build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->