### PR TITLE
Make the FROST SDPA execute path async where it can be, and stop it re-deriving build-time facts

### DIFF
--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -67,6 +67,50 @@ unsupported input runnable.
   descriptors) — acceptance is a promise about the execute path, not about
   what the adapter can patch up.
 
+**Rule 3 — `execute()` never reads device memory to the host.**
+
+Rules 1 and 2 both cite CUDA-graph capture as the reason for what they ban, but
+neither names the thing that breaks it most directly: a device-to-host read.
+
+- **No `.item()` / `.tolist()` / `.cpu()` / `.numpy()` / `float(tensor)` /
+  `int(tensor)`**, and no branch or f-string that forces one, on an execute
+  argument or anything derived from one. A D2H read makes `execute()`
+  synchronous — the whole point of an async launch API is gone.
+- **It is a functional gap, not a slow path.** A blocking D2H during stream
+  capture is illegal, so a path that does one **cannot be CUDA-graph captured
+  at all** — which is how every inference stack runs decode.
+- **Its cost is the queue, not the transfer.** Measured on SM100: one
+  `.tolist()` costs 11 µs against a drained queue, 2.6 ms behind 16 queued
+  matmuls. Any figure you measure in a microbenchmark is the floor.
+- **If a device value must shape the launch**, pass its pointer and dereference
+  in-kernel, or compile on an envelope and let the kernel read the real extent
+  from device metadata (the f16 prefill kernels already do this for head dims).
+- **A validation that needs a device read is not a validation.** Decline the
+  declaration in `check_support()` — per Rule 2, the graph says what it will
+  hand you — or assert in-kernel. Reading lengths back to decide whether to
+  raise buys nothing: the Router had to choose an engine before any buffer
+  existed.
+
+Known violations, all pre-existing and each needing a kernel-side change, so
+none is precedent:
+
+- THD `cu_seqlens` host cumsum (`sdpa/fwd/api_dsl.py`, `_execute_thd` on both
+  SM100 and SM120). `t_q`/`t_kv` reach the host only because `T` is a
+  compile-time constant. Compile on the `b * s_q_max` envelope and pass `T` as a
+  runtime argument, as the f16 kernels already do for head dims;
+  `sdpa_fwd_wrapper_sm80` shows the other half — it requires `max_s_q` from the
+  caller rather than deriving it.
+- Per-tensor FP8 descale readback (`_scalar` in the same file): fold on device,
+  passing the pointers, as the backend FP8 sdpa does.
+- The FP8/MXFP8 `seq_len_q` guard in `sdpa/fwd/engines.py`. This one cannot be
+  lifted to `check_support()`: `use_padding_mask=True` requires a `seq_len_q`
+  tensor even when only KV is padded, so no static rule separates "declares
+  per-batch Q lengths" from "the lengths are actually short" — declining the
+  declaration would drop the KV-only-padding population these kernels serve
+  correctly. It goes away when the FP8 kernels get the epilogue trim; until
+  then the read is what keeps a short length from being silently ignored.
+- The ragged cache-key `max()` in `sdpa/{fwd,bwd}/api.py`.
+
 ## Frontend-only kernel package layout
 
 ```

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -72,10 +72,12 @@ unsupported input runnable.
 Rules 1 and 2 both cite CUDA-graph capture as the reason for what they ban, but
 neither names the thing that breaks it most directly: a device-to-host read.
 
-- **No `.item()` / `.tolist()` / `.cpu()` / `.numpy()` / `float(tensor)` /
-  `int(tensor)`**, and no branch or f-string that forces one, on an execute
-  argument or anything derived from one. A D2H read makes `execute()`
-  synchronous — the whole point of an async launch API is gone.
+- **No `.item()` / `.tolist()` / `.cpu()` / `.to("cpu")` / `.numpy()` /
+  `float(tensor)` / `int(tensor)` / `torch.is_nonzero`**, and no branch or
+  f-string that forces one, on an execute argument or anything derived from one.
+  A D2H read makes `execute()` synchronous — the whole point of an async launch
+  API is gone. **Nor may it block**: no `torch.cuda.synchronize()`, no
+  stream/event `synchronize()`. A sync reads nothing but costs the same.
 - **It is a functional gap, not a slow path.** A blocking D2H during stream
   capture is illegal, so a path that does one **cannot be CUDA-graph captured
   at all** — which is how every inference stack runs decode.

--- a/python/cudnn/AGENTS.md
+++ b/python/cudnn/AGENTS.md
@@ -112,6 +112,15 @@ none is precedent:
   correctly. It goes away when the FP8 kernels get the epilogue trim; until
   then the read is what keeps a short length from being silently ignored.
 - The ragged cache-key `max()` in `sdpa/{fwd,bwd}/api.py`.
+- `cu_seqlens_{q,k}.to(dtype=..., device="cpu")` in the SM80 packed-THD backward
+  (`sdpa/bwd/kernels/bprop_f16_sm80.py`). Reachable only through the standalone
+  wrapper: the registered `sdpa_bwd_sm80` spec declares `thd=False`, so
+  `graph.execute()` does not route here. Still a violation, and it is the one to
+  fix first if that spec ever gains THD.
+
+When auditing this list, grep for the ARGUMENT, not the call shape:
+`device="cpu"` finds `to(dtype=..., device="cpu")`, which `to(device="cpu")`
+misses.
 
 ## Frontend-only kernel package layout
 

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -433,12 +433,16 @@ class pygraph:
         becomes ambiguous and leaves the unique-name index."""
         if name == t.name:
             return
-        # NOT freeze-guarded: names are labels (classic allows renaming after
-        # build — the lowered graph already carries the old label, and labels
-        # have no execution semantics).
+        # Freeze-guarded like every other setter. A name is a label, but it is
+        # also a variant-pack key: a compiled plan may be holding the name it
+        # was built with, and the lowered graph keeps the old one, so a rename
+        # after planning leaves two answers to "which tensor is 'q'" -- and
+        # swapping two names would silently rebind buffers. Nothing needs to
+        # rename a planned graph; build another one.
+        self._check_mutable("rename a tensor")
         if self._tensors.get(t.name) is t:
             del self._tensors[t.name]
-        object.__setattr__(t, "name", name)  # label write is exempt from the freeze
+        object.__setattr__(t, "name", name)
         if name in self._tensors or name in self._ambiguous_names:
             self._tensors.pop(name, None)
             self._ambiguous_names.add(name)

--- a/python/cudnn/api_base.py
+++ b/python/cudnn/api_base.py
@@ -41,6 +41,21 @@ def _torch():
     return sys.modules.get("torch")
 
 
+_RAW_STREAM = None
+
+
+def _raw_stream(torch):
+    """``device_index -> raw CUstream int``, resolved once.
+
+    ``torch._C._cuda_getCurrentRawStream`` is private, so fall back to the
+    documented accessor if a torch build ever drops it.
+    """
+    global _RAW_STREAM
+    if _RAW_STREAM is None:
+        _RAW_STREAM = getattr(torch._C, "_cuda_getCurrentRawStream", None) or (lambda _dev: torch.cuda.current_stream().cuda_stream)
+    return _RAW_STREAM
+
+
 def _is_framework_tensor(obj: Any) -> bool:
     """True for framework tensors (torch/jax/numpy/...) as opposed to dtypes or shape/stride tuples."""
     return hasattr(obj, "__dlpack__")
@@ -566,14 +581,15 @@ class APIBase(ABC):
             ...     current_stream = self._get_default_stream(current_stream)
             ...     # Now current_stream is guaranteed to be a valid stream
         """
-        if stream is None:
-            torch = _torch()
-            if torch is not None:
-                self._logger.debug(f"{self.__class__.__name__}: No CUDA stream provided, using torch current stream")
-                return cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-            self._logger.debug(f"{self.__class__.__name__}: No CUDA stream provided and torch not imported, using CUDA legacy default stream")
+        if stream is not None:
+            return stream
+        torch = _torch()
+        if torch is None:
             return cuda.CUstream(0)
-        return stream
+        # _cuda_getCurrentRawStream is the same value torch.cuda.current_stream()
+        # reports, without building the Stream wrapper: 0.1 us against 4.3 us,
+        # and execute() calls this once per launch.
+        return cuda.CUstream(_raw_stream(torch)(torch.cuda.current_device()))
 
     def _pad_tensor_to_ndim(
         self,

--- a/python/cudnn/sdpa/bwd/engine.py
+++ b/python/cudnn/sdpa/bwd/engine.py
@@ -45,8 +45,8 @@ class _FrostSdpaBwdPlan(CompiledPlan):
         # graph API hands us covers every IO tensor of the graph, so key the
         # kernel's own operands out of it by uid (uids are eager and unique).
         self._tensors = list(compiled.binding.bound_tensors())
-        # get_uid() is a pybind round trip and a bound tensor's uid is fixed
-        # once the graph is frozen, so read them here rather than per execute.
+        # A bound tensor's uid is fixed once the graph is frozen, so read them
+        # here rather than re-walking the list on every execute.
         self._uids = [t.get_uid() for t in self._tensors]
         self._workspace_bytes = int(getattr(compiled, "workspace_bytes", 0) or 0)
 

--- a/python/cudnn/sdpa/bwd/engine.py
+++ b/python/cudnn/sdpa/bwd/engine.py
@@ -45,24 +45,25 @@ class _FrostSdpaBwdPlan(CompiledPlan):
         # graph API hands us covers every IO tensor of the graph, so key the
         # kernel's own operands out of it by uid (uids are eager and unique).
         self._tensors = list(compiled.binding.bound_tensors())
+        # get_uid() is a pybind round trip and a bound tensor's uid is fixed
+        # once the graph is frozen, so read them here rather than per execute.
+        self._uids = [t.get_uid() for t in self._tensors]
+        self._workspace_bytes = int(getattr(compiled, "workspace_bytes", 0) or 0)
 
     def get_workspace_size(self) -> int:
-        return int(getattr(self._compiled, "workspace_bytes", 0) or 0)
+        return self._workspace_bytes
 
     def execute(self, graph: "pygraph", uid_to_data, ctx: ExecutionContext) -> None:
         # Keyed by IR tensor object: that is the binding's own identity, and the
         # only key resolve_variant_pack() accepts for an auto-assigned uid.
         pack = {}
-        missing = []
-        for t in self._tensors:
-            buf = uid_to_data.get(t.get_uid())
+        for t, uid in zip(self._tensors, self._uids):
+            buf = uid_to_data.get(uid)
             if buf is None:
-                missing.append(t.get_name() or t.get_uid())
-            else:
-                pack[t] = buf
-        if missing:
-            raise ValueError(f"{self._name}: the variant pack is missing buffers for {missing}")
-        required = self.get_workspace_size()
+                missing = [t.get_name() or uid for t, uid in zip(self._tensors, self._uids) if uid_to_data.get(uid) is None]
+                raise ValueError(f"{self._name}: the variant pack is missing buffers for {missing}")
+            pack[t] = buf
+        required = self._workspace_bytes
         if required:
             _check_workspace(ctx.workspace, required, self._name)
             self._compiled(pack, ctx.workspace, stream=ctx.stream)

--- a/python/cudnn/sdpa/fwd/engine.py
+++ b/python/cudnn/sdpa/fwd/engine.py
@@ -46,8 +46,8 @@ class _FrostSdpaFwdPlan(CompiledPlan):
         # graph API hands us covers every IO tensor of the graph, so key the
         # kernel's own operands out of it by uid (uids are eager and unique).
         self._tensors = list(compiled.binding.bound_tensors())
-        # get_uid() is a pybind round trip and a bound tensor's uid is fixed
-        # once the graph is frozen, so read them here rather than per execute.
+        # A bound tensor's uid is fixed once the graph is frozen, so read them
+        # here rather than re-walking the list on every execute.
         self._uids = [t.get_uid() for t in self._tensors]
         self._workspace_bytes = int(getattr(compiled, "workspace_bytes", 0) or 0)
 

--- a/python/cudnn/sdpa/fwd/engine.py
+++ b/python/cudnn/sdpa/fwd/engine.py
@@ -46,24 +46,25 @@ class _FrostSdpaFwdPlan(CompiledPlan):
         # graph API hands us covers every IO tensor of the graph, so key the
         # kernel's own operands out of it by uid (uids are eager and unique).
         self._tensors = list(compiled.binding.bound_tensors())
+        # get_uid() is a pybind round trip and a bound tensor's uid is fixed
+        # once the graph is frozen, so read them here rather than per execute.
+        self._uids = [t.get_uid() for t in self._tensors]
+        self._workspace_bytes = int(getattr(compiled, "workspace_bytes", 0) or 0)
 
     def get_workspace_size(self) -> int:
-        return int(getattr(self._compiled, "workspace_bytes", 0) or 0)
+        return self._workspace_bytes
 
     def execute(self, graph: "pygraph", uid_to_data, ctx: ExecutionContext) -> None:
         # Keyed by IR tensor object: that is the binding's own identity, and the
         # only key resolve_variant_pack() accepts for an auto-assigned uid.
         pack = {}
-        missing = []
-        for t in self._tensors:
-            buf = uid_to_data.get(t.get_uid())
+        for t, uid in zip(self._tensors, self._uids):
+            buf = uid_to_data.get(uid)
             if buf is None:
-                missing.append(t.get_name() or t.get_uid())
-            else:
-                pack[t] = buf
-        if missing:
-            raise ValueError(f"{self._name}: the variant pack is missing buffers for {missing}")
-        required = self.get_workspace_size()
+                missing = [t.get_name() or uid for t, uid in zip(self._tensors, self._uids) if uid_to_data.get(uid) is None]
+                raise ValueError(f"{self._name}: the variant pack is missing buffers for {missing}")
+            pack[t] = buf
+        required = self._workspace_bytes
         if required:
             _check_workspace(ctx.workspace, required, self._name)
             self._compiled(pack, ctx.workspace, stream=ctx.stream)

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -666,10 +666,11 @@ class SdpaBinding:
     dsink: Any = None
 
     # Built once on first use and reused. A binding is constructed by the
-    # engine's lowering and never mutated afterwards, so which tensors it binds
-    # -- and their names and uids -- are build-time facts. Rebuilding them per
-    # execute cost ~1.3 us per bound operand: get_name/uid_assigned/get_uid are
-    # pybind round trips, and the old code made three passes.
+    # engine's lowering, after the graph is frozen, and never mutated
+    # afterwards -- and a frozen graph can no longer re-uid or rename a tensor,
+    # so the names and uids this indexes are build-time facts too. Rebuilding
+    # them per execute cost ~1.3 us per bound operand: three passes over the
+    # bound list and five dict constructions, not any one expensive getter.
     # init=False so a replace()d binding rebuilds rather than inheriting a
     # cache for the operands it no longer has; compare/repr excluded so the
     # cache cannot change how a binding prints or compares.

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -20,7 +20,7 @@ variant-pack resolution and TensorDesc construction.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import cudnn
@@ -665,8 +665,18 @@ class SdpaBinding:
     dbias: Any = None
     dsink: Any = None
 
-    def bound_tensors(self) -> list:
-        return [
+    # Built once on first use and reused. A binding is constructed by the
+    # engine's lowering and never mutated afterwards, so which tensors it binds
+    # -- and their names and uids -- are build-time facts. Rebuilding them per
+    # execute cost ~1.3 us per bound operand: get_name/uid_assigned/get_uid are
+    # pybind round trips, and the old code made three passes.
+    # init=False so a replace()d binding rebuilds rather than inheriting a
+    # cache for the operands it no longer has; compare/repr excluded so the
+    # cache cannot change how a binding prints or compares.
+    _index: Optional[tuple] = field(default=None, init=False, repr=False, compare=False)
+
+    def _build_index(self) -> tuple:
+        bound = [
             t
             for t in (
                 self.q,
@@ -701,6 +711,31 @@ class SdpaBinding:
             )
             if t is not None
         ]
+        name_counts: dict = {}
+        uid_counts: dict = {}
+        names, uids = [], []
+        for t in bound:
+            nm = _safe_name(t)
+            names.append(nm)
+            if nm is not None:
+                name_counts[nm] = name_counts.get(nm, 0) + 1
+            uid = _safe_uid(t)
+            uids.append(uid)
+            if uid is not None:
+                uid_counts[uid] = uid_counts.get(uid, 0) + 1
+        # A name or uid carried by two bound tensors identifies neither.
+        by_obj = {id(t): t for t in bound}
+        by_name = {nm: t for nm, t in zip(names, bound) if nm is not None and name_counts[nm] == 1}
+        by_uid = {uid: t for uid, t in zip(uids, bound) if uid is not None and uid_counts[uid] == 1}
+        self._index = (bound, by_obj, by_uid, by_name)
+        return self._index
+
+    def index(self) -> tuple:
+        """``(bound, by_obj, by_uid, by_name)`` — the resolution tables."""
+        return self._index or self._build_index()
+
+    def bound_tensors(self) -> list:
+        return self.index()[0]
 
 
 def _safe_name(t: Any) -> Optional[str]:
@@ -730,22 +765,7 @@ def resolve_variant_pack(variant_pack: dict, binding: SdpaBinding) -> dict:
         raise TypeError(
             f"cudnn.sdpa: compiled plans are called with a variant-pack dict {{cudnn_tensor | uid | name: buffer}}; got {type(variant_pack).__name__}"
         )
-    bound = binding.bound_tensors()
-    by_obj = {id(t): t for t in bound}
-
-    name_counts: dict = {}
-    uid_counts: dict = {}
-    for t in bound:
-        nm = _safe_name(t)
-        if nm is not None:
-            name_counts[nm] = name_counts.get(nm, 0) + 1
-        uid = _safe_uid(t)
-        if uid is not None:
-            uid_counts[uid] = uid_counts.get(uid, 0) + 1
-    by_name = {_safe_name(t): t for t in bound if name_counts.get(_safe_name(t)) == 1}
-    by_uid = {_safe_uid(t): t for t in bound if uid_counts.get(_safe_uid(t)) == 1}
-    by_name.pop(None, None)
-    by_uid.pop(None, None)
+    _bound, by_obj, by_uid, by_name = binding.index()
 
     resolved: dict = {}
     for key, buf in variant_pack.items():

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -665,12 +665,16 @@ class SdpaBinding:
     dbias: Any = None
     dsink: Any = None
 
-    # Built once on first use and reused. A binding is constructed by the
-    # engine's lowering, after the graph is frozen, and never mutated
-    # afterwards -- and a frozen graph can no longer re-uid or rename a tensor,
-    # so the names and uids this indexes are build-time facts too. Rebuilding
-    # them per execute cost ~1.3 us per bound operand: three passes over the
-    # bound list and five dict constructions, not any one expensive getter.
+    # Built once on first use and reused. Rebuilding it per execute cost ~1.3 us
+    # per bound operand: three passes over the bound list and five dict
+    # constructions, not any one expensive getter.
+    #
+    # What makes the cache safe is the graph, not this class: a binding is
+    # constructed by the engine's lowering AFTER the graph is frozen, and a
+    # frozen graph can no longer re-uid or rename a tensor, so the names and
+    # uids indexed here cannot move. The binding itself is still an ordinary
+    # mutable dataclass -- reassigning a field after the first index() would go
+    # unnoticed. Nothing does; an ordered-slot binding would remove the question.
     # init=False so a replace()d binding rebuilds rather than inheriting a
     # cache for the operands it no longer has; compare/repr excluded so the
     # cache cannot change how a binding prints or compares.
@@ -728,14 +732,16 @@ class SdpaBinding:
         by_obj = {id(t): t for t in bound}
         by_name = {nm: t for nm, t in zip(names, bound) if nm is not None and name_counts[nm] == 1}
         by_uid = {uid: t for uid, t in zip(uids, bound) if uid is not None and uid_counts[uid] == 1}
-        self._index = (bound, by_obj, by_uid, by_name)
+        self._index = (tuple(bound), by_obj, by_uid, by_name)
         return self._index
 
     def index(self) -> tuple:
         """``(bound, by_obj, by_uid, by_name)`` — the resolution tables."""
         return self._index or self._build_index()
 
-    def bound_tensors(self) -> list:
+    def bound_tensors(self) -> tuple:
+        """The bound tensors, in slot order. A tuple: this is the binding's own
+        record, not a working list for a caller to edit."""
         return self.index()[0]
 
 

--- a/samples/python/24_layernorm_zero_centered_gamma_forward_training_and_backward.ipynb
+++ b/samples/python/24_layernorm_zero_centered_gamma_forward_training_and_backward.ipynb
@@ -510,7 +510,7 @@
     "d_out = bwd_graph.tensor(name=\"d_out\", dim=x_gpu.size(), stride=x_gpu.stride(), data_type=x_gpu.dtype)\n",
     "x_bwd = bwd_graph.tensor_like(x, name=\"x\")\n",
     "gamma_bwd = bwd_graph.tensor_like(gamma, name=\"gamma\")\n",
-    "one_bwd = graph.tensor_like(one_cpu).set_name(\"one\")\n",
+    "one_bwd = bwd_graph.tensor_like(one_cpu, name=\"one\")\n",
     "mean_bwd = bwd_graph.tensor_like(mean, name=\"mean\")\n",
     "inv_var_bwd = bwd_graph.tensor_like(inv_var, name=\"inv_var\")\n",
     "\n",

--- a/test/python/sdpa/frost/test_sdpa_execute_is_async.py
+++ b/test/python/sdpa/frost/test_sdpa_execute_is_async.py
@@ -3,12 +3,17 @@
 
 """Rule 3 regression: a FROST SDPA ``execute()`` reads no device memory to the host.
 
-A D2H read makes execute synchronous. The user-visible consequences are that the
-path cannot be CUDA-graph captured (covered by test_sdpa_stream_respect.py) and
-that its cost becomes the depth of the queue rather than its own work. This test
-catches the cause instead of the symptom, so it needs no capture support and
-names the offending accessor: every torch D2H accessor is made to raise for the
-duration of one execute.
+A D2H read makes execute synchronous, so its cost becomes the depth of the queue
+rather than its own work, and the path stops being CUDA-graph capturable. Two
+angles here, because each catches what the other misses:
+
+* the cause -- every torch D2H accessor is made to raise for the duration of one
+  execute, so a regression names the accessor rather than surfacing later as a
+  capture failure. Needs no capture support.
+* the symptom, on the path that has no other coverage -- graph.execute() with NO
+  handle leaves ExecutionContext.stream None and the adapter resolves the stream
+  itself. test_sdpa_stream_respect.py captures the handle-carrying path; this
+  file captures the one where the fallback picks the stream.
 
 Scoped to the dense f16 rows, which are clean. The THD and per-tensor FP8 rows
 still read device memory back; each needs a kernel-side change and is listed
@@ -29,8 +34,30 @@ pytestmark = [pytest.mark.L0]
 _B, _H, _S = 2, 8, 256
 _HALF, _F32 = cudnn.data_type.HALF, cudnn.data_type.FLOAT
 
-# Every torch accessor that copies device memory back to the host.
-_D2H_ACCESSORS = ("item", "tolist", "cpu", "numpy", "__float__", "__int__", "__bool__")
+# Tensor methods that copy device memory back to the host. `to` is here because
+# .to("cpu") is a D2H read wearing a dtype-cast's clothes; the guard lets a
+# device-to-device .to() through and only trips on a host target.
+_D2H_METHODS = ("item", "tolist", "cpu", "numpy", "__float__", "__int__", "__bool__", "__index__", "to")
+# Module-level entry points that read or block. torch.is_nonzero reaches the
+# value without going through Tensor.__bool__, and a synchronize does not read
+# anything but still makes execute() synchronous, which is what Rule 3 is about.
+_D2H_FUNCTIONS = (
+    (torch, "is_nonzero"),
+    (torch, "equal"),
+    (torch.cuda, "synchronize"),
+    (torch.cuda.Stream, "synchronize"),
+    (torch.cuda.Event, "synchronize"),
+)
+
+
+def _targets_host(args, kwargs) -> bool:
+    """True when a Tensor.to(...) call names a non-CUDA destination."""
+    for candidate in (*args, kwargs.get("device")):
+        if isinstance(candidate, str) and not candidate.startswith("cuda"):
+            return True
+        if isinstance(candidate, torch.device) and candidate.type != "cuda":
+            return True
+    return False
 
 
 def _build(d):
@@ -52,34 +79,78 @@ def _build(d):
     g.check_support()
     g.build_plans()
     mk = lambda: torch.randn(_B, _S, _H, d, device="cuda", dtype=torch.float16).transpose(1, 2)  # noqa: E731
-    vp = {q: mk(), k: mk(), v: mk(), o: torch.empty(_B, _S, _H, d, device="cuda", dtype=torch.float16).transpose(1, 2)}
+    o_buf = torch.empty(_B, _S, _H, d, device="cuda", dtype=torch.float16).transpose(1, 2)
+    vp = {q: mk(), k: mk(), v: mk(), o: o_buf}
     ws = torch.empty(g.get_workspace_size(), device="cuda", dtype=torch.uint8) if g.get_workspace_size() else None
-    return g, vp, ws
+    return g, vp, ws, o_buf
 
 
 @requires_blackwell
 @requires_dsl
 @pytest.mark.parametrize("d", [256, 512])
 def test_execute_reads_no_device_memory_to_the_host(monkeypatch, d):
-    g, vp, ws = _build(d)
+    g, vp, ws, _out = _build(d)
     g.execute(vp, ws)  # compile/warm outside the ban: JIT may legitimately sync
     torch.cuda.synchronize()
 
     caught = []
 
-    def _forbid(name):
+    def _forbid_method(name, original):
         def guard(self, *a, **kw):
-            if self.is_cuda:
-                caught.append(name)
+            if getattr(self, "is_cuda", False) and (name != "to" or _targets_host(a, kw)):
+                caught.append(f"Tensor.{name}")
                 raise AssertionError(f"execute() called Tensor.{name}() on a CUDA tensor — see Rule 3 in python/cudnn/AGENTS.md")
-            return _originals[name](self, *a, **kw)
+            return original(self, *a, **kw)
 
         return guard
 
-    _originals = {n: getattr(torch.Tensor, n) for n in _D2H_ACCESSORS}
-    for n in _D2H_ACCESSORS:
-        monkeypatch.setattr(torch.Tensor, n, _forbid(n))
+    def _forbid_function(label, original):
+        def guard(*a, **kw):
+            caught.append(label)
+            raise AssertionError(f"execute() called {label}() — see Rule 3 in python/cudnn/AGENTS.md")
+
+        return guard
+
+    for name in _D2H_METHODS:
+        monkeypatch.setattr(torch.Tensor, name, _forbid_method(name, getattr(torch.Tensor, name)))
+    for owner, name in _D2H_FUNCTIONS:
+        label = f"{getattr(owner, '__name__', owner.__class__.__name__)}.{name}"
+        monkeypatch.setattr(owner, name, _forbid_function(label, getattr(owner, name)))
 
     g.execute(vp, ws)
+    monkeypatch.undo()  # the sync below is the test's own, not execute()'s
     torch.cuda.synchronize()
     assert not caught
+
+
+@requires_blackwell
+@requires_dsl
+def test_execute_without_a_handle_is_cuda_graph_capturable():
+    """The no-handle path, which is the one that resolves the stream itself.
+
+    graph.execute() with no handle leaves ExecutionContext.stream None, so the
+    adapter falls back to torch's current stream -- the branch this PR rewrote.
+    Capture is the check that the fallback lands on the CAPTURING stream: a
+    hardcoded stream 0 records an empty graph, and a replay into a zeroed
+    output then reproduces nothing.
+    """
+    g, vp, ws, out = _build(256)
+    g.execute(vp, ws)
+    torch.cuda.synchronize()
+    expected = out.clone()
+
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        g.execute(vp, ws)
+    torch.cuda.current_stream().wait_stream(side)
+    torch.cuda.synchronize()
+
+    captured = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(captured):
+        g.execute(vp, ws)
+    out.zero_()
+    torch.cuda.synchronize()
+    captured.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(out, expected), "replay did not reproduce the eager result — the launch did not land on the capturing stream"

--- a/test/python/sdpa/frost/test_sdpa_execute_is_async.py
+++ b/test/python/sdpa/frost/test_sdpa_execute_is_async.py
@@ -7,9 +7,12 @@ A D2H read makes execute synchronous, so its cost becomes the depth of the queue
 rather than its own work, and the path stops being CUDA-graph capturable. Two
 angles here, because each catches what the other misses:
 
-* the cause -- every torch D2H accessor is made to raise for the duration of one
-  execute, so a regression names the accessor rather than surfacing later as a
-  capture failure. Needs no capture support.
+* the cause -- the KNOWN COMMON D2H and blocking entry points are made to raise
+  for the duration of one execute, so a regression names the offender rather
+  than surfacing later as a capture failure. Needs no capture support. This is a
+  blacklist and cannot be exhaustive: .to(some_cpu_tensor), a CPU-target copy_,
+  and driver-level synchronization all get through. It catches the shapes that
+  actually keep appearing, and the capture test below is the backstop.
 * the symptom, on the path that has no other coverage -- graph.execute() with NO
   handle leaves ExecutionContext.stream None and the adapter resolves the stream
   itself. test_sdpa_stream_respect.py captures the handle-carrying path; this
@@ -34,7 +37,7 @@ pytestmark = [pytest.mark.L0]
 _B, _H, _S = 2, 8, 256
 _HALF, _F32 = cudnn.data_type.HALF, cudnn.data_type.FLOAT
 
-# Tensor methods that copy device memory back to the host. `to` is here because
+# The Tensor methods that keep showing up. `to` is here because
 # .to("cpu") is a D2H read wearing a dtype-cast's clothes; the guard lets a
 # device-to-device .to() through and only trips on a host target.
 _D2H_METHODS = ("item", "tolist", "cpu", "numpy", "__float__", "__int__", "__bool__", "__index__", "to")

--- a/test/python/sdpa/frost/test_sdpa_execute_is_async.py
+++ b/test/python/sdpa/frost/test_sdpa_execute_is_async.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rule 3 regression: a FROST SDPA ``execute()`` reads no device memory to the host.
+
+A D2H read makes execute synchronous. The user-visible consequences are that the
+path cannot be CUDA-graph captured (covered by test_sdpa_stream_respect.py) and
+that its cost becomes the depth of the queue rather than its own work. This test
+catches the cause instead of the symptom, so it needs no capture support and
+names the offending accessor: every torch D2H accessor is made to raise for the
+duration of one execute.
+
+Scoped to the dense f16 rows, which are clean. The THD and per-tensor FP8 rows
+still read device memory back; each needs a kernel-side change and is listed
+under Rule 3 in python/cudnn/AGENTS.md. Widen the parametrization as they land.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import cudnn
+from cudnn.engines import is_python_engine
+from frost_test_utils import requires_blackwell, requires_dsl
+
+pytestmark = [pytest.mark.L0]
+
+_B, _H, _S = 2, 8, 256
+_HALF, _F32 = cudnn.data_type.HALF, cudnn.data_type.FLOAT
+
+# Every torch accessor that copies device memory back to the host.
+_D2H_ACCESSORS = ("item", "tolist", "cpu", "numpy", "__float__", "__int__", "__bool__")
+
+
+def _build(d):
+    dims = (_B, _H, _S, d)
+    strides = (_S * _H * d, d, _H * d, 1)
+    g = cudnn.pygraph(io_data_type=_HALF, intermediate_data_type=_F32, compute_data_type=_F32)
+    q = g.tensor(dim=dims, stride=strides, data_type=_HALF, name="q")
+    k = g.tensor(dim=dims, stride=strides, data_type=_HALF, name="k")
+    v = g.tensor(dim=dims, stride=strides, data_type=_HALF, name="v")
+    o, _ = g.sdpa(name="sdpa", q=q, k=k, v=v, attn_scale=1.0 / (d**0.5), is_inference=True, use_causal_mask=True)
+    o.set_output(True).set_dim(dims).set_stride(strides)
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    python = [i for i, p in enumerate(g.plans) if is_python_engine(p.engine_id)]
+    if not python:
+        pytest.skip(f"no FROST SDPA engine claimed the graph for d={d}")
+    g.select_plan(python[0])
+    g.check_support()
+    g.build_plans()
+    mk = lambda: torch.randn(_B, _S, _H, d, device="cuda", dtype=torch.float16).transpose(1, 2)  # noqa: E731
+    vp = {q: mk(), k: mk(), v: mk(), o: torch.empty(_B, _S, _H, d, device="cuda", dtype=torch.float16).transpose(1, 2)}
+    ws = torch.empty(g.get_workspace_size(), device="cuda", dtype=torch.uint8) if g.get_workspace_size() else None
+    return g, vp, ws
+
+
+@requires_blackwell
+@requires_dsl
+@pytest.mark.parametrize("d", [256, 512])
+def test_execute_reads_no_device_memory_to_the_host(monkeypatch, d):
+    g, vp, ws = _build(d)
+    g.execute(vp, ws)  # compile/warm outside the ban: JIT may legitimately sync
+    torch.cuda.synchronize()
+
+    caught = []
+
+    def _forbid(name):
+        def guard(self, *a, **kw):
+            if self.is_cuda:
+                caught.append(name)
+                raise AssertionError(f"execute() called Tensor.{name}() on a CUDA tensor — see Rule 3 in python/cudnn/AGENTS.md")
+            return _originals[name](self, *a, **kw)
+
+        return guard
+
+    _originals = {n: getattr(torch.Tensor, n) for n in _D2H_ACCESSORS}
+    for n in _D2H_ACCESSORS:
+        monkeypatch.setattr(torch.Tensor, n, _forbid(n))
+
+    g.execute(vp, ws)
+    torch.cuda.synchronize()
+    assert not caught

--- a/test/python/test_graph_native.py
+++ b/test/python/test_graph_native.py
@@ -541,6 +541,13 @@ class TestReviewSemantics:
         g.create_execution_plans()
         with pytest.raises(RuntimeError, match="frozen"):
             A.set_uid(500)
+        # A name is a variant-pack key, so it is identity too: renaming a
+        # planned graph would leave the lowered graph and any compiled binding
+        # holding the old label while the IR reports the new one.
+        with pytest.raises(RuntimeError, match="frozen"):
+            A.set_name("renamed")
+        assert A.get_name() == "A"
+        A.set_name("A")  # a no-op rename stays legal, as a no-op re-uid does
 
     def test_mxfp8_dsink_is_output(self):
         """Follow-up item 4: mxfp8_backward dSink_token is an output port."""


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

Python API or bindings (FROST SDPA engines + the shared `APIBase` helper).

## Summary

`execute()` is an async launch API. The FROST SDPA path had grown host work that
contradicts that in two ways; this fixes the second and documents the first.

A follow-up commit answers review: it **freezes tensor names on a planned graph**, which is what makes the cached name index sound. `_rename_tensor` was the one setter exempt from the freeze; the exemption existed for a typo in sample 24 (`graph.tensor_like(...)` where every sibling line says `bwd_graph`, two cells after that graph was built, against the comment directly above it). The sample is fixed here. A name reaches the lowered graph and is a variant-pack key, so it is identity, like the uid that has been guarded all along.

**A rule for the first.** A device-to-host read makes `execute()` synchronous.
Rules 1 and 2 in `python/cudnn/AGENTS.md` both cite CUDA-graph capture as the
reason for what they ban, but neither names the D2H read itself — which is how
these landed, one of them with a comment calling the syncs "inherent". **Rule 3**
now names it, and lists the reads that remain with what each needs to go. No
kernel changes here, so nothing is removed yet; the list is the plan, not a
claim.

**The second, fixed.** Per-call rework of facts fixed at build:

| | |
|---|---|
| `SdpaBinding` rebuilt its name/uid indices on every execute — three passes over the bound list, five dict constructions | builds the index once |
| the plan wrapper re-read every bound uid per call | reads them at plan construction |
| `_get_default_stream` used `torch.cuda.current_stream()`, whose `Stream` wrapper costs 4.3 µs | `torch._C._cuda_getCurrentRawStream`, 0.1 µs, same value |

## Why

Measured on SM100, dense f16 `(b,h,s,d) = (2,8,256,256)` causal, min over 25 reps
of bursts of 64 calls from a drained queue:

| | before | after |
|---|--:|--:|
| `graph.execute` | 35.5 µs | **24.8 µs** |
| ↳ `resolve_variant_pack` | 5.2 | **0.85** |
| ↳ `api.execute` | 19.8 | **15.2** |
| ↳ compiled-kernel launch (floor) | 6.6 | 6.6 |

`resolve_variant_pack` cost ~1.3 µs per bound operand, so the saving grows with
operand count: 4 for dense f16 fwd, 11 for bwd, 13 for fp8 fwd. Its cost was
three passes over the bound list and five dict constructions — `get_uid` /
`get_name` are plain attribute reads on the IR tensor, not pybind round trips.

Scope, since it is uneven across the 11 registered FROST SDPA specs (9 fwd, 2
bwd):

| | reaches |
|---|---|
| binding index, plan uid list | **all 11** |
| raw default stream | the **6** that share `SdpaFwdDslSm100.execute` — f16 d128 / d192×128 / d256 / d512, FP8, MXFP8 — and only when the caller passes no explicit stream |

The helper runs before the dense/THD/quant branch, so it is not a dense-only
win: four of those six declare `thd=True`, and FP8/MXFP8 enter the same way. The
other five (SM120 fwd ×2, SM80 fwd, SM120 bwd, SM80 bwd) each inline their own
`torch.cuda.current_stream(dev)` and are untouched here — unifying them is a
clean follow-up.

Outside SDPA the same helper is called by NSA Compression / Selection / TopK and
by the block-scaled GLU / DGLU / Wgrad grouped-GEMM APIs.

The layered table above is for attribution only — adjacent rows are not
subtractable, since some layers are handed a raw stream and some resolve it from
None. The end-to-end base/head numbers are the ones to read.

On why the D2H reads matter beyond speed: a blocking D2H during stream capture is
illegal, so a path that does one cannot be CUDA-graph captured — how inference
stacks run decode. And its cost is the queue, not the transfer: one `.tolist()`
measures 11 µs against a drained queue and **2.6 ms** behind 16 queued 4096³
matmuls.

One note for reviewers, since it is the obvious first suggestion: the FP8
`seq_len_q` guard **cannot** move to `check_support()`. `use_padding_mask=True`
requires a `seq_len_q` tensor even when only KV is padded, so no static rule
separates "declares per-batch Q lengths" from "the lengths are actually short".
I tried it; it declines the KV-only-padding population these kernels serve
correctly (`test_fp8_padding`, 4 failures). The read also is not hiding a wrong
answer — it raises. It goes when the FP8 kernels get the epilogue trim.

## Related issues

None.

## API and compatibility impact

**One deliberate tightening: `set_name()` on a planned graph now raises**, as
`set_uid()` already did. A no-op rename (same name) stays legal. There is no
valid caller in-tree — the one that existed was a typo in sample 24, fixed here
— but this is a public-surface restriction and should be read as one, not as an
internal cleanup.

Otherwise none: no kernel change, and no change to which engine serves a graph.
`_get_default_stream` returns the same stream by a cheaper accessor, with a
fallback to the documented one if a torch build ever drops the private symbol.

## Testing

New `test/python/sdpa/frost/test_sdpa_execute_is_async.py`, two angles:

- **the cause** — bans the known common D2H and blocking entry points for one execute
  (`item`/`tolist`/`cpu`/`numpy`/`__float__`/`__int__`/`__bool__`/`__index__`,
  `to` with a host destination, `torch.is_nonzero`, `torch.equal`, and the
  `synchronize` family), so a regression names the accessor instead of surfacing
  later as a capture failure.
- **the symptom, where nothing else looks** — capture/replay of `graph.execute()`
  with **no handle**. That is the path that resolves the stream itself;
  `test_sdpa_stream_respect.py` only covers the handle-carrying one.

It is a blacklist and does not pretend to be exhaustive — `.to(some_cpu_tensor)`,
a CPU-target `copy_` and driver-level synchronization all get through it; the
capture test is the backstop for those. Scoped to the dense f16 rows, which are
clean; widen it as the listed violations land.

All on SM100 (Blackwell), `CUDA_VISIBLE_DEVICES` pinned, no
`CUDNN_FRONTEND_ENABLE_FROST_ENGINES` (CI does not set it):

| suite | result |
|---|---|
| `test/python/sdpa/frost` | **579 passed**, 165 skipped |
| `test/python/test_graph_native.py` (owns the freeze contract) | 54 passed |
| `test_dispatch` + `test_variant_pack_normalization` + `test_sdpa_with_caching` + `test_mhas_v2` | 2247 passed, 707 skipped |
| `test/python/gemm` | 5768 passed, 2860 skipped |
| sdpa thd / edge / flexible / caching / chunked | 43 passed, 1 skipped |
| `test/python/fe_api` | 87 failed, 2404 passed — **all inherited** |

`sdpa/frost` is the suite that actually covers this change; `test_mhas_v2` routes
0/3201 graphs to FROST, so its green means "no backend regression", not coverage.

The `fe_api` failures were A/B'd against the PR base on the same box, GPU, venv
and `.so`, swapping only `python/cudnn`: **87 failed on both sides, identical
sets, zero unique to the branch** (see the comment thread for the run).

<sub>note to self: claude::774e8e99-23ad-4a94-be0d-53ed5ee4def9 — "FROST SDPA host overhead audit"<br>cwd /home/scratch.yanxu_libs/cudnn_frontend · workspace /home/scratch.yanxu_gpu/fe_pr1</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved SDPA execution by reusing prepared buffer and workspace information, reducing repeated setup work.
  * Accelerated tensor binding and buffer resolution for repeated operations.

* **Bug Fixes**
  * Improved default CUDA stream handling across supported execution environments.
  * Prevented SDPA execution from reading device data back to the host, preserving asynchronous behavior and CUDA graph capture.
  * Prevented tensor renaming after graph execution planning, while preserving valid no-op renames.
  * Corrected tensor creation in the LayerNorm training sample.

* **Documentation**
  * Added guidance for avoiding host-side device-memory reads and supporting CUDA graph capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->