### PR TITLE
dsa(indexer_backward): validate output & plan signature before the score-grad precompute (default SM100/SM90)

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -9,8 +9,9 @@ Combines backend-specific CuTe-DSL kernels:
 * IndexerBackwardSm90 or IndexerBackwardSm100 -- warp-specialized backward (kernel 2).
 * DenseIndexerBackward uses the dense full-KV score-grad + GEMM factories.
 
-A pure-torch dtype cast for ``dIndexK`` (FP32 → output dtype) finishes the
-pipeline (kernel 3).
+When the ``dIndexK`` output buffer is bf16, a trailing pure-torch cast
+(FP32 accumulator → bf16) finishes the pipeline (kernel 3); an fp32
+``dIndexK`` buffer receives the accumulator directly, with no cast.
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ import torch
 import cuda.bindings.driver as cuda
 
 from cudnn.api_base import APIBase, TupleDict
+from cudnn.tensor_adapter import canonicalize_unit_dim_strides
 from cudnn.deepseek_sparse_attention.utils.runtime import (
     torch_stream_context as _torch_stream_context,
     validate_q_causal_offsets,
@@ -127,7 +129,7 @@ def _dense_shapes(
 
 
 class IndexerBackward(APIBase):
-    """End-to-end indexer backward (3 fused stages).
+    """End-to-end indexer backward (staged pipeline).
 
     Given the forward-computed ``AttnScore`` (target distribution) and
     ``IndexScore`` (predict distribution) along with the sparse top-K indices,
@@ -138,6 +140,22 @@ class IndexerBackward(APIBase):
     multiplicative factors inside the score-grad precompute. Neither is
     part of the compile cache, so changing them across iterations reuses
     the same compiled kernel.
+
+    Staged pipeline that ``execute`` runs, in order:
+
+    1. Runtime signature re-validation of the tensors against the descriptors
+       captured at plan-build time (dtype, shape, and stride/layout),
+       *before* any kernel launch — kernel 1 mutates the score buffers in
+       place, so a mismatched reuse of an exported plan must raise here to
+       avoid a fail-dirty.
+    2. Kernel 1 — in-place score-grad precompute (overwrites ``attn_score`` and
+       ``index_score``).
+    3. (conditional) fp32 ``d_index_k`` zero-init — when the ``d_index_k``
+       output buffer is fp32, ``execute`` zeroes it on the selected stream
+       before the GEMM, because the dK epilogue atomic-adds into it. This is a
+       promised stage, not a hidden op; a bf16 ``d_index_k`` buffer instead
+       gets an internally-allocated zeroed fp32 scratch + trailing cast.
+    4. Kernel 2 — warp-specialized backward GEMM producing the gradients.
     """
 
     def __init__(
@@ -145,9 +163,9 @@ class IndexerBackward(APIBase):
         sample_index_q: torch.Tensor,  # (B, S_q, H, D) BF16
         sample_weights: torch.Tensor,  # (B, S_q, H) BF16
         sample_index_k: torch.Tensor,  # (B, S_k, D) BF16
-        sample_d_index_q: torch.Tensor,  # same shape/dtype as index_q
-        sample_d_weights: torch.Tensor,  # same shape/dtype as weights
-        sample_d_index_k: torch.Tensor,  # same shape/dtype as index_k
+        sample_d_index_q: torch.Tensor,  # (B, S_q, H, D); bf16 only
+        sample_d_weights: torch.Tensor,  # (B, S_q, H); bf16 only (the kernel's dW store rounds to bf16)
+        sample_d_index_k: torch.Tensor,  # (B, S_k, D); bf16 or fp32 (both arches)
         sample_attn_score: torch.Tensor,  # (B, S_q, topk) FP32 — target
         sample_index_score: torch.Tensor,  # (B, S_q, topk) FP32 — predict
         sample_topk_indices: torch.Tensor,  # (B, S_q, topk) INT32
@@ -166,6 +184,20 @@ class IndexerBackward(APIBase):
         self.idx_score_desc = self._make_tensor_desc(sample_index_score, name="sample_index_score")
         self.topk_desc = self._make_tensor_desc(sample_topk_indices, name="sample_topk_indices")
 
+        # Validate ranks explicitly before deriving the plan dimensions below,
+        # so a wrong-rank tensor surfaces as a clean ValueError instead of a
+        # cryptic tuple-unpack/indexing error. The remaining tensors' ranks are
+        # covered by the semantic shape validation in ``check_support``
+        # (``_validate_plan_shapes_and_layout``).
+        if sample_index_q.ndim != 4:
+            raise ValueError(f"IndexerBackward sample_index_q must be 4D (B, S_q, H, D), got {sample_index_q.ndim}D shape {tuple(sample_index_q.shape)}")
+        if sample_index_k.ndim != 3:
+            raise ValueError(f"IndexerBackward sample_index_k must be 3D (B, S_k, D), got {sample_index_k.ndim}D shape {tuple(sample_index_k.shape)}")
+        if sample_topk_indices.ndim != 3:
+            raise ValueError(
+                f"IndexerBackward sample_topk_indices must be 3D (B, S_q, topk), got {sample_topk_indices.ndim}D shape {tuple(sample_topk_indices.shape)}"
+            )
+
         b, s_q, h, d = sample_index_q.shape
         s_k = sample_index_k.shape[1]
         topk = sample_topk_indices.shape[-1]
@@ -179,6 +211,64 @@ class IndexerBackward(APIBase):
         self.block_I = int(block_I)
         self.topk_indices_global = bool(topk_indices_global)
 
+    def _validate_plan_shapes_and_layout(self) -> None:
+        """Semantic shape + layout validation of the plan's tensor descriptors.
+
+        Runs before kernel 1 mutates the score buffers in place.
+        ``check_support`` otherwise only checks dtypes and ``execute``'s
+        signature check only compares each runtime tensor against the recorded
+        descriptor, so without this a directly-built / first-call plan whose
+        ``d_weights`` / ``d_index_q`` / ``d_index_k`` / score / top-k shape is
+        already inconsistent with ``index_q`` would pass validation, kernel 1
+        would corrupt the scores, and only the GEMM would fault or corrupt
+        memory. The relationships enforced (per the API contract):
+
+          index_q      (B, S_q, H, D)      weights   (B, S_q, H)
+          index_k      (B, S_k, D)         d_index_q == index_q.shape
+          d_weights   == weights.shape     d_index_k == index_k.shape
+          attn_score / index_score / topk_indices == (B, S_q, topk)
+
+        Non-compact (non-contiguous) layouts are also rejected here: the SM100
+        kernel flattens ``index_k`` / ``d_index_k`` to ``(B*S_k, D)`` with a
+        hard-coded ``(D, 1)`` stride and the backend GEMM/score-grad caches do
+        not key the layout, so a consistently non-contiguous plan would be
+        addressed as if it were compact. This is validated on the descriptors,
+        which are re-checked against the runtime tensors by
+        ``_check_execute_signature`` (dtype/shape/stride).
+        """
+        b, s_q, h, d = self.batch, self.seqlen, self.heads, self.head_dim
+        s_k, topk = self.seqlen_k, self.topk
+        q_shape = (b, s_q, h, d)
+        w_shape = (b, s_q, h)
+        k_shape = (b, s_k, d)
+        score_shape = (b, s_q, topk)
+
+        def _require_shape(desc, name, expected):
+            actual = tuple(desc.shape)
+            if actual != tuple(expected):
+                raise ValueError(f"IndexerBackward {name} shape mismatch: expected {tuple(expected)}, got {actual}")
+
+        checks = (
+            (self.iq_desc, "index_q", q_shape),
+            (self.w_desc, "weights", w_shape),
+            (self.ik_desc, "index_k", k_shape),
+            (self.diq_desc, "d_index_q", q_shape),
+            (self.dw_desc, "d_weights", w_shape),
+            (self.dik_desc, "d_index_k", k_shape),
+            (self.attn_desc, "attn_score", score_shape),
+            (self.idx_score_desc, "index_score", score_shape),
+            (self.topk_desc, "topk_indices", score_shape),
+        )
+        for desc, name, expected in checks:
+            _require_shape(desc, name, expected)
+        for desc, name, _ in checks:
+            if not desc.is_contiguous():
+                raise ValueError(
+                    f"IndexerBackward requires contiguous (compact row-major) tensors; {name} has shape "
+                    f"{tuple(desc.shape)} with non-compact stride {tuple(desc.stride)}. The kernel addresses "
+                    "index_k/d_index_k with a hard-coded compact (D, 1) stride and the backend caches do not key the layout."
+                )
+
     def check_support(self) -> bool:
         major, _ = torch.cuda.get_device_capability()
         self._runtime_error_if(
@@ -191,6 +281,33 @@ class IndexerBackward(APIBase):
         self._check_dtype(self.attn_desc, torch.float32, name="attn_score")
         self._check_dtype(self.idx_score_desc, torch.float32, name="index_score")
         self._check_dtype(self.topk_desc, torch.int32, name="topk_indices")
+        # Output-dtype contract, validated here — before compile()/execute(),
+        # i.e. before kernel 1 mutates attn_score/index_score in place (no
+        # fail-dirty on a bad output dtype). ``d_index_q`` is bf16-only (TMA
+        # store of the input dtype). ``d_index_k`` accepts bf16 or fp32 on both
+        # arches (the GEMM accumulates dK in fp32; a bf16 buffer gets a
+        # trailing cast). ``d_weights`` is bf16-only on both arches: the
+        # kernel's dW store rounds the fp32 accumulator to bf16, so an fp32
+        # buffer cannot be produced faithfully and is rejected rather than
+        # silently filled with bf16-precision values.
+        self._check_dtype(self.diq_desc, torch.bfloat16, name="d_index_q")
+        self._check_dtype(
+            self.dw_desc,
+            torch.bfloat16,
+            name="d_weights",
+            extra_error_msg="the kernel's dW store rounds to bf16; fp32 output is not supported",
+        )
+        self._check_dtype(
+            self.dik_desc,
+            [torch.bfloat16, torch.float32],
+            name="d_index_k",
+            extra_error_msg="fp32 buffers receive the fp32 accumulator directly",
+        )
+        # Semantic shape relationships + compact-layout requirement, validated
+        # here (before compile()/execute(), i.e. before kernel 1 mutates the
+        # score buffers). Guards a directly-built / first-call plan whose output
+        # or score shapes are inconsistent, or whose layout is non-compact.
+        self._validate_plan_shapes_and_layout()
         self._is_supported = True
         return True
 
@@ -217,6 +334,36 @@ class IndexerBackward(APIBase):
             topk_indices_global=self.topk_indices_global,
         )
 
+    def _check_execute_signature(self, *entries) -> None:
+        """Validate runtime tensors against the descriptors captured at
+        plan-build time, before any kernel launch.
+
+        Each entry is ``(tensor, descriptor, name)``. Guards against reusing a
+        directly-built/exported plan with a tensor whose dtype, shape, or
+        stride/layout differs from what it was compiled for — kernel 1
+        mutates the score buffers in place, so a mismatch must raise *before*
+        the pipeline starts (no fail-dirty).
+        """
+        for tensor, desc, name in entries:
+            if desc is None:
+                continue
+            if tensor.dtype != desc.dtype:
+                raise ValueError(
+                    f"{name} dtype mismatch: this plan was compiled for {desc.dtype}, got {tensor.dtype}. Build a new plan (or use indexer_backward_wrapper) for a different signature."
+                )
+            tensor_shape = tuple(self._tensor_shape(tensor, name=name))
+            desc_shape = tuple(desc.shape)
+            if tensor_shape != desc_shape:
+                raise ValueError(f"{name} shape mismatch: this plan was compiled for {desc_shape}, got {tensor_shape}.")
+            # Compare layouts with the same unit-dim canonicalization the
+            # framework uses for compile-equality (extent-1 dims carry an
+            # unobservable stride): the compiled kernel bakes in the sample
+            # stride/layout, so a different stride would run the kernel against
+            # a layout it was not compiled for.
+            tensor_stride = tuple(self._tensor_stride(tensor, name=name))
+            if canonicalize_unit_dim_strides(tensor_shape, tensor_stride) != canonicalize_unit_dim_strides(desc_shape, tuple(desc.stride)):
+                raise ValueError(f"{name} stride/layout mismatch: this plan was compiled for stride {tuple(desc.stride)}, got {tensor_stride}.")
+
     def execute(
         self,
         index_q: torch.Tensor,
@@ -233,6 +380,32 @@ class IndexerBackward(APIBase):
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         self._logger.debug("Entering execute")
+        # Stage 1: runtime signature re-validation against the descriptors
+        # captured at plan-build time, BEFORE any kernel launch. The plan is
+        # specialized to the sample dtypes and shapes. Kernel 1
+        # mutates ``attn_score`` / ``index_score`` in place before the GEMM
+        # runs, so reusing an exported plan with a mismatched signature would
+        # otherwise fail (or corrupt memory) only after the scores were
+        # already mutated. Raise a clean ValueError here — no fail-dirty. The
+        # signature-keyed wrapper cache never hits this, but a directly-
+        # built/exported plan can.
+        #
+        # First re-assert the plan's own descriptors are semantically
+        # consistent + compact (idempotent with check_support; also covers a
+        # directly-built plan whose owner skipped check_support), then verify
+        # each runtime tensor matches the descriptor it was compiled for.
+        self._validate_plan_shapes_and_layout()
+        self._check_execute_signature(
+            (index_q, self.iq_desc, "index_q"),
+            (weights, self.w_desc, "weights"),
+            (index_k, self.ik_desc, "index_k"),
+            (d_index_q, self.diq_desc, "d_index_q"),
+            (d_weights, self.dw_desc, "d_weights"),
+            (d_index_k, self.dik_desc, "d_index_k"),
+            (attn_score, self.attn_desc, "attn_score"),
+            (index_score, self.idx_score_desc, "index_score"),
+            (topk_indices, self.topk_desc, "topk_indices"),
+        )
         # ``grad_scale`` is forwarded as a runtime ``Float32`` arg; the
         # compiled kernel is reused when loss_coeff changes for the same
         # cached tensor shape.
@@ -465,6 +638,17 @@ def indexer_backward_wrapper(
             ``index_q``. The kernel reads its value at runtime, including on
             CUDA Graph replay.
     """
+    # Validate ranks explicitly before any allocation or the dimension
+    # derivation below, so a wrong-rank tensor surfaces as a clean ValueError
+    # instead of a cryptic tuple-unpack/indexing error (or a mis-shaped
+    # ``empty_like`` allocation). The remaining tensors' ranks are covered by
+    # the plan's semantic shape validation in ``check_support``.
+    if index_q.ndim != 4:
+        raise ValueError(f"indexer_backward index_q must be 4D (B, S_q, H, D), got {index_q.ndim}D shape {tuple(index_q.shape)}")
+    if index_k.ndim != 3:
+        raise ValueError(f"indexer_backward index_k must be 3D (B, S_k, D), got {index_k.ndim}D shape {tuple(index_k.shape)}")
+    if topk_indices.ndim != 3:
+        raise ValueError(f"indexer_backward topk_indices must be 3D (B, S_q, topk), got {topk_indices.ndim}D shape {tuple(topk_indices.shape)}")
     with _torch_stream_context(stream):
         if d_index_q is None:
             d_index_q = torch.empty_like(index_q)
@@ -481,11 +665,16 @@ def indexer_backward_wrapper(
     # into the score-grad kernel as a runtime ``Float32``), so it is not
     # part of the cache key — same compiled kernel reused across calls
     # with different loss_coeff for the same tensor shape. Shape
-    # changes still get their own cache entries.
+    # changes still get their own cache entries. The output dtypes are keyed
+    # (``d_index_q``/``d_weights``/``d_index_k``) so ``check_support``'s
+    # output-dtype validation cannot be skipped on a cache hit (no fail-dirty).
     key = (
         index_q.dtype,
         weights.dtype,
         index_k.dtype,
+        d_index_q.dtype,
+        d_weights.dtype,
+        d_index_k.dtype,
         b,
         s_q,
         s_k,

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm100.py
@@ -1666,8 +1666,15 @@ def _build_cute_dsl_kernel(heads, dim, topk, sm_scale, block_I, topk_indices_glo
         score_grad(AttnScore, IndexScore, GradLoss, grad_scale, current_stream=current_stream)
 
         if dIndexK.dtype == torch.float32:
-            # Caller provided a pre-zeroed f32 buffer; write directly (no extra
-            # alloc + cast). This matches the SM90 _run fast path.
+            # fp32 output: the dK epilogue atomic-adds into this buffer, so it
+            # must start zeroed. Zero it internally on the selected stream
+            # (cheap; removes the fragile caller pre-zero contract) rather than
+            # trusting the caller. This zero-init is a promised stage of the
+            # execute pipeline (see the IndexerBackward docstring) and mirrors
+            # the SM90 backend and the DenseIndexerBackward fp32 paths, which
+            # zero their fp32 dK buffer the same way.
+            with _torch_stream_context(current_stream):
+                dIndexK.zero_()
             _run_gemm_only(IndexQ, Weights, IndexK, dIndexQ, dWeights, dIndexK, AttnScore, TopkIndices, current_stream=current_stream)
         else:
             # Need a separate f32 buffer for atomicAdd, then cast back to output dtype.

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_sm90.py
@@ -1708,7 +1708,15 @@ def _build_cute_dsl_kernel(
         )
 
         if dIndexK.dtype == torch.float32:
-            # Caller already provides f32 buffer (e.g., __init__.py); write directly
+            # fp32 output: the dK epilogue reduce-/atomic-adds into this
+            # buffer, so it must start zeroed. Zero it internally on the
+            # selected stream (cheap; removes the fragile caller pre-zero
+            # contract) rather than trusting the caller to pass a zeroed
+            # buffer. This is a promised stage of the execute pipeline and
+            # mirrors the SM100 backend and the DenseIndexerBackward fp32
+            # path.
+            with _torch_stream_context(current_stream):
+                dIndexK.zero_()
             _run_gemm_only(
                 IndexQ,
                 Weights,

--- a/test/python/fe_api/dsa/test_DSA_indexer_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_backward.py
@@ -6,7 +6,7 @@ import torch
 
 from test_utils import torch_fork_set_rng
 
-from fe_api.dsa.dsa_utils import dsa_init, with_dsa_indexer_backward_params
+from fe_api.dsa.dsa_utils import dsa_init, with_dsa_indexer_backward_params, _require_sm100
 from fe_api.dsa.dsa_reference import (
     _indexer_predict_distribution,
     check_ref_indexer_backward,
@@ -156,4 +156,359 @@ def test_DSA_indexer_backward_wrapper(
             d_index_k,
             sm_scale=sm_scale,
             grad_scale=grad_scale_expected,
+        )
+
+
+# ===========================================================================
+# Regression coverage for the output/plan-signature validation on the default
+# indexer backward (SM100/SM90):
+#   * illegal output dtypes raise BEFORE kernel 1 mutates the score buffers;
+#   * wrong-rank / wrong-shape / non-contiguous plans are rejected up front;
+#   * a direct plan or a cached wrapper plan reused with a mismatched
+#     shape/stride signature raises (no fail-dirty);
+#   * an fp32 d_index_k buffer is zeroed internally (result independent of the
+#     buffer's incoming contents).
+# The validation lives in the arch-independent plan/wrapper layer; the runs
+# are pinned to SM100, the arch this suite's default kernels are built on.
+# ===========================================================================
+
+_IDXBWD_CFG = {
+    "b": 1,
+    "s_q": 128,
+    "s_kv": 512,
+    "head_dim": 128,
+    "qhead_per_kv_head": 64,
+    "topk": 512,
+}
+_IDXBWD_SM_SCALE = 1.0
+
+
+def _import_dsa():
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    return DSA, cuda
+
+
+def _idxbwd_inputs():
+    """Deterministic inputs + a grad_loss/loss_coeff pair giving grad_scale=1."""
+    (
+        index_q,
+        weights,
+        index_k,
+        attn_score,
+        index_score,
+        topk_indices,
+    ) = _allocate(_IDXBWD_CFG, sm_scale=_IDXBWD_SM_SCALE)
+    loss_coeff = float(_IDXBWD_CFG["b"] * _IDXBWD_CFG["s_q"])  # grad_scale = 1.0
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+    return index_q, weights, index_k, attn_score, index_score, topk_indices, loss_coeff, grad_loss
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_indexer_backward_illegal_output_dtype_raises_before_mutation():
+    """Each illegal output dtype raises ValueError, and the raise happens
+    before kernel 1 mutates attn_score / index_score in place (no fail-dirty)."""
+    _require_sm100()
+    DSA, _ = _import_dsa()
+
+    for label, kw in (
+        ("fp32 d_index_q", {"d_index_q_dtype": torch.float32}),
+        # fp32 d_weights is rejected: the kernel's dW store rounds the fp32
+        # accumulator to bf16, so an fp32 buffer cannot be produced faithfully
+        # and would silently carry bf16 precision.
+        ("fp32 d_weights", {"d_weights_dtype": torch.float32}),
+        ("fp16 d_weights", {"d_weights_dtype": torch.float16}),
+        ("fp16 d_index_k", {"d_index_k_dtype": torch.float16}),
+    ):
+        iq, w, ik, attn, idx, tk, loss_coeff, grad_loss = _idxbwd_inputs()
+        aq = attn.clone()
+        isc = idx.clone()
+        aq_pre = aq.clone()
+        isc_pre = isc.clone()
+        outputs = {}
+        if "d_index_q_dtype" in kw:
+            outputs["d_index_q"] = torch.empty_like(iq, dtype=kw["d_index_q_dtype"])
+        if "d_weights_dtype" in kw:
+            outputs["d_weights"] = torch.empty_like(w, dtype=kw["d_weights_dtype"])
+        if "d_index_k_dtype" in kw:
+            outputs["d_index_k"] = torch.empty_like(ik, dtype=kw["d_index_k_dtype"])
+
+        with pytest.raises(ValueError):
+            DSA.indexer_backward_wrapper(iq, w, ik, aq, isc, tk, sm_scale=_IDXBWD_SM_SCALE, loss_coeff=loss_coeff, grad_loss=grad_loss, block_I=128, **outputs)
+        torch.cuda.synchronize()
+        assert torch.equal(aq, aq_pre), f"{label}: attn_score mutated before the dtype check (fail-dirty)"
+        assert torch.equal(isc, isc_pre), f"{label}: index_score mutated before the dtype check (fail-dirty)"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_indexer_backward_fp32_dindexk_zeroed_internally():
+    """An fp32 d_index_k buffer is zeroed inside execute (the dK epilogue
+    atomic-adds), so the result is independent of the buffer's incoming
+    contents — a nonzero buffer does NOT return old + gradient."""
+    _require_sm100()
+    DSA, _ = _import_dsa()
+
+    iq, w, ik, attn, idx, tk, loss_coeff, grad_loss = _idxbwd_inputs()
+
+    dk_zero = torch.zeros_like(ik, dtype=torch.float32)
+    res_zero = DSA.indexer_backward_wrapper(
+        iq, w, ik, attn.clone(), idx.clone(), tk, sm_scale=_IDXBWD_SM_SCALE, loss_coeff=loss_coeff, grad_loss=grad_loss, block_I=128, d_index_k=dk_zero
+    )
+    torch.cuda.synchronize()
+    dk_from_zero = res_zero["d_index_k"].clone()
+
+    dk_nonzero = torch.full_like(ik, 999.0, dtype=torch.float32)
+    res_nonzero = DSA.indexer_backward_wrapper(
+        iq, w, ik, attn.clone(), idx.clone(), tk, sm_scale=_IDXBWD_SM_SCALE, loss_coeff=loss_coeff, grad_loss=grad_loss, block_I=128, d_index_k=dk_nonzero
+    )
+    torch.cuda.synchronize()
+    dk_from_nonzero = res_nonzero["d_index_k"]
+
+    assert torch.isfinite(dk_from_nonzero).all()
+    max_diff = (dk_from_nonzero.double() - dk_from_zero.double()).abs().max().item()
+    # If the buffer were not zeroed, the 999.0 offset would survive; the fp32
+    # atomic-add jitter between two runs is ~1e-3, so a <1.0 bound cleanly
+    # proves the internal zero-init.
+    assert max_diff < 1.0, f"fp32 d_index_k not zeroed internally: max|nonzero-init - zero-init| = {max_diff:.3e}"
+
+
+def _noncontiguous_like(sample):
+    """A tensor with ``sample``'s shape/dtype/device but a strided (non-dense)
+    layout, so its stride differs from a contiguous descriptor's."""
+    padded = torch.empty(*sample.shape, 2, dtype=sample.dtype, device=sample.device)
+    view = padded[..., 0]
+    assert view.shape == sample.shape and not view.is_contiguous()
+    view.copy_(sample)
+    return view
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_indexer_backward_direct_plan_shape_stride_mismatch_raises():
+    """A directly-built plan rejects a runtime tensor whose shape or
+    stride/layout differs from the descriptor it was compiled for, raising a
+    clean ValueError BEFORE kernel 1 mutates the score buffers (no fail-dirty)."""
+    _require_sm100()
+    DSA, _ = _import_dsa()
+
+    iq, w, ik, attn, idx, tk, loss_coeff, grad_loss = _idxbwd_inputs()
+
+    plan = DSA.IndexerBackward(
+        sample_index_q=iq,
+        sample_weights=w,
+        sample_index_k=ik,
+        sample_d_index_q=torch.empty_like(iq),
+        sample_d_weights=torch.empty_like(w),
+        sample_d_index_k=torch.empty_like(ik),
+        sample_attn_score=attn,
+        sample_index_score=idx,
+        sample_topk_indices=tk,
+        sm_scale=_IDXBWD_SM_SCALE,
+        block_I=128,
+    )
+    assert plan.check_support()
+    plan.compile()
+
+    b, s_q, _, _ = iq.shape
+    topk = tk.shape[-1]
+
+    # Case 1: wrong-shaped attn_score (extra top-k column). Fill it with
+    # meaningful (nonzero) data and snapshot both score buffers so we can assert
+    # neither is mutated before the shape check raises.
+    aq_bad = torch.softmax(torch.randn(b, s_q, topk + 1, device=iq.device), dim=-1).float()
+    isc = idx.clone()
+    aq_bad_pre = aq_bad.clone()
+    isc_pre = isc.clone()
+    with pytest.raises(ValueError):
+        plan.execute(iq, w, ik, torch.empty_like(iq), torch.empty_like(w), torch.empty_like(ik), aq_bad, isc, tk, grad_loss, loss_coeff=loss_coeff)
+    torch.cuda.synchronize()
+    assert torch.equal(aq_bad, aq_bad_pre), "attn_score mutated before the shape check (fail-dirty)"
+    assert torch.equal(isc, isc_pre), "index_score mutated before the shape check (fail-dirty)"
+
+    # Case 2: non-contiguous attn_score (right shape, strided storage).
+    aq_nc = _noncontiguous_like(attn)
+    isc2 = idx.clone()
+    aq_nc_pre = aq_nc.clone()
+    isc2_pre = isc2.clone()
+    with pytest.raises(ValueError):
+        plan.execute(iq, w, ik, torch.empty_like(iq), torch.empty_like(w), torch.empty_like(ik), aq_nc, isc2, tk, grad_loss, loss_coeff=loss_coeff)
+    torch.cuda.synchronize()
+    assert torch.equal(aq_nc, aq_nc_pre), "attn_score mutated before the stride check (fail-dirty)"
+    assert torch.equal(isc2, isc2_pre), "index_score mutated before the stride check (fail-dirty)"
+
+    # Case 3: non-contiguous OUTPUT (d_weights) is rejected before mutation too.
+    aq3 = attn.clone()
+    isc3 = idx.clone()
+    aq3_pre = aq3.clone()
+    isc3_pre = isc3.clone()
+    dw_nc = _noncontiguous_like(torch.empty_like(w))
+    with pytest.raises(ValueError):
+        plan.execute(iq, w, ik, torch.empty_like(iq), dw_nc, torch.empty_like(ik), aq3, isc3, tk, grad_loss, loss_coeff=loss_coeff)
+    torch.cuda.synchronize()
+    assert torch.equal(aq3, aq3_pre), "attn_score mutated before the output-stride check (fail-dirty)"
+    assert torch.equal(isc3, isc3_pre), "index_score mutated before the output-stride check (fail-dirty)"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_indexer_backward_wrapper_cache_hit_stride_mismatch_raises():
+    """A wrapper cache hit (identical shape/dtype/device key) still rejects a
+    non-contiguous score buffer via the cached plan's execute-time signature
+    check, before kernel 1 mutates either score buffer (no fail-dirty)."""
+    _require_sm100()
+    DSA, _ = _import_dsa()
+
+    iq, w, ik, attn, idx, tk, loss_coeff, grad_loss = _idxbwd_inputs()
+
+    # First call with contiguous tensors populates the wrapper cache (its
+    # descriptor is contiguous).
+    DSA.indexer_backward_wrapper(iq, w, ik, attn.clone(), idx.clone(), tk, sm_scale=_IDXBWD_SM_SCALE, loss_coeff=loss_coeff, grad_loss=grad_loss, block_I=128)
+    torch.cuda.synchronize()
+
+    # Second call: identical shape/dtype/device (cache hit) but a
+    # non-contiguous attn_score. The cached plan must raise before mutation.
+    aq_nc = _noncontiguous_like(attn)
+    isc = idx.clone()
+    aq_nc_pre = aq_nc.clone()
+    isc_pre = isc.clone()
+    with pytest.raises(ValueError):
+        DSA.indexer_backward_wrapper(iq, w, ik, aq_nc, isc, tk, sm_scale=_IDXBWD_SM_SCALE, loss_coeff=loss_coeff, grad_loss=grad_loss, block_I=128)
+    torch.cuda.synchronize()
+    assert torch.equal(aq_nc, aq_nc_pre), "attn_score mutated before the cache-hit stride check (fail-dirty)"
+    assert torch.equal(isc, isc_pre), "index_score mutated before the cache-hit stride check (fail-dirty)"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_indexer_backward_wrong_shape_plan_rejected_before_kernel1():
+    """A first-call / directly-built plan whose output/score shape is
+    inconsistent with ``index_q`` is rejected by the semantic shape validation
+    in ``check_support`` BEFORE kernel 1 mutates the score buffers — not
+    silently run on a mismatched signature that only faults in the GEMM. Covers
+    both the wrapper (cache miss) and a directly-built plan. Fail-hard."""
+    _require_sm100()
+    DSA, _ = _import_dsa()
+
+    iq, w, ik, attn, idx, tk, loss_coeff, grad_loss = _idxbwd_inputs()
+    b, s_q, h, _ = iq.shape
+    topk = tk.shape[-1]
+
+    # (a) Wrapper first call (cache miss) with a wrong-shaped d_weights output
+    #     buffer. The plan is built from the mismatched sample, and check_support
+    #     must raise before any kernel launch; the score buffers stay pristine.
+    aq = attn.clone()
+    isc = idx.clone()
+    aq_pre = aq.clone()
+    isc_pre = isc.clone()
+    dw_bad = torch.empty(b, s_q, h + 1, dtype=torch.bfloat16, device=iq.device)
+    with pytest.raises(ValueError):
+        DSA.indexer_backward_wrapper(
+            iq, w, ik, aq, isc, tk, sm_scale=_IDXBWD_SM_SCALE, loss_coeff=loss_coeff, grad_loss=grad_loss, block_I=128, d_weights=dw_bad
+        )
+    torch.cuda.synchronize()
+    assert torch.equal(aq, aq_pre), "attn_score mutated before the wrong-shape check (fail-dirty)"
+    assert torch.equal(isc, isc_pre), "index_score mutated before the wrong-shape check (fail-dirty)"
+
+    # (b) Directly-built plan with a wrong-shaped attn_score sample: check_support
+    #     rejects the inconsistent signature (before compile / any kernel launch).
+    plan = DSA.IndexerBackward(
+        sample_index_q=iq,
+        sample_weights=w,
+        sample_index_k=ik,
+        sample_d_index_q=torch.empty_like(iq),
+        sample_d_weights=torch.empty_like(w),
+        sample_d_index_k=torch.empty_like(ik),
+        sample_attn_score=torch.empty(b, s_q, topk + 1, dtype=torch.float32, device=iq.device),
+        sample_index_score=idx,
+        sample_topk_indices=tk,
+        sm_scale=_IDXBWD_SM_SCALE,
+        block_I=128,
+    )
+    with pytest.raises(ValueError):
+        plan.check_support()
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_indexer_backward_noncontiguous_index_k_plan_rejected():
+    """A plan built from a consistently non-contiguous ``index_k`` is rejected
+    by ``check_support``: the SM100 kernel addresses K/dK with a hard-coded
+    compact (D, 1) stride and the backend caches do not key the layout, so a
+    non-compact plan would be silently mis-addressed. Covers a directly-built
+    plan and a wrapper first call (rejected before kernel 1). Fail-hard."""
+    _require_sm100()
+    DSA, _ = _import_dsa()
+
+    iq, w, ik, attn, idx, tk, loss_coeff, grad_loss = _idxbwd_inputs()
+
+    ik_nc = _noncontiguous_like(ik)
+    assert not ik_nc.is_contiguous()
+
+    # (a) Directly-built plan with a non-contiguous index_k sample.
+    plan = DSA.IndexerBackward(
+        sample_index_q=iq,
+        sample_weights=w,
+        sample_index_k=ik_nc,
+        sample_d_index_q=torch.empty_like(iq),
+        sample_d_weights=torch.empty_like(w),
+        sample_d_index_k=torch.empty_like(ik),
+        sample_attn_score=attn,
+        sample_index_score=idx,
+        sample_topk_indices=tk,
+        sm_scale=_IDXBWD_SM_SCALE,
+        block_I=128,
+    )
+    with pytest.raises(ValueError):
+        plan.check_support()
+
+    # (b) Wrapper first call (cache miss) with a non-contiguous index_k is
+    #     rejected before kernel 1 mutates the score buffers.
+    aq = attn.clone()
+    isc = idx.clone()
+    aq_pre = aq.clone()
+    isc_pre = isc.clone()
+    with pytest.raises(ValueError):
+        DSA.indexer_backward_wrapper(iq, w, ik_nc, aq, isc, tk, sm_scale=_IDXBWD_SM_SCALE, loss_coeff=loss_coeff, grad_loss=grad_loss, block_I=128)
+    torch.cuda.synchronize()
+    assert torch.equal(aq, aq_pre), "attn_score mutated before the non-contiguous check (fail-dirty)"
+    assert torch.equal(isc, isc_pre), "index_score mutated before the non-contiguous check (fail-dirty)"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_DSA_indexer_backward_wrong_ndim_rejected():
+    """A wrong-rank ``index_q`` / ``index_k`` / ``topk_indices`` is rejected
+    with a clean ValueError (not a cryptic tuple-unpack error) by both the
+    wrapper (before any allocation) and a directly-built plan."""
+    _require_sm100()
+    DSA, _ = _import_dsa()
+
+    iq, w, ik, attn, idx, tk, loss_coeff, grad_loss = _idxbwd_inputs()
+    common = dict(sm_scale=_IDXBWD_SM_SCALE, loss_coeff=loss_coeff, grad_loss=grad_loss, block_I=128)
+
+    with pytest.raises(ValueError, match="index_q must be 4D"):
+        DSA.indexer_backward_wrapper(iq[:, :, 0], w, ik, attn.clone(), idx.clone(), tk, **common)
+    with pytest.raises(ValueError, match="index_k must be 3D"):
+        DSA.indexer_backward_wrapper(iq, w, ik[0], attn.clone(), idx.clone(), tk, **common)
+    with pytest.raises(ValueError, match="topk_indices must be 3D"):
+        DSA.indexer_backward_wrapper(iq, w, ik, attn.clone(), idx.clone(), tk[0], **common)
+
+    with pytest.raises(ValueError, match="sample_index_q must be 4D"):
+        DSA.IndexerBackward(
+            sample_index_q=iq[:, :, 0],
+            sample_weights=w,
+            sample_index_k=ik,
+            sample_d_index_q=torch.empty_like(iq),
+            sample_d_weights=torch.empty_like(w),
+            sample_d_index_k=torch.empty_like(ik),
+            sample_attn_score=attn,
+            sample_index_score=idx,
+            sample_topk_indices=tk,
+            sm_scale=_IDXBWD_SM_SCALE,
+            block_I=128,
         )


### PR DESCRIPTION
Fixes #571.

## What

The default indexer backward accepted caller-supplied output buffers without any
signature validation. It runs its kernels in sequence, and the first of them — an
in-place score-gradient precompute (called `kernel 1` in the backend) — overwrites
the caller's `attn_score`/`index_score` before the main GEMM. So a bad output
buffer either crashed hard (non-bf16 `d_index_q` →
async `cudaErrorMisalignedAddress`), silently produced garbage (fp16 `d_index_q`,
rms ≈ 13.6), produced NaN (fp8), silently degraded (fp32 `d_weights` receives
bf16-rounded values), or raised only *after* the caller's in-place
`attn_score`/`index_score` had been mutated (fail-dirty). Repro + measured matrix
in the issue.

This PR makes the default backend validate everything it depends on **before
the score-grad precompute**, at both plan build and execute:

1. **Full signature validation.** `check_support` and `execute()` both verify
   every input/output tensor's **dtype, cross-tensor shape relationships (incl.
   tensor ranks), and compact-contiguous layout** against the plan.
   Anything the kernel cannot faithfully produce is rejected with a clean
   `ValueError` before any mutation: `d_index_q` must be bf16; `d_weights` must be
   bf16 (the kernel's dW store rounds to bf16); `d_index_k` accepts `{bf16, fp32}`. A first call, a directly-built
   plan, and a
   mixed-signature plan reuse all fail cleanly instead of fail-dirty.
2. **Zero the fp32 `d_index_k` buffer internally** on both SM100 and SM90 (the
   GEMM atomic-adds into it), removing a previously-undocumented caller-pre-zero
   requirement.

The default **bf16** path is behaviorally unchanged (validation is all
pre-kernel): on SM100 dQ/dW are bitwise-identical to the pre-fix base and dK sits
within the fp32-atomic run-to-run jitter band; on SM90 dQ is bitwise-identical
and dW/dK sit within the pre-existing atomic-add jitter band (see below).

## Validation (B200/SM100 and H100/SM90)

- **No regression:** on SM100 `d_index_q`/`d_weights` are bitwise-identical vs
  base and `d_index_k` is within the fp32-atomic jitter band; on SM90
  `d_index_q` is bitwise-identical and `d_weights`/`d_index_k` sit within the
  pre-existing atomic-add jitter band. fp32 `d_index_k` with a
  nonzero-initialized buffer now returns the correct gradient (internally
  zeroed).
- **Pre-mutation rejection:** each tested illegal dtype / mis-shaped output /
  non-contiguous layout raises a clean `ValueError` with the in-place
  `attn_score`/`index_score` untouched — for a first wrapper call, a wrapper
  cache hit, and a directly-built plan.
- Tests: 8 pass / 0 skip in `test_DSA_indexer_backward.py` (7 added:
  illegal-output-dtype-before-mutation; direct-plan and wrapper-cache-hit
  shape/stride-mismatch; wrong-shape-plan-rejected; non-contiguous-rejected;
  wrong-ndim-rejected; fp32-dK-zeroed-internally; all fail-hard). `black` clean;
  `git diff --check`
  clean. **SM90 paths hardware-verified on H100**: bf16 outputs vs base in the
  pre-existing band (dq bitwise; dW's SMEM-atomicAdd 1-ulp jitter matches a base
  self-check), fp32-dK internal zeroing correct, and representative pre-mutation
  rejection categories (illegal output dtypes, wrong shape, wrong rank,
  non-contiguous layout) exercised on SM90 via a standalone gate — the seven
  committed PR-A tests are SM100-gated. Two pre-existing `test_DSA_indexer_top_k`
  failures in the wider suite are unrelated — they reproduce on clean `develop`
  on both architectures.

## Scope / notes

- Files: `api.py`, `indexer_backward_sm100.py`, `indexer_backward_sm90.py`,
  test file; +570/−11.
- Deliberate contract tightening: dtypes that previously "worked" incidentally
  (e.g. fp16 `d_index_k` via the cast path, fp32 `d_weights` silently receiving
  bf16-precision values) are now rejected — a clean error instead of a silent
  footgun.
- The dW/dQ/dK kernel math is untouched; every change is pre-kernel validation,
  the fp32-dK zero-init, or output-dtype cache keying.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for tensor ranks, shapes, strides, layouts, and output data types.
  * Added clearer handling for optional bfloat16 casting and fp32 accumulation.
  * FP32 gradient outputs are now automatically zero-initialized before accumulation.
  * Invalid inputs are rejected before modifying score buffers.
  * Improved validation for cached execution plans and non-contiguous inputs.

* **Tests**
  * Expanded regression coverage for invalid inputs, output initialization, layout mismatches, and validation ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->