### PR TITLE
frost(sdpa): drop the redundant zero-fill of the never-read THD sinks dummy (SM100)

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1293,11 +1293,13 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         LSE = lse
         if sinks is not None:
             sinks_t = self._checked_sinks_1d(sinks)
-        elif carver is not None:
-            sinks_t = carver.take(qh, torch.float32)
-            sinks_t.zero_()
         else:
-            sinks_t = torch.zeros(qh, dtype=torch.float32, device=dev)
+            # ABI-only dummy: the sinks slot is always part of the kernel
+            # signature, but CFG.HAS_SINK is a compile-time fold — with the
+            # graph declaring no sink the kernel NEVER reads it, so no
+            # zero-fill (a wasted kernel launch on the execute hot path,
+            # Rule 1).
+            sinks_t = carver.take(qh, torch.float32) if carver is not None else torch.empty(qh, dtype=torch.float32, device=dev)
 
         fn = self._k_mod.compile(
             b=b,


### PR DESCRIPTION
## Problem

A per-execute fill kernel on the SM100 THD execute hot path zeroes the dummy sinks buffer — scratch whose contents provably do not matter: the sinks slot is always part of the kernel ABI, but `CFG.HAS_SINK` is a compile-time fold, so when the graph declares no sink the kernel **never reads** the buffer (and `execute()` enforces `has_sink <=> sinks is not None`, so the dummy only exists in the never-read case).

The fill dates to the original FROST landing (#476) as belt-and-braces; AGENTS.md Rule 1 bans adapter-side fills on the execute hot path.

## Fix

Bind the carved/allocated dummy without the `zero_()` / `torch.zeros` fill (one hunk in `_execute_thd`). Split out of #543 so it can land independently; #543 keeps the matching O-descriptor no-fill and touches the same `else`-branch for stream-binding — whichever lands second has a trivial one-hunk rebase.

## Verification

| What | Where | Result |
|---|---|---|
| THD fp16/graph suites (incl. the sink-less THD cases that bind the deliberately unfilled dummy, and the #522 cu_seq_len forms) | SM100 (B200-class) | 180 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary initialization overhead in SM100 THD execution when sink support is disabled.
* **Bug Fixes**
  * Ensured the unused no-sink buffer is safely provided without requiring explicit zero-filling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->