### PR TITLE
frost(sdpa): has_lse specialization for the FP8/MXFP8 SM100 flavors

### DIFF
--- a/python/cudnn/frost/README.md
+++ b/python/cudnn/frost/README.md
@@ -99,10 +99,9 @@ Reading that sequence line by line:
   still forwarded to the lowered C++ graph.
 - **`get_workspace_size()` is honest.** For a python plan it returns
   `CompiledPlan.get_workspace_size()`, the executor's real requirement (for
-  the graph above on an SM100 engine: the dummy-LSE scratch `b*h*s*4 = 16384`
-  bytes, because an inference graph has no Stats output and the SM100 kernels
-  always write an LSE; `lse_optional` adapters like SM120 compile the LSE
-  store out instead and report 0). `execute()` forwards the caller's
+  the dense graph above: 0 — every SM100/SM120 adapter is `lse_optional`, so
+  a stats-less inference graph compiles the LSE store out and binds no dummy
+  buffer at any level). `execute()` forwards the caller's
   buffer through `ExecutionContext.workspace` and the executor carves its
   scratch out of it in 128-byte-aligned chunks, never touching bytes at or
   beyond the reported size -- no hidden per-execute allocation, stable

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -951,13 +951,16 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             self._compiled_kernel = "thd-deferred"
         elif self._fp8:
             # FP8/MXFP8 kernels are exact-match d128 (gated in check_support);
-            # their compile() has no envelope head-dim parameters.
+            # their compile() has no envelope head-dim parameters. has_lse=False
+            # (no Stats output) compiles the LSE store out — no dummy buffer at
+            # any level (the amax_s/amax_o atomicMax writes are independent).
             self._compiled_kernel = self._k_mod.compile(
                 b=self.batch_size,
                 qh=self.h_q,
                 kh=self.h_kv,
                 sq=self.s_q_max,
                 skv=self.s_k_max,
+                has_lse=self.lse_desc is not None,
             )
         else:
             # ENVELOPE: hand the f16/bf16 kernel the ACTUAL head dims so its
@@ -983,7 +986,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         Fixed by the compiled geometry (call after ``check_support()``); 0 when
         the path allocates nothing per execute. This is the api-level share of
         a FROST executor's ``workspace_bytes`` (the engine lowering adds its
-        own chunks — dummy LSE, synthesized seq_len_kv — on top; see
+        own chunks — synthesized seq_len_kv — on top; see
         ``engines.lower_dsl_prefill``). When ``execute()`` is called WITHOUT a
         workspace (standalone API use), these buffers are torch-allocated per
         execute instead — the carve path is what the FROST dispatch uses.
@@ -1064,30 +1067,21 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             self.lse_desc is not None and lse_tensor is None,
             "lse_tensor is required by this compiled specialization",
         )
-        # Strict presence contract, both directions: the f16 kernels are
-        # compiled with has_lse keyed on sample_lse (no Stats output -> the
-        # LSE store is compiled out and there is no LSE slot to bind), and a
-        # THD lse_tensor is bound in its DECLARED packed layout (recorded at
-        # check_support) — so an lse_tensor without a sample_lse cannot be
-        # honored and is rejected rather than silently dropped. The FP8/MXFP8
-        # kernels (dense-only) still write an LSE unconditionally; their
-        # stats-less write lands in a cached write-only dummy (the FROST
-        # dispatch never reaches it: engines.lower_dsl_prefill carves the
-        # dummy from the caller's workspace instead).
+        # Strict presence contract, both directions: every SM100 kernel
+        # (f16/bf16, FP8, MXFP8) is compiled with has_lse keyed on sample_lse
+        # (no Stats output -> the LSE store is compiled out and there is no
+        # LSE slot to bind), and a THD lse_tensor is bound in its DECLARED
+        # packed layout (recorded at check_support) — so an lse_tensor without
+        # a sample_lse cannot be honored and is rejected rather than silently
+        # dropped.
         self._value_error_if(
-            self.lse_desc is None and lse_tensor is not None and not self._fp8,
+            self.lse_desc is None and lse_tensor is not None,
             "this specialization was compiled without an LSE output; construct the API with sample_lse",
         )
         if self.thd:
             pass  # bound in _execute_thd (declared packed layout)
         elif lse_tensor is not None:
             lse_tensor = self._checked_lse_view(lse_tensor)
-        elif self._fp8:
-            lse_tensor = self._dummy(
-                "lse",
-                q_tensor.device,
-                lambda: torch.empty((self.batch_size, self.h_q, self.s_q_max), dtype=torch.float32, device=q_tensor.device),
-            )
 
         if self._fp8 and self._pertensor:
             # Per-tensor FP8 (sdpa_fp8): scalar descales fold into the softmax scale
@@ -1395,7 +1389,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         sf_k_v = self._reshape_sf(sf_k, h_kv, n_kv_tiles, km.SF_SMEM_SIZE_K)
         sf_v_v = self._reshape_sf(sf_v, h_kv, n_kv_tiles, km.SF_SMEM_SIZE_V)
 
-        lse = lse_tensor.reshape(b, h_q, sq)
+        # has_lse=False (no Stats output): the store is compiled out; bind None.
+        lse = lse_tensor.reshape(b, h_q, sq) if lse_tensor is not None else None
         sinks_t = (
             self._checked_sinks_1d(sinks) if sinks is not None else self._dummy("sinks", device, lambda: torch.zeros(h_q, dtype=torch.float32, device=device))
         )
@@ -1488,7 +1483,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         O_view, o_needs_copy_back, O_scratch = self._to_bshd_writable(o_tensor)
         O = O_scratch if o_needs_copy_back else O_view
 
-        lse = lse_tensor.reshape(b, h_q, sq)
+        # has_lse=False (no Stats output): the store is compiled out; bind None.
+        lse = lse_tensor.reshape(b, h_q, sq) if lse_tensor is not None else None
         sinks_t = (
             self._checked_sinks_1d(sinks) if sinks is not None else self._dummy("sinks", device, lambda: torch.zeros(h_q, dtype=torch.float32, device=device))
         )

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -153,9 +153,10 @@ class Capabilities:
     sink: bool = False
     stats: bool = False
     # The adapter accepts lse_tensor=None (its kernel None-specializes the LSE
-    # store), so a stats-less graph needs no dummy-LSE workspace chunk. Rows
-    # that keep False (the SM100 FP8/MXFP8 flavors) always write an LSE and get
-    # a carved dummy from lower_dsl_prefill when the graph has no Stats output.
+    # store), so a stats-less graph needs no dummy-LSE workspace chunk. Every
+    # lower_dsl_prefill row sets True (the SM100 FP8/MXFP8 flavors were the
+    # last holdouts); the SM80 row keeps the False default but lowers through
+    # its own adapter (lower_sm80_prefill), which never reads this flag.
     lse_optional: bool = False
     # THD lowerings assume FULLY-PACKED storage: the packed addressing is
     # re-derived as prefix(lens) x token stride, and the graph's bound
@@ -451,6 +452,7 @@ def _sm100_mxfp8_spec(d: int) -> EngineSpec:
             padded=True,
             sink=True,
             stats=True,
+            lse_optional=True,
             sched_policies=frozenset({SCHED_NATURAL}),
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
@@ -488,6 +490,7 @@ def _sm100_fp8_spec(d: int) -> EngineSpec:
             padded=True,
             sink=True,
             stats=True,
+            lse_optional=True,
             # The fp8 kernel lacks the SEQ_Q_LENS_PRESENT epilogue trim, but its
             # only reachable padded+stats population is KV-only padding with
             # full-length seq_len_q (the fp8 suite; test_mhas_v2 fp8 padding
@@ -756,22 +759,15 @@ def lower_dsl_prefill(
     # buffer is carved from the CALLER's workspace, so its size is fixed here at
     # build time and recorded on the executor as ``workspace_bytes`` — that
     # number is what the plan's CompiledPlan.get_workspace_size() reports.
-    #   - dummy LSE (dense, stats absent, non-lse_optional adapters): the
-    #     SM100 FP8/MXFP8 kernels always write an LSE; without a Stats output
-    #     it lands in b*h_q*s_q fp32 scratch. lse_optional adapters (the f16
-    #     flavors, SM120) compile the LSE store out instead and bind no
-    #     buffer. (THD needs no engine-level LSE chunk either way.)
     #   - synthesized seq_len_kv (skv_tail_via_padding rows): b int32.
     #   - api-level scratch (api.scratch_workspace_bytes()): the dense padded
     #     [seq_kv|seq_q] combine and the THD metadata/LSE buffers.
-    dummy_lse_bytes = (
-        0
-        if (not spec.capabilities.stats or spec.capabilities.lse_optional or facts.stats_t is not None or facts.thd)
-        else ws_align(facts.b * facts.h_q * facts.s_q * 4)
-    )
+    # No dummy-LSE chunk: every lower_dsl_prefill row is lse_optional (the
+    # kernels None-specialize the LSE argument and compile the store out), so
+    # a stats-less graph binds no LSE buffer at any level.
     synth_kv_bytes = ws_align(facts.b * 4) if synth_kv_padding else 0
     api_scratch_bytes = api.scratch_workspace_bytes()
-    total_workspace_bytes = dummy_lse_bytes + synth_kv_bytes + api_scratch_bytes
+    total_workspace_bytes = synth_kv_bytes + api_scratch_bytes
 
     binding = ga.SdpaBinding(
         q=facts.q_t,
@@ -832,12 +828,9 @@ def lower_dsl_prefill(
         import torch  # execute path: a real tensor is about to be carved
 
         carver = WorkspaceCarver(workspace, total_workspace_bytes, spec.name) if total_workspace_bytes else None
+        # Stats-less graphs bind lse_buf=None: every adapter here is
+        # lse_optional (the kernel compiles the LSE store out) — no dummy.
         lse_buf = resolved.get(id(binding.stats)) if binding.stats is not None else None
-        if lse_buf is None and spec.capabilities.stats and not spec.capabilities.lse_optional and not facts.thd:
-            # Dummy LSE for stats-less dense graphs — carved, not allocated
-            # (uninitialized is fine: the kernel writes every row). lse_optional
-            # adapters take lse_tensor=None instead.
-            lse_buf = carver.take(facts.b * facts.h_q * facts.s_q, torch.float32)
         # Shared presence-checked resolution (graph_analyzer.resolve_feature_operands);
         # bias/block_mask/alibi stay None for these rows (mismatch gates them).
         feature_ops = ga.resolve_feature_operands(facts, resolved)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -30,7 +30,7 @@ follow-up (needs a THD-aware quantizer); drive via the kernel / the DSL backend.
 import os
 import sys
 from functools import lru_cache
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 
 from cutlass.base_dsl.typing import Pointer  # was the legacy DSL Pointer pre-DKG-bump
@@ -223,7 +223,7 @@ def _kernel(
     tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
     tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
     tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
-    lse_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -1522,7 +1522,7 @@ def _correction_warp_group(
     tidx,
     bars,
     sched,
-    lse_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor,
     n_q_supers,
@@ -1710,16 +1710,20 @@ def _correction_warp_group(
                 _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
                 _row_valid = q_row_global < _s_q_b
                 if _row_valid:
-                    lse_arr = cutlass.make_array_view(lse_tensor)
-                    lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
-                    lse_row[_cu_q_b + q_row_global] = lse_val
+                    # has_lse=False: the Stats store is compiled out; the amax_s
+                    # atomicMax is independent of it and always live.
+                    if cutlass.const_expr(lse_tensor is not None):
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse_val
                     nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_s_ptr, _beta_bits)
             else:
                 _row_valid = q_row_global < seqlen_q
                 if _row_valid:
-                    lse_arr = cutlass.make_array_view(lse_tensor)
-                    lse_row = lse_arr[batch_idx, head_idx, :]
-                    lse_row[q_row_global] = lse_val
+                    if cutlass.const_expr(lse_tensor is not None):
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse_val
                     nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_s_ptr, _beta_bits)
 
             # amax_o = max over valid rows of |o_scaled| (the fp32 pre-cast output). Divided
@@ -1859,7 +1863,7 @@ def _host(
     k_tensor: cute.Tensor,
     v_tensor: cute.Tensor,
     o_tensor: cute.Tensor,
-    lse_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -1965,10 +1969,13 @@ def _host(
 
 
 @lru_cache(maxsize=None)
-def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128) -> Callable:  # noqa: A001
+def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128, has_lse: bool = True) -> Callable:  # noqa: A001
     """Compile with ALL dims concrete — pins TMA strides at compile time.
 
-    THD/varlen: q/k/v/o/lse PACKED with batch dim 1; ``b`` = logical batch."""
+    THD/varlen: q/k/v/o/lse PACKED with batch dim 1; ``b`` = logical batch.
+    ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
+    ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
+    at all; the amax_s/amax_o atomicMax writes are independent and unchanged."""
     _fake_batch = 1 if CFG.THD_VARLEN else b
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
@@ -1994,12 +2001,17 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128)
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
-    fake_lse = cute.runtime.make_fake_compact_tensor(
-        cutlass.Float32,
-        (_fake_batch, qh, sq),
-        stride_order=(2, 1, 0),
-        assumed_align=16,
-    )
+    if not has_lse:
+        # No Stats output: the LSE argument is None-specialized and the store
+        # is compiled out entirely — no dummy buffer exists at any level.
+        fake_lse = None
+    else:
+        fake_lse = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
     # Always part of the ABI; unread when CFG.HAS_SINK == 0 (compile-time fold).
     fake_sinks = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -24,7 +24,7 @@ plus the MXFP8 TMEM scale-factor (SF) relayout:
 import os
 import sys
 from functools import lru_cache
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 from cutlass.experimental import primitives as nvvm
 from cutlass.experimental.primitives import vote_sync, VoteSync
@@ -331,7 +331,7 @@ def _kernel(
     tma_q_sf_desc: cutlass.GridConstant[tmap.TensorMap],
     tma_k_sf_desc: cutlass.GridConstant[tmap.TensorMap],
     tma_v_sf_desc: cutlass.GridConstant[tmap.TensorMap],
-    lse_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
     amax_o_tensor: cute.Tensor,
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
@@ -1979,7 +1979,7 @@ def _correction_warp_group(
     tidx,
     bars,
     sched,
-    lse_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
     amax_o_tensor: cute.Tensor,
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor,
@@ -2141,16 +2141,20 @@ def _correction_warp_group(
                 _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
                 _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
                 _row_valid = q_row_global < _s_q_b
-                if _row_valid:
-                    lse_arr = cutlass.make_array_view(lse_tensor)
-                    lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
-                    lse_row[_cu_q_b + q_row_global] = lse_val
+                # has_lse=False: the Stats store is compiled out; the amax_o
+                # atomicMax below is independent of it and always live.
+                if cutlass.const_expr(lse_tensor is not None):
+                    if _row_valid:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse_val
             else:
                 _row_valid = q_row_global < seqlen_q
-                if _row_valid:
-                    lse_arr = cutlass.make_array_view(lse_tensor)
-                    lse_row = lse_arr[batch_idx, head_idx, :]
-                    lse_row[q_row_global] = lse_val
+                if cutlass.const_expr(lse_tensor is not None):
+                    if _row_valid:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse_val
 
             sO_sub_base = sO[qs].base
 
@@ -2234,7 +2238,7 @@ def _host(
     sf_q_tensor: cute.Tensor,
     sf_k_tensor: cute.Tensor,
     sf_v_tensor: cute.Tensor,
-    lse_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
     amax_o_tensor: cute.Tensor,
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
@@ -2387,10 +2391,21 @@ def _host(
 
 
 @lru_cache(maxsize=None)
-def compile(
-    b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128, total_q_sf_tiles: int = 0, total_kv_sf_tiles: int = 0  # noqa: A001
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    total_q_sf_tiles: int = 0,
+    total_kv_sf_tiles: int = 0,
+    has_lse: bool = True,
 ) -> Callable:
     """Compile a kernel with concrete dims; 3 SF tensors layout [B, H, num_seq_tiles, SF_SMEM_SIZE_*].
+
+    ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
+    ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
+    at all; the amax_o atomicMax write is independent and unchanged.
 
     THD/varlen: q/k/v/o/lse + SF tensors are PACKED with batch dim 1; ``b`` is the
     LOGICAL batch (sequence count).  The SF tensors are per-sequence-TILE-padded so
@@ -2455,12 +2470,17 @@ def compile(
         assumed_align=16,
     )
 
-    fake_lse = cute.runtime.make_fake_compact_tensor(
-        cutlass.Float32,
-        (_fake_batch, qh, sq),
-        stride_order=(2, 1, 0),
-        assumed_align=16,
-    )
+    if not has_lse:
+        # No Stats output: the LSE argument is None-specialized and the store
+        # is compiled out entirely — no dummy buffer exists at any level.
+        fake_lse = None
+    else:
+        fake_lse = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
     fake_amax_o = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,
         (1,),

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -72,7 +72,7 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     return torch.matmul(probs, v_e), probs.max().item()
 
 
-def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, seq_lens_kv=None, s_scale=1.0, s_descale_gain=1.0):
+def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, seq_lens_kv=None, s_scale=1.0, s_descale_gain=1.0, stats=True):
     import cudnn
 
     dev = "cuda"
@@ -111,7 +111,7 @@ def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=No
         return g.tensor(dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.FLOAT)
 
     dqn, dkn, dvn, dsn, ssn, son = (_stns() for _ in range(6))
-    kw = dict(q=q, k=k, v=v, descale_q=dqn, descale_k=dkn, descale_v=dvn, descale_s=dsn, scale_s=ssn, scale_o=son, attn_scale=scale, generate_stats=True)
+    kw = dict(q=q, k=k, v=v, descale_q=dqn, descale_k=dkn, descale_v=dvn, descale_s=dsn, scale_s=ssn, scale_o=son, attn_scale=scale, generate_stats=stats)
     vp = {q: Qb, k: Kb, v: Vb, dqn: dqt, dkn: dkt, dvn: dvt, dsn: dst, ssn: sst, son: sot}
     if sink is not None:
         st = g.tensor_like(sink)
@@ -127,9 +127,10 @@ def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=No
         vp[sq_h] = slq
         vp[skv_h] = slk
     kw.update(sdpa_kwargs)
-    o, stats, amx_s, amx_o = g.sdpa_fp8(**kw)
+    o, stats_t, amx_s, amx_o = g.sdpa_fp8(**kw)
     o.set_output(True).set_dim(list(Ob.shape)).set_stride(list(Ob.stride())).set_data_type(getattr(cudnn.data_type, _CUDNN_OTYPE[out_dt]))
-    stats.set_output(True).set_dim([B, H_q, S_q, 1]).set_stride([H_q * S_q, S_q, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
+    if stats:
+        stats_t.set_output(True).set_dim([B, H_q, S_q, 1]).set_stride([H_q * S_q, S_q, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amx_s.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
 
@@ -139,7 +140,13 @@ def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=No
     _select_engine(g, engine_name(128, fp8=True))
     g.check_support()
     g.build_plans()
-    vp.update({o: Ob, stats: lse, amx_s: amax_s, amx_o: amax_o})
+    if not stats:
+        # No Stats output: the kernel compiles the LSE store out (has_lse=False)
+        # — no dummy buffer exists at any level, so the dense workspace is 0.
+        assert g.get_workspace_size() == 0
+    vp.update({o: Ob, amx_s: amax_s, amx_o: amax_o})
+    if stats:
+        vp[stats_t] = lse
     g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8))
     torch.cuda.synchronize()
 
@@ -247,6 +254,58 @@ def test_fp8_padding(in_key, causal):
     sk = dict(use_causal_mask=True) if causal else {}
     O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=sk, seq_lens_kv=[256, 192])
     _check(O, O_ref, torch.float16, in_key, a_s, a_s_ref, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_fp8_stats_less_zero_workspace(in_key):
+    """No Stats output: the kernel compiles the LSE store out (has_lse=False),
+    no dummy buffer exists at any level, and the dense graph reports
+    ``get_workspace_size() == 0`` (asserted inside ``_run``). The Amax_S /
+    Amax_O atomicMax writes are independent of the LSE and still produced."""
+    scale = 1.0 / math.sqrt(128)
+    O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), stats=False)
+    _check(O, O_ref, torch.float16, in_key, a_s, a_s_ref, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm100_execute_lse_contract():
+    """Strict lse_tensor execute contract, both directions (f16 parity):
+    has_lse is keyed on sample_lse at compile time, so a requested LSE must be
+    bound and an unrequested one is rejected (the store is compiled out —
+    there is no LSE slot, and no cached dummy fallback either)."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    b, h, s, d = 1, 4, 256, 128
+    dev = "cuda"
+    qf = torch.randn(b, h, s, d, device=dev) * 0.5
+    q8, dq = _quant(qf, "e4m3")
+    q = q8.permute(0, 2, 1, 3).contiguous().transpose(1, 2)
+    k, v = q.clone(), q.clone()
+    o = torch.empty(b, s, h, d, device=dev, dtype=torch.float16).transpose(1, 2)
+    lse = torch.empty(b, h, s, dtype=torch.float32, device=dev)
+    dsc = torch.tensor([dq], dtype=torch.float32, device=dev)
+
+    kw = dict(sample_q=q, sample_k=k, sample_v=v, sample_o=o, is_causal=True, pertensor_fp8=True, dtype_o=torch.float16)
+    ex = dict(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, descale_q=dsc, descale_k=dsc, descale_v=dsc)
+
+    api = SdpaFwdDslSm100(sample_lse=lse, **kw)
+    assert api.check_support()
+    api.compile()
+    with pytest.raises(ValueError, match="lse_tensor is required"):
+        api.execute(**ex)
+
+    api = SdpaFwdDslSm100(**kw)
+    assert api.check_support()
+    api.compile()
+    with pytest.raises(ValueError, match="without an LSE output"):
+        api.execute(lse_tensor=lse, **ex)
+    api.execute(**ex)
+    torch.cuda.synchronize()
+    o_ref, _ = _ref(q8.float() * dq, q8.float() * dq, q8.float() * dq, scale=api.scale_softmax, is_causal=True)
+    torch.testing.assert_close(o.float(), o_ref, atol=5e-2, rtol=3e-2)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -89,7 +89,7 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     return torch.matmul(torch.softmax(scores, dim=-1), v_e)
 
 
-def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None):
+def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, stats=True):
     """Quantize, build the sdpa_mxfp8 graph, route to the frost engine, execute.
     Returns (O_frost [B,H,S,D] on device, O_ref fp32 [B,H,S,D])."""
     import cudnn
@@ -133,16 +133,17 @@ def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None):
     dq = _sf((B, H_q, sqp, dsc))
     dk = _sf((B, H_kv, skp, dsc))
     dv = _sf((B, H_kv, ssc, dvp))
-    kw = dict(q=q, k=k, v=v, descale_q=dq, descale_k=dk, descale_v=dv, attn_scale=scale, generate_stats=True)
+    kw = dict(q=q, k=k, v=v, descale_q=dq, descale_k=dk, descale_v=dv, attn_scale=scale, generate_stats=stats)
     vp = {q: Qb, k: Kb, v: Vb, dq: sfq_g, dk: sfk_g, dv: sfv_g}
     if sink is not None:
         st = g.tensor_like(sink)
         kw["sink_token"] = st
         vp[st] = sink
     kw.update(sdpa_kwargs)
-    o, stats, amax_o = g.sdpa_mxfp8(**kw)
+    o, stats_t, amax_o = g.sdpa_mxfp8(**kw)
     o.set_output(True).set_dim(list(Ob.shape)).set_stride(list(Ob.stride())).set_data_type(otype)
-    stats.set_output(True).set_dim([B, H_q, S, 1]).set_stride([H_q * S, S, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
+    if stats:
+        stats_t.set_output(True).set_dim([B, H_q, S, 1]).set_stride([H_q * S, S, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amax_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
 
     g.validate()
@@ -151,7 +152,13 @@ def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None):
     _select_engine(g, engine_name(128, mxfp8=True))
     g.check_support()
     g.build_plans()
-    vp.update({o: Ob, stats: lse, amax_o: amax})
+    if not stats:
+        # No Stats output: the kernel compiles the LSE store out (has_lse=False)
+        # — no dummy buffer exists at any level, so the dense workspace is 0.
+        assert g.get_workspace_size() == 0
+    vp.update({o: Ob, amax_o: amax})
+    if stats:
+        vp[stats_t] = lse
     g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8))
     torch.cuda.synchronize()
 
@@ -199,6 +206,19 @@ _MASKS = {
     "causal_br": dict(use_causal_mask_bottom_right=True),
     "swa": dict(use_causal_mask=True, diagonal_band_left_bound=65),  # window = 64
 }
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_stats_less_zero_workspace(in_key):
+    """No Stats output: the kernel compiles the LSE store out (has_lse=False),
+    no dummy buffer exists at any level, and the dense graph reports
+    ``get_workspace_size() == 0`` (asserted inside ``_run``). The Amax_O
+    atomicMax write is independent of the LSE and still produced."""
+    scale = 1.0 / math.sqrt(128)
+    O, O_ref, _ = _run(2, 8, 8, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), stats=False)
+    _check(O, O_ref, torch.float16, in_key)
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran the repo formatter (black -l 160) on the changed files.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

FE OSS kernels or CuTeDSL

## Summary

`has_lse` specialization for the FROST SM100 FP8 (per-tensor) and MXFP8 SDPA forward flavors — `lse_optional` parity with what #512 did for the f16 flavors.

- **Kernels** (`prefill_d128_fp8_sm100.py`, `prefill_d128_mxfp8_sm100.py`): the LSE argument is `Optional[cute.Tensor]` end to end (`_kernel`/`_host`/correction-warp-group), the epilogue Stats store is guarded with `cutlass.const_expr(lse_tensor is not None)` (compiled out entirely when absent), and `compile()` grows `has_lse: bool = True` that builds a `None` fake LSE when `False`. The `amax_s`/`amax_o` atomicMax writes are independent of the LSE and unchanged.
- **Adapter** (`api_dsl.py`): `SdpaFwdDslSm100.compile()` keys `has_lse` on `sample_lse` for the FP8/MXFP8 branch; `execute()` drops the cached dense dummy-LSE fallback (a stats-less compile binds `None`), and the strict `lse_tensor` presence contract now applies to FP8 too (both directions — a requested LSE must be bound, an unrequested one is rejected). `_execute_fp8`/`_execute_mxfp8` pass `None` through.
- **Engine specs** (`engines.py`): `_sm100_fp8_spec` / `_sm100_mxfp8_spec` flip `lse_optional=True`. Every `lower_dsl_prefill` row is now `lse_optional`, so the engine-level dummy-LSE carve (`dummy_lse_bytes` sizing + the `carver.take` in `_execute`) is dead and removed. The SM80 row keeps the `False` default but lowers through `lower_sm80_prefill`, which never read the flag.

## Why

Stats-less FP8/MXFP8 inference graphs go to zero workspace like f16 (`get_workspace_size() == 0` — no dummy buffer at any level), one fewer GMEM write per tile, and the strict `lse_tensor` execute contract becomes uniform across all SM100/SM120 flavors.

## Related issues

Fixes #523

## API and compatibility impact

Stats-less dense FP8/MXFP8 FROST graphs now report `get_workspace_size() == 0` (previously `b*h_q*s_q*4` bytes of engine-carved dummy). Passing an `lse_tensor` to an FP8 `SdpaFwdDslSm100` compiled without `sample_lse` now raises `ValueError` (previously silently accepted via the dummy path) — same contract the f16 flavors adopted in #512. Graphs with a Stats output are unchanged.

## Testing

On a cc 10.0 (SM100) GPU:

* `pytest test_sdpa_fwd_fp8_sm100.py test_sdpa_fwd_mxfp8_sm100.py -q -m "L0 or L1"` — **55 passed**, including new stats-less zero-workspace tests for both flavors (`generate_stats=False`, asserts `get_workspace_size() == 0`, checks O and the in-kernel amaxes against the fp32 reference) and a new fp8 execute lse-contract test mirroring the f16 one.
* `pytest test_sdpa_graph_analyzer.py -q` — **78 passed**.
* `pytest test_sdpa_fwd_dsl_sm100.py -q -k "graph_api"` — **12 passed** (f16 sanity slice over the shared lowering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running SM100 FP8 and MXFP8 attention without LSE statistics output.
  * LSE output is now optional and is only generated when requested.
  * Statistics-free execution preserves output scaling updates and requires no dummy LSE workspace.

* **Bug Fixes**
  * Corrected LSE binding validation for configurations with and without statistics output.
  * Reduced workspace requirements for statistics-free execution.

* **Tests**
  * Added coverage for statistics-free FP8 and MXFP8 execution, output accuracy, workspace usage, and LSE binding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->