### PR TITLE
sdpa fp8 sm100: fix THD O-descriptor row stride (latent)

### DIFF
--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -1925,6 +1925,10 @@ def _host(
         # THD: build the per-batch O descriptor array, then launch the exact
         # flat batch-outermost grid (n_thd_units host-computed); grid_x = units*CGA_M.
         # Works at cga1 (CGA_M=1) and cga2.
+        # Per-token element stride of packed O (QH * d_v) — NOT CFG.TILE_O,
+        # which is only coincidentally right at QH == 1 and otherwise lands
+        # every batch >= 1's descriptor base inside earlier batches' rows
+        # (the f16 kernel carries the same fix).
         _build_o_descs_kernel(
             o_tensor,
             tma_o_desc,
@@ -1932,7 +1936,7 @@ def _host(
             seq_kv_lens_tensor,
             cutlass.Int32(QH),
             cutlass.Int32(B),
-            cutlass.Int32(CFG.TILE_O),
+            cutlass.Int32(o_tensor.stride[1]),
         ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:


### PR DESCRIPTION
## Summary

One-line latent-bug fix in the SM100 per-tensor FP8 kernel's THD path: the per-batch O-descriptor builder takes the **declared per-token element stride of packed O** (`QH * d_v`), but the fp8 kernel passed `CFG.TILE_O` — coincidentally correct only at `QH == 1` with `d_v == 128`, and otherwise landing every batch ≥ 1's descriptor base at `1/QH` of the true offset **inside earlier batches' O rows** (region *b* receives batches *{b, b+1}*'s stores; the last region goes stale). The f16 kernel has carried the correct form (`o_tensor.stride[1]`) since its envelope work — this aligns the fp8 clone.

## Why latent

The engine row declares `thd=False` and no API path drives fp8 THD today, so no shipping configuration reaches the bug. It should land before any fp8 THD enablement does (see the companion SM107 enablement PR, whose sibling kernel copy inherits this fix).

## Evidence

Reproduced and isolated on SM107 silicon (the first hardware ever to run this path) with per-(batch, head) sentinel-V probes:
- `H=1 × B=N` exact, `H=N × B=1` exact, `H>1 × B>1` corrupt — precisely the `QH`-scaling signature
- with the fix: irregular-varlen e2e (mixed lengths, B=3, H=4) matches the per-sequence fp32 dequant reference; the full fp8 suite is green on both SM100 and SM107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved variable-length attention processing by using the correct output stride when constructing output descriptors.
  * Helps ensure accurate results for supported FP8 workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->