### PR TITLE
Improve large tensor fuzzer plan fallback and failure output

### DIFF
--- a/test/python/test_conv_large_tensor_fuzzer.py
+++ b/test/python/test_conv_large_tensor_fuzzer.py
@@ -53,8 +53,11 @@ _NUM_TESTS_L0_ENV = "CUDNN_FUZZ_NUM_TESTS_L0"  # override L0 generated count
 _NUM_TESTS_L1_ENV = "CUDNN_FUZZ_NUM_TESTS_L1"  # override L1 generated count
 _REPRO_CONFIG_ENV = "CUDNN_FUZZ_REPRO_CONFIG"  # exact configuration JSON payload
 _REPRO_FILE_ENV = "CUDNN_FUZZ_REPRO_FILE"  # path to exact configuration JSON payload
+_EVENTS_DIR_ENV = "CUDNN_FUZZ_EVENTS_DIR"  # optional per-worker JSONL diagnostic output
 _REPRO_SCHEMA_VERSION = 1
+_EVENT_SCHEMA_VERSION = 1
 _REPRO_MESSAGE_LIMIT = 4096
+_EVENT_PREFIX = "CUDNN_FUZZ_EVENT"
 _DEFAULT_RUNTIME_WORK_BUDGET = 100_000_000_000_000
 _MAX_CONFIG_GENERATION_ATTEMPTS = 50
 _DEFAULT_ENGINE_REGEN_ATTEMPTS = 50
@@ -792,6 +795,51 @@ def _repro_json(payload: dict, *, pretty: bool = False) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
+def _emit_diagnostic_event(event_type: str, payload: dict, *, human_message: Optional[str] = None) -> None:
+    event = {
+        "schema": _EVENT_SCHEMA_VERSION,
+        "event": event_type,
+        "payload": payload,
+    }
+    encoded = json.dumps(event, sort_keys=True, separators=(",", ":"))
+    if human_message is not None:
+        print(human_message, flush=True)
+    print(f"{_EVENT_PREFIX} {encoded}", flush=True)
+
+    events_dir = os.environ.get(_EVENTS_DIR_ENV, "").strip()
+    if events_dir:
+        os.makedirs(events_dir, exist_ok=True)
+        worker = os.environ.get("PYTEST_XDIST_WORKER", f"pid{os.getpid()}")
+        events_path = os.path.join(events_dir, f"events_{worker}.jsonl")
+        with open(events_path, "a", encoding="ascii") as events_file:
+            events_file.write(encoded + "\n")
+
+
+def _emit_outcome_event(
+    event_type: str,
+    status: str,
+    cfg: LargeTensorConfig,
+    *,
+    test_num: Optional[int] = None,
+    total_tests: Optional[int] = None,
+    config_seed: Optional[int] = None,
+    message: Optional[str] = None,
+    attempt: Optional[int] = None,
+) -> None:
+    rtol, atol = _tolerances(cfg)
+    repro = _repro_payload(
+        cfg,
+        test_num=test_num,
+        total_tests=total_tests,
+        config_seed=config_seed,
+        rtol=rtol,
+        atol=atol,
+        message=message,
+        attempt=attempt,
+    )
+    _emit_diagnostic_event(event_type, {"status": status, "repro": repro})
+
+
 def _repro_command(payload: dict) -> str:
     metadata = payload.get("metadata", {})
     graph_engine_indices = metadata.get("requested_graph_engine_indices", [])
@@ -1415,7 +1463,8 @@ def _run_single_config(
             atol=atol,
             attempt=attempt,
         )
-        print(f"Large tensor fuzzer active configuration: {_repro_json(active_payload)}", flush=True)
+        active_json = _repro_json(active_payload)
+        _emit_diagnostic_event("active_config", active_payload, human_message=f"Large tensor fuzzer active configuration: {active_json}")
 
         phase = "cuDNN execution"
         cudnn_result = _run_cudnn(cfg, X, W, Y, bias, cudnn_handle)
@@ -1504,14 +1553,72 @@ def _run_test(cfg: LargeTensorConfig, cudnn_handle, test_num: int, total_tests: 
         )
         return
 
-    ok, msg = _run_single_config(cfg, cudnn_handle, test_num=test_num, total_tests=total_tests, config_seed=config_seed)
+    try:
+        ok, msg = _run_single_config(cfg, cudnn_handle, test_num=test_num, total_tests=total_tests, config_seed=config_seed)
+    except AssertionError as e:
+        _emit_outcome_event(
+            "failure",
+            "numeric_mismatch",
+            cfg,
+            test_num=test_num,
+            total_tests=total_tests,
+            config_seed=config_seed,
+            message=str(e),
+        )
+        raise
+    except (RuntimeError, OSError) as e:
+        _emit_outcome_event(
+            "failure",
+            "frontend_error",
+            cfg,
+            test_num=test_num,
+            total_tests=total_tests,
+            config_seed=config_seed,
+            message=str(e),
+        )
+        raise
     if ok:
+        _emit_outcome_event(
+            "test_complete",
+            "passed",
+            cfg,
+            test_num=test_num,
+            total_tests=total_tests,
+            config_seed=config_seed,
+        )
         return
     if msg.startswith("insufficient_memory"):
+        _emit_outcome_event(
+            "skip",
+            "insufficient_memory",
+            cfg,
+            test_num=test_num,
+            total_tests=total_tests,
+            config_seed=config_seed,
+            message=msg,
+        )
         context = _format_repro_context(cfg, test_num=test_num, total_tests=total_tests, config_seed=config_seed, message=msg)
         pytest.skip(f"Insufficient GPU memory: {msg}{context}")
     if msg.startswith("not_supported"):
+        _emit_outcome_event(
+            "skip",
+            "not_supported",
+            cfg,
+            test_num=test_num,
+            total_tests=total_tests,
+            config_seed=config_seed,
+            message=msg,
+        )
         pytest.skip(f"Graph not supported on this arch: {msg}")
+    _emit_outcome_event(
+        "failure",
+        "cudnn_execution_error",
+        cfg,
+        test_num=test_num,
+        total_tests=total_tests,
+        config_seed=config_seed,
+        message=msg,
+    )
     context = _format_repro_context(cfg, test_num=test_num, total_tests=total_tests, config_seed=config_seed, message=msg)
     pytest.fail(f"cuDNN execution error: {msg}{context}")
 
@@ -1537,13 +1644,42 @@ def _run_test_with_regen(*, config_seed: int, test_num: int, total_tests: int, a
         candidate_id = _test_id((test_num, total_tests, config_seed, candidate))
         try:
             ok, msg = _run_single_config(candidate, cudnn_handle, test_num=test_num, total_tests=total_tests, config_seed=config_seed, attempt=attempt)
-        except AssertionError:
+        except AssertionError as e:
+            _emit_outcome_event(
+                "failure",
+                "numeric_mismatch",
+                candidate,
+                test_num=test_num,
+                total_tests=total_tests,
+                config_seed=config_seed,
+                message=str(e),
+                attempt=attempt,
+            )
             raise
         except (RuntimeError, OSError) as e:
+            _emit_outcome_event(
+                "failure",
+                "frontend_error",
+                candidate,
+                test_num=test_num,
+                total_tests=total_tests,
+                config_seed=config_seed,
+                message=str(e),
+                attempt=attempt,
+            )
             details = f"regenerated candidate={candidate_id}, attempt={attempt}; pytest node ID identifies attempt 1"
             raise RuntimeError(f"{e} [{details}]") from e
 
         if ok:
+            _emit_outcome_event(
+                "test_complete",
+                "passed",
+                candidate,
+                test_num=test_num,
+                total_tests=total_tests,
+                config_seed=config_seed,
+                attempt=attempt,
+            )
             if attempt > 1:
                 print(
                     f"{_REGEN_ON_UNSUPPORTED_ENV}: selected {candidate_id} " f"after {attempt} attempts; last unsupported: {last_unsupported}",
@@ -1551,6 +1687,16 @@ def _run_test_with_regen(*, config_seed: int, test_num: int, total_tests: int, a
                 )
             return
         if msg.startswith("insufficient_memory"):
+            _emit_outcome_event(
+                "skip",
+                "insufficient_memory",
+                candidate,
+                test_num=test_num,
+                total_tests=total_tests,
+                config_seed=config_seed,
+                message=msg,
+                attempt=attempt,
+            )
             context = _format_repro_context(
                 candidate,
                 test_num=test_num,
@@ -1561,12 +1707,32 @@ def _run_test_with_regen(*, config_seed: int, test_num: int, total_tests: int, a
             )
             pytest.skip(f"Insufficient GPU memory for {candidate_id}: {msg}{context}")
         if not msg.startswith("not_supported"):
+            _emit_outcome_event(
+                "failure",
+                "cudnn_execution_error",
+                candidate,
+                test_num=test_num,
+                total_tests=total_tests,
+                config_seed=config_seed,
+                message=msg,
+                attempt=attempt,
+            )
             context = _format_repro_context(candidate, test_num=test_num, total_tests=total_tests, config_seed=config_seed, message=msg, attempt=attempt)
             identity = f"attempt {attempt}; pytest node ID identifies attempt 1"
             failure = f"cuDNN execution error for regenerated candidate {candidate_id} ({identity}): {msg}{context}"
             pytest.fail(failure)
         last_unsupported = f"attempt {attempt}: {candidate_id}: {msg}"
 
+    _emit_outcome_event(
+        "skip",
+        "not_supported_after_regeneration",
+        candidate,
+        test_num=test_num,
+        total_tests=total_tests,
+        config_seed=config_seed,
+        message=last_unsupported,
+        attempt=max_attempts,
+    )
     pytest.skip(
         f"No supported {_GRAPH_ENGINE_OP_ENV}={filtered_op.name.lower()} config "
         f"found for selected graph engine index after {max_attempts} attempts; "
@@ -1612,13 +1778,24 @@ def test_conv_large_tensor_repro(cudnn_handle):
     if cudnn_handle is None:
         pytest.skip("cuDNN handle not available")
 
-    ok, msg = _run_single_config(cfg, cudnn_handle)
+    try:
+        ok, msg = _run_single_config(cfg, cudnn_handle)
+    except AssertionError as e:
+        _emit_outcome_event("failure", "numeric_mismatch", cfg, message=str(e))
+        raise
+    except (RuntimeError, OSError) as e:
+        _emit_outcome_event("failure", "frontend_error", cfg, message=str(e))
+        raise
     if ok:
+        _emit_outcome_event("test_complete", "passed", cfg)
         return
     if msg.startswith("insufficient_memory"):
+        _emit_outcome_event("skip", "insufficient_memory", cfg, message=msg)
         pytest.skip(f"Insufficient GPU memory: {msg}" f"{_format_repro_context(cfg, message=msg)}")
     if msg.startswith("not_supported"):
+        _emit_outcome_event("skip", "not_supported", cfg, message=msg)
         pytest.skip(f"Graph not supported on this arch: {msg}")
+    _emit_outcome_event("failure", "cudnn_execution_error", cfg, message=msg)
     pytest.fail(f"cuDNN execution error: {msg}" f"{_format_repro_context(cfg, message=msg)}")
 
 

--- a/test/python/test_conv_large_tensor_fuzzer.py
+++ b/test/python/test_conv_large_tensor_fuzzer.py
@@ -77,18 +77,40 @@ class _EngineFilterNotSupported(Exception):
 
 
 @dataclass(frozen=True)
+class _PlanIdentity:
+    execution_plan_index: int
+    graph_engine_index: int
+    knob_choices: Tuple[Tuple[str, int], ...]
+
+    def as_dict(self) -> dict:
+        return {
+            "execution_plan_index": self.execution_plan_index,
+            "graph_engine_index": self.graph_engine_index,
+            "knob_choices": dict(self.knob_choices),
+        }
+
+
+@dataclass(frozen=True)
 class _PlanBuildSelection:
-    selected_plan_index: Optional[int]
+    selected_plan: Optional[_PlanIdentity]
     candidate_count: int
     nvrtc_failures: Tuple[str, ...]
+
+    @property
+    def selected_plan_index(self) -> Optional[int]:
+        return self.selected_plan.execution_plan_index if self.selected_plan is not None else None
 
 
 @dataclass(frozen=True)
 class _CudnnRunResult:
     ok: bool
     message: str
-    selected_plan_index: Optional[int] = None
+    selected_plan: Optional[_PlanIdentity] = None
     nvrtc_failures: Tuple[str, ...] = ()
+
+    @property
+    def selected_plan_index(self) -> Optional[int]:
+        return self.selected_plan.execution_plan_index if self.selected_plan is not None else None
 
 
 def _pytest_worker_count() -> int:
@@ -745,13 +767,14 @@ def _repro_payload(
     atol: Optional[float] = None,
     message: Optional[str] = None,
     attempt: Optional[int] = None,
+    selected_plan: Optional[_PlanIdentity] = None,
 ) -> dict:
     test_id = None
     if test_num is not None and total_tests is not None and config_seed is not None:
         test_id = _test_id((test_num, total_tests, config_seed, cfg))
     graph_engine_op = _FORCED_CONV_TYPE
     graph_engine_indices = _COLLECTED_GRAPH_ENGINE_INDICES
-    selected_graph_engine_index = _select_graph_engine_index(cfg, graph_engine_indices) if graph_engine_indices else None
+    requested_graph_engine_index = _select_graph_engine_index(cfg, graph_engine_indices) if graph_engine_indices else None
 
     metadata = {
         "test_id": test_id,
@@ -780,7 +803,10 @@ def _repro_payload(
         "atol": atol,
         "graph_engine_op": graph_engine_op.name.lower() if graph_engine_op is not None else None,
         "requested_graph_engine_indices": graph_engine_indices,
-        "selected_graph_engine_index": selected_graph_engine_index,
+        "requested_graph_engine_index": requested_graph_engine_index,
+        "execution_plan_index": selected_plan.execution_plan_index if selected_plan is not None else None,
+        "graph_engine_index": selected_plan.graph_engine_index if selected_plan is not None else None,
+        "knob_choices": dict(selected_plan.knob_choices) if selected_plan is not None else None,
     }
     return {
         "schema": _REPRO_SCHEMA_VERSION,
@@ -865,10 +891,21 @@ def _format_repro_context(
     atol: Optional[float] = None,
     message: Optional[str] = None,
     attempt: Optional[int] = None,
+    selected_plan: Optional[_PlanIdentity] = None,
 ) -> str:
     if rtol is None or atol is None:
         rtol, atol = _tolerances(cfg)
-    payload = _repro_payload(cfg, test_num=test_num, total_tests=total_tests, config_seed=config_seed, rtol=rtol, atol=atol, message=message, attempt=attempt)
+    payload = _repro_payload(
+        cfg,
+        test_num=test_num,
+        total_tests=total_tests,
+        config_seed=config_seed,
+        rtol=rtol,
+        atol=atol,
+        message=message,
+        attempt=attempt,
+        selected_plan=selected_plan,
+    )
     return (
         "\n\nLarge tensor fuzzer repro command:\n"
         f"{_repro_command(payload)}\n\n"
@@ -1167,17 +1204,45 @@ def _reference(cfg: LargeTensorConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
 # ---------------------------------------------------------------------------
 
 
-def _nvrtc_plan_build_failure(plan_index: int, error: Exception) -> Optional[str]:
-    """Return a bounded diagnostic when the immediate plan error is NVRTC."""
+def _plan_identity(graph, plan_index: int) -> _PlanIdentity:
+    graph_engine_index, knob_choices = graph.get_engine_and_knobs_at_index(plan_index)
+    serialized_knobs = tuple(sorted((knob.name, int(value)) for knob, value in knob_choices.items()))
+    return _PlanIdentity(plan_index, int(graph_engine_index), serialized_knobs)
+
+
+def _plan_identity_text(plan: _PlanIdentity) -> str:
+    knobs = json.dumps(dict(plan.knob_choices), sort_keys=True, separators=(",", ":"))
+    return f"plan_index={plan.execution_plan_index} graph_engine_index={plan.graph_engine_index} knobs={knobs}"
+
+
+def _bounded_cudnn_error_detail(error: Exception) -> str:
     backend_error = cudnn.get_last_error_string().strip()
     detail = "\n".join(part for part in (str(error).strip(), backend_error) if part)
-    if _NVRTC_COMPILATION_STATUS not in detail:
-        return None
-
     detail = " ".join(detail.split())
     if len(detail) > _PLAN_BUILD_ERROR_LIMIT:
         detail = f"{detail[:_PLAN_BUILD_ERROR_LIMIT]}..."
-    return f"plan index {plan_index}: {detail}"
+    return detail
+
+
+def _nvrtc_plan_build_failure(plan: _PlanIdentity, detail: str) -> Optional[str]:
+    """Return a bounded diagnostic when the immediate plan error is NVRTC."""
+    if _NVRTC_COMPILATION_STATUS not in detail:
+        return None
+    return f"{_plan_identity_text(plan)}: {detail}"
+
+
+def _emit_plan_event(
+    event_type: str, plan: _PlanIdentity, rng_seed: int, outcome: str, *, detail: Optional[str] = None, workspace_bytes: Optional[int] = None
+) -> None:
+    payload = {
+        "rng_seed": rng_seed,
+        **plan.as_dict(),
+        "outcome": outcome,
+        "detail": detail,
+        "workspace_bytes": workspace_bytes,
+    }
+    human_message = f"Large tensor fuzzer plan rng_seed={rng_seed} {_plan_identity_text(plan)}: {outcome}"
+    _emit_diagnostic_event(event_type, payload, human_message=human_message)
 
 
 def _build_first_supported_plan(graph, rng_seed: int) -> _PlanBuildSelection:
@@ -1186,30 +1251,30 @@ def _build_first_supported_plan(graph, rng_seed: int) -> _PlanBuildSelection:
     nvrtc_failures = []
 
     for plan_index in range(candidate_count):
+        plan = _plan_identity(graph, plan_index)
         try:
             graph.build_plan_at_index(plan_index)
         except cudnn.cudnnGraphNotSupportedError as e:
-            nvrtc_failure = _nvrtc_plan_build_failure(plan_index, e)
+            detail = _bounded_cudnn_error_detail(e)
+            nvrtc_failure = _nvrtc_plan_build_failure(plan, detail)
             if nvrtc_failure is not None:
                 nvrtc_failures.append(nvrtc_failure)
                 outcome = "NVRTC compilation failure"
             else:
                 outcome = "unsupported"
-            print(f"Large tensor fuzzer plan rng_seed={rng_seed} index={plan_index}: {outcome}", flush=True)
+            _emit_plan_event("plan_build", plan, rng_seed, outcome, detail=detail)
             continue
         except RuntimeError as e:
-            nvrtc_failure = _nvrtc_plan_build_failure(plan_index, e)
+            detail = _bounded_cudnn_error_detail(e)
+            nvrtc_failure = _nvrtc_plan_build_failure(plan, detail)
             if nvrtc_failure is None:
                 raise
             nvrtc_failures.append(nvrtc_failure)
-            print(f"Large tensor fuzzer plan rng_seed={rng_seed} index={plan_index}: NVRTC compilation failure", flush=True)
+            _emit_plan_event("plan_build", plan, rng_seed, "NVRTC compilation failure", detail=detail)
             continue
 
-        print(
-            f"Large tensor fuzzer plan rng_seed={rng_seed} index={plan_index}: " "built successfully; selected for execution",
-            flush=True,
-        )
-        return _PlanBuildSelection(plan_index, candidate_count, tuple(nvrtc_failures))
+        _emit_plan_event("plan_build", plan, rng_seed, "built successfully; selected for execution")
+        return _PlanBuildSelection(plan, candidate_count, tuple(nvrtc_failures))
 
     print(
         f"Large tensor fuzzer plan rng_seed={rng_seed}: exhausted {candidate_count} candidates without a buildable plan",
@@ -1267,12 +1332,12 @@ def _run_cudnn(cfg: LargeTensorConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
             if cfg.conv_type != filtered_op:
                 raise ValueError(f"{_GRAPH_ENGINE_OP_ENV}={filtered_op.name.lower()} does not match " f"test op {cfg.conv_type.name.lower()}")
             _validate_graph_engine_indices(graph, filtered_graph_engine_indices)
-            selected_graph_engine_index = _select_graph_engine_index(cfg, filtered_graph_engine_indices)
-            _create_filtered_execution_plans(graph, selected_graph_engine_index)
+            requested_graph_engine_index = _select_graph_engine_index(cfg, filtered_graph_engine_indices)
+            _create_filtered_execution_plans(graph, requested_graph_engine_index)
         else:
             graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
         selection = _build_first_supported_plan(graph, cfg.rng_seed)
-        if selection.selected_plan_index is None:
+        if selection.selected_plan is None:
             if selection.nvrtc_failures:
                 detail = "; ".join(selection.nvrtc_failures)
                 return _CudnnRunResult(
@@ -1282,46 +1347,53 @@ def _run_cudnn(cfg: LargeTensorConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
                 )
             return _CudnnRunResult(False, f"not_supported: no buildable execution plan among {selection.candidate_count} candidates")
 
-        plan_index = selection.selected_plan_index
+        plan = selection.selected_plan
+        plan_index = plan.execution_plan_index
         ws_size = graph.get_workspace_size_plan_at_index(plan_index)
         workspace = torch.empty(ws_size, device="cuda", dtype=torch.uint8)
         _poison_workspace(workspace)
 
         graph.execute_plan_at_index(vpack, workspace, index=plan_index, handle=handle)
         torch.cuda.synchronize()
-        print(f"Large tensor fuzzer plan rng_seed={cfg.rng_seed} index={plan_index}: execution passed", flush=True)
-        return _CudnnRunResult(True, "ok", plan_index, selection.nvrtc_failures)
+        _emit_plan_event("plan_execution", plan, cfg.rng_seed, "execution passed", workspace_bytes=ws_size)
+        return _CudnnRunResult(True, "ok", plan, selection.nvrtc_failures)
 
     except _EngineFilterNotSupported as e:
         return _CudnnRunResult(False, f"not_supported: {e}", nvrtc_failures=selection.nvrtc_failures)
     except cudnn.cudnnGraphNotSupportedError as e:
+        if selection.selected_plan is not None:
+            _emit_plan_event("plan_execution", selection.selected_plan, cfg.rng_seed, "execution failed", detail=_bounded_cudnn_error_detail(e))
         if selection.nvrtc_failures:
             prior_failures = "; ".join(selection.nvrtc_failures)
             return _CudnnRunResult(
                 False,
                 f"error: fallback plan index {selection.selected_plan_index} became unsupported after "
                 f"NVRTC compilation failure(s): {e}; prior plan-build failures: {prior_failures}",
-                selection.selected_plan_index,
+                selection.selected_plan,
                 selection.nvrtc_failures,
             )
         return _CudnnRunResult(False, f"not_supported: {e}", nvrtc_failures=selection.nvrtc_failures)
     except torch.cuda.OutOfMemoryError as e:
+        if selection.selected_plan is not None:
+            _emit_plan_event("plan_execution", selection.selected_plan, cfg.rng_seed, "out of memory", detail=str(e))
         if selection.nvrtc_failures:
             prior_failures = "; ".join(selection.nvrtc_failures)
             return _CudnnRunResult(
                 False,
                 f"error: fallback plan index {selection.selected_plan_index} ran out of memory after "
                 f"NVRTC compilation failure(s): {e}; prior plan-build failures: {prior_failures}",
-                selection.selected_plan_index,
+                selection.selected_plan,
                 selection.nvrtc_failures,
             )
         raise
     except (RuntimeError, OSError) as e:
+        if selection.selected_plan is not None:
+            _emit_plan_event("plan_execution", selection.selected_plan, cfg.rng_seed, "execution failed", detail=_bounded_cudnn_error_detail(e))
         prior_failures = f"; prior plan-build failures: {'; '.join(selection.nvrtc_failures)}" if selection.nvrtc_failures else ""
         return _CudnnRunResult(
             False,
             f"error: {type(e).__name__}: {e}{prior_failures}",
-            selection.selected_plan_index,
+            selection.selected_plan,
             selection.nvrtc_failures,
         )
 
@@ -1483,12 +1555,19 @@ def _run_single_config(
         try:
             torch.testing.assert_close(actual.to(torch.float32), ref, rtol=rtol, atol=atol)
         except AssertionError as e:
-            print(
-                f"Large tensor fuzzer plan rng_seed={cfg.rng_seed} index={cudnn_result.selected_plan_index}: numerical comparison failed",
-                flush=True,
-            )
+            selected_plan = cudnn_result.selected_plan
+            if selected_plan is not None:
+                _emit_plan_event("comparison", selected_plan, cfg.rng_seed, "numerical comparison failed")
             context = _format_repro_context(
-                cfg, test_num=test_num, total_tests=total_tests, config_seed=config_seed, rtol=rtol, atol=atol, message=str(e), attempt=attempt
+                cfg,
+                test_num=test_num,
+                total_tests=total_tests,
+                config_seed=config_seed,
+                rtol=rtol,
+                atol=atol,
+                message=str(e),
+                attempt=attempt,
+                selected_plan=selected_plan,
             )
             if cudnn_result.nvrtc_failures:
                 plan_failures = "\n".join(cudnn_result.nvrtc_failures)
@@ -1499,10 +1578,9 @@ def _run_single_config(
                 ) from e
             raise AssertionError(f"{e}{context}") from e
 
-        print(
-            f"Large tensor fuzzer plan rng_seed={cfg.rng_seed} index={cudnn_result.selected_plan_index}: numerical comparison passed",
-            flush=True,
-        )
+        selected_plan = cudnn_result.selected_plan
+        if selected_plan is not None:
+            _emit_plan_event("comparison", selected_plan, cfg.rng_seed, "numerical comparison passed")
         if cudnn_result.nvrtc_failures:
             plan_failures = "; ".join(cudnn_result.nvrtc_failures)
             return (

--- a/test/python/test_conv_large_tensor_fuzzer.py
+++ b/test/python/test_conv_large_tensor_fuzzer.py
@@ -68,6 +68,7 @@ _GRAPH_ENGINE_RNG_SALT = 0xE61A5EED  # split engine selection from config and te
 _OP_SCHEDULE_RNG_SALT = 0x0F5C4ED  # split operation ordering from config generation
 _NVRTC_COMPILATION_STATUS = "CUDNN_STATUS_INTERNAL_ERROR_COMPILATION_FAILED"
 _PLAN_BUILD_ERROR_LIMIT = 1024
+_MISMATCH_SAMPLE_LIMIT = 8
 
 
 class _EngineFilterNotSupported(Exception):
@@ -1199,6 +1200,104 @@ def _reference(cfg: LargeTensorConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
                     del fwd
 
 
+def _json_float(value: float) -> object:
+    value = float(value)
+    if math.isfinite(value):
+        return value
+    if math.isnan(value):
+        return "nan"
+    return "inf" if value > 0 else "-inf"
+
+
+def _flat_index_to_coordinates(flat_index: int, shape: torch.Size) -> List[int]:
+    coordinates = []
+    for size in reversed(shape):
+        coordinates.append(flat_index % size)
+        flat_index //= size
+    return list(reversed(coordinates))
+
+
+def _top_ranked_indices(score: torch.Tensor, mismatch: torch.Tensor, count: int) -> List[int]:
+    if count == 0:
+        return []
+    ranked = torch.where(mismatch, score, torch.full_like(score, -math.inf))
+    return [int(index) for index in torch.topk(ranked, k=count).indices.cpu().tolist()]
+
+
+def _mismatch_diagnostics(actual: torch.Tensor, reference: torch.Tensor, rtol: float, atol: float) -> dict:
+    actual_flat = actual.reshape(-1)
+    reference_flat = reference.reshape(-1)
+    absolute_error = (actual_flat - reference_flat).abs()
+    reference_abs = reference_flat.abs()
+    allowed_error = atol + rtol * reference_abs
+    finite_pair = torch.isfinite(actual_flat) & torch.isfinite(reference_flat)
+    mismatch = (finite_pair & (absolute_error > allowed_error)) | (~finite_pair & (actual_flat != reference_flat))
+    mismatch_count = int(mismatch.sum().item())
+    candidate_count = min(_MISMATCH_SAMPLE_LIMIT, mismatch_count)
+
+    absolute_rank = torch.nan_to_num(absolute_error, nan=math.inf, posinf=math.inf, neginf=math.inf)
+    relative_error = absolute_error / reference_abs
+    relative_error = torch.where((absolute_error == 0) & (reference_abs == 0), 0.0, relative_error)
+    relative_rank = torch.nan_to_num(relative_error, nan=math.inf, posinf=math.inf, neginf=math.inf)
+    absolute_indices = _top_ranked_indices(absolute_rank, mismatch, candidate_count)
+    relative_indices = _top_ranked_indices(relative_rank, mismatch, candidate_count)
+
+    selected_indices = []
+    selection_basis = {}
+    for rank in range(candidate_count):
+        for basis, candidates in (("absolute_error", absolute_indices), ("relative_error", relative_indices)):
+            index = candidates[rank]
+            if index not in selection_basis:
+                selection_basis[index] = basis
+                selected_indices.append(index)
+            if len(selected_indices) == candidate_count:
+                break
+        if len(selected_indices) == candidate_count:
+            break
+
+    selected = torch.tensor(selected_indices, device=actual.device, dtype=torch.long)
+    actual_values = actual_flat[selected].cpu().tolist()
+    reference_values = reference_flat[selected].cpu().tolist()
+    absolute_values = absolute_error[selected].cpu().tolist()
+    relative_values = relative_error[selected].cpu().tolist()
+    samples = [
+        {
+            "flat_index": flat_index,
+            "index": _flat_index_to_coordinates(flat_index, actual.shape),
+            "selected_by": selection_basis[flat_index],
+            "actual": _json_float(actual_value),
+            "reference": _json_float(reference_value),
+            "absolute_error": _json_float(absolute_value),
+            "relative_error": _json_float(relative_value),
+        }
+        for flat_index, actual_value, reference_value, absolute_value, relative_value in zip(
+            selected_indices,
+            actual_values,
+            reference_values,
+            absolute_values,
+            relative_values,
+        )
+    ]
+    return {
+        "mismatch_count": mismatch_count,
+        "sample_limit": _MISMATCH_SAMPLE_LIMIT,
+        "samples": samples,
+    }
+
+
+def _emit_mismatch_event(plan: _PlanIdentity, rng_seed: int, rtol: float, atol: float, diagnostics: dict) -> None:
+    payload = {
+        "rng_seed": rng_seed,
+        **plan.as_dict(),
+        "rtol": rtol,
+        "atol": atol,
+        **diagnostics,
+    }
+    samples = json.dumps(diagnostics, sort_keys=True, separators=(",", ":"))
+    human_message = f"Large tensor fuzzer mismatch samples rng_seed={rng_seed} {_plan_identity_text(plan)}: {samples}"
+    _emit_diagnostic_event("comparison_mismatch", payload, human_message=human_message)
+
+
 # ---------------------------------------------------------------------------
 # cuDNN graph execution
 # ---------------------------------------------------------------------------
@@ -1486,6 +1585,7 @@ def _run_single_config(
     Y = None
     bias = None
     actual = None
+    actual_f32 = None
     ref = None
     cudnn_result = None
     phase = "input setup"
@@ -1552,11 +1652,22 @@ def _run_single_config(
         phase = "PyTorch reference"
         ref = _reference(cfg, X, W, Y, bias)
         phase = "result comparison"
+        actual_f32 = actual.to(torch.float32)
         try:
-            torch.testing.assert_close(actual.to(torch.float32), ref, rtol=rtol, atol=atol)
+            torch.testing.assert_close(actual_f32, ref, rtol=rtol, atol=atol)
         except AssertionError as e:
             selected_plan = cudnn_result.selected_plan
             if selected_plan is not None:
+                try:
+                    diagnostics = _mismatch_diagnostics(actual_f32, ref, rtol, atol)
+                except (RuntimeError, OSError) as diagnostic_error:
+                    diagnostics = {
+                        "mismatch_count": None,
+                        "sample_limit": _MISMATCH_SAMPLE_LIMIT,
+                        "samples": [],
+                        "diagnostic_error": f"{type(diagnostic_error).__name__}: {diagnostic_error}",
+                    }
+                _emit_mismatch_event(selected_plan, cfg.rng_seed, rtol, atol, diagnostics)
                 _emit_plan_event("comparison", selected_plan, cfg.rng_seed, "numerical comparison failed")
             context = _format_repro_context(
                 cfg,
@@ -1609,6 +1720,8 @@ def _run_single_config(
             del bias
         if actual is not None:
             del actual
+        if actual_f32 is not None:
+            del actual_f32
         if ref is not None:
             del ref
         torch.cuda.empty_cache()

--- a/test/python/test_conv_large_tensor_fuzzer.py
+++ b/test/python/test_conv_large_tensor_fuzzer.py
@@ -63,12 +63,29 @@ _SPARSE_INTEGER_TARGET_NONZERO = 32  # max nonzero filter values per output chan
 _SPARSE_INTEGER_RNG_SALT = 0x51A25EED  # split sparse-index RNG from tensor-value RNG
 _GRAPH_ENGINE_RNG_SALT = 0xE61A5EED  # split engine selection from config and tensor RNGs
 _OP_SCHEDULE_RNG_SALT = 0x0F5C4ED  # split operation ordering from config generation
+_NVRTC_COMPILATION_STATUS = "CUDNN_STATUS_INTERNAL_ERROR_COMPILATION_FAILED"
+_PLAN_BUILD_ERROR_LIMIT = 1024
 
 
 class _EngineFilterNotSupported(Exception):
     """Selected graph engine is unsupported, not a cuDNN execution failure."""
 
     pass
+
+
+@dataclass(frozen=True)
+class _PlanBuildSelection:
+    selected_plan_index: Optional[int]
+    candidate_count: int
+    nvrtc_failures: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _CudnnRunResult:
+    ok: bool
+    message: str
+    selected_plan_index: Optional[int] = None
+    nvrtc_failures: Tuple[str, ...] = ()
 
 
 def _pytest_worker_count() -> int:
@@ -1102,7 +1119,59 @@ def _reference(cfg: LargeTensorConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
 # ---------------------------------------------------------------------------
 
 
-def _run_cudnn(cfg: LargeTensorConfig, X: torch.Tensor, W: torch.Tensor, Y: torch.Tensor, bias: Optional[torch.Tensor], handle) -> Tuple[bool, str]:
+def _nvrtc_plan_build_failure(plan_index: int, error: Exception) -> Optional[str]:
+    """Return a bounded diagnostic when the immediate plan error is NVRTC."""
+    backend_error = cudnn.get_last_error_string().strip()
+    detail = "\n".join(part for part in (str(error).strip(), backend_error) if part)
+    if _NVRTC_COMPILATION_STATUS not in detail:
+        return None
+
+    detail = " ".join(detail.split())
+    if len(detail) > _PLAN_BUILD_ERROR_LIMIT:
+        detail = f"{detail[:_PLAN_BUILD_ERROR_LIMIT]}..."
+    return f"plan index {plan_index}: {detail}"
+
+
+def _build_first_supported_plan(graph, rng_seed: int) -> _PlanBuildSelection:
+    """Build plans in priority order, preserving any NVRTC failures."""
+    candidate_count = graph.get_execution_plan_count()
+    nvrtc_failures = []
+
+    for plan_index in range(candidate_count):
+        try:
+            graph.build_plan_at_index(plan_index)
+        except cudnn.cudnnGraphNotSupportedError as e:
+            nvrtc_failure = _nvrtc_plan_build_failure(plan_index, e)
+            if nvrtc_failure is not None:
+                nvrtc_failures.append(nvrtc_failure)
+                outcome = "NVRTC compilation failure"
+            else:
+                outcome = "unsupported"
+            print(f"Large tensor fuzzer plan rng_seed={rng_seed} index={plan_index}: {outcome}", flush=True)
+            continue
+        except RuntimeError as e:
+            nvrtc_failure = _nvrtc_plan_build_failure(plan_index, e)
+            if nvrtc_failure is None:
+                raise
+            nvrtc_failures.append(nvrtc_failure)
+            print(f"Large tensor fuzzer plan rng_seed={rng_seed} index={plan_index}: NVRTC compilation failure", flush=True)
+            continue
+
+        print(
+            f"Large tensor fuzzer plan rng_seed={rng_seed} index={plan_index}: " "built successfully; selected for execution",
+            flush=True,
+        )
+        return _PlanBuildSelection(plan_index, candidate_count, tuple(nvrtc_failures))
+
+    print(
+        f"Large tensor fuzzer plan rng_seed={rng_seed}: exhausted {candidate_count} candidates without a buildable plan",
+        flush=True,
+    )
+    return _PlanBuildSelection(None, candidate_count, tuple(nvrtc_failures))
+
+
+def _run_cudnn(cfg: LargeTensorConfig, X: torch.Tensor, W: torch.Tensor, Y: torch.Tensor, bias: Optional[torch.Tensor], handle) -> _CudnnRunResult:
+    selection = _PlanBuildSelection(None, 0, ())
     try:
         cudnn.set_stream(handle=handle, stream=torch.cuda.current_stream().cuda_stream)
         io_dt = _cudnn_dtype(cfg.dtype)
@@ -1154,25 +1223,59 @@ def _run_cudnn(cfg: LargeTensorConfig, X: torch.Tensor, W: torch.Tensor, Y: torc
             _create_filtered_execution_plans(graph, selected_graph_engine_index)
         else:
             graph.create_execution_plans([cudnn.heur_mode.A, cudnn.heur_mode.FALLBACK])
-        graph.check_support()
-        graph.build_plans()
+        selection = _build_first_supported_plan(graph, cfg.rng_seed)
+        if selection.selected_plan_index is None:
+            if selection.nvrtc_failures:
+                detail = "; ".join(selection.nvrtc_failures)
+                return _CudnnRunResult(
+                    False,
+                    f"error: NVRTC compilation failed and no fallback plan built: {detail}",
+                    nvrtc_failures=selection.nvrtc_failures,
+                )
+            return _CudnnRunResult(False, f"not_supported: no buildable execution plan among {selection.candidate_count} candidates")
 
-        ws_size = graph.get_workspace_size()
+        plan_index = selection.selected_plan_index
+        ws_size = graph.get_workspace_size_plan_at_index(plan_index)
         workspace = torch.empty(ws_size, device="cuda", dtype=torch.uint8)
         _poison_workspace(workspace)
 
-        graph.execute(vpack, workspace, handle=handle)
+        graph.execute_plan_at_index(vpack, workspace, index=plan_index, handle=handle)
         torch.cuda.synchronize()
-        return True, "ok"
+        print(f"Large tensor fuzzer plan rng_seed={cfg.rng_seed} index={plan_index}: execution passed", flush=True)
+        return _CudnnRunResult(True, "ok", plan_index, selection.nvrtc_failures)
 
     except _EngineFilterNotSupported as e:
-        return False, f"not_supported: {e}"
+        return _CudnnRunResult(False, f"not_supported: {e}", nvrtc_failures=selection.nvrtc_failures)
     except cudnn.cudnnGraphNotSupportedError as e:
-        return False, f"not_supported: {e}"
-    except torch.cuda.OutOfMemoryError:
+        if selection.nvrtc_failures:
+            prior_failures = "; ".join(selection.nvrtc_failures)
+            return _CudnnRunResult(
+                False,
+                f"error: fallback plan index {selection.selected_plan_index} became unsupported after "
+                f"NVRTC compilation failure(s): {e}; prior plan-build failures: {prior_failures}",
+                selection.selected_plan_index,
+                selection.nvrtc_failures,
+            )
+        return _CudnnRunResult(False, f"not_supported: {e}", nvrtc_failures=selection.nvrtc_failures)
+    except torch.cuda.OutOfMemoryError as e:
+        if selection.nvrtc_failures:
+            prior_failures = "; ".join(selection.nvrtc_failures)
+            return _CudnnRunResult(
+                False,
+                f"error: fallback plan index {selection.selected_plan_index} ran out of memory after "
+                f"NVRTC compilation failure(s): {e}; prior plan-build failures: {prior_failures}",
+                selection.selected_plan_index,
+                selection.nvrtc_failures,
+            )
         raise
     except (RuntimeError, OSError) as e:
-        return False, f"error: {type(e).__name__}: {e}"
+        prior_failures = f"; prior plan-build failures: {'; '.join(selection.nvrtc_failures)}" if selection.nvrtc_failures else ""
+        return _CudnnRunResult(
+            False,
+            f"error: {type(e).__name__}: {e}{prior_failures}",
+            selection.selected_plan_index,
+            selection.nvrtc_failures,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1264,6 +1367,7 @@ def _run_single_config(
     bias = None
     actual = None
     ref = None
+    cudnn_result = None
     phase = "input setup"
     try:
         gen = torch.Generator(device="cpu")
@@ -1314,9 +1418,9 @@ def _run_single_config(
         print(f"Large tensor fuzzer active configuration: {_repro_json(active_payload)}", flush=True)
 
         phase = "cuDNN execution"
-        ok, msg = _run_cudnn(cfg, X, W, Y, bias, cudnn_handle)
-        if not ok:
-            return False, msg
+        cudnn_result = _run_cudnn(cfg, X, W, Y, bias, cudnn_handle)
+        if not cudnn_result.ok:
+            return False, cudnn_result.message
 
         phase = "result clone"
         actual = Y.clone() if cfg.conv_type == ConvType.FPROP else X.clone() if cfg.conv_type == ConvType.DGRAD else W.clone()
@@ -1330,13 +1434,42 @@ def _run_single_config(
         try:
             torch.testing.assert_close(actual.to(torch.float32), ref, rtol=rtol, atol=atol)
         except AssertionError as e:
+            print(
+                f"Large tensor fuzzer plan rng_seed={cfg.rng_seed} index={cudnn_result.selected_plan_index}: numerical comparison failed",
+                flush=True,
+            )
             context = _format_repro_context(
                 cfg, test_num=test_num, total_tests=total_tests, config_seed=config_seed, rtol=rtol, atol=atol, message=str(e), attempt=attempt
             )
+            if cudnn_result.nvrtc_failures:
+                plan_failures = "\n".join(cudnn_result.nvrtc_failures)
+                raise AssertionError(
+                    f"NVRTC compilation failure(s) occurred before fallback plan index "
+                    f"{cudnn_result.selected_plan_index} executed:\n{plan_failures}\n"
+                    f"The fallback plan also failed numerical comparison:\n{e}{context}"
+                ) from e
             raise AssertionError(f"{e}{context}") from e
+
+        print(
+            f"Large tensor fuzzer plan rng_seed={cfg.rng_seed} index={cudnn_result.selected_plan_index}: numerical comparison passed",
+            flush=True,
+        )
+        if cudnn_result.nvrtc_failures:
+            plan_failures = "; ".join(cudnn_result.nvrtc_failures)
+            return (
+                False,
+                f"error: NVRTC compilation failure(s) occurred before fallback plan index "
+                f"{cudnn_result.selected_plan_index} executed and passed numerical comparison: {plan_failures}",
+            )
         return True, "ok"
 
     except torch.cuda.OutOfMemoryError as e:
+        if cudnn_result is not None and cudnn_result.nvrtc_failures:
+            plan_failures = "; ".join(cudnn_result.nvrtc_failures)
+            return (
+                False,
+                f"error: {phase} ran out of memory after NVRTC compilation failure(s): {e}; " f"prior plan-build failures: {plan_failures}",
+            )
         return False, f"insufficient_memory: {phase}: {e}"
     finally:
         if X is not None:


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- CI or test infrastructure

## Summary

Improves the large-tensor convolution fuzzer's plan handling and failure
output. The fuzzer now builds execution plans in priority order, reports each
plan attempt, and executes the first plan that builds successfully.

If an earlier plan fails NVRTC compilation, the fuzzer continues checking
later plans. If one builds, it still executes and is compared with the PyTorch
reference, but the testcase retains the earlier compilation failure. If no
plan builds, the testcase fails with the attempted-plan details instead of
treating the graph as ordinarily unsupported.

Plan output now includes the execution plan index, public graph engine index,
and knob choices. Versioned JSON events report active configurations, plan
builds, execution, comparison, skips, failures, and passing completion. Events
are printed to standard output and can optionally be written to per-worker
JSONL files through `CUDNN_FUZZ_EVENTS_DIR`.

Numeric failures now report up to eight unique mismatch locations selected
across the largest absolute and relative errors. Each sample includes the
actual value, reference value, absolute error, and relative error.

## Why

A plan compilation failure can otherwise look like an unsupported generated
graph, causing the fuzzer to skip a real backend failure. Building plans one at
a time preserves that failure while still allowing a later plan to run when
one is available.

The additional plan and mismatch details make failures easier to reproduce and
route without changing the generated test space or comparison tolerances. The
JSON event stream also makes large sweeps easier to inspect without parsing
pytest's human-readable output.

## Related issues

Related to #401.

## API and compatibility impact

None. This changes test behavior and output only. `CUDNN_FUZZ_EVENTS_DIR` is an
optional test-only environment variable; normal frontend APIs are unchanged.

## Testing

Formatting and static checks:

```bash
pre-commit run --files test/python/test_conv_large_tensor_fuzzer.py
python3 -m py_compile test/python/test_conv_large_tensor_fuzzer.py
git diff --check origin/develop...HEAD
```

All checks passed.

Four-worker H100 and B100 sweeps used four times the default testcase counts:

```bash
CUDNN_FUZZ_NUM_TESTS_L0=256 \
CUDNN_FUZZ_NUM_TESTS_L1=1792 \
CUDNN_FUZZ_RUNTIME_WORK_BUDGET=1e14 \
CUDNN_FUZZ_EVENTS_DIR=/tmp/large-tensor-events \
python -m pytest test/python/test_conv_large_tensor_fuzzer.py \
  -o addopts= -m "L0 or L1" -n 4 --tb=short --durations=20 -ra
```

| Architecture | Result | Runtime |
| --- | ---: | ---: |
| SM90 | `1994 passed`, `54 skipped` | `6800.76s (1:53:20)` |
| SM100 | `1994 passed`, `54 skipped` | `10057.21s (2:47:37)` |

The skips were generated graphs for which cuDNN returned no buildable plan.

Focused plan-build testing on SM90 and SM100 covered:
- Two configurations where plan finalization returned
  `CUDNN_STATUS_INTERNAL_ERROR_COMPILATION_FAILED`. Both failed the testcase
  instead of being reported as unsupported.
- A supported control configuration that built, executed, and passed the
  PyTorch comparison.
- An ordinary unsupported control configuration that remained a skip.
- The two compilation-failure configurations against a backend build with the
  corresponding fix; both built, executed, and passed the comparison.

Saved event files from the extended sweeps contained `50,409` valid JSON
records with no malformed rows. Four numeric mismatch events each reported no
more than eight unique samples.

The observed NVRTC failures exposed only one execution-plan candidate. These
runs therefore did not exercise the path where an earlier plan fails NVRTC and
a later plan builds and executes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added structured diagnostic events with schema and version metadata.
  * Added optional per-worker JSONL output and richer reproduction details.
  * Improved reporting for numerical mismatches, including error samples, tensor coordinates, and non-finite values.
  * Added clearer tracking for execution plans, fallbacks, skips, retries, and outcomes.
  * Distinguishes unsupported configurations, out-of-memory conditions, compilation failures, and execution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->