### PR TITLE
Add LPT_L2 scheduler

### DIFF
--- a/python/cudnn/frost/tile_dsl/pointwise.py
+++ b/python/cudnn/frost/tile_dsl/pointwise.py
@@ -34,8 +34,7 @@ def _packed_f32x2(op, vec_a, vec_b):
 
 def tmem_load_max_reduction(tmem_addr, num: cutlass.Constexpr = 64):
     """tcgen05.ld.red.sync.aligned.32x32b.x{num}.f32.max — fused TMEM
-    load + HW row-max reduction (LDTM.STAT).  Mirrors C++ templated
-    ``tile::tmem_load_max_reduction<N>``.  ``num`` is the elements-per-
+    load + HW row-max reduction (LDTM.STAT).  ``num`` is the elements-per-
     thread count (= TILE_N/2 for the current dual-MMA softmax path).
     """
     _data_ops = ", ".join("{$w%d}" % i for i in range(num))

--- a/python/cudnn/frost/tile_dsl/scheduler.py
+++ b/python/cudnn/frost/tile_dsl/scheduler.py
@@ -9,9 +9,78 @@ from typing import NamedTuple
 from cutlass.experimental import primitives as nvvm
 import cutlass
 import cutlass.cute as cute
+from cutlass._mlir.dialects import arith
 
 from .barrier import PipelineState, advance, wait, arrive_expect_tx
 
+
+@cute.jit
+def decode_linear_tile_lpt(linear, q_h, batch, q_tiles):
+    hb = q_h * batch
+    row_rank = linear // hb
+    within = linear % hb
+    row = (q_tiles - cutlass.Int32(1)) - row_rank
+    head = within % q_h
+    batch_idx = within // q_h
+    return row, head, batch_idx
+
+
+@cute.jit
+def decode_linear_tile_lpt_l2(linear, q_h, batch, q_tiles, heads_per_kv, seqlen_kv, kv_bytes_per_row, l2_bytes):
+    n_kh = q_h // heads_per_kv
+    num_groups = n_kh * batch
+    # Guard per_group == 0 (the C++ does; a zero KV length would divide by zero).
+    per_group_raw = seqlen_kv * cutlass.Int32(kv_bytes_per_row)
+    per_group = cutlass.Int32(
+        arith.select(
+            (per_group_raw < cutlass.Int32(1)).ir_value(),
+            cutlass.Int32(1).ir_value(),
+            per_group_raw.ir_value(),
+        )
+    )
+    ag_raw = cutlass.Int32(l2_bytes) // per_group
+    ag_min1 = cutlass.Int32(
+        arith.select(
+            (ag_raw < cutlass.Int32(1)).ir_value(),
+            cutlass.Int32(1).ir_value(),
+            ag_raw.ir_value(),
+        )
+    )
+    active_groups = cutlass.Int32(
+        arith.select(
+            (ag_min1 > num_groups).ir_value(),
+            num_groups.ir_value(),
+            ag_min1.ir_value(),
+        )
+    )
+
+    tiles_per_grp = q_tiles * heads_per_kv
+    tiles_per_blk = active_groups * tiles_per_grp
+    num_blocks = (num_groups + active_groups - cutlass.Int32(1)) // active_groups
+    block_idx = linear // tiles_per_blk
+    within_blk = linear % tiles_per_blk
+    # The last block may hold fewer than active_groups groups — clamp so the
+    # decoded group never lands outside [0, num_groups).
+    is_last_block = (block_idx + cutlass.Int32(1)) == num_blocks
+    agroup_eff = cutlass.Int32(
+        arith.select(
+            is_last_block.ir_value(),
+            (num_groups - block_idx * active_groups).ir_value(),
+            active_groups.ir_value(),
+        )
+    )
+
+    row_rank = within_blk // (agroup_eff * heads_per_kv)
+    in_rank = within_blk % (agroup_eff * heads_per_kv)
+    # in_rank lays out as (sub_head, kv_group): every Q-head sharing a kv_head
+    # lands in the same block, so they hit the same resident K/V.
+    sub_head = in_rank // agroup_eff
+    kv_group = (in_rank % agroup_eff) + block_idx * active_groups
+    kv_head = kv_group % n_kh
+    batch_idx = kv_group // n_kh
+    head = kv_head * heads_per_kv + sub_head
+    row = (q_tiles - cutlass.Int32(1)) - row_rank
+    return row, head, batch_idx
 
 @cute.jit
 def read_tile_id_arrive(mb, cga_size: int):

--- a/python/cudnn/frost/tile_dsl/scheduler.py
+++ b/python/cudnn/frost/tile_dsl/scheduler.py
@@ -29,7 +29,7 @@ def decode_linear_tile_lpt(linear, q_h, batch, q_tiles):
 def decode_linear_tile_lpt_l2(linear, q_h, batch, q_tiles, heads_per_kv, seqlen_kv, kv_bytes_per_row, l2_bytes):
     n_kh = q_h // heads_per_kv
     num_groups = n_kh * batch
-    # Guard per_group == 0 (the C++ does; a zero KV length would divide by zero).
+    # Guard per_group == 0: a zero KV length would divide by zero below.
     per_group_raw = seqlen_kv * cutlass.Int32(kv_bytes_per_row)
     per_group = cutlass.Int32(
         arith.select(

--- a/python/cudnn/frost/tile_dsl/scheduler.py
+++ b/python/cudnn/frost/tile_dsl/scheduler.py
@@ -82,6 +82,7 @@ def decode_linear_tile_lpt_l2(linear, q_h, batch, q_tiles, heads_per_kv, seqlen_
     row = (q_tiles - cutlass.Int32(1)) - row_rank
     return row, head, batch_idx
 
+
 @cute.jit
 def read_tile_id_arrive(mb, cga_size: int):
     if cga_size == 1:

--- a/python/cudnn/frost/tile_dsl/scheduler.py
+++ b/python/cudnn/frost/tile_dsl/scheduler.py
@@ -15,7 +15,7 @@ from .barrier import PipelineState, advance, wait, arrive_expect_tx
 
 
 @cute.jit
-def decode_linear_tile_lpt(linear, q_h, batch, q_tiles):
+def lpt_tile_coords(linear, q_h, batch, q_tiles):
     hb = q_h * batch
     row_rank = linear // hb
     within = linear % hb
@@ -26,7 +26,7 @@ def decode_linear_tile_lpt(linear, q_h, batch, q_tiles):
 
 
 @cute.jit
-def decode_linear_tile_lpt_l2(linear, q_h, batch, q_tiles, heads_per_kv, seqlen_kv, kv_bytes_per_row, l2_bytes):
+def lpt_l2_tile_coords(linear, q_h, batch, q_tiles, heads_per_kv, seqlen_kv, kv_bytes_per_row, l2_bytes):
     n_kh = q_h // heads_per_kv
     num_groups = n_kh * batch
     # Guard per_group == 0: a zero KV length would divide by zero below.

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -153,6 +153,7 @@ def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch
     with torch.cuda.stream(launch_stream):
         yield
 
+
 # Causal-balancing scheduler choice: use the L2-GROUPED LPT when ONE head's K+V
 # working set fits this budget -- that is the condition under which the
 # block-cyclic grouping can actually keep that K/V resident; otherwise plain

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -25,6 +25,7 @@ from cudnn.frost.tile_dsl.constants import (
     DTYPE_E5M2,
     DTYPE_FP16,
     SCHED_LPT,
+    SCHED_LPT_L2,
     SCHED_NATURAL,
 )
 from cudnn.sdpa.fwd.config_sm100 import TemplateParams as Sm100TemplateParams
@@ -151,6 +152,18 @@ def _torch_stream_context(current_stream: Optional[cuda.CUstream], device: torch
         launch_stream = torch.cuda.ExternalStream(handle, device=device)
     with torch.cuda.stream(launch_stream):
         yield
+
+# Causal-balancing scheduler choice: use the L2-GROUPED LPT when ONE head's K+V
+# working set fits this budget -- that is the condition under which the
+# block-cyclic grouping can actually keep that K/V resident; otherwise plain
+# reverse-row LPT.
+_SCHED_L2_BUDGET_BYTES = 50 * 1024 * 1024
+
+
+def _causal_sched_policy(s_kv: int, d_qk: int, d_v: int, elem_bytes: int) -> int:
+    """SCHED_LPT_L2 vs SCHED_LPT for a causal graph (see _SCHED_L2_BUDGET_BYTES)."""
+    one_head_bytes = int(s_kv) * (int(d_qk) + int(d_v)) * int(elem_bytes)
+    return SCHED_LPT_L2 if _SCHED_L2_BUDGET_BYTES >= one_head_bytes else SCHED_LPT
 
 
 def ws_align(nbytes: int) -> int:
@@ -926,8 +939,17 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         mxfp8 = self._fp8 and not self._pertensor
         fused_ldtm_stat = mxfp8 and (self._device_cc == (10, 3))
         sched_policy = self.sched_policy
-        if mxfp8 and sched_policy == SCHED_NATURAL and self.window_right is not None:
-            sched_policy = SCHED_LPT
+        if sched_policy == SCHED_NATURAL and self.window_right is not None:
+            # Causal: balance the triangular load; pick the LPT variant by working set.
+            _, _, s_kv_sched, _ = self.k_desc.shape
+            _, _, _, d_qk_sched = self.q_desc.shape
+            _, _, _, d_v_sched = self.v_desc.shape
+            sched_policy = _causal_sched_policy(
+                s_kv=s_kv_sched,
+                d_qk=d_qk_sched,
+                d_v=d_v_sched,
+                elem_bytes=1 if self._fp8 else 2,
+            )
         params = Sm100TemplateParams(
             dtype_qkv=_SM100_DTYPE_QKV_CODE[self.dtype],
             dtype_o=_SM100_DTYPE_QKV_CODE[self.dtype_o],
@@ -1870,10 +1892,6 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             "cu_seq_len_* is THD-only (the dense kernels have no CU read mode yet)",
         )
         self._value_error_if(
-            self.sched_policy is not None and self.sched_policy != SCHED_NATURAL,
-            f"SM120 DSL SDPA only supports sched_policy={SCHED_NATURAL}",
-        )
-        self._value_error_if(
             self.cga is not None and self.cga != 1,
             "SM120 DSL SDPA only supports cga=1",
         )
@@ -2076,9 +2094,22 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         if self._compiled_kernel is not None:
             return
 
+        # Causal: balance the triangular load; pick the LPT variant by working set.
+        sched_policy = self.sched_policy
+        if sched_policy == SCHED_NATURAL and self.window_right is not None:
+            _, _, s_kv_sched, _ = self.k_desc.shape
+            _, _, _, d_qk_sched = self.q_desc.shape
+            _, _, _, d_v_sched = self.v_desc.shape
+            sched_policy = _causal_sched_policy(
+                s_kv=s_kv_sched,
+                d_qk=d_qk_sched,
+                d_v=d_v_sched,
+                elem_bytes=1 if self._fp8 else 2,
+            )
         params = Sm120TemplateParams(
             dtype_qkv=_SM120_DTYPE_QKV_CODE[self.dtype],
             dtype_o=_SM120_DTYPE_QKV_CODE[self.o_desc.dtype],
+            sched_policy=sched_policy,
             window_left=self.window_left,
             window_right=self.window_right,
             bottom_right=self.causal_bottom_right,

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -33,6 +33,7 @@ from cudnn.frost.tile_dsl.constants import (
     MASK_PADDED,
     MASK_SWA,
     SCHED_LPT,
+    SCHED_LPT_L2,
     SCHED_NATURAL,
 )
 
@@ -118,8 +119,8 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
             raise ValueError(f"{flavor}: SEQ_Q_LENS_PRESENT is dense-only (THD carries per-sequence Q lengths via cu_seqlens)")
         if not k.seq_kv_lens_present:
             raise ValueError(f"{flavor}: SEQ_Q_LENS_PRESENT requires SEQ_KV_LENS_PRESENT (padding mask)")
-    if k.sched_policy not in (SCHED_NATURAL, SCHED_LPT):
-        raise ValueError(f"{flavor}: only SCHED_NATURAL (0) / SCHED_LPT (1) are wired up; got {k.sched_policy}")
+    if k.sched_policy not in (SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2):
+        raise ValueError(f"{flavor}: only SCHED_NATURAL (0) / SCHED_LPT (1) / SCHED_LPT_L2 (2) are wired up; got {k.sched_policy}")
 
 
 def _mask_flags_from(params: TemplateParams) -> int:

--- a/python/cudnn/sdpa/fwd/config_sm120.py
+++ b/python/cudnn/sdpa/fwd/config_sm120.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
 from dataclasses import dataclass
 from typing import Optional
 
@@ -67,6 +68,7 @@ class TemplateParams:
     seq_kv_lens_present: bool = False
     has_sink: bool = False
     thd_varlen: bool = False
+    sched_policy: int = SCHED_NATURAL
     q_tile: int = SEQ_Q_TILES[0]
     kv_tile: int = SEQ_KV_TILES[0]
 

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -10,8 +10,8 @@ from cutlass._mlir.dialects import arith
 from cudnn.frost.tile_dsl.scheduler import (
     SCHED_LPT_L2,
     SCHED_NATURAL,
-    decode_linear_tile_lpt,
-    decode_linear_tile_lpt_l2,
+    lpt_tile_coords,
+    lpt_l2_tile_coords,
 )
 from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_PADDED, MASK_SWA
 from cudnn.frost.tile_dsl.barrier import MBarrier, Producer, Scope
@@ -371,7 +371,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
             if cutlass.const_expr(qh_per_kh is None or seqlen_kv is None):
                 raise ValueError("SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call site")
-            row, head, batch = decode_linear_tile_lpt_l2(linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes)
+            row, head, batch = lpt_l2_tile_coords(linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes)
             return _lpt_q_super(row, cta_in_pair), head, batch
 
         @cute.jit
@@ -380,7 +380,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
             if cutlass.const_expr(qh_per_kh is None or seqlen_kv is None):
                 raise ValueError("SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call site")
-            row, head, batch = decode_linear_tile_lpt_l2(linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes)
+            row, head, batch = lpt_l2_tile_coords(linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes)
             return _lpt_q_super(row, cta_in_pair), head, batch
 
     else:
@@ -389,14 +389,14 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
         def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
             linear = _lpt_linear(bidx)
             q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
-            row, head, batch = decode_linear_tile_lpt(linear, n_qh, n_batch, q_tiles)
+            row, head, batch = lpt_tile_coords(linear, n_qh, n_batch, q_tiles)
             return _lpt_q_super(row, cta_in_pair), head, batch
 
         @cute.jit
         def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
             linear = _lpt_linear(t0)
             q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
-            row, head, batch = decode_linear_tile_lpt(linear, n_qh, n_batch, q_tiles)
+            row, head, batch = lpt_tile_coords(linear, n_qh, n_batch, q_tiles)
             return _lpt_q_super(row, cta_in_pair), head, batch
 
     @cute.jit

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -371,9 +371,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
             if cutlass.const_expr(qh_per_kh is None or seqlen_kv is None):
                 raise ValueError("SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call site")
-            row, head, batch = decode_linear_tile_lpt_l2(
-                linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes
-            )
+            row, head, batch = decode_linear_tile_lpt_l2(linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes)
             return _lpt_q_super(row, cta_in_pair), head, batch
 
         @cute.jit
@@ -382,9 +380,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
             if cutlass.const_expr(qh_per_kh is None or seqlen_kv is None):
                 raise ValueError("SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call site")
-            row, head, batch = decode_linear_tile_lpt_l2(
-                linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes
-            )
+            row, head, batch = decode_linear_tile_lpt_l2(linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes)
             return _lpt_q_super(row, cta_in_pair), head, batch
 
     else:
@@ -510,17 +506,13 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
         return q_super, f_head, f_batch
 
     @cute.jit
-    def _dispatch_decode_initial(
-        bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None
-    ):
+    def _dispatch_decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None):
         if cutlass.const_expr(_thd_on):
             return _thd_decode(bidx, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
         return _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh, seqlen_kv)
 
     @cute.jit
-    def _dispatch_decode_payload(
-        t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None
-    ):
+    def _dispatch_decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None):
         if cutlass.const_expr(_thd_on):
             return _thd_decode(t0, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
         return _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh, seqlen_kv)

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -7,7 +7,12 @@ import cutlass
 import cutlass.cute as cute
 from cutlass._mlir.dialects import arith
 
-from cudnn.frost.tile_dsl.scheduler import SCHED_NATURAL
+from cudnn.frost.tile_dsl.scheduler import (
+    SCHED_LPT_L2,
+    SCHED_NATURAL,
+    decode_linear_tile_lpt,
+    decode_linear_tile_lpt_l2,
+)
 from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_PADDED, MASK_SWA
 from cudnn.frost.tile_dsl.barrier import MBarrier, Producer, Scope
 
@@ -297,17 +302,6 @@ def compute_kv_loop_bounds(
     )
 
 
-@cute.jit
-def decode_linear_tile_lpt(linear, q_h, batch, q_tiles):
-    hb = q_h * batch
-    row_rank = linear // hb
-    within = linear % hb
-    row = (q_tiles - cutlass.Int32(1)) - row_rank
-    head = within % q_h
-    batch_idx = within // q_h
-    return row, head, batch_idx
-
-
 class SdpaHelpers(NamedTuple):
     decode_initial: object
     decode_payload: object
@@ -325,16 +319,31 @@ class SdpaHelpers(NamedTuple):
 def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelpers:
     cga_tile_m = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
+    _cga_m = getattr(CFG, "CGA_M", 1)
+    _cta_mma = getattr(CFG, "CTA_MMA", 1)
+
+    @cute.jit
+    def _lpt_linear(block_id):
+        if cutlass.const_expr(_cga_m > 1):
+            return block_id // cutlass.Int32(_cga_m)
+        return block_id
+
+    @cute.jit
+    def _lpt_q_super(row, cta_in_pair):
+        if cutlass.const_expr(_cta_mma > 1):
+            return row * cutlass.Int32(_cta_mma) + cta_in_pair
+        return row
+
     if CFG.SCHEDULER_POLICY == SCHED_NATURAL:
         if CFG.SPLIT_PIPELINE == 1:
 
             @cute.jit
-            def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch):
+            def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
                 blocked_row = (bidx // cutlass.Int32(CFG.CGA_M)) * cutlass.Int32(CFG.CTA_MMA) + cta_in_pair
                 return blocked_row, bidy, bidz
 
             @cute.jit
-            def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch):
+            def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
                 blocked_row = (t0 // cutlass.Int32(CFG.CGA_M)) * cutlass.Int32(CFG.CTA_MMA) + cta_in_pair
                 head = t1 & cutlass.Int32(0xFFFF)
                 batch = (t1 >> cutlass.Int32(16)) & cutlass.Int32(0xFFFF)
@@ -343,30 +352,56 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
         else:
 
             @cute.jit
-            def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch):
+            def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
                 return bidx, bidy, bidz
 
             @cute.jit
-            def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch):
+            def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
                 head = t1 & cutlass.Int32(0xFFFF)
                 batch = (t1 >> cutlass.Int32(16)) & cutlass.Int32(0xFFFF)
                 return t0 + cta_in_pair, head, batch
 
+    elif CFG.SCHEDULER_POLICY == SCHED_LPT_L2:
+        _kv_bytes_per_row = (CFG.TILE_K + CFG.TILE_O) * CFG.BPE
+        _l2_bytes = CFG.L2_SIZE_MIB * 1024 * 1024
+
+        @cute.jit
+        def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+            linear = _lpt_linear(bidx)
+            q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
+            if cutlass.const_expr(qh_per_kh is None or seqlen_kv is None):
+                raise ValueError("SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call site")
+            row, head, batch = decode_linear_tile_lpt_l2(
+                linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes
+            )
+            return _lpt_q_super(row, cta_in_pair), head, batch
+
+        @cute.jit
+        def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+            linear = _lpt_linear(t0)
+            q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
+            if cutlass.const_expr(qh_per_kh is None or seqlen_kv is None):
+                raise ValueError("SCHED_LPT_L2 decode requires qh_per_kh and seqlen_kv at every call site")
+            row, head, batch = decode_linear_tile_lpt_l2(
+                linear, n_qh, n_batch, q_tiles, qh_per_kh, seqlen_kv, _kv_bytes_per_row, _l2_bytes
+            )
+            return _lpt_q_super(row, cta_in_pair), head, batch
+
     else:
 
         @cute.jit
-        def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch):
-            linear = bidx // cutlass.Int32(CFG.CGA_M)
-            q_tiles = n_q_supers // cutlass.Int32(CFG.CTA_MMA) if lpt_q_tiles_in_cga_units else n_q_supers
+        def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+            linear = _lpt_linear(bidx)
+            q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
             row, head, batch = decode_linear_tile_lpt(linear, n_qh, n_batch, q_tiles)
-            return row * cutlass.Int32(CFG.CTA_MMA) + cta_in_pair, head, batch
+            return _lpt_q_super(row, cta_in_pair), head, batch
 
         @cute.jit
-        def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch):
-            linear = t0 // cutlass.Int32(CFG.CGA_M)
-            q_tiles = n_q_supers // cutlass.Int32(CFG.CTA_MMA) if lpt_q_tiles_in_cga_units else n_q_supers
+        def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+            linear = _lpt_linear(t0)
+            q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
             row, head, batch = decode_linear_tile_lpt(linear, n_qh, n_batch, q_tiles)
-            return row * cutlass.Int32(CFG.CTA_MMA) + cta_in_pair, head, batch
+            return _lpt_q_super(row, cta_in_pair), head, batch
 
     @cute.jit
     def _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair):
@@ -475,16 +510,20 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
         return q_super, f_head, f_batch
 
     @cute.jit
-    def _dispatch_decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t):
+    def _dispatch_decode_initial(
+        bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None
+    ):
         if cutlass.const_expr(_thd_on):
             return _thd_decode(bidx, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
-        return _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch)
+        return _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh, seqlen_kv)
 
     @cute.jit
-    def _dispatch_decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t):
+    def _dispatch_decode_payload(
+        t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None
+    ):
         if cutlass.const_expr(_thd_on):
             return _thd_decode(t0, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
-        return _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch)
+        return _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh, seqlen_kv)
 
     @cute.jit
     def _thd_tma_offsets(seq_kv_lens_t, batch_idx, n_batch):

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
@@ -138,7 +138,7 @@ from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     make_classic_bars,
     compute_kv_loop_bounds,
-    decode_linear_tile_lpt,
+    lpt_tile_coords,
     row_max_for_exp2,
     make_sdpa_helpers,
 )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
@@ -429,6 +429,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
@@ -449,6 +450,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
@@ -471,6 +473,7 @@ def _kernel(
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -494,6 +497,7 @@ def _kernel(
                     n_batch=n_batch,
                     mcast_mask=mcast_mask,
                     cta_in_pair=cta_in_pair,
+                    qh_per_kh=qh_per_kh,
                 )
             else:
                 _mma_warp_quiet(tmem_ptr_i32, bars)
@@ -514,6 +518,7 @@ def _kernel(
                 n_batch=n_batch,
                 mcast_mask=mcast_mask,
                 cta_in_pair=cta_in_pair,
+                qh_per_kh=qh_per_kh,
             )
 
     elif warp_idx == CFG.TMALDG_WARP_ID:
@@ -556,6 +561,8 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             o_desc_words=o_desc_words,
+            qh_per_kh=qh_per_kh,
+            seqlen_kv=seqlen_kv,
         )
 
     else:  # warp_idx == CFG.SCHED_WARP_ID
@@ -619,6 +626,8 @@ def _tmaldg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     # GQA: K/V are indexed by kv-head, not Q-head.
     kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
@@ -680,7 +689,6 @@ def _tmaldg_warp_group(
                 # tma_batch==batch_idx) but reads the WRONG packed location for
                 # THD batch>=1 — corrupting the first (diagonal) KV tile and, via
                 # the online-softmax running max/sum, the whole batch>=1 output.
-                # (Ported from VibeTile 7ac72cb "fix THD".)
                 tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
                 bars.mb_k_full[kv_state.idx].smem_ptr,
                 cta_group=CFG.CTA_MMA,
@@ -760,6 +768,8 @@ def _tmaldg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
         # q_row_base compute right after decode drives ptxas R2UR.
@@ -802,6 +812,8 @@ def _tmastg_warp_group(
     cta_in_pair,
     seq_kv_lens_tensor,
     o_desc_words,
+    seqlen_kv,
+    qh_per_kh,
 ):
     """Persistent O-store warp.  First tile from blockIdx; subsequent tiles
     via scheduler warp's clusterlaunchcontrol.try_cancel.async.
@@ -819,6 +831,8 @@ def _tmastg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -873,6 +887,8 @@ def _tmastg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -948,6 +964,7 @@ def _mma_warp_group(
     n_batch,
     mcast_mask,
     cta_in_pair,
+    qh_per_kh,
 ):
     """Unified MMA warp — cga1 / cga2-leader x MASK_NONE / PADDED / CAUSAL / SWA,
     spill-free in CFG.OTHER_REGS (40).  Non-leader under cga2 uses _mma_warp_quiet.
@@ -1018,6 +1035,8 @@ def _mma_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
@@ -1220,6 +1239,8 @@ def _mma_warp_group(
                 n_qh,
                 n_batch,
                 seq_kv_lens_tensor,
+                qh_per_kh,
+                seqlen_kv,
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
@@ -1452,6 +1473,7 @@ def _softmax_warp_group(
     n_batch,
     leader_cta_id,
     cta_in_pair,
+    qh_per_kh,
 ):
     """Softmax warp group (one of two): online softmax per kv iter.
 
@@ -1496,6 +1518,8 @@ def _softmax_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1628,6 +1652,8 @@ def _softmax_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1655,6 +1681,7 @@ def _correction_warp_group(
     leader_cta_id,
     cta_in_pair,
     cta_id_x,
+    qh_per_kh,
 ):
     """Correction warp group: 4 warps x 32 lanes = 128 lanes, 1 lane per O row.
 
@@ -1695,6 +1722,8 @@ def _correction_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1908,6 +1937,8 @@ def _correction_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -139,7 +139,7 @@ from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     make_classic_bars,
     compute_kv_loop_bounds,
-    decode_linear_tile_lpt,
+    lpt_tile_coords,
     make_sdpa_helpers,
 )
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -374,6 +374,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
@@ -393,6 +394,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
@@ -416,6 +418,7 @@ def _kernel(
             cta_id_x=cta_id_x,
             o_scale_fused=o_scale_fused,
             amax_o_tensor=amax_o_tensor,
+            qh_per_kh=qh_per_kh,
         )
 
     # cga2 non-leader runs quiet body (alloc+dealloc only); cga1 folds to full path.
@@ -438,6 +441,7 @@ def _kernel(
                     n_batch=n_batch,
                     mcast_mask=mcast_mask,
                     cta_in_pair=cta_in_pair,
+                    qh_per_kh=qh_per_kh,
                 )
             else:
                 _mma_warp_quiet(tmem_ptr_i32, bars)
@@ -457,6 +461,7 @@ def _kernel(
                 n_batch=n_batch,
                 mcast_mask=mcast_mask,
                 cta_in_pair=cta_in_pair,
+                qh_per_kh=qh_per_kh,
             )
 
     elif warp_idx == CFG.TMALDG_WARP_ID:
@@ -498,6 +503,8 @@ def _kernel(
             n_batch=n_batch,
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
+            qh_per_kh=qh_per_kh,
+            seqlen_kv=seqlen_kv,
         )
 
     else:  # warp_idx == CFG.SCHED_WARP_ID
@@ -553,6 +560,8 @@ def _tmaldg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     # GQA: K/V are indexed by kv-head.
     kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
@@ -686,6 +695,8 @@ def _tmaldg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
         # q_row_base after decode drives ptxas R2UR (keeps nxt_q live before back-edge).
@@ -726,6 +737,8 @@ def _tmastg_warp_group(
     n_batch,
     cta_in_pair,
     seq_kv_lens_tensor,
+    seqlen_kv,
+    qh_per_kh,
 ):
     """Persistent O-store warp; tiles claimed via scheduler's try_cancel.async."""
     o_full_phase = cutlass.Int32(0)
@@ -741,6 +754,8 @@ def _tmastg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -778,6 +793,8 @@ def _tmastg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -843,6 +860,7 @@ def _mma_warp_group(
     n_batch,
     mcast_mask,
     cta_in_pair,
+    qh_per_kh,
 ):
     """Unified MMA warp (cga1 / cga2-leader; MASK_NONE/PADDED/CAUSAL/SWA).
 
@@ -915,6 +933,8 @@ def _mma_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
@@ -1110,6 +1130,8 @@ def _mma_warp_group(
                 n_qh,
                 n_batch,
                 seq_kv_lens_tensor,
+                qh_per_kh,
+                seqlen_kv,
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
@@ -1312,6 +1334,7 @@ def _softmax_warp_group(
     n_batch,
     leader_cta_id,
     cta_in_pair,
+    qh_per_kh,
 ):
     """Softmax warp group: online softmax per kv iter, one lane per S_acc row.
 
@@ -1353,6 +1376,8 @@ def _softmax_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1485,6 +1510,8 @@ def _softmax_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1513,6 +1540,7 @@ def _correction_warp_group(
     cta_id_x,
     o_scale_fused,
     amax_o_tensor,
+    qh_per_kh,
 ):
     """Correction warp group: 4 warps × 32 lanes = 128, one lane per O row.
 
@@ -1552,6 +1580,8 @@ def _correction_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1793,6 +1823,8 @@ def _correction_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -177,7 +177,7 @@ from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     make_classic_bars,
     compute_kv_loop_bounds,
-    decode_linear_tile_lpt,
+    lpt_tile_coords,
     make_sdpa_helpers,
 )
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -534,6 +534,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
@@ -554,6 +555,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
@@ -576,6 +578,7 @@ def _kernel(
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -602,6 +605,7 @@ def _kernel(
                     n_batch=n_batch,
                     mcast_mask=mcast_mask,
                     cta_in_pair=cta_in_pair,
+                    qh_per_kh=qh_per_kh,
                 )
             else:
                 _mma_warp_quiet(
@@ -638,6 +642,7 @@ def _kernel(
                 n_batch=n_batch,
                 mcast_mask=mcast_mask,
                 cta_in_pair=cta_in_pair,
+                qh_per_kh=qh_per_kh,
             )
 
     elif warp_idx == CFG.TMALDG_WARP_ID:
@@ -688,6 +693,8 @@ def _kernel(
             n_batch=n_batch,
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
+            qh_per_kh=qh_per_kh,
+            seqlen_kv=seqlen_kv,
         )
 
     else:  # warp_idx == CFG.SCHED_WARP_ID
@@ -764,6 +771,8 @@ def _tmaldg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     # GQA: K/V indexed by kv-head.
     kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
@@ -964,6 +973,8 @@ def _tmaldg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
         q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
@@ -1001,6 +1012,8 @@ def _tmastg_warp_group(
     n_batch,
     cta_in_pair,
     seq_kv_lens_tensor,
+    seqlen_kv,
+    qh_per_kh,
 ):
     """TMA-STG warp — O SMEM→GMEM store."""
     o_full_phase = cutlass.Int32(0)
@@ -1016,6 +1029,8 @@ def _tmastg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1053,6 +1068,8 @@ def _tmastg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1099,6 +1116,7 @@ def _mma_warp_quiet(
 def _mma_warp_group(
     seqlen_q,
     seqlen_kv,
+    qh_per_kh,
     sQ,
     sK,
     sV,
@@ -1239,6 +1257,8 @@ def _mma_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
@@ -1536,6 +1556,8 @@ def _mma_warp_group(
                 n_qh,
                 n_batch,
                 seq_kv_lens_tensor,
+                qh_per_kh,
+                seqlen_kv,
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
@@ -1765,6 +1787,7 @@ def _softmax_warp_group(
     sub_tile_id: int,
     seqlen_q,
     seqlen_kv,
+    qh_per_kh,
     scale_log2: cutlass.Float32,
     tmem_ptr_i32,
     sQ,
@@ -1811,6 +1834,8 @@ def _softmax_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1942,6 +1967,8 @@ def _softmax_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1954,6 +1981,7 @@ def _softmax_warp_group(
 def _correction_warp_group(
     seqlen_q,
     seqlen_kv,
+    qh_per_kh,
     sO,
     tmem_ptr_i32,
     tidx,
@@ -2003,6 +2031,8 @@ def _correction_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -2179,6 +2209,8 @@ def _correction_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -189,7 +189,7 @@ from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     make_classic_bars,
     compute_kv_loop_bounds,
-    decode_linear_tile_lpt,
+    lpt_tile_coords,
     make_sdpa_helpers,
     assert_tile_n_supported,
 )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -483,6 +483,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
@@ -503,6 +504,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
@@ -525,6 +527,7 @@ def _kernel(
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -548,6 +551,7 @@ def _kernel(
                     n_batch=n_batch,
                     mcast_mask=mcast_mask,
                     cta_in_pair=cta_in_pair,
+                    qh_per_kh=qh_per_kh,
                 )
             else:
                 _mma_warp_quiet(tmem_ptr_i32, bars)
@@ -568,6 +572,7 @@ def _kernel(
                 n_batch=n_batch,
                 mcast_mask=mcast_mask,
                 cta_in_pair=cta_in_pair,
+                qh_per_kh=qh_per_kh,
             )
 
     elif warp_idx == CFG.TMALDG_WARP_ID:
@@ -610,6 +615,8 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             o_desc_words=o_desc_words,
+            qh_per_kh=qh_per_kh,
+            seqlen_kv=seqlen_kv,
         )
 
     else:  # warp_idx == CFG.SCHED_WARP_ID
@@ -673,6 +680,8 @@ def _tmaldg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     # GQA: K/V are indexed by kv-head, not Q-head.
     kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
@@ -749,7 +758,6 @@ def _tmaldg_warp_group(
                 # tma_batch==batch_idx) but reads the WRONG packed location for
                 # THD batch>=1 — corrupting the first (diagonal) KV tile and, via
                 # the online-softmax running max/sum, the whole batch>=1 output.
-                # (Ported from VibeTile 7ac72cb "fix THD".)
                 tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
                 bars.mb_k_full[kv_state.idx].smem_ptr,
                 cta_group=CFG.CTA_MMA,
@@ -830,6 +838,8 @@ def _tmaldg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
         # q_row_base compute right after decode drives ptxas R2UR.
@@ -872,6 +882,8 @@ def _tmastg_warp_group(
     cta_in_pair,
     seq_kv_lens_tensor,
     o_desc_words,
+    seqlen_kv,
+    qh_per_kh,
 ):
     """Persistent O-store warp.  First tile from blockIdx; subsequent tiles
     via scheduler warp's clusterlaunchcontrol.try_cancel.async.
@@ -892,6 +904,8 @@ def _tmastg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -957,6 +971,8 @@ def _tmastg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1032,6 +1048,7 @@ def _mma_warp_group(
     n_batch,
     mcast_mask,
     cta_in_pair,
+    qh_per_kh,
 ):
     """Unified MMA warp — cga1 / cga2-leader x MASK_NONE / PADDED / CAUSAL / SWA,
     spill-free in CFG.OTHER_REGS (40).  Non-leader under cga2 uses _mma_warp_quiet.
@@ -1102,6 +1119,8 @@ def _mma_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
@@ -1303,6 +1322,8 @@ def _mma_warp_group(
                 n_qh,
                 n_batch,
                 seq_kv_lens_tensor,
+                qh_per_kh,
+                seqlen_kv,
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
@@ -1563,6 +1584,7 @@ def _softmax_warp_group(
     n_batch,
     leader_cta_id,
     cta_in_pair,
+    qh_per_kh,
 ):
     """Softmax warp group (one of two): online softmax per kv iter.
 
@@ -1604,6 +1626,8 @@ def _softmax_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1739,6 +1763,8 @@ def _softmax_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1766,6 +1792,7 @@ def _correction_warp_group(
     leader_cta_id,
     cta_in_pair,
     cta_id_x,
+    qh_per_kh,
 ):
     """Correction warp group: 4 warps x 32 lanes = 128 lanes, 1 lane per O row.
 
@@ -1806,6 +1833,8 @@ def _correction_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -2029,6 +2058,8 @@ def _correction_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
@@ -88,7 +88,7 @@ from cudnn.sdpa.fwd.kernels._common_sm100 import (
     make_d256_bars,
     compute_kv_loop_bounds,
     row_max_for_exp2,
-    decode_linear_tile_lpt,
+    lpt_tile_coords,
     make_sdpa_helpers,
 )
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
@@ -330,6 +330,7 @@ def _kernel(
             n_batch=n_batch,
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
@@ -352,6 +353,7 @@ def _kernel(
             leader_cta_id=leader_cta_id,
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx == CFG.MMA_WARP_ID:
@@ -374,6 +376,7 @@ def _kernel(
                     n_batch=n_batch,
                     mcast_mask=mcast_mask,
                     cta_in_pair=cta_in_pair,
+                    qh_per_kh=qh_per_kh,
                 )
             else:
                 _mma_warp_quiet(tmem_ptr_i32, bars)
@@ -394,6 +397,7 @@ def _kernel(
                 n_batch=n_batch,
                 mcast_mask=mcast_mask,
                 cta_in_pair=cta_in_pair,
+                qh_per_kh=qh_per_kh,
             )
 
     elif warp_idx == CFG.TMALDG_WARP_ID:
@@ -436,6 +440,8 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             o_desc_words=o_desc_words,
+            qh_per_kh=qh_per_kh,
+            seqlen_kv=seqlen_kv,
         )
 
     else:
@@ -483,6 +489,8 @@ def _tmaldg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
     q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
@@ -572,6 +580,8 @@ def _tmaldg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
         q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
@@ -605,6 +615,8 @@ def _tmastg_warp_group(
     cta_in_pair,
     seq_kv_lens_tensor,
     o_desc_words,
+    seqlen_kv,
+    qh_per_kh,
 ):
 
     tmastg_go_phase = cutlass.Int32(0)
@@ -621,6 +633,8 @@ def _tmastg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -670,6 +684,8 @@ def _tmastg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -702,6 +718,7 @@ def _mma_warp_group(
     n_batch,
     mcast_mask,
     cta_in_pair,
+    qh_per_kh,
 ):
     tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
     nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
@@ -767,6 +784,8 @@ def _mma_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
@@ -909,6 +928,8 @@ def _mma_warp_group(
                 n_qh,
                 n_batch,
                 seq_kv_lens_tensor,
+                qh_per_kh,
+                seqlen_kv,
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
@@ -939,6 +960,7 @@ def _softmax_warp_group(
     n_batch,
     leader_cta_id,
     cta_in_pair,
+    qh_per_kh,
 ):
     nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
 
@@ -957,6 +979,8 @@ def _softmax_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1322,6 +1346,8 @@ def _softmax_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1349,6 +1375,7 @@ def _correction_warp_group(
     leader_cta_id,
     cta_in_pair,
     cta_id_x,
+    qh_per_kh,
 ):
     nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
 
@@ -1368,6 +1395,8 @@ def _correction_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1581,6 +1610,8 @@ def _correction_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
@@ -526,6 +526,7 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
             cross_sg_peer=cross_sg_peer,
+            qh_per_kh=qh_per_kh,
         )
 
     elif warp_idx == cutlass.Int32(CFG.MMA_WARP_ID):
@@ -552,6 +553,7 @@ def _kernel(
                 sg0_mcast_mask=sg0_mcast_mask,
                 cta_in_pair=cta_in_pair,
                 leader_cta_id=leader_cta_id,
+                qh_per_kh=qh_per_kh,
             )
         else:
             _mma_warp_non_leader(
@@ -571,6 +573,7 @@ def _kernel(
                 mcast_mask=mcast_mask,
                 cta_in_pair=cta_in_pair,
                 leader_cta_id=leader_cta_id,
+                qh_per_kh=qh_per_kh,
             )
 
     elif warp_idx == cutlass.Int32(CFG.TMALDG_WARP_ID):
@@ -616,6 +619,8 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             o_desc_words=o_desc_words,
+            qh_per_kh=qh_per_kh,
+            seqlen_kv=seqlen_kv,
         )
 
     else:
@@ -792,6 +797,7 @@ def _compute_warp_group(
     cta_in_pair,
     cta_id_x,
     cross_sg_peer,
+    qh_per_kh,
 ):
     nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WG_WARPS + 1))
     tmem_base_addr = tmem_ptr_i32.load()
@@ -810,6 +816,8 @@ def _compute_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1185,6 +1193,8 @@ def _compute_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1235,6 +1245,7 @@ def _mma_warp_group(
     sg0_mcast_mask,
     cta_in_pair,
     leader_cta_id,
+    qh_per_kh,
 ):
     tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
     nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
@@ -1291,6 +1302,8 @@ def _mma_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1442,6 +1455,8 @@ def _mma_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1474,6 +1489,7 @@ def _mma_warp_non_leader(
     mcast_mask,
     cta_in_pair,
     leader_cta_id,
+    qh_per_kh,
 ):
     tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
     nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WG_WARPS + 1))
@@ -1496,6 +1512,8 @@ def _mma_warp_non_leader(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = cutlass.Int32(1)
         sched_state = PipelineState.start()
@@ -1540,6 +1558,8 @@ def _mma_warp_non_leader(
                 n_qh,
                 n_batch,
                 seq_kv_lens_tensor,
+                qh_per_kh,
+                seqlen_kv,
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1595,6 +1615,8 @@ def _tmaldg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
     q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
@@ -1691,6 +1713,8 @@ def _tmaldg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
         q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
@@ -1730,6 +1754,8 @@ def _tmastg_warp_group(
     cta_in_pair,
     seq_kv_lens_tensor,
     o_desc_words,
+    seqlen_kv,
+    qh_per_kh,
 ):
     o_full_state = PipelineState.start(phase=0)
 
@@ -1744,6 +1770,8 @@ def _tmastg_warp_group(
         n_qh,
         n_batch,
         seq_kv_lens_tensor,
+        qh_per_kh,
+        seqlen_kv,
     )
     is_valid_tile = cutlass.Int32(1)
     sched_state = PipelineState.start()
@@ -1789,6 +1817,8 @@ def _tmastg_warp_group(
             n_qh,
             n_batch,
             seq_kv_lens_tensor,
+            qh_per_kh,
+            seqlen_kv,
         )
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -54,8 +54,8 @@ from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_FP16
 from cudnn.frost.tile_dsl.scheduler import (
     SCHED_LPT_L2,
     SCHED_NATURAL,
-    decode_linear_tile_lpt,
-    decode_linear_tile_lpt_l2,
+    lpt_tile_coords,
+    lpt_l2_tile_coords,
 )
 from cudnn.frost.tile_dsl.mma import mma_m16n8k16_f32
 from cudnn.frost.tile_dsl.swizzle import swizzle_xor
@@ -838,7 +838,7 @@ class SM120FusedMultiHeadAttentionForward:
             # value, so the decode cannot disagree with the launch geometry.
             _q_tiles = n_q_tiles
             if cutlass.const_expr(self.sched_policy == SCHED_LPT_L2):
-                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt_l2(
+                q_tile_idx, head_idx, batch_idx = lpt_l2_tile_coords(
                     q_tile_idx,
                     _n_qh,
                     _n_batch,
@@ -849,7 +849,7 @@ class SM120FusedMultiHeadAttentionForward:
                     _SCHED_L2_BUDGET_BYTES,
                 )
             else:
-                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt(q_tile_idx, _n_qh, _n_batch, _q_tiles)
+                q_tile_idx, head_idx, batch_idx = lpt_tile_coords(q_tile_idx, _n_qh, _n_batch, _q_tiles)
         elif cutlass.const_expr(self.is_causal):
             # Diagonal-bounded work grows with the Q tile. Launch long tiles
             # first to avoid leaving a few expensive CTAs in the final

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -51,6 +51,12 @@ import cutlass.cute as cute
 
 from cutlass.experimental import primitives as prims
 from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_FP16
+from cudnn.frost.tile_dsl.scheduler import (
+    SCHED_LPT_L2,
+    SCHED_NATURAL,
+    decode_linear_tile_lpt,
+    decode_linear_tile_lpt_l2,
+)
 from cudnn.frost.tile_dsl.mma import mma_m16n8k16_f32
 from cudnn.frost.tile_dsl.swizzle import swizzle_xor
 from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_kernel as _build_thd_meta_kernel
@@ -131,6 +137,10 @@ def pack_to_i32(
     return vals.bitcast(cutlass.Int32)[0]
 
 
+# L2 working-set budget used by the LPT_L2 group sizing.
+_SCHED_L2_BUDGET_BYTES = 50 * 1024 * 1024
+
+
 def ceil_div(a: int, b: int) -> int:
     """Return the ceiling division of a by b."""
     return (a + b - 1) // b
@@ -192,6 +202,7 @@ class SM120FusedMultiHeadAttentionForward:
         in_dtype: Type[cutlass.Numeric] = cutlass.Float16,
         out_dtype: Type[cutlass.Numeric] = cutlass.Float16,
         is_causal: bool = False,
+        sched_policy: int = SCHED_NATURAL,
         bottom_right: bool = False,
         window_size_left: int | None = None,
         window_size_right: int | None = None,
@@ -250,6 +261,7 @@ class SM120FusedMultiHeadAttentionForward:
         self.in_dtype = in_dtype
         self.out_dtype = in_dtype
         self.is_causal = is_causal
+        self.sched_policy = sched_policy
         self.bottom_right = bottom_right
         self.window_size_left = window_size_left
         # Band model: a right bound implies the causal upper limit (compile()
@@ -797,6 +809,7 @@ class SM120FusedMultiHeadAttentionForward:
         tma_k_desc: cutlass.GridConstant[cuda.TensorMap],
         tma_v_desc: cutlass.GridConstant[cuda.TensorMap],
         softmax_scale_log2: cutlass.Float32,
+        n_q_tiles: cutlass.Int32,
     ) -> None:
         """SM120 FMHA prefill kernel.
 
@@ -818,7 +831,30 @@ class SM120FusedMultiHeadAttentionForward:
         """
         tidx, _, _ = cute.arch.thread_idx()
         q_tile_idx, batch_idx, head_idx = cute.arch.block_idx()
-        if cutlass.const_expr(self.is_causal):
+        if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
+            _n_qh = cutlass.Int32(q.shape[2])
+            _n_batch = cutlass.Int32(
+                self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
+            )
+            # Host-computed (see __call__): the grid is sized from the same
+            # value, so the decode cannot disagree with the launch geometry.
+            _q_tiles = n_q_tiles
+            if cutlass.const_expr(self.sched_policy == SCHED_LPT_L2):
+                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt_l2(
+                    q_tile_idx,
+                    _n_qh,
+                    _n_batch,
+                    _q_tiles,
+                    _n_qh // cutlass.Int32(k.shape[2]),
+                    cutlass.Int32(k.shape[1]),
+                    (self.head_tile_qk + self.head_tile_v) * self.in_dtype.width // 8,
+                    _SCHED_L2_BUDGET_BYTES,
+                )
+            else:
+                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt(
+                    q_tile_idx, _n_qh, _n_batch, _q_tiles
+                )
+        elif cutlass.const_expr(self.is_causal):
             # Diagonal-bounded work grows with the Q tile. Launch long tiles
             # first to avoid leaving a few expensive CTAs in the final
             # scheduler waves (right-band graphs share the causal shape).
@@ -1440,6 +1476,20 @@ class SM120FusedMultiHeadAttentionForward:
                 thd_lens_form,
                 cutlass.Int32(self.thd_batch),
             ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        # Grid geometry. THD: ceil(max_seq_q / q_tile) tiles per sequence over the
+        # REAL batch count (the packed view's batch mode is 1); tiles past a shorter
+        # sequence's length drain without work. NOTE thd_max_sq is a __call__
+        # argument in this base, not a member.
+        n_q_tiles = ceil_div(thd_max_sq, self.q_tile) if cutlass.const_expr(self.thd_varlen) else ceil_div(q.shape[1], self.q_tile)
+        n_batch = self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
+        n_head = q.shape[2]
+        # LPT / LPT_L2 flatten the 3-D grid so the decode can order the whole tile
+        # set globally (heaviest causal rows first); NATURAL keeps the zero-overhead
+        # 3-D grid. The kernel receives n_q_tiles so its decode uses the same value.
+        if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
+            grid = (n_q_tiles * n_batch * n_head, 1, 1)
+        else:
+            grid = (n_q_tiles, n_batch, n_head)
         self.kernel(
             q,
             k,
@@ -1452,15 +1502,9 @@ class SM120FusedMultiHeadAttentionForward:
             tma_k_desc,
             tma_v_desc,
             softmax_scale_log2,
+            cutlass.Int32(n_q_tiles),
         ).launch(
-            # THD: ceil(max_seq_q / q_tile) tiles per sequence over the real
-            # batch count (the packed view's batch mode is 1); tiles past a
-            # shorter sequence's length drain without work.
-            grid=(
-                ceil_div(thd_max_sq, cutlass.Int32(self.q_tile)) if cutlass.const_expr(self.thd_varlen) else ceil_div(q.shape[1], self.q_tile),
-                self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0],
-                q.shape[2],
-            ),
+            grid=grid,
             block=(self.threads_per_cta, 1, 1),
             stream=stream,
             min_blocks_per_mp=1,
@@ -1512,6 +1556,7 @@ def compile(  # noqa: A001
         in_dtype=STORAGE_DTYPE,
         out_dtype=STORAGE_DTYPE,
         is_causal=PARAMS.window_right is not None,
+        sched_policy=PARAMS.sched_policy,
         bottom_right=PARAMS.bottom_right,
         window_size_left=PARAMS.window_left,
         window_size_right=PARAMS.window_right,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -833,9 +833,7 @@ class SM120FusedMultiHeadAttentionForward:
         q_tile_idx, batch_idx, head_idx = cute.arch.block_idx()
         if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
             _n_qh = cutlass.Int32(q.shape[2])
-            _n_batch = cutlass.Int32(
-                self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
-            )
+            _n_batch = cutlass.Int32(self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0])
             # Host-computed (see __call__): the grid is sized from the same
             # value, so the decode cannot disagree with the launch geometry.
             _q_tiles = n_q_tiles
@@ -851,9 +849,7 @@ class SM120FusedMultiHeadAttentionForward:
                     _SCHED_L2_BUDGET_BYTES,
                 )
             else:
-                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt(
-                    q_tile_idx, _n_qh, _n_batch, _q_tiles
-                )
+                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt(q_tile_idx, _n_qh, _n_batch, _q_tiles)
         elif cutlass.const_expr(self.is_causal):
             # Diagonal-bounded work grows with the Q tile. Launch long tiles
             # first to avoid leaving a few expensive CTAs in the final

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -68,8 +68,8 @@ from cudnn.frost.tile_dsl.pointwise import fp32_to_fp8x2, pack_fp8x2_pairs
 from cudnn.frost.tile_dsl.scheduler import (
     SCHED_LPT_L2,
     SCHED_NATURAL,
-    decode_linear_tile_lpt,
-    decode_linear_tile_lpt_l2,
+    lpt_tile_coords,
+    lpt_l2_tile_coords,
 )
 from cudnn.frost.tile_dsl.swizzle import swizzle_xor
 from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_kernel as _build_thd_meta_kernel
@@ -979,7 +979,7 @@ class SM120FusedMultiHeadAttentionForward:
             # value, so the decode cannot disagree with the launch geometry.
             _q_tiles = n_q_tiles
             if cutlass.const_expr(self.sched_policy == SCHED_LPT_L2):
-                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt_l2(
+                q_tile_idx, head_idx, batch_idx = lpt_l2_tile_coords(
                     q_tile_idx,
                     _n_qh,
                     _n_batch,
@@ -990,7 +990,7 @@ class SM120FusedMultiHeadAttentionForward:
                     _SCHED_L2_BUDGET_BYTES,
                 )
             else:
-                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt(q_tile_idx, _n_qh, _n_batch, _q_tiles)
+                q_tile_idx, head_idx, batch_idx = lpt_tile_coords(q_tile_idx, _n_qh, _n_batch, _q_tiles)
         elif cutlass.const_expr(self.is_causal):
             # Causal work grows with the Q tile. Launch long tiles first to
             # avoid leaving a few expensive CTAs in the final scheduler waves.

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -65,6 +65,12 @@ from cutlass.experimental import primitives as prims
 from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_E4M3, DTYPE_E5M2, DTYPE_FP16
 from cudnn.frost.tile_dsl.mma import mma_m16n8k32_f32
 from cudnn.frost.tile_dsl.pointwise import fp32_to_fp8x2, pack_fp8x2_pairs
+from cudnn.frost.tile_dsl.scheduler import (
+    SCHED_LPT_L2,
+    SCHED_NATURAL,
+    decode_linear_tile_lpt,
+    decode_linear_tile_lpt_l2,
+)
 from cudnn.frost.tile_dsl.swizzle import swizzle_xor
 from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_kernel as _build_thd_meta_kernel
 from cudnn.sdpa.fwd.config_sm120 import (
@@ -155,6 +161,10 @@ def pack_to_i32(
     return vals.bitcast(cutlass.Int32)[0]
 
 
+# L2 working-set budget used by the LPT_L2 group sizing.
+_SCHED_L2_BUDGET_BYTES = 50 * 1024 * 1024
+
+
 def ceil_div(a: int, b: int) -> int:
     """Return the ceiling division of a by b."""
     return (a + b - 1) // b
@@ -209,6 +219,7 @@ class SM120FusedMultiHeadAttentionForward:
         in_dtype: Type[cutlass.Numeric] = cutlass.Float8E4M3FN,
         out_dtype: Type[cutlass.Numeric] = cutlass.Float16,
         is_causal: bool = False,
+        sched_policy: int = SCHED_NATURAL,
         bottom_right: bool = False,
         window_size_left: int | None = None,
         window_size_right: int | None = None,
@@ -274,6 +285,7 @@ class SM120FusedMultiHeadAttentionForward:
         self.in_dtype = in_dtype
         self.out_dtype = out_dtype
         self.is_causal = is_causal
+        self.sched_policy = sched_policy
         self.bottom_right = bottom_right
         self.window_size_left = window_size_left
         # The band only TRANSLATES the diagonal (frontier width is
@@ -929,6 +941,7 @@ class SM120FusedMultiHeadAttentionForward:
         softmax_scale_log2: cutlass.Float32,
         o_scale_fused: cutlass.Float32,
         scale_s: cutlass.Float32,
+        n_q_tiles: cutlass.Int32,
     ) -> None:
         """SM120 per-tensor FP8 FMHA prefill kernel.
 
@@ -959,7 +972,30 @@ class SM120FusedMultiHeadAttentionForward:
         """
         tidx, _, _ = cute.arch.thread_idx()
         q_tile_idx, batch_idx, head_idx = cute.arch.block_idx()
-        if cutlass.const_expr(self.is_causal):
+        if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
+            _n_qh = cutlass.Int32(q.shape[2])
+            _n_batch = cutlass.Int32(
+                self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
+            )
+            # Host-computed (see __call__): the grid is sized from the same
+            # value, so the decode cannot disagree with the launch geometry.
+            _q_tiles = n_q_tiles
+            if cutlass.const_expr(self.sched_policy == SCHED_LPT_L2):
+                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt_l2(
+                    q_tile_idx,
+                    _n_qh,
+                    _n_batch,
+                    _q_tiles,
+                    _n_qh // cutlass.Int32(k.shape[2]),
+                    cutlass.Int32(k.shape[1]),
+                    (self.head_tile_qk + self.head_tile_v) * self.in_dtype.width // 8,
+                    _SCHED_L2_BUDGET_BYTES,
+                )
+            else:
+                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt(
+                    q_tile_idx, _n_qh, _n_batch, _q_tiles
+                )
+        elif cutlass.const_expr(self.is_causal):
             # Causal work grows with the Q tile. Launch long tiles first to
             # avoid leaving a few expensive CTAs in the final scheduler waves.
             grid_q, _, _ = cute.arch.grid_dim()
@@ -1631,6 +1667,20 @@ class SM120FusedMultiHeadAttentionForward:
                 thd_lens_form,
                 cutlass.Int32(self.thd_batch),
             ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        # Grid geometry. THD: ceil(max_seq_q / q_tile) tiles per sequence over the
+        # REAL batch count (the packed view's batch mode is 1); tiles past a shorter
+        # sequence's length drain without work. NOTE thd_max_sq is a __call__
+        # argument in this base, not a member.
+        n_q_tiles = ceil_div(thd_max_sq, self.q_tile) if cutlass.const_expr(self.thd_varlen) else ceil_div(q.shape[1], self.q_tile)
+        n_batch = self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
+        n_head = q.shape[2]
+        # LPT / LPT_L2 flatten the 3-D grid so the decode can order the whole tile
+        # set globally (heaviest causal rows first); NATURAL keeps the zero-overhead
+        # 3-D grid. The kernel receives n_q_tiles so its decode uses the same value.
+        if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
+            grid = (n_q_tiles * n_batch * n_head, 1, 1)
+        else:
+            grid = (n_q_tiles, n_batch, n_head)
         self.kernel(
             q,
             k,
@@ -1646,15 +1696,9 @@ class SM120FusedMultiHeadAttentionForward:
             softmax_scale_log2,
             o_scale_fused,
             scale_s,
+            cutlass.Int32(n_q_tiles),
         ).launch(
-            # THD: ceil(max_seq_q / q_tile) tiles per sequence over the real
-            # batch count (the packed view's batch mode is 1); tiles past a
-            # shorter sequence's length drain without work.
-            grid=(
-                ceil_div(thd_max_sq, cutlass.Int32(self.q_tile)) if cutlass.const_expr(self.thd_varlen) else ceil_div(q.shape[1], self.q_tile),
-                self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0],
-                q.shape[2],
-            ),
+            grid=grid,
             block=(self.threads_per_cta, 1, 1),
             stream=stream,
             min_blocks_per_mp=1,
@@ -1702,6 +1746,7 @@ def compile(  # noqa: A001
         in_dtype=IN_DTYPE,
         out_dtype=OUT_DTYPE,
         is_causal=PARAMS.window_right is not None,
+        sched_policy=PARAMS.sched_policy,
         bottom_right=PARAMS.bottom_right,
         window_size_left=PARAMS.window_left,
         window_size_right=PARAMS.window_right,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -974,9 +974,7 @@ class SM120FusedMultiHeadAttentionForward:
         q_tile_idx, batch_idx, head_idx = cute.arch.block_idx()
         if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
             _n_qh = cutlass.Int32(q.shape[2])
-            _n_batch = cutlass.Int32(
-                self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
-            )
+            _n_batch = cutlass.Int32(self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0])
             # Host-computed (see __call__): the grid is sized from the same
             # value, so the decode cannot disagree with the launch geometry.
             _q_tiles = n_q_tiles
@@ -992,9 +990,7 @@ class SM120FusedMultiHeadAttentionForward:
                     _SCHED_L2_BUDGET_BYTES,
                 )
             else:
-                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt(
-                    q_tile_idx, _n_qh, _n_batch, _q_tiles
-                )
+                q_tile_idx, head_idx, batch_idx = decode_linear_tile_lpt(q_tile_idx, _n_qh, _n_batch, _q_tiles)
         elif cutlass.const_expr(self.is_causal):
             # Causal work grows with the Q tile. Launch long tiles first to
             # avoid leaving a few expensive CTAs in the final scheduler waves.

--- a/test/python/sdpa/mxfp8_quant.py
+++ b/test/python/sdpa/mxfp8_quant.py
@@ -38,8 +38,7 @@ Semantics are replicated from the TE sources (verified against the checkout at
   (``swizzle_row_scaling_kernel`` / ``swizzle_col_scaling_kernel``, the target
   of ``tex.swizzle_scales_for_gemm_``), cross-checked against the consumer side
   in this repo (``python/cudnn/sdpa/fwd/api_dsl.py`` ``_reshape_sf`` +
-  ``kernels/prefill_d128_mxfp8_sm100.py`` SF_SMEM_SIZE_*) and VibeTile's
-  ``kernels/ctm/common/quant/mxfp8_quant.py`` SF store: the scale matrix
+  ``kernels/prefill_d128_mxfp8_sm100.py`` SF_SMEM_SIZE_*): the scale matrix
   ``[R, C]`` (R = rows of the GEMM operand as consumed, C = number of
   32-element blocks along the contraction dim) is tiled into 128x4 "atoms" of
   512 bytes, atoms ordered row-major, and inside an atom byte


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable tile scheduling for supported attention workloads, including natural, LPT, and L2-aware LPT strategies.
  * Improved causal-attention scheduling by selecting L2-aware grouping when beneficial.
  * Added support for grouped-query attention and variable key/value sequence lengths across execution paths.
  * Extended scheduler support across supported SM100 and SM120 execution paths.

* **Documentation**
  * Clarified reduction and quantization swizzle documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->