### PR TITLE
Rubin single group runtime offsets

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
+++ b/python/cudnn/gemm/cutedsl/grouped/backend_utils.py
@@ -79,14 +79,8 @@ def backend_cache_key(backend, *components):
 def rubin_single_group_offsets_kwarg(is_rubin_kernel, use_single_group_runtime_offsets):
     """Return the ``use_single_group_runtime_offsets`` kwarg for a kernel constructor.
 
-    The Rubin (sm107) grouped GEMM kernels predate ``use_single_group_runtime_offsets``
-    and do not accept it, so forwarding it unconditionally is a ``TypeError`` even when
-    it is ``False``. Send it only to kernels that implement it, and reject an explicit
-    request on Rubin rather than silently ignoring it and running a different schedule
-    than the caller asked for.
+    All grouped GEMM kernels accepting this helper implement
+    ``use_single_group_runtime_offsets``. Keep the helper so the call sites share a
+    single constructor-argument policy.
     """
-    if not is_rubin_kernel:
-        return {"use_single_group_runtime_offsets": use_single_group_runtime_offsets}
-    if use_single_group_runtime_offsets:
-        raise NotImplementedError("The Rubin grouped GEMM kernels do not support use_single_group_runtime_offsets")
-    return {}
+    return {"use_single_group_runtime_offsets": use_single_group_runtime_offsets}

--- a/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py
@@ -212,6 +212,7 @@ class BlockScaledMoEGroupedGemmGluKernel:
         act_func: str = "swiglu",
         enable_bias: bool = False,
         generate_c: bool = True,
+        use_single_group_runtime_offsets: bool = False,
     ):
         """Initializes the configuration for a Blackwell blockscaled grouped GEMM GLU kernel.
 
@@ -265,11 +266,14 @@ class BlockScaledMoEGroupedGemmGluKernel:
                 )
         if expert_cnt > 1024:
             raise ValueError("Expert count > 1024 is not supported.")
+        if use_single_group_runtime_offsets and expert_cnt != 1:
+            raise ValueError("use_single_group_runtime_offsets requires exactly one expert")
         if not isinstance(weight_mode, MoEWeightMode):
             raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
 
         self.sf_vec_size = sf_vec_size
         self.expert_cnt = expert_cnt
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn
@@ -1632,6 +1636,10 @@ class BlockScaledMoEGroupedGemmGluKernel:
                 cpasync.prefetch_descriptor(tma_atom_d_col)
 
         use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+        if cutlass.const_expr(self.use_single_group_runtime_offsets):
+            runtime_padded_offsets = cute.make_rmem_tensor((1,), cutlass.Int32)
+            runtime_padded_offsets[0] = cutlass.Int32(cute.size(mA_mkl.shape[0]))
+            padded_offsets = runtime_padded_offsets
         total_token = padded_offsets[self.expert_cnt - 1]
 
         #

--- a/python/cudnn/gemm/cutedsl/grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py
@@ -185,6 +185,7 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         weight_mode: MoEWeightMode = MoEWeightMode.DENSE,
         use_dynamic_sched: bool = False,
         epilogue_type: int = EpilogueType.NONE.value,
+        use_single_group_runtime_offsets: bool = False,
     ):
         # Hardware MMA instruction M: 2CTA → 256, 1CTA → 128
         mma_inst_m = 256 if use_2cta_instrs else 128
@@ -209,11 +210,14 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                 )
         if expert_cnt > 1024:
             raise ValueError("Expert count > 1024 is not supported.")
+        if use_single_group_runtime_offsets and expert_cnt != 1:
+            raise ValueError("use_single_group_runtime_offsets requires exactly one expert")
         if not isinstance(weight_mode, MoEWeightMode):
             raise TypeError(f"weight_mode must be a MoEWeightMode, got {type(weight_mode)}")
 
         self.sf_vec_size = sf_vec_size
         self.expert_cnt = expert_cnt
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn
@@ -1367,6 +1371,10 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                 cpasync.prefetch_descriptor(tma_atom_c)
 
         use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+        if cutlass.const_expr(self.use_single_group_runtime_offsets):
+            runtime_padded_offsets = cute.make_rmem_tensor((1,), cutlass.Int32)
+            runtime_padded_offsets[0] = cutlass.Int32(cute.size(mA_mkl.shape[0]))
+            padded_offsets = runtime_padded_offsets
         total_token = padded_offsets[self.expert_cnt - 1]
 
         bidx, bidy, bidz = cute.arch.block_idx()


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option for single-expert grouped matrix multiplication to derive runtime offsets automatically from the input token count.
  * The option is available for both GLU and quantized execution paths.

* **Bug Fixes**
  * Improved handling of runtime offsets by consistently honoring the single-group configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->