### PR TITLE
Memoize the CuTeDSL hot-path dtype/stride conversions (~20% off per-call host)

### DIFF
--- a/python/cudnn/datatypes.py
+++ b/python/cudnn/datatypes.py
@@ -3,6 +3,7 @@
 
 import sys
 import importlib
+import functools
 
 
 def is_windows():
@@ -246,6 +247,9 @@ def _torch_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2: bool = Fals
     return None
 
 
+# Memoized: pure map from a (hashable) dtype to its cutlass type, called O(10x) per
+# CuTeDSL launch to build the per-shape cache key. Finite dtype key space.
+@functools.lru_cache(maxsize=None)
 def _convert_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2: bool = False):
     if is_cutlass_available():
         import cutlass

--- a/python/cudnn/tensor_adapter.py
+++ b/python/cudnn/tensor_adapter.py
@@ -13,6 +13,7 @@ already in sys.modules, so probing sys.modules never triggers an import.
 
 from __future__ import annotations
 
+import functools
 import sys
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple
@@ -152,6 +153,9 @@ def get_compute_capability() -> Tuple[int, int]:
     return major, minor
 
 
+# Memoized: pure function of (shape, stride), called per input tensor on every
+# CuTeDSL launch to build the cache key; bounded since keys are shape-derived.
+@functools.lru_cache(maxsize=4096)
 def canonicalize_unit_dim_strides(shape: Tuple[int, ...], stride: Tuple[int, ...]) -> Tuple[int, ...]:
     """Give extent-1 dims the dense "outermost" stride (numel) so that layouts that differ
     only in unit-dim strides -- which the kernels cannot observe -- compare and compile equal."""


### PR DESCRIPTION
## Summary

Every CuTeDSL GEMM API rebuilds a per-shape cache key on **every** call. Building that key re-runs `_convert_to_cutlass_data_type` ~10×/call and `canonicalize_unit_dim_strides` ~4×/call — even on a cache hit, and even though both are pure functions whose results are invariant for a given shape/dtype. This memoizes them.

Both live in the shared `datatypes.py` / `tensor_adapter.py`, so the win applies to **all** cutedsl kernels (amax, swiglu, srelu, dsrelu, grouped, …), not just amax.

## Measurement (SM100, torch wrapper host cost / call, async dispatch)

Same compiled kernel; only the host path is timed. fp8, c=bf16, sf_vec=32.

| shape | before | after |
|---|---|---|
| 512×256×256 | 33.8 µs | 27.5 µs |
| 2048×2048×2048 | 33.3 µs | **26.8 µs** |
| 8192×4096×2048 | 33.0 µs | 27.1 µs |

~**20% off the per-call host overhead**, shape-independent (it's fixed host work). At small kernels this is the difference between host-bound and not; at large kernels it's hidden under the GPU anyway.

Cache behaves as expected after warmup (50 calls, one shape):
```
_convert_to_cutlass_data_type : hits=368 misses=15 currsize=15   # finite dtype key space
canonicalize_unit_dim_strides : hits=205 misses=3  currsize=3
```

## Why it's safe

- Both are **pure functions of hashable args** (dtype objects / shape+stride tuples). Same input → same output for the process lifetime (cutlass availability is fixed at import).
- `_convert_to_cutlass_data_type` raises `ValueError` for unmappable dtypes — `lru_cache` does not cache exceptions, so that path is unchanged.
- `_convert` → `maxsize=None` (finite dtype space, currsize stays ~15). `canonicalize` → `maxsize=4096` (keys are shape-derived; bounded for hygiene).
- No behavior change; correctness verified against the gemm_amax reference (`check_ref_gemm_amax`, amax bit-exact vs max|c|).

## Context

Part of a host-overhead investigation on the imperative cutedsl APIs (TE/JAX MLPerf ask). This is the cheapest, zero-risk slice; the larger levers (per-launch bare-launch of the cute dispatch, C++/AOT execute to remove Python entirely, folding the amax `-inf` fill into the kernel) are separate.

## Test plan

- [x] Correctness vs reference on SM100 (gemm_amax fp8), unchanged.
- [x] `pre-commit run` (black) clean.
- [ ] CI test suites (not run locally).

---
<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code) · note to self: claude session — "cutedsl host-overhead: hot-path memoization" · cwd /home/scratch.yanxu_libs/cudnn_frontend</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance for repeated data type conversions.
  * Improved performance when repeatedly processing tensor dimension strides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->