### PR TITLE
Avoid zero-initializing JAX grouped GEMM outputs

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/unfused/jax_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused/jax_api.py
@@ -28,7 +28,7 @@ from cutlass.cute.nvgpu import OperandMajorMode
 
 from cudnn.datatypes import _convert_to_cutlass_data_type
 from cudnn.tensor_adapter import framework_dtype
-from cudnn.jax import TensorSpec, call, gemm_operand_spec, zeros_init
+from cudnn.jax import TensorSpec, call, gemm_operand_spec
 from ..moe_utils import MoEWeightMode
 from .moe_grouped_gemm import MoEGroupedGemmBf16Kernel
 
@@ -108,9 +108,8 @@ def grouped_gemm_jax_sm100(
     row offsets, ``alpha (experts,)`` float32, ``prob (m, 1, 1)`` float32, and
     ``b_ptrs`` holding per-expert ``(n, k)`` k-major bfloat16 weight base addresses
     (packed little-endian uint8, 8 bytes per pointer — or int64 with x64 mode).
-    Returns ``(d_tensor, c_tensor)`` with ``c_tensor`` None unless ``generate_c``;
-    rows at/past ``padded_offsets[-1]`` come back zero-filled (the outputs are
-    donated zero-initialized buffers).
+    Returns ``(d_tensor, c_tensor)`` with ``c_tensor`` None unless ``generate_c``.
+    Rows at/past ``padded_offsets[-1]`` are unspecified.
     """
     c_dtype = _convert_to_cutlass_data_type(c_dtype)
     d_dtype = _convert_to_cutlass_data_type(d_dtype)
@@ -207,10 +206,6 @@ def grouped_gemm_jax_sm100(
         ),
         input_spec=(operand, None, None, None, _prob_spec()),
         output_spec=(operand, operand, None),
-        # All three donated: c/d for the trailing-unit-dim layout spec (and defined
-        # bytes past the last offset); the workspace because the helper kernel writes
-        # the per-expert TMA descriptors into it (XLA inputs are immutable).
-        initialized_outputs={0: zeros_init, 1: zeros_init, 2: zeros_init},
         kernel=kernel,
         n=int(n),
         k=int(k),


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

Python API or bindings

## Summary

Stop zero-initializing the D, C, and workspace outputs of `grouped_gemm_jax_sm100`. The output specs and CuTeDSL kernel are unchanged. Document that rows at or beyond the final padded offset are unspecified.

## Why

Passing `initialized_outputs` makes JAX zero-fill three output buffers before every grouped GEMM dispatch. The grouped GEMM writes the addressed D/C rows, and its helper writes the workspace. Requiring zero-filled padding adds large device operations to the JAX path without benefiting full-coverage calls, while the equivalent PyTorch API allocates outputs with `empty_strided`.

Same-node A/B results on an isolated ComputeLab B200 using
`benchmark/grouped_gemm_dispatch/bench_dispatch.py` from
[MR 2332](https://gitlab-master.nvidia.com/cudnn/cudnn_frontend/-/merge_requests/2332)
at head `92b46b39099cec904d62aec0de074b8c0c712201`:

| M x N x K | Parent (us) | This PR (us) | Latency reduction |
| --- | ---: | ---: | ---: |
| 2048 x 2048 x 2048 | 37.135 | 30.751 | 17.2% |
| 4096 x 2048 x 2048 | 53.145 | 37.618 | 29.2% |
| 8192 x 4096 x 2048 | 132.452 | 101.144 | 23.6% |
| 16384 x 4096 x 4096 | 412.191 | 367.296 | 10.9% |

Environment: one B200 (SM100), cuDNN 9.24.0, CUDA 13.3, JAX 0.11.0, and NVIDIA CUTLASS DSL 4.6.2. Each value is the median of five complete harness invocations, alternating parent/head run order. Each invocation uses five warmups followed by 30 calls and one final `block_until_ready()`. Median kernel and Torch-execute controls differed by at most 1.5% between variants.

## Related issues

None.

## API and compatibility impact

Rows before `padded_offsets[-1]` are unchanged. Rows at or beyond that offset are now explicitly unspecified instead of guaranteed to be zero. No kernel or output-layout changes are included.

## Testing

- `uvx pre-commit run --files python/cudnn/gemm/cutedsl/grouped/unfused/jax_api.py` (passed)
- `cd test/python && timeout 120 python -m pytest -q -m L0 fe_api/grouped_gemm/test_grouped_gemm_jax.py::test_grouped_gemm_jax_jit_matches_eager` on ComputeLab B200 (`1 passed`)
- Five alternating parent/head runs of `timeout 900 python benchmark/grouped_gemm_dispatch/bench_dispatch.py --api unfused --json <output>` on the same ComputeLab B200
