### PR TITLE
frost(sdpa): add more features to sm120 frost fp8 sdpa_fwd kernel

### DIFF
--- a/python/cudnn/frost/tile_dsl/mma.py
+++ b/python/cudnn/frost/tile_dsl/mma.py
@@ -13,7 +13,7 @@ from .swizzle import swizzle_xor_128b, swizzle_lin_128b
 
 
 @cute.jit
-def ptx_mma_m16n8k16_f32(
+def mma_m16n8k16_f32(
     a0: cutlass.Int32,
     a1: cutlass.Int32,
     a2: cutlass.Int32,
@@ -43,7 +43,7 @@ def ptx_mma_m16n8k16_f32(
 
 
 @cute.jit
-def ptx_mma_m16n8k32_e4m3_f32(
+def mma_m16n8k32_f32(
     a0: cutlass.Int32,
     a1: cutlass.Int32,
     a2: cutlass.Int32,
@@ -54,18 +54,22 @@ def ptx_mma_m16n8k32_e4m3_f32(
     c1: cutlass.Float32,
     c2: cutlass.Float32,
     c3: cutlass.Float32,
+    ab_dtype: cutlass.Constexpr[Type[cutlass.Numeric]],
 ) -> tuple[cutlass.Float32, cutlass.Float32, cutlass.Float32, cutlass.Float32]:
-    """``mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32`` (SM89+/SM120).
+    """``mma.sync.aligned.m16n8k32.row.col.f32.{e4m3|e5m2}.{e4m3|e5m2}.f32``.
 
     The C operands travel as ``Int32`` bit patterns and are ``mov.b32``'d into
     ``.f32`` temps inside the asm block: cutlass-dsl 4.7.0's ``inline_ptx``
     fails in libNVVM when a compile-time-constant ``Float32`` reaches
     ``read_only_args``, and an accumulator's zero-init can fold to a constant.
     """
+    if cutlass.const_expr(ab_dtype != cutlass.Float8E4M3FN and ab_dtype != cutlass.Float8E5M2):
+        raise TypeError(f"Invalid A/B dtype: {ab_dtype}")
+    ab_tag = "e4m3" if cutlass.const_expr(ab_dtype == cutlass.Float8E4M3FN) else "e5m2"
     return cute.arch.inline_ptx(
         "{ .reg .f32 fc<4>; "
         "mov.b32 fc0, {$r6}; mov.b32 fc1, {$r7}; mov.b32 fc2, {$r8}; mov.b32 fc3, {$r9}; "
-        "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
+        f"mma.sync.aligned.m16n8k32.row.col.f32.{ab_tag}.{ab_tag}.f32 "
         "{{$w0},{$w1},{$w2},{$w3}}, {{$r0},{$r1},{$r2},{$r3}}, {{$r4},{$r5}}, {fc0,fc1,fc2,fc3}; }",
         write_only_types=[
             cutlass.Float32,
@@ -85,34 +89,6 @@ def ptx_mma_m16n8k32_e4m3_f32(
             c2.bitcast(cutlass.Int32),
             c3.bitcast(cutlass.Int32),
         ],
-    )
-
-
-@cute.jit
-def ptx_cvt_e4m3x2(hi: cutlass.Float32, lo: cutlass.Float32) -> cutlass.Uint16:
-    """Pack two fp32 into e4m3 bytes: low byte = e4m3(lo), byte 1 = e4m3(hi).
-
-    ``cvt.rn.satfinite.e4m3x2.f32`` matches torch's ``.to(float8_e4m3fn)``
-    bit-exactly. Operands ride as Int32 bit patterns for the same
-    constant-operand ``inline_ptx`` reason as :func:`ptx_mma_m16n8k32_e4m3_f32`.
-
-    Stays 16-bit so two results pair into one MMA operand register with
-    :func:`pack_f8x2_pairs`.
-    """
-    return cute.arch.inline_ptx(
-        "{ .reg .f32 fa, fb; " "mov.b32 fa, {$r0}; mov.b32 fb, {$r1}; " "cvt.rn.satfinite.e4m3x2.f32 {$w0}, fa, fb; }",
-        write_only_types=[cutlass.Uint16],
-        read_only_args=[hi.bitcast(cutlass.Int32), lo.bitcast(cutlass.Int32)],
-    )
-
-
-@cute.jit
-def pack_f8x2_pairs(pair0: cutlass.Uint16, pair1: cutlass.Uint16) -> cutlass.Int32:
-    """Two e4m3x2 halves into one 32-bit MMA A/B operand (pair0 = low half)."""
-    return cute.arch.inline_ptx(
-        "mov.b32 $0, {$1, $2};",
-        write_only_types=[cutlass.Int32],
-        read_only_args=[pair0, pair1],
     )
 
 

--- a/python/cudnn/frost/tile_dsl/pointwise.py
+++ b/python/cudnn/frost/tile_dsl/pointwise.py
@@ -3,6 +3,7 @@
 
 
 import inspect
+from typing import Type
 
 import cutlass
 from cutlass.cute.arch.nvvm_wrappers import inline_ptx
@@ -146,6 +147,29 @@ def fp32_to_fp8_pack(values, *, dtype_tag: str):
         read_only_args=list(values),
     )
     return cutlass.Vector.from_elements((u0, u1, u2, u3), cutlass.Int32)
+
+
+@cute.jit
+def fp32_to_fp8x2(lo: cutlass.Float32, hi: cutlass.Float32, *, dtype: cutlass.Constexpr[Type[cutlass.Numeric]] = cutlass.Float8E4M3FN) -> cutlass.Uint16:
+    """Pack two fp32 into fp8 bytes: low byte = fp8(lo), byte 1 = fp8(hi)."""
+    if cutlass.const_expr(dtype != cutlass.Float8E4M3FN and dtype != cutlass.Float8E5M2):
+        raise TypeError(f"Invalid FP8 dtype: {dtype}")
+    cvt_tag = "e4m3x2" if cutlass.const_expr(dtype == cutlass.Float8E4M3FN) else "e5m2x2"
+    return cute.arch.inline_ptx(
+        "{ .reg .f32 fa, fb; mov.b32 fa, {$r0}; mov.b32 fb, {$r1}; " + f"cvt.rn.satfinite.{cvt_tag}.f32 " + "{$w0}, fa, fb; }",
+        write_only_types=[cutlass.Uint16],
+        read_only_args=[hi.bitcast(cutlass.Int32), lo.bitcast(cutlass.Int32)],
+    )
+
+
+@cute.jit
+def pack_fp8x2_pairs(pair0: cutlass.Uint16, pair1: cutlass.Uint16) -> cutlass.Int32:
+    """Two fp8x2 halves into one 32-bit MMA A/B operand (pair0 = low half)."""
+    return cute.arch.inline_ptx(
+        "mov.b32 $0, {$1, $2};",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[pair0, pair1],
+    )
 
 
 def vec_scale_pair(vec, scalar, N):

--- a/python/cudnn/frost/tile_dsl/pointwise.py
+++ b/python/cudnn/frost/tile_dsl/pointwise.py
@@ -125,9 +125,14 @@ def fp32_to_fp16(lo, hi, *, dtype=cutlass.Float16):
     )
 
 
-def fp32_to_fp8_pack(values, *, dtype_tag: str):
+def fp32_to_fp8_pack(values, *, dtype: Type[cutlass.Numeric]):
     assert len(values) == 16, f"fp32_to_fp8_pack: expected 16 input values, got {len(values)}"
-    assert dtype_tag in ("e4m3", "e5m2"), f"fp32_to_fp8_pack: dtype_tag must be 'e4m3' or 'e5m2', got {dtype_tag!r}"
+    if dtype == cutlass.Float8E4M3FN:
+        dtype_tag = "e4m3"
+    elif dtype == cutlass.Float8E5M2:
+        dtype_tag = "e5m2"
+    else:
+        raise TypeError(f"fp32_to_fp8_pack: dtype must be Float8E4M3FN or Float8E5M2, got {dtype}")
 
     u0, u1, u2, u3 = inline_ptx(
         "{ .reg .b16 lo, hi;\n"

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm120.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm120.py
@@ -47,7 +47,7 @@ from cutlass.experimental import primitives as prims
 from cutlass._mlir.dialects import arith
 
 from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_FP16
-from cudnn.frost.tile_dsl.mma import ptx_mma_m16n8k16_f32
+from cudnn.frost.tile_dsl.mma import mma_m16n8k16_f32
 from cudnn.frost.tile_dsl.swizzle import swizzle_xor
 from cudnn.sdpa.bwd.config_sm120 import TemplateParams, validate_params
 
@@ -205,7 +205,7 @@ def mma_bstream(
             a_off = m_block * a_stride
             for half in cutlass.range_constexpr(2):
                 s = (m_block * N_FRAGS + n_frag + half) * 4
-                c0, c1, c2, c3 = ptx_mma_m16n8k16_f32(
+                c0, c1, c2, c3 = mma_m16n8k16_f32(
                     a_frag[a_off + 0],
                     a_frag[a_off + 1],
                     a_frag[a_off + 2],
@@ -249,7 +249,7 @@ def mma_abregs(
             a_off = m_block * a_stride
             for half in cutlass.range_constexpr(2):
                 s = (m_block * N_FRAGS + n_frag + half) * 4
-                c0, c1, c2, c3 = ptx_mma_m16n8k16_f32(
+                c0, c1, c2, c3 = mma_m16n8k16_f32(
                     a_frag[a_off + 0],
                     a_frag[a_off + 1],
                     a_frag[a_off + 2],

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -33,7 +33,7 @@ from cudnn.sdpa.fwd.config_sm120 import (
     SEQ_KV_TILES as _SM120_KV_TILES,
     SEQ_Q_TILES as _SM120_Q_TILES,
     SUPPORTED_HEAD_TILE_MAX as _SM120_HEAD_TILE_MAX,
-    SUPPORTED_HEAD_TILES_FP8 as _SM120_FP8_HEAD_TILES,
+    FP8_HEAD_TILE_GRANULE as _SM120_FP8_HEAD_TILE_GRANULE,
     TemplateParams as Sm120TemplateParams,
     smem_bytes as _sm120_smem_bytes,
 )
@@ -117,10 +117,12 @@ _SM107_FP8_KERNEL_FILE = "prefill_d128_fp8_sm107.py"
 _SM100_TILE_N = 128
 
 _SM120_KERNEL_FILE = "prefill_f16_sm120.py"
-# Per-tensor FP8 sibling (E4M3 in as Uint8 storage, FP16 out, mma.sync
+# Per-tensor FP8 kernel (E4M3/E5M2 in, FP16/BF16/FP8 out, mma.sync
 # m16n8k32); selected by the graph op (sdpa_fp8) via check_support's dtype.
 _SM120_FP8_KERNEL_FILE = "prefill_fp8_sm120.py"
 _SM120_DTYPE_QKV_CODE = {
+    torch.float8_e4m3fn: DTYPE_E4M3,
+    torch.float8_e5m2: DTYPE_E5M2,
     torch.bfloat16: DTYPE_BF16,
     torch.float16: DTYPE_FP16,
 }
@@ -1949,13 +1951,13 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             f"D_V ({d_v}) must be a multiple of 8 (TMA 16-byte global-stride rule at 2 B/elem) and <= {_SM120_HEAD_TILE_MAX}",
         )
 
-        self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16, torch.float8_e4m3fn], name="Q")
-        self._fp8 = self.dtype == torch.float8_e4m3fn
+        self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16, *_SM100_FP8_DTYPES], name="Q")
+        self._fp8 = self.dtype in _SM100_FP8_DTYPES
         for desc in (self.k_desc, self.v_desc, self.o_desc):
             if self._fp8 and desc is self.o_desc:
-                # The fp8 kernel's epilogue emits FP16 only (see the kernel
-                # docstring); fp8 O would need a scale_o quantizing store.
-                self._check_dtype(desc, torch.float16, name="O", extra_error_msg="SM120 fp8 emits FP16 O only")
+                # SDPA_FP8's O dtype is independent of QKV: fp16/bf16 ride the
+                # staging epilogue, fp8 the direct quantizing store.
+                self._check_dtype(desc, [torch.float16, torch.bfloat16, *_SM100_FP8_DTYPES], name="O")
             else:
                 self._check_dtype(
                     desc,
@@ -1972,20 +1974,9 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
                 not self._pertensor,
                 "SM120 fp8 serves the per-tensor SDPA_FP8 op only (no MXFP8 cell)",
             )
-            # THD is served; token-major ragged Stats is not. This kernel's
-            # ragged LSE store is unconditionally head-major (it writes
-            # lse[0, head, q_row_base + row]) — the f16 cell is the one that
-            # specializes on both layouts.
-            self._not_implemented_error_if(
-                self.thd and self.lse_desc is not None and not self.thd_stats_head_major,
-                "SM120 fp8 THD serves head-major ragged Stats only (token-major is f16-only)",
-            )
-            self._value_error_if(self.has_sink, "SM120 fp8 does not support attention sinks (Amax_S semantics)")
-            self._value_error_if(self.seq_q_lens_present and not self.thd, "SM120 fp8 does not support per-batch seq_len_q")
             self._value_error_if(
-                any(d not in _SM120_FP8_HEAD_TILES for d in (d_q, d_v)),
-                f"SM120 fp8 requires D_QK and D_V to be multiples of 32 within 32..256 (k32 contraction and 1-byte "
-                f"TMA swizzle span; no zero-padding envelope on the 8-bit fragment path); got ({d_q}, {d_v})",
+                d_q % 16 != 0 or d_v % 16 != 0,
+                f"SM120 fp8 requires D_QK/D_V multiples of 16, got ({d_q}, {d_v})",
             )
 
         self._value_error_if(
@@ -2036,8 +2027,9 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         # SMEM tiles are sized at the ENVELOPE-padded head tiles (rounded up
         # to the head-tile granule), not the actual dims — the kernel stages
         # full tiles and the TMA zero-fills the pad columns.
-        d_qp = -(-d_q // _SM120_HEAD_TILE_GRANULE) * _SM120_HEAD_TILE_GRANULE
-        d_vp = -(-d_v // _SM120_HEAD_TILE_GRANULE) * _SM120_HEAD_TILE_GRANULE
+        granule = _SM120_FP8_HEAD_TILE_GRANULE if self._fp8 else _SM120_HEAD_TILE_GRANULE
+        d_qp = -(-d_q // granule) * granule
+        d_vp = -(-d_v // granule) * granule
 
         def _smem_bytes(kv_tile: int) -> int:
             # FP8 stages a byte per KV element but still writes O in half.
@@ -2078,7 +2070,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             return
 
         params = Sm120TemplateParams(
-            dtype_qkv=DTYPE_E4M3 if self._fp8 else _SM120_DTYPE_QKV_CODE[self.dtype],
+            dtype_qkv=_SM120_DTYPE_QKV_CODE[self.dtype],
+            dtype_o=_SM120_DTYPE_QKV_CODE[self.o_desc.dtype],
             window_left=self.window_left,
             window_right=self.window_right,
             bottom_right=self.causal_bottom_right,
@@ -2181,6 +2174,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
                 amax_o,
                 descale_s,
                 scale_s,
+                sinks=sinks,
                 seq_q_lens=seq_q_lens,
                 workspace=workspace,
                 current_stream=current_stream,
@@ -2270,6 +2264,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         amax_o,
         descale_s=None,
         scale_s=None,
+        sinks=None,
         seq_q_lens=None,
         workspace=None,
         current_stream=None,
@@ -2279,13 +2274,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         ``descale_q*descale_k`` folds into ``scale_softmax_log2`` and
         ``descale_s*descale_v*scale_o`` into the kernel's ``o_scale_fused``
         scalar; ``scale_s`` goes in separately because it multiplies P before
-        the e4m3 cast rather than the output (the FORT ordering: amax on the
-        unscaled softmax result, then scale, then cast).
-        ``Amax_S`` is produced in-kernel (bitcast-int32 atomicMax of the
-        per-row ``1/row_sum``) into the caller's pre-zeroed buffer; ``Amax_O``
-        is ``max|o_scaled|/scale_o`` post-kernel (exact for the FP16 output).
-        E4M3 tensors travel as ``uint8`` views — the kernel consumes bit
-        patterns (see the kernel docstring).
+        the fp8 cast rather than the output (the FORT ordering: the softmax
+        denominator reads the unscaled result, then scale, then cast).
+        ``Amax_O`` is ``max|o_scaled|/scale_o`` post-kernel (pre-cast fp32,
+        so exact for every O dtype including the fp8 quantizing store).
         """
         import cutlass
 
@@ -2306,39 +2298,70 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             self.lse_desc is None and lse_tensor is not None,
             "this specialization was compiled without an LSE output; construct the API with sample_lse",
         )
-        seq_kv_t = (
-            self._checked_seq_lens(seq_kv_lens, "seq_kv_lens")
-            if seq_kv_lens is not None
-            else self._dummy("seq_kv_lens", device, lambda: torch.zeros(self.batch_size, dtype=torch.int32, device=device))
-        )
-        seq_q_dummy = self._dummy("seq_q_lens", device, lambda: torch.zeros(self.batch_size, dtype=torch.int32, device=device))
         if current_stream is None:
             current_stream = cuda.CUstream(torch.cuda.current_stream(device).cuda_stream)
 
-        q = self._to_bshd(q_tensor).view(torch.uint8)
-        k = self._to_bshd(k_tensor).view(torch.uint8)
-        v = self._to_bshd(v_tensor).view(torch.uint8)
-        o_view, o_needs_copy_back, o_scratch = self._to_bshd_writable(o_tensor)
-        o = o_scratch if o_needs_copy_back else o_view
-
+        sinks_t = self._checked_sinks_1d(sinks) if sinks is not None else None
         # THD packs the batch away, so the ragged views and the per-execute
         # compile replace the dense buffers; everything else (the folded
-        # scalars, the amax protocol) is identical.
+        # scalars, the amax protocol) is identical. THD buffers go to
+        # _thd_pack RAW: callers may bind ragged storage in any rank (mhas
+        # hands flat (T, H, D) buffers), the packed as_strided views read raw
+        # storage directly, and the dense _to_bshd_writable normalization
+        # must NOT run -- its scratch copy-back is a SEMANTIC (shape-wise)
+        # copy that scrambles packed bytes whenever it misreads such a buffer
+        # as a non-BSHD dense layout (h > 1; size-1 axes made h == 1 immune).
         pack = None
+        q = k = v = o = None
+        o_needs_copy_back = False
+        seq_kv_t = seq_q_t = None
         if self.thd:
-            pack = self._thd_pack(q, k, v, o, seq_q_lens, seq_kv_lens, workspace, "SdpaFwdDslSm120 (FP8 THD)", current_stream=current_stream)
+            # A token-major LSE shares the Q/O dynamic token symbol, so its
+            # capacity joins their floor; head-major carries its own declared
+            # head_stride (covering the packed total is caller contract — t_q
+            # is a device value, Rule 3).
+            lse_cap = lse_tensor.numel() // self.h_q if (lse_tensor is not None and not self.thd_stats_head_major) else None
+            pack = self._thd_pack(
+                q_tensor,
+                k_tensor,
+                v_tensor,
+                o_tensor,
+                seq_q_lens,
+                seq_kv_lens,
+                workspace,
+                "SdpaFwdDslSm120 (FP8 THD)",
+                current_stream=current_stream,
+                lse_tokens_cap=lse_cap,
+            )
             if pack is None:
                 return
-            # This kernel's ragged LSE store is head-major (H, head_stride):
-            # tokens contiguous within a head row. (The f16 cell specializes on
-            # either layout; check_support declines token-major here.)
-            # head_stride covering the packed total is caller contract — the
-            # total is a device value (Rule 3).
+            # The kernel specializes on either ragged-Stats layout:
+            #   token-major packed (T, H) or head-major (H, head_stride)
             lse = None
             if lse_tensor is not None:
-                head_stride = self.thd_stats_head_stride
-                lse = lse_tensor.as_strided((self.h_q, head_stride), (head_stride, 1), lse_tensor.storage_offset())
+                if self.thd_stats_head_major:
+                    head_stride = self.thd_stats_head_stride
+                    lse = lse_tensor.as_strided((self.h_q, head_stride), (head_stride, 1), lse_tensor.storage_offset())
+                else:
+                    lse = lse_tensor.as_strided((pack.t_q, self.h_q), (self.h_q, 1), lse_tensor.storage_offset())
         else:
+            seq_kv_t = (
+                self._checked_seq_lens(seq_kv_lens, "seq_kv_lens")
+                if seq_kv_lens is not None
+                else self._dummy("seq_kv_lens", device, lambda: torch.zeros(self.batch_size, dtype=torch.int32, device=device))
+            )
+            # Dense padded-Q trim: bind the REAL per-batch Q lengths whenever
+            # the graph carries them — a zeroed dummy would trim every row.
+            seq_q_t = (
+                self._checked_seq_lens(seq_q_lens, "seq_q_lens")
+                if seq_q_lens is not None
+                else self._dummy("seq_q_lens", device, lambda: torch.zeros(self.batch_size, dtype=torch.int32, device=device))
+            )
+            q = self._to_bshd(q_tensor)
+            k = self._to_bshd(k_tensor)
+            v = self._to_bshd(v_tensor)
+            o_view, o_needs_copy_back, o_scratch = self._to_bshd_writable(o_tensor)
+            o = o_scratch if o_needs_copy_back else o_view
             lse = self._checked_lse_view(lse_tensor) if lse_tensor is not None else None
 
         # amax_o: the kernel atomicMax'es into this buffer, so it MUST start
@@ -2359,8 +2382,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             pack.V if pack is not None else v,
             pack.O if pack is not None else o,
             lse,
-            None,  # sinks: fp8 cell rejects has_sink
-            pack.seq_q_dummy if pack is not None else seq_q_dummy,
+            sinks_t,
+            pack.seq_q_dummy if pack is not None else seq_q_t,
             pack.meta if pack is not None else seq_kv_t,
             amax_o_buf.view(torch.int32),
             cutlass.Float32(scale_softmax_log2),
@@ -2400,8 +2423,9 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             lse_head_stride=self.thd_stats_head_stride,
         )
         if self._fp8:
-            # The FP8 cell serves only the packed contract (no stride keys)
-            # and its ragged LSE store is head-major-only.
+            # The FP8 cell serves only the packed contract (no stride keys);
+            # its ragged LSE store specializes on either layout.
+            kwargs.update(lse_head_major=self.thd_stats_head_major)
             return kwargs
 
         def _key(desc):

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1350,12 +1350,18 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # A zero-token packed K/V view cannot back a CuTe layout / TMA
             # descriptor, so clamp the packed KV extent to ONE
             # never-dereferenced token (every tile sees kv_left ==
-            # kv_right == 0, so no K/V load is ever issued) bound over
-            # storage guaranteed large enough: Q backs K (kh*d_qk <=
-            # t_q*qh*d_qk) and O backs V (kh*d_v <= t_q*qh*d_v).
+            # kv_right == 0, so no K/V load is ever issued). Q backs K
+            # (same element type, and kh*d_qk <= t_q*qh*d_qk); V must carry
+            # the INPUT element type, which no output buffer guarantees (O's
+            # dtype is independent), and Q's storage is not always large
+            # enough for kh*d_v — so V binds a cached zero stub (allocated
+            # once, off the execute hot path).
             t_kv = 1
             K = q_buf.as_strided((1, 1, kh, d_qk), (kh * d_qk, kh * d_qk, d_qk, 1), q_buf.storage_offset())
-            V = o_buf.as_strided((1, 1, kh, d_v), (kh * d_v, kh * d_v, d_v, 1), o_buf.storage_offset())
+            with _torch_stream_context(current_stream, dev):
+                V = self._dummy(f"thd_v_stub_{d_v}", dev, lambda: torch.zeros(kh * d_v, dtype=q_buf.dtype, device=dev)).as_strided(
+                    (1, 1, kh, d_v), (kh * d_v, kh * d_v, d_v, 1), 0
+                )
         else:
             K = self._thd_view(k_buf, self.k_desc, t_kv)
             V = self._thd_view(v_buf, self.v_desc, t_kv)
@@ -2512,13 +2518,19 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             # (AGENTS.md Rule 1). A zero-token packed K/V view cannot back a
             # CuTe layout, so clamp the packed KV extent to ONE
             # never-dereferenced token (every sequence's KV tile range is
-            # empty, so no K/V load is ever issued) bound over storage
-            # guaranteed large enough: Q backs K (kh*d_qk <= t_q*qh*d_qk) and
-            # O backs V (kh*d_v <= t_q*qh*d_v). All-zero LENGTHS over live
-            # storage launch normally through the dead-row path.
+            # empty, so no K/V load is ever issued). Q backs K (same element
+            # type, and kh*d_qk <= t_q*qh*d_qk); V must carry the INPUT
+            # element type, which no output buffer guarantees (O's dtype is
+            # independent), and Q's storage is not always large enough for
+            # kh*d_v — so V binds a cached zero stub (allocated once, off the
+            # execute hot path). All-zero LENGTHS over live storage launch
+            # normally through the dead-row path.
             t_kv = 1
             K = q_buf.as_strided((1, 1, kh, d_qk), (kh * d_qk, kh * d_qk, d_qk, 1), q_buf.storage_offset())
-            V = o_buf.as_strided((1, 1, kh, d_v), (kh * d_v, kh * d_v, d_v, 1), o_buf.storage_offset())
+            with _torch_stream_context(current_stream, dev):
+                V = self._dummy(f"thd_v_stub_{d_v}", dev, lambda: torch.zeros(kh * d_v, dtype=q_buf.dtype, device=dev)).as_strided(
+                    (1, 1, kh, d_v), (kh * d_v, kh * d_v, d_v, 1), 0
+                )
         else:
             K = _view(k_buf, self.k_desc, t_kv, kh, d_qk)
             V = _view(v_buf, self.v_desc, t_kv, kh, d_v)

--- a/python/cudnn/sdpa/fwd/config_sm120.py
+++ b/python/cudnn/sdpa/fwd/config_sm120.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_E4M3, DTYPE_FP16  # noqa: F401  (DTYPE_E4M3 re-exported for the FP8 template)
+from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_E4M3, DTYPE_E5M2, DTYPE_FP16  # noqa: F401  (DTYPE_E4M3 re-exported for the FP8 template)
 
 SEQ_Q_TILES = (128, 64)
 SEQ_KV_TILES = (128, 64)
@@ -51,6 +51,10 @@ class TemplateParams:
     """
 
     dtype_qkv: int = DTYPE_FP16
+    # O dtype (frost tile_dsl codes, same table as dtype_qkv). The f16
+    # template stores O at the input dtype and ignores this; the FP8 template
+    # selects its quantizing-store epilogue from it (E4M3/E5M2/BF16/FP16).
+    dtype_o: int = DTYPE_FP16
     # The mask is ONE diagonal band (same model as config_sm100 / the analyzer
     # facts): per-side offsets from the diagonal, None = unbounded on that
     # side. window_right = 0 is plain causal; window_right > 0 widens the
@@ -77,12 +81,14 @@ def validate_params(
     Reachable failures should already have been rejected by the engine
     capabilities or adapter support checks; this validation is a backstop for
     direct template use. ``allowed_dtypes`` defaults to the FP16/BF16 template's
-    set; the FP8 template passes its own. ``allow_right_band=False`` also
-    rejects a widened right band, which the FP8 template does not plumb.
+    set; the FP8 template passes its own. ``allow_right_band=False`` rejects a
+    widened right band for templates that do not plumb one.
     """
 
     if params.dtype_qkv not in allowed_dtypes:
         raise ValueError(f"SM120 SDPA: dtype_qkv must be one of {allowed_dtypes}; got {params.dtype_qkv}")
+    if params.dtype_o not in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16):
+        raise ValueError(f"SM120 SDPA: dtype_o must be a frost tile_dsl dtype code (E4M3/E5M2/BF16/FP16); got {params.dtype_o}")
     if params.window_right is not None and params.window_right < 0:
         raise ValueError(f"SM120 SDPA: window_right must be None (unbounded) or >= 0 (0 = plain causal); got {params.window_right}")
     if not allow_right_band and params.window_right not in (None, 0):

--- a/python/cudnn/sdpa/fwd/config_sm120.py
+++ b/python/cudnn/sdpa/fwd/config_sm120.py
@@ -74,21 +74,24 @@ class TemplateParams:
 def validate_params(
     params: TemplateParams,
     allowed_dtypes: tuple[int, ...] = (DTYPE_BF16, DTYPE_FP16),
+    allowed_o_dtypes: tuple[int, ...] = (DTYPE_BF16, DTYPE_FP16),
     allow_right_band: bool = True,
 ) -> None:
     """Validate the SM120 template specialization.
 
     Reachable failures should already have been rejected by the engine
     capabilities or adapter support checks; this validation is a backstop for
-    direct template use. ``allowed_dtypes`` defaults to the FP16/BF16 template's
-    set; the FP8 template passes its own. ``allow_right_band=False`` rejects a
+    direct template use. ``allowed_dtypes``/``allowed_o_dtypes`` default to the
+    FP16/BF16 template's sets (which stores O at the input dtype and plumbs no
+    quantizing epilogue); the FP8 template passes its own — FP8 in, any of its
+    four quantizing-store epilogues out. ``allow_right_band=False`` rejects a
     widened right band for templates that do not plumb one.
     """
 
     if params.dtype_qkv not in allowed_dtypes:
         raise ValueError(f"SM120 SDPA: dtype_qkv must be one of {allowed_dtypes}; got {params.dtype_qkv}")
-    if params.dtype_o not in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16):
-        raise ValueError(f"SM120 SDPA: dtype_o must be a frost tile_dsl dtype code (E4M3/E5M2/BF16/FP16); got {params.dtype_o}")
+    if params.dtype_o not in allowed_o_dtypes:
+        raise ValueError(f"SM120 SDPA: dtype_o must be one of {allowed_o_dtypes}; got {params.dtype_o}")
     if params.window_right is not None and params.window_right < 0:
         raise ValueError(f"SM120 SDPA: window_right must be None (unbounded) or >= 0 (0 = plain causal); got {params.window_right}")
     if not allow_right_band and params.window_right not in (None, 0):

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -109,7 +109,7 @@ class Capabilities:
     # global-stride rule at 2 bytes/elem) via TMA zero-padding — the kernel's
     # descriptors carry the ACTUAL extents, so padded contraction columns load
     # as exact zeros (S/softmax unchanged) and O stores past d_v are
-    # OOB-clipped. False = only the native dims above are eligible (FP8/MXFP8,
+    # OOB-clipped. False = only the native dims above are eligible (MXFP8,
     # whose SF plumbing is not audited for zero-padding).
     d_envelope: bool = False
     # Alignment rule for envelope rows: graph head dims must be multiples of
@@ -171,8 +171,9 @@ class Capabilities:
     cu_seq_len: bool = False
     # Dense padded + stats needs the per-batch seq_len_q LSE trim (padded
     # q-rows write LSE=-inf / O=0, cuDNN >= 9.14). Plumbed for the half
-    # kernels via SEQ_Q_LENS_PRESENT; the FP8/MXFP8 kernels lack the epilogue
-    # trim, so their specs keep this False.
+    # kernels and the SM120 fp8 kernel via SEQ_Q_LENS_PRESENT; the SM100
+    # FP8/MXFP8 kernels lack the epilogue trim, so their specs keep this
+    # False.
     padded_stats: bool = False
     # s_q == 1 (decode-shaped) graphs; the SM80 prefill kernels are gated off.
     decode: bool = True
@@ -278,7 +279,7 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
         if m > 1 and (facts.d_qk % m != 0 or facts.d_v % m != 0):
             return (
                 f"envelope zero-padding requires D_QK/D_V multiples of {m} (TMA 16-byte "
-                f"global-stride constraint at 2 bytes/elem); graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
+                f"global-stride constraint); graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
             )
     elif facts.d_qk not in capabilities.d_qk or facts.d_v not in capabilities.d_v:
         return f"serves D_QK in {sorted(capabilities.d_qk)}/D_V in {sorted(capabilities.d_v)}; graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
@@ -736,7 +737,7 @@ def lower_dsl_prefill(
     # buffer the FP8/MXFP8 kernels can't honor (dense padded-Q trim is not
     # plumbed there — known gap) is dropped here rather than erroring at
     # execute.
-    seq_q_lens_present = facts.padded and not facts.thd and facts.seq_q_t is not None and not (facts.is_mxfp8 or facts.is_fp8)
+    seq_q_lens_present = facts.padded and not facts.thd and facts.seq_q_t is not None and not ((facts.is_mxfp8 or facts.is_fp8) and api_type == _SM100)
     api = _adapter(api_type)(
         sample_q=ga.tensor_desc_from_ir(facts.q_t, name="q"),
         sample_k=ga.tensor_desc_from_ir(facts.k_t, name="k"),
@@ -753,8 +754,8 @@ def lower_dsl_prefill(
         seq_kv_lens_present=facts.padded or synth_kv_padding,
         # Dense padded-Q trim (q rows >= seq_len_q[b] -> O := 0, LSE := -inf):
         # enabled whenever a dense padded graph carries per-batch Q lengths.
-        # THD carries Q lengths via cu_seqlens; the FP8/MXFP8 kernels are not
-        # plumbed (their specs also keep padded_stats=False).
+        # THD carries Q lengths via cu_seqlens; the SM100 FP8/MXFP8 kernels
+        # are not plumbed (see seq_q_lens_present above).
         seq_q_lens_present=seq_q_lens_present,
         # cu_seq_len form (THD-only; the probe declined dense cu graphs): the
         # adapter's seq-lens execute arguments carry (B+1,) prefix sums.
@@ -952,25 +953,30 @@ def engine_name(
 # Engine IDS do NOT follow this order — they are pinned per name in
 # engine._ID_OFFSETS and never move.
 def _sm120_fp8_spec() -> EngineSpec:
-    """SM120 per-tensor FP8 engine (E4M3 in + scalar descales, FP16 out).
+    """SM120 per-tensor FP8 engine (E4M3/E5M2 in + scalar descales, FP16/BF16/FP8 out).
 
-    P quantization follows the backend's FORT ordering: Amax_S on the unscaled
-    softmax result, then Scale_S, then the e4m3 cast, with Descale_S folded into
-    o_scale_fused. (cuDNN's Scale_S/Descale_S scale the softmax OUTPUT, not the
-    scores.) The SM100 FP8 row deliberately does NOT do this: its lazy-rescale
-    skip leaves P bounded by 2^RESCALE_THRESHOLD rather than 1, so e4m3's range
-    above 1.0 is already spent and a caller Scale_S would saturate it. It
-    honours a reciprocal pair analytically instead and declines anything else.
+    P quantization follows the backend's FORT ordering: the softmax denominator
+    reads the unscaled result, then Scale_S multiplies P, then the fp8 cast,
+    with Descale_S folded into o_scale_fused. (cuDNN's Scale_S/Descale_S scale
+    the softmax OUTPUT, not the scores.) The SM100 FP8 row deliberately does
+    NOT do this: its lazy-rescale skip leaves P bounded by 2^RESCALE_THRESHOLD
+    rather than 1, so e4m3's range above 1.0 is already spent and a caller
+    Scale_S would saturate it. It honours a reciprocal pair analytically
+    instead and declines anything else.
 
     Same mma.sync architecture as the f16 SM120 cell with the MMA lowered to
     m16n8k32 e4m3; ``descale_q*descale_k`` folds into the softmax scale and
-    ``descale_v*scale_o`` into an epilogue scalar, so the kernel adds only the
-    Amax_S/Amax_O atomics over the f16 sibling. E4M3 only (no E5M2 tag in the
-    kernel yet), FP16 O only, head dims any multiple of 32 up to 256 with the
-    QK^T and P@V sides independent (exact — no zero-padding envelope on the
-    8-bit fragment path), and no sink (Amax_S semantics with a sink column are
-    undefined here). THD (ragged) is served with token-major Stats; head-major
-    ragged Stats stays f16-only (the fp8 kernel carries no such specialization).
+    ``descale_v*scale_o`` into an epilogue scalar, so beyond those the kernel
+    adds only the Amax_O atomic (no Amax_S — the shared mismatch rule declines
+    graphs that declare one). E4M3/E5M2 QKV supported; O may
+    be FP16, BF16, or FP8 (either flavor — a direct quantizing store applies
+    ``scale_o`` before the cast, and Amax_O stays the pre-cast fp32 amax).
+    Head TILES any multiple of 32 up to 256 with the QK^T and P@V sides
+    independent; actual head dims may be any multiple of 16 up to the tile
+    (TMA 16-byte global-stride rule at 1 byte/elem) via TMA zero-padding.
+    Attention sinks fold into the softmax denominator: the sink is a virtual
+    column with no V row — it rescales O and enters the LSE. THD (ragged) is
+    served with token- or head-major Stats.
     """
     from cudnn.sdpa.fwd.config_sm120 import SUPPORTED_HEAD_TILES_FP8
 
@@ -982,22 +988,29 @@ def _sm120_fp8_spec() -> EngineSpec:
             phase="prefill",
             d_qk=frozenset(SUPPORTED_HEAD_TILES_FP8),
             d_v=frozenset(SUPPORTED_HEAD_TILES_FP8),
-            dtypes=frozenset({cudnn.data_type.FP8_E4M3}),
-            out_dtypes=frozenset({cudnn.data_type.HALF}),
+            d_envelope=True,  # native tile box d; smaller dims via TMA zero-padding
+            d_pad_multiple=16,  # TMA 16-byte global-stride rule at 1 byte/elem
+            dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
+            out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             is_fp8=True,
             causal=True,
             bottom_right=True,
             bottom_right_with_swa=True,
             bottom_right_padded_seq_q=True,
             swa=True,
+            right_band_widening=True,
             padded=True,
+            sink=True,
             stats=True,
             lse_optional=True,
             thd=True,
-            # Same caveat as the SM100 fp8 row: no SEQ_Q_LENS epilogue trim,
-            # but fp8 graphs cannot carry seq_len_q here (lower_dsl_prefill
-            # forces seq_q_lens_present=False for the fp8 family).
             padded_stats=True,
+            skv_tile=0,
+            # dense_flex: any dense layout with the head dim
+            # innermost-contiguous is normalized to the kernel's compact BSHD
+            # by the shared adapter (one gather copy in, one scatter copy
+            # back for O; zero-copy when already BSHD-physical).
+            layouts=frozenset({"bshd", "dense_flex"}),
             sched_policies=frozenset({SCHED_NATURAL}),
             tile_ms=frozenset({64, 128}),
             tile_ns=frozenset({64, 128}),

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -175,6 +175,14 @@ class Capabilities:
     # FP8/MXFP8 kernels lack the epilogue trim, so their specs keep this
     # False.
     padded_stats: bool = False
+    # Dense padded graphs carrying per-batch seq_len_q: the kernel's epilogue
+    # trims padded q rows (O := 0, LSE := -inf). Rows whose kernel lacks the
+    # trim keep False: lower_dsl_prefill then drops the buffer instead of
+    # binding it, and _execute runtime-rejects lengths shorter than S_q (a
+    # kernel property must live here, not in an adapter-class test — a future
+    # row reusing an adapter for a trim-less kernel would silently inherit
+    # the wrong answer otherwise).
+    dense_seq_q_trim: bool = False
     # s_q == 1 (decode-shaped) graphs; the SM80 prefill kernels are gated off.
     decode: bool = True
 
@@ -421,6 +429,7 @@ def _sm100_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
             thd=True,
             cu_seq_len=True,
             padded_stats=True,
+            dense_seq_q_trim=True,
             # Ragged S_kv with an uncovered tail is served through the padded
             # path with synthesized full-length per-batch KV lengths (see
             # lower_dsl_prefill's synth_kv_padding) — mathematically identical,
@@ -662,6 +671,7 @@ def _sm120_spec() -> EngineSpec:
             stats=True,
             lse_optional=True,
             padded_stats=True,
+            dense_seq_q_trim=True,
             thd=True,
             # No KV-tail rule: the kernel walks KV tiles right-to-left and its
             # first (masked) step always covers the rightmost — and therefore
@@ -734,10 +744,10 @@ def lower_dsl_prefill(
     # Mirrors the seq_q_lens_present constructor argument below. Execute
     # forwards seq_q only when the compiled specialization consumes it (or THD,
     # which sources cu_seqlens from it) — the adapter rejects mismatches, so a
-    # buffer the FP8/MXFP8 kernels can't honor (dense padded-Q trim is not
-    # plumbed there — known gap) is dropped here rather than erroring at
-    # execute.
-    seq_q_lens_present = facts.padded and not facts.thd and facts.seq_q_t is not None and not ((facts.is_mxfp8 or facts.is_fp8) and api_type == _SM100)
+    # buffer a trim-less kernel can't honor is dropped here rather than
+    # erroring at execute (the row declares plumbed-ness; see
+    # Capabilities.dense_seq_q_trim).
+    seq_q_lens_present = facts.padded and not facts.thd and facts.seq_q_t is not None and spec.capabilities.dense_seq_q_trim
     api = _adapter(api_type)(
         sample_q=ga.tensor_desc_from_ir(facts.q_t, name="q"),
         sample_k=ga.tensor_desc_from_ir(facts.k_t, name="k"),
@@ -868,17 +878,21 @@ def lower_dsl_prefill(
         so_buf = resolved.get(id(binding.scale_o)) if binding.scale_o is not None else None
         ds_buf = resolved.get(id(binding.descale_s)) if binding.descale_s is not None else None
         ss_buf = resolved.get(id(binding.scale_s)) if binding.scale_s is not None else None
-        # The quantized DENSE lowerings drop the per-batch Q trim, which is
-        # harmless only while every seq_len_q equals S_q -- a shorter one writes
-        # O and a finite LSE past the valid length. Checked here because the
-        # lengths are device values; this path already reads the descale
-        # scalars back. THD is exempt: ragged lengths ARE shorter than S_q by
-        # construction, and the packed layout gives each sequence its own
-        # extent, so nothing is written past a valid length.
-        if (facts.is_mxfp8 or facts.is_fp8) and not facts.thd and seq_q_buf is not None and not seq_q_lens_present:
+        # Rows whose kernel lacks the dense padded-Q trim (dense_seq_q_trim
+        # False) drop the per-batch Q lengths, which is harmless only while
+        # every seq_len_q equals S_q -- a shorter one writes O and a finite
+        # LSE past the valid length. Checked here because the lengths are
+        # device values; this path already reads the descale scalars back.
+        # THD is exempt: ragged lengths ARE shorter than S_q by construction,
+        # and the packed layout gives each sequence its own extent, so
+        # nothing is written past a valid length.
+        if not spec.capabilities.dense_seq_q_trim and not facts.thd and seq_q_buf is not None:
             min_seq_q = int(seq_q_buf.min().item())
             if min_seq_q < int(facts.s_q):
-                raise NotImplementedError(f"per-tensor FP8/MXFP8: per-batch seq_len_q shorter than S_q={facts.s_q} is not plumbed; got min {min_seq_q}")
+                raise NotImplementedError(
+                    f"{spec.name}: per-batch seq_len_q shorter than S_q={facts.s_q} is not plumbed "
+                    f"(no dense padded-Q trim in this kernel); got min {min_seq_q}"
+                )
         execute_kwargs = dict(
             q_tensor=q_buf,
             k_tensor=k_buf,
@@ -1005,6 +1019,7 @@ def _sm120_fp8_spec() -> EngineSpec:
             lse_optional=True,
             thd=True,
             padded_stats=True,
+            dense_seq_q_trim=True,
             skv_tile=0,
             # dense_flex: any dense layout with the head dim
             # innermost-contiguous is normalized to the kernel's compact BSHD

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Tuple
 import cudnn
 
 from cudnn.engines.base import PlanConfig
-from cudnn.sdpa.fwd.config_sm120 import SMEM_CAPACITY_BYTES, smem_bytes
+from cudnn.sdpa.fwd.config_sm120 import FP8_HEAD_TILE_GRANULE, HEAD_TILE_GRANULE, SMEM_CAPACITY_BYTES, smem_bytes
 from cudnn.sdpa.fwd.engines import ENGINE_SPECS, Capabilities, SdpaFwdKnobs, mismatch
 
 # Cells timed against the backend's kernel and found SLOWER, so the backend's
@@ -77,9 +77,15 @@ def _sm120_tiles(caps: Capabilities, facts) -> Tuple[int, int]:
     fine = sm_count > 0 and (grid * 2 <= sm_count or (grid * 2 <= 3 * sm_count and kv_tiles >= 12))
     tile_m = 64 if fine else 128
     # FP8 stages a byte per KV element but still writes O in half, so the two
-    # SMEM terms size differently -- see config_sm120.smem_bytes.
+    # SMEM terms size differently -- see config_sm120.smem_bytes. The kernel
+    # stages ENVELOPE head tiles (actual dims round up to the granule), so
+    # the fit check must round the same way or a tile offered here declines
+    # at build -- and a knob-carried tile skips the adapter's fallback.
     qkv_itemsize, o_itemsize = (1, 2) if facts.is_fp8 else (2, 2)
-    fits = [n for n in sorted(caps.tile_ns, reverse=True) if smem_bytes(facts.d_qk, facts.d_v, tile_m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES]
+    granule = FP8_HEAD_TILE_GRANULE if facts.is_fp8 else HEAD_TILE_GRANULE
+    d_qp = -(-facts.d_qk // granule) * granule
+    d_vp = -(-facts.d_v // granule) * granule
+    fits = [n for n in sorted(caps.tile_ns, reverse=True) if smem_bytes(d_qp, d_vp, tile_m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES]
     return tile_m, (fits[0] if fits else min(caps.tile_ns))
 
 
@@ -125,9 +131,11 @@ def _mode_a(facts, offered: Dict[str, int], mode) -> List[PlanConfig]:
         # offering to a caller who measures. Configs the kernel cannot fit are
         # not runners-up -- they would sit in the list only to decline at build.
         qkv_itemsize, o_itemsize = (1, 2) if facts.is_fp8 else (2, 2)
-        domain = [
-            (m, n) for m in caps.tile_ms for n in caps.tile_ns if smem_bytes(facts.d_qk, facts.d_v, m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES
-        ]
+        # Same envelope rounding as _sm120_tiles / the adapter's SMEM check.
+        granule = FP8_HEAD_TILE_GRANULE if facts.is_fp8 else HEAD_TILE_GRANULE
+        d_qp = -(-facts.d_qk // granule) * granule
+        d_vp = -(-facts.d_v // granule) * granule
+        domain = [(m, n) for m in caps.tile_ms for n in caps.tile_ns if smem_bytes(d_qp, d_vp, m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES]
         ordered = sorted(domain or [best], key=lambda mn: (mn != best, mn[1] != best[1], -mn[0]))
         for tile_m, tile_n in ordered:
             knobs = _knobs(caps, tile_m, tile_n)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -1728,7 +1728,6 @@ def _correction_warp_group(
                 _SWZ_SHIFT_C = 3 - _O_SWZ_B
                 _SWZ_MASK_C = (1 << _O_SWZ_B) - 1
                 _SUBTILE_BYTES_C = CFG.TILE_M * _SWZ_BYTES_C
-                _FP8_TAG = "e4m3" if cutlass.const_expr(CFG.DTYPE_O == 0) else "e5m2"
 
                 row_base_bytes = tid_in_wg * cutlass.Int32(_SWZ_BYTES_C)
                 row_xor_field = ((tid_in_wg >> cutlass.Int32(_SWZ_SHIFT_C)) & cutlass.Int32(_SWZ_MASK_C)) << cutlass.Int32(4)
@@ -1750,7 +1749,7 @@ def _correction_warp_group(
                     # Plain range (not range_constexpr) — extraction at Python trace time.
                     o_packed_v = fp32_to_fp8_pack(
                         [o_scaled[i] for i in range(16)],
-                        dtype_tag=_FP8_TAG,
+                        dtype=OUT_STORAGE_DTYPE,
                     )
 
                     col_elems = chunk_idx * O_CHUNK

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -1866,7 +1866,6 @@ def _correction_warp_group(
                 _SWZ_SHIFT_C = 3 - _O_SWZ_B
                 _SWZ_MASK_C = (1 << _O_SWZ_B) - 1
                 _SUBTILE_BYTES_C = CFG.TILE_M * _SWZ_BYTES_C
-                _FP8_TAG = "e4m3" if cutlass.const_expr(CFG.DTYPE_O == 0) else "e5m2"
 
                 row_base_bytes = tid_in_wg * cutlass.Int32(_SWZ_BYTES_C)
                 row_xor_field = ((tid_in_wg >> cutlass.Int32(_SWZ_SHIFT_C)) & cutlass.Int32(_SWZ_MASK_C)) << cutlass.Int32(4)
@@ -1888,7 +1887,7 @@ def _correction_warp_group(
                     # Plain range (not range_constexpr) — extraction at Python trace time.
                     o_packed_v = fp32_to_fp8_pack(
                         [o_scaled[i] for i in range(16)],
-                        dtype_tag=_FP8_TAG,
+                        dtype=OUT_STORAGE_DTYPE,
                     )
 
                     col_elems = chunk_idx * O_CHUNK

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -29,14 +29,14 @@ The kernel implements key optimizations including:
   single TMA descriptor's seq coordinate
 
 Constraints:
-* Supported input dtypes: Float16 and BFloat16, output dtype must match input dtype
-* Runtime head dimensions must be multiples of 8 up to 256 (TMA 16-byte
+- Supported input dtypes: Float16 and BFloat16, output dtype must match input dtype
+- Runtime head dimensions must be multiples of 8 up to 256 (TMA 16-byte
   global-stride rule); the kernel compiles at head TILES rounded up to 16 and
   TMA zero-fills the pad columns (the head-dim ENVELOPE)
-* Q heads must be divisible by the number of K/V heads
-* Q/K/V/O use compact BSHD storage
-* Supported CTA Q/KV tiles are 128 or 64
-* K/V pipeline and output staging storage must fit within the target SM120 SMEM
+- Q heads must be divisible by the number of K/V heads
+- Q/K/V/O use compact BSHD storage
+- Supported CTA Q/KV tiles are 128 or 64
+- K/V pipeline and output staging storage must fit within the target SM120 SMEM
   capacity
 """
 
@@ -51,7 +51,7 @@ import cutlass.cute as cute
 
 from cutlass.experimental import primitives as prims
 from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_FP16
-from cudnn.frost.tile_dsl.mma import ptx_mma_m16n8k16_f32
+from cudnn.frost.tile_dsl.mma import mma_m16n8k16_f32
 from cudnn.frost.tile_dsl.swizzle import swizzle_xor
 from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_kernel as _build_thd_meta_kernel
 from cudnn.sdpa.fwd.config_sm120 import (
@@ -252,14 +252,13 @@ class SM120FusedMultiHeadAttentionForward:
         self.is_causal = is_causal
         self.bottom_right = bottom_right
         self.window_size_left = window_size_left
-        self.window_size_right = window_size_right
         # Band model: a right bound implies the causal upper limit (compile()
         # maps window_right -> is_causal), so the masking sites key off
-        # is_causal and add the (compile-time) widening.
-        self.right_slack = window_size_right if window_size_right is not None else 0
+        # is_causal and add the (compile-time) widening. 0 = plain causal.
+        self.window_right = window_size_right if window_size_right is not None else 0
         # A translated diagonal (bottom-right anchoring or a right band) can
         # straddle one more KV tile than the tile-aligned top-left one.
-        self.diag_shifted = bottom_right or self.right_slack > 0
+        self.diag_shifted = bottom_right or self.window_right > 0
         self.seq_q_lens_present = seq_q_lens_present
         self.seq_kv_lens_present = seq_kv_lens_present
         self.has_sink = has_sink
@@ -488,7 +487,7 @@ class SM120FusedMultiHeadAttentionForward:
                 k_vec = load_k_frag_pair(k_frag_pair, d_frag)
                 q_off = d_frag * 4
                 s_off = (k_frag_pair * 2) * 4
-                s_regs[s_off:4] = ptx_mma_m16n8k16_f32(
+                s_regs[s_off:4] = mma_m16n8k16_f32(
                     q_regs[q_off + 0],
                     q_regs[q_off + 1],
                     q_regs[q_off + 2],
@@ -501,7 +500,7 @@ class SM120FusedMultiHeadAttentionForward:
                     s_regs[s_off + 3],
                     self.in_dtype,
                 )
-                s_regs[s_off + 4 : 4] = ptx_mma_m16n8k16_f32(
+                s_regs[s_off + 4 : 4] = mma_m16n8k16_f32(
                     q_regs[q_off + 0],
                     q_regs[q_off + 1],
                     q_regs[q_off + 2],
@@ -564,10 +563,10 @@ class SM120FusedMultiHeadAttentionForward:
             valid_cols = basic_params.seqlen_k
             if cutlass.const_expr(self.is_causal):
                 # Causal upper bound, widened right by the (compile-time) band
-                # slack — 0 for plain causal, R for diagonal_band_right_bound.
+                # widening — 0 for plain causal, R for diagonal_band_right_bound.
                 valid_cols = cute.math.max(
                     cutlass.Int32(0),
-                    cute.math.min(diagonal_position + 1 + self.right_slack, basic_params.seqlen_k),
+                    cute.math.min(diagonal_position + 1 + self.window_right, basic_params.seqlen_k),
                 )
 
             first_valid_col = cutlass.Int32(0)
@@ -708,7 +707,7 @@ class SM120FusedMultiHeadAttentionForward:
                 p2 = p_regs[p_pack_off + 4].bitcast(cutlass.Int32)
                 p3 = p_regs[p_pack_off + 6].bitcast(cutlass.Int32)
                 o_off = (d_frag_pair * 2) * 4
-                o_regs[o_off:4] = ptx_mma_m16n8k16_f32(
+                o_regs[o_off:4] = mma_m16n8k16_f32(
                     p0,
                     p1,
                     p2,
@@ -721,7 +720,7 @@ class SM120FusedMultiHeadAttentionForward:
                     o_regs[o_off + 3],
                     self.in_dtype,
                 )
-                o_regs[o_off + 4 : 4] = ptx_mma_m16n8k16_f32(
+                o_regs[o_off + 4 : 4] = mma_m16n8k16_f32(
                     p0,
                     p1,
                     p2,
@@ -889,7 +888,7 @@ class SM120FusedMultiHeadAttentionForward:
             if q_seq_idx >= seqlen_q:
                 num_kv_tiles = cutlass.Int32(0)
         if cutlass.const_expr(self.is_causal):
-            causal_k_end = q_seq_idx + self.q_tile + self.right_slack
+            causal_k_end = q_seq_idx + self.q_tile + self.window_right
             if cutlass.const_expr(self.bottom_right):
                 causal_k_end += seqlen_k - seqlen_q
             causal_k_end = cute.math.max(cutlass.Int32(0), cute.math.min(causal_k_end, seqlen_k))

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -71,7 +71,7 @@ from cudnn.sdpa.fwd.config_sm120 import (
     FP8_HEAD_TILE_GRANULE,
     SEQ_KV_TILES as _SEQ_KV_TILES,
     SEQ_Q_TILES as _SEQ_Q_TILES,
-    SUPPORTED_HEAD_TILES as _SUPPORTED_HEAD_TILES,
+    SUPPORTED_HEAD_TILES_FP8 as _SUPPORTED_HEAD_TILES_FP8,
     TemplateParams,
     validate_params,
 )
@@ -79,7 +79,12 @@ from cudnn.sdpa.fwd.config_sm120 import (
 # The FROST loader injects one immutable specialization before executing this
 # module. A direct import uses dense e4m3 defaults.
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams(dtype_qkv=DTYPE_E4M3))
-validate_params(PARAMS, allowed_dtypes=(DTYPE_E4M3, DTYPE_E5M2), allow_right_band=True)
+validate_params(
+    PARAMS,
+    allowed_dtypes=(DTYPE_E4M3, DTYPE_E5M2),
+    allowed_o_dtypes=(DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16),
+    allow_right_band=True,
+)
 
 IN_DTYPE = cutlass.Float8E4M3FN if PARAMS.dtype_qkv == DTYPE_E4M3 else cutlass.Float8E5M2
 OUT_DTYPE = {
@@ -174,7 +179,7 @@ class SM120FusedMultiHeadAttentionForward:
 
     SEQ_Q_TILES = _SEQ_Q_TILES
     SEQ_KV_TILES = _SEQ_KV_TILES
-    SUPPORTED_HEAD_TILES = _SUPPORTED_HEAD_TILES
+    SUPPORTED_HEAD_TILES = _SUPPORTED_HEAD_TILES_FP8
     MMA_TILER = (16, 8, 32)  # mma.sync.aligned.m16n8k32 (e4m3)
 
     @staticmethod
@@ -260,6 +265,12 @@ class SM120FusedMultiHeadAttentionForward:
             raise ValueError("out_dtype must be Float16, BFloat16, Float8E4M3FN, or Float8E5M2")
         if thd_varlen and thd_batch < 1:
             raise ValueError("thd_varlen requires thd_batch >= 1")
+        for tile_name, tile in (("head_tile_qk", head_tile_qk), ("head_tile_v", head_tile_v)):
+            if tile not in _SUPPORTED_HEAD_TILES_FP8:
+                raise ValueError(
+                    f"{tile_name} must be a multiple of {FP8_HEAD_TILE_GRANULE} between "
+                    f"{_SUPPORTED_HEAD_TILES_FP8[0]} and {_SUPPORTED_HEAD_TILES_FP8[-1]}, got {tile}"
+                )
         self.in_dtype = in_dtype
         self.out_dtype = out_dtype
         self.is_causal = is_causal
@@ -1639,7 +1650,7 @@ def compile(  # noqa: A001
         is_causal=PARAMS.window_right is not None,
         bottom_right=PARAMS.bottom_right,
         window_size_left=PARAMS.window_left,
-        window_size_right=(PARAMS.window_right if PARAMS.window_right else None),
+        window_size_right=PARAMS.window_right,
         seq_q_lens_present=PARAMS.seq_q_lens_present,
         seq_kv_lens_present=PARAMS.seq_kv_lens_present,
         has_sink=PARAMS.has_sink,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -702,6 +702,58 @@ class SM120FusedMultiHeadAttentionForward:
         return p_regs
 
     @cute.jit
+    def sanitize_v_tail(
+        self,
+        basic_params: SimpleNamespace,
+        mma_params: SimpleNamespace,
+        kv_seq_idx: cutlass.Int32,
+    ) -> None:
+        """Zero ``sV`` rows at/past this tile's valid KV extent before P @ V.
+
+        The K/V TMA descriptors span the bound buffers' CAPACITY (under THD
+        the packed totals are device values, so the views bind whole-buffer
+        extents), so rows between the valid KV length and the tile end can
+        carry UNINITIALIZED storage — including fp8 NaN bit patterns. The
+        S-side mask overwrites those columns with -inf (a select, NaN-safe),
+        but P @ V still multiplies P = 0 against the NaN V row and
+        ``0 * NaN = NaN`` poisons the whole accumulator column-free. Reached
+        only from THD specializations' first masked step (see the call
+        site): dense descriptors carry the declared S_kv, so their overhang
+        loads zero-fill in hardware — a dense PADDED graph's pad rows are
+        user memory and deliberately NOT sanitized here (whether the
+        contract requires tolerating NaN bit patterns there is an open
+        question for the sibling kernels too).
+
+        Every compute warp redundantly zeroes the full overhang (idempotent
+        zero stores race benignly), so a warp-level sync is enough for each
+        warp's own ``ldmatrix`` lanes to observe the zeros.
+        """
+        segs_per_row = self.head_tile_v // 16  # 16-byte segments per V row
+        row_lo = cute.math.max(cutlass.Int32(0), basic_params.seqlen_k - kv_seq_idx)
+        for r_it in cutlass.range_constexpr(self.kv_tile // 32):
+            row = cutlass.Int32(r_it * 32) + basic_params.lane
+            for seg in cutlass.range_constexpr(segs_per_row):
+                col = seg * 16
+                phys_row = (col // self.v_swizzle_chunk_elems) * self.kv_tile + row
+                sv_ptr = (
+                    mma_params.sV.data_ptr()
+                    + phys_row * self.v_swizzle_chunk_elems
+                    + swizzle_xor(
+                        phys_row,
+                        col % self.v_swizzle_chunk_elems,
+                        self.v_swizzle_chunk_elems,
+                        self.in_dtype.bytes,
+                    )
+                )
+                zero16 = cutlass.Vector.from_elements(
+                    tuple(self.in_dtype(0.0) for _ in range(16)),
+                    self.in_dtype,
+                )
+                if row >= row_lo:
+                    sv_ptr.store(zero16, alignment=16)
+        prims.bar_warp_sync(cute.arch.FULL_MASK)
+
+    @cute.jit
     def mma_pv(
         self,
         basic_params: SimpleNamespace,
@@ -855,6 +907,8 @@ class SM120FusedMultiHeadAttentionForward:
             is_first_kv_tile,
         )
 
+        if cutlass.const_expr(self.thd_varlen and in_mask_steps and is_first_kv_tile):
+            self.sanitize_v_tail(basic_params, mma_params, kv_tile_idx * self.kv_tile)
         self.mma_pv(basic_params, mma_params, p_regs)
         prims.barrier_cta_arrive(self.bar_v_consumed, self.threads_kv_pipeline)
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-A fused multi-head attention (FMHA) per-tensor FP8 (e4m3) kernel for the NVIDIA
-Blackwell SM120 family (SM120 and SM121), sibling of ``prefill_f16_sm120.py``.
+A fused multi-head attention (FMHA) per-tensor FP8 (e4m3 / e5m2) kernel for
+the NVIDIA Blackwell GeForce (SM120 / SM121).
 
 Same architecture as the f16 kernel — dedicated TMA load warp, GMEM-direct Q,
 fp32 online softmax in registers, right-to-left masked KV walk — with the MMA
-lowered to ``mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32``:
+lowered to ``mma.sync.aligned.m16n8k32.row.col.f32.{e4m3|e5m2}.{...}.f32``:
 
-- Q/K/V arrive PRE-QUANTIZED e4m3 and travel as **Uint8 storage**: the kernel
-  never does elementwise math on them, so bytes flow TMA -> ldmatrix -> MMA as
-  bit patterns and no Float8 element support is needed in the DSL plumbing.
+- Q/K/V arrive PRE-QUANTIZED e4m3/e5m2: the kernel never does elementwise
+  math on them, so bytes flow TMA -> ldmatrix -> MMA as bit patterns; the
+  element dtype only selects the MMA tag and the P-cast cvt tag.
   ``descale_q * descale_k`` folds host-side into ``softmax_scale_log2`` and
   ``descale_v * scale_o`` into the ``o_scale_fused`` scalar (cuDNN SDPA_FP8
   node convention; see the SM100 fp8 adapter).
@@ -21,30 +21,35 @@ lowered to ``mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32``:
 - V B-fragments: hardware 8-bit transposed ``ldmatrix.m16n16.x2.trans.b8``
   (SASS ``LDSM.8.MT1616``) — one issue covers a 32(kv) x 16(d-bytes) tile and
   feeds two MMAs, register map (0, 2, 1, 3).
-- P: fp32 softmax output packed to e4m3 with ``cvt.rn.satfinite.e4m3x2.f32``
-  and kept in REGISTERS — the k32 C->A fragment-column mismatch is an exchange
-  inside each thread quad, so two ``shfl.sync`` and one ``prmt`` in ``mma_pv``
-  replace the SMEM round trip (and the 16 KB it needed). ``Scale_S`` multiplies
-  P immediately before the cast (FORT ordering); the softmax denominator, and
-  therefore ``Amax_S``, read the UNSCALED fp32 P.
-- O is Float16; the epilogue and the sKV/sO SMEM alias are sized in BYTES
-  because KV (1B) and O (2B) element sizes differ.
-- ``Amax_S`` (max over valid rows of ``1/row_sum``) and ``Amax_O``
-  (max ``|o_scaled|`` pre-cast) are produced via bitcast-int32 atomic max on
-  1-element Int32 buffers the host pre-zeros on the launch stream; the host
-  divides Amax_O by ``scale_o`` afterwards (SM100 fp8 convention).
+- P: fp32 softmax output packed to the INPUT fp8 dtype with
+  ``cvt.rn.satfinite.{e4m3x2|e5m2x2}.f32`` and kept in REGISTERS — the k32 C->A
+  fragment-column mismatch is an exchange inside each thread quad, so two
+  ``shfl.sync`` and one ``prmt`` in ``mma_pv`` replace the SMEM round trip (and
+  the 16 KB it needed). ``Scale_S`` multiplies P immediately before the cast;
+  the softmax denominator reads the UNSCALED fp32 P.
+- O may be FP16 / BF16 / E4M3 / E5M2: 2-byte O rides the stmatrix staging
+  epilogue (the sKV/sO SMEM alias is sized in BYTES because KV and O element
+  sizes differ); fp8 O takes a direct GMEM quantizing store.
+- ``Amax_O`` (max ``|o_scaled|`` pre-cast) is produced via bitcast-int32
+  atomic max on a 1-element Int32 buffer the host pre-zeros on the launch
+  stream; the host divides it by ``scale_o`` afterwards (SM100 fp8
+  convention). There is no Amax_S output — nothing consumes it, and graphs
+  that declare one are declined at the engine row.
 
 Constraints:
-* Input dtype: e4m3 only (as Uint8 storage); output dtype Float16
-* Head dimensions must be multiples of 32 between 32 and 256, inclusive
-* Q heads must be divisible by the number of K/V heads
-* Q/K/V/O use compact BSHD storage (THD packs them to ``(1, T, H, D)``)
-* Supported CTA Q/KV tiles are 128 or 64
-* ``has_sink`` is not supported (Amax_S semantics with a sink column are
-  undefined in this cell; the adapter declines such graphs). No sink math
-  exists here — the ``sinks`` argument is always ``None``.
-* THD (ragged) is supported with token-major Stats; the head-major ragged
-  Stats layout the f16 cell carries has no specialization here
+- Input dtype: e4m3 or e5m2 (the MMA tag and the P quantization target
+  follow it); output dtype FP16 / BF16 / E4M3 / E5M2 (fp8 O via a direct
+  quantizing store, ``o_scale_fused`` applied before the cast)
+- Head TILES are multiples of 32 between 32 and 256, inclusive; actual head
+  dims may be smaller multiples of 16 (TMA 16-byte global-stride rule at
+  1 byte/elem) — TMA zero-fills the pad columns (the head-dim ENVELOPE)
+- Q heads must be divisible by the number of K/V heads
+- Q/K/V/O use compact BSHD storage (THD packs them to ``(1, T, H, D)``)
+- Supported CTA Q/KV tiles are 128 or 64
+- Optional per-Q-head attention-sink logits folded into the softmax
+  denominator: the sink is a virtual column with no V row — it rescales O
+  and enters the LSE.
+- THD (ragged) is supported with token-major or head-major Stats
 """
 
 from functools import lru_cache, partial
@@ -57,11 +62,13 @@ import cutlass.experimental.cuda as cuda
 import cutlass.cute as cute
 
 from cutlass.experimental import primitives as prims
-from cudnn.frost.tile_dsl.constants import DTYPE_E4M3
-from cudnn.frost.tile_dsl.mma import pack_f8x2_pairs, ptx_cvt_e4m3x2, ptx_mma_m16n8k32_e4m3_f32
+from cudnn.frost.tile_dsl.constants import DTYPE_BF16, DTYPE_E4M3, DTYPE_E5M2, DTYPE_FP16
+from cudnn.frost.tile_dsl.mma import mma_m16n8k32_f32
+from cudnn.frost.tile_dsl.pointwise import fp32_to_fp8x2, pack_fp8x2_pairs
 from cudnn.frost.tile_dsl.swizzle import swizzle_xor
 from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_kernel as _build_thd_meta_kernel
 from cudnn.sdpa.fwd.config_sm120 import (
+    FP8_HEAD_TILE_GRANULE,
     SEQ_KV_TILES as _SEQ_KV_TILES,
     SEQ_Q_TILES as _SEQ_Q_TILES,
     SUPPORTED_HEAD_TILES as _SUPPORTED_HEAD_TILES,
@@ -72,12 +79,15 @@ from cudnn.sdpa.fwd.config_sm120 import (
 # The FROST loader injects one immutable specialization before executing this
 # module. A direct import uses dense e4m3 defaults.
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams(dtype_qkv=DTYPE_E4M3))
-validate_params(PARAMS, allowed_dtypes=(DTYPE_E4M3,), allow_right_band=False)
+validate_params(PARAMS, allowed_dtypes=(DTYPE_E4M3, DTYPE_E5M2), allow_right_band=True)
 
-# e4m3 travels as raw bytes: TMA, ldmatrix, and the MMA consume bit patterns,
-# so Uint8 storage sidesteps Float8 element support in the DSL plumbing.
-STORAGE_DTYPE = cutlass.Uint8
-OUT_STORAGE_DTYPE = cutlass.Float16
+IN_DTYPE = cutlass.Float8E4M3FN if PARAMS.dtype_qkv == DTYPE_E4M3 else cutlass.Float8E5M2
+OUT_DTYPE = {
+    DTYPE_E4M3: cutlass.Float8E4M3FN,
+    DTYPE_E5M2: cutlass.Float8E5M2,
+    DTYPE_BF16: cutlass.BFloat16,
+    DTYPE_FP16: cutlass.Float16,
+}[PARAMS.dtype_o]
 
 # ---------------------------------------------------------------------------
 # PTX and layout helpers.
@@ -145,6 +155,11 @@ def ceil_div(a: int, b: int) -> int:
     return (a + b - 1) // b
 
 
+def round_up_head_tile(d: int) -> int:
+    """Smallest supported head TILE covering an actual head dim ``d``."""
+    return ceil_div(d, FP8_HEAD_TILE_GRANULE) * FP8_HEAD_TILE_GRANULE
+
+
 fmul2 = partial(prims.mul_packed_f32x2, ftz=False, rnd=prims.FPRoundingMode.RN)
 fma2 = partial(prims.fma_packed_f32x2, ftz=False, rnd=prims.FPRoundingMode.RN)
 
@@ -186,15 +201,17 @@ class SM120FusedMultiHeadAttentionForward:
 
     def __init__(
         self,
-        in_dtype: Type[cutlass.Numeric] = cutlass.Uint8,
+        in_dtype: Type[cutlass.Numeric] = cutlass.Float8E4M3FN,
         out_dtype: Type[cutlass.Numeric] = cutlass.Float16,
         is_causal: bool = False,
         bottom_right: bool = False,
         window_size_left: int | None = None,
+        window_size_right: int | None = None,
         seq_q_lens_present: bool = False,
         seq_kv_lens_present: bool = False,
         has_sink: bool = False,
         thd_varlen: bool = False,
+        thd_lse_head_major: bool = False,
         thd_batch: int = 1,
         head_tile_qk: int = 128,
         head_tile_v: int = 128,
@@ -203,13 +220,20 @@ class SM120FusedMultiHeadAttentionForward:
     ):
         """Initialize the FMHA prefill kernel configuration.
 
-        :param in_dtype: Q/K/V element type. Uint8 (E4M3 storage) only;
-            the checks below reject anything else.
-        :param out_dtype: O element type. Float16 only -- the epilogue
-            emits no other type.
+        :param in_dtype: Q/K/V element type, Float8E4M3FN or Float8E5M2.
+            Selects the MMA operand tag and the P-quantization target (the
+            SDPA_FP8 contract quantizes P at the input dtype); TMA/ldmatrix/
+            swizzle are byte-oriented and do not care.
+        :param out_dtype: O element type: Float16, BFloat16, Float8E4M3FN,
+            or Float8E5M2. 2-byte types ride the stmatrix staging epilogue;
+            fp8 takes the direct quantizing-store one.
         :param is_causal: Apply an upper causal bound to QK.
         :param bottom_right: Shift the causal diagonal by ``Skv - Sq``.
         :param window_size_left: Inclusive left-window offset, or ``None``.
+        :param window_size_right: Widen the causal diagonal to the right by
+            R columns (keep ``j <= diag + R``, inclusive), or ``None``. The
+            loader maps ``window_right`` to ``is_causal=(window_right is not
+            None)`` plus this widening.
         :param seq_q_lens_present: Read per-batch query lengths at runtime.
         :param seq_kv_lens_present: Read per-batch key/value lengths at runtime.
         :param has_sink: Fold the per-Q-head sink logit from the ``sinks``
@@ -220,20 +244,20 @@ class SM120FusedMultiHeadAttentionForward:
             ``[seq_kv(B) | cu_q(B+1) | cu_k(B+1)]`` metadata tensor, and the
             grid covers ``ceil(thd_max_sq / q_tile)`` tiles per sequence.
         :param thd_batch: THD only: the real sequence count B.
-        :param head_tile_qk: Q/K head dimension (the QK^T contraction width).
-            Must be a multiple of 32 between 32 and 256, inclusive.
-        :param head_tile_v: V/O head dimension (the P@V output width). Same
+        :param head_tile_qk: Q/K head TILE (the QK^T contraction width). Must
+            be a multiple of 32 between 32 and 256, inclusive. The ACTUAL head
+            dim may be any multiple of 16 up to the tile — the TMA descriptors
+            keep the actual extents and zero-fill the pad columns.
+        :param head_tile_v: V/O head TILE (the P@V output width). Same
             constraint as ``head_tile_qk``.
         :param q_tile: Query sequence tile size.
         :param kv_tile: Key/value sequence tile size.
         """
 
-        if in_dtype != cutlass.Uint8:
-            raise ValueError("fp8 kernel takes e4m3 Q/K/V as Uint8 storage")
-        if out_dtype != cutlass.Float16:
-            raise ValueError("fp8 kernel emits Float16 O only")
-        if has_sink:
-            raise ValueError("has_sink is not supported by the fp8 cell (Amax_S semantics)")
+        if in_dtype not in (cutlass.Float8E4M3FN, cutlass.Float8E5M2):
+            raise ValueError("in_dtype must be Float8E4M3FN or Float8E5M2")
+        if out_dtype not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float8E4M3FN, cutlass.Float8E5M2):
+            raise ValueError("out_dtype must be Float16, BFloat16, Float8E4M3FN, or Float8E5M2")
         if thd_varlen and thd_batch < 1:
             raise ValueError("thd_varlen requires thd_batch >= 1")
         self.in_dtype = in_dtype
@@ -241,10 +265,16 @@ class SM120FusedMultiHeadAttentionForward:
         self.is_causal = is_causal
         self.bottom_right = bottom_right
         self.window_size_left = window_size_left
+        # The band only TRANSLATES the diagonal (frontier width is
+        # R-independent); masking sites add the widening, mask_steps keys off
+        # diag_shifted. 0 = plain causal.
+        self.window_right = window_size_right if window_size_right is not None else 0
+        self.diag_shifted = bottom_right or self.window_right > 0
         self.seq_q_lens_present = seq_q_lens_present
         self.seq_kv_lens_present = seq_kv_lens_present
         self.has_sink = has_sink
         self.thd_varlen = thd_varlen
+        self.thd_lse_head_major = thd_lse_head_major
         self.thd_batch = thd_batch
 
         self.head_tile_qk = head_tile_qk
@@ -315,29 +345,62 @@ class SM120FusedMultiHeadAttentionForward:
         batch_idx: cutlass.Int32,
         head_idx: cutlass.Int32,
         seq_coord: cutlass.Int32,
+        is_v: cutlass.Constexpr[bool],
+        envelope: cutlass.Constexpr[bool],
     ) -> None:
-        """Launch one TMA load for a complete K/V tile into swizzled SMEM.
+        """Launch the TMA load(s) for a complete K/V tile into swizzled SMEM.
 
-        The tensor map exposes compact ``(B, S, H, D)`` storage through a
-        logical ``(B, H, I, S, C)`` view, where ``D = I * C``. Its TMA-order
-        dimensions are ``(C, S, I, H, B)``, so one rank-5 copy covers every
-        head chunk and uses coordinates ``(c, seq, i, head, batch)``.
+        Exact head dims (``envelope=False``, the common case) issue ONE rank-5
+        copy whose descriptor pre-splits the head dim into swizzle-span chunks
+        — the head boundary coincides with the tile so no zero-fill is needed.
+
+        Envelope head dims (``envelope=True``, actual d < compile-time tile)
+        issue ``chunks`` copies over a rank-4 descriptor that keeps the ACTUAL
+        head extent as the innermost dimension, stepping the head coordinate
+        by ``chunk_elems``. Head columns at or past the actual extent are
+        outside that dimension, so the hardware zero-fills them (zero K columns
+        add exact zero terms to every Q@K^T; zero V columns produce O columns
+        the store guard clips). A single copy cannot serve this case: TMA
+        bounds-checks each coordinate against its OWN dimension, so a
+        chunk-dimension descriptor would fetch the next head's data instead of
+        zeros past d.
 
         :param s_dst: Swizzled SMEM destination tile.
-        :param tma_desc: K or V tensor map descriptor.
+        :param tma_desc: K or V tensor map descriptor (rank matches
+            ``envelope``).
         :param mbar: TMA completion mbarrier for this stream.
         :param batch_idx: Batch index.
         :param head_idx: Attention head index.
         :param seq_coord: Starting sequence row for the K/V tile.
+        :param is_v: Selects the V-side chunk geometry over the K-side one
+            (the two carry independent head tiles and swizzle spans).
+        :param envelope: Actual head dim < compile-time tile (zero-padded).
         """
+        chunks = self.v_tma_swizzle_chunks if is_v else self.k_tma_swizzle_chunks
+        chunk_elems = self.v_swizzle_chunk_elems if is_v else self.k_swizzle_chunk_elems
         if prims.elect_sync():
-            prims.mbarrier_arrive_expect_tx(mbar, tma_desc.global_tx_bytes())
-            prims.cp_async_bulk_tensor_shared_cta_global(
-                s_dst,
-                tma_desc.get_ptr(),
-                (0, seq_coord, 0, head_idx, batch_idx),
-                mbar,
-            )
+            if cutlass.const_expr(envelope):
+                # Every copy completes with its full box (OOB regions arrive as
+                # zeros but still count), so the expected transaction total is
+                # simply chunks x the per-copy box bytes.
+                prims.mbarrier_arrive_expect_tx(mbar, chunks * tma_desc.global_tx_bytes())
+                for i in cutlass.range_constexpr(chunks):
+                    prims.cp_async_bulk_tensor_shared_cta_global(
+                        s_dst.subview(i * self.kv_tile * chunk_elems),
+                        tma_desc.get_ptr(),
+                        (i * chunk_elems, seq_coord, head_idx, batch_idx),
+                        mbar,
+                    )
+            else:
+                # Rank-5 coordinates (c, seq, i, head, batch): one copy covers
+                # every head chunk of the tile.
+                prims.mbarrier_arrive_expect_tx(mbar, tma_desc.global_tx_bytes())
+                prims.cp_async_bulk_tensor_shared_cta_global(
+                    s_dst,
+                    tma_desc.get_ptr(),
+                    (0, seq_coord, 0, head_idx, batch_idx),
+                    mbar,
+                )
 
     @cute.jit
     def load_q_tile(
@@ -442,7 +505,7 @@ class SM120FusedMultiHeadAttentionForward:
                 k_vec = load_k_frag_pair(k_frag_pair, d_frag)
                 q_off = d_frag * 4
                 s_off = (k_frag_pair * 2) * 4
-                s_regs[s_off:4] = ptx_mma_m16n8k32_e4m3_f32(
+                s_regs[s_off:4] = mma_m16n8k32_f32(
                     q_regs[q_off + 0],
                     q_regs[q_off + 1],
                     q_regs[q_off + 2],
@@ -453,8 +516,9 @@ class SM120FusedMultiHeadAttentionForward:
                     s_regs[s_off + 1],
                     s_regs[s_off + 2],
                     s_regs[s_off + 3],
+                    self.in_dtype,
                 )
-                s_regs[s_off + 4 : 4] = ptx_mma_m16n8k32_e4m3_f32(
+                s_regs[s_off + 4 : 4] = mma_m16n8k32_f32(
                     q_regs[q_off + 0],
                     q_regs[q_off + 1],
                     q_regs[q_off + 2],
@@ -465,6 +529,7 @@ class SM120FusedMultiHeadAttentionForward:
                     s_regs[s_off + 5],
                     s_regs[s_off + 6],
                     s_regs[s_off + 7],
+                    self.in_dtype,
                 )
 
         return s_regs
@@ -519,7 +584,7 @@ class SM120FusedMultiHeadAttentionForward:
             if cutlass.const_expr(self.is_causal):
                 valid_cols = cute.math.max(
                     cutlass.Int32(0),
-                    cute.math.min(diagonal_position + 1, basic_params.seqlen_k),
+                    cute.math.min(diagonal_position + 1 + self.window_right, basic_params.seqlen_k),
                 )
 
             first_valid_col = cutlass.Int32(0)
@@ -612,7 +677,7 @@ class SM120FusedMultiHeadAttentionForward:
                 # Scale_S via the exp2 bias, so the cast input is the scaled
                 # value the contract asks for; descale_s stays folded into
                 # o_scale_fused.
-                p_regs[k_frag * 2 + row_half] = ptx_cvt_e4m3x2(p1, p0)
+                p_regs[k_frag * 2 + row_half] = fp32_to_fp8x2(p0, p1, dtype=self.in_dtype)
 
             # Reduce tile_sum across the four lanes that own one Q row.
             tile_sum = nvvm_threadquad_reduction_sum(tile_sum)
@@ -653,7 +718,7 @@ class SM120FusedMultiHeadAttentionForward:
         selector = cutlass.Int32(0x5410) if lane_mod4 < 2 else cutlass.Int32(0x7632)
 
         def pack_p_cols(k_frag0: cutlass.Constexpr[int], row_half: cutlass.Constexpr[int]) -> cutlass.Int32:
-            pairs = pack_f8x2_pairs(p_regs[k_frag0 * 2 + row_half], p_regs[(k_frag0 + 1) * 2 + row_half])
+            pairs = pack_fp8x2_pairs(p_regs[k_frag0 * 2 + row_half], p_regs[(k_frag0 + 1) * 2 + row_half])
             lo = prims.shfl_sync(thread_mask=0xFFFFFFFF, val=pairs, offset=src0, mask_and_clamp=0x1F, kind=prims.Shfl.IDX)
             hi = prims.shfl_sync(thread_mask=0xFFFFFFFF, val=pairs, offset=src0 + 1, mask_and_clamp=0x1F, kind=prims.Shfl.IDX)
             return cute.arch.inline_ptx(
@@ -706,7 +771,7 @@ class SM120FusedMultiHeadAttentionForward:
             for d_frag_pair in cutlass.range_constexpr(self.pv_d_frags // 2):
                 v_vec = load_v_frags(v_frag, d_frag_pair)
                 o_off = (d_frag_pair * 2) * 4
-                o_regs[o_off:4] = ptx_mma_m16n8k32_e4m3_f32(
+                o_regs[o_off:4] = mma_m16n8k32_f32(
                     p_vec[0],
                     p_vec[1],
                     p_vec[2],
@@ -717,8 +782,9 @@ class SM120FusedMultiHeadAttentionForward:
                     o_regs[o_off + 1],
                     o_regs[o_off + 2],
                     o_regs[o_off + 3],
+                    self.in_dtype,
                 )
-                o_regs[o_off + 4 : 4] = ptx_mma_m16n8k32_e4m3_f32(
+                o_regs[o_off + 4 : 4] = mma_m16n8k32_f32(
                     p_vec[0],
                     p_vec[1],
                     p_vec[2],
@@ -729,6 +795,7 @@ class SM120FusedMultiHeadAttentionForward:
                     o_regs[o_off + 5],
                     o_regs[o_off + 6],
                     o_regs[o_off + 7],
+                    self.in_dtype,
                 )
 
     @cute.jit
@@ -800,14 +867,16 @@ class SM120FusedMultiHeadAttentionForward:
     ) -> None:
         """SM120 per-tensor FP8 FMHA prefill kernel.
 
-        :param q: Query tensor (e4m3 as Uint8 storage).
-        :param k: Key tensor (e4m3 as Uint8 storage).
-        :param v: Value tensor (e4m3 as Uint8 storage).
-        :param o: Output tensor (Float16).
+        :param q: Query tensor (fp8).
+        :param k: Key tensor (fp8).
+        :param v: Value tensor (fp8).
+        :param o: Output tensor (the configured ``out_dtype``).
         :param lse: fp32 log-sum-exp output — ``(B, H, Sq)`` dense, or packed
-            head-major ``(H, head_stride)`` under ``thd_varlen``; or ``None`` to
-            compile the LSE store out (the DSL specializes on ``None``).
-        :param sinks: Unused; must be ``None`` (fp8 cell rejects has_sink).
+            token-major ``(T, H)`` / head-major ``(H, head_stride)`` under
+            ``thd_varlen``; or ``None`` to compile the LSE store out (the DSL
+            specializes on ``None``).
+        :param sinks: ``(H,)`` fp32 per-Q-head sink logits; ``None`` iff the
+            kernel is configured without ``has_sink``.
         :param seq_q_lens: Per-batch query lengths, or an unused dummy tensor.
         :param seq_kv_lens: Per-batch key/value lengths, or an unused dummy tensor.
         :param amax_o: 1-element Int32 buffer, host pre-zeroed; receives
@@ -865,6 +934,10 @@ class SM120FusedMultiHeadAttentionForward:
         num_heads_kv = k.shape[2]
         head_dim_qk = q.shape[3]
         head_dim_v = v.shape[3]
+        # Envelope: actual head dims narrower than the compile-time tiles —
+        # the TMA loads must zero-fill the pad columns via per-chunk copies.
+        k_envelope = head_dim_qk != self.head_tile_qk
+        v_envelope = head_dim_v != self.head_tile_v
         q_ptr = q.iterator.raw_ptr()
         o_ptr = o.iterator.raw_ptr()
 
@@ -890,7 +963,7 @@ class SM120FusedMultiHeadAttentionForward:
             if q_seq_idx >= seqlen_q:
                 num_kv_tiles = cutlass.Int32(0)
         if cutlass.const_expr(self.is_causal):
-            causal_k_end = q_seq_idx + self.q_tile
+            causal_k_end = q_seq_idx + self.q_tile + self.window_right
             if cutlass.const_expr(self.bottom_right):
                 causal_k_end += seqlen_k - seqlen_q
             causal_k_end = cute.math.max(cutlass.Int32(0), cute.math.min(causal_k_end, seqlen_k))
@@ -964,6 +1037,8 @@ class SM120FusedMultiHeadAttentionForward:
                     tma_batch_idx,
                     kv_head_idx,
                     kv_row_base + kv_seq_idx,
+                    is_v=False,
+                    envelope=k_envelope,
                 )
                 self.load_one_kv_tile(
                     sV,
@@ -972,6 +1047,8 @@ class SM120FusedMultiHeadAttentionForward:
                     tma_batch_idx,
                     kv_head_idx,
                     kv_row_base + kv_seq_idx,
+                    is_v=True,
+                    envelope=v_envelope,
                 )
 
                 kv_seq_idx -= self.kv_tile
@@ -987,6 +1064,8 @@ class SM120FusedMultiHeadAttentionForward:
                         tma_batch_idx,
                         kv_head_idx,
                         kv_row_base + kv_seq_idx,
+                        is_v=False,
+                        envelope=k_envelope,
                     )
 
                     prims.barrier_cta_sync(
@@ -1000,6 +1079,8 @@ class SM120FusedMultiHeadAttentionForward:
                         tma_batch_idx,
                         kv_head_idx,
                         kv_row_base + kv_seq_idx,
+                        is_v=True,
+                        envelope=v_envelope,
                     )
                     kv_seq_idx -= self.kv_tile
         # /////////////////////////////////////////////////////////////////////////////
@@ -1073,8 +1154,11 @@ class SM120FusedMultiHeadAttentionForward:
             mask_steps = 1
             if cutlass.const_expr(self.is_causal):
                 mask_steps = ceil_div(self.q_tile, self.kv_tile)
-                if cutlass.const_expr(self.bottom_right):
-                    # The shifted diagonal can straddle one additional KV tile.
+                if cutlass.const_expr(self.diag_shifted):
+                    # A translated diagonal (bottom-right anchoring or a right
+                    # band) can straddle one additional KV tile; the frontier
+                    # width itself is R-independent -- the band only
+                    # translates the diagonal.
                     mask_steps = ceil_div(self.q_tile + self.kv_tile - 1, self.kv_tile)
             elif cutlass.const_expr(not self.seq_kv_lens_present and not self.thd_varlen and k.shape[1] % self.kv_tile == 0):
                 mask_steps = 0
@@ -1146,24 +1230,39 @@ class SM120FusedMultiHeadAttentionForward:
             # the four lanes that share a Q row, so every lane finalizes the two
             # rows it owns without further exchange. row_max holds the raw (unscaled)
             # score max; the scale is applied in log2 domain and converted with ln(2).
+            # With has_sink, the per-head sink logit joins the softmax denominator
+            # as a virtual column with no V row: it rescales O, enters the LSE,
+            # and gives a row with no visible key a finite LSE (the sink alone).
             LN2 = cutlass.Float32(0.6931471805599453)
             row_sum_inv = cutlass.Array(cutlass.Float32, 2, alignment=8)
             row_lse = cutlass.Array(cutlass.Float32, 2, alignment=8)
             for row_half in cutlass.range_constexpr(2):
                 row_sum[row_half] = row_sum[row_half] * inv_scale_s
                 row_max_nat = row_max[row_half] * softmax_scale_log2 * LN2
-                inv = cutlass.Float32(0.0)
-                if row_sum[row_half] > 0.0:
-                    inv = cute.math.rcp(row_sum[row_half], approx=True, ftz=True)
-                row_sum_inv[row_half] = inv
-                lse_val = row_max_nat + cute.math.log(
-                    cute.math.max(row_sum[row_half], cutlass.Float32(1e-30)),
-                    fastmath=True,
-                )
-                # Rows with no visible key write -inf / O := 0.
-                if row_sum[row_half] <= 0.0:
-                    lse_val = -cutlass.Float32.inf
-                row_lse[row_half] = lse_val
+                if cutlass.const_expr(self.has_sink):
+                    sinks_arr = cutlass.make_array_view(sinks)
+                    sink_logit = cutlass.Float32(sinks_arr[head_idx])
+                    new_max = cute.arch.fmax(row_max_nat, sink_logit)
+                    # alpha re-normalizes the loop's accumulator and sum from
+                    # row_max_nat to the sink-extended max; it is 0 for a row
+                    # with no visible key, so O := 0 falls out.
+                    alpha = cute.math.exp(row_max_nat - new_max, fastmath=True)
+                    new_sum = row_sum[row_half] * alpha + cute.math.exp(sink_logit - new_max, fastmath=True)
+                    row_sum_inv[row_half] = alpha / new_sum
+                    row_lse[row_half] = new_max + cute.math.log(new_sum, fastmath=True)
+                else:
+                    inv = cutlass.Float32(0.0)
+                    if row_sum[row_half] > 0.0:
+                        inv = cute.math.rcp(row_sum[row_half], approx=True, ftz=True)
+                    row_sum_inv[row_half] = inv
+                    lse_val = row_max_nat + cute.math.log(
+                        cute.math.max(row_sum[row_half], cutlass.Float32(1e-30)),
+                        fastmath=True,
+                    )
+                    # Rows with no visible key write -inf / O := 0.
+                    if row_sum[row_half] <= 0.0:
+                        lse_val = -cutlass.Float32.inf
+                    row_lse[row_half] = lse_val
 
             for row_half in cutlass.range_constexpr(2):
                 row_sum_inv[row_half] = row_sum_inv[row_half] * o_scale_fused
@@ -1175,14 +1274,19 @@ class SM120FusedMultiHeadAttentionForward:
                         lse_q_idx = q_seq_idx + q_warp_row0 + (lane // 4) + row_half * 8
                         lse_out = cutlass.Float32(row_lse[row_half])
                         if cutlass.const_expr(self.thd_varlen):
-                            # Packed head-major (H, head_stride) LSE: tokens are
-                            # contiguous within a head row, heads strided by the
-                            # caller's token capacity. Rows past this sequence's
-                            # Q length belong to the NEXT sequence — never
-                            # written, and there is no padded region to trim.
+                            # Packed ragged-Stats LSE, written directly in the
+                            # caller's declared layout: token-major (T, H) or
+                            # head-major (H, head_stride). Rows past this
+                            # sequence's Q length belong to the NEXT sequence —
+                            # never written, and there is no padded region to
+                            # trim.
                             if lse_q_idx < seqlen_q:
-                                lse_row = lse_arr[head_idx, :]
-                                lse_row[q_row_base + lse_q_idx] = lse_out
+                                if cutlass.const_expr(self.thd_lse_head_major):
+                                    lse_row = lse_arr[head_idx, :]
+                                    lse_row[q_row_base + lse_q_idx] = lse_out
+                                else:
+                                    lse_row = lse_arr[q_row_base + lse_q_idx, :]
+                                    lse_row[head_idx] = lse_out
                         else:
                             # Rows at/past this batch's Q length trim to -inf.
                             if lse_q_idx >= seqlen_q:
@@ -1230,13 +1334,31 @@ class SM120FusedMultiHeadAttentionForward:
                     half = (i // 2) % 2
                     acc = half * 2 + (i % 2)
                     lane_amax_half[acc] = cute.arch.fmax(lane_amax_half[acc], cute.math.abs(o_scaled[i]))
-                o_packed = o_scaled.to(self.out_dtype).bitcast(cutlass.Int32)
-                sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * o_block_bytes + lane * 16
-                prims.stmatrix(
-                    sO_ptr,
-                    o_packed,
-                    prims.MMALayout.ROW,
-                )
+                if cutlass.const_expr(self.out_dtype.bytes == 1):
+                    for frag in cutlass.range_constexpr(2):
+                        for row_half in cutlass.range_constexpr(2):
+                            e = frag * 4 + row_half * 2
+                            o_pair = fp32_to_fp8x2(o_scaled[e], o_scaled[e + 1], dtype=self.out_dtype)
+                            pair_q_seq_idx = q_seq_idx + q_warp_row0 + (lane // 4) + row_half * 8
+                            pair_col_in_cta = d_frag_pair * 16 + frag * 8 + (lane % 4) * 2
+                            if cutlass.const_expr(self.thd_varlen):
+                                if pair_q_seq_idx < seqlen_q and pair_col_in_cta < head_dim_v:
+                                    gO_pair = o_ptr + o_head_off + pair_q_seq_idx * o_seq_stride + pair_col_in_cta
+                                    gO_pair.store(cutlass.Vector.from_elements((o_pair,), cutlass.Uint16).bitcast(self.out_dtype), alignment=2)
+                            else:
+                                if pair_q_seq_idx < q.shape[1] and pair_col_in_cta < head_dim_v:
+                                    if pair_q_seq_idx >= seqlen_q:
+                                        o_pair = cutlass.Uint16(0)
+                                    gO_pair = o_ptr + o_head_off + pair_q_seq_idx * o_seq_stride + pair_col_in_cta
+                                    gO_pair.store(cutlass.Vector.from_elements((o_pair,), cutlass.Uint16).bitcast(self.out_dtype), alignment=2)
+                else:
+                    o_packed = o_scaled.to(self.out_dtype).bitcast(cutlass.Int32)
+                    sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * o_block_bytes + lane * 16
+                    prims.stmatrix(
+                        sO_ptr,
+                        o_packed,
+                        prims.MMALayout.ROW,
+                    )
             lane_amax_o = cute.arch.fmax(
                 cute.arch.fmax(lane_amax_half[0], lane_amax_half[1]) * row_valid[0],
                 cute.arch.fmax(lane_amax_half[2], lane_amax_half[3]) * row_valid[1],
@@ -1248,40 +1370,41 @@ class SM120FusedMultiHeadAttentionForward:
                 lane_amax_o.bitcast(cutlass.Int32),
             )
 
-            store_row = lane_mod8 + ((lane_div8) % 2) * 8
-            store_col = lane_div16 * 8
-            store_q_seq_idx = q_seq_idx + q_warp_row0 + store_row
-            for d_frag_pair in cutlass.range_constexpr(self.pv_d_frags // 2):
-                store_col_in_cta = d_frag_pair * 16 + store_col
-                if cutlass.const_expr(self.thd_varlen):
-                    # Packed storage: rows past this sequence's Q length are
-                    # the NEXT sequence's tokens — no store, and never the
-                    # dense path's zero-fill.
-                    if store_q_seq_idx < seqlen_q and store_col_in_cta < head_dim_v:
-                        gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
-                        sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * o_block_bytes + lane * 16
-                        gO_ptr.store(sO_ptr.load(count=16, alignment=16).bitcast(self.out_dtype), alignment=16)
-                else:
-                    if store_q_seq_idx < q.shape[1] and store_col_in_cta < head_dim_v:
-                        gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
-                        if store_q_seq_idx < seqlen_q:
+            if cutlass.const_expr(self.out_dtype.bytes != 1):
+                store_row = lane_mod8 + ((lane_div8) % 2) * 8
+                store_col = lane_div16 * 8
+                store_q_seq_idx = q_seq_idx + q_warp_row0 + store_row
+                for d_frag_pair in cutlass.range_constexpr(self.pv_d_frags // 2):
+                    store_col_in_cta = d_frag_pair * 16 + store_col
+                    if cutlass.const_expr(self.thd_varlen):
+                        # Packed storage: rows past this sequence's Q length are
+                        # the NEXT sequence's tokens — no store, and never the
+                        # dense path's zero-fill.
+                        if store_q_seq_idx < seqlen_q and store_col_in_cta < head_dim_v:
+                            gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
                             sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * o_block_bytes + lane * 16
                             gO_ptr.store(sO_ptr.load(count=16, alignment=16).bitcast(self.out_dtype), alignment=16)
-                        else:
-                            zero_vec = cutlass.Vector.from_elements(
-                                (
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                    o.dtype(0.0),
-                                ),
-                                o.dtype,
-                            )
-                            gO_ptr.store(zero_vec, alignment=16)
+                    else:
+                        if store_q_seq_idx < q.shape[1] and store_col_in_cta < head_dim_v:
+                            gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
+                            if store_q_seq_idx < seqlen_q:
+                                sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * o_block_bytes + lane * 16
+                                gO_ptr.store(sO_ptr.load(count=16, alignment=16).bitcast(self.out_dtype), alignment=16)
+                            else:
+                                zero_vec = cutlass.Vector.from_elements(
+                                    (
+                                        o.dtype(0.0),
+                                        o.dtype(0.0),
+                                        o.dtype(0.0),
+                                        o.dtype(0.0),
+                                        o.dtype(0.0),
+                                        o.dtype(0.0),
+                                        o.dtype(0.0),
+                                        o.dtype(0.0),
+                                    ),
+                                    o.dtype,
+                                )
+                                gO_ptr.store(zero_vec, alignment=16)
 
         # /////////////////////////////////////////////////////////////////////////////
         #  EMPTY
@@ -1312,13 +1435,14 @@ class SM120FusedMultiHeadAttentionForward:
     ) -> None:
         """Launch the SM120 per-tensor FP8 FMHA kernel.
 
-        :param q: Query tensor with shape ``(B, Sq, H, D)`` (e4m3 as Uint8).
-        :param k: Key tensor with shape ``(B, Sk, H, D)`` (e4m3 as Uint8).
-        :param v: Value tensor with shape ``(B, Sk, H, D)`` (e4m3 as Uint8).
-        :param o: Output tensor with shape ``(B, Sq, H, D)`` (Float16).
+        :param q: Query tensor with shape ``(B, Sq, H, D)`` (fp8).
+        :param k: Key tensor with shape ``(B, Sk, H, D)`` (fp8).
+        :param v: Value tensor with shape ``(B, Sk, H, D)`` (fp8).
+        :param o: Output tensor with shape ``(B, Sq, H, D)`` (``out_dtype``).
         :param lse: ``(B, H, Sq)`` fp32 log-sum-exp output, or ``None`` to
             compile the LSE store out entirely (no dummy buffer needed).
-        :param sinks: Must be ``None`` (fp8 cell rejects has_sink).
+        :param sinks: ``(H,)`` fp32 per-Q-head sink logits; must be ``None``
+            exactly when the kernel is configured without ``has_sink``.
         :param seq_q_lens: Per-batch query lengths, or an unused dummy tensor.
         :param seq_kv_lens: Per-batch key/value lengths, or an unused dummy tensor.
         :param amax_o: 1-element Int32 amax buffer (pre-zeroed; dummy ok).
@@ -1340,10 +1464,12 @@ class SM120FusedMultiHeadAttentionForward:
         """
         head_dim_qk = q.shape[3]
         head_dim_v = v.shape[3]
-        if cutlass.const_expr(head_dim_qk != k.shape[3] or head_dim_qk != self.head_tile_qk):
-            raise ValueError("runtime Q/K head dimensions must match the kernel head_tile_qk")
-        if cutlass.const_expr(head_dim_v != o.shape[3] or head_dim_v != self.head_tile_v):
-            raise ValueError("runtime V/O head dimensions must match the kernel head_tile_v")
+        if cutlass.const_expr(head_dim_qk != k.shape[3] or round_up_head_tile(head_dim_qk) != self.head_tile_qk):
+            raise ValueError("runtime Q/K head dimensions must round up to the kernel head_tile_qk")
+        if cutlass.const_expr(head_dim_v != o.shape[3] or round_up_head_tile(head_dim_v) != self.head_tile_v):
+            raise ValueError("runtime V/O head dimensions must round up to the kernel head_tile_v")
+        if cutlass.const_expr(head_dim_qk % 16 != 0 or head_dim_v % 16 != 0):
+            raise ValueError("head dims must be multiples of 16 (TMA 16-byte global-stride rule at 1 byte/elem)")
 
         # THD compiles the token extents DYNAMIC (mode 1 is a symbol, not an
         # int), so only statically-known modes can be compared at trace time;
@@ -1366,89 +1492,69 @@ class SM120FusedMultiHeadAttentionForward:
                 raise ValueError(f"{name} must use compact BSHD storage")
         if cutlass.const_expr(lse is not None):
             if cutlass.const_expr(self.thd_varlen):
-                # Packed head-major (H, head_stride): the head stride is the
-                # caller's token capacity and may exceed the packed total, so
-                # only the head extent is pinned.
-                if cutlass.const_expr(len(lse.shape) != 2 or lse.shape[0] != q.shape[2]):
-                    raise ValueError("THD LSE must have shape (H, head_stride)")
-                # head_stride >= T is validated by the adapter at execute:
-                # the packed total (q.shape[1]) is DYNAMIC under THD.
-                if cutlass.const_expr(lse.stride != (lse.shape[1], 1)):
-                    raise ValueError("THD LSE must be head-major with unit token stride")
+                if cutlass.const_expr(self.thd_lse_head_major):
+                    # Packed head-major (H, head_stride): the head stride is
+                    # the caller's token capacity and may exceed the packed
+                    # total, so only the head extent is pinned.
+                    if cutlass.const_expr(len(lse.shape) != 2 or lse.shape[0] != q.shape[2]):
+                        raise ValueError("head-major THD LSE must have shape (H, head_stride)")
+                    # head_stride >= T is validated by the adapter at execute:
+                    # the packed total (q.shape[1]) is DYNAMIC under THD.
+                    if cutlass.const_expr(lse.stride != (lse.shape[1], 1)):
+                        raise ValueError("THD LSE must be head-major with unit token stride")
+                else:
+                    # Token-major (T, H): T is the DYNAMIC packed total (the
+                    # adapter binds it to the same symbol as Q's), so only the
+                    # static head extent and strides are trace-checkable.
+                    if cutlass.const_expr(len(lse.shape) != 2 or lse.shape[1] != q.shape[2]):
+                        raise ValueError("THD LSE must have shape (T, H)")
+                    if cutlass.const_expr(lse.stride != (q.shape[2], 1)):
+                        raise ValueError("THD LSE must be compact token-major")
             else:
                 if cutlass.const_expr(lse.shape != (q.shape[0], q.shape[2], q.shape[1])):
                     raise ValueError("LSE must have shape (B, H, Sq)")
                 if cutlass.const_expr(lse.stride != (q.shape[2] * q.shape[1], q.shape[1], 1)):
                     raise ValueError("LSE must be compact row-major")
-        if cutlass.const_expr(sinks is not None):
-            raise ValueError("sinks must be None (the fp8 cell rejects has_sink)")
+        if cutlass.const_expr(self.has_sink != (sinks is not None)):
+            raise ValueError("sinks must be provided exactly when the kernel is configured with has_sink")
+        if cutlass.const_expr(sinks is not None and sinks.shape != (q.shape[2],)):
+            raise ValueError("sinks must have shape (H,)")
         if cutlass.const_expr(self.thd_varlen):
             if cutlass.const_expr(q.shape[0] != 1):
                 raise ValueError("THD Q/K/V/O must be packed batch-1 views")
             if cutlass.const_expr(seq_kv_lens.shape != (3 * self.thd_batch + 2,)):
                 raise ValueError("THD seq_kv_lens must be the (3*B+2,) metadata tensor")
 
-        # Split D into I contiguous C-element chunks while preserving the
-        # compact (B, S, H, D) global-memory address calculation. TMA order
-        # (C, S, I, H, B) linearizes the SMEM destination as [I][kv_tile][C].
-        k_tma_layout = cute.make_layout(
-            (
-                k.shape[0],
-                k.shape[2],
-                self.k_tma_swizzle_chunks,
-                k.shape[1],
-                self.k_swizzle_chunk_elems,
-            ),
-            stride=(
-                k.shape[1] * k.shape[2] * head_dim_qk,
-                head_dim_qk,
-                self.k_swizzle_chunk_elems,
-                k.shape[2] * head_dim_qk,
-                1,
-            ),
-        )
-        k_tma_box = (
-            1,
-            1,
-            self.k_tma_swizzle_chunks,
-            self.kv_tile,
-            self.k_swizzle_chunk_elems,
-        )
-        tma_k_desc = cuda.create_tensor_map_tiled_from_view(
-            cute.make_tensor(k.iterator, k_tma_layout),
-            box_dims=k_tma_box,
-            stride_order=(4, 3, 2, 1, 0),
-            swizzle=self.k_tma_swizzle,
-        )
-        v_tma_layout = cute.make_layout(
-            (
-                v.shape[0],
-                v.shape[2],
-                self.v_tma_swizzle_chunks,
-                v.shape[1],
-                self.v_swizzle_chunk_elems,
-            ),
-            stride=(
-                v.shape[1] * v.shape[2] * head_dim_v,
-                head_dim_v,
-                self.v_swizzle_chunk_elems,
-                v.shape[2] * head_dim_v,
-                1,
-            ),
-        )
-        v_tma_box = (
-            1,
-            1,
-            self.v_tma_swizzle_chunks,
-            self.kv_tile,
-            self.v_swizzle_chunk_elems,
-        )
-        tma_v_desc = cuda.create_tensor_map_tiled_from_view(
-            cute.make_tensor(v.iterator, v_tma_layout),
-            box_dims=v_tma_box,
-            stride_order=(4, 3, 2, 1, 0),
-            swizzle=self.v_tma_swizzle,
-        )
+        # Exact head dims: split D into I contiguous C-element chunks while
+        # preserving the compact (B, S, H, D) global-memory address
+        # calculation; TMA order (C, S, I, H, B) linearizes the SMEM
+        # destination as [I][kv_tile][C] in ONE rank-5 copy. Envelope head
+        # dims: a rank-4 descriptor keeps the ACTUAL head extent innermost so
+        # per-chunk copies zero-fill columns past it (see load_one_kv_tile).
+        def kv_tma_desc(t, head_dim, swizzle, swizzle_chunks, swizzle_chunk_elems, envelope):
+            if cutlass.const_expr(not envelope):
+                layout = cute.make_layout(
+                    (t.shape[0], t.shape[2], swizzle_chunks, t.shape[1], swizzle_chunk_elems),
+                    stride=(t.shape[1] * t.shape[2] * head_dim, head_dim, swizzle_chunk_elems, t.shape[2] * head_dim, 1),
+                )
+                box = (1, 1, swizzle_chunks, self.kv_tile, swizzle_chunk_elems)
+                stride_order = (4, 3, 2, 1, 0)
+            else:
+                layout = cute.make_layout(
+                    (t.shape[0], t.shape[2], t.shape[1], head_dim),
+                    stride=(t.shape[1] * t.shape[2] * head_dim, head_dim, t.shape[2] * head_dim, 1),
+                )
+                box = (1, 1, self.kv_tile, swizzle_chunk_elems)
+                stride_order = (3, 2, 1, 0)
+            return cuda.create_tensor_map_tiled_from_view(
+                cute.make_tensor(t.iterator, layout),
+                box_dims=box,
+                stride_order=stride_order,
+                swizzle=swizzle,
+            )
+
+        tma_k_desc = kv_tma_desc(k, head_dim_qk, self.k_tma_swizzle, self.k_tma_swizzle_chunks, self.k_swizzle_chunk_elems, head_dim_qk != self.head_tile_qk)
+        tma_v_desc = kv_tma_desc(v, head_dim_v, self.v_tma_swizzle, self.v_tma_swizzle_chunks, self.v_swizzle_chunk_elems, head_dim_v != self.head_tile_v)
         if cutlass.const_expr(self.thd_varlen):
             # Build the [kv|cu_q|cu_k] metadata buffer DEVICE-side from the
             # caller's length tensors (no host cumsum, no H2D — issue #552);
@@ -1501,6 +1607,7 @@ def compile(  # noqa: A001
     d_qk: int = 128,
     d_v: int = 128,
     has_lse: bool = True,
+    lse_head_major: bool = False,
     lse_head_stride: int = 0,
 ) -> Callable:
     """Compile and cache one architecture-specific compact BSHD shape.
@@ -1520,24 +1627,27 @@ def compile(  # noqa: A001
     ``None`` LSE argument) — callers that don't want stats pass no LSE buffer
     at all instead of a dummy.
 
-    Under THD the LSE is packed head-major ``(H, lse_head_stride)``: tokens
-    contiguous within a head row, heads strided by the caller's token capacity
-    (which may exceed the packed total, so it cannot be derived from ``sq``).
+    THD LSE is token-major ``(T, H)`` by default; ``lse_head_major=True``
+    switches to head-major ``(H, lse_head_stride)`` (FlashAttention's
+    ``softmax_lse`` layout), where ``lse_head_stride`` is the caller-declared
+    head-row stride (``>= T``, a shape — part of the cache key).
     """
 
     kernel = SM120FusedMultiHeadAttentionForward(
-        in_dtype=STORAGE_DTYPE,
-        out_dtype=OUT_STORAGE_DTYPE,
+        in_dtype=IN_DTYPE,
+        out_dtype=OUT_DTYPE,
         is_causal=PARAMS.window_right is not None,
         bottom_right=PARAMS.bottom_right,
         window_size_left=PARAMS.window_left,
+        window_size_right=(PARAMS.window_right if PARAMS.window_right else None),
         seq_q_lens_present=PARAMS.seq_q_lens_present,
         seq_kv_lens_present=PARAMS.seq_kv_lens_present,
         has_sink=PARAMS.has_sink,
         thd_varlen=PARAMS.thd_varlen,
+        thd_lse_head_major=lse_head_major,
         thd_batch=b,
-        head_tile_qk=d_qk,
-        head_tile_v=d_v,
+        head_tile_qk=round_up_head_tile(d_qk),
+        head_tile_v=round_up_head_tile(d_v),
         q_tile=PARAMS.q_tile,
         kv_tile=PARAMS.kv_tile,
     )
@@ -1549,25 +1659,25 @@ def compile(  # noqa: A001
         sq = cute.sym_int(divisibility=1)
         skv = cute.sym_int(divisibility=1)
     fake_q = cute.runtime.make_fake_compact_tensor(
-        STORAGE_DTYPE,
+        IN_DTYPE,
         (fake_batch, sq, qh, d_qk),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_k = cute.runtime.make_fake_compact_tensor(
-        STORAGE_DTYPE,
+        IN_DTYPE,
         (fake_batch, skv, kh, d_qk),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_v = cute.runtime.make_fake_compact_tensor(
-        STORAGE_DTYPE,
+        IN_DTYPE,
         (fake_batch, skv, kh, d_v),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
-        OUT_STORAGE_DTYPE,
+        OUT_DTYPE,
         (fake_batch, sq, qh, d_v),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
@@ -1575,7 +1685,7 @@ def compile(  # noqa: A001
     fake_lse = (
         cute.runtime.make_fake_compact_tensor(
             cutlass.Float32,
-            (qh, lse_head_stride) if PARAMS.thd_varlen else (fake_batch, qh, sq),
+            (((qh, lse_head_stride) if lse_head_major else (sq, qh)) if PARAMS.thd_varlen else (fake_batch, qh, sq)),
             stride_order=(1, 0) if PARAMS.thd_varlen else (2, 1, 0),
             assumed_align=4,
         )
@@ -1615,7 +1725,7 @@ def compile(  # noqa: A001
     # THD: the caller's Q/KV length tensors, consumed by the setup kernel's
     # device-side metadata build. DYNAMIC extents — (B,) per-batch lengths and
     # (B+1,) cu prefix sums bind the same artifact; the form rides the runtime
-    # thd_lens_form bitmask, so no compile key grows (Rule 4).
+    # thd_lens_form bitmask, so no compile key grows.
     if PARAMS.thd_varlen:
         fake_thd_q_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
         fake_thd_kv_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
@@ -988,17 +988,20 @@ def _run_thd_fp8(
     if check_stats:
         assert stats is not None
         stats.set_output(True).set_data_type(cudnn.data_type.FLOAT)
-        # head-major [h, t]: tokens contiguous within a head, heads strided by
-        # the padded token capacity; offsets = cu_q * stride_s = cu_q. This is
-        # the only ragged Stats layout the fp8 kernel stores.
+        # One flat fp32 buffer covers either ragged Stats layout; the ragged
+        # offsets are ELEMENT offsets under the declared strides, so each
+        # layout scales cu_q by its own token stride.
         stats_storage = torch.full((h_q * t_cap,), _THD_SENTINEL, dtype=torch.float32, device=dev)
         if stats_layout == "head_major":
-            # (H, t_cap): tokens contiguous within a head row.
+            # (H, t_cap): tokens contiguous within a head row (stride_s = 1);
+            # element offsets = cu_q.
             stats.set_dim((batch, h_q, s_q_max, 1)).set_stride((h_q * t_cap, t_cap, 1, 1))
+            stats_ro_t = (q_ro.flatten() // (D * h_q)).view(batch + 1, 1, 1, 1).contiguous()
         else:
-            # token-major packed (T, H): heads contiguous within a token row.
+            # token-major packed (T, H): heads contiguous within a token row
+            # (stride_s = h_q); element offsets = cu_q * h_q.
             stats.set_dim((batch, h_q, s_q_max, 1)).set_stride((s_q_max * h_q, 1, h_q, 1))
-        stats_ro_t = (q_ro.flatten() // (D * h_q)).view(batch + 1, 1, 1, 1).contiguous()
+            stats_ro_t = (q_ro.flatten() // D).view(batch + 1, 1, 1, 1).contiguous()
         stats_ro = g.tensor_like(stats_ro_t)
         stats.set_ragged_offset(stats_ro)
         vp[stats_ro] = stats_ro_t

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
@@ -5,15 +5,20 @@
 
 Drives ``graph.sdpa_fp8`` (FP8 E4M3 Q/K/V + scalar per-tensor descales) routed to
 the ``sdpa_fwd_prefill_sm120_fp8`` engine, and validates O against an fp32-dequant
-reference. ``Amax_O`` is produced in-kernel (bitcast-int32
-atomicMax over the pre-cast fp32 values); both are checked.
+reference. ``Amax_O`` is produced in-kernel (bitcast-int32 atomicMax over the
+pre-cast fp32 values) and checked; there is no Amax_S output (graphs that
+declare one are declined and route to the native backend).
 
-SM120 envelope (see engines._sm120_fp8_spec): E4M3 in / FP16 out only, head
-dims any multiple of 32 up to 256 with the QK^T and P@V sides independent
+SM120 envelope (see engines._sm120_fp8_spec): E4M3/E5M2 in, FP16/BF16/FP8
+out (fp8 O via a direct quantizing store, Scale_O applied pre-cast), head
+TILES any multiple of 32 up to 256 with the QK^T and P@V sides independent,
+actual head dims any multiple of 16 up to the tile via TMA zero-padding
 (what graphs can reach is further gated by the C++ sdpa_fp8 node:
 d_qk <= 128 x d_v <= 128 plus the (192, 128) MLA pair), causal /
-bottom-right / SWA / KV-padding masks, THD (ragged) with token-major Stats;
-no sink, no head-major ragged Stats.
+bottom-right / SWA / right-band / KV-padding masks, per-batch seq_len_q trim,
+ragged S_kv without a padding mask (skv_tile=0), dense_flex layouts, THD
+(ragged) with token- or head-major Stats, and attention sinks
+(sink-extended denominator, no sink column in P).
 
 Requires: SM120/SM121 (Blackwell GeForce), cutlass-dsl. Skips otherwise.
 """
@@ -31,14 +36,17 @@ from frost_test_utils import requires_blackwell_geforce, requires_dsl, select_en
 pytestmark = [requires_blackwell_geforce, requires_dsl]
 
 _E4M3_MAX = 448.0
+_E5M2_MAX = 57344.0
+_FP8_MAX = {torch.float8_e4m3fn: _E4M3_MAX, torch.float8_e5m2: _E5M2_MAX}
 
 
-def _quant(x):
-    dq = (x.abs().amax().clamp_min(1e-8) / _E4M3_MAX).item()
-    return (x / dq).clamp(-_E4M3_MAX, _E4M3_MAX).to(torch.float8_e4m3fn), dq
+def _quant(x, dtype=torch.float8_e4m3fn):
+    fmax = _FP8_MAX[dtype]
+    dq = (x.abs().amax().clamp_min(1e-8) / fmax).item()
+    return (x / dq).clamp(-fmax, fmax).to(dtype), dq
 
 
-def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=None, seq_lens_kv=None):
+def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=None, right_bound=0, seq_lens_kv=None, seq_lens_q=None, sinks=None):
     b, h_q, s_q, _ = qd.shape
     _, h_kv, s_kv, _ = vd.shape
     dev = qd.device
@@ -50,7 +58,7 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     j = torch.arange(s_kv, device=dev).view(1, 1, 1, s_kv)
     masked = torch.zeros(1, 1, s_q, s_kv, dtype=torch.bool, device=dev)
     if is_causal:
-        lim = i + (s_kv - s_q) if bottom_right else i
+        lim = (i + (s_kv - s_q) if bottom_right else i) + right_bound
         masked = masked | (j > lim)
     if swa_window is not None:
         masked = masked | (j < i - swa_window)
@@ -58,12 +66,46 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
         slk = torch.as_tensor(seq_lens_kv, device=dev, dtype=torch.long).view(b, 1, 1, 1)
         masked = masked | (j >= slk)
     scores = scores.masked_fill(masked, float("-inf"))
-    probs = torch.softmax(scores, dim=-1)
+    if sinks is not None:
+        sink_col = sinks.flatten().float().view(1, h_q, 1, 1).expand(b, h_q, s_q, 1)
+        scores = torch.cat([scores, sink_col], dim=-1)
+    probs = torch.softmax(scores, dim=-1).nan_to_num(0.0)[..., :s_kv]
+    out = torch.matmul(probs, v_e)
+    lse = torch.logsumexp(scores, dim=-1)
+    if seq_lens_q is not None:
+        # cuDNN dense padded-Q trim: rows at/past seq_len_q[b] write O := 0 /
+        # LSE := -inf and contribute nothing to the amaxes (softmax of a
+        # fully -inf row is NaN in torch; the trim replaces it).
+        slq = torch.as_tensor(seq_lens_q, device=dev, dtype=torch.long).view(b, 1, 1, 1)
+        row_dead = i >= slq
+        out = torch.where(row_dead, torch.zeros((), device=dev), out)
+        probs = torch.where(row_dead, torch.zeros((), device=dev), probs)
+        lse = lse.masked_fill(row_dead.squeeze(-1), float("-inf"))
     # Fully-masked rows are -inf in logsumexp; the kernel writes -inf too.
-    return torch.matmul(probs, v_e), torch.logsumexp(scores, dim=-1)
+    return out, lse
 
 
-def _run(B, H_q, H_kv, S_q, S_kv, *, scale, sdpa_kwargs, seq_lens_kv=None, tiles=None, s_descale_gain=1.0, D=128, D_v=None):
+def _run(
+    B,
+    H_q,
+    H_kv,
+    S_q,
+    S_kv,
+    *,
+    scale,
+    sdpa_kwargs,
+    seq_lens_kv=None,
+    seq_lens_q=None,
+    tiles=None,
+    s_descale_gain=1.0,
+    D=128,
+    D_v=None,
+    io_dtype=torch.float8_e4m3fn,
+    o_dtype=torch.float16,
+    so_val=1.0,
+    layout="bshd",
+    sinks=None,
+):
     import cudnn
 
     dev = "cuda"
@@ -71,28 +113,46 @@ def _run(B, H_q, H_kv, S_q, S_kv, *, scale, sdpa_kwargs, seq_lens_kv=None, tiles
     Qf = torch.randn(B, H_q, S_q, D, device=dev) * 0.5
     Kf = torch.randn(B, H_kv, S_kv, D, device=dev) * 0.5
     Vf = torch.randn(B, H_kv, S_kv, D_v, device=dev) * 0.5
-    Q8, dq = _quant(Qf)
-    K8, dk = _quant(Kf)
-    V8, dv = _quant(Vf)
+    Q8, dq = _quant(Qf, io_dtype)
+    K8, dk = _quant(Kf, io_dtype)
+    V8, dv = _quant(Vf, io_dtype)
 
     def bshd(x8):
         return x8.permute(0, 2, 1, 3).contiguous().transpose(1, 2)
 
-    Qb, Kb, Vb = bshd(Q8), bshd(K8), bshd(V8)
-    Ob = torch.empty(B, S_q, H_q, D_v, device=dev, dtype=torch.float16).transpose(1, 2)
+    if layout == "bshd":
+        Qb, Kb, Vb = bshd(Q8), bshd(K8), bshd(V8)
+        Ob = torch.empty(B, S_q, H_q, D_v, device=dev, dtype=o_dtype).transpose(1, 2)
+    elif layout == "bhsd":
+        # BHSD-contiguous (torch's natural layout) -- NOT BSHD-physical; the
+        # dense_flex relaxation normalizes it via one gather / scatter copy.
+        Qb, Kb, Vb = Q8.contiguous(), K8.contiguous(), V8.contiguous()
+        Ob = torch.empty(B, H_q, S_q, D_v, device=dev, dtype=o_dtype)
+    elif layout == "padded_s":
+        # Padded S stride: rows allocated with slack between sequences.
+        def pad_s(x8, s):
+            buf = torch.zeros(x8.shape[0], x8.shape[1], s + 24, x8.shape[3], device=dev, dtype=x8.dtype)
+            buf[:, :, :s, :] = x8
+            return buf[:, :, :s, :]
+
+        Qb, Kb, Vb = pad_s(Q8, S_q), pad_s(K8, S_kv), pad_s(V8, S_kv)
+        Ob = torch.zeros(B, H_q, S_q + 24, D_v, device=dev, dtype=o_dtype)[:, :, :S_q, :]
+    else:
+        raise ValueError(f"unknown layout {layout!r}")
     lse = torch.empty(B, H_q, S_q, 1, device=dev, dtype=torch.float32)
     amax_o = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
 
     def sc(val):
         return torch.tensor([[[[val]]]], dtype=torch.float32, device=dev)
 
-    # Scale_S maps P (in (0,1] after the row-max subtraction) onto E4M3's
-    # range; Descale_S undoes it in the epilogue. Non-unit on purpose -- unit
-    # values would not exercise the scaling at all.
-    s_scale = _E4M3_MAX
-    dqt, dkt, dvt, dst, sst, sot = sc(dq), sc(dk), sc(dv), sc(s_descale_gain / s_scale), sc(s_scale), sc(1.0)
+    # Scale_S maps P (in (0,1] after the row-max subtraction) onto the io
+    # dtype's range; Descale_S undoes it in the epilogue. Non-unit on
+    # purpose -- unit values would not exercise the scaling at all.
+    s_scale = _FP8_MAX[io_dtype]
+    dqt, dkt, dvt, dst, sst, sot = sc(dq), sc(dk), sc(dv), sc(s_descale_gain / s_scale), sc(s_scale), sc(so_val)
 
-    g = cudnn.pygraph(io_data_type=cudnn.data_type.FP8_E4M3, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    io_cudnn = {torch.float8_e4m3fn: cudnn.data_type.FP8_E4M3, torch.float8_e5m2: cudnn.data_type.FP8_E5M2}[io_dtype]
+    g = cudnn.pygraph(io_data_type=io_cudnn, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
     q = g.tensor_like(Qb)
     k = g.tensor_like(Kb)
     v = g.tensor_like(Vb)
@@ -103,17 +163,33 @@ def _run(B, H_q, H_kv, S_q, S_kv, *, scale, sdpa_kwargs, seq_lens_kv=None, tiles
     dqn, dkn, dvn, dsn, ssn, son = (_stns() for _ in range(6))
     kw = dict(q=q, k=k, v=v, descale_q=dqn, descale_k=dkn, descale_v=dvn, descale_s=dsn, scale_s=ssn, scale_o=son, attn_scale=scale, generate_stats=True)
     vp = {q: Qb, k: Kb, v: Vb, dqn: dqt, dkn: dkt, dvn: dvt, dsn: dst, ssn: sst, son: sot}
+    if seq_lens_q is not None and seq_lens_kv is None:
+        seq_lens_kv = [S_kv] * B
     if seq_lens_kv is not None:
-        slq = torch.full((B, 1, 1, 1), S_q, dtype=torch.int32, device=dev)
+        slq = (
+            torch.tensor(seq_lens_q, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
+            if seq_lens_q is not None
+            else torch.full((B, 1, 1, 1), S_q, dtype=torch.int32, device=dev)
+        )
         slk = torch.tensor(seq_lens_kv, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
         sq_h = g.tensor(dim=[B, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
         skv_h = g.tensor(dim=[B, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
         kw.update(use_padding_mask=True, seq_len_q=sq_h, seq_len_kv=skv_h)
         vp[sq_h] = slq
         vp[skv_h] = slk
+    if sinks is not None:
+        sink_t = g.tensor_like(sinks, name="sink")
+        kw["sink_token"] = sink_t
+        vp[sink_t] = sinks
     kw.update(sdpa_kwargs)
-    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested
-    o.set_output(True).set_dim(list(Ob.shape)).set_stride(list(Ob.stride())).set_data_type(cudnn.data_type.HALF)
+    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested (FROST does not produce it)
+    o_cudnn = {
+        torch.float16: cudnn.data_type.HALF,
+        torch.bfloat16: cudnn.data_type.BFLOAT16,
+        torch.float8_e4m3fn: cudnn.data_type.FP8_E4M3,
+        torch.float8_e5m2: cudnn.data_type.FP8_E5M2,
+    }[o_dtype]
+    o.set_output(True).set_dim(list(Ob.shape)).set_stride(list(Ob.stride())).set_data_type(o_cudnn)
     stats.set_output(True).set_dim([B, H_q, S_q, 1]).set_stride([H_q * S_q, S_q, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
 
@@ -128,8 +204,10 @@ def _run(B, H_q, H_kv, S_q, S_kv, *, scale, sdpa_kwargs, seq_lens_kv=None, tiles
     torch.cuda.synchronize()
 
     ref_kw = _ref_kwargs(sdpa_kwargs)
-    o_ref, lse_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kw)
-    return Ob, o_ref, amax_o.item(), o_ref.abs().max().item(), lse.squeeze(-1), lse_ref
+    o_ref, lse_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, seq_lens_q=seq_lens_q, sinks=sinks, **ref_kw)
+    # O carries Scale_O; Amax_O is the pre-scale amax (the kernel divides it
+    # back out), so both compare against the unscaled reference.
+    return Ob.float() / so_val, o_ref, amax_o.item(), o_ref.abs().max().item(), lse.squeeze(-1), lse_ref
 
 
 def _ref_kwargs(sdpa_kwargs):
@@ -142,12 +220,18 @@ def _ref_kwargs(sdpa_kwargs):
     lb = sdpa_kwargs.get("left_bound")
     if lb is not None:
         out["swa_window"] = lb - 1
+    rb = sdpa_kwargs.get("right_bound")
+    if rb is not None:
+        # A band graph is NON-causal in cuDNN's vocabulary; the kernel lowers
+        # it as the causal machinery with the diagonal translated right by R.
+        out["is_causal"] = True
+        out["right_bound"] = rb
     return out
 
 
-def _check(out, o_ref, amax_o, amax_o_ref, lse=None, lse_ref=None):
+def _check(out, o_ref, amax_o, amax_o_ref, lse=None, lse_ref=None, tol_o=5e-2):
     diff = (out.float() - o_ref).abs().max().item()
-    assert diff <= 5e-2, f"max|O-ref|={diff:.4f} > 0.05"
+    assert diff <= tol_o, f"max|O-ref|={diff:.4f} > {tol_o}"
     assert abs(amax_o - amax_o_ref) <= 0.03, f"amax_o {amax_o:.4f} vs ref {amax_o_ref:.4f}"
     if lse is not None:
         finite = torch.isfinite(lse_ref)
@@ -213,16 +297,176 @@ def test_fp8_sm120_padding(causal):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("mask", ["none", "causal"])
+@pytest.mark.parametrize("mask", ["none", "none_dense", "causal"])
 @pytest.mark.parametrize("s", [96, 97, 110], ids=lambda s: f"s{s}")
 @torch_fork_set_rng(seed=0)
 def test_fp8_sm120_single_kv_tile(mask, s):
-    """Single-KV-tile shapes (s_kv <= kv_tile), repeated."""
+    """Single-KV-tile shapes (s_kv <= kv_tile), repeated.
+
+    "none" reaches the shape through the padded route (per-batch KV length);
+    "none_dense" through the dense route that skv_tile=0 opened -- both bound
+    the KV trip count at compile time, i.e. both are collapse-guard
+    populations."""
     scale = 1.0 / math.sqrt(128)
     seq_lens_kv = [s] if mask == "none" else None
     for _ in range(3):
-        res = _run(1, 4, 4, s, s, scale=scale, sdpa_kwargs=_MASKS[mask], seq_lens_kv=seq_lens_kv)
+        res = _run(1, 4, 4, s, s, scale=scale, sdpa_kwargs=_MASKS.get(mask, {}), seq_lens_kv=seq_lens_kv)
         _check(*res)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("layout", ["bhsd", "padded_s"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_dense_flex_layout(layout):
+    """Non-BSHD dense layouts (the dense_flex relaxation): BHSD-contiguous
+    (torch's natural layout) and padded S strides. The shared adapter
+    normalizes to the kernel's compact BSHD via one gather / scatter copy."""
+    scale = 1.0 / math.sqrt(128)
+    res = _run(2, 4, 4, 256, 256, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), layout=layout)
+    _check(*res)
+
+
+_O_TOL = {torch.bfloat16: 5e-2, torch.float8_e4m3fn: 1.5e-1, torch.float8_e5m2: 3.5e-1}
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("o_dtype", [torch.float8_e4m3fn, torch.float8_e5m2, torch.bfloat16])
+@pytest.mark.parametrize("mask", ["none", "causal"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_o_dtype(o_dtype, mask):
+    """Non-FP16 O dtypes. fp8 O exercises the direct quantizing store with a
+    NON-UNIT Scale_O (applied before the cast; Amax_O stays the pre-scale
+    fp32 amax); bf16 rides the staging epilogue. Tolerances widen with the
+    output mantissa (e5m2 keeps 2 bits)."""
+    scale = 1.0 / math.sqrt(128)
+    kwargs = dict(use_causal_mask=True) if mask == "causal" else {}
+    res = _run(2, 4, 2, 256, 256, scale=scale, sdpa_kwargs=kwargs, o_dtype=o_dtype, so_val=2.0)
+    _check(*res, tol_o=_O_TOL[o_dtype])
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_fp8_out_mixed_in():
+    """E5M2 in with E4M3 out: the MMA tag follows the input, the quantizing
+    store the independent O dtype."""
+    scale = 1.0 / math.sqrt(128)
+    res = _run(2, 2, 2, 256, 256, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), io_dtype=torch.float8_e5m2, o_dtype=torch.float8_e4m3fn, so_val=2.0)
+    _check(*res, tol_o=_O_TOL[torch.float8_e4m3fn])
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_fp8_out_envelope():
+    """fp8 O x d_envelope: the 2-byte column-pair stores clip at the actual
+    head dim (pairs never straddle it -- dims are multiples of 16)."""
+    scale = 1.0 / math.sqrt(80)
+    res = _run(2, 4, 2, 256, 256, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), D=80, o_dtype=torch.float8_e4m3fn, so_val=2.0)
+    _check(*res, tol_o=_O_TOL[torch.float8_e4m3fn])
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_fp8_out_seq_q_trim():
+    """fp8 O x per-batch Q trim: rows at/past seq_len_q[b] zero-fill through
+    the direct-store path."""
+    scale = 1.0 / math.sqrt(128)
+    res = _run(3, 2, 2, 256, 256, scale=scale, sdpa_kwargs={}, seq_lens_q=[256, 129, 0], o_dtype=torch.float8_e4m3fn, so_val=2.0)
+    _check(*res, tol_o=_O_TOL[torch.float8_e4m3fn])
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("D,D_v", [(48, 48), (80, 80), (112, 112), (112, 80)])
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_d_envelope(D, D_v):
+    """Actual head dims narrower than the 32-granule head tiles (multiples of
+    16): TMA zero-fills the pad K/V columns, the Q load and O store guards
+    clip to the actual widths. Causal exercises the masked-tile path too."""
+    scale = 1.0 / math.sqrt(D)
+    res = _run(2, 4, 2, 256, 256, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), D=D, D_v=D_v)
+    _check(*res)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_d_envelope_offering():
+    """Multiples of 16 are served via the envelope; other alignments decline
+    (TMA 16-byte global-stride rule at 1 byte/elem)."""
+    import cudnn
+
+    assert _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.HALF, D=80)
+    assert not _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.HALF, D=72)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mask", ["none", "causal"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_sink(mask):
+    """Attention sink: per-Q-head logit in the softmax denominator (virtual
+    column with no V row). O rescales, the LSE extends, and Amax_S follows
+    the SM100 fp8 cell's sink-extended convention."""
+    scale = 1.0 / math.sqrt(128)
+    sinks = torch.randn(1, 4, 1, 1, dtype=torch.float32, device="cuda")
+    kwargs = dict(use_causal_mask=True) if mask == "causal" else {}
+    res = _run(2, 4, 2, 256, 256, scale=scale, sdpa_kwargs=kwargs, sinks=sinks)
+    _check(*res)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=20)
+def test_fp8_sm120_sink_dead_rows():
+    """With a sink, rows with no visible key keep a finite LSE (the sink
+    alone) and O := 0; rows past seq_len_q[b] still trim to -inf."""
+    scale = 1.0 / math.sqrt(128)
+    sinks = torch.randn(1, 4, 1, 1, dtype=torch.float32, device="cuda")
+    res = _run(2, 4, 4, 128, 128, scale=scale, sdpa_kwargs={}, seq_lens_q=[96, 128], seq_lens_kv=[0, 64], sinks=sinks)
+    _check(*res)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_right_band():
+    """diagonal band right bound R > 0 (keep j <= diag + R, inclusive): the
+    causal machinery with the diagonal TRANSLATED right -- the frontier width
+    is R-independent. Cases: plain band; full band (left + right bounds);
+    a band across a ragged KV tail; degenerate R >= S_kv (clamps to full
+    visibility)."""
+    scale = 1.0 / math.sqrt(128)
+    for kwargs, s_q, s_kv in (
+        (dict(right_bound=32), 256, 256),
+        (dict(right_bound=32, left_bound=65), 256, 256),
+        (dict(right_bound=48), 256, 300),
+        (dict(right_bound=500), 128, 128),
+    ):
+        res = _run(2, 4, 4, s_q, s_kv, scale=scale, sdpa_kwargs=kwargs)
+        _check(*res)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("causal", [False, True], ids=["none", "causal"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_seq_q_trim(causal):
+    """Dense padded graphs with per-batch Q lengths shorter than S_q: rows at
+    or past seq_len_q[b] write O = 0 and LSE = -inf. Batch 2 is ZERO-length --
+    the ragged population that crashes the backend's eng11; the frost path
+    must handle it exactly."""
+    scale = 1.0 / math.sqrt(128)
+    kw = dict(use_causal_mask=True) if causal else {}
+    res = _run(3, 4, 4, 256, 256, scale=scale, sdpa_kwargs=kw, seq_lens_q=[256, 129, 0], seq_lens_kv=[256, 200, 256])
+    _check(*res)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("s_q,s_kv", [(256, 130), (255, 321)], ids=lambda v: str(v))
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_dense_kv_tail(s_q, s_kv):
+    """Dense no-mask with S_kv not a whole number of KV tiles (skv_tile=0):
+    the kernel's first (masked) KV step bounds columns against the
+    compile-time seqlen_k regardless of mask flags, so ragged S_kv is served
+    natively -- no padding mask, no synthesized lengths. Rectangular S_q
+    exercises the Q-row trim alongside the KV tail."""
+    scale = 1.0 / math.sqrt(128)
+    res = _run(2, 4, 4, s_q, s_kv, scale=scale, sdpa_kwargs={})
+    _check(*res)
 
 
 @pytest.mark.L0
@@ -238,46 +482,32 @@ def test_fp8_sm120_single_kv_tile_padded():
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("mask", ["none", "causal"])
 @torch_fork_set_rng(seed=0)
-def test_fp8_sm120_e5m2_not_offered():
-    """The v1 kernel hardcodes the e4m3 MMA tag; E5M2 graphs must not route here."""
-    import cudnn
-
-    dev = "cuda"
-    B, H, S, D = 1, 4, 256, 128
-    X = torch.randn(B, S, H, D, device=dev).to(torch.float8_e5m2).transpose(1, 2)
-    g = cudnn.pygraph(io_data_type=cudnn.data_type.FP8_E5M2, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
-    q, k, v = g.tensor_like(X), g.tensor_like(X), g.tensor_like(X)
-    scalars = [g.tensor(dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.FLOAT) for _ in range(6)]
-    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(
-        q=q,
-        k=k,
-        v=v,
-        descale_q=scalars[0],
-        descale_k=scalars[1],
-        descale_v=scalars[2],
-        descale_s=scalars[3],
-        scale_s=scalars[4],
-        scale_o=scalars[5],
-        attn_scale=1.0 / math.sqrt(D),
-        generate_stats=True,
-    )
-    o.set_output(True).set_dim([B, H, S, D]).set_stride([S * H * D, D, H * D, 1]).set_data_type(cudnn.data_type.HALF)
-    stats.set_output(True).set_dim([B, H, S, 1]).set_stride([H * S, S, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
-    amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
-    g.validate()
-    g.build_operation_graph()
-    try:
-        g.create_execution_plans([cudnn.heur_mode.A])
-    except cudnn.cudnnGraphNotSupportedError:
-        # Nothing — python engine or backend — serves E5M2 here: also a pass
-        # (the point is only that the e4m3-tagged sm120 fp8 cell declined).
-        return
-    names = [g.get_plan_name_at_index(i) for i in range(len(g.plans))]
-    assert engine_name(arch="sm120", fp8=True) not in names, f"E5M2 graph must not offer the sm120 fp8 engine; plans={names}"
+def test_fp8_sm120_e5m2(mask):
+    """E5M2 inputs: the MMA tag and the P-quantization target follow the
+    input dtype (P is cast to e5m2, Scale_S maps it onto e5m2's range).
+    E5M2's 2-bit mantissa doubles the P-quantization floor, hence the wider
+    O tolerance; Amax_S / Amax_O are fp32 pre-cast values and keep theirs."""
+    scale = 1.0 / math.sqrt(128)
+    res = _run(2, 4, 4, 256, 256, scale=scale, sdpa_kwargs=_MASKS[mask], io_dtype=torch.float8_e5m2)
+    _check(*res, tol_o=1e-1)
 
 
-def _fp8_graph_offers_sm120(io_dtype, o_dtype, D=128, D_v=None, sink=False):
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_e5m2_single_kv_tile():
+    """The collapse-guard shape on the E5M2 specialization: a different MMA
+    tag and P conversion make it a distinct compiled artifact, so it needs
+    its own toolchain guard (repeated -- the guarded failure mode was
+    nondeterministic)."""
+    scale = 1.0 / math.sqrt(128)
+    for _ in range(3):
+        res = _run(1, 4, 4, 97, 97, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), io_dtype=torch.float8_e5m2)
+        _check(*res, tol_o=1e-1)
+
+
+def _fp8_graph_offers_sm120(io_dtype, o_dtype, D=128, D_v=None, sink=False, layout="bshd"):
     """Build one sdpa_fp8 graph and report whether the sm120 fp8 cell claims it.
 
     A capability rejection is the point, so nothing is executed; a graph that
@@ -289,8 +519,13 @@ def _fp8_graph_offers_sm120(io_dtype, o_dtype, D=128, D_v=None, sink=False):
     B, H, S = 1, 4, 256
     D_v = D if D_v is None else D_v
     torch_in = torch.float8_e5m2 if io_dtype == cudnn.data_type.FP8_E5M2 else torch.float8_e4m3fn
-    X = torch.randn(B, S, H, D, device=dev).to(torch_in).transpose(1, 2)
-    Xv = torch.randn(B, S, H, D_v, device=dev).to(torch_in).transpose(1, 2)
+    if layout == "bhsd":
+        # BHSD-contiguous: dense but NOT BSHD-physical.
+        X = torch.randn(B, H, S, D, device=dev).to(torch_in)
+        Xv = torch.randn(B, H, S, D_v, device=dev).to(torch_in)
+    else:
+        X = torch.randn(B, S, H, D, device=dev).to(torch_in).transpose(1, 2)
+        Xv = torch.randn(B, S, H, D_v, device=dev).to(torch_in).transpose(1, 2)
     g = cudnn.pygraph(io_data_type=io_dtype, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
     q, k, v = g.tensor_like(X), g.tensor_like(X), g.tensor_like(Xv)
     scalars = [g.tensor(dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.FLOAT) for _ in range(6)]
@@ -309,7 +544,7 @@ def _fp8_graph_offers_sm120(io_dtype, o_dtype, D=128, D_v=None, sink=False):
     )
     if sink:
         kw["sink_token"] = g.tensor(dim=[1, H, 1, 1], stride=[H, 1, 1, 1], data_type=cudnn.data_type.FLOAT)
-    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested
+    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested (FROST does not produce it)
     o.set_output(True).set_dim([B, H, S, D_v]).set_stride([S * H * D_v, D_v, H * D_v, 1]).set_data_type(o_dtype)
     stats.set_output(True).set_dim([B, H, S, 1]).set_stride([H * S, S, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
@@ -326,29 +561,31 @@ def _fp8_graph_offers_sm120(io_dtype, o_dtype, D=128, D_v=None, sink=False):
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
-def test_fp8_sm120_sink_not_offered():
-    """The fp8 cell does not implement the sink fold, so it must decline."""
+def test_fp8_sm120_sink_offered():
+    """Sink graphs are served (SM100 fp8 Amax_S semantics: the sink extends
+    the softmax denominator; P carries no sink column)."""
     import cudnn
 
-    assert not _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.HALF, sink=True)
+    assert _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.HALF, sink=True)
 
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
-def test_fp8_sm120_fp8_output_not_offered():
-    """The epilogue stores FP16; an fp8 O would need a quantizing store."""
+def test_fp8_sm120_fp8_output_offered():
+    """fp8 O is served via the direct quantizing store (Scale_O before the
+    cast; Amax_O pre-cast)."""
     import cudnn
 
-    assert not _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E4M3)
+    assert _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E4M3)
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("D", [16, 48, 144, 288])
+@pytest.mark.parametrize("D", [24, 144, 288])
 @torch_fork_set_rng(seed=0)
 def test_fp8_sm120_off_granule_head_dim_not_offered(D):
-    """No zero-padding envelope on the 8-bit fragment path: dims are exact
-    multiples of 32 (k32 contraction; 1-byte TMA swizzle span). 16-odd
-    multiples of 16 and out-of-range dims decline."""
+    """Declined head dims: 24 breaks the envelope alignment (multiples of 16,
+    the TMA 16-byte global-stride rule at 1 byte/elem); 144/288 exceed the
+    C++ sdpa_fp8 node's front door (d <= 128) / the row's 256 cap."""
     import cudnn
 
     assert not _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.HALF, D=D)
@@ -481,9 +718,9 @@ def _run_template_tail(D, D_v, *, mask, S=256):
     amax_o = torch.zeros(1, dtype=torch.float32, device=dev)
     scale = 1.0 / math.sqrt(D)
     fn(
-        q8.view(torch.uint8),  # the adapter's ABI: e4m3 as uint8 storage
-        k8.view(torch.uint8),
-        v8.view(torch.uint8),
+        q8,  # native fp8 element types across the ABI
+        k8,
+        v8,
         o,
         None,  # lse (has_lse=False)
         None,  # sinks (unsupported; ABI slot)
@@ -493,6 +730,10 @@ def _run_template_tail(D, D_v, *, mask, S=256):
         cutlass.Float32(scale * math.log2(math.e)),  # softmax_scale_log2 (descale_q = descale_k = 1)
         cutlass.Float32(1.0),  # o_scale_fused = descale_s * descale_v * scale_o, all 1.0 here
         cutlass.Float32(1.0),  # scale_s
+        cutlass.Int32(0),  # thd_max_sq (dense: ignored)
+        None,  # thd_q_lens (dense: folded out of the ABI)
+        None,  # thd_kv_lens
+        None,  # thd_lens_form
         cuda_driver.CUstream(torch.cuda.current_stream().cuda_stream),
     )
     torch.cuda.synchronize()
@@ -593,7 +834,23 @@ def _pack_thd(seqs, s_max, dtype):
     return view, storage, ro
 
 
-def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bottom_right=False, check_stats=False):
+def _run_thd_fp8(
+    *,
+    seq_q_lens,
+    seq_kv_lens,
+    h_q=8,
+    h_kv=8,
+    D=128,
+    is_causal=True,
+    bottom_right=False,
+    window_size_right=None,
+    with_sink=False,
+    o_dtype=torch.float16,
+    so_val=1.0,
+    check_stats=False,
+    stats_layout="head_major",
+    raw_bind=False,
+):
     """Run a ragged FP8 graph on the SM120 engine vs per-sequence references.
 
     Per-tensor FP8 means ONE descale per tensor for the whole packed batch, so
@@ -601,13 +858,13 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
     """
     import cudnn
 
-    dev, D = "cuda", 128
+    dev = "cuda"
     batch = len(seq_q_lens)
     s_q_max, s_kv_max = max(max(seq_q_lens), 1), max(max(seq_kv_lens), 1)
     scale = 1.0 / math.sqrt(D)
 
     def _quant_seqs(seqs):
-        amax = max((s.abs().amax().item() for s in seqs), default=1.0)
+        amax = max((s.abs().amax().item() for s in seqs if s.numel()), default=1.0)
         d = max(amax, 1e-8) / _E4M3_MAX
         return [(s / d).clamp(-_E4M3_MAX, _E4M3_MAX).to(torch.float8_e4m3fn) for s in seqs], d
 
@@ -618,15 +875,14 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
     k_8, dk = _quant_seqs([s.contiguous() for s in k_f])
     v_8, dv = _quant_seqs([s.contiguous() for s in v_f])
 
-    q_view, _, q_ro = _pack_thd(q_8, s_q_max, torch.float8_e4m3fn)
-    k_view, _, k_ro = _pack_thd(k_8, s_kv_max, torch.float8_e4m3fn)
-    v_view, _, v_ro = _pack_thd(v_8, s_kv_max, torch.float8_e4m3fn)
-    o_view, o_storage, o_ro = _pack_thd(
-        [torch.zeros(1, h_q, max(n, 1), D, dtype=torch.float16, device=dev)[:, :, :n] for n in seq_q_lens], s_q_max, torch.float16
-    )
+    q_view, q_storage, q_ro = _pack_thd(q_8, s_q_max, torch.float8_e4m3fn)
+    k_view, k_storage, k_ro = _pack_thd(k_8, s_kv_max, torch.float8_e4m3fn)
+    v_view, v_storage, v_ro = _pack_thd(v_8, s_kv_max, torch.float8_e4m3fn)
+    o_view, o_storage, o_ro = _pack_thd([torch.zeros(1, h_q, max(n, 1), D, dtype=o_dtype, device=dev)[:, :, :n] for n in seq_q_lens], s_q_max, o_dtype)
     # The kernel writes every valid packed O token; everything else must come
-    # back untouched.
-    o_storage.fill_(_THD_SENTINEL)
+    # back untouched. (Clamped into the O dtype's range for fp8 outputs.)
+    sentinel = min(_THD_SENTINEL, torch.finfo(o_dtype).max)
+    o_storage.fill_(sentinel)
 
     sq_t = torch.tensor(seq_q_lens, dtype=torch.int32, device=dev).view(batch, 1, 1, 1)
     skv_t = torch.tensor(seq_kv_lens, dtype=torch.int32, device=dev).view(batch, 1, 1, 1)
@@ -636,7 +892,8 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
         return torch.tensor([[[[val]]]], dtype=torch.float32, device=dev)
 
     s_scale = _E4M3_MAX
-    dqt, dkt, dvt, dst, sst, sot = sc(dq), sc(dk), sc(dv), sc(1.0 / s_scale), sc(s_scale), sc(1.0)
+    dqt, dkt, dvt, dst, sst, sot = sc(dq), sc(dk), sc(dv), sc(1.0 / s_scale), sc(s_scale), sc(so_val)
+    sinks = torch.randn(1, h_q, 1, 1, dtype=torch.float32, device=dev) if with_sink else None
 
     g = cudnn.pygraph(io_data_type=cudnn.data_type.FP8_E4M3, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
     tq, tk, tv = g.tensor_like(q_view), g.tensor_like(k_view), g.tensor_like(v_view)
@@ -667,20 +924,45 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
         seq_len_q=sq_h,
         seq_len_kv=skv_h,
     )
-    if bottom_right:
+    if window_size_right is not None:
+        # A band graph is NON-causal in cuDNN's vocabulary (right_bound = R).
+        kw["right_bound"] = window_size_right
+    elif bottom_right:
         kw["use_causal_mask_bottom_right"] = True
     elif is_causal:
         kw["use_causal_mask"] = True
+    sink_t = None
+    if sinks is not None:
+        sink_t = g.tensor_like(sinks, name="sink")
+        kw["sink_token"] = sink_t
 
-    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested
-    o.set_output(True).set_dim(list(o_view.shape)).set_stride(list(o_view.stride())).set_data_type(cudnn.data_type.HALF)
+    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested (FROST does not produce it)
+    o_cudnn = {
+        torch.float16: cudnn.data_type.HALF,
+        torch.bfloat16: cudnn.data_type.BFLOAT16,
+        torch.float8_e4m3fn: cudnn.data_type.FP8_E4M3,
+        torch.float8_e5m2: cudnn.data_type.FP8_E5M2,
+    }[o_dtype]
+    o.set_output(True).set_dim(list(o_view.shape)).set_stride(list(o_view.stride())).set_data_type(o_cudnn)
     o.set_ragged_offset(ro)
     amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
 
+    if raw_bind:
+        # mhas-style runtime binding: RAW rank-3 (T_cap, H, D) buffers rather
+        # than the declared-rank BSHD views. The adapter must read/write the
+        # packed storage directly (as_strided), never normalize through the
+        # dense _to_bshd path -- its semantic-copy scratch write-back
+        # scrambles packed bytes for h > 1 (the mhas test16/25/28/32 class).
+        q_bind = q_storage.view(-1, h_q, D)
+        k_bind = k_storage.view(-1, h_kv, D)
+        v_bind = v_storage.view(-1, h_kv, D)
+        o_bind = o_storage.view(-1, h_q, D)
+    else:
+        q_bind, k_bind, v_bind, o_bind = q_view, k_view, v_view, o_view
     vp = {
-        tq: q_view,
-        tk: k_view,
-        tv: v_view,
+        tq: q_bind,
+        tk: k_bind,
+        tv: v_bind,
         rq: q_ro,
         rk: k_ro,
         rv: v_ro,
@@ -693,9 +975,11 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
         dsn: dst,
         ssn: sst,
         son: sot,
-        o: o_view,
+        o: o_bind,
         amx_o: amax_o,
     }
+    if sink_t is not None:
+        vp[sink_t] = sinks
     cu = [0]
     for n in seq_q_lens:
         cu.append(cu[-1] + n)
@@ -708,7 +992,12 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
         # the padded token capacity; offsets = cu_q * stride_s = cu_q. This is
         # the only ragged Stats layout the fp8 kernel stores.
         stats_storage = torch.full((h_q * t_cap,), _THD_SENTINEL, dtype=torch.float32, device=dev)
-        stats.set_dim((batch, h_q, s_q_max, 1)).set_stride((h_q * t_cap, t_cap, 1, 1))
+        if stats_layout == "head_major":
+            # (H, t_cap): tokens contiguous within a head row.
+            stats.set_dim((batch, h_q, s_q_max, 1)).set_stride((h_q * t_cap, t_cap, 1, 1))
+        else:
+            # token-major packed (T, H): heads contiguous within a token row.
+            stats.set_dim((batch, h_q, s_q_max, 1)).set_stride((s_q_max * h_q, 1, h_q, 1))
         stats_ro_t = (q_ro.flatten() // (D * h_q)).view(batch + 1, 1, 1, 1).contiguous()
         stats_ro = g.tensor_like(stats_ro_t)
         stats.set_ragged_offset(stats_ro)
@@ -729,19 +1018,35 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
         if nq == 0:
             continue
         o_ref, lse_ref = _ref(
-            q_8[i].float() * dq, k_8[i].float() * dk, v_8[i].float() * dv, scale=scale, is_causal=is_causal or bottom_right, bottom_right=bottom_right
+            q_8[i].float() * dq,
+            k_8[i].float() * dk,
+            v_8[i].float() * dv,
+            scale=scale,
+            is_causal=is_causal or bottom_right or window_size_right is not None,
+            bottom_right=bottom_right,
+            right_bound=window_size_right if window_size_right is not None else 0,
+            sinks=sinks,
         )
-        got = packed_o[cu[i] : cu[i + 1]].float()
+        # O carries Scale_O; compare against the unscaled reference.
+        got = packed_o[cu[i] : cu[i + 1]].float() / so_val
         want = o_ref[0].permute(1, 0, 2).float()
         diff = (got - want).abs().max().item()
-        assert diff <= 5e-2, f"seq {i}: max|O-ref|={diff:.4f}"
+        tol_o = _O_TOL.get(o_dtype, 5e-2)
+        assert diff <= tol_o, f"seq {i}: max|O-ref|={diff:.4f}"
         if check_stats:
-            got_lse = stats_storage.view(h_q, t_cap)[:, cu[i] : cu[i + 1]]
-            ld = (got_lse - lse_ref[0]).abs().max().item()
+            if stats_layout == "head_major":
+                got_lse = stats_storage.view(h_q, t_cap)[:, cu[i] : cu[i + 1]]
+            else:
+                got_lse = stats_storage[: cu[-1] * h_q].view(cu[-1], h_q)[cu[i] : cu[i + 1]].transpose(0, 1)
+            # Mirror _check: match the +-inf pattern first (zero-KV rows are
+            # -inf on both sides), then compare only the finite entries.
+            finite = torch.isfinite(lse_ref[0])
+            assert torch.equal(torch.isfinite(got_lse), finite), f"seq {i}: LSE -inf pattern differs from the reference"
+            ld = (got_lse[finite] - lse_ref[0][finite]).abs().max().item() if finite.any() else 0.0
             assert ld <= 5e-2, f"seq {i}: max|LSE-ref|={ld:.4f}"
 
     # Nothing outside the packed token range may be written.
-    assert (o_storage[cu[-1] * h_q * D :] == _THD_SENTINEL).all(), "wrote past the packed O tokens"
+    assert (o_storage[cu[-1] * h_q * D :] == sentinel).all(), "wrote past the packed O tokens"
 
 
 @pytest.mark.L0
@@ -765,10 +1070,23 @@ def test_fp8_sm120_thd_cross():
 
 
 @pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_thd_raw_buffer_binding():
+    """THD with mhas-style RAW rank-3 runtime buffers (not the declared-rank
+    BSHD views), h > 1, no mask: regression for the dense _to_bshd_writable
+    scratch copy-back scrambling packed O bytes (mhas fp8 ragged
+    test16/25/28/32)."""
+    _run_thd_fp8(seq_q_lens=[35, 75], seq_kv_lens=[289, 190], h_q=3, h_kv=3, is_causal=False, raw_bind=True)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("stats_layout", ["head_major", "token_major"])
 @torch_fork_set_rng(seed=42)
-def test_fp8_sm120_thd_stats():
-    """THD + generate_stats: the ragged Stats output is token-major [t, h]."""
-    _run_thd_fp8(seq_q_lens=[200, 150], seq_kv_lens=[200, 150], is_causal=True, check_stats=True)
+def test_fp8_sm120_thd_stats(stats_layout):
+    """THD + generate_stats in BOTH ragged-Stats layouts: head-major
+    (H, head_stride) and token-major packed (T, H) -- the kernel specializes
+    on either."""
+    _run_thd_fp8(seq_q_lens=[200, 150], seq_kv_lens=[200, 150], is_causal=True, check_stats=True, stats_layout=stats_layout)
 
 
 @pytest.mark.L1
@@ -776,3 +1094,56 @@ def test_fp8_sm120_thd_stats():
 def test_fp8_sm120_thd_gqa():
     """THD + grouped-query: the ragged path and the head mapping compose."""
     _run_thd_fp8(seq_q_lens=[128, 64, 192], seq_kv_lens=[128, 64, 192], h_q=8, h_kv=2, is_causal=True)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=27)
+def test_fp8_sm120_thd_no_mask():
+    """THD with NO causal/band mask (padding only), tile-unaligned per-sequence
+    KV lengths: the first masked step must trim each sequence's ragged KV tail
+    (the mhas fp8 ragged family's shape class)."""
+    _run_thd_fp8(seq_q_lens=[35, 75], seq_kv_lens=[289, 190], h_q=3, h_kv=3, is_causal=False)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=28)
+def test_fp8_sm120_thd_fp8_out():
+    """THD x fp8 O: the direct quantizing store's thd_varlen branch (packed
+    rows, no dense zero-fill) with a NON-UNIT Scale_O applied before the
+    cast."""
+    _run_thd_fp8(seq_q_lens=[200, 150], seq_kv_lens=[200, 150], is_causal=True, o_dtype=torch.float8_e4m3fn, so_val=2.0)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=29)
+def test_fp8_sm120_thd_d_envelope():
+    """THD x head-dim envelope (actual d = 112 < tile 128): the rank-4
+    envelope TMA descriptor addresses packed K/V rows via kv_row_base and
+    zero-fills the pad columns per sequence (the mhas test16 shape)."""
+    _run_thd_fp8(seq_q_lens=[35, 75], seq_kv_lens=[289, 190], h_q=3, h_kv=3, D=112, is_causal=False)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("stats_layout", ["token_major", "head_major"])
+@torch_fork_set_rng(seed=25)
+def test_fp8_sm120_thd_gqa_sink(stats_layout):
+    """THD + GQA + attention sink through the packed epilogue fold, with the
+    sink entering the ragged Stats (both declared layouts)."""
+    _run_thd_fp8(seq_q_lens=[130, 70], seq_kv_lens=[130, 70], h_q=8, h_kv=2, is_causal=True, with_sink=True, check_stats=True, stats_layout=stats_layout)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=26)
+def test_fp8_sm120_thd_zero_length_sequence():
+    """A zero-length sequence contributes no tokens and must not perturb its
+    packed neighbors (O and ragged Stats). The last sequence has Q tokens but
+    ZERO keys inside a live launch: its rows must come back O := 0 with
+    LSE := -inf through the kernel's row_sum <= 0 guard, not stale memory."""
+    _run_thd_fp8(seq_q_lens=[128, 0, 64], seq_kv_lens=[100, 0, 0], is_causal=True, check_stats=True, stats_layout="token_major")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=30)
+def test_fp8_sm120_thd_right_band():
+    """THD + TOP_LEFT right band: per-sequence diagonals each widened by R."""
+    _run_thd_fp8(seq_q_lens=[130, 70], seq_kv_lens=[130, 70], is_causal=False, window_size_right=24)

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
@@ -74,12 +74,11 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     lse = torch.logsumexp(scores, dim=-1)
     if seq_lens_q is not None:
         # cuDNN dense padded-Q trim: rows at/past seq_len_q[b] write O := 0 /
-        # LSE := -inf and contribute nothing to the amaxes (softmax of a
-        # fully -inf row is NaN in torch; the trim replaces it).
+        # LSE := -inf (softmax of a fully -inf row is NaN in torch; the trim
+        # replaces it).
         slq = torch.as_tensor(seq_lens_q, device=dev, dtype=torch.long).view(b, 1, 1, 1)
         row_dead = i >= slq
         out = torch.where(row_dead, torch.zeros((), device=dev), out)
-        probs = torch.where(row_dead, torch.zeros((), device=dev), probs)
         lse = lse.masked_fill(row_dead.squeeze(-1), float("-inf"))
     # Fully-masked rows are -inf in logsumexp; the kernel writes -inf too.
     return out, lse
@@ -309,8 +308,9 @@ def test_fp8_sm120_single_kv_tile(mask, s):
     populations."""
     scale = 1.0 / math.sqrt(128)
     seq_lens_kv = [s] if mask == "none" else None
+    kwargs = {**_MASKS, "none_dense": _MASKS["none"]}[mask]
     for _ in range(3):
-        res = _run(1, 4, 4, s, s, scale=scale, sdpa_kwargs=_MASKS.get(mask, {}), seq_lens_kv=seq_lens_kv)
+        res = _run(1, 4, 4, s, s, scale=scale, sdpa_kwargs=kwargs, seq_lens_kv=seq_lens_kv)
         _check(*res)
 
 
@@ -324,6 +324,17 @@ def test_fp8_sm120_dense_flex_layout(layout):
     scale = 1.0 / math.sqrt(128)
     res = _run(2, 4, 4, 256, 256, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), layout=layout)
     _check(*res)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_dense_flex_offered():
+    """The dense_flex capability is a DECLARED offer: a BHSD-contiguous (non
+    BSHD-physical) graph must be claimed by the row, not merely survive
+    engine selection. Guards the ``layouts={"bshd", "dense_flex"}`` entry."""
+    import cudnn
+
+    assert _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.HALF, layout="bhsd")
 
 
 _O_TOL = {torch.bfloat16: 5e-2, torch.float8_e4m3fn: 1.5e-1, torch.float8_e5m2: 3.5e-1}
@@ -366,6 +377,29 @@ def test_fp8_sm120_fp8_out_envelope():
 
 @pytest.mark.L1
 @torch_fork_set_rng(seed=0)
+def test_fp8_sm120_fp8_out_dense_flex():
+    """fp8 O x dense_flex: the adapter's O normalization allocates an fp8
+    scratch and ``o_view.copy_(o_scratch)`` does a strided fp8 copy-back — a
+    torch path with historically uneven fp8 support."""
+    scale = 1.0 / math.sqrt(128)
+    res = _run(2, 4, 4, 256, 256, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), layout="bhsd", o_dtype=torch.float8_e4m3fn, so_val=2.0)
+    _check(*res, tol_o=_O_TOL[torch.float8_e4m3fn])
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_fp8_out_sink():
+    """fp8 O x sink: the sink rescales ``row_sum_inv`` before the direct
+    quantizing store, so a sink-scaled value must still land inside
+    ``cvt.rn.satfinite``'s saturation rather than corrupt the pair pack."""
+    scale = 1.0 / math.sqrt(128)
+    sinks = torch.randn(1, 4, 1, 1, dtype=torch.float32, device="cuda")
+    res = _run(2, 4, 2, 256, 256, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), sinks=sinks, o_dtype=torch.float8_e4m3fn, so_val=2.0)
+    _check(*res, tol_o=_O_TOL[torch.float8_e4m3fn])
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
 def test_fp8_sm120_fp8_out_seq_q_trim():
     """fp8 O x per-batch Q trim: rows at/past seq_len_q[b] zero-fill through
     the direct-store path."""
@@ -402,8 +436,7 @@ def test_fp8_sm120_d_envelope_offering():
 @torch_fork_set_rng(seed=0)
 def test_fp8_sm120_sink(mask):
     """Attention sink: per-Q-head logit in the softmax denominator (virtual
-    column with no V row). O rescales, the LSE extends, and Amax_S follows
-    the SM100 fp8 cell's sink-extended convention."""
+    column with no V row). O rescales and the LSE extends by the sink term."""
     scale = 1.0 / math.sqrt(128)
     sinks = torch.randn(1, 4, 1, 1, dtype=torch.float32, device="cuda")
     kwargs = dict(use_causal_mask=True) if mask == "causal" else {}
@@ -488,7 +521,7 @@ def test_fp8_sm120_e5m2(mask):
     """E5M2 inputs: the MMA tag and the P-quantization target follow the
     input dtype (P is cast to e5m2, Scale_S maps it onto e5m2's range).
     E5M2's 2-bit mantissa doubles the P-quantization floor, hence the wider
-    O tolerance; Amax_S / Amax_O are fp32 pre-cast values and keep theirs."""
+    O tolerance; Amax_O is a fp32 pre-cast value and keeps its own."""
     scale = 1.0 / math.sqrt(128)
     res = _run(2, 4, 4, 256, 256, scale=scale, sdpa_kwargs=_MASKS[mask], io_dtype=torch.float8_e5m2)
     _check(*res, tol_o=1e-1)
@@ -562,8 +595,8 @@ def _fp8_graph_offers_sm120(io_dtype, o_dtype, D=128, D_v=None, sink=False, layo
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_fp8_sm120_sink_offered():
-    """Sink graphs are served (SM100 fp8 Amax_S semantics: the sink extends
-    the softmax denominator; P carries no sink column)."""
+    """Sink graphs are served (the sink extends the softmax denominator as a
+    virtual column; P carries no sink column)."""
     import cudnn
 
     assert _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.HALF, sink=True)
@@ -1143,6 +1176,17 @@ def test_fp8_sm120_thd_zero_length_sequence():
     ZERO keys inside a live launch: its rows must come back O := 0 with
     LSE := -inf through the kernel's row_sum <= 0 guard, not stale memory."""
     _run_thd_fp8(seq_q_lens=[128, 0, 64], seq_kv_lens=[100, 0, 0], is_causal=True, check_stats=True, stats_layout="token_major")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=57)
+def test_fp8_sm120_thd_all_kv_zero():
+    """EVERY sequence has zero keys: all Q rows are dead and must come back
+    O := 0 / LSE := -inf through the kernel's row_sum <= 0 guard. This shape
+    also exercises the adapter's all-KV-zero clamp, whose V binding is a
+    zero stub carrying the INPUT dtype (Q's storage cannot back V when
+    kh*d_v exceeds it, and O's dtype is independent of the input's)."""
+    _run_thd_fp8(seq_q_lens=[200, 150], seq_kv_lens=[0, 0], is_causal=False, check_stats=True, stats_layout="token_major")
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
@@ -883,6 +883,7 @@ def _run_thd_fp8(
     check_stats=False,
     stats_layout="head_major",
     raw_bind=False,
+    poison_pad=False,
 ):
     """Run a ragged FP8 graph on the SM120 engine vs per-sequence references.
 
@@ -912,6 +913,14 @@ def _run_thd_fp8(
     k_view, k_storage, k_ro = _pack_thd(k_8, s_kv_max, torch.float8_e4m3fn)
     v_view, v_storage, v_ro = _pack_thd(v_8, s_kv_max, torch.float8_e4m3fn)
     o_view, o_storage, o_ro = _pack_thd([torch.zeros(1, h_q, max(n, 1), D, dtype=o_dtype, device=dev)[:, :, :n] for n in seq_q_lens], s_q_max, o_dtype)
+    if poison_pad:
+        # Model uninitialized capacity: fp8 NaN bit patterns past the packed
+        # KV tokens (real binders hand rounded-up allocations). The kernel
+        # must keep them out of P @ V — masking S alone is not enough
+        # (P = 0 times a NaN V row is still NaN).
+        t_kv_total = sum(seq_kv_lens)
+        for st, heads in ((k_storage, h_kv), (v_storage, h_kv)):
+            st[t_kv_total * heads * D :] = torch.tensor(float("nan")).to(st.dtype)
     # The kernel writes every valid packed O token; everything else must come
     # back untouched. (Clamped into the O dtype's range for fp8 outputs.)
     sentinel = min(_THD_SENTINEL, torch.finfo(o_dtype).max)
@@ -1113,6 +1122,17 @@ def test_fp8_sm120_thd_raw_buffer_binding():
     scratch copy-back scrambling packed O bytes (mhas fp8 ragged
     test16/25/28/32)."""
     _run_thd_fp8(seq_q_lens=[35, 75], seq_kv_lens=[289, 190], h_q=3, h_kv=3, is_causal=False, raw_bind=True)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=56)
+def test_fp8_sm120_thd_dirty_kv_pad():
+    """KV storage CAPACITY beyond the packed tokens is uninitialized in real
+    binders (rounded-up allocations), and fp8 has NaN bit patterns. The
+    S-side column mask survives them (a select), but P @ V would multiply
+    P = 0 into a NaN V row and 0 * NaN = NaN poisons every output row; the
+    masked step must zero the sV tail rows before the PV MMA."""
+    _run_thd_fp8(seq_q_lens=[35, 75], seq_kv_lens=[289, 190], h_q=3, h_kv=3, is_causal=False, poison_pad=True)
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- FE OSS kernels or CuTeDSL

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

Widens the SM120 FP8 SDPA forward engine (`sdpa_fwd_prefill_sm120_fp8`) from its initial envelope (e4m3 in → fp16 out, head dims %32, BSHD dense, causal/SWA/padded/THD) toward parity with the f16 SM120 engine.

**New capabilities** (each with a declared `Capabilities` bit and tests):

- **E5M2 inputs**: Q/K/V may be e4m3 or e5m2.
- **Independent output dtype**: O may be fp16, bf16, e4m3, or e5m2.
- **Attention sinks**: align with SM100 fp8 cell semantics. The sink logit joins the softmax denominator and LSE, P carries no sink column, and Amax_S becomes the sink-extended `alpha / new_sum`. Rows with zero visible keys produce finite LSE (= sink logit) and O = 0.
- **Head-dim envelope**: actual head dims may be any multiple of 16 (TMA 16-byte global-stride rule at 1 byte/elem; f16 is %8 at 2 bytes/elem). Head tiles round up to the 32-element fp8 granule and TMA zero-fills the padded columns, so S and O stay bit-exact: zero K columns don't change QK^T, zero V columns produce zero O columns, and neither Amax is affected. Native tiles stay any multiple of 32 up to 256 with QK^T / P@V sides independent.
- **Per-batch `seq_len_q` trim (dense padded)**: padded Q rows write O := 0, LSE := −inf, and are excluded from the amaxes; zero-length Q batches included.
- **Right-band widening**: `window_size_right > 0` on both top-left and bottom-right diagonals.
- **Single-KV-tile shapes**: `skv_tile=0`: s_kv ≤ 128 graphs are served.
- **THD token-major Stats**: (T, H) LSE layout in addition to head-major, matching the f16 engine.
- **`dense_flex` layouts**: any dense layout with the head dim innermost-contiguous is normalized to the kernel's compact BSHD by the shared adapter (one gather copy in, one scatter copy back for O; zero-copy when already BSHD-physical).

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

To enhance the SM120 SDPA forward FP8 engine.

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

Related to #381.

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

- **Public API**: none. No graph-API or Python-API surface changes; the engine's declared `Capabilities` widen, so graphs previously declined by this row are now served by it (previously-served graphs select the same specializations).
- **Behavior/correctness**: THD graphs binding raw rank-3 (T, H, D) ragged buffers with h > 1 previously produced corrupted O; they are now correct.
- **Supported platforms**: unchanged — SM120/SM121 for this engine; cuDNN 9.x backend, `nvidia-cutlass-dsl` 4.7.0, Python/torch requirements as before.
- **Internal surface**: `frost/tile_dsl` helper renames (`mma_m16n8k16_f32`, `mma_m16n8k32_f32`, `fp32_to_fp8x2`, `pack_fp8x2_pairs`); all in-tree call sites (f16 fwd/bwd kernels) updated in this PR.
- **Performance**: none. All new features are `const_expr`-gated compile-time specializations.

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->

```bash
cd test/python
pytest sdpa/frost/test_sdpa_fwd_fp8_sm120.py sdpa/frost/test_sdpa_fwd_dsl_sm120.py \
       sdpa/frost/test_sm120_tile_rule.py sdpa/frost/test_sdpa_bwd_dsl_sm120.py -m "L0 or L1"
# 235 passed, 8 skipped (pre-existing backend-version gates)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded SM120 FP8 attention support for E4M3 and E5M2 inputs.
  - Added FP16, BF16, E4M3, and E5M2 output options.
  - Added attention sinks, right-side causal windows, sequence trimming, ragged inputs, and flexible head dimensions.
  - Added token-major and head-major attention-statistics layouts, dense-flex support, and zero-length sequence handling.
  - Improved FP8 conversion and support for padded or non-aligned head dimensions.

- **Tests**
  - Expanded coverage for mixed FP8 types, layouts, masking, trimming, quantized outputs, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->