### PR TITLE
NSA compression: suppress aliased O1 store for static short queries

### DIFF
--- a/python/cudnn/native_sparse_attention/compression/fmha.py
+++ b/python/cudnn/native_sparse_attention/compression/fmha.py
@@ -1235,6 +1235,9 @@ class BlackwellFusedMultiHeadAttentionForward:
 
                     o0_coord = 2 * curr_block_coord_o[0]
                     o1_coord = o0_coord + 1
+                    store_o1 = True
+                    if cutlass.const_expr(cute.is_static(mO_qdl.shape[0])):
+                        store_o1 = cutlass.const_expr(mO_qdl.shape[0] > self.qk_mma_tiler[0])
                     gO_qdl = cute.flat_divide(mO_qdl_, cute.select(self.pv_mma_tiler, mode=[0, 1]))
                     gO = gO_qdl[None, None, None, 0, curr_block_coord_o[2]]
                     tOsO, tOgO = cute.nvgpu.cpasync.tma_partition(
@@ -1256,15 +1259,21 @@ class BlackwellFusedMultiHeadAttentionForward:
                     # O1
                     # 1. wait for O1 final
                     o1_handle = corr_epi_consumer.wait_and_advance()
-                    # 2. copy O1 to gmem
-                    cute.copy(tma_atom_o, tOsO[None, 1], tOgO[None, o1_coord])
-                    cute.arch.cp_async_bulk_commit_group()
+                    # A static single-tile residual mode folds its stride to zero,
+                    # so O1 aliases O0 instead of relying on TMA's OOB handling.
+                    if cutlass.const_expr(store_o1):
+                        cute.copy(tma_atom_o, tOsO[None, 1], tOgO[None, o1_coord])
+                        cute.arch.cp_async_bulk_commit_group()
 
                     # Ensure O0 buffer is ready to be released
-                    cute.arch.cp_async_bulk_wait_group(1, read=True)
+                    if cutlass.const_expr(store_o1):
+                        cute.arch.cp_async_bulk_wait_group(1, read=True)
+                    else:
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
                     o0_handle.release()
                     # Ensure O1 buffer is ready to be released
-                    cute.arch.cp_async_bulk_wait_group(0, read=True)
+                    if cutlass.const_expr(store_o1):
+                        cute.arch.cp_async_bulk_wait_group(0, read=True)
                     o1_handle.release()
 
                 # Advance to next tile

--- a/test/python/fe_api/nsa/test_NSA_compression_attention_jax.py
+++ b/test/python/fe_api/nsa/test_NSA_compression_attention_jax.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+ml_dtypes = pytest.importorskip("ml_dtypes")
+pytest.importorskip("torch")  # Imported transitively by the NSA compression package.
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.jax
+from cutlass.cutlass_dsl import extract_mlir_values, new_from_mlir_values
+from cutlass.cute.typing import Int32
+
+
+def _skip_unless_sm100():
+    if not cutlass.jax.is_available():
+        pytest.skip("CuTeDSL JAX extensions unavailable (jax >= 0.5 required)")
+    if not any(device.platform == "gpu" for device in jax.devices()):
+        pytest.skip("JAX has no CUDA device")
+
+    from cudnn.tensor_adapter import get_compute_capability
+
+    major, _ = get_compute_capability()
+    if major < 10:
+        pytest.skip(f"Environment not supported: requires compute capability >= 10, found {major}")
+
+
+def _alias_leading_batch_dim(tensor):
+    shape = tensor.shape
+    stride = tensor.stride
+    return cute.make_tensor(
+        tensor.iterator,
+        cute.make_layout(
+            (1, shape[0], shape[1], shape[2]),
+            stride=(stride[0], stride[0], stride[1], stride[2]),
+        ),
+    )
+
+
+def _allow_static_scheduler_values(fmha_helpers, monkeypatch):
+    scheduler_type = fmha_helpers.FmhaStaticTileScheduler
+
+    def extract(scheduler):
+        values = []
+        scheduler._value_counts = []
+        for part in (scheduler._params, scheduler._current_work_linear_idx, scheduler._blk_coord, scheduler._grid_shape):
+            part_values = extract_mlir_values(part)
+            values.extend(part_values)
+            scheduler._value_counts.append(len(part_values))
+        return values
+
+    def reconstruct(scheduler, values):
+        parts = []
+        offset = 0
+        originals = (scheduler._params, scheduler._current_work_linear_idx, scheduler._blk_coord, scheduler._grid_shape)
+        for original, count in zip(originals, scheduler._value_counts):
+            parts.append(new_from_mlir_values(original, values[offset : offset + count]))
+            offset += count
+        return scheduler_type(*parts)
+
+    monkeypatch.setattr(scheduler_type, "__extract_mlir_values__", extract)
+    monkeypatch.setattr(scheduler_type, "__new_from_mlir_values__", reconstruct)
+
+
+def _make_launcher(head_dim, monkeypatch):
+    from cudnn.native_sparse_attention.compression import fmha_helpers
+    from cudnn.native_sparse_attention.compression.fmha import BlackwellFusedMultiHeadAttentionForward
+
+    # Static problem shapes elide scheduler MLIR values; use value-count-based
+    # reconstruction so this test reaches the independent output-store path.
+    _allow_static_scheduler_values(fmha_helpers, monkeypatch)
+    kernel = BlackwellFusedMultiHeadAttentionForward(
+        qk_acc_dtype=cutlass.Float32,
+        pv_acc_dtype=cutlass.Float32,
+        mma_tiler=(128, 128, head_dim),
+        is_persistent=False,
+        mask_type=fmha_helpers.MaskType.COMPRESSED_CAUSAL_MASK,
+    )
+
+    @cute.jit
+    def launcher(
+        stream,
+        q,
+        k,
+        v,
+        cum_seqlen_q,
+        cum_seqlen_k,
+        o,
+        *,
+        problem_size,
+        scale_softmax_log2,
+        scale_softmax,
+    ):
+        kernel(
+            _alias_leading_batch_dim(q),
+            _alias_leading_batch_dim(k),
+            _alias_leading_batch_dim(v),
+            _alias_leading_batch_dim(o),
+            problem_size,
+            cum_seqlen_q,
+            cum_seqlen_k,
+            None,
+            scale_softmax_log2,
+            scale_softmax,
+            1.0,
+            None,
+            Int32(0),
+            stream,
+        )
+
+    return launcher
+
+
+def _reference(q, k, v):
+    q = q.astype(np.float32)
+    k = np.repeat(k.astype(np.float32), q.shape[1] // k.shape[1], axis=1)
+    v = np.repeat(v.astype(np.float32), q.shape[1] // v.shape[1], axis=1)
+
+    scores = np.einsum("qhd,khd->hqk", q, k) / math.sqrt(q.shape[-1])
+    compression_factor = max(1, q.shape[0] // k.shape[0])
+    q_coords = np.arange(q.shape[0])[:, None]
+    k_coords = ((np.arange(k.shape[0]) + 1) * compression_factor - 1)[None, :]
+    valid = k_coords <= q_coords
+
+    scores = np.where(valid[None, :, :], scores, -np.inf)
+    row_max = np.max(scores, axis=-1, keepdims=True)
+    row_max = np.where(np.isfinite(row_max), row_max, 0.0)
+    probabilities = np.where(valid[None, :, :], np.exp(scores - row_max), 0.0)
+    row_sum = probabilities.sum(axis=-1, keepdims=True)
+    probabilities = np.divide(probabilities, row_sum, out=np.zeros_like(probabilities), where=row_sum != 0)
+    return np.einsum("hqk,khd->qhd", probabilities, v)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("seqlen_q", [127, 128, 129, 300])
+def test_nsa_compression_jax_static_query_tile_boundaries(seqlen_q, monkeypatch):
+    _skip_unless_sm100()
+
+    head_dim = 64
+    num_q_heads = 2
+    num_kv_heads = 1
+    seqlen_k = seqlen_q // 8
+    rng = np.random.default_rng(0)
+    q = (rng.standard_normal((seqlen_q, num_q_heads, head_dim), dtype=np.float32) * 0.1).astype(ml_dtypes.bfloat16)
+    k = (rng.standard_normal((seqlen_k, num_kv_heads, head_dim), dtype=np.float32) * 0.1).astype(ml_dtypes.bfloat16)
+    v = (rng.standard_normal((seqlen_k, num_kv_heads, head_dim), dtype=np.float32) * 0.1).astype(ml_dtypes.bfloat16)
+
+    q_device, k_device, v_device = (jax.device_put(x) for x in (q, k, v))
+    cum_seqlen_q = jax.device_put(np.array([0, seqlen_q], dtype=np.int32))
+    cum_seqlen_k = jax.device_put(np.array([0, seqlen_k], dtype=np.int32))
+    scale_softmax = 1.0 / math.sqrt(head_dim)
+    o = cutlass.jax.cutlass_call(
+        _make_launcher(head_dim, monkeypatch),
+        output_shape_dtype=jax.ShapeDtypeStruct(q.shape, q.dtype),
+        problem_size=(1, seqlen_q, seqlen_q, seqlen_k, num_q_heads, num_kv_heads, head_dim),
+        scale_softmax_log2=scale_softmax * math.log2(math.e),
+        scale_softmax=scale_softmax,
+        use_static_tensors=True,
+    )(q_device, k_device, v_device, cum_seqlen_q, cum_seqlen_k)
+
+    actual = np.asarray(o).astype(np.float32)
+    expected = _reference(q, k, v)
+    assert np.isfinite(actual).all()
+    np.testing.assert_allclose(actual, expected, atol=2e-2, rtol=2e-2)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`. Maintainer action requested: `cat-bug`, `mod-cutedsl`, and `orig-nv-eng`; the contributor token cannot add upstream labels.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Compile out the second 128-row NSA compression output store only when the query extent is statically known to contain one MMA tile or less.
- Keep both correction/epilogue pipeline stages consumed and released, with the TMA wait count adjusted to the number of committed stores.
- Add a JAX static-specialization regression at query lengths 127, 128, 129, and 300.

## Why

Each compression CTA processes two 128-row query tiles. When a statically specialized query extent contains only one tile, `flat_divide` canonicalizes the singleton residual tile mode to stride zero. The unconditional O1 TMA store therefore aliases O0 and overwrites valid output instead of remaining out of bounds.

The guard checks the layout extent with `cute.is_static` and evaluates the tile-count condition with `cutlass.const_expr`. Dynamic extents and static multi-tile extents retain the original O1 store/wait path; only the static singleton specialization prunes the aliased store. Both correction pipeline handles are still consumed and released unconditionally.

## Related issues

None.

## API and compatibility impact

None. This is a correctness fix for the SM100 NSA compression kernel and does not change its public API. The guard folds during tracing, so the dynamic path adds no runtime comparison or branch. The short static specialization removes one invalid TMA store and commit.

## Testing

- NVIDIA B200, CUDA 13.0, CuTeDSL 4.7.0, JAX 0.10.2:
  - Before the fix, `seqlen_q=128` failed against the FP32 reference with max absolute error 0.27612305; `seqlen_q=129` passed.
  - `cd test/python && pytest -q fe_api/nsa/test_NSA_compression_attention_jax.py -m L0`: 4 passed (127, 128, 129, 300).
  - The supplied bridge/direct repro produced zero difference at 128, 200, 256, and 300.
  - Direct dynamic outputs at 128, 129, and 300 were bit-identical to the unmodified cuDNN Frontend 1.25 kernel.
- `uvx pre-commit run --files python/cudnn/native_sparse_attention/compression/fmha.py test/python/fe_api/nsa/test_NSA_compression_attention_jax.py`: passed.
- `python3 -m py_compile python/cudnn/native_sparse_attention/compression/fmha.py test/python/fe_api/nsa/test_NSA_compression_attention_jax.py`: passed.
- `git diff --check`: passed.
