### PR TITLE
frost(sdpa): drop the Amax_S output from the FP8 kernels

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -666,8 +666,7 @@ class SdpaFwdDsl(APIBase):
         signature only with additional optional keyword arguments; an adapter
         whose engine capabilities accept FP8/MXFP8 graphs must also accept the
         FP8 operand set the lowering adds for those graphs (``sf_q/sf_k/sf_v``,
-        ``descale_q/descale_k/descale_v``, ``scale_o``, ``amax_o``,
-        ``amax_s`` — see :meth:`SdpaFwdDslSm100.execute`).
+        ``descale_q/descale_k/descale_v``, ``scale_o``, ``amax_o`` — see :meth:`SdpaFwdDslSm100.execute`).
         """
 
 
@@ -961,7 +960,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # FP8/MXFP8 kernels are exact-match d128 (gated in check_support);
             # their compile() has no envelope head-dim parameters. has_lse=False
             # (no Stats output) compiles the LSE store out — no dummy buffer at
-            # any level (the amax_s/amax_o atomicMax writes are independent).
+            # any level (the amax_o atomicMax write is independent).
             self._compiled_kernel = self._k_mod.compile(
                 b=self.batch_size,
                 qh=self.h_q,
@@ -1038,7 +1037,6 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         descale_k: Optional[torch.Tensor] = None,
         descale_v: Optional[torch.Tensor] = None,
         scale_o: Optional[torch.Tensor] = None,
-        amax_s: Optional[torch.Tensor] = None,
         descale_s: Optional[torch.Tensor] = None,
         scale_s: Optional[torch.Tensor] = None,
         workspace: Optional[torch.Tensor] = None,
@@ -1108,7 +1106,6 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 descale_k,
                 descale_v,
                 scale_o,
-                amax_s,
                 amax_o,
                 descale_s,
                 scale_s,
@@ -1455,7 +1452,6 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         descale_k,
         descale_v,
         scale_o,
-        amax_s,
         amax_o,
         descale_s=None,
         scale_s=None,
@@ -1503,15 +1499,13 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         )
         o_desc_dummy = self._dummy("o_desc", device, lambda: torch.zeros(1, dtype=torch.int64, device=device))
 
-        # amax_s / amax_o: the kernel atomicMax'es into these buffers, so they MUST
-        # start at 0. amax_o accumulates max|o_scaled| (pre-cast, exact even for FP8 O);
+        # amax_o: the kernel atomicMax'es into this buffer, so it MUST start
+        # at 0. It accumulates max|o_scaled| (pre-cast, exact even for FP8 O);
         # dividing by scale_o below yields the pre-quant output amax.
-        amax_s_buf = self._amax_slot(amax_s, "amax_s", device)
         amax_o_buf = self._amax_slot(amax_o, "amax_o", device)
-        # Same-stream ordering as MXFP8: the resets must precede the kernel's
+        # Same-stream ordering as MXFP8: the reset must precede the kernel's
         # atomicMax on the launch stream, not on torch's current stream.
         with _torch_stream_context(current_stream, device):
-            amax_s_buf.zero_()
             amax_o_buf.zero_()
 
         self._compiled_kernel(
@@ -1527,7 +1521,6 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             cutlass.Float32(scale_softmax_log2),
             cutlass.Float32(o_scale_fused),
             cutlass.Int32(0),  # n_thd_units (dense)
-            amax_s_buf,
             amax_o_buf,
             stream=current_stream,
         )
@@ -2046,7 +2039,6 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         descale_k: Optional[torch.Tensor] = None,
         descale_v: Optional[torch.Tensor] = None,
         scale_o: Optional[torch.Tensor] = None,
-        amax_s: Optional[torch.Tensor] = None,
         descale_s: Optional[torch.Tensor] = None,
         scale_s: Optional[torch.Tensor] = None,
         amax_o: Optional[torch.Tensor] = None,
@@ -2093,7 +2085,6 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
                 descale_k,
                 descale_v,
                 scale_o,
-                amax_s,
                 amax_o,
                 descale_s,
                 scale_s,
@@ -2179,7 +2170,6 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         descale_k,
         descale_v,
         scale_o,
-        amax_s,
         amax_o,
         descale_s=None,
         scale_s=None,
@@ -2256,12 +2246,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         else:
             lse = self._checked_lse_view(lse_tensor) if lse_tensor is not None else None
 
-        # amax_s / amax_o: the kernel atomicMax'es into these buffers, so they
-        # MUST start at 0, reset on the LAUNCH stream (ordering vs the kernel).
-        amax_s_buf = self._amax_slot(amax_s, "amax_s", device)
+        # amax_o: the kernel atomicMax'es into this buffer, so it MUST start
+        # at 0, reset on the LAUNCH stream (ordering vs the kernel).
         amax_o_buf = self._amax_slot(amax_o, "amax_o", device)
         with _torch_stream_context(current_stream, device):
-            amax_s_buf.zero_()
             amax_o_buf.zero_()
 
         fn = self._compiled_kernel
@@ -2288,7 +2276,6 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             None,  # sinks: fp8 cell rejects has_sink
             pack.seq_q_dummy if pack is not None else seq_q_dummy,
             pack.meta if pack is not None else seq_kv_t,
-            amax_s_buf.view(torch.int32),
             amax_o_buf.view(torch.int32),
             cutlass.Float32(scale_softmax_log2),
             cutlass.Float32(o_scale_fused),

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -346,6 +346,12 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
         if (facts.seq_q_t is not None and facts.cu_seq_q_t is not None) or (facts.seq_kv_t is not None and facts.cu_seq_kv_t is not None):
             return "seq_len_* and cu_seq_len_* on the same side is ambiguous (backend precedence is not replicated here)"
 
+    if facts.amax_s_t is not None:
+        # The FROST FP8 kernels no longer compute Amax_S (dropped: nothing
+        # consumed it and the atomicMax serialized the epilogue); a graph that
+        # DECLARES the output must go to an engine that writes it.
+        return "graph requests the Amax_S output, which the FROST engines do not produce"
+
     if facts.bottom_right:
         if not (facts.causal or facts.right_band_widening):
             return "bottom-right alignment requires a causal upper bound (plain or right-widened)"
@@ -477,7 +483,7 @@ def _sm100_fp8_spec(d: int) -> EngineSpec:
 
     Padding mask (per-batch ``seq_len_kv`` → KV-side masking) is supported: KV-only
     padding leaves every query row real, so each row's total_sum > 0 and the
-    in-kernel amax_s (= max over rows of 1/total_sum) stays well-defined — no
+    per-row softmax normalization stays well-defined — no
     fully-masked row can poison the global amax.  THD/varlen is still deferred
     (dense execute only for v1), so thd=False.
     """
@@ -799,7 +805,6 @@ def lower_dsl_prefill(
         descale_k=facts.descale_k_t,
         descale_v=facts.descale_v_t,
         scale_o=facts.scale_o_t,
-        amax_s=facts.amax_s_t,
         descale_s=facts.descale_s_t,
         scale_s=facts.scale_s_t,
     )
@@ -860,7 +865,6 @@ def lower_dsl_prefill(
         dk_buf = resolved.get(id(binding.descale_k)) if binding.descale_k is not None else None
         dv_buf = resolved.get(id(binding.descale_v)) if binding.descale_v is not None else None
         so_buf = resolved.get(id(binding.scale_o)) if binding.scale_o is not None else None
-        amax_s_buf = resolved.get(id(binding.amax_s)) if binding.amax_s is not None else None
         ds_buf = resolved.get(id(binding.descale_s)) if binding.descale_s is not None else None
         ss_buf = resolved.get(id(binding.scale_s)) if binding.scale_s is not None else None
         # The quantized DENSE lowerings drop the per-batch Q trim, which is
@@ -898,7 +902,6 @@ def lower_dsl_prefill(
                 descale_k=dk_buf,
                 descale_v=dv_buf,
                 scale_o=so_buf,
-                amax_s=amax_s_buf,
                 descale_s=ds_buf,
                 scale_s=ss_buf,
             )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -235,7 +235,6 @@ def _kernel(
     qh_per_kh: cutlass.Int32,
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
-    amax_s_tensor: cute.Tensor,
     amax_o_tensor: cute.Tensor,
 ) -> None:
 
@@ -421,7 +420,6 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
             o_scale_fused=o_scale_fused,
-            amax_s_tensor=amax_s_tensor,
             amax_o_tensor=amax_o_tensor,
         )
 
@@ -1532,7 +1530,6 @@ def _correction_warp_group(
     cta_in_pair,
     cta_id_x,
     o_scale_fused,
-    amax_s_tensor,
     amax_o_tensor,
 ):
     """Correction warp group: 4 warps × 32 lanes = 128, one lane per O row.
@@ -1693,14 +1690,6 @@ def _correction_warp_group(
                 # Safe inverse: avoid div by 0 on fully-masked rows.
                 inv_sum = o_scale_fused / cute.math.max(total_sum, cutlass.Float32(1e-30))
 
-            # amax_s = max over valid rows of the softmax normalization (1/total_sum),
-            # o_scale_fused divided back out so it is the pure softmax-prob amax (cuDNN
-            # FP8 ref: `beta = 1/total_sum`). atomicrmw MAX has no fp variant, so — like
-            # the reference — reinterpret the (always-positive) float as int32 and MAX on
-            # the bits (IEEE754 positive floats are monotonic in their int encoding).
-            _beta_bits = (inv_sum / o_scale_fused).bitcast(cutlass.Int32)
-            _amax_s_ptr = Pointer(amax_s_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
-
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
             if cutlass.const_expr(CFG.THD_VARLEN):
@@ -1710,13 +1699,10 @@ def _correction_warp_group(
                 _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
                 _row_valid = q_row_global < _s_q_b
                 if _row_valid:
-                    # has_lse=False: the Stats store is compiled out; the amax_s
-                    # atomicMax is independent of it and always live.
                     if cutlass.const_expr(lse_tensor is not None):
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
                         lse_row[_cu_q_b + q_row_global] = lse_val
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_s_ptr, _beta_bits)
             else:
                 _row_valid = q_row_global < seqlen_q
                 if _row_valid:
@@ -1724,7 +1710,6 @@ def _correction_warp_group(
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[batch_idx, head_idx, :]
                         lse_row[q_row_global] = lse_val
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_s_ptr, _beta_bits)
 
             # amax_o = max over valid rows of |o_scaled| (the fp32 pre-cast output). Divided
             # by scale_o in api to give the pre-quant output amax (cuDNN FP8 ref, in-kernel).
@@ -1871,7 +1856,6 @@ def _host(
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
     n_thd_units: cutlass.Int32,
-    amax_s_tensor: cute.Tensor,
     amax_o_tensor: cute.Tensor,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
@@ -1962,7 +1946,6 @@ def _host(
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
         o_scale_fused,
-        amax_s_tensor,
         amax_o_tensor,
     ).launch(
         grid=grid_shape,
@@ -1979,7 +1962,7 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
     THD/varlen: q/k/v/o/lse PACKED with batch dim 1; ``b`` = logical batch.
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
-    at all; the amax_s/amax_o atomicMax writes are independent and unchanged."""
+    at all; the amax_o atomicMax write is independent and unchanged."""
     _fake_batch = 1 if CFG.THD_VARLEN else b
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
@@ -2040,14 +2023,6 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         stride_order=(0,),
         assumed_align=16,
     )
-    # amax_s output (scalar): max softmax prob (1/total_sum) via atomicMax. Always
-    # part of the ABI; api pre-zeros it and reads it back (Amax_S output).
-    fake_amax_s = cute.runtime.make_fake_compact_tensor(
-        cutlass.Float32,
-        (1,),
-        stride_order=(0,),
-        assumed_align=16,
-    )
     fake_amax_o = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,
         (1,),
@@ -2068,7 +2043,6 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),
         cutlass.Int32(0),
-        fake_amax_s,
         fake_amax_o,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -302,7 +302,6 @@ def _kernel(
     qh_per_kh: cutlass.Int32,
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
-    amax_s_tensor: cute.Tensor,
     amax_o_tensor: cute.Tensor,
 ) -> None:
 
@@ -503,7 +502,6 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
             o_scale_fused=o_scale_fused,
-            amax_s_tensor=amax_s_tensor,
             amax_o_tensor=amax_o_tensor,
         )
 
@@ -1648,7 +1646,6 @@ def _correction_warp_group(
     cta_in_pair,
     cta_id_x,
     o_scale_fused,
-    amax_s_tensor,
     amax_o_tensor,
 ):
     """Correction warp group: 4 warps × 32 lanes = 128, one lane per O row.
@@ -1831,14 +1828,6 @@ def _correction_warp_group(
                 # Safe inverse: avoid div by 0 on fully-masked rows.
                 inv_sum = o_scale_fused / cute.math.max(total_sum, cutlass.Float32(1e-30))
 
-            # amax_s = max over valid rows of the softmax normalization (1/total_sum),
-            # o_scale_fused divided back out so it is the pure softmax-prob amax (cuDNN
-            # FP8 ref: `beta = 1/total_sum`). atomicrmw MAX has no fp variant, so — like
-            # the reference — reinterpret the (always-positive) float as int32 and MAX on
-            # the bits (IEEE754 positive floats are monotonic in their int encoding).
-            _beta_bits = (inv_sum / o_scale_fused).bitcast(cutlass.Int32)
-            _amax_s_ptr = Pointer(amax_s_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
-
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
             if cutlass.const_expr(CFG.THD_VARLEN):
@@ -1848,13 +1837,10 @@ def _correction_warp_group(
                 _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
                 _row_valid = q_row_global < _s_q_b
                 if _row_valid:
-                    # has_lse=False: the Stats store is compiled out; the amax_s
-                    # atomicMax is independent of it and always live.
                     if cutlass.const_expr(lse_tensor is not None):
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
                         lse_row[_cu_q_b + q_row_global] = lse_val
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_s_ptr, _beta_bits)
             else:
                 _row_valid = q_row_global < seqlen_q
                 if _row_valid:
@@ -1862,7 +1848,6 @@ def _correction_warp_group(
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[batch_idx, head_idx, :]
                         lse_row[q_row_global] = lse_val
-                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_s_ptr, _beta_bits)
 
             # amax_o = max over valid rows of |o_scaled| (the fp32 pre-cast output). Divided
             # by scale_o in api to give the pre-quant output amax (cuDNN FP8 ref, in-kernel).
@@ -2009,7 +1994,6 @@ def _host(
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
     n_thd_units: cutlass.Int32,
-    amax_s_tensor: cute.Tensor,
     amax_o_tensor: cute.Tensor,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
@@ -2099,7 +2083,6 @@ def _host(
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
         o_scale_fused,
-        amax_s_tensor,
         amax_o_tensor,
     ).launch(
         grid=grid_shape,
@@ -2116,7 +2099,7 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
     THD/varlen: q/k/v/o/lse PACKED with batch dim 1; ``b`` = logical batch.
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
-    at all; the amax_s/amax_o atomicMax writes are independent and unchanged."""
+    at all; the amax_o atomicMax write is independent and unchanged."""
     _fake_batch = 1 if CFG.THD_VARLEN else b
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
@@ -2177,14 +2160,6 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         stride_order=(0,),
         assumed_align=16,
     )
-    # amax_s output (scalar): max softmax prob (1/total_sum) via atomicMax. Always
-    # part of the ABI; api pre-zeros it and reads it back (Amax_S output).
-    fake_amax_s = cute.runtime.make_fake_compact_tensor(
-        cutlass.Float32,
-        (1,),
-        stride_order=(0,),
-        assumed_align=16,
-    )
     fake_amax_o = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,
         (1,),
@@ -2205,7 +2180,6 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),
         cutlass.Int32(0),
-        fake_amax_s,
         fake_amax_o,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -788,7 +788,6 @@ class SM120FusedMultiHeadAttentionForward:
         sinks: Optional[cute.Tensor],
         seq_q_lens: cute.Tensor,
         seq_kv_lens: cute.Tensor,
-        amax_s: cute.Tensor,
         amax_o: cute.Tensor,
         tma_k_desc: cutlass.GridConstant[cuda.TensorMap],
         tma_v_desc: cutlass.GridConstant[cuda.TensorMap],
@@ -808,9 +807,6 @@ class SM120FusedMultiHeadAttentionForward:
         :param sinks: Unused; must be ``None`` (fp8 cell rejects has_sink).
         :param seq_q_lens: Per-batch query lengths, or an unused dummy tensor.
         :param seq_kv_lens: Per-batch key/value lengths, or an unused dummy tensor.
-        :param amax_s: 1-element Int32 buffer, host pre-zeroed on the launch
-            stream; receives bitcast-fp32 atomic max of ``1/row_sum`` over
-            valid rows (cuDNN Amax_S convention). Pass a dummy when unused.
         :param amax_o: 1-element Int32 buffer, host pre-zeroed; receives
             bitcast-fp32 atomic max of ``|o_scaled|`` pre-cast. The host
             divides by ``scale_o`` afterwards. Pass a dummy when unused.
@@ -1166,21 +1162,6 @@ class SM120FusedMultiHeadAttentionForward:
                     lse_val = -cutlass.Float32.inf
                 row_lse[row_half] = lse_val
 
-            # Amax_S = max over valid rows of the raw 1/row_sum (cuDNN
-            # convention: the softmax-probability amax proxy), captured BEFORE
-            # o_scale_fused folds into the normalization factor. One lane per
-            # thread-quad carries the replicated row state; bitcast-int32
-            # atomic max is exact for non-negative fp32.
-            amax_s_arr = cutlass.make_array_view(amax_s)
-            if lane % 4 == 0:
-                for row_half in cutlass.range_constexpr(2):
-                    amax_q_idx = q_seq_idx + q_warp_row0 + (lane // 4) + row_half * 8
-                    if amax_q_idx < seqlen_q:
-                        prims.atomicrmw(
-                            prims.AtomicOp.MAX,
-                            amax_s_arr,
-                            row_sum_inv[row_half].bitcast(cutlass.Int32),
-                        )
             for row_half in cutlass.range_constexpr(2):
                 row_sum_inv[row_half] = row_sum_inv[row_half] * o_scale_fused
 
@@ -1316,7 +1297,6 @@ class SM120FusedMultiHeadAttentionForward:
         sinks: Optional[cute.Tensor],
         seq_q_lens: cute.Tensor,
         seq_kv_lens: cute.Tensor,
-        amax_s: cute.Tensor,
         amax_o: cute.Tensor,
         softmax_scale_log2: cutlass.Float32,
         o_scale_fused: cutlass.Float32,
@@ -1334,7 +1314,6 @@ class SM120FusedMultiHeadAttentionForward:
         :param sinks: Must be ``None`` (fp8 cell rejects has_sink).
         :param seq_q_lens: Per-batch query lengths, or an unused dummy tensor.
         :param seq_kv_lens: Per-batch key/value lengths, or an unused dummy tensor.
-        :param amax_s: 1-element Int32 amax buffer (pre-zeroed; dummy ok).
         :param amax_o: 1-element Int32 amax buffer (pre-zeroed; dummy ok).
         :param softmax_scale_log2: ``softmax_scale * descale_q * descale_k * log2(e)``.
         :param o_scale_fused: ``descale_s * descale_v * scale_o``.
@@ -1452,7 +1431,6 @@ class SM120FusedMultiHeadAttentionForward:
             sinks,
             seq_q_lens,
             seq_kv_lens,
-            amax_s,
             amax_o,
             tma_k_desc,
             tma_v_desc,
@@ -1582,12 +1560,6 @@ def compile(  # noqa: A001
     )
     # Amax buffers are Int32 at the ABI (bitcast-fp32 atomic max targets);
     # the adapter passes torch fp32 buffers as .view(torch.int32).
-    fake_amax_s = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32,
-        (1,),
-        stride_order=(0,),
-        assumed_align=4,
-    )
     fake_amax_o = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
         (1,),
@@ -1604,7 +1576,6 @@ def compile(  # noqa: A001
         fake_sinks,
         fake_seq_q_lens,
         fake_seq_kv_lens,
-        fake_amax_s,
         fake_amax_o,
         cutlass.Float32(1.0),
         cutlass.Float32(1.0),

--- a/python/cudnn/sdpa/graph_analyzer.py
+++ b/python/cudnn/sdpa/graph_analyzer.py
@@ -623,7 +623,9 @@ def _extract_facts(rec: dict) -> SdpaGraphFacts:
         scale_o_t=(rec.get("scale_o") if is_fp8 else None),
         descale_s_t=(rec.get("descale_s") if is_fp8 else None),
         scale_s_t=(rec.get("scale_s") if is_fp8 else None),
-        amax_s_t=(rec.get("amax_s") if is_fp8 else None),
+        # Amax_S: the op RETURNS the port unconditionally; only a real
+        # (non-virtual, set_output(True)) tensor is a requested output.
+        amax_s_t=(rec.get("amax_s") if (is_fp8 and rec.get("amax_s") is not None and not getattr(rec.get("amax_s"), "is_virtual", True)) else None),
     )
 
 
@@ -671,7 +673,6 @@ class SdpaBinding:
     scale_o: Any = None
     descale_s: Any = None
     scale_s: Any = None
-    amax_s: Any = None
     # SM80 feature operands + backward ports.
     bias: Any = None
     block_mask: Any = None
@@ -721,7 +722,6 @@ class SdpaBinding:
                 self.descale_k,
                 self.descale_v,
                 self.scale_o,
-                self.amax_s,
                 self.descale_s,
                 self.scale_s,
                 self.bias,

--- a/test/python/sdpa/fp8.py
+++ b/test/python/sdpa/fp8.py
@@ -41,7 +41,6 @@ class GraphFwdUid(IntEnum):
     o_scale = 10
     o = 3
     stats = 4
-    s_amax = 11
     o_amax = 12
     kv_seq_len = 13
     q_seq_len = 14
@@ -178,7 +177,9 @@ def generate_graph_fwd(cudnn_itype, cudnn_otype, b, h_q, h_k, h_v, s_qo, s_kv, d
     # Only pass diagonal_alignment if it's not None (pybind11 doesn't accept None for enum types)
     if diag_align is not None:
         sdpa_kwargs['diagonal_alignment'] = diag_align
-    o, stats, amax_s, amax_o = graph_fwd.sdpa_fp8(**sdpa_kwargs)
+    # Amax_S is not requested: nothing downstream consumes it, and the FROST
+    # engines no longer produce it (they decline graphs that declare it).
+    o, stats, _amax_s_unused, amax_o = graph_fwd.sdpa_fp8(**sdpa_kwargs)
 
     stride_o = (s_qo * h_q * d_vo, d_vo, h_q * d_vo, 1)
     o.set_uid(GraphFwdUid.o).set_output(True).set_dim((b, h_q, s_qo, d_vo)).set_stride(stride_o).set_data_type(cudnn_otype)
@@ -193,7 +194,6 @@ def generate_graph_fwd(cudnn_itype, cudnn_otype, b, h_q, h_k, h_v, s_qo, s_kv, d
         if is_ragged:
             stats.set_ragged_offset(stats_ragged_offset)
 
-    amax_s.set_uid(GraphFwdUid.s_amax).set_output(True).set_dim((1, 1, 1, 1)).set_stride((1, 1, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
     amax_o.set_uid(GraphFwdUid.o_amax).set_output(True).set_dim((1, 1, 1, 1)).set_stride((1, 1, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
 
     return graph_fwd
@@ -462,7 +462,6 @@ def exec_sdpa_fp8(cfg, request, cudnn_handle):
         o_gpu = torch.full((b, s_qo, h_q, d_vo), float('nan'), dtype=torch_otype, device="cuda")
         stats_gpu = torch.full((b, h_q, s_qo, 1), float('nan'), dtype=torch.float, device="cuda")
 
-    s_amax_gpu = torch.tensor([float('nan')], dtype=torch.float, device="cuda")
     o_amax_gpu = torch.tensor([float('nan')], dtype=torch.float, device="cuda")
 
     variant_pack = {
@@ -477,7 +476,6 @@ def exec_sdpa_fp8(cfg, request, cudnn_handle):
         int(GraphFwdUid.o_scale): o_scale_gpu,
         int(GraphFwdUid.o): o_gpu,
         int(GraphFwdUid.stats): stats_gpu,
-        int(GraphFwdUid.s_amax): s_amax_gpu,
         int(GraphFwdUid.o_amax): o_amax_gpu,
     }
 
@@ -703,7 +701,6 @@ def exec_sdpa_fp8(cfg, request, cudnn_handle):
 
     # Print hash and stats for determinism verification
     print_tensor_stats(o_gpu, tag="o_gpu")
-    print_tensor_stats(s_amax_gpu, tag="s_amax_gpu")
     print_tensor_stats(o_amax_gpu, tag="o_amax_gpu")
     if not cfg.is_infer:
         print_tensor_stats(stats_gpu, tag="stats_gpu")

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -5,7 +5,7 @@
 
 Drives ``graph.sdpa_fp8`` (FP8 E4M3/E5M2 Q/K/V + scalar per-tensor descales) routed to
 the ``sdpa_fwd_prefill_sm100_d128_fp8`` engine, and validates O against an fp32-dequant
-reference. ``Amax_S`` and ``Amax_O`` are both produced in-kernel (atomicMax over the
+reference. ``Amax_O`` is produced in-kernel (atomicMax over the
 pre-cast fp32 values); both are checked.
 
 cuDNN's ``sdpa_fp8`` op exposes causal / bottom-right / sliding-window masks, attention
@@ -67,9 +67,9 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     if sinks is not None:
         col = sinks.view(1, h_q, 1, 1).float().expand(b, h_q, s_q, 1).to(dev)
         probs = torch.softmax(torch.cat([scores, col], dim=-1), dim=-1)
-        return torch.matmul(probs[..., :s_kv], v_e), probs[..., :s_kv].max().item()
+        return torch.matmul(probs[..., :s_kv], v_e)
     probs = torch.softmax(scores, dim=-1)
-    return torch.matmul(probs, v_e), probs.max().item()
+    return torch.matmul(probs, v_e)
 
 
 def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, seq_lens_kv=None, s_scale=1.0, s_descale_gain=1.0, stats=True):
@@ -90,7 +90,6 @@ def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=No
     Qb, Kb, Vb = bshd(Q8), bshd(K8), bshd(V8)
     Ob = torch.empty(B, S_q, H_q, D, device=dev, dtype=out_dt).transpose(1, 2)
     lse = torch.empty(B, H_q, S_q, 1, device=dev, dtype=torch.float32)
-    amax_s = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
     amax_o = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
 
     def sc(val):
@@ -127,11 +126,10 @@ def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=No
         vp[sq_h] = slq
         vp[skv_h] = slk
     kw.update(sdpa_kwargs)
-    o, stats_t, amx_s, amx_o = g.sdpa_fp8(**kw)
+    o, stats_t, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested (engines decline graphs that declare it)
     o.set_output(True).set_dim(list(Ob.shape)).set_stride(list(Ob.stride())).set_data_type(getattr(cudnn.data_type, _CUDNN_OTYPE[out_dt]))
     if stats:
         stats_t.set_output(True).set_dim([B, H_q, S_q, 1]).set_stride([H_q * S_q, S_q, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
-    amx_s.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
 
     g.validate()
@@ -144,7 +142,7 @@ def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=No
         # No Stats output: the kernel compiles the LSE store out (has_lse=False)
         # — no dummy buffer exists at any level, so the dense workspace is 0.
         assert g.get_workspace_size() == 0
-    vp.update({o: Ob, amx_s: amax_s, amx_o: amax_o})
+    vp.update({o: Ob, amx_o: amax_o})
     if stats:
         vp[stats_t] = lse
     g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8))
@@ -153,8 +151,8 @@ def _run(B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=No
     ref_kw = _ref_kwargs(sdpa_kwargs)
     if sink is not None:
         ref_kw["sinks"] = sink.flatten()
-    o_ref, amax_s_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kw)
-    return Ob, o_ref, amax_s.item(), amax_s_ref, amax_o.item(), o_ref.abs().max().item()
+    o_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kw)
+    return Ob, o_ref, amax_o.item(), o_ref.abs().max().item()
 
 
 def _ref_kwargs(sdpa_kwargs):
@@ -170,16 +168,15 @@ def _ref_kwargs(sdpa_kwargs):
     return out
 
 
-def _check(O, O_ref, out_dt, in_key, amax_s, amax_s_ref, amax_o, amax_o_ref):
+def _check(out, o_ref, out_dt, in_key, amax_o, amax_o_ref):
     atol = 7e-2 if in_key == "e5m2" else 5e-2
-    diff = (O.float() - O_ref).abs().max().item()
+    diff = (out.float() - o_ref).abs().max().item()
     if out_dt in (torch.float8_e4m3fn, torch.float8_e5m2):
-        floor = (O_ref - O_ref.to(out_dt).float()).abs().max().item()
+        floor = (o_ref - o_ref.to(out_dt).float()).abs().max().item()
         atol = max(atol, 3.0 * floor)
     assert diff <= atol, f"max|O-ref|={diff:.4f} > {atol:.4f}"
-    # Amax_S and Amax_O are both produced in-kernel (atomicMax over the pre-cast fp32
+    # Amax_O is produced in-kernel (atomicMax over the pre-cast fp32
     # values), so they match the exact fp32 reference for every output dtype, incl. FP8.
-    assert abs(amax_s - amax_s_ref) <= 0.03, f"amax_s {amax_s:.4f} vs ref {amax_s_ref:.4f}"
     assert abs(amax_o - amax_o_ref) <= 0.03, f"amax_o {amax_o:.4f} vs ref {amax_o_ref:.4f}"
 
 
@@ -200,8 +197,8 @@ _MASKS = {
 @torch_fork_set_rng(seed=0)
 def test_fp8_masks(in_key, mask):
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=_MASKS[mask])
-    _check(O, O_ref, torch.float16, in_key, a_s, a_s_ref, a_o, a_o_ref)
+    out, o_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=_MASKS[mask])
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
 @pytest.mark.L0
@@ -210,8 +207,8 @@ def test_fp8_masks(in_key, mask):
 @torch_fork_set_rng(seed=0)
 def test_fp8_output_dtypes(in_key, out_key):
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(1, 8, 8, 512, 512, in_key, _OUT[out_key], scale=scale, sdpa_kwargs=dict(use_causal_mask=True))
-    _check(O, O_ref, _OUT[out_key], in_key, a_s, a_s_ref, a_o, a_o_ref)
+    out, o_ref, a_o, a_o_ref = _run(1, 8, 8, 512, 512, in_key, _OUT[out_key], scale=scale, sdpa_kwargs=dict(use_causal_mask=True))
+    _check(out, o_ref, _OUT[out_key], in_key, a_o, a_o_ref)
 
 
 @pytest.mark.L0
@@ -220,8 +217,8 @@ def test_fp8_output_dtypes(in_key, out_key):
 def test_fp8_sink(in_key):
     scale = 1.0 / math.sqrt(128)
     sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
-    O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), sink=sink)
-    _check(O, O_ref, torch.float16, in_key, a_s, a_s_ref, a_o, a_o_ref)
+    out, o_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), sink=sink)
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
 @pytest.mark.L0
@@ -229,16 +226,16 @@ def test_fp8_sink(in_key):
 @torch_fork_set_rng(seed=0)
 def test_fp8_gqa(in_key):
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(2, 8, 2, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True))
-    _check(O, O_ref, torch.float16, in_key, a_s, a_s_ref, a_o, a_o_ref)
+    out, o_ref, a_o, a_o_ref = _run(2, 8, 2, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True))
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_fp8_bottom_right_rectangular():
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(2, 8, 8, 128, 256, "e4m3", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask_bottom_right=True))
-    _check(O, O_ref, torch.float16, "e4m3", a_s, a_s_ref, a_o, a_o_ref)
+    out, o_ref, a_o, a_o_ref = _run(2, 8, 8, 128, 256, "e4m3", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask_bottom_right=True))
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
 @pytest.mark.L0
@@ -247,13 +244,13 @@ def test_fp8_bottom_right_rectangular():
 @torch_fork_set_rng(seed=0)
 def test_fp8_padding(in_key, causal):
     # KV padding mask: batch 0 uses all 256 KV cols, batch 1 only 192 (a partial
-    # KV tile).  Exercises per-batch eff_seqlen_kv masking AND the in-kernel amax_s
+    # KV tile).  Exercises per-batch eff_seqlen_kv masking AND the in-kernel amax_o
     # / amax_o over the padding-masked scores (padded cols/rows must not leak or
     # poison the global amax).
     scale = 1.0 / math.sqrt(128)
     sk = dict(use_causal_mask=True) if causal else {}
-    O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=sk, seq_lens_kv=[256, 192])
-    _check(O, O_ref, torch.float16, in_key, a_s, a_s_ref, a_o, a_o_ref)
+    out, o_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=sk, seq_lens_kv=[256, 192])
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
 @pytest.mark.L0
@@ -262,11 +259,11 @@ def test_fp8_padding(in_key, causal):
 def test_fp8_stats_less_zero_workspace(in_key):
     """No Stats output: the kernel compiles the LSE store out (has_lse=False),
     no dummy buffer exists at any level, and the dense graph reports
-    ``get_workspace_size() == 0`` (asserted inside ``_run``). The Amax_S /
-    Amax_O atomicMax writes are independent of the LSE and still produced."""
+    ``get_workspace_size() == 0`` (asserted inside ``_run``). The Amax_O
+    atomicMax write is independent of the LSE and still produced."""
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, a_s, a_s_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), stats=False)
-    _check(O, O_ref, torch.float16, in_key, a_s, a_s_ref, a_o, a_o_ref)
+    out, o_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), stats=False)
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
 
 
 @pytest.mark.L0
@@ -304,7 +301,7 @@ def test_fp8_sm100_execute_lse_contract():
         api.execute(lse_tensor=lse, **ex)
     api.execute(**ex)
     torch.cuda.synchronize()
-    o_ref, _ = _ref(q8.float() * dq, q8.float() * dq, q8.float() * dq, scale=api.scale_softmax, is_causal=True)
+    o_ref = _ref(q8.float() * dq, q8.float() * dq, q8.float() * dq, scale=api.scale_softmax, is_causal=True)
     torch.testing.assert_close(o.float(), o_ref, atol=5e-2, rtol=3e-2)
 
 

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
@@ -5,7 +5,7 @@
 
 Drives ``graph.sdpa_fp8`` (FP8 E4M3 Q/K/V + scalar per-tensor descales) routed to
 the ``sdpa_fwd_prefill_sm120_fp8`` engine, and validates O against an fp32-dequant
-reference. ``Amax_S`` and ``Amax_O`` are both produced in-kernel (bitcast-int32
+reference. ``Amax_O`` is produced in-kernel (bitcast-int32
 atomicMax over the pre-cast fp32 values); both are checked.
 
 SM120 envelope (see engines._sm120_fp8_spec): E4M3 in / FP16 out only, head
@@ -13,7 +13,7 @@ dims any multiple of 32 up to 256 with the QK^T and P@V sides independent
 (what graphs can reach is further gated by the C++ sdpa_fp8 node:
 d_qk <= 128 x d_v <= 128 plus the (192, 128) MLA pair), causal /
 bottom-right / SWA / KV-padding masks, THD (ragged) with token-major Stats;
-no sink (Amax_S semantics), no head-major ragged Stats.
+no sink, no head-major ragged Stats.
 
 Requires: SM120/SM121 (Blackwell GeForce), cutlass-dsl. Skips otherwise.
 """
@@ -60,7 +60,7 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     scores = scores.masked_fill(masked, float("-inf"))
     probs = torch.softmax(scores, dim=-1)
     # Fully-masked rows are -inf in logsumexp; the kernel writes -inf too.
-    return torch.matmul(probs, v_e), probs.max().item(), torch.logsumexp(scores, dim=-1)
+    return torch.matmul(probs, v_e), torch.logsumexp(scores, dim=-1)
 
 
 def _run(B, H_q, H_kv, S_q, S_kv, *, scale, sdpa_kwargs, seq_lens_kv=None, tiles=None, s_descale_gain=1.0, D=128, D_v=None):
@@ -81,7 +81,6 @@ def _run(B, H_q, H_kv, S_q, S_kv, *, scale, sdpa_kwargs, seq_lens_kv=None, tiles
     Qb, Kb, Vb = bshd(Q8), bshd(K8), bshd(V8)
     Ob = torch.empty(B, S_q, H_q, D_v, device=dev, dtype=torch.float16).transpose(1, 2)
     lse = torch.empty(B, H_q, S_q, 1, device=dev, dtype=torch.float32)
-    amax_s = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
     amax_o = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
 
     def sc(val):
@@ -113,10 +112,9 @@ def _run(B, H_q, H_kv, S_q, S_kv, *, scale, sdpa_kwargs, seq_lens_kv=None, tiles
         vp[sq_h] = slq
         vp[skv_h] = slk
     kw.update(sdpa_kwargs)
-    o, stats, amx_s, amx_o = g.sdpa_fp8(**kw)
+    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested
     o.set_output(True).set_dim(list(Ob.shape)).set_stride(list(Ob.stride())).set_data_type(cudnn.data_type.HALF)
     stats.set_output(True).set_dim([B, H_q, S_q, 1]).set_stride([H_q * S_q, S_q, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
-    amx_s.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
 
     g.validate()
@@ -125,13 +123,13 @@ def _run(B, H_q, H_kv, S_q, S_kv, *, scale, sdpa_kwargs, seq_lens_kv=None, tiles
     _select_engine(g, engine_name(arch="sm120", fp8=True), tiles=tiles)
     g.check_support()
     g.build_plans()
-    vp.update({o: Ob, stats: lse, amx_s: amax_s, amx_o: amax_o})
+    vp.update({o: Ob, stats: lse, amx_o: amax_o})
     g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8))
     torch.cuda.synchronize()
 
     ref_kw = _ref_kwargs(sdpa_kwargs)
-    o_ref, amax_s_ref, lse_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kw)
-    return Ob, o_ref, amax_s.item(), amax_s_ref, amax_o.item(), o_ref.abs().max().item(), lse.squeeze(-1), lse_ref
+    o_ref, lse_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kw)
+    return Ob, o_ref, amax_o.item(), o_ref.abs().max().item(), lse.squeeze(-1), lse_ref
 
 
 def _ref_kwargs(sdpa_kwargs):
@@ -147,10 +145,9 @@ def _ref_kwargs(sdpa_kwargs):
     return out
 
 
-def _check(out, o_ref, amax_s, amax_s_ref, amax_o, amax_o_ref, lse=None, lse_ref=None):
+def _check(out, o_ref, amax_o, amax_o_ref, lse=None, lse_ref=None):
     diff = (out.float() - o_ref).abs().max().item()
     assert diff <= 5e-2, f"max|O-ref|={diff:.4f} > 0.05"
-    assert abs(amax_s - amax_s_ref) <= 0.03, f"amax_s {amax_s:.4f} vs ref {amax_s_ref:.4f}"
     assert abs(amax_o - amax_o_ref) <= 0.03, f"amax_o {amax_o:.4f} vs ref {amax_o_ref:.4f}"
     if lse is not None:
         finite = torch.isfinite(lse_ref)
@@ -252,7 +249,7 @@ def test_fp8_sm120_e5m2_not_offered():
     g = cudnn.pygraph(io_data_type=cudnn.data_type.FP8_E5M2, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
     q, k, v = g.tensor_like(X), g.tensor_like(X), g.tensor_like(X)
     scalars = [g.tensor(dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.FLOAT) for _ in range(6)]
-    o, stats, amx_s, amx_o = g.sdpa_fp8(
+    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(
         q=q,
         k=k,
         v=v,
@@ -267,7 +264,6 @@ def test_fp8_sm120_e5m2_not_offered():
     )
     o.set_output(True).set_dim([B, H, S, D]).set_stride([S * H * D, D, H * D, 1]).set_data_type(cudnn.data_type.HALF)
     stats.set_output(True).set_dim([B, H, S, 1]).set_stride([H * S, S, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
-    amx_s.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     g.validate()
     g.build_operation_graph()
@@ -313,11 +309,10 @@ def _fp8_graph_offers_sm120(io_dtype, o_dtype, D=128, D_v=None, sink=False):
     )
     if sink:
         kw["sink_token"] = g.tensor(dim=[1, H, 1, 1], stride=[H, 1, 1, 1], data_type=cudnn.data_type.FLOAT)
-    o, stats, amx_s, amx_o = g.sdpa_fp8(**kw)
+    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested
     o.set_output(True).set_dim([B, H, S, D_v]).set_stride([S * H * D_v, D_v, H * D_v, 1]).set_data_type(o_dtype)
     stats.set_output(True).set_dim([B, H, S, 1]).set_stride([H * S, S, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
-    for t in (amx_s, amx_o):
-        t.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
+    amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     try:
         g.validate()
         g.build_operation_graph()
@@ -332,8 +327,7 @@ def _fp8_graph_offers_sm120(io_dtype, o_dtype, D=128, D_v=None, sink=False):
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_fp8_sm120_sink_not_offered():
-    """Amax_S over a softmax that includes a sink column has no agreed meaning,
-    so the row declines rather than reporting an amax for a different quantity."""
+    """The fp8 cell does not implement the sink fold, so it must decline."""
     import cudnn
 
     assert not _fp8_graph_offers_sm120(cudnn.data_type.FP8_E4M3, cudnn.data_type.HALF, sink=True)
@@ -484,7 +478,6 @@ def _run_template_tail(D, D_v, *, mask, S=256):
     o = torch.zeros(B, S, H, D_v, device=dev, dtype=torch.float16)
     seq_q = torch.full((B,), S, dtype=torch.int32, device=dev)
     seq_kv = torch.tensor(seq_kv_lens, dtype=torch.int32, device=dev) if seq_kv_lens else seq_q
-    amax_s = torch.zeros(1, dtype=torch.float32, device=dev)
     amax_o = torch.zeros(1, dtype=torch.float32, device=dev)
     scale = 1.0 / math.sqrt(D)
     fn(
@@ -496,8 +489,7 @@ def _run_template_tail(D, D_v, *, mask, S=256):
         None,  # sinks (unsupported; ABI slot)
         seq_q,
         seq_kv,
-        amax_s.view(torch.int32),  # bitcast-int32 atomicMax storage
-        amax_o.view(torch.int32),
+        amax_o.view(torch.int32),  # bitcast-int32 atomicMax storage
         cutlass.Float32(scale * math.log2(math.e)),  # softmax_scale_log2 (descale_q = descale_k = 1)
         cutlass.Float32(1.0),  # o_scale_fused = descale_s * descale_v * scale_o, all 1.0 here
         cutlass.Float32(1.0),  # scale_s
@@ -508,7 +500,7 @@ def _run_template_tail(D, D_v, *, mask, S=256):
     def bhsd(t):
         return t.float().permute(0, 2, 1, 3)
 
-    o_ref, _, _ = _ref(bhsd(q8), bhsd(k8), bhsd(v8), scale=scale, is_causal=mask in ("causal", "swa"), swa_window=swa_window, seq_lens_kv=seq_kv_lens)
+    o_ref, _ = _ref(bhsd(q8), bhsd(k8), bhsd(v8), scale=scale, is_causal=mask in ("causal", "swa"), swa_window=swa_window, seq_lens_kv=seq_kv_lens)
     of = bhsd(o)
     assert not torch.isnan(of).any(), "NaN in O"
     diff = (of - o_ref).abs().max().item()
@@ -638,7 +630,6 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
 
     sq_t = torch.tensor(seq_q_lens, dtype=torch.int32, device=dev).view(batch, 1, 1, 1)
     skv_t = torch.tensor(seq_kv_lens, dtype=torch.int32, device=dev).view(batch, 1, 1, 1)
-    amax_s = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
     amax_o = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
 
     def sc(val):
@@ -681,10 +672,9 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
     elif is_causal:
         kw["use_causal_mask"] = True
 
-    o, stats, amx_s, amx_o = g.sdpa_fp8(**kw)
+    o, stats, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested
     o.set_output(True).set_dim(list(o_view.shape)).set_stride(list(o_view.stride())).set_data_type(cudnn.data_type.HALF)
     o.set_ragged_offset(ro)
-    amx_s.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
     amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
 
     vp = {
@@ -704,7 +694,6 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
         ssn: sst,
         son: sot,
         o: o_view,
-        amx_s: amax_s,
         amx_o: amax_o,
     }
     cu = [0]
@@ -736,14 +725,12 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
     torch.cuda.synchronize()
 
     packed_o = o_storage[: max(cu[-1], 1) * h_q * D].view(max(cu[-1], 1), h_q, D)
-    amax_s_ref = 0.0
     for i, (nq, nkv) in enumerate(zip(seq_q_lens, seq_kv_lens)):
         if nq == 0:
             continue
-        o_ref, a_s_ref, lse_ref = _ref(
+        o_ref, lse_ref = _ref(
             q_8[i].float() * dq, k_8[i].float() * dk, v_8[i].float() * dv, scale=scale, is_causal=is_causal or bottom_right, bottom_right=bottom_right
         )
-        amax_s_ref = max(amax_s_ref, a_s_ref)
         got = packed_o[cu[i] : cu[i + 1]].float()
         want = o_ref[0].permute(1, 0, 2).float()
         diff = (got - want).abs().max().item()
@@ -755,7 +742,6 @@ def _run_thd_fp8(*, seq_q_lens, seq_kv_lens, h_q=8, h_kv=8, is_causal=True, bott
 
     # Nothing outside the packed token range may be written.
     assert (o_storage[cu[-1] * h_q * D :] == _THD_SENTINEL).all(), "wrote past the packed O tokens"
-    assert abs(amax_s.item() - amax_s_ref) <= 5e-2 * max(amax_s_ref, 1e-3), f"amax_s {amax_s.item()} vs {amax_s_ref}"
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -587,6 +587,64 @@ def test_sm120_probe_accepts_causal_swa_on_both_minors(monkeypatch):
         assert not any("sm100" in name for name in elig)
 
 
+def test_probe_rejects_requested_amax_s():
+    # The FP8 kernels no longer compute Amax_S; a graph that DECLARES the
+    # output (set_output(True), non-virtual) must go elsewhere. The port the
+    # op returns unconditionally does NOT count (is_virtual stays True).
+    import math
+
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.FP8_E4M3, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    dims, strides = (B, H, S, 128), (S * H * 128, 128, H * 128, 1)
+    q = g.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.FP8_E4M3, name="q")
+    k = g.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.FP8_E4M3, name="k")
+    v = g.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.FP8_E4M3, name="v")
+    sc = [g.tensor(dim=(1, 1, 1, 1), stride=(1, 1, 1, 1), data_type=cudnn.data_type.FLOAT) for _ in range(6)]
+    kw = dict(
+        q=q,
+        k=k,
+        v=v,
+        descale_q=sc[0],
+        descale_k=sc[1],
+        descale_v=sc[2],
+        descale_s=sc[3],
+        scale_s=sc[4],
+        scale_o=sc[5],
+        attn_scale=1.0 / math.sqrt(128),
+        generate_stats=False,
+        use_causal_mask=True,
+    )
+
+    def build(request_amax_s):
+        gg = cudnn.pygraph(io_data_type=cudnn.data_type.FP8_E4M3, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        qq = gg.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.FP8_E4M3, name="q")
+        kk = gg.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.FP8_E4M3, name="k")
+        vv = gg.tensor(dim=dims, stride=strides, data_type=cudnn.data_type.FP8_E4M3, name="v")
+        ss = [gg.tensor(dim=(1, 1, 1, 1), stride=(1, 1, 1, 1), data_type=cudnn.data_type.FLOAT) for _ in range(6)]
+        o, _stats, amx_s, amx_o = gg.sdpa_fp8(
+            q=qq,
+            k=kk,
+            v=vv,
+            descale_q=ss[0],
+            descale_k=ss[1],
+            descale_v=ss[2],
+            descale_s=ss[3],
+            scale_s=ss[4],
+            scale_o=ss[5],
+            attn_scale=1.0 / math.sqrt(128),
+            generate_stats=False,
+            use_causal_mask=True,
+        )
+        _finish_output(o, dims, strides, dtype=cudnn.data_type.HALF)
+        amx_o.set_output(True).set_dim((1, 1, 1, 1)).set_stride((1, 1, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
+        if request_amax_s:
+            amx_s.set_output(True).set_dim((1, 1, 1, 1)).set_stride((1, 1, 1, 1)).set_data_type(cudnn.data_type.FLOAT)
+        return gg
+
+    fp8_name = engines.engine_name(128, fp8=True)
+    assert fp8_name in _eligible(build(request_amax_s=False))
+    assert fp8_name not in _eligible(build(request_amax_s=True))
+
+
 def test_probe_accepts_bottom_right_with_swa():
     # The band shifts wholesale with the diagonal: the SM100 kernels apply the
     # same causal_diag offset to the SWA lower limit as to the causal upper one.


### PR DESCRIPTION
**Stacks on #584** (frost-br-swa) — the diff shows both commits until #584 merges; review only `9f4255b` here.

Nothing consumes `Amax_S`, and producing it cost every FP8 execute a stream-ordered zero-fill plus a per-row bitcast-int32 `atomicMax` in the epilogue. This removes it end to end:

- **Kernels** (SM100, SM107 sibling, SM120 FP8): epilogue reduction + atomicMax gone, ABI slot and fake-tensor compile args dropped. `Amax_O` untouched.
- **Adapters**: `amax_s` buffer plumbing and the launch-stream `.zero_()` removed from both execute paths.
- **Engines**: binding/resolve plumbing removed, plus an honesty gate — a graph that *declares* the `Amax_S` output is declined ("which the FROST engines do not produce") so it routes to an engine that writes it.
- **Analyzer subtlety**: `sdpa_fp8` returns the `Amax_S` port unconditionally, so the fact counts only a real (non-virtual, `set_output(True)`) tensor — pinned by a new probe test (unrequested port ⇒ eligible; requested output ⇒ ineligible).
- **Tests**: the mhas fp8 harness and both frost fp8 suites stop requesting/checking `Amax_S`; the sm120 sink-decline test keeps its behavior with an amax-free rationale.

**Validation** (B200, pip cuDNN 9.23, on top of #584): analyzer + fp8 + sm100 suites + mhas_v2 (paged/bwd_ragged env-excluded): **2105 pass**, fp8 routing unchanged (101 graphs), only the two known pre-existing `cu_seq_len` failures (9.23 backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SM100 and SM120 attention now support bottom-right causal masking with sliding windows where supported.
  * FP8 attention now reports and validates only the independently produced output scaling metric.

* **Bug Fixes**
  * Graphs requesting the unsupported softmax scaling metric are now rejected.
  * Removed obsolete FP8 output handling that could produce unsupported results.

* **Documentation**
  * Updated FP8 execution and output behavior documentation to reflect streamlined metric support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->