### PR TITLE
benchmark(sdpa): enable FA4 auto split-KV by default (num_splits=0)

### DIFF
--- a/benchmark/sdpa_benchmark_training/benchmark_single_sdpa.py
+++ b/benchmark/sdpa_benchmark_training/benchmark_single_sdpa.py
@@ -213,9 +213,11 @@ def parse_args():
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
     parser.add_argument(
         "--fa4_num_splits",
-        default=None,
+        default=0,
         type=int,
-        help="FlashAttention-4 only: force num_splits (KV split count). " "Default is None (FA4 picks automatically).",
+        help="FlashAttention-4 only: num_splits (KV split count) passed to flash_attn_func. "
+        "Default 0 enables FA4's split-KV heuristic; FA4's own default of 1 never splits. "
+        "On SM120 (which only supports num_splits=1) 0 resolves to 1.",
     )
     parser.add_argument(
         "--fwd_bwd",
@@ -1306,15 +1308,22 @@ else:
     if args.sdpa_backend == "flash_attention_4" or (not args.skip_ref):
         import flash_attn.cute.interface as flash_attn_interface
 
+        # flash_attn_func's own default is num_splits=1 (never split KV); 0 engages
+        # FA4's split-KV heuristic. Always pass the resolved value explicitly.
+        # SM120's forward kernel only supports num_splits=1 (the heuristic path
+        # asserts there), so the auto default resolves to 1 on that arch.
+        fa4_num_splits = args.fa4_num_splits
+        if fa4_num_splits == 0 and torch.cuda.get_device_capability()[0] == 12:
+            fa4_num_splits = 1
+
         def flash_attention_4_sdpa(query, key, value):
             window_size = (args.sliding_window_size, 0) if args.sliding_window_size else (None, None)
             kwargs = dict(
                 causal=args.attn_mask != "no_mask",
                 window_size=window_size,
                 deterministic=args.deterministic_bwd,
+                num_splits=fa4_num_splits,
             )
-            if args.fa4_num_splits is not None:
-                kwargs["num_splits"] = args.fa4_num_splits
             output, _ = flash_attn_interface.flash_attn_func(
                 query,
                 key,


### PR DESCRIPTION
The SDPA training benchmark previously omitted the `num_splits` kwarg when calling `flash_attn_func`, whose own default is `num_splits=1` — i.e. never split KV. Shapes whose `batch x kv_heads x m_blocks` underfills the GPU's SMs (low-KV-head GQA such as qwen35, or short-Q/long-KV configs such as auto_regressive_dit) were therefore timed without FA4's split-KV path, understating FA4 performance. The flag's help text ("Default is None (FA4 picks automatically)") was also incorrect: omitting the kwarg means 1 split, not auto.

Changes:
- `--fa4_num_splits` now defaults to `0`, which engages FA4's split-KV heuristic (`num_splits_heuristic`). **All FA4 timings produced by this benchmark from here on use auto split-KV.**
- On SM120, whose FA4 forward kernel only supports `num_splits=1` (the heuristic path asserts), the default resolves to 1.
- An explicit `--fa4_num_splits N` still forces a split count, as before.

Published FA4 result artifacts will be regenerated under this setting in a subsequent artifact-refresh PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit `--fa4_num_splits` option with a default of `0`.
  * Enabled automatic split-KV selection for FlashAttention-4, including resolution to one split on SM120 hardware.
* **Bug Fixes**
  * Improved consistency when passing the resolved split count to FlashAttention-4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->