### PR TITLE
FE execute-path host overhead: idempotent set_stream + skip the discarded per-call context

### DIFF
--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -21,7 +21,6 @@ symbols_to_import = [
     "backend_version",
     "backend_version_string",
     "get_last_error_string",
-    "destroy_handle",
     "norm_forward_phase",
     "reduction_mode",
     "behavior_note",
@@ -31,7 +30,6 @@ symbols_to_import = [
     "create_device_properties",
     "get_stream",
     "numerical_note",
-    "set_stream",
     "build_plan_policy",
     "data_type",
     "tensor_reordering",
@@ -59,6 +57,36 @@ for _optional_symbol in [
 ]:
     if hasattr(_pybind_module, _optional_symbol):
         globals()[_optional_symbol] = getattr(_pybind_module, _optional_symbol)
+
+
+# The last stream set on each handle, so set_stream() below can skip a redundant backend call.
+_handle_to_stream: dict = {}
+
+
+def set_stream(handle, stream):
+    """Set the CUDA stream a cuDNN handle runs on (wraps the compiled ``cudnnSetStream``).
+
+    ``cudnnSetStream`` is not free: for a non-null stream it issues several CUDA driver queries
+    on every call (green-context detection, stream priority, priority range) to maintain cuDNN's
+    internal per-priority stream pool, even when the stream is unchanged -- ~2.4us/call on
+    Blackwell. Frameworks that call this before every ``execute`` pay it every iteration, so we
+    cache the last stream per handle and skip the backend call when it has not changed; a
+    steady-state loop pays it once. (Assumes a handle is not driven from two streams
+    concurrently, which is the normal single-stream case; a caller that does needs its own
+    handle per stream regardless.)
+    """
+    if _handle_to_stream.get(handle) == stream:
+        return
+    _pybind_module._raw_set_stream(handle, stream)
+    _handle_to_stream[handle] = stream
+
+
+def destroy_handle(handle):
+    """Destroy a cuDNN handle (wraps the compiled binding); forget its cached stream so a
+    reused handle address is not wrongly skipped by set_stream()."""
+    _handle_to_stream.pop(handle, None)
+    return _pybind_module._raw_destroy_handle(handle)
+
 
 from .datatypes import _library_type, _is_torch_tensor
 

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -1755,9 +1755,12 @@ class pygraph:
                     ``set_stream`` semantics, both python engines and backend)
             override_uids/shapes/strides: dynamic-shape overrides (backend path)
         """
-        # A JIT engine must compile for the device/stream it will run on.
-        caller_ctx = self._build_context(handle) if handle is not None else None
         if not self._is_built:
+            # A JIT engine must compile for the device/stream it will run on, so
+            # build the caller context here. Only here: a steady-state execute()
+            # otherwise discarded this (a cudnnGetStream round-trip + an
+            # ExecutionContext alloc, ~2.9us) on every already-built call.
+            caller_ctx = self._build_context(handle) if handle is not None else None
             if not self._planning_done:
                 self.create_execution_plans()
             self.build(ctx=caller_ctx)

--- a/python/properties.cpp
+++ b/python/properties.cpp
@@ -285,9 +285,12 @@ init_properties(py::module_& m) {
               &create_device_properties_helper));
 
     m.def("create_handle", &HandleManagement::create_handle);
-    m.def("destroy_handle", &HandleManagement::destroy_handle);
+    // destroy_handle / set_stream are exposed under a raw name and wrapped in Python
+    // (cudnn/__init__.py) to skip a redundant cudnnSetStream when the stream is unchanged,
+    // matching how the graph execute binding (_execute) is wrapped as the public execute().
+    m.def("_raw_destroy_handle", &HandleManagement::destroy_handle);
     m.def("get_stream", &HandleManagement::get_stream);
-    m.def("set_stream", &HandleManagement::set_stream, py::arg("handle"), py::arg("stream"));
+    m.def("_raw_set_stream", &HandleManagement::set_stream, py::arg("handle"), py::arg("stream"));
 
     py::enum_<cudnn_frontend::NormFwdPhase_t>(m, "norm_forward_phase")
         .value("INFERENCE", cudnn_frontend::NormFwdPhase_t::INFERENCE)

--- a/test/python/test_set_stream_cache.py
+++ b/test/python/test_set_stream_cache.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cudnn.set_stream caches the last stream per handle and skips the backend call
+(cudnnSetStream, which re-issues several CUDA driver queries every call) when the
+stream has not changed. These tests mock the raw backend call, so no GPU is needed."""
+
+import pytest
+
+import cudnn
+
+pytestmark = pytest.mark.L0
+
+
+def test_set_stream_skips_backend_call_when_unchanged(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: calls.append((h, s)))
+    cudnn._handle_to_stream.clear()
+
+    cudnn.set_stream(handle=1, stream=100)
+    cudnn.set_stream(handle=1, stream=100)  # unchanged -> skipped
+    cudnn.set_stream(handle=1, stream=200)  # changed -> forwarded
+    cudnn.set_stream(handle=2, stream=100)  # different handle -> forwarded
+
+    assert calls == [(1, 100), (1, 200), (2, 100)]
+
+
+def test_destroy_handle_forgets_cached_stream(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: calls.append((h, s)))
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_destroy_handle", lambda h: None)
+    cudnn._handle_to_stream.clear()
+
+    cudnn.set_stream(handle=7, stream=100)
+    cudnn.destroy_handle(7)
+    cudnn.set_stream(handle=7, stream=100)  # a reused handle address must re-arm the backend
+
+    assert calls == [(7, 100), (7, 100)]


### PR DESCRIPTION
Two independent, self-contained cuts to the FE Python execute path's per-call host overhead. Both remove a redundant per-call `cudnn*` backend round-trip that a framework routing ops one-by-one through cuDNN pays every iteration. Neither changes API or results.

For context, the cuDNN backend execute itself is already at cuBLAS parity (`execute_plan_at_index`, pinned plan, ~8.4µs vs `torch.mm` ~7.6µs for a 256³ matmul); these two FE-side round-trips are a large part of the remaining per-op host gap.

## 1. Make `cudnn.set_stream` idempotent (skip `cudnnSetStream` when the stream is unchanged)

`cudnnSetStream` is not a cheap pointer store. For a non-null stream, `cudnn::ops::SetStream` (backend `src/graph/src/context.cpp`) issues **several CUDA driver queries on every call** — green-context detection (`cuStreamGetGreenCtx`), `cudaStreamGetPriority`, `cudaDeviceGetStreamPriorityRange`, plus a `cudaEventRecord` device check when the stream changes — to maintain cuDNN's internal per-priority / per-green-context stream pool. It does this **even when the stream has not changed** (no unchanged-stream early return).

Measured on B200 (host-bound µs/call): `cudnn.set_stream` is **~2.5µs regardless of stream kind** (legacy 2.49 / normal 2.63 / high-priority 2.66 / same-stream-repeated 2.63), and it is **not** the pybind layer (a trivial pybind→backend call is 0.11µs). A framework that calls `set_stream` before every `execute` pays this ~2.4µs every iteration.

Cache `{handle: last_stream}` in the Python layer; `set_stream` forwards to the backend only on a change, and `destroy_handle` forgets the entry so a reused handle address is not wrongly skipped. The bindings are renamed `set_stream`/`destroy_handle` → `_raw_set_stream`/`_raw_destroy_handle` (private, same pattern as `_execute`→`execute`) and the public names become thin caching wrappers; `get_stream` is unchanged and stays consistent with the cache. Assumes a handle is not driven from two streams concurrently (the normal single-stream case).

Regression test mocks the raw backend call (no GPU): verifies unchanged→skipped, changed/new-handle→forwarded, and destroy→re-armed.

## 2. Skip the discarded per-call context in `graph.execute()`

`execute()` built a caller `ExecutionContext` (a `cudnnGetStream` round-trip + an object alloc) at the top of **every** call, but only used it when the plan was not yet built. In steady state the plan is built, so the context was computed and thrown away every call — a ~2.9µs tax that made `execute()` slower than `execute_plan_at_index()` for the *identical* plan.

The fix moves the context build inside the `not _is_built` branch, its only user. Rigorously isolated on a single-plan graph (both calls run the identical kernel, so no plan confound), SM100, 256³ bf16 matmul:

| | before | after |
|---|---|---|
| `execute()` | 16.3 µs | **10.5 µs** |
| `execute_plan_at_index(0)` | 13.9 µs | 10.9 µs |
| gap | +2.4 µs | **~0** (execute() now matches/beats it) |

A surgical control (patch `_build_context` to a no-op) drops unpatched `execute()` by exactly 2.87µs and the patched build by 0.48µs — i.e. the fix removes precisely that discarded round-trip. `test_matmul_bias_relu` 34 passed on SM100 with the change; results bit-identical.

## Complementary backend fix

An unchanged-stream early return in `SetStream` (backend) would help **all** callers, including framework code that calls `cudnnSetStream` directly (e.g. before each op). Filed as a backend MR; this FE cache is the immediate, backend-version-independent half.

---
<sub>note to self: claude::11323ca1-07bc-4fc4-8ec7-ba95d8f061d8 — cuDNN per-call host-overhead. cwd /home/scratch.yanxu_libs/cudnn_frontend</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stream management support for cuDNN handles.
  * Stream assignments are tracked independently for each handle.
  * Reassigning the same stream avoids unnecessary backend operations.

* **Bug Fixes**
  * Stream changes are applied correctly when a handle receives a different stream.
  * Cached stream settings are cleared when handles are destroyed, ensuring correct behavior when handles are reused.

* **Performance**
  * Stream and execution context setup is reduced during repeated graph executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->