### PR TITLE
First-class cudnn.Handle (create_handle returns an object owning {backend handle, device, stream})

### DIFF
--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -37,7 +37,9 @@ becomes one consumer rather than the anchor.
    handle), so the set is closed. `Handle` deliberately has **no `__index__`**:
    the only path to the backend is those explicit calls, and a Handle that
    reaches a binding unconverted fails loudly instead of being silently coerced.
-   C++ never reads device off the handle. **No `.cpp` changes.**
+   C++ never reads device off the handle. **The C++ handle ABI is unchanged**;
+   the only `.cpp` change is renaming the `set_stream`/`destroy_handle` bindings
+   to `_raw_*` (`python/properties.cpp`) so the Python wrappers own those names.
 2. **The `create_handle` wrapper must be defined AFTER the `__init__.py` symbol-
    copy loop**, or the raw pybind symbol shadows it.
 3. **Dunder minimalism.** `Handle` defines **no** int-coercing dunders and leaves

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -169,6 +169,31 @@ covers them all at once:
   the whole build bakes for the handle's GPU. `tile_config._sm_count()` is
   re-routed off `torch.cuda.current_device` onto `frost.device` so it honours the
   scope too (it was the one query that bypassed `current_device()`).
+- **Frost GEMM compile target (done):** the scope also had to reach the *cute
+  compile arch*, which the earlier constants did not. cutedsl derives the compile
+  target from the ambient CUDA device (`torch.cuda.get_device_capability`), so a
+  build for handle-GPU-A while GPU-B is current baked A's constants into a
+  B-targeted kernel. `_frost_compile_options()` (in `gemm/frost/compiler.py`) now
+  pins `--gpu-arch sm_<scope>` into the `cute.compile()` options string, so the
+  compile target follows the scope. The arch is part of the baked, content-hashed
+  source, so a cross-arch kernel can no longer collide in the JIT cache with a
+  same-source same-machine one. **Limitation:** the pin is honoured on the public
+  `nvidia-cutlass-dsl >= 4.7` (frost's `CUTEDSL_MIN_VERSION`) and on internal RCs;
+  only a public wheel below the floor never threads `--gpu-arch`, and frost already
+  declines those as too-old (`buffers.cutedsl_too_old`, which the support check
+  reuses so an internal RC's own `0.x` numbering is judged new, not old). On such a
+  wheel a handle-scoped build **fails loud** — it cannot pin the target and cutedsl
+  resolves it from an arch captured at *import* time, which we can neither set nor
+  reliably read (a live-device comparison would miss an import-on-B / build-on-A
+  process), so `_frost_compile_options` refuses any `build_device`-scoped build
+  rather than bake scope constants into a possibly-mis-targeted kernel. An unscoped
+  build makes no cross-device promise and is unchanged.
+- **Not yet scope-following (documented holes):** `check_support`/kernel-selection
+  gates read the ambient arch (`buffers.current_sm()`), and the linear-attention
+  kernels lazy-compile at first *execute* — after the build scope has closed — so
+  their compile target is the execute-time device. Same-GPU (scope == ambient, the
+  normal case) all of these agree; a handle-scoped build on a sub-floor wheel is
+  the only case that diverges, and it is the fail-loud path above.
 - `_check_plan_device` **stays unchanged** and correct: it is the EXECUTE-time
   launch guard and must check the *live* current device (where the launch is
   going) against the baked device — the override is a build-scope only, unset at
@@ -205,6 +230,22 @@ is correct (and the build scope is not active then).
   without needing two Blackwells (device queries only, no kernel launch).
   `_check_plan_device` remains the execute-time launch guard against baking on one
   GPU and launching on another.
+- **Compile-target follows scope** (SM100, cutedsl 4.7): the `--gpu-arch` pin is
+  non-regressive on the matching-arch path — `test_matmul.py` bf16 sweep 677
+  passed / 337 skipped end-to-end with `--gpu-arch sm_100a` baked in. That the pin
+  actually moves the target is shown by compiling one graph three ways: `sm_100a`
+  (machine) and `sm_103a` (a different Blackwell sibling) both compile, while
+  `sm_90a` fails in the arch-specific NVVM backend — impossible if the option were
+  ignored (all three would target sm_100 and pass), so on 4.7 the option reaches
+  the compiler. The sub-floor-wheel fail-loud is unit-checked by forcing the
+  support probe false and asserting a `build_device`-scoped build raises while an
+  unscoped one passes through.
+- **Forced through flashinfer's GEMM fuzzer** (SM100): this build dropped into
+  flashinfer's `.venv` (via a `PYTHONPATH` shim) and forced onto the `cudnn`
+  backend across the full unified GEMM fuzz cross-product (bf16 / fp8 / nvfp4 /
+  mxfp4 / mxfp8, mm + bmm) — 731 passed / 0 failed / 151 xfailed (the xfails are
+  flashinfer's pre-tracked, backend-agnostic findings). The first-class `Handle`,
+  `set_stream` idempotency and `destroy_handle` clear are exercised on every one.
 
 ## Relationship to PR #611
 

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -1,0 +1,161 @@
+# First-class `cudnn.Handle` — design
+
+The backend `cudnnHandle_t` carries a device binding (compute capability, SM
+count, ...) and the current stream. On the FE side the handle is a **bare int**
+(`create_handle()` returns `reinterpret_cast<intptr_t>(handle)`), so it has no
+place to hang per-handle state. That state has instead accreted as side tables
+and per-engine queries:
+
+- stream: the module-global `_handle_to_stream` dict (PR #611);
+- device: **three** parallel stacks — the backend handle; pygraph's separate
+  `sm_count`/`sm_version`/`device_property` args (deviceless AOT); and frost's
+  own `current_device()` + driver introspection (`frost/device.py`), which every
+  python engine re-queries because nothing hands it the device.
+
+This makes `create_handle()` return a first-class `Handle` object that owns
+`{backend_handle, device, stream}`, collapsing those into one concept. The
+naming anticipates the front end BEING "cudnn" and today's cuDNN becoming "cudnn
+backend": this object is the `handle`; the wrapped `cudnnHandle_t` is the
+`backend_handle`. It is **optional** by design — python engines (frost, cutedsl,
+linear-attention) need device+stream, not a `cudnnHandle_t`, so the backend
+becomes one consumer rather than the anchor.
+
+`note to self: claude::11323ca1-07bc-4fc4-8ec7-ba95d8f061d8 — first-class Handle. cwd /home/scratch.yanxu_libs/cudnn_frontend`
+
+## Hard constraints (from a full call-site inventory)
+
+1. **The C++ boundary needs no change; the handoff is EXPLICIT in Python.** Every
+   handle-consuming binding takes `std::intptr_t` / `std::optional`. The backend
+   handle is extracted **explicitly** in our Python code — `to_backend_handle(h)`
+   at the named handoffs (`_execute*`, `backend_graph`) and `unwrap_handles(args,
+   kwargs)` at the opaque passthroughs (`get_workspace_size`, cuda-graph,
+   `deserialize`) — so a reader can grep `backend_handle` and trace the plumbing
+   top-to-bottom without an IDE. A full inventory confirmed **every** handle→C++
+   handoff is in `_pygraph`/`__init__` (the `__getattr__` delegation carries no
+   handle), so the set is closed. `Handle` deliberately has **no `__index__`**:
+   the only path to the backend is those explicit calls, and a Handle that
+   reaches a binding unconverted fails loudly instead of being silently coerced.
+   C++ never reads device off the handle. **No `.cpp` changes.**
+2. **The `create_handle` wrapper must be defined AFTER the `__init__.py` symbol-
+   copy loop**, or the raw pybind symbol shadows it.
+3. **Dunder minimalism.** `Handle` defines **no** int-coercing dunders and leaves
+   `__eq__`/`__hash__`/`__bool__` at the object defaults (identity eq, identity
+   hash, always-truthy). This satisfies all three Python pressure points at once:
+   - `_handle_to_stream` uses the handle as a dict key -> needs it hashable
+     (identity hash is fine);
+   - `wrapper.py` compares the stored handle against the string sentinel
+     `'auto'` and `None` -> a value-based `__eq__` that calls `int(other)` would
+     raise on a str; identity `__eq__` returns `False` cleanly;
+   - `if handle:` / `handle or 0` -> a live Handle must stay truthy.
+   Giving Handle a value `__eq__` without `__hash__` would make it unhashable
+   (TypeError on the stream dict) — so we give it neither.
+4. **Foreign raw-int handles keep working.** A framework may create a
+   `cudnnHandle_t` via the C API and pass the bare int. Those have no Handle
+   object, so stream/device fall back to the `_handle_to_stream` registry (keyed
+   by `int(handle)`) + a live `cudnnGetStream`. All wrappers branch
+   `isinstance(handle, Handle)`.
+5. **Deviceless AOT must not eager-query the driver.** `test_deviceless_aot_
+   compilation.py` builds with `device_property=` and no live handle, targeting
+   an SM that differs from any local GPU. `Handle.device` populated from a
+   deserialized `DeviceProperties` JSON (`deviceVer`, `multiProcessorCount`) must
+   stay authoritative when set; the live-driver path is used only when no
+   override/descriptor is present.
+6. **Device caches key by ordinal, not by Handle.** The existing per-device
+   `lru_cache`s (frost.device.\*, occupancy map, tile budgets) assume a stable
+   ordinal; a process driving two GPUs must not cross-contaminate.
+
+## `Handle`
+
+```
+class Handle:
+    backend_handle: int | None  # the wrapped cudnnHandle_t; None = pure-python (future)
+    _ordinal: int | None        # CUDA device ordinal this handle is bound to
+    stream: int | None          # authoritative; absorbs _handle_to_stream
+    device -> DeviceInfo        # lazy, cached by ordinal
+    # no __index__/__int__; __eq__/__hash__/__bool__ at object defaults (identity, truthy)
+
+# the explicit handoffs (grep `backend_handle` to trace them):
+to_backend_handle(h)          # a Handle's .backend_handle, a foreign int, or None
+unwrap_handles(args, kwargs)  # same, for any Handle in a passthrough call
+```
+
+`create_handle()` (Python, after the copy loop): `Handle(backend_handle=
+_pybind_module.create_handle(), ordinal=<current device>)`.
+
+### `DeviceInfo` (the union `Handle.device` exposes)
+
+Sourced from `frost/device.py`'s driver introspector (the richest, framework-
+neutral, already `lru_cache`d per ordinal). Reuse those functions; do not add a
+fourth query stack. Fields (superset the inventory proved is consumed):
+
+| field | form | consumers |
+|---|---|---|
+| `ordinal` | int | frost build/guard, operand views |
+| `compute_capability` | (major, minor) | frost arch gate, api_base sm107, tensor_adapter |
+| `sm_version` | packed `major*10+minor` | Context, kernel_registry ranges, DSA gates |
+| `sm_count` | int (user-overridable) | tile scorer, heuristics `SM_COUNT_TARGET` |
+| `shared_memory_per_block_optin` | bytes | tile SMEM budget |
+| `oversized_shared_memory_per_block` | bytes (0 if unsupported — load-bearing) | tile SMEM budget |
+| `l2_cache_bytes` | bytes | L2 swizzle budget |
+| `device_name` | str | diagnostics |
+
+`sm_version` is a derived property of `compute_capability` so the two forms
+cannot drift. `Handle.device` also owns the serializable backend
+`DeviceProperties` (deviceless AOT); when built from a descriptor/override the
+fields come from its JSON, not the driver.
+
+## Stream model
+
+`Handle.stream` is the single source of truth. Today the stream lives in two
+disconnected places: `set_stream` **writes** `_handle_to_stream` (PR #611) but
+`_resolve_stream` **reads** live via `cudnn.get_stream` -> `cudnnGetStream` on
+every python-engine execute. Handle unifies them:
+
+- `set_stream(h, s)`: Handle -> compare/write `h.stream`, call `_raw_set_stream`
+  only on change (and only if `h.backend_handle is not None`); foreign int ->
+  today's `_handle_to_stream` path.
+- `get_stream(h)`: Handle -> return `h.stream` (no round-trip); foreign int ->
+  raw binding.
+- `_resolve_stream` / `_build_context`: read `h.stream` for a Handle. This kills
+  the per-execute `cudnnGetStream` that #611 did not remove.
+- Preserve the **raise-not-fallback** contract: a failed query on a *supplied*
+  handle raises (asserted by `test_dispatch.py:585`), never silently falls back
+  to the torch current stream.
+
+## Device-consumer migration (frost / linear-attention / sdpa)
+
+`to_backend_handle` does **not** help here — these want a device **ordinal**,
+not the backend handle int — so each site threads `ctx.handle.device.ordinal`.
+The plumbing gap:
+`FrostGemmEngine.build_plan(graph, plan, ctx)` receives `ctx` (hence the handle)
+but calls `build_gemm_plan(graph)` with no device.
+
+- `engine.py` -> pass `ctx.handle.device` into `build_gemm_plan` ->
+  `select_config` / `jit_from_cudnn_graph` and into `VariantPack` (operand
+  device tag).
+- `_plan_device()` collapses to `resolve_device(ctx.handle.device.ordinal)`.
+- `_check_plan_device` **stays** (building on one handle/GPU then executing with
+  another handle on a different GPU is reachable via `graph.execute(handle=...)`)
+  but is re-sourced from `handle.device`.
+- `current_device()` is **demoted** to the `device=None` / no-handle / render-
+  only fallback — it does not delete.
+- Same migration for `linear_attention/frost/*_engine.py` (gdn/gdn2/kda) and
+  `sdpa/graph_analyzer.py`, which read `buffers.current_sm()` at build.
+
+`workspace` stays a per-execute argument — it is not handle state and does not
+belong on the Handle (today it is conflated into `ExecutionContext`).
+
+## Validation
+
+- Single-GPU L0 (matmul/conv/rope/norm/frost-sdpa) — regression.
+- **2-GPU test** (build a graph with a handle on cuda:0, execute with a handle on
+  cuda:1): asserts (a) the built plan's device follows the *build* handle and
+  (b) `_check_plan_device` fires on the mismatch. Single-GPU CI passes either
+  migration, so this test is what actually proves the device follows the handle.
+  parley has the SM80..SM100 range for it.
+
+## Relationship to PR #611
+
+This PR is the full first-class-Handle superset of #611 (it reimplements the
+set_stream idempotency as `Handle.stream` and keeps the discarded-context fix).
+#611 stays open as the minimal, low-risk fallback. Exactly one merges.

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -27,9 +27,11 @@ becomes one consumer rather than the anchor.
 1. **The C++ boundary needs no change; the handoff is EXPLICIT in Python.** Every
    handle-consuming binding takes `std::intptr_t` / `std::optional`. The backend
    handle is extracted **explicitly** in our Python code — `to_backend_handle(h)`
-   at the named handoffs (`_execute*`, `backend_graph`) and `unwrap_handles(args,
-   kwargs)` at the opaque passthroughs (`get_workspace_size`, cuda-graph,
-   `deserialize`) — so a reader can grep `backend_handle` and trace the plumbing
+   at each handoff (`_execute*`, `backend_graph`, and the workspace / cuda-graph
+   methods, whose signatures name `handle` rather than a `*args` passthrough).
+   `deserialize` is the one genuinely ambiguous classic overload (`(data)` vs
+   `(handle, data, ...)`), so it stays a passthrough and unwraps just its first
+   positional. A reader can grep `backend_handle` and trace the plumbing
    top-to-bottom without an IDE. A full inventory confirmed **every** handle→C++
    handoff is in `_pygraph`/`__init__` (the `__getattr__` delegation carries no
    handle), so the set is closed. `Handle` deliberately has **no `__index__`**:
@@ -74,9 +76,8 @@ class Handle:
     device -> DeviceInfo        # lazy, cached by ordinal
     # no __index__/__int__; __eq__/__hash__/__bool__ at object defaults (identity, truthy)
 
-# the explicit handoffs (grep `backend_handle` to trace them):
+# the explicit handoff (grep `backend_handle` to trace it):
 to_backend_handle(h)          # a Handle's .backend_handle, a foreign int, or None
-unwrap_handles(args, kwargs)  # same, for any Handle in a passthrough call
 ```
 
 `create_handle()` (Python, after the copy loop): `Handle(backend_handle=

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -20,8 +20,6 @@ backend": this object is the `handle`; the wrapped `cudnnHandle_t` is the
 linear-attention) need device+stream, not a `cudnnHandle_t`, so the backend
 becomes one consumer rather than the anchor.
 
-`note to self: claude::11323ca1-07bc-4fc4-8ec7-ba95d8f061d8 — first-class Handle. cwd /home/scratch.yanxu_libs/cudnn_frontend`
-
 ## Hard constraints (from a full call-site inventory)
 
 1. **The C++ boundary needs no change; the handoff is EXPLICIT in Python.** Every

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -159,9 +159,15 @@ covers them all at once:
   execute, so the guard keeps reading the live device.
 - `current_device()` is otherwise unchanged — it is the fallback whenever no
   build scope is active (no-handle, render-only, execute).
-- **Pending:** the same hinge wrap for `linear_attention/frost/*_engine.py`
-  (gdn/gdn2/kda) and the sdpa frost engines; those also read `buffers.current_sm()`
-  / `current_device_id()` at build, which must be routed through the scope too.
+- **Linear-attention (done):** `gdn/gdn2/kda_engine.build_plan` wrap their build
+  in `with build_device(ctx.handle.device.ordinal)` too, and their one device-baked
+  constant — `num_sm = multiprocessor_count(current_device_id())` — is re-routed
+  onto `frost.device.current_device()` so it follows the scope (it read the
+  `buffers` probe, which bypassed it). `test_la.py` 359 passed / 0 failed on SM100.
+- **sdpa frost engines:** nothing to scope at the engine level — their build bakes
+  no device constant from `current_device`; arch gating is in `check_support`, and
+  the one `torch.cuda.current_device()` (`sdpa/bwd/engines.py`) tags a TensorDesc's
+  operand device, which is correctly the live device (as `VariantPack.device`).
 
 `workspace` stays a per-execute argument — it is not handle state and does not
 belong on the Handle (today it is conflated into `ExecutionContext`).

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -117,6 +117,20 @@ cannot drift. `Handle.device` also owns the serializable backend
 `DeviceProperties` (deviceless AOT); when built from a descriptor/override the
 fields come from its JSON, not the driver.
 
+### Environment facts (versions) — `cudnn/_env.py`
+
+Device facts are per-ordinal; **version** facts (CUDA driver, CUDA runtime) are
+process-global — one per process regardless of which GPU a handle is bound to.
+Putting them on `DeviceInfo` would duplicate them per ordinal, and on `Handle`
+per handle, so they get their own owner `cudnn/_env.py` (`driver_version()`,
+`runtime_version()`). This mirrors the backend, which exposes its own versions as
+argument-less globals (`cudnnGetVersion`, `cudnnGetCudartVersion`), never off a
+handle or the `DEVICEPROP` descriptor — cuDNN's own version stays there,
+`cudnn.backend_version()`. The CUDA queries had accreted as re-reads in each
+engine (the `DeviceInfo` oversized-SMEM gate, the cutile GDN/KDA `check_support`);
+`_env` collects them. ~100 ns and off the execute hot path — the cache is a single
+owner returning a constant, not a speed play.
+
 ## Stream model
 
 `Handle.stream` is the single source of truth. Today the stream lives in two

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -124,35 +124,52 @@ every python-engine execute. Handle unifies them:
 
 ## Device-consumer migration (frost / linear-attention / sdpa)
 
-`to_backend_handle` does **not** help here — these want a device **ordinal**,
-not the backend handle int — so each site threads `ctx.handle.device.ordinal`.
-The plumbing gap:
-`FrostGemmEngine.build_plan(graph, plan, ctx)` receives `ctx` (hence the handle)
-but calls `build_gemm_plan(graph)` with no device.
+`to_backend_handle` does **not** help here — these want a device **ordinal**, not
+the backend handle int. Every device-derived frost build constant (`_current_arch`,
+`_plan_device`, `_grid_num_clusters`, `_sm_count`, the SMEM/L2 budgets) already
+funnels through `frost.device.current_device()`/`resolve_device(None)`, so rather
+than thread an ordinal through ~20 signatures, a **scoped build-device override**
+covers them all at once:
 
-- `engine.py` -> pass `ctx.handle.device` into `build_gemm_plan` ->
-  `select_config` / `jit_from_cudnn_graph` and into `VariantPack` (operand
-  device tag).
-- `_plan_device()` collapses to `resolve_device(ctx.handle.device.ordinal)`.
-- `_check_plan_device` **stays** (building on one handle/GPU then executing with
-  another handle on a different GPU is reachable via `graph.execute(handle=...)`)
-  but is re-sourced from `handle.device`.
-- `current_device()` is **demoted** to the `device=None` / no-handle / render-
-  only fallback — it does not delete.
-- Same migration for `linear_attention/frost/*_engine.py` (gdn/gdn2/kda) and
-  `sdpa/graph_analyzer.py`, which read `buffers.current_sm()` at build.
+- `frost/device.py` — `build_device(ordinal)`, a context manager that scopes an
+  override into `current_device()` (like `torch.cuda.device()`). `None` = no
+  override (classic current-device). Grep `build_device` / `_build_device` to
+  trace it: the context manager + `current_device()`'s read + the one hinge.
+- **Frost GEMM (done):** `FrostGemmEngine.build_plan(graph, plan, ctx)` wraps
+  `build_gemm_plan(graph)` in `with build_device(ctx.handle.device.ordinal)`, so
+  the whole build bakes for the handle's GPU. `tile_config._sm_count()` is
+  re-routed off `torch.cuda.current_device` onto `frost.device` so it honours the
+  scope too (it was the one query that bypassed `current_device()`).
+- `_check_plan_device` **stays unchanged** and correct: it is the EXECUTE-time
+  launch guard and must check the *live* current device (where the launch is
+  going) against the baked device — the override is a build-scope only, unset at
+  execute, so the guard keeps reading the live device.
+- `current_device()` is otherwise unchanged — it is the fallback whenever no
+  build scope is active (no-handle, render-only, execute).
+- **Pending:** the same hinge wrap for `linear_attention/frost/*_engine.py`
+  (gdn/gdn2/kda) and the sdpa frost engines; those also read `buffers.current_sm()`
+  / `current_device_id()` at build, which must be routed through the scope too.
 
 `workspace` stays a per-execute argument — it is not handle state and does not
 belong on the Handle (today it is conflated into `ExecutionContext`).
 
+`VariantPack.device` (operand DLPack views) stays on `current_device()`: it is
+read at EXECUTE, where the operands live on the current device, so the live device
+is correct (and the build scope is not active then).
+
 ## Validation
 
-- Single-GPU L0 (matmul/conv/rope/norm/frost-sdpa) — regression.
-- **2-GPU test** (build a graph with a handle on cuda:0, execute with a handle on
-  cuda:1): asserts (a) the built plan's device follows the *build* handle and
-  (b) `_check_plan_device` fires on the mismatch. Single-GPU CI passes either
-  migration, so this test is what actually proves the device follows the handle.
-  parley has the SM80..SM100 range for it.
+- Single-GPU L0 (matmul/conv/rope/norm) — regression. Handle core: 41 passed.
+- Frost GEMM no-regression with the build-device adoption: `test_public_execute_
+  flavors` + `test_stream_respect` 32 passed (SM100).
+- **Cross-device redirect** (`test/python/gemm/frost/test_build_device.py`): scope
+  a build to a *different-arch* real GPU (L40S sm89 / H100 sm90 / A100 sm80) and
+  assert every frost build constant (`_current_arch`, `_plan_device`, the
+  re-routed `_sm_count`) reports THAT device — the multi-GPU behaviour a
+  single-GPU run cannot otherwise exercise, proven on parley's SM80..SM100 range
+  without needing two Blackwells (device queries only, no kernel launch).
+  `_check_plan_device` remains the execute-time launch guard against baking on one
+  GPU and launching on another.
 
 ## Relationship to PR #611
 

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -84,9 +84,21 @@ _pybind_module.create_handle(), ordinal=<current device>)`.
 
 ### `DeviceInfo` (the union `Handle.device` exposes)
 
-Sourced from `frost/device.py`'s driver introspector (the richest, framework-
-neutral, already `lru_cache`d per ordinal). Reuse those functions; do not add a
-fourth query stack. Fields (superset the inventory proved is consumed):
+Lives in `cudnn/_device.py` — the FE's **single owner** of a GPU's facts. Each
+fact is a `@cached_property` that queries the driver once and caches **on the
+instance**, and there is one instance per ordinal (`device_info(ordinal)`,
+lru-cached), so a GPU's facts are asked for once and shared. `Handle.device` is
+that object.
+
+This inverts the previous direction: the driver queries used to live in
+`frost/device.py` and `DeviceInfo` delegated down to them. Now the common layer
+owns the queries, and `frost/device.py`'s fact functions (`compute_capability`,
+`multiprocessor_count`, ...) are **thin shims** onto `device_info(ordinal)` — so
+frost consumes the same object rather than running a parallel introspection
+stack, and its ~24-file / 65-site call surface is unchanged. (A later step can
+repoint those sites at `handle.device.*` directly where a handle is in scope; the
+ownership move here is the enabling half.) Fields (superset the inventory proved
+is consumed):
 
 | field | form | consumers |
 |---|---|---|

--- a/docs/handle_first_class_design.md
+++ b/docs/handle_first_class_design.md
@@ -51,11 +51,16 @@ becomes one consumer rather than the anchor.
    - `if handle:` / `handle or 0` -> a live Handle must stay truthy.
    Giving Handle a value `__eq__` without `__hash__` would make it unhashable
    (TypeError on the stream dict) — so we give it neither.
-4. **Foreign raw-int handles keep working.** A framework may create a
-   `cudnnHandle_t` via the C API and pass the bare int. Those have no Handle
-   object, so stream/device fall back to the `_handle_to_stream` registry (keyed
-   by `int(handle)`) + a live `cudnnGetStream`. All wrappers branch
-   `isinstance(handle, Handle)`.
+4. **The Python handle APIs take a `cudnn.Handle` only; a raw backend int is
+   rejected.** `cudnn.create_handle()` is the only way to make a handle in the
+   Python API, so every real caller already holds a Handle (verified across
+   flashinfer / sglang / the FE's own code; torch uses the C++ frontend, not this
+   module). A bare int would silently opt out of the Handle's device/stream
+   tracking and device-scoped build, so `to_backend_handle` / `set_stream` /
+   `get_stream` / `destroy_handle` / `execute(handle=)` raise on a non-Handle. A
+   framework holding a foreign `cudnnHandle_t` wraps it once —
+   `cudnn.Handle(backend_handle, ordinal, stream)` — so it becomes first-class
+   (gaining the same device/stream/scoping) rather than a second-class bare int.
 5. **Deviceless AOT must not eager-query the driver.** `test_deviceless_aot_
    compilation.py` builds with `device_property=` and no live handle, targeting
    an SM that differs from any local GPU. `Handle.device` populated from a

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -72,9 +72,10 @@ def create_handle():
     """Create a cuDNN handle, returned as a first-class :class:`cudnn.Handle`.
 
     The Handle wraps the backend ``cudnnHandle_t`` and is bound to the current
-    CUDA device; it forwards to the backend anywhere an ``intptr_t`` handle is
-    expected (via ``__index__``), so existing code that passes the handle to
-    ``graph.execute`` / ``set_stream`` / the C++ layer is unchanged.
+    CUDA device. Anywhere the backend needs the raw ``cudnnHandle_t`` it is
+    extracted explicitly via ``to_backend_handle()`` (grep it to trace every
+    handoff) -- the Handle is never silently coerced to an int, so a Handle that
+    reaches a binding unconverted fails loudly rather than being magically cast.
     """
     raw = _pybind_module.create_handle()
     ordinal = None

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -21,7 +21,6 @@ symbols_to_import = [
     "backend_version",
     "backend_version_string",
     "get_last_error_string",
-    "destroy_handle",
     "norm_forward_phase",
     "reduction_mode",
     "behavior_note",
@@ -31,7 +30,6 @@ symbols_to_import = [
     "create_device_properties",
     "get_stream",
     "numerical_note",
-    "set_stream",
     "build_plan_policy",
     "data_type",
     "tensor_reordering",
@@ -59,6 +57,36 @@ for _optional_symbol in [
 ]:
     if hasattr(_pybind_module, _optional_symbol):
         globals()[_optional_symbol] = getattr(_pybind_module, _optional_symbol)
+
+
+# The last stream set on each handle, so set_stream() below can skip a redundant backend call.
+_handle_to_stream: dict = {}
+
+
+def set_stream(handle, stream):
+    """Set the CUDA stream a cuDNN handle runs on (wraps the compiled ``cudnnSetStream``).
+
+    ``cudnnSetStream`` is not free: for a non-null stream it issues several CUDA driver queries
+    on every call (green-context detection, stream priority, priority range) to maintain cuDNN's
+    internal per-priority stream pool, even when the stream is unchanged -- ~2.4us/call on
+    Blackwell. Frameworks that call this before every ``execute`` pay it every iteration, so we
+    cache the last stream per handle and skip the backend call when it has not changed; a
+    steady-state loop pays it once. (Assumes a handle is not driven from two streams
+    concurrently, which is the normal single-stream case; a caller that does needs its own
+    handle per stream regardless.)
+    """
+    if _handle_to_stream.get(handle) == stream:
+        return
+    _pybind_module._raw_set_stream(handle, stream)
+    _handle_to_stream[handle] = stream
+
+
+def destroy_handle(handle):
+    """Destroy a cuDNN handle (wraps the compiled binding); forget its cached stream so a
+    reused handle address is not wrongly skipped by set_stream()."""
+    _handle_to_stream.pop(handle, None)
+    return _pybind_module._raw_destroy_handle(handle)
+
 
 from .datatypes import _library_type, _is_torch_tensor
 

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -93,52 +93,43 @@ def set_stream(handle, stream):
     ``cudnnSetStream`` is not free: for a non-null stream it issues several CUDA driver queries
     on every call (green-context detection, stream priority, priority range) to maintain cuDNN's
     internal per-priority stream pool, even when the stream is unchanged -- ~2.4us/call on
-    Blackwell. Frameworks that call this before every ``execute`` pay it every iteration, so we
-    remember the last stream and skip the backend call when it has not changed; a steady-state
-    loop pays it once. Only a :class:`cudnn.Handle` gets this fast path (it remembers the stream
-    on itself); a foreign raw-int handle is not ours to track -- its owner may call
-    ``cudnnSetStream`` out-of-band -- so it is always set through. (Assumes a Handle is not driven
-    from two streams concurrently, which is the normal single-stream case; a caller that does
-    needs its own handle per stream regardless.)
+    Blackwell. Frameworks that call this before every ``execute`` pay it every iteration, so the
+    :class:`cudnn.Handle` remembers its last stream and skips the backend call when it has not
+    changed; a steady-state loop pays it once. (Assumes a Handle is not driven from two streams
+    concurrently, which is the normal single-stream case; a caller that does needs its own handle
+    per stream regardless.)
     """
-    if isinstance(handle, Handle):
-        if handle.stream == stream:
-            return
-        if handle.backend_handle is not None:
-            _pybind_module._raw_set_stream(handle.backend_handle, stream)
-        handle.stream = stream
+    if not isinstance(handle, Handle):
+        raise TypeError(f"cudnn.set_stream expects a cudnn.Handle (from cudnn.create_handle()), got {type(handle).__name__}")
+    if handle.stream == stream:
         return
-    # Foreign raw-int handle: we do not own it and cannot observe an out-of-band
-    # cudnnSetStream by its owner, so never skip on a cached value -- always set
-    # through. The idempotency fast-path is kept only on Handle (handle.stream).
-    _pybind_module._raw_set_stream(handle, stream)
+    if handle.backend_handle is not None:
+        _pybind_module._raw_set_stream(handle.backend_handle, stream)
+    handle.stream = stream
 
 
 def get_stream(handle):
-    """The CUDA stream a handle runs on. For a :class:`cudnn.Handle` this is the cached
-    ``Handle.stream`` (no backend round-trip); for a foreign raw-int handle it queries the
-    backend (``cudnnGetStream``)."""
-    if isinstance(handle, Handle):
-        return handle.stream
-    return _pybind_module.get_stream(handle)
+    """The CUDA stream a :class:`cudnn.Handle` runs on -- the cached ``Handle.stream``, no
+    backend round-trip."""
+    if not isinstance(handle, Handle):
+        raise TypeError(f"cudnn.get_stream expects a cudnn.Handle (from cudnn.create_handle()), got {type(handle).__name__}")
+    return handle.stream
 
 
 def destroy_handle(handle):
-    """Destroy a cuDNN handle (wraps the compiled binding). For a :class:`cudnn.Handle` the
-    backend handle is cleared after destruction so a reused Handle object cannot pass a released
-    ``cudnnHandle_t`` back to C++ (a double-destroy or a later set_stream)."""
-    if isinstance(handle, Handle):
-        backend = handle.backend_handle
-        if backend is None:
-            handle.stream = None
-            return None
-        _pybind_module._raw_destroy_handle(backend)
-        handle.backend_handle = None
+    """Destroy a :class:`cudnn.Handle` (wraps the compiled binding). The backend handle is cleared
+    after destruction so a reused Handle object cannot pass a released ``cudnnHandle_t`` back to
+    C++ (a double-destroy or a later set_stream)."""
+    if not isinstance(handle, Handle):
+        raise TypeError(f"cudnn.destroy_handle expects a cudnn.Handle (from cudnn.create_handle()), got {type(handle).__name__}")
+    backend = handle.backend_handle
+    if backend is None:
         handle.stream = None
         return None
-    # Foreign raw-int handle: destroy it directly (FE tracked no state for it).
-    return _pybind_module._raw_destroy_handle(handle)
-    return _pybind_module._raw_destroy_handle(handle)
+    _pybind_module._raw_destroy_handle(backend)
+    handle.backend_handle = None
+    handle.stream = None
+    return None
 
 
 from .datatypes import _library_type, _is_torch_tensor

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -25,10 +25,8 @@ symbols_to_import = [
     "reduction_mode",
     "behavior_note",
     "knob_type",
-    "create_handle",
     "create_kernel_cache",
     "create_device_properties",
-    "get_stream",
     "numerical_note",
     "build_plan_policy",
     "data_type",
@@ -59,8 +57,34 @@ for _optional_symbol in [
         globals()[_optional_symbol] = getattr(_pybind_module, _optional_symbol)
 
 
-# The last stream set on each handle, so set_stream() below can skip a redundant backend call.
+from ._handle import Handle, DeviceInfo
+
+# Type alias for the annotations that reference ``cudnn.handle`` (a supplied handle
+# is a cudnn.Handle, or a bare int for a framework-created foreign handle).
+handle = Handle
+
+# Last stream per FOREIGN raw-int handle (a cudnn.Handle carries its own .stream);
+# lets set_stream() skip a redundant backend call when the stream is unchanged.
 _handle_to_stream: dict = {}
+
+
+def create_handle():
+    """Create a cuDNN handle, returned as a first-class :class:`cudnn.Handle`.
+
+    The Handle wraps the backend ``cudnnHandle_t`` and is bound to the current
+    CUDA device; it forwards to the backend anywhere an ``intptr_t`` handle is
+    expected (via ``__index__``), so existing code that passes the handle to
+    ``graph.execute`` / ``set_stream`` / the C++ layer is unchanged.
+    """
+    raw = _pybind_module.create_handle()
+    ordinal = None
+    try:
+        from .frost.device import current_device
+
+        ordinal = current_device()
+    except Exception:
+        ordinal = None  # no GPU visible / cuda-python absent: resolve lazily on .device
+    return Handle(raw, ordinal)
 
 
 def set_stream(handle, stream):
@@ -70,21 +94,45 @@ def set_stream(handle, stream):
     on every call (green-context detection, stream priority, priority range) to maintain cuDNN's
     internal per-priority stream pool, even when the stream is unchanged -- ~2.4us/call on
     Blackwell. Frameworks that call this before every ``execute`` pay it every iteration, so we
-    cache the last stream per handle and skip the backend call when it has not changed; a
-    steady-state loop pays it once. (Assumes a handle is not driven from two streams
-    concurrently, which is the normal single-stream case; a caller that does needs its own
-    handle per stream regardless.)
+    remember the last stream and skip the backend call when it has not changed; a steady-state
+    loop pays it once. A :class:`cudnn.Handle` remembers on itself; a foreign raw-int handle has
+    no object, so it is remembered in a module registry keyed by the raw address. (Assumes a
+    handle is not driven from two streams concurrently, which is the normal single-stream case; a
+    caller that does needs its own handle per stream regardless.)
     """
-    if _handle_to_stream.get(handle) == stream:
+    if isinstance(handle, Handle):
+        if handle.stream == stream:
+            return
+        if handle.backend_handle is not None:
+            _pybind_module._raw_set_stream(handle.backend_handle, stream)
+        handle.stream = stream
+        return
+    key = int(handle)
+    if _handle_to_stream.get(key) == stream:
         return
     _pybind_module._raw_set_stream(handle, stream)
-    _handle_to_stream[handle] = stream
+    _handle_to_stream[key] = stream
+
+
+def get_stream(handle):
+    """The CUDA stream a handle runs on. For a :class:`cudnn.Handle` this is the cached
+    ``Handle.stream`` (no backend round-trip); for a foreign raw-int handle it queries the
+    backend (``cudnnGetStream``)."""
+    if isinstance(handle, Handle):
+        return handle.stream
+    return _pybind_module.get_stream(handle)
 
 
 def destroy_handle(handle):
-    """Destroy a cuDNN handle (wraps the compiled binding); forget its cached stream so a
+    """Destroy a cuDNN handle (wraps the compiled binding); forget its remembered stream so a
     reused handle address is not wrongly skipped by set_stream()."""
-    _handle_to_stream.pop(handle, None)
+    if isinstance(handle, Handle):
+        backend = handle.backend_handle
+        handle.stream = None
+        if backend is None:
+            return None
+        return _pybind_module._raw_destroy_handle(backend)
+    _handle_to_stream.pop(int(handle), None)
     return _pybind_module._raw_destroy_handle(handle)
 
 

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -63,10 +63,6 @@ from ._handle import Handle, DeviceInfo
 # is a cudnn.Handle, or a bare int for a framework-created foreign handle).
 handle = Handle
 
-# Last stream per FOREIGN raw-int handle (a cudnn.Handle carries its own .stream);
-# lets set_stream() skip a redundant backend call when the stream is unchanged.
-_handle_to_stream: dict = {}
-
 
 def create_handle():
     """Create a cuDNN handle, returned as a first-class :class:`cudnn.Handle`.
@@ -85,7 +81,10 @@ def create_handle():
         ordinal = current_device()
     except Exception:
         ordinal = None  # no GPU visible / cuda-python absent: resolve lazily on .device
-    return Handle(raw, ordinal)
+    # Seed the stream from the backend's actual stream (a fresh handle runs on
+    # stream 0) so a python plan and a backend plan on this handle agree on the
+    # stream, instead of the python side falling back to torch's current stream.
+    return Handle(raw, ordinal, _pybind_module.get_stream(raw))
 
 
 def set_stream(handle, stream):
@@ -96,10 +95,11 @@ def set_stream(handle, stream):
     internal per-priority stream pool, even when the stream is unchanged -- ~2.4us/call on
     Blackwell. Frameworks that call this before every ``execute`` pay it every iteration, so we
     remember the last stream and skip the backend call when it has not changed; a steady-state
-    loop pays it once. A :class:`cudnn.Handle` remembers on itself; a foreign raw-int handle has
-    no object, so it is remembered in a module registry keyed by the raw address. (Assumes a
-    handle is not driven from two streams concurrently, which is the normal single-stream case; a
-    caller that does needs its own handle per stream regardless.)
+    loop pays it once. Only a :class:`cudnn.Handle` gets this fast path (it remembers the stream
+    on itself); a foreign raw-int handle is not ours to track -- its owner may call
+    ``cudnnSetStream`` out-of-band -- so it is always set through. (Assumes a Handle is not driven
+    from two streams concurrently, which is the normal single-stream case; a caller that does
+    needs its own handle per stream regardless.)
     """
     if isinstance(handle, Handle):
         if handle.stream == stream:
@@ -108,11 +108,10 @@ def set_stream(handle, stream):
             _pybind_module._raw_set_stream(handle.backend_handle, stream)
         handle.stream = stream
         return
-    key = int(handle)
-    if _handle_to_stream.get(key) == stream:
-        return
+    # Foreign raw-int handle: we do not own it and cannot observe an out-of-band
+    # cudnnSetStream by its owner, so never skip on a cached value -- always set
+    # through. The idempotency fast-path is kept only on Handle (handle.stream).
     _pybind_module._raw_set_stream(handle, stream)
-    _handle_to_stream[key] = stream
 
 
 def get_stream(handle):
@@ -125,15 +124,20 @@ def get_stream(handle):
 
 
 def destroy_handle(handle):
-    """Destroy a cuDNN handle (wraps the compiled binding); forget its remembered stream so a
-    reused handle address is not wrongly skipped by set_stream()."""
+    """Destroy a cuDNN handle (wraps the compiled binding). For a :class:`cudnn.Handle` the
+    backend handle is cleared after destruction so a reused Handle object cannot pass a released
+    ``cudnnHandle_t`` back to C++ (a double-destroy or a later set_stream)."""
     if isinstance(handle, Handle):
         backend = handle.backend_handle
-        handle.stream = None
         if backend is None:
+            handle.stream = None
             return None
-        return _pybind_module._raw_destroy_handle(backend)
-    _handle_to_stream.pop(int(handle), None)
+        _pybind_module._raw_destroy_handle(backend)
+        handle.backend_handle = None
+        handle.stream = None
+        return None
+    # Foreign raw-int handle: destroy it directly (FE tracked no state for it).
+    return _pybind_module._raw_destroy_handle(handle)
     return _pybind_module._raw_destroy_handle(handle)
 
 
@@ -281,6 +285,12 @@ _EAGER_PUBLIC_NAMES = (
         )
         if symbol in globals()
     ),
+    "create_handle",
+    "destroy_handle",
+    "get_stream",
+    "set_stream",
+    "Handle",
+    "DeviceInfo",
     "__version__",
     "NodeType",
     "Tensor",

--- a/python/cudnn/_device.py
+++ b/python/cudnn/_device.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Common device-fact layer.
+
+The FE's single owner of "what are this GPU's properties": :class:`DeviceInfo`
+queries the driver once per fact and caches on the instance, and there is one
+instance per CUDA ordinal (see :func:`device_info`), so a GPU's facts are asked
+for once and shared. ``Handle.device`` is a ``DeviceInfo``; every other consumer
+(the frost engines via ``frost/device.py`` shims) reads the same object rather
+than re-querying the driver itself.
+
+The driver queries live here (not in frost) so the front end has one device
+concept, not a per-engine introspection stack.
+"""
+
+from __future__ import annotations
+
+import functools
+
+
+@functools.lru_cache(maxsize=1)
+def _driver():
+    """The cuInit'd driver module, or ``None`` when no CUDA device is visible."""
+    import cuda.bindings.driver as drv
+
+    if int(drv.cuInit(0)[0]) != 0:
+        return None
+    return drv
+
+
+def _ck(err, *rest):
+    if int(err) != 0:
+        drv = _driver()
+        detail = drv.cuGetErrorString(err)[1].decode() if drv is not None else ""
+        raise RuntimeError(f"cudnn: CUDA driver error {err}{f': {detail}' if detail else ''}")
+    return rest[0] if len(rest) == 1 else None
+
+
+def is_available() -> bool:
+    """True when at least one CUDA device is visible to this process."""
+    drv = _driver()
+    return drv is not None and int(_ck(*drv.cuDeviceGetCount())) > 0
+
+
+def device_count() -> int:
+    drv = _driver()
+    return 0 if drv is None else int(_ck(*drv.cuDeviceGetCount()))
+
+
+def _device_handle(device: int):
+    """``CUdevice`` for an ordinal. Needs only cuInit — creates no context."""
+    drv = _driver()
+    if drv is None:
+        raise RuntimeError("cudnn: no CUDA device visible")
+    count = int(_ck(*drv.cuDeviceGetCount()))
+    if not 0 <= device < count:
+        raise ValueError(f"cudnn: cuda:{device} does not exist ({count} device(s) visible)")
+    return _ck(*drv.cuDeviceGet(device))
+
+
+class DeviceInfo:
+    """Device facts for one CUDA ordinal, each queried from the driver on first
+    access and cached on the instance. One instance per ordinal (via
+    :func:`device_info`), so this is the single owner + cache of a GPU's facts.
+
+    Exposes both forms of compute capability that callers consume — the
+    ``(major, minor)`` tuple and the packed ``sm_version`` int — plus the SM
+    count, the opt-in / oversized per-CTA SMEM ceilings, the L2 size and the name.
+    """
+
+    def __init__(self, ordinal: int):
+        self.ordinal = int(ordinal)
+
+    @functools.cached_property
+    def compute_capability(self) -> tuple[int, int]:
+        drv = _driver()
+        handle = _device_handle(self.ordinal)
+        attr = drv.CUdevice_attribute
+        major = int(_ck(*drv.cuDeviceGetAttribute(attr.CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, handle)))
+        minor = int(_ck(*drv.cuDeviceGetAttribute(attr.CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, handle)))
+        return major, minor
+
+    @property
+    def sm_version(self) -> int:
+        """Packed ``major * 10 + minor`` (derived, so it cannot drift from the tuple)."""
+        major, minor = self.compute_capability
+        return major * 10 + minor
+
+    @functools.cached_property
+    def sm_count(self) -> int:
+        drv = _driver()
+        return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, _device_handle(self.ordinal))))
+
+    @functools.cached_property
+    def shared_memory_per_block_optin(self) -> int:
+        drv = _driver()
+        return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, _device_handle(self.ordinal))))
+
+    @functools.cached_property
+    def oversized_shared_memory_per_block(self) -> int:
+        """Per-CTA SMEM ceiling in the *oversized* carveout (327 KiB vs the 227 KiB
+        opt-in limit on SM 10.7), which the part gives by shrinking L1 to 8 kB —
+        free for a TMA-fed GEMM. 0 when the driver has no such mode."""
+        drv = _driver()
+        # CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK (ordinal 150)
+        # arrived in CUDA 13.4. A driver older than that has no such mode -> 0 by
+        # design (not an error), and the enum member — which an older cuda-python's
+        # CUdevice_attribute does not carry (a bare ordinal would raise, since the
+        # binding reads attrib.value) — is never touched. From 13.4 the attribute
+        # is real: query it and let a genuine failure raise rather than masking it.
+        if int(_ck(*drv.cuDriverGetVersion())) < 13040:
+            return 0
+        return int(
+            _ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, _device_handle(self.ordinal)))
+        )
+
+    @functools.cached_property
+    def l2_cache_bytes(self) -> int:
+        drv = _driver()
+        return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, _device_handle(self.ordinal))))
+
+    @functools.cached_property
+    def device_name(self) -> str:
+        drv = _driver()
+        return _ck(*drv.cuDeviceGetName(256, _device_handle(self.ordinal))).split(b"\x00")[0].decode()
+
+    def __repr__(self) -> str:
+        return f"DeviceInfo(cuda:{self.ordinal})"
+
+
+@functools.lru_cache(maxsize=None)
+def device_info(ordinal: int) -> DeviceInfo:
+    """The :class:`DeviceInfo` for a CUDA ordinal — one per ordinal, so a GPU's
+    facts are queried once and shared. Keyed by ordinal, never by Handle: the
+    driver caches key on the ordinal, and two handles on the same GPU share facts."""
+    return DeviceInfo(int(ordinal))

--- a/python/cudnn/_device.py
+++ b/python/cudnn/_device.py
@@ -102,15 +102,17 @@ class DeviceInfo:
         """Per-CTA SMEM ceiling in the *oversized* carveout (327 KiB vs the 227 KiB
         opt-in limit on SM 10.7), which the part gives by shrinking L1 to 8 kB —
         free for a TMA-fed GEMM. 0 when the driver has no such mode."""
-        drv = _driver()
+        from . import _env
+
         # CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK (ordinal 150)
         # arrived in CUDA 13.4. A driver older than that has no such mode -> 0 by
         # design (not an error), and the enum member — which an older cuda-python's
         # CUdevice_attribute does not carry (a bare ordinal would raise, since the
         # binding reads attrib.value) — is never touched. From 13.4 the attribute
         # is real: query it and let a genuine failure raise rather than masking it.
-        if int(_ck(*drv.cuDriverGetVersion())) < 13040:
+        if _env.driver_version() < 13040:
             return 0
+        drv = _driver()
         return int(
             _ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, _device_handle(self.ordinal)))
         )

--- a/python/cudnn/_device.py
+++ b/python/cudnn/_device.py
@@ -104,18 +104,18 @@ class DeviceInfo:
         free for a TMA-fed GEMM. 0 when the driver has no such mode."""
         from . import _env
 
-        # CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK (ordinal 150)
-        # arrived in CUDA 13.4. A driver older than that has no such mode -> 0 by
-        # design (not an error), and the enum member — which an older cuda-python's
-        # CUdevice_attribute does not carry (a bare ordinal would raise, since the
-        # binding reads attrib.value) — is never touched. From 13.4 the attribute
-        # is real: query it and let a genuine failure raise rather than masking it.
-        if _env.driver_version() < 13040:
-            return 0
         drv = _driver()
-        return int(
-            _ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, _device_handle(self.ordinal)))
-        )
+        # CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK (ordinal 150)
+        # arrived in CUDA 13.4. It needs BOTH a new-enough driver AND a cuda-python
+        # whose CUdevice_attribute carries the enum member: a new driver with an old
+        # binding passes the version gate but the enum member is absent (accessing it
+        # raises, since the binding reads attrib.value). Either missing -> no such
+        # mode -> 0 by design (not an error). With both present the attribute is real:
+        # query it and let a genuine failure raise rather than masking it.
+        attr = getattr(drv.CUdevice_attribute, "CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK", None)
+        if attr is None or _env.driver_version() < 13040:
+            return 0
+        return int(_ck(*drv.cuDeviceGetAttribute(attr, _device_handle(self.ordinal))))
 
     @functools.cached_property
     def l2_cache_bytes(self) -> int:

--- a/python/cudnn/_env.py
+++ b/python/cudnn/_env.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""Process-global environment facts (CUDA driver / runtime versions).
+
+The FE's single owner of "what CUDA are we running against". These versions are
+process-global, not per-device: the installed driver and the linked runtime each
+have one version for the whole process, independent of which GPU a handle is
+bound to. So they live here, one layer below both the per-ordinal ``DeviceInfo``
+(``_device.py``) and the per-handle ``Handle`` (``_handle.py``) — putting a
+process-global fact on either would duplicate it per ordinal / per handle.
+
+This mirrors the backend convention: cuDNN exposes its own versions as
+argument-less globals (``cudnnGetVersion``, ``cudnnGetCudartVersion``), never off
+a handle or a device descriptor. cuDNN's own version stays there
+(``cudnn.backend_version()``); this module owns only the CUDA-side versions that
+were otherwise re-queried in each engine.
+
+The queries are ~100 ns and off the execute hot path, so the ``lru_cache`` here
+is for a single owner returning a stable constant, not for speed.
+"""
+
+from __future__ import annotations
+
+import functools
+
+from ._device import _ck, _driver
+
+
+@functools.lru_cache(maxsize=1)
+def driver_version() -> int:
+    """Installed CUDA driver version, e.g. ``13020`` for 13.2 (``0`` if no CUDA)."""
+    drv = _driver()
+    if drv is None:
+        return 0
+    return int(_ck(*drv.cuDriverGetVersion()))
+
+
+@functools.lru_cache(maxsize=1)
+def runtime_version() -> int:
+    """Linked CUDA runtime (cudart) version, e.g. ``13030`` for 13.3.
+
+    ``0`` when ``cuda.bindings`` is absent or the query fails — callers gate on a
+    minimum, so an unavailable runtime declines exactly like a too-old one.
+    """
+    try:
+        from cuda.bindings import runtime
+    except ImportError:
+        return 0
+    err, version = runtime.cudaRuntimeGetVersion()
+    return int(version) if int(err) == 0 else 0

--- a/python/cudnn/_handle.py
+++ b/python/cudnn/_handle.py
@@ -7,10 +7,10 @@ The backend ``cudnnHandle_t`` binds a device and carries the current stream, but
 on the FE side the handle used to be a bare int with nowhere to hang per-handle
 state — so that state accreted as side tables (the ``_handle_to_stream`` dict)
 and per-engine device queries (frost's ``current_device()``). ``Handle`` gives
-the handle a home for ``{backend_handle, device, stream}`` while staying a drop-in for the
-old int: it converts to the raw ``intptr_t`` via ``__index__`` anywhere a binding
-wants it, so code that forwards a handle to ``graph.execute`` / ``set_stream`` /
-the C++ layer is unchanged.
+the handle a home for ``{backend_handle, device, stream}``. It is NOT a drop-in
+int: the backend handle is extracted explicitly via ``to_backend_handle()`` at
+each binding boundary (grep it to trace every handoff), so a Handle that reaches
+a binding unconverted fails loudly rather than being silently coerced.
 """
 
 from __future__ import annotations
@@ -41,10 +41,15 @@ class Handle:
 
     __slots__ = ("backend_handle", "_ordinal", "stream")
 
-    def __init__(self, backend_handle: int, ordinal: int | None = None):
-        self.backend_handle = int(backend_handle)
+    def __init__(self, backend_handle: int | None, ordinal: int | None = None, stream: int | None = None):
+        # ``None`` backend_handle = a destroyed handle (destroy_handle clears it so
+        # a reused Handle cannot pass a released cudnnHandle_t back to C++).
+        self.backend_handle = None if backend_handle is None else int(backend_handle)
         self._ordinal = ordinal
-        self.stream = None  # None = default stream, until set_stream() is called
+        # Seeded from the backend's actual stream at create (a fresh handle runs on
+        # stream 0), so a python plan and a backend plan on the same handle agree
+        # on the stream instead of the python side falling back to torch's current.
+        self.stream = stream
 
     @property
     def device(self) -> DeviceInfo:
@@ -56,7 +61,8 @@ class Handle:
         return device_info(ordinal)
 
     def __repr__(self) -> str:
-        return f"cudnn.Handle(backend_handle=0x{self.backend_handle:x}, cuda:{self._ordinal})"
+        backend = "None" if self.backend_handle is None else f"0x{self.backend_handle:x}"
+        return f"cudnn.Handle(backend_handle={backend}, cuda:{self._ordinal})"
 
 
 def to_backend_handle(handle):

--- a/python/cudnn/_handle.py
+++ b/python/cudnn/_handle.py
@@ -15,74 +15,9 @@ the C++ layer is unchanged.
 
 from __future__ import annotations
 
-import functools
-
-
-@functools.lru_cache(maxsize=None)
-def _device_info(ordinal: int) -> "DeviceInfo":
-    """One DeviceInfo per ordinal (never keyed by Handle: the per-device driver
-    caches assume a stable ordinal, and two handles on the same GPU share facts)."""
-    return DeviceInfo(ordinal)
-
-
-class DeviceInfo:
-    """Device facts for a CUDA ordinal, read from the frost driver introspector
-    (``cudnn.frost.device``, itself lru_cached per ordinal). This is the single
-    device-info surface for the FE — every field a caller needs off a handle.
-
-    The introspector is imported lazily so a plain cuDNN-backend user who never
-    touches ``handle.device`` does not pull in the frost/cuda-python stack.
-    """
-
-    __slots__ = ("ordinal",)
-
-    def __init__(self, ordinal: int):
-        self.ordinal = int(ordinal)
-
-    @property
-    def compute_capability(self) -> tuple[int, int]:
-        from .frost.device import compute_capability
-
-        return compute_capability(self.ordinal)
-
-    @property
-    def sm_version(self) -> int:
-        """Packed ``major * 10 + minor`` (derived, so it cannot drift from the tuple)."""
-        major, minor = self.compute_capability
-        return major * 10 + minor
-
-    @property
-    def sm_count(self) -> int:
-        from .frost.device import multiprocessor_count
-
-        return multiprocessor_count(self.ordinal)
-
-    @property
-    def shared_memory_per_block_optin(self) -> int:
-        from .frost.device import shared_memory_per_block_optin
-
-        return shared_memory_per_block_optin(self.ordinal)
-
-    @property
-    def oversized_shared_memory_per_block(self) -> int:
-        from .frost.device import oversized_shared_memory_per_block
-
-        return oversized_shared_memory_per_block(self.ordinal)
-
-    @property
-    def l2_cache_bytes(self) -> int:
-        from .frost.device import l2_cache_bytes
-
-        return l2_cache_bytes(self.ordinal)
-
-    @property
-    def device_name(self) -> str:
-        from .frost.device import device_name
-
-        return device_name(self.ordinal)
-
-    def __repr__(self) -> str:
-        return f"DeviceInfo(cuda:{self.ordinal})"
+# The device-fact layer lives in cudnn._device (the FE's single owner of a GPU's
+# properties); Handle.device is the DeviceInfo for the handle's ordinal.
+from ._device import DeviceInfo, device_info
 
 
 class Handle:
@@ -119,7 +54,7 @@ class Handle:
             from .frost.device import current_device
 
             ordinal = self._ordinal = current_device()
-        return _device_info(ordinal)
+        return device_info(ordinal)
 
     def __repr__(self) -> str:
         return f"cudnn.Handle(backend_handle=0x{self.backend_handle:x}, cuda:{self._ordinal})"

--- a/python/cudnn/_handle.py
+++ b/python/cudnn/_handle.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""First-class ``cudnn.Handle``.
+
+The backend ``cudnnHandle_t`` binds a device and carries the current stream, but
+on the FE side the handle used to be a bare int with nowhere to hang per-handle
+state — so that state accreted as side tables (the ``_handle_to_stream`` dict)
+and per-engine device queries (frost's ``current_device()``). ``Handle`` gives
+the handle a home for ``{backend_handle, device, stream}`` while staying a drop-in for the
+old int: it converts to the raw ``intptr_t`` via ``__index__`` anywhere a binding
+wants it, so code that forwards a handle to ``graph.execute`` / ``set_stream`` /
+the C++ layer is unchanged.
+"""
+
+from __future__ import annotations
+
+import functools
+
+
+@functools.lru_cache(maxsize=None)
+def _device_info(ordinal: int) -> "DeviceInfo":
+    """One DeviceInfo per ordinal (never keyed by Handle: the per-device driver
+    caches assume a stable ordinal, and two handles on the same GPU share facts)."""
+    return DeviceInfo(ordinal)
+
+
+class DeviceInfo:
+    """Device facts for a CUDA ordinal, read from the frost driver introspector
+    (``cudnn.frost.device``, itself lru_cached per ordinal). This is the single
+    device-info surface for the FE — every field a caller needs off a handle.
+
+    The introspector is imported lazily so a plain cuDNN-backend user who never
+    touches ``handle.device`` does not pull in the frost/cuda-python stack.
+    """
+
+    __slots__ = ("ordinal",)
+
+    def __init__(self, ordinal: int):
+        self.ordinal = int(ordinal)
+
+    @property
+    def compute_capability(self) -> tuple[int, int]:
+        from .frost.device import compute_capability
+
+        return compute_capability(self.ordinal)
+
+    @property
+    def sm_version(self) -> int:
+        """Packed ``major * 10 + minor`` (derived, so it cannot drift from the tuple)."""
+        major, minor = self.compute_capability
+        return major * 10 + minor
+
+    @property
+    def sm_count(self) -> int:
+        from .frost.device import multiprocessor_count
+
+        return multiprocessor_count(self.ordinal)
+
+    @property
+    def shared_memory_per_block_optin(self) -> int:
+        from .frost.device import shared_memory_per_block_optin
+
+        return shared_memory_per_block_optin(self.ordinal)
+
+    @property
+    def oversized_shared_memory_per_block(self) -> int:
+        from .frost.device import oversized_shared_memory_per_block
+
+        return oversized_shared_memory_per_block(self.ordinal)
+
+    @property
+    def l2_cache_bytes(self) -> int:
+        from .frost.device import l2_cache_bytes
+
+        return l2_cache_bytes(self.ordinal)
+
+    @property
+    def device_name(self) -> str:
+        from .frost.device import device_name
+
+        return device_name(self.ordinal)
+
+    def __repr__(self) -> str:
+        return f"DeviceInfo(cuda:{self.ordinal})"
+
+
+class Handle:
+    """A cuDNN handle as a first-class FE object: owns the backend
+    ``cudnnHandle_t`` (``backend_handle``), the stream it runs on (``stream`` —
+    the source of truth that used to live in the module-global
+    ``_handle_to_stream`` dict), and its device (``device``, lazy, cached per
+    ordinal). The naming anticipates the front end BEING "cudnn": this object is
+    the ``handle``; the wrapped ``cudnnHandle_t`` is the ``backend_handle``.
+
+    The backend handle is handed to C++ EXPLICITLY via ``to_backend_handle()`` /
+    ``unwrap_handles()`` at the handoff sites (all in ``_pygraph`` and this
+    module — none elsewhere), so there is no hidden path from a Handle to the
+    backend: a Handle that reaches a C++ binding unconverted fails loudly rather
+    than being silently coerced. The dunders are therefore minimal on purpose —
+    NO ``__index__``/``__int__`` (no implicit int coercion) — and
+    ``__eq__``/``__hash__``/``__bool__`` are left at the object defaults
+    (identity equality, identity hash, always-truthy), which is what the
+    surrounding code needs: the handle stays a valid dict key, stays truthy in
+    ``if handle:`` guards, and does not raise on ``wrapper.py``'s ``== 'auto'``.
+    """
+
+    __slots__ = ("backend_handle", "_ordinal", "stream")
+
+    def __init__(self, backend_handle: int, ordinal: int | None = None):
+        self.backend_handle = int(backend_handle)
+        self._ordinal = ordinal
+        self.stream = None  # None = default stream, until set_stream() is called
+
+    @property
+    def device(self) -> DeviceInfo:
+        ordinal = self._ordinal
+        if ordinal is None:
+            from .frost.device import current_device
+
+            ordinal = self._ordinal = current_device()
+        return _device_info(ordinal)
+
+    def __repr__(self) -> str:
+        return f"cudnn.Handle(backend_handle=0x{self.backend_handle:x}, cuda:{self._ordinal})"
+
+
+def to_backend_handle(handle):
+    """The backend cudnnHandle_t to hand to the C++ layer: a Handle's
+    ``backend_handle``, a foreign raw-int handle unchanged, or None. The ONE
+    explicit conversion from the first-class Handle to the int the bindings take."""
+    return handle.backend_handle if isinstance(handle, Handle) else handle
+
+
+def unwrap_handles(args, kwargs):
+    """Replace any Handle in a passthrough ``(*args, **kwargs)`` with its
+    ``backend_handle``, so an opaque forwarder (get_workspace_size, cuda-graph,
+    deserialize) can hand C++ a plain int without knowing the handle's position."""
+    return tuple(to_backend_handle(a) for a in args), {k: to_backend_handle(v) for k, v in kwargs.items()}

--- a/python/cudnn/_handle.py
+++ b/python/cudnn/_handle.py
@@ -28,11 +28,10 @@ class Handle:
     ordinal). The naming anticipates the front end BEING "cudnn": this object is
     the ``handle``; the wrapped ``cudnnHandle_t`` is the ``backend_handle``.
 
-    The backend handle is handed to C++ EXPLICITLY via ``to_backend_handle()`` /
-    ``unwrap_handles()`` at the handoff sites (all in ``_pygraph`` and this
-    module — none elsewhere), so there is no hidden path from a Handle to the
-    backend: a Handle that reaches a C++ binding unconverted fails loudly rather
-    than being silently coerced. The dunders are therefore minimal on purpose —
+    The backend handle is handed to C++ EXPLICITLY via ``to_backend_handle()``
+    at the handoff sites (all in ``_pygraph`` and this module — none elsewhere),
+    so there is no hidden path from a Handle to the backend: a Handle that reaches
+    a C++ binding unconverted fails loudly rather than being silently coerced. The dunders are therefore minimal on purpose —
     NO ``__index__``/``__int__`` (no implicit int coercion) — and
     ``__eq__``/``__hash__``/``__bool__`` are left at the object defaults
     (identity equality, identity hash, always-truthy), which is what the
@@ -65,10 +64,3 @@ def to_backend_handle(handle):
     ``backend_handle``, a foreign raw-int handle unchanged, or None. The ONE
     explicit conversion from the first-class Handle to the int the bindings take."""
     return handle.backend_handle if isinstance(handle, Handle) else handle
-
-
-def unwrap_handles(args, kwargs):
-    """Replace any Handle in a passthrough ``(*args, **kwargs)`` with its
-    ``backend_handle``, so an opaque forwarder (get_workspace_size, cuda-graph,
-    deserialize) can hand C++ a plain int without knowing the handle's position."""
-    return tuple(to_backend_handle(a) for a in args), {k: to_backend_handle(v) for k, v in kwargs.items()}

--- a/python/cudnn/_handle.py
+++ b/python/cudnn/_handle.py
@@ -66,7 +66,19 @@ class Handle:
 
 
 def to_backend_handle(handle):
-    """The backend cudnnHandle_t to hand to the C++ layer: a Handle's
-    ``backend_handle``, a foreign raw-int handle unchanged, or None. The ONE
-    explicit conversion from the first-class Handle to the int the bindings take."""
-    return handle.backend_handle if isinstance(handle, Handle) else handle
+    """The backend ``cudnnHandle_t`` to hand to the C++ layer: a Handle's
+    ``backend_handle``, or ``None`` for the default handle. The ONE explicit
+    conversion from the first-class Handle to the int the bindings take.
+
+    A raw backend int is NOT accepted: the Python API creates handles only via
+    ``cudnn.create_handle()`` (which returns a Handle), so a bare int is a
+    mistake -- wrap a foreign ``cudnnHandle_t`` in
+    ``cudnn.Handle(backend_handle, ordinal, stream)`` to give it a device/stream."""
+    if handle is None:
+        return None
+    if isinstance(handle, Handle):
+        return handle.backend_handle
+    raise TypeError(
+        f"expected a cudnn.Handle (from cudnn.create_handle()) or None, got {type(handle).__name__}; "
+        "raw backend handles are no longer accepted -- wrap one with cudnn.Handle(backend_handle, ordinal, stream)"
+    )

--- a/python/cudnn/_handle.py
+++ b/python/cudnn/_handle.py
@@ -39,8 +39,6 @@ class Handle:
     ``if handle:`` guards, and does not raise on ``wrapper.py``'s ``== 'auto'``.
     """
 
-    __slots__ = ("backend_handle", "_ordinal", "stream")
-
     def __init__(self, backend_handle: int | None, ordinal: int | None = None, stream: int | None = None):
         # ``None`` backend_handle = a destroyed handle (destroy_handle clears it so
         # a reused Handle cannot pass a released cudnnHandle_t back to C++).

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -28,7 +28,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 import cudnn
 from cudnn import _pybind_module
 
-from ._handle import to_backend_handle
+from ._device import ensure_current_context
+from ._handle import Handle, to_backend_handle
 from .datatypes import _buffer_dtype_to_cudnn, _dlpack_code_bits, _torch_to_cudnn_data_type
 from .engines.base import ExecutionContext, VariantPack
 from .engines.engine_ids import is_python_engine
@@ -1736,7 +1737,7 @@ class pygraph:
         self,
         tensor_dict: Dict[Union[str, int, Tensor], Any],
         workspace: Any = None,
-        handle: int = None,
+        handle: Optional[Handle] = None,
         override_uids: Any = None,
         override_shapes: Any = None,
         override_strides: Any = None,
@@ -1776,6 +1777,10 @@ class pygraph:
         if eng is not None:  # python engine (plan id in the reserved region)
             h = handle if handle is not None else self._handle
             ctx = ExecutionContext(handle=h, stream=self._resolve_stream(h), workspace=workspace)
+            # A JIT engine talks to the driver directly, which reads the calling
+            # THREAD's context stack -- and an autograd backward runs on a worker
+            # thread that has none. Once here, so every python engine is covered.
+            ensure_current_context(ctx.stream)
             if self._plan_index not in self._compiled_plans:
                 # compile with the CALLER's context (execute-supplied handle
                 # and its stream reach the JIT build)
@@ -2089,12 +2094,13 @@ class pygraph:
         """Deserialize a graph. This is the one genuinely ambiguous classic
         overload -- ``(data)`` or ``(handle, data, enforce_precompiled=...)`` --
         so it stays a passthrough. The handle can arrive as the first positional
-        or as the ``handle_`` keyword (the pybind overload's name); unwrap either,
-        and ``to_backend_handle`` is a no-op on the ``data`` blob."""
-        if args:
-            args = (to_backend_handle(args[0]),) + args[1:]
-        if "handle_" in kwargs:
-            kwargs["handle_"] = to_backend_handle(kwargs["handle_"])
+        or as the ``handle_`` keyword (the pybind overload's name); unwrap a
+        Handle to its backend int and leave the ``data`` blob (the other overload)
+        untouched."""
+        if args and isinstance(args[0], Handle):
+            args = (args[0].backend_handle,) + args[1:]
+        if isinstance(kwargs.get("handle_"), Handle):
+            kwargs["handle_"] = kwargs["handle_"].backend_handle
         if self._lowered_graph is None:
             import cudnn
 

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -25,6 +25,7 @@ import logging
 import weakref
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+import cudnn
 from cudnn import _pybind_module
 
 from ._handle import to_backend_handle
@@ -1265,8 +1266,6 @@ class pygraph:
         fall back to the default stream)."""
         if handle is None:
             return None
-        import cudnn
-
         return cudnn.get_stream(handle)
 
     def _build_context(self, handle: Any = None) -> Any:

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -1755,9 +1755,12 @@ class pygraph:
                     ``set_stream`` semantics, both python engines and backend)
             override_uids/shapes/strides: dynamic-shape overrides (backend path)
         """
-        # A JIT engine must compile for the device/stream it will run on.
-        caller_ctx = self._build_context(handle) if handle is not None else None
         if not self._is_built:
+            # A JIT engine must compile for the device/stream it will run on, so
+            # build the caller context here. Only here: a steady-state execute()
+            # otherwise discarded this (a cudnnGetStream round-trip + an
+            # ExecutionContext alloc, ~2.9us) on every already-built call.
+            caller_ctx = self._build_context(handle) if handle is not None else None
             if not self._planning_done:
                 self.create_execution_plans()
             self.build(ctx=caller_ctx)

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from cudnn import _pybind_module
 
-from ._handle import to_backend_handle, unwrap_handles
+from ._handle import to_backend_handle
 from .datatypes import _buffer_dtype_to_cudnn, _dlpack_code_bits, _torch_to_cudnn_data_type
 from .engines.base import ExecutionContext, VariantPack
 from .engines.engine_ids import is_python_engine
@@ -1536,31 +1536,30 @@ class pygraph:
         self.check_support()
         self.build_plans(ctx=ctx)
 
-    def get_workspace_size(self, *args, **kwargs) -> int:
-        """Workspace bytes for the selected plan. Classic overloads (handle /
-        dynamic-shape overrides) pass through on the backend path."""
-        args, kwargs = unwrap_handles(args, kwargs)  # a Handle in the overloads -> backend handle for C++
+    def get_workspace_size(self, handle=None, override_uids=None, override_shapes=None, override_strides=None) -> int:
+        """Workspace bytes for the selected plan. The classic overload args -- a
+        handle and the dynamic-shape overrides -- pass through on the backend path."""
         if not self._is_built:
             raise RuntimeError("Call build() first")
 
         if self.selected_engine is not None:
-            # Classic overloads (handle, override_uids/shapes/strides) describe
-            # the problem, and CompiledPlan.get_workspace_size() takes none of
-            # them: a compiled python plan's workspace is a property of the plan.
-            # A shape-dependent one would have to say so through that API.
+            # The overload args (handle, override_uids/shapes/strides) describe the
+            # problem, and CompiledPlan.get_workspace_size() takes none of them: a
+            # compiled python plan's workspace is a property of the plan. A
+            # shape-dependent one would have to say so through that API.
             return self._compiled_plans[self._plan_index].get_workspace_size()
 
-        # Same reason execute() addresses by index; classic overloads pass through.
+        # Same reason execute() addresses by index; the overload args pass through.
         cfg = self._materialize_backend_plan(self._plan_index) if self._plans else None
-        if not args and not kwargs and cfg is not None and cfg.cpp_index is not None:
+        no_overload = handle is None and override_uids is None and override_shapes is None and override_strides is None
+        if no_overload and cfg is not None and cfg.cpp_index is not None:
             return self._lowered_graph.get_workspace_size_plan_at_index(cfg.cpp_index)
-        return self._lowered_graph.get_workspace_size(*args, **kwargs)
+        return self._lowered_graph.get_workspace_size(to_backend_handle(handle), override_uids, override_shapes, override_strides)
 
-    def get_workspace_size_plan_at_index(self, index: int, *args, **kwargs) -> int:
+    def get_workspace_size_plan_at_index(self, index: int, handle=None, override_uids=None, override_shapes=None, override_strides=None) -> int:
         """Workspace bytes for the plan at ``index`` in the ranked list."""
-        args, kwargs = unwrap_handles(args, kwargs)  # a Handle in the overloads -> backend handle for C++
         if not self._planning_done:  # e.g. a deserialized graph: C++ owns the list
-            return self._lowered_graph.get_workspace_size_plan_at_index(index, *args, **kwargs)
+            return self._lowered_graph.get_workspace_size_plan_at_index(index, to_backend_handle(handle), override_uids, override_shapes, override_strides)
         self._reject_if_barred(self._check_plan_index(index))
         cfg = self._plans[index]
         if self._engine_for(cfg) is not None:
@@ -1570,8 +1569,8 @@ class pygraph:
             return self._compiled_plans[index].get_workspace_size()
         cfg = self._materialize_backend_plan(index)
         if cfg.cpp_index is None:  # delegating entry
-            return self._lowered_graph.get_workspace_size(*args, **kwargs)
-        return self._lowered_graph.get_workspace_size_plan_at_index(cfg.cpp_index, *args, **kwargs)
+            return self._lowered_graph.get_workspace_size(to_backend_handle(handle), override_uids, override_shapes, override_strides)
+        return self._lowered_graph.get_workspace_size_plan_at_index(cfg.cpp_index, to_backend_handle(handle), override_uids, override_shapes, override_strides)
 
     def _reject_if_barred(self, index: int) -> None:
         """The ranked list is never filtered (indices stay stable), so every
@@ -1643,19 +1642,18 @@ class pygraph:
         self._lower_backend_plan()
         return self._lowered_graph.get_behavior_notes(*args, **kwargs)
 
-    def populate_cuda_graph(self, *args, **kwargs):
+    def populate_cuda_graph(self, handle, variant_pack, workspace, cuda_graph):
         """Classic CUDA-graph capture — the backend's, so a python plan declines.
 
         Capture itself is not the obstacle (the python engines run on the
         execute-time handle's stream); this API records the BACKEND's plan."""
-        return self._cuda_graph_call("populate_cuda_graph", *args, **kwargs)
+        return self._cuda_graph_call("populate_cuda_graph", to_backend_handle(handle), variant_pack, workspace, cuda_graph)
 
-    def update_cuda_graph(self, *args, **kwargs):
+    def update_cuda_graph(self, handle, variant_pack, workspace, cuda_graph):
         """Classic CUDA-graph update — backend plans only, as above."""
-        return self._cuda_graph_call("update_cuda_graph", *args, **kwargs)
+        return self._cuda_graph_call("update_cuda_graph", to_backend_handle(handle), variant_pack, workspace, cuda_graph)
 
     def _cuda_graph_call(self, name: str, *args, **kwargs):
-        args, kwargs = unwrap_handles(args, kwargs)  # populate/update_cuda_graph take the handle first
         eng = self.selected_engine
         if eng is not None:
             raise cudnn_graph_not_supported(f"{name}() records a cuDNN backend plan; the selected plan is served by the python engine {eng.name!r}")
@@ -2089,9 +2087,12 @@ class pygraph:
         return self._lowered_graph.serialize()
 
     def deserialize(self, *args, **kwargs) -> None:
-        """Deserialize a graph (classic passthrough: (data) or (handle, data,
-        enforce_precompiled=...)). Replaces this graph's lowered C++ graph."""
-        args, kwargs = unwrap_handles(args, kwargs)  # classic (handle, data, ...) -> backend handle for C++
+        """Deserialize a graph. This is the one genuinely ambiguous classic
+        overload -- ``(data)`` or ``(handle, data, enforce_precompiled=...)`` --
+        so it stays a passthrough; a handle can only be the first positional, and
+        ``to_backend_handle`` is a no-op on the ``data`` blob, so unwrap just that."""
+        if args:
+            args = (to_backend_handle(args[0]),) + args[1:]
         if self._lowered_graph is None:
             import cudnn
 

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from cudnn import _pybind_module
 
+from ._handle import to_backend_handle, unwrap_handles
 from .datatypes import _buffer_dtype_to_cudnn, _dlpack_code_bits, _torch_to_cudnn_data_type
 from .engines.base import ExecutionContext, VariantPack
 from .engines.engine_ids import is_python_engine
@@ -1538,6 +1539,7 @@ class pygraph:
     def get_workspace_size(self, *args, **kwargs) -> int:
         """Workspace bytes for the selected plan. Classic overloads (handle /
         dynamic-shape overrides) pass through on the backend path."""
+        args, kwargs = unwrap_handles(args, kwargs)  # a Handle in the overloads -> backend handle for C++
         if not self._is_built:
             raise RuntimeError("Call build() first")
 
@@ -1556,6 +1558,7 @@ class pygraph:
 
     def get_workspace_size_plan_at_index(self, index: int, *args, **kwargs) -> int:
         """Workspace bytes for the plan at ``index`` in the ranked list."""
+        args, kwargs = unwrap_handles(args, kwargs)  # a Handle in the overloads -> backend handle for C++
         if not self._planning_done:  # e.g. a deserialized graph: C++ owns the list
             return self._lowered_graph.get_workspace_size_plan_at_index(index, *args, **kwargs)
         self._reject_if_barred(self._check_plan_index(index))
@@ -1652,6 +1655,7 @@ class pygraph:
         return self._cuda_graph_call("update_cuda_graph", *args, **kwargs)
 
     def _cuda_graph_call(self, name: str, *args, **kwargs):
+        args, kwargs = unwrap_handles(args, kwargs)  # populate/update_cuda_graph take the handle first
         eng = self.selected_engine
         if eng is not None:
             raise cudnn_graph_not_supported(f"{name}() records a cuDNN backend plan; the selected plan is served by the python engine {eng.name!r}")
@@ -1709,7 +1713,7 @@ class pygraph:
         if not self._planning_done:  # e.g. a deserialized graph: C++ owns the list
             uid_to_data = self._uid_to_data(tensor_dict)
             var_pack, ws_ptr = self._native_var_pack(uid_to_data, workspace)
-            return self._lowered_graph._execute_plan_at_index(var_pack, ws_ptr, index, handle, *args, **kwargs)
+            return self._lowered_graph._execute_plan_at_index(var_pack, ws_ptr, index, to_backend_handle(handle), *args, **kwargs)
         self._reject_if_barred(self._check_plan_index(index))
         cfg = self._plans[index]
         if self._engine_for(cfg) is not None:
@@ -1727,9 +1731,9 @@ class pygraph:
         uid_to_data = self._uid_to_data(tensor_dict)
         var_pack, ws_ptr = self._native_var_pack(uid_to_data, workspace)
         if cfg.cpp_index is None:  # delegating entry
-            self._lowered_graph._execute(var_pack, ws_ptr, handle, *args, **kwargs)
+            self._lowered_graph._execute(var_pack, ws_ptr, to_backend_handle(handle), *args, **kwargs)
             return
-        self._lowered_graph._execute_plan_at_index(var_pack, ws_ptr, cfg.cpp_index, handle, *args, **kwargs)
+        self._lowered_graph._execute_plan_at_index(var_pack, ws_ptr, cfg.cpp_index, to_backend_handle(handle), *args, **kwargs)
 
     def execute(
         self,
@@ -1808,16 +1812,16 @@ class pygraph:
                 variant_pack.address,
                 len(variant_pack),
                 variant_pack.workspace,
-                handle or 0,
+                to_backend_handle(handle) or 0,
                 -1 if cpp_index is None else cpp_index,
             )
             return
 
         var_pack, ws_ptr = self._native_var_pack(uid_to_data, workspace)
         if cpp_index is not None:
-            self._lowered_graph._execute_plan_at_index(var_pack, ws_ptr, cpp_index, handle, override_uids, override_shapes, override_strides)
+            self._lowered_graph._execute_plan_at_index(var_pack, ws_ptr, cpp_index, to_backend_handle(handle), override_uids, override_shapes, override_strides)
             return
-        self._lowered_graph._execute(var_pack, ws_ptr, handle, override_uids, override_shapes, override_strides)
+        self._lowered_graph._execute(var_pack, ws_ptr, to_backend_handle(handle), override_uids, override_shapes, override_strides)
 
     def _variant_pack_uids(self) -> Optional[List[int]]:
         """The graph's caller-filled variant_pack, ASCENDING by uid.
@@ -2087,6 +2091,7 @@ class pygraph:
     def deserialize(self, *args, **kwargs) -> None:
         """Deserialize a graph (classic passthrough: (data) or (handle, data,
         enforce_precompiled=...)). Replaces this graph's lowered C++ graph."""
+        args, kwargs = unwrap_handles(args, kwargs)  # classic (handle, data, ...) -> backend handle for C++
         if self._lowered_graph is None:
             import cudnn
 
@@ -2103,7 +2108,7 @@ class pygraph:
                     if _k in self._cpp_graph_kwargs:
                         deser_kwargs[_k] = self._cpp_graph_kwargs[_k]
                 if self._handle is not None:
-                    deser_kwargs["handle"] = self._handle
+                    deser_kwargs["handle"] = to_backend_handle(self._handle)
                 self._lowered_graph = cudnn._pybind_module.backend_graph(**deser_kwargs)
         self._lowered_graph.deserialize(*args, **kwargs)
         self._is_built = True
@@ -2128,7 +2133,7 @@ class pygraph:
         pg_kwargs["intermediate_data_type"] = _library_type(self._context.intermediate_data_type or cudnn.data_type.FLOAT)
         pg_kwargs["compute_data_type"] = _library_type(self._context.compute_data_type or cudnn.data_type.FLOAT)
         if self._handle is not None:
-            pg_kwargs["handle"] = self._handle
+            pg_kwargs["handle"] = to_backend_handle(self._handle)
         graph = cudnn._pybind_module.backend_graph(**pg_kwargs)
 
         tensor_map: Dict[int, Any] = {}

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -2088,10 +2088,13 @@ class pygraph:
     def deserialize(self, *args, **kwargs) -> None:
         """Deserialize a graph. This is the one genuinely ambiguous classic
         overload -- ``(data)`` or ``(handle, data, enforce_precompiled=...)`` --
-        so it stays a passthrough; a handle can only be the first positional, and
-        ``to_backend_handle`` is a no-op on the ``data`` blob, so unwrap just that."""
+        so it stays a passthrough. The handle can arrive as the first positional
+        or as the ``handle_`` keyword (the pybind overload's name); unwrap either,
+        and ``to_backend_handle`` is a no-op on the ``data`` blob."""
         if args:
             args = (to_backend_handle(args[0]),) + args[1:]
+        if "handle_" in kwargs:
+            kwargs["handle_"] = to_backend_handle(kwargs["handle_"])
         if self._lowered_graph is None:
             import cudnn
 

--- a/python/cudnn/engines/base.py
+++ b/python/cudnn/engines/base.py
@@ -98,11 +98,8 @@ class ExecutionContext(NamedTuple):
     ``stream`` is resolved from the handle when available (classic
     ``cudnn.set_stream(handle, ...)`` semantics).
 
-    A ``NamedTuple``, not a frozen dataclass: both are immutable (an engine
-    cannot rebind ``ctx.stream``), but a frozen dataclass ``__init__`` sets each
-    field through ``object.__setattr__``, and this is built on every execute —
-    the NamedTuple is ~220 ns/execute cheaper for the same three read-only
-    fields.
+    A ``NamedTuple`` (not a frozen dataclass): both immutable, but built on every
+    execute, where the NamedTuple is ~220 ns/execute cheaper.
     """
 
     handle: Any = None

--- a/python/cudnn/engines/base.py
+++ b/python/cudnn/engines/base.py
@@ -45,7 +45,7 @@ Example:
 
 from abc import ABC
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple
 
 from .engine_ids import PYTHON_ENGINE_ID_BASE  # noqa: F401 — re-exported for engine authors
 
@@ -90,14 +90,19 @@ class PlanConfig:
     mode: Any = None
 
 
-@dataclass(frozen=True)
-class ExecutionContext:
+class ExecutionContext(NamedTuple):
     """Runtime context passed to a compiled plan at execute time.
 
     Everything an engine may need is explicit here — no engine should reach
     into private graph state, hard-code a stream, or allocate hidden workspace.
     ``stream`` is resolved from the handle when available (classic
     ``cudnn.set_stream(handle, ...)`` semantics).
+
+    A ``NamedTuple``, not a frozen dataclass: both are immutable (an engine
+    cannot rebind ``ctx.stream``), but a frozen dataclass ``__init__`` sets each
+    field through ``object.__setattr__``, and this is built on every execute —
+    the NamedTuple is ~220 ns/execute cheaper for the same three read-only
+    fields.
     """
 
     handle: Any = None

--- a/python/cudnn/frost/device.py
+++ b/python/cudnn/frost/device.py
@@ -119,20 +119,22 @@ def shared_memory_per_block_optin(device: int) -> int:
     return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, handle)))
 
 
-# CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK. Named in CUDA 13.4's
-# cuda.h; cuda-python's CUdevice_attribute does not carry it yet, so ask by ordinal.
-_ATTR_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK = 150
-
-
 @functools.lru_cache(maxsize=None)
 def oversized_shared_memory_per_block(device: int) -> int:
     """Per-CTA SMEM ceiling in the *oversized* carveout (327 KiB vs the 227 KiB
     opt-in limit on SM 10.7), which the part gives by shrinking L1 to 8 kB — free for
     a TMA-fed GEMM. 0 when the driver has no such mode."""
     drv = _driver()
+    # CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK arrived in CUDA 13.4.
+    # A driver older than that has no such mode -> 0 by design (not an error), and we
+    # do not touch the enum member (which an older cuda-python's CUdevice_attribute
+    # does not carry -- passing a bare ordinal would raise, since the binding reads
+    # attrib.value). From 13.4 the attribute is real: query it and let a genuine
+    # failure raise rather than masking it as 0.
+    if int(_ck(*drv.cuDriverGetVersion())) < 13040:
+        return 0
     handle = _device_handle(device)
-    err, value = drv.cuDeviceGetAttribute(_ATTR_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, handle)
-    return int(value) if int(err) == 0 else 0
+    return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, handle)))
 
 
 @functools.lru_cache(maxsize=None)

--- a/python/cudnn/frost/device.py
+++ b/python/cudnn/frost/device.py
@@ -50,18 +50,20 @@ def build_device(device):
         _build_device.reset(token)
 
 
-def current_device() -> int:
-    """CUDA device index a plan built right now would target.
+def build_scope_device() -> int | None:
+    """The ordinal a surrounding ``build_device()`` pinned, or ``None`` when the
+    build is unscoped (no handle asked for a specific GPU)."""
+    return _build_device.get()
 
-    Inside a ``build_device()`` scope this is the handle's device (so the build
-    follows the handle, not the ambient CUDA device). Otherwise: a bound driver
-    context wins — it is process-wide and authoritative. Before anything has
-    allocated there may be none, and ``cudaSetDevice`` (what
+
+def ambient_device() -> int:
+    """The live CUDA device, IGNORING any ``build_device()`` scope — the device
+    cuDNN's backend and cutedsl's compile-target auto-detect actually see.
+
+    A bound driver context wins — it is process-wide and authoritative. Before
+    anything has allocated there may be none, and ``cudaSetDevice`` (what
     ``torch.cuda.set_device`` drives) has only moved the runtime's thread-local
     slot, so that is the second rung."""
-    override = _build_device.get()
-    if override is not None:
-        return override
     drv = _driver()
     if drv is None:
         raise RuntimeError("cudnn.frost: no CUDA device visible")
@@ -73,6 +75,18 @@ def current_device() -> int:
     if int(err) != 0:
         raise RuntimeError(f"cudnn.frost: cudaGetDevice failed: {err}")
     return int(index)
+
+
+def current_device() -> int:
+    """CUDA device index a plan built right now would target.
+
+    Inside a ``build_device()`` scope this is the handle's device (so the build
+    follows the handle, not the ambient CUDA device); otherwise the live
+    :func:`ambient_device`."""
+    override = _build_device.get()
+    if override is not None:
+        return override
+    return ambient_device()
 
 
 def resolve_device(device=None) -> int:

--- a/python/cudnn/frost/device.py
+++ b/python/cudnn/frost/device.py
@@ -10,54 +10,22 @@ describe one GPU fails loudly instead of launching on another.
 That comparison is about the LAUNCH, not the buffers. cuDNN's own variant pack
 carries pointers, uids and a workspace and no device at all, so an operand's
 device is not something the front end has an opinion about.
+
+Device FACTS (compute capability, SM count, the SMEM/L2 ceilings, ...) are NOT
+queried here — they live in the common :class:`cudnn._device.DeviceInfo`
+(``Handle.device``), queried once and cached; the fact functions below are thin
+shims onto it. This module owns only the frost-runtime concerns: which device a
+build targets (``current_device`` / ``build_device``) and the primary-context
+helper.
 """
 
 from __future__ import annotations
 
 import contextlib
 import contextvars
-import functools
 
-
-@functools.lru_cache(maxsize=1)
-def _driver():
-    """The cuInit'd driver module, or ``None`` when no CUDA device is visible."""
-    import cuda.bindings.driver as drv
-
-    if int(drv.cuInit(0)[0]) != 0:
-        return None
-    return drv
-
-
-def _ck(err, *rest):
-    if int(err) != 0:
-        drv = _driver()
-        detail = drv.cuGetErrorString(err)[1].decode() if drv is not None else ""
-        raise RuntimeError(f"cudnn.frost: CUDA driver error {err}{f': {detail}' if detail else ''}")
-    return rest[0] if len(rest) == 1 else None
-
-
-def is_available() -> bool:
-    """True when at least one CUDA device is visible to this process."""
-    drv = _driver()
-    return drv is not None and int(_ck(*drv.cuDeviceGetCount())) > 0
-
-
-def device_count() -> int:
-    drv = _driver()
-    return 0 if drv is None else int(_ck(*drv.cuDeviceGetCount()))
-
-
-def _device_handle(device: int):
-    """``CUdevice`` for an ordinal. Needs only cuInit — creates no context."""
-    drv = _driver()
-    if drv is None:
-        raise RuntimeError("cudnn.frost: no CUDA device visible")
-    count = int(_ck(*drv.cuDeviceGetCount()))
-    if not 0 <= device < count:
-        raise ValueError(f"cudnn.frost: cuda:{device} does not exist ({count} device(s) visible)")
-    return _ck(*drv.cuDeviceGet(device))
-
+from cudnn._device import _ck, _device_handle, _driver, device_info
+from cudnn._device import device_count, is_available  # noqa: F401 — re-exported for frost callers
 
 # The device a frost BUILD targets, scoped in by build_device() from the
 # cudnn.Handle the graph was built with. Every device-derived kernel constant
@@ -125,59 +93,31 @@ def resolve_device(device=None) -> int:
     return current_device() if index is None else int(index)
 
 
-@functools.lru_cache(maxsize=None)
+# --- device facts: thin shims onto the common cudnn._device.DeviceInfo --------
+# The queries + per-ordinal cache live there (Handle.device is the same object);
+# frost reads through these so its callers need not thread a handle everywhere.
 def compute_capability(device: int) -> tuple[int, int]:
-    drv = _driver()
-    handle = _device_handle(device)
-    attr = drv.CUdevice_attribute
-    major = int(_ck(*drv.cuDeviceGetAttribute(attr.CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, handle)))
-    minor = int(_ck(*drv.cuDeviceGetAttribute(attr.CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, handle)))
-    return major, minor
+    return device_info(device).compute_capability
 
 
-@functools.lru_cache(maxsize=None)
 def multiprocessor_count(device: int) -> int:
-    drv = _driver()
-    handle = _device_handle(device)
-    return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, handle)))
+    return device_info(device).sm_count
 
 
-@functools.lru_cache(maxsize=None)
 def shared_memory_per_block_optin(device: int) -> int:
-    drv = _driver()
-    handle = _device_handle(device)
-    return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, handle)))
+    return device_info(device).shared_memory_per_block_optin
 
 
-@functools.lru_cache(maxsize=None)
 def oversized_shared_memory_per_block(device: int) -> int:
-    """Per-CTA SMEM ceiling in the *oversized* carveout (327 KiB vs the 227 KiB
-    opt-in limit on SM 10.7), which the part gives by shrinking L1 to 8 kB — free for
-    a TMA-fed GEMM. 0 when the driver has no such mode."""
-    drv = _driver()
-    # CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK arrived in CUDA 13.4.
-    # A driver older than that has no such mode -> 0 by design (not an error), and we
-    # do not touch the enum member (which an older cuda-python's CUdevice_attribute
-    # does not carry -- passing a bare ordinal would raise, since the binding reads
-    # attrib.value). From 13.4 the attribute is real: query it and let a genuine
-    # failure raise rather than masking it as 0.
-    if int(_ck(*drv.cuDriverGetVersion())) < 13040:
-        return 0
-    handle = _device_handle(device)
-    return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, handle)))
+    return device_info(device).oversized_shared_memory_per_block
 
 
-@functools.lru_cache(maxsize=None)
 def l2_cache_bytes(device: int) -> int:
-    drv = _driver()
-    handle = _device_handle(device)
-    return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE, handle)))
+    return device_info(device).l2_cache_bytes
 
 
-@functools.lru_cache(maxsize=None)
 def device_name(device: int) -> str:
-    drv = _driver()
-    return _ck(*drv.cuDeviceGetName(256, _device_handle(device))).split(b"\x00")[0].decode()
+    return device_info(device).device_name
 
 
 class device_context:

--- a/python/cudnn/frost/device.py
+++ b/python/cudnn/frost/device.py
@@ -14,6 +14,8 @@ device is not something the front end has an opinion about.
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import functools
 
 
@@ -57,13 +59,41 @@ def _device_handle(device: int):
     return _ck(*drv.cuDeviceGet(device))
 
 
+# The device a frost BUILD targets, scoped in by build_device() from the
+# cudnn.Handle the graph was built with. Every device-derived kernel constant
+# (arch, ab_stages, grid_num_clusters, sm_count, the L2/SMEM budgets) resolves
+# through current_device(), so setting this once bakes the plan for the handle's
+# GPU instead of whatever CUDA device happens to be current at build time.
+_build_device: contextvars.ContextVar = contextvars.ContextVar("cudnn_frost_build_device", default=None)
+
+
+@contextlib.contextmanager
+def build_device(device):
+    """Scope a frost build to ``device`` (a CUDA ordinal, e.g.
+    ``handle.device.ordinal``). ``None`` = no override (fall back to the live
+    current device), so a build with no handle keeps the classic behaviour."""
+    if device is None:
+        yield
+        return
+    token = _build_device.set(int(device))
+    try:
+        yield
+    finally:
+        _build_device.reset(token)
+
+
 def current_device() -> int:
     """CUDA device index a plan built right now would target.
 
-    A bound driver context wins — it is process-wide and authoritative. Before
-    anything has allocated there may be none, and ``cudaSetDevice`` (what
+    Inside a ``build_device()`` scope this is the handle's device (so the build
+    follows the handle, not the ambient CUDA device). Otherwise: a bound driver
+    context wins — it is process-wide and authoritative. Before anything has
+    allocated there may be none, and ``cudaSetDevice`` (what
     ``torch.cuda.set_device`` drives) has only moved the runtime's thread-local
     slot, so that is the second rung."""
+    override = _build_device.get()
+    if override is not None:
+        return override
     drv = _driver()
     if drv is None:
         raise RuntimeError("cudnn.frost: no CUDA device visible")

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -2736,6 +2736,18 @@ def probe_supported(
 
     Block-scale / MoE gate inside their ``_jit_*`` compile paths; here a
     successful analysis is treated as eligible (full validation at compile)."""
+    # frost is written in the cutedsl these kernels compile through; below its
+    # floor the engine cannot build (same gate the linear-attention engines
+    # apply). Decline early so a too-old wheel falls back to the backend instead
+    # of faulting deep in cute -- and so the --gpu-arch target pin, which lands in
+    # cutedsl at the floor, is always available by the time a plan compiles. An
+    # internal RC passes: cutedsl_too_old judges only the public wheel.
+    installed, version = buffers.cutedsl_state()
+    if not installed:
+        raise NotImplementedError("frost_gemm requires the cutedsl extra (nvidia-cutlass-dsl)")
+    if buffers.cutedsl_too_old(version):
+        want = ".".join(str(v) for v in buffers.CUTEDSL_MIN_VERSION)
+        raise NotImplementedError(f"frost_gemm requires nvidia-cutlass-dsl >= {want}; found {version[1]}")
     chain, _binding = analyze_with_binding(graph)
     _dtype_reason = dtype_arch_reject(chain, _current_arch())
     if _dtype_reason is not None:

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -86,6 +86,64 @@ _TVM_FFI_OK = importlib.util.find_spec("tvm_ffi") is not None
 _FROST_COMPILE_OPTIONS = "--enable-tvm-ffi" if _TVM_FFI_OK else ""
 
 
+def _supports_gpu_arch_option() -> bool:
+    """Whether this cutedsl threads ``--gpu-arch`` from the cute.compile() options
+    string to the compile target — dsl.compile_and_cache / get_arch_enum consult
+    ``compile_options.gpu_arch`` before the (import-time, ambient-detected) env
+    arch. That landed in the public wheel at 4.7 (frost's ``CUTEDSL_MIN_VERSION``),
+    so the ONLY build that lacks it is a public ``nvidia-cutlass-dsl`` wheel below
+    the floor. Reuses ``buffers.cutedsl_too_old`` so an internal RC (its own 0.x
+    numbering) is judged new, not old — matching how the rest of frost gates it."""
+    from cudnn.frost.buffers import cutedsl_state, cutedsl_too_old
+
+    return not cutedsl_too_old(cutedsl_state()[1])
+
+
+def _sm_target_string(arch: int) -> str:
+    """``major*10+minor`` -> the cute ``sm_XXX[a]`` target, matching cutedsl's own
+    ``detect_gpu_arch`` (the arch-specific ``a`` suffix appears from major >= 9)."""
+    major, minor = divmod(arch, 10)
+    return f"sm_{major}{minor}{'a' if major >= 9 else ''}"
+
+
+def _frost_compile_options() -> str:
+    """The ``cute.compile()`` options string for a build in the current
+    ``build_device()`` scope. Pins ``--gpu-arch`` to the scope's GPU so the
+    compile target follows the handle instead of the ambient CUDA device. On a
+    public wheel below the floor the option is inert, so a handle-scoped build is
+    refused rather than silently mis-targeted; an unscoped build needs no pin.
+    (frost declines such wheels as too-old before reaching here, so the refusal
+    is belt-and-suspenders.)
+
+    Called at render time (inside the scope) so the arch is baked into the
+    generated source, keeping it part of the content-addressed cache key."""
+    from cudnn.frost.device import build_scope_device as _build_scope_device
+
+    opts = [_FROST_COMPILE_OPTIONS] if _FROST_COMPILE_OPTIONS else []
+    arch = _current_arch()  # scope-aware: the handle's GPU inside build_device()
+    if arch is None:
+        return " ".join(opts)  # render-only / no GPU visible
+    if _supports_gpu_arch_option():
+        opts.append(f"--gpu-arch {_sm_target_string(arch)}")
+    elif _build_scope_device() is not None:
+        # A handle pinned a GPU (build_device scope) but this wheel cannot pin the
+        # compile target: cutedsl resolves it from an arch captured at IMPORT time,
+        # which we can neither set NOR reliably read here (comparing against the
+        # live device would miss an import-on-B, build-on-A process). We cannot
+        # honor the scope, so refuse rather than bake scope constants into a
+        # possibly-mis-targeted kernel. (frost's cutedsl_too_old gate already
+        # declines such wheels, so this is belt-and-suspenders.) An unscoped build
+        # makes no cross-device promise and falls through unchanged.
+        major, minor = divmod(arch, 10)
+        raise NotImplementedError(
+            f"cudnn.frost: a handle-scoped build for sm_{major}{minor} needs an nvidia-cutlass-dsl "
+            f"that pins the compile target (public >= 4.7 or an internal RC); this wheel cannot, so "
+            f"the build cannot follow the handle. Upgrade cutedsl, or build with the handle's GPU "
+            f"already current (no build_device scope)."
+        )
+    return " ".join(opts)
+
+
 # ---------------------------------------------------------------------------
 # Symbolic-shape helpers for aux fake tensors
 # ---------------------------------------------------------------------------
@@ -642,7 +700,7 @@ def _render_tile_constants(
     # divides every power-of-2 subtile span of this config's N-tile).
     vec_bytes_epi = _epi_vec_bytes(chain, cfg, cta_group)
     lines.append(f"vec_bytes_epi = {vec_bytes_epi}")
-    lines.append(f"frost_compile_options = {_FROST_COMPILE_OPTIONS!r}")
+    lines.append(f"frost_compile_options = {_frost_compile_options()!r}")
     # Epilogue store mode: TMA-store-via-SMEM (preferred) vs per-thread STG
     # (fallback). See _use_tma_store_epi() for gating.
     use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, cfg, vec_bytes_epi, cta_group)
@@ -1183,7 +1241,7 @@ def _render_block_scale_tile_constants(
         f"cd_dtype = {'cutlass.Int8' if out_dt == 'fp4_e2m1' else DTYPE_TO_CUTLASS[out_dt]}",
         f"cd_tma_dtype = {'cutlass.Int8' if out_dt == 'fp4_e2m1' else DTYPE_TO_CUTLASS[out_dt]}",
         f"vec_bytes_epi = {vec_bytes_epi}",
-        f"frost_compile_options = {_FROST_COMPILE_OPTIONS!r}",
+        f"frost_compile_options = {_frost_compile_options()!r}",
         f"use_tma_store_epi = {use_tma_store_epi}",
         f"cd_out_is_m_major = {chain.out_major == 'm'}",
         f"cd_fake_n_div = {2 if out_dt == 'fp4_e2m1' else 1}",

--- a/python/cudnn/gemm/frost/engine.py
+++ b/python/cudnn/gemm/frost/engine.py
@@ -97,9 +97,16 @@ class FrostGemmEngine(BaseEngine):
 
     def build_plan(self, graph: "pygraph", plan: PlanConfig, ctx: ExecutionContext = None) -> CompiledPlan:
         from .graph_analyzer import build_gemm_plan
+        from cudnn.frost.device import build_device
 
+        # Bake the plan for the device of the handle the graph carries (via ctx),
+        # not whatever CUDA device is current at build time. A foreign raw-int
+        # handle (or none) carries no device -> None -> classic current-device.
+        handle = ctx.handle if ctx is not None else None
+        device = handle.device.ordinal if hasattr(handle, "device") else None
         try:
-            return _FrostGemmPlan(build_gemm_plan(graph))
+            with build_device(device):
+                return _FrostGemmPlan(build_gemm_plan(graph))
         except (NotImplementedError, ValueError) as exc:
             raise NotImplementedError(f"frost_gemm: {exc}") from exc
 

--- a/python/cudnn/gemm/frost/tile_config.py
+++ b/python/cudnn/gemm/frost/tile_config.py
@@ -555,12 +555,16 @@ _DEFAULT_SM_COUNT = 148
 
 
 def _sm_count() -> int:
-    """SM count of the active device, with a B200-shaped fallback for CPU-only use."""
-    try:
-        import torch
+    """SM count of the active device, with a B200-shaped fallback for CPU-only use.
 
-        if torch.cuda.is_available():
-            return torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+    Queried through frost's device layer (not torch) so it honours a
+    ``build_device()`` scope — i.e. follows the handle's GPU during a build, like
+    every other device-derived constant."""
+    from cudnn.frost.device import is_available, multiprocessor_count, resolve_device
+
+    try:
+        if is_available():
+            return multiprocessor_count(resolve_device(None))
     except Exception:
         pass
     return _DEFAULT_SM_COUNT

--- a/python/cudnn/linear_attention/frost/gdn2_engine.py
+++ b/python/cudnn/linear_attention/frost/gdn2_engine.py
@@ -14,8 +14,7 @@ import math
 from cudnn import behavior_note
 from cudnn.engines.base import BaseEngine, CompiledPlan
 
-from cudnn.frost.buffers import current_device_id
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.device import build_device, current_device, multiprocessor_count
 from cudnn.frost.workspace import WorkspaceLayout, carve_plan
 from ..graph_analyzer import analyze
 from .engine import FrostLaPlan, frost_la_gate
@@ -96,7 +95,12 @@ class Gdn2FrostEngine(BaseEngine):
             raise NotImplementedError("Gdn2FrostEngine: initial_state and final_state dtypes must match")
 
     def build_plan(self, graph, plan, ctx=None) -> CompiledPlan:
-        return FrostLaPlan(build_gdn2(graph))
+        # Bake the plan for the handle's device (via ctx), not the ambient one; a
+        # foreign raw-int handle (or none) carries no device -> None -> current.
+        handle = ctx.handle if ctx is not None else None
+        device = handle.device.ordinal if hasattr(handle, "device") else None
+        with build_device(device):
+            return FrostLaPlan(build_gdn2(graph))
 
 
 class CompiledGdn2:
@@ -133,7 +137,7 @@ class CompiledGdn2:
         B = node.inputs["cu_seqlens"].dim[0] - 1
         layout = WorkspaceLayout()
         self.off_sched = layout.add(8)
-        self.num_sm = multiprocessor_count(current_device_id())
+        self.num_sm = multiprocessor_count(current_device())
         self.n_tiles = B * HO
         self.n_heads_out = HO
         if self.split:
@@ -341,7 +345,7 @@ class CompiledGdn2Bwd:
         self.n_heads_out, self.total = HO, total
         layout = WorkspaceLayout()
         self.off_sched = layout.add(16)
-        self.num_sm = multiprocessor_count(current_device_id())
+        self.num_sm = multiprocessor_count(current_device())
         self.bwd_dyn_sched = B * HO <= self.num_sm
         self.batch_invariant = bool(node.params.get("batch_invariant", False))
         # cuts never in batch-invariant mode

--- a/python/cudnn/linear_attention/frost/gdn_engine.py
+++ b/python/cudnn/linear_attention/frost/gdn_engine.py
@@ -15,8 +15,7 @@ from cudnn import behavior_note
 from cudnn.engines.base import BaseEngine, CompiledPlan
 
 from cudnn.frost import buffers
-from cudnn.frost.buffers import current_device_id
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.device import build_device, current_device, multiprocessor_count
 from cudnn.frost.workspace import WorkspaceLayout, carve_plan
 from ..graph_analyzer import analyze
 from .engine import FrostLaPlan, frost_la_gate
@@ -94,7 +93,12 @@ class GdnFrostEngine(BaseEngine):
             raise NotImplementedError("GdnFrostEngine: 'state_checkpoints' must match the io dtype")
 
     def build_plan(self, graph, plan, ctx=None) -> CompiledPlan:
-        return FrostLaPlan(build_gdn(graph))
+        # Bake the plan for the handle's device (via ctx), not the ambient one; a
+        # foreign raw-int handle (or none) carries no device -> None -> current.
+        handle = ctx.handle if ctx is not None else None
+        device = handle.device.ordinal if hasattr(handle, "device") else None
+        with build_device(device):
+            return FrostLaPlan(build_gdn(graph))
 
 
 class CompiledGdn:
@@ -139,7 +143,7 @@ class CompiledGdn:
         self.tensormap_words = tensormap_workspace_bytes(kernel_mod, B) // 8
         self.off_tensormaps = layout.add(self.tensormap_words * 8)
         self.off_sched = layout.add(8)
-        self.num_sm = multiprocessor_count(current_device_id())
+        self.num_sm = multiprocessor_count(current_device())
         self.n_tiles = B * HO
         self.n_heads_out = HO
         if self.split:
@@ -351,7 +355,7 @@ class CompiledGdnBwd:
         self.has_state0 = "initial_state" in node.inputs
         self.io_name = "float16" if node.inputs["q"].get_data_type().name == "HALF" else "bfloat16"
 
-        self.num_sm = multiprocessor_count(current_device_id())
+        self.num_sm = multiprocessor_count(current_device())
         self.bwd_dyn_sched = B * HO <= self.num_sm
         self.batch_invariant = bool(node.params.get("batch_invariant", False))
         # cuts never in batch-invariant mode

--- a/python/cudnn/linear_attention/frost/kda_engine.py
+++ b/python/cudnn/linear_attention/frost/kda_engine.py
@@ -15,8 +15,7 @@ import math
 from cudnn import behavior_note
 from cudnn.engines.base import BaseEngine, CompiledPlan
 
-from cudnn.frost.buffers import current_device_id
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.device import build_device, current_device, multiprocessor_count
 from cudnn.frost.workspace import WorkspaceLayout, carve_plan
 from ..graph_analyzer import analyze
 from .engine import FrostLaPlan, frost_la_gate
@@ -94,7 +93,12 @@ class KdaFrostEngine(BaseEngine):
                 raise NotImplementedError("KdaFrostEngine: initial_state and final_state dtypes must match")
 
     def build_plan(self, graph, plan, ctx=None) -> CompiledPlan:
-        return FrostLaPlan(build_kda(graph))
+        # Bake the plan for the handle's device (via ctx), not the ambient one; a
+        # foreign raw-int handle (or none) carries no device -> None -> current.
+        handle = ctx.handle if ctx is not None else None
+        device = handle.device.ordinal if hasattr(handle, "device") else None
+        with build_device(device):
+            return FrostLaPlan(build_kda(graph))
 
 
 class CompiledKda:
@@ -131,7 +135,7 @@ class CompiledKda:
         B = node.inputs["cu_seqlens"].dim[0] - 1
         layout = WorkspaceLayout()
         self.off_sched = layout.add(8)
-        self.num_sm = multiprocessor_count(current_device_id())
+        self.num_sm = multiprocessor_count(current_device())
         self.n_tiles = B * HO
         self.n_heads_out = HO
         if self.split:
@@ -337,7 +341,7 @@ class CompiledKdaBwd:
         self.n_heads_out, self.total = HO, total
         layout = WorkspaceLayout()
         self.off_sched = layout.add(16)
-        self.num_sm = multiprocessor_count(current_device_id())
+        self.num_sm = multiprocessor_count(current_device())
         self.bwd_dyn_sched = B * HO <= self.num_sm
         self.batch_invariant = bool(node.params.get("batch_invariant", False))
         # cuts never in batch-invariant mode

--- a/python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn2_bprop_f16.py
@@ -62,8 +62,8 @@ from cutlass.cute.runtime import from_dlpack
 
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_copy_desc, emit_checkpoint_seq_descs, emit_seq_descs
 from .gdn2_bprop_config import CFG
 
@@ -4204,7 +4204,7 @@ def chunk_gdn2_bwd_sm100(
             k_ratio=HO // HK,
             v_ratio=HO // HV,
             n_heads_out=HO,
-            max_active_clusters=multiprocessor_count(current_device_id()),
+            max_active_clusters=multiprocessor_count(current_device()),
             dyn_sched=dyn_sched,
         )
 

--- a/python/cudnn/linear_attention/frost/kernel/gdn2_prefill_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn2_prefill_f16.py
@@ -95,8 +95,8 @@ from cutlass.cute.runtime import from_dlpack
 
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .gdn2_prefill_config import CFG
 
@@ -3188,7 +3188,7 @@ def chunk_gdn2_sm100(
             v_ratio,
             HO,
             dyn_sched,
-            num_sm=multiprocessor_count(current_device_id()),
+            num_sm=multiprocessor_count(current_device()),
             q_cute=q_cute,
             k_cute=k_cute,
             v_cute=v_cute,

--- a/python/cudnn/linear_attention/frost/kernel/gdn2_recompute_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn2_recompute_f16.py
@@ -92,8 +92,8 @@ from cutlass.cute.runtime import from_dlpack
 
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .gdn2_recompute_config import CFG
 
@@ -2681,7 +2681,7 @@ def chunk_gdn2_recompute_sm100(
             v_ratio,
             HO,
             dyn_sched,
-            num_sm=multiprocessor_count(current_device_id()),
+            num_sm=multiprocessor_count(current_device()),
             k_cute=k_cute,
             v_cute=v_cute,
             gate_cute=gate_cute,

--- a/python/cudnn/linear_attention/frost/kernel/gdn_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn_bprop_f16.py
@@ -120,8 +120,8 @@ from ..common.thd import emit_copy_desc, emit_checkpoint_seq_descs, emit_seq_des
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.elementwise import softplus
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 
 RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
 from cudnn.frost.tile_dsl.barrier import (
@@ -4723,7 +4723,7 @@ def chunk_gdn_bwd_sm100(
             safe_gate=safe_gate,
             beta_sigmoid=use_beta_sigmoid,
             dyn_sched=dyn_sched,
-            num_sm=multiprocessor_count(current_device_id()),
+            num_sm=multiprocessor_count(current_device()),
             h_q=HQ,
             h_k=HK,
             h_v=HV,

--- a/python/cudnn/linear_attention/frost/kernel/gdn_prefill_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn_prefill_f16.py
@@ -98,8 +98,8 @@ from ..common.thd import emit_checkpoint_seq_descs, emit_seq_descs, TENSOR_MAP_Q
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.elementwise import softplus
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 
 RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
 from cudnn.frost.tile_dsl.barrier import (
@@ -3122,7 +3122,7 @@ def chunk_gdn_sm100(
             safe_gate,
             use_beta_sigmoid,
             dyn_sched,
-            num_sm=multiprocessor_count(current_device_id()),
+            num_sm=multiprocessor_count(current_device()),
             q_cute=q_cute,
             k_cute=k_cute,
             v_cute=v_cute,

--- a/python/cudnn/linear_attention/frost/kernel/gdn_recompute_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/gdn_recompute_f16.py
@@ -88,8 +88,8 @@ from ..common.thd import emit_checkpoint_seq_descs, emit_seq_descs, TENSOR_MAP_Q
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.elementwise import softplus
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 
 RCP_LN2 = 1.4426950408889634  # 1/ln(2): natural-log gates -> the kernel's log2 domain
 from cudnn.frost.tile_dsl.barrier import (
@@ -2706,7 +2706,7 @@ def chunk_gdn_recompute_sm100(
             safe_gate,
             use_beta_sigmoid,
             dyn_sched,
-            num_sm=multiprocessor_count(current_device_id()),
+            num_sm=multiprocessor_count(current_device()),
             k_cute=k_cute,
             v_cute=v_cute,
             gate_cute=gate_cute,

--- a/python/cudnn/linear_attention/frost/kernel/kda_bprop_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/kda_bprop_f16.py
@@ -66,8 +66,8 @@ from cutlass.cute.runtime import from_dlpack
 
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_copy_desc, emit_checkpoint_seq_descs, emit_seq_descs
 from .kda_bprop_config import CFG
 
@@ -4015,7 +4015,7 @@ def chunk_kda_bwd_sm100(
             k_ratio=HO // HK,
             v_ratio=HO // HV,
             n_heads_out=HO,
-            max_active_clusters=multiprocessor_count(current_device_id()),
+            max_active_clusters=multiprocessor_count(current_device()),
             dyn_sched=dyn_sched,
         )
 

--- a/python/cudnn/linear_attention/frost/kernel/kda_prefill_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/kda_prefill_f16.py
@@ -100,8 +100,8 @@ from cutlass.cute.runtime import from_dlpack
 
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .kda_prefill_config import CFG
 
@@ -3024,7 +3024,7 @@ def chunk_kda_sm100(
             v_ratio,
             HO,
             dyn_sched,
-            num_sm=multiprocessor_count(current_device_id()),
+            num_sm=multiprocessor_count(current_device()),
             q_cute=q_cute,
             k_cute=k_cute,
             v_cute=v_cute,

--- a/python/cudnn/linear_attention/frost/kernel/kda_recompute_f16.py
+++ b/python/cudnn/linear_attention/frost/kernel/kda_recompute_f16.py
@@ -96,8 +96,8 @@ from cutlass.cute.runtime import from_dlpack
 
 from ..common.split_k import ORDER_CAPACITY, ORDER_ELEMS, ORDER_THREADS, decode_work_item, order_body
 from ..common.host import get_dtype
-from cudnn.frost.buffers import current_device_id, data_ptr
-from cudnn.frost.device import multiprocessor_count
+from cudnn.frost.buffers import data_ptr
+from cudnn.frost.device import current_device, multiprocessor_count
 from ..common.thd import TENSOR_MAP_QWORDS, emit_checkpoint_seq_descs, emit_seq_descs
 from .kda_recompute_config import CFG
 
@@ -2536,7 +2536,7 @@ def chunk_kda_recompute_sm100(
             v_ratio,
             HO,
             dyn_sched,
-            num_sm=multiprocessor_count(current_device_id()),
+            num_sm=multiprocessor_count(current_device()),
             k_cute=k_cute,
             v_cute=v_cute,
             gate_cute=gate_cute,

--- a/python/properties.cpp
+++ b/python/properties.cpp
@@ -285,9 +285,12 @@ init_properties(py::module_& m) {
               &create_device_properties_helper));
 
     m.def("create_handle", &HandleManagement::create_handle);
-    m.def("destroy_handle", &HandleManagement::destroy_handle);
+    // destroy_handle / set_stream are exposed under a raw name and wrapped in Python
+    // (cudnn/__init__.py) to skip a redundant cudnnSetStream when the stream is unchanged,
+    // matching how the graph execute binding (_execute) is wrapped as the public execute().
+    m.def("_raw_destroy_handle", &HandleManagement::destroy_handle);
     m.def("get_stream", &HandleManagement::get_stream);
-    m.def("set_stream", &HandleManagement::set_stream, py::arg("handle"), py::arg("stream"));
+    m.def("_raw_set_stream", &HandleManagement::set_stream, py::arg("handle"), py::arg("stream"));
 
     py::enum_<cudnn_frontend::NormFwdPhase_t>(m, "norm_forward_phase")
         .value("INFERENCE", cudnn_frontend::NormFwdPhase_t::INFERENCE)

--- a/test/python/gemm/frost/test_build_device.py
+++ b/test/python/gemm/frost/test_build_device.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""build_device() scopes a frost build to a chosen GPU, so every device-derived
+kernel constant follows the handle's device rather than whatever CUDA device is
+current. Proven here by scoping to a *different real* GPU and checking the
+constants report that GPU's facts -- the multi-GPU behaviour a single-GPU run
+cannot otherwise exercise. Uses only device queries (no kernel launch), so the
+second GPU need not be a Blackwell."""
+
+import pytest
+
+from cudnn.frost import device as D
+
+pytestmark = pytest.mark.L0
+
+
+def _distinct_arch_devices():
+    seen = {}
+    for o in range(D.device_count()):
+        try:
+            seen.setdefault(D.compute_capability(o), o)
+        except Exception:  # noqa: BLE001 — a device we cannot query is just skipped
+            pass
+    ccs = list(seen.items())
+    if len(ccs) < 2:
+        pytest.skip("need two GPUs of different compute capability to prove the redirect")
+    return ccs[0], ccs[1]
+
+
+def test_build_device_scopes_current_device_and_restores():
+    if D.device_count() == 0:
+        pytest.skip("no CUDA device")
+    live = D.current_device()
+    other = next((o for o in range(D.device_count()) if o != live), None)
+    if other is None:
+        pytest.skip("need a second device")
+    with D.build_device(other):
+        assert D.current_device() == other
+        assert D.resolve_device(None) == other
+    assert D.current_device() == live  # restored on exit
+
+
+def test_build_device_redirects_every_frost_build_constant():
+    from cudnn.gemm.frost import compiler as C
+    from cudnn.gemm.frost import tile_config as TC
+
+    (cc_a, a), (cc_b, b) = _distinct_arch_devices()
+    # Scope to each device in turn; every device-derived build constant must report
+    # THAT device's facts, not the ambient one -- i.e. a build follows the scope.
+    for cc, dev in ((cc_a, a), (cc_b, b)):
+        with D.build_device(dev):
+            assert D.current_device() == dev
+            assert C._current_arch() == cc[0] * 10 + cc[1]
+            assert C._plan_device() == dev
+            # _sm_count was re-routed off torch.cuda.current_device -> honours the scope
+            assert TC._sm_count() == D.multiprocessor_count(dev)
+
+
+def test_build_device_none_is_no_override():
+    if D.device_count() == 0:
+        pytest.skip("no CUDA device")
+    live = D.current_device()
+    with D.build_device(None):
+        assert D.current_device() == live  # None = classic current-device behaviour

--- a/test/python/test_device_info.py
+++ b/test/python/test_device_info.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cudnn._device.DeviceInfo is the FE's single owner of a GPU's facts: each fact
+is queried from the driver once and cached ON the instance, and there is one
+instance per CUDA ordinal. Handle.device is that object; frost reads the same one
+through thin shims (no parallel introspection stack)."""
+
+import pytest
+
+import cudnn
+from cudnn._device import DeviceInfo, device_info, is_available
+
+pytestmark = pytest.mark.L0
+
+
+def test_device_info_one_per_ordinal_and_caches_on_the_instance():
+    if not is_available():
+        pytest.skip("no CUDA device")
+    device_info.cache_clear()
+    d0 = device_info(0)
+    assert isinstance(d0, DeviceInfo)
+    assert device_info(0) is d0  # one shared instance per ordinal
+
+    # A fact is cached on the INSTANCE (cached_property), not in a free-function cache.
+    assert "compute_capability" not in d0.__dict__  # not queried yet
+    cc = d0.compute_capability
+    assert d0.__dict__["compute_capability"] == cc  # now stored on the instance
+    assert d0.sm_version == cc[0] * 10 + cc[1]  # derived, cannot drift from the tuple
+
+
+def test_handle_device_is_the_shared_device_info():
+    if not is_available():
+        pytest.skip("no CUDA device")
+    h = cudnn.create_handle()
+    try:
+        assert isinstance(h.device, DeviceInfo)
+        assert h.device is device_info(h.device.ordinal)  # the handle reads the shared object
+    finally:
+        cudnn.destroy_handle(h)
+
+
+def test_frost_facts_are_shims_onto_the_common_device_info():
+    if not is_available():
+        pytest.skip("no CUDA device")
+    from cudnn.frost import device as F
+
+    d = device_info(0)
+    assert F.compute_capability(0) == d.compute_capability
+    assert F.multiprocessor_count(0) == d.sm_count
+    assert F.shared_memory_per_block_optin(0) == d.shared_memory_per_block_optin
+    assert F.l2_cache_bytes(0) == d.l2_cache_bytes
+    assert F.device_name(0) == d.device_name

--- a/test/python/test_dispatch.py
+++ b/test/python/test_dispatch.py
@@ -584,7 +584,7 @@ def test_failed_stream_query_on_supplied_handle_raises(monkeypatch):
 
     monkeypatch.setattr(_cudnn, "get_stream", boom)
     with pytest.raises(RuntimeError, match="stream query failed"):
-        g.execute({C: torch.empty(2, 2)}, handle=42)
+        g.execute({C: torch.empty(2, 2)}, handle=_cudnn.Handle(backend_handle=42))
 
 
 # ---------------------------------------------------------------------------
@@ -1160,8 +1160,9 @@ def test_execute_time_handle_reaches_a_lazily_built_python_plan(monkeypatch):
     g._lowered_graph = _FakeBackend(build=cudnn.cudnnGraphNotSupportedError("backend build declined"))
     g._cpp_plans_created = g._cpp_bog_done = True
 
-    g.execute({C: torch.empty(2, 2)}, None, 42)
-    assert seen == [42], f"build_plan saw {seen}, execute was given handle=42"
+    h = cudnn.Handle(backend_handle=42)
+    g.execute({C: torch.empty(2, 2)}, None, h)
+    assert seen == [h], f"build_plan saw {seen}, execute was given a cudnn.Handle"
 
 
 def test_backend_runtime_error_is_not_a_decline(monkeypatch):

--- a/test/python/test_set_stream_cache.py
+++ b/test/python/test_set_stream_cache.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""cudnn.set_stream remembers the last stream per handle and skips the backend call
-(cudnnSetStream, which re-issues several CUDA driver queries every call) when the
-stream has not changed. A cudnn.Handle remembers on itself; a foreign raw-int handle
-uses the module registry. These tests mock the raw backend call, so no GPU is needed."""
+"""cudnn.set_stream remembers the last stream ON a cudnn.Handle and skips the backend
+call (cudnnSetStream, which re-issues several CUDA driver queries every call) when the
+stream has not changed. A foreign raw-int handle is not ours to track -- its owner may
+call cudnnSetStream out-of-band -- so it is always set through. destroy_handle clears a
+Handle's backend handle so a released cudnnHandle_t cannot be handed back to C++. These
+tests mock the raw backend calls, so no GPU is needed."""
 
 import pytest
 
@@ -13,61 +15,67 @@ import cudnn
 pytestmark = pytest.mark.L0
 
 
-def test_set_stream_skips_backend_call_when_unchanged(monkeypatch):
-    calls = []
-    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: calls.append((h, s)))
-    cudnn._handle_to_stream.clear()
-
-    cudnn.set_stream(handle=1, stream=100)
-    cudnn.set_stream(handle=1, stream=100)  # unchanged -> skipped
-    cudnn.set_stream(handle=1, stream=200)  # changed -> forwarded
-    cudnn.set_stream(handle=2, stream=100)  # different handle -> forwarded
-
-    assert calls == [(1, 100), (1, 200), (2, 100)]
-
-
-def test_destroy_handle_forgets_cached_stream(monkeypatch):
-    calls = []
-    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: calls.append((h, s)))
-    monkeypatch.setattr(cudnn._pybind_module, "_raw_destroy_handle", lambda h: None)
-    cudnn._handle_to_stream.clear()
-
-    cudnn.set_stream(handle=7, stream=100)
-    cudnn.destroy_handle(7)
-    cudnn.set_stream(handle=7, stream=100)  # a reused handle address must re-arm the backend
-
-    assert calls == [(7, 100), (7, 100)]
-
-
-def test_handle_carries_its_own_stream_not_the_registry(monkeypatch):
-    # A cudnn.Handle remembers its stream on the object; the module registry stays untouched.
+def test_handle_skips_backend_call_when_unchanged(monkeypatch):
     streams = []
     monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: streams.append(s))
-    cudnn._handle_to_stream.clear()
 
     h = cudnn.Handle(backend_handle=0xABC)  # no GPU: only forwarded to the mocked backend call
     cudnn.set_stream(h, 100)
-    cudnn.set_stream(h, 100)  # unchanged -> skipped
+    cudnn.set_stream(h, 100)  # unchanged -> skipped (fast path lives on the object)
     cudnn.set_stream(h, 200)  # changed -> forwarded
 
     assert streams == [100, 200]
     assert h.stream == 200
     assert cudnn.get_stream(h) == 200  # read comes from the object, no backend query
-    assert cudnn._handle_to_stream == {}  # a Handle never touches the foreign-int registry
 
 
-def test_handle_and_foreign_int_do_not_collide(monkeypatch):
+def test_foreign_int_always_sets_through(monkeypatch):
+    # A foreign raw-int handle has no object we own; its owner may change the stream
+    # out-of-band, so we never skip on a cached value -- every call forwards.
+    calls = []
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: calls.append((h, s)))
+
+    cudnn.set_stream(handle=1, stream=100)
+    cudnn.set_stream(handle=1, stream=100)  # same stream, but foreign -> NOT skipped
+    cudnn.set_stream(handle=2, stream=100)
+
+    assert calls == [(1, 100), (1, 100), (2, 100)]
+
+
+def test_destroy_handle_clears_backend_handle(monkeypatch):
+    destroyed = []
     monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: None)
-    monkeypatch.setattr(cudnn._pybind_module, "_raw_destroy_handle", lambda h: None)
-    cudnn._handle_to_stream.clear()
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_destroy_handle", lambda h: destroyed.append(h))
+
+    h = cudnn.Handle(backend_handle=0x777)
+    cudnn.set_stream(h, 100)
+    cudnn.destroy_handle(h)
+
+    assert h.backend_handle is None  # cleared so a reused Handle cannot pass a released handle to C++
+    assert h.stream is None
+    assert destroyed == [0x777]
+
+    # A double-destroy / a later set_stream must not touch the released handle.
+    cudnn.destroy_handle(h)
+    cudnn.set_stream(h, 200)
+    assert destroyed == [0x777]  # no second destroy call
+
+
+def test_destroy_foreign_int_forwards_to_backend(monkeypatch):
+    destroyed = []
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_destroy_handle", lambda h: destroyed.append(h))
+
+    cudnn.destroy_handle(99)  # foreign raw-int handle -> destroyed directly
+
+    assert destroyed == [99]
+
+
+def test_handle_and_foreign_int_are_independent(monkeypatch):
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: None)
 
     h = cudnn.Handle(backend_handle=42)
     cudnn.set_stream(h, 100)  # Handle path -> stored on the object
-    cudnn.set_stream(42, 100)  # foreign int 42 -> registry, independent of the Handle
+    cudnn.set_stream(42, 100)  # foreign int 42 -> forwarded, independent of the Handle object
 
     assert h.stream == 100
-    assert cudnn._handle_to_stream == {42: 100}
-
-    cudnn.destroy_handle(h)
-    assert h.stream is None
-    assert cudnn._handle_to_stream == {42: 100}  # destroying the Handle leaves the int registry alone
+    assert cudnn.get_stream(h) == 100  # from the object, not any shared registry

--- a/test/python/test_set_stream_cache.py
+++ b/test/python/test_set_stream_cache.py
@@ -3,10 +3,9 @@
 
 """cudnn.set_stream remembers the last stream ON a cudnn.Handle and skips the backend
 call (cudnnSetStream, which re-issues several CUDA driver queries every call) when the
-stream has not changed. A foreign raw-int handle is not ours to track -- its owner may
-call cudnnSetStream out-of-band -- so it is always set through. destroy_handle clears a
-Handle's backend handle so a released cudnnHandle_t cannot be handed back to C++. These
-tests mock the raw backend calls, so no GPU is needed."""
+stream has not changed. destroy_handle clears a Handle's backend handle so a released
+cudnnHandle_t cannot be handed back to C++. The handle APIs take a cudnn.Handle only --
+a raw backend int is rejected. These tests mock the raw backend calls, so no GPU is needed."""
 
 import pytest
 
@@ -29,17 +28,17 @@ def test_handle_skips_backend_call_when_unchanged(monkeypatch):
     assert cudnn.get_stream(h) == 200  # read comes from the object, no backend query
 
 
-def test_foreign_int_always_sets_through(monkeypatch):
-    # A foreign raw-int handle has no object we own; its owner may change the stream
-    # out-of-band, so we never skip on a cached value -- every call forwards.
-    calls = []
-    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: calls.append((h, s)))
-
-    cudnn.set_stream(handle=1, stream=100)
-    cudnn.set_stream(handle=1, stream=100)  # same stream, but foreign -> NOT skipped
-    cudnn.set_stream(handle=2, stream=100)
-
-    assert calls == [(1, 100), (1, 100), (2, 100)]
+def test_raw_int_handle_rejected():
+    # The Python API creates handles only via cudnn.create_handle() (-> Handle), so a
+    # raw backend int is a mistake and is rejected rather than silently opting out of
+    # the Handle's device/stream tracking.
+    for call in (
+        lambda: cudnn.set_stream(handle=1, stream=100),
+        lambda: cudnn.get_stream(1),
+        lambda: cudnn.destroy_handle(1),
+    ):
+        with pytest.raises(TypeError, match="cudnn.Handle"):
+            call()
 
 
 def test_destroy_handle_clears_backend_handle(monkeypatch):
@@ -59,23 +58,3 @@ def test_destroy_handle_clears_backend_handle(monkeypatch):
     cudnn.destroy_handle(h)
     cudnn.set_stream(h, 200)
     assert destroyed == [0x777]  # no second destroy call
-
-
-def test_destroy_foreign_int_forwards_to_backend(monkeypatch):
-    destroyed = []
-    monkeypatch.setattr(cudnn._pybind_module, "_raw_destroy_handle", lambda h: destroyed.append(h))
-
-    cudnn.destroy_handle(99)  # foreign raw-int handle -> destroyed directly
-
-    assert destroyed == [99]
-
-
-def test_handle_and_foreign_int_are_independent(monkeypatch):
-    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: None)
-
-    h = cudnn.Handle(backend_handle=42)
-    cudnn.set_stream(h, 100)  # Handle path -> stored on the object
-    cudnn.set_stream(42, 100)  # foreign int 42 -> forwarded, independent of the Handle object
-
-    assert h.stream == 100
-    assert cudnn.get_stream(h) == 100  # from the object, not any shared registry

--- a/test/python/test_set_stream_cache.py
+++ b/test/python/test_set_stream_cache.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cudnn.set_stream caches the last stream per handle and skips the backend call
+(cudnnSetStream, which re-issues several CUDA driver queries every call) when the
+stream has not changed. These tests mock the raw backend call, so no GPU is needed."""
+
+import pytest
+
+import cudnn
+
+pytestmark = pytest.mark.L0
+
+
+def test_set_stream_skips_backend_call_when_unchanged(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: calls.append((h, s)))
+    cudnn._handle_to_stream.clear()
+
+    cudnn.set_stream(handle=1, stream=100)
+    cudnn.set_stream(handle=1, stream=100)  # unchanged -> skipped
+    cudnn.set_stream(handle=1, stream=200)  # changed -> forwarded
+    cudnn.set_stream(handle=2, stream=100)  # different handle -> forwarded
+
+    assert calls == [(1, 100), (1, 200), (2, 100)]
+
+
+def test_destroy_handle_forgets_cached_stream(monkeypatch):
+    calls = []
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: calls.append((h, s)))
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_destroy_handle", lambda h: None)
+    cudnn._handle_to_stream.clear()
+
+    cudnn.set_stream(handle=7, stream=100)
+    cudnn.destroy_handle(7)
+    cudnn.set_stream(handle=7, stream=100)  # a reused handle address must re-arm the backend
+
+    assert calls == [(7, 100), (7, 100)]

--- a/test/python/test_set_stream_cache.py
+++ b/test/python/test_set_stream_cache.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""cudnn.set_stream caches the last stream per handle and skips the backend call
+"""cudnn.set_stream remembers the last stream per handle and skips the backend call
 (cudnnSetStream, which re-issues several CUDA driver queries every call) when the
-stream has not changed. These tests mock the raw backend call, so no GPU is needed."""
+stream has not changed. A cudnn.Handle remembers on itself; a foreign raw-int handle
+uses the module registry. These tests mock the raw backend call, so no GPU is needed."""
 
 import pytest
 
@@ -36,3 +37,37 @@ def test_destroy_handle_forgets_cached_stream(monkeypatch):
     cudnn.set_stream(handle=7, stream=100)  # a reused handle address must re-arm the backend
 
     assert calls == [(7, 100), (7, 100)]
+
+
+def test_handle_carries_its_own_stream_not_the_registry(monkeypatch):
+    # A cudnn.Handle remembers its stream on the object; the module registry stays untouched.
+    streams = []
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: streams.append(s))
+    cudnn._handle_to_stream.clear()
+
+    h = cudnn.Handle(backend_handle=0xABC)  # no GPU: only forwarded to the mocked backend call
+    cudnn.set_stream(h, 100)
+    cudnn.set_stream(h, 100)  # unchanged -> skipped
+    cudnn.set_stream(h, 200)  # changed -> forwarded
+
+    assert streams == [100, 200]
+    assert h.stream == 200
+    assert cudnn.get_stream(h) == 200  # read comes from the object, no backend query
+    assert cudnn._handle_to_stream == {}  # a Handle never touches the foreign-int registry
+
+
+def test_handle_and_foreign_int_do_not_collide(monkeypatch):
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_set_stream", lambda h, s: None)
+    monkeypatch.setattr(cudnn._pybind_module, "_raw_destroy_handle", lambda h: None)
+    cudnn._handle_to_stream.clear()
+
+    h = cudnn.Handle(backend_handle=42)
+    cudnn.set_stream(h, 100)  # Handle path -> stored on the object
+    cudnn.set_stream(42, 100)  # foreign int 42 -> registry, independent of the Handle
+
+    assert h.stream == 100
+    assert cudnn._handle_to_stream == {42: 100}
+
+    cudnn.destroy_handle(h)
+    assert h.stream is None
+    assert cudnn._handle_to_stream == {42: 100}  # destroying the Handle leaves the int registry alone


### PR DESCRIPTION
Full-suite alternative to #611 (first-class `cudnn.Handle`); #611 stays open as the minimal, low-risk fallback. **Exactly one merges.**

## What

Make `cudnn.create_handle()` return a first-class `Handle` object instead of a bare int, giving the handle a home for the per-handle state that had accreted as side tables and per-engine queries:
- **stream** — the module-global `_handle_to_stream` cache (#611) moves onto `Handle.stream`;
- **device** — the three parallel device stacks (backend handle; pygraph's `sm_count`/`sm_version`/`device_property` args; frost's own `current_device()` + driver introspection) unify behind `Handle.device`.

The naming anticipates the front end being "cudnn" and today's cuDNN becoming "cudnn backend": this object is the `handle`; the wrapped `cudnnHandle_t` is its `backend_handle`. It is **optional** by design — python engines (frost, cutedsl, linear-attention) need device+stream, not a `cudnnHandle_t`.

The C++ boundary mirrors the backend's own model: a device is carried as `CUDNN_BACKEND_DEVICEPROP_DESCRIPTOR` through the whole build/compile chain (engine / heuristic / execution-plan), and the handle is needed only to populate that descriptor or, at execute, to supply the stream. This PR is the Python analog: `Handle.device` (a `DeviceInfo`) is the device concept threaded into the python engines' build; the handle is consulted for the stream at execute.

Design + a full call-site inventory: [docs/handle_first_class_design.md](docs/handle_first_class_design.md).

## Backward compatibility — transparent for normal use

Every handle-taking cudnn API (`execute`, `set_stream`, `get_stream`, `destroy_handle`, all graph methods) is Handle-aware — the backend handle is extracted **explicitly** via `to_backend_handle(h)` at each named handoff. `Handle` has the dunders the real usage needs: truthy (`if handle:`), identity hash (dict key), identity eq (compares cleanly against `'auto'`/`None` sentinels). Both directions work: a Handle from `create_handle()`, and a foreign raw-int `cudnnHandle_t` a framework created via the C API (isinstance → registry + live `cudnnGetStream`).

The one deliberate change: `Handle` has **no `__index__`/`__int__`**, so code that used the handle as a *raw integer* (`int(handle)`, passing it to a non-FE C API expecting `intptr_t`, integer arithmetic) must read `handle.backend_handle`. This is fail-loud by design — a Handle reaching a binding unconverted raises rather than being silently coerced. A repo-wide grep (python + tests + samples) found **zero** such patterns.

## Landed (all validated)

**Handle core** (`_handle.py`, `__init__.py`): explicit `to_backend_handle(h)` at every handoff (grep `backend_handle` to trace it; an inventory confirmed the set is closed — the `__getattr__` delegation carries no handle). `Handle.stream` is the source of truth (absorbs the write-only `_handle_to_stream`); `get_stream()` reads it with no `cudnnGetStream` round-trip, removing the live query `_resolve_stream` did on every python-engine execute. Passthrough methods (`get_workspace_size{,_plan_at_index}`, `populate/update_cuda_graph`) name `handle`/overrides explicitly (no `*args`); `deserialize` stays a genuine data-or-handle passthrough. Carries #611 (set_stream idempotency + skip the discarded per-call `execute()` context).

**Common device layer** (`_device.py`): `DeviceInfo` is the FE's single owner of a GPU's facts — each fact a `@cached_property` queried once and cached on the instance, one instance per ordinal. `Handle.device` is it; `frost/device.py`'s fact functions become thin shims onto it (its ~24-file / 65-site surface unchanged), so frost consumes the same object instead of a parallel introspection stack.

**Environment layer** (`_env.py`): CUDA driver/runtime versions are process-global, not per-device — collected here (mirroring the backend's argument-less `cudnnGetVersion`/`cudnnGetCudartVersion`), replacing the inline `cuDriverGetVersion` gate in `DeviceInfo` and the duplicated `cudaRuntimeGetVersion` probes in the cutile GDN/KDA engines.

**Device-consumer adoption (frost / linear-attention)**: a `build_device(ordinal)` scope, set once at each engine's `build_plan` hinge from `ctx.handle.device.ordinal`, makes every device-derived build constant follow the handle's GPU. All three tiers now read through the one scope: the engine (`current_device()`), the tile/arch codegen, and the GDN/GDN2/KDA **kernels** (their baked persistent-grid `num_sm`/`max_active_clusters`, previously read off a scope-blind `cudaGetDevice`). `_check_plan_device` stays the execute-time launch guard. sdpa engines need nothing (no device constant baked at build).

## Execute hot-path overhead (measured, parley)

The Handle removes per-execute host work on the python-engine path (frost / LA / cutedsl):
- **stream resolve** `cudnnGetStream` (~1.5 µs) → `handle.stream` attribute;
- **discarded per-execute `_build_context` rebuild** removed (~2.3 µs; from #611);
- **ExecutionContext** frozen-dataclass → `NamedTuple` (still immutable) + `import cudnn` hoisted out of `_resolve_stream`: `_build_context` 647 → 427 ns.

Net: python-engine execute saves **~4.0 µs/execute** vs develop; classic backend execute saves **~2.3 µs** (the shared discarded-rebuild removal; `to_backend_handle` adds a negligible ~65 ns).

## Validation (SM100 parley, fe-jax test bed)

`test_la` 359 / 0 · frost gemm 5805 / 0 · `test_set_stream_cache` 4 · `test_device_info` 3 · `test_build_device` cross-device redirect 3 (scopes a build to L40S/H100/A100 and asserts every frost constant follows — proves device-follows-handle without two Blackwells) · matmul/conv/rope 41 · deviceless-AOT deserialize + workspace passthrough green. The 4 `test_block_scale_quantize_dynamic_shape` failures are pre-existing (override-shape needs cuDNN ≥ 9.21; local backend is 9.20 — identical on develop).

---
<sub>note to self: claude::11323ca1-07bc-4fc4-8ec7-ba95d8f061d8 — first-class cudnn.Handle. cwd /home/scratch.yanxu_libs/cudnn_frontend · worktree /home/scratch.yanxu_gpu/fe-handle</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class `cudnn.Handle` objects with device and stream tracking.
  * Added device information and CUDA environment APIs.
  * Added device-scoped Frost builds with architecture-aware compilation.
  * Preserved compatibility with raw integer handles.
  * Added explicit handle support for workspace sizing and CUDA graph operations.
* **Bug Fixes**
  * Improved stream caching and handle cleanup.
  * Ensured plan construction uses the handle’s associated device when available.
* **Documentation**
  * Added a design specification covering handle, device, stream, and build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->