### PR TITLE
frost: fix oversized-SMEM query crashing all frost GEMM on CUDA<13.4 cuda-python

### DIFF
--- a/python/cudnn/frost/device.py
+++ b/python/cudnn/frost/device.py
@@ -119,20 +119,22 @@ def shared_memory_per_block_optin(device: int) -> int:
     return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, handle)))
 
 
-# CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK. Named in CUDA 13.4's
-# cuda.h; cuda-python's CUdevice_attribute does not carry it yet, so ask by ordinal.
-_ATTR_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK = 150
-
-
 @functools.lru_cache(maxsize=None)
 def oversized_shared_memory_per_block(device: int) -> int:
     """Per-CTA SMEM ceiling in the *oversized* carveout (327 KiB vs the 227 KiB
     opt-in limit on SM 10.7), which the part gives by shrinking L1 to 8 kB — free for
     a TMA-fed GEMM. 0 when the driver has no such mode."""
     drv = _driver()
+    # CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK arrived in CUDA 13.4.
+    # A driver older than that has no such mode -> 0 by design (not an error), and we
+    # do not touch the enum member (which an older cuda-python's CUdevice_attribute
+    # does not carry -- passing a bare ordinal would raise, since the binding reads
+    # attrib.value). From 13.4 the attribute is real: query it and let a genuine
+    # failure raise rather than masking it as 0.
+    if int(_ck(*drv.cuDriverGetVersion())) < 13040:
+        return 0
     handle = _device_handle(device)
-    err, value = drv.cuDeviceGetAttribute(_ATTR_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, handle)
-    return int(value) if int(err) == 0 else 0
+    return int(_ck(*drv.cuDeviceGetAttribute(drv.CUdevice_attribute.CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK, handle)))
 
 
 @functools.lru_cache(maxsize=None)


### PR DESCRIPTION
## What

`frost/device.py:oversized_shared_memory_per_block()` passed a **bare attribute ordinal** (`150` = `CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK`, added in CUDA 13.4) to cuda-python's `cuDeviceGetAttribute`. That binding is strongly typed on the attribute — internally it reads `attrib.value` — so a bare `int` (for an enum member the installed cuda-python does not carry; 13.0.2 tops out at 148) raises `'int' object has no attribute 'value'`.

The query sits on the tile-selection **hot path** (`_sm_smem_budget_bytes_of`), so this one call takes down **every** frost GEMM kernel.

## Impact (regression, introduced in #593)

On `develop` tip, the frost gemm suite is **5641 failed / 163 passed**, all with that single error signature. 40 commits earlier (before #593 added this query) `test_matmul.py` was **3398 passed / 0 failed** on the same venv + the same public `nvidia-cutlass-dsl` 4.7.0 wheel — so the earlier "public cutlass lacks an nv-internal DSL surface" read was wrong; this is the sole cause.

Root cause verified directly: cuda-python 13.0.2 `CUdevice_attribute` max ordinal = 148 (no 150); the enum member is absent; `cuDeviceGetAttribute(150, dev)` → the exact `AttributeError`.

## Fix

**Gate on the driver's CUDA version.** The attribute arrived in CUDA 13.4:

- **driver < 13.4** → no such mode → return `0` **by design** (not an error), and the enum member — which an older cuda-python lacks — is never touched.
- **driver ≥ 13.4** → the attribute is real → query it via the proper `CUdevice_attribute` enum and let a genuine failure **raise** rather than masking it as `0`.

This keeps "expected absence" (below 13.4) distinct from an unexpected driver error — no blanket error-swallowing — and needs no `ctypes` / bare-ordinal workaround. The one environment that surfaces an error is a driver ≥ 13.4 paired with a cuda-python too old to name the attribute (a mismatched install), which is a real problem worth surfacing, not silently degrading.

## Validation

| | result |
|---|---|
| frost gemm suite, fe venv, public cutlass 4.7.0 | **5804 passed / 0 failed** (was 5641 failed / 163 passed) |
| `test_public_execute_flavors.py`, py3.12 (fe-jax, driver 13.2 → returns 0) | **30 passed / 0 failed** |
| distinct error signatures | **0** |

Cost: build-time (tile selection) + `@lru_cache`d per device — **0.38 µs** first call, **50 ns** cached, never on the execute path.

---
<sub>note to self: claude::11323ca1-07bc-4fc4-8ec7-ba95d8f061d8 — frost oversized-SMEM cuda-python fix (driver-version gate). cwd /home/scratch.yanxu_libs/cudnn_frontend</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when checking oversized shared-memory limits across CUDA driver versions.
  * Older CUDA drivers now safely report zero for unsupported limits.
  * Supported drivers now provide the detected limit accurately, while driver-related errors are surfaced instead of being silently converted to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->