### PR TITLE
frost(sdpa): retire the bottom_right_with_swa notch — every row serves BR + SWA

### DIFF
--- a/python/cudnn/frost/README.md
+++ b/python/cudnn/frost/README.md
@@ -506,7 +506,7 @@ expressible, with one discipline separating them:
 - The box is pure data: per-axis fields on `Capabilities`. Covers most of the
   surface; adding an engine is writing a row, not logic.
 - A notch is a rule in `mismatch()` gated by a conjunction flag on the row
-  (e.g. `bottom_right_with_swa: bool`). The matcher encodes the SHAPE of the
+  (e.g. `bottom_right_padded_seq_q: bool`). The matcher encodes the SHAPE of the
   interaction once; each engine's row supplies the VERDICT. When a future
   kernel supports the conjunction, flip its flag -- never edit the matcher.
   This is what keeps interaction checks from regressing into a per-engine

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -140,7 +140,6 @@ class Capabilities:
 
     causal: bool = False
     bottom_right: bool = False
-    bottom_right_with_swa: bool = False  # kernel gap: BR diagonal excludes SWA
     # Kernel gap (pre-existing): for a DENSE padded graph the BR diagonal is
     # computed as seq_len_kv[b] - GLOBAL S_q, but cuDNN semantics for a dense
     # padded graph carrying per-batch seq_len_q anchor it at
@@ -357,8 +356,6 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
             return "bottom-right alignment requires a causal upper bound (plain or right-widened)"
         if not capabilities.bottom_right:
             return "graph uses bottom-right causal, which this kernel does not support"
-        if facts.window_left is not None and not capabilities.bottom_right_with_swa:
-            return "bottom-right causal combined with a sliding window is not supported"
         if facts.padded and not facts.thd and facts.seq_q_t is not None and not capabilities.bottom_right_padded_seq_q:
             return (
                 "bottom-right causal with a dense padding mask carrying per-batch seq_len_q is not "
@@ -410,7 +407,6 @@ def _sm100_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
             dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
             causal=True,
             bottom_right=True,
-            bottom_right_with_swa=True,
             right_band_widening=True,
             swa=True,
             padded=True,
@@ -460,9 +456,6 @@ def _sm100_mxfp8_spec(d: int) -> EngineSpec:
             is_mxfp8=True,
             causal=True,
             bottom_right=True,
-            # BR+SWA stays off this row: the one mhas graph it admits trips the
-            # mxfp8 executor's SF-size mismatch (pre-existing SF-layout issue,
-            # independent of the mask) — flip once that plumbing is fixed.
             right_band_widening=True,
             swa=True,
             padded=True,
@@ -501,7 +494,6 @@ def _sm100_fp8_spec(d: int) -> EngineSpec:
             is_fp8=True,
             causal=True,
             bottom_right=True,
-            bottom_right_with_swa=True,
             right_band_widening=True,
             swa=True,
             padded=True,
@@ -556,7 +548,6 @@ def _sm80_spec() -> EngineSpec:
             right_band_widening=True,
             causal=True,
             bottom_right=True,
-            bottom_right_with_swa=True,
             bottom_right_padded_seq_q=True,
             swa=True,
             padded=True,
@@ -652,7 +643,6 @@ def _sm120_spec() -> EngineSpec:
             dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
             causal=True,
             bottom_right=True,
-            bottom_right_with_swa=True,
             bottom_right_padded_seq_q=True,
             swa=True,
             right_band_widening=True,
@@ -987,7 +977,6 @@ def _sm120_fp8_spec() -> EngineSpec:
             is_fp8=True,
             causal=True,
             bottom_right=True,
-            bottom_right_with_swa=True,
             bottom_right_padded_seq_q=True,
             swa=True,
             padded=True,


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

FROST engine capabilities (`python/cudnn/sdpa/fwd/engines.py`) + the frost README's notch example.

## Summary

Retire the `bottom_right_with_swa` capability notch — every row now serves the conjunction.

The notch guarded exactly one kernel gap: the mxfp8 row kept it off with a note to flip it "once that plumbing is fixed" — the plumbing being the `_reshape_sf` SF-size mismatch (B read from the bound tensor's shape, misread for flat F8_128x4 bindings), fixed in #606's mxfp8 commit. With that gone, all six `bottom_right` rows (SM100 f16/fp8/mxfp8, SM80, SM120 f16/fp8) serve BR + SWA and the flag differentiates nothing, so instead of flipping the last row on, this removes the field, its `mismatch()` rule, and the five constant-True spec lines.

The frost README's "notch" design example now points at `bottom_right_padded_seq_q` — a live notch (on for SM80/SM120, off for the three SM100 rows, whose kernels anchor the BR diagonal at the global S_q). The two probe tests pinning BR+SWA acceptance (`test_probe_accepts_bottom_right_with_swa`, `test_sm120_probe_accepts_bottom_right_with_swa`) are unchanged — they assert behavior, not the flag.

## Validation

B200, cuDNN 9.26 nightly: graph-analyzer probe suite + full `test_sdpa_mxfp8_fwd_L0` + `test_sdpa_mxfp8_bwd_L0` sweeps — the mxfp8 engine serves the newly admitted BR+SWA config with numerics green against the fp32 reference (routing count 2, up from 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
