### PR TITLE
fix missing attribute in Rubin grouped dGLU

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_rubin.py
@@ -290,6 +290,7 @@ class BlockScaledMoEGroupedGemmDgluKernel:
 
         self.sf_vec_size = sf_vec_size
         self.expert_cnt = expert_cnt
+        self.use_single_group_runtime_offsets = use_single_group_runtime_offsets
         self.acc_dtype: Type[cutlass.Numeric] = acc_dtype
         self.use_2cta_instrs = use_2cta_instrs
         self.cluster_shape_mn = cluster_shape_mn


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- Python API or bindings

## Summary

A variable wasn't assigned to an attribute, so we hit a missing attribute later in the code.

Traceback snippet:

```
15:   File "/usr/local/lib/python3.12/dist-packages/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_rubin.py", line 2126, in kernel
15:     if cutlass.const_expr(self.use_single_group_runtime_offsets):
15:                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
15: AttributeError: 'BlockScaledMoEGroupedGemmDgluKernel' object has no attribute 'use_single_group_runtime_offsets'
```

## Related PRs

Related to #588 and #590.

## Testing

I ran our failing training runs with this patch and they worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Preserved the single-group runtime offsets configuration for use during kernel execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->