### PR TITLE
fix: bind a CUDA context on the calling thread — the right one, and on both sides of the boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Python (editable; compiles the pybind11 extension via CMake):
 ```bash
 pip install -e .              # core graph API only
 pip install -e ".[cutedsl]"   # + OSS CuTeDSL kernels (nvidia-cutlass-dsl, cuda-python, tvm-ffi; framework-neutral)
+pip install -e ".[cutile]"    # + the cuTile linear-attention engines (cuda-tile; needs a system tileiras)
 pip install --group torch      # + torch for the CuTeDSL APIs (torch, torch-c-dlpack-ext)
 pip install --group jax        # + jax for the CuTeDSL APIs (jax >= 0.5; XLA entry points via cutlass.jax)
 ```

--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -1456,8 +1456,10 @@ class Graph : public ICudnn, public INode {
                           std::vector<std::vector<int64_t>> const &override_strides = {}) const {
         // The driver-API engines read the calling THREAD's context stack, and a
         // thread that has done no CUDA work yet (a PyTorch autograd worker) has
-        // none. All roads reach here, so every backend and OSS execute is covered.
-        {
+        // none. All roads reach here, so every execute is covered; the steady
+        // state is one cuCtxGetCurrent, and the stream query only runs when a
+        // context actually has to be established.
+        if (!detail::has_current_context()) {
             cudaStream_t stream = nullptr;
             detail::get_stream(handle, &stream);
             detail::ensure_current_context(stream);

--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -1454,6 +1454,15 @@ class Graph : public ICudnn, public INode {
                           std::vector<int64_t> const &override_uids                 = {},
                           std::vector<std::vector<int64_t>> const &override_shapes  = {},
                           std::vector<std::vector<int64_t>> const &override_strides = {}) const {
+        // The driver-API engines read the calling THREAD's context stack, and a
+        // thread that has done no CUDA work yet (a PyTorch autograd worker) has
+        // none. All roads reach here, so every backend and OSS execute is covered.
+        {
+            cudaStream_t stream = nullptr;
+            detail::get_stream(handle, &stream);
+            detail::ensure_current_context(stream);
+        }
+
         // Lazy init: prepare template if not done (e.g. deserialized graphs, build_plan_at_index)
         if (!varpack_prep_state->prepared.load(std::memory_order_acquire)) {
             CHECK_CUDNN_FRONTEND_ERROR(const_cast<Graph *>(this)->prepare_variant_pack_template());

--- a/include/cudnn_frontend_shim.h
+++ b/include/cudnn_frontend_shim.h
@@ -471,6 +471,24 @@ get_driver_entry_point(const char *name) {
 #endif
 }
 
+// True when the calling thread already has a context. One driver call, so the
+// execute path can skip the rest -- including the stream query -- in the steady
+// state.
+inline bool
+has_current_context() {
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 12000
+    using PfnCtxGetCurrent            = CUresult(CUDAAPI *)(CUcontext *);
+    static const auto ctx_get_current = reinterpret_cast<PfnCtxGetCurrent>(get_driver_entry_point("cuCtxGetCurrent"));
+    if (ctx_get_current == nullptr) {
+        return true;  // cannot tell; leave the thread alone
+    }
+    CUcontext current = nullptr;
+    return ctx_get_current(&current) == CUDA_SUCCESS && current != nullptr;
+#else
+    return true;
+#endif
+}
+
 // Bind a driver context to the calling thread when it has none: a driver-API
 // launch reads that stack, and a thread that has done no CUDA work has nothing
 // on it (a PyTorch autograd worker). A bound context is left alone -- it is

--- a/include/cudnn_frontend_shim.h
+++ b/include/cudnn_frontend_shim.h
@@ -417,6 +417,122 @@ cuda_get_device(int *device) {
     NV_FE_CALL_TO_CUDA(cuda_get_device, cudaGetDevice, device);
 }
 
+// Driver entry points resolved through the runtime, so the front end never links
+// libcuda.so -- the same approach as cu_tensor_map_encode_tiled(). Returns
+// nullptr when the entry point is unavailable.
+inline void *
+get_driver_entry_point(const char *name) {
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 12000
+    void *pfn = nullptr;
+    cudaDriverEntryPointQueryResult query_result;
+    cudaError_t err;
+#if defined NV_CUDNN_FRONTEND_USE_DYNAMIC_LOADING
+#if CUDART_VERSION >= 12080
+    using GetEntryPointFn =
+        cudaError_t (*)(const char *, void **, unsigned int, int, cudaDriverEntryPointQueryResult *);
+    const char *resolver = "cudaGetDriverEntryPointByVersion";
+#else
+    using GetEntryPointFn =
+        cudaError_t (*)(const char *, void **, unsigned long long, cudaDriverEntryPointQueryResult *);
+    const char *resolver = "cudaGetDriverEntryPoint";
+#endif
+    GetEntryPointFn get_entry_point = nullptr;
+    // get_cuda_symbol throws when the library or symbol is missing; this lookup is
+    // best-effort and runs inside a static initializer, so it must not escape.
+#ifndef NV_CUDNN_DISABLE_EXCEPTION
+    try {
+        get_entry_point = reinterpret_cast<GetEntryPointFn>(get_cuda_symbol(CudaLibrary::CUDART, resolver));
+    } catch (...) {
+        return nullptr;
+    }
+#else
+    get_entry_point = reinterpret_cast<GetEntryPointFn>(get_cuda_symbol(CudaLibrary::CUDART, resolver));
+#endif
+    if (get_entry_point == nullptr) {
+        return nullptr;
+    }
+#if CUDART_VERSION >= 12080
+    err = get_entry_point(name, &pfn, 12000, cudaEnableDefault, &query_result);
+#else
+    err = get_entry_point(name, &pfn, cudaEnableDefault, &query_result);
+#endif
+#elif CUDART_VERSION >= 12080
+    err = cudaGetDriverEntryPointByVersion(name, &pfn, 12000, cudaEnableDefault, &query_result);
+#else
+    err = cudaGetDriverEntryPoint(name, &pfn, cudaEnableDefault, &query_result);
+#endif
+    if (err != cudaSuccess || query_result != cudaDriverEntryPointSuccess) {
+        return nullptr;
+    }
+    return pfn;
+#else
+    (void)name;
+    return nullptr;
+#endif
+}
+
+// Bind a driver context to the calling thread when it has none: a driver-API
+// launch reads that stack, and a thread that has done no CUDA work has nothing
+// on it (a PyTorch autograd worker). A bound context is left alone -- it is
+// process-wide and the caller chose it. A real stream names the right context;
+// the default-stream handles name none, so the runtime's device decides there.
+// Best-effort: what this cannot establish fails at the launch.
+inline void
+ensure_current_context(cudaStream_t stream) {
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 12000
+    using PfnCtxGetCurrent    = CUresult(CUDAAPI *)(CUcontext *);
+    using PfnCtxSetCurrent    = CUresult(CUDAAPI *)(CUcontext);
+    using PfnStreamGetCtx     = CUresult(CUDAAPI *)(CUstream, CUcontext *);
+    using PfnDeviceGet        = CUresult(CUDAAPI *)(CUdevice *, int);
+    using PfnPrimaryCtxRetain = CUresult(CUDAAPI *)(CUcontext *, CUdevice);
+
+    // Thread-safe static initialization (C++11): the lookups happen once.
+    static const auto ctx_get_current = reinterpret_cast<PfnCtxGetCurrent>(get_driver_entry_point("cuCtxGetCurrent"));
+    static const auto ctx_set_current = reinterpret_cast<PfnCtxSetCurrent>(get_driver_entry_point("cuCtxSetCurrent"));
+    static const auto stream_get_ctx  = reinterpret_cast<PfnStreamGetCtx>(get_driver_entry_point("cuStreamGetCtx"));
+    static const auto device_get      = reinterpret_cast<PfnDeviceGet>(get_driver_entry_point("cuDeviceGet"));
+    static const auto primary_retain =
+        reinterpret_cast<PfnPrimaryCtxRetain>(get_driver_entry_point("cuDevicePrimaryCtxRetain"));
+    if (ctx_get_current == nullptr || ctx_set_current == nullptr) {
+        return;
+    }
+
+    CUcontext current = nullptr;
+    if (ctx_get_current(&current) == CUDA_SUCCESS && current != nullptr) {
+        return;
+    }
+
+    const bool names_a_context = stream != nullptr && stream != reinterpret_cast<cudaStream_t>(CU_STREAM_LEGACY) &&
+                                 stream != reinterpret_cast<cudaStream_t>(CU_STREAM_PER_THREAD);
+    if (names_a_context && stream_get_ctx != nullptr) {
+        CUcontext stream_ctx = nullptr;
+        if (stream_get_ctx(reinterpret_cast<CUstream>(stream), &stream_ctx) == CUDA_SUCCESS && stream_ctx != nullptr) {
+            ctx_set_current(stream_ctx);
+            return;
+        }
+    }
+
+    if (device_get == nullptr || primary_retain == nullptr) {
+        return;
+    }
+    int ordinal = 0;
+    if (cuda_get_device(&ordinal) != cudaSuccess) {
+        return;
+    }
+    CUdevice device = 0;
+    if (device_get(&device, ordinal) != CUDA_SUCCESS) {
+        return;
+    }
+    // Retained for the process lifetime, like the primary context itself.
+    CUcontext primary = nullptr;
+    if (primary_retain(&primary, device) == CUDA_SUCCESS) {
+        ctx_set_current(primary);
+    }
+#else
+    (void)stream;
+#endif
+}
+
 inline cudaError_t
 cuda_pointer_get_attributes(cudaPointerAttributes *attributes, const void *ptr) {
     NV_FE_CALL_TO_CUDA(cuda_pointer_get_attributes, cudaPointerGetAttributes, attributes, ptr);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,16 @@ cutedsl = [
     "cuda-python",
     "apache-tvm-ffi>=0.1.11",
 ]
+cutile = [
+    # The cuTile linear-attention engines. Base cuda-tile only -- its [tileiras]
+    # extra pins cuda-toolkit>=13.2,<13.4, and that upper bound would cap the
+    # whole environment's toolkit and shut out CUDA 12 entirely. Without it,
+    # cuda.tile falls back to a system `tileiras`, the same way this package
+    # already leaves GPU wheels to the user. Engines that cannot import the
+    # runtime decline in check_support, so a missing compiler costs those
+    # engines and nothing else.
+    "cuda-tile>=1.4; python_version >= '3.10'",
+]
 
 [dependency-groups]
 dev = [

--- a/python/cudnn/_device.py
+++ b/python/cudnn/_device.py
@@ -59,38 +59,101 @@ def _device_handle(device: int):
     return _ck(*drv.cuDeviceGet(device))
 
 
-def ensure_current_context(stream=None) -> None:
-    """Bind a driver context to the calling thread when none is bound.
+@functools.lru_cache(maxsize=1)
+def _default_streams() -> frozenset:
+    """Stream handles that name no context of their own. ``cuStreamGetCtx``
+    answers for the CALLING THREAD's current context on all of them, so they
+    cannot say which GPU the work belongs to."""
+    drv = _driver()
+    if drv is None:
+        return frozenset({0})
+    return frozenset({0, int(drv.CU_STREAM_LEGACY), int(drv.CU_STREAM_PER_THREAD)})
 
-    JIT engines talk to the driver directly, which reads the calling THREAD's
-    context stack — and an autograd backward runs on a worker thread where
-    ``cudaSetDevice`` has only moved the runtime's thread-local slot. Prefer
-    the stream's context, else retain the runtime-current device's primary one
-    (the retain ref is held for the process lifetime, like the primary context
-    itself). Best-effort: a context this cannot establish fails at the launch,
-    with the launch's own diagnostics."""
+
+@functools.lru_cache(maxsize=None)
+def _primary_context(device: int):
+    """This process's retained primary context for ``device``, or ``None``.
+
+    Retained once per ordinal and held for the process lifetime, like the
+    primary context itself: a retain per execute would grow the usage count
+    without bound, and holding one is what makes caching the handle safe."""
+    drv = _driver()
+    if drv is None:
+        return None
+    err, handle = drv.cuDeviceGet(device)
+    if int(err) != 0:
+        return None
+    err, primary = drv.cuDevicePrimaryCtxRetain(handle)
+    return primary if int(err) == 0 else None
+
+
+def _runtime_device():
+    """Ordinal the CUDA *runtime* holds current on this thread, or ``None``.
+
+    The driver cannot answer this: ``cudaSetDevice`` moves a runtime
+    thread-local slot and binds no context, which is exactly the state
+    :func:`ensure_current_context` exists to repair."""
     try:
-        drv = _driver()
-        if drv is None:
-            return
-        err, cur = drv.cuCtxGetCurrent()
-        if int(err) == 0 and int(cur) != 0:
-            return
-        if stream:
-            err, sctx = drv.cuStreamGetCtx(int(stream))
-            if int(err) == 0:
-                drv.cuCtxSetCurrent(sctx)
-                return
         import cuda.bindings.runtime as rt
+    except ImportError:
+        return None
 
-        err, device = rt.cudaGetDevice()
-        if int(err) != 0:
+    err, device = rt.cudaGetDevice()
+    return int(device) if int(err) == 0 else None
+
+
+def ensure_current_context(stream=None, device=None) -> None:
+    """Bind the context this work runs in to the calling thread.
+
+    JIT engines reach the driver directly (``cuTensorMapEncodeTiled``,
+    ``cuLaunchKernelEx``, the cuTile launcher) and the driver reads the CALLING
+    thread's context stack, and a PyTorch autograd backward runs on a worker
+    thread whose stack is empty (measured: ``cuCtxGetCurrent()`` is 0 inside
+    ``backward()``), so the first driver call there fails with
+    ``CUDA_ERROR_INVALID_CONTEXT``. A runtime-API launch would have bound one as
+    a side effect; a driver-API launch does not.
+
+    *Which* context is right depends on the stream. A real stream carries one,
+    and that is the answer. The default-stream handles (``0``,
+    ``CU_STREAM_LEGACY``, ``CU_STREAM_PER_THREAD``) carry none — they resolve
+    against whatever is current — so there ``device`` decides, and a context on
+    another GPU is replaced rather than accepted. Accepting it is not benign:
+    under a foreign context a default stream runs the work on that context's
+    GPU, where the pointers are invalid, so it surfaces as an async fault at
+    some later sync instead of at the launch. With no ``device`` named there is
+    nothing to correct, so a bound context is left alone and only a cold thread
+    is given one — the rung order ``frost.device.ambient_device`` documents (a
+    bound driver context is process-wide and authoritative; the runtime's
+    thread-local slot is second).
+
+    Best-effort by contract: a context this cannot establish fails at the
+    launch, with the launch's own diagnostics. The primary-context retain is
+    held for the process lifetime, like the primary context itself."""
+    drv = _driver()
+    if drv is None:
+        return
+    err, cur = drv.cuCtxGetCurrent()
+    cur = int(cur) if int(err) == 0 else 0
+    stream = 0 if stream is None else int(stream)
+    if stream not in _default_streams():
+        err, stream_ctx = drv.cuStreamGetCtx(stream)
+        if int(err) == 0 and int(stream_ctx) != 0:
+            if int(stream_ctx) != cur:
+                drv.cuCtxSetCurrent(stream_ctx)
             return
-        err, pctx = drv.cuDevicePrimaryCtxRetain(_device_handle(int(device)))
-        if int(err) == 0:
-            drv.cuCtxSetCurrent(pctx)
-    except Exception:  # noqa: BLE001
-        pass
+    if device is None:
+        if cur:
+            return
+        device = _runtime_device()
+        if device is None:
+            return
+    elif cur:
+        err, cur_device = drv.cuCtxGetDevice()
+        if int(err) == 0 and int(cur_device) == int(device):
+            return
+    primary = _primary_context(int(device))
+    if primary is not None:
+        drv.cuCtxSetCurrent(primary)
 
 
 class DeviceInfo:

--- a/python/cudnn/_device.py
+++ b/python/cudnn/_device.py
@@ -61,9 +61,8 @@ def _device_handle(device: int):
 
 @functools.lru_cache(maxsize=1)
 def _default_streams() -> frozenset:
-    """Stream handles that name no context of their own. ``cuStreamGetCtx``
-    answers for the CALLING THREAD's current context on all of them, so they
-    cannot say which GPU the work belongs to."""
+    """Handles that name no context: ``cuStreamGetCtx`` answers for the calling
+    thread's current context on all of them."""
     drv = _driver()
     if drv is None:
         return frozenset({0})
@@ -72,11 +71,8 @@ def _default_streams() -> frozenset:
 
 @functools.lru_cache(maxsize=None)
 def _primary_context(device: int):
-    """This process's retained primary context for ``device``, or ``None``.
-
-    Retained once per ordinal and held for the process lifetime, like the
-    primary context itself: a retain per execute would grow the usage count
-    without bound, and holding one is what makes caching the handle safe."""
+    """The retained primary context for ``device``, or ``None``. Once per
+    ordinal: a retain per execute would grow the usage count without bound."""
     drv = _driver()
     if drv is None:
         return None
@@ -89,10 +85,7 @@ def _primary_context(device: int):
 
 def _runtime_device():
     """Ordinal the CUDA *runtime* holds current on this thread, or ``None``.
-
-    The driver cannot answer this: ``cudaSetDevice`` moves a runtime
-    thread-local slot and binds no context, which is exactly the state
-    :func:`ensure_current_context` exists to repair."""
+    The driver cannot see that slot."""
     try:
         import cuda.bindings.runtime as rt
     except ImportError:
@@ -105,30 +98,12 @@ def _runtime_device():
 def ensure_current_context(stream=None, device=None) -> None:
     """Bind the context this work runs in to the calling thread.
 
-    JIT engines reach the driver directly (``cuTensorMapEncodeTiled``,
-    ``cuLaunchKernelEx``, the cuTile launcher) and the driver reads the CALLING
-    thread's context stack, and a PyTorch autograd backward runs on a worker
-    thread whose stack is empty (measured: ``cuCtxGetCurrent()`` is 0 inside
-    ``backward()``), so the first driver call there fails with
-    ``CUDA_ERROR_INVALID_CONTEXT``. A runtime-API launch would have bound one as
-    a side effect; a driver-API launch does not.
-
-    *Which* context is right depends on the stream. A real stream carries one,
-    and that is the answer. The default-stream handles (``0``,
-    ``CU_STREAM_LEGACY``, ``CU_STREAM_PER_THREAD``) carry none — they resolve
-    against whatever is current — so there ``device`` decides, and a context on
-    another GPU is replaced rather than accepted. Accepting it is not benign:
-    under a foreign context a default stream runs the work on that context's
-    GPU, where the pointers are invalid, so it surfaces as an async fault at
-    some later sync instead of at the launch. With no ``device`` named there is
-    nothing to correct, so a bound context is left alone and only a cold thread
-    is given one — the rung order ``frost.device.ambient_device`` documents (a
-    bound driver context is process-wide and authoritative; the runtime's
-    thread-local slot is second).
-
-    Best-effort by contract: a context this cannot establish fails at the
-    launch, with the launch's own diagnostics. The primary-context retain is
-    held for the process lifetime, like the primary context itself."""
+    A driver-API launch reads the calling thread's context stack; an autograd
+    backward runs on a worker whose stack is empty. A real stream names the
+    right context; the default-stream handles name none, so ``device`` decides
+    there. With no ``device``, a bound context is authoritative and only a cold
+    thread is given one (``frost.device.ambient_device``'s rung order).
+    Best-effort: what this cannot establish fails at the launch."""
     drv = _driver()
     if drv is None:
         return

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -1780,7 +1780,8 @@ class pygraph:
             # A JIT engine talks to the driver directly, which reads the calling
             # THREAD's context stack -- and an autograd backward runs on a worker
             # thread that has none. Once here, so every python engine is covered.
-            ensure_current_context(ctx.stream)
+            # The handle's device decides when the stream is 0: it names no context.
+            ensure_current_context(ctx.stream, h.device.ordinal if h is not None else None)
             if self._plan_index not in self._compiled_plans:
                 # compile with the CALLER's context (execute-supplied handle
                 # and its stream reach the JIT build)

--- a/python/cudnn/_pygraph.py
+++ b/python/cudnn/_pygraph.py
@@ -1777,10 +1777,9 @@ class pygraph:
         if eng is not None:  # python engine (plan id in the reserved region)
             h = handle if handle is not None else self._handle
             ctx = ExecutionContext(handle=h, stream=self._resolve_stream(h), workspace=workspace)
-            # A JIT engine talks to the driver directly, which reads the calling
-            # THREAD's context stack -- and an autograd backward runs on a worker
-            # thread that has none. Once here, so every python engine is covered.
-            # The handle's device decides when the stream is 0: it names no context.
+            # A JIT engine launches through the driver, which reads the calling
+            # thread's context stack; an autograd worker has none. The handle's
+            # device decides when the stream names no context.
             ensure_current_context(ctx.stream, h.device.ordinal if h is not None else None)
             if self._plan_index not in self._compiled_plans:
                 # compile with the CALLER's context (execute-supplied handle

--- a/test/python/test_ensure_current_context.py
+++ b/test/python/test_ensure_current_context.py
@@ -1,16 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""``ensure_current_context`` binds the context a python plan's work runs in to
-the calling thread. Two halves, and only the first used to hold: a cold thread
-must end up bound at all, and a thread bound to ANOTHER GPU's context must be
-moved off it -- a context is not interchangeable just because it exists.
-
-The second half is not cosmetic. A real stream carries its context, so a
-cross-context launch is rejected outright (``CUDA_ERROR_INVALID_HANDLE``); the
-legacy default stream (handle 0) carries none, and under a foreign context it
-runs the work on THAT context's GPU, where the pointers are invalid -- an async
-fault at some later sync rather than an error at the launch."""
+"""``ensure_current_context`` binds the context a plan's work runs in to the
+calling thread. Two halves, and only the first used to hold: a cold thread must
+end up bound at all, and a thread bound to ANOTHER GPU's context must be moved
+off it. The second is not cosmetic -- a default stream under a foreign context
+runs the work on that context's GPU, where the pointers are invalid."""
 
 import threading
 
@@ -79,9 +74,8 @@ def test_binds_a_cold_thread(drv):
 
 @pytest.mark.parametrize("handle", ["null", "legacy", "per_thread"])
 def test_replaces_a_context_on_another_device(drv, handle):
-    """All three default-stream handles resolve against the CALLING thread's
-    current context, so none of them can name the GPU: the device decides, and a
-    context on the wrong one must be replaced rather than accepted."""
+    """No default-stream handle can name a GPU -- each resolves against the
+    calling thread's current context -- so ``device`` decides."""
     a, b = _two_devices()
     ctx_a, ctx_b = _bind_primary(drv, a), _bind_primary(drv, b)
     assert ctx_a != ctx_b
@@ -94,8 +88,7 @@ def test_replaces_a_context_on_another_device(drv, handle):
 
 
 def test_follows_the_streams_context(drv):
-    """A real stream carries the context the work runs in; it wins over whatever
-    the thread happens to have current."""
+    """A real stream carries its context, and it wins over ``device``."""
     a, b = _two_devices()
     ctx_a, ctx_b = _bind_primary(drv, a), _bind_primary(drv, b)
     stream = drv.cuStreamCreate(0)[1]  # created under ctx_b, so it belongs to it
@@ -109,7 +102,7 @@ def test_follows_the_streams_context(drv):
 
 
 def test_leaves_an_already_correct_context_alone(drv):
-    """The steady state is a no-op: no rebind, no primary-context churn."""
+    """Steady state is a no-op: no rebind, no primary-context churn."""
     ctx = _bind_primary(drv, 0)
     ensure_current_context(0, 0)
     assert _current(drv) == ctx
@@ -118,9 +111,8 @@ def test_leaves_an_already_correct_context_alone(drv):
 
 
 def test_an_unnamed_device_does_not_override_a_bound_context(drv):
-    """With no device named there is nothing to correct: a bound driver context
-    is authoritative (frost.device.ambient_device's first rung), so it must
-    survive even when the runtime's thread-local slot names another GPU."""
+    """No device named means nothing to correct: a bound context is
+    authoritative (``ambient_device``'s first rung)."""
     a, b = _two_devices()
     _bind_primary(drv, a)
     ctx_b = _bind_primary(drv, b)
@@ -132,7 +124,7 @@ def test_an_unnamed_device_does_not_override_a_bound_context(drv):
 
 
 def test_the_primary_context_is_retained_once_per_device(drv):
-    """An unbalanced retain per execute would grow the usage count without bound."""
+    """A retain per execute would grow the usage count without bound."""
     a, b = _two_devices()
     for _ in range(20):  # alternating default-stream execution over two GPUs
         ensure_current_context(0, a)
@@ -143,3 +135,55 @@ def test_the_primary_context_is_retained_once_per_device(drv):
         # the cache instead: one retained handle per ordinal, reused.
         assert _primary_context(ordinal) is _primary_context(ordinal)
         assert int(drv.cuDevicePrimaryCtxGetState(dev)[2]) == 1  # still active, not churned
+
+
+def test_a_backend_graph_runs_on_a_cold_thread(drv):
+    """The C++ execute funnel binds one too, for the same reason.
+
+    cuDNN's runtime-compiled engines launch through the driver and read the
+    calling thread's stack; the precompiled ones go through the runtime and are
+    unaffected, so the fused ``matmul + relu + relu`` is what exercises this."""
+    torch = pytest.importorskip("torch")
+    import cudnn
+
+    if not torch.cuda.is_available():
+        pytest.skip("needs CUDA")
+    if torch.cuda.get_device_capability()[0] < 8:
+        pytest.skip("bf16 matmul needs sm80+")
+    a = torch.randn(1, 128, 128, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(1, 128, 128, device="cuda", dtype=torch.bfloat16)
+    out = torch.empty(1, 128, 128, device="cuda", dtype=torch.bfloat16)
+    torch.cuda.synchronize()
+
+    handle = cudnn.create_handle()
+    try:
+        g = cudnn.pygraph(handle=handle, io_data_type=cudnn.data_type.BFLOAT16, compute_data_type=cudnn.data_type.FLOAT)
+        ta, tb = g.tensor_like(a), g.tensor_like(b)
+        y = g.relu(input=g.relu(input=g.matmul(A=ta, B=tb)))
+        y.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+        try:
+            g.build([cudnn.heur_mode.A])
+        except cudnn.cudnnGraphNotSupportedError as exc:
+            pytest.skip(f"no engine for the fused graph on this arch/backend: {exc}")
+        ws = torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8)
+        pack = {ta: a, tb: b, y: out}
+        g.execute(pack, ws, handle=handle)  # warm, on this thread
+        torch.cuda.synchronize()
+
+        def body(seen):
+            # No torch op before execute -- even out.zero_() binds the context.
+            seen["before"] = _current(drv)
+            try:
+                g.execute(pack, ws, handle=handle)
+            except BaseException as exc:  # noqa: BLE001
+                seen["exc"] = exc
+            seen["after"] = _current(drv)
+
+        seen = _on_a_cold_thread(body)
+        assert seen["before"] == 0, "the worker was already bound, so this no longer covers the cold path"
+        assert seen["after"] != 0
+        torch.cuda.synchronize()
+        expected = torch.relu(torch.relu(a.float() @ b.float()))
+        assert (out.float() - expected).abs().max().item() < 1.0
+    finally:
+        cudnn.destroy_handle(handle)

--- a/test/python/test_ensure_current_context.py
+++ b/test/python/test_ensure_current_context.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``ensure_current_context`` binds the context a python plan's work runs in to
+the calling thread. Two halves, and only the first used to hold: a cold thread
+must end up bound at all, and a thread bound to ANOTHER GPU's context must be
+moved off it -- a context is not interchangeable just because it exists.
+
+The second half is not cosmetic. A real stream carries its context, so a
+cross-context launch is rejected outright (``CUDA_ERROR_INVALID_HANDLE``); the
+legacy default stream (handle 0) carries none, and under a foreign context it
+runs the work on THAT context's GPU, where the pointers are invalid -- an async
+fault at some later sync rather than an error at the launch."""
+
+import threading
+
+import pytest
+
+from cudnn._device import _primary_context, device_count, ensure_current_context, is_available
+
+pytestmark = pytest.mark.L0
+
+
+@pytest.fixture
+def drv():
+    d = pytest.importorskip("cuda.bindings.driver")
+    if not is_available():
+        pytest.skip("no CUDA device")
+    entry = d.cuCtxGetCurrent()[1]
+    yield d
+    d.cuCtxSetCurrent(entry)  # these tests move the thread's context on purpose
+
+
+def _current(drv):
+    err, ctx = drv.cuCtxGetCurrent()
+    return int(ctx) if int(err) == 0 else 0
+
+
+def _bind_primary(drv, ordinal):
+    """Retain ``ordinal``'s primary context and make it current on this thread."""
+    dev = drv.cuDeviceGet(ordinal)[1]
+    ctx = drv.cuDevicePrimaryCtxRetain(dev)[1]
+    drv.cuCtxSetCurrent(ctx)
+    return int(ctx)
+
+
+def _two_devices():
+    if device_count() < 2:
+        pytest.skip("needs two GPUs to tell 'a context' from 'the right context'")
+    return 0, 1
+
+
+def _on_a_cold_thread(body):
+    """Run ``body`` on a thread that has never bound a context. Returns its dict."""
+    seen = {}
+    worker = threading.Thread(target=body, args=(seen,))
+    worker.start()
+    worker.join()
+    if "exc" in seen:
+        raise seen["exc"]
+    return seen
+
+
+def test_binds_a_cold_thread(drv):
+    _bind_primary(drv, 0)  # the process has a context; the worker below does not
+
+    def body(seen):
+        try:
+            seen["before"] = _current(drv)
+            ensure_current_context(0, 0)
+            seen["after"] = _current(drv)
+        except BaseException as exc:  # noqa: BLE001
+            seen["exc"] = exc
+
+    seen = _on_a_cold_thread(body)
+    assert seen["before"] == 0, "the worker was already bound, so this no longer covers the cold path"
+    assert seen["after"] != 0
+
+
+@pytest.mark.parametrize("handle", ["null", "legacy", "per_thread"])
+def test_replaces_a_context_on_another_device(drv, handle):
+    """All three default-stream handles resolve against the CALLING thread's
+    current context, so none of them can name the GPU: the device decides, and a
+    context on the wrong one must be replaced rather than accepted."""
+    a, b = _two_devices()
+    ctx_a, ctx_b = _bind_primary(drv, a), _bind_primary(drv, b)
+    assert ctx_a != ctx_b
+    stream = {"null": 0, "legacy": int(drv.CU_STREAM_LEGACY), "per_thread": int(drv.CU_STREAM_PER_THREAD)}[handle]
+    assert int(drv.cuStreamGetCtx(stream)[1]) == ctx_b  # follows the thread, names nothing
+
+    drv.cuCtxSetCurrent(drv.CUcontext(ctx_a))
+    ensure_current_context(stream, b)
+    assert _current(drv) == ctx_b, "left the thread on another GPU's context"
+
+
+def test_follows_the_streams_context(drv):
+    """A real stream carries the context the work runs in; it wins over whatever
+    the thread happens to have current."""
+    a, b = _two_devices()
+    ctx_a, ctx_b = _bind_primary(drv, a), _bind_primary(drv, b)
+    stream = drv.cuStreamCreate(0)[1]  # created under ctx_b, so it belongs to it
+    try:
+        drv.cuCtxSetCurrent(drv.CUcontext(ctx_a))
+        ensure_current_context(int(stream), a)  # device says a, the stream says b
+        assert _current(drv) == ctx_b, "the stream's context did not win"
+    finally:
+        drv.cuCtxSetCurrent(drv.CUcontext(ctx_b))
+        drv.cuStreamDestroy(stream)
+
+
+def test_leaves_an_already_correct_context_alone(drv):
+    """The steady state is a no-op: no rebind, no primary-context churn."""
+    ctx = _bind_primary(drv, 0)
+    ensure_current_context(0, 0)
+    assert _current(drv) == ctx
+    ensure_current_context(0, 0)
+    assert _current(drv) == ctx
+
+
+def test_an_unnamed_device_does_not_override_a_bound_context(drv):
+    """With no device named there is nothing to correct: a bound driver context
+    is authoritative (frost.device.ambient_device's first rung), so it must
+    survive even when the runtime's thread-local slot names another GPU."""
+    a, b = _two_devices()
+    _bind_primary(drv, a)
+    ctx_b = _bind_primary(drv, b)
+    torch = pytest.importorskip("torch")
+    torch.cuda.set_device(a)  # runtime slot -> a, while the driver context is b's
+    drv.cuCtxSetCurrent(drv.CUcontext(ctx_b))
+    ensure_current_context(0, None)
+    assert _current(drv) == ctx_b, "overrode a bound context on the runtime's word"
+
+
+def test_the_primary_context_is_retained_once_per_device(drv):
+    """An unbalanced retain per execute would grow the usage count without bound."""
+    a, b = _two_devices()
+    for _ in range(20):  # alternating default-stream execution over two GPUs
+        ensure_current_context(0, a)
+        ensure_current_context(0, b)
+    for ordinal in (a, b):
+        dev = drv.cuDeviceGet(ordinal)[1]
+        # cuDevicePrimaryCtxGetState reports active/flags, not the count, so assert
+        # the cache instead: one retained handle per ordinal, reused.
+        assert _primary_context(ordinal) is _primary_context(ordinal)
+        assert int(drv.cuDevicePrimaryCtxGetState(dev)[2]) == 1  # still active, not churned


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- Python API or bindings; FE OSS kernels or CuTeDSL

## Summary

A driver-API launch reads the **calling thread's** context stack, and a thread that has done no CUDA work has nothing on it. Two fixes, one problem, one on each side of the Python/C++ boundary:

- **Python** (`_device.py`, `_pygraph.py`): `ensure_current_context` returned as soon as *any* context was current, so a thread bound to another GPU's context kept it. It now resolves the target instead of accepting the incumbent, and `execute()` passes the handle's device.
- **C++** (`cudnn_frontend_shim.h`, `graph_interface.h`): the backend has the same gap. cuDNN's runtime-compiled engines fail with `CUDA_ERROR_INVALID_CONTEXT` on a genuinely cold thread — measured, 3/3 — and pass as soon as any runtime call touches the thread first. A guard at the C++ execute funnel covers every backend and OSS execute.

**This PR has been rebased and rescoped.** Everything it originally carried is already on `develop`; what is left is the one thing nobody fixed, plus the backend-side half it exposed. See the history below.

## Why

A context is not interchangeable just because it exists.

| stream | wrong context current | what happens |
|---|---|---|
| a real stream | it carries its own context | cross-context launch **rejected** — `CUDA_ERROR_INVALID_HANDLE`. Loud. |
| a default-stream handle — `0`, `CU_STREAM_LEGACY` (`0x1`), `CU_STREAM_PER_THREAD` (`0x2`) | carries **no** context; resolves against whatever is current | work runs on **that context's GPU**, where the pointers are invalid → async fault at some later sync. **Silent.** |

Measured on parley (5 GPUs, sm89/sm100/sm90/sm80):

```
torch default stream handle: dev0=0x0  dev1=0x0        <- carries no device information
  cuStreamGetCtx(0)                    with ctx0 -> ctx0   with ctx1 -> ctx1
  cuStreamGetCtx(CU_STREAM_LEGACY)     with ctx0 -> ctx0   with ctx1 -> ctx1
  cuStreamGetCtx(CU_STREAM_PER_THREAD) with ctx0 -> ctx0   with ctx1 -> ctx1
                                                       <- all three follow the thread, not the work

module loaded in ctx0, launched on ctx1's explicit stream:
  cuLaunchKernelEx -> 400 (CUDA_ERROR_INVALID_HANDLE)  <- the loud path
module loaded in ctx0, launched on stream 0 with a cuda:1 pointer:
  cuLaunchKernelEx -> 0 ; cuStreamSynchronize -> 700   <- CUDA_ERROR_ILLEGAL_ADDRESS, and the context is poisoned
```

torch's default stream *is* stream 0, so the reachable path is the silent one. Before/after, same scenario (thread holds cuda:0's context, work belongs to cuda:1, stream 0):

```
  develop today  -> ctx cuda:0   WRONG GPU
  this PR        -> ctx cuda:1   correct
```

Two further changes fall out of resolving the target:

- **`execute()` passes `handle.device.ordinal`.** `#612` made the handle own its device; the function was still asking the CUDA *runtime* which GPU the thread was on. `cudaGetDevice()` stays only as the fallback for a caller that cannot name a device — the FE's own path no longer reaches it. (`cuda.bindings.runtime` is not a new dependency: `cuda-python` is already required, `cuda.bindings.driver` is imported at module scope in ~20 files, and this same probe is already reached on this path via `frost/buffers.py::current_device_id`.)
- **The blanket `except Exception: pass` is gone.** Every failure path is now an explicit driver error code, so an out-of-range ordinal no longer turns into "silently no context" and then reappears at the launch wearing a different face. The contract stays best-effort for driver conditions.

## Why the backend never needed this, and the python path does

The obvious objection: cuDNN's own FORT engines launch through the driver too, from the same autograd worker threads, and nobody ever wrote this for them. So what is different?

Nothing in the stack establishes it deliberately — **the CUDA runtime does, incidentally, and every driver-API launcher rides on that.** The cuDNN backend included: it has the same requirement and the same gap, it just never surfaces because something runtime-flavoured almost always touches the thread first.

Measured on a cuDNN graph that lands on the runtime-compiled (FORT) engines — `matmul + relu + relu`, a driver-API launch, not the `<<<>>>` precompiled path:

```
A. genuinely cold thread — cuDNN is the FIRST cuda work on it
   cold #0/#1/#2   ctx 0x0 -> 0x0
                   cuCtxGetLimit returned error invalid device context (201)
                   -> CUDNN_STATUS_NOT_SUPPORTED

B. same thread, ONE torch op first
   warmed #0/#1/#2 ctx 0x44b446b0 -> 0x44b446b0   OK
```

Deterministic, 3/3 each way. (Allocating the output tensor is enough to warm it, which is why no framework has ever seen this; an earlier version of this experiment had a stray `C.zero_()` on the worker thread and reported the opposite.)

So this is not "the front end is missing something the backend has". Both need a bound context; the backend gets one for free from the runtime work that always precedes it, and the python-engine path is where the accident finally does not happen — a `batch_invariant` GDN backward on an autograd worker issues no runtime call before `cuTensorMapEncodeTiled`. Fixing it at the FE's own execute seam is the same placement torch uses for cuBLAS (`CublasHandlePool.cpp::getCurrentCUDABlasHandle`, device-aware, warn-once) and Triton uses in its launcher.

The backend cannot be patched retroactively, so the guard is placed in the front end instead — at `execute_plan_at_index`, which `graph_interface.h` already documents as the point every `execute` overload funnels through. Verified by rebuilding the pybind module and re-running the same reproducer:

```
before (develop's C++)   cold #0/#1/#2   ctx 0x0 -> 0x0          error 201
after                    cold #0/#1/#2   ctx 0x0 -> 0x31275a20   OK
```

Driver entry points are resolved through the runtime (`cudaGetDriverEntryPointByVersion`), so the front end still never links `libcuda` — the approach `cu_tensor_map_encode_tiled` already uses and documents. (`NV_FE_CALL_TO_CU` exists in the shim but is unused, and expands to a direct call that *would* require the link in the non-dynamic-loading build.) Both build configurations compile clean.

Context-independent loading (`cuLibrary*`/`CUkernel`) is in there too, and it solves a *different* problem — a `CUfunction` is valid only in the context it was loaded into, which is why a ctx0 module launched on a ctx1 stream returns `CUDA_ERROR_INVALID_HANDLE`. It does not help a thread that has no context at all. cuDNN ships both because they are two problems; the crash that opened this PR was `cuTensorMapEncodeTiled` → `CUDA_ERROR_INVALID_CONTEXT`, which is neither a launch nor a load — just a driver call that requires a current context.

So the gap is a boundary artifact, not a missing idea. Every backend op enters through a C entry point that establishes the context on the way in. The python engines never enter `libcudnn` at all — Python → CuTeDSL/cuTile → driver — so there is no entry point on that path to do it. `pygraph.execute`'s python-engine branch **is** our `cudnnBackendExecute`, which is why the call belongs there and not in `create_handle` (context binding is thread-local, and the handle is created on a different thread than the one that executes) nor in the torch integration (`aten/src/ATen/{cudnn,native/cudnn}` contains no context code at all — it never needed any; torch writes this pattern for cuBLAS, in `CublasHandlePool.cpp::getCurrentCUDABlasHandle`, at that library's handle seam, and device-aware exactly as here).

## Overhead — measured on both sides, and not visible on either

**C++ (every backend execute).** The guard probes with one `cuCtxGetCurrent` and fetches the stream only when a context has to be established. Backend `graph.execute()` host time, rebuilding the module for each configuration:

| | median |
|---|---|
| `develop`, no guard | 10.805 µs |
| this PR, probe first | 10.498 µs |
| this PR, probe first (second build) | 10.683 µs |
| this PR, earlier unconditional `cudnnGetStream` | 10.788 µs |

The PR measured *faster* than `develop` in both builds, so the between-build delta is noise — run-to-run spread alone is ~0.35 µs across the samples, against a guard that costs one `cuCtxGetCurrent` (~106 ns, ~1%). The unconditional version landed inside the same band, so `cudnnGetStream` from C++ is nowhere near the ~1.5 µs the Python path costs through pybind; probing first is still the right shape, but it was not buying back a visible regression.

**Python (every python-engine execute).**

Resolving the target costs a second driver call. I expected that to matter and it does not:

| | microbenchmark | in situ |
|---|---|---|
| raw `cuCtxGetCurrent` | 106 ns | |
| accept-any (develop today) | 235 ns | |
| resolve-target (this PR) | 417–526 ns | |
| **cost of the whole call inside a real op** | | **59 ns, 0.1%** |

Measured by no-op'ing the call around a real GDN execute on sm100: 78.80 µs with it, 78.88 µs without, 1.00 call per op. The microbenchmark delta is real and irrelevant — the denominator is 79 µs. No memoization, no thread-local cache; the simple correct version is the one that ships.

## History — how the pieces got separated

This PR was opened 2026-08-17 with the function in `frost/device.py`, the call site in `pygraph.execute`, deletion of the duplicate `ensure_cuda_context` in the cuTile LA engines, and a cold-thread test. Since then:

1. **#612** (first-class `cudnn.Handle`) refactored `frost/device.py` into shims over a new `_device.py`, and carried this PR's **call site** over with the import rewritten to the new home — while the **definition** stayed on this branch. `import cudnn` then failed on `develop` (#634), and every python test failed at collection.
2. **#638** restored the missing half by re-deriving the function into `_device.py`. It is behaviourally identical to what this branch had — including the accept-any early return, which is the bug this PR now fixes. (It also picked up the blanket `except` from the cuTile ancestor and dropped a `!= 0` guard.)
3. **#644** absorbed the rest of this PR: the cuTile duplicate deletion and the cold-thread test, both already on `develop`.

So the accept-any semantics were never anyone's decision — the shape was inherited from `linear_attention/cutile/kernels/common.py`, hoisted twice, and reviewed as a hotfix each time.

## The cuTile runtime is now a declared extra

`cuda.tile` was not declared anywhere — not an extra, not `requirements.txt` — so whether the cuTile linear-attention engines run at all depended on the environment happening to have it. That is the other half of the coverage note below: those engines decline in `check_support` when the import fails, and the test skips, silently.

`cutile = ["cuda-tile>=1.4; python_version >= '3.10'"]`. Base `cuda-tile` only: its `[tileiras]` extra pins `cuda-toolkit>=13.2,<13.4`, and that upper bound would cap the whole environment's toolkit and shut CUDA 12 out entirely — the same reason `nvidia-cutlass-dsl` is not pinned to the FROST floor here. Without it, `cuda.tile` falls back to a system `tileiras` (`_compile.py::_find_pip_tileiras`), consistent with this package already leaving GPU wheels to the user.

Resolution checked rather than assumed — `.[cutedsl,cutile]` together:

```
Resolved 15 packages in 3.17s
 + cuda-tile==1.5.0
```

One package added, nothing downgraded, no `cuda-toolkit` pulled in: base `cuda-tile` requires only `typing-extensions`. The `python_version` marker keeps the extra resolvable on the declared 3.9 floor, which `cuda-tile` itself does not support.

**Note on #644's absorption** (checked, and it is structurally correct): the deleted `ensure_cuda_context(stream)` was the first statement of the cuTile engine's `execute()`, and the seam call in `pygraph.execute` runs strictly earlier — before `build_plan` and before `plan.execute` — so it dominates. But `test_execute_from_a_thread_with_no_cuda_context` **skips the entire cuTile backend** wherever `cuda.tile` is not installed (`no gdn_cutile plan for this graph (offered: ['gdn_frost'])`), so that half is only actually exercised on a runner that ships it. That was because `cuda.tile` was not declared anywhere; the `[cutile]` extra above fixes the declaration, but whether CI installs it is still worth confirming.

## Testing

`test/python/test_ensure_current_context.py` (new, L0, driver-only — no engine, no torch):

- cold thread ends up bound
- a context on **another GPU** is replaced, parametrized over all three default-stream handles, each asserting first that `cuStreamGetCtx` follows the thread (skips below 2 GPUs)
- a real stream's context wins over the named device (skips below 2 GPUs)
- steady state is a no-op — no rebind, no primary-context churn

Run on parley (sm100 for the engine suites, all 5 GPUs for the driver-only tests):

```
test_ensure_current_context + test_device_info + test_set_stream_cache        14 passed
test_la.py -k no_cuda_context (sm100)                          3 passed, 3 skipped (cuTile: no cuda.tile)
test_la.py + test_ensure_current_context (sm100, -n 4)       386 passed,   0 failed,  488 skipped
default path: test_dispatch + gemm + matmul + the device tests
  (no CUDNN_FRONTEND_ENABLE_FROST_ENGINES, as CI runs it)   5905 passed,   0 failed, 3002 skipped
conv_fuzzer + wgrads + dispatch + gemm + matmul, against the
  rebuilt module (i.e. exercising the C++ change)           1259 passed,   2 failed, 8688 skipped
```

The two failures are `test_render_e5m3_tile_constants[16-8-2]` and `[32-4-1]` — sm107 block-scale TMEM budget arithmetic, pure Python, no CUDA. Confirmed pre-existing by pointing the same test bed at `gh/develop`'s `python/cudnn` and getting the identical two failures.

The `test_la` skips are the cuTile half (`cuda.tile` absent in this test bed) and the arch-gated rows — identical on `develop`.

CI on `991b9bb` (this change before the two review rounds below): pipeline **success** — 14 jobs green, 0 failed, covering `py_test:{rel,dev}` on Ampere / Hopper / Blackwell and `frost:rel:{gemm,linear}:sm100`, `frost:rel:sdpa:{sm80,sm100,sm120}`. Re-run on the final commit is in flight.

## API and compatibility impact

`ensure_current_context(stream)` gains an optional second parameter `device`. Existing single-argument calls keep working, and with no device named the behaviour is the previous one. Internal helper; not part of the public `cudnn` surface.

## Review

- **codex, P1 — do not override a bound context when no device was named.** Valid, and the contract it violates is this repo's own: `frost/device.py::ambient_device` documents *"a bound driver context wins — it is process-wide and authoritative"*, with the runtime's thread-local slot as the second rung. The `device is None` branch had inverted those. Now a bound context is left alone when nobody named a GPU, and only a cold thread is given one.
- **codex, P2 — unbalanced primary-context retains.** Valid: a thread alternating default-stream work across two GPUs re-retained on every transition. `_primary_context` is now `lru_cache`d, so each ordinal is retained once and held for the process lifetime — which is what the docstring already claimed.
- **CodeRabbit, `_device.py` (Major)**: `CU_STREAM_LEGACY` / `CU_STREAM_PER_THREAD` must be treated as default streams. Confirmed on hardware and fixed — they are `0x1`/`0x2` and `cuStreamGetCtx` answers with the calling thread's current context for both, so the accept-any behaviour was re-admitted for exactly those two handles. The fix reads the constants off the binding (no hardcoded `0x1`/`0x2`) and the regression test is parametrized over all three.

## Related issues

Supersedes the original scope of this PR (absorbed by #644). Fixes the semantics introduced by #638 / #634.

---
<sub>note to self: claude::c2a7afc6-a7b4-4a29-a477-370aaaa6adf1 — "Investigate why PR 612 broke test_mhas". cwd /home/scratch.yanxu_libs/cudnn_frontend · worktree /home/scratch.yanxu_gpu/fe-ctxfix · probes /home/scratch.yanxu_gpu/probe638</sub>
