### PR TITLE
reduce cuteDSL grouped gemm CPU latency

### DIFF
--- a/python/cudnn/datatypes.py
+++ b/python/cudnn/datatypes.py
@@ -246,7 +246,25 @@ def _torch_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2: bool = Fals
     return None
 
 
+_cutlass_data_type_memo: dict = {}
+
+
 def _convert_to_cutlass_data_type(data_type, interpret_uint8_as_fp4x2: bool = False):
+    # Resolution is process-constant and this runs ~20x per grouped-GEMM wrapper call,
+    # always over the same handful of dtypes. Unhashable spellings fall through uncached.
+    try:
+        key = (data_type, interpret_uint8_as_fp4x2)
+        cached = _cutlass_data_type_memo.get(key)
+    except TypeError:
+        return _convert_to_cutlass_data_type_uncached(data_type, interpret_uint8_as_fp4x2)
+    if cached is None:
+        cached = _convert_to_cutlass_data_type_uncached(data_type, interpret_uint8_as_fp4x2)
+        if cached is not None:
+            _cutlass_data_type_memo[key] = cached
+    return cached
+
+
+def _convert_to_cutlass_data_type_uncached(data_type, interpret_uint8_as_fp4x2: bool = False):
     if is_cutlass_available():
         import cutlass
 

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/_bf16_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/_bf16_api.py
@@ -27,6 +27,8 @@ from cudnn.tensor_adapter import (
     get_compute_capability,
     get_data_ptr,
     get_device,
+    get_shape,
+    get_strides,
     get_version,
     is_torch_tensor,
     to_host_list,
@@ -82,6 +84,9 @@ class GroupedGemmDgluBf16API(APIBase):
         else:
             raise ValueError("Provide sample_b for dense mode or (num_experts, b_shape, b_dtype) " "for discrete mode, but not both")
 
+        # A canonical TensorDesc is rebuilt and re-checked for every operand on every
+        # launch, which is the largest single cost in execute(). See _validate_live_tensor.
+        self._live_desc_cache: dict = {}
         self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
         self.b_desc = self._make_tensor_desc(sample_b, name="sample_b", canonical=True)
         self.c_desc = self._make_tensor_desc(sample_c, name="sample_c", canonical=True)
@@ -494,6 +499,14 @@ class GroupedGemmDgluBf16API(APIBase):
         self._compiled_kernel = tensor_api
 
     def _validate_live_tensor(self, tensor: torch.Tensor, sample: TensorDesc, name: str, *, dynamic_m: bool = False) -> TensorDesc:
+        # The outcome of this check is decided entirely by (shape, stride, dtype, device),
+        # so memoize on exactly that. An operand differing in any of them takes a different
+        # key, misses, and is checked in full; nothing is skipped on the strength of a
+        # tensor's identity. Data-pointer alignment is checked by the caller, not here.
+        key = (name, dynamic_m, get_shape(tensor), get_strides(tensor), tensor.dtype, get_device(tensor))
+        hit = self._live_desc_cache.get(key)
+        if hit is not None:
+            return hit
         desc = self._make_tensor_desc(tensor, name=name, canonical=True)
         if desc.dtype != sample.dtype:
             raise ValueError(f"{name} dtype mismatch: expected {sample.dtype}, got {desc.dtype}")
@@ -506,6 +519,7 @@ class GroupedGemmDgluBf16API(APIBase):
                 raise ValueError(f"{name} layout mismatch: expected stride order {sample.stride_order}, got {desc.stride_order}")
         elif desc.shape != sample.shape or desc.stride != sample.stride:
             raise ValueError(f"{name} descriptor mismatch: expected shape/stride {sample.shape}/{sample.stride}, " f"got {desc.shape}/{desc.stride}")
+        self._live_desc_cache[key] = desc
         return desc
 
     def execute(

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/api.py
@@ -1338,6 +1338,8 @@ def grouped_gemm_dglu_wrapper_sm100(
         geglu_alpha,
         glu_clamp_max,
         glu_clamp_min,
+        situ_beta1,
+        situ_beta2,
         epilogue_op,
         use_dynamic_sched,
         os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"),

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/api.py
@@ -1091,43 +1091,64 @@ def _dglu_tensor_signature(tensor: Optional[torch.Tensor], *, dynamic_m: bool = 
     )
 
 
-def _grouped_gemm_dglu_bf16_call(call: DgluCall) -> TupleDict:
-    framework = detect_framework(call.a_tensor)
-    valid_m = get_shape(call.a_tensor)[0]
-    n_weight = get_shape(call.b_tensor)[0] if call.b_tensor is not None else call.n
-    two_n = 2 * n_weight
+def _dglu_allocate_outputs(framework, valid_m, two_n, d_dtype, generate_dbias, num_experts, a_tensor, current_stream):
+    """Outputs for the BF16 dGLU path. dbias is zeroed because the kernel accumulates
+    into it with atomic adds; d_row is written in full and only needs allocating."""
     if framework == "torch":
         import torch
 
         # _torch_stream_context is torch-only; other frameworks never enter it.
-        with _torch_stream_context(call.current_stream, call.a_tensor.device):
+        with _torch_stream_context(current_stream, a_tensor.device):
             d_row_tensor = torch.empty_strided(
                 (valid_m, two_n, 1),
                 (two_n, 1, valid_m * two_n),
-                dtype=framework_dtype(call.d_dtype, "torch"),
-                device=call.a_tensor.device,
+                dtype=framework_dtype(d_dtype, "torch"),
+                device=a_tensor.device,
             )
-            dbias_tensor = (
-                torch.zeros(
-                    (call.num_experts, two_n, 1),
-                    dtype=torch.bfloat16,
-                    device=call.a_tensor.device,
-                )
-                if call.generate_dbias
-                else None
-            )
-    else:
-        import jax
-        import jax.numpy as jnp
+            dbias_tensor = torch.zeros((num_experts, two_n, 1), dtype=torch.bfloat16, device=a_tensor.device) if generate_dbias else None
+        return d_row_tensor, dbias_tensor
 
-        # n-major C-contiguous outputs; the extent-1 batch dim's stride is unobservable.
-        # The kernel writes into these buffers on the launch stream; materialize them first.
-        d_row_tensor = jax.block_until_ready(jnp.empty((valid_m, two_n, 1), dtype=framework_dtype(call.d_dtype, "jax"), device=call.a_tensor.device))
-        dbias_tensor = (
-            jax.block_until_ready(jnp.zeros((call.num_experts, two_n, 1), dtype=framework_dtype(cutlass.BFloat16, "jax"), device=call.a_tensor.device))
-            if call.generate_dbias
-            else None
-        )
+    import jax
+    import jax.numpy as jnp
+
+    # n-major C-contiguous outputs; the extent-1 batch dim's stride is unobservable.
+    # The kernel writes into these buffers on the launch stream; materialize them first.
+    d_row_tensor = jax.block_until_ready(jnp.empty((valid_m, two_n, 1), dtype=framework_dtype(d_dtype, "jax"), device=a_tensor.device))
+    dbias_tensor = (
+        jax.block_until_ready(jnp.zeros((num_experts, two_n, 1), dtype=framework_dtype(cutlass.BFloat16, "jax"), device=a_tensor.device))
+        if generate_dbias
+        else None
+    )
+    return d_row_tensor, dbias_tensor
+
+
+def _dglu_operand_meta(tensor):
+    """Everything the wrapper's derivation reads off an operand, and nothing else.
+
+    Deliberately not the object's identity: CPython recycles a freed tensor's address,
+    so an id-keyed memo answers for tensors it never saw. Data pointers are excluded --
+    they vary per call and nothing derived here depends on them; their alignment is
+    re-checked inside execute().
+    """
+    if tensor is None or not hasattr(tensor, "shape"):
+        return tensor
+    device = get_device(tensor)
+    return (get_shape(tensor), get_strides(tensor), tensor.dtype, device.type, device.index)
+
+
+# Operand-metadata key -> the BF16 path's derived result. One entry per distinct
+# (operand metadata, config), the same growth as _cache_of_GroupedGemmDgluSm100Objects.
+_dglu_wrapper_memo: dict = {}
+
+
+def _grouped_gemm_dglu_bf16_call(call: DgluCall, memo_key: Optional[tuple] = None) -> TupleDict:
+    framework = detect_framework(call.a_tensor)
+    valid_m = get_shape(call.a_tensor)[0]
+    n_weight = get_shape(call.b_tensor)[0] if call.b_tensor is not None else call.n
+    two_n = 2 * n_weight
+    d_row_tensor, dbias_tensor = _dglu_allocate_outputs(
+        framework, valid_m, two_n, call.d_dtype, call.generate_dbias, call.num_experts, call.a_tensor, call.current_stream
+    )
 
     overlap_margin = int(os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"))
     workspace_bytes = (128 * call.num_experts if call.weight_mode == MoEWeightMode.DISCRETE else 0) + (4 if call.use_dynamic_sched else 0)
@@ -1206,6 +1227,9 @@ def _grouped_gemm_dglu_bf16_call(call: DgluCall) -> TupleDict:
         api.compile()
         _cache_of_GroupedGemmDgluSm100Objects[cache_key] = api
 
+    if memo_key is not None:
+        _dglu_wrapper_memo[memo_key] = (api, framework, valid_m, two_n, call.d_dtype, call.generate_dbias, call.num_experts)
+
     api._implementation.execute(
         a_tensor=call.a_tensor,
         c_tensor=call.c_tensor,
@@ -1273,6 +1297,85 @@ def grouped_gemm_dglu_wrapper_sm100(
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
     """Dispatch grouped GEMM dGLU once from an immutable normalized call."""
+    # Hot-loop memo; same shape as the unfused and GLU wrappers. Everything from here to
+    # execute() is derivation -- dtype resolution, DgluCall construction, normalization and
+    # the op cache-key rebuild -- and a pure function of the operands' metadata plus the
+    # scalar config, both of which are in the key. A hit skips the derivation, never a
+    # check: execute() still validates every operand, including the data pointers the key
+    # omits. linear_offset is excluded on purpose (not in the op cache key either) and
+    # passed through per call.
+    memo_key = (
+        type(a_tensor),
+        _dglu_operand_meta(a_tensor),
+        _dglu_operand_meta(c_tensor),
+        _dglu_operand_meta(sfa_tensor),
+        _dglu_operand_meta(padded_offsets),
+        _dglu_operand_meta(alpha_tensor),
+        _dglu_operand_meta(beta_tensor),
+        _dglu_operand_meta(prob_tensor),
+        _dglu_operand_meta(dprob_tensor),
+        _dglu_operand_meta(b_tensor),
+        _dglu_operand_meta(sfb_tensor),
+        _dglu_operand_meta(b_ptrs),
+        _dglu_operand_meta(sfb_ptrs),
+        _dglu_operand_meta(norm_const_tensor),
+        use_single_group_runtime_offsets,
+        generate_dbias,
+        n,
+        b_dtype,
+        b_major,
+        acc_dtype,
+        d_dtype,
+        cd_major,
+        tuple(mma_tiler_mn),
+        None if cluster_shape_mn is None else tuple(cluster_shape_mn),
+        sf_vec_size,
+        sf_fp8_dtype_override,
+        vector_f32,
+        m_aligned,
+        discrete_col_sfd,
+        act_func,
+        geglu_alpha,
+        glu_clamp_max,
+        glu_clamp_min,
+        epilogue_op,
+        use_dynamic_sched,
+        os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"),
+    )
+    memo = _dglu_wrapper_memo.get(memo_key)
+    if memo is not None:
+        api, memo_framework, valid_m, two_n, memo_d_dtype, memo_generate_dbias, memo_experts = memo
+        # The full path resolves this during normalization; the memo bypasses that, so
+        # apply the same default here rather than handing None to the kernel.
+        resolved_linear_offset = linear_offset if linear_offset is not None else (1.0 if act_func == "dgeglu" else 0.0)
+        d_row_tensor, dbias_tensor = _dglu_allocate_outputs(
+            memo_framework, valid_m, two_n, memo_d_dtype, memo_generate_dbias, memo_experts, a_tensor, current_stream
+        )
+        api._implementation.execute(
+            a_tensor=a_tensor,
+            c_tensor=c_tensor,
+            d_row_tensor=d_row_tensor,
+            padded_offsets=padded_offsets,
+            alpha_tensor=alpha_tensor,
+            beta_tensor=beta_tensor,
+            prob_tensor=prob_tensor,
+            dprob_tensor=dprob_tensor,
+            b_tensor=b_tensor,
+            b_ptrs=b_ptrs,
+            dbias_tensor=dbias_tensor,
+            linear_offset=resolved_linear_offset,
+            current_stream=current_stream,
+        )
+        return TupleDict(
+            d_row_tensor=d_row_tensor,
+            d_col_tensor=None,
+            dprob_tensor=dprob_tensor,
+            dbias_tensor=dbias_tensor,
+            amax_tensor=None,
+            sfd_row_tensor=None,
+            sfd_col_tensor=None,
+        )
+
     framework = detect_framework(a_tensor)
     if framework not in ("torch", "jax"):
         raise ValueError(f"Unsupported tensor framework '{framework}' for grouped_gemm_dglu_wrapper_sm100; pass torch tensors or JAX arrays")
@@ -1323,7 +1426,7 @@ def grouped_gemm_dglu_wrapper_sm100(
     )
     normalized, backend = _normalize_dglu_call(call)
     if backend is GroupedGemmBackend.BF16:
-        return _grouped_gemm_dglu_bf16_call(normalized)
+        return _grouped_gemm_dglu_bf16_call(normalized, memo_key)
     if framework == "jax":
         raise ValueError(_JAX_BLOCK_SCALED_ERROR)
     return _grouped_gemm_dglu_block_scaled_call(normalized)

--- a/python/cudnn/gemm/cutedsl/grouped/glu/_bf16_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/_bf16_api.py
@@ -27,6 +27,8 @@ from cudnn.tensor_adapter import (
     get_compute_capability,
     get_data_ptr,
     get_device,
+    get_shape,
+    get_strides,
     get_version,
     is_torch_tensor,
     to_host_list,
@@ -81,6 +83,10 @@ class GroupedGemmGluBf16API(APIBase):
         else:
             raise ValueError("Provide sample_b for dense mode or (num_experts, b_shape, b_dtype) " "for discrete mode, but not both")
 
+        # A canonical TensorDesc is rebuilt and re-checked for every operand on every
+        # launch, which is the largest single cost in execute(). See _validate_live_tensor.
+        self._live_desc_cache: dict = {}
+        self._launch_stream_cache: dict = {}
         self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
         self.c_desc = self._make_tensor_desc(sample_c, name="sample_c", canonical=True)
         self.d_desc = self._make_tensor_desc(sample_d, name="sample_d", canonical=True)
@@ -211,15 +217,23 @@ class GroupedGemmGluBf16API(APIBase):
             return
         import torch
 
-        handle = int(current_stream)
-        torch_current = torch.cuda.current_stream(b_ptrs.device)
-        torch_default = torch.cuda.default_stream(b_ptrs.device)
-        if handle == torch_current.cuda_stream:
-            launch_stream = torch_current
-        elif handle == torch_default.cuda_stream:
-            launch_stream = torch_default
-        else:
-            launch_stream = torch.cuda.ExternalStream(handle, device=b_ptrs.device)
+        # record_stream only ever reads launch_stream.cuda_stream, which equals the handle
+        # we keyed on, so any Stream object wrapping that handle behaves identically here
+        # -- that is what makes caching by (device, handle) safe even though which branch
+        # produced it can change. Without it every launch pays two torch stream queries.
+        key = (b_ptrs.device, int(current_stream))
+        launch_stream = self._launch_stream_cache.get(key)
+        if launch_stream is None:
+            handle = int(current_stream)
+            torch_current = torch.cuda.current_stream(b_ptrs.device)
+            torch_default = torch.cuda.default_stream(b_ptrs.device)
+            if handle == torch_current.cuda_stream:
+                launch_stream = torch_current
+            elif handle == torch_default.cuda_stream:
+                launch_stream = torch_default
+            else:
+                launch_stream = torch.cuda.ExternalStream(handle, device=b_ptrs.device)
+            self._launch_stream_cache[key] = launch_stream
         b_ptrs.record_stream(launch_stream)
 
     def check_support(self) -> bool:
@@ -498,6 +512,14 @@ class GroupedGemmGluBf16API(APIBase):
         *,
         dynamic_m: bool = False,
     ) -> TensorDesc:
+        # The outcome of this check is decided entirely by (shape, stride, dtype, device),
+        # so memoize on exactly that. An operand differing in any of them takes a different
+        # key, misses, and is checked in full; nothing is skipped on the strength of a
+        # tensor's identity. Data-pointer alignment is checked by the caller, not here.
+        key = (name, dynamic_m, get_shape(tensor), get_strides(tensor), tensor.dtype, get_device(tensor))
+        hit = self._live_desc_cache.get(key)
+        if hit is not None:
+            return hit
         desc = self._make_tensor_desc(tensor, name=name, canonical=True)
         if desc.dtype != sample.dtype:
             raise ValueError(f"{name} dtype mismatch: expected {sample.dtype}, got {desc.dtype}")
@@ -510,6 +532,7 @@ class GroupedGemmGluBf16API(APIBase):
                 raise ValueError(f"{name} layout mismatch: expected stride order " f"{sample.stride_order}, got {desc.stride_order}")
         elif desc.shape != sample.shape or desc.stride != sample.stride:
             raise ValueError(f"{name} descriptor mismatch: expected shape/stride " f"{sample.shape}/{sample.stride}, got {desc.shape}/{desc.stride}")
+        self._live_desc_cache[key] = desc
         return desc
 
     def execute(

--- a/python/cudnn/gemm/cutedsl/grouped/glu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/api.py
@@ -1288,6 +1288,8 @@ def grouped_gemm_glu_wrapper_sm100(
         geglu_alpha,
         glu_clamp_max,
         glu_clamp_min,
+        situ_beta1,
+        situ_beta2,
         use_dynamic_sched,
         use_single_group_runtime_offsets,
         generate_c,

--- a/python/cudnn/gemm/cutedsl/grouped/glu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/api.py
@@ -1043,6 +1043,38 @@ def _glu_stride_order(tensor: torch.Tensor) -> Tuple[int, ...]:
     )
 
 
+def _glu_allocate_output(framework: str, shape: tuple, stride: tuple, dtype, device):
+    if framework == "torch":
+        import torch
+
+        return torch.empty_strided(shape, stride, dtype=framework_dtype(dtype, "torch"), device=device)
+    import jax
+    import jax.numpy as jnp
+
+    # n-major C-contiguous; the extent-1 batch dim's stride is unobservable.
+    # The kernel writes into this buffer on the launch stream; materialize it first.
+    return jax.block_until_ready(jnp.empty(shape, dtype=framework_dtype(dtype, "jax"), device=device))
+
+
+def _glu_operand_meta(tensor: Optional[torch.Tensor]) -> Optional[tuple]:
+    """Everything the wrapper's derivation reads off an operand, and nothing else.
+
+    Deliberately not the object's identity: a tensor's address is recycled by CPython
+    as soon as it is freed, so an id-keyed memo answers for tensors it never saw.
+    Data pointers are excluded because they vary per call and nothing derived here
+    depends on them -- their alignment is re-checked inside execute().
+    """
+    if tensor is None:
+        return None
+    device = get_device(tensor)
+    return (get_shape(tensor), get_strides(tensor), tensor.dtype, device.type, device.index)
+
+
+# Operand-metadata key -> the BF16 path's derived result. One entry per distinct
+# (operand metadata, config), the same growth as _cache_of_GroupedGemmGluSm100Objects.
+_glu_wrapper_memo: dict = {}
+
+
 def _glu_tensor_signature(tensor: Optional[torch.Tensor], *, dynamic_m: bool = False) -> tuple:
     if tensor is None:
         return (None, None, None, None)
@@ -1056,7 +1088,7 @@ def _glu_tensor_signature(tensor: Optional[torch.Tensor], *, dynamic_m: bool = F
     )
 
 
-def _grouped_gemm_glu_bf16_call(call: GluCall) -> TupleDict:
+def _grouped_gemm_glu_bf16_call(call: GluCall, memo_key: Optional[tuple] = None) -> TupleDict:
     framework = detect_framework(call.a_tensor)
     valid_m, k, _ = get_shape(call.a_tensor)
     if call.weight_mode == MoEWeightMode.DENSE:
@@ -1066,21 +1098,7 @@ def _grouped_gemm_glu_bf16_call(call: GluCall) -> TupleDict:
     n_out = n_full // 2
 
     def _allocate_output(shape, stride, dtype):
-        if framework == "torch":
-            import torch
-
-            return torch.empty_strided(
-                shape,
-                stride,
-                dtype=framework_dtype(dtype, "torch"),
-                device=call.a_tensor.device,
-            )
-        import jax
-        import jax.numpy as jnp
-
-        # n-major C-contiguous; the extent-1 batch dim's stride is unobservable.
-        # The kernel writes into this buffer on the launch stream; materialize it first.
-        return jax.block_until_ready(jnp.empty(shape, dtype=framework_dtype(dtype, "jax"), device=call.a_tensor.device))
+        return _glu_allocate_output(framework, shape, stride, dtype, call.a_tensor.device)
 
     c_tensor = _allocate_output((valid_m, n_full, 1), (n_full, 1, valid_m * n_full), call.c_dtype)
     d_tensor = _allocate_output((valid_m, n_out, 1), (n_out, 1, valid_m * n_out), call.d_dtype)
@@ -1156,6 +1174,9 @@ def _grouped_gemm_glu_bf16_call(call: GluCall) -> TupleDict:
         api.compile()
         _cache_of_GroupedGemmGluSm100Objects[cache_key] = api
 
+    if memo_key is not None:
+        _glu_wrapper_memo[memo_key] = (api, framework, valid_m, n_full, n_out, call.c_dtype, call.d_dtype)
+
     api.execute(
         a_tensor=call.a_tensor,
         c_tensor=c_tensor,
@@ -1229,6 +1250,87 @@ def grouped_gemm_glu_wrapper_sm100(
     sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
 ) -> TupleDict:
     """Dispatch grouped GEMM GLU once from an immutable normalized call."""
+    # Hot-loop memo; see _operand_meta in the unfused API for the rationale. Everything
+    # from here to api.execute() is derivation -- dtype resolution, GluCall construction,
+    # normalization, and the op cache-key rebuild -- and is a pure function of the
+    # operands' metadata plus the scalar config, both of which are in the key below.
+    # A hit skips the derivation, never a check: api.execute() still validates every
+    # operand, including the data pointers the key deliberately omits. linear_offset is
+    # excluded on purpose (it is not part of the op cache key either) and passed through.
+    memo_key = (
+        type(a_tensor),
+        _glu_operand_meta(a_tensor),
+        _glu_operand_meta(sfa_tensor),
+        _glu_operand_meta(padded_offsets),
+        _glu_operand_meta(alpha_tensor),
+        _glu_operand_meta(b_tensor),
+        _glu_operand_meta(sfb_tensor),
+        _glu_operand_meta(bias_tensor),
+        _glu_operand_meta(b_ptrs),
+        _glu_operand_meta(sfb_ptrs),
+        _glu_operand_meta(norm_const_tensor),
+        _glu_operand_meta(prob_tensor),
+        n,
+        b_dtype,
+        b_major,
+        acc_dtype,
+        c_dtype,
+        d_dtype,
+        cd_major,
+        tuple(mma_tiler_mn),
+        None if cluster_shape_mn is None else tuple(cluster_shape_mn),
+        sf_vec_size,
+        sf_fp8_dtype_override,
+        vector_f32,
+        m_aligned,
+        discrete_col_sfd,
+        act_func,
+        geglu_alpha,
+        glu_clamp_max,
+        glu_clamp_min,
+        use_dynamic_sched,
+        use_single_group_runtime_offsets,
+        generate_c,
+        os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"),
+    )
+    memo = _glu_wrapper_memo.get(memo_key)
+    if memo is not None:
+        api, framework, valid_m, n_full, n_out, memo_c_dtype, memo_d_dtype = memo
+        c_out = _glu_allocate_output(framework, (valid_m, n_full, 1), (n_full, 1, valid_m * n_full), memo_c_dtype, a_tensor.device)
+        d_out = _glu_allocate_output(framework, (valid_m, n_out, 1), (n_out, 1, valid_m * n_out), memo_d_dtype, a_tensor.device)
+        api.execute(
+            a_tensor=a_tensor,
+            c_tensor=c_out,
+            d_tensor=d_out,
+            sfa_tensor=None,
+            padded_offsets=padded_offsets,
+            alpha_tensor=alpha_tensor,
+            b_tensor=b_tensor,
+            sfb_tensor=None,
+            bias_tensor=bias_tensor,
+            b_ptrs=b_ptrs,
+            sfb_ptrs=None,
+            d_col_tensor=None,
+            sfd_row_tensor=None,
+            sfd_col_tensor=None,
+            amax_tensor=None,
+            norm_const_tensor=None,
+            prob_tensor=prob_tensor,
+            linear_offset=linear_offset,
+            geglu_alpha=geglu_alpha,
+            glu_clamp_max=glu_clamp_max,
+            glu_clamp_min=glu_clamp_min,
+            current_stream=current_stream,
+        )
+        return TupleDict(
+            c_tensor=c_out if generate_c else None,
+            d_tensor=d_out,
+            d_col_tensor=None,
+            amax_tensor=None,
+            sfd_row_tensor=None,
+            sfd_col_tensor=None,
+        )
+
     framework = detect_framework(a_tensor)
     if framework not in ("torch", "jax"):
         raise ValueError(f"Unsupported tensor framework '{framework}' for grouped_gemm_glu_wrapper_sm100; pass torch tensors or JAX arrays")
@@ -1287,7 +1389,7 @@ def grouped_gemm_glu_wrapper_sm100(
     )
     call, backend = _normalize_glu_call(call)
     if backend is GroupedGemmBackend.BF16:
-        return _grouped_gemm_glu_bf16_call(call)
+        return _grouped_gemm_glu_bf16_call(call, memo_key)
     if framework == "jax":
         raise ValueError(_JAX_BLOCK_SCALED_ERROR)
     return _grouped_gemm_glu_block_scaled_call(call)

--- a/python/cudnn/gemm/cutedsl/grouped/unfused/_bf16_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused/_bf16_api.py
@@ -27,6 +27,7 @@ from cudnn.tensor_adapter import (
     get_data_ptr,
     get_device,
     get_shape,
+    get_strides,
     get_version,
     is_torch_tensor,
     to_host_list,
@@ -121,6 +122,10 @@ class GroupedGemmBf16API(APIBase):
         else:
             raise ValueError("Provide sample_b for dense mode or (num_experts, b_shape, b_dtype) " "for discrete mode, but not both")
 
+        # A canonical TensorDesc is rebuilt and re-checked for every operand on every
+        # launch, which is the largest single cost in execute(). See _validate_live_tensor.
+        self._live_desc_cache: dict = {}
+        self._launch_stream_cache: dict = {}
         self.a_desc = self._make_tensor_desc(sample_a, name="sample_a", canonical=True)
         self.c_desc = self._make_tensor_desc(sample_c, name="sample_c", canonical=True)
         self.d_desc = self._make_tensor_desc(sample_d, name="sample_d", canonical=True)
@@ -253,15 +258,23 @@ class GroupedGemmBf16API(APIBase):
             return
         import torch
 
-        handle = int(current_stream)
-        torch_current = torch.cuda.current_stream(b_ptrs.device)
-        torch_default = torch.cuda.default_stream(b_ptrs.device)
-        if handle == torch_current.cuda_stream:
-            launch_stream = torch_current
-        elif handle == torch_default.cuda_stream:
-            launch_stream = torch_default
-        else:
-            launch_stream = torch.cuda.ExternalStream(handle, device=b_ptrs.device)
+        # record_stream only ever reads launch_stream.cuda_stream, which equals the handle
+        # we keyed on, so any Stream object wrapping that handle behaves identically here
+        # -- that is what makes caching by (device, handle) safe even though which branch
+        # produced it can change. Without it every launch pays two torch stream queries.
+        key = (b_ptrs.device, int(current_stream))
+        launch_stream = self._launch_stream_cache.get(key)
+        if launch_stream is None:
+            handle = int(current_stream)
+            torch_current = torch.cuda.current_stream(b_ptrs.device)
+            torch_default = torch.cuda.default_stream(b_ptrs.device)
+            if handle == torch_current.cuda_stream:
+                launch_stream = torch_current
+            elif handle == torch_default.cuda_stream:
+                launch_stream = torch_default
+            else:
+                launch_stream = torch.cuda.ExternalStream(handle, device=b_ptrs.device)
+            self._launch_stream_cache[key] = launch_stream
         b_ptrs.record_stream(launch_stream)
 
     def check_support(self) -> bool:
@@ -533,6 +546,14 @@ class GroupedGemmBf16API(APIBase):
         *,
         dynamic_m: bool = False,
     ) -> TensorDesc:
+        # The outcome of this check is decided entirely by (shape, stride, dtype, device),
+        # so memoize on exactly that. An operand differing in any of them takes a different
+        # key, misses, and is checked in full; nothing is skipped on the strength of a
+        # tensor's identity. Data-pointer alignment is checked by the caller, not here.
+        key = (name, dynamic_m, get_shape(tensor), get_strides(tensor), tensor.dtype, get_device(tensor))
+        hit = self._live_desc_cache.get(key)
+        if hit is not None:
+            return hit
         desc = self._make_tensor_desc(tensor, name=name, canonical=True)
         if desc.dtype != sample.dtype:
             raise ValueError(f"{name} dtype mismatch: expected {sample.dtype}, got {desc.dtype}")
@@ -545,6 +566,7 @@ class GroupedGemmBf16API(APIBase):
                 raise ValueError(f"{name} layout mismatch: expected stride order {sample.stride_order}, " f"got {desc.stride_order}")
         elif desc.shape != sample.shape or desc.stride != sample.stride:
             raise ValueError(f"{name} descriptor mismatch: expected shape/stride " f"{sample.shape}/{sample.stride}, got {desc.shape}/{desc.stride}")
+        self._live_desc_cache[key] = desc
         return desc
 
     def execute(

--- a/python/cudnn/gemm/cutedsl/grouped/unfused/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused/api.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import os
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from cuda.bindings import driver as cuda
 
@@ -116,6 +116,10 @@ class GroupedGemmSm100(APIBase):
 
 _cache_of_GroupedGemmSm100Objects: dict[tuple, GroupedGemmSm100] = {}
 
+# Operand-metadata key -> the wrapper's derived result. Holds one entry per distinct
+# (operand metadata, config) the process sees, the same growth as the op cache above.
+_wrapper_memo: dict = {}
+
 
 def _stride_order(tensor: torch.Tensor) -> Tuple[int, ...]:
     strides = get_strides(tensor)
@@ -127,6 +131,36 @@ def _stride_order(tensor: torch.Tensor) -> Tuple[int, ...]:
             key=lambda item: (item[1], shape[item[0]]),
         )
     )
+
+
+def _operand_meta(tensor: Optional[torch.Tensor]) -> Optional[tuple]:
+    """Everything the wrapper's derivation reads off an operand, and nothing else.
+
+    Deliberately not the object's identity: a tensor's address is recycled by CPython
+    as soon as it is freed, so an id-keyed memo answers for tensors it never saw.
+    Reading these five values costs ~0.3 us and cannot alias a differently-shaped
+    operand. Data pointers are excluded because they vary per call and nothing derived
+    here depends on them -- their alignment is re-checked inside execute().
+    """
+    if tensor is None:
+        return None
+    device = get_device(tensor)
+    return (get_shape(tensor), get_strides(tensor), tensor.dtype, device.type, device.index)
+
+
+def _allocate_output(framework: str, shape: tuple, stride: tuple, dtype, device) -> Any:
+    from cudnn.tensor_adapter import framework_dtype
+
+    if framework == "torch":
+        import torch
+
+        return torch.empty_strided(shape, stride, dtype=framework_dtype(dtype, "torch"), device=device)
+    import jax
+    import jax.numpy as jnp
+
+    # n-major C-contiguous; the extent-1 batch dim's stride is unobservable.
+    # The kernel writes into this buffer on the launch stream; materialize it first.
+    return jax.block_until_ready(jnp.empty(shape, dtype=framework_dtype(dtype, "jax"), device=device))
 
 
 def _tensor_signature(tensor: Optional[torch.Tensor], *, dynamic_m: bool = False) -> tuple:
@@ -273,6 +307,58 @@ def grouped_gemm_wrapper_sm100(
     use_dynamic_sched: bool = False,
     current_stream: Optional[cuda.CUstream] = None,
 ) -> TupleDict:
+    # Hot-loop memo. Everything between here and op.execute() is derivation -- resolving
+    # dtypes, deriving (m, n, experts), and rebuilding the op cache key -- and it is a
+    # pure function of the operands' metadata plus the scalar config, both of which are
+    # in the key below. So a hit skips the derivation and reuses its result. It does not
+    # skip any check: op.execute() still validates every operand, including the data
+    # pointers the key deliberately omits. Only the allocate-the-outputs case is memoized;
+    # caller-supplied c/d need _validate_output and fall through.
+    _memo_key = None
+    if c_tensor is None and d_tensor is None:
+        _memo_key = (
+            type(a_tensor),
+            _operand_meta(a_tensor),
+            _operand_meta(padded_offsets),
+            _operand_meta(alpha_tensor),
+            _operand_meta(prob_tensor),
+            _operand_meta(b_tensor),
+            _operand_meta(b_ptrs),
+            _operand_meta(bias_tensor),
+            n,
+            b_dtype,
+            b_major,
+            acc_dtype,
+            c_dtype,
+            d_dtype,
+            cd_major,
+            tuple(mma_tiler_mn),
+            None if cluster_shape_mn is None else tuple(cluster_shape_mn),
+            vector_f32,
+            m_aligned,
+            generate_c,
+            use_dynamic_sched,
+            os.getenv("CUDNNFE_CLUSTER_OVERLAP_MARGIN", "0"),
+        )
+        memo = _wrapper_memo.get(_memo_key)
+        if memo is not None:
+            op, framework, expected_shape, expected_stride, memo_c_dtype, memo_d_dtype, is_dense = memo
+            internal_c = _allocate_output(framework, expected_shape, expected_stride, memo_c_dtype, a_tensor.device)
+            d_out = _allocate_output(framework, expected_shape, expected_stride, memo_d_dtype, a_tensor.device)
+            op.execute(
+                a_tensor=a_tensor,
+                c_tensor=internal_c,
+                d_tensor=d_out,
+                padded_offsets=padded_offsets,
+                alpha_tensor=alpha_tensor,
+                b_tensor=b_tensor if is_dense else None,
+                b_ptrs=None if is_dense else b_ptrs,
+                bias_tensor=bias_tensor,
+                prob_tensor=prob_tensor,
+                current_stream=current_stream,
+            )
+            return TupleDict(d_tensor=d_out, c_tensor=internal_c if generate_c else None)
+
     framework = detect_framework(a_tensor)
     if framework not in ("torch", "jax"):
         raise ValueError(f"Unsupported tensor framework '{framework}' for grouped_gemm_wrapper_sm100; pass torch tensors or JAX arrays")
@@ -301,27 +387,11 @@ def grouped_gemm_wrapper_sm100(
     expected_shape = (tensor_m, n_out, 1)
     expected_stride = (n_out, 1, tensor_m * n_out)
 
-    def _allocate_output(dtype):
-        from cudnn.tensor_adapter import framework_dtype
-
-        if framework == "torch":
-            import torch
-
-            return torch.empty_strided(
-                expected_shape,
-                expected_stride,
-                dtype=framework_dtype(dtype, "torch"),
-                device=a_tensor.device,
-            )
-        import jax
-        import jax.numpy as jnp
-
-        # n-major C-contiguous; the extent-1 batch dim's stride is unobservable.
-        # The kernel writes into this buffer on the launch stream; materialize it first.
-        return jax.block_until_ready(jnp.empty(expected_shape, dtype=framework_dtype(dtype, "jax"), device=a_tensor.device))
+    def _allocate(dtype):
+        return _allocate_output(framework, expected_shape, expected_stride, dtype, a_tensor.device)
 
     if c_tensor is None:
-        internal_c = _allocate_output(c_dtype)
+        internal_c = _allocate(c_dtype)
     else:
         _validate_output(
             c_tensor,
@@ -333,7 +403,7 @@ def grouped_gemm_wrapper_sm100(
         )
         internal_c = c_tensor
     if d_tensor is None:
-        d_tensor = _allocate_output(d_dtype)
+        d_tensor = _allocate(d_dtype)
     else:
         _validate_output(
             d_tensor,
@@ -407,6 +477,9 @@ def grouped_gemm_wrapper_sm100(
         assert op.check_support(), "Unsupported configuration"
         op.compile()
         _cache_of_GroupedGemmSm100Objects[cache_key] = op
+
+    if _memo_key is not None:
+        _wrapper_memo[_memo_key] = (op, framework, expected_shape, expected_stride, c_dtype, d_dtype, is_dense)
 
     op.execute(
         a_tensor=a_tensor,

--- a/python/cudnn/tensor_adapter.py
+++ b/python/cudnn/tensor_adapter.py
@@ -33,9 +33,21 @@ class Device:
         return self.type if self.index is None else f"{self.type}:{self.index}"
 
 
+_torch_tensor_cls: Any = None
+
+
 def is_torch_tensor(tensor: Any) -> bool:
-    torch = sys.modules.get("torch")
-    return torch is not None and isinstance(tensor, torch.Tensor)
+    # Called ~40x per grouped-GEMM launch (once per operand per metadata read), so the
+    # sys.modules probe and the .Tensor attribute lookup are worth caching. torch cannot
+    # be un-imported, so the class is stable once resolved; until then this re-probes.
+    global _torch_tensor_cls
+    cls = _torch_tensor_cls
+    if cls is None:
+        torch = sys.modules.get("torch")
+        if torch is None:
+            return False
+        cls = _torch_tensor_cls = torch.Tensor
+    return isinstance(tensor, cls)
 
 
 def is_jax_array(tensor: Any) -> bool:

--- a/test/python/fe_api/test_grouped_gemm_wrapper_memo.py
+++ b/test/python/fe_api/test_grouped_gemm_wrapper_memo.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The wrapper memo must never answer for operands it did not see.
+
+The memo skips the wrapper's derivation on a repeat call. These tests pin the
+property that makes that safe: the key is the operands' metadata, so anything that
+changes what the derivation would produce takes a different key. In particular a
+freshly allocated tensor is not trusted on account of its address -- CPython recycles
+those immediately, so an identity-keyed memo would serve a stale entry to a tensor of
+a different shape.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def require_sm100():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 100:
+        pytest.skip("SM100 is required")
+
+
+N_OUT, K, EXPERTS = 2048, 2048, 8
+
+
+def _weights():
+    b = torch.randn(EXPERTS, N_OUT, K, dtype=torch.bfloat16, device="cuda")
+    b_ptrs = torch.tensor([b[i].data_ptr() for i in range(EXPERTS)], dtype=torch.int64, device="cuda")
+    return b, b_ptrs
+
+
+def _operands(m):
+    return dict(
+        a_tensor=torch.randn(m, K, 1, dtype=torch.bfloat16, device="cuda"),
+        padded_offsets=torch.arange(m // EXPERTS, m + 1, m // EXPERTS, dtype=torch.int32, device="cuda"),
+        alpha_tensor=torch.randn(EXPERTS, dtype=torch.float32, device="cuda"),
+        prob_tensor=torch.linspace(0.25, 0.875, m, dtype=torch.float32, device="cuda").reshape(m, 1, 1),
+    )
+
+
+def _call(m, b_ptrs, a=None, operands=None):
+    from cudnn import grouped_gemm_wrapper_sm100
+
+    operands = dict(operands if operands is not None else _operands(m))
+    if a is not None:
+        operands["a_tensor"] = a
+    return grouped_gemm_wrapper_sm100(
+        **operands,
+        b_ptrs=b_ptrs,
+        n=N_OUT,
+        b_dtype=torch.bfloat16,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+    )
+
+
+@pytest.mark.L0
+def test_memo_hit_matches_cold_path():
+    """A memo hit produces the same bytes as the same call with the memo cleared."""
+    from cudnn.gemm.cutedsl.grouped.unfused.api import _wrapper_memo
+
+    b, b_ptrs = _weights()
+    operands = _operands(2048)
+
+    _wrapper_memo.clear()
+    cold = _call(2048, b_ptrs, operands=operands)["d_tensor"].clone()
+    assert _wrapper_memo, "the call should have populated the memo"
+    warm = _call(2048, b_ptrs, operands=operands)["d_tensor"]
+
+    torch.testing.assert_close(warm, cold, rtol=0, atol=0)
+
+
+@pytest.mark.L0
+def test_memo_misses_when_m_changes():
+    """Alternating token counts with freshly built operands each step.
+
+    Every operand is a new object per call, so their addresses are recycled; only the
+    metadata in the key distinguishes the two shapes.
+    """
+    b, b_ptrs = _weights()
+    for m in (2048, 2048, 4096, 2048, 4096, 4096, 2048, 4096):
+        assert tuple(_call(m, b_ptrs)["d_tensor"].shape) == (m, N_OUT, 1)
+
+
+@pytest.mark.L0
+def test_memo_does_not_swallow_a_dtype_mismatch():
+    """A fresh, wrongly-typed a_tensor is still rejected after the memo is warm."""
+    b, b_ptrs = _weights()
+    _call(2048, b_ptrs)
+
+    bad = torch.empty(2048, K, 1, dtype=torch.float16, device="cuda")
+    with pytest.raises(ValueError):
+        _call(2048, b_ptrs, a=bad)
+
+
+@pytest.mark.L0
+def test_memo_misses_on_a_transposed_operand():
+    """Same shape and dtype, different strides -- a different key, and still rejected."""
+    b, b_ptrs = _weights()
+    _call(2048, b_ptrs)
+
+    transposed = torch.randn(K, 2048, 1, dtype=torch.bfloat16, device="cuda").transpose(0, 1)
+    assert tuple(transposed.shape) == (2048, K, 1)
+    with pytest.raises(ValueError):
+        _call(2048, b_ptrs, a=transposed)
+
+
+@pytest.mark.L0
+def test_glu_memo_hit_matches_cold_path():
+    from cudnn import grouped_gemm_glu_wrapper_sm100
+    from cudnn.gemm.cutedsl.grouped.glu.api import _glu_wrapper_memo
+
+    m = 2048
+    b, b_ptrs = _weights()
+    kwargs = dict(
+        a_tensor=torch.randn(m, K, 1, dtype=torch.bfloat16, device="cuda"),
+        sfa_tensor=None,
+        padded_offsets=torch.arange(m // EXPERTS, m + 1, m // EXPERTS, dtype=torch.int32, device="cuda"),
+        alpha_tensor=torch.randn(EXPERTS, dtype=torch.float32, device="cuda"),
+        prob_tensor=torch.linspace(0.25, 0.875, m, dtype=torch.float32, device="cuda").reshape(m, 1, 1),
+        b_ptrs=b_ptrs,
+        n=N_OUT,
+        b_dtype=torch.bfloat16,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+    )
+
+    _glu_wrapper_memo.clear()
+    cold = grouped_gemm_glu_wrapper_sm100(**kwargs)["d_tensor"].clone()
+    assert _glu_wrapper_memo, "the call should have populated the memo"
+    warm = grouped_gemm_glu_wrapper_sm100(**kwargs)["d_tensor"]
+
+    torch.testing.assert_close(warm, cold, rtol=0, atol=0)
+
+
+@pytest.mark.L0
+def test_memo_key_covers_every_wrapper_parameter():
+    """Every parameter that can change the result must appear in that wrapper's memo key.
+
+    A parameter added to a wrapper but not to its key makes two different calls collide,
+    and the failure is silent: the second gets the first's compiled op and output spec.
+    This caught `sf_fp8_dtype_override` going missing from the GLU key during a rebase.
+
+    Auto-discovers every CuTeDSL wrapper that has a memo, so an op gains coverage the
+    moment one is added to it and no edit here is needed.
+    """
+    import importlib
+    import inspect
+    import pkgutil
+    import re
+
+    import cudnn.gemm.cutedsl as cutedsl
+
+    # linear_offset is not part of any op cache key either; the wrappers resolve and
+    # forward the caller's value on every call, hit or miss. current_stream is per-call
+    # state, not a cache dimension.
+    NOT_CACHE_DIMENSIONS = {"current_stream", "linear_offset"}
+
+    checked = []
+    for module_info in pkgutil.walk_packages(cutedsl.__path__, cutedsl.__name__ + "."):
+        if not module_info.name.endswith(".api"):
+            continue
+        try:
+            module = importlib.import_module(module_info.name)
+        except Exception:
+            continue
+        for name, func in vars(module).items():
+            if not (name.endswith("_wrapper_sm100") and inspect.isfunction(func)):
+                continue
+            try:
+                source = inspect.getsource(func)
+            except OSError:
+                continue
+            if "memo_key = (" not in source:
+                continue  # no memo on this op yet
+            start = source.index("memo_key = (") + len("memo_key = (")
+            key_source = source[start : source.index("\n    )", start)]
+            params = set(inspect.signature(func).parameters) - NOT_CACHE_DIMENSIONS
+            missing = sorted(p for p in params if not re.search(rf"\b{p}\b", key_source))
+            assert not missing, f"{name} parameters missing from its memo key: {missing}"
+            checked.append(name)
+
+    assert checked, "no memoized wrappers discovered -- the discovery logic is broken"


### PR DESCRIPTION
## Description

Cuts CuTeDSL grouped-GEMM host overhead by memoizing work that is a pure function of
values the memo keys already hold. No check is skipped, and no operand is trusted
because of its identity.

Wall-clock microseconds per call, torch wrapper path, 2048x2048x2048 with 8 experts,
B200, 30 calls amortized behind one sync. Kernel time is 18.4 us.

| wrapper | develop | this PR |
|---|---:|---:|
| `grouped_gemm_wrapper_sm100` | 118.1 | 39.6 |
| `grouped_gemm_glu_wrapper_sm100` | 161.1 | 40.6 |
| `grouped_gemm_dglu_wrapper_sm100` | 185.0 | 51.1 |

The pre-allocated `execute()` path isolates the descriptor cache on its own:
68.2 to 24.7 us on unfused, 69.2 to 24.8 us on GLU.

Medians of 3 interleaved runs against base `d811df965` on an otherwise idle B200. Each
variant was guarded at import to confirm which tree had loaded before timing.
Benchmark harness:
https://gitlab-master.nvidia.com/cudnn/cudnn_frontend/-/merge_requests/2332

### Three changes, smallest first

1. Two process-wide lookup caches, 34 lines. `_convert_to_cutlass_data_type` and the
   `torch.Tensor` class probe in `is_torch_tensor` each get called tens of times per
   launch, and each answers from a fixed table. Every CuTeDSL op benefits.

2. Per-launch descriptor and stream caches, about 14 lines per op. `execute()` rebuilds
   a canonical `TensorDesc` for every operand on every launch, which is the largest
   single cost in `execute()`, and it re-resolves the launch stream. Both outcomes are
   decided entirely by values that now sit in the cache key. A miss runs the full check.

3. The wrapper memo, which is most of the diff. Everything between the wrapper entry and
   `op.execute()` is derivation: resolving dtypes, deriving `(m, n, experts)`, rebuilding
   the op cache key. All of it is a pure function of operand metadata plus the scalar
   config. A hit skips the derivation and reuses the result. It still calls
   `op.execute()`, which validates every operand.

### Why the key is metadata and not id()

An identity-keyed memo is unsound here. CPython recycles a tensor's address as soon as
it is freed, so a freshly allocated tensor routinely lands on an address the memo has
already seen. Measured on this branch's benchmark, 200 freshly allocated tensors
produced 1 distinct `id()`. That means 199 of 200 calls would take a fast path derived
from an object the memo never validated, silently returning a wrong-sized output once
the token count changed.

`_operand_meta` reads shape, strides, dtype and device. That is everything the
derivation consumes and nothing else. Data pointers stay out because they vary per call
and nothing derived depends on them. Their alignment gets re-checked inside `execute()`.

## What this PR deliberately does not do

Four things were built, measured, and then cut because the win did not justify the code.

The validation hoist, `_metadata_validated`, 141 lines. It let a memo hit skip the
metadata block inside `execute()`. It looked worth 53 us on dGLU, but only because dGLU
lacked change 2. Give dGLU the 14-line descriptor cache instead and the hoist drops to
5-10 us across the three ops. It also put a validation-skipping parameter on the public
`execute()` signature. Dropped.

The wgrad memo, 180 lines for roughly 15 us. Worst ratio in the set by 3-5x. Dropped.

A `_stride_order` rewrite. I originally claimed the tuple-sort form beat the `key=`
lambda it replaced by about 1.3 us per operand. Measured in isolation, it is not faster
at all: 10.30 vs 10.38 us for nine operands. Reverted, and the comment claiming
otherwise is gone.

A dsrelu memo, which broke 12 cache-behaviour tests. `use_full_dynamic` masks shapes
from the cache key on purpose, `valid_m == 0` returns before the derivation runs, and
`deterministic=None` resolves from a global. A metadata key cannot hold any of those
honestly. Reverted.

Of the 17 CuTeDSL GEMM ops, 3 are optimized here. Of the remaining 14, none has the
`_validate_live_tensor` layer that change 2 attaches to, so there is nothing there to
cache. Seven mask shapes via `use_full_dynamic` or return early on `valid_m == 0`, which
rules out the wrapper memo. The last six are tractable but unbenchmarked, and I would
not memoize one without building its benchmark first.

## Two traps worth knowing if you extend this

dGLU defaults `linear_offset` during normalization. The memo bypasses normalization, so
the hit path has to resolve the same default from `act_func` or it hands `None` to the
kernel. A single-call test cannot catch this, because only the second call takes the hit
path.

A parameter added to a wrapper but not to its memo key collides silently. This has now
happened twice on rebases: `sf_fp8_dtype_override` in GLU, then `situ_beta1` and
`situ_beta2` in both GLU and dGLU after the SiTU-GLU activation landed in #645. Both
feed the op cache key, so a hit would have served an op compiled for different betas.
Wrong numerics, no error. `test_memo_key_covers_every_wrapper_parameter` auto-discovers
every memoized wrapper and fails on an uncovered parameter. It caught both.

## Type of change

- [x] Performance improvement

## Testing

`test/python/fe_api/test_grouped_gemm_wrapper_memo.py`, 6 tests, pins that a hit matches
the cold path byte for byte, that alternating token counts with freshly built operands
each step still return correct shapes, that a fresh wrongly-typed tensor is still
rejected once the memo is warm, that a transposed operand takes a different key, that
the GLU hit matches its cold path, and the key-coverage guard above.

Scoped to what this diff can reach: `test/python/fe_api/grouped_gemm/` plus the memo
tests. `test_gemm_swiglu.py`, `test_sdpa_bwd.py` and `test_NSA_swa.py` were also run
against develop, because `datatypes.py` and `tensor_adapter.py` are process-wide.

Those three files fail 80 tests identically on develop with this branch reverted, same
64 / 12 / 4 split and same test IDs. They are tolerance misses in dense GEMM and
attention backward, plus an NSA gate that wants backend 9.26.0 against 9.24 here. This
PR adds no new failures.

## Checklist

- [x] Code follows the style guidelines, `black --line-length 160`
- [x] Self-review performed
- [x] Comments added where the reasoning is not obvious from the code
- [x] New tests added and passing
