### PR TITLE
benchmark(sdpa): qwen3vl_vit writes to results/ like every other config

### DIFF
--- a/benchmark/sdpa_benchmark_training/configs/qwen3vl_vit.py
+++ b/benchmark/sdpa_benchmark_training/configs/qwen3vl_vit.py
@@ -62,4 +62,5 @@ CONFIG = BenchmarkConfig(
     batch_size=1,
     num_iterations=10,
     num_warmup_iterations=5,
+    output_dir="results",
 )


### PR DESCRIPTION
The qwen3vl_vit config omitted `output_dir`, falling to `BenchmarkConfig`'s default of `"../results"` — one directory above where every other config (`output_dir="results"`) writes, and where tooling that collects runner output looks. One line: set `output_dir="results"` to match the rest of the configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a default `results` output directory for the Qwen3VL vision benchmark configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->