### PR TITLE
test_mhas_v2: draw sink tokens in the ragged bwd suites

### DIFF
--- a/test/python/test_mhas_v2.py
+++ b/test/python/test_mhas_v2.py
@@ -495,6 +495,7 @@ def test_sdpa_random_bwd_ragged_L0(env_info, test_no, request, cudnn_handle):
         is_ragged_or_padded_or_full=RandomChoice({"ragged" : 1, "padded" : 0, "full" : 0}),
         is_deterministic=RandomChoice({True : 3, False : 1}),
         ragged_stats_layout=RandomChoice({"token_major" : 1, "head_major" : 1}),
+        with_sink_token=RandomChoice({True : 1, False : 3}),
     ) as randomization_ctx:
         test.cfg = randomization_ctx(rng, data_seed, geom_seed)
 
@@ -903,6 +904,7 @@ def test_sdpa_fp8_bwd_ragged_L0(env_info, test_no, request, cudnn_handle):
         diag_align=RandomChoice({cudnn.diagonal_alignment.TOP_LEFT: 1}),
         is_ragged_or_padded_or_full=RandomChoice({"ragged": 1, "padded": 0, "full": 0}),
         is_deterministic=RandomChoice({True: 1, False: 1}),
+        with_sink_token=RandomChoice({True: 1, False: 2}),
     ) as randomization_ctx:
         test.cfg = randomization_ctx(rng, data_seed, geom_seed)
 


### PR DESCRIPTION
## What

Add the same `with_sink_token` draw the dense bwd suites already use to `test_sdpa_random_bwd_ragged_L0` and `test_sdpa_fp8_bwd_ragged_L0`.

## Why

Backward x ragged x learnable-sink was structurally untestable: the dense bwd suite draws sink tokens but never ragged layout, and the ragged bwd suites never drew sink tokens. That empty cell let a dSink corruption in the cuDNN backward `dot_do_o` pre-kernel ship unnoticed for every THD config with d_v not in {64,128,256} (bf16/fp16) and all ragged fp8 configs - reported via TransformerEngine issue [#3249](https://github.com/NVIDIA/TransformerEngine/issues/3249), fixed in cuDNN backend MR !4223 (dev) / !4224 (9.26).

Note: adding a drawn knob reshuffles downstream draws for every seed, so per-seed configs change (same property as #304's stats-stride draw).

## Status: draft until remaining backend fixes land

On H100 with a cuDNN dev build that includes the dot_do_o fix, this coverage exposes two further pre-existing backend defects (64/256 fail; baseline without the knob is 256/256 green in the same environment):

1. **fwd THD+sink stats slack fill**: with a sink, the SM90 forward fills the stats padding slack with `-inf` where the no-sink kernel (and the test reference) produce `0` - a contract mismatch in the undefined region (2007/31872-element slack-only mismatches, valid rows and dQ/dK/dV all clean).
2. **dSink with head-major ragged stats**: the backward `dot_do_o` kernels derive the per-batch stats base as `batch_offset_o[b]/d`, a token-major-only convention, so head-major THD stats produce corrupt dSink for **all** head dims. Proper fix is plumbing the Stats tensor's own ragged offsets into the kernel.

Once those are fixed in the backend, this suite goes green and gates the whole class of bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded ragged backward attention test coverage with randomized sink-token scenarios.
  * Added coverage for both standard-precision and FP8 execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->