### PR TITLE
Avoid zero-initializing JAX outputs the kernel already writes

### DIFF
--- a/python/cudnn/gemm/cutedsl/dense/swiglu/jax_api.py
+++ b/python/cudnn/gemm/cutedsl/dense/swiglu/jax_api.py
@@ -20,7 +20,7 @@ import cutlass.utils
 
 from cudnn.datatypes import _convert_to_cutlass_data_type
 from cudnn.tensor_adapter import framework_dtype
-from cudnn.jax import call, gemm_operand_spec, row_major_desc as _make_desc, sf_atom_spec, zeros_init
+from cudnn.jax import call, gemm_operand_spec, row_major_desc as _make_desc, sf_atom_spec
 from .api import GemmSwigluSm100
 
 # config_key -> (kernel instance, max_active_clusters). The instance does not vary
@@ -145,16 +145,14 @@ def gemm_swiglu_jax_sm100(
         jax.ShapeDtypeStruct((m, n, l), framework_dtype(ab12_dtype, "jax")),  # ab12
         jax.ShapeDtypeStruct((m, n // 2, l), framework_dtype(c_dtype, "jax")),  # c
     )
-    # Outputs are donated pre-initialized inputs: the bridge's leading-dim inference
-    # rejects trailing-unit-dim buffers on pure results, and the donated-input path
-    # carries the explicit (1, 0, 2) layout spec.
+    # Neither output needs zeroing: the kernel writes ab12 and c in full over (m, n, l)
+    # and (m, n // 2, l). Zero-filling them was a full-size device write per dispatch.
     if not is_quantized:
         ab12_tensor, c_tensor = call(
             _swiglu_adapter,
             output_shape_dtype=out_types,
             input_spec=(operand, operand),
             output_spec=(operand, operand),
-            initialized_outputs={0: zeros_init, 1: zeros_init},
             kernel=kernel,
             mac=mac,
             alpha=float(alpha),
@@ -166,7 +164,6 @@ def gemm_swiglu_jax_sm100(
             output_shape_dtype=(out_types[1], out_types[0]),
             input_spec=(operand, operand, sf, sf),
             output_spec=(operand, operand),
-            initialized_outputs={0: zeros_init, 1: zeros_init},
             kernel=kernel,
             mac=mac,
             alpha=float(alpha),

--- a/python/cudnn/gemm/cutedsl/grouped/glu/jax_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/jax_api.py
@@ -29,7 +29,7 @@ from cutlass.cute.nvgpu import OperandMajorMode
 
 from cudnn.datatypes import _convert_to_cutlass_data_type
 from cudnn.tensor_adapter import framework_dtype
-from cudnn.jax import call, gemm_operand_spec, zeros_init
+from cudnn.jax import call, gemm_operand_spec
 from ..moe_utils import MoEWeightMode
 from ..unfused.jax_api import _pointer_count, _prob_spec
 from .moe_grouped_gemm_glu_bias import MoEGroupedGemmGluBiasBf16Kernel
@@ -101,9 +101,8 @@ def grouped_gemm_glu_jax_sm100(
     ``n`` is the full weight N before the GLU split; ``d`` comes back ``(m, n // 2, 1)``.
     ``linear_offset`` defaults per ``act_func`` (1.0 for ``"geglu"``, 0.0 for
     ``"swiglu"``) and is a compile-time constant of the traced call. Returns
-    ``(d_tensor, c_tensor)`` with ``c_tensor`` None unless ``generate_c``; rows
-    at/past ``padded_offsets[-1]`` come back zero-filled (the outputs are donated
-    zero-initialized buffers).
+    ``(d_tensor, c_tensor)`` with ``c_tensor`` None unless ``generate_c``. Rows
+    at/past ``padded_offsets[-1]`` are unspecified.
     """
     c_dtype = _convert_to_cutlass_data_type(c_dtype)
     d_dtype = _convert_to_cutlass_data_type(d_dtype)
@@ -207,10 +206,13 @@ def grouped_gemm_glu_jax_sm100(
         ),
         input_spec=(operand, None, None, None, _prob_spec()),
         output_spec=(operand, operand, None),
-        # All three donated: c/d for the trailing-unit-dim layout spec (and defined
-        # bytes past the last offset); the workspace because the helper kernel writes
-        # the per-expert TMA descriptors into it (XLA inputs are immutable).
-        initialized_outputs={0: zeros_init, 1: zeros_init, 2: zeros_init},
+        # Only zero what the kernel does not write. Zero-filling an output the
+        # kernel overwrites is a full-size device write on every dispatch, and it
+        # scales with the output -- the dominant host-visible cost of the JAX path.
+        # Nothing here qualifies: the kernel writes d/c over the addressed rows and the
+        # descriptor helper writes the workspace before the kernel reads it. Rows at or
+        # past padded_offsets[-1] are consequently unspecified, matching what the torch
+        # wrapper has always returned from empty_strided.
         kernel=kernel,
         n=int(n),
         k=int(k),

--- a/python/cudnn/gemm/cutedsl/grouped/unfused/jax_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/unfused/jax_api.py
@@ -28,7 +28,7 @@ from cutlass.cute.nvgpu import OperandMajorMode
 
 from cudnn.datatypes import _convert_to_cutlass_data_type
 from cudnn.tensor_adapter import framework_dtype
-from cudnn.jax import TensorSpec, call, gemm_operand_spec, zeros_init
+from cudnn.jax import TensorSpec, call, gemm_operand_spec
 from ..moe_utils import MoEWeightMode
 from .moe_grouped_gemm import MoEGroupedGemmBf16Kernel
 
@@ -108,9 +108,8 @@ def grouped_gemm_jax_sm100(
     row offsets, ``alpha (experts,)`` float32, ``prob (m, 1, 1)`` float32, and
     ``b_ptrs`` holding per-expert ``(n, k)`` k-major bfloat16 weight base addresses
     (packed little-endian uint8, 8 bytes per pointer — or int64 with x64 mode).
-    Returns ``(d_tensor, c_tensor)`` with ``c_tensor`` None unless ``generate_c``;
-    rows at/past ``padded_offsets[-1]`` come back zero-filled (the outputs are
-    donated zero-initialized buffers).
+    Returns ``(d_tensor, c_tensor)`` with ``c_tensor`` None unless ``generate_c``.
+    Rows at/past ``padded_offsets[-1]`` are unspecified.
     """
     c_dtype = _convert_to_cutlass_data_type(c_dtype)
     d_dtype = _convert_to_cutlass_data_type(d_dtype)
@@ -207,10 +206,13 @@ def grouped_gemm_jax_sm100(
         ),
         input_spec=(operand, None, None, None, _prob_spec()),
         output_spec=(operand, operand, None),
-        # All three donated: c/d for the trailing-unit-dim layout spec (and defined
-        # bytes past the last offset); the workspace because the helper kernel writes
-        # the per-expert TMA descriptors into it (XLA inputs are immutable).
-        initialized_outputs={0: zeros_init, 1: zeros_init, 2: zeros_init},
+        # Only zero what the kernel does not write. Zero-filling an output the
+        # kernel overwrites is a full-size device write on every dispatch, and it
+        # scales with the output -- the dominant host-visible cost of the JAX path.
+        # Nothing here qualifies: the kernel writes d/c over the addressed rows and the
+        # descriptor helper writes the workspace before the kernel reads it. Rows at or
+        # past padded_offsets[-1] are consequently unspecified, matching what the torch
+        # wrapper has always returned from empty_strided.
         kernel=kernel,
         n=int(n),
         k=int(k),

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/jax_api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/jax_api.py
@@ -195,10 +195,13 @@ def grouped_gemm_wgrad_jax_sm100(
             jax.ShapeDtypeStruct((m, n), framework_dtype(wgrad_dtype, "jax")),
             jax.ShapeDtypeStruct((workspace_bytes,), jnp.uint8),
         ),
-        # Both donated: the template so the returned token has defined (zero) bytes
-        # (the kernel never writes it); the workspace because the helper kernel writes
-        # the per-expert TMA descriptors into it (XLA inputs are immutable).
-        initialized_outputs={0: zeros_init, 1: zeros_init},
+        # Only zero what the kernel does not write. Zero-filling an output the
+        # kernel overwrites is a full-size device write on every dispatch, and it
+        # scales with the output -- the dominant host-visible cost of the JAX path.
+        # The template keeps its zeros: the kernel writes through wgrad_ptrs and never
+        # touches this buffer, so zeros are the only defined value it can carry. The
+        # workspace is written by the descriptor helper before the kernel reads it.
+        initialized_outputs={0: zeros_init},
         kernel=kernel,
         mac=mac,
     )(a_tensor, b_tensor, offsets_tensor, wgrad_ptrs)

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_jax.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_jax.py
@@ -218,3 +218,58 @@ def test_grouped_gemm_glu_jax_errors():
             n=n_full,
             b_dtype="uint8",
         )
+
+
+@pytest.mark.L0
+def test_grouped_gemm_glu_jax_addressed_rows_survive_a_dirty_allocator():
+    """Rows before ``padded_offsets[-1]`` are correct whatever the output buffer held.
+
+    The outputs are no longer zero-initialized, so the rows the kernel does not
+    address carry whatever XLA last left in the buffer. A test that runs on a clean
+    allocator passes either way -- fresh device memory reads as zeros -- so this one
+    dirties the allocator first and checks only the contract that still holds.
+    """
+    skip_unless_sm100()
+    from cudnn import grouped_gemm_glu_jax_sm100, grouped_gemm_glu_wrapper_sm100
+
+    m, n_full, k, experts = 1024, 256, 128, 2
+    a_np, b_storage_np, _, alpha_np, prob_np = make_problem(m, n_full, k, experts)
+    # 256-aligned, and the last offset stops short of m, so the tail is never addressed
+    offsets_np = np.array([256, 512], dtype=np.int32)
+
+    to_torch = lambda x: torch.from_numpy(x.view(np.uint8)).view(torch.bfloat16).cuda()
+    a_t = to_torch(a_np).reshape(m, k, 1)
+    b_t = to_torch(b_storage_np).reshape(experts, n_full, k)
+    b_ptrs_t = torch.tensor([b_t[i].data_ptr() for i in range(experts)], dtype=torch.int64, device="cuda")
+    expected = grouped_gemm_glu_wrapper_sm100(
+        a_tensor=a_t,
+        sfa_tensor=None,
+        padded_offsets=torch.from_numpy(offsets_np).cuda(),
+        alpha_tensor=torch.from_numpy(alpha_np).cuda(),
+        prob_tensor=torch.from_numpy(prob_np).cuda(),
+        b_ptrs=b_ptrs_t,
+        n=n_full,
+        b_dtype=torch.bfloat16,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+    )["d_tensor"]
+    device_sync()
+
+    a_j = jnp.asarray(a_np)
+    weights = [jnp.asarray(b_storage_np[i]) for i in range(experts)]
+    offsets_j, alpha_j, prob_j = (jnp.asarray(x) for x in (offsets_np, alpha_np, prob_np))
+    jax.block_until_ready((a_j, offsets_j, alpha_j, prob_j, *weights))
+    b_ptrs_j = _packed_jax_ptrs(weights)
+    jitted = jax.jit(lambda a, off, alpha, ptrs, prob: grouped_gemm_glu_jax_sm100(a, off, alpha, ptrs, n_full, prob)[0])
+
+    # Poison the allocator so a reused output buffer cannot read back as zeros.
+    for _ in range(8):
+        junk = jax.block_until_ready(jnp.full((m, n_full // 2, 1), -7.5, dtype=jnp.bfloat16))
+        del junk
+
+    actual = jax.block_until_ready(jitted(a_j, offsets_j, alpha_j, b_ptrs_j, prob_j))
+    valid = int(offsets_np[-1])
+    np.testing.assert_array_equal(
+        np.asarray(actual)[:valid],
+        expected[:valid].float().cpu().numpy().astype(np.asarray(actual).dtype),
+    )

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_jax.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_jax.py
@@ -229,6 +229,10 @@ def test_grouped_gemm_glu_jax_addressed_rows_survive_a_dirty_allocator():
     allocator passes either way -- fresh device memory reads as zeros -- so this one
     dirties the allocator first and checks only the contract that still holds.
     """
+    import cutlass.jax
+
+    if not cutlass.jax.is_available():
+        pytest.skip("CuTeDSL JAX extensions unavailable (jax >= 0.5 required)")
     skip_unless_sm100()
     from cudnn import grouped_gemm_glu_jax_sm100, grouped_gemm_glu_wrapper_sm100
 

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_jax.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_jax.py
@@ -200,6 +200,10 @@ def test_grouped_gemm_jax_addressed_rows_survive_a_dirty_allocator():
     allocator passes either way -- fresh device memory reads as zeros -- so this one
     dirties the allocator first and checks only the contract that still holds.
     """
+    import cutlass.jax
+
+    if not cutlass.jax.is_available():
+        pytest.skip("CuTeDSL JAX extensions unavailable (jax >= 0.5 required)")
     skip_unless_sm100()
     from cudnn import grouped_gemm_jax_sm100, grouped_gemm_wrapper_sm100
 

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_jax.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_jax.py
@@ -189,3 +189,58 @@ def test_grouped_gemm_jax_errors():
             b_dtype="bfloat16",
             bias_tensor=bias_j,
         )
+
+
+@pytest.mark.L0
+def test_grouped_gemm_jax_addressed_rows_survive_a_dirty_allocator():
+    """Rows before ``padded_offsets[-1]`` are correct whatever the output buffer held.
+
+    The outputs are no longer zero-initialized, so the rows the kernel does not
+    address carry whatever XLA last left in the buffer. A test that runs on a clean
+    allocator passes either way -- fresh device memory reads as zeros -- so this one
+    dirties the allocator first and checks only the contract that still holds.
+    """
+    skip_unless_sm100()
+    from cudnn import grouped_gemm_jax_sm100, grouped_gemm_wrapper_sm100
+
+    m, n, k, experts = 1024, 256, 128, 2
+    a_np, b_storage_np, _, alpha_np, prob_np = make_problem(m, n, k, experts)
+    # 256-aligned, and the last offset stops short of m, so the tail is never addressed
+    offsets_np = np.array([256, 512], dtype=np.int32)
+
+    to_torch = lambda x: torch.from_numpy(x.view(np.uint8)).view(torch.bfloat16).cuda()
+    a_t = to_torch(a_np).reshape(m, k, 1)
+    b_t = to_torch(b_storage_np).reshape(experts, n, k)
+    b_ptrs_t = torch.tensor([b_t[i].data_ptr() for i in range(experts)], dtype=torch.int64, device="cuda")
+    expected = grouped_gemm_wrapper_sm100(
+        a_tensor=a_t,
+        padded_offsets=torch.from_numpy(offsets_np).cuda(),
+        alpha_tensor=torch.from_numpy(alpha_np).cuda(),
+        prob_tensor=torch.from_numpy(prob_np).cuda(),
+        b_ptrs=b_ptrs_t,
+        n=n,
+        b_dtype=torch.bfloat16,
+        c_dtype=torch.bfloat16,
+        d_dtype=torch.bfloat16,
+    )["d_tensor"]
+    device_sync()
+
+    a_j = jnp.asarray(a_np)
+    weights = [jnp.asarray(b_storage_np[i]) for i in range(experts)]
+    offsets_j, alpha_j, prob_j = (jnp.asarray(x) for x in (offsets_np, alpha_np, prob_np))
+    jax.block_until_ready((a_j, offsets_j, alpha_j, prob_j, *weights))
+    ptr_values = np.array([w.unsafe_buffer_pointer() for w in weights], dtype=np.int64)
+    b_ptrs_j = jax.block_until_ready(jnp.asarray(ptr_values.view(np.uint8)))
+    jitted = jax.jit(lambda a, off, alpha, ptrs, prob: grouped_gemm_jax_sm100(a, off, alpha, ptrs, n, prob)[0])
+
+    # Poison the allocator so a reused output buffer cannot read back as zeros.
+    for _ in range(8):
+        junk = jax.block_until_ready(jnp.full((m, n, 1), -7.5, dtype=jnp.bfloat16))
+        del junk
+
+    actual = jax.block_until_ready(jitted(a_j, offsets_j, alpha_j, b_ptrs_j, prob_j))
+    valid = int(offsets_np[-1])
+    np.testing.assert_array_equal(
+        np.asarray(actual)[:valid],
+        expected[:valid].float().cpu().numpy().astype(np.asarray(actual).dtype),
+    )


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

FE OSS kernels or CuTeDSL (Python/JAX entry points)

## Summary

Stop passing `initialized_outputs` for JAX outputs the kernel already writes, in `grouped/unfused`, `grouped/glu`, `dense/swiglu`, and the workspace of `grouped/wgrad`. No kernel, output spec, or layout changes. Adds two JAX tests.

**Supersedes and closes #592** (@mgoldfarb-nvidia), which established this for `grouped/unfused` and is folded in here so the whole audit lands as one piece. The mechanism, measurement protocol and framing are Michael's.

## Why

`initialized_outputs` makes XLA zero-fill the buffer before every dispatch. That fill scales with the output, so it was the dominant host-visible cost of the JAX path — and the torch wrapper never paid it, since it allocates with `torch.empty_strided`.

| entry point | dropped |
|---|---|
| `grouped/unfused` | `d`, `c`, workspace — from #592 |
| `grouped/glu` | `d`, `c`, workspace |
| `dense/swiglu` | `ab12`, `c` |
| `grouped/wgrad` | workspace only; the template keeps its zeros, since the kernel writes through `wgrad_ptrs` and never touches that buffer |

### Deliberately unchanged — the part worth carrying forward

I tried removing it from every remaining site and reverted six: `dense/amax`, `dense/srelu`, `grouped/dglu`, `grouped/dsrelu`, `discrete_grouped/swiglu`, `discrete_grouped/dswiglu`.

Their comments cite the bridge's leading-dim inference rejecting trailing-unit-dim buffers on pure results, and that reason is **still accurate** — not stale documentation, which is what I had assumed. All six fail the JAX jit-vs-eager test without the donation, and `grouped/dglu` returns results differing from torch by 1.125 where it matched exactly.

So this is not mechanically applicable across the JAX entry points. An audit that assumes it is will silently corrupt six of them.

## Related issues

Supersedes #592.

## API and compatibility impact

For `grouped/unfused` and `grouped/glu`, rows at or past `padded_offsets[-1]` are now **unspecified** rather than zero — the same behavior the torch wrapper has always had via `empty_strided`. Documented in both docstrings. Rows before that offset are bit-identical to the torch path under full and partial coverage. No change to supported GPU/cuDNN/CUDA/Python versions.

Performance — B200, bf16, 8 experts, `jax.jit` wall time, median of 3 alternating base/head runs via `benchmark/grouped_gemm_dispatch/bench_dispatch.py`. Each invocation asserts which module tree it loaded before measuring, so the two columns cannot silently be the same build:

| API | M × N × K | kernel | base (µs) | this PR (µs) |
|---|---|---:|---:|---:|
| unfused | 2048 × 2048 × 2048 | 18.8 | 38.8 | **35.4** |
| unfused | 4096 × 2048 × 2048 | 32.0 | 52.6 | **37.2** |
| unfused | 8192 × 4096 × 2048 | 106.9 | 136.9 | **110.5** |
| unfused | 16384 × 4096 × 4096 | 388.0 | 443.2 | **392.2** |
| glu | 2048 × 2048 × 2048 | 18.4 | 41.5 | **34.5** |
| glu | 4096 × 2048 × 2048 | 31.4 | 50.1 | **36.1** |
| glu | 8192 × 4096 × 2048 | 105.0 | 122.9 | **108.7** |
| glu | 16384 × 4096 × 4096 | 384.0 | 416.3 | **387.1** |

At the largest shape that is +4.2 µs over the kernel for unfused and +3.1 for glu, against +55 and +32 before. The overhead no longer grows with output size, which was the original complaint.

## Testing

Two new JAX tests, one per changed grouped entry point:

- `fe_api/grouped_gemm/test_grouped_gemm_jax.py::test_grouped_gemm_jax_addressed_rows_survive_a_dirty_allocator`
- `fe_api/grouped_gemm/test_grouped_gemm_glu_jax.py::test_grouped_gemm_glu_jax_addressed_rows_survive_a_dirty_allocator`

Both run partial coverage (`padded_offsets[-1] < m`) with the allocator poisoned before dispatch, and assert the addressed rows match the torch wrapper bit-for-bit. The poisoning is the point: on fresh device memory the untouched tail reads back as zeros whether or not the fill is present, so a test that does not dirty the allocator first passes either way and proves nothing.

```
cd test/python && pytest fe_api -q -m L0 -k jax
57 passed, 4252 deselected, 2 xfailed
```

That suite is what caught the six reverts above.

```
uvx pre-commit run --files <changed>
clang-format....(no files to check)Skipped
black...........Passed
black-jupyter...Passed
```
