### PR TITLE
Skip SM107 causal conv1d samples before cuDNN 9.26

### DIFF
--- a/samples/cpp/causal_conv1d/b2b_causal_conv1d.cpp
+++ b/samples/cpp/causal_conv1d/b2b_causal_conv1d.cpp
@@ -28,6 +28,9 @@ TEST_CASE("B2B causal conv1d forward", "[b2b_causal_conv1d][forward]") {
     if (is_arch_supported_by_cudnn() == false) {
         SKIP("Architecture is not supported by current cudnn version");
     }
+    if (get_compute_capability() == 107 && cudnnGetVersion() < 92600) {
+        SKIP("B2B causal conv1d kernels on SM107 require cuDNN 9.26.0 or newer");
+    }
 
     int batch             = 2;
     int dim               = 64;
@@ -72,6 +75,9 @@ TEST_CASE("B2B causal conv1d backward", "[b2b_causal_conv1d][backward]") {
 #else
     if (is_arch_supported_by_cudnn() == false) {
         SKIP("Architecture is not supported by current cudnn version");
+    }
+    if (get_compute_capability() == 107 && cudnnGetVersion() < 92600) {
+        SKIP("B2B causal conv1d kernels on SM107 require cuDNN 9.26.0 or newer");
     }
 
     int batch             = 2;

--- a/samples/cpp/causal_conv1d/causal_conv1d.cpp
+++ b/samples/cpp/causal_conv1d/causal_conv1d.cpp
@@ -26,6 +26,9 @@ TEST_CASE("Causal conv1d forward", "[causal_conv1d][forward]") {
     if (is_arch_supported_by_cudnn() == false) {
         SKIP("Architecture is not supported by current cudnn version");
     }
+    if (get_compute_capability() == 107 && cudnnGetVersion() < 92600) {
+        SKIP("Causal conv1d kernels on SM107 require cuDNN 9.26.0 or newer");
+    }
 
     int batch       = 2;
     int dim         = 64;
@@ -63,6 +66,9 @@ TEST_CASE("Causal conv1d backward", "[causal_conv1d][backward]") {
 #else
     if (is_arch_supported_by_cudnn() == false) {
         SKIP("Architecture is not supported by current cudnn version");
+    }
+    if (get_compute_capability() == 107 && cudnnGetVersion() < 92600) {
+        SKIP("Causal conv1d kernels on SM107 require cuDNN 9.26.0 or newer");
     }
 
     int batch       = 2;

--- a/samples/cpp/causal_conv1d/causal_conv1d_nwh.cpp
+++ b/samples/cpp/causal_conv1d/causal_conv1d_nwh.cpp
@@ -28,6 +28,9 @@ TEST_CASE("Causal conv1d NWH forward", "[causal_conv1d_nwh][forward]") {
     if (is_arch_supported_by_cudnn() == false) {
         SKIP("Architecture is not supported by current cudnn version");
     }
+    if (get_compute_capability() == 107 && cudnnGetVersion() < 92600) {
+        SKIP("Causal conv1d NWH kernels on SM107 require cuDNN 9.26.0 or newer");
+    }
 
     int batch       = 2;
     int dim         = 64;
@@ -67,6 +70,9 @@ TEST_CASE("Causal conv1d NWH backward", "[causal_conv1d_nwh][backward]") {
 #else
     if (is_arch_supported_by_cudnn() == false) {
         SKIP("Architecture is not supported by current cudnn version");
+    }
+    if (get_compute_capability() == 107 && cudnnGetVersion() < 92600) {
+        SKIP("Causal conv1d NWH kernels on SM107 require cuDNN 9.26.0 or newer");
     }
 
     int batch       = 2;


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

Documentation or samples

## Summary

Skip the forward and backward causal conv1d, NWH causal conv1d, and B2B causal conv1d C++ sample tests on SM107 when the loaded cuDNN runtime is older than 9.26.0.

## Why

These SM107 kernels fail during NVRTC compilation with cuDNN 9.25. cuDNN 9.26 contains the runtime fix. Checking `cudnnGetVersion()` keeps the tests enabled on SM107 when the loaded runtime contains that fix, including binaries compiled with older cuDNN headers, while leaving other architectures unaffected.

## Related issues

None.

## API and compatibility impact

None. This only changes sample-test skip conditions.

## Testing

- SM107, binary compiled with cuDNN 9.25 headers and loaded with the cuDNN 9.25 runtime: all six affected tests reproduced the NVRTC failure.
- The same SM107 binary loaded with the cuDNN 9.26 runtime: all six affected tests passed.
- SM100 with cuDNN 9.26: all six affected tests passed.
- Full C++ samples build completed successfully against cuDNN 9.26.
- `clang-format` 21.1.6 dry-run and `git diff --check` passed for the patch.

The full pre-commit hook was not available locally because the installed pre-commit 2.17.0 cannot parse the repository's current `textproto` manifest entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for causal convolution tests on SM107 hardware.
  * Tests now skip gracefully when running with cuDNN versions older than 9.26.0.
  * Applied to forward and backward paths, including standard and back-to-back causal convolution variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->