### PR TITLE
sdpa: throw cudnnGraphNotSupportedException when no implementation supports the attributes

### DIFF
--- a/include/cudnn_frontend/graph_interface.h
+++ b/include/cudnn_frontend/graph_interface.h
@@ -408,7 +408,10 @@ class Graph : public ICudnn, public INode {
 
         switch (attributes.implementation) {
             case AttentionImplementation_t::AUTO:
-                throw std::runtime_error("No suitable implementation for given SDPA_attributes");
+                // No implementation supports the requested feature combination on this
+                // arch/version. Throw the typed exception (a std::runtime_error subclass)
+                // so callers get GRAPH_NOT_SUPPORTED semantics rather than a generic error.
+                throw cudnnGraphNotSupportedException("No suitable implementation for given SDPA_attributes");
                 break;
             case AttentionImplementation_t::COMPOSITE:
                 sub_nodes.emplace_back(std::make_unique<CompositeSDPANode>(std::move(attributes), context));


### PR DESCRIPTION
## What

When `_auto_select_implementation` finds no implementation for the requested SDPA feature combination on the current arch/version, `sdpa_internal` threw a plain `std::runtime_error`. Throw `cudnnGraphNotSupportedException` instead - it subclasses `std::runtime_error` (existing catch sites keep working) and pybind already maps it to `cudnn.cudnnGraphNotSupportedError`.

## Why

`test_sdpa_fp8_fwd_ragged_L0` draws `cu_ragged`/`cu_ragged_mult` layouts. On SM90 fp8 there is no implementation for `CU_SEQ_LEN` inputs (the composite path rejects them by design, the unified engines do not cover SM90 fp8), which is a legitimate *unsupported* configuration - but the generic RuntimeError made the test framework `pytest.fail` instead of skip, so the suite reported **23 hard failures on H100**. C++ callers likewise could not distinguish unsupported-graph from a real error.

## Verification (H100, cuDNN dev build)

`-k fp8_fwd_ragged`: before = 23 failed / 2 passed / 7 skipped; after = **2 passed / 30 skipped / 0 failed**. Numeric failures are unaffected - only the no-implementation path changes type.

Note: branch is based on 6c39f8b9b rather than develop tip because tip (#612) currently has a broken import - `_pygraph.py` imports `ensure_current_context` from `cudnn._device`, which no longer defines it, so `import cudnn` fails. Flagging separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for unsupported SDPA configurations by providing a more specific graph support exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->