### PR TITLE
Fix device crash

### DIFF
--- a/python/cudnn/_device.py
+++ b/python/cudnn/_device.py
@@ -140,16 +140,19 @@ class DeviceInfo:
 
         drv = _driver()
         # CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK (ordinal 150)
-        # arrived in CUDA 13.4. It needs BOTH a new-enough driver AND a cuda-python
-        # whose CUdevice_attribute carries the enum member: a new driver with an old
-        # binding passes the version gate but the enum member is absent (accessing it
-        # raises, since the binding reads attrib.value). Either missing -> no such
-        # mode -> 0 by design (not an error). With both present the attribute is real:
-        # query it and let a genuine failure raise rather than masking it.
-        attr = getattr(drv.CUdevice_attribute, "CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK", None)
-        if attr is None or _env.driver_version() < 13040:
+        # arrived in CUDA 13.4. The DRIVER decides whether the mode exists at all,
+        # so an older one is 0 by design (not an error). The BINDING only decides
+        # how to ask: a cuda-python older than the driver cannot name the enum
+        # member but still forwards the bare ordinal, and only bindings old enough
+        # to reject an int (they read attrib.value) genuinely cannot make the query
+        # -> 0. A real driver failure still raises rather than being masked.
+        if _env.driver_version() < 13040:
             return 0
-        return int(_ck(*drv.cuDeviceGetAttribute(attr, _device_handle(self.ordinal))))
+        attr = getattr(drv.CUdevice_attribute, "CU_DEVICE_ATTRIBUTE_MAX_OVERSIZED_SHARED_MEMORY_PER_BLOCK", 150)
+        try:
+            return int(_ck(*drv.cuDeviceGetAttribute(attr, _device_handle(self.ordinal))))
+        except AttributeError:
+            return 0
 
     @functools.cached_property
     def l2_cache_bytes(self) -> int:


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Incorporate https://github.com/NVIDIA/cudnn-frontend/pull/615 and clean up rest of the failures

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of oversized shared-memory support across different driver versions and CUDA binding variations.
  * Capability checks now use a compatible fallback when the required enum is unavailable.
  * Binding-level attribute errors during capability checks safely report unsupported functionality instead of failing.
  * Driver query errors continue to be reported for visibility and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->