### PR TITLE
python: add the ensure_current_context #612 imports but never defined

### DIFF
--- a/python/cudnn/_device.py
+++ b/python/cudnn/_device.py
@@ -59,6 +59,40 @@ def _device_handle(device: int):
     return _ck(*drv.cuDeviceGet(device))
 
 
+def ensure_current_context(stream=None) -> None:
+    """Bind a driver context to the calling thread when none is bound.
+
+    JIT engines talk to the driver directly, which reads the calling THREAD's
+    context stack — and an autograd backward runs on a worker thread where
+    ``cudaSetDevice`` has only moved the runtime's thread-local slot. Prefer
+    the stream's context, else retain the runtime-current device's primary one
+    (the retain ref is held for the process lifetime, like the primary context
+    itself). Best-effort: a context this cannot establish fails at the launch,
+    with the launch's own diagnostics."""
+    try:
+        drv = _driver()
+        if drv is None:
+            return
+        err, cur = drv.cuCtxGetCurrent()
+        if int(err) == 0 and int(cur) != 0:
+            return
+        if stream:
+            err, sctx = drv.cuStreamGetCtx(int(stream))
+            if int(err) == 0:
+                drv.cuCtxSetCurrent(sctx)
+                return
+        import cuda.bindings.runtime as rt
+
+        err, device = rt.cudaGetDevice()
+        if int(err) != 0:
+            return
+        err, pctx = drv.cuDevicePrimaryCtxRetain(_device_handle(int(device)))
+        if int(err) == 0:
+            drv.cuCtxSetCurrent(pctx)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 class DeviceInfo:
     """Device facts for one CUDA ordinal, each queried from the driver on first
     access and cached on the instance. One instance per ordinal (via


### PR DESCRIPTION
Fixes #634.

## What

#612 added `from ._device import ensure_current_context` to `_pygraph.py` (used on the python-engine execute path at `_pygraph.py:1783`) without adding the function to `_device.py`, so **`import cudnn` fails with ImportError** on any package built from current develop, and every python test fails at collection.

Hoist the established pattern from `linear_attention/cutile/kernels/common.py` (`ensure_cuda_context`) into `_device.py` using this module's own driver shim: bind a driver context to the calling thread when none is bound. A JIT engine talks to the driver directly, which reads the calling THREAD's context stack - and an autograd backward runs on a worker thread where `cudaSetDevice` has only moved the runtime's thread-local slot. Prefer the stream's context (`cuStreamGetCtx`), else retain the runtime-current device's primary one; best-effort like the cutile original (a context this cannot establish fails at the launch, with the launch's own diagnostics).

A follow-up could de-duplicate cutile's `ensure_cuda_context` onto this; kept out of this PR to stay minimal.

## Verification (H100, cuDNN dev build, package built from this branch)

- `import cudnn` succeeds; `create_handle()` returns a `Handle`.
- A bare worker thread (no bound context) calling `ensure_current_context(None)` after the process established a primary context ends up with a bound context.
- `test_mhas_v2 -k "random_bwd_ragged or fp8_fwd_ragged"`: 258 passed / 7 skipped / 23 failed - the 23 are the pre-existing no-implementation typing issue fixed separately in #633, unrelated to this import fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA context handling to help ensure operations run on the correct device and stream.
  * Added more resilient behavior when CUDA is unavailable, device information cannot be determined, or a context is already active.
  * Prevented context-related errors from interrupting supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->