### PR TITLE
dsa(indexer_backward): opt-in SM100 sparse backward v2 — 1.16-1.92x faster (fp32-accurate d_index_k at no extra cost)

### DIFF
--- a/docs/fe-oss-apis/dsa.md
+++ b/docs/fe-oss-apis/dsa.md
@@ -341,6 +341,94 @@ the singleton K head and add a batch dimension) together with global Top-K
 indices. FP8 and MXFP8 indexer backward are not currently supported because
 the backward wrapper requires BF16 Q/K/W inputs.
 
+#### SM100 sparse backward v2 (opt-in)
+
+`backend="sm100_v2"` on `IndexerBackward` / `indexer_backward_wrapper`
+selects an alternative kernel-2 (GEMM stage) implementation. `backend` is a
+string enum, one of `{"default", "sm100_v2"}` (default `"default"`; an
+unknown value raises `ValueError`). The semantics are
+**request-or-fail**: outside the envelope below the wrapper raises
+`ValueError` (or `RuntimeError` off SM100) and never silently falls back to
+the default backend.
+
+- **What it computes differently** — weights are upcast to fp32 in-register
+  (exact) and the fp32 per-slot gradient matrix is split into a two-term BF16
+  expansion (`hi + lo`) before the MMAs, so each individual product in the
+  dQ/dK contractions is exact in the fp32 accumulator when it is finite
+  there (~675x lower
+  gradient-matrix representation error than the default single-BF16 rounding,
+  measured as an aggregate over 1e6 random values; individual values gain
+  less when their `lo` term is small). `lo` is ~2^-9 of `hi`, so it starts to
+  underflow for gradient-matrix magnitudes below ~1e-35 (measured 518x at
+  1e-35, 63x at 1e-36, and no advantage left at 1e-38), and the FP32->BF16
+  conversion is non-saturating, so a magnitude at or above BF16's
+  round-to-nearest overflow threshold (`2^128 - 2^119` ~= 3.3962e38, itself
+  above BF16's 3.3895e38 maximum) becomes an infinity in `hi` and the opposite
+  infinity in `lo`, which sum to NaN rather than being clamped. `d_weights` is reduced deterministically — `d_weights` and
+  `d_index_q` are bitwise run-to-run stable; `d_index_k` stays in the same
+  fp32-atomic summation-order class as the default backend.
+- **Output dtype selects output precision** — `d_weights` and `d_index_k`
+  accept FP32 buffers, which receive the fp32 accumulators directly; **the
+  headline accuracy gains require caller-supplied FP32 buffers.** The default
+  wrapper-allocated outputs keep the input dtypes (BF16), which rounds the
+  extra accuracy back to the BF16 representation floor (~1.7e-3 relative).
+  FP32 `d_index_k` is zeroed internally (no caller pre-zero contract).
+  `d_index_q` is always BF16.
+- **Envelope** (validated by `check_support` when a plan is created, and
+  re-validated against the real tensors on every execute -- cache hits
+  included -- before any buffer is mutated) —
+  SM100 (10, 0) only; `H == 64`, `D == 128`, `block_I == 128`;
+  `topk % 128 == 0` with `128 <= topk <= 2048`; `sm_scale > 0`; contiguous
+  same-device tensors; `attn_score`/`index_score`/`topk_indices` shaped
+  `(B, S_q, topk)`. `sm_scale` folds into the gradient in kernel 2 while the
+  relu gate reads the *unscaled* score, which is equivalent for any positive
+  scale except at the underflow-to-zero boundary: for a slot whose scaled
+  score `sm_scale * S` rounds to zero the default backend drops the slot and
+  this backend keeps it, and because the gate is a step function that slot's
+  full dQ/dK contribution (`g' * w`, not scaled by `S`) is what differs. The
+  default backend's multiply preserves subnormals, so reaching it takes an
+  exact `sm_scale * S` below `2^-150` (~7.0e-46).
+- **Scratch / workspace behavior** — `attn_score`/`index_score` are consumed
+  in place exactly like the default backend (`attn_score` is left holding
+  kernel 1's `grad_signal`; `sm_scale` folds inside kernel 2 without touching
+  the buffer). The backend owns a per-plan workspace (a dynamic-ticket
+  counter, plus a `B * S_k * D` fp32 dK scratch when `d_index_k` is BF16 —
+  2 MiB = 2,097,152 bytes at B=1, S_k=4096, D=128, growing with `S_k`),
+  allocated once
+  on first execute — later executes of that plan allocate nothing (the
+  wrapper still allocates any output buffer you do not pass in).
+- **Concurrency** — executions sharing one plan must not overlap on the
+  device (the ticket counter is per-plan workspace). One plan serves one
+  device: the workspace is device-resident, and execution rejects tensors on
+  any other device before touching the score buffers. The wrapper keys its
+  plan cache on the CUDA device and on the **resolved** stream (`stream` when
+  given, otherwise `torch.cuda.current_stream()` at call time), so calls that
+  differ in device or stream get a private plan and private workspace; calls
+  that land on the same cache entry must not be allowed to overlap. The key
+  is the integer stream handle, plus the calling thread's id for the one handle
+  CUDA does not make unique across host threads: `cudaStreamPerThread`
+  is the value 2 in every thread and means "the calling thread's own stream",
+  so two threads that pass it explicitly get a private plan each. Users
+  driving `IndexerBackward` objects directly must use one object per device,
+  and one per stream wherever those streams' executions can overlap; a single
+  object may target any stream if its executions are serialized.
+- **Local top-k ids** (`topk_indices_global=False`) are masked against the
+  per-batch `S_k` before the batch offset is applied, in-kernel: ids `< 0` or
+  `>= S_k` contribute nothing and can never alias a neighbouring batch.
+
+```python
+# fp32 output buffers unlock the full accuracy gain
+d_weights = torch.empty(B, S_q, H, dtype=torch.float32, device="cuda")
+d_index_k = torch.empty(B, S_k, D, dtype=torch.float32, device="cuda")
+result = DSA.indexer_backward_wrapper(
+    index_q, weights, index_k,
+    attn_score, index_score, topk_indices,
+    grad_loss=grad_loss, sm_scale=1.0, loss_coeff=1.0, block_I=128,
+    backend="sm100_v2",
+    d_weights=d_weights, d_index_k=d_index_k,
+)
+```
+
 ### 9. Dense Indexer Backward
 
 Full-KV counterpart to Indexer Backward. It consumes raw dense score tensors

--- a/docs/fe-oss-apis/dsa.md
+++ b/docs/fe-oss-apis/dsa.md
@@ -391,12 +391,15 @@ the default backend.
 - **Scratch / workspace behavior** — `attn_score`/`index_score` are consumed
   in place exactly like the default backend (`attn_score` is left holding
   kernel 1's `grad_signal`; `sm_scale` folds inside kernel 2 without touching
-  the buffer). The backend owns a per-plan workspace (a dynamic-ticket
-  counter, plus a `B * S_k * D` fp32 dK scratch when `d_index_k` is BF16 —
-  2 MiB = 2,097,152 bytes at B=1, S_k=4096, D=128, growing with `S_k`),
-  allocated once
-  on first execute — later executes of that plan allocate nothing (the
-  wrapper still allocates any output buffer you do not pass in).
+  the buffer). The backend owns one piece of per-plan workspace — the
+  dynamic-ticket counter — allocated on first execute and reused by every
+  later one. A BF16 `d_index_k` additionally needs a `B * S_k * D` fp32
+  accumulator (2 MiB = 2,097,152 bytes at B=1, S_k=4096, D=128, growing with
+  `S_k`); that one comes from PyTorch's caching allocator on every call, which
+  is a pool hit in steady state — it has to be re-zeroed per call anyway, and
+  this way it stays reclaimable via `torch.cuda.empty_cache()` instead of
+  staying pinned for as long as the plan is cached. The wrapper still
+  allocates any output buffer you do not pass in.
 - **Concurrency** — executions sharing one plan must not overlap on the
   device (the ticket counter is per-plan workspace). One plan serves one
   device: the workspace is device-resident, and execution rejects tensors on

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -562,9 +562,9 @@ class IndexerBackward(APIBase):
             (topk_indices, self.topk_desc, "topk_indices"),
         )
         # One plan serves one device: the v2 backend's per-plan
-        # workspace (ticket counter, optional dK scratch) lives on the
-        # sample tensors' device, so reject cross-device execution before
-        # kernel 1 mutates the score buffers. The backend re-checks every
+        # workspace (the ticket counter) lives on the sample tensors'
+        # device, so reject cross-device execution before kernel 1 mutates
+        # the score buffers. The backend re-checks every
         # tensor against index_q.device, so validating index_q covers all.
         if self.use_v2 and index_q.device != self.iq_desc.device:
             raise ValueError(
@@ -830,9 +830,11 @@ def indexer_backward_wrapper(
             gains)**; the default wrapper-allocated buffers keep the input
             dtypes (bf16), which rounds the extra accuracy back to the bf16
             representation floor. fp32 ``d_index_k`` is zeroed internally.
-            The backend owns a per-plan workspace (dynamic-ticket counter;
-            a ``B * S_k * D`` fp32 dK scratch for bf16 outputs), so one plan
-            must never have two executions in flight at once. The wrapper keys
+            The backend owns a per-plan workspace (the dynamic-ticket
+            counter; a bf16 ``d_index_k`` additionally takes a
+            ``B * S_k * D`` fp32 accumulator from the caching allocator on
+            every call), so one plan must never have two executions in flight
+            at once. The wrapper keys
             its plan cache on the CUDA device and on the **resolved** stream
             (``stream`` when given, otherwise ``torch.cuda.current_stream()``
             at call time), so calls that differ in device or stream get
@@ -874,12 +876,12 @@ def indexer_backward_wrapper(
     # the sm100_v2 backend additionally compiles a d_weights-dtype variant
     # and validates the output dtype matrix. The CUDA device is keyed: the
     # sm100_v2 backend owns device-resident per-plan workspace (the
-    # ticket counter; the dK scratch), so a cached plan must never be
+    # ticket counter), so a cached plan must never be
     # reused on another device — execute() additionally enforces the plan
     # device.
     #
     # For backend="sm100_v2" the *resolved* stream is keyed too, so that a
-    # plan (and thus its ticket-counter / dK-scratch workspace) is never
+    # plan (and thus its ticket-counter workspace) is never
     # shared by two different streams. It must be the resolved stream, not
     # the ``stream`` argument: ``stream=None`` does not mean "the default
     # stream", it means "whatever ``torch.cuda.current_stream()`` is at call

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/api.py
@@ -16,6 +16,7 @@ When the ``dIndexK`` output buffer is bf16, a trailing pure-torch cast
 
 from __future__ import annotations
 
+import threading
 from typing import Optional
 
 import torch
@@ -24,14 +25,37 @@ import cuda.bindings.driver as cuda
 from cudnn.api_base import APIBase, TupleDict
 from cudnn.tensor_adapter import canonicalize_unit_dim_strides
 from cudnn.deepseek_sparse_attention.utils.runtime import (
+    resolve_stream as _resolve_stream,
     torch_stream_context as _torch_stream_context,
     validate_q_causal_offsets,
 )
 
 from .dense_indexer_backward_sm100 import dense_indexer_backward_sm100
 from .dense_indexer_backward_sm90 import dense_indexer_backward_sm90
+from .indexer_backward_v2_sm100 import indexer_backward_v2_sm100
 from .indexer_backward_sm100 import indexer_backward_sm100
 from .indexer_backward_sm90 import indexer_backward_sm90
+
+# Compute-backend selector for the sparse indexer backward. ``"default"`` is
+# the architecture-generic path (SM90 or SM100); ``"sm100_v2"`` is the
+# SM100-only v2 backend (two-term bf16-expansion GEMM, deterministic
+# d_weights). The value is architecture-explicit on purpose: it names the arch
+# it targets so it is self-evidently capability-gated (``check_support`` is
+# request-or-fail on non-SM100) and the enum can grow new backends without
+# overloading a boolean. It is part of the wrapper plan-cache key.
+INDEXER_BACKWARD_BACKENDS = ("default", "sm100_v2")
+
+# CUDA's magic per-thread default-stream handle (``cudaStreamPerThread`` /
+# ``CU_STREAM_PER_THREAD``): the integer 2 in every host thread, each time
+# denoting that thread's own stream. Handles 0 and 1 (the legacy default
+# stream) are global rather than per-thread, so this is the only handle value
+# that needs a thread discriminator in the plan-cache key.
+_CUDA_STREAM_PER_THREAD = 2
+
+
+def _validate_indexer_backward_backend(backend: str) -> None:
+    if backend not in INDEXER_BACKWARD_BACKENDS:
+        raise ValueError(f"backend must be one of {INDEXER_BACKWARD_BACKENDS}, got {backend!r}")
 
 
 def _validate_grad_loss_tensor(grad_loss: torch.Tensor, device: torch.device) -> torch.Tensor:
@@ -156,6 +180,32 @@ class IndexerBackward(APIBase):
        promised stage, not a hidden op; a bf16 ``d_index_k`` buffer instead
        gets an internally-allocated zeroed fp32 scratch + trailing cast.
     4. Kernel 2 — warp-specialized backward GEMM producing the gradients.
+
+    ``backend="sm100_v2"`` (SM100 only, request-or-fail: ``check_support``
+    raises outside the envelope, there is no silent fallback) selects an
+    alternative GEMM stage that upcasts the weights to fp32 in-register and
+    splits the per-slot fp32 gradient matrix into a two-term bf16 expansion
+    (``hi + lo``) before the MMAs, so each individual product in the dQ / dK
+    contractions is exact in the fp32 accumulator when it is finite there (the
+    expansion carries ~16
+    of the 24 fp32 significand bits — measured ~675x lower gradient-matrix
+    representation error than the default single-bf16 rounding);
+    ``d_weights`` is additionally reduced deterministically (bitwise
+    run-to-run, as is ``d_index_q``). Same wrapper contract and in-place
+    score consumption. Output dtype selects output precision: ``d_weights``
+    and ``d_index_k`` accept fp32 buffers, which receive the fp32
+    accumulators directly — **the headline accuracy gains require fp32
+    output buffers**; bf16 output buffers round the result and keep only the
+    bf16-representation floor. Requires H == 64, D == 128,
+    topk % 128 == 0 with 128 <= topk <= 2048, block_I == 128, sm_scale > 0,
+    contiguous same-device tensors. Executions of one object must not
+    overlap on the device (per-plan ticket-counter workspace; see the
+    backend module docstring — the ``indexer_backward_wrapper`` keys its
+    cache on the device and on the resolved stream, so wrapper users get
+    one object per device/stream automatically). One object serves one
+    device: the per-plan workspace lives on the sample tensors' device, and
+    ``execute`` rejects tensors on any other device. ``backend`` must be one
+    of ``{"default", "sm100_v2"}``.
     """
 
     def __init__(
@@ -163,15 +213,16 @@ class IndexerBackward(APIBase):
         sample_index_q: torch.Tensor,  # (B, S_q, H, D) BF16
         sample_weights: torch.Tensor,  # (B, S_q, H) BF16
         sample_index_k: torch.Tensor,  # (B, S_k, D) BF16
-        sample_d_index_q: torch.Tensor,  # (B, S_q, H, D); bf16 only
-        sample_d_weights: torch.Tensor,  # (B, S_q, H); bf16 only (the kernel's dW store rounds to bf16)
-        sample_d_index_k: torch.Tensor,  # (B, S_k, D); bf16 or fp32 (both arches)
+        sample_d_index_q: torch.Tensor,  # (B, S_q, H, D); same shape/dtype as index_q (bf16)
+        sample_d_weights: torch.Tensor,  # (B, S_q, H); bf16 (the default kernel's dW store rounds to bf16), or fp32 with backend="sm100_v2" (receives the fp32 accumulator directly)
+        sample_d_index_k: torch.Tensor,  # (B, S_k, D); bf16 or fp32 (both arches; with backend="sm100_v2" fp32 receives the fp32 accumulator directly)
         sample_attn_score: torch.Tensor,  # (B, S_q, topk) FP32 — target
         sample_index_score: torch.Tensor,  # (B, S_q, topk) FP32 — predict
         sample_topk_indices: torch.Tensor,  # (B, S_q, topk) INT32
         sm_scale: float = 1.0,
         block_I: int = 128,
         topk_indices_global: bool = False,
+        backend: str = "default",
     ):
         super().__init__()
         self.iq_desc = self._make_tensor_desc(sample_index_q, name="sample_index_q")
@@ -210,6 +261,11 @@ class IndexerBackward(APIBase):
         self.sm_scale = float(sm_scale)
         self.block_I = int(block_I)
         self.topk_indices_global = bool(topk_indices_global)
+        _validate_indexer_backward_backend(backend)
+        self.backend = backend
+        # Derived gate kept so the internal dispatch/validation sites read a
+        # single boolean; ``backend`` remains the public, cache-keyed selector.
+        self.use_v2 = backend == "sm100_v2"
 
     def _validate_plan_shapes_and_layout(self) -> None:
         """Semantic shape + layout validation of the plan's tensor descriptors.
@@ -270,11 +326,82 @@ class IndexerBackward(APIBase):
                 )
 
     def check_support(self) -> bool:
-        major, _ = torch.cuda.get_device_capability()
+        # The generic gate reads the plan's own device for backend="sm100_v2"
+        # (its kernel and workspace are bound to that device, and a param-less
+        # query would reject a valid plan whenever an unrelated pre-SM90 device
+        # happens to be current, masking the specific v2 gate below). The
+        # default path keeps the pre-existing current-device query, so it stays
+        # self-consistent with the sm90/sm100 factories, which check the
+        # current device themselves.
+        major, _ = torch.cuda.get_device_capability(self.iq_desc.device if self.use_v2 else None)
         self._runtime_error_if(
             major != 9 and major < 10,
             f"IndexerBackward requires SM90 or SM100+, found SM{major}",
         )
+        if self.use_v2:
+            b, s_q, s_k = self.batch, self.seqlen, self.seqlen_k
+            h, d, topk = self.heads, self.head_dim, self.topk
+            self._runtime_error_if(
+                torch.cuda.get_device_capability(self.iq_desc.device) != (10, 0),
+                f"backend='sm100_v2' requires an SM100 device (capability (10, 0)); the plan device "
+                f"{self.iq_desc.device} reports {torch.cuda.get_device_capability(self.iq_desc.device)} "
+                f"(use backend='default' on non-SM100)",
+            )
+            self._value_error_if(
+                h != 64 or d != 128,
+                f"backend='sm100_v2' requires H=64, D=128, got H={h}, D={d}",
+            )
+            self._value_error_if(
+                topk % 128 != 0 or not (128 <= topk <= 2048),
+                f"backend='sm100_v2' requires topk % 128 == 0 with 128 <= topk <= 2048, got topk={topk}",
+            )
+            self._value_error_if(
+                self.block_I != 128,
+                f"backend='sm100_v2' requires block_I=128, got block_I={self.block_I}",
+            )
+            self._value_error_if(
+                not self.sm_scale > 0.0,
+                f"backend='sm100_v2' requires sm_scale > 0 (the relu gate reads unscaled scores), got sm_scale={self.sm_scale}",
+            )
+            # full metadata matrix: cross-tensor shapes, output dtypes,
+            # devices, contiguity — the backend binds true views and uses
+            # 16B-aligned row pointers, so reject bad metadata before
+            # kernel 1 mutates the score buffers.
+            self._check_tensor_shape(self.w_desc, (b, s_q, h), name="weights")
+            self._check_tensor_shape(self.ik_desc, (b, s_k, d), name="index_k")
+            self._check_tensor_shape(self.diq_desc, (b, s_q, h, d), name="d_index_q")
+            self._check_tensor_shape(self.dw_desc, (b, s_q, h), name="d_weights")
+            self._check_tensor_shape(self.dik_desc, (b, s_k, d), name="d_index_k")
+            self._check_tensor_shape(self.attn_desc, (b, s_q, topk), name="attn_score")
+            self._check_tensor_shape(self.idx_score_desc, (b, s_q, topk), name="index_score")
+            self._check_tensor_shape(self.topk_desc, (b, s_q, topk), name="topk_indices")
+            self._check_dtype(self.diq_desc, torch.bfloat16, name="d_index_q")
+            self._check_dtype(
+                self.dw_desc, [torch.bfloat16, torch.float32], name="d_weights", extra_error_msg="fp32 buffers receive the fp32 accumulator directly"
+            )
+            self._check_dtype(
+                self.dik_desc, [torch.bfloat16, torch.float32], name="d_index_k", extra_error_msg="fp32 buffers receive the fp32 accumulator directly"
+            )
+            all_descs = (
+                ("index_q", self.iq_desc),
+                ("weights", self.w_desc),
+                ("index_k", self.ik_desc),
+                ("d_index_q", self.diq_desc),
+                ("d_weights", self.dw_desc),
+                ("d_index_k", self.dik_desc),
+                ("attn_score", self.attn_desc),
+                ("index_score", self.idx_score_desc),
+                ("topk_indices", self.topk_desc),
+            )
+            for name, desc in all_descs:
+                self._value_error_if(
+                    not desc.is_contiguous(),
+                    f"backend='sm100_v2' requires contiguous tensors: {name} has shape {tuple(desc.shape)} with stride {tuple(desc.stride)}",
+                )
+                self._value_error_if(
+                    desc.device != self.iq_desc.device,
+                    f"backend='sm100_v2' requires all tensors on one device: {name} is on {desc.device}, index_q on {self.iq_desc.device}",
+                )
         self._check_dtype(self.iq_desc, torch.bfloat16, name="index_q")
         self._check_dtype(self.w_desc, torch.bfloat16, name="weights")
         self._check_dtype(self.ik_desc, torch.bfloat16, name="index_k")
@@ -286,23 +413,27 @@ class IndexerBackward(APIBase):
         # fail-dirty on a bad output dtype). ``d_index_q`` is bf16-only (TMA
         # store of the input dtype). ``d_index_k`` accepts bf16 or fp32 on both
         # arches (the GEMM accumulates dK in fp32; a bf16 buffer gets a
-        # trailing cast). ``d_weights`` is bf16-only on both arches: the
-        # kernel's dW store rounds the fp32 accumulator to bf16, so an fp32
-        # buffer cannot be produced faithfully and is rejected rather than
-        # silently filled with bf16-precision values.
-        self._check_dtype(self.diq_desc, torch.bfloat16, name="d_index_q")
-        self._check_dtype(
-            self.dw_desc,
-            torch.bfloat16,
-            name="d_weights",
-            extra_error_msg="the kernel's dW store rounds to bf16; fp32 output is not supported",
-        )
-        self._check_dtype(
-            self.dik_desc,
-            [torch.bfloat16, torch.float32],
-            name="d_index_k",
-            extra_error_msg="fp32 buffers receive the fp32 accumulator directly",
-        )
+        # trailing cast). ``d_weights`` is bf16-only on the default backend:
+        # its kernel's dW store rounds the fp32 accumulator to bf16, so an
+        # fp32 buffer cannot be produced faithfully and is rejected rather
+        # than silently filled with bf16-precision values. The sm100_v2
+        # branch above validates its own output-dtype matrix instead (fp32
+        # ``d_weights`` / ``d_index_k`` buffers receive the fp32 accumulators
+        # directly).
+        if not self.use_v2:
+            self._check_dtype(self.diq_desc, torch.bfloat16, name="d_index_q")
+            self._check_dtype(
+                self.dw_desc,
+                torch.bfloat16,
+                name="d_weights",
+                extra_error_msg="the kernel's dW store rounds to bf16; fp32 output is not supported",
+            )
+            self._check_dtype(
+                self.dik_desc,
+                [torch.bfloat16, torch.float32],
+                name="d_index_k",
+                extra_error_msg="fp32 buffers receive the fp32 accumulator directly",
+            )
         # Semantic shape relationships + compact-layout requirement, validated
         # here (before compile()/execute(), i.e. before kernel 1 mutates the
         # score buffers). Guards a directly-built / first-call plan whose output
@@ -320,6 +451,30 @@ class IndexerBackward(APIBase):
         # time — passing it to the factory is a no-op now that it's not
         # part of the cache key, and it's been removed from the factory
         # signature on both backends.
+        if self.use_v2:
+            # SM100-only v2 backend (check_support gated). The
+            # d_weights output dtype is a compile-time kernel variant (the
+            # deterministic accumulator is stored directly in the output
+            # dtype); d_index_k dtype is handled at execute time. Build
+            # under the plan's device so the factory's architecture check
+            # queries the device the plan is bound to, not whatever device
+            # happens to be current.
+            with torch.cuda.device(self.iq_desc.device):
+                self._compiled_kernel = indexer_backward_v2_sm100(
+                    self.batch,
+                    self.seqlen,
+                    self.seqlen_k,
+                    self.heads,
+                    self.head_dim,
+                    self.topk,
+                    sm_scale=self.sm_scale,
+                    block_I=self.block_I,
+                    topk_indices_global=self.topk_indices_global,
+                    dw_out_dtype=self.dw_desc.dtype,
+                )
+            return
+        # Default path: capability from the current device, unchanged from
+        # the pre-v2 code (the v2 branch above never reaches here).
         major, _ = torch.cuda.get_device_capability()
         kernel_factory = indexer_backward_sm90 if major == 9 else indexer_backward_sm100
         self._compiled_kernel = kernel_factory(
@@ -406,6 +561,17 @@ class IndexerBackward(APIBase):
             (index_score, self.idx_score_desc, "index_score"),
             (topk_indices, self.topk_desc, "topk_indices"),
         )
+        # One plan serves one device: the v2 backend's per-plan
+        # workspace (ticket counter, optional dK scratch) lives on the
+        # sample tensors' device, so reject cross-device execution before
+        # kernel 1 mutates the score buffers. The backend re-checks every
+        # tensor against index_q.device, so validating index_q covers all.
+        if self.use_v2 and index_q.device != self.iq_desc.device:
+            raise ValueError(
+                f"backend='sm100_v2' requires execute on the plan's device: index_q is on {index_q.device}, "
+                f"but this plan (and its per-plan workspace) is bound to {self.iq_desc.device} — "
+                f"build one IndexerBackward per device (the wrapper keys its plan cache on the device)"
+            )
         # ``grad_scale`` is forwarded as a runtime ``Float32`` arg; the
         # compiled kernel is reused when loss_coeff changes for the same
         # cached tensor shape.
@@ -612,6 +778,8 @@ def indexer_backward_wrapper(
     d_weights: Optional[torch.Tensor] = None,
     d_index_k: Optional[torch.Tensor] = None,
     stream: Optional[cuda.CUstream] = None,
+    *,
+    backend: str = "default",
 ) -> TupleDict:
     """High-level wrapper. Returns ``{'d_index_q', 'd_weights', 'd_index_k'}``.
 
@@ -637,7 +805,42 @@ def indexer_backward_wrapper(
         grad_loss: single-element float32 tensor on the same CUDA device as
             ``index_q``. The kernel reads its value at runtime, including on
             CUDA Graph replay.
+        backend: keyword-only compute-backend selector, one of
+            ``{"default", "sm100_v2"}`` (default ``"default"``; an invalid
+            value raises ``ValueError``). Appended after the historical
+            parameter list as keyword-only so the existing positional
+            argument order (``d_index_q``/``d_weights``/``d_index_k``/
+            ``stream``) is preserved for legacy callers.
+            ``"default"`` is the architecture-generic path (SM90 or SM100).
+            ``"sm100_v2"`` is the SM100-only opt-in v2 backend,
+            **request-or-fail**: it raises (``ValueError``/``RuntimeError``)
+            outside its envelope — SM100, H == 64, D == 128, block_I == 128,
+            topk % 128 == 0 with 128 <= topk <= 2048, sm_scale > 0, contiguous
+            same-device tensors — and never silently falls back to the default
+            backend. It keeps the wrapper contract (same inputs, outputs, and
+            in-place score consumption: ``attn_score`` is left holding
+            exactly kernel 1's ``grad_signal``; ``sm_scale`` folds in-kernel)
+            and computes the GEMM stage with fp32 weights and a two-term
+            bf16 expansion of the gradient matrix, plus deterministic
+            (bitwise run-to-run) ``d_weights`` / ``d_index_q``.
+            ``backend="sm100_v2"`` selects the compute path only — output
+            precision follows the buffers you pass: supply **fp32
+            ``d_weights`` / ``d_index_k`` buffers to receive the fp32
+            accumulators directly (required for the headline accuracy
+            gains)**; the default wrapper-allocated buffers keep the input
+            dtypes (bf16), which rounds the extra accuracy back to the bf16
+            representation floor. fp32 ``d_index_k`` is zeroed internally.
+            The backend owns a per-plan workspace (dynamic-ticket counter;
+            a ``B * S_k * D`` fp32 dK scratch for bf16 outputs), so one plan
+            must never have two executions in flight at once. The wrapper keys
+            its plan cache on the CUDA device and on the **resolved** stream
+            (``stream`` when given, otherwise ``torch.cuda.current_stream()``
+            at call time), so calls that differ in device or stream get
+            private plans and therefore private workspace; calls that land on
+            the same cache entry (the identical full cache key) must not be
+            allowed to overlap on the device.
     """
+    _validate_indexer_backward_backend(backend)
     # Validate ranks explicitly before any allocation or the dimension
     # derivation below, so a wrong-rank tensor surfaces as a clean ValueError
     # instead of a cryptic tuple-unpack/indexing error (or a mis-shaped
@@ -667,8 +870,45 @@ def indexer_backward_wrapper(
     # with different loss_coeff for the same tensor shape. Shape
     # changes still get their own cache entries. The output dtypes are keyed
     # (``d_index_q``/``d_weights``/``d_index_k``) so ``check_support``'s
-    # output-dtype validation cannot be skipped on a cache hit (no fail-dirty).
+    # output-dtype validation cannot be skipped on a cache hit (no fail-dirty);
+    # the sm100_v2 backend additionally compiles a d_weights-dtype variant
+    # and validates the output dtype matrix. The CUDA device is keyed: the
+    # sm100_v2 backend owns device-resident per-plan workspace (the
+    # ticket counter; the dK scratch), so a cached plan must never be
+    # reused on another device — execute() additionally enforces the plan
+    # device.
+    #
+    # For backend="sm100_v2" the *resolved* stream is keyed too, so that a
+    # plan (and thus its ticket-counter / dK-scratch workspace) is never
+    # shared by two different streams. It must be the resolved stream, not
+    # the ``stream`` argument: ``stream=None`` does not mean "the default
+    # stream", it means "whatever ``torch.cuda.current_stream()`` is at call
+    # time" (see ``resolve_stream``, which the backend itself uses to pick
+    # the launch stream). Keying the raw argument would map every
+    # ``stream=None`` call onto one cache entry even when the callers sit in
+    # different ``torch.cuda.stream(...)`` contexts. Two caveats on the
+    # handle: (a) handles are not unique across devices — the legacy default
+    # stream is handle 0 on every device — so ``index_q.device`` above stays
+    # load-bearing and is what keeps per-device plans apart; (b) CUDA's magic
+    # handles are not unique across host threads either — ``cudaStreamPerThread``
+    # is the integer 2 in every thread while denoting a different stream in
+    # each. The handle itself carries no thread information, but the caller
+    # does: that value means "the calling thread's own stream" by definition, so
+    # the calling thread's id is exactly the missing discriminator and is
+    # appended to the key for that one value. Real handles (and 0 / 1, which are
+    # global rather than per-thread) are keyed as-is, so threads that share a
+    # real stream keep sharing one plan, as they should.
+    # ``threading.get_ident()`` is only unique among live threads — an id can
+    # be reused after its thread exits — which is harmless here: that thread's
+    # per-thread stream died with it, so nothing can still be running on the
+    # plan the reused id reaches.
+    stream_key = None
+    if backend == "sm100_v2":
+        stream_key = int(_resolve_stream(stream))
+        if stream_key == _CUDA_STREAM_PER_THREAD:
+            stream_key = (stream_key, threading.get_ident())
     key = (
+        index_q.device,
         index_q.dtype,
         weights.dtype,
         index_k.dtype,
@@ -684,6 +924,8 @@ def indexer_backward_wrapper(
         float(sm_scale),
         int(block_I),
         bool(topk_indices_global),
+        backend,
+        stream_key,
     )
     obj = _cache_of_IndexerBackwardObjects.get(key)
     if obj is None:
@@ -700,6 +942,7 @@ def indexer_backward_wrapper(
             sm_scale=sm_scale,
             block_I=block_I,
             topk_indices_global=topk_indices_global,
+            backend=backend,
         )
         assert obj.check_support()
         obj.compile()

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_v2_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_v2_sm100.py
@@ -1651,9 +1651,11 @@ def indexer_backward_v2_sm100(
     rows = batch * seqlen
     seq_k_total = batch * seqlen_k
     idx_local = (not topk_indices_global) and batch > 1
-    # Per-plan workspace (module docstring: concurrency contract). Created
-    # once on the plan's first execute — steady-state execute() allocates
-    # nothing.
+    # Per-plan workspace (module docstring: concurrency contract): the
+    # dynamic-ticket counter, created once on the plan's first execute. The
+    # fp32 dK accumulator a bf16 ``d_index_k`` needs is deliberately not in
+    # here; it comes from the caching allocator on every call, the same way
+    # the sm90 / sm100 backends take theirs.
     plan_ws: dict = {}
 
     def _check(cond, msg):

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_v2_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_v2_sm100.py
@@ -40,7 +40,7 @@ a **two-term bf16-expansion** formulation:
   to keep the full accuracy gain).
 * ``d_index_k`` is accumulated with vectorized fp32 atomics (four-element
   ``cute.arch.atomic_add``), the same numerics class as the default backend,
-  into the caller's fp32 buffer (zeroed here) or a per-plan fp32 scratch
+  into the caller's fp32 buffer (zeroed here) or a per-call fp32 scratch
   that is cast to a bf16 output buffer.
 
 Semantics (H = indexer heads, D = head dim; per query row ``s`` and top-k
@@ -142,10 +142,11 @@ Requires SM100, H == 64, D == 128, and topk % 128 == 0 with
 
 ``api.py`` raises before compile otherwise.
 
-Workspace ownership / concurrency contract: the dynamic-ticket counter (and
-the fp32 dK scratch used for bf16 ``d_index_k`` outputs) are **per-plan
-workspace**, allocated once when the plan first executes and reused by every
-subsequent execute of that plan. The kernel self-resets the counter (the CTA
+Workspace ownership / concurrency contract: the dynamic-ticket counter is
+**per-plan workspace**, allocated once when the plan first executes and reused
+by every subsequent execute of that plan. (The fp32 dK accumulator a bf16
+``d_index_k`` needs is not per-plan: it comes from the caching allocator on
+every call.) The kernel self-resets the counter (the CTA
 that draws the final raw ticket stores 0), so back-to-back launches need no
 host reset — but that also means executions of the SAME plan must be
 serialized: they may target any stream, provided the launches do not overlap
@@ -1614,10 +1615,10 @@ def indexer_backward_v2_sm100(
       (the atomic accumulator is fp32); fp32 ``d_index_k`` buffers are
       written directly (zeroed here, no caller pre-zero needed).
 
-    The returned callable performs **no allocations after the first
-    execute**: the ticket counter and (for bf16 ``d_index_k``) the fp32 dK
-    scratch are per-plan workspace, allocated on the first execute and reused
-    by every later one. The
+    The returned callable allocates its ticket counter on the first execute
+    and reuses it on every later one; a bf16 ``d_index_k`` additionally takes
+    a ``B * S_k * D`` fp32 accumulator from the caching allocator per call (it
+    has to be re-zeroed each time regardless). The per-plan ticket-counter
     workspace is device-resident: the plan binds the device of its first
     execute and raises on any indexer tensor from another device
     (``grad_loss`` is validated by ``api.py``'s wrapper). Executions
@@ -1717,12 +1718,12 @@ def indexer_backward_v2_sm100(
             _check(t.is_cuda and t.device == IndexQ.device, f"{name} must be on {IndexQ.device}")
             _check(t.is_contiguous(), f"{name} must be contiguous")
 
-        # One plan serves one device: the per-plan workspace (ticket
-        # counter, optional dK scratch) is device-resident, so bind the
-        # plan to the device of its first execute and reject any other
-        # device BEFORE kernel 1 mutates the score buffers. api.py keys
-        # its plan cache on the device; this check keeps direct users of
-        # the factory safe independently of that cache.
+        # One plan serves one device: the per-plan ticket counter is
+        # device-resident, so bind the plan to the device of its first
+        # execute and reject any other device BEFORE kernel 1 mutates the
+        # score buffers. api.py keys its plan cache on the device; this
+        # check keeps direct users of the factory safe independently of
+        # that cache.
         plan_device = plan_ws.get("device")
         if plan_device is None:
             plan_ws["device"] = plan_device = IndexQ.device
@@ -1750,11 +1751,15 @@ def indexer_backward_v2_sm100(
                 # zeroed here — no caller pre-zero contract)
                 dk_f32_flat = dIndexK.view(seq_k_total, d)
             else:
-                dk_f32_flat = plan_ws.get("dk_scratch")
-                if dk_f32_flat is None:
-                    # one-time per-plan workspace
-                    dk_f32_flat = torch.empty((seq_k_total, d), dtype=torch.float32, device=IndexK.device)
-                    plan_ws["dk_scratch"] = dk_f32_flat
+                # fp32 accumulator for a bf16 ``d_index_k``, taken from the
+                # caching allocator per call instead of being pinned to the
+                # plan: it is B * S_k * D * 4 B and has to be re-zeroed on
+                # every call either way, so caching it inside the plan would
+                # save no work while keeping it alive (and unreclaimable by
+                # ``empty_cache()``) for as long as the plan is cached. The
+                # allocator hands the same block back for the same size on the
+                # same stream, so steady state is a pool hit, not a cudaMalloc.
+                dk_f32_flat = torch.empty((seq_k_total, d), dtype=torch.float32, device=IndexK.device)
             dk_f32_flat.zero_()
             cnt = plan_ws.get("counter")
             if cnt is None:

--- a/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_v2_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/indexer_backward/indexer_backward_v2_sm100.py
@@ -1,0 +1,1829 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Indexer backward v2 — SM100 CuTe-DSL, persistent dynamic-ticket kernel.
+
+Opt-in alternative backend for ``IndexerBackward`` (selected via
+``backend="sm100_v2"`` in ``api.py``). It keeps the exact 3-stage wrapper contract of
+``indexer_backward_sm100`` — kernel 1 (score-grad precompute) is literally
+shared with the default backend — and replaces the GEMM stage (kernel 2) with
+a **two-term bf16-expansion** formulation:
+
+* ``weights`` are upcast to fp32 in-register (exact) and the per-slot fp32
+  gradient matrix ``A = grad_signal * weights`` is split into a two-term
+  bf16 expansion ``hi + lo`` (``hi = bf16(A)``, ``lo = bf16(A - hi)``)
+  before the MMA. Each individual bf16 x bf16 product in the dQ / dK
+  contractions is then exact in the fp32 accumulator when it is finite
+  there (<= 16 significand bits); the expansion itself is NOT exact — ``hi + lo`` carries ~16 of
+  ``A``'s 24 significand bits, so the summed result is not the correctly
+  rounded ``A @ K``. Measured on 1e6 random fp32/bf16 pairs, the two-term
+  expansion reduces the representation error of ``A`` (and the resulting
+  per-product error) from 1.66e-3 to 2.46e-6 rms relative (~675x) over the
+  default backend's single-bf16 rounding of ``A``, which dominates its fp32
+  dK error and adds to its bf16-stored dQ error. That ratio is an aggregate
+  over that random population, not a
+  per-element guarantee: individual values with a small ``lo`` term gain
+  less (e.g. A = 1.7880821228027344 gains ~257x). The gain is bounded by
+  bf16's exponent range, not just its mantissa: ``lo`` is ~2^-9 of ``hi``,
+  so it underflows for |A| below ~1e-35 (measured 518x at 1e-35, 63x at
+  1e-36, 1x at 1e-38), and the fp32 -> bf16 conversion is non-saturating, so
+  |A| at or above bf16's round-to-nearest overflow threshold
+  (2^128 - 2^119 ~= 3.3962e38, itself above bf16's 3.3895e38 maximum) becomes
+  an infinity in ``hi`` and the opposite infinity in ``lo`` (NaN in ``lo`` if
+  ``A`` was already infinite), which the two MMA terms then sum to NaN
+  instead of clamping.
+* ``d_weights`` is accumulated in fp32 and reduced **deterministically**
+  in-CTA (per-warp butterfly, smem partial exchange, fixed-order combine,
+  plain store) — bitwise run-to-run stable. The final store rounds to the
+  caller's ``d_weights`` dtype (fp32 buffers receive the accumulator
+  verbatim; bf16 buffers receive its bf16 rounding — supply an fp32 buffer
+  to keep the full accuracy gain).
+* ``d_index_k`` is accumulated with vectorized fp32 atomics (four-element
+  ``cute.arch.atomic_add``), the same numerics class as the default backend,
+  into the caller's fp32 buffer (zeroed here) or a per-plan fp32 scratch
+  that is cast to a bf16 output buffer.
+
+Semantics (H = indexer heads, D = head dim; per query row ``s`` and top-k
+slot ``t`` with id ``n = idx[s, t]``; invalid slots contribute nothing —
+``n`` is invalid iff ``n < 0`` or ``n >= S_k`` where the bound is the
+per-batch ``S_k`` for local ids (``topk_indices_global=False``, masked
+in-kernel BEFORE the batch offset is applied, so a positive out-of-range
+local id can never alias a neighbouring batch) or the flattened
+``B * S_k`` for global ids):
+
+    S[t,h]    = sum_d K[n,d] * Q[s,h,d]             (fp32 acc)
+    g'[s,t]   = sm_scale * g[s,t]                   (runtime fold, kernel 2)
+    dW[s,h]   = sum_t g'[s,t] * max(S[t,h], 0)      (fp32, deterministic)
+    A[t,h]    = (S[t,h] > 0) ? g'[s,t] * w[s,h] : 0 (fp32, split hi+lo bf16)
+    dQ[s,h,d] = sum_t A[t,h] * K[n,d]               (bf16 out)
+    dK[n,d]  += sum_h A[t,h] * Q[s,h,d]             (fp32 atomic)
+
+``sm_scale`` is a runtime kernel-2 argument folded multiplicatively into the
+grad-signal read (no recompilation across values, and the ``attn_score``
+scratch is left holding exactly kernel 1's ``grad_signal``, identical to the
+default backend). The relu gate reads the unscaled ``S``, which matches the
+default backend's gate on ``sm_scale * S`` for positive scales, up to the
+underflow corner documented at the kernel-2 gate itself — ``check_support``
+therefore requires ``sm_scale > 0`` for this backend.
+
+Kernel design — persistent grid (one CTA per SM), 512 threads / 16 warps
+per CTA, dynamic row tickets:
+
+    warp  0     : TMA Q row tile (64 x 128 bf16), double-buffered across rows
+    warp  1     : MMA — software-pipelined issue of the three tcgen05
+                  contractions per 128-slot tile (the hi and lo terms of
+                  MMA2 / MMA3 are separate accumulating issues); S runs up
+                  to 2 tiles ahead of its consumer (one MMA warp feeding
+                  multiple pipelines, latency hidden by buffer depth):
+                    MMA1  S(128x64)    = Ksel(128x128) @ Q^T      (K,K)
+                    MMA2  dQT(128x64) += Ksel^T @ A_hi, then A_lo (MN,MN) acc
+                    MMA3  dKp(128x128) = A_hi @ Q^T-view, += A_lo (K,MN)
+                  Ksel^T / Q^T-view / A^T are MN-major descriptor views of
+                  the same smem (``recast_ptr`` idiom).
+    warp  2     : dynamic ticket writer — lane 0 draws global row tickets
+                  (a scalar global atomic fetch-add) into a smem ring
+                  consumed by all warpgroups
+    warps 4-7   : S-epilogue — TMEM S -> RF (thread == slot row), relu, fp32
+                  dW accumulation, A split hi+lo -> smem; then the
+                  deterministic dW combine and the dQT TMEM -> bf16 dQ store
+    warps 8-11  : metadata restage (idx/grad, parity double-buffered) +
+                  sparse K gather (cp.async 16B, invalid rows zero-filled so
+                  garbage never reaches S/dW/dQ)
+    warps 12-15 : dK reduce — TMEM dKp -> RF -> a four-element fp32 atomic
+                  add per valid row, two independent select/shuffle/reduce
+                  chains per column block to expose ILP to the scheduler
+
+The ticket ring makes the row <-> CTA assignment dynamic (work stealing),
+which removes the end-of-kernel tail imbalance of a static row stripe. All
+warpgroups consume the identical ticket sequence, so the cross-row skew
+pipeline (warps 0-11 run row i+1's front while warps 12-15 drain row i's dK
+tail) is preserved; cross-row hazards ride the existing mbarrier pipelines
+whose phases roll across rows without reset. Ring arrivals are warp-elected
+(14 consumer warps arrive via lane 0 each) and the ring depth bounds the
+writer's pre-commit lead over the TMA front.
+
+Requires SM100, H == 64, D == 128, and topk % 128 == 0 with
+128 <= topk <= 2048:
+
+* ``topk % 128 == 0`` — 128-slot tiles; the metadata restage loop moves 512
+  elements/step with a predicated tail covering any 128-multiple;
+* ``topk >= 128`` (>= 1 tile/row) — for T >= 3 the S-epilogue warpgroup's sG
+  reads ride the implicit A->K pipe chain, which covers the previous row's
+  last tile only from 3 tiles/row upward, and the pipe depths keep their full
+  values. For T < 3 (topk 128/256) the K/S pipes and ``mma_lookahead`` are
+  clamped to the tile count (see ``__init__``) so a whole row's tile sequence
+  is resident at once and the S chain does not lap within the row. The dK
+  warpgroup's sIdx reads are protected by a parity-slot WAR barrier that is
+  EXPLICIT where it is load-bearing (``pipe_M``, compiled in for <= 7
+  tiles/row: the gather warpgroup waits on a metadata slot before restaging
+  it; the dK warpgroup releases the slot only after its last sIdx read of the
+  row) and left to the K->S->A->DK acquire-chain arithmetic for >= 8
+  tiles/row, where that chain is long enough by the tile-count arithmetic
+  in ``__init__`` (a conservative bound, not a measured boundary).
+  The explicit barrier is load-bearing in the low-tile regime: forcing it off
+  corrupts ``d_index_k`` only (dQ and dW keep the same error to four digits at
+  the same seed), by 8.1e-3 .. 5.9e-1 rms relative against an fp64 recompute
+  where it is otherwise 2.4e-6, because the restage of a later metadata slot
+  laps the dK drain of an earlier one and the dK scatter reads overwritten
+  sIdx. Measured at 2 and 3 tiles/row (topk 256/384 at S_q = 512, S_k = 4096;
+  5 of 5 runs each); at 1, 4 and 5 tiles/row (topk 128/512/640, same shape)
+  forcing it off reproduced the barriered result exactly in 3 of 3 runs, so
+  ``<= 7`` is a conservative bound, not a measured boundary. Being a race, the
+  rate depends strongly on the shape: at the S_q = 128 / S_k = 512 shape the
+  other v2 tests use it appeared in only 1 of 5 seeds, against 5 of 5 at
+  S_q = 512 / S_k = 4096 — which is the shape
+  ``test_DSA_indexer_backward_wrapper_v2_low_tile_metadata_war`` forces. The
+  low-tile regime (topk 128/256/384) is additionally checked against an fp64
+  oracle by ``test_DSA_indexer_backward_wrapper_v2``, at its own smaller shape;
+* ``topk <= 2048`` (16 tiles/row) — the SM100 dynamic-smem cap: 2048 fills
+  the 232448 B CTA budget exactly (the ticket ring lives in the alignment
+  padding between the dW partials and the 1024-aligned sQ buffer, so it
+  costs no extra bytes); 2176 would need 234496 B.
+
+``api.py`` raises before compile otherwise.
+
+Workspace ownership / concurrency contract: the dynamic-ticket counter (and
+the fp32 dK scratch used for bf16 ``d_index_k`` outputs) are **per-plan
+workspace**, allocated once when the plan first executes and reused by every
+subsequent execute of that plan. The kernel self-resets the counter (the CTA
+that draws the final raw ticket stores 0), so back-to-back launches need no
+host reset — but that also means executions of the SAME plan must be
+serialized: they may target any stream, provided the launches do not overlap
+on the device (in-flight overlap of two launches sharing one counter would
+interleave ticket draws/reset). The workspace is device-resident: the plan
+binds the device of its first execute and rejects any indexer tensor from
+another device (one plan serves one device). ``indexer_backward_wrapper``
+enforces
+both by keying its plan cache on the CUDA device and on the *resolved*
+stream (``stream`` if given, else ``torch.cuda.current_stream()`` at call
+time — the same resolution this module uses to pick the launch stream, plus
+the calling thread's id for ``cudaStreamPerThread``, the one handle CUDA does
+not make unique across host threads), so each device/stream owns a private
+plan/counter and same-stream executes are stream-ordered. Users driving ``IndexerBackward``
+objects directly across streams (or replaying captured graphs concurrently)
+must use one object per device, and one per stream wherever those streams'
+executions can overlap (a single object may target any stream as long as its
+executions are serialized). A launch killed before its final ticket draw
+resets the counter can leave it non-zero; re-creating the plan (or the
+process) clears it.
+"""
+
+from __future__ import annotations
+
+import torch
+import cuda.bindings.driver as cuda
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+from cutlass import Int32, const_expr
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.cute.typing import BFloat16, Float32
+from cutlass._mlir import ir
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+
+from cudnn.deepseek_sparse_attention.utils.compiler import compile_options
+from cudnn.deepseek_sparse_attention.utils.runtime import (
+    resolve_stream as _resolve_stream,
+    torch_stream_context as _torch_stream_context,
+)
+from cudnn.deepseek_sparse_attention.utils.tensor_conversion import to_cute_tensor
+
+from .indexer_backward_sm100 import _score_grad_inplace
+
+
+@dsl_user_op
+def _cvt_f32x2_bf16x2_rn_pure(
+    src0: Float32,
+    src1: Float32,
+    *,
+    loc=None,
+    ip=None,
+) -> ir.Value:
+    """Pack two scalar round-to-nearest FP32->BF16 conversions into one
+    ``cvt.rn.bf16x2.f32`` (raw PTX, NON-satfinite -> bit-identical to the
+    scalar ``BFloat16(x)`` cvt.rn.bf16.f32 element-wise; the satfinite
+    bf16x2 variant flushes NaN payloads and saturates infinities, which
+    would silently change the hi/lo split). PURE (no side-effect fence):
+    the conversion carries no ordering constraint, and an ordered inline-asm
+    variant forces ptxas to serialize the register-heavy S-epilogue.
+    Returned vector[0] = BFloat16(src0), [1] = BFloat16(src1)."""
+    packed = llvm.inline_asm(
+        Int32.mlir_type,
+        [
+            Float32(src1).ir_value(loc=loc, ip=ip),
+            Float32(src0).ir_value(loc=loc, ip=ip),
+        ],
+        "cvt.rn.bf16x2.f32 $0, $1, $2;",
+        "=r,f,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+    vec_type = ir.VectorType.get([2], BFloat16.mlir_type, loc=loc)
+    return llvm.bitcast(vec_type, packed, loc=loc, ip=ip)
+
+
+class IndexerBackwardV2Sm100:
+    """Persistent gather-GEMM indexer backward with dynamic row tickets."""
+
+    arch = 100
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_dim: int,
+        topk: int,
+        num_ctas: int,
+        ticket_slots: int,
+        ring_depth: int = 4,
+        dw_out_bf16: bool = False,
+        idx_local: bool = False,
+    ):
+        assert num_heads == 64, "specialized for H=64"
+        assert head_dim == 128, "specialized for D=128"
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.topk = topk
+        self.n_block = 128
+        # dW output dtype variant: fp32 buffers receive the deterministic
+        # accumulator verbatim; bf16 buffers receive its bf16 rounding at
+        # the store, which is the same value a separate fp32 scratch buffer
+        # plus a cast kernel would produce.
+        self.dw_out_bf16 = bool(dw_out_bf16)
+        # idx_local: sIdx holds per-batch local ids. They are masked against
+        # the per-batch S_k BEFORE the batch offset is applied (in-kernel),
+        # so positive out-of-range local ids contribute nothing instead of
+        # aliasing the next batch. False: sIdx holds global flat ids checked
+        # against B * S_k. (B == 1 local ids compile the global variant —
+        # offset 0 and identical bound.)
+        self.idx_local = bool(idx_local)
+        # 128-slot tiles; the restage loop moves 512 elements/step with a
+        # predicated constexpr tail covering any 128-multiple.
+        assert topk > 0 and topk % 128 == 0, topk
+        self.num_tiles = topk // self.n_block
+        # >= 1 tile/row. For T >= 3 the S-epilogue's sG reads ride the implicit
+        # A->K pipe chain (which covers the previous row's last tile only from
+        # T >= 3 upward) and the pipe depths keep their full production values.
+        # For T < 3 (topk 128/256) the S/K pipes and mma_lookahead are clamped
+        # to the tile count below, so a whole row's tile sequence is resident
+        # at once and there is no intra-row lap of the S chain; the dK-side
+        # metadata WAR is then covered by the explicit pipe_M barrier (compiled
+        # in for T <= 7 regardless). The low-tile regime is checked against a
+        # strict fp64 recompute by the topk 128/256/384 cases of
+        # test_DSA_indexer_backward_wrapper_v2 in
+        # test/python/fe_api/dsa/test_DSA_indexer_backward.py.
+        assert self.num_tiles >= 1, self.num_tiles
+        # metadata parity slots (sIdx/sG double buffer + pipe_M stages)
+        self.meta_stage = 2
+
+        # Persistent schedule parameters. ``num_ctas`` is the grid size (one
+        # CTA per SM); every CTA runs exactly ``ticket_slots`` ring slots, so
+        # ``ticket_slots * num_ctas >= rows`` must hold — the surplus slots
+        # come back as -1 tickets: no row work, but each still costs the
+        # writer's atomic draw plus one ring publish and 14 consumer releases.
+        # ``ring_depth`` bounds how far the ticket writer can pre-commit
+        # ahead of the slowest consumer warp.
+        assert num_ctas >= 1, num_ctas
+        assert ticket_slots >= 1, ticket_slots
+        assert 2 <= ring_depth <= ticket_slots, (ring_depth, ticket_slots)
+        self.num_ctas = num_ctas
+        self.ticket_slots = ticket_slots
+        self.ring_depth = ring_depth
+        # Idle warp 2 of warpgroup 0 is the ticket writer; the ring is
+        # consumed by 14 warps (TMA + MMA + 4 each for warpgroups 1/2/3),
+        # each arriving via its elected lane 0 only. The producer <=
+        # min(all consumers) + ring invariant is unchanged by the elected
+        # arrival, and the ring read is warp-uniform converged code, so
+        # lanes 1..31 have always read the slot by the time lane 0's
+        # arrive can enable its reuse.
+        self.ticket_warp_id = 2
+        self.ring_consumer_arrivals = 14
+
+        # (M, N, K) tilers for the three contractions
+        self.tiler_S = (self.n_block, num_heads, head_dim)  # S    = Ksel @ Q^T
+        self.tiler_dQ = (head_dim, num_heads, self.n_block)  # dQT += Ksel^T @ A
+        self.tiler_dK = (self.n_block, head_dim, num_heads)  # dKp  = A @ Q^T-view
+
+        # Pipeline depths. The single MMA warp issues the S contraction as
+        # an async producer running ``mma_lookahead`` (= 2) tiles ahead of
+        # the S-epilogue consumer, so the S TMEM accumulators and the K
+        # gather pipe are 3 deep; the A and dK pipes stay 2 deep (TMEM is
+        # exactly full at 512 columns). sQ is double-buffered so the TMA
+        # fetch of row i+1 only waits on the MMA-warp release from row i-1,
+        # keeping the Q fetch off the row-boundary critical chain.
+        # For T >= 3 (topk >= 384) these min-clamps are all no-ops, so the
+        # schedule is the unclamped one; for
+        # T < 3 (topk 128/256) the S/K pipes and the lookahead shrink to the
+        # tile count so a whole row is resident at once. a_stage/dk_stage stay
+        # 2 unconditionally: the odd-tile dK drain references tAccdK[1] and the
+        # T==2 paired drain rolls by dk_stage==2, so both need two dK
+        # accumulators even at T in {1, 2}.
+        self.q_stage = 2
+        self.kv_stage = min(3, self.num_tiles)
+        self.a_stage = 2
+        self.s_stage = min(3, self.num_tiles)
+        self.dk_stage = 2
+        self.mma_lookahead = min(2, self.num_tiles)
+        # Explicit metadata WAR barrier gate. The implicit K->S->A->DK chain
+        # orders the gather warpgroup's restage of valid row i+2 behind the
+        # dK warpgroup's completed sIdx reads of tile (i+2)*T - kv_stage -
+        # dk_stage - 3; that covers row i's last tile (i*T + T - 1) iff
+        # T >= kv_stage + dk_stage + 2 (== 7 with these stages). pipe_M is
+        # compiled in below that bound PLUS one tile of margin (explicit for
+        # T <= 7), so the regime that relies on the implicit chain is strictly
+        # inside the arithmetic proof. Forcing pipe_M off at T == 2 breaks
+        # d_index_k (8.1e-3 .. 5.2e-2 vs 2.4e-6 rms relative against an fp64
+        # recompute, 5 of 5 runs at S_q = 512 / S_k = 4096; see the module
+        # docstring), which is what makes the explicit barrier load-bearing
+        # here.
+        self.meta_war_explicit = self.num_tiles < self.kv_stage + self.dk_stage + 3
+
+        self.load_warp_id = 0
+        self.mma_warp_id = 1
+        self.epi_warp_ids = (4, 5, 6, 7)
+        self.gather_warp_ids = (8, 9, 10, 11)
+        self.dk_warp_ids = (12, 13, 14, 15)
+        self.num_warps = 16
+        self.threads_per_cta = 32 * self.num_warps
+
+        # TMEM column map (fp32 cols): S slots, dQT, dK slots. 512 = full.
+        self.tmem_S_off = (0, 64, 448)
+        self.tmem_dQ_off = 128
+        self.tmem_dK_off = (192, 320)
+        self.tmem_alloc_cols = 512
+
+        # Warp-specialized register budgets. ptxas honors setmaxnreg only when
+        # it can derive the entry register count from a thread-count bound; the
+        # DSL emits that as ``.reqntid`` from ``block=`` at the launch below.
+        # The epilogue warpgroup carries the S-epilogue, the hi/lo conversions
+        # and the dQ drain, hence the asymmetric split.
+        self.num_regs_wg0 = 32
+        self.num_regs_epi = 256
+        self.num_regs_gather = 64
+        self.num_regs_dk = 160
+
+        # participants: MMA warp + S-epi warps + dK warps (TMEM users)
+        self.tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=2,
+            num_threads=32 * (1 + len(self.epi_warp_ids) + len(self.dk_warp_ids)),
+        )
+        # TMEM dealloc gate: S-epi + dK warps
+        self.tmem_dealloc_barrier = pipeline.NamedBarrier(
+            barrier_id=3,
+            num_threads=32 * (len(self.epi_warp_ids) + len(self.dk_warp_ids)),
+        )
+        # dW partial exchange between the 4 S-epi warps. Split-phase: each
+        # warp arrive()s right after staging its smem partial
+        # (non-blocking), the combine arrive_and_wait()s after the dQ
+        # store -> count = 2 x 128.
+        self.epi_dw_barrier = pipeline.NamedBarrier(
+            barrier_id=4,
+            num_threads=2 * 32 * len(self.epi_warp_ids),
+        )
+        # Metadata restage barrier, internal to the gather warpgroup (128
+        # threads). The gather warpgroup alone restages sIdx/sG (vectorized
+        # 16B); the S-epilogue warpgroup reads them through the K->S pipe
+        # acquire chain, the dK warpgroup through the A->DK chain, so
+        # neither joins this barrier and it never stalls them directly
+        # (those pipe chains, not this barrier, are what order the next row's
+        # front behind the restage). The S-epilogue warpgroup loads its
+        # weights row
+        # straight from gmem (mW is read-only), so weights are never staged
+        # in smem.
+        self.stage_barrier = pipeline.NamedBarrier(barrier_id=5, num_threads=128)
+
+    # -----------------------------------------------------------------
+    # host side
+    # -----------------------------------------------------------------
+    @cute.jit
+    def __call__(
+        self,
+        mQ: cute.Tensor,  # (S, H, D) bf16
+        mK: cute.Tensor,  # (SK, D) bf16
+        mW: cute.Tensor,  # (S, H) bf16 (upcast to fp32 in-register, exact)
+        mIdx: cute.Tensor,  # (S, topk) int32
+        mG: cute.Tensor,  # (S, topk) fp32
+        mdQ: cute.Tensor,  # (S, H, D) bf16 out
+        mdW: cute.Tensor,  # (S, H) out — fp32 or bf16 per dw_out_bf16
+        mdK: cute.Tensor,  # (SK, D) fp32 out (zero-initialized)
+        sm_scale: Float32,  # runtime fold into the grad signal (positive)
+        s_q_per_batch: Int32,  # rows per batch (idx_local row -> batch map)
+        s_k_local: Int32,  # per-batch KV extent (idx_local mask bound)
+        stream: cuda.CUstream,
+        mCnt: cute.Tensor,  # (2,) i32 persistent ticket counter
+    ):
+        # (S, H, D) -> (H, D, S): B-operand view (N=heads, K=dim, rest=row)
+        mQ_v = cute.make_tensor(mQ.iterator, cute.select(mQ.layout, mode=[1, 2, 0]))
+
+        cta_group = tcgen05.CtaGroup.ONE
+        mma_S = sm100_utils.make_trivial_tiled_mma(
+            BFloat16,
+            BFloat16,
+            tcgen05.OperandMajorMode.K,  # A = gathered K rows (slot, dim)
+            tcgen05.OperandMajorMode.K,  # B = Q rows (head, dim)
+            Float32,
+            cta_group,
+            self.tiler_S[:2],
+        )
+        mma_dQ = sm100_utils.make_trivial_tiled_mma(
+            BFloat16,
+            BFloat16,
+            tcgen05.OperandMajorMode.MN,  # A = Ksel^T view (dim, slot)
+            tcgen05.OperandMajorMode.MN,  # B = A_mat^T view (head, slot)
+            Float32,
+            cta_group,
+            self.tiler_dQ[:2],
+        )
+        mma_dK = sm100_utils.make_trivial_tiled_mma(
+            BFloat16,
+            BFloat16,
+            tcgen05.OperandMajorMode.K,  # A = A_mat (slot, head)
+            tcgen05.OperandMajorMode.MN,  # B = Q^T view (dim, head)
+            Float32,
+            cta_group,
+            self.tiler_dK[:2],
+        )
+
+        sK_layout = sm100_utils.make_smem_layout_a(mma_S, self.tiler_S, BFloat16, self.kv_stage)
+        sKT_layout = sm100_utils.make_smem_layout_a(mma_dQ, self.tiler_dQ, BFloat16, self.kv_stage)
+        sQ_layout = sm100_utils.make_smem_layout_b(mma_S, self.tiler_S, BFloat16, self.q_stage)
+        sQT_layout = sm100_utils.make_smem_layout_b(mma_dK, self.tiler_dK, BFloat16, self.q_stage)
+        sA_layout = sm100_utils.make_smem_layout_a(mma_dK, self.tiler_dK, BFloat16, self.a_stage)
+        sAT_layout = sm100_utils.make_smem_layout_b(mma_dQ, self.tiler_dQ, BFloat16, self.a_stage)
+
+        cluster_layout_vmnk = cute.tiled_divide(cute.make_layout((1, 1, 1)), (mma_S.thr_id.shape,))
+        tma_load_op = cpasync.CopyBulkTensorTileG2SOp(cta_group)
+        tma_atom_Q, tma_tensor_Q = cute.nvgpu.make_tiled_tma_atom_B(
+            tma_load_op,
+            mQ_v,
+            cute.select(sQ_layout, mode=[0, 1, 2]),
+            self.tiler_S,
+            mma_S,
+            cluster_layout_vmnk.shape,
+        )
+        self.tma_copy_q_bytes = self.num_heads * self.head_dim * (BFloat16.width // 8)
+
+        self.kernel(
+            mma_S,
+            mma_dQ,
+            mma_dK,
+            tma_atom_Q,
+            tma_tensor_Q,
+            mK,
+            mW,
+            mIdx,
+            mG,
+            mdQ,
+            mdW,
+            mdK,
+            sQ_layout,
+            sK_layout,
+            sKT_layout,
+            sQT_layout,
+            sA_layout,
+            sAT_layout,
+            mCnt,
+            sm_scale,
+            s_q_per_batch,
+            s_k_local,
+        ).launch(
+            grid=(self.num_ctas, 1, 1),
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(1, 1, 1),
+            min_blocks_per_mp=1,
+            stream=stream,
+        )
+
+    # -----------------------------------------------------------------
+    # device side — persistent dynamic-ticket schedule
+    # -----------------------------------------------------------------
+    @cute.kernel
+    def kernel(
+        self,
+        mma_S: cute.TiledMma,
+        mma_dQ: cute.TiledMma,
+        mma_dK: cute.TiledMma,
+        tma_atom_Q: cute.CopyAtom,
+        tma_tensor_Q: cute.Tensor,
+        mK: cute.Tensor,  # (SK, D) bf16
+        mW: cute.Tensor,  # (S, H) bf16
+        mIdx: cute.Tensor,  # (S, topk) int32
+        mG: cute.Tensor,  # (S, topk) fp32
+        mdQ: cute.Tensor,  # (S, H, D) bf16
+        mdW: cute.Tensor,  # (S, H) fp32 or bf16 (dw_out_bf16)
+        mdK: cute.Tensor,  # (SK, D) fp32
+        sQ_layout: cute.ComposedLayout,
+        sK_layout: cute.ComposedLayout,
+        sKT_layout: cute.ComposedLayout,
+        sQT_layout: cute.ComposedLayout,
+        sA_layout: cute.ComposedLayout,
+        sAT_layout: cute.ComposedLayout,
+        mCnt: cute.Tensor,  # (2,) i32 ticket counter
+        sm_scale: Float32,
+        s_q_per_batch: Int32,
+        s_k_local: Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        seq_k = cute.size(mdK.shape[0])
+        seq_len = cute.size(mIdx.shape[0])
+
+        if warp_idx == self.load_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_Q)
+
+        @cute.struct
+        class SharedStorage:
+            Q_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.q_stage]
+            K_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.kv_stage]
+            A_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.a_stage]
+            S_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.s_stage]
+            DK_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.dk_stage]
+            DQ_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2]
+            # sIdx/sG parity-slot WAR pipe (gather WG producer / dK WG
+            # consumer); inert 32B unless meta_war_explicit
+            M_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.meta_stage]
+            tmem_holding_buf: cutlass.Int32
+            # sIdx/sG parity double-buffered: the dK warpgroup (and the
+            # S-epilogue's late sG reads) still consume row i while the
+            # gather warpgroup restages row i+1.
+            # No sW: the S-epilogue loads its weights row straight from gmem.
+            sIdx: cute.struct.Align[cute.struct.MemRange[Int32, 2 * self.topk], 16]
+            sG: cute.struct.Align[cute.struct.MemRange[Float32, 2 * self.topk], 16]
+            # per-epi-warp dW partials, parity double-buffered (row i's
+            # fixed-order combine reads vs row i+1's restage)
+            sdWp: cute.struct.Align[
+                cute.struct.MemRange[Float32, 2 * self.num_heads * len(self.epi_warp_ids)],
+                16,
+            ]
+            # Ticket ring (mbar pairs + row ids). Placed HERE — between
+            # sdWp and the 1024-aligned sQ — so it sits inside the
+            # pre-existing alignment-padding hole (768B at this config;
+            # the ring fits for depth <= 38): ZERO smem growth and
+            # identical sQ/sK/sAhi/sAlo offsets. As a separate trailing
+            # allocation it added 80B past the sAlo end, which pushed
+            # topk == 2048 to 232528B — 80B over the SM100 232448B
+            # dynamic-smem cap.
+            T_mbar_ptr: cute.struct.MemRange[cutlass.Int64, 2 * self.ring_depth]
+            sRowQ: cute.struct.Align[cute.struct.MemRange[Int32, self.ring_depth], 16]
+            sQ: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(sQ_layout)], 1024]
+            sK: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(sK_layout)], 1024]
+            sAhi: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(sA_layout)], 1024]
+            sAlo: cute.struct.Align[cute.struct.MemRange[BFloat16, cute.cosize(sA_layout)], 1024]
+
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(SharedStorage)
+
+        # ---- pipelines (phases roll across rows without reset) ----
+        pipe_Q = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.Q_mbar_ptr.data_ptr(),
+            num_stages=self.q_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            tx_count=self.tma_copy_q_bytes,
+            defer_sync=True,
+        )
+        pipe_K = pipeline.PipelineAsyncUmma.create(
+            barrier_storage=storage.K_mbar_ptr.data_ptr(),
+            num_stages=self.kv_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 128),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            defer_sync=True,
+        )
+        pipe_A = pipeline.PipelineAsyncUmma.create(
+            barrier_storage=storage.A_mbar_ptr.data_ptr(),
+            num_stages=self.a_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 128),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            defer_sync=True,
+        )
+        pipe_S = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.S_mbar_ptr.data_ptr(),
+            num_stages=self.s_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 128),
+            defer_sync=True,
+        )
+        pipe_DK = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.DK_mbar_ptr.data_ptr(),
+            num_stages=self.dk_stage,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 128),
+            defer_sync=True,
+        )
+        pipe_DQ = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.DQ_mbar_ptr.data_ptr(),
+            num_stages=1,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 128),
+            defer_sync=True,
+        )
+        # pipe_M: EXPLICIT sIdx/sG parity-slot WAR protection, compiled in
+        # iff meta_war_explicit (num_tiles <= 7; see __init__ for the bound
+        # derivation). The implicit K->S->A->DK acquire chain is too short
+        # there to delay the gather warpgroup's restage of row i+2 past the
+        # dK warpgroup's last sIdx read of row i (measured at topk=256 -> 2
+        # tiles: forcing this barrier off makes the restage lap the drain, the
+        # dK scatter reads overwritten sIdx, and dk rms_rel goes 2.4e-6 ->
+        # 8.1e-3 .. 5.2e-2). Consumer = the dK warpgroup: after the
+        # last sIdx read of a row, each warp syncs and its lane 0 arrives
+        # on the slot's empty barrier (4 arrivals). Producer = the gather
+        # warpgroup: before restaging a parity slot, each warp's lane 0
+        # waits that barrier (sync_warp holds the warp's stores behind it).
+        # States advance once per VALID row, so pipeline index == parity
+        # buffer and phases roll across rows exactly like every other pipe
+        # here. The full direction is unused (the dK warpgroup's visibility
+        # of the fresh sIdx rides the K->S->A->DK chain as before).
+        if const_expr(self.meta_war_explicit):
+            pipe_M = pipeline.PipelineAsync.create(
+                barrier_storage=storage.M_mbar_ptr.data_ptr(),
+                num_stages=self.meta_stage,
+                producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+                consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, len(self.dk_warp_ids)),
+                defer_sync=True,
+            )
+        # Ticket ring: producer = idle warp 2 lane 0, consumers = the 14
+        # worker warps (TMA + MMA + 4 each for warpgroups 1/2/3), each
+        # arriving via its elected lane 0 once per slot. The ring depth is
+        # the writer's pre-commit lead over the slowest consumer's loop top
+        # (the writer leads the front by <= q_stage + 1 rows; the dK
+        # warpgroup's loop top lags < 2 rows).
+        pipe_T = pipeline.PipelineAsync.create(
+            barrier_storage=storage.T_mbar_ptr.data_ptr(),
+            num_stages=self.ring_depth,
+            producer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, 1),
+            consumer_group=pipeline.CooperativeGroup(pipeline.Agent.Thread, self.ring_consumer_arrivals),
+            defer_sync=True,
+        )
+
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf,
+            barrier_for_retrieve=self.tmem_alloc_barrier,
+            allocator_warp_id=self.epi_warp_ids[0],
+        )
+
+        pipeline.pipeline_init_arrive(is_relaxed=True)
+
+        sQ = storage.sQ.get_tensor(sQ_layout.outer, swizzle=sQ_layout.inner)
+        sK = storage.sK.get_tensor(sK_layout.outer, swizzle=sK_layout.inner)
+        sAhi = storage.sAhi.get_tensor(sA_layout.outer, swizzle=sA_layout.inner)
+        sAlo = storage.sAlo.get_tensor(sA_layout.outer, swizzle=sA_layout.inner)
+        # MN-major descriptor views over the same smem
+        sKT = cute.make_tensor(cute.recast_ptr(sK.iterator, sKT_layout.inner), sKT_layout.outer)
+        sQT = cute.make_tensor(cute.recast_ptr(sQ.iterator, sQT_layout.inner), sQT_layout.outer)
+        sAThi = cute.make_tensor(cute.recast_ptr(sAhi.iterator, sAT_layout.inner), sAT_layout.outer)
+        sATlo = cute.make_tensor(cute.recast_ptr(sAlo.iterator, sAT_layout.inner), sAT_layout.outer)
+        sIdx = storage.sIdx.get_tensor(cute.make_layout((self.topk, 2)))
+        sG = storage.sG.get_tensor(cute.make_layout((self.topk, 2)))
+        sdWp = storage.sdWp.get_tensor(cute.make_layout((self.num_heads, len(self.epi_warp_ids), 2)))
+        sRowQ = storage.sRowQ.get_tensor(cute.make_layout((self.ring_depth,)))
+
+        pipeline.pipeline_init_wait()
+
+        # accumulator reference layouts
+        acc_S_ref = mma_S.make_fragment_C(mma_S.partition_shape_C(cute.select(self.tiler_S, mode=[0, 1])))
+        acc_dQ_ref = mma_dQ.make_fragment_C(mma_dQ.partition_shape_C(cute.select(self.tiler_dQ, mode=[0, 1])))
+        acc_dK_ref = mma_dK.make_fragment_C(mma_dK.partition_shape_C(cute.select(self.tiler_dK, mode=[0, 1])))
+
+        wg_idx = tidx // 128
+        # Every CTA and every warpgroup runs exactly ticket_slots ring slots
+        # (compile-time trip count); overdrawn slots publish row = -1.
+        n_slots = self.ticket_slots
+
+        # =============================================================
+        # Warpgroup 0: TMA warp + MMA warp + ticket-writer warp (+1 idle)
+        # =============================================================
+        if wg_idx == 0:
+            cute.arch.setmaxregister_decrease(self.num_regs_wg0)
+
+            if warp_idx == self.load_warp_id:
+                thr_mma = mma_S.get_slice(0)
+                # partition ONCE against the full row axis; per row only the
+                # coordinate is sliced (at the 32-reg budget a per-row
+                # tma_partition recompute spills)
+                pt_gQ = cute.local_tile(
+                    tma_tensor_Q,
+                    cute.select(self.tiler_S, mode=[1, 2]),
+                    (None, None, None),
+                )
+                pt_tSgQ = thr_mma.partition_B(pt_gQ)
+                pt_tQsQ, pt_tQgQ = cpasync.tma_partition(
+                    tma_atom_Q,
+                    0,
+                    cute.make_layout(1),
+                    cute.group_modes(sQ, 0, 3),
+                    cute.group_modes(pt_tSgQ, 0, 3),
+                )
+                q_state = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.q_stage)
+                pt_tst = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.ring_depth)
+                for pt_k in cutlass.range(n_slots, unroll=1):
+                    # ticket ring row (row < 0 -> skip slot); warp-elected
+                    # arrive (lane 0)
+                    pipe_T.consumer_wait(pt_tst)
+                    pt_row = Int32(sRowQ[pt_tst.index])
+                    if tidx % 32 == 0:
+                        pipe_T.consumer_release(pt_tst)
+                    pt_tst.advance()
+                    if pt_row >= 0:
+                        # 2-stage sQ: waits the MMA warp's UMMA-commit
+                        # release from row i-2, i.e. the Q fetch runs a full
+                        # row ahead of its consumer
+                        pipe_Q.producer_acquire(q_state)
+                        pt_q_bar = pipe_Q.producer_get_barrier(q_state)
+                        cute.copy(
+                            tma_atom_Q,
+                            pt_tQgQ[None, 0, 0, pt_row],
+                            pt_tQsQ[None, q_state.index],
+                            tma_bar_ptr=pt_q_bar,
+                        )
+                        q_state.advance()
+
+            elif warp_idx == self.mma_warp_id:
+                tmem.wait_for_alloc()
+                tmem_base = tmem.retrieve_ptr(Float32)
+                tAccdQ = cute.make_tensor(tmem_base + self.tmem_dQ_off, acc_dQ_ref.layout)
+
+                tSrK = mma_S.make_fragment_A(sK)
+                tSrQ = mma_S.make_fragment_B(sQ)
+                tdQrKT = mma_dQ.make_fragment_A(sKT)
+                tdQrAThi = mma_dQ.make_fragment_B(sAThi)
+                tdQrATlo = mma_dQ.make_fragment_B(sATlo)
+                tdKrAhi = mma_dK.make_fragment_A(sAhi)
+                tdKrAlo = mma_dK.make_fragment_A(sAlo)
+                tdKrQT = mma_dK.make_fragment_B(sQT)
+
+                q_cons = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.q_stage)
+                # dual K states: lead feeds the hoisted MMA1(i+lookahead),
+                # trail feeds MMA2(i) and is released afterwards
+                k_lead = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.kv_stage)
+                k_trail = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.kv_stage)
+                a_cons = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.a_stage)
+                s_prod = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.s_stage)
+                dk_prod = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.dk_stage)
+                dq_prod = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, 1)
+
+                pm_tst = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.ring_depth)
+                for pm_k in cutlass.range(n_slots, unroll=1):
+                    # ring read for the shared skip/trip bookkeeping (the row
+                    # value itself is unused by the MMAs); warp-elected arrive
+                    pipe_T.consumer_wait(pm_tst)
+                    pm_rowt = Int32(sRowQ[pm_tst.index])
+                    if tidx % 32 == 0:
+                        pipe_T.consumer_release(pm_tst)
+                    pm_tst.advance()
+                    if pm_rowt >= 0:
+                        pipe_Q.consumer_wait(q_cons)
+
+                        # ---- prologue: fill the S pipe mma_lookahead deep.
+                        # The S TMEM slot comes from the pipeline state (S
+                        # slots misalign across rows, e.g. 8 tiles over 3
+                        # slots at topk 1024).
+                        for p in cutlass.range_constexpr(self.mma_lookahead):
+                            if const_expr(p < self.num_tiles):
+                                pipe_S.producer_acquire(s_prod)
+                                pipe_K.consumer_wait(k_lead)
+                                pm_psel1 = s_prod.index == 1
+                                pm_psel2 = s_prod.index == 2
+                                pm_po01 = Int32(self.tmem_S_off[1]) if pm_psel1 else Int32(self.tmem_S_off[0])
+                                pm_poff = Int32(self.tmem_S_off[2]) if pm_psel2 else pm_po01
+                                pm_ptAccS = cute.make_tensor(tmem_base + pm_poff, acc_S_ref.layout)
+                                mma_S.set(tcgen05.Field.ACCUMULATE, False)
+                                for kb in cutlass.range(0, cute.size(tSrQ, mode=[2]), unroll_full=True):
+                                    cute.gemm(
+                                        mma_S,
+                                        pm_ptAccS,
+                                        tSrK[None, None, kb, k_lead.index],
+                                        tSrQ[None, None, kb, q_cons.index],
+                                        pm_ptAccS,
+                                    )
+                                    mma_S.set(tcgen05.Field.ACCUMULATE, True)
+                                pipe_S.producer_commit(s_prod)
+                                s_prod.advance()
+                                k_lead.advance()
+
+                        # 1-slot dQ TMEM: wait for the S-epilogue's post-drain
+                        # release of the previous row before MMA2 overwrites it
+                        pipe_DQ.producer_acquire(dq_prod)
+
+                        # ---- rolled tile loop (runtime i). A fully unrolled
+                        # body at the 32-reg budget spills the pipeline states
+                        # + MMA descriptor bases to local memory; rolling
+                        # shrinks the live working set. dk slot / S slot both
+                        # come from the pipeline-state index at runtime.
+                        for pm_i in cutlass.range(self.num_tiles, unroll=1):
+                            # ---- hoisted MMA1(i+lookahead), predicated ----
+                            if pm_i + self.mma_lookahead < self.num_tiles:
+                                pipe_S.producer_acquire(s_prod)
+                                pipe_K.consumer_wait(k_lead)
+                                pm_hsel1 = s_prod.index == 1
+                                pm_hsel2 = s_prod.index == 2
+                                pm_ho01 = Int32(self.tmem_S_off[1]) if pm_hsel1 else Int32(self.tmem_S_off[0])
+                                pm_hoff = Int32(self.tmem_S_off[2]) if pm_hsel2 else pm_ho01
+                                pm_htAccS = cute.make_tensor(tmem_base + pm_hoff, acc_S_ref.layout)
+                                mma_S.set(tcgen05.Field.ACCUMULATE, False)
+                                for kb in cutlass.range(0, cute.size(tSrQ, mode=[2]), unroll_full=True):
+                                    cute.gemm(
+                                        mma_S,
+                                        pm_htAccS,
+                                        tSrK[None, None, kb, k_lead.index],
+                                        tSrQ[None, None, kb, q_cons.index],
+                                        pm_htAccS,
+                                    )
+                                    mma_S.set(tcgen05.Field.ACCUMULATE, True)
+                                pipe_S.producer_commit(s_prod)
+                                s_prod.advance()
+                                k_lead.advance()
+
+                            # ---- MMA2: dQT += Ksel^T @ (A_hi + A_lo) ----
+                            pipe_A.consumer_wait(a_cons)
+                            mma_dQ.set(tcgen05.Field.ACCUMULATE, pm_i != 0)
+                            for kb in cutlass.range(0, cute.size(tdQrAThi, mode=[2]), unroll_full=True):
+                                cute.gemm(
+                                    mma_dQ,
+                                    tAccdQ,
+                                    tdQrKT[None, None, kb, k_trail.index],
+                                    tdQrAThi[None, None, kb, a_cons.index],
+                                    tAccdQ,
+                                )
+                                mma_dQ.set(tcgen05.Field.ACCUMULATE, True)
+                                cute.gemm(
+                                    mma_dQ,
+                                    tAccdQ,
+                                    tdQrKT[None, None, kb, k_trail.index],
+                                    tdQrATlo[None, None, kb, a_cons.index],
+                                    tAccdQ,
+                                )
+                            pipe_K.consumer_release(k_trail)
+                            k_trail.advance()
+
+                            # ---- MMA3: dKp = (A_hi + A_lo) @ Q^T-view ----
+                            if pm_i == self.num_tiles - 1:
+                                # dQT is complete after MMA2(last tile):
+                                # commit it BEFORE MMA3's DK-slot acquire so
+                                # the S-epilogue's dQ drain is not gated on
+                                # the dK warpgroup's drain tail (the acquire
+                                # waits on the dK release two tiles back).
+                                pipe_DQ.producer_commit(dq_prod)
+                                dq_prod.advance()
+                            pipe_DK.producer_acquire(dk_prod)
+                            pm_dksel = dk_prod.index == 1
+                            pm_dkoff = Int32(self.tmem_dK_off[1]) if pm_dksel else Int32(self.tmem_dK_off[0])
+                            pm_tAccdK = cute.make_tensor(tmem_base + pm_dkoff, acc_dK_ref.layout)
+                            mma_dK.set(tcgen05.Field.ACCUMULATE, False)
+                            for kb in cutlass.range(0, cute.size(tdKrQT, mode=[2]), unroll_full=True):
+                                cute.gemm(
+                                    mma_dK,
+                                    pm_tAccdK,
+                                    tdKrAhi[None, None, kb, a_cons.index],
+                                    tdKrQT[None, None, kb, q_cons.index],
+                                    pm_tAccdK,
+                                )
+                                mma_dK.set(tcgen05.Field.ACCUMULATE, True)
+                                cute.gemm(
+                                    mma_dK,
+                                    pm_tAccdK,
+                                    tdKrAlo[None, None, kb, a_cons.index],
+                                    tdKrQT[None, None, kb, q_cons.index],
+                                    pm_tAccdK,
+                                )
+                            pipe_DK.producer_commit(dk_prod)
+                            dk_prod.advance()
+                            pipe_A.consumer_release(a_cons)
+                            a_cons.advance()
+
+                        # row epilogue: release this row's sQ slot for the
+                        # TMA warp (UMMA-commit arrive -> fires once all of
+                        # this row's MMAs have actually completed).
+                        pipe_Q.consumer_release(q_cons)
+                        q_cons.advance()
+            else:
+                # Ticket writer: idle warp 2, lane 0. Draws global row
+                # tickets (a scalar global atomic fetch-add) and publishes
+                # them into the sRowQ ring; every CTA runs exactly
+                # ticket_slots slots,
+                # overdrawn slots publish -1. The drawer of the LAST raw ticket
+                # (ticket_slots * num_ctas - 1, unique by atomic total
+                # order — all other CTAs have already drawn by then) resets
+                # the counter for the next launch. Warp 3 stays idle.
+                if warp_idx == self.ticket_warp_id:
+                    if tidx % 32 == 0:
+                        tw_tst = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.ring_depth)
+                        for tw_k in cutlass.range(self.ticket_slots, unroll=1):
+                            pipe_T.producer_acquire(tw_tst)
+                            tw_raw = Int32(cute.arch.atomic_add(mCnt.iterator.llvm_ptr, Int32(1)))
+                            tw_row = tw_raw if tw_raw < seq_len else Int32(-1)
+                            sRowQ[tw_tst.index] = tw_row
+                            pipe_T.producer_commit(tw_tst)
+                            tw_tst.advance()
+                            if tw_raw == Int32(self.ticket_slots * self.num_ctas - 1):
+                                mCnt[0] = Int32(0)
+        # =============================================================
+        # Warpgroup 1: S-epilogue -> A(hi/lo) + dW ; then dQ store
+        # =============================================================
+        elif wg_idx == 1:
+            cute.arch.setmaxregister_increase(self.num_regs_epi)
+            if warp_idx == self.epi_warp_ids[0]:
+                tmem.allocate(self.tmem_alloc_cols)
+            tmem.wait_for_alloc()
+            tmem_base = tmem.retrieve_ptr(Float32)
+            tAccS0 = cute.make_tensor(tmem_base + self.tmem_S_off[0], acc_S_ref.layout)
+            tAccdQ = cute.make_tensor(tmem_base + self.tmem_dQ_off, acc_dQ_ref.layout)
+
+            tidx_wg = tidx % 128
+            lane = tidx % 32
+            # wide S-epilogue TMEM load: Ld32x32b.x32 keeps the thread ==
+            # slot-row mapping of the narrow x8 atom with 4x fewer
+            # tcgen05.ld
+            tmem_load_atom_S = cute.make_copy_atom(
+                tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(32)),
+                Float32,
+            )
+            tiled_t2r = tcgen05.make_tmem_copy(tmem_load_atom_S, tAccS0)
+            thr_t2r = tiled_t2r.get_slice(tidx_wg)
+
+            thr_mma_epi = mma_S.get_slice(tidx_wg)
+            cS = cute.make_identity_tensor(cute.select(self.tiler_S, mode=[0, 1]))
+            tScS = thr_t2r.partition_D(thr_mma_epi.partition_C(cS))
+            # this thread's topk slot within the tile (== TMEM lane)
+            pe_row = cute.get(tScS[0], mode=[0])
+
+            tSrS_shape = thr_t2r.partition_D(cute.make_identity_tensor(tAccS0.shape)).shape
+            tSrS = cute.make_rmem_tensor(tSrS_shape, Float32)
+
+            s_cons = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.s_stage)
+            a_prod = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.a_stage)
+            dq_cons = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, 1)
+
+            rW = cute.make_rmem_tensor((self.num_heads,), Float32)
+            rWb = cute.make_rmem_tensor((self.num_heads,), BFloat16)
+            rdW = cute.make_rmem_tensor((self.num_heads,), Float32)
+            # A row buffers, chunked (8, 8) for 16B vector STS
+            rAhi = cute.make_rmem_tensor((8, 8), BFloat16)
+            rAlo = cute.make_rmem_tensor((8, 8), BFloat16)
+
+            epi_wid = warp_idx - self.epi_warp_ids[0]
+
+            pe_tst = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.ring_depth)
+            pe_vcnt = Int32(0)
+            for pe_k in cutlass.range(n_slots, unroll=1):
+                # ticket ring row (row < 0 -> skip slot); the sG/sdWp parity
+                # buffer alternates per VALID row and must match the gather /
+                # dK warpgroups' valid-count parity exactly; warp-elected
+                # arrive
+                pipe_T.consumer_wait(pe_tst)
+                pe_rowi = Int32(sRowQ[pe_tst.index])
+                if lane == 0:
+                    pipe_T.consumer_release(pe_tst)
+                pe_tst.advance()
+                pe_ok = pe_rowi >= 0
+                pe_buf = pe_vcnt % 2
+                pe_vcnt = pe_vcnt + (Int32(1) if pe_ok else Int32(0))
+                if pe_ok:
+                    # rW straight from gmem (mW is a read-only input; a smem
+                    # stage + barrier would put this warpgroup on the restage
+                    # critical path). The row is loaded bf16 (16B vectors)
+                    # and upcast to fp32 in-register — bf16 -> fp32 is exact,
+                    # so this is bit-for-bit the fp32 view of mW without
+                    # needing a per-execute upcast kernel and buffer.
+                    pe_wptr = cute.make_ptr(
+                        BFloat16,
+                        mW[pe_rowi, None].iterator.llvm_ptr,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    )
+                    pe_wrow = cute.make_tensor(pe_wptr, cute.make_layout((self.num_heads,)))
+                    cute.autovec_copy(pe_wrow, rWb)
+                    for h in cutlass.range_constexpr(self.num_heads):
+                        rW[h] = Float32(rWb[h])
+                        rdW[h] = Float32(0.0)
+
+                    # rolled tile loop: the inner per-head-pair loop stays
+                    # static (register fragments cannot be dynamically
+                    # indexed); the S TMEM slot offsets are non-uniform so
+                    # the accumulator tensor is selected at runtime
+                    for pe_i in cutlass.range(self.num_tiles, unroll=1):
+                        # S TMEM slot from the pipeline state (rolls across
+                        # rows; the local tile number is not slot-aligned)
+                        pe_sel1 = s_cons.index == 1
+                        pe_sel2 = s_cons.index == 2
+                        pe_o01 = Int32(self.tmem_S_off[1]) if pe_sel1 else Int32(self.tmem_S_off[0])
+                        pe_off = Int32(self.tmem_S_off[2]) if pe_sel2 else pe_o01
+                        pe_tAccS = cute.make_tensor(tmem_base + pe_off, acc_S_ref.layout)
+                        pipe_S.consumer_wait(s_cons)
+                        pe_tTR = thr_t2r.partition_S(pe_tAccS)
+                        cute.copy(tiled_t2r, pe_tTR, tSrS)
+                        cute.arch.fence_view_async_tmem_load()
+                        pipe_S.consumer_release(s_cons)
+                        s_cons.advance()
+
+                        pe_pos = Int32(pe_i * self.n_block) + pe_row
+                        # runtime sm_scale fold (g' = sm_scale * g): one FMUL
+                        # per (thread, tile); exact identity at the
+                        # production sm_scale == 1.0. The relu gate below
+                        # reads the unscaled S — equivalent to the default
+                        # backend's gate on sm_scale * S for the positive
+                        # scales this backend accepts (check_support). The
+                        # one gap is underflow to zero: if sm_scale * S
+                        # rounds to +0 for a tiny positive S, the default
+                        # backend's gate on the scaled score sees 0 and drops
+                        # the slot while this gate keeps it. The gate is a
+                        # step function, so on such a slot the two backends
+                        # can differ by that slot's whole contribution: dW's
+                        # term is g' * relu(S) and stays negligible, but the
+                        # dQ/dK term is g' * w (times K / Q) and is not
+                        # bounded by the score magnitude at all. The default
+                        # backend's multiply preserves subnormals (its
+                        # packed mul sets no .ftz), so reaching it needs the
+                        # exact sm_scale * S below 2^-150 (~7.0e-46).
+                        pe_gv = Float32(sG[pe_pos, pe_buf]) * sm_scale
+
+                        pipe_A.producer_acquire(a_prod)
+                        # invalid rows were zero-filled by the gather ->
+                        # S == 0 -> relu = 0, A = 0: no masking needed here.
+                        # Packed hi/lo cvt: 2 heads per cvt.rn.bf16x2.f32.
+                        # The relu mask is applied to the fp32 input (a := 0
+                        # for gated heads) so bf16(0) = 0 reproduces the
+                        # scalar else-branch exactly; hi is computed before
+                        # lo and lo uses fp32(hi), keeping the hi/lo
+                        # accumulate order of the MMA stage exact.
+                        for pe_hp in cutlass.range_constexpr(self.num_heads // 2):
+                            pe_h0 = 2 * pe_hp
+                            pe_h1 = pe_h0 + 1
+                            pe_s0 = Float32(tSrS[pe_h0])
+                            pe_s1 = Float32(tSrS[pe_h1])
+                            pe_k0 = pe_s0 > Float32(0.0)
+                            pe_k1 = pe_s1 > Float32(0.0)
+                            pe_a0 = pe_gv * rW[pe_h0] if pe_k0 else Float32(0.0)
+                            pe_a1 = pe_gv * rW[pe_h1] if pe_k1 else Float32(0.0)
+                            pe_hi = cute.TensorSSA(
+                                _cvt_f32x2_bf16x2_rn_pure(pe_a0, pe_a1),
+                                (2,),
+                                BFloat16,
+                            )
+                            pe_lo = cute.TensorSSA(
+                                _cvt_f32x2_bf16x2_rn_pure(
+                                    pe_a0 - Float32(pe_hi[0]),
+                                    pe_a1 - Float32(pe_hi[1]),
+                                ),
+                                (2,),
+                                BFloat16,
+                            )
+                            rdW[pe_h0] = rdW[pe_h0] + (pe_gv * pe_s0 if pe_k0 else Float32(0.0))
+                            rdW[pe_h1] = rdW[pe_h1] + (pe_gv * pe_s1 if pe_k1 else Float32(0.0))
+                            rAhi[pe_h0 % 8, pe_h0 // 8] = pe_hi[0]
+                            rAlo[pe_h0 % 8, pe_h0 // 8] = pe_lo[0]
+                            rAhi[pe_h1 % 8, pe_h1 // 8] = pe_hi[1]
+                            rAlo[pe_h1 % 8, pe_h1 // 8] = pe_lo[1]
+
+                        pe_sAhi = cute.composition(
+                            sAhi[None, None, None, a_prod.index],
+                            cute.make_layout((self.n_block, self.num_heads)),
+                        )
+                        pe_sAlo = cute.composition(
+                            sAlo[None, None, None, a_prod.index],
+                            cute.make_layout((self.n_block, self.num_heads)),
+                        )
+                        pe_hic = cute.flat_divide(pe_sAhi[pe_row, None], (8,))
+                        pe_loc = cute.flat_divide(pe_sAlo[pe_row, None], (8,))
+                        for pe_cc in cutlass.range_constexpr(8):
+                            cute.autovec_copy(rAhi[None, pe_cc], pe_hic[None, pe_cc])
+                            cute.autovec_copy(rAlo[None, pe_cc], pe_loc[None, pe_cc])
+                        cute.arch.fence_view_async_shared()
+                        pipe_A.producer_commit(a_prod)
+                        a_prod.advance()
+
+                    # ---- dW butterfly + stage partial (parity smem buffer)
+                    for h in cutlass.range_constexpr(self.num_heads):
+                        pe_v = rdW[h]
+                        for off in cutlass.range_constexpr(5):
+                            pe_v += cute.arch.shuffle_sync_bfly(pe_v, 1 << off)
+                        rdW[h] = pe_v
+                    if lane == 0:
+                        cute.autovec_copy(rdW, sdWp[None, epi_wid, pe_buf])
+                    self.epi_dw_barrier.arrive()
+
+                    # ---- dQ drain; the partition setup is rebuilt per row
+                    # (pure address math) so nothing dQ-related stays live
+                    # across the whole row loop (this warpgroup sits at the
+                    # 256-reg ceiling; hoisting these spills rW/rdW)
+                    tiled_t2r_dq = tcgen05.make_tmem_copy(tmem_load_atom_S, tAccdQ)
+                    thr_t2r_dq = tiled_t2r_dq.get_slice(tidx_wg)
+                    cdq = cute.make_identity_tensor(cute.select(self.tiler_dQ, mode=[0, 1]))
+                    tdqcdq = thr_t2r_dq.partition_D(thr_mma_epi.partition_C(cdq))
+                    pe_drow = cute.get(tdqcdq[0], mode=[0])
+                    tSrdQ_shape = thr_t2r_dq.partition_D(cute.make_identity_tensor(tAccdQ.shape)).shape
+                    tSrdQ = cute.make_rmem_tensor(tSrdQ_shape, Float32)
+                    tTR_tdQ = thr_t2r_dq.partition_S(tAccdQ)
+                    # release the TMEM slot right after the fence so the next
+                    # row's MMA2 can start while this warp is still storing
+                    # registers to gmem
+                    pipe_DQ.consumer_wait(dq_cons)
+                    cute.copy(tiled_t2r_dq, tTR_tdQ, tSrdQ)
+                    cute.arch.fence_view_async_tmem_load()
+                    pipe_DQ.consumer_release(dq_cons)
+                    dq_cons.advance()
+                    for h in cutlass.range_constexpr(self.num_heads):
+                        mdQ[pe_rowi, h, pe_drow] = BFloat16(Float32(tSrdQ[h]))
+
+                    # ---- deterministic dW combine (fixed order, plain
+                    # store; this CTA exclusively owns mdW[pe_rowi]). The
+                    # store rounds to the output dtype: fp32 buffers get the
+                    # accumulator verbatim, bf16 buffers its bf16 rounding
+                    # (the same value an fp32 scratch plus a cast would give).
+                    self.epi_dw_barrier.arrive_and_wait()
+                    if tidx_wg < self.num_heads:
+                        pe_dw = Float32(sdWp[tidx_wg, 0, pe_buf])
+                        pe_dw += Float32(sdWp[tidx_wg, 1, pe_buf])
+                        pe_dw += Float32(sdWp[tidx_wg, 2, pe_buf])
+                        pe_dw += Float32(sdWp[tidx_wg, 3, pe_buf])
+                        if const_expr(self.dw_out_bf16):
+                            mdW[pe_rowi, tidx_wg] = BFloat16(pe_dw)
+                        else:
+                            mdW[pe_rowi, tidx_wg] = pe_dw
+
+            self.tmem_dealloc_barrier.arrive_and_wait()
+            if warp_idx == self.epi_warp_ids[0]:
+                cute.arch.dealloc_tmem(tmem_base, self.tmem_alloc_cols)
+
+        # =============================================================
+        # Warpgroup 2: metadata restage + sparse K gather (cp.async)
+        # =============================================================
+        elif wg_idx == 2:
+            cute.arch.setmaxregister_decrease(self.num_regs_gather)
+            wg_tidx = tidx % 128
+            idx_in_group = wg_tidx % 8
+            group_idx = wg_tidx // 8  # 16 groups x 8 threads
+            NUM_GROUPS = 16
+            ROWS_PER_GROUP = self.n_block // NUM_GROUPS
+
+            gather_atom = cute.make_copy_atom(
+                cpasync.CopyG2SOp(cache_mode=cpasync.LoadCacheMode.GLOBAL),
+                BFloat16,
+                num_bits_per_copy=128,
+            )
+            gather_tv = cute.make_tiled_copy_tv(gather_atom, cute.make_layout((1,)), cute.make_layout((8,)))
+            thr_gather = gather_tv.get_slice(0)
+
+            rZero = cute.make_rmem_tensor((8,), BFloat16)
+            for z in cutlass.range_constexpr(8):
+                rZero[z] = BFloat16(0.0)
+
+            k_prod = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.kv_stage)
+            if const_expr(self.meta_war_explicit):
+                # sIdx/sG slot WAR pipe (advances once per VALID row)
+                pg_mst = pipeline.make_pipeline_state(pipeline.PipelineUserType.Producer, self.meta_stage)
+
+            pg_tst = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.ring_depth)
+            pg_vcnt = Int32(0)
+            for pg_k in cutlass.range(n_slots, unroll=1):
+                # ticket ring row (row < 0 -> skip slot; the sIdx/sG parity
+                # buffer alternates per VALID row so the restage-vs-dK-drain
+                # protection chain keeps its 2-valid-row distance);
+                # warp-elected arrive
+                pipe_T.consumer_wait(pg_tst)
+                pg_rowi = Int32(sRowQ[pg_tst.index])
+                if wg_tidx % 32 == 0:
+                    pipe_T.consumer_release(pg_tst)
+                pg_tst.advance()
+                pg_ok = pg_rowi >= 0
+                pg_buf = pg_vcnt % 2
+                pg_vcnt = pg_vcnt + (Int32(1) if pg_ok else Int32(0))
+                if pg_ok:
+                    # local-id mode: per-row batch offset, applied AFTER the
+                    # validity mask against the per-batch bound (below), so
+                    # positive out-of-range local ids contribute nothing
+                    # instead of aliasing the next batch's K rows.
+                    pg_off = Int32(0)
+                    if const_expr(self.idx_local):
+                        pg_off = (pg_rowi // s_q_per_batch) * s_k_local
+                    # ---- explicit slot WAR acquire (pipe_M): wait until the
+                    # dK warpgroup has finished the LAST sIdx read of the row
+                    # that was staged in this parity slot 2 valid rows ago.
+                    # Warp-elected: lane 0 waits, sync_warp holds the warp's
+                    # restage stores behind it. This is the fix that stops
+                    # the restage from lapping the dK drain at <= 7
+                    # tiles/row.
+                    if const_expr(self.meta_war_explicit):
+                        if wg_tidx % 32 == 0:
+                            pipe_M.producer_acquire(pg_mst)
+                        cute.arch.sync_warp()
+                        pg_mst.advance()
+                    # ---- metadata restage (this warpgroup only, 16B
+                    # vectorized). The S-epilogue warpgroup sees the writes
+                    # through the K->S pipe acquire chain, the dK warpgroup
+                    # through the A->DK chain; neither joins this barrier, so
+                    # it never stalls them directly (those pipe chains are what
+                    # order the next row's front behind the restage).
+                    pg_gIptr = cute.make_ptr(
+                        Int32,
+                        mIdx[pg_rowi, None].iterator.llvm_ptr,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    )
+                    pg_gIrow = cute.make_tensor(pg_gIptr, cute.make_layout((self.topk,)))
+                    pg_gIch = cute.flat_divide(pg_gIrow, (4,))
+                    pg_gGptr = cute.make_ptr(
+                        Float32,
+                        mG[pg_rowi, None].iterator.llvm_ptr,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    )
+                    pg_gGrow = cute.make_tensor(pg_gGptr, cute.make_layout((self.topk,)))
+                    pg_gGch = cute.flat_divide(pg_gGrow, (4,))
+                    pg_sIch = cute.flat_divide(sIdx[None, pg_buf], (4,))
+                    pg_sGch = cute.flat_divide(sG[None, pg_buf], (4,))
+                    for pg_c in cutlass.range_constexpr(self.topk // (4 * 128)):
+                        pg_e4 = wg_tidx + pg_c * 128
+                        cute.autovec_copy(pg_gIch[None, pg_e4], pg_sIch[None, pg_e4])
+                        cute.autovec_copy(pg_gGch[None, pg_e4], pg_sGch[None, pg_e4])
+                    # predicated tail: covers topk % 512 != 0 (e.g. 640 /
+                    # 896); constexpr-eliminated whenever topk % 512 == 0
+                    # (512 / 1024 / 1536 / 2048)
+                    if const_expr((self.topk // 4) % 128 != 0):
+                        pg_e4t = wg_tidx + (self.topk // (4 * 128)) * 128
+                        if pg_e4t < self.topk // 4:
+                            cute.autovec_copy(pg_gIch[None, pg_e4t], pg_sIch[None, pg_e4t])
+                            cute.autovec_copy(pg_gGch[None, pg_e4t], pg_sGch[None, pg_e4t])
+                    self.stage_barrier.arrive_and_wait()
+
+                    for i in cutlass.range_constexpr(self.num_tiles):
+                        pipe_K.producer_acquire(k_prod)
+                        pg_sK = cute.composition(
+                            sK[None, None, None, k_prod.index],
+                            cute.make_layout((self.n_block, self.head_dim)),
+                        )
+                        for r in cutlass.range_constexpr(ROWS_PER_GROUP):
+                            pg_rrow = r * NUM_GROUPS + group_idx
+                            pg_pos = Int32(i * self.n_block) + pg_rrow
+                            pg_raw = Int32(sIdx[pg_pos, pg_buf])
+                            if const_expr(self.idx_local):
+                                # mask against the per-batch bound BEFORE the
+                                # batch offset (invalid ids never alias)
+                                pg_valid = pg_raw >= 0 and pg_raw < s_k_local
+                                pg_kv = pg_raw + pg_off
+                            else:
+                                pg_valid = pg_raw >= 0 and pg_raw < seq_k
+                                pg_kv = pg_raw
+                            pg_sKrow = pg_sK[pg_rrow, None]
+                            pg_sKch = cute.flat_divide(pg_sKrow, (8,))
+                            if pg_valid:
+                                pg_gKptr = cute.make_ptr(
+                                    BFloat16,
+                                    mK[pg_kv, None].iterator.llvm_ptr,
+                                    cute.AddressSpace.gmem,
+                                    assumed_align=16,
+                                )
+                                pg_gKrow = cute.make_tensor(pg_gKptr, cute.make_layout((self.head_dim,)))
+                                pg_gKch = cute.flat_divide(pg_gKrow, (8,))
+                                for t in cutlass.range_constexpr(self.head_dim // 64):
+                                    pg_ch = t * 8 + idx_in_group
+                                    pg_tSg = thr_gather.partition_S(pg_gKch[None, pg_ch])
+                                    pg_tSs = thr_gather.partition_D(pg_sKch[None, pg_ch])
+                                    cute.copy(gather_atom, pg_tSg, pg_tSs)
+                            else:
+                                # zero-fill: garbage must not reach S/dW/dQT
+                                for t in cutlass.range_constexpr(self.head_dim // 64):
+                                    pg_ch = t * 8 + idx_in_group
+                                    cute.autovec_copy(rZero, pg_sKch[None, pg_ch])
+                        cute.arch.cp_async_commit_group()
+                        cute.arch.cp_async_wait_group(0)
+                        cute.arch.fence_view_async_shared()
+                        pipe_K.producer_commit(k_prod)
+                        k_prod.advance()
+
+        # =============================================================
+        # Warpgroup 3: dK reduce — TMEM -> RF -> atom.global.add.v4.f32
+        # =============================================================
+        else:
+            cute.arch.setmaxregister_increase(self.num_regs_dk)
+            tmem.wait_for_alloc()
+            tmem_base = tmem.retrieve_ptr(Float32)
+            tAccdK = [cute.make_tensor(tmem_base + self.tmem_dK_off[s], acc_dK_ref.layout) for s in range(self.dk_stage)]
+
+            tidx_wg = tidx % 128
+            # wide dK TMEM drain: Ld16x256b.x16 — 16 256-bit-datapath loads
+            # replace 128 narrow loads per 8 tiles of a row (a whole row at
+            # topk 1024; both counts scale with the tile count). The wide
+            # atom repartitions four logical rows across adjacent threads,
+            # so the drain below uses xor-1 register exchanges to
+            # reconstruct the exact contiguous 4-element atomic chunks.
+            tmem_load_atom = cute.make_copy_atom(
+                tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(16)),
+                Float32,
+            )
+            tiled_t2r_dk = tcgen05.make_tmem_copy(tmem_load_atom, tAccdK[0])
+            thr_t2r_dk = tiled_t2r_dk.get_slice(tidx_wg)
+
+            thr_mma_dk = mma_dK.get_slice(tidx_wg)
+            cdk = cute.make_identity_tensor(cute.select(self.tiler_dK, mode=[0, 1]))
+            tdkcdk = thr_t2r_dk.partition_D(thr_mma_dk.partition_C(cdk))
+
+            tSrdK_shape = thr_t2r_dk.partition_D(cute.make_identity_tensor(tAccdK[0].shape)).shape
+            tSrdK = cute.make_rmem_tensor(tSrdK_shape, Float32)
+            frag4 = cute.make_rmem_tensor((4,), Float32)
+
+            dk_cons = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.dk_stage)
+            pk_lane_odd = tidx_wg % 2 != 0
+            if const_expr(self.meta_war_explicit):
+                # sIdx/sG slot WAR pipe (advances once per VALID row)
+                pk_mst = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.meta_stage)
+
+            pk_tst = pipeline.make_pipeline_state(pipeline.PipelineUserType.Consumer, self.ring_depth)
+            pk_vcnt = Int32(0)
+            for pk_k in cutlass.range(n_slots, unroll=1):
+                # identical ticket sequence in every warpgroup; the row value
+                # feeds only the local-id batch offset (sIdx carries the
+                # scatter targets) plus skip/parity bookkeeping; warp-elected
+                # arrive
+                pipe_T.consumer_wait(pk_tst)
+                pk_ticket_row = Int32(sRowQ[pk_tst.index])
+                if tidx_wg % 32 == 0:
+                    pipe_T.consumer_release(pk_tst)
+                pk_tst.advance()
+                pk_ok = pk_ticket_row >= 0
+                pk_buf = pk_vcnt % 2
+                pk_vcnt = pk_vcnt + (Int32(1) if pk_ok else Int32(0))
+                if pk_ok:
+                    # local-id mode: this row's batch offset (the ticket row
+                    # value is load-bearing here), applied after the validity
+                    # mask against the per-batch bound at each sIdx read.
+                    pk_off = Int32(0)
+                    if const_expr(self.idx_local):
+                        pk_off = (pk_ticket_row // s_q_per_batch) * s_k_local
+                    # Two-chain software-pipelined drain: prepare the
+                    # select+shuffle results of the second column block
+                    # before issuing the first block's reductions, exposing
+                    # two independent chains to the scheduler while keeping
+                    # the reduction order and grouping exact. The outer tile
+                    # loop is rolled by dk_stage (the wide TMEM atom needs a
+                    # statically aligned column offset, so the inner slot
+                    # loop stays constexpr over the 2 aligned accumulators);
+                    # dk slots realign every row when the tile count is
+                    # even (e.g. 8 tiles over 2 slots at topk 1024).
+                    # (pipe_M's full direction is unused: this warpgroup's
+                    # VISIBILITY of the freshly staged sIdx rides the
+                    # K->S->A->DK acquire chain as before; only the WAR
+                    # arrive below is load-bearing.)
+                    if const_expr(self.num_tiles % self.dk_stage == 0):
+                        for pk_i2 in cutlass.range(self.num_tiles // self.dk_stage, unroll=1):
+                            for pk_slot in cutlass.range_constexpr(self.dk_stage):
+                                pk_i = pk_i2 * self.dk_stage + pk_slot
+                                pipe_DK.consumer_wait(dk_cons)
+                                pk_tTR = thr_t2r_dk.partition_S(tAccdK[pk_slot])
+                                cute.copy(tiled_t2r_dk, pk_tTR, tSrdK)
+                                cute.arch.fence_view_async_tmem_load()
+                                pipe_DK.consumer_release(dk_cons)
+                                dk_cons.advance()
+
+                                for pk_rp in cutlass.range_constexpr(2):
+                                    pk_re = cute.get(tdkcdk[pk_rp * 64], mode=[0])
+                                    pk_ro = cute.get(tdkcdk[pk_rp * 64 + 2], mode=[0])
+                                    pk_row = pk_ro if pk_lane_odd else pk_re
+                                    pk_pos = Int32(pk_i * self.n_block) + pk_row
+                                    pk_raw = Int32(sIdx[pk_pos, pk_buf])
+                                    if const_expr(self.idx_local):
+                                        pk_valid = pk_raw >= 0 and pk_raw < s_k_local
+                                        pk_glob = pk_raw + pk_off
+                                    else:
+                                        pk_valid = pk_raw >= 0 and pk_raw < seq_k
+                                        pk_glob = pk_raw
+                                    pk_safe = pk_glob if pk_valid else Int32(0)
+                                    pk_ptr = cute.make_ptr(
+                                        Float32,
+                                        mdK[pk_safe, None].iterator.llvm_ptr,
+                                        cute.AddressSpace.gmem,
+                                        assumed_align=16,
+                                    )
+                                    pk_rowt = cute.make_tensor(pk_ptr, cute.make_layout((self.head_dim,)))
+                                    pk_ch = cute.flat_divide(pk_rowt, (4,))
+
+                                    for pk_cb2 in cutlass.range_constexpr(8):
+                                        pk_e0 = pk_rp * 64 + pk_cb2 * 8
+                                        pk_e1 = pk_e0 + 4
+
+                                        # chain A: pre-select the OPPOSITE value
+                                        # to send (a single xor-1 pair delivers
+                                        # exactly the two partner values each
+                                        # lane needs -> 2 SHFL per chunk)
+                                        pk_aev0 = Float32(tSrdK[pk_e0])
+                                        pk_aev1 = Float32(tSrdK[pk_e0 + 1])
+                                        pk_aov0 = Float32(tSrdK[pk_e0 + 2])
+                                        pk_aov1 = Float32(tSrdK[pk_e0 + 3])
+                                        pk_av0 = pk_aov0 if pk_lane_odd else pk_aev0
+                                        pk_av1 = pk_aov1 if pk_lane_odd else pk_aev1
+                                        pk_as0 = pk_aev0 if pk_lane_odd else pk_aov0
+                                        pk_as1 = pk_aev1 if pk_lane_odd else pk_aov1
+                                        pk_ap0 = cute.arch.shuffle_sync_bfly(pk_as0, 1)
+                                        pk_ap1 = cute.arch.shuffle_sync_bfly(pk_as1, 1)
+
+                                        # chain B: independent select+shuffle
+                                        pk_bev0 = Float32(tSrdK[pk_e1])
+                                        pk_bev1 = Float32(tSrdK[pk_e1 + 1])
+                                        pk_bov0 = Float32(tSrdK[pk_e1 + 2])
+                                        pk_bov1 = Float32(tSrdK[pk_e1 + 3])
+                                        pk_bv0 = pk_bov0 if pk_lane_odd else pk_bev0
+                                        pk_bv1 = pk_bov1 if pk_lane_odd else pk_bev1
+                                        pk_bs0 = pk_bev0 if pk_lane_odd else pk_bov0
+                                        pk_bs1 = pk_bev1 if pk_lane_odd else pk_bov1
+                                        pk_bp0 = cute.arch.shuffle_sync_bfly(pk_bs0, 1)
+                                        pk_bp1 = cute.arch.shuffle_sync_bfly(pk_bs1, 1)
+
+                                        pk_aec = cute.get(tdkcdk[pk_e0], mode=[1])
+                                        pk_aoc = cute.get(tdkcdk[pk_e0 + 2], mode=[1])
+                                        pk_aown = pk_aoc if pk_lane_odd else pk_aec
+                                        pk_acol = pk_aown - (Int32(2) if pk_lane_odd else Int32(0))
+                                        pk_bec = cute.get(tdkcdk[pk_e1], mode=[1])
+                                        pk_boc = cute.get(tdkcdk[pk_e1 + 2], mode=[1])
+                                        pk_bown = pk_boc if pk_lane_odd else pk_bec
+                                        pk_bcol = pk_bown - (Int32(2) if pk_lane_odd else Int32(0))
+
+                                        if pk_valid:
+                                            frag4[0] = pk_ap0 if pk_lane_odd else pk_av0
+                                            frag4[1] = pk_ap1 if pk_lane_odd else pk_av1
+                                            frag4[2] = pk_av0 if pk_lane_odd else pk_ap0
+                                            frag4[3] = pk_av1 if pk_lane_odd else pk_ap1
+                                            cute.arch.atomic_add(
+                                                pk_ch[None, pk_acol // 4].iterator.llvm_ptr,
+                                                frag4.load(),
+                                            )
+                                            frag4[0] = pk_bp0 if pk_lane_odd else pk_bv0
+                                            frag4[1] = pk_bp1 if pk_lane_odd else pk_bv1
+                                            frag4[2] = pk_bv0 if pk_lane_odd else pk_bp0
+                                            frag4[3] = pk_bv1 if pk_lane_odd else pk_bp1
+                                            cute.arch.atomic_add(
+                                                pk_ch[None, pk_bcol // 4].iterator.llvm_ptr,
+                                                frag4.load(),
+                                            )
+                    else:
+                        # odd tile count (topk in {384, 640, 896, ...}): the dk TMEM
+                        # slot no longer realigns at row start (dk_prod / dk_cons
+                        # roll continuously across rows), so the slot is picked at
+                        # runtime. A runtime column offset cannot prove the 2-col
+                        # TMEM alignment the wide Ld16x256b atom requires, so this
+                        # BRANCHES between the two statically-aligned accumulators;
+                        # dk_cons.index is warp-uniform, so the branch is converged.
+                        for pk_i in cutlass.range(self.num_tiles, unroll=1):
+                            pipe_DK.consumer_wait(dk_cons)
+                            if dk_cons.index == 1:
+                                pk_tTR1 = thr_t2r_dk.partition_S(tAccdK[1])
+                                cute.copy(tiled_t2r_dk, pk_tTR1, tSrdK)
+                            else:
+                                pk_tTR0 = thr_t2r_dk.partition_S(tAccdK[0])
+                                cute.copy(tiled_t2r_dk, pk_tTR0, tSrdK)
+                            cute.arch.fence_view_async_tmem_load()
+                            pipe_DK.consumer_release(dk_cons)
+                            dk_cons.advance()
+
+                            for pk_rp in cutlass.range_constexpr(2):
+                                pk_re = cute.get(tdkcdk[pk_rp * 64], mode=[0])
+                                pk_ro = cute.get(tdkcdk[pk_rp * 64 + 2], mode=[0])
+                                pk_row = pk_ro if pk_lane_odd else pk_re
+                                pk_pos = Int32(pk_i * self.n_block) + pk_row
+                                pk_raw = Int32(sIdx[pk_pos, pk_buf])
+                                if const_expr(self.idx_local):
+                                    pk_valid = pk_raw >= 0 and pk_raw < s_k_local
+                                    pk_glob = pk_raw + pk_off
+                                else:
+                                    pk_valid = pk_raw >= 0 and pk_raw < seq_k
+                                    pk_glob = pk_raw
+                                pk_safe = pk_glob if pk_valid else Int32(0)
+                                pk_ptr = cute.make_ptr(
+                                    Float32,
+                                    mdK[pk_safe, None].iterator.llvm_ptr,
+                                    cute.AddressSpace.gmem,
+                                    assumed_align=16,
+                                )
+                                pk_rowt = cute.make_tensor(pk_ptr, cute.make_layout((self.head_dim,)))
+                                pk_ch = cute.flat_divide(pk_rowt, (4,))
+
+                                for pk_cb2 in cutlass.range_constexpr(8):
+                                    pk_e0 = pk_rp * 64 + pk_cb2 * 8
+                                    pk_e1 = pk_e0 + 4
+
+                                    # chain A: pre-select the OPPOSITE value
+                                    # to send (a single xor-1 pair delivers
+                                    # exactly the two partner values each
+                                    # lane needs -> 2 SHFL per chunk)
+                                    pk_aev0 = Float32(tSrdK[pk_e0])
+                                    pk_aev1 = Float32(tSrdK[pk_e0 + 1])
+                                    pk_aov0 = Float32(tSrdK[pk_e0 + 2])
+                                    pk_aov1 = Float32(tSrdK[pk_e0 + 3])
+                                    pk_av0 = pk_aov0 if pk_lane_odd else pk_aev0
+                                    pk_av1 = pk_aov1 if pk_lane_odd else pk_aev1
+                                    pk_as0 = pk_aev0 if pk_lane_odd else pk_aov0
+                                    pk_as1 = pk_aev1 if pk_lane_odd else pk_aov1
+                                    pk_ap0 = cute.arch.shuffle_sync_bfly(pk_as0, 1)
+                                    pk_ap1 = cute.arch.shuffle_sync_bfly(pk_as1, 1)
+
+                                    # chain B: independent select+shuffle
+                                    pk_bev0 = Float32(tSrdK[pk_e1])
+                                    pk_bev1 = Float32(tSrdK[pk_e1 + 1])
+                                    pk_bov0 = Float32(tSrdK[pk_e1 + 2])
+                                    pk_bov1 = Float32(tSrdK[pk_e1 + 3])
+                                    pk_bv0 = pk_bov0 if pk_lane_odd else pk_bev0
+                                    pk_bv1 = pk_bov1 if pk_lane_odd else pk_bev1
+                                    pk_bs0 = pk_bev0 if pk_lane_odd else pk_bov0
+                                    pk_bs1 = pk_bev1 if pk_lane_odd else pk_bov1
+                                    pk_bp0 = cute.arch.shuffle_sync_bfly(pk_bs0, 1)
+                                    pk_bp1 = cute.arch.shuffle_sync_bfly(pk_bs1, 1)
+
+                                    pk_aec = cute.get(tdkcdk[pk_e0], mode=[1])
+                                    pk_aoc = cute.get(tdkcdk[pk_e0 + 2], mode=[1])
+                                    pk_aown = pk_aoc if pk_lane_odd else pk_aec
+                                    pk_acol = pk_aown - (Int32(2) if pk_lane_odd else Int32(0))
+                                    pk_bec = cute.get(tdkcdk[pk_e1], mode=[1])
+                                    pk_boc = cute.get(tdkcdk[pk_e1 + 2], mode=[1])
+                                    pk_bown = pk_boc if pk_lane_odd else pk_bec
+                                    pk_bcol = pk_bown - (Int32(2) if pk_lane_odd else Int32(0))
+
+                                    if pk_valid:
+                                        frag4[0] = pk_ap0 if pk_lane_odd else pk_av0
+                                        frag4[1] = pk_ap1 if pk_lane_odd else pk_av1
+                                        frag4[2] = pk_av0 if pk_lane_odd else pk_ap0
+                                        frag4[3] = pk_av1 if pk_lane_odd else pk_ap1
+                                        cute.arch.atomic_add(
+                                            pk_ch[None, pk_acol // 4].iterator.llvm_ptr,
+                                            frag4.load(),
+                                        )
+                                        frag4[0] = pk_bp0 if pk_lane_odd else pk_bv0
+                                        frag4[1] = pk_bp1 if pk_lane_odd else pk_bv1
+                                        frag4[2] = pk_bv0 if pk_lane_odd else pk_bp0
+                                        frag4[3] = pk_bv1 if pk_lane_odd else pk_bp1
+                                        cute.arch.atomic_add(
+                                            pk_ch[None, pk_bcol // 4].iterator.llvm_ptr,
+                                            frag4.load(),
+                                        )
+
+                    # arrive AFTER the LAST sIdx read of this row -> completes
+                    # the empty phase that the gather warpgroup's restage of
+                    # this parity slot (2 valid rows later) waits on. THE
+                    # explicit timing invariant. Warp-elected: sync_warp
+                    # orders all 32 lanes' reads before lane 0's arrive
+                    # (4 arrivals/slot, see pipe_M create).
+                    if const_expr(self.meta_war_explicit):
+                        cute.arch.sync_warp()
+                        if tidx_wg % 32 == 0:
+                            pipe_M.consumer_release(pk_mst)
+                        pk_mst.advance()
+            self.tmem_dealloc_barrier.arrive_and_wait()
+
+
+# =============================================================================
+# Factory
+# =============================================================================
+# compile_key -> compiled kernel. The key holds only params that change the
+# generated code: topk (tile trip counts), the persistent grid size, the
+# ticket-slot trip count, the ring depth, the dW output dtype, and the
+# local-vs-global id variant. Row count / seq_k / sm_scale are dynamic
+# runtime arguments.
+_compile_cache: dict = {}
+
+
+def indexer_backward_v2_sm100(
+    batch,
+    seqlen,
+    seqlen_k,
+    heads,
+    dim,
+    topk,
+    sm_scale=1.0,
+    block_I=128,
+    topk_indices_global: bool = True,
+    dw_out_dtype: torch.dtype = torch.float32,
+):
+    """SM100 indexer backward v2 factory.
+
+    Mirrors the ``indexer_backward_sm100`` factory API and the returned
+    callable's signature so ``api.py`` can dispatch on ``backend="sm100_v2"``
+    without changing the execute path:
+
+    * Kernel 1 (score-grad precompute) is shared with the default backend —
+      both paths consume bit-identical grad signals.
+    * Kernel 2 is the persistent v2 GEMM kernel above. It
+      consumes a (rows, topk) flattened view of the inputs; weights are
+      upcast bf16 -> fp32 in-register (exact), ``sm_scale`` is folded into
+      the grad-signal read as a runtime argument (``attn_score`` is left
+      holding exactly kernel 1's ``grad_signal``, like the default
+      backend), local per-batch top-k ids are masked against the per-batch
+      ``S_k`` and offset in-kernel when ``topk_indices_global`` is False,
+      and ``d_weights`` is stored directly in the output dtype.
+    * A trailing fp32 -> bf16 cast runs only for bf16 ``d_index_k`` buffers
+      (the atomic accumulator is fp32); fp32 ``d_index_k`` buffers are
+      written directly (zeroed here, no caller pre-zero needed).
+
+    The returned callable performs **no allocations after the first
+    execute**: the ticket counter and (for bf16 ``d_index_k``) the fp32 dK
+    scratch are per-plan workspace, allocated on the first execute and reused
+    by every later one. The
+    workspace is device-resident: the plan binds the device of its first
+    execute and raises on any indexer tensor from another device
+    (``grad_loss`` is validated by ``api.py``'s wrapper). Executions
+    of one plan must not overlap on the device (see the module docstring's
+    concurrency contract); ``api.py``'s wrapper keys its plan cache on the
+    CUDA device and on the resolved stream to keep the wrapper contract
+    device- and stream-safe.
+
+    ``sm_scale`` must be positive (the in-kernel relu gate reads the
+    unscaled scores; positive scales keep that equivalent to the default
+    backend's gate on the scaled scores, except in the underflow corner noted
+    at the gate itself). ``batch``/``seqlen``/``seqlen_k``
+    fix the plan's shape; execute re-validates the real tensors against it.
+    """
+    if torch.cuda.get_device_capability() != (10, 0):
+        raise RuntimeError("indexer_backward_v2_sm100 requires SM100; use backend='default' elsewhere")
+    if heads != 64 or dim != 128:
+        raise ValueError(f"indexer backward v2 is specialized for H=64, D=128 (got H={heads}, D={dim})")
+    if block_I != 128:
+        raise ValueError(f"indexer backward v2 requires block_I=128 (got block_I={block_I})")
+    if topk % 128 != 0 or not (128 <= topk <= 2048):
+        raise ValueError(
+            f"indexer backward v2 supports topk % 128 == 0 with 128 <= topk <= 2048 — 128-slot tiles, >=1 tile/row (the S/K pipes clamp to the tile count below 3 tiles/row and the dK-side metadata hazard is explicitly barriered), <=2048 smem cap (got topk={topk})"
+        )
+    if not float(sm_scale) > 0.0:
+        raise ValueError(f"indexer backward v2 requires sm_scale > 0 (got sm_scale={sm_scale}); the relu gate reads unscaled scores")
+    if dw_out_dtype not in (torch.float32, torch.bfloat16):
+        raise ValueError(f"indexer backward v2 supports d_weights dtype float32 or bfloat16 (got {dw_out_dtype})")
+
+    rows = batch * seqlen
+    seq_k_total = batch * seqlen_k
+    idx_local = (not topk_indices_global) and batch > 1
+    # Per-plan workspace (module docstring: concurrency contract). Created
+    # once on the plan's first execute — steady-state execute() allocates
+    # nothing.
+    plan_ws: dict = {}
+
+    def _check(cond, msg):
+        if not cond:
+            raise ValueError(f"indexer_backward_v2_sm100 execute: {msg}")
+
+    def _run(
+        IndexQ,
+        Weights,
+        IndexK,
+        dIndexQ,
+        dWeights,
+        dIndexK,
+        AttnScore,
+        IndexScore,
+        TopkIndices,
+        GradLoss,
+        grad_scale,
+        current_stream=None,
+    ):
+        # ---- execute-time contract validation: views only, no implicit
+        # conversion, no allocation (python/cudnn/AGENTS.md Rule 1).
+        # api.check_support() already validated the descriptor metadata;
+        # this re-checks the real tensors against the compiled plan.
+        b, s_q, h, d = IndexQ.shape
+        s_k = IndexK.shape[1]
+        _check(
+            (b, s_q, s_k, h, d) == (batch, seqlen, seqlen_k, heads, dim),
+            f"tensor shape {(b, s_q, s_k, h, d)} does not match the compiled plan {(batch, seqlen, seqlen_k, heads, dim)}",
+        )
+        # index_k is consumed as a dense flat (b * s_k, d) view, so its dim 0
+        # and dim 2 must be exactly index_q's b and d. Only dim 1 reaches the
+        # wrapper's plan-cache key, so a cache hit can deliver an index_k whose
+        # dim 0 / dim 2 disagree without api.check_support() re-running.
+        _check(
+            tuple(IndexK.shape) == (b, s_k, d),
+            f"index_k shape {tuple(IndexK.shape)} is not the dense {(b, s_k, d)} layout implied by index_q (index_k is read as a flat (b * s_k, d) view)",
+        )
+        _check(TopkIndices.shape == (b, s_q, topk), f"topk_indices shape {tuple(TopkIndices.shape)} != {(b, s_q, topk)}")
+        _check(Weights.shape == (b, s_q, h), f"weights shape {tuple(Weights.shape)} != {(b, s_q, h)}")
+        _check(AttnScore.shape == (b, s_q, topk) and IndexScore.shape == (b, s_q, topk), "attn_score/index_score shape mismatch")
+        _check(dIndexQ.shape == IndexQ.shape and dWeights.shape == Weights.shape and dIndexK.shape == IndexK.shape, "gradient output shape mismatch")
+        _check(dIndexQ.dtype == torch.bfloat16, f"d_index_q must be bfloat16 (got {dIndexQ.dtype})")
+        _check(dWeights.dtype == dw_out_dtype, f"d_weights dtype {dWeights.dtype} does not match the compiled plan ({dw_out_dtype})")
+        _check(dIndexK.dtype in (torch.float32, torch.bfloat16), f"d_index_k must be float32 or bfloat16 (got {dIndexK.dtype})")
+        _check(
+            IndexQ.dtype == torch.bfloat16 and Weights.dtype == torch.bfloat16 and IndexK.dtype == torch.bfloat16,
+            f"index_q/weights/index_k must be bfloat16 (got {IndexQ.dtype}/{Weights.dtype}/{IndexK.dtype})",
+        )
+        _check(TopkIndices.dtype == torch.int32, f"topk_indices must be int32 (got {TopkIndices.dtype})")
+        for name, t in (
+            ("index_q", IndexQ),
+            ("weights", Weights),
+            ("index_k", IndexK),
+            ("d_index_q", dIndexQ),
+            ("d_weights", dWeights),
+            ("d_index_k", dIndexK),
+            ("attn_score", AttnScore),
+            ("index_score", IndexScore),
+            ("topk_indices", TopkIndices),
+        ):
+            _check(t.is_cuda and t.device == IndexQ.device, f"{name} must be on {IndexQ.device}")
+            _check(t.is_contiguous(), f"{name} must be contiguous")
+
+        # One plan serves one device: the per-plan workspace (ticket
+        # counter, optional dK scratch) is device-resident, so bind the
+        # plan to the device of its first execute and reject any other
+        # device BEFORE kernel 1 mutates the score buffers. api.py keys
+        # its plan cache on the device; this check keeps direct users of
+        # the factory safe independently of that cache.
+        plan_device = plan_ws.get("device")
+        if plan_device is None:
+            plan_ws["device"] = plan_device = IndexQ.device
+        _check(
+            IndexQ.device == plan_device,
+            f"tensors are on {IndexQ.device} but this plan's workspace is bound to {plan_device}; one plan serves one device — build one plan per device",
+        )
+
+        # Kernel 1: shared in-place score-grad precompute.
+        #   AttnScore  <- grad_signal, IndexScore <- sum_grad
+        _score_grad_inplace(AttnScore, IndexScore, GradLoss, grad_scale, block_I=block_I, current_stream=current_stream)
+
+        # true views (validated contiguous above — cannot copy)
+        q_flat = IndexQ.view(rows, h, d)
+        k_flat = IndexK.view(seq_k_total, d)
+        w_flat = Weights.view(rows, h)
+        g_flat = AttnScore.view(rows, topk)
+        idx_flat = TopkIndices.view(rows, topk)
+        dq_flat = dIndexQ.view(rows, h, d)
+        dw_flat = dWeights.view(rows, h)
+
+        with _torch_stream_context(current_stream):
+            if dIndexK.dtype == torch.float32:
+                # write the caller's f32 buffer directly (atomic target;
+                # zeroed here — no caller pre-zero contract)
+                dk_f32_flat = dIndexK.view(seq_k_total, d)
+            else:
+                dk_f32_flat = plan_ws.get("dk_scratch")
+                if dk_f32_flat is None:
+                    # one-time per-plan workspace
+                    dk_f32_flat = torch.empty((seq_k_total, d), dtype=torch.float32, device=IndexK.device)
+                    plan_ws["dk_scratch"] = dk_f32_flat
+            dk_f32_flat.zero_()
+            cnt = plan_ws.get("counter")
+            if cnt is None:
+                # one-time per-plan dynamic-ticket counter (self-resetting;
+                # see the module docstring's concurrency contract)
+                cnt = torch.zeros(2, dtype=torch.int32, device=IndexQ.device)
+                plan_ws["counter"] = cnt
+
+        num_ctas = torch.cuda.get_device_properties(IndexQ.device).multi_processor_count
+        # per-CTA ring-slot trip count; the +8 surplus slots are the
+        # work-stealing headroom (they come back as -1 tickets)
+        ticket_slots = (rows + num_ctas - 1) // num_ctas + 8
+        ring_depth = 4
+
+        s = _resolve_stream(current_stream)
+        compile_key = (heads, dim, topk, num_ctas, ticket_slots, ring_depth, dw_out_dtype, idx_local)
+        fn = _compile_cache.get(compile_key)
+        if fn is None:
+            kernel_obj = IndexerBackwardV2Sm100(
+                num_heads=heads,
+                head_dim=dim,
+                topk=topk,
+                num_ctas=num_ctas,
+                ticket_slots=ticket_slots,
+                ring_depth=ring_depth,
+                dw_out_bf16=dw_out_dtype == torch.bfloat16,
+                idx_local=idx_local,
+            )
+            fn = cute.compile(
+                kernel_obj,
+                to_cute_tensor(q_flat, divisibility=dim),
+                to_cute_tensor(k_flat, divisibility=dim),
+                to_cute_tensor(w_flat),
+                to_cute_tensor(idx_flat),
+                to_cute_tensor(g_flat),
+                to_cute_tensor(dq_flat, divisibility=dim),
+                to_cute_tensor(dw_flat),
+                to_cute_tensor(dk_f32_flat, divisibility=dim),
+                cutlass.Float32(float(sm_scale)),
+                cutlass.Int32(s_q),
+                cutlass.Int32(s_k),
+                s,
+                to_cute_tensor(cnt),
+                options=compile_options(),
+            )
+            _compile_cache[compile_key] = fn
+
+        # Kernel 2: persistent v2 gather-GEMM backward.
+        with torch.cuda.nvtx.range("indexer_backward_v2_gemm"):
+            fn(
+                q_flat,
+                k_flat,
+                w_flat,
+                idx_flat,
+                g_flat,
+                dq_flat,
+                dw_flat,
+                dk_f32_flat,
+                cutlass.Float32(float(sm_scale)),
+                cutlass.Int32(s_q),
+                cutlass.Int32(s_k),
+                s,
+                cnt,
+            )
+
+        # Trailing cast only for bf16 d_index_k buffers (fp32 atomic
+        # accumulator -> output dtype); fp32 buffers were written directly.
+        if dIndexK.dtype != torch.float32:
+            with _torch_stream_context(current_stream):
+                dIndexK.copy_(dk_f32_flat.view(dIndexK.shape))
+
+    return _run

--- a/test/python/fe_api/dsa/dsa_reference.py
+++ b/test/python/fe_api/dsa/dsa_reference.py
@@ -16,7 +16,7 @@ sink is folded into the softmax denominator by the backward kernel.
 """
 
 import math
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 
@@ -575,7 +575,8 @@ def _indexer_predict_distribution(
     weights: torch.Tensor,  # (B, S_q, H)
     topk_indices: torch.Tensor,  # (B, S_q, topk) INT32
     sm_scale: float,
-) -> torch.Tensor:
+    return_scores: bool = False,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """Differentiable predict-distribution computation for autograd reference.
 
     Mirrors the cudnn ``sparse_indexer_score_recompute`` math, but as a plain
@@ -603,7 +604,8 @@ def _indexer_predict_distribution(
 
     valid = topk_indices >= 0
     scores = scores.masked_fill(~valid, float("-inf"))
-    return torch.softmax(scores, dim=-1)
+    predict = torch.softmax(scores, dim=-1)
+    return (predict, scores) if return_scores else predict
 
 
 def ref_indexer_backward(
@@ -611,46 +613,60 @@ def ref_indexer_backward(
     weights: torch.Tensor,  # (B, S_q, H)   bf16
     index_k: torch.Tensor,  # (B, S_k, D)   bf16
     attn_score: torch.Tensor,  # (B, S_q, topk) target FP32
-    index_score: torch.Tensor,  # (B, S_q, topk) predict FP32 (unused — recomputed)
+    index_score: torch.Tensor,  # (B, S_q, topk) predict FP32 (kernel 1 signal operand)
     topk_indices: torch.Tensor,  # (B, S_q, topk) INT32
     sm_scale: float = 1.0,
     grad_scale: float = 1.0,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """PyTorch autograd reference for ``DSA.indexer_backward_wrapper``.
 
-    Recomputes the predict distribution from ``(index_q, weights, index_k,
-    topk_indices)`` and takes the gradient of
-    ``-grad_scale * sum(attn_score * log(predict))`` (the clipped-log KL
-    ``d/d(predict)`` contracted against ``-target``, mirroring the kernel's
-    ``_score_grad_inplace`` stage) with respect to ``index_q``, ``weights``,
-    and ``index_k``. Returns gradients in the same dtype as the inputs.
+    Forms the clipped-log KL grad signal from the supplied fp32
+    ``index_score`` exactly as the kernel's ``_score_grad_inplace`` stage
+    does (same ``exp(-100)`` clip constant, same fp32 operand), then
+    backpropagates it through scores recomputed from ``(index_q, weights,
+    index_k, topk_indices)`` to ``index_q``, ``weights``, and ``index_k``.
+    Returns gradients in the same dtype as the inputs.
 
-    Inputs remain in their original dtype through the forward / softmax so
-    the internal predict distribution matches the kernel's bf16 GEMMs with
-    fp32 accumulator — otherwise the two would disagree purely because
+    Inputs remain in their original dtype through the recomputed score
+    chain so the VJP models the kernel's bf16 GEMMs with fp32 accumulator —
+    otherwise the two would disagree purely because
     ``fp32(bf16(x)) * fp32(bf16(y))`` ≠ ``fp32(x) * fp32(y)``.
     """
     q = index_q.detach().clone().requires_grad_(True)
     w = weights.detach().clone().requires_grad_(True)
     k = index_k.detach().clone().requires_grad_(True)
 
-    predict = _indexer_predict_distribution(
+    _, scores = _indexer_predict_distribution(
         q,
         k,
         w,
         topk_indices,
         sm_scale,
-    )  # (B, S_q, topk) — dtype follows inputs, cast to fp32 inside softmax
+        return_scores=True,
+    )  # scores: (B, S_q, topk) — dtype follows inputs (the kernel GEMMs are bf16)
 
-    eps = torch.finfo(torch.float32).tiny
-    predict_clipped = predict.to(torch.float32).clamp(min=eps)
-    target = attn_score.to(torch.float32).clamp(min=eps)
-
-    # KL gradient stage: d/d(logits) of KL = g - predict * sum(g) where
-    # g = -target. We sum g * log(predict) directly so autograd gives the
-    # identical gradient w.r.t. (q, w, k).
-    loss = -grad_scale * (target * torch.log(predict_clipped)).sum()
-    grads = torch.autograd.grad(loss, (q, w, k))
+    # KL gradient stage, evaluated analytically exactly like the kernel's
+    # ``_score_grad_inplace``: g = -max(target, eps) * [predict >= eps] and
+    # grad_signal = g - predict * sum(g), with eps = exp(CLIP_LOG_MIN) — the
+    # kernel's clip constant — and predict = the supplied fp32 ``index_score``,
+    # the exact tensor the kernel reads (a recomputed bf16 predict would flush
+    # kernel-eligible subnormal probabilities to zero and move the clip mask
+    # off the kernel's). Autograd through ``log(predict.clamp(min=eps))`` is
+    # NOT equivalent either: at eps = exp(-100) the log backward's 1/predict
+    # overflows fp32 (predict can be subnormal), and clipping at
+    # ``float32.tiny`` instead also moves the clip mask — on sharply peaked
+    # predict distributions (large valid top-k with wide score range) the mask
+    # difference alone dominates the comparison (measured ~0.55 rms_rel vs the
+    # kernel where this construction measures <= 0.005).
+    # ``ref_dense_indexer_backward`` below uses the same analytic construction.
+    eps = math.exp(-100.0)  # kernel CLIP_LOG_MIN = -100.0
+    predict_f32 = index_score.detach().to(torch.float32)
+    target_eff = attn_score.to(torch.float32).clamp(min=eps)
+    log_clip_mask = (predict_f32 >= eps).to(torch.float32)
+    g = -target_eff * log_clip_mask * grad_scale
+    grad_signal = g - predict_f32 * g.sum(dim=-1, keepdim=True)
+    grad_signal = grad_signal.masked_fill(topk_indices < 0, 0.0)
+    grads = torch.autograd.grad(scores, (q, w, k), grad_outputs=grad_signal.to(scores.dtype))
 
     dq, dw, dk = grads
     return (

--- a/test/python/fe_api/dsa/test_DSA_indexer_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_backward.py
@@ -1173,9 +1173,10 @@ def test_DSA_indexer_backward_wrapper_v2_sm_scale(
     request,
 ):
     """Non-unit sm_scale: (a) the gradients match a strict fp64 recompute that
-    folds the scale into the grad signal -- an autograd-reference check alone
-    does not catch a mis-applied scale here, since its own bf16 noise floor
-    (rms_rel ~0.29) is larger than a 1.2x scale error; (b) both in-place score
+    folds the scale into the grad signal -- an autograd-reference check
+    alone historically could not catch a mis-applied scale here (its noise
+    floor has since dropped to rms_rel <= 0.005, but the fp64 recompute stays
+    the authoritative scale check); (b) both in-place score
     buffers are left bitwise identical to the default backend's, i.e. the
     scratch holds exactly kernel 1's grad_signal and ``index_score`` is
     consumed the same way (the scale folds inside kernel 2, no host-side

--- a/test/python/fe_api/dsa/test_DSA_indexer_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_backward.py
@@ -900,6 +900,11 @@ def test_DSA_indexer_backward_wrapper_v2_full_valid_topk2048(
         s_q_default=128,
         s_kv_default=2048,
     )
+    # ``dsa_init`` honours --dsa-s_kv; topk=2048 needs at least that many keys
+    # per batch or the all-slots-valid premise below cannot hold, so raise it
+    # back up rather than failing the run.
+    cfg = dict(cfg)
+    cfg["s_kv"] = max(cfg["s_kv"], 2048)
     sm_scale = 1.0
     b, s_q = cfg["b"], cfg["s_q"]
     loss_coeff = float(b * s_q)
@@ -1012,7 +1017,7 @@ def test_DSA_indexer_backward_wrapper_v2_envelope_rejection(
             backend="sm100_v2",
         )
         torch.cuda.synchronize()
-        index_k = index_k.reshape(2, cfg["s_kv"], head_dim // 2).contiguous()
+        index_k = index_k.reshape(2 * cfg["b"], cfg["s_kv"], head_dim // 2).contiguous()
         d_index_k = torch.empty_like(index_k)
 
     attn_before = attn_score.clone()

--- a/test/python/fe_api/dsa/test_DSA_indexer_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_backward.py
@@ -651,9 +651,25 @@ _BF16_OUT_BAND = 3e-3
 _DK_ATOMIC_BAND = 1e-3
 
 
-@pytest.mark.L0
+# Each topk compiles its own SM100 kernel variant (20-60 s apiece), so the
+# default L0 smoke run keeps exactly one numeric point: topk=512, which
+# exercises the multi-I-block path (4 blocks of 128). The rest of the sweep --
+# including the topk=2048 smem-cap boundary -- runs at L1, per test/AGENTS.md
+# ("L0 must stay fast (default CI smoke); big parameter sweeps go to higher
+# levels").
+_V2_TOPK_PARAMS = [
+    pytest.param(128, marks=pytest.mark.L1),
+    pytest.param(256, marks=pytest.mark.L1),
+    pytest.param(384, marks=pytest.mark.L1),
+    pytest.param(512, marks=pytest.mark.L0),
+    pytest.param(640, marks=pytest.mark.L1),
+    pytest.param(1024, marks=pytest.mark.L1),
+    pytest.param(2048, marks=pytest.mark.L1),
+]
+
+
 @torch_fork_set_rng(seed=0)
-@pytest.mark.parametrize("topk", (128, 256, 384, 512, 640, 1024, 2048))
+@pytest.mark.parametrize("topk", _V2_TOPK_PARAMS)
 @with_dsa_indexer_backward_params
 def test_DSA_indexer_backward_wrapper_v2(
     dtype,
@@ -774,7 +790,7 @@ def test_DSA_indexer_backward_wrapper_v2(
         assert dk_rr < _BF16_OUT_BAND, f"topk={topk}: d_index_k rms_rel {dk_rr:.3e} vs fp64 oracle above the bf16-output band"
 
 
-@pytest.mark.L0
+@pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 @pytest.mark.parametrize("topk", (256, 384))
 @with_dsa_indexer_backward_params
@@ -863,7 +879,7 @@ def test_DSA_indexer_backward_wrapper_v2_low_tile_metadata_war(
     assert dq_rr < _BF16_OUT_BAND, f"topk={topk}: d_index_q rms_rel {dq_rr:.3e} above the bf16-output band"
 
 
-@pytest.mark.L0
+@pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 @with_dsa_indexer_backward_params
 def test_DSA_indexer_backward_wrapper_v2_full_valid_topk2048(
@@ -1042,7 +1058,7 @@ def test_DSA_indexer_backward_wrapper_v2_envelope_rejection(
     assert torch.equal(attn_score, attn_before), "rejected request must not mutate attn_score"
 
 
-@pytest.mark.L0
+@pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 @with_dsa_indexer_backward_params
 def test_DSA_indexer_backward_wrapper_v2_batch_local_global_oob(
@@ -1141,7 +1157,7 @@ def test_DSA_indexer_backward_wrapper_v2_batch_local_global_oob(
         )
 
 
-@pytest.mark.L0
+@pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 @with_dsa_indexer_backward_params
 def test_DSA_indexer_backward_wrapper_v2_sm_scale(
@@ -1242,7 +1258,7 @@ def test_DSA_indexer_backward_wrapper_v2_sm_scale(
         )
 
 
-@pytest.mark.L0
+@pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 @with_dsa_indexer_backward_params
 def test_DSA_indexer_backward_wrapper_v2_fp32_outputs(
@@ -1407,7 +1423,7 @@ def _v2_plan_cache():
     return _api._cache_of_IndexerBackwardObjects
 
 
-@pytest.mark.L0
+@pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 @with_dsa_indexer_backward_params
 def test_DSA_indexer_backward_wrapper_v2_stream_none_ambient_streams(
@@ -1531,7 +1547,7 @@ def test_DSA_indexer_backward_wrapper_v2_stream_none_ambient_streams(
             assert _rms_rel(r["d_index_k"], refs[lane]["d_index_k"].double()) < _DK_ATOMIC_BAND, f"ambient stream {lane} iter {it}: d_index_k diverged"
 
 
-@pytest.mark.L0
+@pytest.mark.L1
 @torch_fork_set_rng(seed=0)
 @with_dsa_indexer_backward_params
 def test_DSA_indexer_backward_wrapper_v2_stream_per_thread_two_threads(

--- a/test/python/fe_api/dsa/test_DSA_indexer_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_backward.py
@@ -4,6 +4,9 @@
 import pytest
 import torch
 
+import inspect
+import threading
+
 from test_utils import torch_fork_set_rng
 
 from fe_api.dsa.dsa_utils import dsa_init, with_dsa_indexer_backward_params, _require_sm100
@@ -11,6 +14,19 @@ from fe_api.dsa.dsa_reference import (
     _indexer_predict_distribution,
     check_ref_indexer_backward,
 )
+
+
+def _require_exact_sm100():
+    """Skip unless the current device is exactly SM100 (capability ``(10, 0)``).
+
+    ``dsa_init(min_compute_capability=100)`` means "SM100 **or newer**" — it
+    compares ``major * 10 + minor`` — so an SM103/SM107/SM120 runner falls
+    straight through it. ``backend="sm100_v2"`` is exact-``(10, 0)`` by
+    construction (``check_support`` raises otherwise), so the v2 tests need
+    the exact gate on top of ``dsa_init``'s floor.
+    """
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 0):
+        pytest.skip("backend='sm100_v2' requires an SM100 (10, 0) GPU")
 
 
 def _allocate(cfg, sm_scale: float):
@@ -512,3 +528,1666 @@ def test_DSA_indexer_backward_wrong_ndim_rejected():
             sm_scale=_IDXBWD_SM_SCALE,
             block_I=128,
         )
+
+
+def _v2_call(
+    index_q,
+    weights,
+    index_k,
+    attn_score,
+    index_score,
+    topk_indices,
+    loss_coeff,
+    grad_loss,
+    block_I,
+    sm_scale=1.0,
+    topk_indices_global=False,
+    d_weights=None,
+    d_index_k=None,
+    stream=None,
+):
+    """Run the wrapper with backend="sm100_v2" on CLONED score buffers.
+
+    Returns (result, grad_signal, predict) -- the two in-place score buffers
+    after the call: grad_signal is the attn_score scratch (kernel 1's output)
+    and predict is the consumed index_score buffer. Both are shared
+    bit-for-bit with the default backend.
+    """
+    from cudnn import DSA
+    from cuda.bindings import driver as cuda
+
+    attn = attn_score.clone()
+    index = index_score.clone()
+    torch_stream = torch.cuda.Stream()
+    cu_stream = stream if stream is not None else cuda.CUstream(torch_stream.cuda_stream)
+    if stream is None:
+        torch_stream.wait_stream(torch.cuda.current_stream())
+    result = DSA.indexer_backward_wrapper(
+        index_q,
+        weights,
+        index_k,
+        attn,
+        index,
+        topk_indices,
+        sm_scale=sm_scale,
+        loss_coeff=loss_coeff,
+        grad_loss=grad_loss,
+        block_I=block_I,
+        topk_indices_global=topk_indices_global,
+        backend="sm100_v2",
+        d_weights=d_weights,
+        d_index_k=d_index_k,
+        stream=cu_stream,
+    )
+    if stream is None:
+        torch_stream.synchronize()
+    return result, attn, index
+
+
+def _fp64_oracle(index_q, weights, index_k, grad_signal, topk_indices):
+    """Strict fp64 recompute of kernel 2's math on the captured grad signal
+    (B=1, local == global ids). Pass ``grad_signal`` already multiplied by
+    ``sm_scale`` when the kernel ran with a non-unit scale: kernel 2 folds the
+    scale into the dQ/dW/dK products but gates on the *unscaled* score, which
+    is what ``S > 0`` reproduces here."""
+    b, s_q, h, d = index_q.shape
+    s_k = index_k.shape[1]
+    topk = topk_indices.shape[-1]
+    assert b == 1
+    qd = index_q.view(s_q, h, d).double()
+    kd = index_k.view(s_k, d).double()
+    wd = weights.view(s_q, h).double()
+    ix = topk_indices.view(s_q, topk).long()
+    gg = grad_signal.view(s_q, topk).double()
+    valid = (ix >= 0) & (ix < s_k)
+    k_g = kd[ix.clamp(0, s_k - 1)]
+    S = torch.einsum("rtd,rhd->rth", k_g, qd) * valid.unsqueeze(-1)
+    dw = torch.einsum("rt,rth->rh", gg, S.clamp(min=0))
+    A = torch.where(
+        S > 0,
+        gg.unsqueeze(-1) * wd.unsqueeze(1),
+        torch.zeros((), dtype=torch.float64, device=index_q.device),
+    ) * valid.unsqueeze(-1)
+    dq = torch.einsum("rth,rtd->rhd", A, k_g)
+    dk = torch.zeros(s_k, d, dtype=torch.float64, device=index_q.device)
+    dk.index_add_(0, ix.clamp(0, s_k - 1)[valid], torch.einsum("rth,rhd->rtd", A, qd)[valid])
+    return dq, dw, dk
+
+
+def _rms_rel(actual, oracle):
+    err = actual.double().view(oracle.shape) - oracle
+    return (err.pow(2).mean().sqrt() / oracle.pow(2).mean().sqrt().clamp(min=1e-30)).item()
+
+
+# Band for a bf16 *output buffer* compared against an fp64 oracle: the store
+# rounds to bf16, whose maximum relative roundoff is 2**-8 = 3.9e-3, so on
+# inputs like these (randn, no catastrophic cancellation in the reference) the
+# achievable
+# rms_rel floor is a fraction of that however exact the kernel math is.
+# Measured floor on B200 at s_q=128: 1.607e-3 .. 1.679e-3 over topk
+# 128/256/384/512 and all three outputs -- flat in topk, as expected of a
+# per-element quantisation floor -- so the band below keeps ~1.8x headroom.
+# The v2 compute path itself is far tighter (the fp32-output test asserts
+# 1e-5 / 1e-3 bands on the same oracle), so this band only certifies "no
+# structurally wrong math", which is what the low-tile drain/clamp shapes and
+# the sm_scale fold need from it: a dropped or doubled sm_scale fold measures
+# 1.0 / 0.5 rms_rel here, i.e. 333x / 167x outside the band. What it covers only
+# unreliably is the metadata-WAR hazard: at this shape a barrier-off kernel
+# corrupted d_index_k in 1 of 5 seeds (4.0e-2 / 5.1e-2), against 5 of 5 at the
+# larger shape -- hence the separate low-tile test.
+_BF16_OUT_BAND = 3e-3
+
+# Band for comparing two runs of the SAME shape against each other when
+# ``d_index_k`` is a bf16 buffer. ``d_index_k`` is the one output reduced with
+# fp32 atomics, so its summation order varies run to run *even serially*, and
+# the bf16 store turns a sub-ulp fp32 difference into a whole-LSB flip on some
+# elements. Measured serial run-to-run rms_rel on B200: 1.1e-6 at S_q=128 and
+# 3.9e-5 at S_q=512 (both topk=512), i.e. it grows with the number of rows
+# accumulating into a key, so the band is set well above the largest of those
+# while still catching the class of defect these tests look for -- a scatter
+# that reads stale metadata measures 8.1e-3 .. 5.9e-1 (see
+# ``test_DSA_indexer_backward_wrapper_v2_low_tile_metadata_war``). A row whose
+# contribution is near zero would of course do proportionally less damage.
+_DK_ATOMIC_BAND = 1e-3
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@pytest.mark.parametrize("topk", (128, 256, 384, 512, 640, 1024, 2048))
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    topk,
+    request,
+):
+    """``backend="sm100_v2"`` keeps the wrapper contract with two-term
+    bf16-expansion GEMMs and a deterministic d_weights reduction. Exactly
+    SM100 (``_require_exact_sm100``); every parametrized config here is inside
+    the declared support envelope, so any error past the gate is a real failure
+    and MUST fail -- no skip conversion. topk coverage: 128 = the 1-tile floor
+    (odd-tile dK drain, K/S pipes clamped to 1); 256 = 2 tiles (paired dK
+    drain, pipes clamped to 2); 384 = 3 tiles, where the min-clamps become
+    no-ops; 512 = 4 tiles, the smallest topk whose metadata restage needs no
+    predicated tail (topk % 512 == 0), with the explicit metadata-WAR barrier
+    still compiled in; 640 = odd tile count + predicated
+    restage tail (topk % 512 != 0); 1024 = the compiled-out implicit regime;
+    2048 = fills the SM100 dynamic-smem budget exactly (232448 B) and guards
+    the ticket-ring placement."""
+    try:
+        from cudnn import DSA  # noqa: F401
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=topk,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    sm_scale = 1.0
+    b_cfg = cfg["b"]
+    s_q_cfg = cfg["s_q"]
+    loss_coeff = float(b_cfg * s_q_cfg)
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+    grad_scale_expected = loss_coeff / (b_cfg * s_q_cfg)  # = 1.0
+
+    (
+        index_q,
+        weights,
+        index_k,
+        attn_score,
+        index_score,
+        topk_indices,
+    ) = _allocate(cfg, sm_scale=sm_scale)
+
+    result, grad_signal, _ = _v2_call(
+        index_q,
+        weights,
+        index_k,
+        attn_score,
+        index_score,
+        topk_indices,
+        loss_coeff,
+        grad_loss,
+        block_I,
+        sm_scale=sm_scale,
+    )
+
+    d_index_q = result["d_index_q"]
+    d_weights = result["d_weights"]
+    d_index_k = result["d_index_k"]
+
+    assert d_index_q.shape == index_q.shape
+    assert d_weights.shape == weights.shape
+    assert d_index_k.shape == index_k.shape
+    assert d_index_q.dtype == index_q.dtype
+    assert d_weights.dtype == weights.dtype
+    assert d_index_k.dtype == index_k.dtype
+    assert torch.isfinite(d_index_q.float()).all()
+    assert torch.isfinite(d_weights.float()).all()
+    assert torch.isfinite(d_index_k.float()).all()
+
+    if not cfg["skip_ref"]:
+        check_ref_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            index_score,
+            topk_indices,
+            d_index_q,
+            d_weights,
+            d_index_k,
+            sm_scale=sm_scale,
+            grad_scale=grad_scale_expected,
+        )
+
+    # Low-tile regime (the clamped-pipe shapes) additionally against the strict
+    # fp64 recompute of kernel 2 on the captured grad signal, which pins the
+    # odd-/paired-dK-drain and pipe-clamp paths to exact math instead of only to
+    # the autograd reference's own bf16-rounded recompute. Restricted to the
+    # small-topk cases to keep the fp64 einsums cheap; ``_fp64_oracle`` models
+    # B == 1 with local ids, which is this test's default configuration. This
+    # is not a reliable detector for the metadata-WAR barrier: at the default
+    # S_q = 128 a barrier-off kernel corrupted d_index_k in only 1 of 5 seeds
+    # (5 of 5 at S_q = 512) -- see
+    # ``test_DSA_indexer_backward_wrapper_v2_low_tile_metadata_war``.
+    if topk <= 384 and cfg["b"] == 1:
+        dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, grad_signal, topk_indices)
+        dq_rr = _rms_rel(d_index_q, dq_o)
+        dw_rr = _rms_rel(d_weights, dw_o)
+        dk_rr = _rms_rel(d_index_k, dk_o)
+        assert dq_rr < _BF16_OUT_BAND, f"topk={topk}: d_index_q rms_rel {dq_rr:.3e} vs fp64 oracle above the bf16-output band"
+        assert dw_rr < _BF16_OUT_BAND, f"topk={topk}: d_weights rms_rel {dw_rr:.3e} vs fp64 oracle above the bf16-output band"
+        assert dk_rr < _BF16_OUT_BAND, f"topk={topk}: d_index_k rms_rel {dk_rr:.3e} vs fp64 oracle above the bf16-output band"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@pytest.mark.parametrize("topk", (256, 384))
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_low_tile_metadata_war(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    topk,
+    request,
+):
+    """Regression cover for the low-tile metadata-WAR barrier (``pipe_M``),
+    which stops the gather warpgroup from restaging a metadata slot the dK
+    warpgroup has not finished reading.
+
+    The hazard is a race whose rate depends strongly on the shape: the more
+    rows a CTA processes (the grid is one CTA per SM, 148 on B200) and the
+    larger the dK atomic scatter, the further its drain lags the gather front.
+    So this test forces S_q >= 512 and S_k >= 4096 and takes fp32 outputs,
+    where the kernel's own d_index_k error is ~2.5e-6 and a corrupted scatter
+    cannot hide under the bf16 store floor. Measured on B200 with the barrier
+    compiled out: d_index_k rms_rel 8.1e-3 .. 5.2e-2 at topk 256 and
+    4.6e-1 .. 5.9e-1 at topk 384, in 5 of 5 runs each (2.4e-6 with the barrier
+    in), while d_index_q / d_weights keep the same error to four digits. At the
+    S_q = 128 / S_k = 512 shape the other v2 tests use, the same barrier-off
+    kernel tripped in only 1 of 5 seeds, which is why this test exists; a
+    correct kernel never trips the bound."""
+    try:
+        from cudnn import DSA  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=topk,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=512,
+        s_kv_default=4096,
+    )
+    if cfg["b"] != 1:
+        pytest.skip("B == 1 required for this test: _fp64_oracle models a single batch")
+    # ``dsa_init`` honours --dsa-s_q / --dsa-s_kv; raise them back up if the
+    # run requested something smaller, otherwise the hazard window closes and
+    # the test silently stops covering anything.
+    cfg = dict(cfg)
+    cfg["s_q"] = max(cfg["s_q"], 512)
+    cfg["s_kv"] = max(cfg["s_kv"], 4096)
+
+    sm_scale = 1.0
+    b, s_q, s_k, d = cfg["b"], cfg["s_q"], cfg["s_kv"], cfg["head_dim"]
+    loss_coeff = float(b * s_q)
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=sm_scale)
+    dw32 = torch.empty(b, s_q, cfg["qhead_per_kv_head"], dtype=torch.float32, device="cuda")
+    dk32 = torch.empty(b, s_k, d, dtype=torch.float32, device="cuda")
+
+    result, grad_signal, _ = _v2_call(
+        index_q,
+        weights,
+        index_k,
+        attn_score,
+        index_score,
+        topk_indices,
+        loss_coeff,
+        grad_loss,
+        block_I,
+        sm_scale=sm_scale,
+        d_weights=dw32,
+        d_index_k=dk32,
+    )
+
+    dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, grad_signal, topk_indices)
+    dk_rr = _rms_rel(result["d_index_k"], dk_o)
+    dw_rr = _rms_rel(result["d_weights"], dw_o)
+    dq_rr = _rms_rel(result["d_index_q"], dq_o)
+    assert dk_rr < 1e-3, f"topk={topk}: fp32 d_index_k rms_rel {dk_rr:.3e} vs fp64 oracle above the v2 band (metadata-WAR corruption?)"
+    assert dw_rr < 1e-5, f"topk={topk}: fp32 d_weights rms_rel {dw_rr:.3e} above the deterministic-accumulator band"
+    assert dq_rr < _BF16_OUT_BAND, f"topk={topk}: d_index_q rms_rel {dq_rr:.3e} above the bf16-output band"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_full_valid_topk2048(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """topk=2048 with S_k = 2048: every slot holds a valid id (no -1
+    padding), so the maximum supported topk is exercised at its full
+    top-k workload, not mostly padding. Checked against the strict fp64
+    oracle on the captured grad signal (the autograd reference's recomputed
+    predict distribution loses fidelity at full-valid topk=2048 — the
+    default backend deviates from it by the same amount v2 does, measured
+    0.604 rms relative for both on the same inputs, so the deviation is a
+    reference artifact, not a v2 one)."""
+    try:
+        from cudnn import DSA  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=2048,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=128,
+        s_kv_default=2048,
+    )
+    sm_scale = 1.0
+    b, s_q = cfg["b"], cfg["s_q"]
+    loss_coeff = float(b * s_q)
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=sm_scale)
+    assert int((topk_indices >= 0).sum()) == topk_indices.numel(), "test setup: all slots must be valid"
+
+    dw32 = torch.empty(b, s_q, cfg["qhead_per_kv_head"], dtype=torch.float32, device="cuda")
+    dk32 = torch.empty(b, cfg["s_kv"], cfg["head_dim"], dtype=torch.float32, device="cuda")
+    result, g, _ = _v2_call(index_q, weights, index_k, attn_score, index_score, topk_indices, loss_coeff, grad_loss, block_I, d_weights=dw32, d_index_k=dk32)
+
+    for t in (result["d_index_q"], result["d_weights"], result["d_index_k"]):
+        assert torch.isfinite(t.float()).all()
+    dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, g, topk_indices)
+    dw_rr = _rms_rel(result["d_weights"], dw_o)
+    dk_rr = _rms_rel(result["d_index_k"], dk_o)
+    dq_rr = _rms_rel(result["d_index_q"], dq_o)
+    assert dw_rr < 1e-5, f"fp32 d_weights rms_rel {dw_rr:.3e} above the deterministic-accumulator band"
+    assert dk_rr < 1e-3, f"fp32 d_index_k rms_rel {dk_rr:.3e} above the v2 band"
+    assert dq_rr < 3e-3, f"d_index_q rms_rel {dq_rr:.3e} above the bf16-output floor band"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@pytest.mark.parametrize(
+    "bad",
+    (
+        "topk_2176",
+        "topk_not_mult_128",
+        "sm_scale_zero",
+        "sm_scale_negative",
+        "d_index_q_fp32",
+        "d_weights_fp16",
+        "topk_indices_noncontig",
+        "index_k_dims",
+    ),
+)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_envelope_rejection(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    bad,
+    request,
+):
+    """check_support must reject out-of-envelope requests with ValueError
+    BEFORE kernel 1 mutates the score buffers: topk bounds (2176 above the
+    smem cap, non-multiple-of-128), non-positive sm_scale, unsupported output
+    dtypes, non-contiguous metadata, and an index_k whose dim 0 / dim 2
+    disagree with index_q. (topk 128/256 are now inside the envelope and are
+    exercised by the acceptance test above.)"""
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    topk = {"topk_2176": 2176, "topk_not_mult_128": 1000}.get(bad, 512)
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=topk,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    sm_scale = {"sm_scale_zero": 0.0, "sm_scale_negative": -1.0}.get(bad, 1.0)
+    loss_coeff = float(cfg["b"] * cfg["s_q"])
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=1.0)
+    d_index_q = None
+    d_weights = None
+    if bad == "d_index_q_fp32":
+        d_index_q = torch.empty_like(index_q, dtype=torch.float32)
+    if bad == "d_weights_fp16":
+        d_weights = torch.empty_like(weights, dtype=torch.float16)
+    if bad == "topk_indices_noncontig":
+        wide = torch.full((cfg["b"], cfg["s_q"], 2 * topk), -1, dtype=torch.int32, device="cuda")
+        wide[..., ::2] = topk_indices
+        topk_indices = wide[..., ::2]
+        assert not topk_indices.is_contiguous()
+    d_index_k = None
+    if bad == "index_k_dims":
+        # Only index_k dim 1 reaches the wrapper plan-cache key, so warm the
+        # cache with a valid call first: the mis-shaped index_k below then hits
+        # that entry without re-running check_support, and the backend's
+        # execute-time contract check is the only thing left to reject it. The
+        # element count is unchanged, so the flat (b * s_k, d) view alone cannot
+        # catch it.
+        DSA.indexer_backward_wrapper(
+            index_q,
+            weights,
+            index_k,
+            attn_score.clone(),
+            index_score.clone(),
+            topk_indices,
+            sm_scale=sm_scale,
+            loss_coeff=loss_coeff,
+            grad_loss=grad_loss,
+            block_I=block_I,
+            backend="sm100_v2",
+        )
+        torch.cuda.synchronize()
+        index_k = index_k.reshape(2, cfg["s_kv"], head_dim // 2).contiguous()
+        d_index_k = torch.empty_like(index_k)
+
+    attn_before = attn_score.clone()
+    with pytest.raises(ValueError):
+        DSA.indexer_backward_wrapper(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            index_score,
+            topk_indices,
+            sm_scale=sm_scale,
+            loss_coeff=loss_coeff,
+            grad_loss=grad_loss,
+            block_I=block_I,
+            backend="sm100_v2",
+            d_index_q=d_index_q,
+            d_weights=d_weights,
+            d_index_k=d_index_k,
+        )
+    torch.cuda.synchronize()
+    assert torch.equal(attn_score, attn_before), "rejected request must not mutate attn_score"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_batch_local_global_oob(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """B > 1 id handling: (a) local per-batch ids match the equivalent
+    global flat ids bit-for-bit on dq/dw; (b) a positive out-of-range local
+    id (== S_k) contributes nothing — bitwise-identical dq/dw to the same
+    slot holding -1 — instead of aliasing batch 1's first KV row; (c) a
+    negative id likewise; (d) the clean local run matches the autograd
+    reference."""
+    try:
+        from cudnn import DSA  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=100,
+        b_default=2,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    if cfg["b"] < 2:
+        pytest.skip("B > 1 required for this test")
+    sm_scale = 1.0
+    b, s_k = cfg["b"], cfg["s_kv"]
+    loss_coeff = float(b * cfg["s_q"])
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=sm_scale)
+
+    def run(idx, global_ids):
+        dk32 = torch.empty(b, s_k, cfg["head_dim"], dtype=torch.float32, device="cuda")
+        return _v2_call(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            index_score,
+            idx,
+            loss_coeff,
+            grad_loss,
+            block_I,
+            topk_indices_global=global_ids,
+            d_index_k=dk32,
+        )[0]
+
+    # (a) local ids vs equivalent global flat ids
+    r_local = run(topk_indices, False)
+    offs = (torch.arange(b, device="cuda", dtype=torch.int32) * s_k).view(b, 1, 1)
+    idx_global = torch.where(topk_indices >= 0, topk_indices + offs, topk_indices)
+    r_global = run(idx_global, True)
+    assert torch.equal(r_local["d_index_q"], r_global["d_index_q"])
+    assert torch.equal(r_local["d_weights"], r_global["d_weights"])
+    assert _rms_rel(r_global["d_index_k"], r_local["d_index_k"].double()) < 1e-5  # fp32-atomic order class
+
+    # (b)/(c) positive-OOB and negative ids behave as "contributes nothing"
+    idx_inv = topk_indices.clone()
+    idx_inv[0, 0, 0] = -1
+    r_ref = run(idx_inv, False)
+    for oob in (s_k, -7):
+        idx_oob = topk_indices.clone()
+        idx_oob[0, 0, 0] = oob
+        r_oob = run(idx_oob, False)
+        assert torch.equal(r_oob["d_index_q"], r_ref["d_index_q"]), f"id={oob} leaked into d_index_q"
+        assert torch.equal(r_oob["d_weights"], r_ref["d_weights"]), f"id={oob} leaked into d_weights"
+        assert _rms_rel(r_oob["d_index_k"], r_ref["d_index_k"].double()) < 1e-5, f"id={oob} leaked into d_index_k"
+
+    # (d) clean local run vs autograd reference
+    if not cfg["skip_ref"]:
+        check_ref_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            index_score,
+            topk_indices,
+            r_local["d_index_q"],
+            r_local["d_weights"],
+            r_local["d_index_k"],
+            sm_scale=sm_scale,
+            grad_scale=1.0,
+        )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_sm_scale(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """Non-unit sm_scale: (a) the gradients match a strict fp64 recompute that
+    folds the scale into the grad signal -- an autograd-reference check alone
+    does not catch a mis-applied scale here, since its own bf16 noise floor
+    (rms_rel ~0.29) is larger than a 1.2x scale error; (b) both in-place score
+    buffers are left bitwise identical to the default backend's, i.e. the
+    scratch holds exactly kernel 1's grad_signal and ``index_score`` is
+    consumed the same way (the scale folds inside kernel 2, no host-side
+    buffer mutation)."""
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    sm_scale = 0.5
+    loss_coeff = float(cfg["b"] * cfg["s_q"])
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=sm_scale)
+
+    result, g_v2, predict_v2 = _v2_call(index_q, weights, index_k, attn_score, index_score, topk_indices, loss_coeff, grad_loss, block_I, sm_scale=sm_scale)
+
+    # default backend on the identical inputs: scratch must agree bitwise
+    attn_def = attn_score.clone()
+    index_def = index_score.clone()
+    torch_stream = torch.cuda.Stream()
+    torch_stream.wait_stream(torch.cuda.current_stream())
+    DSA.indexer_backward_wrapper(
+        index_q,
+        weights,
+        index_k,
+        attn_def,
+        index_def,
+        topk_indices,
+        sm_scale=sm_scale,
+        loss_coeff=loss_coeff,
+        grad_loss=grad_loss,
+        block_I=block_I,
+        stream=cuda.CUstream(torch_stream.cuda_stream),
+    )
+    torch_stream.synchronize()
+    assert torch.equal(g_v2, attn_def), "v2 must leave attn_score holding exactly kernel 1's grad_signal"
+    assert torch.equal(predict_v2, index_def), "v2 must consume index_score exactly like the default backend"
+
+    # The scale is the whole point of this test, so check it against an oracle
+    # that can actually see it: folding sm_scale into the captured grad signal
+    # reproduces kernel 2's math, while dropping the fold lands at rms_rel 1.0
+    # and doubling it at 0.5 -- 333x / 167x outside the 3e-3 band below. The
+    # autograd reference further down cannot do this job: its own bf16 noise
+    # floor is rms_rel ~0.29 / cos 0.9935 at this shape and seed, so a 1.2x
+    # scale error still reads 0.53 (inside the default 0.55) and cosine is
+    # scale-blind.
+    if cfg["b"] == 1:
+        dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, g_v2 * sm_scale, topk_indices)
+        dq_rr = _rms_rel(result["d_index_q"], dq_o)
+        dw_rr = _rms_rel(result["d_weights"], dw_o)
+        dk_rr = _rms_rel(result["d_index_k"], dk_o)
+        assert dq_rr < _BF16_OUT_BAND, f"d_index_q rms_rel {dq_rr:.3e} vs the scale-folded fp64 oracle above the bf16-output band"
+        assert dw_rr < _BF16_OUT_BAND, f"d_weights rms_rel {dw_rr:.3e} vs the scale-folded fp64 oracle above the bf16-output band"
+        assert dk_rr < _BF16_OUT_BAND, f"d_index_k rms_rel {dk_rr:.3e} vs the scale-folded fp64 oracle above the bf16-output band"
+
+    if not cfg["skip_ref"]:
+        check_ref_indexer_backward(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            index_score,
+            topk_indices,
+            result["d_index_q"],
+            result["d_weights"],
+            result["d_index_k"],
+            sm_scale=sm_scale,
+            grad_scale=1.0,
+        )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_fp32_outputs(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """fp32 d_weights / d_index_k output contract: caller-supplied fp32
+    buffers receive the fp32 accumulators directly. Checks the advertised
+    precision property against a strict fp64 oracle consuming the captured
+    grad signal (asserted below at rms_rel < 1e-5 for d_weights and < 1e-3
+    for d_index_k — both bands well under the ~1.7e-3 bf16 output floor the
+    same outputs hit when they are bf16), plus bitwise run-to-run determinism
+    of d_weights/d_index_q."""
+    try:
+        from cudnn import DSA  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    sm_scale = 1.0
+    b, s_q, s_k, d = cfg["b"], cfg["s_q"], cfg["s_kv"], cfg["head_dim"]
+    loss_coeff = float(b * s_q)
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=sm_scale)
+
+    def run_fp32():
+        dw32 = torch.empty(b, s_q, cfg["qhead_per_kv_head"], dtype=torch.float32, device="cuda")
+        dk32 = torch.empty(b, s_k, d, dtype=torch.float32, device="cuda")
+        return _v2_call(index_q, weights, index_k, attn_score, index_score, topk_indices, loss_coeff, grad_loss, block_I, d_weights=dw32, d_index_k=dk32)
+
+    r1, g1, _ = run_fp32()
+    r2, g2, _ = run_fp32()
+    assert torch.equal(g1, g2)
+    assert r1["d_weights"].dtype == torch.float32 and r1["d_index_k"].dtype == torch.float32
+
+    # determinism: dw and dq bitwise run-to-run (dk is fp32-atomic class)
+    assert torch.equal(r1["d_weights"], r2["d_weights"]), "d_weights must be bitwise deterministic"
+    assert torch.equal(r1["d_index_q"], r2["d_index_q"]), "d_index_q must be bitwise deterministic"
+
+    # advertised precision property vs strict fp64 oracle on the captured g
+    dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, g1, topk_indices)
+    dw_rr = _rms_rel(r1["d_weights"], dw_o)
+    dk_rr = _rms_rel(r1["d_index_k"], dk_o)
+    dq_rr = _rms_rel(r1["d_index_q"], dq_o)
+    assert dw_rr < 1e-5, f"fp32 d_weights rms_rel {dw_rr:.3e} above the deterministic-accumulator band"
+    assert dk_rr < 1e-3, f"fp32 d_index_k rms_rel {dk_rr:.3e} above the v2 band"
+    assert dq_rr < 3e-3, f"d_index_q rms_rel {dq_rr:.3e} above the bf16-output floor band"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_multi_stream(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """Ticket-counter ownership under concurrency: the wrapper keys its plan
+    cache on the stream, so two explicit streams get private plans/counters.
+    Interleave executes on two streams without host synchronization between
+    launches and check every result against its serial reference (dq/dw
+    bitwise, dk in the fp32-atomic class)."""
+    try:
+        from cudnn import DSA  # noqa: F401
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    sm_scale = 1.0
+    loss_coeff = float(cfg["b"] * cfg["s_q"])
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+    n_iters = 6
+
+    inputs = [_allocate(cfg, sm_scale=sm_scale) for _ in range(2)]
+
+    # serial references (one call at a time)
+    refs = []
+    for index_q, weights, index_k, attn_score, index_score, topk_indices in inputs:
+        r, _, _ = _v2_call(index_q, weights, index_k, attn_score, index_score, topk_indices, loss_coeff, grad_loss, block_I)
+        refs.append(r)
+
+    streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    cu_streams = [cuda.CUstream(s.cuda_stream) for s in streams]
+    # pre-clone the in-place score buffers for every iteration up front so
+    # the interleaved phase enqueues only wrapper work
+    clones = [[(inp[3].clone(), inp[4].clone()) for _ in range(n_iters)] for inp in inputs]
+    results = [[None] * n_iters for _ in range(2)]
+    torch.cuda.synchronize()
+
+    for it in range(n_iters):
+        for lane in range(2):
+            index_q, weights, index_k, _, _, topk_indices = inputs[lane]
+            attn, index = clones[lane][it]
+            streams[lane].wait_stream(torch.cuda.current_stream())
+            results[lane][it] = DSA.indexer_backward_wrapper(
+                index_q,
+                weights,
+                index_k,
+                attn,
+                index,
+                topk_indices,
+                sm_scale=sm_scale,
+                loss_coeff=loss_coeff,
+                grad_loss=grad_loss,
+                block_I=block_I,
+                backend="sm100_v2",
+                stream=cu_streams[lane],
+            )
+        # no host sync inside the loop: the two lanes are enqueued back to back,
+        # so the device is free to overlap them (whether it does depends on the
+        # shape -- at the default S_q = 128 each call is short enough that the
+        # host stays ahead)
+    torch.cuda.synchronize()
+
+    for lane in range(2):
+        for it in range(n_iters):
+            r = results[lane][it]
+            assert torch.equal(r["d_index_q"], refs[lane]["d_index_q"]), f"stream {lane} iter {it}: d_index_q diverged"
+            assert torch.equal(r["d_weights"], refs[lane]["d_weights"]), f"stream {lane} iter {it}: d_weights diverged"
+            assert _rms_rel(r["d_index_k"], refs[lane]["d_index_k"].double()) < _DK_ATOMIC_BAND, f"stream {lane} iter {it}: d_index_k diverged"
+
+
+def _v2_plan_cache():
+    """The wrapper's plan cache. Reached into on purpose: how many plans a call
+    pattern creates is exactly what the cache key controls, and it is the only
+    *deterministic* observable of two streams sharing one plan."""
+    from cudnn.deepseek_sparse_attention.indexer_backward import api as _api
+
+    return _api._cache_of_IndexerBackwardObjects
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_stream_none_ambient_streams(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """``stream=None`` under two different ambient ``torch.cuda.stream``
+    contexts must not share one plan.
+
+    ``stream=None`` does not mean "the default stream": the backend resolves it
+    with ``torch.cuda.current_stream()``, i.e. to the *ambient* stream of the
+    calling context. Keying the plan cache on the ``stream`` argument alone
+    therefore mapped two genuinely different execution streams onto one cached
+    plan, and so onto one per-plan workspace -- the self-resetting ticket
+    counter and the fp32 dK scratch -- which the backend documents as
+    single-execution-at-a-time state. The committed multi-stream test only
+    passes ``stream=`` explicitly, which is the gap this covers.
+
+    What this test asserts is the *invariant* (one plan per resolved stream),
+    not gradient corruption: the two checks are (a) the two ambient streams get
+    separate plan-cache entries, which is deterministic and is what a
+    regression in the cache key breaks (keying the raw ``stream`` argument
+    yields one entry instead of two), and (b) the interleaved executions still
+    reproduce their serial results, which is a correctness guard on the keyed
+    path. (b) is not a second detector for the same bug -- a deliberately
+    shared plan does not reliably corrupt on a dedicated B200, because the v2
+    kernel is a persistent grid of one CTA per SM that still requests 207872 of
+    the 232448 B per-CTA shared-memory budget at this shape (the layout's only
+    topk-dependent part is 2 KB per 128 slots), so a second launch mostly cannot
+    get co-resident CTAs and the damage window stays closed. That is a property of this device being
+    fully available to one launch, not a guarantee the backend offers.
+
+    ``s_q``/``S_k``/topk together are deliberately different from every other
+    v2 test's, so this test's plan-cache keys cannot collide with theirs
+    regardless of test order."""
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=512,
+        s_kv_default=512,
+    )
+    sm_scale = 1.0
+    loss_coeff = float(cfg["b"] * cfg["s_q"])
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+    n_iters = 8
+
+    inputs = [_allocate(cfg, sm_scale=sm_scale) for _ in range(2)]
+    streams = [torch.cuda.Stream(), torch.cuda.Stream()]
+    default_stream = torch.cuda.current_stream()
+
+    def call_ambient(lane, attn, index):
+        """Run the v2 wrapper with NO ``stream`` argument inside lane's
+        ambient stream context."""
+        index_q, weights, index_k, _, _, topk_indices = inputs[lane]
+        streams[lane].wait_stream(default_stream)
+        with torch.cuda.stream(streams[lane]):
+            return DSA.indexer_backward_wrapper(
+                index_q,
+                weights,
+                index_k,
+                attn,
+                index,
+                topk_indices,
+                sm_scale=sm_scale,
+                loss_coeff=loss_coeff,
+                grad_loss=grad_loss,
+                block_I=block_I,
+                backend="sm100_v2",
+            )
+
+    # (a) serial warm-up: one lane at a time, fully synchronized -- each
+    # lane's result is the serial baseline that the interleaved run below
+    # must reproduce (a self-generated baseline, not an oracle; the fp64
+    # oracle checks live in the accuracy tests).
+    cache = _v2_plan_cache()
+    keys_before = set(cache.keys())
+    refs = []
+    for lane in range(2):
+        attn, index = inputs[lane][3].clone(), inputs[lane][4].clone()
+        refs.append(call_ambient(lane, attn, index))
+        streams[lane].synchronize()
+    added = set(cache.keys()) - keys_before
+    assert len(added) == 2, (
+        "stream=None under two different ambient streams must key two separate plans "
+        f"(the per-plan ticket counter / dK scratch cannot be shared across concurrent streams); "
+        f"got {len(added)} new plan-cache entries"
+    )
+
+    # (b) interleaved: enqueue both lanes without host synchronization so the
+    # launches are free to overlap on the device.
+    clones = [[(inp[3].clone(), inp[4].clone()) for _ in range(n_iters)] for inp in inputs]
+    results = [[None] * n_iters for _ in range(2)]
+    torch.cuda.synchronize()
+    for it in range(n_iters):
+        for lane in range(2):
+            attn, index = clones[lane][it]
+            results[lane][it] = call_ambient(lane, attn, index)
+    torch.cuda.synchronize()
+
+    for lane in range(2):
+        for it in range(n_iters):
+            r = results[lane][it]
+            assert torch.equal(r["d_index_q"], refs[lane]["d_index_q"]), f"ambient stream {lane} iter {it}: d_index_q diverged"
+            assert torch.equal(r["d_weights"], refs[lane]["d_weights"]), f"ambient stream {lane} iter {it}: d_weights diverged"
+            assert _rms_rel(r["d_index_k"], refs[lane]["d_index_k"].double()) < _DK_ATOMIC_BAND, f"ambient stream {lane} iter {it}: d_index_k diverged"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_stream_per_thread_two_threads(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """Two host threads passing ``cudaStreamPerThread`` explicitly must not
+    share one plan.
+
+    ``cudaStreamPerThread`` is the integer 2 in every host thread, each time
+    denoting that thread's own stream, so the handle alone cannot tell the two
+    streams apart -- but the caller can: that handle means "the calling
+    thread's stream" by definition, so the wrapper appends the calling thread's
+    id to the key for that one value. Without it both threads land on one plan
+    and so on one per-plan workspace -- the self-resetting ticket counter and
+    the fp32 dK scratch -- which the backend documents as
+    single-execution-at-a-time state.
+
+    This is the explicit-handle twin of the ``stream=None`` ambient-stream test
+    above and asserts the same invariant: one plan per resolved stream. Two
+    implementation details of the test matter. The threads are held alive across
+    the whole measured window by a barrier, because ``threading.get_ident()`` is
+    only unique among *live* threads and Python does hand a dead thread's id to
+    a later one. Their wrapper calls are serialized with a lock, so what is
+    asserted is the cache key and not the thread-safety of first-call
+    compilation.
+
+    ``s_q``/``S_k``/topk together are deliberately different from every other
+    v2 test's, so this test's plan-cache keys cannot collide with theirs
+    regardless of test order."""
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=256,
+        s_kv_default=512,
+    )
+    sm_scale = 1.0
+    loss_coeff = float(cfg["b"] * cfg["s_q"])
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=sm_scale)
+    per_thread_stream = cuda.CUstream(2)
+
+    def call(stream):
+        return DSA.indexer_backward_wrapper(
+            index_q,
+            weights,
+            index_k,
+            attn_score.clone(),
+            index_score.clone(),
+            topk_indices,
+            sm_scale=sm_scale,
+            loss_coeff=loss_coeff,
+            grad_loss=grad_loss,
+            block_I=block_I,
+            backend="sm100_v2",
+            stream=stream,
+        )
+
+    # Main-thread reference on the ambient stream; also warms the compile cache
+    # so the threaded phase below cannot be a first-call compile race.
+    ref = call(None)
+    torch.cuda.synchronize()
+
+    cache = _v2_plan_cache()
+    keys_before = set(cache.keys())
+    results, errors = {}, {}
+    barrier = threading.Barrier(2)
+    serialize = threading.Lock()
+
+    def lane(lane_id):
+        try:
+            barrier.wait()  # both threads alive before any id is observed
+            with serialize:
+                results[lane_id] = (threading.get_ident(), call(per_thread_stream))
+                torch.cuda.synchronize()
+            barrier.wait()  # still alive, so neither id can have been recycled
+        except BaseException as exc:  # surfaced in the main thread below
+            errors[lane_id] = exc
+            barrier.abort()
+
+    threads = [threading.Thread(target=lane, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, f"worker thread(s) raised: {errors}"
+    assert len({ident for ident, _ in results.values()}) == 2, "test setup: the two worker threads must have distinct live ids"
+
+    added = set(cache.keys()) - keys_before
+    assert len(added) == 2, (
+        "two host threads passing cudaStreamPerThread must key two separate plans "
+        "(the handle is the integer 2 in both threads but denotes a different stream in each, "
+        "and the per-plan ticket counter / dK scratch cannot be shared across concurrent streams); "
+        f"got {len(added)} new plan-cache entries"
+    )
+
+    # Correctness guard on the keyed path: d_index_q / d_weights are
+    # deterministic, so each thread must reproduce the main-thread reference
+    # bitwise; d_index_k is fp32-atomic and only reproducible within its band.
+    for lane_id, (_, result) in sorted(results.items()):
+        assert torch.equal(result["d_index_q"], ref["d_index_q"]), f"per-thread stream lane {lane_id}: d_index_q diverged"
+        assert torch.equal(result["d_weights"], ref["d_weights"]), f"per-thread stream lane {lane_id}: d_weights diverged"
+        assert _rms_rel(result["d_index_k"], ref["d_index_k"].double()) < _DK_ATOMIC_BAND, f"per-thread stream lane {lane_id}: d_index_k diverged"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_v2_multi_device(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """Per-device plan/workspace ownership: the wrapper keys its plan cache
+    on the CUDA device, so same-shape default-stream calls on two devices get
+    private plans (the ticket-counter workspace is device-resident, so sharing
+    one cached plan across devices would hand device 1 the device-0 counter).
+    Run the identical input bits on each device, then interleave the devices,
+    checking dq/dw bitwise against each device's serial result and dk in the
+    fp32-atomic class; finally, executing a plan with tensors on the wrong
+    device must raise ValueError before kernel 1 mutates the score buffers."""
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    if torch.cuda.device_count() < 2:
+        pytest.skip("2+ CUDA devices required")
+    if torch.cuda.get_device_capability(1) != (10, 0):
+        pytest.skip("SM100 required on the second device")
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    sm_scale = 1.0
+    loss_coeff = float(cfg["b"] * cfg["s_q"])
+    n_iters = 3
+
+    with torch.cuda.device(0):
+        base = _allocate(cfg, sm_scale=sm_scale)
+    # identical input bits on both devices
+    inputs = {0: base, 1: tuple(t.to("cuda:1") for t in base)}
+    grad_loss = {dev: torch.ones((), dtype=torch.float32, device=f"cuda:{dev}") for dev in (0, 1)}
+
+    def call(dev):
+        index_q, weights, index_k, attn_score, index_score, topk_indices = inputs[dev]
+        with torch.cuda.device(dev):
+            # stream=None on purpose: the default-stream path shares one
+            # stream_key, so only the device key separates the two plans
+            r = DSA.indexer_backward_wrapper(
+                index_q,
+                weights,
+                index_k,
+                attn_score.clone(),
+                index_score.clone(),
+                topk_indices,
+                sm_scale=sm_scale,
+                loss_coeff=loss_coeff,
+                grad_loss=grad_loss[dev],
+                block_I=block_I,
+                backend="sm100_v2",
+            )
+            torch.cuda.synchronize()
+        return r
+
+    # each device serially: without the device in the cache key, device 1 would
+    # reuse device 0's plan and with it device 0's ticket counter / dK scratch
+    refs = {dev: call(dev) for dev in (0, 1)}
+
+    # identical bits + deterministic dq/dw => cross-device bitwise equality,
+    # asserted only when both devices report the same model name (on mixed
+    # models this test checks d_index_k alone)
+    if torch.cuda.get_device_properties(0).name == torch.cuda.get_device_properties(1).name:
+        assert torch.equal(refs[1]["d_index_q"].cpu(), refs[0]["d_index_q"].cpu()), "cross-device d_index_q diverged"
+        assert torch.equal(refs[1]["d_weights"].cpu(), refs[0]["d_weights"].cpu()), "cross-device d_weights diverged"
+    assert _rms_rel(refs[1]["d_index_k"].cpu(), refs[0]["d_index_k"].cpu().double()) < _DK_ATOMIC_BAND, "cross-device d_index_k diverged"
+
+    # interleave the devices: every call must keep hitting its own plan
+    for it in range(n_iters):
+        for dev in (0, 1):
+            r = call(dev)
+            assert torch.equal(r["d_index_q"], refs[dev]["d_index_q"]), f"device {dev} iter {it}: d_index_q diverged"
+            assert torch.equal(r["d_weights"], refs[dev]["d_weights"]), f"device {dev} iter {it}: d_weights diverged"
+            assert _rms_rel(r["d_index_k"], refs[dev]["d_index_k"].double()) < _DK_ATOMIC_BAND, f"device {dev} iter {it}: d_index_k diverged"
+
+    # direct-object contract: a plan built on device 0 must reject device-1
+    # tensors BEFORE kernel 1 mutates the score buffers
+    iq0, w0, ik0, attn0, index0, tki0 = inputs[0]
+    with torch.cuda.device(0):
+        plan = DSA.IndexerBackward(
+            sample_index_q=iq0,
+            sample_weights=w0,
+            sample_index_k=ik0,
+            sample_d_index_q=torch.empty_like(iq0),
+            sample_d_weights=torch.empty_like(w0),
+            sample_d_index_k=torch.empty_like(ik0),
+            sample_attn_score=attn0,
+            sample_index_score=index0,
+            sample_topk_indices=tki0,
+            sm_scale=sm_scale,
+            block_I=block_I,
+            backend="sm100_v2",
+        )
+        assert plan.check_support()
+        plan.compile()
+    iq1, w1, ik1, attn1, index1, tki1 = inputs[1]
+    attn1 = attn1.clone()
+    index1 = index1.clone()
+    attn1_before = attn1.clone()
+    index1_before = index1.clone()
+    with torch.cuda.device(1):
+        with pytest.raises(ValueError, match="device"):
+            plan.execute(
+                iq1,
+                w1,
+                ik1,
+                torch.empty_like(iq1),
+                torch.empty_like(w1),
+                torch.empty_like(ik1),
+                attn1,
+                index1,
+                tki1,
+                grad_loss=grad_loss[1],
+                loss_coeff=loss_coeff,
+            )
+        torch.cuda.synchronize()
+    assert torch.equal(attn1, attn1_before), "cross-device rejection must not mutate attn_score"
+    assert torch.equal(index1, index1_before), "cross-device rejection must not mutate index_score"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_v2_plan_device_capability(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+    monkeypatch,
+):
+    """Architecture gating for ``backend="sm100_v2"`` must query the plan's
+    (sample-tensor) device, not whatever CUDA device is current.
+
+    The plan's kernel and its device-resident workspace belong to the sample
+    tensors' device, so on a heterogeneous machine a valid
+    ``backend="sm100_v2"`` plan whose tensors live on an SM100 device must not
+    be rejected because an unrelated pre-SM90 device happens to be current. The
+    failure this pins is ``IndexerBackward.check_support`` reading a *param-less*
+    ``torch.cuda.get_device_capability()`` in its generic SM90/SM100+ gate,
+    which runs BEFORE the device-bound SM100 gate and would raise "requires
+    SM90 or SM100+, found SM8" for a perfectly valid plan.
+
+    A real SM100 device cannot be made to report a pre-SM90 capability, so the
+    test patches only the *current-device* (no-argument) capability query to
+    report SM80 while every *device-bound* query keeps returning the real
+    capability. That is what separates current-device capability from
+    sample-device capability. (The default backend deliberately keeps the
+    param-less query: its factories check the current device themselves.)
+    """
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda  # noqa: F401
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+    _require_exact_sm100()
+
+    # Build a real, valid backend="sm100_v2" plan on the true (SM100) device
+    # BEFORE patching, so dsa_init's own capability gate and the tensor
+    # allocation observe the real hardware.
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=100,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=1.0)
+    plan = DSA.IndexerBackward(
+        sample_index_q=index_q,
+        sample_weights=weights,
+        sample_index_k=index_k,
+        sample_d_index_q=torch.empty_like(index_q),
+        sample_d_weights=torch.empty_like(weights),
+        sample_d_index_k=torch.empty_like(index_k),
+        sample_attn_score=attn_score,
+        sample_index_score=index_score,
+        sample_topk_indices=topk_indices,
+        sm_scale=1.0,
+        block_I=block_I,
+        backend="sm100_v2",
+    )
+    sample_dev = index_q.device
+    real_get_cap = torch.cuda.get_device_capability
+    assert real_get_cap(sample_dev)[0] >= 9, "test presumes an SM90+ sample device"
+
+    # Model a heterogeneous machine: no-arg (current-device) query -> SM80;
+    # any device-bound query -> the real capability.
+    pre_sm90 = (8, 0)
+
+    def fake_get_device_capability(device=None):
+        if device is None:
+            return pre_sm90
+        return real_get_cap(device)
+
+    monkeypatch.setattr(torch.cuda, "get_device_capability", fake_get_device_capability)
+
+    # The patch genuinely separates the two devices: a param-less gate WOULD
+    # reject and a device-bound gate WOULD accept. Guards against a no-op patch
+    # silently passing the test.
+    assert torch.cuda.get_device_capability() == pre_sm90
+    assert torch.cuda.get_device_capability(sample_dev)[0] >= 9
+
+    # Both of ``check_support``'s architecture gates read the sample device for
+    # this backend -> accepted. A param-less generic gate would read SM8 and
+    # raise "requires SM90 or SM100+, found SM8".
+    assert plan.check_support() is True
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_invalid_backend(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """An unknown ``backend`` value is rejected with a ValueError that lists the
+    legal set, before any score buffer is touched. Covers both the public
+    wrapper and the directly-constructed IndexerBackward object. Nothing here is
+    SM100-specific (no v2 plan is ever built), so it gates on SM90 and runs on
+    every supported architecture."""
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=90,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    loss_coeff = float(cfg["b"] * cfg["s_q"])
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=1.0)
+
+    attn_before = attn_score.clone()
+    with pytest.raises(ValueError, match="backend must be one of"):
+        DSA.indexer_backward_wrapper(
+            index_q,
+            weights,
+            index_k,
+            attn_score,
+            index_score,
+            topk_indices,
+            sm_scale=1.0,
+            loss_coeff=loss_coeff,
+            grad_loss=grad_loss,
+            block_I=block_I,
+            backend="not_a_backend",  # not a legal enum value
+        )
+    torch.cuda.synchronize()
+    assert torch.equal(attn_score, attn_before), "invalid-backend rejection must not mutate attn_score"
+
+    # A directly-constructed object rejects the value in __init__ too.
+    with pytest.raises(ValueError, match="backend must be one of"):
+        DSA.IndexerBackward(
+            sample_index_q=index_q,
+            sample_weights=weights,
+            sample_index_k=index_k,
+            sample_d_index_q=torch.empty_like(index_q),
+            sample_d_weights=torch.empty_like(weights),
+            sample_d_index_k=torch.empty_like(index_k),
+            sample_attn_score=attn_score,
+            sample_index_score=index_score,
+            sample_topk_indices=topk_indices,
+            sm_scale=1.0,
+            block_I=block_I,
+            backend="nope",
+        )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_backend_sm100_v2_requires_sm100(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+    monkeypatch,
+):
+    """``backend="sm100_v2"`` is capability-gated (request-or-fail, no silent
+    fallback): on a non-SM100 device check_support raises. The capability query
+    is patched to report SM90 (9, 0) for the plan's device — the generic
+    SM90/SM100+ gate still passes at that capability, so the raise is
+    attributable to the sm100_v2-specific SM100 gate — and check_support must
+    raise naming the backend. The plan and its tensors are built on the real
+    hardware BEFORE the patch, and no v2 kernel is ever compiled or launched, so
+    this gates on SM90 and runs on every supported architecture (including a
+    real SM90 device, where the patch is a no-op)."""
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        topk=512,
+        block_I=block_I,
+        min_compute_capability=90,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    index_q, weights, index_k, attn_score, index_score, topk_indices = _allocate(cfg, sm_scale=1.0)
+    plan = DSA.IndexerBackward(
+        sample_index_q=index_q,
+        sample_weights=weights,
+        sample_index_k=index_k,
+        sample_d_index_q=torch.empty_like(index_q),
+        sample_d_weights=torch.empty_like(weights),
+        sample_d_index_k=torch.empty_like(index_k),
+        sample_attn_score=attn_score,
+        sample_index_score=index_score,
+        sample_topk_indices=topk_indices,
+        sm_scale=1.0,
+        block_I=block_I,
+        backend="sm100_v2",
+    )
+
+    # Simulate a non-SM100 (but still generically supported SM90) plan device:
+    # the generic gate passes, so only the sm100_v2 SM100 gate can fire.
+    sm90 = (9, 0)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: sm90)
+    assert torch.cuda.get_device_capability(index_q.device) == sm90
+
+    attn_before = attn_score.clone()
+    with pytest.raises(RuntimeError, match="sm100_v2"):
+        plan.check_support()
+    assert torch.equal(attn_score, attn_before), "capability rejection must not mutate attn_score"
+
+
+# The frozen ``develop`` positional-or-keyword parameter order of
+# ``indexer_backward_wrapper`` (the public signature before ``backend`` was
+# added). Legacy positional callers depend on this exact order; ``backend``
+# must be appended keyword-only so it never perturbs a positional binding.
+_DEVELOP_POSITIONAL_PARAMS = [
+    "index_q",
+    "weights",
+    "index_k",
+    "attn_score",
+    "index_score",
+    "topk_indices",
+    "grad_loss",
+    "sm_scale",
+    "loss_coeff",
+    "block_I",
+    "topk_indices_global",
+    "d_index_q",
+    "d_weights",
+    "d_index_k",
+    "stream",
+]
+
+
+@pytest.mark.L0
+def test_DSA_indexer_backward_wrapper_backend_keyword_only_signature():
+    """``backend`` is appended keyword-only after the develop parameter list, so
+    a develop-era positional call keeps binding
+    ``d_index_q``/``d_weights``/``d_index_k``/``stream`` to the right
+    parameters. Inserting ``backend`` ahead of those optionals would bind a
+    caller's ``d_index_q`` tensor to ``backend`` instead."""
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    sig = inspect.signature(DSA.indexer_backward_wrapper)
+    params = sig.parameters
+
+    positional = [
+        name
+        for name, p in params.items()
+        if p.kind
+        in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.POSITIONAL_ONLY,
+        )
+    ]
+    assert positional == _DEVELOP_POSITIONAL_PARAMS, (
+        "positional parameter order must match develop exactly and backend " f"must not appear among positional params; got {positional}"
+    )
+
+    assert "backend" in params
+    assert params["backend"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert params["backend"].default == "default"
+
+    # A legacy positional call in develop order binds the trailing tensors to
+    # d_index_q/d_weights/d_index_k/stream (not to backend) and leaves backend
+    # at its default.
+    sentinels = [object() for _ in _DEVELOP_POSITIONAL_PARAMS]
+    bound = sig.bind(*sentinels)
+    for name, value in zip(_DEVELOP_POSITIONAL_PARAMS, sentinels):
+        assert bound.arguments[name] is value
+    assert "backend" not in bound.arguments  # untouched -> default "default"
+
+    # backend is reachable only by keyword: a 16th positional arg is a
+    # TypeError.
+    with pytest.raises(TypeError):
+        sig.bind(*(sentinels + [object()]))
+    bound_kw = sig.bind(*sentinels, backend="sm100_v2")
+    assert bound_kw.arguments["backend"] == "sm100_v2"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@with_dsa_indexer_backward_params
+def test_DSA_indexer_backward_wrapper_legacy_positional_call(
+    dtype,
+    acc_dtype,
+    head_dim,
+    qhead_per_kv_head,
+    block_I,
+    request,
+):
+    """A develop-era positional call that supplies
+    ``d_index_q``/``d_weights``/``d_index_k``/``stream`` positionally (no
+    ``backend`` kwarg) still binds them correctly and runs the default
+    backend. Were ``backend`` not keyword-only-and-last, position 12 would
+    bind the ``d_index_q`` tensor to ``backend`` and raise
+    ``ValueError('backend must be one of ...')``."""
+    try:
+        from cudnn import DSA
+        from cuda.bindings import driver as cuda
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    cfg = dsa_init(
+        request=request,
+        dtype=dtype,
+        acc_dtype=acc_dtype,
+        head_dim=head_dim,
+        qhead_per_kv_head=qhead_per_kv_head,
+        block_I=block_I,
+        min_compute_capability=90,
+        s_q_default=128,
+        s_kv_default=512,
+    )
+    sm_scale = 1.0
+    b_cfg = cfg["b"]
+    s_q_cfg = cfg["s_q"]
+    loss_coeff = float(b_cfg * s_q_cfg)
+    grad_loss = torch.ones((), dtype=torch.float32, device="cuda")
+
+    (
+        index_q,
+        weights,
+        index_k,
+        attn_score,
+        index_score,
+        topk_indices,
+    ) = _allocate(cfg, sm_scale=sm_scale)
+
+    # Caller-supplied output buffers, passed POSITIONALLY in develop order.
+    d_index_q = torch.empty_like(index_q)
+    d_weights = torch.empty_like(weights)
+    d_index_k = torch.empty_like(index_k)
+
+    torch_stream = torch.cuda.Stream()
+    stream = cuda.CUstream(torch_stream.cuda_stream)
+    torch_stream.wait_stream(torch.cuda.current_stream())
+    # Run the develop-era positional call directly -- NO failure-to-skip here.
+    # The only legitimate skips are environmental and already happened above:
+    # the cudnn[cutedsl] ImportError guard and the dsa_init SM90+ capability
+    # gate. Every parametrized shape (head_dim=128 / qhead=64 / block_I=128,
+    # s_q=128 / s_kv=512) is inside the default backend's envelope, so any
+    # error raised by the wrapper past this point is a real regression and
+    # MUST fail the suite -- it must not be swallowed into a skip. In
+    # particular, this is the guard for the positional-API contract: if
+    # `backend` ever stops being keyword-only-and-last, the trailing develop
+    # positional args rebind onto `backend`, the invalid value raises
+    # ``ValueError("backend must be one of ...")``, and this call fails instead
+    # of silently skipping.
+    result = DSA.indexer_backward_wrapper(
+        index_q,  # index_q
+        weights,  # weights
+        index_k,  # index_k
+        attn_score,  # attn_score
+        index_score,  # index_score
+        topk_indices,  # topk_indices
+        grad_loss,  # grad_loss
+        sm_scale,  # sm_scale
+        loss_coeff,  # loss_coeff
+        block_I,  # block_I
+        False,  # topk_indices_global
+        d_index_q,  # d_index_q (would bind to backend if backend moved)
+        d_weights,  # d_weights
+        d_index_k,  # d_index_k
+        stream,  # stream
+    )
+    torch_stream.synchronize()
+
+    # The positional buffers must be exactly the ones the wrapper filled and
+    # returned -- i.e. the develop-order positional args bound to their
+    # intended parameters, not onto the keyword-only ``backend``.
+    assert result["d_index_q"] is d_index_q
+    assert result["d_weights"] is d_weights
+    assert result["d_index_k"] is d_index_k
+    assert torch.isfinite(d_index_q.float()).all()
+    assert torch.isfinite(d_weights.float()).all()
+    assert torch.isfinite(d_index_k.float()).all()

--- a/test/python/fe_api/dsa/test_DSA_indexer_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_indexer_backward.py
@@ -935,13 +935,17 @@ def test_DSA_indexer_backward_wrapper_v2_full_valid_topk2048(
 
     for t in (result["d_index_q"], result["d_weights"], result["d_index_k"]):
         assert torch.isfinite(t.float()).all()
-    dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, g, topk_indices)
-    dw_rr = _rms_rel(result["d_weights"], dw_o)
-    dk_rr = _rms_rel(result["d_index_k"], dk_o)
-    dq_rr = _rms_rel(result["d_index_q"], dq_o)
-    assert dw_rr < 1e-5, f"fp32 d_weights rms_rel {dw_rr:.3e} above the deterministic-accumulator band"
-    assert dk_rr < 1e-3, f"fp32 d_index_k rms_rel {dk_rr:.3e} above the v2 band"
-    assert dq_rr < 3e-3, f"d_index_q rms_rel {dq_rr:.3e} above the bf16-output floor band"
+    # ``_fp64_oracle`` recomputes at B == 1 only (same guard as
+    # ``test_DSA_indexer_backward_wrapper_v2``): a ``--dsa-b`` override keeps
+    # everything above and drops just the oracle bands.
+    if cfg["b"] == 1:
+        dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, g, topk_indices)
+        dw_rr = _rms_rel(result["d_weights"], dw_o)
+        dk_rr = _rms_rel(result["d_index_k"], dk_o)
+        dq_rr = _rms_rel(result["d_index_q"], dq_o)
+        assert dw_rr < 1e-5, f"fp32 d_weights rms_rel {dw_rr:.3e} above the deterministic-accumulator band"
+        assert dk_rr < 1e-3, f"fp32 d_index_k rms_rel {dk_rr:.3e} above the v2 band"
+        assert dq_rr < 3e-3, f"d_index_q rms_rel {dq_rr:.3e} above the bf16-output floor band"
 
 
 @pytest.mark.L0
@@ -1316,13 +1320,17 @@ def test_DSA_indexer_backward_wrapper_v2_fp32_outputs(
     assert torch.equal(r1["d_index_q"], r2["d_index_q"]), "d_index_q must be bitwise deterministic"
 
     # advertised precision property vs strict fp64 oracle on the captured g
-    dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, g1, topk_indices)
-    dw_rr = _rms_rel(r1["d_weights"], dw_o)
-    dk_rr = _rms_rel(r1["d_index_k"], dk_o)
-    dq_rr = _rms_rel(r1["d_index_q"], dq_o)
-    assert dw_rr < 1e-5, f"fp32 d_weights rms_rel {dw_rr:.3e} above the deterministic-accumulator band"
-    assert dk_rr < 1e-3, f"fp32 d_index_k rms_rel {dk_rr:.3e} above the v2 band"
-    assert dq_rr < 3e-3, f"d_index_q rms_rel {dq_rr:.3e} above the bf16-output floor band"
+    # ``_fp64_oracle`` recomputes at B == 1 only (same guard as
+    # ``test_DSA_indexer_backward_wrapper_v2``): a ``--dsa-b`` override keeps
+    # the determinism checks above and drops just the oracle bands.
+    if cfg["b"] == 1:
+        dq_o, dw_o, dk_o = _fp64_oracle(index_q, weights, index_k, g1, topk_indices)
+        dw_rr = _rms_rel(r1["d_weights"], dw_o)
+        dk_rr = _rms_rel(r1["d_index_k"], dk_o)
+        dq_rr = _rms_rel(r1["d_index_q"], dq_o)
+        assert dw_rr < 1e-5, f"fp32 d_weights rms_rel {dw_rr:.3e} above the deterministic-accumulator band"
+        assert dk_rr < 1e-3, f"fp32 d_index_k rms_rel {dk_rr:.3e} above the v2 band"
+        assert dq_rr < 3e-3, f"d_index_q rms_rel {dq_rr:.3e} above the bf16-output floor band"
 
 
 @pytest.mark.L0
@@ -1442,8 +1450,8 @@ def test_DSA_indexer_backward_wrapper_v2_stream_none_ambient_streams(
     calling context. Keying the plan cache on the ``stream`` argument alone
     therefore mapped two genuinely different execution streams onto one cached
     plan, and so onto one per-plan workspace -- the self-resetting ticket
-    counter and the fp32 dK scratch -- which the backend documents as
-    single-execution-at-a-time state. The committed multi-stream test only
+    counter -- which the backend documents as single-execution-at-a-time
+    state. The committed multi-stream test only
     passes ``stream=`` explicitly, which is the gap this covers.
 
     What this test asserts is the *invariant* (one plan per resolved stream),
@@ -1524,7 +1532,7 @@ def test_DSA_indexer_backward_wrapper_v2_stream_none_ambient_streams(
     added = set(cache.keys()) - keys_before
     assert len(added) == 2, (
         "stream=None under two different ambient streams must key two separate plans "
-        f"(the per-plan ticket counter / dK scratch cannot be shared across concurrent streams); "
+        f"(the per-plan ticket counter cannot be shared across concurrent streams); "
         f"got {len(added)} new plan-cache entries"
     )
 
@@ -1566,9 +1574,8 @@ def test_DSA_indexer_backward_wrapper_v2_stream_per_thread_two_threads(
     streams apart -- but the caller can: that handle means "the calling
     thread's stream" by definition, so the wrapper appends the calling thread's
     id to the key for that one value. Without it both threads land on one plan
-    and so on one per-plan workspace -- the self-resetting ticket counter and
-    the fp32 dK scratch -- which the backend documents as
-    single-execution-at-a-time state.
+    and so on one per-plan workspace -- the self-resetting ticket counter --
+    which the backend documents as single-execution-at-a-time state.
 
     This is the explicit-handle twin of the ``stream=None`` ambient-stream test
     above and asserts the same invariant: one plan per resolved stream. Two
@@ -1657,7 +1664,7 @@ def test_DSA_indexer_backward_wrapper_v2_stream_per_thread_two_threads(
     assert len(added) == 2, (
         "two host threads passing cudaStreamPerThread must key two separate plans "
         "(the handle is the integer 2 in both threads but denotes a different stream in each, "
-        "and the per-plan ticket counter / dK scratch cannot be shared across concurrent streams); "
+        "and the per-plan ticket counter cannot be shared across concurrent streams); "
         f"got {len(added)} new plan-cache entries"
     )
 
@@ -1745,7 +1752,7 @@ def test_DSA_indexer_backward_wrapper_v2_multi_device(
         return r
 
     # each device serially: without the device in the cache key, device 1 would
-    # reuse device 0's plan and with it device 0's ticket counter / dK scratch
+    # reuse device 0's plan and with it device 0's ticket counter
     refs = {dev: call(dev) for dev in (0, 1)}
 
     # identical bits + deterministic dq/dw => cross-device bitwise equality,


### PR DESCRIPTION
## TL;DR

An opt-in `backend="sm100_v2"` — a **faster** drop-in for the SM100 sparse
indexer backward. Same wrapper contract; the default backend's kernels and
dispatch are untouched. The win is **speed** (1.16-1.92x on the GEMM stage,
universal — no dtype opt-in, no downstream cooperation); it also keeps
`d_index_k` fp32-accurate at no extra cost, a bonus only fp32 consumers realize.

- **Speed — the win.** Kernel 2, nsys pure-kernel median, N=60: **1.16-1.92x vs
  current `develop`** (1.92x at topk=128 down to 1.17x at topk=2048; 1.31x at
  topk=1024). Public-wrapper end-to-end **1.31x** at S=8192/topk=1024.
- **Precision — a no-cost secondary property, not the headline.** The GEMM uses
  a two-term bf16 (hi/lo) expansion of `A = g·w`, so `d_index_k` is
  fp32-accurate when written to an fp32 buffer, at ~no cost (the extra MMA hides
  under the memory-bound bottleneck). Realized **only** by consumers that keep
  `index_k` in fp32; a bf16 `d_index_k` consumer sees only the ~1.41x
  double-rounding residual. Details and the honest error bars under Accuracy.
- **Scope.** SM100 (exactly capability `(10, 0)`), H=64, D=128, topk in
  [128, 2048] (multiples of 128), `sm_scale > 0`; request-or-fail, no silent
  fallback. Out-of-envelope or non-SM100 callers use the default backend,
  unchanged.
- **Output-dtype safety.** v2 validates output dtypes in `check_support` and
  raises a clean `ValueError` before kernel 1 touches the score buffers
  (`d_index_q` bf16-only; `d_weights`/`d_index_k` in {bf16, fp32}). The default
  backend validates none — reported separately as
  [#550](https://github.com/NVIDIA/cudnn-frontend/issues/550) /
  [#571](https://github.com/NVIDIA/cudnn-frontend/issues/571). This PR does not
  depend on either; why v2 accepts an fp32 `d_weights` at all is spelled out
  under Accuracy.

## Summary

This PR adds a keyword-only `backend: str = "default"` selector (values
`{"default", "sm100_v2"}`) to `IndexerBackward` /
`DSA.indexer_backward_wrapper`. It is **purely additive**: keyword-only on the
wrapper and appended last on `IndexerBackward.__init__`, so positional callers
are unaffected, and the default backend's kernel and dispatch are not modified.
The one piece of shared code it does change is the wrapper's plan-cache key,
which now also carries the tensor device and the three output dtypes for
**both** backends — before, a plan built for one device (or one output dtype)
could be handed back for another. That is a strictly narrowing key: it costs the
default path an extra compile in those cases and nothing else.
`backend="sm100_v2"` keeps the
existing 3-stage wrapper contract — kernel 1 (the in-place score-grad
precompute) is literally shared with the default backend, bit-for-bit
(`g_default == g_sm100_v2`, `max_abs_diff = 0` at topk 128/256/384/1024/2048) —
and replaces only the GEMM stage (kernel 2):

* **fp32 weights + two-term bf16 expansion.** Weights are upcast to fp32
  in-register (exact) and the per-slot fp32 gradient matrix
  `A = grad_signal * weights` is split into `hi = bf16(A)`,
  `lo = bf16(A - hi)` before the MMAs. Each bf16 x bf16 product is exact in the
  fp32 accumulator; the expansion carries ~16 of `A`'s 24 significand bits,
  dropping the representation error of `A` from ~1.6e-3 to ~2.5e-6 (a stable,
  seed-independent property of the expansion, upstream of the GEMM) versus the
  default's single bf16 rounding of `A`, which dominates its fp32 dK error and
  adds to its bf16-stored dQ error. The expansion is exact for finite `A` in the
  normal bf16 range. At the low end the `lo` term underflows for denormal-scale
  inputs, where it degrades to the default's single-rounding accuracy (never
  worse); at the high end, `|A|` at or above bf16's round-to-nearest overflow
  threshold (`2^128 - 2^119` ~= 3.396e38, itself above bf16's 3.3895e38 maximum)
  makes `hi` an infinity and `lo` the opposite infinity, so the two terms sum to
  NaN rather than saturating. Both ends are far outside any trained range and are
  documented in `docs/fe-oss-apis/dsa.md`.
* **Output dtype selects output precision.** `d_weights` / `d_index_k` accept
  caller-supplied fp32 buffers, which receive the fp32 accumulators directly;
  for `d_index_k` this is what unlocks the compute-accuracy gain (fp32
  `d_index_k` is zeroed internally). The default wrapper-allocated outputs keep
  the input dtypes (bf16), which rounds `d_index_k` back to the bf16 floor.
* **Execution.** Steady state is a zero-allocation execute (kernel 1, one dK
  zero-fill, kernel 2, and — for bf16 `d_index_k` — one cast; workspace is
  per-plan, created once). The kernel uses a persistent, work-stealing schedule
  (no end-of-kernel tail imbalance) and masks local top-k ids against the
  per-batch `S_k` in-kernel, so a positive out-of-range id can never alias a
  neighbouring batch. Because a v2 plan owns device-resident state (a ticket
  counter and the fp32 dK scratch), the wrapper keys its plan cache on the
  **resolved** stream and on the device — plus, for `cudaStreamPerThread`, the
  calling thread's id, since that one handle is the integer 2 in every host
  thread while denoting a different stream in each — so each stream gets a
  private plan; executions that share one plan must not overlap. The shared-memory footprint
  hits the 232448 B SM100 limit exactly at topk=2048 (hence the topk bound).
  Scheduling, smem layout, and the metadata WAR invariant are documented in the
  module docstring and `docs/fe-oss-apis/dsa.md`.

## Performance

**Construction (used identically for timing and accuracy):** B=1, H=64, D=128,
SK=4096; seeded (`manual_seed`); `q`,`k` = `bf16(randn * 0.1)`,
`w` = `bf16(randn * 0.5)`; uniform-random valid in-envelope top-k ids;
softmax-distributed fp32 grad signal consumed identically by both backends
(kernel-1 grad is bit-shared, see above).

**Instrument.** nsys, pure-kernel caliber: `nsys stats --report
cuda_gpu_kern_sum`, with medians recomputed from the per-instance
`CUPTI_ACTIVITY_KIND_KERNEL` rows of the sqlite export. N=60 instances per
backend, both backends interleaved in a single `cudaProfilerApi` window, one
point at a time on an otherwise idle B200. Kernel 1 is bypassed with a no-op in
the timing harness so both backends' kernel 2 consumes bit-identical input; all
buffers (including the pre-zeroed fp32 dK) are allocated and zeroed outside the
window. A CUPTI-via-`torch.profiler` capture in the same session agrees with
these numbers to within 0.2% on every ratio.

**Baseline = the default backend at this PR's base** (`6bfde413`). The 15-point
table was captured at `491805ea`, whose `deepseek_sparse_attention/` tree is
byte-identical at `6bfde413`; a 3-point re-capture on the current base reproduces
1.9199x / 1.3045x / 1.1717x against the 1.9204x / 1.3078x / 1.1744x below
(<= 0.25% on each). Kernel 2 only (kernel 1 is shared and bit-identical):

| shape (B=1, H=64, D=128, SK=4096) | develop default | sm100_v2 | speedup |
|---|---|---|---|
| S=4096, topk=128  | 236.16 us | 127.33 us | **1.85x** |
| S=4096, topk=256  | 343.19 us | 222.54 us | **1.54x** |
| S=4096, topk=512  | 492.52 us | 352.03 us | **1.40x** |
| S=4096, topk=1024 | 855.59 us | 668.29 us | **1.28x** |
| S=4096, topk=1536 | 1221.65 us | 1000.11 us | **1.22x** |
| S=4096, topk=2048 | 1590.62 us | 1373.67 us | **1.16x** |
| S=8192, topk=128  | 466.55 us | 242.94 us | **1.92x** |
| S=8192, topk=256  | 677.45 us | 431.48 us | **1.57x** |
| S=8192, topk=384  | 815.44 us | 532.95 us | **1.53x** |
| S=8192, topk=512  | 969.23 us | 679.86 us | **1.43x** |
| S=8192, topk=640  | 1040.27 us | 816.84 us | **1.27x** |
| S=8192, topk=1024 | 1693.57 us | 1294.97 us | **1.31x** |
| S=8192, topk=1536 | 2415.69 us | 1948.90 us | **1.24x** |
| S=8192, topk=2048 | 3137.57 us | 2671.70 us | **1.17x** |

The speedup shrinks monotonically with topk: the win comes from the kernel-2
schedule, and its fixed advantages amortize away as the per-row GEMM grows. A
repeat capture of S=8192/topk=1024 gave 1693.80 vs 1295.00 us = 1.3079x (vs
1.3078x above), which sets the run-to-run scale of these ratios.

Public wrapper, steady state, S=8192/topk=1024, N=60, **all GPU kernels per
call** (kernel 1 at ~48-49 us, kernel 2, the staging fills, and for bf16 outputs
one cast — nothing excluded): default **1750.93 us** vs sm100_v2 **1337.54 us** =
**1.31x** with bf16 outputs; 1744.57 vs 1335.64 = **1.31x** with fp32 outputs.
The kernel-2 ratio carries through because the auxiliary work is a small
fraction of the call — 1337.54 - 1282.57 = 54.97 us, ~4.1% of the v2 call and
~3.1% of the default's — and kernel 1 is backend-invariant as expected (49.28 vs
48.26 us).

## Accuracy

rms-relative error vs a strict **fp64 oracle** fed the identical (bit-shared)
kernel-1 grad signal, so the comparison isolates the kernel-2 GEMM. B=1, S=8192,
S_k=4096, H=64, D=128, `sm_scale=1.0`. **One caliber throughout: ratio of mean
errors over 5 seeds** (never the peak per-seed ratio). Both backends given fp32
`d_weights`/`d_index_k`; `d_index_q` is bf16-only in both, so its column is
bf16-vs-bf16.

| topk (SK=4096) | dq (bf16 both) | dw: default / v2 | dk: default / v2 |
|---|---|---|---|
| 128  | 2.28e-3 / 1.66e-3 (1.38x) | 1.60e-3 / 1.02e-7 (output-dtype only) | 1.66e-3 / 3.40e-5 (48.8x) |
| 256  | 2.23e-3 / 1.66e-3 (1.34x) | 1.57e-3 / 1.01e-7 (output-dtype only) | 1.66e-3 / 6.29e-5 (26.4x) |
| 384  | 2.19e-3 / 1.66e-3 (1.32x) | 1.56e-3 / 1.00e-7 (output-dtype only) | 1.66e-3 / 1.05e-4 (15.9x) |
| 512  | 2.15e-3 / 1.66e-3 (1.29x) | 1.56e-3 / 1.00e-7 (output-dtype only) | 1.66e-3 / 7.54e-5 (22.0x) |
| 640  | 2.13e-3 / 1.67e-3 (1.27x) | 1.56e-3 / 1.00e-7 (output-dtype only) | 1.68e-3 / 1.69e-4 (9.9x) |
| 1024 | 2.05e-3 / 1.66e-3 (1.23x) | 1.56e-3 / 1.00e-7 (output-dtype only) | 1.66e-3 / 1.24e-4 (13.4x) |
| 2048 | 1.93e-3 / 1.66e-3 (1.16x) | 1.56e-3 / 1.00e-7 (output-dtype only) | 1.66e-3 / 1.32e-4 (12.6x) |

* **dk — a genuine same-dtype compute gain, but quote it as an order of
  magnitude, not a constant.** Both backends emit real fp32 dk here, so the
  difference is purely the hi/lo expansion of `A`. v2's fp32 dk accumulates
  through fp32 atomics, so its *absolute* error is run-variable while the
  default sits pinned at its single-bf16-`A` floor (~1.66e-3): per-(seed, topk)
  point ratios span ~3x to ~670x, and even the 5-seed aggregate is unstable —
  re-running topk 128/256/384 at 20 seeds moves the aggregate from 48.8/26.4/15.9
  to **19.0/14.2/16.7**. So: **more than an order of magnitude, ~10-50x
  depending on seed count and topk.** We deliberately do not claim a sharper
  number, and the headline claims none.
* **dq.** Both backends write bf16 `d_index_q`. v2 sits pinned at the bf16 store
  floor (~1.66e-3) across the whole envelope, while the default's error falls
  from 2.28e-3 at topk=128 to 1.93e-3 at topk=2048, so the ratio narrows
  monotonically from 1.38x to 1.16x. We report the measurement; we did not chase
  why the default's dq error is topk-dependent.
* **dw — no compute-precision claim; output-dtype only.** dw is computed
  identically in both backends (fp32-accumulated `Σ g·relu(S)`, deterministic
  fixed-order reduction, **not** through the hi/lo expansion — confirmed by
  deleting the lo-term GEMM, after which dw is bit-unchanged). The default
  hard-rounds dw to bf16 at the store (`mdW = q_dtype(total)`) regardless of
  buffer dtype; v2 keeps the fp32 accumulator. Hence the ~1.55e4x column is
  entirely "the default rounds away digits it already computed", not a better
  algorithm. At matched bf16 output the two dw agree to a ratio of
  1.000000001 — numerically indistinguishable, though **not** bitwise identical
  (a small number of 1-ulp store differences remain; we did not chase them).
* **At matched bf16 output** (what the wrapper allocates by default): **dk** is
  a flat **~1.41x (=sqrt(2))** — 1.415 / 1.409 / 1.407 at topk 128 / 1024 /
  2048, i.e. a double-rounding penalty, not a surviving compute gain (the
  default rounds twice, compute `A -> bf16` then the bf16 store; v2's hi/lo
  compute error is far below the floor so its store rounds once). **dq** is
  1.38x -> 1.16x as above. **dw** is 1.000x.
* **What a bf16 stack realizes.** With `index_k` in bf16, autograd casts
  `d_index_k` fp32->bf16 at the `Function.backward` boundary and nets the ~1.41x
  residual; the fp32 order-of-magnitude gain is realized only by a consumer that
  keeps `index_k` in fp32. An fp32 index-weight consumer does receive the fp32
  `d_weights` unrounded — the same values the default computes but rounds away,
  not a more-accurate gradient. Parity with the default backend: cos >= 0.999996
  on all three gradients across 7 topk x 5 seeds — the bf16 `d_index_q` is the
  binding one (worst at topk=128, tightening monotonically with topk), while both
  fp32 gradients stay above 0.999998.

### Why v2 accepts an fp32 `d_weights`

The rule is: **an output dtype is supported only if the kernel can faithfully
deliver that precision.**

The default backend's dW epilogue hard-rounds at the store
(`mdW = q_dtype(total)`) regardless of the buffer dtype, so an fp32 `d_weights`
there comes back holding bf16-precision values on an fp32 grid — measured and
reported in [#571](https://github.com/NVIDIA/cudnn-frontend/issues/571). v2
stores the fp32 accumulator itself, so here the same buffer dtype means what it
says: 1.00-1.02e-7 across the envelope against 1.56-1.60e-3. The matched-bf16 row
is the control that separates the two claims — with a bf16 `d_weights` v2 and the
default agree to 1.000x, i.e. the difference is the store, never the arithmetic.

It is worth supporting because it is the only way a caller can receive digits the
kernel has already computed, and it is measurably free: requesting **both** fp32
outputs (dW and dK) moves the kernel-2 median from 1282.57 to 1282.72 us (+0.01%,
N=60 each) and *lowers* the whole wrapper call, 1337.54 -> 1335.64 us, because the
bf16 path pays for a cast kernel the fp32 path does not need. It is cheap in bytes
too: `d_weights` is `(b, s_q, h)` against `d_index_q`'s `(b, s_q, h, d)`, i.e.
1/128 of its elements at D=128. The alternative is not "smaller error later" — the
bf16 store applies its ~1.6e-3 relative rounding to every element before any
downstream fp32 accumulation can see it, and no downstream accumulator recovers it.

The rest of the output matrix follows the same rule rather than a preference:
`d_index_q` stays bf16-only because its TMA store is built at the `index_q`
element width, so a wider buffer would be mis-strided (that is the
misaligned-address crash in #571); `d_index_k` accepts {bf16, fp32}, which the
default backend's own fp32 dK fast path and the dense plan already do.

## Support envelope

`check_support` raises a clean `ValueError` (or `RuntimeError` off SM100)
outside: capability exactly `(10, 0)`, H == 64, D == 128, block_I == 128,
**topk % 128 == 0 with 128 <= topk <= 2048**, **sm_scale > 0**, output dtypes
`d_index_q == bf16` and `d_weights`/`d_index_k` in {bf16, fp32}, matching
shapes, one device, contiguous layouts. No silent fallback. The topk bounds are
structural (128-slot tiles, >= 1 tile per row; <= 2048 fills the 232448 B smem
budget exactly). `docs/fe-oss-apis/dsa.md` documents the full contract
(envelope, the fp32-output prerequisite for the dk gain, the hi/lo finite-range
caveat, workspace/scratch, determinism boundary, stream/concurrency, local-id
masking).

## Testing

`test_DSA_indexer_backward.py`, skipped unless the device reports exactly
`(10, 0)`; in-envelope cases fail rather than skip:

* wrapper test over topk {128, 256, 384, 512, 640, 1024, 2048}: the 1-tile
  floor, the 2-tile shape, the 3-tile shape where the min-clamps become no-ops,
  the historical metadata-restage corruption shape, an odd tile count with the
  predicated restage tail, and the exact smem-cap shape;
* full-valid topk=2048 vs a strict fp64 oracle; envelope rejection (topk
  2176/1000, sm_scale 0/-1, fp32 `d_index_q`, fp16 `d_weights`, non-contiguous
  ids, an `index_k` whose dim 0 / dim 2 disagree with `index_q` — all raise
  before touching score buffers); B=2 local-vs-global id parity
  (bitwise dq/dw), positive-OOB and negative-id semantics; non-unit `sm_scale`;
  fp32-output accuracy vs oracle plus bitwise dw/dq determinism; multi-stream
  parity for both an explicit `stream=` and `stream=None` under distinct ambient
  `torch.cuda.stream()` contexts; `cudaStreamPerThread` passed from two host
  threads (barrier-held so thread ids cannot be recycled, wrapper calls
  serialized by a lock, asserting two distinct plan-cache entries); multi-device
  parity (per-device plans, cross-device bitwise dq/dw).

Additional out-of-tree gates: a 20-seed fresh-seed fp64-oracle soak; a
2-stream x 20-iteration interleaved soak; kernel-1 bit-sharing at five topk; and
a default-path byte-identity check (default-backend outputs bitwise equal to the
base commit's on the same seeded inputs). `pre-commit` (black 26.3.1, repo's
160-column config): clean.

`backend` is a compute-backend selector and, together with the output dtypes,
device, and resolved stream, is part of the wrapper's plan-cache key. On the v2
path the architecture-capability query reads the plan's device rather than the
ambient current device, which is required because a cached plan is device-bound;
the default and dense paths still query the current device, unchanged.

## Notes for reviewers

* Observation (pre-existing, not touched by this PR): with
  `topk_indices_global=False` and B > 1, the default backend offsets positive
  out-of-range local ids into the next batch (measured dK/dQ leak); v2 masks
  before offsetting, in-kernel. Filed as
  [#550](https://github.com/NVIDIA/cudnn-frontend/issues/550) together with the
  related gap that the default `check_support` validates no output dtype (fp32
  `d_index_q` -> `cudaErrorMisalignedAddress`, fp16 -> silent wrong output, fp8
  -> NaN); the validation half is
  [#571](https://github.com/NVIDIA/cudnn-frontend/issues/571).
* The default kernel's fp32 `d_index_k` fast path assumes a caller-pre-zeroed
  buffer, which `indexer_backward_wrapper` neither zeroes nor documents; the v2
  path zeroes internally. Happy to fix the default path here or as a follow-up.
* Related merged work in this area:
  [#548](https://github.com/NVIDIA/cudnn-frontend/issues/548) /
  [#549](https://github.com/NVIDIA/cudnn-frontend/pull/549) (`range_constexpr`
  regression), already in this PR's base.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `sm100_v2` backend for sparse indexer backward operations.
  * Added support for FP32 gradient outputs, deterministic reductions, and local Top-K ID masking.
  * Added backend-specific stream, concurrency, workspace, and plan-cache handling.
  * Added documentation and usage examples for configuring the backend.

* **Bug Fixes**
  * Improved validation for supported hardware, tensor shapes, data types, devices, and parameters.
  * Improved isolation across devices, streams, threads, and execution plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->