### PR TITLE
Enable CSA compressor on SM100+ GPUs

### DIFF
--- a/docs/fe-oss-apis/csa.md
+++ b/docs/fe-oss-apis/csa.md
@@ -130,8 +130,8 @@ that need a fully deterministic backward must use an eager implementation.
 
 ### Support surface (`check_support`)
 
-- Compute capability **10.0** (the only validated architecture so far; the kernels use
-  no arch-specific features, wider enablement is possible after validation)
+- Compute-capability major **>= 10** (SM100 and newer; the kernels use no
+  architecture-specific features beyond the SM100 baseline)
 - `ratio == 4`, `coff in {1, 2}` (`coff == 2` is the production CSA/HCA configuration,
   `coff == 1` the own-block window form) — served by the generic kernels, which are
   generic over `(ratio, head_dim, coff in {1, 2})` but keep the whole pooling window in

--- a/python/cudnn/csa/compressor/api.py
+++ b/python/cudnn/csa/compressor/api.py
@@ -18,7 +18,7 @@ The framework-side autograd wiring stays in the caller (e.g. a ``torch.autograd.
 that calls the forward wrapper in ``forward()`` and the backward wrapper in
 ``backward()``); these APIs are pure kernels-plus-validation.
 
-Validated envelope (``check_support``): compute capability 10.0, BF16 ``kv``/``score``/
+Validated envelope (``check_support``): compute capability major >= 10 (SM100+), BF16 ``kv``/``score``/
 ``out``, FP32 ``ape``, int32 ``cu_seqlens``/``cu_seqlens_comp``, int32 flat offsets
 (``total_tokens * coff * head_dim < 2**31``), and per ratio:
 
@@ -66,8 +66,8 @@ from cudnn.api_base import APIBase, TupleDict
 
 from .compressor_sm100 import (
     CU_ALIGN_BYTES,
+    MINIMUM_COMPUTE_CAPABILITY_MAJOR,
     PTR_ALIGN_BYTES,
-    SUPPORTED_COMPUTE_CAPABILITY,
     precompile_bwd,
     precompile_fwd,
     run_bwd,
@@ -321,8 +321,9 @@ class _CSACompressorBase(APIBase):
 
         capability = torch.cuda.get_device_capability(target)
         self._runtime_error_if(
-            capability != SUPPORTED_COMPUTE_CAPABILITY,
-            f"CSA compressor requires compute capability {SUPPORTED_COMPUTE_CAPABILITY} (the only validated architecture so far), found SM{capability[0]}.{capability[1]} on {target}",
+            capability[0] < MINIMUM_COMPUTE_CAPABILITY_MAJOR,
+            f"CSA compressor requires compute capability major >= {MINIMUM_COMPUTE_CAPABILITY_MAJOR} "
+            f"(SM100+), found SM{capability[0]}.{capability[1]} on {target}",
         )
 
         self.total_tokens = total_tokens

--- a/python/cudnn/csa/compressor/compressor_sm100.py
+++ b/python/cudnn/csa/compressor/compressor_sm100.py
@@ -92,12 +92,10 @@ from cutlass.cute.runtime import make_ptr
 
 _ENV_FAST_LAUNCH = "CUDNNFE_CSA_COMPRESSOR_FAST_LAUNCH"
 
-# The only compute capability the kernels have been validated on so far. The kernels use
-# no architecture-specific features (plain loads/stores, fp32 atomics, pinned mul/fma
-# PTX), but wider coverage stays opt-in until validated per architecture. The
-# ``cute.compile`` default arch resolution maps (10, 0) to ``sm_100a``, so the CC gate
-# also pins the generated SASS target.
-SUPPORTED_COMPUTE_CAPABILITY = (10, 0)
+# The kernels use no architecture-specific features beyond the SM100 baseline (plain
+# loads/stores, fp32 atomics, pinned mul/fma PTX), so admit SM100 and newer GPU
+# families. ``cute.compile`` resolves the concrete SASS target from the active device.
+MINIMUM_COMPUTE_CAPABILITY_MAJOR = 10
 
 
 # =============================================================================

--- a/test/python/fe_api/csa/test_CSA_compressor.py
+++ b/test/python/fe_api/csa/test_CSA_compressor.py
@@ -36,7 +36,8 @@ measurements and numerics in https://github.com/NVIDIA/Megatron-LM/issues/5968).
     data and a smaller device-side true row count, checked on all four outputs and
     bitwise against a direct call), and the loud error when the first call for a
     configuration would JIT under capture;
-  - ``check_support`` boundaries (validated envelope: CC 10.0; ratio 4 with coff
+  - ``check_support`` boundaries (validated envelope: compute-capability major >= 10;
+    ratio 4 with coff
     {1, 2}, ratio 128 with coff {1, 2} x head_dim {128, 512}; BF16 kv/score, FP32 ape,
     int32 cu_seqlens and int32 flat-offset bounds).
 
@@ -66,11 +67,11 @@ def _import_compressor():
 
 
 def _require_sm100():
-    """Skip the test unless a CC 10.0 (Blackwell) CUDA GPU is available."""
+    """Skip the test unless an SM100-or-newer CUDA GPU is available."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA GPU required")
-    if torch.cuda.get_device_capability() != (10, 0):
-        pytest.skip("compute capability 10.0 GPU required")
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("compute capability major >= 10 (SM100+) required")
 
 
 # ---------------------------------------------------------------------------
@@ -1064,6 +1065,26 @@ def test_check_support_accepts_envelope_r128(d, coff):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("capability", [(10, 0), (10, 3), (11, 0)])
+def test_check_support_accepts_compute_capability_major_10_or_newer(monkeypatch, capability):
+    """The architecture gate admits SM100, SM103, and newer major families."""
+    compressor = _import_compressor()
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: capability)
+    api = compressor.CSACompressorForward(**_meta_samples(), ratio=4, coff=2)
+    assert api.check_support() is True
+
+
+@pytest.mark.L0
+def test_check_support_rejects_compute_capability_major_below_10(monkeypatch):
+    """The architecture gate still rejects pre-SM100 devices."""
+    compressor = _import_compressor()
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device=None: (9, 0))
+    api = compressor.CSACompressorForward(**_meta_samples(), ratio=4, coff=2)
+    with pytest.raises(RuntimeError, match="compute capability major >= 10"):
+        api.check_support()
+
+
+@pytest.mark.L0
 @pytest.mark.parametrize(
     "kwargs,ctor,match",
     [
@@ -1297,8 +1318,8 @@ def test_multi_device_launch():
     compressor = _import_compressor()
     if torch.cuda.device_count() < 2:
         pytest.skip("needs >= 2 visible GPUs")
-    if torch.cuda.get_device_capability(1) != (10, 0):
-        pytest.skip("second GPU is not CC 10.0")
+    if torch.cuda.get_device_capability(1)[0] < 10:
+        pytest.skip("second GPU is below SM100")
     d, ratio, coff = 128, 4, 2
     kv, score, ape, cu, cuc, total_comp, go = _make_inputs([1024], d, ratio, coff, device="cuda:1")
     total = kv.shape[0]

--- a/test/python/fe_api/csa/test_CSA_compressor.py
+++ b/test/python/fe_api/csa/test_CSA_compressor.py
@@ -1065,7 +1065,7 @@ def test_check_support_accepts_envelope_r128(d, coff):
 
 
 @pytest.mark.L0
-@pytest.mark.parametrize("capability", [(10, 0), (10, 3), (11, 0)])
+@pytest.mark.parametrize("capability", [(10, 0), (10, 3), (10, 7)])
 def test_check_support_accepts_compute_capability_major_10_or_newer(monkeypatch, capability):
     """The architecture gate admits SM100, SM103, and newer major families."""
     compressor = _import_compressor()


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [ ] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area
- FE OSS kernels or CuTeDSL
- 
<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

- Relax the CSA compressor architecture check from exactly compute capability 10.0 to compute-capability major >= 10.
- Enable the compressor kernels on GB300 / SM103.
- Add coverage for accepting SM100, SM103, and newer major architectures while continuing to reject pre-SM100 GPUs.
- Update the CSA support documentation accordingly.

## Why

The kernel supports major >= 10 but only SM100 is allowed.
<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

None.
<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

No API changes.
<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

Added tests for major >= 10.
<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for GPUs with compute capability 10.0 and newer.
  * Automatically selects the appropriate GPU target for supported devices.

* **Bug Fixes**
  * Improved capability validation to accept newer supported GPU architectures.
  * Devices with compute capability below 10.0 are correctly rejected.

* **Documentation**
  * Clarified GPU compatibility requirements and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->