### PR TITLE
fix(sdpa): move the pre-9.26 Stats packed-BHSD check to post_validate_node

### DIFF
--- a/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
+++ b/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h
@@ -498,6 +498,25 @@ class SDPANodeBase : public NodeCRTP<DerivedT> {
 
         CUDNN_FE_VALIDATE_STRIDE(output_names::O, attributes.outputs);
 
+        // Non-ragged Stats layouts other than packed BHSD are not correctly supported prior to 9.26.0.
+        // Runs post shape inference so that an unset Stats layout (always inferred as packed BHSD)
+        // is not rejected.
+        auto const& stats_out = attributes.outputs.find(output_names::Stats);
+        bool const has_stats  = (stats_out != attributes.outputs.end()) && (stats_out->second != nullptr);
+        if (has_stats && !stats_out->second->get_ragged_offset() && detail::get_backend_version() < 92600) {
+            auto const& stats_dim           = stats_out->second->get_dim();
+            auto const& stats_stride        = stats_out->second->get_stride();
+            bool const stats_is_packed_bhsd = stats_dim.size() == 4 && stats_stride.size() == 4 &&
+                                              stats_stride[3] == 1 && stats_stride[2] == stats_dim[3] &&
+                                              stats_stride[1] == stats_dim[2] * stats_dim[3] &&
+                                              stats_stride[0] == stats_dim[1] * stats_dim[2] * stats_dim[3];
+            RETURN_CUDNN_FRONTEND_ERROR_IF(
+                !stats_is_packed_bhsd,
+                error_code_t::GRAPH_NOT_SUPPORTED,
+                "For cuDNN version below 9.26.0, a non-ragged Stats output must be a packed BHSD "
+                "tensor.");
+        }
+
 #undef CUDNN_FE_VALIDATE_STRIDE
 
         return {error_code_t::OK, ""};

--- a/include/cudnn_frontend/node/sdpa_support_surface.h
+++ b/include/cudnn_frontend/node/sdpa_support_surface.h
@@ -49,9 +49,6 @@ SDPA_attributes::validate_sdpa_support_surface(const detail::Context& context,
     auto const& rng_tensor = outputs.find(SDPA_attributes::output_names::RNG_DUMP);
     bool const is_rng      = (rng_tensor != outputs.end() && rng_tensor->second != nullptr);
 
-    auto const& stats_out = outputs.find(SDPA_attributes::output_names::Stats);
-    bool const has_stats  = (stats_out != outputs.end()) && (stats_out->second != nullptr);
-
     bool const max_seq_kv_explicit = max_seq_len_kv.has_value();
 
     auto const& attn_scale    = inputs.find(SDPA_attributes::input_names::Attn_scale);
@@ -162,20 +159,9 @@ SDPA_attributes::validate_sdpa_support_surface(const detail::Context& context,
                                    error_code_t::ATTRIBUTE_NOT_SET,
                                    "Intermediate tensor data type needs to be set as internal tensors require it.");
 
-    // Non-ragged layouts other than BHSD are not correctly supported prior to 9.26.0.
-    if (has_stats && !stats_out->second->get_ragged_offset() && detail::get_backend_version() < 92600) {
-        auto const& stats_dim           = stats_out->second->get_dim();
-        auto const& stats_stride        = stats_out->second->get_stride();
-        bool const stats_is_packed_bhsd = stats_dim.size() == 4 && stats_stride.size() == 4 && stats_stride[3] == 1 &&
-                                          stats_stride[2] == stats_dim[3] &&
-                                          stats_stride[1] == stats_dim[2] * stats_dim[3] &&
-                                          stats_stride[0] == stats_dim[1] * stats_dim[2] * stats_dim[3];
-        RETURN_CUDNN_FRONTEND_ERROR_IF(
-            !stats_is_packed_bhsd,
-            error_code_t::GRAPH_NOT_SUPPORTED,
-            "For cuDNN version below 9.26.0, a non-ragged Stats output must be a packed BHSD "
-            "tensor.");
-    }
+    // The Stats layout check (packed BHSD required prior to 9.26.0) lives in
+    // SDPANode::post_validate_node(), as it must run after shape inference has
+    // filled in the dim/stride of an unset Stats output.
 
     if (mma_core_mode == DataType_t::FP8_E4M3 || mma_core_mode == DataType_t::FP8_E5M2) {
         // FP8 specific validation


### PR DESCRIPTION
## Problem

The Stats layout check added in 423767bf4 (#304) runs in `validate_sdpa_support_surface()`, which is called from `pre_validate_node()` — i.e. **before shape inference**. Users (and every C++ sample) that leave the Stats output dim/stride unset for inference, e.g.

```cpp
Stats->set_output(true).set_data_type(fe::DataType_t::FLOAT).set_uid(STATS_UID);
```

hit `stats_dim.size() == 4` == false at check time, so `graph->build()` fails with `GRAPH_NOT_SUPPORTED` on every cuDNN < 9.26. This broke the nightly `cpp_samples:cudnn_9.19.0.56` CI jobs (Ampere + Hopper) on develop starting 2026-08-15 — every stats-generating fwd sample fails. 9.26+ jobs skip the check entirely, which is why only the old-cuDNN jobs went red.

## Fix

Move the check to `SDPANodeBase::post_validate_node()`, which runs after `infer_properties_node()` has filled an unset Stats with packed BHSD (`{h*s_q, s_q, 1, 1}`) — alongside the existing O innermost-stride check. Inferred layouts now pass by construction; explicitly-set non-BHSD layouts are still rejected, and the error still surfaces from `validate()`/`build()`.

The backward-node twin of this check is left where it is: Stats is an *input* there, so its dims/strides are always user-set before validation.

## Verification

- Full `cudnn_frontend.h` TU compiles with `-Wall -Werror` (g++ 11, cuDNN 9.2x headers, CUDA 13.1).
- clang-format applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for scaled dot-product attention statistics outputs on older cuDNN versions.
  * Unsupported non-ragged statistics layouts are now rejected with a clear “graph not supported” result.
  * Valid ragged outputs and supported newer cuDNN versions remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->