### PR TITLE
frost(sdpa): THD/varlen on the FP8/MXFP8 SM100/SM107 forward engines via the write_thd_meta envelope design (issue #552)

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -722,7 +722,13 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 )
 
         if self.thd:
-            self._thd_check_strides_native()
+            if self.q_desc.dtype in _SM100_FP8_DTYPES:
+                # FP8/MXFP8 THD serves only the packed contract (their
+                # compile() builds compact fakes); the f16 kernels address
+                # declared strides natively.
+                self._thd_check_strides_packed()
+            else:
+                self._thd_check_strides_native()
 
         b, h_qo, s_qo, d_qk = self.q_desc.shape
         _, h_kv, s_kv, _ = self.k_desc.shape
@@ -861,13 +867,14 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             (self.cu_seq_q_lens or self.cu_seq_kv_lens) and not self.thd,
             "cu_seq_len_* is THD-only (the dense kernels have no CU read mode yet)",
         )
-        # The engine specs already declare thd=False for the FP8/MXFP8 cells
-        # (graph-API routing); this gate covers direct construction.
+        # Of the FP8/MXFP8 flavors only d128/d128 carries the write_thd_meta
+        # THD leg; the d192/d128 siblings are dense-only. The engine specs
+        # already route this (their d192 rows declare thd=False); the gate
+        # covers direct construction.
         self._not_implemented_error_if(
-            self.thd and self._fp8,
-            "THD/varlen is not supported by the SM100 FP8/MXFP8 kernels (the "
-            "legacy THD leg was removed; the port will follow the write_thd_meta "
-            "envelope design — issue #552)",
+            self.thd and self._fp8 and (int(d_qk), int(d_v)) != (128, 128),
+            f"THD/varlen on the FP8/MXFP8 path requires D_QK=D_V=128 (the d192/d128 "
+            f"kernels are dense-only); got (D_QK={d_qk}, D_V={d_v})",
         )
         # Dense padded-Q trim backstops (engines.lower_dsl_prefill never sets
         # these combinations; a direct caller could).
@@ -978,9 +985,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # compile as dynamic extents — issue #552), so compile HERE like
             # every dense specialization; execute()'s lru-cached call re-binds
             # this artifact. (The all-KV-zero clamp swaps the K/V strides and
-            # mints its own entry on first hit.) FP8/MXFP8 THD is rejected in
-            # check_support (the legacy THD leg was removed), so this branch is
-            # f16-only.
+            # mints its own entry on first hit.) The FP8/MXFP8 flavors serve
+            # the packed contract — their key carries no stride/head-dim
+            # entries (see _thd_compile_kwargs).
             self._compiled_kernel = self._k_mod.compile(**self._thd_compile_kwargs())
         elif self._fp8:
             # FP8/MXFP8 kernels use exact native shapes (gated in check_support);
@@ -1132,6 +1139,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 scale_o,
                 amax_o,
                 current_stream,
+                workspace=workspace,
             )
             return
 
@@ -1153,6 +1161,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 sf_v,
                 amax_o,
                 current_stream,
+                workspace=workspace,
             )
             return
 
@@ -1234,12 +1243,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             return (0, ts, hs, es)
 
         has_lse = self.lse_desc is not None
-        return dict(
+        kwargs = dict(
             b=self.batch_size,
             qh=self.h_q,
             kh=self.h_kv,
-            d_qk=self.head_dim_qk,
-            d_v=self.head_dim_v,
             # The Stats layout is a per-shape specialization (like d_qk/d_v):
             # has_lse=False compiles the store out; token-major binds the
             # packed rank-2 (T, H) view; head-major carries the caller-declared
@@ -1247,11 +1254,20 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             has_lse=has_lse,
             lse_head_major=has_lse and self.thd_stats_head_major,
             lse_head_stride=(self.thd_stats_head_stride if (has_lse and self.thd_stats_head_major) else 0),
+        )
+        if self._fp8:
+            # The FP8/MXFP8 cells serve only the packed contract at exact
+            # d128 (check_support) — no stride/head-dim keys.
+            return kwargs
+        kwargs.update(
+            d_qk=self.head_dim_qk,
+            d_v=self.head_dim_v,
             q_stride=_key(self.q_desc),
             k_stride=_key(self.k_desc),
             v_stride=_key(self.v_desc),
             o_stride=_key(self.o_desc),
         )
+        return kwargs
 
     def _thd_unit_envelope(self) -> int:
         """PLAN-TIME upper bound on live THD units:
@@ -1271,108 +1287,58 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         s_q_decl = int(self.q_desc.shape[2])
         return self.batch_size * ((s_q_decl + cga_tile_m - 1) // cga_tile_m) * self.h_q
 
-    def _execute_thd(self, q_buf, k_buf, v_buf, o_buf, scale_softmax_log2, sinks, seq_len_kv, seq_q_lens, lse_tensor=None, workspace=None, current_stream=None):
-        """THD / varlen execute: reconstruct the kernel's packed [1, T, H, D] views and metadata buffer from the cuDNN ragged buffers, then launch.
+    def _thd_pack(self, q_buf, k_buf, v_buf, o_buf, sinks, seq_kv_lens, seq_q_lens, workspace, label, current_stream=None, lse_tokens_cap=None):
+        """Shared SM100 THD (ragged) packing — issue #552, zero host reads.
 
-        With a ``workspace`` the metadata buffers (int32 length copies, the
-        [seq_kv | cu_q | cu_k] buffer, the per-sequence O TMA descriptors, the
-        sinks dummy) are carved from it — zero per-execute allocations;
-        without one they are torch-allocated (standalone use). ``lse_tensor``,
-        when given, is the caller's ragged Stats buffer, written by the
-        kernel directly in its declared layout: token-major packed ``(T, H)``
-        in the first ``T*H`` elements, or head-major ``(H, head_stride)``
-        with tokens contiguous within each head row; when ``None`` the kernel
-        compiles the LSE store out (has_lse=False) and no scratch exists.
-        Host round-trips (issue #552): NONE — the lengths never reach the
-        host (the setup kernel builds the metadata buffer device-side),
-        every ragged view binds its buffer's capacity, and the launch grid
-        is the plan-time envelope (dead units exit by kernel contract) —
-        the execute is fully async and CUDA-graph capturable. No compile is
-        keyed on runtime data: the kernels compile with DYNAMIC token
-        extents, so a new packed total re-binds the same artifact."""
-        import cutlass
+        Builds the [seq_kv | cu_q | cu_k] metadata scratch (WRITTEN device-side
+        by the kernels' setup launch from the caller's length tensors, returned
+        as ``q_lens_dev``/``kv_lens_dev`` + the ``lens_form`` bitmask), the
+        per-batch O-descriptor scratch, the plan-time envelope unit count, the
+        sinks binding, and the declared-stride ``(1, T, H, D)`` views with
+        CAPACITY token extents — Q/O (and a token-major LSE, via
+        ``lse_tokens_cap``) share one dynamic token symbol, K/V the other;
+        writes/loads never step past the real per-sequence lengths the kernel
+        reads from the device metadata, so the over-claim only widens the TMA
+        descriptors' bound. The FP8/MXFP8 packed contract declares compact
+        strides, so the same views ARE the packed ones. With a ``workspace``
+        every scratch chunk is carved from it (zero per-execute allocations);
+        torch allocations run on the LAUNCH stream. The prefix-sum invariants
+        are caller contract (a validation that needs a device read is not a
+        validation — AGENTS.md Rule 3).
 
+        Returns ``None`` when no Q token is addressable (zero capacity —
+        all-zero LENGTHS over live storage launch normally: every unit
+        decodes dead and neither O nor LSE is touched)."""
         dev = q_buf.device
-        b = self.batch_size
-        carver = WorkspaceCarver(workspace, self.scratch_workspace_bytes(), "SdpaFwdDslSm100 (THD)") if workspace is not None else None
-        # Metadata buffer: [ seq_kv_lens(B) | cu_seqlens_q(B+1) | cu_seqlens_k(B+1) ],
-        # built DEVICE-side by the setup kernel from the caller's length
-        # tensors (either form) — no host cumsum, no H2D, and the lengths
-        # NEVER reach the host (issue #552); the prefix-sum invariants are
-        # caller contract (a validation that needs a device read is not a
-        # validation — AGENTS.md Rule 3). The torch allocations run on the
-        # LAUNCH stream so they are ordered against the kernels that consume
-        # them — the execute-time handle may carry a stream that is not
-        # torch's current.
+        b, qh, kh = self.batch_size, self.h_q, self.h_kv
+        d_qk, d_v = self.head_dim_qk, self.head_dim_v
+        carver = WorkspaceCarver(workspace, self.scratch_workspace_bytes(), label) if workspace is not None else None
         with _torch_stream_context(current_stream, dev):
             meta = carver.take(3 * b + 2, torch.int32) if carver is not None else torch.empty(3 * b + 2, dtype=torch.int32, device=dev)
         q_lens_dev = self._checked_cu_seq_lens(seq_q_lens, "cu_seq_len_q") if self.cu_seq_q_lens else self._checked_seq_lens(seq_q_lens, "seq_q_lens")
-        kv_lens_dev = self._checked_cu_seq_lens(seq_len_kv, "cu_seq_len_kv") if self.cu_seq_kv_lens else self._checked_seq_lens(seq_len_kv, "seq_kv_lens")
+        kv_lens_dev = self._checked_cu_seq_lens(seq_kv_lens, "cu_seq_len_kv") if self.cu_seq_kv_lens else self._checked_seq_lens(seq_kv_lens, "seq_kv_lens")
+        lens_form = (1 if self.cu_seq_q_lens else 0) | (2 if self.cu_seq_kv_lens else 0)
 
-        qh, kh = self.h_q, self.h_kv
-        d_qk, d_v = self.head_dim_qk, self.head_dim_v
-
-        # Q/O token extent = buffer CAPACITY (issue #552: the packed Q total
-        # lives on device only). Q, O and a token-major (or compact
-        # head-major) LSE bind ONE dynamic token symbol, so take the shared
-        # floor. Writes never step past the real per-sequence lengths the
-        # kernel reads from the device metadata (O through the per-batch
-        # descriptors' extents, LSE via the row predicate), so the
-        # over-claim only widens the TMA descriptors' bound.
         (q_ts, _, _), _ = self._thd_declared(self.q_desc)
         (o_ts, _, _), _ = self._thd_declared(self.o_desc)
         t_q = min(q_buf.numel() // q_ts, o_buf.numel() // o_ts)
-        if lse_tensor is not None and not (self.thd_stats_head_major and self.thd_stats_head_stride):
-            t_q = min(t_q, lse_tensor.numel() // qh)
-
-        # Degenerate Q side: zero CAPACITY — no token is addressable, and a
-        # zero-token view cannot back a TMA descriptor — nothing to compute
-        # or write. All-zero LENGTHS over live storage launch normally:
-        # every unit decodes dead and neither O nor LSE is touched.
-        # (t_kv == 0 launches normally through the kernel's dead-row path;
-        # see the K/V binding below.)
+        if lse_tokens_cap is not None:
+            t_q = min(t_q, lse_tokens_cap)
         if t_q == 0:
-            self._logger.debug("execute (THD): no addressable Q token, nothing to do")
-            return
-        lse = None
-        if lse_tensor is not None:
-            if self.thd_stats_head_major:
-                # head_stride covering the packed total is caller contract
-                # (t_q is a device value — Rule 3).
-                head_stride = self.thd_stats_head_stride
-                if head_stride == 0:
-                    head_stride = t_q  # compact: the token extent itself
-                lse = lse_tensor.as_strided((1, qh, head_stride), (qh * head_stride, head_stride, 1), lse_tensor.storage_offset())
-            else:
-                # Token-major (TH1, the default): natural packed rank-2 (T, H)
-                # view — the kernel's epilogue dispatches on this static rank.
-                lse = lse_tensor.as_strided((t_q, qh), (qh, 1), lse_tensor.storage_offset())
+            return None
 
         # Per-sequence O TMA descriptors. No zero-init: the kernel's builder
         # pass copies every qword of each sequence's slot from the base
         # descriptor (then patches address/extent) before the fence and
         # before any consumer read, so stale bytes never survive — a fill
         # here is a wasted kernel launch on the execute hot path (Rule 1).
-        # Allocated on the launch stream (allocator stream-tagging + ordering
-        # vs the builder pass).
         with _torch_stream_context(current_stream, dev):
             o_desc = carver.take(b * 16 + 16, torch.int64) if carver is not None else torch.empty(b * 16 + 16, dtype=torch.int64, device=dev)
         # The PLAN-TIME envelope grid — dead units exit by kernel contract.
         units = self._thd_unit_envelope()
 
-        # Declared-stride (1, T, H, D) views, addressed NATIVELY by the kernel
-        # (the Q/K/V/O TMA descriptors are built from the tensor views, and
-        # the THD O-descriptor builder steps by O's declared seq stride);
-        # check_support rejected any declaration TMA cannot express.
         Q = self._thd_view(q_buf, self.q_desc, t_q)
         O = self._thd_view(o_buf, self.o_desc, t_q)
-        # KV token extent = buffer CAPACITY (issue #552: the packed KV total
-        # lives on device only). K and V bind the same dynamic token symbol,
-        # so take the shared floor. Loads never step past the REAL
-        # per-sequence lengths the kernel reads from the device metadata, so
-        # an over-claimed extent only widens the TMA descriptors' bound.
-        # All-zero lengths with a live buffer launch normally through the
-        # kernel's per-sequence dead-row path.
         (k_ts, _, _), _ = self._thd_declared(self.k_desc)
         (v_ts, _, _), _ = self._thd_declared(self.v_desc)
         t_kv = min(k_buf.numel() // k_ts, v_buf.numel() // v_ts)
@@ -1401,10 +1367,6 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         else:
             K = self._thd_view(k_buf, self.k_desc, t_kv)
             V = self._thd_view(v_buf, self.v_desc, t_kv)
-        # LSE binding: the caller's ragged Stats buffer in its declared layout
-        # when a Stats output exists; None otherwise — the kernel compiles the
-        # LSE store out (has_lse=False), so no dummy buffer exists at all.
-        LSE = lse
         if sinks is not None:
             sinks_t = self._checked_sinks_1d(sinks)
         else:
@@ -1415,38 +1377,96 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                     sinks_t.zero_()
                 else:
                     sinks_t = torch.zeros(qh, dtype=torch.float32, device=dev)
+        return SimpleNamespace(
+            meta=meta,
+            o_desc=o_desc,
+            units=units,
+            t_q=t_q,
+            t_kv=t_kv,
+            Q=Q,
+            K=K,
+            V=V,
+            O=O,
+            sinks_t=sinks_t,
+            q_lens_dev=q_lens_dev,
+            kv_lens_dev=kv_lens_dev,
+            lens_form=lens_form,
+        )
+
+    def _thd_lse_view(self, lse_tensor, t_q):
+        """The caller's ragged Stats buffer in its declared layout — token-major
+        packed rank-2 (T, H) (the default; cuDNN's TH1 ragged Stats recipe) or
+        head-major rank-3 (1, QH, head_stride) with head_stride covering the
+        packed total (caller contract — t_q is a device value, Rule 3; 0 =
+        compact = the token extent itself)."""
+        if lse_tensor is None:
+            return None
+        qh = self.h_q
+        if self.thd_stats_head_major:
+            head_stride = self.thd_stats_head_stride
+            if head_stride == 0:
+                head_stride = t_q
+            return lse_tensor.as_strided((1, qh, head_stride), (qh * head_stride, head_stride, 1), lse_tensor.storage_offset())
+        return lse_tensor.as_strided((t_q, qh), (qh, 1), lse_tensor.storage_offset())
+
+    def _execute_thd(self, q_buf, k_buf, v_buf, o_buf, scale_softmax_log2, sinks, seq_len_kv, seq_q_lens, lse_tensor=None, workspace=None, current_stream=None):
+        """THD / varlen execute (f16 kernels): shared packing + launch.
+
+        ``lse_tensor``, when given, is the caller's ragged Stats buffer,
+        written by the kernel directly in its declared layout (token-major
+        packed ``(T, H)`` or head-major ``(H, head_stride)``); when ``None``
+        the kernel compiles the LSE store out (has_lse=False) and no scratch
+        exists. Host round-trips (issue #552): NONE — the lengths never reach
+        the host (the setup kernel builds the metadata buffer device-side),
+        every ragged view binds its buffer's capacity, and the launch grid is
+        the plan-time envelope (dead units exit by kernel contract) — the
+        execute is fully async and CUDA-graph capturable. No compile is keyed
+        on runtime data: the kernels compile with DYNAMIC token extents, so a
+        new packed total re-binds the same artifact."""
+        import cutlass
+
+        # A token-major (or compact head-major) LSE shares the Q/O dynamic
+        # token symbol, so its capacity joins their floor; head-major with a
+        # declared head_stride carries its own extent.
+        lse_cap = lse_tensor.numel() // self.h_q if (lse_tensor is not None and not (self.thd_stats_head_major and self.thd_stats_head_stride)) else None
+        pack = self._thd_pack(
+            q_buf, k_buf, v_buf, o_buf, sinks, seq_len_kv, seq_q_lens, workspace, "SdpaFwdDslSm100 (THD)", current_stream=current_stream, lse_tokens_cap=lse_cap
+        )
+        if pack is None:
+            self._logger.debug("execute (THD): no addressable Q token, nothing to do")
+            return
+        LSE = self._thd_lse_view(lse_tensor, pack.t_q)
 
         # PLAN-TIME-ONLY compile key (issue #552: keying on the packed totals
         # degenerated into a per-step recompile under continuous batching):
         # this lru-cached call re-binds the artifact compile() already built.
         # The K/V strides are taken from the BOUND views because the
-        # all-KV-zero clamp above swaps in packed batch-1 views (that rare
-        # shape mints its own cache entry); the batch stride is zeroed out of
-        # the key (a runtime value the kernel rebuilds symbolically).
+        # all-KV-zero clamp swaps in packed batch-1 views (that rare shape
+        # mints its own cache entry); the batch stride is zeroed out of the
+        # key (a runtime value the kernel rebuilds symbolically).
         kwargs = self._thd_compile_kwargs()
-        kwargs.update(k_stride=(0, *K.stride()[1:]), v_stride=(0, *V.stride()[1:]))
+        kwargs.update(k_stride=(0, *pack.K.stride()[1:]), v_stride=(0, *pack.V.stride()[1:]))
         fn = self._k_mod.compile(**kwargs)
         # The caller's length tensors ride to the setup kernel, which builds
         # the metadata buffer device-side; the form bitmask is a runtime
         # value (no compile key grows). problem_size sq/skv slots are 0 by
         # the THD contract (_host reads the dynamic extents).
-        lens_form = (1 if self.cu_seq_q_lens else 0) | (2 if self.cu_seq_kv_lens else 0)
         fn(
-            Q,
-            K,
-            V,
-            O,
+            pack.Q,
+            pack.K,
+            pack.V,
+            pack.O,
             LSE,
-            sinks_t,
-            meta,
-            o_desc,
-            (b, qh, kh, 0, 0, 0),
+            pack.sinks_t,
+            pack.meta,
+            pack.o_desc,
+            (self.batch_size, self.h_q, self.h_kv, 0, 0, 0),
             cutlass.Float32(scale_softmax_log2),
-            cutlass.Int32(units),
+            cutlass.Int32(pack.units),
             None,
-            q_lens_dev,
-            kv_lens_dev,
-            cutlass.Int32(lens_form),
+            pack.q_lens_dev,
+            pack.kv_lens_dev,
+            cutlass.Int32(pack.lens_form),
             stream=current_stream,
         )
         self._logger.debug("execute (THD) completed")
@@ -1481,6 +1501,38 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             )
         return flat.reshape(b, h, n_tiles, sf_smem_size)
 
+    def _reshape_sf_packed(self, sf: torch.Tensor, h: int, sf_smem_size: int, name: str, current_stream=None) -> torch.Tensor:
+        """THD packed SF buffer → the kernel's ``[1, H, T_sf, sf_smem_size]`` int8 view.
+
+        THD SF buffers hold the PACKED per-sequence-TILE-padded layout: per
+        head, every sequence's 128-row F8_128x4 SF tiles concatenated in
+        cu_seqlens order (tile index = cu_sf_base[b] + local tile — the same
+        base the kernel derives device-side from the metadata). The packed
+        tile extent ``T_sf`` is a runtime value that must come WITHOUT a
+        device read (Rule 3), so it derives from the buffer's byte size —
+        the buffer is the packed layout exactly (its head stride is
+        ``T_sf * sf_smem_size``, so a larger allocation could not be
+        addressed anyway). A zero-sized buffer (zero-capacity KV storage —
+        the one-token K/V clamp) binds a one-tile stub: the KV range of
+        every tile is empty there, so no SF byte is ever loaded."""
+        flat = sf.contiguous()
+        if flat.dtype != torch.int8:
+            flat = flat.view(torch.int8)
+        flat = flat.reshape(-1)
+        row = h * sf_smem_size
+        if flat.numel() == 0:
+            with _torch_stream_context(current_stream, sf.device):
+                return self._dummy(f"thd_sf_stub_{name}_{sf_smem_size}", sf.device, lambda: torch.zeros(row, dtype=torch.int8, device=sf.device)).reshape(
+                    1, h, 1, sf_smem_size
+                )
+        if flat.numel() % row != 0:
+            raise ValueError(
+                f"MXFP8 THD SF buffer {name}: {flat.numel()} bytes is not a whole number of packed "
+                f"[H={h} x SF_SMEM={sf_smem_size}] tile rows — THD SF buffers must hold exactly the "
+                f"packed per-sequence-TILE-padded layout (Σ_b ceil(S_b/128) tiles per head)"
+            )
+        return flat.reshape(1, h, flat.numel() // row, sf_smem_size)
+
     def _execute_mxfp8(
         self,
         q_tensor,
@@ -1497,16 +1549,21 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         sf_v,
         amax_o,
         current_stream=None,
+        workspace=None,
     ):
-        """MXFP8 execute (dense): FP8 Q/K/V + per-32-block E8M0 SF → half O.
+        """MXFP8 execute: FP8 Q/K/V + per-32-block E8M0 SF → half/FP8 O.
 
         SF tensors come from cuDNN in F8_128x4 layout and are reshaped into the
-        kernel's per-tile view; ``Amax_O`` (if requested) is filled with ``max|O|``.
+        kernel's per-tile view; ``Amax_O`` (if requested) is produced in-kernel
+        (atomicMax over the pre-cast fp32 output rows). THD/varlen rides the
+        shared packed lowering (``_thd_pack``); there the SF buffers hold the
+        PACKED per-sequence-TILE-padded layout ([1, H, Σ_b ceil(S_b/128),
+        SF_SMEM] tile sequences in cu_seqlens order — the same TILE base the
+        kernel derives device-side from the metadata) and their packed tile
+        extent is derived from the buffer size (``_reshape_sf_packed``).
         """
         import cutlass
 
-        if self.thd:
-            raise NotImplementedError("Frost MXFP8: the legacy THD leg was removed (dense only); see issue #552")
         if sf_q is None or sf_k is None or sf_v is None:
             raise ValueError("Frost MXFP8 execute requires sf_q/sf_k/sf_v (block-scale descale tensors)")
 
@@ -1514,6 +1571,60 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         b, h_q, h_kv = self.batch_size, self.h_q, self.h_kv
         sq, skv = self.s_q_max, self.s_k_max
         device = q_tensor.device
+
+        if self.thd:
+            # amax_o reset first (launch-stream ordered): the degenerate
+            # early-returns below leave the correct 0 (no valid row).
+            amax_o_buf = self._amax_slot(amax_o, "amax_o", device)
+            with _torch_stream_context(current_stream, device):
+                amax_o_buf.zero_()
+            lse_cap = lse_tensor.numel() // h_q if (lse_tensor is not None and not (self.thd_stats_head_major and self.thd_stats_head_stride)) else None
+            pack = self._thd_pack(
+                q_tensor,
+                k_tensor,
+                v_tensor,
+                o_tensor,
+                sinks,
+                seq_kv_lens,
+                seq_q_lens,
+                workspace,
+                "SdpaFwdDslSm100 (MXFP8 THD)",
+                current_stream=current_stream,
+                lse_tokens_cap=lse_cap,
+            )
+            if pack is None:
+                self._logger.debug("execute (MXFP8 THD): no addressable Q token, nothing to do")
+                return
+            sf_q_v = self._reshape_sf_packed(sf_q, h_q, km.SF_SMEM_SIZE_Q, "sf_q", current_stream)
+            sf_k_v = self._reshape_sf_packed(sf_k, h_kv, km.SF_SMEM_SIZE_K, "sf_k", current_stream)
+            sf_v_v = self._reshape_sf_packed(sf_v, h_kv, km.SF_SMEM_SIZE_V, "sf_v", current_stream)
+            LSE = self._thd_lse_view(lse_tensor, pack.t_q)
+            # PLAN-TIME-ONLY compile key: re-binds the artifact compile()
+            # already built (packed totals + SF tile extents are dynamic).
+            fn = km.compile(**self._thd_compile_kwargs())
+            fn(
+                pack.Q,
+                pack.K,
+                pack.V,
+                pack.O,
+                sf_q_v,
+                sf_k_v,
+                sf_v_v,
+                LSE,
+                amax_o_buf,
+                pack.sinks_t,
+                pack.meta,
+                pack.o_desc,
+                (b, h_q, h_kv, 0, 0, 0),
+                cutlass.Float32(scale_softmax_log2),
+                cutlass.Int32(pack.units),
+                pack.q_lens_dev,
+                pack.kv_lens_dev,
+                cutlass.Int32(pack.lens_form),
+                stream=current_stream,
+            )
+            self._logger.debug("execute (MXFP8 THD) completed")
+            return
 
         Q = self._to_bshd(q_tensor)
         K = self._to_bshd(k_tensor)
@@ -1545,6 +1656,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         with _torch_stream_context(current_stream, device):
             amax_o_buf.zero_()
 
+        o_desc_dummy = self._dummy("o_desc", device, lambda: torch.zeros(1, dtype=torch.int64, device=device))
         self._compiled_kernel(
             Q,
             K,
@@ -1557,8 +1669,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             amax_o_buf,
             sinks_t,
             seq_kv_t,
+            o_desc_dummy,
             (b, h_q, h_kv, sq, skv, 0),
             cutlass.Float32(scale_softmax_log2),
+            cutlass.Int32(0),
             stream=current_stream,
         )
         if o_needs_copy_back:
@@ -1582,18 +1696,16 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         scale_o,
         amax_o,
         current_stream=None,
+        workspace=None,
     ):
-        """Per-tensor FP8 execute (dense): scalar descales fold into scale_softmax_log2
-        (attn·descale_q·descale_k·log2 e) and o_scale_fused (descale_v·scale_o).
-
-        ``Amax_S`` is produced in-kernel (atomicMax of the per-row softmax prob) into the
-        caller's pre-zeroed buffer; ``Amax_O`` is ``max|O|/scale_o`` post-kernel (exact
-        for half output).
+        """Per-tensor FP8 execute: scalar descales fold into scale_softmax_log2
+        (attn·descale_q·descale_k·log2 e) and o_scale_fused (descale_v·scale_o) —
+        both IN-KERNEL from device scales (Rule 3); ``Amax_O`` is produced
+        in-kernel and divided by scale_o on device post-kernel. THD/varlen
+        rides the shared packed lowering (``_thd_pack``); the scale folding
+        and the amax protocol are identical.
         """
         import cutlass
-
-        if self.thd:
-            raise NotImplementedError("Frost per-tensor FP8: the legacy THD leg was removed (dense d128 only); see issue #552")
 
         b, h_q, h_kv = self.batch_size, self.h_q, self.h_kv
         sq, skv = self.s_q_max, self.s_k_max
@@ -1610,6 +1722,64 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         so_t = self._scale_view(scale_o, "scale_o", device)
         scale_softmax_log2 = scale_val * math.log2(math.e)
         o_scale_fused = 1.0
+
+        if self.thd:
+            # amax_o reset first (launch-stream ordered): the degenerate
+            # early-returns below leave the correct 0 (no valid row).
+            amax_o_buf = self._amax_slot(amax_o, "amax_o", device)
+            with _torch_stream_context(current_stream, device):
+                amax_o_buf.zero_()
+            lse_cap = lse_tensor.numel() // h_q if (lse_tensor is not None and not (self.thd_stats_head_major and self.thd_stats_head_stride)) else None
+            pack = self._thd_pack(
+                q_tensor,
+                k_tensor,
+                v_tensor,
+                o_tensor,
+                sinks,
+                seq_kv_lens,
+                seq_q_lens,
+                workspace,
+                "SdpaFwdDslSm100 (FP8 THD)",
+                current_stream=current_stream,
+                lse_tokens_cap=lse_cap,
+            )
+            if pack is None:
+                self._logger.debug("execute (FP8 THD): no addressable Q token, nothing to do")
+                return
+            LSE = self._thd_lse_view(lse_tensor, pack.t_q)
+            # PLAN-TIME-ONLY compile key: re-binds the artifact compile()
+            # already built (the packed totals are dynamic extents).
+            fn = self._k_mod.compile(**self._thd_compile_kwargs())
+            fn(
+                pack.Q,
+                pack.K,
+                pack.V,
+                pack.O,
+                LSE,
+                pack.sinks_t,
+                pack.meta,
+                pack.o_desc,
+                (b, h_q, h_kv, 0, 0, 0),
+                cutlass.Float32(scale_softmax_log2),
+                cutlass.Float32(o_scale_fused),
+                cutlass.Int32(pack.units),
+                dq_t,
+                dk_t,
+                dv_t,
+                so_t,
+                amax_o_buf,
+                pack.q_lens_dev,
+                pack.kv_lens_dev,
+                cutlass.Int32(pack.lens_form),
+                stream=current_stream,
+            )
+            with _torch_stream_context(current_stream, device):
+                if amax_o is not None:
+                    # Device divisor: same div_, no readback; scale_o > 0 is
+                    # caller contract (None bound a cached 1.0 above).
+                    amax_o_buf.div_(so_t)
+            self._logger.debug("execute (FP8 per-tensor THD) completed")
+            return
 
         Q = self._to_bshd(q_tensor)
         K = self._to_bshd(k_tensor)
@@ -1637,6 +1807,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         with _torch_stream_context(current_stream, device):
             amax_o_buf.zero_()
 
+        o_desc_dummy = self._dummy("o_desc", device, lambda: torch.zeros(1, dtype=torch.int64, device=device))
         self._compiled_kernel(
             Q,
             K,
@@ -1645,9 +1816,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             lse,
             sinks_t,
             seq_kv_t,
+            o_desc_dummy,
             (b, h_q, h_kv, sq, skv, 0),
             cutlass.Float32(scale_softmax_log2),
             cutlass.Float32(o_scale_fused),
+            cutlass.Int32(0),
             dq_t,
             dk_t,
             dv_t,

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1042,7 +1042,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # kernel (issue #552). o_desc: 16 int64 per
             # sequence + 16 spare, the per-sequence O TMA descriptors the
             # builder kernel fills.
-            return ws_align((3 * b + 2) * 4) + ws_align((b * 16 + 16) * 8) + (0 if self.has_sink else ws_align(qh * 4))
+            # o_desc: 16 int64 per sequence + the dead-unit pad slot; the
+            # FP8/MXFP8 flavors carry two more slots for the packed-total-
+            # clamped K/V runtime descriptors (see the kernels' THD closures).
+            o_desc_slots = b + (3 if self._fp8 else 1)
+            return ws_align((3 * b + 2) * 4) + ws_align(o_desc_slots * 16 * 8) + (0 if self.has_sink else ws_align(qh * 4))
         if self._fp8:
             return 0  # dense FP8/MXFP8: no per-execute scratch (dummies are cached one-time)
         # Dense padded-Q lens bind directly as their own kernel parameter
@@ -1332,7 +1336,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # before any consumer read, so stale bytes never survive — a fill
         # here is a wasted kernel launch on the execute hot path (Rule 1).
         with _torch_stream_context(current_stream, dev):
-            o_desc = carver.take(b * 16 + 16, torch.int64) if carver is not None else torch.empty(b * 16 + 16, dtype=torch.int64, device=dev)
+            # +2 slots on the FP8/MXFP8 flavors: the packed-total-clamped K/V
+            # runtime descriptors the setup kernel writes after the pad slot.
+            o_desc_slots = b + (3 if self._fp8 else 1)
+            o_desc = carver.take(o_desc_slots * 16, torch.int64) if carver is not None else torch.empty(o_desc_slots * 16, dtype=torch.int64, device=dev)
         # The PLAN-TIME envelope grid — dead units exit by kernel contract.
         units = self._thd_unit_envelope()
 

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -873,8 +873,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # covers direct construction.
         self._not_implemented_error_if(
             self.thd and self._fp8 and (int(d_qk), int(d_v)) != (128, 128),
-            f"THD/varlen on the FP8/MXFP8 path requires D_QK=D_V=128 (the d192/d128 "
-            f"kernels are dense-only); got (D_QK={d_qk}, D_V={d_v})",
+            f"THD/varlen on the FP8/MXFP8 path requires D_QK=D_V=128 (the d192/d128 " f"kernels are dense-only); got (D_QK={d_qk}, D_V={d_v})",
         )
         # Dense padded-Q trim backstops (engines.lower_dsl_prefill never sets
         # these combinations; a direct caller could).
@@ -1393,6 +1392,17 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             lens_form=lens_form,
         )
 
+    def _thd_lse_tokens_cap(self, lse_tensor):
+        """The LSE buffer's token capacity when it shares the Q/O dynamic token
+        symbol — token-major (the default) and COMPACT head-major (declared
+        head stride 0, i.e. the token extent itself) both do, so their
+        capacity joins the packed-Q floor; head-major with a declared
+        head_stride carries its own extent (covering the packed total is
+        caller contract — t_q is a device value, Rule 3), so it stays out."""
+        if lse_tensor is None or (self.thd_stats_head_major and self.thd_stats_head_stride):
+            return None
+        return lse_tensor.numel() // self.h_q
+
     def _thd_lse_view(self, lse_tensor, t_q):
         """The caller's ragged Stats buffer in its declared layout — token-major
         packed rank-2 (T, H) (the default; cuDNN's TH1 ragged Stats recipe) or
@@ -1425,10 +1435,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         new packed total re-binds the same artifact."""
         import cutlass
 
-        # A token-major (or compact head-major) LSE shares the Q/O dynamic
-        # token symbol, so its capacity joins their floor; head-major with a
-        # declared head_stride carries its own extent.
-        lse_cap = lse_tensor.numel() // self.h_q if (lse_tensor is not None and not (self.thd_stats_head_major and self.thd_stats_head_stride)) else None
+        lse_cap = self._thd_lse_tokens_cap(lse_tensor)
         pack = self._thd_pack(
             q_buf, k_buf, v_buf, o_buf, sinks, seq_len_kv, seq_q_lens, workspace, "SdpaFwdDslSm100 (THD)", current_stream=current_stream, lse_tokens_cap=lse_cap
         )
@@ -1578,7 +1585,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             amax_o_buf = self._amax_slot(amax_o, "amax_o", device)
             with _torch_stream_context(current_stream, device):
                 amax_o_buf.zero_()
-            lse_cap = lse_tensor.numel() // h_q if (lse_tensor is not None and not (self.thd_stats_head_major and self.thd_stats_head_stride)) else None
+            lse_cap = self._thd_lse_tokens_cap(lse_tensor)
             pack = self._thd_pack(
                 q_tensor,
                 k_tensor,
@@ -1729,7 +1736,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             amax_o_buf = self._amax_slot(amax_o, "amax_o", device)
             with _torch_stream_context(current_stream, device):
                 amax_o_buf.zero_()
-            lse_cap = lse_tensor.numel() // h_q if (lse_tensor is not None and not (self.thd_stats_head_major and self.thd_stats_head_stride)) else None
+            lse_cap = self._thd_lse_tokens_cap(lse_tensor)
             pack = self._thd_pack(
                 q_tensor,
                 k_tensor,

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -455,12 +455,17 @@ def _sm100_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
 def _sm100_mxfp8_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
     """Block-scale MXFP8 engine (E4M3/E5M2 + per-32-block E8M0 SF).
 
-    THD/varlen is not supported by the current MXFP8 kernels, so this engine is
-    intentionally dense-only.
+    THD/varlen (d128/d128 only — the d192/d128 kernel is dense-only) rides the
+    shared packed lowering (write_thd_meta envelope design, issue #552; packed
+    Q/K/V/O contract only). The SF tensors travel PACKED
+    per-sequence-TILE-padded ([1, H, Σ_b ceil(S_b/128), SF_SMEM] tile sequences
+    in cu_seqlens order — see api_dsl._reshape_sf_packed); the graph's declared
+    SF dims stay the dense capacity, like the ragged Q/K/V storage.
     """
 
     d_v = d if d_v is None else d_v
     suffix = f"d{d}" if d_v == d else f"d{d}_d{d_v}"
+    thd = (d, d_v) == (128, 128)
     return EngineSpec(
         name=f"sdpa_fwd_prefill_sm100_{suffix}_mxfp8",
         capabilities=Capabilities(
@@ -480,6 +485,8 @@ def _sm100_mxfp8_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
             sink=True,
             stats=True,
             lse_optional=True,
+            thd=thd,
+            cu_seq_len=thd,
             sched_policies=frozenset({SCHED_NATURAL}),
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
@@ -501,12 +508,16 @@ def _sm100_fp8_spec(
     Padding mask (per-batch ``seq_len_kv`` → KV-side masking) is supported: KV-only
     padding leaves every query row real, so each row's total_sum > 0 and the
     per-row softmax normalization stays well-defined — no
-    fully-masked row can poison the global amax.  THD/varlen is still deferred
-    (dense execute only for v1), so thd=False.
+    fully-masked row can poison the global amax.  THD/varlen (d128/d128 only —
+    the d192/d128 kernel is dense-only) rides the shared packed lowering
+    (write_thd_meta envelope design, issue #552; packed Q/K/V/O contract
+    only) — on cc10.7 (Rubin) through the SM107 sibling kernel, which carries
+    the same THD leg.
     """
 
     d_v = d if d_v is None else d_v
     suffix = f"d{d}" if d_v == d else f"d{d}_d{d_v}"
+    thd = (d, d_v) == (128, 128)
     if dtypes is None:
         dtypes = frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2})
     return EngineSpec(
@@ -529,6 +540,8 @@ def _sm100_fp8_spec(
             sink_dtypes=sink_dtypes,
             stats=True,
             lse_optional=True,
+            thd=thd,
+            cu_seq_len=thd,
             # The fp8 kernel lacks the SEQ_Q_LENS_PRESENT epilogue trim, but its
             # only reachable padded+stats population is KV-only padding with
             # full-length seq_len_q (the fp8 suite; test_mhas_v2 fp8 padding

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -202,7 +202,7 @@ _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 # The setup kernel builds it DEVICE-side from the caller's length tensors and
 # the adapter launches the plan-time envelope grid (issue #552) — no length
 # ever reaches the host.
-from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel, TENSOR_MAP_QWORDS
 
 _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
@@ -568,6 +568,7 @@ def _kernel(
             seqlen_q=seqlen_q,
             seqlen_kv=seqlen_kv,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
             n_q_supers=n_q_supers,
             n_qh=n_qh,
             n_batch=n_batch,
@@ -617,6 +618,7 @@ def _tmaldg_warp_group(
     seqlen_q,
     seqlen_kv,
     seq_kv_lens_tensor,
+    o_desc_words,
     n_q_supers,
     n_qh,
     n_batch,
@@ -635,8 +637,23 @@ def _tmaldg_warp_group(
     kv_state = PipelineState.start(phase=1)
 
     tma_q = GmemTileTma(tma_q_desc)
-    tma_k = GmemTileTma(tma_k_desc)
-    tma_v = GmemTileTma(tma_v_desc)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: K/V ride the setup kernel's RUNTIME descriptors (o_desc_words
+        # slots n_batch+1 / n_batch+2), whose seq extent is clamped to the
+        # packed KV total cu_k[B]. The last sequence's tile steps past that
+        # total into the buffer's capacity tail; through the clamped
+        # descriptors those rows are TMA-OOB and land as EXACT ZEROS — a NaN
+        # tail (test_mhas_v2 poisons it) would otherwise wipe the tile via
+        # BMM2's P·V (0 · NaN == NaN) and, on cc10.3, the pre-mask fused-LDTM
+        # row-max. Same closure shape as the dense GmemTileTma, so every load
+        # site below is branch-free.
+        _k_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(1)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        _v_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(2)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        tma_k = lambda *coords: tma_slice_runtime_desc(_k_rt_ptr, *coords)  # noqa: E731
+        tma_v = lambda *coords: tma_slice_runtime_desc(_v_rt_ptr, *coords)  # noqa: E731
+    else:
+        tma_k = GmemTileTma(tma_k_desc)
+        tma_v = GmemTileTma(tma_v_desc)
 
     q_super_idx, head_idx, batch_idx, split_idx = _decode_initial_split(
         sched.bidx_init,
@@ -1810,6 +1827,11 @@ def _correction_warp_group(
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
+            # Dead row (no valid KV column at all): O := 0 in BOTH branches
+            # (with a sink the denominator is finite but the O numerator is an
+            # empty sum).  total_sum >= 2^P_CAST_LOG2_SCALE for any alive row
+            # so this never fires spuriously.
+            row_dead = total_sum <= cutlass.Float32(0.0)
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
                 sink_logit = sinks_arr[head_idx]
@@ -1825,6 +1847,10 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True) - cutlass.Float32(P_CAST_LOG2_SCALE) * LN2
                 # Safe inverse: avoid div by 0 on fully-masked rows.
                 inv_sum = o_scale_fused / cute.math.max(total_sum, cutlass.Float32(1e-30))
+                # Dead row without a sink: LSE := -inf on top of O := 0.
+                neg_inf_lse = cutlass.Float32(float("-inf"))
+                lse_val = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse_val.ir_value()))
+                inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
@@ -1892,14 +1918,19 @@ def _correction_warp_group(
                     )
                     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     o_scaled = o_chunk * inv_sum
+                    # Dead-row sanitize: an empty mainloop never writes O TMEM,
+                    # so o_chunk is garbage (possibly NaN) and `* inv_sum(=0)`
+                    # cannot zero it — select 0 explicitly (keeps amax_o clean).
+                    _zero_f = cutlass.Float32(0.0)
+                    o_elems = [cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)]
 
                     for _i in cutlass.range_constexpr(O_CHUNK):
-                        _e = o_scaled[_i]
+                        _e = o_elems[_i]
                         _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
 
                     # Plain range (not range_constexpr) — extraction at Python trace time.
                     o_packed_v = fp32_to_fp8_pack(
-                        [o_scaled[i] for i in range(16)],
+                        [o_elems[i] for i in range(16)],
                         dtype=OUT_STORAGE_DTYPE,
                     )
 
@@ -1934,6 +1965,14 @@ def _correction_warp_group(
                     )
                     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     o_scaled_h = o_chunk * inv_sum
+                    # Dead-row sanitize — see the fp8-pack path above.
+                    _zero_f = cutlass.Float32(0.0)
+                    o_scaled_h = cutlass.Vector.from_elements(
+                        tuple(
+                            cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled_h[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)
+                        ),
+                        cutlass.Float32,
+                    )
                     for _i in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
                         _e = o_scaled_h[_i]
                         _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
@@ -2097,9 +2136,15 @@ def _host(
         # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
         # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
         # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
-        _build_thd_meta_o_descs_kernel(
+        # The FP8 setup variant also clamps runtime K/V descriptors to the
+        # packed KV total (slots n_batch+1/+2 of o_desc_words) so tile-tail
+        # loads past it zero-fill instead of reading the buffer's capacity
+        # tail — a NaN tail would poison BMM2's P·V (0 · NaN == NaN).
+        _build_thd_meta_o_kv_descs_kernel(
             o_tensor,
             tma_o_desc,
+            tma_k_desc,
+            tma_v_desc,
             o_desc_words,
             seq_kv_lens_tensor,
             thd_q_lens_tensor,
@@ -2264,9 +2309,11 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
-    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
-    # dummy 1-elem when THD off (kernel never reads it).
-    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot +
+    # the packed-total-clamped K and V runtime descriptors (slots n_batch+1 /
+    # n_batch+2 — see the THD tma_k/tma_v closures); dummy 1-elem when THD
+    # off (kernel never reads it).
+    _odesc_len = ((b + 3) * _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
     fake_o_desc = cute.runtime.make_fake_compact_tensor(
         cutlass.Int64,
         (_odesc_len,),

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -21,11 +21,17 @@ f16 / mxfp8 SM100 d=128 layout plus the FP8-on-Blackwell K-path:
      ``CFG.TILE_K_HW_BMM2`` (→ 4 k-steps at TILE_K_HW=32).  Confirmed by the
      cuDNN f8 reference (UTCMMA_TILE_K=32, BMM_XMMAS_K=4, kind::f8f6f4).
 
-THD / varlen is NOT supported here: the legacy (pre-#606) THD leg was removed
-(issue #552) — it was never wired (engine spec thd=False; the adapter rejects
-FP8 THD in check_support).  A future port must follow the device-built-metadata
-plus plan-time-envelope design (``write_thd_meta``, issue #552 / PRs #606, #608)
-used by the f16 kernels; ``CFG.THD_VARLEN=1`` now fails loudly at trace time.
+THD / varlen (``CFG.THD_VARLEN=1``) follows the device-built-metadata +
+plan-time-envelope design (``write_thd_meta``, issue #552 / PRs #606, #608)
+used by the f16 kernels — FP8 is element-addressed (no block-scale SF), so it
+rides the same path: packed ``[1,T,H,D]`` with DYNAMIC token extents (the
+packed totals never reach the host), the setup kernel builds the
+[kv|cu_q|cu_k] metadata + per-batch O TMA descriptors device-side, and the
+launch grid is the plan-time envelope (units past a sequence's live tiles
+decode the batch == n_batch sentinel and drain without loads or stores).
+Ragged Stats ride the caller's declared layout (token-major (T, H) or
+head-major); the amax_o atomicMax is gated on live rows. Dense path
+byte-identical.
 """
 
 import os
@@ -94,7 +100,7 @@ from cudnn.frost.tile_dsl.pointwise import (
 from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
 from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
 from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
-from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
 from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
 from cudnn.frost.tile_dsl.mask import (
     apply_mask_chunk,
@@ -187,10 +193,18 @@ _bounds_for_tile = _sdpa_h.bounds_for_tile
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
-# Flat-grid decode dispatch + seq-offset helper from the shared factory.  The
-# legacy THD leg was removed (issue #552); _thd_tma_offsets folds to
-# (0, 0, batch_idx) at THD_VARLEN=0, so the dense TMA coords below are
-# byte-identical.
+# THD / varlen — shared helpers (FP8 element-addressed like f16, per-tensor
+# dequant scales, no block-scale SF).  Gated by CFG.THD_VARLEN (folds out:
+# _thd_tma_offsets is (0, 0, batch_idx) dense — TMA coords byte-identical).
+# TILES_Q=2: q_seq_off applies to BOTH Q slabs + both O-store slabs.
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+# The setup kernel builds it DEVICE-side from the caller's length tensors and
+# the adapter launches the plan-time envelope grid (issue #552) — no length
+# ever reaches the host.
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
@@ -274,6 +288,7 @@ def _kernel(
     lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
     seqlen_q: cutlass.Int32,
     seqlen_kv: cutlass.Int32,
     n_q_supers: cutlass.Int32,
@@ -574,6 +589,7 @@ def _kernel(
             n_batch=n_batch,
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
             qh_per_kh=qh_per_kh,
             seqlen_kv=seqlen_kv,
         )
@@ -687,8 +703,9 @@ def _tmaldg_warp_group(
                 bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sK[kv_state.idx],
-                # kv_seq_off / tma_batch fold to (0, batch_idx) — dense-identity
-                # with the THD leg removed.
+                # THD: prologue K load MUST apply the per-sequence kv offset
+                # (kv_seq_off) + packed batch coord (tma_batch), like the mainloop
+                # K load + the V loads (dense-identity fold at THD_VARLEN=0).
                 tma_k(cutlass.Int32(0), kv_head_idx, kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off, tma_batch),
                 bars.mb_k_full[kv_state.idx].smem_ptr,
                 cta_group=CFG.CTA_MMA,
@@ -812,6 +829,7 @@ def _tmastg_warp_group(
     n_batch,
     cta_in_pair,
     seq_kv_lens_tensor,
+    o_desc_words,
     seqlen_kv,
     qh_per_kh,
 ):
@@ -848,10 +866,26 @@ def _tmastg_warp_group(
             bars.mb_o_full[qs].wait(o_full_phase)
 
             # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
-            tma_store_tile(
-                sO[qs],
-                tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
-            )
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (base at the sequence's packed row, seq extent = S_q_b → a box
+                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                # batch coord collapses to 0.  Both slabs share one descriptor.
+                # (split_kv is dense-only — the config backstop rejects THD —
+                # so o_batch never applies here.)
+                # DEAD unit (batch == n_batch, over-launched envelope grid —
+                # issue #552): no O rows exist and descriptor slot n_batch is
+                # never built, so skip the store; the barrier protocol below
+                # still runs.
+                if batch_idx < n_batch:
+                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                    tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
+                )
 
             tma_store_commit()
             tma_store_wait(0)
@@ -1794,16 +1828,39 @@ def _correction_warp_group(
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
-            _row_valid = q_row_global < seqlen_q
-            if _row_valid:
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; the row is valid against
+                # the per-sequence Q length from the device metadata (negative
+                # for the dead-unit sentinel batch == n_batch — issue #552 —
+                # so no dead-unit row ever writes LSE or feeds amax_o). The
+                # packed ragged-Stats LSE is written in the caller's declared
+                # layout — token-major rank-2 [T, QH] (index
+                # [cu_q[b] + local, head]) or head-major rank-3
+                # [1, QH, head_stride] (index [0, head, cu_q[b] + local]).
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                _row_valid = q_row_global < _s_q_b
                 if cutlass.const_expr(lse_tensor is not None):
-                    lse_arr = cutlass.make_array_view(lse_tensor)
-                    # This chunk's LSE goes to its own split-major slot, matching where
-                    # TMA-STG put the chunk's O.  The pair (O_s, lse_s) is everything
-                    # the combine needs.
-                    lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
-                    lse_row = lse_arr[lse_batch, head_idx, :]
-                    lse_row[q_row_global] = lse_val
+                    if _row_valid:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        if cutlass.const_expr(len(lse_tensor.shape) == 2):
+                            lse_row = lse_arr[_cu_q_b + q_row_global, :]
+                            lse_row[head_idx] = lse_val
+                        else:
+                            lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                            lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                _row_valid = q_row_global < seqlen_q
+                if _row_valid:
+                    if cutlass.const_expr(lse_tensor is not None):
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        # This chunk's LSE goes to its own split-major slot, matching where
+                        # TMA-STG put the chunk's O.  The pair (O_s, lse_s) is everything
+                        # the combine needs.  Folds to batch_idx at SPLIT_KV == 1.
+                        lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
+                        lse_row = lse_arr[lse_batch, head_idx, :]
+                        lse_row[q_row_global] = lse_val
 
             # amax_o = max over valid rows of |o_scaled| (the fp32 pre-cast output). Divided
             # by scale_o in api to give the pre-quant output amax (cuDNN FP8 ref, in-kernel).
@@ -1952,21 +2009,34 @@ def _host(
     lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
     problem_size: Tuple[int, int, int, int, int, int],
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
     # 1-element fp32 device scales (Rule 3 — see _kernel).
     descale_q_t: cute.Tensor,
     descale_k_t: cute.Tensor,
     descale_v_t: cute.Tensor,
     scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
+    # THD device metadata build (issue #552): the CALLER's Q/KV length
+    # tensors — (B,) per-batch lengths or (B+1,) cu prefix sums, per side via
+    # thd_lens_form (bit 0: Q is cu, bit 1: KV is cu) — consumed only by the
+    # setup kernel, which writes the [kv|cu_q|cu_k] metadata buffer
+    # (seq_kv_lens_tensor) device-side. None (folded out of the ABI) for
+    # dense graphs.
+    thd_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_kv_lens_tensor: Optional[cute.Tensor] = None,
+    thd_lens_form: Optional[cutlass.Int32] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
-    # Legacy THD leg removed — fail loudly at trace time (issue #552).
-    if cutlass.const_expr(CFG.THD_VARLEN):
-        raise NotImplementedError("prefill_d128_fp8_sm100: the legacy THD leg was removed; port the write_thd_meta envelope design (issue #552) instead")
     B, QH, KH, SQ, SKV, _ = problem_size
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # Packed token totals are runtime values (dynamic extents); the
+        # problem_size slots are 0 by contract.
+        SQ = q_tensor.shape[1]
+        SKV = k_tensor.shape[1]
 
     # K box rows are per-CTA (TILE_N/CTA_MMA); O box inner must match O's swizzle, not V's.
     # O box sized in BPE_O — O may be written at BF16/FP16 (DTYPE_O != DTYPE_QKV).
@@ -2016,10 +2086,35 @@ def _host(
     q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
-    # KV split rides the BATCH axis: z = batch + split*B.  The decode
-    # already recovers the batch coord on both the blockIdx and the
-    # scheduler-handout paths, so the split travels with it for free.
-    grid_shape = (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD setup launch: build the [kv|cu_q|cu_k] metadata buffer
+        # DEVICE-side from the caller's length tensors (no host cumsum, no
+        # H2D — issue #552), then the per-batch O descriptor array (reuse
+        # tma_o_desc over the packed [1,T,QH,D_v] O as base). Main grid: the
+        # PLAN-TIME ENVELOPE (n_thd_units = B * ceil(S_q_decl/CGA_TILE_M) * QH,
+        # from the DECLARED S_q — no runtime length reaches the host); units
+        # past a sequence's live tiles decode the batch == n_batch sentinel
+        # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
+        # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
+        # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            thd_q_lens_tensor,
+            thd_kv_lens_tensor,
+            thd_lens_form,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(o_tensor.stride[1]),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        # KV split rides the BATCH axis: z = batch + split*B.  The decode
+        # already recovers the batch coord on both the blockIdx and the
+        # scheduler-handout paths, so the split travels with it for free.
+        grid_shape = (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
     _kernel(
         tma_q_desc,
         tma_k_desc,
@@ -2028,6 +2123,7 @@ def _host(
         lse_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
+        o_desc_words,
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
@@ -2050,9 +2146,25 @@ def _host(
 
 
 @lru_cache(maxsize=None)
-def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128, has_lse: bool = True) -> Callable:  # noqa: A001
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    has_lse: bool = True,
+    lse_head_major: bool = False,
+    lse_head_stride: int = 0,
+) -> Callable:
     """Compile with ALL dims concrete — pins TMA strides at compile time.
 
+    THD/varlen: q/k/v/o/lse PACKED with batch dim 1 ([1,T,H,D]); ``b`` is the
+    LOGICAL batch (sequence count) driving n_batch / metadata + O-desc sizes.
+    ``sq``/``skv`` are IGNORED under THD — the packed token totals are runtime
+    values, so the token extents compile DYNAMIC (``cute.sym_int``) and the
+    cache key stays plan-time-only (issue #552). THD Stats layouts: token-major
+    packed rank-2 (T, H) by default (cuDNN's TH1 ragged Stats recipe);
+    ``lse_head_major=True`` = rank-3 [1, QH, head_stride] (0 → compact).
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
     at all; the amax_o atomicMax write is independent and unchanged."""
@@ -2060,25 +2172,34 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         # Each split's LSE is not optional under KV split — it IS the weight
         # the combine reduces with.  Without it the partials cannot be recombined.
         raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
     # KV split: O and LSE are the PARTIAL workspaces, stacked split-major on
-    # the batch axis (B*SPLIT_KV).  Q/K/V keep the real batch.
-    _o_batch = b * SPLIT_KV
+    # the batch axis (B*SPLIT_KV).  Q/K/V keep the real batch.  THD packs the
+    # batch away (dim 1) and split_kv is dense-only (config backstop), so the
+    # THD fakes see SPLIT_KV == 1.
+    _o_batch = _fake_batch * SPLIT_KV
     _lse_batch = b * SPLIT_KV
+    if CFG.THD_VARLEN:
+        # Dynamic packed token totals: one symbol per ragged group (Q/O and a
+        # token-major LSE share t_q; K/V share t_kv), so a new total re-binds
+        # the same compiled artifact instead of minting a new one (issue #552).
+        sq = cute.sym_int(divisibility=1)
+        skv = cute.sym_int(divisibility=1)
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, sq, qh, CFG.TILE_K),
+        (_fake_batch, sq, qh, CFG.TILE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_k = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, skv, kh, CFG.TILE_K),
+        (_fake_batch, skv, kh, CFG.TILE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_v = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, skv, kh, CFG.TILE_O),
+        (_fake_batch, skv, kh, CFG.TILE_O),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
@@ -2091,8 +2212,34 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride require has_lse=True")
         fake_lse = None
+    elif CFG.THD_VARLEN:
+        # Packed ragged-Stats LSE in the caller's declared layout (align 4:
+        # the store is scalar f32 and the caller's Stats buffer only
+        # guarantees element alignment). The epilogue store branches on the
+        # STATIC rank, so the layout is fully encoded in this fake tensor.
+        if lse_head_major:
+            _lse_hs = lse_head_stride if lse_head_stride else sq
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (1, qh, _lse_hs),
+                stride_order=(2, 1, 0),
+                assumed_align=4,
+            )
+        else:
+            if lse_head_stride:
+                raise ValueError("lse_head_stride is head-major-only (token-major (T, H) is compact)")
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (sq, qh),
+                stride_order=(1, 0),
+                assumed_align=4,
+            )
     else:
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride are THD-only (dense LSE is compact (B, H, Sq))")
         fake_lse = cute.runtime.make_fake_compact_tensor(
             cutlass.Float32,
             (_lse_batch, qh, sq),
@@ -2106,10 +2253,21 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         stride_order=(0,),
         assumed_align=16,
     )
-    # Always part of the ABI; unread when CFG.SEQ_KV_LENS_PRESENT == 0.
+    # Always part of the ABI; unread when CFG.SEQ_KV_LENS_PRESENT == 0.  THD
+    # overloads it as [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] (len 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
     fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (b,),
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
+    # dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
         stride_order=(0,),
         assumed_align=16,
     )
@@ -2128,6 +2286,19 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
             assumed_align=4,
         )
 
+    # THD: the caller's Q/KV length tensors, consumed by the setup kernel's
+    # device-side metadata build. DYNAMIC extents — (B,) per-batch lengths and
+    # (B+1,) cu prefix sums bind the same artifact; the form rides the runtime
+    # thd_lens_form bitmask, so no compile key grows (Rule 4). align 4: bound
+    # directly, only natural int32 alignment is guaranteed.
+    if CFG.THD_VARLEN:
+        fake_thd_q_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
+        fake_thd_kv_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
+        fake_thd_lens_form = cutlass.Int32(0)
+    else:
+        fake_thd_q_lens = None
+        fake_thd_kv_lens = None
+        fake_thd_lens_form = None
     return cute.compile(
         _host,
         fake_q,
@@ -2137,14 +2308,21 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         fake_lse,
         fake_sinks,
         fake_seq_kv_lens,
-        (b, qh, kh, sq, skv, 0),
+        fake_o_desc,
+        # THD: the packed totals are runtime values carried by the (dynamic)
+        # tensor extents — _host reads them from the views' shapes.
+        (b, qh, kh, 0, 0, 0) if CFG.THD_VARLEN else (b, qh, kh, sq, skv, 0),
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),
+        cutlass.Int32(0),
         _fake_scale(),
         _fake_scale(),
         _fake_scale(),
         _fake_scale(),
         fake_amax_o,
+        fake_thd_q_lens,
+        fake_thd_kv_lens,
+        fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -2114,7 +2114,9 @@ def _host(
         # KV split rides the BATCH axis: z = batch + split*B.  The decode
         # already recovers the batch coord on both the blockIdx and the
         # scheduler-handout paths, so the split travels with it for free.
-        grid_shape = (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+        grid_shape = (
+            (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+        )
     _kernel(
         tma_q_desc,
         tma_k_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -239,7 +239,7 @@ _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 # The setup kernel builds it DEVICE-side from the caller's length tensors and
 # the adapter launches the plan-time envelope grid (issue #552) — no length
 # ever reaches the host.
-from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel, TENSOR_MAP_QWORDS
 
 _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
@@ -608,6 +608,7 @@ def _kernel(
             seqlen_q=seqlen_q,
             seqlen_kv=seqlen_kv,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
             n_q_supers=n_q_supers,
             n_qh=n_qh,
             n_batch=n_batch,
@@ -655,6 +656,7 @@ def _tmaldg_warp_group(
     seqlen_q,
     seqlen_kv,
     seq_kv_lens_tensor,
+    o_desc_words,
     n_q_supers,
     n_qh,
     n_batch,
@@ -673,8 +675,22 @@ def _tmaldg_warp_group(
     kv_state = PipelineState.start(phase=1)
 
     tma_q = GmemTileTma(tma_q_desc)
-    tma_k = GmemTileTma(tma_k_desc)
-    tma_v = GmemTileTma(tma_v_desc)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: K/V ride the setup kernel's RUNTIME descriptors (o_desc_words
+        # slots n_batch+1 / n_batch+2), whose seq extent is clamped to the
+        # packed KV total cu_k[B]. The last sequence's tile steps past that
+        # total into the buffer's capacity tail; through the clamped
+        # descriptors those rows are TMA-OOB and land as EXACT ZEROS — a NaN
+        # tail (test_mhas_v2 poisons it) would otherwise wipe the tile via
+        # BMM2's P·V (0 · NaN == NaN). Same closure shape as the dense
+        # GmemTileTma, so every load site below is branch-free.
+        _k_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(1)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        _v_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(2)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        tma_k = lambda *coords: tma_slice_runtime_desc(_k_rt_ptr, *coords)  # noqa: E731
+        tma_v = lambda *coords: tma_slice_runtime_desc(_v_rt_ptr, *coords)  # noqa: E731
+    else:
+        tma_k = GmemTileTma(tma_k_desc)
+        tma_v = GmemTileTma(tma_v_desc)
 
     q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
         sched.bidx_init,
@@ -1862,6 +1878,11 @@ def _correction_warp_group(
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
+            # Dead row (no valid KV column at all): O := 0 in BOTH branches
+            # (with a sink the denominator is finite but the O numerator is an
+            # empty sum).  total_sum >= 2^P_CAST_LOG2_SCALE for any alive row
+            # so this never fires spuriously.
+            row_dead = total_sum <= cutlass.Float32(0.0)
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
                 sink_logit = sinks_arr[head_idx]
@@ -1877,6 +1898,10 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True) - cutlass.Float32(P_CAST_LOG2_SCALE) * LN2
                 # Safe inverse: avoid div by 0 on fully-masked rows.
                 inv_sum = o_scale_fused / cute.math.max(total_sum, cutlass.Float32(1e-30))
+                # Dead row without a sink: LSE := -inf on top of O := 0.
+                neg_inf_lse = cutlass.Float32(float("-inf"))
+                lse_val = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse_val.ir_value()))
+                inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
@@ -1940,14 +1965,19 @@ def _correction_warp_group(
                     )
                     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     o_scaled = o_chunk * inv_sum
+                    # Dead-row sanitize: an empty mainloop never writes O TMEM,
+                    # so o_chunk is garbage (possibly NaN) and `* inv_sum(=0)`
+                    # cannot zero it — select 0 explicitly (keeps amax_o clean).
+                    _zero_f = cutlass.Float32(0.0)
+                    o_elems = [cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)]
 
                     for _i in cutlass.range_constexpr(O_CHUNK):
-                        _e = o_scaled[_i]
+                        _e = o_elems[_i]
                         _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
 
                     # Plain range (not range_constexpr) — extraction at Python trace time.
                     o_packed_v = fp32_to_fp8_pack(
-                        [o_scaled[i] for i in range(16)],
+                        [o_elems[i] for i in range(16)],
                         dtype=OUT_STORAGE_DTYPE,
                     )
 
@@ -1982,6 +2012,14 @@ def _correction_warp_group(
                     )
                     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                     o_scaled_h = o_chunk * inv_sum
+                    # Dead-row sanitize — see the fp8-pack path above.
+                    _zero_f = cutlass.Float32(0.0)
+                    o_scaled_h = cutlass.Vector.from_elements(
+                        tuple(
+                            cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled_h[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)
+                        ),
+                        cutlass.Float32,
+                    )
                     for _i in cutlass.range_constexpr(O_EPI_BLOCK_SIZE):
                         _e = o_scaled_h[_i]
                         _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
@@ -2137,9 +2175,15 @@ def _host(
         # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
         # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
         # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
-        _build_thd_meta_o_descs_kernel(
+        # The FP8 setup variant also clamps runtime K/V descriptors to the
+        # packed KV total (slots n_batch+1/+2 of o_desc_words) so tile-tail
+        # loads past it zero-fill instead of reading the buffer's capacity
+        # tail — a NaN tail would poison BMM2's P·V (0 · NaN == NaN).
+        _build_thd_meta_o_kv_descs_kernel(
             o_tensor,
             tma_o_desc,
+            tma_k_desc,
+            tma_v_desc,
             o_desc_words,
             seq_kv_lens_tensor,
             thd_q_lens_tensor,
@@ -2289,9 +2333,11 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
-    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
-    # dummy 1-elem when THD off (kernel never reads it).
-    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot +
+    # the packed-total-clamped K and V runtime descriptors (slots n_batch+1 /
+    # n_batch+2 — see the THD tma_k/tma_v closures); dummy 1-elem when THD
+    # off (kernel never reads it).
+    _odesc_len = ((b + 3) * _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
     fake_o_desc = cute.runtime.make_fake_compact_tensor(
         cutlass.Int64,
         (_odesc_len,),

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -34,11 +34,17 @@ f16 / mxfp8 SM100 d=128 layout plus the FP8-on-Blackwell K-path:
      ``CFG.TILE_K_HW_BMM2`` (→ 4 k-steps at TILE_K_HW=32).  Confirmed by the
      cuDNN f8 reference (UTCMMA_TILE_K=32, BMM_XMMAS_K=4, kind::f8f6f4).
 
-THD / varlen is NOT supported here: the legacy (pre-#606) THD leg was removed
-(issue #552) — it was never wired (engine spec thd=False; the adapter rejects
-FP8 THD in check_support).  A future port must follow the device-built-metadata
-plus plan-time-envelope design (``write_thd_meta``, issue #552 / PRs #606, #608)
-used by the f16 kernels; ``CFG.THD_VARLEN=1`` now fails loudly at trace time.
+THD / varlen (``CFG.THD_VARLEN=1``) follows the device-built-metadata +
+plan-time-envelope design (``write_thd_meta``, issue #552 / PRs #606, #608)
+used by the f16 kernels — FP8 is element-addressed (no block-scale SF), so it
+rides the same path: packed ``[1,T,H,D]`` with DYNAMIC token extents (the
+packed totals never reach the host), the setup kernel builds the
+[kv|cu_q|cu_k] metadata + per-batch O TMA descriptors device-side, and the
+launch grid is the plan-time envelope (units past a sequence's live tiles
+decode the batch == n_batch sentinel and drain without loads or stores).
+Ragged Stats ride the caller's declared layout (token-major (T, H) or
+head-major); the amax_o atomicMax is gated on live rows. Dense path
+byte-identical. Hunk-symmetric with prefill_d128_fp8_sm100.py.
 """
 
 import os
@@ -132,7 +138,7 @@ from cudnn.frost.tile_dsl.pointwise import (
 from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
 from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts, mma_ts_step
 from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
-from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
 from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
 from cudnn.frost.tile_dsl.mask import (
     apply_mask_chunk,
@@ -224,10 +230,18 @@ _bounds_for_tile = _sdpa_h.bounds_for_tile
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
-# Flat-grid decode dispatch + seq-offset helper from the shared factory.  The
-# legacy THD leg was removed (issue #552); _thd_tma_offsets folds to
-# (0, 0, batch_idx) at THD_VARLEN=0, so the dense TMA coords below are
-# byte-identical.
+# THD / varlen — shared helpers (FP8 element-addressed like f16, per-tensor
+# dequant scales, no block-scale SF).  Gated by CFG.THD_VARLEN (folds out:
+# _thd_tma_offsets is (0, 0, batch_idx) dense — TMA coords byte-identical).
+# TILES_Q=2: q_seq_off applies to BOTH Q slabs + both O-store slabs.
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+# The setup kernel builds it DEVICE-side from the caller's length tensors and
+# the adapter launches the plan-time envelope grid (issue #552) — no length
+# ever reaches the host.
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
@@ -302,6 +316,7 @@ def _kernel(
     lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
     seqlen_q: cutlass.Int32,
     seqlen_kv: cutlass.Int32,
     n_q_supers: cutlass.Int32,
@@ -614,6 +629,7 @@ def _kernel(
             n_batch=n_batch,
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
         )
 
     else:  # warp_idx == CFG.SCHED_WARP_ID
@@ -842,6 +858,7 @@ def _tmastg_warp_group(
     n_batch,
     cta_in_pair,
     seq_kv_lens_tensor,
+    o_desc_words,
 ):
     """Persistent O-store warp; tiles claimed via scheduler's try_cancel.async."""
     o_full_phase = cutlass.Int32(0)
@@ -870,10 +887,24 @@ def _tmastg_warp_group(
             bars.mb_o_full[qs].wait(o_full_phase)
 
             # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
-            tma_store_tile(
-                sO[qs],
-                tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
-            )
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (base at the sequence's packed row, seq extent = S_q_b → a box
+                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                # batch coord collapses to 0.  Both slabs share one descriptor.
+                # DEAD unit (batch == n_batch, over-launched envelope grid —
+                # issue #552): no O rows exist and descriptor slot n_batch is
+                # never built, so skip the store; the barrier protocol below
+                # still runs.
+                if batch_idx < n_batch:
+                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                    tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                )
 
             tma_store_commit()
             tma_store_wait(0)
@@ -1849,12 +1880,35 @@ def _correction_warp_group(
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
-            _row_valid = q_row_global < seqlen_q
-            if _row_valid:
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; the row is valid against
+                # the per-sequence Q length from the device metadata (negative
+                # for the dead-unit sentinel batch == n_batch — issue #552 —
+                # so no dead-unit row ever writes LSE or feeds amax_o). The
+                # packed ragged-Stats LSE is written in the caller's declared
+                # layout — token-major rank-2 [T, QH] (index
+                # [cu_q[b] + local, head]) or head-major rank-3
+                # [1, QH, head_stride] (index [0, head, cu_q[b] + local]).
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                _row_valid = q_row_global < _s_q_b
                 if cutlass.const_expr(lse_tensor is not None):
-                    lse_arr = cutlass.make_array_view(lse_tensor)
-                    lse_row = lse_arr[batch_idx, head_idx, :]
-                    lse_row[q_row_global] = lse_val
+                    if _row_valid:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        if cutlass.const_expr(len(lse_tensor.shape) == 2):
+                            lse_row = lse_arr[_cu_q_b + q_row_global, :]
+                            lse_row[head_idx] = lse_val
+                        else:
+                            lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                            lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                _row_valid = q_row_global < seqlen_q
+                if _row_valid:
+                    if cutlass.const_expr(lse_tensor is not None):
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse_val
 
             # amax_o = max over valid rows of |o_scaled| (the fp32 pre-cast output). Divided
             # by scale_o in api to give the pre-quant output amax (cuDNN FP8 ref, in-kernel).
@@ -1995,21 +2049,34 @@ def _host(
     lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
     problem_size: Tuple[int, int, int, int, int, int],
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
     # 1-element fp32 device scales (Rule 3 — see _kernel).
     descale_q_t: cute.Tensor,
     descale_k_t: cute.Tensor,
     descale_v_t: cute.Tensor,
     scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
+    # THD device metadata build (issue #552): the CALLER's Q/KV length
+    # tensors — (B,) per-batch lengths or (B+1,) cu prefix sums, per side via
+    # thd_lens_form (bit 0: Q is cu, bit 1: KV is cu) — consumed only by the
+    # setup kernel, which writes the [kv|cu_q|cu_k] metadata buffer
+    # (seq_kv_lens_tensor) device-side. None (folded out of the ABI) for
+    # dense graphs.
+    thd_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_kv_lens_tensor: Optional[cute.Tensor] = None,
+    thd_lens_form: Optional[cutlass.Int32] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
-    # Legacy THD leg removed — fail loudly at trace time (issue #552).
-    if cutlass.const_expr(CFG.THD_VARLEN):
-        raise NotImplementedError("prefill_d128_fp8_sm107: the legacy THD leg was removed; port the write_thd_meta envelope design (issue #552) instead")
     B, QH, KH, SQ, SKV, _ = problem_size
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # Packed token totals are runtime values (dynamic extents); the
+        # problem_size slots are 0 by contract.
+        SQ = q_tensor.shape[1]
+        SKV = k_tensor.shape[1]
 
     # K box rows are per-CTA (TILE_N/CTA_MMA); O box inner must match O's swizzle, not V's.
     # O box sized in BPE_O — O may be written at BF16/FP16 (DTYPE_O != DTYPE_QKV).
@@ -2059,7 +2126,32 @@ def _host(
     q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
-    grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD setup launch: build the [kv|cu_q|cu_k] metadata buffer
+        # DEVICE-side from the caller's length tensors (no host cumsum, no
+        # H2D — issue #552), then the per-batch O descriptor array (reuse
+        # tma_o_desc over the packed [1,T,QH,D_v] O as base). Main grid: the
+        # PLAN-TIME ENVELOPE (n_thd_units = B * ceil(S_q_decl/CGA_TILE_M) * QH,
+        # from the DECLARED S_q — no runtime length reaches the host); units
+        # past a sequence's live tiles decode the batch == n_batch sentinel
+        # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
+        # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
+        # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            thd_q_lens_tensor,
+            thd_kv_lens_tensor,
+            thd_lens_form,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(o_tensor.stride[1]),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
     _kernel(
         tma_q_desc,
         tma_k_desc,
@@ -2068,6 +2160,7 @@ def _host(
         lse_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
+        o_desc_words,
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
@@ -2090,41 +2183,90 @@ def _host(
 
 
 @lru_cache(maxsize=None)
-def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128, has_lse: bool = True) -> Callable:  # noqa: A001
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    has_lse: bool = True,
+    lse_head_major: bool = False,
+    lse_head_stride: int = 0,
+) -> Callable:
     """Compile with ALL dims concrete — pins TMA strides at compile time.
 
+    THD/varlen: q/k/v/o/lse PACKED with batch dim 1 ([1,T,H,D]); ``b`` is the
+    LOGICAL batch (sequence count) driving n_batch / metadata + O-desc sizes.
+    ``sq``/``skv`` are IGNORED under THD — the packed token totals are runtime
+    values, so the token extents compile DYNAMIC (``cute.sym_int``) and the
+    cache key stays plan-time-only (issue #552). THD Stats layouts: token-major
+    packed rank-2 (T, H) by default (cuDNN's TH1 ragged Stats recipe);
+    ``lse_head_major=True`` = rank-3 [1, QH, head_stride] (0 → compact).
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
     at all; the amax_o atomicMax write is independent and unchanged."""
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    if CFG.THD_VARLEN:
+        # Dynamic packed token totals: one symbol per ragged group (Q/O and a
+        # token-major LSE share t_q; K/V share t_kv), so a new total re-binds
+        # the same compiled artifact instead of minting a new one (issue #552).
+        sq = cute.sym_int(divisibility=1)
+        skv = cute.sym_int(divisibility=1)
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, sq, qh, CFG.TILE_K),
+        (_fake_batch, sq, qh, CFG.TILE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_k = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, skv, kh, CFG.TILE_K),
+        (_fake_batch, skv, kh, CFG.TILE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_v = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, skv, kh, CFG.TILE_O),
+        (_fake_batch, skv, kh, CFG.TILE_O),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
         OUT_STORAGE_DTYPE,
-        (b, sq, qh, CFG.TILE_O),
+        (_fake_batch, sq, qh, CFG.TILE_O),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride require has_lse=True")
         fake_lse = None
+    elif CFG.THD_VARLEN:
+        # Packed ragged-Stats LSE in the caller's declared layout (align 4:
+        # the store is scalar f32 and the caller's Stats buffer only
+        # guarantees element alignment). The epilogue store branches on the
+        # STATIC rank, so the layout is fully encoded in this fake tensor.
+        if lse_head_major:
+            _lse_hs = lse_head_stride if lse_head_stride else sq
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (1, qh, _lse_hs),
+                stride_order=(2, 1, 0),
+                assumed_align=4,
+            )
+        else:
+            if lse_head_stride:
+                raise ValueError("lse_head_stride is head-major-only (token-major (T, H) is compact)")
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (sq, qh),
+                stride_order=(1, 0),
+                assumed_align=4,
+            )
     else:
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride are THD-only (dense LSE is compact (B, H, Sq))")
         fake_lse = cute.runtime.make_fake_compact_tensor(
             cutlass.Float32,
             (b, qh, sq),
@@ -2138,10 +2280,21 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         stride_order=(0,),
         assumed_align=16,
     )
-    # Always part of the ABI; unread when CFG.SEQ_KV_LENS_PRESENT == 0.
+    # Always part of the ABI; unread when CFG.SEQ_KV_LENS_PRESENT == 0.  THD
+    # overloads it as [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] (len 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
     fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (b,),
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
+    # dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
         stride_order=(0,),
         assumed_align=16,
     )
@@ -2160,6 +2313,20 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
             assumed_align=4,
         )
 
+    # THD: the caller's Q/KV length tensors, consumed by the setup kernel's
+    # device-side metadata build. DYNAMIC extents — (B,) per-batch lengths and
+    # (B+1,) cu prefix sums bind the same artifact; the form rides the runtime
+    # thd_lens_form bitmask, so no compile key grows (Rule 4). align 4: bound
+    # directly, only natural int32 alignment is guaranteed.
+    if CFG.THD_VARLEN:
+        fake_thd_q_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
+        fake_thd_kv_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
+        fake_thd_lens_form = cutlass.Int32(0)
+    else:
+        fake_thd_q_lens = None
+        fake_thd_kv_lens = None
+        fake_thd_lens_form = None
+
     return cute.compile(
         _host,
         fake_q,
@@ -2169,14 +2336,21 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         fake_lse,
         fake_sinks,
         fake_seq_kv_lens,
-        (b, qh, kh, sq, skv, 0),
+        fake_o_desc,
+        # THD: the packed totals are runtime values carried by the (dynamic)
+        # tensor extents — _host reads them from the views' shapes.
+        (b, qh, kh, 0, 0, 0) if CFG.THD_VARLEN else (b, qh, kh, sq, skv, 0),
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),
+        cutlass.Int32(0),
         _fake_scale(),
         _fake_scale(),
         _fake_scale(),
         _fake_scale(),
         fake_amax_o,
+        fake_thd_q_lens,
+        fake_thd_kv_lens,
+        fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -2525,7 +2525,9 @@ def _host(
         # KV split rides the BATCH axis: z = batch + split*B.  The decode
         # already recovers the batch coord on both the blockIdx and the
         # scheduler-handout paths, so the split travels with it for free.
-        grid_shape = (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+        grid_shape = (
+            (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+        )
     _kernel(
         tma_q_desc,
         tma_k_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -248,7 +248,7 @@ _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 # — built DEVICE-side by the setup kernel (issue #552).
 # MXFP8-only: _thd_sf_tile_bases returns the per-sequence SF-tile prefix bases
 # (cu_sf_q_base / cu_sf_k_base) for the packed scale-factor layout.
-from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_kv_descs_kernel as _build_thd_meta_o_kv_descs_kernel, TENSOR_MAP_QWORDS
 
 _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
@@ -734,6 +734,7 @@ def _kernel(
             seqlen_q=seqlen_q,
             seqlen_kv=seqlen_kv,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
             n_q_supers=n_q_supers,
             n_qh=n_qh,
             n_batch=n_batch,
@@ -789,6 +790,7 @@ def _tmaldg_warp_group(
     seqlen_q,
     seqlen_kv,
     seq_kv_lens_tensor,
+    o_desc_words,
     n_q_supers,
     n_qh,
     n_batch,
@@ -809,8 +811,25 @@ def _tmaldg_warp_group(
 
     # SF TMA handles 5-D (innermost = 128-B row); tma_load_tile auto-selects on coord_0.
     tma_q = GmemTileTma(tma_q_desc)
-    tma_k = GmemTileTma(tma_k_desc)
-    tma_v = GmemTileTma(tma_v_desc)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: K/V ride the setup kernel's RUNTIME descriptors (o_desc_words
+        # slots n_batch+1 / n_batch+2), whose seq extent is clamped to the
+        # packed KV total cu_k[B]. The last sequence's tile steps past that
+        # total into the buffer's capacity tail; through the clamped
+        # descriptors those rows are TMA-OOB and land as EXACT ZEROS — a NaN
+        # tail (test_mhas_v2 poisons it) would otherwise wipe the tile via
+        # BMM2's P·V (0 · NaN == NaN) and, on cc10.3, the pre-mask fused-LDTM
+        # row-max. The SF descriptors stay grid-constant: THD SF buffers are
+        # exactly the packed per-sequence-TILE-padded layout (caller
+        # contract), so SF loads never leave caller-quantized bytes. Same
+        # closure shape as the dense GmemTileTma — load sites are branch-free.
+        _k_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(1)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        _v_rt_ptr = (o_desc_words.iterator.raw_ptr() + (n_batch + cutlass.Int32(2)) * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+        tma_k = lambda *coords: tma_slice_runtime_desc(_k_rt_ptr, *coords)  # noqa: E731
+        tma_v = lambda *coords: tma_slice_runtime_desc(_v_rt_ptr, *coords)  # noqa: E731
+    else:
+        tma_k = GmemTileTma(tma_k_desc)
+        tma_v = GmemTileTma(tma_v_desc)
     tma_q_sf = GmemTileTma(tma_q_sf_desc)
     tma_k_sf = GmemTileTma(tma_k_sf_desc)
     tma_v_sf = GmemTileTma(tma_v_sf_desc)
@@ -2226,6 +2245,11 @@ def _correction_warp_group(
             lse_val = cutlass.Float32(0.0)
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
+            # Dead row (no valid KV column at all): O := 0 in BOTH branches
+            # (with a sink the denominator is finite but the O numerator is an
+            # empty sum).  total_sum >= 2^P_CAST_LOG2_SCALE for any alive row
+            # so this never fires spuriously.
+            row_dead = total_sum <= cutlass.Float32(0.0)
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
                 sink_logit = sinks_arr[head_idx]
@@ -2241,6 +2265,10 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True) - cutlass.Float32(P_CAST_LOG2_SCALE) * LN2
                 # Safe inverse: avoid div by 0 (rows fully masked).
                 inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+                # Dead row without a sink: LSE := -inf on top of O := 0.
+                neg_inf_lse = cutlass.Float32(float("-inf"))
+                lse_val = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse_val.ir_value()))
+                inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
 
             # OOB-row guard: under cga2 cluster Q rows can exceed seqlen_q (else write aliases next head's LSE slot).
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
@@ -2294,6 +2322,14 @@ def _correction_warp_group(
                 )
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 o_scaled = o_chunk * inv_sum
+                # Dead-row sanitize: an empty mainloop never writes O TMEM,
+                # so o_chunk is garbage (possibly NaN) and `* inv_sum(=0)`
+                # cannot zero it — select 0 explicitly (keeps amax_o clean).
+                _zero_f = cutlass.Float32(0.0)
+                o_scaled = cutlass.Vector.from_elements(
+                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                    cutlass.Float32,
+                )
                 for _i in cutlass.range_constexpr(O_CHUNK):
                     _e = o_scaled[_i]
                     _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
@@ -2508,9 +2544,15 @@ def _host(
         # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
         # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
         # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
-        _build_thd_meta_o_descs_kernel(
+        # The FP8-family setup variant also clamps runtime K/V descriptors to
+        # the packed KV total (slots n_batch+1/+2 of o_desc_words) so
+        # tile-tail loads past it zero-fill instead of reading the buffer's
+        # capacity tail — a NaN tail would poison BMM2's P·V (0 · NaN == NaN).
+        _build_thd_meta_o_kv_descs_kernel(
             o_tensor,
             tma_o_desc,
+            tma_k_desc,
+            tma_v_desc,
             o_desc_words,
             seq_kv_lens_tensor,
             thd_q_lens_tensor,
@@ -2708,7 +2750,9 @@ def compile(  # noqa: A001
     )
     # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
     # dummy 1-elem when THD off (kernel never reads it).
-    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    # +2 slots after the pad slot: the packed-total-clamped K and V runtime
+    # descriptors (see the THD tma_k/tma_v closures).
+    _odesc_len = ((b + 3) * _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
     fake_o_desc = cute.runtime.make_fake_compact_tensor(
         cutlass.Int64,
         (_odesc_len,),

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -52,11 +52,17 @@ Cfg = type(CFG)
 # row_max_reduction_64 (default 0). api_dsl sets this from the device capability at
 # compile time; a distinct value yields a distinct kernel specialization (cache key).
 FUSED_LDTM_STAT = int(PARAMS.fused_ldtm_stat)
-# THD / varlen is NOT supported here: the legacy (pre-#606) THD leg was removed
-# (issue #552) — it was never wired (engine spec thd=False; the adapter rejects
-# FP8 THD in check_support).  A future port must follow the device-built-metadata
-# plus plan-time-envelope design (write_thd_meta, issue #552 / PRs #606, #608) used
-# by the f16 kernels; CFG.THD_VARLEN=1 now fails loudly at trace time.
+# THD / varlen (CFG.THD_VARLEN=1) follows the device-built-metadata +
+# plan-time-envelope design (write_thd_meta, issue #552 / PRs #606, #608) used
+# by the f16 kernels: packed [1,T,H,D] Q/K/V/O with DYNAMIC token extents, the
+# setup kernel builds the [kv|cu_q|cu_k] metadata + per-batch O TMA descriptors
+# device-side, and the launch grid is the plan-time envelope (dead units decode
+# the batch == n_batch sentinel and drain).  MXFP8-only addition: the SF
+# tensors travel PACKED per-sequence-TILE-padded (the shared MXFP8 quantizer
+# writes SF tiles at cu_sf[b] + local_tile; this kernel reads them with the
+# matching tile base from _thd_sf_tile_bases) as [1, H, Σ_b ceil(S_b/TILE),
+# SF_SMEM] with a DYNAMIC packed tile extent — the SF descriptors use B=1 and
+# the bound view's tile extent.  Dense path byte-identical.
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
 TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
@@ -101,7 +107,7 @@ from cudnn.frost.tile_dsl.tma import (
     bulk_copy,
     bulk_copy_multicast,
 )
-from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, GmemTileLinear
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, GmemTileLinear, tma_slice_runtime_desc
 from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
 from cudnn.frost.tile_dsl.mask import (
     apply_mask_chunk,
@@ -232,10 +238,19 @@ _bounds_for_tile = _sdpa_h.bounds_for_tile
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
-# Flat-grid decode dispatch + seq-offset helpers from the shared factory.  The
-# legacy THD leg was removed (issue #552); _thd_tma_offsets folds to
-# (0, 0, batch_idx) and _thd_sf_tile_bases to (0, 0) at THD_VARLEN=0, so the
-# dense TMA coords below are byte-identical.
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; the setup kernel + TENSOR_MAP_QWORDS from the shared
+# kernels thd_sm100.py.  Gated by CFG.THD_VARLEN (folds out: _thd_tma_offsets
+# is (0, 0, batch_idx) and _thd_sf_tile_bases (0, 0) dense — TMA coords
+# byte-identical).  Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs /
+# O stores per tile).  seq_kv_lens overloaded as the THD metadata buffer
+# (int32 len 3B+2): [0..B-1]=seq_kv_lens [B..2B]=cu_q(B+1) [2B+1..3B+1]=cu_k(B+1)
+# — built DEVICE-side by the setup kernel (issue #552).
+# MXFP8-only: _thd_sf_tile_bases returns the per-sequence SF-tile prefix bases
+# (cu_sf_q_base / cu_sf_k_base) for the packed scale-factor layout.
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_thd_meta_o_descs_kernel as _build_thd_meta_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
@@ -374,6 +389,7 @@ def _kernel(
     amax_o_tensor: cute.Tensor,
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
     seqlen_q: cutlass.Int32,
     seqlen_kv: cutlass.Int32,
     n_q_supers: cutlass.Int32,
@@ -740,6 +756,7 @@ def _kernel(
             n_batch=n_batch,
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
             qh_per_kh=qh_per_kh,
             seqlen_kv=seqlen_kv,
         )
@@ -1063,6 +1080,7 @@ def _tmastg_warp_group(
     n_batch,
     cta_in_pair,
     seq_kv_lens_tensor,
+    o_desc_words,
     seqlen_kv,
     qh_per_kh,
 ):
@@ -1099,10 +1117,26 @@ def _tmastg_warp_group(
             bars.mb_o_full[qs].wait(o_full_phase)
 
             # O TMA params follow O's swizzle, NOT V's — required when V_SWZ_B != O_SWZ_B.
-            tma_store_tile(
-                sO[qs],
-                tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
-            )
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (base at the sequence's packed row, seq extent = S_q_b → a box
+                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                # batch coord collapses to 0.  Both slabs share one descriptor.
+                # (split_kv is dense-only — the config backstop rejects THD —
+                # so o_batch never applies here.)
+                # DEAD unit (batch == n_batch, over-launched envelope grid —
+                # issue #552): no O rows exist and descriptor slot n_batch is
+                # never built, so skip the store; the barrier protocol below
+                # still runs.
+                if batch_idx < n_batch:
+                    o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                    tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
+                )
 
             tma_store_commit()
             tma_store_wait(0)
@@ -2210,18 +2244,41 @@ def _correction_warp_group(
 
             # OOB-row guard: under cga2 cluster Q rows can exceed seqlen_q (else write aliases next head's LSE slot).
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
-            _row_valid = q_row_global < seqlen_q
             # has_lse=False: the Stats store is compiled out; the amax_o
-            # atomicMax below is independent of it and always live.
-            if cutlass.const_expr(lse_tensor is not None):
-                if _row_valid:
-                    lse_arr = cutlass.make_array_view(lse_tensor)
-                    # This chunk's LSE goes to its own split-major slot, matching where
-                    # TMA-STG put the chunk's O.  The pair (O_s, lse_s) is everything
-                    # the combine needs.
-                    lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
-                    lse_row = lse_arr[lse_batch, head_idx, :]
-                    lse_row[q_row_global] = lse_val
+            # atomicMax below is independent of it, gated only on _row_valid.
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; the row is valid against
+                # the per-sequence Q length from the device metadata (negative
+                # for the dead-unit sentinel batch == n_batch — issue #552 —
+                # so no dead-unit row ever writes LSE or feeds amax_o). The
+                # packed ragged-Stats LSE is written in the caller's declared
+                # layout — token-major rank-2 [T, QH] (index
+                # [cu_q[b] + local, head]) or head-major rank-3
+                # [1, QH, head_stride] (index [0, head, cu_q[b] + local]).
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                _row_valid = q_row_global < _s_q_b
+                if cutlass.const_expr(lse_tensor is not None):
+                    if _row_valid:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        if cutlass.const_expr(len(lse_tensor.shape) == 2):
+                            lse_row = lse_arr[_cu_q_b + q_row_global, :]
+                            lse_row[head_idx] = lse_val
+                        else:
+                            lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                            lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                _row_valid = q_row_global < seqlen_q
+                if cutlass.const_expr(lse_tensor is not None):
+                    if _row_valid:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        # This chunk's LSE goes to its own split-major slot, matching where
+                        # TMA-STG put the chunk's O.  The pair (O_s, lse_s) is everything
+                        # the combine needs.  Folds to batch_idx at SPLIT_KV == 1.
+                        lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
+                        lse_row = lse_arr[lse_batch, head_idx, :]
+                        lse_row[q_row_global] = lse_val
 
             sO_sub_base = sO[qs].base
 
@@ -2318,15 +2375,33 @@ def _host(
     amax_o_tensor: cute.Tensor,
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
     problem_size: Tuple[int, int, int, int, int, int],
     scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    # THD device metadata build (issue #552): the CALLER's Q/KV length
+    # tensors — (B,) per-batch lengths or (B+1,) cu prefix sums, per side via
+    # thd_lens_form (bit 0: Q is cu, bit 1: KV is cu) — consumed only by the
+    # setup kernel, which writes the [kv|cu_q|cu_k] metadata buffer
+    # (seq_kv_lens_tensor) device-side. None (folded out of the ABI) for
+    # dense graphs.
+    thd_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_kv_lens_tensor: Optional[cute.Tensor] = None,
+    thd_lens_form: Optional[cutlass.Int32] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
-    """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors."""
-    # Legacy THD leg removed — fail loudly at trace time (issue #552).
-    if cutlass.const_expr(CFG.THD_VARLEN):
-        raise NotImplementedError("prefill_d128_mxfp8_sm100: the legacy THD leg was removed; port the write_thd_meta envelope design (issue #552) instead")
+    """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors.
+
+    THD/varlen: q/k/v/o/lse + SF tensors are PACKED with batch dim 1 and
+    DYNAMIC token / SF-tile extents; the SF descriptors use B=1 + the bound
+    SF views' packed tile extents (per-sequence-TILE-padded layout); O uses a
+    per-batch descriptor array built by the setup kernel."""
     B, QH, KH, SQ, SKV, _ = problem_size
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # Packed token totals are runtime values (dynamic extents); the
+        # problem_size slots are 0 by contract.
+        SQ = q_tensor.shape[1]
+        SKV = k_tensor.shape[1]
 
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O  # O box sized in BPE_O (BF16/FP16 O)
     qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
@@ -2374,13 +2449,21 @@ def _host(
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
     # SF TMA strides in 16-B units (TMA convention); reinterpret 4-D runner SF
-    # tensor as 5-D split-byte view.  Per-batch tile counts (SQ/TILE_M,
-    # SKV/TILE_N), B-extent = B.
+    # tensor as 5-D split-byte view.  Dense: per-batch tile counts (SQ/TILE_M,
+    # SKV/TILE_N), B-extent = B.  THD: the SF tensor is PACKED (batch dim 1)
+    # and per-sequence-TILE-padded, so the descriptor uses the bound view's
+    # packed tile extent (Σ_b ceil(S/TILE), a DYNAMIC value carried by the SF
+    # tensor's shape) and B = 1.
     sq_sf_tiles = (SQ + CFG.TILE_M - 1) // CFG.TILE_M
     skv_sf_tiles = (SKV + CFG.TILE_N - 1) // CFG.TILE_N
-    _B_SF = B
-    _q_sf_num_tiles = sq_sf_tiles
-    _kv_sf_num_tiles = skv_sf_tiles
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        _B_SF = 1
+        _q_sf_num_tiles = sf_q_tensor.shape[2]
+        _kv_sf_num_tiles = sf_k_tensor.shape[2]
+    else:
+        _B_SF = B
+        _q_sf_num_tiles = sq_sf_tiles
+        _kv_sf_num_tiles = skv_sf_tiles
 
     def _build_sf_desc(sf_tensor, num_tiles, sf_smem_size, num_rows_box, num_heads):
         sf_base = cutlass.Int64(sf_tensor.iterator.toint())
@@ -2414,10 +2497,35 @@ def _host(
     q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
-    # KV split rides the BATCH axis: z = batch + split*B.  The decode
-    # already recovers the batch coord on both the blockIdx and the
-    # scheduler-handout paths, so the split travels with it for free.
-    grid_shape = (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD setup launch: build the [kv|cu_q|cu_k] metadata buffer
+        # DEVICE-side from the caller's length tensors (no host cumsum, no
+        # H2D — issue #552), then the per-batch O descriptor array (reuse
+        # tma_o_desc over the packed [1,T,QH,D_v] O as base). Main grid: the
+        # PLAN-TIME ENVELOPE (n_thd_units = B * ceil(S_q_decl/CGA_TILE_M) * QH,
+        # from the DECLARED S_q — no runtime length reaches the host); units
+        # past a sequence's live tiles decode the batch == n_batch sentinel
+        # and drain without loads or stores. grid_x = n_thd_units * CGA_M.
+        # Per-token element stride of packed O (o_tensor.stride[1] = QH * d_v)
+        # — NOT CFG.TILE_O, which is only coincidentally right at QH == 1.
+        _build_thd_meta_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            thd_q_lens_tensor,
+            thd_kv_lens_tensor,
+            thd_lens_form,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(o_tensor.stride[1]),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        # KV split rides the BATCH axis: z = batch + split*B.  The decode
+        # already recovers the batch coord on both the blockIdx and the
+        # scheduler-handout paths, so the split travels with it for free.
+        grid_shape = (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
     _kernel(
         tma_q_desc,
         tma_k_desc,
@@ -2430,6 +2538,7 @@ def _host(
         amax_o_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
+        o_desc_words,
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
@@ -2453,9 +2562,18 @@ def compile(  # noqa: A001
     sq: int = 256,
     skv: int = 128,
     has_lse: bool = True,
+    lse_head_major: bool = False,
+    lse_head_stride: int = 0,
 ) -> Callable:
     """Compile a kernel with concrete dims; 3 SF tensors layout [B, H, num_seq_tiles, SF_SMEM_SIZE_*].
 
+    THD/varlen: q/k/v/o/lse + SF tensors are PACKED with batch dim 1; ``b`` is
+    the LOGICAL batch (sequence count).  ``sq``/``skv`` are IGNORED under THD —
+    the packed token totals AND the packed SF tile extents (Σ_b ceil(S/TILE),
+    per-sequence-TILE-padded) are runtime values, so they compile DYNAMIC
+    (``cute.sym_int``) and the cache key stays plan-time-only (issue #552).
+    THD Stats layouts: token-major packed rank-2 (T, H) by default;
+    ``lse_head_major=True`` = rank-3 [1, QH, head_stride] (0 → compact).
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
     at all; the amax_o atomicMax write is independent and unchanged."""
@@ -2463,32 +2581,42 @@ def compile(  # noqa: A001
         # Each split's LSE is not optional under KV split — it IS the weight
         # the combine reduces with.  Without it the partials cannot be recombined.
         raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
+    _fake_batch = 1 if CFG.THD_VARLEN else b
     # KV split: O and LSE are the PARTIAL workspaces, stacked split-major on
-    # the batch axis (B*SPLIT_KV).  Q/K/V keep the real batch.
-    _o_batch = b * SPLIT_KV
+    # the batch axis (B*SPLIT_KV).  Q/K/V keep the real batch.  THD packs the
+    # batch away (dim 1) and split_kv is dense-only (config backstop), so the
+    # THD fakes see SPLIT_KV == 1.
+    _o_batch = _fake_batch * SPLIT_KV
     _lse_batch = b * SPLIT_KV
-
-    # Q SF tiles TILE_M-row wide → num_tiles = SQ/TILE_M; K/V SF TILE_N-row wide → num_tiles = SKV/TILE_N.
-    sq_tiles = (sq + CFG.TILE_M - 1) // CFG.TILE_M
-    skv_tiles = (skv + CFG.TILE_N - 1) // CFG.TILE_N
-    _q_sf_tiles = sq_tiles
-    _kv_sf_tiles = skv_tiles
+    if CFG.THD_VARLEN:
+        # Dynamic packed extents: one symbol per ragged group (Q/O and a
+        # token-major LSE share t_q; K/V share t_kv; the Q and K/V SF packed
+        # tile totals carry their own), so a new packed partition re-binds the
+        # same compiled artifact instead of minting a new one (issue #552).
+        sq = cute.sym_int(divisibility=1)
+        skv = cute.sym_int(divisibility=1)
+        _q_sf_tiles = cute.sym_int(divisibility=1)
+        _kv_sf_tiles = cute.sym_int(divisibility=1)
+    else:
+        # Q SF tiles TILE_M-row wide → num_tiles = SQ/TILE_M; K/V SF TILE_N-row wide → num_tiles = SKV/TILE_N.
+        _q_sf_tiles = (sq + CFG.TILE_M - 1) // CFG.TILE_M
+        _kv_sf_tiles = (skv + CFG.TILE_N - 1) // CFG.TILE_N
 
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, sq, qh, CFG.TILE_K),
+        (_fake_batch, sq, qh, CFG.TILE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_k = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, skv, kh, CFG.TILE_K),
+        (_fake_batch, skv, kh, CFG.TILE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_v = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (b, skv, kh, CFG.TILE_O),
+        (_fake_batch, skv, kh, CFG.TILE_O),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
@@ -2501,19 +2629,19 @@ def compile(  # noqa: A001
 
     fake_sf_q = cute.runtime.make_fake_compact_tensor(
         cutlass.Int8,
-        (b, qh, _q_sf_tiles, SF_SMEM_SIZE_Q),
+        (_fake_batch, qh, _q_sf_tiles, SF_SMEM_SIZE_Q),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_sf_k = cute.runtime.make_fake_compact_tensor(
         cutlass.Int8,
-        (b, kh, _kv_sf_tiles, SF_SMEM_SIZE_K),
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_sf_v = cute.runtime.make_fake_compact_tensor(
         cutlass.Int8,
-        (b, kh, _kv_sf_tiles, SF_SMEM_SIZE_V),
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_V),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
@@ -2521,8 +2649,34 @@ def compile(  # noqa: A001
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride require has_lse=True")
         fake_lse = None
+    elif CFG.THD_VARLEN:
+        # Packed ragged-Stats LSE in the caller's declared layout (align 4:
+        # the store is scalar f32 and the caller's Stats buffer only
+        # guarantees element alignment). The epilogue store branches on the
+        # STATIC rank, so the layout is fully encoded in this fake tensor.
+        if lse_head_major:
+            _lse_hs = lse_head_stride if lse_head_stride else sq
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (1, qh, _lse_hs),
+                stride_order=(2, 1, 0),
+                assumed_align=4,
+            )
+        else:
+            if lse_head_stride:
+                raise ValueError("lse_head_stride is head-major-only (token-major (T, H) is compact)")
+            fake_lse = cute.runtime.make_fake_compact_tensor(
+                cutlass.Float32,
+                (sq, qh),
+                stride_order=(1, 0),
+                assumed_align=4,
+            )
     else:
+        if lse_head_major or lse_head_stride:
+            raise ValueError("lse_head_major / lse_head_stride are THD-only (dense LSE is compact (B, H, Sq))")
         fake_lse = cute.runtime.make_fake_compact_tensor(
             cutlass.Float32,
             (_lse_batch, qh, sq),
@@ -2541,13 +2695,37 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
-    # seq_kv_lens always part of the ABI; unread when CFG.SEQ_KV_LENS_PRESENT == 0.
+    # seq_kv_lens always part of the ABI; unread when CFG.SEQ_KV_LENS_PRESENT
+    # == 0.  THD overloads it as [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] (len 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
     fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (b,),
+        (_skv_len,),
         stride_order=(0,),
         assumed_align=16,
     )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot;
+    # dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # THD: the caller's Q/KV length tensors, consumed by the setup kernel's
+    # device-side metadata build. DYNAMIC extents — (B,) per-batch lengths and
+    # (B+1,) cu prefix sums bind the same artifact; the form rides the runtime
+    # thd_lens_form bitmask, so no compile key grows (Rule 4). align 4: bound
+    # directly, only natural int32 alignment is guaranteed.
+    if CFG.THD_VARLEN:
+        fake_thd_q_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
+        fake_thd_kv_lens = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(divisibility=1),), stride_order=(0,), assumed_align=4)
+        fake_thd_lens_form = cutlass.Int32(0)
+    else:
+        fake_thd_q_lens = None
+        fake_thd_kv_lens = None
+        fake_thd_lens_form = None
     return cute.compile(
         _host,
         fake_q,
@@ -2561,8 +2739,15 @@ def compile(  # noqa: A001
         fake_amax_o,
         fake_sinks,
         fake_seq_kv_lens,
-        (b, qh, kh, sq, skv, 0),
+        fake_o_desc,
+        # THD: the packed totals are runtime values carried by the (dynamic)
+        # tensor extents — _host reads them from the views' shapes.
+        (b, qh, kh, 0, 0, 0) if CFG.THD_VARLEN else (b, qh, kh, sq, skv, 0),
         cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        fake_thd_q_lens,
+        fake_thd_kv_lens,
+        fake_thd_lens_form,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -2138,14 +2138,22 @@ def _host(
     lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
+    # SM100 FP8-family shared ABI: the THD slots ride every flavor so the
+    # adapter's launch shape is uniform; this dense-only kernel never reads
+    # them (o_desc_words is the 1-elem dense dummy, n_thd_units is 0).
+    o_desc_words: cute.Tensor,
     problem_size: Tuple[int, int, int, int, int, int],
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
     descale_q_t: cute.Tensor,
     descale_k_t: cute.Tensor,
     descale_v_t: cute.Tensor,
     scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
+    thd_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_kv_lens_tensor: Optional[cute.Tensor] = None,
+    thd_lens_form: Optional[cutlass.Int32] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     if cutlass.const_expr(CFG.THD_VARLEN):
@@ -2317,6 +2325,14 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
             assumed_align=4,
         )
 
+    # SM100 FP8-family shared ABI: dense 1-elem o_desc dummy + n_thd_units=0
+    # (this flavor is dense-only; the kernel never reads either).
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
     return cute.compile(
         _host,
         fake_q,
@@ -2326,14 +2342,19 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         fake_lse,
         fake_sinks,
         fake_seq_kv_lens,
+        fake_o_desc,
         (b, qh, kh, sq, skv, 0),
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),
+        cutlass.Int32(0),
         _fake_scale(),
         _fake_scale(),
         _fake_scale(),
         _fake_scale(),
         fake_amax_o,
+        None,
+        None,
+        None,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi --ptxas-options -uumn",
     )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
@@ -2544,8 +2544,16 @@ def _host(
     amax_o_tensor: cute.Tensor,
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
+    # SM100 FP8-family shared ABI: the THD slots ride every flavor so the
+    # adapter's launch shape is uniform; this dense-only kernel never reads
+    # them (o_desc_words is the 1-elem dense dummy, n_thd_units is 0).
+    o_desc_words: cute.Tensor,
     problem_size: Tuple[int, int, int, int, int, int],
     scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    thd_q_lens_tensor: Optional[cute.Tensor] = None,
+    thd_kv_lens_tensor: Optional[cute.Tensor] = None,
+    thd_lens_form: Optional[cutlass.Int32] = None,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
     """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors."""
@@ -2781,6 +2789,14 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
+    # SM100 FP8-family shared ABI: dense 1-elem o_desc dummy + n_thd_units=0
+    # (this flavor is dense-only; the kernel never reads either).
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
     return cute.compile(
         _host,
         fake_q,
@@ -2794,8 +2810,13 @@ def compile(  # noqa: A001
         fake_amax_o,
         fake_sinks,
         fake_seq_kv_lens,
+        fake_o_desc,
         (b, qh, kh, sq, skv, 0),
         cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        None,
+        None,
+        None,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/thd_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/thd_sm100.py
@@ -80,6 +80,80 @@ def build_thd_meta_kernel(
 
 
 @cute.kernel
+def build_thd_meta_o_kv_descs_kernel(
+    o_tensor: cute.Tensor,
+    base_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    base_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    base_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    o_desc_words: cute.Tensor,
+    meta_t: cute.Tensor,
+    q_lens_t: cute.Tensor,
+    kv_lens_t: cute.Tensor,
+    lens_form: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    o_row_stride: cutlass.Int32,
+) -> None:
+    """``build_thd_meta_o_descs_kernel`` + packed-total-clamped K/V descriptors
+    (the FP8/MXFP8 THD flavors).
+
+    The K/V loads tile in TILE_N rows, so the LAST sequence's tile steps past
+    the packed KV total into the buffer's capacity tail — caller-owned bytes
+    that may be NaN (test_mhas_v2 poisons them deliberately). Masked S columns
+    are NaN-safe (the mask is a select), but BMM2's ``P·V`` is not
+    (``0 · NaN == NaN`` wipes every valid row of the tile), and on cc10.3 the
+    fused-LDTM row-max reduces S BEFORE the mask. So the setup thread also
+    copies the K and V base descriptors into ``o_desc_words`` slots
+    ``n_batch+1`` / ``n_batch+2`` with their seq extent (GLOBAL_DIM ord=2)
+    patched to the packed total ``cu_k[B]`` — tile-tail loads past it become
+    TMA-OOB and land as EXACT ZEROS in SMEM (zero V nulls the masked P·V
+    terms; zero K keeps the pre-mask row-max finite). Slot ``n_batch`` stays
+    the never-built dead-unit pad slot."""
+    if nvvm.elect_sync():
+        meta = cutlass.make_array_view(meta_t)
+        write_thd_meta(meta, cutlass.make_array_view(q_lens_t), cutlass.make_array_view(kv_lens_t), lens_form, n_batch)
+        cuq0 = n_batch
+        o_ptr = o_tensor.iterator.raw_ptr()
+        desc_base = o_desc_words.iterator.raw_ptr()
+        src_words = Pointer(base_o_desc.get_ptr(), dtype=cutlass.Int64)
+        row_elems = o_row_stride
+        for b in cutlass.range(0, n_batch, 1, unroll=1):
+            dptr = desc_base + b * cutlass.Int32(TENSOR_MAP_QWORDS)
+            for i in cutlass.range_constexpr(TENSOR_MAP_QWORDS):
+                (dptr + i).store((src_words + i).load())
+            cu_q_b = cutlass.Int32(meta[cuq0 + b])
+            s_i = cutlass.Int32(meta[cuq0 + b + cutlass.Int32(1)]) - cu_q_b
+            row_base = o_ptr + cu_q_b * row_elems
+            nvvm.tensormap_replace(
+                nvvm.TensormapField.GLOBAL_ADDRESS,
+                dptr,
+                new_value=row_base.toint(cutlass.Int64),
+            )
+            nvvm.tensormap_replace(
+                nvvm.TensormapField.GLOBAL_DIM,
+                dptr,
+                new_value=s_i,
+                ord=2,
+            )
+        t_kv = cutlass.Int32(meta[cutlass.Int32(3) * n_batch + cutlass.Int32(1)])  # cu_k[B]
+        k_dptr = desc_base + (n_batch + cutlass.Int32(1)) * cutlass.Int32(TENSOR_MAP_QWORDS)
+        k_src = Pointer(base_k_desc.get_ptr(), dtype=cutlass.Int64)
+        for i in cutlass.range_constexpr(TENSOR_MAP_QWORDS):
+            (k_dptr + i).store((k_src + i).load())
+        nvvm.tensormap_replace(nvvm.TensormapField.GLOBAL_DIM, k_dptr, new_value=t_kv, ord=2)
+        v_dptr = desc_base + (n_batch + cutlass.Int32(2)) * cutlass.Int32(TENSOR_MAP_QWORDS)
+        v_src = Pointer(base_v_desc.get_ptr(), dtype=cutlass.Int64)
+        for i in cutlass.range_constexpr(TENSOR_MAP_QWORDS):
+            (v_dptr + i).store((v_src + i).load())
+        nvvm.tensormap_replace(nvvm.TensormapField.GLOBAL_DIM, v_dptr, new_value=t_kv, ord=2)
+        nvvm.fence_proxy_release(
+            nvvm.MemScope.GPU,
+            from_proxy=nvvm.Proxy.GENERIC,
+            to_proxy=nvvm.Proxy.TENSORMAP,
+        )
+
+
+@cute.kernel
 def build_thd_meta_o_descs_kernel(
     o_tensor: cute.Tensor,
     base_o_desc: cutlass.GridConstant[tmap.TensorMap],

--- a/python/pygraph/pygraph.h
+++ b/python/pygraph/pygraph.h
@@ -558,7 +558,12 @@ class PyGraph {
                py::object const& generate_stats,
                std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> sink_token,
                bool const unfuse_fma,
-               cudnn_frontend::AttentionImplementation_t const& implementation);
+               cudnn_frontend::AttentionImplementation_t const& implementation,
+               bool const use_padding_mask,
+               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& seq_len_q,
+               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& seq_len_kv,
+               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_q,
+               std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_kv);
 
     // return [dQ, dK, dV, amax_dQ, amax_dK, amax_dV, amax_dP]
     // dSink_token is an optional output set via set_dsink_token() attribute

--- a/python/pygraph/sdpa.cpp
+++ b/python/pygraph/sdpa.cpp
@@ -661,9 +661,31 @@ PyGraph::sdpa_mxfp8(std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& q
                     py::object const& generate_stats,
                     std::shared_ptr<cudnn_frontend::graph::Tensor_attributes> sink_token,
                     bool const unfuse_fma,
-                    cudnn_frontend::AttentionImplementation_t const& implementation) {
+                    cudnn_frontend::AttentionImplementation_t const& implementation,
+                    bool const use_padding_mask,
+                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& seq_len_q,
+                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& seq_len_kv,
+                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_q,
+                    std::shared_ptr<cudnn_frontend::graph::Tensor_attributes>& cu_seq_len_kv) {
     auto attributes =
         cudnn_frontend::graph::SDPA_fp8_attributes().set_name(name).set_compute_data_type(compute_data_type);
+
+    // Padding mask (per-batch valid lengths, or their (B+1,) cu prefix-sum
+    // form). Also the length carrier for THD/ragged graphs (ragged offsets
+    // are set on the tensors themselves).
+    attributes.set_padding_mask(use_padding_mask);
+    if (seq_len_q) {
+        attributes.set_seq_len_q(seq_len_q);
+    }
+    if (seq_len_kv) {
+        attributes.set_seq_len_kv(seq_len_kv);
+    }
+    if (cu_seq_len_q) {
+        attributes.set_cu_seq_len_q(cu_seq_len_q);
+    }
+    if (cu_seq_len_kv) {
+        attributes.set_cu_seq_len_kv(cu_seq_len_kv);
+    }
 
     // Handle causal mask settings
     cudnn_frontend::DiagonalAlignment_t actual_diagonal_alignment = diagonal_alignment;
@@ -1348,6 +1370,11 @@ init_pygraph_sdpa_submodule(py::class_<PyGraph>& m) {
           py::arg_v("sink_token", nullptr),
           py::arg_v("unfuse_fma", false),
           py::arg_v("implementation", cudnn_frontend::AttentionImplementation_t::AUTO),
+          py::arg_v("use_padding_mask", false),
+          py::arg_v("seq_len_q", nullptr),
+          py::arg_v("seq_len_kv", nullptr),
+          py::arg_v("cu_seq_len_q", nullptr),
+          py::arg_v("cu_seq_len_kv", nullptr),
           R"pbdoc(
                 Perform MXFP8 (Microscaling FP8) scaled dot product attention.
 
@@ -1388,6 +1415,9 @@ init_pygraph_sdpa_submodule(py::class_<PyGraph>& m) {
                     sink_token (Optional[cudnn_tensor]): Sink token bias for streaming attention. Shape is (1, h_q, 1, 1), type is float32. Default is None.
                     unfuse_fma (Optional[bool]): For SM100: use unfused __fmul_rn + __fadd_rn instead of ffma2 in softmax. Default is False.
                     implementation (Optional[cudnn.attention_implementation]): Which underlying implementation to use in the cuDNN backend. Default is AUTO (recommended).
+                    use_padding_mask (Optional[bool]): Whether per-batch valid lengths mask the attention. Default is False.
+                    seq_len_q (Optional[cudnn_tensor]): The per-batch valid sequence lengths of Q (int32, shape (B, 1, 1, 1)). Required with use_padding_mask and for THD/ragged inputs. Default is None.
+                    seq_len_kv (Optional[cudnn_tensor]): The per-batch valid sequence lengths of K/V (int32, shape (B, 1, 1, 1)). Required with use_padding_mask and for THD/ragged inputs. Default is None.
 
                 Returns:
                     o (cudnn_tensor): The output data.

--- a/python/pygraph/sdpa.cpp
+++ b/python/pygraph/sdpa.cpp
@@ -1418,6 +1418,8 @@ init_pygraph_sdpa_submodule(py::class_<PyGraph>& m) {
                     use_padding_mask (Optional[bool]): Whether per-batch valid lengths mask the attention. Default is False.
                     seq_len_q (Optional[cudnn_tensor]): The per-batch valid sequence lengths of Q (int32, shape (B, 1, 1, 1)). Required with use_padding_mask and for THD/ragged inputs. Default is None.
                     seq_len_kv (Optional[cudnn_tensor]): The per-batch valid sequence lengths of K/V (int32, shape (B, 1, 1, 1)). Required with use_padding_mask and for THD/ragged inputs. Default is None.
+                    cu_seq_len_q (Optional[cudnn_tensor]): Cumulative sequence length of Q, shape (B+1, 1, 1, 1), int32. Mutually exclusive with seq_len_q; pair with a KV-side length tensor and set use_padding_mask=True. Requires cuDNN 9.24 or above. Default is None.
+                    cu_seq_len_kv (Optional[cudnn_tensor]): Cumulative sequence length of K/V, shape (B+1, 1, 1, 1), int32. Mutually exclusive with seq_len_kv; pair with a Q-side length tensor and set use_padding_mask=True. Requires cuDNN 9.24 or above. Default is None.
 
                 Returns:
                     o (cudnn_tensor): The output data.

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -24,12 +24,12 @@ pytestmark = [pytest.mark.L0, requires_dsl]
 _E4M3, _BF16_OUT = 0, 2
 
 
-def _load(rubin):
+def _load(rubin, **params):
     from cudnn.sdpa.fwd.api_dsl import _load_sm100_kernel_module
 
     return _load_sm100_kernel_module(
         (128, 128),
-        TemplateParams(dtype_qkv=_E4M3, dtype_o=_BF16_OUT),
+        TemplateParams(dtype_qkv=_E4M3, dtype_o=_BF16_OUT, **params),
         fp8=True,
         pertensor=True,
         rubin=rubin,
@@ -56,3 +56,16 @@ def test_sm100_module_unchanged():
 def test_sm107_per_tensor_fp8_advertises_only_d128():
     assert _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7)) == frozenset({(128, 128)})
     assert (192, 128) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
+
+
+@pytest.mark.parametrize("rubin", [True, False], ids=["sm107", "sm100"])
+def test_fp8_thd_leg_loads(rubin):
+    """The write_thd_meta THD leg (issue #552) is baked into BOTH fp8 d128
+    siblings: a THD specialization template-loads with the flag folded in and
+    exports the envelope tile constant the adapter's plan-time grid derives
+    from. End-to-end THD numerics ride test_sdpa_fwd_fp8_sm100.py on whichever
+    SM10x part is present (Rubin included) through the same adapter."""
+    mod = _load(rubin=rubin, thd_varlen=True, seq_kv_lens_present=True)
+    assert mod.CFG.THD_VARLEN == 1
+    assert mod.CFG.SEQ_KV_LENS_PRESENT == 1  # THD overloads the metadata buffer
+    assert mod.CGA_TILE_M == mod.CFG.TILES_Q * mod.CFG.TILE_M * mod.CFG.CTA_MMA

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -9,8 +9,10 @@ reference. ``Amax_O`` is produced in-kernel (atomicMax over the pre-cast fp32 va
 and checked.
 
 cuDNN's ``sdpa_fp8`` op exposes causal / bottom-right / sliding-window masks, attention
-sink, and a padding mask (per-batch ``seq_len_kv`` → KV-side masking, tested here). THD /
-ragged inputs are still deferred (engine declares thd=False).
+sink, a padding mask (per-batch ``seq_len_kv`` → KV-side masking, tested here), and THD /
+ragged inputs (packed Q/K/V/O + per-operand ragged_offset + seq_len_q/kv or the
+cu_seq_len prefix-sum form, tested here — write_thd_meta envelope design, issue #552;
+ragged Stats in the packed token-major TH1 layout).
 
 Requires: SM100 (Blackwell), cutlass-dsl, cuDNN >= 9.21 (fp8 SDPA). Skips otherwise.
 """
@@ -361,6 +363,230 @@ def test_fp8_stats_less_zero_workspace(in_key):
     scale = 1.0 / math.sqrt(128)
     out, o_ref, a_o, a_o_ref = _run(2, 8, 8, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), stats=False)
     _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, *, scale, causal=False, sink=None, stats=False, cu_lens=False):
+    """THD/varlen: packed [T,H,D] Q/K/V/O + per-operand ragged_offset + per-batch
+    lengths (or their cu prefix-sum form).
+
+    Per-tensor quantization of the packed tokens (one scalar per operand —
+    identical semantics to the dense per-tensor path). Returns the packed frost
+    O, the packed fp32 reference, the (amax_o, amax_o_ref) pair, and — with
+    ``stats`` — the packed token-major (T, H) LSE next to its natural-log
+    reference."""
+    import cudnn
+
+    dev = "cuda"
+    D = 128
+    B = len(seq_lens_q)
+    S_max_q, S_max_kv = max(seq_lens_q), max(seq_lens_kv)
+    T_q, T_kv = sum(seq_lens_q), sum(seq_lens_kv)
+
+    def _cu(sl):
+        c = [0]
+        for s in sl:
+            c.append(c[-1] + s)
+        return c
+
+    cu_q, cu_k = _cu(seq_lens_q), _cu(seq_lens_kv)
+
+    q_pk = torch.randn(T_q, H_q, D, device=dev) * 0.5
+    k_pk = torch.randn(T_kv, H_kv, D, device=dev) * 0.5
+    v_pk = torch.randn(T_kv, H_kv, D, device=dev) * 0.5
+    q8, dq = _quant(q_pk, in_key)
+    k8, dk = _quant(k_pk, in_key)
+    v8, dv = _quant(v_pk, in_key)
+
+    def _dense_buf(packed, s_max, h, dt):
+        # Dense-capacity storage; packed tokens in the leading elements (THD contract).
+        stride = (s_max * h * D, D, h * D, 1)
+        stor = torch.zeros(B * s_max * h * D, device=dev, dtype=dt)
+        stor[: packed.numel()] = packed.reshape(-1)
+        return stor, stor.as_strided((B, h, s_max, D), stride), stride
+
+    _, q_gpu, stride_q = _dense_buf(q8, S_max_q, H_q, q8.dtype)
+    _, k_gpu, stride_kv = _dense_buf(k8, S_max_kv, H_kv, k8.dtype)
+    _, v_gpu, _ = _dense_buf(v8, S_max_kv, H_kv, v8.dtype)
+    o_stor = torch.zeros(B * S_max_q * H_q * D, device=dev, dtype=torch.float16)
+    o_gpu = o_stor.as_strided((B, H_q, S_max_q, D), stride_q)
+    amax_o = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
+
+    slq = torch.tensor(seq_lens_q, dtype=torch.int32, device=dev).view(B, 1, 1, 1)
+    slk = torch.tensor(seq_lens_kv, dtype=torch.int32, device=dev).view(B, 1, 1, 1)
+    cuq_t = torch.tensor(cu_q, dtype=torch.int32, device=dev).view(B + 1, 1, 1, 1)
+    cuk_t = torch.tensor(cu_k, dtype=torch.int32, device=dev).view(B + 1, 1, 1, 1)
+    ro_q = (torch.tensor(cu_q, dtype=torch.int64, device=dev) * H_q * D).view(B + 1, 1, 1, 1)
+    ro_k = (torch.tensor(cu_k, dtype=torch.int64, device=dev) * H_kv * D).view(B + 1, 1, 1, 1)
+
+    def sc(val):
+        return torch.tensor([[[[val]]]], dtype=torch.float32, device=dev)
+
+    io = getattr(cudnn.data_type, _CUDNN_ITYPE[in_key])
+    g = cudnn.pygraph(io_data_type=io, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    tq = g.tensor(dim=[B, H_q, S_max_q, D], stride=list(stride_q), data_type=io, name="q")
+    tk = g.tensor(dim=[B, H_kv, S_max_kv, D], stride=list(stride_kv), data_type=io, name="k")
+    tv = g.tensor(dim=[B, H_kv, S_max_kv, D], stride=list(stride_kv), data_type=io, name="v")
+    sq_h = g.tensor_like(cuq_t if cu_lens else slq)
+    skv_h = g.tensor_like(cuk_t if cu_lens else slk)
+    qro, kro, vro, oro = (g.tensor_like(ro_q) for _ in range(4))
+    tq.set_ragged_offset(qro)
+    tk.set_ragged_offset(kro)
+    tv.set_ragged_offset(vro)
+
+    def _stns():
+        return g.tensor(dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.FLOAT)
+
+    dqn, dkn, dvn, dsn, ssn, son = (_stns() for _ in range(6))
+    kw = dict(
+        q=tq,
+        k=tk,
+        v=tv,
+        descale_q=dqn,
+        descale_k=dkn,
+        descale_v=dvn,
+        descale_s=dsn,
+        scale_s=ssn,
+        scale_o=son,
+        attn_scale=scale,
+        generate_stats=stats,
+        use_padding_mask=True,
+    )
+    if cu_lens:
+        kw.update(cu_seq_len_q=sq_h, cu_seq_len_kv=skv_h)
+    else:
+        kw.update(seq_len_q=sq_h, seq_len_kv=skv_h)
+    if causal:
+        kw["use_causal_mask"] = True
+    vp = {
+        tq: q_gpu,
+        tk: k_gpu,
+        tv: v_gpu,
+        dqn: sc(dq),
+        dkn: sc(dk),
+        dvn: sc(dv),
+        dsn: sc(1.0),
+        ssn: sc(1.0),
+        son: sc(1.0),
+        sq_h: (cuq_t if cu_lens else slq),
+        skv_h: (cuk_t if cu_lens else slk),
+        qro: ro_q,
+        kro: ro_k,
+        vro: ro_k,
+        oro: ro_q,
+    }
+    if sink is not None:
+        st = g.tensor_like(sink)
+        kw["sink_token"] = st
+        vp[st] = sink
+    o, stats_t, _amx_s_unused, amx_o = g.sdpa_fp8(**kw)  # Amax_S: not requested (engines decline graphs that declare it)
+    o.set_output(True).set_dim([B, H_q, S_max_q, D]).set_stride(list(stride_q)).set_data_type(cudnn.data_type.HALF)
+    o.set_ragged_offset(oro)
+    amx_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
+    stats_stor = None
+    if stats:
+        # Ragged Stats, packed token-major TH1 ([t, h]; offsets = cu_q * h_q).
+        stats_stor = torch.zeros(B * S_max_q * H_q, dtype=torch.float32, device=dev)
+        stats_t.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+        stats_t.set_dim((B, H_q, S_max_q, 1)).set_stride((S_max_q * H_q, 1, H_q, 1))
+        stats_ro_t = (ro_q.flatten() // D).view(B + 1, 1, 1, 1).contiguous()
+        stats_ro = g.tensor_like(stats_ro_t, name="stats_ro")
+        stats_t.set_ragged_offset(stats_ro)
+        vp[stats_ro] = stats_ro_t
+        vp[stats_t] = stats_stor
+
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    _select_engine(g, engine_name(128, fp8=True))
+    g.check_support()
+    g.build_plans()
+    vp.update({o: o_gpu, amx_o: amax_o})
+    g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8))
+    torch.cuda.synchronize()
+
+    o_ref = torch.zeros(T_q, H_q, D, device=dev, dtype=torch.float32)
+    lse_ref = torch.zeros(T_q, H_q, dtype=torch.float32, device=dev)
+    for b in range(B):
+        qb = (q8[cu_q[b] : cu_q[b + 1]].float() * dq).permute(1, 0, 2).unsqueeze(0)
+        kb = (k8[cu_k[b] : cu_k[b + 1]].float() * dk).permute(1, 0, 2).unsqueeze(0)
+        vb = (v8[cu_k[b] : cu_k[b + 1]].float() * dv).permute(1, 0, 2).unsqueeze(0)
+        ref_kw = dict(is_causal=True) if causal else {}
+        if sink is not None:
+            ref_kw["sinks"] = sink.flatten()
+        ob = _ref(qb, kb, vb, scale=scale, **ref_kw)
+        o_ref[cu_q[b] : cu_q[b + 1]] = ob.squeeze(0).permute(1, 0, 2)
+        if stats:
+            lse_ref[cu_q[b] : cu_q[b + 1]] = _ref_lse(qb, kb, scale=scale, causal=causal, sinks=(sink.flatten() if sink is not None else None)).squeeze(0).T
+
+    o_out = o_stor[: T_q * H_q * D].reshape(T_q, H_q, D)
+    lse_out = stats_stor[: T_q * H_q].reshape(T_q, H_q) if stats else None
+    return o_out, o_ref, amax_o.item(), o_ref.abs().max().item(), lse_out, (lse_ref if stats else None)
+
+
+def _ref_lse(qd, kd, *, scale, causal, sinks=None):
+    """Natural-log LSE reference over per-sequence scores, [1, H, S_q]."""
+    _, h_q, s_q, _ = qd.shape
+    _, h_kv, s_kv, _ = kd.shape
+    dev = qd.device
+    k_e = kd.repeat_interleave(h_q // h_kv, dim=1)
+    scores = torch.matmul(qd, k_e.transpose(-1, -2)) * scale
+    if causal:
+        i = torch.arange(s_q, device=dev).view(1, 1, s_q, 1)
+        j = torch.arange(s_kv, device=dev).view(1, 1, 1, s_kv)
+        scores = scores.masked_fill(j > i, float("-inf"))
+    if sinks is not None:
+        col = sinks.view(1, h_q, 1, 1).float().expand(1, h_q, s_q, 1).to(dev)
+        scores = torch.cat([scores, col], dim=-1)
+    return torch.logsumexp(scores, dim=-1)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("causal", [False, True])
+@torch_fork_set_rng(seed=0)
+def test_fp8_thd(in_key, causal):
+    """THD/varlen self-attention: two packed sequences of unequal, tile-ragged length."""
+    scale = 1.0 / math.sqrt(128)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, in_key, scale=scale, causal=causal)
+    _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_thd_cross_gqa():
+    """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
+    scale = 1.0 / math.sqrt(128)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", scale=scale)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_thd_sink():
+    """THD causal + attention sink."""
+    scale = 1.0 / math.sqrt(128)
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", scale=scale, causal=True, sink=sink)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_thd_stats():
+    """THD + generate_stats: the ragged token-major TH1 LSE is written next to O."""
+    scale = 1.0 / math.sqrt(128)
+    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", scale=scale, causal=True, stats=True)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+    torch.testing.assert_close(lse, lse_ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_thd_cu_seq_len():
+    """THD via the (B+1,) cu_seq_len prefix-sum length form."""
+    scale = 1.0 / math.sqrt(128)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([200, 150], [180, 120], 8, 8, "e4m3", scale=scale, cu_lens=True)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -398,9 +398,14 @@ def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, *, scale, causal=False,
     v8, dv = _quant(v_pk, in_key)
 
     def _dense_buf(packed, s_max, h, dt):
-        # Dense-capacity storage; packed tokens in the leading elements (THD contract).
+        # Dense-capacity storage; packed tokens in the leading elements (THD
+        # contract). The capacity tail is NaN-POISONED (test_mhas_v2 parity):
+        # the last sequence's KV tile steps past the packed total, and those
+        # tail loads must land as zeros through the setup kernel's
+        # packed-total-clamped K/V descriptors — a leaked NaN would wipe the
+        # tile via BMM2's P·V (0 · NaN == NaN).
         stride = (s_max * h * D, D, h * D, 1)
-        stor = torch.zeros(B * s_max * h * D, device=dev, dtype=dt)
+        stor = torch.full((B * s_max * h * D,), float("nan"), device=dev, dtype=torch.float32).to(dt)
         stor[: packed.numel()] = packed.reshape(-1)
         return stor, stor.as_strided((B, h, s_max, D), stride), stride
 
@@ -507,6 +512,14 @@ def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, *, scale, causal=False,
     o_ref = torch.zeros(T_q, H_q, D, device=dev, dtype=torch.float32)
     lse_ref = torch.zeros(T_q, H_q, dtype=torch.float32, device=dev)
     for b in range(B):
+        if cu_q[b + 1] == cu_q[b]:
+            continue
+        if cu_k[b + 1] == cu_k[b]:
+            # Zero-length KV: every Q row of the sequence is dead — O := 0
+            # (o_ref is pre-zeroed) and, sink-less, LSE := -inf.
+            if stats:
+                lse_ref[cu_q[b] : cu_q[b + 1]] = sink.flatten().to(lse_ref) if sink is not None else float("-inf")
+            continue
         qb = (q8[cu_q[b] : cu_q[b + 1]].float() * dq).permute(1, 0, 2).unsqueeze(0)
         kb = (k8[cu_k[b] : cu_k[b + 1]].float() * dk).permute(1, 0, 2).unsqueeze(0)
         vb = (v8[cu_k[b] : cu_k[b + 1]].float() * dv).permute(1, 0, 2).unsqueeze(0)
@@ -578,6 +591,21 @@ def test_fp8_thd_stats():
     out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", scale=scale, causal=True, stats=True)
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
     torch.testing.assert_close(lse, lse_ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_thd_zero_len_kv():
+    """Zero-length Q and KV sequences (test_mhas_v2 ragged parity, e.g.
+    seq_len_q=[126, 0, 60] / seq_len_kv=[0, 83, 77]): the zero-KV sequence's
+    rows are dead — the epilogue must come back O := 0 / LSE := -inf, not the
+    unwritten O TMEM (garbage survives `* inv_sum(=0)` when it is NaN)."""
+    scale = 1.0 / math.sqrt(128)
+    out, o_ref, a_o, a_o_ref, lse, lse_ref = _run_thd([126, 40, 60], [0, 83, 77], 8, 8, "e4m3", scale=scale, stats=True)
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+    torch.testing.assert_close(lse, lse_ref, atol=2e-2, rtol=2e-2, equal_nan=False)
+    out, o_ref, a_o, a_o_ref, _, _ = _run_thd([126, 0, 60], [0, 83, 77], 8, 8, "e5m2", scale=scale)
+    _check(out, o_ref, torch.float16, "e5m2", a_o, a_o_ref)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -12,8 +12,13 @@ reach the engine in cuDNN's F8_128x4 reordering. TransformerEngine is NOT
 required.
 
 cuDNN's ``sdpa_mxfp8`` op exposes causal / bottom-right / sliding-window masks +
-attention sink, but NOT a padding mask or THD/ragged inputs — so those are out of
-scope here (and the engine declares thd=False to match).
+attention sink, and (frontend extension) ``use_padding_mask``/``seq_len_q``/
+``seq_len_kv`` — which also carry THD/ragged inputs (packed Q/K/V/O + per-operand
+ragged_offset, tested here, incl. the cu_seq_len prefix-sum form). THD scale
+factors travel PACKED: per head, each sequence's TILE(128-row)-padded F8_128x4
+SF tiles concatenated in cu_seqlens order (the F8_128x4 atom padding rounds each
+sequence's SF to whole 128-row tiles, so the dense per-sequence quantizer output
+concatenates directly). Ragged Stats use the packed token-major TH1 layout.
 
 Requires: SM100 (Blackwell), cutlass-dsl, cuDNN >= 9.21 (mxfp8 support).
 Skips cleanly otherwise.
@@ -64,7 +69,7 @@ def _quantize(t, b, h, s, d, fp8, *, columnwise):
     return data_d, swz_d, dq, (s_pad, d_scale_pad)
 
 
-def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=None, sinks=None):
+def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=None, sinks=None, seq_lens_kv=None):
     """fp32 reference matching the kernel's mask + sink semantics (BHSD; GQA-aware)."""
     b, h_q, s_q, _ = qd.shape
     _, h_kv, s_kv, _ = vd.shape
@@ -81,6 +86,10 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
         masked = masked | (j > lim)
     if swa_window is not None:
         masked = masked | (j < i - swa_window)
+    if seq_lens_kv is not None:
+        # Per-batch KV padding: columns j >= seq_len_kv[b] are padding -> masked.
+        slk = torch.as_tensor(seq_lens_kv, device=dev, dtype=torch.long).view(b, 1, 1, 1)
+        masked = masked | (j >= slk)
     scores = scores.masked_fill(masked, float("-inf"))
     if sinks is not None:
         col = sinks.view(1, h_q, 1, 1).float().expand(b, h_q, s_q, 1).to(dev)
@@ -89,7 +98,7 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     return torch.matmul(torch.softmax(scores, dim=-1), v_e)
 
 
-def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, stats=True, d_qk=128, d_v=128):
+def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, stats=True, seq_lens_kv=None, d_qk=128, d_v=128):
     """Quantize, build the sdpa_mxfp8 graph, route to the frost engine, execute.
     Returns (O_frost [B,H,S,D] on device, O_ref fp32 [B,H,S,D])."""
     import cudnn
@@ -138,6 +147,16 @@ def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, stat
         st = g.tensor_like(sink)
         kw["sink_token"] = st
         vp[st] = sink
+    if seq_lens_kv is not None:
+        # KV padding (frontend extension on sdpa_mxfp8): full (unpadded) query
+        # lengths + per-batch valid KV lengths.
+        slq = torch.full((B, 1, 1, 1), S, dtype=torch.int32, device=dev)
+        slk = torch.tensor(seq_lens_kv, dtype=torch.int32, device=dev).reshape(B, 1, 1, 1)
+        sq_h = g.tensor(dim=[B, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+        skv_h = g.tensor(dim=[B, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.INT32)
+        kw.update(use_padding_mask=True, seq_len_q=sq_h, seq_len_kv=skv_h)
+        vp[sq_h] = slq
+        vp[skv_h] = slk
     kw.update(sdpa_kwargs)
     o, stats_t, amax_o = g.sdpa_mxfp8(**kw)
     o.set_output(True).set_dim(list(Ob.shape)).set_stride(list(Ob.stride())).set_data_type(otype)
@@ -164,7 +183,7 @@ def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, stat
     ref_kwargs = {k2: v2 for k2, v2 in _ref_from_sdpa(sdpa_kwargs).items()}
     if sink is not None:
         ref_kwargs["sinks"] = sink.flatten()
-    o_ref = _ref(Q8.float() * dqq, K8.float() * dqk, V8.float() * dqv, scale=scale, **ref_kwargs)
+    o_ref = _ref(Q8.float() * dqq, K8.float() * dqk, V8.float() * dqv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kwargs)
     return Ob, o_ref, amax
 
 
@@ -450,3 +469,265 @@ def _run_rect(B, H, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, d_qk=128, 
     torch.cuda.synchronize()
     o_ref = _ref(Q8.float() * dqq, K8.float() * dqk, V8.float() * dqv, scale=scale, is_causal=True, bottom_right=True)
     return Ob, o_ref, amax
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("causal", [False, True])
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_dense_padding(in_key, causal):
+    """Dense KV padding mask (frontend extension on sdpa_mxfp8): batch 0 uses all
+    256 KV cols, batch 1 only 192 (a partial KV tile). Padded columns must not
+    leak into the softmax or the in-kernel Amax_O. Stats stay off (padded+stats
+    needs the per-batch LSE trim, which this cell does not declare)."""
+    scale = 1.0 / math.sqrt(128)
+    sk = dict(use_causal_mask=True) if causal else {}
+    O, O_ref, amax = _run(2, 8, 8, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=sk, seq_lens_kv=[256, 192], stats=False)
+    _check(O, O_ref, torch.float16, in_key)
+    assert abs(amax.item() - O_ref.abs().max().item()) <= 0.03
+
+
+def _quantize_seq(t_1hsd, h, s, d, fp8, *, columnwise):
+    """Per-sequence MXFP8 quantization for the THD packing.
+
+    Returns (fp8_data [1,h,s,d], per-elem dequant scale [1,h,s,d], SF tiles
+    [h, n_tiles, SF_SMEM] uint8) where n_tiles = ceil(s/128): the quantizer's
+    F8_128x4 atom padding rounds the S extent up to a multiple of 128, i.e.
+    exactly the kernel's per-sequence-TILE-padded SF layout."""
+    from sdpa.mxfp8_quant import quantize_to_mxfp8
+
+    data_d, dq_d, swz_d, data_s, dq_s, swz_s = quantize_to_mxfp8(t_1hsd, 1, h, s, d, _BLOCK, fp8, with_ref=True)
+    n_tiles = _cdiv(s, 128)
+    if columnwise:
+        return data_s, dq_s.reshape(1, h, s, d), swz_s.view(torch.uint8).reshape(h, n_tiles, -1)
+    return data_d, dq_d.reshape(1, h, s, d), swz_d.view(torch.uint8).reshape(h, n_tiles, -1)
+
+
+def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, out_dt, *, scale, causal=False, sink=None, stats=False, cu_lens=False):
+    """THD/varlen: packed [T,H,D] Q/K/V/O + ragged offsets + per-batch lengths
+    (or their cu prefix-sum form) + PACKED per-sequence-TILE-padded SF."""
+    import cudnn
+
+    dev = "cuda"
+    D = 128
+    fp8 = _FP8[in_key]
+    B = len(seq_lens_q)
+    S_max_q, S_max_kv = max(seq_lens_q), max(seq_lens_kv)
+    T_q = sum(seq_lens_q)
+
+    def _cu(sl):
+        c = [0]
+        for s in sl:
+            c.append(c[-1] + s)
+        return c
+
+    cu_q, cu_k = _cu(seq_lens_q), _cu(seq_lens_kv)
+
+    # Per-sequence quantization; pack the fp8 tokens and, per head, the
+    # TILE-padded SF tiles in cu_seqlens order.
+    q8_seqs, k8_seqs, v8_seqs, dq_seqs, dk_seqs, dv_seqs = [], [], [], [], [], []
+    sfq_seqs, sfk_seqs, sfv_seqs = [], [], []
+    for b in range(B):
+        s_q, s_kv = seq_lens_q[b], seq_lens_kv[b]
+        Qf = torch.randn(1, H_q, s_q, D, device=dev) * 0.5
+        Kf = torch.randn(1, H_kv, s_kv, D, device=dev) * 0.5
+        Vf = torch.randn(1, H_kv, s_kv, D, device=dev) * 0.5
+        q8, dqq, sfq = _quantize_seq(Qf, H_q, s_q, D, fp8, columnwise=False)
+        k8, dqk, sfk = _quantize_seq(Kf, H_kv, s_kv, D, fp8, columnwise=False)
+        v8, dqv, sfv = _quantize_seq(Vf, H_kv, s_kv, D, fp8, columnwise=True)
+        q8_seqs.append(q8)
+        k8_seqs.append(k8)
+        v8_seqs.append(v8)
+        dq_seqs.append(dqq)
+        dk_seqs.append(dqk)
+        dv_seqs.append(dqv)
+        sfq_seqs.append(sfq)
+        sfk_seqs.append(sfk)
+        sfv_seqs.append(sfv)
+
+    def _pack_tokens(x8_seqs):
+        # [1,h,s,d] per sequence -> packed [T,h,D] tokens.
+        return torch.cat([x.squeeze(0).permute(1, 0, 2) for x in x8_seqs], dim=0)
+
+    q_pk = _pack_tokens(q8_seqs)
+    k_pk = _pack_tokens(k8_seqs)
+    v_pk = _pack_tokens(v8_seqs)
+    # Packed SF: [h, total_tiles, SF_SMEM] — per head, sequences' tiles in
+    # cu_seqlens order. The buffer is EXACTLY the packed layout (the engine
+    # derives the packed tile extent from its byte size).
+    sfq_pk = torch.cat(sfq_seqs, dim=1).contiguous()
+    sfk_pk = torch.cat(sfk_seqs, dim=1).contiguous()
+    sfv_pk = torch.cat(sfv_seqs, dim=1).contiguous()
+
+    def _dense_buf(packed, s_max, h, dt):
+        stride = (s_max * h * D, D, h * D, 1)
+        stor = torch.zeros(B * s_max * h * D, device=dev, dtype=dt)
+        stor[: packed.numel()] = packed.reshape(-1)
+        return stor, stor.as_strided((B, h, s_max, D), stride), stride
+
+    _, q_gpu, stride_q = _dense_buf(q_pk, S_max_q, H_q, q_pk.dtype)
+    _, k_gpu, stride_kv = _dense_buf(k_pk, S_max_kv, H_kv, k_pk.dtype)
+    _, v_gpu, _ = _dense_buf(v_pk, S_max_kv, H_kv, v_pk.dtype)
+    o_stor = torch.zeros(B * S_max_q * H_q * D, device=dev, dtype=out_dt)
+    o_gpu = o_stor.as_strided((B, H_q, S_max_q, D), stride_q)
+    amax = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
+
+    slq = torch.tensor(seq_lens_q, dtype=torch.int32, device=dev).view(B, 1, 1, 1)
+    slk = torch.tensor(seq_lens_kv, dtype=torch.int32, device=dev).view(B, 1, 1, 1)
+    cuq_t = torch.tensor(cu_q, dtype=torch.int32, device=dev).view(B + 1, 1, 1, 1)
+    cuk_t = torch.tensor(cu_k, dtype=torch.int32, device=dev).view(B + 1, 1, 1, 1)
+    ro_q = (torch.tensor(cu_q, dtype=torch.int64, device=dev) * H_q * D).view(B + 1, 1, 1, 1)
+    ro_k = (torch.tensor(cu_k, dtype=torch.int64, device=dev) * H_kv * D).view(B + 1, 1, 1, 1)
+
+    io = getattr(cudnn.data_type, _CUDNN_ITYPE[in_key])
+    g = cudnn.pygraph(io_data_type=io, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    tq = g.tensor(dim=[B, H_q, S_max_q, D], stride=list(stride_q), data_type=io, name="q")
+    tk = g.tensor(dim=[B, H_kv, S_max_kv, D], stride=list(stride_kv), data_type=io, name="k")
+    tv = g.tensor(dim=[B, H_kv, S_max_kv, D], stride=list(stride_kv), data_type=io, name="v")
+    sq_h = g.tensor_like(cuq_t if cu_lens else slq)
+    skv_h = g.tensor_like(cuk_t if cu_lens else slk)
+    qro, kro, vro, oro = (g.tensor_like(ro_q) for _ in range(4))
+    tq.set_ragged_offset(qro)
+    tk.set_ragged_offset(kro)
+    tv.set_ragged_offset(vro)
+
+    def _sf(dims):
+        # Dense-capacity declaration; the bound buffer holds the PACKED layout
+        # (same convention as the ragged Q/K/V storage).
+        return g.tensor(
+            dim=list(dims),
+            stride=[dims[1] * dims[2] * dims[3], dims[2] * dims[3], dims[3], 1],
+            data_type=cudnn.data_type.FP8_E8M0,
+            reordering_type=cudnn.tensor_reordering.F8_128x4,
+        )
+
+    dsc = _cdiv(_cdiv(D, _BLOCK), 4) * 4
+    dvp = dsc * _BLOCK
+    dq = _sf((B, H_q, _cdiv(S_max_q, 128) * 128, dsc))
+    dk = _sf((B, H_kv, _cdiv(S_max_kv, 128) * 128, dsc))
+    dv = _sf((B, H_kv, _cdiv(S_max_kv, 128) * 4, dvp))
+    kw = dict(
+        q=tq,
+        k=tk,
+        v=tv,
+        descale_q=dq,
+        descale_k=dk,
+        descale_v=dv,
+        attn_scale=scale,
+        generate_stats=stats,
+        use_padding_mask=True,
+    )
+    if cu_lens:
+        kw.update(cu_seq_len_q=sq_h, cu_seq_len_kv=skv_h)
+    else:
+        kw.update(seq_len_q=sq_h, seq_len_kv=skv_h)
+    if causal:
+        kw["use_causal_mask"] = True
+    vp = {
+        tq: q_gpu,
+        tk: k_gpu,
+        tv: v_gpu,
+        dq: sfq_pk,
+        dk: sfk_pk,
+        dv: sfv_pk,
+        sq_h: (cuq_t if cu_lens else slq),
+        skv_h: (cuk_t if cu_lens else slk),
+        qro: ro_q,
+        kro: ro_k,
+        vro: ro_k,
+        oro: ro_q,
+    }
+    if sink is not None:
+        st = g.tensor_like(sink)
+        kw["sink_token"] = st
+        vp[st] = sink
+    o, stats_t, amax_o = g.sdpa_mxfp8(**kw)
+    o.set_output(True).set_dim([B, H_q, S_max_q, D]).set_stride(list(stride_q)).set_data_type(getattr(cudnn.data_type, _CUDNN_OTYPE[out_dt]))
+    o.set_ragged_offset(oro)
+    amax_o.set_output(True).set_dim([1, 1, 1, 1]).set_stride([1, 1, 1, 1]).set_data_type(cudnn.data_type.FLOAT)
+    stats_stor = None
+    if stats:
+        # Ragged Stats, packed token-major TH1 ([t, h]; offsets = cu_q * h_q).
+        stats_stor = torch.zeros(B * S_max_q * H_q, dtype=torch.float32, device=dev)
+        stats_t.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+        stats_t.set_dim((B, H_q, S_max_q, 1)).set_stride((S_max_q * H_q, 1, H_q, 1))
+        stats_ro_t = (ro_q.flatten() // D).view(B + 1, 1, 1, 1).contiguous()
+        stats_ro = g.tensor_like(stats_ro_t, name="stats_ro")
+        stats_t.set_ragged_offset(stats_ro)
+        vp[stats_ro] = stats_ro_t
+        vp[stats_t] = stats_stor
+
+    g.validate()
+    g.build_operation_graph()
+    g.create_execution_plans([cudnn.heur_mode.A])
+    _select_engine(g, engine_name(128, mxfp8=True))
+    g.check_support()
+    g.build_plans()
+    vp.update({o: o_gpu, amax_o: amax})
+    g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8))
+    torch.cuda.synchronize()
+
+    o_ref = torch.zeros(T_q, H_q, D, device=dev, dtype=torch.float32)
+    for b in range(B):
+        qd = q8_seqs[b].float() * dq_seqs[b]
+        kd = k8_seqs[b].float() * dk_seqs[b]
+        vd = v8_seqs[b].float() * dv_seqs[b]
+        ref_kw = dict(is_causal=True) if causal else {}
+        if sink is not None:
+            ref_kw["sinks"] = sink.flatten()
+        ob = _ref(qd, kd, vd, scale=scale, **ref_kw)
+        o_ref[cu_q[b] : cu_q[b + 1]] = ob.squeeze(0).permute(1, 0, 2)
+
+    o_out = o_stor[: T_q * H_q * D].reshape(T_q, H_q, D)
+    lse_out = stats_stor[: T_q * H_q].reshape(T_q, H_q) if stats else None
+    return o_out, o_ref, amax, lse_out
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("causal", [False, True])
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd(in_key, causal):
+    """THD/varlen self-attention: two packed sequences of unequal, tile-ragged length."""
+    scale = 1.0 / math.sqrt(128)
+    O, O_ref, amax, _ = _run_thd([200, 150], [200, 150], 8, 8, in_key, torch.float16, scale=scale, causal=causal)
+    _check(O, O_ref, torch.float16, in_key)
+    assert abs(amax.item() - O_ref.abs().max().item()) <= 0.03
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_cross_gqa():
+    """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
+    scale = 1.0 / math.sqrt(128)
+    O, O_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", torch.float16, scale=scale)
+    _check(O, O_ref, torch.float16, "e4m3")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_sink():
+    """THD causal + attention sink."""
+    scale = 1.0 / math.sqrt(128)
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    O, O_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, sink=sink)
+    _check(O, O_ref, torch.float16, "e4m3")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_stats():
+    """THD + generate_stats: the ragged token-major TH1 LSE is written next to O."""
+    scale = 1.0 / math.sqrt(128)
+    O, O_ref, _, lse = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, stats=True)
+    _check(O, O_ref, torch.float16, "e4m3")
+    assert lse is not None and torch.isfinite(lse).all()
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_cu_seq_len():
+    """THD via the (B+1,) cu_seq_len prefix-sum length form."""
+    scale = 1.0 / math.sqrt(128)
+    O, O_ref, _, _ = _run_thd([200, 150], [180, 120], 8, 8, "e4m3", torch.float16, scale=scale, cu_lens=True)
+    _check(O, O_ref, torch.float16, "e4m3")

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -496,6 +496,10 @@ def _quantize_seq(t_1hsd, h, s, d, fp8, *, columnwise):
     exactly the kernel's per-sequence-TILE-padded SF layout."""
     from sdpa.mxfp8_quant import quantize_to_mxfp8
 
+    if s == 0:
+        # Zero-length sequence: no tokens, no SF tiles.
+        empty = t_1hsd.new_zeros((1, h, 0, d))
+        return empty.to(fp8), empty.float(), torch.zeros((h, 0, 128 * d // _BLOCK), dtype=torch.uint8, device=t_1hsd.device)
     data_d, dq_d, swz_d, data_s, dq_s, swz_s = quantize_to_mxfp8(t_1hsd, 1, h, s, d, _BLOCK, fp8, with_ref=True)
     n_tiles = _cdiv(s, 128)
     if columnwise:
@@ -560,8 +564,14 @@ def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, out_dt, *, scale, causa
     sfv_pk = torch.cat(sfv_seqs, dim=1).contiguous()
 
     def _dense_buf(packed, s_max, h, dt):
+        # Dense-capacity storage; packed tokens in the leading elements (THD
+        # contract). The capacity tail is NaN-POISONED (test_mhas_v2 parity):
+        # the last sequence's KV tile steps past the packed total, and those
+        # tail loads must land as zeros through the setup kernel's
+        # packed-total-clamped K/V descriptors — a leaked NaN would wipe the
+        # tile via BMM2's P·V (0 · NaN == NaN).
         stride = (s_max * h * D, D, h * D, 1)
-        stor = torch.zeros(B * s_max * h * D, device=dev, dtype=dt)
+        stor = torch.full((B * s_max * h * D,), float("nan"), device=dev, dtype=torch.float32).to(dt)
         stor[: packed.numel()] = packed.reshape(-1)
         return stor, stor.as_strided((B, h, s_max, D), stride), stride
 
@@ -669,6 +679,10 @@ def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, out_dt, *, scale, causa
 
     o_ref = torch.zeros(T_q, H_q, D, device=dev, dtype=torch.float32)
     for b in range(B):
+        if cu_q[b + 1] == cu_q[b] or cu_k[b + 1] == cu_k[b]:
+            # Zero-length Q contributes no rows; zero-length KV leaves every
+            # row of the sequence dead — O := 0 (o_ref is pre-zeroed).
+            continue
         qd = q8_seqs[b].float() * dq_seqs[b]
         kd = k8_seqs[b].float() * dk_seqs[b]
         vd = v8_seqs[b].float() * dv_seqs[b]
@@ -722,6 +736,17 @@ def test_mxfp8_thd_stats():
     o_out, o_ref, _, lse = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, stats=True)
     _check(o_out, o_ref, torch.float16, "e4m3")
     assert lse is not None and torch.isfinite(lse).all()
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_thd_zero_len_kv():
+    """Zero-length Q and KV sequences (test_mhas_v2 ragged parity): the
+    zero-KV sequence's rows are dead — the epilogue must come back O := 0,
+    not the unwritten O TMEM (garbage survives `* inv_sum(=0)` when NaN)."""
+    scale = 1.0 / math.sqrt(128)
+    o_out, o_ref, _, _ = _run_thd([126, 0, 60], [0, 83, 77], 8, 8, "e4m3", torch.float16, scale=scale)
+    _check(o_out, o_ref, torch.float16, "e4m3")
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -482,9 +482,9 @@ def test_mxfp8_dense_padding(in_key, causal):
     needs the per-batch LSE trim, which this cell does not declare)."""
     scale = 1.0 / math.sqrt(128)
     sk = dict(use_causal_mask=True) if causal else {}
-    O, O_ref, amax = _run(2, 8, 8, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=sk, seq_lens_kv=[256, 192], stats=False)
-    _check(O, O_ref, torch.float16, in_key)
-    assert abs(amax.item() - O_ref.abs().max().item()) <= 0.03
+    o_out, o_ref, amax = _run(2, 8, 8, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=sk, seq_lens_kv=[256, 192], stats=False)
+    _check(o_out, o_ref, torch.float16, in_key)
+    assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
 
 
 def _quantize_seq(t_1hsd, h, s, d, fp8, *, columnwise):
@@ -690,9 +690,9 @@ def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, out_dt, *, scale, causa
 def test_mxfp8_thd(in_key, causal):
     """THD/varlen self-attention: two packed sequences of unequal, tile-ragged length."""
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, amax, _ = _run_thd([200, 150], [200, 150], 8, 8, in_key, torch.float16, scale=scale, causal=causal)
-    _check(O, O_ref, torch.float16, in_key)
-    assert abs(amax.item() - O_ref.abs().max().item()) <= 0.03
+    o_out, o_ref, amax, _ = _run_thd([200, 150], [200, 150], 8, 8, in_key, torch.float16, scale=scale, causal=causal)
+    _check(o_out, o_ref, torch.float16, in_key)
+    assert abs(amax.item() - o_ref.abs().max().item()) <= 0.03
 
 
 @pytest.mark.L0
@@ -700,8 +700,8 @@ def test_mxfp8_thd(in_key, causal):
 def test_mxfp8_thd_cross_gqa():
     """THD cross-attention (unequal packed Q and K/V totals) with GQA heads."""
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", torch.float16, scale=scale)
-    _check(O, O_ref, torch.float16, "e4m3")
+    o_out, o_ref, _, _ = _run_thd([64, 200], [256, 128], 8, 2, "e4m3", torch.float16, scale=scale)
+    _check(o_out, o_ref, torch.float16, "e4m3")
 
 
 @pytest.mark.L0
@@ -710,8 +710,8 @@ def test_mxfp8_thd_sink():
     """THD causal + attention sink."""
     scale = 1.0 / math.sqrt(128)
     sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
-    O, O_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, sink=sink)
-    _check(O, O_ref, torch.float16, "e4m3")
+    o_out, o_ref, _, _ = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, sink=sink)
+    _check(o_out, o_ref, torch.float16, "e4m3")
 
 
 @pytest.mark.L0
@@ -719,8 +719,8 @@ def test_mxfp8_thd_sink():
 def test_mxfp8_thd_stats():
     """THD + generate_stats: the ragged token-major TH1 LSE is written next to O."""
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, _, lse = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, stats=True)
-    _check(O, O_ref, torch.float16, "e4m3")
+    o_out, o_ref, _, lse = _run_thd([200, 150], [200, 150], 8, 8, "e4m3", torch.float16, scale=scale, causal=True, stats=True)
+    _check(o_out, o_ref, torch.float16, "e4m3")
     assert lse is not None and torch.isfinite(lse).all()
 
 
@@ -729,5 +729,5 @@ def test_mxfp8_thd_stats():
 def test_mxfp8_thd_cu_seq_len():
     """THD via the (B+1,) cu_seq_len prefix-sum length form."""
     scale = 1.0 / math.sqrt(128)
-    O, O_ref, _, _ = _run_thd([200, 150], [180, 120], 8, 8, "e4m3", torch.float16, scale=scale, cu_lens=True)
-    _check(O, O_ref, torch.float16, "e4m3")
+    o_out, o_ref, _, _ = _run_thd([200, 150], [180, 120], 8, 8, "e4m3", torch.float16, scale=scale, cu_lens=True)
+    _check(o_out, o_ref, torch.float16, "e4m3")

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
@@ -454,7 +454,9 @@ def _fp8_family_split(kfile, dtype_qkv, splits, cta_mma, mx):
         # The FP8 entry takes four 1-element fp32 DEVICE scale tensors
         # (descale_q/k/v, scale_o) — the scales fold in-kernel — and no Amax_S.
         one = lambda: torch.ones(1, dtype=torch.float32, device=dev)
-        fn(q, k, v, o_p, lse_p, zH, zB, ps, log2e, cutlass.Float32(1.0), one(), one(), one(), one(), amax_o, stream=stream)
+        # o_desc dummy + n_thd_units=0: THD-only ABI slots (dense fold), like the f16 call above.
+        o_desc = torch.zeros(1, dtype=torch.int64, device=dev)
+        fn(q, k, v, o_p, lse_p, zH, zB, o_desc, ps, log2e, cutlass.Float32(1.0), cutlass.Int32(0), one(), one(), one(), one(), amax_o, stream=stream)
         qf, kf, vf = (t.float().permute(0, 2, 1, 3) for t in (q, k, v))
     else:
         from sdpa.mxfp8_quant import quantize_to_mxfp8
@@ -472,7 +474,9 @@ def _fp8_family_split(kfile, dtype_qkv, splits, cta_mma, mx):
         q8 = q8.reshape(B, H, SQ, D).permute(0, 2, 1, 3).contiguous()
         k8 = k8.reshape(B, H, SKV, D).permute(0, 2, 1, 3).contiguous()
         v8 = v8.reshape(B, H, SKV, D).permute(0, 2, 1, 3).contiguous()
-        fn(q8, k8, v8, o_p, sfq, sfk, sfv, lse_p, amax_o, zH, zB, ps, log2e, stream=stream)
+        # o_desc dummy + n_thd_units=0: THD-only ABI slots (dense fold), like the f16 call above.
+        o_desc = torch.zeros(1, dtype=torch.int64, device=dev)
+        fn(q8, k8, v8, o_p, sfq, sfk, sfv, lse_p, amax_o, zH, zB, o_desc, ps, log2e, cutlass.Int32(0), stream=stream)
 
     ref = torch.matmul(torch.softmax(torch.matmul(qf, kf.transpose(-1, -2)) * scale, -1), vf).permute(0, 2, 1, 3)
     if splits == 1:


### PR DESCRIPTION
Port the device-built-metadata + plan-time-envelope THD design (PRs #606/#608) into the per-tensor FP8 SM100 kernel, its SM107 sibling (hunk-symmetric), and the block-scale MXFP8 SM100 kernel — the port #622 prescribed when it removed the legacy leg. Closes the FP8/MXFP8 gap of issue #552.

## Kernels (`prefill_d128_fp8_sm100.py`, `prefill_d128_fp8_sm107.py`, `prefill_d128_mxfp8_sm100.py`)

- Dynamic packed token extents (`cute.sym_int`) — the THD compile keys are plan-time-only; a new packed total re-binds the same artifact.
- The shared `build_thd_meta_o_descs_kernel` setup launch: the `[kv | cu_q | cu_k]` metadata buffer and the per-batch O TMA descriptors are built device-side from the caller's length tensors (either the `(B,)` per-batch or the `(B+1,)` cu prefix-sum form, via the runtime `lens_form` bitmask) — no length ever reaches the host.
- Plan-time envelope grid with the `batch == n_batch` dead-unit sentinel: the O-store role skips the store explicitly, and the epilogue's LSE write + `amax_o` atomicMax are predicated on the per-sequence Q length from the device metadata (negative for dead units).
- Ragged Stats in the caller's declared layout — token-major TH1 rank-2 `(T, H)` or head-major rank-3 `(1, QH, head_stride)` — via static-rank dispatch in the epilogue.
- MXFP8-only: THD scale factors travel PACKED per-sequence-TILE-padded (`[1, H, sum_b ceil(S_b/128), SF_SMEM]` tile sequences in cu_seqlens order, matching the tile base the kernel derives device-side via `_thd_sf_tile_bases`). The packed tile extent is a runtime value that must come without a device read (Rule 3), so it derives from the SF buffer's byte size — THD SF buffers are exactly the packed layout (their head stride could address nothing else); the SF descriptors use B=1 + dynamic tile extents.
- No `Amax_S`, no `descale_s`/`scale_s` — dropped on these kernels (#602/#619); the `amax_o` protocol (in-kernel atomicMax, device-side `scale_o` divide) is unchanged under THD.

## Adapter (`api_dsl.py`)

- The SM100 THD packing is factored into `_thd_pack` (mirroring the SM120 class): metadata/O-descriptor scratch carving, capacity token floors, the zero-capacity K/V clamp, and the envelope unit count — shared by the f16 `_execute_thd` and the new FP8/MXFP8 THD branches.
- FP8/MXFP8 serve the packed contract only (`_thd_check_strides_packed`; no stride keys in `_thd_compile_kwargs` — same split as SM120).

## Engines / bindings

- The SM100 FP8/MXFP8 rows declare `thd=True` + `cu_seq_len=True`; the arch RANGE (sm 100..119) already routes cc10.7 through the SM107 sibling kernel, which carries the same THD leg.
- `sdpa_mxfp8` gains trailing `use_padding_mask` / `seq_len_q` / `seq_len_kv` / `cu_seq_len_q` / `cu_seq_len_kv` kwargs (`sdpa_fp8` already had them) — the THD length carriers. Side effect: dense mxfp8 + KV padding becomes constructible for the first time, and is tested (stats off — the row does not declare `padded_stats`).

## Tests

- FP8: THD self-attention (masks x e4m3/e5m2), cross-attention + GQA, causal+sink, THD + ragged-TH1-Stats (LSE checked against a logsumexp reference), cu_seq_len form.
- MXFP8: the same THD matrix with per-sequence quantization + packed SF assembly, plus dense KV-padding.
- SM107: module-level checks that the THD leg template-loads on BOTH fp8 siblings with the flag folded in.

## Validation

B200 (backend 9.23.01), `test/python/sdpa/frost`: **669 passed, 5 failed** — all five failures are `cu_seq_len` graphs hitting the pre-existing native-lowering version gate (fp8-family cu_seq_len needs the unified node, cuDNN >= 9.24/9.25; develop's own f16 cu tests fail identically on this backend and are green on CI's newer backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FP8 and MXFP8 support for variable-length (THD/ragged) attention on supported architectures.
  * Added dense FP8/MXFP8 support for d192/d128 dimensions.
  * Added sequence-length inputs, padding-mask controls, optional workspace support, and configurable statistics layouts.
  * Added support for causal masking, grouped-query attention, attention sinks, and packed LSE statistics.
* **Bug Fixes**
  * Prevented packed-buffer tail reads and invalid outputs for empty or padded sequences.
  * Improved runtime metadata handling for dense and variable-length workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->