### PR TITLE
style: fix black formatting in cutedsl grouped GEMM python files

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/dglu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/api.py
@@ -107,7 +107,7 @@ class DgluCall:
     mma_tiler_mn: Tuple[int, int] = (256, 256)
     cluster_shape_mn: Optional[Tuple[int, int]] = None
     sf_vec_size: int = 16
-    sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+    sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None
     vector_f32: bool = False
     m_aligned: int = 256
     discrete_col_sfd: bool = False

--- a/python/cudnn/gemm/cutedsl/grouped/glu/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/api.py
@@ -107,7 +107,7 @@ class GluCall:
     mma_tiler_mn: Tuple[int, int] = (256, 256)
     cluster_shape_mn: Optional[Tuple[int, int]] = None
     sf_vec_size: int = 16
-    sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,
+    sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None
     vector_f32: bool = False
     m_aligned: int = 256
     discrete_col_sfd: bool = False

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad_rubin.py
@@ -99,18 +99,9 @@ class BlockScaledMoEGroupedGemmWgradRubinKernel(BlockScaledMoEGroupedGemmWgradKe
             self.a_dtype is cutlass.Float4E2M1FN
             and self.b_dtype is cutlass.Float4E2M1FN
             and (
-                (
-                    self.sf_dtype is cutlass.Float8E4M3FN
-                    and self.sf_vec_size == 16
-                )
-                or (
-                    self.sf_dtype is cutlass.Float8E8M0FNU
-                    and self.sf_vec_size == 32
-                )
-                or (
-                    self.sf_dtype is cutlass.FloatNV8E5M3FNU
-                    and self.sf_vec_size == 16
-                )
+                (self.sf_dtype is cutlass.Float8E4M3FN and self.sf_vec_size == 16)
+                or (self.sf_dtype is cutlass.Float8E8M0FNU and self.sf_vec_size == 32)
+                or (self.sf_dtype is cutlass.FloatNV8E5M3FNU and self.sf_vec_size == 16)
             )
         ) or (
             self.a_dtype in (cutlass.Float8E4M3FN, cutlass.Float8E5M2)
@@ -119,10 +110,7 @@ class BlockScaledMoEGroupedGemmWgradRubinKernel(BlockScaledMoEGroupedGemmWgradKe
             and self.sf_vec_size == 32
         )
         if not valid_quantization:
-            raise ValueError(
-                "Rubin wgrad supports NVFP4 (E4M3 or E5M3 scales), MXFP4, "
-                "MXFP8-E4M3, or MXFP8-E5M2 block scaling."
-            )
+            raise ValueError("Rubin wgrad supports NVFP4 (E4M3 or E5M3 scales), MXFP4, MXFP8-E4M3, or MXFP8-E5M2 block scaling.")
         if self.acc_dtype is not cutlass.Float32:
             raise ValueError("Rubin wgrad requires Float32 accumulators.")
         if self.a_dtype.width == 4 and (self.a_major_mode != OperandMajorMode.K or self.b_major_mode != OperandMajorMode.K):
@@ -147,15 +135,9 @@ class BlockScaledMoEGroupedGemmWgradRubinKernel(BlockScaledMoEGroupedGemmWgradKe
             and self.mma_tiler[1] == 256
             and self.mma_tiler[2] == 512
         )
-        self.sf_window_k = (
-            self.instruction_k * 2 if use_sf_window else self.mma_tiler[2]
-        )
-        self.num_mma_instructions_per_sf_window = (
-            self.sf_window_k // self.instruction_k
-        )
-        self.num_sf_windows_per_ab_stage = (
-            self.mma_tiler[2] // self.sf_window_k
-        )
+        self.sf_window_k = self.instruction_k * 2 if use_sf_window else self.mma_tiler[2]
+        self.num_mma_instructions_per_sf_window = self.sf_window_k // self.instruction_k
+        self.num_sf_windows_per_ab_stage = self.mma_tiler[2] // self.sf_window_k
 
         tiled_mma = self._create_tiled_mma()
         tiled_mma_sfb = self._create_tiled_mma_sfb()


### PR DESCRIPTION
@coderabbitai ignore

## Problem

The scheduled `analysis:clang-format` job on `develop` fails on the black check ([job 401881704](https://gitlab-master.nvidia.com/cudnn/cudnn_frontend/-/jobs/401881704)):

```
would reformat python/cudnn/gemm/cutedsl/grouped/glu/api.py
would reformat python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad_rubin.py
would reformat python/cudnn/gemm/cutedsl/grouped/dglu/api.py

Oh no! 3 files would be reformatted, 602 files would be left unchanged.
```

## Fix

Ran `black --line-length 160 --fast` (pinned 26.3.1, matching `.pre-commit-config.yaml`) on the three files.

Two manual follow-ups on top of the mechanical reformat:

- **Latent bug** in `GluCall` / `DgluCall`: `sf_fp8_dtype_override: Optional[Literal["e5m3"]] = None,` had a stray trailing comma, so the dataclass default was the tuple `(None,)`, not `None`. Black faithfully rewrote it to `= (None,)`; dropped the comma instead so the default matches the annotation and the public API's own `= None` default.
- Joined an implicitly-concatenated `ValueError` message that black collapsed onto one line.

## Verification

`black --line-length 160 --fast --check python test samples` → `606 files would be left unchanged`.