### PR TITLE
benchmark(sdpa): add the Hopper (sm90) row to the peak-MMA table

### DIFF
--- a/benchmark/sdpa_benchmark_training/benchmark_single_sdpa.py
+++ b/benchmark/sdpa_benchmark_training/benchmark_single_sdpa.py
@@ -49,6 +49,10 @@ class UnsupportedConfigError(RuntimeError):
 # sparsity figure), which at 188 SMs x 2.62 GHz is 1024 BF16 FLOPs/clk/SM.
 # Keys match the strings accepted by the --data_type CLI flag.
 _FLOPS_PER_CLOCK_PER_SM = {
+    # Hopper (sm90): H100 SXM lists 989.5 dense BF16 TFLOPS (FP32 accumulate;
+    # 1979 is the sparsity figure) = 132 SMs x 1.83 GHz x 4096 FLOPs/clk/SM;
+    # FP8 dense is 2x. (No mxfp8 entry: Hopper has no MXFP8 datapath.)
+    9: {"bfloat16": 4096, "float16": 4096, "fp8": 8192},
     10: {"bfloat16": 8192, "float16": 8192, "fp8": 16384, "mxfp8": 16384},
     12: {"bfloat16": 1024, "float16": 1024, "fp8": 2048, "mxfp8": 2048},
 }


### PR DESCRIPTION
`_FLOPS_PER_CLOCK_PER_SM` only had sm100 and sm12x entries, so H200 runs computed no `peak_mma_tflops` and their charts drew no MMA-throughput max line while every other GPU's charts have one.

H100/H200 (sm90): 989.5 dense BF16 TFLOPS with FP32 accumulate = 132 SMs x 1.83 GHz x **4096 FLOPs/clk/SM**; FP8 dense is 2x (8192). No mxfp8 entry — Hopper has no MXFP8 datapath, and those cases already record as unsupported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added Hopper SM90 peak-throughput benchmarks for BF16, FP16, and FP8 dense MMA operations.
  * Updated FP8 performance estimates to reflect twice the BF16 and FP16 rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->