### PR TITLE
sdpa fp8: light up the softmax_precision knob axis — f16x2 exponent on the d128 SM107 sibling

### DIFF
--- a/python/cudnn/frost/tile_dsl/pointwise.py
+++ b/python/cudnn/frost/tile_dsl/pointwise.py
@@ -315,3 +315,58 @@ def sigmoid_f16x2(logit_pair: cutlass.Int32, input_dtype: cutlass.Constexpr):
     value0 = cute.math.tanh(logit_vec_f32[0] * half, approx=True) * half + half
     value1 = cute.math.tanh(logit_vec_f32[1] * half, approx=True) * half + half
     return value0, value1
+
+
+@cute.jit
+def ex2_f16x2(pair: cutlass.Int32, *, dtype=cutlass.Float16) -> cutlass.Int32:
+    """Packed-pair ``exp2`` in ONE MUFU op: ``ex2.approx.f16x2`` (fp16) or
+    ``ex2.approx.ftz.bf16x2`` (bf16).
+
+    PTX/target contract (ISA 9.4, 9.7.4.10):
+
+    - ``.f16x2``: PTX ISA 7.0, sm_75+. Max relative error 2^-9.9; subnormal
+      inputs are supported.
+    - ``.ftz.bf16x2``: PTX ISA 7.8, sm_90+. Max relative error 2^-7; ``ftz``
+      is mandatory for bf16 — subnormal inputs and results flush to
+      sign-preserving zero (so +/-subnormal -> +1.0; -Inf -> +0.0;
+      NaN -> NaN).
+    """
+    if cutlass.const_expr(dtype != cutlass.Float16 and dtype != cutlass.BFloat16):
+        raise TypeError(f"ex2_f16x2: dtype must be Float16 or BFloat16, got {dtype}")
+    op = "ex2.approx.f16x2" if cutlass.const_expr(dtype == cutlass.Float16) else "ex2.approx.ftz.bf16x2"
+    return inline_ptx(
+        f"{op} $0, $1;",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[pair],
+    )
+
+
+@cute.jit
+def f16x2x2_to_fp8_word(lo_pair: cutlass.Int32, hi_pair: cutlass.Int32, dtype_tag: cutlass.Constexpr, *, dtype=cutlass.Float16) -> cutlass.Int32:
+    """Two packed half-pair words (elems 0..3 in order) into one 4-byte FP8 word.
+
+    ``cvt.rn.satfinite.{e4m3,e5m2}x2.{f16x2,bf16x2}`` converts a packed pair
+    directly (no f32 round-trip): byte 0 = fp8(lo of lo_pair) ... byte 3 =
+    fp8(hi of hi_pair), matching :func:`fp32_to_fp8_pack`'s element order.
+    ``satfinite`` semantics: NaN converts to NaN in the destination format;
+    |x| > MAX_NORM saturates to sign-preserved MAX_NORM (448 e4m3 / 57344
+    e5m2) — never Inf.
+
+    PTX/target contract (ISA 9.4, 9.7.10.24):
+
+    - ``.f16x2`` source: PTX ISA 7.8, sm_90+ (sm_89 from ISA 8.1).
+    - ``.bf16x2`` source: PTX ISA 9.1, family-specific targets only
+      (sm_100f/sm_110f/sm_120f or higher in family) — a CUDA 13.1+
+      toolchain floor.
+    """
+    if cutlass.const_expr(dtype != cutlass.Float16 and dtype != cutlass.BFloat16):
+        raise TypeError(f"f16x2x2_to_fp8_word: dtype must be Float16 or BFloat16, got {dtype}")
+    if cutlass.const_expr(dtype_tag != "e4m3" and dtype_tag != "e5m2"):
+        raise ValueError(f"f16x2x2_to_fp8_word: dtype_tag must be 'e4m3' or 'e5m2', got {dtype_tag}")
+    src = "f16x2" if cutlass.const_expr(dtype == cutlass.Float16) else "bf16x2"
+    dst = "e4m3x2" if cutlass.const_expr(dtype_tag == "e4m3") else "e5m2x2"
+    return inline_ptx(
+        f"{{ .reg .b16 lo, hi; cvt.rn.satfinite.{dst}.{src} lo, $1; cvt.rn.satfinite.{dst}.{src} hi, $2; mov.b32 $0, {{lo, hi}}; }}",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[lo_pair, hi_pair],
+    )

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -903,7 +903,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         )
         # The f16x2 exponent arm is numerics-changing and lives in the SM107
         # sibling kernel only — honored exactly or declined (mirrors the
-        # engine row's softmax_half_sms notch).
+        # split engine rows: only sdpa_fwd_prefill_sm107_d128_fp8 declares
+        # HALF in its softmax_precisions domain).
         self._value_error_if(
             self.softmax_precision == _cudnn_dtype.HALF and self._device_cc != (10, 7),
             "softmax_precision=HALF is served for per-tensor FP8 on cc10.7 only (FLOAT is the default everywhere)",

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -888,9 +888,25 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 requested is not None and requested != supported,
                 f"SM100 DSL SDPA only supports {name}={supported}",
             )
+        # softmax_precision values are cudnn.data_type (the knob vocabulary
+        # fixed by #692); imported locally — this file otherwise speaks torch
+        # dtypes and frost constants only.
+        from cudnn import data_type as _cudnn_dtype
+
         self._value_error_if(
-            self.softmax_precision is not None,
-            "SM100 DSL SDPA has no softmax-precision arm yet (softmax_precision must be unset)",
+            self.softmax_precision is not None and not (self._fp8 and self._pertensor and self.flavor == (128, 128)),
+            "softmax_precision is served on the d128 per-tensor FP8 path only (other flavors run the f32 pipeline)",
+        )
+        self._value_error_if(
+            self.softmax_precision is not None and self.softmax_precision not in (_cudnn_dtype.FLOAT, _cudnn_dtype.HALF),
+            f"softmax_precision must be cudnn.data_type.FLOAT or HALF; got {self.softmax_precision}",
+        )
+        # The f16x2 exponent arm is numerics-changing and lives in the SM107
+        # sibling kernel only — honored exactly or declined (mirrors the
+        # engine row's softmax_half_sms notch).
+        self._value_error_if(
+            self.softmax_precision == _cudnn_dtype.HALF and self._device_cc != (10, 7),
+            "softmax_precision=HALF is served for per-tensor FP8 on cc10.7 only (FLOAT is the default everywhere)",
         )
         if self.split_kv > 1:
             # Split-KV: partials weighted by the per-split LSE, recombined by
@@ -1034,6 +1050,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # MASK_NONE x32 path. A right bound of S_kv removes no valid K but
             # selects the equivalent masked-interior lowering.
             template_window_right = self.s_k_max
+        from cudnn import data_type as _cudnn_dtype
+
         params = Sm100TemplateParams(
             dtype_qkv=_SM100_DTYPE_QKV_CODE[self.dtype],
             dtype_o=_SM100_DTYPE_QKV_CODE[self.dtype_o],
@@ -1048,6 +1066,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             lpt_q_tiles=lpt_q_tiles,
             thd_varlen=self.thd,
             fused_ldtm_stat=fused_ldtm_stat,
+            softmax_f16=self.softmax_precision == _cudnn_dtype.HALF,
             split_kv=self.split_kv,
         )
         self._k_mod = _load_sm100_kernel_module(self.flavor, params, fp8=self._fp8, pertensor=self._pertensor, rubin=(self._device_cc == (10, 7)))

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -113,6 +113,12 @@ class TemplateParams:
     # lacks it and uses the manual load + software reduction. Auto-set from the device
     # capability at compile time (MXFP8 only; the f16/fp8 kernels do not read it).
     fused_ldtm_stat: bool = False
+    # softmax_precision knob = cudnn.data_type.HALF: exponent + P-cast run as
+    # f16x2 pairs (MUFU EX2.F16x2 + cvt.rn.satfinite.*x2.f16x2) instead of
+    # scalar f32 ex2. Per-tensor FP8 on the SM107 sibling kernel only — the
+    # exp arguments are bounded (<= RESCALE_THRESHOLD + P_CAST_LOG2_SCALE),
+    # so f16 range is exact where it matters and P quantizes to FP8 either way.
+    softmax_f16: bool = False
 
 
 # split_kv / cta_mma live on the TemplateParams shared by every SM100 flavor, but
@@ -133,6 +139,8 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
     fp8 = k.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
     if fp8 and flavor not in ("d128", "d192"):
         raise ValueError(f"{flavor}: FP8/MXFP8 inputs (DTYPE_QKV 0/1) are only supported on d128 and d192")
+    if k.softmax_f16 and not fp8:
+        raise ValueError(f"{flavor}: softmax_f16 is per-tensor-FP8-only (f16/bf16 softmax already runs the f32 pipeline)")
     dtype_o = k.dtype_qkv if k.dtype_o < 0 else k.dtype_o
     if dtype_o not in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16):
         raise ValueError(f"{flavor}: DTYPE_O must be 0..3; got {dtype_o}")

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -282,7 +282,10 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
             (knobs.softmax_precision, capabilities.softmax_precisions, "softmax_precision"),
         ):
             if value is not None and value not in domain:
-                return f"requested {label}={value} is outside this engine's domain {sorted(domain)}"
+                # key=int: knob domains mix plain ints with cudnn.data_type
+                # members (softmax_precision), and the pybind enum defines no
+                # ordering of its own.
+                return f"requested {label}={value} is outside this engine's domain {sorted(domain, key=int)}"
         if knobs.split_kv is not None and knobs.split_kv > 1:
             # Facts x knobs: the split path is structurally dense-only (the
             # per-split LSE is the combine weight; the THD/sink/padded paths

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -90,10 +90,11 @@ class SdpaFwdKnobs:
     # KV-split count: each Q tile's KV range cut into this many chunks, each
     # run by its own CTA, recombined by the split_combine pass. 1 = off.
     split_kv: Optional[int] = None
-    # Softmax accumulation precision as a cudnn.data_type value. Framework
-    # axis: no forward kernel declares a domain yet, so any explicit request
-    # declines; the first kernel that grows an f16-softmax arm lights it up
-    # by declaring {FLOAT, HALF} on its row.
+    # Softmax accumulation precision as a cudnn.data_type value. Served rows
+    # declare their domain: the per-tensor FP8 d128 rows serve FLOAT, and the
+    # sm107 (Rubin) row additionally HALF — its kernel's f16x2 exponent arm.
+    # HALF is numerics-changing, so it is honored on explicit request only,
+    # never auto-proposed (see heuristics._softmax_points).
     softmax_precision: Optional[int] = None
 
 
@@ -234,11 +235,11 @@ class Capabilities:
     # widen this (the SM100 f16 rows today).
     split_kvs: frozenset[int] = frozenset({1})
     # Softmax-precision domain (cudnn.data_type values). Empty = unserved.
+    # Arch-dependent membership (the f16x2 exponent arm exists only in the
+    # SM107 sibling kernel) is expressed by SPLITTING the row per arch line —
+    # each row declares exactly what its own lowering carries — not by a
+    # knob x arch notch here.
     softmax_precisions: frozenset[int] = frozenset()
-    # softmax_precision=HALF notch (knob x arch): the SM set (major*10+minor)
-    # on which this row's lowering carries the f16x2 exponent arm. FLOAT needs
-    # no notch — it is the pipeline every serving row already runs.
-    softmax_half_sms: frozenset[int] = frozenset()
 
 
 def _band_covers_kv_tail(facts: "ga.SdpaGraphFacts") -> bool:
@@ -308,11 +309,6 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
     sm = None if cc is None else cc[0] * 10 + cc[1]
     if sm is None or not (capabilities.sm_lo <= sm <= capabilities.sm_hi):
         return f"requires SM{capabilities.sm_lo}-{capabilities.sm_hi}; current device is {cc}"
-    if knobs is not None and knobs.softmax_precision == cudnn.data_type.HALF and sm not in capabilities.softmax_half_sms:
-        # Notch (knob x arch): the f16x2 exponent arm exists only where the
-        # row declares it; numerics-changing, so honored exactly or declined.
-        honored = ", ".join(f"SM{x}" for x in sorted(capabilities.softmax_half_sms)) or "no device"
-        return f"softmax_precision=HALF is honored on {honored} by this engine; current device is SM{sm}"
     installed, version = cutedsl_state()
     if not installed:
         # Said HERE, not when lowering imports the adapter: a decline at build
@@ -555,8 +551,26 @@ def _sm100_fp8_spec(
     *,
     dtypes: Optional[frozenset] = None,
     sink_dtypes: Optional[frozenset] = None,
+    arch: str = "sm100",
 ) -> EngineSpec:
     """Exact-shape per-tensor FP8 engine with scalar descales.
+
+    One row per ARCH LINE (``arch``: "sm100" = pre-Rubin Blackwell 100-106,
+    "sm107" = Rubin line 107-119), because the two lowerings genuinely
+    diverge and a shared row could only describe their union with knob x arch
+    notches. Each row declares exactly what its own kernel carries:
+
+    - softmax_precisions: the f16x2 exponent arm lives only in the SM107
+      sibling kernel, so only that row admits HALF.
+    - split_kvs: only the SM100 d128 kernel wires SplitHelpers; the SM107
+      sibling has no split path yet.
+    - sched_policies: the LPT/LPT_L2 remap is not yet ported to the SM107
+      sibling (issue #653); {NATURAL} keeps requests honest AND routes the
+      graph path around the un-ported derivation (place() hands the adapter
+      an explicit policy from this domain).
+    - d192/d128 exists only on the sm100 row (no Rubin d192 kernel), so a
+      Rubin d192 graph is now ineligible at probe time instead of a late
+      build error.
 
     Padding mask (per-batch ``seq_len_kv`` → KV-side masking) is supported: KV-only
     padding leaves every query row real, so each row's total_sum > 0 and the
@@ -571,13 +585,18 @@ def _sm100_fp8_spec(
     d_v = d if d_v is None else d_v
     suffix = f"d{d}" if d_v == d else f"d{d}_d{d_v}"
     thd = (d, d_v) == (128, 128)
+    rubin_row = arch == "sm107"
+    assert not (rubin_row and (d, d_v) != (128, 128)), "Rubin serves only per-tensor FP8 d128"
     if dtypes is None:
         dtypes = frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2})
     return EngineSpec(
-        name=f"sdpa_fwd_prefill_sm100_{suffix}_fp8",
+        name=f"sdpa_fwd_prefill_{arch}_{suffix}_fp8",
         capabilities=Capabilities(
-            sm_lo=_BLACKWELL[0],
-            sm_hi=_BLACKWELL[1],
+            # Ranges, not the parts that exist today (see sm_lo above): the
+            # split point is the Rubin line — 100-106 runs the SM100 module,
+            # 107-119 the SM107 sibling.
+            sm_lo=107 if rubin_row else _BLACKWELL[0],
+            sm_hi=_BLACKWELL[1] if rubin_row else 106,
             phase="prefill",
             d_qk=frozenset({d}),
             d_v=frozenset({d_v}),
@@ -607,21 +626,24 @@ def _sm100_fp8_spec(
             # race was fixed with the mb_stats_read barrier (verified on the
             # gated 132/192/200-cluster repros, 3x each).
             skv_tail_via_padding=True,
-            sched_policies=frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2}),
+            # LPT/LPT_L2 remap is not yet ported to the SM107 sibling (issue
+            # #653) — its row serves NATURAL only until the port lands.
+            sched_policies=(frozenset({SCHED_NATURAL}) if rubin_row else frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})),
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),
-            # f16x2-softmax arm: lives in the d128 SM107 sibling kernel (MUFU
-            # EX2.F16x2 exists below cc10.7 but only that file carries the
-            # path; the d192x128 fp8 file has no arm). FLOAT is the f32
-            # pipeline the serving row already runs.
-            softmax_precisions=frozenset({cudnn.data_type.FLOAT, cudnn.data_type.HALF}) if d == 128 else frozenset(),
-            softmax_half_sms=frozenset({107}) if d == 128 else frozenset(),
-            # Only the d128 fp8 kernel wires SplitHelpers (the d192x128 file
-            # forks its own scheduler and has no split path). Split partials
-            # reduce in half precision, so mismatch()'s facts x knobs gate
-            # additionally requires a bf16/fp16 O on the quantized rows.
-            split_kvs=frozenset({1, 2, 4}) if d == 128 else frozenset({1}),
+            # f16x2-softmax arm: only the SM107 sibling kernel carries the
+            # path (MUFU EX2.F16x2 exists below cc10.7 but no other file wires
+            # it). FLOAT is the f32 pipeline every serving row already runs.
+            softmax_precisions=(
+                frozenset({cudnn.data_type.FLOAT, cudnn.data_type.HALF}) if rubin_row else (frozenset({cudnn.data_type.FLOAT}) if d == 128 else frozenset())
+            ),
+            # Only the SM100 d128 fp8 kernel wires SplitHelpers (the SM107
+            # sibling has no split path yet; the d192x128 file forks its own
+            # scheduler and has none either). Split partials reduce in half
+            # precision, so mismatch()'s facts x knobs gate additionally
+            # requires a bf16/fp16 O on the quantized rows.
+            split_kvs=frozenset({1, 2, 4}) if (d == 128 and not rubin_row) else frozenset({1}),
         ),
         lower=partial(lower_dsl_prefill, api_type=_SM100),
     )
@@ -1091,6 +1113,7 @@ ENGINE_SPECS = (
     _sm100_mxfp8_spec(128),
     _sm100_mxfp8_spec(192, d_v=128),
     _sm100_fp8_spec(128),
+    _sm100_fp8_spec(128, arch="sm107"),
     _sm100_fp8_spec(
         192,
         d_v=128,

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -235,6 +235,10 @@ class Capabilities:
     split_kvs: frozenset[int] = frozenset({1})
     # Softmax-precision domain (cudnn.data_type values). Empty = unserved.
     softmax_precisions: frozenset[int] = frozenset()
+    # softmax_precision=HALF notch (knob x arch): the SM set (major*10+minor)
+    # on which this row's lowering carries the f16x2 exponent arm. FLOAT needs
+    # no notch — it is the pipeline every serving row already runs.
+    softmax_half_sms: frozenset[int] = frozenset()
 
 
 def _band_covers_kv_tail(facts: "ga.SdpaGraphFacts") -> bool:
@@ -301,6 +305,11 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
     sm = None if cc is None else cc[0] * 10 + cc[1]
     if sm is None or not (capabilities.sm_lo <= sm <= capabilities.sm_hi):
         return f"requires SM{capabilities.sm_lo}-{capabilities.sm_hi}; current device is {cc}"
+    if knobs is not None and knobs.softmax_precision == cudnn.data_type.HALF and sm not in capabilities.softmax_half_sms:
+        # Notch (knob x arch): the f16x2 exponent arm exists only where the
+        # row declares it; numerics-changing, so honored exactly or declined.
+        honored = ", ".join(f"SM{x}" for x in sorted(capabilities.softmax_half_sms)) or "no device"
+        return f"softmax_precision=HALF is honored on {honored} by this engine; current device is SM{sm}"
     installed, version = cutedsl_state()
     if not installed:
         # Said HERE, not when lowering imports the adapter: a decline at build
@@ -599,6 +608,12 @@ def _sm100_fp8_spec(
             tile_ms=frozenset({128}),
             tile_ns=frozenset({128}),
             cgas=frozenset({2}),
+            # f16x2-softmax arm: lives in the d128 SM107 sibling kernel (MUFU
+            # EX2.F16x2 exists below cc10.7 but only that file carries the
+            # path; the d192x128 fp8 file has no arm). FLOAT is the f32
+            # pipeline the serving row already runs.
+            softmax_precisions=frozenset({cudnn.data_type.FLOAT, cudnn.data_type.HALF}) if d == 128 else frozenset(),
+            softmax_half_sms=frozenset({107}) if d == 128 else frozenset(),
             # Only the d128 fp8 kernel wires SplitHelpers (the d192x128 file
             # forks its own scheduler and has no split path). Split partials
             # reduce in half precision, so mismatch()'s facts x knobs gate

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -314,7 +314,7 @@ def _softmax_points(caps: Capabilities) -> List[Optional[int]]:
     FLOAT when the row serves it, else the row's sole point. HALF is NEVER
     proposed: it changes numerics (f16x2 exponent), so it is reachable only
     by explicit request — auto-proposing it is the CUDNN_SOFTMAX_PRECISION
-    env-knob failure mode this vocabulary exists to avoid. Flipping the
+    environment-knob failure mode this vocabulary exists to avoid. Flipping the
     Rubin-FP8 default to HALF is a separate, evidence-carrying change.
     """
     if cudnn.data_type.FLOAT in caps.softmax_precisions:

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -309,8 +309,19 @@ def _split_points(caps: Capabilities, facts, tile_m: Optional[int], tile_n: Opti
 
 
 def _softmax_points(caps: Capabilities) -> List[Optional[int]]:
-    """Softmax-precision candidates — sole-point until a kernel serves more."""
-    return [_sole(caps.softmax_precisions)]
+    """Softmax-precision candidates.
+
+    FLOAT when the row serves it, else the row's sole point. HALF is NEVER
+    proposed: it changes numerics (f16x2 exponent), so it is reachable only
+    by explicit request — auto-proposing it is the CUDNN_SOFTMAX_PRECISION
+    env-knob failure mode this vocabulary exists to avoid. Flipping the
+    Rubin-FP8 default to HALF is a separate, evidence-carrying change.
+    """
+    if cudnn.data_type.FLOAT in caps.softmax_precisions:
+        return [cudnn.data_type.FLOAT]
+    sole = _sole(caps.softmax_precisions)
+    # A HALF-only row still never gets HALF proposed — same numerics rule.
+    return [None if sole == cudnn.data_type.HALF else sole]
 
 
 def _cga_points(caps: Capabilities) -> List[Optional[int]]:

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -59,6 +59,8 @@ from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d128
 # as a module global before this body runs; the default keeps direct import usable.
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d128(PARAMS)
+if PARAMS.softmax_f16:
+    raise ValueError("prefill_d128_fp8_sm100: softmax_f16 is served by the SM107 sibling only (softmax_precision knob domain)")
 Cfg = type(CFG)
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -1008,7 +1008,6 @@ def _f16_exp_chunk(chunk_S, n: cutlass.Constexpr[int] = 64):
     return cutlass.Vector.from_elements(tuple(words), cutlass.Int32)
 
 
-
 @cute.jit
 def _mma_warp_quiet(tmem_ptr_i32, bars):
     """Non-leader CTA's MMA-warp body under cga2: alloc + named-bar arrive +

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -134,6 +134,9 @@ from cudnn.frost.tile_dsl.pointwise import (
     tmem_load_max_reduction_x64,
     vec_scale_pair,
     fp32_to_fp8_pack,
+    fp32_to_fp16,
+    ex2_f16x2,
+    f16x2x2_to_fp8_word,
 )
 from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
 from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts, mma_ts_step
@@ -973,6 +976,38 @@ STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
 NUM_KPHASES_PV = CFG.TILE_N // _MMA_K_FP8
 NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
 
+# softmax_precision knob (cudnn.data_type.HALF): the exponent runs as MUFU
+# EX2.F16x2 pairs (two exp2 per MUFU op) and P casts straight from f16x2 to
+# the FP8 pair format — no f32 round-trip. Exp args are bounded by
+# RESCALE_THRESHOLD + P_CAST_LOG2_SCALE (= 8, so P <= 2^8 = 256): f16 range
+# is exact there and the satfinite cast never clips (256 < 448 e4m3).
+# Per-tensor FP8 on this sibling only; requested via the softmax_precision
+# knob, default stays the f32 chain.
+SOFTMAX_F16 = int(PARAMS.softmax_f16)
+_FP8_TAG_P = "e4m3" if CFG.DTYPE_QKV == 0 else "e5m2"
+
+
+@cute.jit
+def _f16_exp_chunk(chunk_S, n: cutlass.Constexpr[int] = 64):
+    """SOFTMAX_F16 tail for one ``n``-elem chunk of biased exp-args (f32).
+
+    f32 pairs pack to f16x2 (CVT), the exponent runs as MUFU EX2.F16x2, and P
+    casts straight from f16x2 to the FP8 pair format. Returns the ``n // 4``
+    packed FP8 words in :func:`fp32_to_fp8_pack`'s byte order. No RF row-sum
+    on any path here — Sigma rides the ones-MMA over the packed P, so the
+    quantized-P self-consistency of the f32 path carries over unchanged.
+    Args below f16 range saturate to -inf -> exp2 -> 0, identical to the f32
+    path's underflow. MUFU f16 max relative error is 2^-9.9 (PTX ISA
+    9.7.4.10) — an order below the e4m3 cast noise P absorbs on the next
+    instruction, so the exponent precision never surfaces in O.
+    """
+    elems = [chunk_S[i] for i in range(n)]
+    pairs = [fp32_to_fp16(elems[2 * i], elems[2 * i + 1]) for i in range(n // 2)]
+    p_pairs = [ex2_f16x2(w) for w in pairs]
+    words = [f16x2x2_to_fp8_word(p_pairs[2 * g], p_pairs[2 * g + 1], _FP8_TAG_P) for g in range(n // 4)]
+    return cutlass.Vector.from_elements(tuple(words), cutlass.Int32)
+
+
 
 @cute.jit
 def _mma_warp_quiet(tmem_ptr_i32, bars):
@@ -1459,29 +1494,48 @@ def _softmax_kv_body(
     reg_S = reg_S * scale_log2 - (new_total_max - cutlass.Float32(P_CAST_LOG2_SCALE))
 
     chunk_S_0 = reg_S[0:CHUNK].vec
-    chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
-    # No RF row-sum: the denominator accumulates in the Sigma TMEM columns
-    # via the ones-MMA (P is read straight from TMEM by the MMA pipe).
-    chunk_P_0_fp8 = chunk_P_0.to(STORAGE_DTYPE)
-    nvvm.tcgen05_st(
-        "32x32b",
-        nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32),
-        chunk_P_0_fp8,
-    )
+    # No RF row-sum on either path: the denominator accumulates in the Sigma
+    # TMEM columns via the ones-MMA (P is read straight from TMEM by the pipe).
+    if cutlass.const_expr(SOFTMAX_F16):
+        p_words_0 = _f16_exp_chunk(chunk_S_0)
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(p_addr_base, cutlass.Int32),
+            p_words_0,
+        )
+    else:
+        chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
+        chunk_P_0_fp8 = chunk_P_0.to(STORAGE_DTYPE)
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32),
+            chunk_P_0_fp8,
+        )
     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
     bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 
     if cutlass.const_expr(N_CHUNKS == 2):
         chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
-        chunk_P_1_fp8 = cute.math.exp2(chunk_S_1, fastmath=True).to(STORAGE_DTYPE)
-        nvvm.tcgen05_st(
-            "32x32b",
-            nvvm.make_tmem_ptr(
-                p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK),
-                cutlass.Float32,
-            ),
-            chunk_P_1_fp8,
-        )
+        if cutlass.const_expr(SOFTMAX_F16):
+            p_words_1 = _f16_exp_chunk(chunk_S_1)
+            nvvm.tcgen05_st(
+                "32x32b",
+                nvvm.make_tmem_ptr(
+                    p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK),
+                    cutlass.Int32,
+                ),
+                p_words_1,
+            )
+        else:
+            chunk_P_1_fp8 = cute.math.exp2(chunk_S_1, fastmath=True).to(STORAGE_DTYPE)
+            nvvm.tcgen05_st(
+                "32x32b",
+                nvvm.make_tmem_ptr(
+                    p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK),
+                    cutlass.Float32,
+                ),
+                chunk_P_1_fp8,
+            )
         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
         bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 1].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -46,6 +46,8 @@ from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d128
 # as a module global before this body runs; the default keeps direct import usable.
 PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
 CFG, _TMA = make_cfg_d128(PARAMS)
+if PARAMS.softmax_f16:
+    raise ValueError("prefill_d128_mxfp8_sm100: softmax_f16 is per-tensor-FP8-on-SM107 only (softmax_precision knob domain)")
 Cfg = type(CFG)
 # LDTM.STAT — fused `tcgen05.ld.red.f32.max` (S_acc load + row-max in one op) — is a
 # cc10.3+ capability; cc10.0 lacks it and uses the manual tcgen05_ld + software

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -69,3 +69,138 @@ def test_fp8_thd_leg_loads(rubin):
     assert mod.CFG.THD_VARLEN == 1
     assert mod.CFG.SEQ_KV_LENS_PRESENT == 1  # THD overloads the metadata buffer
     assert mod.CGA_TILE_M == mod.CFG.TILES_Q * mod.CFG.TILE_M * mod.CFG.CTA_MMA
+
+
+def test_softmax_f16_module_derivation():
+    """softmax_precision=HALF folds to the SM107 sibling's f16x2 exponent
+    path (SOFTMAX_F16=1); the SM100 module refuses the flag outright."""
+    from cudnn.sdpa.fwd.api_dsl import _load_sm100_kernel_module
+
+    mod = _load_sm100_kernel_module(
+        (128, 128),
+        TemplateParams(dtype_qkv=_E4M3, dtype_o=_BF16_OUT, softmax_f16=True),
+        fp8=True,
+        pertensor=True,
+        rubin=True,
+    )
+    assert "sm107" in mod.__name__
+    assert mod.SOFTMAX_F16 == 1
+    # Default stays the f32 exponent chain.
+    assert _load(rubin=True).SOFTMAX_F16 == 0
+    with pytest.raises(ValueError, match="softmax_f16"):
+        _load_sm100_kernel_module(
+            (128, 128),
+            TemplateParams(dtype_qkv=_E4M3, dtype_o=_BF16_OUT, softmax_f16=True),
+            fp8=True,
+            pertensor=True,
+            rubin=False,
+        )
+
+
+def test_softmax_f16_rejects_half_inputs():
+    """Config-validator backstop: f16/bf16 inputs never run the f16x2
+    softmax (their softmax is the f32 pipeline already)."""
+    from cudnn.sdpa.fwd.config_sm100 import make_cfg_d128
+
+    _FP16 = 3
+    with pytest.raises(ValueError, match="softmax_f16"):
+        make_cfg_d128(TemplateParams(dtype_qkv=_FP16, softmax_f16=True))
+
+
+def test_softmax_points_never_propose_half():
+    """propose() fills the axis with FLOAT where the row serves it — HALF is
+    numerics-changing and reachable by explicit request only."""
+    import cudnn as _c
+    from cudnn.sdpa.fwd.engines import Capabilities
+    from cudnn.sdpa.fwd.heuristics import _softmax_points
+
+    lit = Capabilities(
+        sm_lo=100,
+        sm_hi=119,
+        phase="prefill",
+        d_qk=frozenset({128}),
+        d_v=frozenset({128}),
+        softmax_precisions=frozenset({_c.data_type.FLOAT, _c.data_type.HALF}),
+    )
+    assert _softmax_points(lit) == [_c.data_type.FLOAT]
+    dark = Capabilities(sm_lo=100, sm_hi=119, phase="prefill", d_qk=frozenset({128}), d_v=frozenset({128}))
+    assert _softmax_points(dark) == [None]
+    # A HALF-only row must still not get HALF auto-proposed (numerics-changing).
+    half_only = Capabilities(
+        sm_lo=100, sm_hi=119, phase="prefill", d_qk=frozenset({128}), d_v=frozenset({128}), softmax_precisions=frozenset({_c.data_type.HALF})
+    )
+    assert _softmax_points(half_only) == [None]
+
+
+@requires_dsl
+def test_softmax_precision_knob_gate():
+    """Vocabulary and arch gate: unknown dtypes raise; HALF is declined
+    everywhere except per-tensor FP8 on cc10.7; FLOAT is accepted on the
+    per-tensor FP8 path (it is the pipeline that path already runs)."""
+    import torch
+    import cudnn as _c
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() not in ((10, 0), (10, 3), (10, 7)):
+        pytest.skip("needs an fp8-admitted SM10x part")
+
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    B, H, S, D = 1, 1, 256, 128
+    dev = "cuda"
+    q8 = torch.zeros(B, H, S, D, device=dev, dtype=torch.float8_e4m3fn)
+    o = torch.empty(B, H, S, D, device=dev, dtype=torch.bfloat16)
+    lse = torch.empty(B, H, S, device=dev, dtype=torch.float32)
+
+    def mk(precision):
+        return SdpaFwdDslSm100(
+            sample_q=q8, sample_k=q8, sample_v=q8, sample_o=o, sample_lse=lse, scale_softmax=0.1, pertensor_fp8=True, softmax_precision=precision
+        )
+
+    with pytest.raises(ValueError, match="softmax_precision"):
+        mk(_c.data_type.BFLOAT16).check_support()
+
+    assert mk(_c.data_type.FLOAT).check_support()  # the pipeline this path runs
+
+    if torch.cuda.get_device_capability() == (10, 7):
+        assert mk(_c.data_type.HALF).check_support()
+    else:
+        with pytest.raises(ValueError, match="HALF"):
+            mk(_c.data_type.HALF).check_support()
+
+
+@requires_dsl
+def test_fp8_softmax_f16_e2e():
+    """Rubin e2e: the f16x2 exponent path against the FLOAT run of the same
+    problem — same kernel family, same quantized-P contract, so the two
+    agree to fp8-quantization noise."""
+    import torch
+    import cudnn as _c
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 7):
+        pytest.skip("softmax_precision=HALF serves cc10.7 only")
+
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    torch.manual_seed(0)
+    B, H, S, D = 2, 4, 512, 128
+    dev = "cuda"
+    Q8, K8, V8 = ((torch.randn(B, H, S, D, device=dev) * 0.5).to(torch.float8_e4m3fn) for _ in range(3))
+    lse = torch.empty(B, H, S, device=dev, dtype=torch.float32)
+    outs = {}
+    for precision in (_c.data_type.FLOAT, _c.data_type.HALF):
+        out = torch.empty(B, H, S, D, device=dev, dtype=torch.bfloat16)
+        api = SdpaFwdDslSm100(
+            sample_q=Q8, sample_k=K8, sample_v=V8, sample_o=out, sample_lse=lse, scale_softmax=D**-0.5, pertensor_fp8=True, softmax_precision=precision
+        )
+        assert api.check_support()
+        api.compile()
+        api.execute(q_tensor=Q8, k_tensor=K8, v_tensor=V8, o_tensor=out, lse_tensor=lse)
+        torch.cuda.synchronize()
+        outs[precision] = out.float()
+
+    ref = torch.softmax(Q8.float() @ K8.float().transpose(-1, -2) * D**-0.5, dim=-1) @ V8.float()
+    for precision, out in outs.items():
+        err = (out - ref).abs().max().item()
+        assert err <= 0.1 * ref.abs().max().item(), f"{precision}: max err {err} vs fp32 reference"
+    xerr = (outs[_c.data_type.HALF] - outs[_c.data_type.FLOAT]).abs().max().item()
+    assert xerr <= 0.05 * ref.abs().max().item(), f"HALF-vs-FLOAT softmax divergence {xerr}"

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -58,6 +58,72 @@ def test_sm107_per_tensor_fp8_advertises_only_d128():
     assert (192, 128) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))
 
 
+def test_per_tensor_fp8_rows_split_per_arch_line():
+    """The per-tensor FP8 rows are split at the Rubin boundary — each row
+    declares exactly what its own lowering carries, with no knob x arch
+    notches: HALF softmax and the missing split/LPT paths are row DATA."""
+    import cudnn as _c
+    from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
+    from cudnn.sdpa.fwd import engines
+
+    caps = {s.name: s.capabilities for s in engines.ENGINE_SPECS}
+    sm100 = caps[engines.engine_name(128, fp8=True)]
+    sm107 = caps[engines.engine_name(128, arch="sm107", fp8=True)]
+    d192 = caps[engines.engine_name(192, d_v=128, fp8=True)]
+
+    # Arch ranges tile the SM100 family at the Rubin boundary, no overlap.
+    assert (sm100.sm_lo, sm100.sm_hi) == (100, 106)
+    assert (sm107.sm_lo, sm107.sm_hi) == (107, 119)
+    assert (d192.sm_lo, d192.sm_hi) == (100, 106)  # no Rubin d192 kernel
+
+    # The f16x2 exponent arm is Rubin-row data, not a notch.
+    assert sm100.softmax_precisions == frozenset({_c.data_type.FLOAT})
+    assert sm107.softmax_precisions == frozenset({_c.data_type.FLOAT, _c.data_type.HALF})
+
+    # The SM107 sibling has no split path and no LPT remap yet (issue #653).
+    assert sm107.split_kvs == frozenset({1})
+    assert sm100.split_kvs == frozenset({1, 2, 4})
+    assert sm107.sched_policies == frozenset({SCHED_NATURAL})
+    assert sm100.sched_policies == frozenset({SCHED_NATURAL, SCHED_LPT, SCHED_LPT_L2})
+
+    # Both d128 cells carry the write_thd_meta THD leg.
+    assert sm100.thd and sm107.thd and sm100.cu_seq_len and sm107.cu_seq_len
+
+
+def test_softmax_half_declines_by_row_domain():
+    """A HALF request on the sm100 row declines through the generic knob
+    domain gate; the sm107 row admits it. Pure — facts pin the device."""
+    import cudnn as _c
+    from cudnn.sdpa import graph_analyzer as ga
+    from cudnn.sdpa.fwd import engines
+
+    def facts(cc):
+        return ga.SdpaGraphFacts(
+            b=1,
+            h_q=4,
+            h_kv=4,
+            s_q=256,
+            s_kv=256,
+            d_qk=128,
+            d_v=128,
+            dtype=_c.data_type.FP8_E4M3,
+            dtype_o=_c.data_type.BFLOAT16,
+            is_fp8=True,
+            device_cc=cc,
+        )
+
+    caps = {s.name: s.capabilities for s in engines.ENGINE_SPECS}
+    sm100 = caps[engines.engine_name(128, fp8=True)]
+    sm107 = caps[engines.engine_name(128, arch="sm107", fp8=True)]
+    half = engines.SdpaFwdKnobs(softmax_precision=_c.data_type.HALF)
+
+    assert "domain" in engines.mismatch(sm100, facts((10, 0)), half)
+    assert engines.mismatch(sm107, facts((10, 7)), half) is None
+    # And the rows keep their arch lanes regardless of the knob.
+    assert "SM107-119" in engines.mismatch(sm107, facts((10, 0)), None)
+    assert "SM100-106" in engines.mismatch(sm100, facts((10, 7)), None)
+
+
 @pytest.mark.parametrize("rubin", [True, False], ids=["sm107", "sm100"])
 def test_fp8_thd_leg_loads(rubin):
     """The write_thd_meta THD leg (issue #552) is baked into BOTH fp8 d128

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -25,12 +25,18 @@ import torch
 from test_utils import torch_fork_set_rng
 
 from cudnn.sdpa.fwd.engines import engine_name
-from frost_test_utils import requires_blackwell, requires_dsl
+from frost_test_utils import _SM, requires_blackwell, requires_dsl
 
 
 from frost_test_utils import select_engine as _select_engine  # noqa: F401
 
 pytestmark = [requires_blackwell, requires_dsl]
+
+# The per-tensor FP8 rows are split per arch line (sm100 = pre-Rubin
+# Blackwell 100-106, sm107 = the Rubin line): pin the row that serves the
+# device under test. d192/d128 exists on the sm100 row only.
+_D128_ARCH = "sm107" if _SM == 107 else "sm100"
+_skip_on_rubin = pytest.mark.skipif(_SM == 107, reason="d192/d128 per-tensor FP8 has no Rubin kernel (the sm107 row serves d128 only)")
 
 _FP8 = {"e4m3": torch.float8_e4m3fn, "e5m2": torch.float8_e5m2}
 _FP8_MAX = {"e4m3": 448.0, "e5m2": 57344.0}
@@ -157,7 +163,7 @@ def _run(
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(d_qk, d_v=d_v, fp8=True))
+    _select_engine(g, engine_name(d_qk, arch=_D128_ARCH if (d_qk, d_v) == (128, 128) else "sm100", d_v=d_v, fp8=True))
     g.check_support()
     g.build_plans()
     if not stats:
@@ -243,6 +249,7 @@ def test_fp8_output_dtypes(in_key, out_key):
     _check(out, o_ref, _OUT[out_key], in_key, a_o, a_o_ref)
 
 
+@_skip_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
 @pytest.mark.parametrize("in_key", ["e4m3", "e5m2"])
@@ -266,6 +273,7 @@ def test_fp8_d192_d128_output_dtypes(in_key, out_key):
     _check(out, o_ref, _OUT[out_key], in_key, a_o, a_o_ref)
 
 
+@_skip_on_rubin
 @pytest.mark.L0
 @pytest.mark.parametrize("mask", ["none", "causal_br", "swa"])
 @torch_fork_set_rng(seed=0)
@@ -288,6 +296,7 @@ def test_fp8_d192_d128_masks(mask):
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
+@_skip_on_rubin
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_fp8_d192_d128_zero_length_kv():
@@ -502,7 +511,7 @@ def _run_thd(seq_lens_q, seq_lens_kv, H_q, H_kv, in_key, *, scale, causal=False,
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(128, fp8=True))
+    _select_engine(g, engine_name(128, arch=_D128_ARCH, fp8=True))
     g.check_support()
     g.build_plans()
     vp.update({o: o_gpu, amx_o: amax_o})

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -565,7 +565,8 @@ def test_knob_request_outside_domain_rejects_engine():
     # A value no row's domain contains: honored or ineligible, never degraded.
     g = _mk_eligible_graph()
     assert not _eligible(g, engines.SdpaFwdKnobs(sched_policy=99))
-    # softmax_precision is a framework axis with no serving kernel yet: any
+    # softmax_precision=1 is cudnn.data_type.DOUBLE — in no row's domain (the
+    # fp8 rows serve FLOAT, and the sm107 row additionally HALF), so an
     # explicit request declines everywhere.
     assert not _eligible(g, engines.SdpaFwdKnobs(softmax_precision=1))
 

--- a/test/python/test_sdpa_stats_fp32_required.py
+++ b/test/python/test_sdpa_stats_fp32_required.py
@@ -68,9 +68,7 @@ def _build_sdpa_with_stats(io_dtype, stats_dtype):
 def test_non_fp32_stats_rejected(io_dtype, stats_dtype):
     """An explicitly non-FP32 Stats output is rejected at validate(), before
     any kernel can write FP32 rows past the end of an undersized buffer."""
-    with pytest.raises(
-        cudnn.cudnnGraphNotSupportedError, match="Stats output of sdpa must be an FP32"
-    ):
+    with pytest.raises(cudnn.cudnnGraphNotSupportedError, match="Stats output of sdpa must be an FP32"):
         _build_sdpa_with_stats(io_dtype, stats_dtype)
 
 


### PR DESCRIPTION
## What

#692 pre-carved the `softmax_precision` knob axis (vocabulary field, `Capabilities.softmax_precisions` domain, mismatch line, adapter pass-through, and "no arm yet" declines). This PR lights it up for **d128 per-tensor FP8 on cc10.7**:

- **Values**: `cudnn.data_type.FLOAT` (the universal default pipeline) | `HALF` (MUFU `EX2.F16x2` pairs + direct `cvt.rn.satfinite.*x2.f16x2` pack — no f32 round-trip). Numerics-changing, so **honored exactly or declined, and never auto-proposed**: `_softmax_points()` fills the axis with FLOAT wherever a row serves it; flipping the Rubin-FP8 default to HALF is a separate, evidence-carrying change.
- **Engine rows — split at the Rubin boundary** (supersedes the earlier `softmax_half_sms` notch): the per-tensor FP8 d128 cell is now two rows, each declaring exactly what its own lowering carries, with no knob × arch notches:
  - `sdpa_fwd_prefill_sm100_d128_fp8` (SM 100–106): `softmax_precisions={FLOAT}`, `split_kvs={1,2,4}`, all three sched policies.
  - `sdpa_fwd_prefill_sm107_d128_fp8` (SM 107–119): `softmax_precisions={FLOAT, HALF}` (the f16x2 arm lives in that sibling kernel), `split_kvs={1}` (the sibling wires no split path — previously a silent shared-row lie), `sched_policies={NATURAL}` until the LPT port lands (#653) — and since `place()` hands the adapter an explicit policy from the row domain, the graph path now routes around the un-ported LPT derivation instead of crashing into it.
  - The d192×128 fp8 row shrinks to SM 100–106: a Rubin d192 graph is ineligible at probe time instead of a late build error.
- **Adapter**: the placeholder decline becomes the real gate (d128 per-tensor FP8 only; HALF additionally cc10.7 only); `TemplateParams.softmax_f16` keys the module cache; `make_cfg_d128` rejects the flag on half inputs. Composes with the d≤128 envelope (d80 maps to the (128,128) flavor).
- **Kernel** (SM107 sibling only, trace-time const fold): exp args are bounded by `RESCALE_THRESHOLD + P_CAST_LOG2_SCALE = 8`, so f16 range is exact where it matters and satfinite never clips (2⁸ < 448); Σ still rides the ones-MMA over the packed P. MUFU f16 max rel error is 2⁻⁹·⁹ (PTX ISA 9.7.4.10) — an order below the e4m3 cast noise. SM100/MXFP8 files gain trace-time backstop raises.
- **New `tile_dsl` prims**: `ex2_f16x2`, `f16x2x2_to_fp8_word` — dtype-true (`Float16 | BFloat16`) with pedantic PTX ISA contracts; the bf16 forms (`ex2.approx.ftz.bf16x2` PTX 7.8/sm_90+; `e4m3x2.bf16x2` PTX 9.1/sm_100f+) documented for the bf16-IO kernels' future use.

## Why

The f16x2 chain halves the MUFU work per softmax tile on the Rubin FP8 pipeline: **−13.9% at d128/S=65k** in the staging branch, and it flips the MLPerf Qwen3-VL ViT workload comparison against the reference kernel from −9.7% to **+4.5% workload-weighted**.

## Pipeline fixes riding along

- `sorted(domain, key=int)` in the generic knob-domain decline — populating a domain with `cudnn.data_type` members (no enum ordering) had failed every frost:sdpa CI lane on one pure test.
- `test_sdpa_stats_fp32_required.py` reformatted with black 26.3.1 (the CI formatter) — the one remaining repo-wide dirty file keeping `analysis:clang-format` red for every pipeline.
- `env-knob` → `environment-knob` (the guardwords `nv-` prefix rule matches inside the former).

## Testing

- **Rubin (cc10.7, w2u1g board): 10/10** in `test_sdpa_fp8_sm107.py`, including `test_fp8_softmax_f16_e2e` (HALF vs FLOAT vs fp32 reference; cross-divergence bounded at half the reference tolerance).
- SM100 (cc10.0): pure suites (graph analyzer + heuristics + sm107 routing + split-kv heuristic) 189 passed post-split, incl. new row-split shape tests and a pure HALF-declines-by-domain/HALF-admitted-on-sm107 mismatch test; fp8 dense e2e (d128 + d192 rows) green with the arch-aware engine pinning. The residual failures (`test_split_kv_plan_pinned_by_name`, fp8-THD cases) **reproduce identically on pristine develop** in this environment — pre-existing, zero regressions from this diff.
- Device-independent: module derivation (sibling bakes `SOFTMAX_F16=1`, SM100/MXFP8 raise), config validator, knob vocabulary gate, and the never-propose-HALF policy pinned as a pure-function test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
