### PR TITLE
Fix to #652: SM100 Grouped GEMM: read the TMEM accumulator before releasing the overlapping stage

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dsrelu/moe_blockscaled_grouped_gemm_dsrelu_quant.py
@@ -2150,15 +2150,15 @@ class BlockScaledMoEGroupedGemmQuantBwdKernel:
                         if reverse_subtile:
                             real_subtile_idx = self.cta_tile_shape_mnk[1] // self.epi_tile_n_required - 1 - subtile_idx
 
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
                     if cutlass.const_expr(self.overlapping_accum):
                         if subtile_idx == self.iter_acc_early_release_in_epilogue:
                             cute.arch.fence_view_async_tmem_load()
                             with cute.arch.elect_one():
                                 acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
-
-                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
-                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
 
                     # Apply alpha scaling
                     if cutlass.const_expr(self.vectorized_f32):

--- a/python/cudnn/gemm/cutedsl/grouped/quant/grouped_gemm_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/quant/grouped_gemm_quant.py
@@ -1854,6 +1854,9 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                         if reverse_subtile:
                             real_subtile_idx = self.cta_tile_shape_mnk[1] // self.epi_tile_n_required - 1 - subtile_idx
 
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
                     # C1 fix: fence + early release for overlapping_accum
                     if cutlass.const_expr(self.overlapping_accum):
                         if subtile_idx == self.iter_acc_early_release_in_epilogue:
@@ -1861,9 +1864,6 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                             with cute.arch.elect_one():
                                 acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
-
-                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
-                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
 
                     if cutlass.const_expr(self.enable_bias):
                         # m7 fix: use real_subtile_idx directly (matches contiguous)

--- a/python/cudnn/gemm/cutedsl/grouped/srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
+++ b/python/cudnn/gemm/cutedsl/grouped/srelu/moe_blockscaled_grouped_gemm_srelu_quant.py
@@ -1905,15 +1905,15 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                         if reverse_subtile:
                             real_subtile_idx = self.cta_tile_shape_mnk[1] // self.epi_tile_n_required - 1 - subtile_idx
 
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
                     if cutlass.const_expr(self.overlapping_accum):
                         if subtile_idx == self.iter_acc_early_release_in_epilogue:
                             cute.arch.fence_view_async_tmem_load()
                             with cute.arch.elect_one():
                                 acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
-
-                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
-                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
 
                     if cutlass.const_expr(self.enable_bias):
                         # m7 fix: use real_subtile_idx directly (matches contiguous)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Moves the TMEM→register `cute.copy` above the fence/release block in the epilogue of three
SM100 grouped-GEMM kernels — `dsrelu`, `srelu`, and `quant`.

## Related issues

Fixes #652

**Not tested:**

- Runtime evidence covers the **dSReLU kernel only**; `srelu` and `quant` carry the identical
  source pattern but were not executed.
- The Rubin-family `quant_rubin` kernel has the same defect and is **deliberately not touched** as no sm_107 hardware was available to validate it on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grouped GEMM quantization and activation processing by preserving accumulator data before pipeline release.
  * Helps ensure reliable results when overlapping accumulator operations are used.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->