### PR TITLE
Benchmark scripts unification

### DIFF
--- a/benchmark/gemm/frost/benchmark_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_block_scale_matmul.py
@@ -10,14 +10,8 @@ in / BF16 out) vs a reference. Perf only, no CPU verify.
 from __future__ import annotations
 
 import argparse
-import os
-import re
-import shutil
-import subprocess
 import sys
-import tempfile
 import time
-from typing import Callable
 
 import cudnn  # noqa: F401
 import cudnn.gemm.frost  # noqa: F401
@@ -25,7 +19,24 @@ import torch
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 from cudnn.gemm.frost.tile_config import CATALOG as _CATALOG
-from cudnn.gemm.frost.tile_config import by_name as _by_name
+
+from benchmark_utils import (
+    add_sweep_args,
+    ceil_div,
+    find_cublas_time,
+    kernel_match_token,
+    nsys_run_and_parse,
+    rand_e8m0,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_configs,
+    set_bytes,
+    spec_for,
+    time_ms_delayed,
+    time_ms_events,
+    to_blocked,
+)
 
 
 def _build_spec_map():
@@ -49,27 +60,6 @@ def _build_spec_map():
 
 _SPEC_MAP = _build_spec_map()
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting UNKNOWN_CONFIG."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
 
 def _vp_bs(handles, a, b, c, sfa, sfb):
     """Block-scale single-GEMM variant-pack dict keyed by the graph's tensors."""
@@ -79,7 +69,7 @@ def _vp_bs(handles, a, b, c, sfa, sfb):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg, cta_group=_spec_for(name)[1], scheduler=_spec_for(name)[2])
+    return jit_from_cudnn_graph(g, config=cfg, cta_group=spec_for(name, _SPEC_MAP)[1], scheduler=spec_for(name, _SPEC_MAP)[2])
 
 
 # Combo table (input dtype family + scale dtype + block size)
@@ -124,24 +114,6 @@ def _graph_block_scale(batch: int, M: int, N: int, K: int, combo: str):
     return g, (A, Bt, C, SFA, SFB)
 
 
-def _ceil_div(a, b):
-    return (a + b - 1) // b
-
-
-def _to_blocked(x):
-    """Pack a (rows, cols) scale tensor into the 128x4 blocked layout."""
-    rows, cols = x.shape
-    nrb, ncb = _ceil_div(rows, 128), _ceil_div(cols, 4)
-    pad = torch.zeros(nrb * 128, ncb * 4, dtype=x.dtype, device=x.device)
-    pad[:rows, :cols] = x
-    blocks = pad.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
-    return blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16).flatten()
-
-
-def _rand_e8m0(shape, dev):
-    return torch.randint(125, 129, shape, dtype=torch.uint8, device=dev).view(torch.float8_e8m0fnu)
-
-
 def _mkdata(batch: int, M: int, N: int, K: int, combo: str):
     """Block-scale runtime tensors: (a, b, c, sfa_blocked, sfb_blocked). a/b are
     packed FP4 or FP8; c is BF16; SFA/SFB are F8_128x4-reordered per batch."""
@@ -163,31 +135,16 @@ def _mkdata(batch: int, M: int, N: int, K: int, combo: str):
         sfa_log = torch.randint(1, 4, (batch, M, sf_k), device=dev).to(torch.float8_e4m3fn)
         sfb_log = torch.randint(1, 4, (batch, N, sf_k), device=dev).to(torch.float8_e4m3fn)
     else:
-        sfa_log = _rand_e8m0((batch, M, sf_k), dev)
-        sfb_log = _rand_e8m0((batch, N, sf_k), dev)
+        sfa_log = rand_e8m0((batch, M, sf_k), dev)
+        sfb_log = rand_e8m0((batch, N, sf_k), dev)
 
     c = torch.empty(batch, M, N, dtype=torch.bfloat16, device=dev)
     # The blocked blob carries the PADDED dims (whole 128-row x 4-SF-K atoms) —
     # that is what the kernel reads. The graph keeps the logical [batch, M, sf_k].
-    sf_k_pad = _ceil_div(sf_k, 4) * 4
-    sfa = torch.cat([_to_blocked(sfa_log[i]) for i in range(batch)]).view(batch, _ceil_div(M, 128) * 128, sf_k_pad)
-    sfb = torch.cat([_to_blocked(sfb_log[i]) for i in range(batch)]).view(batch, _ceil_div(N, 128) * 128, sf_k_pad)
+    sf_k_pad = ceil_div(sf_k, 4) * 4
+    sfa = torch.cat([to_blocked(sfa_log[i]) for i in range(batch)]).view(batch, ceil_div(M, 128) * 128, sf_k_pad)
+    sfb = torch.cat([to_blocked(sfb_log[i]) for i in range(batch)]).view(batch, ceil_div(N, 128) * 128, sf_k_pad)
     return a, b, c, sfa, sfb
-
-
-# Buffer rotation defeats the hot-L2 artifact on small shapes: rotate timed
-# launches across a pool of independent tensor sets so a kernel never re-reads the
-# previous launch's inputs from a hot L2 (which inflates TFLOPS). Warmup uses a
-# separate dedicated buffer. A pool smaller than the ~126 MB B200 L2 stays warm
-# after one rotation — warn the user to bump --rotate-buffers.
-_L2_BYTES_B200 = 126 * 1024 * 1024
-_AUTO_POOL_BUDGET_BYTES = 4 * 1024 * 1024 * 1024  # 4 GB
-_AUTO_NBUF_CAP = 1024
-
-
-def _set_bytes(tensors) -> int:
-    """GMEM footprint of one tensor set (packed FP4 is 1 byte per pair)."""
-    return sum(t.numel() * t.element_size() for t in tensors)
 
 
 def _mkdata_pool(batch: int, M: int, N: int, K: int, combo: str, nbuf: int):
@@ -197,32 +154,6 @@ def _mkdata_pool(batch: int, M: int, N: int, K: int, combo: str, nbuf: int):
     for _ in range(max(0, nbuf - 1)):
         pool.append(tuple(t.clone() for t in base))
     return pool
-
-
-def _auto_nbuf(per_set_bytes: int) -> int:
-    """Smallest buffer count whose pool exceeds L2 (1.5× margin), clamped to a
-    memory budget. Large shapes → 2; small shapes → scaled up until L2-cold."""
-    target = int(1.5 * _L2_BYTES_B200)
-    nbuf = max(2, -(-target // per_set_bytes))  # ceil-div
-    budget = _AUTO_POOL_BUDGET_BYTES
-    if torch.cuda.is_available():
-        free, _total = torch.cuda.mem_get_info()
-        budget = min(budget, free // 2)
-    max_by_budget = max(1, budget // per_set_bytes)
-    return max(1, min(nbuf, max_by_budget, _AUTO_NBUF_CAP))
-
-
-def _resolve_nbuf(spec: str, per_set_bytes: int) -> int:
-    """Resolve --rotate-buffers: 'auto' → shape-sized count, else the integer."""
-    if str(spec).strip().lower() == "auto":
-        return _auto_nbuf(per_set_bytes)
-    return max(1, int(spec))
-
-
-def _rotating(fn_of_set: Callable, pool: list) -> Callable:
-    """Wrap a `set -> None` callable into `i -> pool[i % len(pool)]`."""
-    n = len(pool)
-    return lambda i: fn_of_set(pool[i % n])
 
 
 def _scaled_mm_ref(batch: int, M: int, N: int, K: int, combo: str, verbose: bool = True):
@@ -323,194 +254,6 @@ def _make_reference_pool(batch: int, M: int, N: int, K: int, combo: str, ref_mod
     return label, warmup_call, timed_calls
 
 
-# Timing (events / delayed) — identical to benchmark_matmul.py
-
-
-def _time_ms_events(
-    timed_fn: Callable,
-    warmup_fn: Callable,
-    *,
-    warmup: int,
-    iters: int,
-) -> float:
-    """`timed_fn(i)` rotates buffers; `warmup_fn()` uses a dedicated buffer."""
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-def _time_ms_delayed(
-    timed_fn: Callable,
-    warmup_fn: Callable,
-    *,
-    warmup: int,
-    iters: int,
-) -> float:
-    """Kernel-only timing: hide host-launch overhead behind a delay kernel (see
-    benchmark_matmul.py). `timed_fn(i)` rotates buffers; `warmup_fn()` dedicated."""
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-
-    delay_cycles = max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6))
-    torch.cuda._sleep(delay_cycles)
-
-    post_warmup = max(5, warmup)
-    for _ in range(post_warmup):
-        warmup_fn()
-
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-# nsys mode — mirrors benchmark_matmul.py
-
-
-def _nsys_run_and_parse(shape, combo, configs, warmup, iters, ref_mode, nbuf) -> dict[str, float]:
-    nsys = "/usr/local/bin/nsys" if os.path.exists("/usr/local/bin/nsys") else shutil.which("nsys")
-    if nsys is None:
-        sys.exit("nsys not found — install nsight-systems or use the default events mode.")
-
-    workdir = os.path.join(os.environ.get("TMPDIR", "/tmp"), f"bench_bs_nsys_{os.getpid()}")
-    os.makedirs(workdir, exist_ok=True)
-    report_prefix = os.path.join(workdir, "report")
-
-    nsys_env = os.environ.copy()
-    nsys_env.setdefault("TMPDIR", os.environ.get("TMPDIR", tempfile.gettempdir()))
-
-    inner = [
-        sys.executable,
-        "-u",
-        os.path.abspath(__file__),
-        "--_nsys-worker",
-        "--shape",
-        shape,
-        "--combo",
-        combo,
-        "--ref",
-        ref_mode,
-        "--warmup",
-        str(warmup),
-        "--iters",
-        str(iters),
-        "--rotate-buffers",
-        str(nbuf),
-    ]
-    if configs:
-        inner += ["--configs", ",".join(configs)]
-
-    profile_cmd = [
-        nsys,
-        "profile",
-        "-o",
-        report_prefix,
-        "--force-overwrite=true",
-        "--cuda-um-cpu-page-faults=false",
-        "--cuda-um-gpu-page-faults=false",
-        "--trace=cuda",
-    ] + inner
-
-    print(f"  + {' '.join(profile_cmd)}\n")
-    proc = subprocess.run(profile_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stdout:\n" + proc.stdout)
-        print("nsys stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys profile exited {proc.returncode}")
-
-    stats_cmd = [
-        nsys,
-        "stats",
-        "--report",
-        "cuda_gpu_kern_sum",
-        "--force-export=true",
-        report_prefix + ".nsys-rep",
-    ]
-    proc = subprocess.run(stats_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stats stdout:\n" + proc.stdout)
-        print("nsys stats stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys stats exited {proc.returncode}")
-
-    return _parse_nsys_stats(proc.stdout)
-
-
-def _parse_nsys_stats(text: str) -> dict[str, float]:
-    lines = text.splitlines()
-    header_i = None
-    for i, ln in enumerate(lines):
-        if "Med (" in ln and "Name" in ln and ("ns)" in ln or "us)" in ln or "ms)" in ln):
-            header_i = i
-            break
-    if header_i is None:
-        sys.exit("could not find kernel-summary header in nsys stats output:\n  " + "\n  ".join(lines[:60]))
-
-    m_unit = re.search(r"Med \((\w+)\)", lines[header_i])
-    unit = m_unit.group(1) if m_unit else "ns"
-    unit_div = {"ns": 1e6, "us": 1e3, "ms": 1.0, "s": 1e-3}.get(unit, 1e6)
-
-    NUM_NUMERIC_COLS = 8
-    MED_COL = 4
-
-    result: dict[str, float] = {}
-    in_data = False
-    for j in range(header_i + 1, len(lines)):
-        row = lines[j]
-        stripped = row.strip()
-        if not stripped:
-            if in_data:
-                break
-            continue
-        if set(stripped) <= set("- "):
-            in_data = True
-            continue
-        if not in_data:
-            continue
-        if stripped.startswith("**") or stripped.startswith("##"):
-            break
-
-        toks = stripped.split()
-        if len(toks) <= NUM_NUMERIC_COLS:
-            continue
-        try:
-            med = float(toks[MED_COL].replace(",", ""))
-        except ValueError:
-            continue
-        name = " ".join(toks[NUM_NUMERIC_COLS:]).rstrip()
-        if not name:
-            continue
-        result[name] = med / unit_div
-    return result
-
-
-def _match_kernel_name(kern_name: str, config_name: str) -> bool:
-    return config_name in kern_name
-
-
-def _find_cublas_time(kern_times: dict[str, float]) -> tuple[str, float] | None:
-    """The reference kernel in the nsys report: cuBLAS GEMMs show up as `nvjet_*`;
-    if none match, fall back to the heaviest non-tagged kernel."""
-    cands = [(k, v) for k, v in kern_times.items() if k.startswith("nvjet_")]
-    if not cands:
-        cands = [(k, v) for k, v in kern_times.items() if "_kernel_CONFIG_sm100_" not in k]
-    if not cands:
-        return None
-    return max(cands, key=lambda x: x[1])
-
-
 # Worker mode: run the kernels under nsys profile, no Python timing.
 
 
@@ -532,7 +275,7 @@ def _nsys_worker(shape, combo, configs, warmup, iters, ref_mode, nbuf) -> None:
     # 2. each block-scale config.
     config_names = configs or list(_SPEC_MAP)
     for name in config_names:
-        spec = _spec_for(name)
+        spec = spec_for(name, _SPEC_MAP)
         cfg = spec[0] if spec else None
         if cfg is None:
             continue
@@ -564,20 +307,6 @@ def main() -> int:
         default="nvfp4",
         help="block-scale dtype family (default nvfp4: FP4 + E4M3 SF, block16)",
     )
-    parser.add_argument("--warmup", type=int, default=10)
-    # CLAUDE.md: keep iters <= 20 — more just lengthens the run / holds the GPU.
-    parser.add_argument("--iters", type=int, default=20)
-    parser.add_argument(
-        "--configs",
-        default=None,
-        help="comma-separated config names (default: every compatible CATALOG entry)",
-    )
-    parser.add_argument(
-        "--timing",
-        choices=("delayed", "events", "nsys"),
-        default="delayed",
-        help="delayed (default), events, or nsys — see benchmark_matmul.py",
-    )
     parser.add_argument(
         "--ref",
         choices=("auto", "scaled_mm", "bf16"),
@@ -587,23 +316,7 @@ def main() -> int:
         "dense BF16 cuBLAS yardstick; auto (default) = scaled_mm, "
         "falling back to bf16 if this env's cuBLASLt can't run it.",
     )
-    parser.add_argument(
-        "--stream",
-        action="store_true",
-        help="print each config's result as soon as it finishes " "(events/delayed only; the last 'running' line points at a hang).",
-    )
-    parser.add_argument(
-        "--rotate-buffers",
-        default="auto",
-        metavar="N",
-        help="allocate N independent copies of every tensor and rotate the timed "
-        "launches across them so a kernel doesn't re-read the previous "
-        "launch's data from a hot L2 (inflates small-shape TFLOPS). Warmup "
-        "uses a separate dedicated buffer. Default 'auto': size the pool to "
-        "exceed the ~126 MB B200 L2 (large shapes → 2, small → scaled up), "
-        "capped at 4 GB. Pass an integer to override; 1 disables.",
-    )
-    parser.add_argument("--_nsys-worker", action="store_true", help=argparse.SUPPRESS)
+    add_sweep_args(parser)
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
@@ -615,30 +328,20 @@ def main() -> int:
     if len(parts) != 4:
         sys.exit("--shape must be B,M,N,K (four values; use B=1 for a single GEMM)")
     B, M, N, K = parts
-    per_set = _set_bytes(_mkdata(B, M, N, K, combo))
-    nbuf = _resolve_nbuf(args.rotate_buffers, per_set)
+    per_set = set_bytes(_mkdata(B, M, N, K, combo))
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
     if getattr(args, "_nsys_worker"):
-        configs = [c.strip() for c in args.configs.split(",")] if args.configs else []
+        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, args.combo, configs, args.warmup, args.iters, args.ref, nbuf)
         return 0
 
     flops = 2 * B * M * N * K
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    config_names = select_configs(args.configs, _SPEC_MAP)
 
     print(f"\n=== block-scale matmul B={B} {M}x{N}x{K}  (~{flops / 1e9:.1f} GFLOP) — " f"{combo} in / BF16 out ===")
 
-    if nbuf > 1:
-        footprint = per_set * nbuf
-        print(f"  [rotate-buffers: {nbuf} copies/tensor, " f"{footprint / 1024 / 1024:.0f} MB pool — defeats hot-L2 on small shapes]")
-        if footprint < _L2_BYTES_B200:
-            print(
-                f"  [WARNING: pool ({footprint / 1024 / 1024:.0f} MB) < B200 L2 "
-                f"(~{_L2_BYTES_B200 / 1024 / 1024:.0f} MB) — it fits in cache, so "
-                f"launches stay warm after one rotation. Bump --rotate-buffers.]"
-            )
-    else:
-        print("  [rotate-buffers: disabled (1) — small-shape TFLOPS may be hot-L2-inflated]")
+    report_pool(nbuf, per_set)
 
     rows: list[tuple[str, float, float, str]] = []  # (name, tflops, ms, note)
     t0 = time.time()
@@ -652,9 +355,25 @@ def main() -> int:
     ref_label = "reference"
     if args.timing == "nsys":
         print(f"  [timing: nsys median kernel duration; ref={args.ref}]\n")
-        kern_times = _nsys_run_and_parse(args.shape, combo, config_names, args.warmup, args.iters, args.ref, nbuf)
+        inner_args = [
+            "--shape",
+            args.shape,
+            "--combo",
+            combo,
+            "--ref",
+            args.ref,
+            "--warmup",
+            str(args.warmup),
+            "--iters",
+            str(args.iters),
+            "--rotate-buffers",
+            str(nbuf),
+        ]
+        if config_names:
+            inner_args += ["--configs", ",".join(config_names)]
+        kern_times = nsys_run_and_parse(__file__, inner_args, tag="bench_bs")
 
-        cublas_hit = _find_cublas_time(kern_times)
+        cublas_hit = find_cublas_time(kern_times)
         if cublas_hit:
             cublas_name, cublas_ms = cublas_hit
             cublas_tflops = flops / (cublas_ms * 1e-3) / 1e12
@@ -665,19 +384,20 @@ def main() -> int:
             print("  reference kernel: not detected in nsys output")
 
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
                 continue
-            matches = [(k, v) for k, v in kern_times.items() if _match_kernel_name(k, name)]
+            tok = kernel_match_token(cfg, spec[1], spec[2])
+            matches = [(k, v) for k, v in kern_times.items() if tok in k]
             if not matches:
                 rows.append((name, 0.0, float("inf"), "NO_KERNEL_IN_NSYS"))
                 continue
             _, ms = max(matches, key=lambda x: x[1])
             rows.append((name, flops / (ms * 1e-3) / 1e12, ms, ""))
     else:
-        timer = _time_ms_delayed if args.timing == "delayed" else _time_ms_events
+        timer = time_ms_delayed if args.timing == "delayed" else time_ms_events
         if args.timing == "delayed":
             print("  [timing: events around delayed back-to-back launches — " "host overhead hidden behind a CUDA _sleep]\n")
         else:
@@ -689,7 +409,7 @@ def main() -> int:
         if args.stream:
             print(f"  ▶ running {ref_label} reference ...", flush=True)
         cublas_ms = timer(
-            _rotating(lambda call: call(), ref_timed),
+            rotating(lambda call: call(), ref_timed),
             ref_warmup,
             warmup=args.warmup,
             iters=args.iters,
@@ -709,7 +429,7 @@ def main() -> int:
 
         ctx_dead = False
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")
@@ -723,7 +443,7 @@ def main() -> int:
                     plan = _build_plan(g, cfg, name)
                     wa, wb, wc, wsfa, wsfb = wset
                     ms = timer(
-                        _rotating(
+                        rotating(
                             lambda s, _plan=plan, _h=h: _plan(_vp_bs(_h, s[0], s[1], s[2], s[3], s[4])),
                             pool,
                         ),

--- a/benchmark/gemm/frost/benchmark_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_block_scale_matmul.py
@@ -46,7 +46,7 @@ def _build_spec_map():
     m = {}
     for cfg in _CATALOG:
         kb_want = 384 if cfg.pipeline == "sm103" else 128
-        if cfg.cta_tile_m % 128 or cfg.cta_tile_n % 128 or cfg.cta_tile_k_bytes != kb_want:
+        if cfg.mma_inst_m % 128 or cfg.mma_inst_n % 128 or cfg.cta_tile_k_bytes != kb_want:
             continue
         # Only sm100 has static-scheduler variants; sm103 / sm107 are CLC-only.
         scheds = (("clc", ""), ("static", "_static")) if cfg.pipeline == "sm100" else (("clc", ""),)

--- a/benchmark/gemm/frost/benchmark_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_block_scale_matmul.py
@@ -69,7 +69,8 @@ def _vp_bs(handles, a, b, c, sfa, sfb):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg, cta_group=spec_for(name, _SPEC_MAP)[1], scheduler=spec_for(name, _SPEC_MAP)[2])
+    _, cta_group, scheduler = spec_for(name, _SPEC_MAP)
+    return jit_from_cudnn_graph(g, config=cfg, cta_group=cta_group, scheduler=scheduler)
 
 
 # Combo table (input dtype family + scale dtype + block size)
@@ -328,10 +329,11 @@ def main() -> int:
     if len(parts) != 4:
         sys.exit("--shape must be B,M,N,K (four values; use B=1 for a single GEMM)")
     B, M, N, K = parts
-    per_set = set_bytes(_mkdata(B, M, N, K, combo))
+    wset = _mkdata(B, M, N, K, combo)  # dedicated warmup buffer, and the pool's size unit
+    per_set = set_bytes(wset)
     nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
-    if getattr(args, "_nsys_worker"):
+    if args._nsys_worker:
         configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, args.combo, configs, args.warmup, args.iters, args.ref, nbuf)
         return 0
@@ -403,7 +405,6 @@ def main() -> int:
         else:
             print("  [timing: torch.cuda.Event wall-clock around python loop — " "includes ~50us/call dispatch overhead]\n")
 
-        wset = _mkdata(B, M, N, K, combo)  # dedicated warmup buffer
         pool = _mkdata_pool(B, M, N, K, combo, nbuf)  # rotation pool
         ref_label, ref_warmup, ref_timed = _make_reference_pool(B, M, N, K, combo, args.ref, nbuf)
         if args.stream:

--- a/benchmark/gemm/frost/benchmark_block_scale_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_block_scale_matmul_swiglu.py
@@ -181,7 +181,7 @@ def _build_spec_map():
     chain = analyze(_graph(1, 256, 128, 512)[0])
     m = {}
     for t, cfg in _registry_candidates(chain):
-        if cfg.pipeline not in ("sm100", "sm107") or cfg.cta_tile_m != 128 or cfg.cta_tile_n != 128:
+        if cfg.pipeline not in ("sm100", "sm107") or cfg.mma_inst_m != 128 or cfg.cta_tile_n != 128:
             continue
         label = f"{cfg.name}_{t.cta_group}ctamma" + ("_static" if t.static_sched else "")
         m[label] = (cfg, t.cta_group, t.scheduler)

--- a/benchmark/gemm/frost/benchmark_block_scale_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_block_scale_matmul_swiglu.py
@@ -11,9 +11,7 @@ operand (+ SFA), loaded once. Runs on 1-CTA-MMA templates; cta_n capped at 128
 from __future__ import annotations
 
 import argparse
-import re
 import sys
-from typing import Callable
 
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  (installs hook)
@@ -22,9 +20,10 @@ import torch
 from types import SimpleNamespace
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.tile_config import by_name as _by_name
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
+
+from benchmark_utils import add_sweep_args, ceil_div, report_pool, resolve_nbuf, rotating, select_configs, set_bytes, spec_for, time_ms, to_blocked
 
 
 def _build_plan(g, cfg, cta_group, sched):
@@ -76,19 +75,6 @@ _E2M1 = [
 ]
 
 
-def _ceil_div(a, b):
-    return (a + b - 1) // b
-
-
-def _to_blocked(x):
-    rows, cols = x.shape
-    nrb, ncb = _ceil_div(rows, 128), _ceil_div(cols, 4)
-    pad = torch.zeros(nrb * 128, ncb * 4, dtype=x.dtype, device=x.device)
-    pad[:rows, :cols] = x
-    blocks = pad.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
-    return blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16).flatten()
-
-
 def _unpack_fp4(u8, lut):
     lo = lut[(u8 & 0xF).long()]
     hi = lut[(u8 >> 4).long()]
@@ -129,6 +115,9 @@ def _graph(B, M, N, K, bs=16):
 
 
 def _mkdata(B, M, N, K, bs=16):
+    """One independent input set: the per-GEMM ((a, sfa), (b, sfb)) pairs (A shared
+    by both GEMMs), the dequantized fp32 operands the reference/baseline read, and
+    its own fused / baseline output buffers."""
     dev = "cuda"
     sf_k = K // bs
     lut = torch.tensor(_E2M1, dtype=torch.float32, device=dev)
@@ -143,8 +132,8 @@ def _mkdata(B, M, N, K, bs=16):
 
     def _sf(rows):
         log = torch.randint(1, 4, (B, rows, sf_k), device=dev).to(torch.float8_e4m3fn)
-        # _to_blocked pads to whole 128-row x 4-SF-K atoms — view the PADDED dims.
-        blk = torch.stack([_to_blocked(log[b]) for b in range(B)]).view(B, _ceil_div(rows, 128) * 128, _ceil_div(sf_k, 4) * 4)
+        # to_blocked pads to whole 128-row x 4-SF-K atoms — view the PADDED dims.
+        blk = torch.stack([to_blocked(log[b]) for b in range(B)]).view(B, ceil_div(rows, 128) * 128, ceil_div(sf_k, 4) * 4)
         return log, blk
 
     sfa_log, sfa_b = _sf(M)
@@ -155,7 +144,20 @@ def _mkdata(B, M, N, K, bs=16):
     b0_s = b0_deq * sfb0_log.float().repeat_interleave(bs, 2)
     b1_s = b1_deq * sfb1_log.float().repeat_interleave(bs, 2)
     pairs = [((a_rt, sfa_b), (b0_rt, sfb0_b)), ((a_rt, sfa_b), (b1_rt, sfb1_b))]
-    return pairs, (a_s, b0_s, b1_s)
+    out = torch.zeros(B, M, N, dtype=torch.float32, device=dev)
+    out_bl = torch.empty_like(out)
+    return SimpleNamespace(
+        pairs=pairs,
+        deq=(a_s, b0_s, b1_s),
+        out=out,
+        out_bl=out_bl,
+        tensors=(a_rt, sfa_b, b0_rt, sfb0_b, b1_rt, sfb1_b, a_s, b0_s, b1_s, out, out_bl),
+    )
+
+
+def _mkdata_pool(B, M, N, K, nbuf):
+    """`nbuf` independent input sets at distinct GMEM addresses."""
+    return [_mkdata(B, M, N, K) for _ in range(nbuf)]
 
 
 def _reference(a_s, b0_s, b1_s):
@@ -172,24 +174,6 @@ def _unfused_launch(a_s, b0_s, b1_s, out):
     out.copy_(torch.nn.functional.silu(c0.float()) * c1.float())
 
 
-# --- Timing (delayed / events) ---
-def _time_ms(timed_fn: Callable, *, warmup: int, iters: int, delayed: bool) -> float:
-    for _ in range(warmup):
-        timed_fn()
-    torch.cuda.synchronize()
-    if delayed:
-        torch.cuda._sleep(max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6)))
-        for _ in range(max(5, warmup)):
-            timed_fn()
-    start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
-    start.record()
-    for _ in range(iters):
-        timed_fn()
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
 def _build_spec_map():
     """Label CONFIG_..._Nctamma[_static] -> (cfg, cta_group, scheduler) for every
     multi-GEMM-capable sm100 block-scale strategy. Pins cta_tile_n=128 (SF 128x4
@@ -197,7 +181,7 @@ def _build_spec_map():
     chain = analyze(_graph(1, 256, 128, 512)[0])
     m = {}
     for t, cfg in _registry_candidates(chain):
-        if cfg.pipeline != "sm100" or cfg.cta_tile_m != 128 or cfg.cta_tile_n != 128:
+        if cfg.pipeline not in ("sm100", "sm107") or cfg.cta_tile_m != 128 or cfg.cta_tile_n != 128:
             continue
         label = f"{cfg.name}_{t.cta_group}ctamma" + ("_static" if t.static_sched else "")
         m[label] = (cfg, t.cta_group, t.scheduler)
@@ -206,35 +190,11 @@ def _build_spec_map():
 
 _SPEC_MAP = _build_spec_map()
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting it unsweepable."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--shape", default="1,4096,4096,4096", help="B,M,N,K")
-    p.add_argument("--warmup", type=int, default=10)
-    p.add_argument("--iters", type=int, default=20)  # CLAUDE.md: <= 20
-    p.add_argument("--configs", default=None)
-    p.add_argument("--timing", choices=("delayed", "events"), default="delayed")
+    add_sweep_args(p, nsys=False)
     args = p.parse_args()
 
     if not torch.cuda.is_available():
@@ -245,33 +205,40 @@ def main() -> int:
     if len(parts) != 4:
         sys.exit("--shape must be B,M,N,K")
     B, M, N, K = parts
-    delayed = args.timing == "delayed"
     flops = 2 * (2 * B * M * N * K)
     print(f"\n=== block-scale SwiGLU dual-matmul (nvfp4)  B={B} {M}x{N}x{K}  " f"(~{flops / 1e9:.1f} GFLOP, 2 GEMMs) ===")
-    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]\n")
+    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]")
 
-    pairs, (a_s, b0_s, b1_s) = _mkdata(B, M, N, K)
-    ref = _reference(a_s, b0_s, b1_s)
-    out = torch.zeros(B, M, N, dtype=torch.float32, device="cuda")
+    wset = _mkdata(B, M, N, K)
+    per_set = set_bytes(wset.tensors)
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set)
+    report_pool(nbuf, per_set)
+    print()
+    pool = _mkdata_pool(B, M, N, K, nbuf)
+    ref = _reference(*wset.deq)
 
-    out_bl = torch.empty_like(out)
-    bl_ms = _time_ms(
-        lambda: _unfused_launch(a_s, b0_s, b1_s, out_bl),
+    if args.stream:
+        print("  ▶ running unfused baseline ...", flush=True)
+    bl_ms = time_ms(
+        rotating(lambda s: _unfused_launch(*s.deq, s.out_bl), pool),
+        lambda: _unfused_launch(*wset.deq, wset.out_bl),
         warmup=args.warmup,
         iters=args.iters,
-        delayed=delayed,
+        timing=args.timing,
     )
     print(f"  {'unfused dequant+2xcuBLAS+pointwise':52s} " f"{flops / (bl_ms * 1e-3) / 1e12:8.2f} TFLOP/s  {bl_ms:8.3f} ms   {'1.00×':>8s}")
 
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    config_names = select_configs(args.configs, _SPEC_MAP)
 
     best = None
     for name in config_names:
-        spec = _spec_for(name)
+        spec = spec_for(name, _SPEC_MAP)
         if spec is None:
             print(f"  {name:62s} UNKNOWN (not a sweepable block-scale strategy)")
             continue
         cfg, cta_group, sched = spec
+        if args.stream:
+            print(f"  ▶ running {name} ...", flush=True)
         try:
             g, h = _graph(B, M, N, K)
             plan = _build_plan(g, cfg, cta_group, sched)
@@ -279,22 +246,23 @@ def main() -> int:
             print(f"  {name:62s} SKIP: {str(e)[:42]}")
             continue
         try:
-            plan(_vp_bs_mg(h, pairs, out))
+            plan(_vp_bs_mg(h, wset.pairs, wset.out))
             torch.cuda.synchronize()
         except Exception as e:  # noqa: BLE001
             print(f"  {name:62s} LAUNCH FAIL: {type(e).__name__}: {str(e)[:30]}")
             continue
-        ok = torch.allclose(out.float(), ref.float(), rtol=2e-2, atol=2e-1)  # swish: fast approx
-        err = (out.float() - ref.float()).abs().max().item()
-        ms = _time_ms(
-            lambda: plan(_vp_bs_mg(h, pairs, out)),
+        ok = torch.allclose(wset.out.float(), ref.float(), rtol=2e-2, atol=2e-1)  # swish: fast approx
+        err = (wset.out.float() - ref.float()).abs().max().item()
+        ms = time_ms(
+            rotating(lambda s, _plan=plan, _h=h: _plan(_vp_bs_mg(_h, s.pairs, s.out)), pool),
+            lambda _plan=plan, _h=h: _plan(_vp_bs_mg(_h, wset.pairs, wset.out)),
             warmup=args.warmup,
             iters=args.iters,
-            delayed=delayed,
+            timing=args.timing,
         )
         ratio = bl_ms / ms if ms > 0 else 0.0
         flag = "" if ok else f"  !! maxerr={err:.3g}"
-        print(f"  {name:62s} {flops / (ms * 1e-3) / 1e12:8.2f} TFLOP/s  " f"{ms:8.3f} ms   {ratio:>7.2f}×{flag}")
+        print(f"  {name:62s} {flops / (ms * 1e-3) / 1e12:8.2f} TFLOP/s  " f"{ms:8.3f} ms   {ratio:>7.2f}×{flag}", flush=True)
         if ok and (best is None or ms < best[1]):
             best = (name, ms, flops / (ms * 1e-3) / 1e12, ratio)
 

--- a/benchmark/gemm/frost/benchmark_matmul.py
+++ b/benchmark/gemm/frost/benchmark_matmul.py
@@ -200,7 +200,7 @@ def main() -> int:
     B, M, N, K = parts
     nbuf = resolve_nbuf(args.rotate_buffers, _per_set_bytes(B, M, N, K))
 
-    if getattr(args, "_nsys_worker"):
+    if args._nsys_worker:
         configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf)
         return 0

--- a/benchmark/gemm/frost/benchmark_matmul.py
+++ b/benchmark/gemm/frost/benchmark_matmul.py
@@ -13,14 +13,8 @@ hot-L2 inflation on small shapes.
 from __future__ import annotations
 
 import argparse
-import os
-import re
-import shutil
-import subprocess
 import sys
-import tempfile
 import time
-from typing import Callable
 
 import cudnn  # noqa: F401
 import cudnn.gemm.frost  # noqa: F401
@@ -29,7 +23,20 @@ import torch
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 from cudnn.gemm.frost.fusion_ir import FusionChain as _FC, MatmulSpec as _MS, OutputSpec as _OS
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
-from cudnn.gemm.frost.tile_config import by_name as _by_name
+
+from benchmark_utils import (
+    add_sweep_args,
+    find_cublas_time,
+    kernel_match_token,
+    nsys_run_and_parse,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_configs,
+    spec_for,
+    time_ms_delayed,
+    time_ms_events,
+)
 
 
 def _build_spec_map():
@@ -58,27 +65,6 @@ def _build_spec_map():
 
 _SPEC_MAP = _build_spec_map()
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting UNKNOWN_CONFIG."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
 
 def _vp(handles, a, b, c):
     """Variant-pack dict {cuDNN tensor: buffer} keyed by the graph's tensors."""
@@ -88,7 +74,7 @@ def _vp(handles, a, b, c):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the recorded graph with a forced tile config."""
-    _, cta_group, scheduler = _spec_for(name)
+    _, cta_group, scheduler = spec_for(name, _SPEC_MAP)
     return jit_from_cudnn_graph(g, config=cfg, cta_group=cta_group, scheduler=scheduler)
 
 
@@ -121,13 +107,6 @@ def _mkdata(batch: int, M: int, N: int, K: int):
 # ---------------------------------------------------------------------------
 # Buffer rotation — defeat the hot-L2 artifact on small shapes
 # ---------------------------------------------------------------------------
-# Rotating launches across a pool of independent tensor copies (launch i uses
-# pool[i % N]) forces DRAM reads once the pool exceeds L2 — otherwise a small
-# matmul re-reads hot-L2 inputs and reports inflated TFLOPS.
-
-
-# B200 L2 is ~126 MB; a pool smaller than this stays fully cached — warn to bump.
-_L2_BYTES_B200 = 126 * 1024 * 1024
 
 
 def _mkdata_pool(batch: int, M: int, N: int, K: int, nbuf: int):
@@ -144,260 +123,6 @@ def _mkdata_pool(batch: int, M: int, N: int, K: int, nbuf: int):
 def _per_set_bytes(batch: int, M: int, N: int, K: int) -> int:
     # BF16 = 2 bytes/elem; a:(batch,M,K) b:(batch,N,K) c:(batch,M,N).
     return 2 * batch * (M * K + N * K + M * N)
-
-
-def _pool_footprint_bytes(batch: int, M: int, N: int, K: int, nbuf: int) -> int:
-    return _per_set_bytes(batch, M, N, K) * nbuf
-
-
-# Cap the auto-sized pool so a large shape doesn't allocate needless copies.
-_AUTO_POOL_BUDGET_BYTES = 4 * 1024 * 1024 * 1024  # 4 GB
-_AUTO_NBUF_CAP = 1024
-
-
-def _auto_nbuf(batch: int, M: int, N: int, K: int) -> int:
-    """Smallest buffer count whose pool exceeds L2 (1.5× margin), clamped to a
-    memory budget. Large shapes → 2; small shapes → scaled up until L2-cold."""
-    per_set = _per_set_bytes(batch, M, N, K)
-    target = int(1.5 * _L2_BYTES_B200)
-    nbuf = max(2, -(-target // per_set))  # ceil-div
-
-    # Cap at min(4 GB, half of currently-free GMEM).
-    budget = _AUTO_POOL_BUDGET_BYTES
-    if torch.cuda.is_available():
-        free, _total = torch.cuda.mem_get_info()
-        budget = min(budget, free // 2)
-    max_by_budget = max(1, budget // per_set)
-
-    return max(1, min(nbuf, max_by_budget, _AUTO_NBUF_CAP))
-
-
-def _resolve_nbuf(spec: str, batch: int, M: int, N: int, K: int) -> int:
-    """Resolve --rotate-buffers: 'auto' → shape-sized count, else the integer
-    (1 = rotation disabled)."""
-    if spec.strip().lower() == "auto":
-        return _auto_nbuf(batch, M, N, K)
-    return max(1, int(spec))
-
-
-def _rotating(fn_of_buf: Callable, pool: list) -> Callable:
-    """Wrap `(a,b,c) -> None` into `i -> None` selecting pool[i % len(pool)]."""
-    n = len(pool)
-    return lambda i: fn_of_buf(pool[i % n])
-
-
-# ---------------------------------------------------------------------------
-# Timing (events mode)
-# ---------------------------------------------------------------------------
-
-
-def _time_ms_events(
-    timed_fn: Callable,
-    warmup_fn: Callable,
-    *,
-    warmup: int,
-    iters: int,
-) -> float:
-    """Wall-clock CUDA Event timing around a python loop. Inflated by
-    Python+TVM-FFI dispatch overhead (~50us/call). `timed_fn(i)` rotates
-    buffers; `warmup_fn()` uses a separate dedicated buffer."""
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-def _time_ms_delayed(
-    timed_fn: Callable,
-    warmup_fn: Callable,
-    *,
-    warmup: int,
-    iters: int,
-) -> float:
-    """Kernel-only timing: queue a long `_sleep` first so the host enqueues
-    every launch behind it → kernels run back-to-back with no host gaps.
-    `timed_fn(i)` rotates buffers; `warmup_fn()` uses a separate buffer.
-
-    The post-sleep warmup ramps SM clocks (DVFS) back up before timing —
-    without it the first fast-config measurement inflates ~2×."""
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-
-    # Delay must outlast iters × ~50us host overhead. B200 ~1.7 GHz; floor 1e8.
-    delay_cycles = max(
-        int(1e8),
-        int((iters * 0.05 + 20.0) * 1.7e6),
-    )
-    torch.cuda._sleep(delay_cycles)
-
-    # Post-sleep warmup (behind the sleep) ramps clocks before timing.
-    post_warmup = max(5, warmup)
-    for _ in range(post_warmup):
-        warmup_fn()
-
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-# ---------------------------------------------------------------------------
-# nsys mode
-# ---------------------------------------------------------------------------
-
-
-def _nsys_run_and_parse(
-    shape: str,
-    configs: list[str],
-    warmup: int,
-    iters: int,
-    nbuf: int,
-) -> dict[str, float]:
-    """Re-exec self under nsys, parse `cuda_gpu_kern_sum` for median kernel
-    time (ms) per config. Returns {config_name_or_'cuBLAS': median_ms}."""
-    nsys = "/usr/local/bin/nsys" if os.path.exists("/usr/local/bin/nsys") else shutil.which("nsys")
-    if nsys is None:
-        sys.exit("nsys not found — install nsight-systems or use the default events mode.")
-
-    workdir = os.path.join(os.environ.get("TMPDIR", "/tmp"), f"benchmark_matmul_nsys_{os.getpid()}")
-    os.makedirs(workdir, exist_ok=True)
-    report_prefix = os.path.join(workdir, "report")
-
-    # Redirect nsys's default /tmp/nvidia path (root-owned on this host) via env.
-    nsys_env = os.environ.copy()
-    nsys_env.setdefault("TMPDIR", os.environ.get("TMPDIR", tempfile.gettempdir()))
-
-    # Inner command — same script with --_nsys-worker.
-    inner = [
-        sys.executable,
-        "-u",
-        os.path.abspath(__file__),
-        "--_nsys-worker",
-        "--shape",
-        shape,
-        "--warmup",
-        str(warmup),
-        "--iters",
-        str(iters),
-        "--rotate-buffers",
-        str(nbuf),
-    ]
-    if configs:
-        inner += ["--configs", ",".join(configs)]
-
-    # Step 1: profile (record only; --stats stdout is unreliable across versions).
-    profile_cmd = [
-        nsys,
-        "profile",
-        "-o",
-        report_prefix,
-        "--force-overwrite=true",
-        "--cuda-um-cpu-page-faults=false",
-        "--cuda-um-gpu-page-faults=false",
-        "--trace=cuda",
-    ] + inner
-
-    print(f"  + {' '.join(profile_cmd)}\n")
-    proc = subprocess.run(profile_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stdout:\n" + proc.stdout)
-        print("nsys stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys profile exited {proc.returncode}")
-
-    # Step 2: extract the kernel-summary table.
-    stats_cmd = [
-        nsys,
-        "stats",
-        "--report",
-        "cuda_gpu_kern_sum",
-        "--force-export=true",
-        report_prefix + ".nsys-rep",
-    ]
-    proc = subprocess.run(stats_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stats stdout:\n" + proc.stdout)
-        print("nsys stats stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys stats exited {proc.returncode}")
-
-    return _parse_nsys_stats(proc.stdout)
-
-
-def _parse_nsys_stats(text: str) -> dict[str, float]:
-    """Parse `nsys stats --report cuda_gpu_kern_sum`. Returns {kernel_name:
-    median_ms}. Columns: 8 numeric (Time% Total Instances Avg Med Min Max
-    StdDev), then Name. Numbers may carry commas but no internal spaces, so
-    whitespace tokenization is reliable."""
-    lines = text.splitlines()
-    header_i = None
-    for i, ln in enumerate(lines):
-        if "Med (" in ln and "Name" in ln and ("ns)" in ln or "us)" in ln or "ms)" in ln):
-            header_i = i
-            break
-    if header_i is None:
-        sys.exit("could not find kernel-summary header in nsys stats output:\n  " + "\n  ".join(lines[:60]))
-
-    m_unit = re.search(r"Med \((\w+)\)", lines[header_i])
-    unit = m_unit.group(1) if m_unit else "ns"
-    unit_div = {"ns": 1e6, "us": 1e3, "ms": 1.0, "s": 1e-3}.get(unit, 1e6)
-
-    # Med is numeric col 4 (0-indexed); the name is everything after col 8.
-    NUM_NUMERIC_COLS = 8
-    MED_COL = 4
-
-    result: dict[str, float] = {}
-    in_data = False
-    for j in range(header_i + 1, len(lines)):
-        row = lines[j]
-        stripped = row.strip()
-        if not stripped:
-            if in_data:
-                break
-            continue
-        if set(stripped) <= set("- "):
-            in_data = True
-            continue
-        if not in_data:
-            continue
-        if stripped.startswith("**") or stripped.startswith("##"):
-            break
-
-        toks = stripped.split()
-        if len(toks) <= NUM_NUMERIC_COLS:
-            continue
-        try:
-            med = float(toks[MED_COL].replace(",", ""))
-        except ValueError:
-            continue
-        name = " ".join(toks[NUM_NUMERIC_COLS:]).rstrip()
-        if not name:
-            continue
-        result[name] = med / unit_div
-    return result
-
-
-def _match_kernel_name(kern_name: str, config_name: str) -> bool:
-    """Match a config against nsys's demangled symbol by substring."""
-    return config_name in kern_name
-
-
-def _find_cublas_time(kern_times: dict[str, float]) -> tuple[str, float] | None:
-    """The cuBLAS 'nvjet_*' kernel with the longest median."""
-    cands = [(k, v) for k, v in kern_times.items() if k.startswith("nvjet_")]
-    if not cands:
-        return None
-    return max(cands, key=lambda x: x[1])
 
 
 # ---------------------------------------------------------------------------
@@ -432,7 +157,7 @@ def _nsys_worker(
     # 2. each GEMM config.
     config_names = configs or list(_SPEC_MAP)
     for name in config_names:
-        spec = _spec_for(name)
+        spec = spec_for(name, _SPEC_MAP)
         if spec is None:
             continue
         cfg = spec[0]
@@ -462,50 +187,7 @@ def main() -> int:
         default="1,4096,4096,4096",
         help="B,M,N,K (default 1,4096,4096,4096; B = batch / number of " "independent same-shape GEMMs)",
     )
-    parser.add_argument("--warmup", type=int, default=10)
-    # CLAUDE.md: keep iters <= 20 (more doesn't sharpen the measurement).
-    parser.add_argument("--iters", type=int, default=20)
-    parser.add_argument(
-        "--configs",
-        default=None,
-        help="comma-separated config names to test (default: every CATALOG entry)",
-    )
-    parser.add_argument(
-        "--timing",
-        choices=("delayed", "events", "nsys"),
-        default="delayed",
-        help="delayed (default): events-around-loop, with a long delay kernel "
-        "queued first to hide host-launch overhead — matches nsys to "
-        "<2%%. events: plain events around a loop (has ~50us/call "
-        "Python overhead — inflates sub-ms kernels). nsys: ground "
-        "truth via nsys profile (read GPU-side kernel timestamps).",
-    )
-    parser.add_argument(
-        "--stream",
-        action="store_true",
-        help="print each config's result line as soon as it finishes (and a "
-        "'running …' line before measurement starts). Useful when a "
-        "config hangs — the last 'running' line points at the culprit. "
-        "events/delayed modes only; no effect under --timing nsys.",
-    )
-    parser.add_argument(
-        "--rotate-buffers",
-        default="auto",
-        metavar="N",
-        help="allocate N independent copies of every tensor and rotate the "
-        "timed launches across them (launch i uses copy i%%N) so a kernel "
-        "doesn't re-read the previous launch's data from a hot L2 — the "
-        "main source of inflated TFLOPS on small shapes. Warmup uses a "
-        "separate dedicated buffer (never rotated). Default 'auto': size "
-        "the pool to exceed the ~126 MB B200 L2 for this shape (large "
-        "shapes → 2 copies, small shapes → scaled up), capped at 4 GB. "
-        "Pass an integer to override; 1 disables rotation.",
-    )
-    parser.add_argument(
-        "--_nsys-worker",
-        action="store_true",
-        help=argparse.SUPPRESS,
-    )
+    add_sweep_args(parser)
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
@@ -516,29 +198,19 @@ def main() -> int:
     if len(parts) != 4:
         sys.exit("--shape must be B,M,N,K (four values; use B=1 for a plain matmul)")
     B, M, N, K = parts
-    nbuf = _resolve_nbuf(args.rotate_buffers, B, M, N, K)
+    nbuf = resolve_nbuf(args.rotate_buffers, _per_set_bytes(B, M, N, K))
 
     if getattr(args, "_nsys_worker"):
-        configs = [c.strip() for c in args.configs.split(",")] if args.configs else []
+        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf)
         return 0
 
     flops = 2 * B * M * N * K
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    config_names = select_configs(args.configs, _SPEC_MAP)
 
     print(f"\n=== matmul B={B} {M}x{N}x{K}  (~{flops / 1e9:.1f} GFLOP) — BF16 ===")
 
-    if nbuf > 1:
-        footprint = _pool_footprint_bytes(B, M, N, K, nbuf)
-        print(f"  [rotate-buffers: {nbuf} copies/tensor, " f"{footprint / 1024 / 1024:.0f} MB pool — defeats hot-L2 on small shapes]")
-        if footprint < _L2_BYTES_B200:
-            print(
-                f"  [WARNING: pool ({footprint / 1024 / 1024:.0f} MB) < B200 L2 "
-                f"(~{_L2_BYTES_B200 / 1024 / 1024:.0f} MB) — it fits in cache, so "
-                f"launches stay warm after one rotation. Bump --rotate-buffers.]"
-            )
-    else:
-        print("  [rotate-buffers: disabled (1) — small-shape TFLOPS may be hot-L2-inflated]")
+    report_pool(nbuf, _per_set_bytes(B, M, N, K))
 
     rows: list[tuple[str, float, float, str]] = []  # (name, tflops, ms, note)
     t0 = time.time()
@@ -551,9 +223,12 @@ def main() -> int:
 
     if args.timing == "nsys":
         print("  [timing: nsys median kernel duration]\n")
-        kern_times = _nsys_run_and_parse(args.shape, config_names, args.warmup, args.iters, nbuf)
+        inner_args = ["--shape", args.shape, "--warmup", str(args.warmup), "--iters", str(args.iters), "--rotate-buffers", str(nbuf)]
+        if config_names:
+            inner_args += ["--configs", ",".join(config_names)]
+        kern_times = nsys_run_and_parse(__file__, inner_args, tag="benchmark_matmul")
 
-        cublas_hit = _find_cublas_time(kern_times)
+        cublas_hit = find_cublas_time(kern_times)
         if cublas_hit:
             cublas_name, cublas_ms = cublas_hit
             cublas_tflops = flops / (cublas_ms * 1e-3) / 1e12
@@ -563,12 +238,13 @@ def main() -> int:
             print("  cuBLAS kernel: not detected in nsys output")
 
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
                 continue
-            matches = [(k, v) for k, v in kern_times.items() if _match_kernel_name(k, name)]
+            tok = kernel_match_token(cfg, spec[1], spec[2])
+            matches = [(k, v) for k, v in kern_times.items() if tok in k]
             if not matches:
                 rows.append((name, 0.0, float("inf"), "NO_KERNEL_IN_NSYS"))
                 continue
@@ -576,7 +252,7 @@ def main() -> int:
             _, ms = max(matches, key=lambda x: x[1])
             rows.append((name, flops / (ms * 1e-3) / 1e12, ms, ""))
     else:
-        timer = _time_ms_delayed if args.timing == "delayed" else _time_ms_events
+        timer = time_ms_delayed if args.timing == "delayed" else time_ms_events
         if args.timing == "delayed":
             print("  [timing: events bracketed around delayed back-to-back " "launches — host overhead hidden behind a CUDA _sleep]\n")
         else:
@@ -590,7 +266,7 @@ def main() -> int:
         if args.stream:
             print("  ▶ running cuBLAS reference ...", flush=True)
         cublas_ms = timer(
-            _rotating(lambda t: torch.matmul(t[0], t[1].transpose(-1, -2), out=t[2]), pool),
+            rotating(lambda t: torch.matmul(t[0], t[1].transpose(-1, -2), out=t[2]), pool),
             lambda: torch.matmul(wa, wb.transpose(-1, -2), out=wc),
             warmup=args.warmup,
             iters=args.iters,
@@ -607,7 +283,7 @@ def main() -> int:
         # first such error, short-circuit the remaining configs as CTX_DEAD.
         ctx_dead = False
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")
@@ -620,7 +296,7 @@ def main() -> int:
                     g, h = _graph_matmul(B, M, N, K)
                     plan = _build_plan(g, cfg, name)
                     ms = timer(
-                        _rotating(
+                        rotating(
                             lambda t, _plan=plan, _h=h: _plan(_vp(_h, t[0], t[1], t[2])),
                             pool,
                         ),

--- a/benchmark/gemm/frost/benchmark_matmul_mixed_input.py
+++ b/benchmark/gemm/frost/benchmark_matmul_mixed_input.py
@@ -98,7 +98,8 @@ def _vp(handles, a, b, c):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the graph with a forced tile config -> callable kernel."""
-    return jit_from_cudnn_graph(g, config=cfg, cta_group=spec_for(name, _SPEC_MAP)[1], scheduler=spec_for(name, _SPEC_MAP)[2])
+    _, cta_group, scheduler = spec_for(name, _SPEC_MAP)
+    return jit_from_cudnn_graph(g, config=cfg, cta_group=cta_group, scheduler=scheduler)
 
 
 # ---------------------------------------------------------------------------
@@ -230,7 +231,7 @@ def main() -> int:
     per_set = _per_set_bytes(B, M, N, K, load_dt, tin_dt, tout_dt)
     nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
-    if getattr(args, "_nsys_worker"):
+    if args._nsys_worker:
         configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf, load_dt, tin_dt, tout_dt)
         return 0

--- a/benchmark/gemm/frost/benchmark_matmul_mixed_input.py
+++ b/benchmark/gemm/frost/benchmark_matmul_mixed_input.py
@@ -13,23 +13,30 @@ benchmark_matmul.py.
 from __future__ import annotations
 
 import argparse
-import os
-import re
-import shutil
-import subprocess
 import sys
-import tempfile
 import time
-from typing import Callable
 
 import cudnn  # noqa: F401
 import cudnn.gemm.frost  # noqa: F401
 import torch
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.tile_config import by_name as _by_name
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
+
+from benchmark_utils import (
+    add_sweep_args,
+    find_cublas_time,
+    kernel_match_token,
+    nsys_run_and_parse,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_configs,
+    spec_for,
+    time_ms_delayed,
+    time_ms_events,
+)
 
 # name -> (cudnn enum, torch dtype, element bytes, is_integer). load = narrow A
 # storage; tin = MMA / B dtype; tout = output.
@@ -82,27 +89,6 @@ def _build_spec_map():
 
 _SPEC_MAP = _build_spec_map()
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting UNKNOWN_CONFIG."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
 
 def _vp(handles, a, b, c):
     """Variant-pack dict {tensor: buffer}; `a` is the narrow (load-dtype) A root operand."""
@@ -112,7 +98,7 @@ def _vp(handles, a, b, c):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the graph with a forced tile config -> callable kernel."""
-    return jit_from_cudnn_graph(g, config=cfg, cta_group=_spec_for(name)[1], scheduler=_spec_for(name)[2])
+    return jit_from_cudnn_graph(g, config=cfg, cta_group=spec_for(name, _SPEC_MAP)[1], scheduler=spec_for(name, _SPEC_MAP)[2])
 
 
 # ---------------------------------------------------------------------------
@@ -159,12 +145,6 @@ def _cublas_ref(a, b, c, tin_dt: str):
     torch.matmul(a.to(t_tin), b.to(t_tin).transpose(-1, -2), out=c)
 
 
-# Buffer rotation — rotate timed launches across independent tensor copies so a
-# kernel doesn't re-read the prior launch's data from a hot L2 (inflates
-# small-shape TFLOPS). See benchmark_matmul.py.
-_L2_BYTES_B200 = 126 * 1024 * 1024
-
-
 def _mkdata_pool(batch, M, N, K, load_dt, tin_dt, tout_dt, nbuf):
     a, b, c = _mkdata(batch, M, N, K, load_dt, tin_dt, tout_dt)
     pool = [(a, b, c)]
@@ -178,202 +158,6 @@ def _per_set_bytes(batch, M, N, K, load_dt, tin_dt, tout_dt) -> int:
     bin_ = _dt(tin_dt)[2]
     bout = _dt(tout_dt)[2]
     return batch * (bl * M * K + bin_ * N * K + bout * M * N)
-
-
-_AUTO_POOL_BUDGET_BYTES = 4 * 1024 * 1024 * 1024
-_AUTO_NBUF_CAP = 1024
-
-
-def _auto_nbuf(batch, M, N, K, load_dt, tin_dt, tout_dt) -> int:
-    per_set = _per_set_bytes(batch, M, N, K, load_dt, tin_dt, tout_dt)
-    target = int(1.5 * _L2_BYTES_B200)
-    nbuf = max(2, -(-target // per_set))
-    budget = _AUTO_POOL_BUDGET_BYTES
-    if torch.cuda.is_available():
-        free, _total = torch.cuda.mem_get_info()
-        budget = min(budget, free // 2)
-    max_by_budget = max(1, budget // per_set)
-    return max(1, min(nbuf, max_by_budget, _AUTO_NBUF_CAP))
-
-
-def _resolve_nbuf(spec, batch, M, N, K, load_dt, tin_dt, tout_dt) -> int:
-    if spec.strip().lower() == "auto":
-        return _auto_nbuf(batch, M, N, K, load_dt, tin_dt, tout_dt)
-    return max(1, int(spec))
-
-
-def _rotating(fn_of_buf: Callable, pool: list) -> Callable:
-    n = len(pool)
-    return lambda i: fn_of_buf(pool[i % n])
-
-
-# Timing (events / delayed) — identical to benchmark_matmul.py.
-
-
-def _time_ms_events(timed_fn, warmup_fn, *, warmup, iters) -> float:
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-def _time_ms_delayed(timed_fn, warmup_fn, *, warmup, iters) -> float:
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-    delay_cycles = max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6))
-    torch.cuda._sleep(delay_cycles)
-    post_warmup = max(5, warmup)
-    for _ in range(post_warmup):
-        warmup_fn()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-# ---------------------------------------------------------------------------
-# nsys mode
-# ---------------------------------------------------------------------------
-
-
-def _nsys_run_and_parse(shape, configs, warmup, iters, nbuf, load_dt, tin_dt, tout_dt) -> dict[str, float]:
-    nsys = "/usr/local/bin/nsys" if os.path.exists("/usr/local/bin/nsys") else shutil.which("nsys")
-    if nsys is None:
-        sys.exit("nsys not found — install nsight-systems or use the default events mode.")
-
-    workdir = os.path.join(os.environ.get("TMPDIR", "/tmp"), f"benchmark_mixed_nsys_{os.getpid()}")
-    os.makedirs(workdir, exist_ok=True)
-    report_prefix = os.path.join(workdir, "report")
-
-    nsys_env = os.environ.copy()
-    nsys_env.setdefault("TMPDIR", os.environ.get("TMPDIR", tempfile.gettempdir()))
-
-    inner = [
-        sys.executable,
-        "-u",
-        os.path.abspath(__file__),
-        "--_nsys-worker",
-        "--shape",
-        shape,
-        "--warmup",
-        str(warmup),
-        "--iters",
-        str(iters),
-        "--rotate-buffers",
-        str(nbuf),
-        "--load-dtype",
-        load_dt,
-        "--tin",
-        tin_dt,
-        "--tout",
-        tout_dt,
-    ]
-    if configs:
-        inner += ["--configs", ",".join(configs)]
-
-    profile_cmd = [
-        nsys,
-        "profile",
-        "-o",
-        report_prefix,
-        "--force-overwrite=true",
-        "--cuda-um-cpu-page-faults=false",
-        "--cuda-um-gpu-page-faults=false",
-        "--trace=cuda",
-    ] + inner
-
-    print(f"  + {' '.join(profile_cmd)}\n")
-    proc = subprocess.run(profile_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stdout:\n" + proc.stdout)
-        print("nsys stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys profile exited {proc.returncode}")
-
-    stats_cmd = [
-        nsys,
-        "stats",
-        "--report",
-        "cuda_gpu_kern_sum",
-        "--force-export=true",
-        report_prefix + ".nsys-rep",
-    ]
-    proc = subprocess.run(stats_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stats stdout:\n" + proc.stdout)
-        print("nsys stats stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys stats exited {proc.returncode}")
-
-    return _parse_nsys_stats(proc.stdout)
-
-
-def _parse_nsys_stats(text: str) -> dict[str, float]:
-    lines = text.splitlines()
-    header_i = None
-    for i, ln in enumerate(lines):
-        if "Med (" in ln and "Name" in ln and ("ns)" in ln or "us)" in ln or "ms)" in ln):
-            header_i = i
-            break
-    if header_i is None:
-        sys.exit("could not find kernel-summary header in nsys stats output:\n  " + "\n  ".join(lines[:60]))
-
-    m_unit = re.search(r"Med \((\w+)\)", lines[header_i])
-    unit = m_unit.group(1) if m_unit else "ns"
-    unit_div = {"ns": 1e6, "us": 1e3, "ms": 1.0, "s": 1e-3}.get(unit, 1e6)
-
-    NUM_NUMERIC_COLS = 8
-    MED_COL = 4
-
-    result: dict[str, float] = {}
-    in_data = False
-    for j in range(header_i + 1, len(lines)):
-        row = lines[j]
-        stripped = row.strip()
-        if not stripped:
-            if in_data:
-                break
-            continue
-        if set(stripped) <= set("- "):
-            in_data = True
-            continue
-        if not in_data:
-            continue
-        if stripped.startswith("**") or stripped.startswith("##"):
-            break
-        toks = stripped.split()
-        if len(toks) <= NUM_NUMERIC_COLS:
-            continue
-        try:
-            med = float(toks[MED_COL].replace(",", ""))
-        except ValueError:
-            continue
-        name = " ".join(toks[NUM_NUMERIC_COLS:]).rstrip()
-        if not name:
-            continue
-        result[name] = med / unit_div
-    return result
-
-
-def _match_kernel_name(kern_name: str, config_name: str) -> bool:
-    return config_name in kern_name
-
-
-def _find_cublas_time(kern_times: dict[str, float]):
-    cands = [(k, v) for k, v in kern_times.items() if k.startswith("nvjet_")]
-    if not cands:
-        return None
-    return max(cands, key=lambda x: x[1])
 
 
 # ---------------------------------------------------------------------------
@@ -402,7 +186,7 @@ def _nsys_worker(shape, configs, warmup, iters, nbuf, load_dt, tin_dt, tout_dt) 
     # 2. each GEMM config.
     config_names = configs or list(_SPEC_MAP)
     for name in config_names:
-        spec = _spec_for(name)
+        spec = spec_for(name, _SPEC_MAP)
         cfg = spec[0] if spec else None
         if cfg is None:
             continue
@@ -428,29 +212,10 @@ def _nsys_worker(shape, configs, warmup, iters, nbuf, load_dt, tin_dt, tout_dt) 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--shape", default="1,4096,4096,4096", help="B,M,N,K")
-    parser.add_argument("--warmup", type=int, default=10)
-    parser.add_argument("--iters", type=int, default=20)
     parser.add_argument("--load-dtype", default="int8", help="A storage dtype (default int8)")
     parser.add_argument("--tin", default="bf16", help="compute / B dtype (default bf16)")
     parser.add_argument("--tout", default="bf16", help="output dtype (default bf16)")
-    parser.add_argument(
-        "--configs",
-        default=None,
-        help="comma-separated config names (default: every mainloop CATALOG entry)",
-    )
-    parser.add_argument("--timing", choices=("delayed", "events", "nsys"), default="delayed")
-    parser.add_argument(
-        "--stream",
-        action="store_true",
-        help="print each config's result as it finishes (events/delayed only)",
-    )
-    parser.add_argument(
-        "--rotate-buffers",
-        default="auto",
-        metavar="N",
-        help="independent tensor copies to rotate timed launches across " "(default 'auto'; 1 disables).",
-    )
-    parser.add_argument("--_nsys-worker", action="store_true", help=argparse.SUPPRESS)
+    add_sweep_args(parser)
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
@@ -462,25 +227,20 @@ def main() -> int:
         sys.exit("--shape must be B,M,N,K (four values; use B=1 for a plain matmul)")
     B, M, N, K = parts
     load_dt, tin_dt, tout_dt = args.load_dtype, args.tin, args.tout
-    nbuf = _resolve_nbuf(args.rotate_buffers, B, M, N, K, load_dt, tin_dt, tout_dt)
+    per_set = _per_set_bytes(B, M, N, K, load_dt, tin_dt, tout_dt)
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
     if getattr(args, "_nsys_worker"):
-        configs = [c.strip() for c in args.configs.split(",")] if args.configs else []
+        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf, load_dt, tin_dt, tout_dt)
         return 0
 
     flops = 2 * B * M * N * K
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    config_names = select_configs(args.configs, _SPEC_MAP)
 
     print(f"\n=== mixed-input matmul B={B} {M}x{N}x{K}  (~{flops / 1e9:.1f} GFLOP) " f"— A={load_dt} -> {tin_dt} @ {tin_dt} -> {tout_dt} ===")
 
-    if nbuf > 1:
-        footprint = _per_set_bytes(B, M, N, K, load_dt, tin_dt, tout_dt) * nbuf
-        print(f"  [rotate-buffers: {nbuf} copies/tensor, " f"{footprint / 1024 / 1024:.0f} MB pool]")
-        if footprint < _L2_BYTES_B200:
-            print(f"  [WARNING: pool ({footprint / 1024 / 1024:.0f} MB) < B200 L2 " f"(~{_L2_BYTES_B200 / 1024 / 1024:.0f} MB) — bump --rotate-buffers.]")
-    else:
-        print("  [rotate-buffers: disabled (1) — small-shape TFLOPS may be hot-L2-inflated]")
+    report_pool(nbuf, per_set)
 
     rows: list[tuple[str, float, float, str]] = []
     t0 = time.time()
@@ -493,18 +253,27 @@ def main() -> int:
 
     if args.timing == "nsys":
         print("  [timing: nsys median kernel duration]\n")
-        kern_times = _nsys_run_and_parse(
+        inner_args = [
+            "--shape",
             args.shape,
-            config_names,
-            args.warmup,
-            args.iters,
-            nbuf,
+            "--warmup",
+            str(args.warmup),
+            "--iters",
+            str(args.iters),
+            "--rotate-buffers",
+            str(nbuf),
+            "--load-dtype",
             load_dt,
+            "--tin",
             tin_dt,
+            "--tout",
             tout_dt,
-        )
+        ]
+        if config_names:
+            inner_args += ["--configs", ",".join(config_names)]
+        kern_times = nsys_run_and_parse(__file__, inner_args, tag="benchmark_mixed")
 
-        cublas_hit = _find_cublas_time(kern_times)
+        cublas_hit = find_cublas_time(kern_times)
         if cublas_hit:
             cublas_name, cublas_ms = cublas_hit
             cublas_tflops = flops / (cublas_ms * 1e-3) / 1e12
@@ -514,19 +283,19 @@ def main() -> int:
             print("  cuBLAS kernel: not detected in nsys output")
 
         for name in config_names:
-            spec = _spec_for(name)
-            cfg = spec[0] if spec else None
-            if cfg is None:
+            spec = spec_for(name, _SPEC_MAP)
+            if spec is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
                 continue
-            matches = [(k, v) for k, v in kern_times.items() if _match_kernel_name(k, name)]
+            tok = kernel_match_token(spec[0], spec[1], spec[2])
+            matches = [(k, v) for k, v in kern_times.items() if tok in k]
             if not matches:
                 rows.append((name, 0.0, float("inf"), "NO_KERNEL_IN_NSYS"))
                 continue
             _, ms = max(matches, key=lambda x: x[1])
             rows.append((name, flops / (ms * 1e-3) / 1e12, ms, ""))
     else:
-        timer = _time_ms_delayed if args.timing == "delayed" else _time_ms_events
+        timer = time_ms_delayed if args.timing == "delayed" else time_ms_events
         if args.timing == "delayed":
             print("  [timing: events bracketed around delayed back-to-back launches]\n")
         else:
@@ -536,7 +305,7 @@ def main() -> int:
         if args.stream:
             print("  ▶ running cuBLAS reference ...", flush=True)
         cublas_ms = timer(
-            _rotating(lambda t: _cublas_ref(t[0], t[1], t[2], tin_dt), pool),
+            rotating(lambda t: _cublas_ref(t[0], t[1], t[2], tin_dt), pool),
             lambda: _cublas_ref(wa, wb, wc, tin_dt),
             warmup=args.warmup,
             iters=args.iters,
@@ -550,7 +319,7 @@ def main() -> int:
 
         ctx_dead = False
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")
@@ -563,7 +332,7 @@ def main() -> int:
                     g, h = _graph_mixed_input(B, M, N, K, load_dt, tin_dt, tout_dt)
                     plan = _build_plan(g, cfg, name)
                     ms = timer(
-                        _rotating(
+                        rotating(
                             lambda t, _plan=plan, _h=h: _plan(_vp(_h, t[0], t[1], t[2])),
                             pool,
                         ),

--- a/benchmark/gemm/frost/benchmark_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_matmul_swiglu.py
@@ -10,10 +10,7 @@ unfused 2×cuBLAS + pointwise baseline. --shape is B,M,N,K.
 from __future__ import annotations
 
 import argparse
-import re
 import sys
-import time
-from typing import Callable
 
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  (installs hook)
@@ -22,9 +19,10 @@ import torch
 from types import SimpleNamespace
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.tile_config import by_name as _by_name
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
+
+from benchmark_utils import add_sweep_args, report_pool, resolve_nbuf, rotating, select_configs, set_bytes, spec_for, time_ms
 
 
 def _build_plan(g, cfg, cta_group, sched):
@@ -95,6 +93,15 @@ def _mkdata(B, M, N, K, in_dt, out_dt):
     return a, b0, b1, out, scale
 
 
+def _mkdata_pool(B, M, N, K, in_dt, out_dt, nbuf):
+    """`nbuf` independent (a, b0, b1, out, scale) sets at distinct GMEM addresses."""
+    base = _mkdata(B, M, N, K, in_dt, out_dt)
+    pool = [base]
+    for _ in range(max(0, nbuf - 1)):
+        pool.append(tuple(t.clone() for t in base))
+    return pool
+
+
 def _reference(a, b0, b1, scale, out_dt):
     """Correctness reference: 2 GEMMs + elementwise chain (einsum 'bmk,bnk->bmn'
     matches the (B,N,K) operands)."""
@@ -108,29 +115,6 @@ def _unfused_launch(a, b0, b1, scale, out):
     c0 = torch.matmul(a, b0.transpose(-1, -2))
     c1 = torch.matmul(a, b1.transpose(-1, -2))
     out.copy_((torch.nn.functional.silu(c0.float()) * c1.float() * scale.flatten()[0]).to(out.dtype))
-
-
-# Timing (delayed / events) — same pattern as benchmark_matmul.py. delayed hides
-# host-launch overhead behind a CUDA _sleep so kernels run back-to-back.
-
-
-def _time_ms(timed_fn: Callable, *, warmup: int, iters: int, delayed: bool) -> float:
-    for _ in range(warmup):
-        timed_fn()
-    torch.cuda.synchronize()
-    if delayed:
-        delay_cycles = max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6))
-        torch.cuda._sleep(delay_cycles)
-        for _ in range(max(5, warmup)):
-            timed_fn()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for _ in range(iters):
-        timed_fn()
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
 
 
 def _build_spec_map():
@@ -149,28 +133,6 @@ def _build_spec_map():
 
 _SPEC_MAP = _build_spec_map()
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting it unsweepable."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -180,14 +142,7 @@ def main() -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--shape", default="1,4096,4096,4096", help="B,M,N,K")
     p.add_argument("--dtype", choices=("bf16", "fp16"), default="bf16")
-    p.add_argument("--warmup", type=int, default=10)
-    p.add_argument("--iters", type=int, default=20)  # CLAUDE.md: <= 20
-    p.add_argument(
-        "--configs",
-        default=None,
-        help="comma-separated CONFIG_..._Nctamma[_static] labels " "(same form as benchmark_matmul.py; default: sweep all)",
-    )
-    p.add_argument("--timing", choices=("delayed", "events"), default="delayed")
+    add_sweep_args(p, nsys=False)
     p.add_argument("--rtol", type=float, default=2e-2)
     p.add_argument("--atol", type=float, default=2e-1)
     args = p.parse_args()
@@ -201,60 +156,70 @@ def main() -> int:
         sys.exit("--shape must be B,M,N,K (four values; B=1 = a single SwiGLU block)")
     B, M, N, K = parts
     in_dt = out_dt = args.dtype
-    delayed = args.timing == "delayed"
 
     # 2 GEMMs, each 2*B*M*N*K flops.
     flops = 2 * (2 * B * M * N * K)
     print(f"\n=== SwiGLU dual-matmul  B={B} {M}x{N}x{K}  " f"(~{flops / 1e9:.1f} GFLOP, 2 GEMMs) — {in_dt} in / {out_dt} out ===")
-    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]\n")
+    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]")
 
-    a, b0, b1, out, scale = _mkdata(B, M, N, K, in_dt, out_dt)
-    ref = _reference(a, b0, b1, scale, out_dt)
+    wa, wb0, wb1, w_out, wscale = _mkdata(B, M, N, K, in_dt, out_dt)
+    per_set = set_bytes((wa, wb0, wb1, w_out, wscale))
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set)
+    report_pool(nbuf, per_set)
+    print()
+    pool = _mkdata_pool(B, M, N, K, in_dt, out_dt, nbuf)
+    ref = _reference(wa, wb0, wb1, wscale, out_dt)
 
     # --- baseline: unfused 2×cuBLAS + pointwise ---
-    out_bl = torch.empty_like(out)
-    bl_ms = _time_ms(
-        lambda: _unfused_launch(a, b0, b1, scale, out_bl),
+    out_bl = torch.empty_like(w_out)
+    if args.stream:
+        print("  ▶ running unfused baseline ...", flush=True)
+    bl_ms = time_ms(
+        rotating(lambda s: _unfused_launch(s[0], s[1], s[2], s[4], s[3]), pool),
+        lambda: _unfused_launch(wa, wb0, wb1, wscale, out_bl),
         warmup=args.warmup,
         iters=args.iters,
-        delayed=delayed,
+        timing=args.timing,
     )
     bl_tflops = flops / (bl_ms * 1e-3) / 1e12
     print(f"  {'unfused 2xcuBLAS + pointwise':52s} {bl_tflops:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms   {'1.00×':>8s}")
 
     # --- candidate (config, cta_group, scheduler) strategies ---
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    config_names = select_configs(args.configs, _SPEC_MAP)
 
     best = None
     for label in config_names:
-        spec = _spec_for(label)
+        spec = spec_for(label, _SPEC_MAP)
         if spec is None:
             print(f"  {label:62s} UNKNOWN (not a sweepable swiglu strategy)")
             continue
         cfg, cta_group, sched = spec
+        if args.stream:
+            print(f"  ▶ running {label} ...", flush=True)
         try:
             g, h = _graph_swiglu(B, M, N, K, in_dt, out_dt)
             plan = _build_plan(g, cfg, cta_group, sched)
         except (NotImplementedError, ValueError):
             continue  # geometry/strategy can't run this shape/dtype — skip
         try:
-            plan(_vp_mg(h, [(a, b0), (a, b1)], out, scale))
+            plan(_vp_mg(h, [(wa, wb0), (wa, wb1)], w_out, wscale))
             torch.cuda.synchronize()
         except Exception as e:  # noqa: BLE001
             print(f"  {label:62s} LAUNCH FAIL: {type(e).__name__}: {str(e)[:30]}")
             continue
-        err = (out.float() - ref.float()).abs().max().item()
-        ok = torch.allclose(out.float(), ref.float(), rtol=args.rtol, atol=args.atol)
-        ms = _time_ms(
-            lambda: plan(_vp_mg(h, [(a, b0), (a, b1)], out, scale)),
+        err = (w_out.float() - ref.float()).abs().max().item()
+        ok = torch.allclose(w_out.float(), ref.float(), rtol=args.rtol, atol=args.atol)
+        ms = time_ms(
+            rotating(lambda s, _plan=plan, _h=h: _plan(_vp_mg(_h, [(s[0], s[1]), (s[0], s[2])], s[3], s[4])), pool),
+            lambda _plan=plan, _h=h: _plan(_vp_mg(_h, [(wa, wb0), (wa, wb1)], w_out, wscale)),
             warmup=args.warmup,
             iters=args.iters,
-            delayed=delayed,
+            timing=args.timing,
         )
         tflops = flops / (ms * 1e-3) / 1e12
         ratio = bl_ms / ms if ms > 0 else 0.0
         flag = "" if ok else f"  !! maxerr={err:.3g}"
-        print(f"  {label:62s} {tflops:8.2f} TFLOP/s  {ms:8.3f} ms   " f"{ratio:>7.2f}×{flag}")
+        print(f"  {label:62s} {tflops:8.2f} TFLOP/s  {ms:8.3f} ms   " f"{ratio:>7.2f}×{flag}", flush=True)
         if ok and (best is None or ms < best[1]):
             best = (label, ms, tflops, ratio)
 

--- a/benchmark/gemm/frost/benchmark_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_matmul_swiglu.py
@@ -124,7 +124,7 @@ def _build_spec_map():
     chain = analyze(_graph_swiglu(1, 256, 256, 256, "bf16", "bf16")[0])
     m = {}
     for t, cfg in _registry_candidates(chain):
-        if cfg.pipeline != "sm100" or cfg.cta_tile_n > 256 or cfg.cgrp_size_n != 1 or cfg.cta_tile_m != 128:
+        if cfg.pipeline != "sm100" or cfg.cta_tile_n > 256 or cfg.cgrp_size_n != 1 or cfg.mma_inst_m != 128:
             continue
         label = f"{cfg.name}_{t.cta_group}ctamma" + ("_static" if t.static_sched else "")
         m[label] = (cfg, t.cta_group, t.scheduler)

--- a/benchmark/gemm/frost/benchmark_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_matmul_swiglu.py
@@ -102,6 +102,18 @@ def _mkdata_pool(B, M, N, K, in_dt, out_dt, nbuf):
     return pool
 
 
+def _unpack(s):
+    """A pooled set is (a, b0, b1, out, scale); _unfused_launch wants scale before out."""
+    a, b0, b1, out, scale = s
+    return a, b0, b1, scale, out
+
+
+def _gemm_args(s):
+    """A pooled set -> _vp_mg's (gemm_pairs, outs, *aux)."""
+    a, b0, b1, out, scale = s
+    return [(a, b0), (a, b1)], out, scale
+
+
 def _reference(a, b0, b1, scale, out_dt):
     """Correctness reference: 2 GEMMs + elementwise chain (einsum 'bmk,bnk->bmn'
     matches the (B,N,K) operands)."""
@@ -175,7 +187,7 @@ def main() -> int:
     if args.stream:
         print("  ▶ running unfused baseline ...", flush=True)
     bl_ms = time_ms(
-        rotating(lambda s: _unfused_launch(s[0], s[1], s[2], s[4], s[3]), pool),
+        rotating(lambda s: _unfused_launch(*_unpack(s)), pool),
         lambda: _unfused_launch(wa, wb0, wb1, wscale, out_bl),
         warmup=args.warmup,
         iters=args.iters,
@@ -210,7 +222,7 @@ def main() -> int:
         err = (w_out.float() - ref.float()).abs().max().item()
         ok = torch.allclose(w_out.float(), ref.float(), rtol=args.rtol, atol=args.atol)
         ms = time_ms(
-            rotating(lambda s, _plan=plan, _h=h: _plan(_vp_mg(_h, [(s[0], s[1]), (s[0], s[2])], s[3], s[4])), pool),
+            rotating(lambda s, _plan=plan, _h=h: _plan(_vp_mg(_h, *_gemm_args(s))), pool),
             lambda _plan=plan, _h=h: _plan(_vp_mg(_h, [(wa, wb0), (wa, wb1)], w_out, wscale)),
             warmup=args.warmup,
             iters=args.iters,

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul.py
@@ -11,24 +11,34 @@ the "vs cuBLAS" ratio is FP4/FP8-MoE throughput relative to equivalent BF16 cuBL
 from __future__ import annotations
 
 import argparse
-import os
-import re
-import shutil
-import subprocess
 import sys
-import tempfile
 import time
-from typing import Callable
 
 import cudnn  # noqa: F401
 import cudnn.gemm.frost  # noqa: F401
 import torch
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.tile_config import by_name as _by_name
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
-from cudnn.gemm.frost.tile_config import TileConfig
+
+from benchmark_utils import (
+    add_sweep_args,
+    find_cublas_time,
+    group_offsets,
+    kernel_match_token,
+    nsys_run_and_parse,
+    rand_e8m0,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_configs,
+    set_bytes,
+    spec_for,
+    time_ms_delayed,
+    time_ms_events,
+    to_blocked,
+)
 
 
 def _vp_moe_bs(handles, token, weight, sfa, sfb, fto, output):
@@ -39,7 +49,7 @@ def _vp_moe_bs(handles, token, weight, sfa, sfb, fto, output):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the recorded graph with a forced tile config -> compiled kernel."""
-    return jit_from_cudnn_graph(g, config=cfg, cta_group=_spec_for(name)[1], scheduler=_spec_for(name)[2])
+    return jit_from_cudnn_graph(g, config=cfg, cta_group=spec_for(name, _SPEC_MAP)[1], scheduler=spec_for(name, _SPEC_MAP)[2])
 
 
 # combo : (is_fp4, block_size, a_dtype, sf_dtype)
@@ -110,51 +120,6 @@ def _build_spec_map():
 
 _SPEC_MAP = _build_spec_map()
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting UNKNOWN_CONFIG."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
-
-def _offsets(S: int, E: int) -> torch.Tensor:
-    """Even split: group g owns rows [g*group_m, (g+1)*group_m)."""
-    group_m = S // E
-    return torch.arange(E, dtype=torch.int32, device="cuda") * group_m
-
-
-def _ceil_div(a, b):
-    return (a + b - 1) // b
-
-
-def _to_blocked(x):
-    """(rows, cols) scale tensor -> flat F8_128x4 blocked layout (padded to 128 rows / 4 cols)."""
-    rows, cols = x.shape
-    nrb, ncb = _ceil_div(rows, 128), _ceil_div(cols, 4)
-    pad = torch.zeros(nrb * 128, ncb * 4, dtype=x.dtype, device=x.device)
-    pad[:rows, :cols] = x
-    blocks = pad.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
-    return blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16).flatten()
-
-
-def _rand_e8m0(shape, dev):
-    return torch.randint(125, 129, shape, dtype=torch.uint8, device=dev).view(torch.float8_e8m0fnu)
-
 
 def _mkdata(S: int, N: int, K: int, E: int, combo: str):
     """MoE-block-scale runtime tensors: (token, weight, sfa, sfb, output).
@@ -178,12 +143,12 @@ def _mkdata(S: int, N: int, K: int, E: int, combo: str):
         sfa_log = torch.randint(1, 4, (S, sf_k), device=dev).to(torch.float8_e4m3fn)
         sfb_log = torch.randint(1, 4, (E, N, sf_k), device=dev).to(torch.float8_e4m3fn)
     else:
-        sfa_log = _rand_e8m0((S, sf_k), dev)
-        sfb_log = _rand_e8m0((E, N, sf_k), dev)
+        sfa_log = rand_e8m0((S, sf_k), dev)
+        sfb_log = rand_e8m0((E, N, sf_k), dev)
 
     # SFA padded to 128 rows PER GROUP (group sizes need not be 128-aligned); SFB per-expert.
-    sfa = torch.cat([_to_blocked(sfa_log[g * group_m : (g + 1) * group_m]) for g in range(E)]).view(1, -1, 1)
-    sfb = torch.cat([_to_blocked(sfb_log[e]) for e in range(E)]).reshape(E, sf_k, N)
+    sfa = torch.cat([to_blocked(sfa_log[g * group_m : (g + 1) * group_m]) for g in range(E)]).view(1, -1, 1)
+    sfb = torch.cat([to_blocked(sfb_log[e]) for e in range(E)]).reshape(E, sf_k, N)
     out = torch.empty(1, S, N, dtype=torch.bfloat16, device=dev)
     return tok, w, sfa, sfb, out
 
@@ -199,14 +164,6 @@ def _mkdata_bf16(S: int, N: int, K: int, E: int):
 
 # Buffer rotation: rotate timed launches across N independent tensor sets so a
 # kernel never re-reads its inputs from a hot L2 (inflates small-shape TFLOPS).
-
-_L2_BYTES_B200 = 126 * 1024 * 1024
-_AUTO_POOL_BUDGET_BYTES = 4 * 1024 * 1024 * 1024  # 4 GB
-_AUTO_NBUF_CAP = 1024
-
-
-def _set_bytes(tensors) -> int:
-    return sum(t.numel() * t.element_size() for t in tensors)
 
 
 def _mkdata_pool(S: int, N: int, K: int, E: int, combo: str, nbuf: int):
@@ -226,34 +183,7 @@ def _mkdata_bf16_pool(S: int, N: int, K: int, E: int, nbuf: int):
 
 
 def _per_set_bytes(S: int, N: int, K: int, E: int, combo: str) -> int:
-    return _set_bytes(_mkdata(S, N, K, E, combo))
-
-
-def _pool_footprint_bytes(S, N, K, E, combo, nbuf) -> int:
-    return _per_set_bytes(S, N, K, E, combo) * nbuf
-
-
-def _auto_nbuf(S: int, N: int, K: int, E: int, combo: str) -> int:
-    per_set = _per_set_bytes(S, N, K, E, combo)
-    target = int(1.5 * _L2_BYTES_B200)
-    nbuf = max(2, -(-target // per_set))
-    budget = _AUTO_POOL_BUDGET_BYTES
-    if torch.cuda.is_available():
-        free, _total = torch.cuda.mem_get_info()
-        budget = min(budget, free // 4)
-    max_by_budget = max(1, budget // per_set)
-    return max(1, min(nbuf, max_by_budget, _AUTO_NBUF_CAP))
-
-
-def _resolve_nbuf(spec: str, S, N, K, E, combo: str) -> int:
-    if spec.strip().lower() == "auto":
-        return _auto_nbuf(S, N, K, E, combo)
-    return max(1, int(spec))
-
-
-def _rotating(fn_of_buf: Callable, pool: list) -> Callable:
-    n = len(pool)
-    return lambda i: fn_of_buf(pool[i % n])
+    return set_bytes(_mkdata(S, N, K, E, combo))
 
 
 # cuBLAS reference — BF16 batched GEMM over the E equal-sized groups.
@@ -267,169 +197,13 @@ def _cublas_launch(buf, S: int, N: int, K: int, E: int) -> None:
     torch.matmul(tok_g, w.transpose(-1, -2), out=out_g)
 
 
-# Timing (events / delayed).
-
-
-def _time_ms_events(timed_fn, warmup_fn, *, warmup, iters) -> float:
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-def _time_ms_delayed(timed_fn, warmup_fn, *, warmup, iters) -> float:
-    """Kernel-only timing: hide host-launch overhead behind a delay kernel
-    (queue a long _sleep first so launches enqueue behind it, then run back-to-back)."""
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-    delay_cycles = max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6))
-    torch.cuda._sleep(delay_cycles)
-    for _ in range(max(5, warmup)):
-        warmup_fn()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-# nsys mode.
-
-
-def _nsys_run_and_parse(shape, combo, configs, warmup, iters, nbuf, no_baseline=False) -> dict[str, float]:
-    nsys = "/usr/local/bin/nsys" if os.path.exists("/usr/local/bin/nsys") else shutil.which("nsys")
-    if nsys is None:
-        sys.exit("nsys not found — install nsight-systems or use the default events mode.")
-    workdir = os.path.join(os.environ.get("TMPDIR", "/tmp"), f"bench_moebs_nsys_{os.getpid()}")
-    os.makedirs(workdir, exist_ok=True)
-    report_prefix = os.path.join(workdir, "report")
-    nsys_env = os.environ.copy()
-    nsys_env.setdefault("TMPDIR", os.environ.get("TMPDIR", tempfile.gettempdir()))
-    inner = [
-        sys.executable,
-        "-u",
-        os.path.abspath(__file__),
-        "--_nsys-worker",
-        "--shape",
-        shape,
-        "--combo",
-        combo,
-        "--warmup",
-        str(warmup),
-        "--iters",
-        str(iters),
-        "--rotate-buffers",
-        str(nbuf),
-    ]
-    if configs:
-        inner += ["--configs", ",".join(configs)]
-    if no_baseline:
-        inner += ["--no-baseline"]
-    profile_cmd = [
-        nsys,
-        "profile",
-        "-o",
-        report_prefix,
-        "--force-overwrite=true",
-        "--cuda-um-cpu-page-faults=false",
-        "--cuda-um-gpu-page-faults=false",
-        "--trace=cuda",
-    ] + inner
-    print(f"  + {' '.join(profile_cmd)}\n")
-    proc = subprocess.run(profile_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stdout:\n" + proc.stdout)
-        print("nsys stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys profile exited {proc.returncode}")
-    stats_cmd = [
-        nsys,
-        "stats",
-        "--report",
-        "cuda_gpu_kern_sum",
-        "--force-export=true",
-        report_prefix + ".nsys-rep",
-    ]
-    proc = subprocess.run(stats_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stats stdout:\n" + proc.stdout)
-        print("nsys stats stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys stats exited {proc.returncode}")
-    return _parse_nsys_stats(proc.stdout)
-
-
-def _parse_nsys_stats(text: str) -> dict[str, float]:
-    """Parse `nsys stats --report cuda_gpu_kern_sum` -> {kernel_name: median_ms}."""
-    lines = text.splitlines()
-    header_i = None
-    for i, ln in enumerate(lines):
-        if "Med (" in ln and "Name" in ln and ("ns)" in ln or "us)" in ln or "ms)" in ln):
-            header_i = i
-            break
-    if header_i is None:
-        sys.exit("could not find kernel-summary header in nsys stats output:\n  " + "\n  ".join(lines[:60]))
-    m_unit = re.search(r"Med \((\w+)\)", lines[header_i])
-    unit = m_unit.group(1) if m_unit else "ns"
-    unit_div = {"ns": 1e6, "us": 1e3, "ms": 1.0, "s": 1e-3}.get(unit, 1e6)
-    NUM_NUMERIC_COLS = 8
-    MED_COL = 4
-    result: dict[str, float] = {}
-    in_data = False
-    for j in range(header_i + 1, len(lines)):
-        stripped = lines[j].strip()
-        if not stripped:
-            if in_data:
-                break
-            continue
-        if set(stripped) <= set("- "):
-            in_data = True
-            continue
-        if not in_data:
-            continue
-        if stripped.startswith("**") or stripped.startswith("##"):
-            break
-        toks = stripped.split()
-        if len(toks) <= NUM_NUMERIC_COLS:
-            continue
-        try:
-            med = float(toks[MED_COL].replace(",", ""))
-        except ValueError:
-            continue
-        name = " ".join(toks[NUM_NUMERIC_COLS:]).rstrip()
-        if name:
-            result[name] = med / unit_div
-    return result
-
-
-def _kernel_match_token(cfg: TileConfig, cta_group: int) -> str:
-    """`<G>ctamma_<geometry_name>` — the substring the nsys-demangled kernel symbol carries."""
-    return f"{cta_group}ctamma_{cfg.geometry_name}"
-
-
-def _find_cublas_time(kern_times: dict[str, float]) -> tuple[str, float] | None:
-    cands = [(k, v) for k, v in kern_times.items() if k.startswith("nvjet_")]
-    if not cands:
-        return None
-    return max(cands, key=lambda x: x[1])
-
-
 # Worker mode (re-exec'd under nsys).
 
 
 def _nsys_worker(shape, combo, configs, warmup, iters, nbuf, no_baseline=False) -> None:
     G, M, N, K = (int(x) for x in shape.split(","))
     S, E = G * M, G
-    offsets = _offsets(S, E)
+    offsets = group_offsets(S, E)
     print(f"[worker] shape G={G} M={M} N={N} K={K} (S={S}) combo={combo}, " f"configs={len(configs)}, warmup={warmup}, iters={iters}, rotate={nbuf}")
 
     # 1. BF16 batched-GEMM reference.
@@ -448,7 +222,7 @@ def _nsys_worker(shape, combo, configs, warmup, iters, nbuf, no_baseline=False) 
 
     # 2. each MoE-block-scale config.
     for name in configs or list(_SPEC_MAP):
-        spec = _spec_for(name)
+        spec = spec_for(name, _SPEC_MAP)
         cfg = spec[0] if spec else None
         if cfg is None:
             continue
@@ -477,31 +251,12 @@ def main() -> int:
         help="G,M,N,K (groups × per-group-M × N × K; default " "8,512,4096,4096 → S=G*M=4096 tokens)",
     )
     parser.add_argument("--combo", choices=tuple(_COMBOS), default="nvfp4")
-    parser.add_argument("--warmup", type=int, default=10)
-    parser.add_argument("--iters", type=int, default=20)  # CLAUDE.md: keep <= 20
-    parser.add_argument(
-        "--configs",
-        default=None,
-        help="comma-separated config names (default: every MoE-block-scale entry)",
-    )
-    parser.add_argument("--timing", choices=("delayed", "events", "nsys"), default="delayed")
-    parser.add_argument(
-        "--stream",
-        action="store_true",
-        help="print each config's result as soon as it finishes (events/delayed)",
-    )
-    parser.add_argument(
-        "--rotate-buffers",
-        default="auto",
-        metavar="N",
-        help="independent tensor copies to rotate timed launches across " "(default 'auto' sizes the pool past L2; 1 disables).",
-    )
     parser.add_argument(
         "--no-baseline",
         action="store_true",
         help="skip the cuBLAS BF16 reference; its BF16 tensor set is never " "allocated, which is the larger footprint on big shapes",
     )
-    parser.add_argument("--_nsys-worker", action="store_true", help=argparse.SUPPRESS)
+    add_sweep_args(parser)
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
@@ -514,25 +269,20 @@ def main() -> int:
     G, M, N, K = parts
     S, E = G * M, G  # total tokens, num groups (== experts)
     combo = args.combo
-    nbuf = _resolve_nbuf(args.rotate_buffers, S, N, K, E, combo)
+    per_set_bytes = _per_set_bytes(S, N, K, E, combo)
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set_bytes, free_divisor=4)
 
     if getattr(args, "_nsys_worker"):
-        configs = [c.strip() for c in args.configs.split(",")] if args.configs else []
+        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, combo, configs, args.warmup, args.iters, nbuf, args.no_baseline)
         return 0
 
     flops = 2 * S * N * K
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    config_names = select_configs(args.configs, _SPEC_MAP)
 
     print(f"\n=== moe_block_scale_matmul G={G} M={M} N={N} K={K}  " f"(S={S} tokens, ~{flops / 1e9:.1f} GFLOP) — {combo} ===")
 
-    if nbuf > 1:
-        footprint = _pool_footprint_bytes(S, N, K, E, combo, nbuf)
-        print(f"  [rotate-buffers: {nbuf} copies/tensor, {footprint / 1024 / 1024:.0f} MB pool]")
-        if footprint < _L2_BYTES_B200:
-            print(f"  [WARNING: pool ({footprint / 1024 / 1024:.0f} MB) < B200 L2 " f"(~{_L2_BYTES_B200 / 1024 / 1024:.0f} MB) — bump --rotate-buffers.]")
-    else:
-        print("  [rotate-buffers: disabled (1) — small-shape TFLOPS may be hot-L2-inflated]")
+    report_pool(nbuf, per_set_bytes)
 
     rows: list[tuple[str, float, float, str]] = []
     t0 = time.time()
@@ -546,9 +296,14 @@ def main() -> int:
 
     if args.timing == "nsys":
         print("  [timing: nsys median kernel duration]\n")
-        kern_times = _nsys_run_and_parse(args.shape, combo, config_names, args.warmup, args.iters, nbuf, args.no_baseline)
+        inner = ["--shape", args.shape, "--combo", combo, "--warmup", str(args.warmup), "--iters", str(args.iters), "--rotate-buffers", str(nbuf)]
+        if config_names:
+            inner += ["--configs", ",".join(config_names)]
+        if args.no_baseline:
+            inner += ["--no-baseline"]
+        kern_times = nsys_run_and_parse(__file__, inner, tag="bench_moebs")
         cublas_tflops, cublas_ms = 0.0, float("nan")
-        cublas_hit = None if args.no_baseline else _find_cublas_time(kern_times)
+        cublas_hit = None if args.no_baseline else find_cublas_time(kern_times)
         if cublas_hit:
             cublas_name, cublas_ms = cublas_hit
             cublas_tflops = flops / (cublas_ms * 1e-3) / 1e12
@@ -557,12 +312,12 @@ def main() -> int:
             cublas_tflops, cublas_ms = float("nan"), float("nan")
             print("  cuBLAS kernel: not detected in nsys output")
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
                 continue
-            tok = _kernel_match_token(cfg, _spec_for(name)[1])
+            tok = kernel_match_token(cfg, spec[1], spec[2])
             matches = [(k, v) for k, v in kern_times.items() if tok in k]
             if not matches:
                 rows.append((name, 0.0, float("inf"), "NO_KERNEL_IN_NSYS"))
@@ -570,12 +325,12 @@ def main() -> int:
             _, ms = max(matches, key=lambda x: x[1])
             rows.append((name, flops / (ms * 1e-3) / 1e12, ms, ""))
     else:
-        timer = _time_ms_delayed if args.timing == "delayed" else _time_ms_events
+        timer = time_ms_delayed if args.timing == "delayed" else time_ms_events
         if args.timing == "delayed":
             print("  [timing: events around delayed back-to-back launches]\n")
         else:
             print("  [timing: torch.cuda.Event wall-clock (incl ~50us/call host overhead)]\n")
-        offsets = _offsets(S, E)
+        offsets = group_offsets(S, E)
         cublas_tflops, cublas_ms = 0.0, float("nan")
         if not args.no_baseline:
             wbf = _mkdata_bf16(S, N, K, E)
@@ -583,7 +338,7 @@ def main() -> int:
             if args.stream:
                 print("  ▶ running cuBLAS (BF16) reference ...", flush=True)
             cublas_ms = timer(
-                _rotating(lambda t: _cublas_launch(t, S, N, K, E), bf_pool),
+                rotating(lambda t: _cublas_launch(t, S, N, K, E), bf_pool),
                 lambda: _cublas_launch(wbf, S, N, K, E),
                 warmup=args.warmup,
                 iters=args.iters,
@@ -609,7 +364,7 @@ def main() -> int:
 
         ctx_dead = False
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")
@@ -622,7 +377,7 @@ def main() -> int:
                     g, h = _graph_moe_bs(S, N, K, E, combo)
                     plan = _build_plan(g, cfg, name)
                     ms = timer(
-                        _rotating(
+                        rotating(
                             lambda t, _plan=plan, _h=h: _plan(_vp_moe_bs(_h, t[0], t[1], t[2], t[3], offsets, t[4])),
                             pool,
                         ),

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul.py
@@ -49,7 +49,8 @@ def _vp_moe_bs(handles, token, weight, sfa, sfb, fto, output):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the recorded graph with a forced tile config -> compiled kernel."""
-    return jit_from_cudnn_graph(g, config=cfg, cta_group=spec_for(name, _SPEC_MAP)[1], scheduler=spec_for(name, _SPEC_MAP)[2])
+    _, cta_group, scheduler = spec_for(name, _SPEC_MAP)
+    return jit_from_cudnn_graph(g, config=cfg, cta_group=cta_group, scheduler=scheduler)
 
 
 # combo : (is_fp4, block_size, a_dtype, sf_dtype)
@@ -182,10 +183,6 @@ def _mkdata_bf16_pool(S: int, N: int, K: int, E: int, nbuf: int):
     return pool
 
 
-def _per_set_bytes(S: int, N: int, K: int, E: int, combo: str) -> int:
-    return set_bytes(_mkdata(S, N, K, E, combo))
-
-
 # cuBLAS reference — BF16 batched GEMM over the E equal-sized groups.
 
 
@@ -269,10 +266,11 @@ def main() -> int:
     G, M, N, K = parts
     S, E = G * M, G  # total tokens, num groups (== experts)
     combo = args.combo
-    per_set_bytes = _per_set_bytes(S, N, K, E, combo)
+    wset = _mkdata(S, N, K, E, combo)  # dedicated warmup buffer, and the pool's size unit
+    per_set_bytes = set_bytes(wset)
     nbuf = resolve_nbuf(args.rotate_buffers, per_set_bytes, free_divisor=4)
 
-    if getattr(args, "_nsys_worker"):
+    if args._nsys_worker:
         configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, combo, configs, args.warmup, args.iters, nbuf, args.no_baseline)
         return 0
@@ -359,7 +357,6 @@ def main() -> int:
             # with, and on large shapes its BF16 set is the bigger allocation.
             del wbf, bf_pool
             torch.cuda.empty_cache()
-        wset = _mkdata(S, N, K, E, combo)
         pool = _mkdata_pool(S, N, K, E, combo, nbuf)
 
         ctx_dead = False

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu.py
@@ -9,9 +9,7 @@ once, feeding both grouped matmuls. --combo picks nvfp4 / mxfp4 / mxfp8.
 from __future__ import annotations
 
 import argparse
-import re
 import sys
-from typing import Callable
 
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  (installs hook)
@@ -20,9 +18,22 @@ import torch
 from types import SimpleNamespace
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.tile_config import by_name as _by_name
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
+
+from benchmark_utils import (
+    add_sweep_args,
+    group_offsets,
+    rand_e8m0,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_configs,
+    set_bytes,
+    spec_for,
+    time_ms,
+    to_blocked,
+)
 
 
 def _build_plan(g, cfg, cta_group, sched):
@@ -59,23 +70,6 @@ _COMBOS = {
     "mxfp4": (32, cudnn.data_type.FP4_E2M1, cudnn.data_type.FP8_E8M0),
     "mxfp8": (32, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E8M0),
 }
-
-
-def _ceil_div(a, b):
-    return (a + b - 1) // b
-
-
-def _to_blocked(x: torch.Tensor) -> torch.Tensor:
-    rows, cols = x.shape
-    nrb, ncb = _ceil_div(rows, 128), _ceil_div(cols, 4)
-    pad = torch.zeros(nrb * 128, ncb * 4, dtype=x.dtype, device=x.device)
-    pad[:rows, :cols] = x
-    blocks = pad.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
-    return blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16).flatten()
-
-
-def _rand_e8m0(shape, dev):
-    return torch.randint(125, 129, shape, dtype=torch.uint8, device=dev).view(torch.float8_e8m0fnu)
 
 
 def _graph_swiglu(S, N, K, E, combo):
@@ -156,11 +150,6 @@ def _graph_swiglu(S, N, K, E, combo):
     )
 
 
-def _offsets(S, E):
-    group_m = S // E
-    return torch.arange(E, dtype=torch.int32, device="cuda") * group_m
-
-
 def _mkdata(S, N, K, E, combo):
     """Packed FP4/FP8 token+weights + F8_128x4-blocked SFs (even split)."""
     dev = "cuda"
@@ -182,15 +171,34 @@ def _mkdata(S, N, K, E, combo):
         sfb0_log = torch.randint(1, 4, (E, N, sf_k), device=dev).to(torch.float8_e4m3fn)
         sfb1_log = torch.randint(1, 4, (E, N, sf_k), device=dev).to(torch.float8_e4m3fn)
     else:
-        sfa_log = _rand_e8m0((S, sf_k), dev)
-        sfb0_log = _rand_e8m0((E, N, sf_k), dev)
-        sfb1_log = _rand_e8m0((E, N, sf_k), dev)
-    sfa = torch.cat([_to_blocked(sfa_log[g * group_m : (g + 1) * group_m]) for g in range(E)]).view(1, -1, 1)
-    sfb0 = torch.cat([_to_blocked(sfb0_log[e]) for e in range(E)]).reshape(E, sf_k, N)
-    sfb1 = torch.cat([_to_blocked(sfb1_log[e]) for e in range(E)]).reshape(E, sf_k, N)
+        sfa_log = rand_e8m0((S, sf_k), dev)
+        sfb0_log = rand_e8m0((E, N, sf_k), dev)
+        sfb1_log = rand_e8m0((E, N, sf_k), dev)
+    sfa = torch.cat([to_blocked(sfa_log[g * group_m : (g + 1) * group_m]) for g in range(E)]).view(1, -1, 1)
+    sfb0 = torch.cat([to_blocked(sfb0_log[e]) for e in range(E)]).reshape(E, sf_k, N)
+    sfb1 = torch.cat([to_blocked(sfb1_log[e]) for e in range(E)]).reshape(E, sf_k, N)
     out = torch.empty(1, S, N, dtype=torch.bfloat16, device=dev)
     scale = torch.tensor([[[0.5]]], dtype=torch.float32, device=dev)
     return tok, w0, w1, sfa, sfb0, sfb1, out, scale
+
+
+def _mkdata_pool(S, N, K, E, combo, nbuf):
+    """`nbuf` independent token/weight/SF sets at distinct GMEM addresses."""
+    base = _mkdata(S, N, K, E, combo)
+    pool = [base]
+    for _ in range(max(0, nbuf - 1)):
+        pool.append(tuple(t.clone() for t in base))
+    return pool
+
+
+def _gemm_pairs(s):
+    """((token, SFA), (weight_g, SFB_g)) per GEMM — token+SFA shared."""
+    tok, w0, w1, sfa, sfb0, sfb1 = s[:6]
+    return [((tok, sfa), (w0, sfb0)), ((tok, sfa), (w1, sfb1))]
+
+
+def _fused_launch(plan, handles, s, offsets):
+    plan(_vp_moe_bs_mg(handles, _gemm_pairs(s), offsets, s[6], s[7]))
 
 
 def _mkdata_bf16(S, N, K, E):
@@ -200,6 +208,14 @@ def _mkdata_bf16(S, N, K, E):
     w1 = torch.empty(E, N, K, dtype=torch.int32).random_(-2, 2).to(dtype=torch.bfloat16, device=dev)
     out = torch.empty(1, S, N, dtype=torch.bfloat16, device=dev)
     return tok, w0, w1, out
+
+
+def _mkdata_bf16_pool(S, N, K, E, nbuf):
+    base = _mkdata_bf16(S, N, K, E)
+    pool = [base]
+    for _ in range(max(0, nbuf - 1)):
+        pool.append(tuple(t.clone() for t in base))
+    return pool
 
 
 def _unfused_launch(tok, w0, w1, out, S, N, K, E):
@@ -212,32 +228,13 @@ def _unfused_launch(tok, w0, w1, out, S, N, K, E):
     out.view(E, group_m, N).copy_(res.to(out.dtype))
 
 
-def _time_ms(timed_fn: Callable, *, warmup: int, iters: int, delayed: bool) -> float:
-    for _ in range(warmup):
-        timed_fn()
-    torch.cuda.synchronize()
-    if delayed:
-        delay_cycles = max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6))
-        torch.cuda._sleep(delay_cycles)
-        for _ in range(max(5, warmup)):
-            timed_fn()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for _ in range(iters):
-        timed_fn()
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
 def _build_spec_map():
     """Label -> (geometry cfg, cta_group, scheduler) for multi-GEMM MoE
     block-scale strategies. Dual TMEM fits two accs + SF only at cta_tile_n<=128."""
     chain = analyze(_graph_swiglu(1024, 256, 512, 2, "nvfp4")[0])
     m = {}
     for t, cfg in _registry_candidates(chain):
-        if cfg.pipeline != "sm100" or cfg.cta_tile_n > 128 or cfg.cta_tile_m != 128:
+        if cfg.pipeline not in ("sm100", "sm107") or cfg.cta_tile_n > 128 or cfg.cta_tile_m != 128:
             continue
         label = f"{cfg.name}_{t.cta_group}ctamma" + ("_static" if t.static_sched else "")
         m[label] = (cfg, t.cta_group, t.scheduler)
@@ -246,45 +243,12 @@ def _build_spec_map():
 
 _SPEC_MAP = _build_spec_map()
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting it unsweepable."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--shape", default="8,512,4096,4096", help="G,M,N,K (even split)")
     p.add_argument("--combo", choices=tuple(_COMBOS), default="nvfp4")
-    p.add_argument("--warmup", type=int, default=10)
-    p.add_argument("--iters", type=int, default=20)  # CLAUDE.md: <= 20
-    p.add_argument(
-        "--configs",
-        default=None,
-        help="comma-separated CONFIG_..._Nctamma labels (default: sweep all)",
-    )
-    p.add_argument("--timing", choices=("delayed", "events"), default="delayed")
-    p.add_argument(
-        "--stream",
-        action="store_true",
-        help="accepted for CLI parity; results already print inline",
-    )
+    add_sweep_args(p, nsys=False)
     args = p.parse_args()
 
     if not torch.cuda.is_available():
@@ -297,56 +261,70 @@ def main() -> int:
     G, M, N, K = parts
     E, S = G, G * M
     combo = args.combo
-    delayed = args.timing == "delayed"
+
+    config_names = select_configs(args.configs, _SPEC_MAP)
+    per_set = set_bytes(_mkdata(S, N, K, E, combo))
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
     flops = 2 * (2 * S * N * K)  # 2 grouped GEMMs
     print(f"\n=== MoE dual block-scale ({combo}) grouped-matmul SwiGLU  " f"G={G} × M={M} (S={S}) {N}x{K}  (~{flops / 1e9:.1f} GFLOP, 2 GEMMs) ===")
-    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]\n")
+    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]")
+    report_pool(nbuf, per_set)
+    print()
 
-    tok, w0, w1, sfa, sfb0, sfb1, out, scale = _mkdata(S, N, K, E, combo)
-    offsets = _offsets(S, E)
+    offsets = group_offsets(S, E)
 
     # --- baseline: unfused 2×cuBLAS batched BF16 GEMM + pointwise ---
-    btok, bw0, bw1, bout = _mkdata_bf16(S, N, K, E)
-    bl_ms = _time_ms(
-        lambda: _unfused_launch(btok, bw0, bw1, bout, S, N, K, E),
+    wbf = _mkdata_bf16(S, N, K, E)
+    bf_pool = _mkdata_bf16_pool(S, N, K, E, nbuf)
+    if args.stream:
+        print("  ▶ running unfused 2xcuBLAS batched bf16 baseline ...", flush=True)
+    bl_ms = time_ms(
+        rotating(lambda t: _unfused_launch(t[0], t[1], t[2], t[3], S, N, K, E), bf_pool),
+        lambda: _unfused_launch(wbf[0], wbf[1], wbf[2], wbf[3], S, N, K, E),
         warmup=args.warmup,
         iters=args.iters,
-        delayed=delayed,
+        timing=args.timing,
     )
     bl_tflops = flops / (bl_ms * 1e-3) / 1e12
     print(f"  {'unfused 2xcuBLAS batched bf16 + pointwise':56s} {bl_tflops:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms   {'1.00×':>8s}")
+    # Freed before the block-scale pool: on large shapes the BF16 sets dominate.
+    del wbf, bf_pool
+    torch.cuda.empty_cache()
 
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    wset = _mkdata(S, N, K, E, combo)  # dedicated warmup set, never rotated
+    pool = _mkdata_pool(S, N, K, E, combo, nbuf)
 
     best = None
     for label in config_names:
-        spec = _spec_for(label)
+        spec = spec_for(label, _SPEC_MAP)
         if spec is None:
             print(f"  {label:66s} UNKNOWN (not a sweepable MoE block-scale swiglu strategy)")
             continue
         cfg, cta_group, sched = spec
+        if args.stream:
+            print(f"  ▶ running {label} ...", flush=True)
         try:
             g, h = _graph_swiglu(S, N, K, E, combo)
             plan = _build_plan(g, cfg, cta_group, sched)
         except (NotImplementedError, ValueError):
             continue
-        gemm = [((tok, sfa), (w0, sfb0)), ((tok, sfa), (w1, sfb1))]
         try:
-            plan(_vp_moe_bs_mg(h, gemm, offsets, out, scale))
+            _fused_launch(plan, h, wset, offsets)
             torch.cuda.synchronize()
         except Exception as e:  # noqa: BLE001
             print(f"  {label:66s} LAUNCH FAIL: {type(e).__name__}: {str(e)[:30]}")
             continue
-        ms = _time_ms(
-            lambda: plan(_vp_moe_bs_mg(h, gemm, offsets, out, scale)),
+        ms = time_ms(
+            rotating(lambda s, _plan=plan, _h=h: _fused_launch(_plan, _h, s, offsets), pool),
+            lambda _plan=plan, _h=h: _fused_launch(_plan, _h, wset, offsets),
             warmup=args.warmup,
             iters=args.iters,
-            delayed=delayed,
+            timing=args.timing,
         )
         tflops = flops / (ms * 1e-3) / 1e12
         ratio = bl_ms / ms if ms > 0 else 0.0
-        print(f"  {label:66s} {tflops:8.2f} TFLOP/s  {ms:8.3f} ms   {ratio:>7.2f}×")
+        print(f"  {label:66s} {tflops:8.2f} TFLOP/s  {ms:8.3f} ms   {ratio:>7.2f}×", flush=True)
         if best is None or ms < best[1]:
             best = (label, ms, tflops, ratio)
 

--- a/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_moe_block_scale_matmul_swiglu.py
@@ -234,7 +234,7 @@ def _build_spec_map():
     chain = analyze(_graph_swiglu(1024, 256, 512, 2, "nvfp4")[0])
     m = {}
     for t, cfg in _registry_candidates(chain):
-        if cfg.pipeline not in ("sm100", "sm107") or cfg.cta_tile_n > 128 or cfg.cta_tile_m != 128:
+        if cfg.pipeline not in ("sm100", "sm107") or cfg.cta_tile_n > 128 or cfg.mma_inst_m != 128:
             continue
         label = f"{cfg.name}_{t.cta_group}ctamma" + ("_static" if t.static_sched else "")
         m[label] = (cfg, t.cta_group, t.scheduler)

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul.py
@@ -11,21 +11,14 @@ split makes the baseline a single batched GEMM over (E, group_m, K) @ (E, K, N).
 from __future__ import annotations
 
 import argparse
-import os
-import re
-import shutil
-import subprocess
 import sys
-import tempfile
 import time
-from typing import Callable
 
 import cudnn  # noqa: F401
 import cudnn.gemm.frost  # noqa: F401
 import torch
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.tile_config import by_name as _by_name
 from cudnn.gemm.frost.fusion_ir import (
     FusionChain as _FC,
     MatmulSpec as _MS,
@@ -33,7 +26,21 @@ from cudnn.gemm.frost.fusion_ir import (
     OutputSpec as _OS,
 )
 from cudnn.gemm.frost.kernel_registry import candidates as _candidates
-from cudnn.gemm.frost.tile_config import TileConfig
+
+from benchmark_utils import (
+    add_sweep_args,
+    find_cublas_time,
+    group_offsets,
+    kernel_match_token,
+    nsys_run_and_parse,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_configs,
+    spec_for,
+    time_ms_delayed,
+    time_ms_events,
+)
 
 
 def _vp_moe(handles, token, weight, fto, output):
@@ -44,7 +51,7 @@ def _vp_moe(handles, token, weight, fto, output):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg, cta_group=_spec_for(name)[1], scheduler=_spec_for(name)[2])
+    return jit_from_cudnn_graph(g, config=cfg, cta_group=spec_for(name, _SPEC_MAP)[1], scheduler=spec_for(name, _SPEC_MAP)[2])
 
 
 def _build_spec_map():
@@ -72,28 +79,6 @@ def _build_spec_map():
 
 
 _SPEC_MAP = _build_spec_map()
-
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting UNKNOWN_CONFIG."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
 
 # ---------------------------------------------------------------------------
 # Graph + data setup
@@ -136,12 +121,6 @@ def _graph_moe(S: int, N: int, K: int, E: int):
     return g, (tok, w, fto, out)
 
 
-def _offsets(S: int, E: int) -> torch.Tensor:
-    """Even split: group g owns rows [g*group_m, (g+1)*group_m)."""
-    group_m = S // E
-    return torch.arange(E, dtype=torch.int32, device="cuda") * group_m
-
-
 def _mkdata(S: int, N: int, K: int, E: int):
     torch.manual_seed(0)
     tok = torch.empty(1, S, K, dtype=torch.int32).random_(-2, 2).to(dtype=torch.bfloat16, device="cuda")
@@ -153,8 +132,6 @@ def _mkdata(S: int, N: int, K: int, E: int):
 # Buffer rotation — defeat the hot-L2 artifact on small shapes: rotate timed
 # launches across nbuf independent tensor sets so a kernel doesn't re-read the
 # prior launch's inputs from a hot L2 (see benchmark_matmul).
-
-_L2_BYTES_B200 = 126 * 1024 * 1024
 
 
 def _mkdata_pool(S: int, N: int, K: int, E: int, nbuf: int):
@@ -170,39 +147,6 @@ def _mkdata_pool(S: int, N: int, K: int, E: int, nbuf: int):
 def _per_set_bytes(S: int, N: int, K: int, E: int) -> int:
     # BF16 = 2 bytes/elem; token:(S,K) weight:(E,N,K) output:(S,N).
     return 2 * (S * K + E * N * K + S * N)
-
-
-def _pool_footprint_bytes(S: int, N: int, K: int, E: int, nbuf: int) -> int:
-    return _per_set_bytes(S, N, K, E) * nbuf
-
-
-_AUTO_POOL_BUDGET_BYTES = 4 * 1024 * 1024 * 1024  # 4 GB
-_AUTO_NBUF_CAP = 1024
-
-
-def _auto_nbuf(S: int, N: int, K: int, E: int) -> int:
-    """Smallest buffer count whose pool exceeds L2 (1.5× margin), clamped to a
-    memory budget."""
-    per_set = _per_set_bytes(S, N, K, E)
-    target = int(1.5 * _L2_BYTES_B200)
-    nbuf = max(2, -(-target // per_set))
-    budget = _AUTO_POOL_BUDGET_BYTES
-    if torch.cuda.is_available():
-        free, _total = torch.cuda.mem_get_info()
-        budget = min(budget, free // 2)
-    max_by_budget = max(1, budget // per_set)
-    return max(1, min(nbuf, max_by_budget, _AUTO_NBUF_CAP))
-
-
-def _resolve_nbuf(spec: str, S: int, N: int, K: int, E: int) -> int:
-    if spec.strip().lower() == "auto":
-        return _auto_nbuf(S, N, K, E)
-    return max(1, int(spec))
-
-
-def _rotating(fn_of_buf: Callable, pool: list) -> Callable:
-    n = len(pool)
-    return lambda i: fn_of_buf(pool[i % n])
 
 
 # ---------------------------------------------------------------------------
@@ -221,164 +165,6 @@ def _cublas_launch(buf, S: int, N: int, K: int, E: int) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Timing (events / delayed) — identical to benchmark_matmul
-# ---------------------------------------------------------------------------
-
-
-def _time_ms_events(timed_fn, warmup_fn, *, warmup, iters) -> float:
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-def _time_ms_delayed(timed_fn, warmup_fn, *, warmup, iters) -> float:
-    """Kernel-only timing: queue a _sleep first so the host enqueues every launch
-    behind it and the GPU runs them back-to-back (see benchmark_matmul)."""
-    for _ in range(warmup):
-        warmup_fn()
-    torch.cuda.synchronize()
-    delay_cycles = max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6))
-    torch.cuda._sleep(delay_cycles)
-    for _ in range(max(5, warmup)):
-        warmup_fn()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for i in range(iters):
-        timed_fn(i)
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
-# ---------------------------------------------------------------------------
-# nsys mode — identical machinery to benchmark_matmul (parser shared verbatim)
-# ---------------------------------------------------------------------------
-
-
-def _nsys_run_and_parse(shape, configs, warmup, iters, nbuf) -> dict[str, float]:
-    nsys = "/usr/local/bin/nsys" if os.path.exists("/usr/local/bin/nsys") else shutil.which("nsys")
-    if nsys is None:
-        sys.exit("nsys not found — install nsight-systems or use the default events mode.")
-    workdir = os.path.join(os.environ.get("TMPDIR", "/tmp"), f"bench_moe_nsys_{os.getpid()}")
-    os.makedirs(workdir, exist_ok=True)
-    report_prefix = os.path.join(workdir, "report")
-    nsys_env = os.environ.copy()
-    nsys_env.setdefault("TMPDIR", os.environ.get("TMPDIR", tempfile.gettempdir()))
-    inner = [
-        sys.executable,
-        "-u",
-        os.path.abspath(__file__),
-        "--_nsys-worker",
-        "--shape",
-        shape,
-        "--warmup",
-        str(warmup),
-        "--iters",
-        str(iters),
-        "--rotate-buffers",
-        str(nbuf),
-    ]
-    if configs:
-        inner += ["--configs", ",".join(configs)]
-    profile_cmd = [
-        nsys,
-        "profile",
-        "-o",
-        report_prefix,
-        "--force-overwrite=true",
-        "--cuda-um-cpu-page-faults=false",
-        "--cuda-um-gpu-page-faults=false",
-        "--trace=cuda",
-    ] + inner
-    print(f"  + {' '.join(profile_cmd)}\n")
-    proc = subprocess.run(profile_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stdout:\n" + proc.stdout)
-        print("nsys stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys profile exited {proc.returncode}")
-    stats_cmd = [
-        nsys,
-        "stats",
-        "--report",
-        "cuda_gpu_kern_sum",
-        "--force-export=true",
-        report_prefix + ".nsys-rep",
-    ]
-    proc = subprocess.run(stats_cmd, capture_output=True, text=True, env=nsys_env)
-    if proc.returncode != 0:
-        print("nsys stats stdout:\n" + proc.stdout)
-        print("nsys stats stderr:\n" + proc.stderr, file=sys.stderr)
-        sys.exit(f"nsys stats exited {proc.returncode}")
-    return _parse_nsys_stats(proc.stdout)
-
-
-def _parse_nsys_stats(text: str) -> dict[str, float]:
-    """Parse `nsys stats --report cuda_gpu_kern_sum` -> {kernel_name: median_ms}."""
-    lines = text.splitlines()
-    header_i = None
-    for i, ln in enumerate(lines):
-        if "Med (" in ln and "Name" in ln and ("ns)" in ln or "us)" in ln or "ms)" in ln):
-            header_i = i
-            break
-    if header_i is None:
-        sys.exit("could not find kernel-summary header in nsys stats output:\n  " + "\n  ".join(lines[:60]))
-    m_unit = re.search(r"Med \((\w+)\)", lines[header_i])
-    unit = m_unit.group(1) if m_unit else "ns"
-    unit_div = {"ns": 1e6, "us": 1e3, "ms": 1.0, "s": 1e-3}.get(unit, 1e6)
-    NUM_NUMERIC_COLS = 8
-    MED_COL = 4
-    result: dict[str, float] = {}
-    in_data = False
-    for j in range(header_i + 1, len(lines)):
-        stripped = lines[j].strip()
-        if not stripped:
-            if in_data:
-                break
-            continue
-        if set(stripped) <= set("- "):
-            in_data = True
-            continue
-        if not in_data:
-            continue
-        if stripped.startswith("**") or stripped.startswith("##"):
-            break
-        toks = stripped.split()
-        if len(toks) <= NUM_NUMERIC_COLS:
-            continue
-        try:
-            med = float(toks[MED_COL].replace(",", ""))
-        except ValueError:
-            continue
-        name = " ".join(toks[NUM_NUMERIC_COLS:]).rstrip()
-        if name:
-            result[name] = med / unit_div
-    return result
-
-
-def _kernel_match_token(cfg: TileConfig, cta_group: int) -> str:
-    """`<G>ctamma_<geometry_name>` — the substring the nsys-demangled symbol
-    `cutlass::_kernel_sm100_moe_grouped_matmul_fwd_<G>ctamma_<geom>(...)` carries;
-    uniquely identifies the (group, geometry) pair."""
-    return f"{cta_group}ctamma_{cfg.geometry_name}"
-
-
-def _find_cublas_time(kern_times: dict[str, float]) -> tuple[str, float] | None:
-    cands = [(k, v) for k, v in kern_times.items() if k.startswith("nvjet_")]
-    if not cands:
-        return None
-    return max(cands, key=lambda x: x[1])
-
-
-# ---------------------------------------------------------------------------
 # Worker mode (re-exec'd under nsys)
 # ---------------------------------------------------------------------------
 
@@ -388,7 +174,7 @@ def _nsys_worker(shape, configs, warmup, iters, nbuf) -> None:
     S, E = G * M, G
     wtok, ww, wout = _mkdata(S, N, K, E)  # dedicated warmup buffer
     pool = _mkdata_pool(S, N, K, E, nbuf)  # rotation pool for timed iters
-    offsets = _offsets(S, E)
+    offsets = group_offsets(S, E)
     print(f"[worker] shape G={G} M={M} N={N} K={K} (S={S}), configs={len(configs)}, " f"warmup={warmup}, iters={iters}, rotate_buffers={nbuf}")
 
     # 1. cuBLAS baseline — batched GEMM.
@@ -401,7 +187,7 @@ def _nsys_worker(shape, configs, warmup, iters, nbuf) -> None:
     # 2. each MoE config.
     config_names = configs or list(_SPEC_MAP)
     for name in config_names:
-        spec = _spec_for(name)
+        spec = spec_for(name, _SPEC_MAP)
         cfg = spec[0] if spec else None
         if cfg is None:
             continue
@@ -431,26 +217,7 @@ def main() -> int:
         default="8,512,4096,4096",
         help="G,M,N,K (groups × per-group-M × N × K; default " "8,512,4096,4096 → S=G*M=4096 tokens)",
     )
-    parser.add_argument("--warmup", type=int, default=10)
-    parser.add_argument("--iters", type=int, default=20)  # CLAUDE.md: keep <= 20 (more just holds the GPU)
-    parser.add_argument(
-        "--configs",
-        default=None,
-        help="comma-separated config names (default: every MoE-capable CATALOG entry)",
-    )
-    parser.add_argument("--timing", choices=("delayed", "events", "nsys"), default="delayed")
-    parser.add_argument(
-        "--stream",
-        action="store_true",
-        help="print each config's result as soon as it finishes (events/delayed only)",
-    )
-    parser.add_argument(
-        "--rotate-buffers",
-        default="auto",
-        metavar="N",
-        help="independent tensor copies to rotate timed launches across " "(default 'auto' sizes the pool past L2; 1 disables). See benchmark_matmul.",
-    )
-    parser.add_argument("--_nsys-worker", action="store_true", help=argparse.SUPPRESS)
+    add_sweep_args(parser)
     args = parser.parse_args()
 
     if not torch.cuda.is_available():
@@ -462,25 +229,20 @@ def main() -> int:
         sys.exit("--shape must be G,M,N,K (four values: groups × per-group-M × N × K)")
     G, M, N, K = parts
     S, E = G * M, G  # total tokens, num groups (== experts)
-    nbuf = _resolve_nbuf(args.rotate_buffers, S, N, K, E)
+    per_set = _per_set_bytes(S, N, K, E)
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
     if getattr(args, "_nsys_worker"):
-        configs = [c.strip() for c in args.configs.split(",")] if args.configs else []
+        configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf)
         return 0
 
     flops = 2 * S * N * K
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    config_names = select_configs(args.configs, _SPEC_MAP)
 
     print(f"\n=== moe_grouped_matmul G={G} M={M} N={N} K={K}  " f"(S={S} tokens, ~{flops / 1e9:.1f} GFLOP) — BF16 ===")
 
-    if nbuf > 1:
-        footprint = _pool_footprint_bytes(S, N, K, E, nbuf)
-        print(f"  [rotate-buffers: {nbuf} copies/tensor, {footprint / 1024 / 1024:.0f} MB pool]")
-        if footprint < _L2_BYTES_B200:
-            print(f"  [WARNING: pool ({footprint / 1024 / 1024:.0f} MB) < B200 L2 " f"(~{_L2_BYTES_B200 / 1024 / 1024:.0f} MB) — bump --rotate-buffers.]")
-    else:
-        print("  [rotate-buffers: disabled (1) — small-shape TFLOPS may be hot-L2-inflated]")
+    report_pool(nbuf, per_set)
 
     rows: list[tuple[str, float, float, str]] = []
     t0 = time.time()
@@ -493,8 +255,11 @@ def main() -> int:
 
     if args.timing == "nsys":
         print("  [timing: nsys median kernel duration]\n")
-        kern_times = _nsys_run_and_parse(args.shape, config_names, args.warmup, args.iters, nbuf)
-        cublas_hit = _find_cublas_time(kern_times)
+        inner_args = ["--shape", args.shape, "--warmup", str(args.warmup), "--iters", str(args.iters), "--rotate-buffers", str(nbuf)]
+        if config_names:
+            inner_args += ["--configs", ",".join(config_names)]
+        kern_times = nsys_run_and_parse(__file__, inner_args, tag="bench_moe")
+        cublas_hit = find_cublas_time(kern_times)
         if cublas_hit:
             cublas_name, cublas_ms = cublas_hit
             cublas_tflops = flops / (cublas_ms * 1e-3) / 1e12
@@ -503,12 +268,12 @@ def main() -> int:
             cublas_tflops, cublas_ms = float("nan"), float("nan")
             print("  cuBLAS kernel: not detected in nsys output")
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 rows.append((name, 0.0, float("inf"), "UNKNOWN_CONFIG"))
                 continue
-            tok = _kernel_match_token(cfg, _spec_for(name)[1])
+            tok = kernel_match_token(cfg, spec[1], spec[2])
             matches = [(k, v) for k, v in kern_times.items() if tok in k]
             if not matches:
                 rows.append((name, 0.0, float("inf"), "NO_KERNEL_IN_NSYS"))
@@ -516,18 +281,18 @@ def main() -> int:
             _, ms = max(matches, key=lambda x: x[1])
             rows.append((name, flops / (ms * 1e-3) / 1e12, ms, ""))
     else:
-        timer = _time_ms_delayed if args.timing == "delayed" else _time_ms_events
+        timer = time_ms_delayed if args.timing == "delayed" else time_ms_events
         if args.timing == "delayed":
             print("  [timing: events around delayed back-to-back launches]\n")
         else:
             print("  [timing: torch.cuda.Event wall-clock (incl ~50us/call host overhead)]\n")
         wtok, ww, wout = _mkdata(S, N, K, E)
         pool = _mkdata_pool(S, N, K, E, nbuf)
-        offsets = _offsets(S, E)
+        offsets = group_offsets(S, E)
         if args.stream:
             print("  ▶ running cuBLAS reference ...", flush=True)
         cublas_ms = timer(
-            _rotating(lambda t: _cublas_launch(t, S, N, K, E), pool),
+            rotating(lambda t: _cublas_launch(t, S, N, K, E), pool),
             lambda: _cublas_launch((wtok, ww, wout), S, N, K, E),
             warmup=args.warmup,
             iters=args.iters,
@@ -541,7 +306,7 @@ def main() -> int:
 
         ctx_dead = False
         for name in config_names:
-            spec = _spec_for(name)
+            spec = spec_for(name, _SPEC_MAP)
             cfg = spec[0] if spec else None
             if cfg is None:
                 row = (name, 0.0, float("inf"), "UNKNOWN_CONFIG")
@@ -554,7 +319,7 @@ def main() -> int:
                     g, h = _graph_moe(S, N, K, E)
                     plan = _build_plan(g, cfg, name)
                     ms = timer(
-                        _rotating(
+                        rotating(
                             lambda t, _plan=plan, _h=h: _plan(_vp_moe(_h, t[0], t[1], offsets, t[2])),
                             pool,
                         ),

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul.py
@@ -51,7 +51,8 @@ def _vp_moe(handles, token, weight, fto, output):
 
 def _build_plan(g, cfg, name):
     """JIT-compile the recorded graph with a forced tile config."""
-    return jit_from_cudnn_graph(g, config=cfg, cta_group=spec_for(name, _SPEC_MAP)[1], scheduler=spec_for(name, _SPEC_MAP)[2])
+    _, cta_group, scheduler = spec_for(name, _SPEC_MAP)
+    return jit_from_cudnn_graph(g, config=cfg, cta_group=cta_group, scheduler=scheduler)
 
 
 def _build_spec_map():
@@ -232,7 +233,7 @@ def main() -> int:
     per_set = _per_set_bytes(S, N, K, E)
     nbuf = resolve_nbuf(args.rotate_buffers, per_set)
 
-    if getattr(args, "_nsys_worker"):
+    if args._nsys_worker:
         configs = select_configs(args.configs, _SPEC_MAP) if args.configs else []
         _nsys_worker(args.shape, configs, args.warmup, args.iters, nbuf)
         return 0

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul_models.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul_models.py
@@ -30,36 +30,33 @@ BF16 output are identical.
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from types import SimpleNamespace
-from typing import Callable
 
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  (installs hook)
 import torch
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.tile_config import by_name as _by_name
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
 
+from benchmark_utils import (
+    add_sweep_args,
+    ceil_div,
+    even_offsets,
+    rand_e8m0,
+    report_pool,
+    resolve_nbuf,
+    rotating,
+    select_configs,
+    set_bytes,
+    spec_for,
+    time_ms,
+    to_blocked,
+)
+
 # Model cases
-
-
-def _even_offsets(S: int, E: int) -> list[int]:
-    """Routed-group start offsets for ``S`` tokens spread as evenly as possible
-    over ``E`` experts — the first ``S % E`` groups take one extra token.
-    ``S=10, E=3`` -> group sizes 4, 3, 3 -> ``[0, 4, 7]``."""
-    if E < 1:
-        raise ValueError(f"expert count must be >= 1, got {E}")
-    base, rem = divmod(S, E)
-    offsets, start = [], 0
-    for i in range(E):
-        offsets.append(start)
-        start += base + (1 if i < rem else 0)
-    return offsets
-
 
 MODELS: dict[str, dict] = {
     "dsv4_pro": dict(
@@ -115,7 +112,7 @@ def _sf_rows(offsets: list[int], S: int) -> int:
     """SFA height: every routed group is padded to 128 rows in the F8_128x4 blob,
     so it is Σ ceil(group_m/128)*128 — equal to S only when every group size is a
     multiple of 128 (Kimi K3's 585/586-token groups are not: 14*640 = 8960)."""
-    return sum(_ceil_div(hi - lo, 128) * 128 for lo, hi in _group_ranges(offsets, S))
+    return sum(ceil_div(hi - lo, 128) * 128 for lo, hi in _group_ranges(offsets, S))
 
 
 def _operands(g, S: int, N: int, K: int, E: int, dtype: str, offsets: list[int]):
@@ -153,7 +150,7 @@ def _graph(S: int, N: int, K: int, E: int, variant: str, dtype: str = "bf16", of
         intermediate_data_type=cudnn.data_type.FLOAT,
         compute_data_type=cudnn.data_type.FLOAT,
     )
-    offsets = offsets if offsets is not None else _even_offsets(S, E)
+    offsets = offsets if offsets is not None else even_offsets(S, E)
     (a, b0, b1), a_ops, b_ops, sfa_ops, sfb_ops = _operands(g, S, N, K, E, dtype, offsets)
     # fto MUST be the SAME tensor for both matmuls (shared routed-group layout).
     fto = g.tensor(name="first_token_offset", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
@@ -236,25 +233,6 @@ def _vp(handles, d, fto, out, aux_bufs):
 # Data + reference
 
 
-def _ceil_div(a: int, b: int) -> int:
-    return (a + b - 1) // b
-
-
-def _to_blocked(x: torch.Tensor) -> torch.Tensor:
-    """(rows, cols) scale factors -> the F8_128x4 reordered blob, rows padded to
-    128 and cols to 4."""
-    rows, cols = x.shape
-    nrb, ncb = _ceil_div(rows, 128), _ceil_div(cols, 4)
-    pad = torch.zeros(nrb * 128, ncb * 4, dtype=x.dtype, device=x.device)
-    pad[:rows, :cols] = x
-    blocks = pad.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
-    return blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16).flatten()
-
-
-def _rand_e8m0(shape, dev):
-    return torch.randint(125, 129, shape, dtype=torch.uint8, device=dev).view(torch.float8_e8m0fnu)
-
-
 def _dequant_bf16(data: torch.Tensor, sf_log: torch.Tensor) -> torch.Tensor:
     """E4M3 x per-32-block E8M0 -> BF16, exactly (3-bit mantissa, power-of-two
     scale), so the BF16 reference sees the kernel's true operand values.
@@ -287,14 +265,14 @@ def _mkdata(S: int, N: int, K: int, E: int, offsets: list[int], dtype: str, need
     tok = (torch.randn(1, S, K, device=dev) * 0.4).to(torch.float8_e4m3fn)
     w0 = (torch.randn(E, N, K, device=dev) * 0.4).to(torch.float8_e4m3fn)
     w1 = (torch.randn(E, N, K, device=dev) * 0.4).to(torch.float8_e4m3fn)
-    sfa_log = _rand_e8m0((S, sf_k), dev)
-    sfb0_log = _rand_e8m0((E, N, sf_k), dev)
-    sfb1_log = _rand_e8m0((E, N, sf_k), dev)
+    sfa_log = rand_e8m0((S, sf_k), dev)
+    sfb0_log = rand_e8m0((E, N, sf_k), dev)
+    sfb1_log = rand_e8m0((E, N, sf_k), dev)
     # SFA is blocked PER routed group (each padded to 128 rows) then concatenated —
     # the kernel walks the same ceil(group_m/128) SF-block prefix. SFB is per expert.
-    sfa = torch.cat([_to_blocked(sfa_log[lo:hi]) for lo, hi in _group_ranges(offsets, S)]).view(1, -1, 1)
-    sfb0 = torch.cat([_to_blocked(sfb0_log[e]) for e in range(E)]).view(E, sf_k, N)
-    sfb1 = torch.cat([_to_blocked(sfb1_log[e]) for e in range(E)]).view(E, sf_k, N)
+    sfa = torch.cat([to_blocked(sfa_log[lo:hi]) for lo, hi in _group_ranges(offsets, S)]).view(1, -1, 1)
+    sfb0 = torch.cat([to_blocked(sfb0_log[e]) for e in range(E)]).view(E, sf_k, N)
+    sfb1 = torch.cat([to_blocked(sfb1_log[e]) for e in range(E)]).view(E, sf_k, N)
     return SimpleNamespace(
         tok=tok,
         w0=w0,
@@ -307,6 +285,12 @@ def _mkdata(S: int, N: int, K: int, E: int, offsets: list[int], dtype: str, need
         w1_ref=_dequant_bf16(w1, sfb1_log) if need_ref else None,
         out=out,
     )
+
+
+def _mkdata_pool(S: int, N: int, K: int, E: int, offsets: list[int], dtype: str, nbuf: int):
+    """``nbuf`` independent operand sets at distinct GMEM addresses. They feed only
+    the timed launches, so they skip the widened reference copies."""
+    return [_mkdata(S, N, K, E, offsets, dtype, need_ref=False) for _ in range(nbuf)]
 
 
 def _epilogue_ref(gate: torch.Tensor, up: torch.Tensor, variant: str) -> torch.Tensor:
@@ -361,29 +345,6 @@ def _unfused_launch(tok, w0, w1, out, offsets, S, N, K, E, variant) -> None:
         out2[lo:hi] = _epilogue_ref(gate, up, variant).to(out.dtype)
 
 
-# Timing. delayed mode queues a torch.cuda._sleep first so the host can enqueue
-# every launch behind it -> kernels run back-to-back (kernel-only, matches nsys).
-
-
-def _time_ms(timed_fn: Callable, *, warmup: int, iters: int, delayed: bool) -> float:
-    for _ in range(warmup):
-        timed_fn()
-    torch.cuda.synchronize()
-    if delayed:
-        delay_cycles = max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6))
-        torch.cuda._sleep(delay_cycles)
-        for _ in range(max(5, warmup)):
-            timed_fn()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for _ in range(iters):
-        timed_fn()
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
-
-
 # Config candidates — MoE templates only, dual-GEMM TMEM fits two accumulators
 # only for cta_tile_n <= 256 (2*256 <= 512), and only <= 128 under mxfp8 where the
 # per-operand SF shares those TMEM columns; cta_tile_m=128.
@@ -401,37 +362,14 @@ def _build_spec_map(variant: str, dtype: str) -> dict[str, tuple]:
     return m
 
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(label: str, spec_map: dict):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    Takes the sweep map because this one is built per (variant, dtype). A label
-    naming a geometry outside CATALOG (e.g. a num_mma_m > 1 tile, which `by_name`
-    synthesizes) is still runnable, so parse it rather than calling it unsweepable."""
-    spec = spec_map.get(label)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(label)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
-
 # Main
 
 
 def _run_model(key: str, spec: dict, args) -> tuple | None:
     N, K = spec["N"], spec["K"]
     S, E = args.tokens, args.experts
-    offsets = _even_offsets(S, E)
+    offsets = even_offsets(S, E)
     variant = spec["variant"]
-    delayed = args.timing == "delayed"
 
     flops = 2 * (2 * S * N * K)  # 2 grouped GEMMs, each 2*S*N*K
     group_sizes = [hi - lo for lo, hi in _group_ranges(offsets, S)]
@@ -443,30 +381,42 @@ def _run_model(key: str, spec: dict, args) -> tuple | None:
     out = d.out
     fto = torch.tensor(offsets, dtype=torch.int32, device="cuda")
 
+    per_set = set_bytes([t for t in (d.tok, d.w0, d.w1, d.sfa, d.sfb0, d.sfb1, d.out) if t is not None])
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set)
+    report_pool(nbuf, per_set)
+    pool = _mkdata_pool(S, N, K, E, offsets, args.dtype, nbuf)
+
     ref = None if args.no_verify else _reference(d.tok_ref, d.w0_ref, d.w1_ref, offsets, S, N, K, E, variant)
 
     bl_ms = None
     if not args.no_baseline:
         out_bl = torch.empty_like(out)
-        bl_ms = _time_ms(
+        # An mxfp8 pool set holds no widened copy, so the bf16 baseline stays on the verify set.
+        bl_sets = pool if args.dtype == "bf16" else [d]
+        if args.stream:
+            print("  ▶ running unfused per-group cuBLAS baseline ...", flush=True)
+        bl_ms = time_ms(
+            rotating(lambda s: _unfused_launch(s.tok_ref, s.w0_ref, s.w1_ref, out_bl, offsets, S, N, K, E, variant), bl_sets),
             lambda: _unfused_launch(d.tok_ref, d.w0_ref, d.w1_ref, out_bl, offsets, S, N, K, E, variant),
             warmup=args.warmup,
             iters=args.iters,
-            delayed=delayed,
+            timing=args.timing,
         )
         print(f"  {'unfused per-group cuBLAS bf16 + pointwise':64s} {flops / (bl_ms * 1e-3) / 1e12:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms", flush=True)
 
     spec_map = _build_spec_map(variant, args.dtype)
-    labels = [c.strip() for c in args.configs.split(",")] if args.configs else list(spec_map)
+    labels = select_configs(args.configs, spec_map)
     print(f"  sweeping {len(labels)} configs (each JITs once, ~15-25 s)", flush=True)
 
     best = None
     for label in labels:
-        spec = _spec_for(label, spec_map)
-        if spec is None:
+        sel = spec_for(label, spec_map)
+        if sel is None:
             print(f"  {label:64s} UNKNOWN (not a sweepable MoE dual-GEMM strategy)", flush=True)
             continue
-        cfg, cta_group, sched = spec
+        cfg, cta_group, sched = sel
+        if args.stream:
+            print(f"  ▶ running {label} ...", flush=True)
         try:
             g, h = _graph(S, N, K, E, variant, args.dtype, offsets)
             plan = jit_from_cudnn_graph(g, config=cfg, cta_group=cta_group, scheduler=sched)
@@ -488,7 +438,8 @@ def _run_model(key: str, spec: dict, args) -> tuple | None:
             ok = torch.allclose(got, ref.float(), rtol=args.rtol, atol=args.atol)
             if not ok:
                 flag = f"  !! maxerr={(got - ref.float()).abs().max().item():.3g}"
-        ms = _time_ms(lambda: plan(vp), warmup=args.warmup, iters=args.iters, delayed=delayed)
+        vps = [_vp(h, s, fto, s.out, aux_bufs) for s in pool]
+        ms = time_ms(rotating(plan, vps), lambda: plan(vp), warmup=args.warmup, iters=args.iters, timing=args.timing)
         tflops = flops / (ms * 1e-3) / 1e12
         ratio = f"{bl_ms / ms:>7.2f}x" if bl_ms else " " * 8
         print(f"  {label:64s} {tflops:8.2f} TFLOP/s  {ms:8.3f} ms  {ratio}{flag}", flush=True)
@@ -508,10 +459,7 @@ def main() -> int:
     p.add_argument("--dtype", choices=DTYPES, default="bf16", help="operand precision: bf16, or mxfp8 (e4m3 + per-32-block e8m0)")
     p.add_argument("-S", "--tokens", type=int, default=None, help="token count (required)")
     p.add_argument("-E", "--experts", type=int, default=None, help="expert count (required)")
-    p.add_argument("--configs", default=None, help="comma-separated CONFIG_..._Nctamma labels (default: sweep all)")
-    p.add_argument("--warmup", type=int, default=10)
-    p.add_argument("--iters", type=int, default=20)  # CLAUDE.md: <= 20
-    p.add_argument("--timing", choices=("delayed", "events"), default="delayed")
+    add_sweep_args(p, nsys=False)
     p.add_argument("--no-verify", action="store_true", help="skip the torch reference check")
     p.add_argument("--no-baseline", action="store_true", help="skip the unfused per-group cuBLAS baseline")
     p.add_argument("--list-models", action="store_true")

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul_models.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul_models.py
@@ -402,7 +402,8 @@ def _run_model(key: str, spec: dict, args) -> tuple | None:
             iters=args.iters,
             timing=args.timing,
         )
-        print(f"  {'unfused per-group cuBLAS bf16 + pointwise':64s} {flops / (bl_ms * 1e-3) / 1e12:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms", flush=True)
+        bl_label = "unfused per-group cuBLAS bf16 + pointwise" + ("" if bl_sets is pool else " [no rotation]")
+        print(f"  {bl_label:64s} {flops / (bl_ms * 1e-3) / 1e12:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms", flush=True)
 
     spec_map = _build_spec_map(variant, args.dtype)
     labels = select_configs(args.configs, spec_map)
@@ -439,7 +440,7 @@ def _run_model(key: str, spec: dict, args) -> tuple | None:
             if not ok:
                 flag = f"  !! maxerr={(got - ref.float()).abs().max().item():.3g}"
         vps = [_vp(h, s, fto, s.out, aux_bufs) for s in pool]
-        ms = time_ms(rotating(plan, vps), lambda: plan(vp), warmup=args.warmup, iters=args.iters, timing=args.timing)
+        ms = time_ms(rotating(plan, vps), lambda _plan=plan, _vp=vp: _plan(_vp), warmup=args.warmup, iters=args.iters, timing=args.timing)
         tflops = flops / (ms * 1e-3) / 1e12
         ratio = f"{bl_ms / ms:>7.2f}x" if bl_ms else " " * 8
         print(f"  {label:64s} {tflops:8.2f} TFLOP/s  {ms:8.3f} ms  {ratio}{flag}", flush=True)

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul_models.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul_models.py
@@ -355,7 +355,7 @@ def _build_spec_map(variant: str, dtype: str) -> dict[str, tuple]:
     n_cap = 128 if dtype == "mxfp8" else 256
     m = {}
     for t, cfg in _registry_candidates(chain):
-        if cfg.pipeline != "sm100" or cfg.cta_tile_n > n_cap or cfg.cta_tile_m != 128:
+        if cfg.pipeline != "sm100" or cfg.cta_tile_n > n_cap or cfg.mma_inst_m != 128:
             continue
         label = f"{cfg.name}_{t.cta_group}ctamma" + ("_static" if t.static_sched else "")
         m[label] = (cfg, t.cta_group, t.scheduler)

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul_swiglu.py
@@ -173,7 +173,7 @@ def _build_spec_map():
     chain = analyze(_graph_swiglu(2048, 256, 256, 9)[0])
     m = {}
     for t, cfg in _registry_candidates(chain):
-        if cfg.pipeline != "sm100" or cfg.cta_tile_n > 256 or cfg.cta_tile_m != 128:
+        if cfg.pipeline != "sm100" or cfg.cta_tile_n > 256 or cfg.mma_inst_m != 128:
             continue
         label = f"{cfg.name}_{t.cta_group}ctamma" + ("_static" if t.static_sched else "")
         m[label] = (cfg, t.cta_group, t.scheduler)

--- a/benchmark/gemm/frost/benchmark_moe_grouped_matmul_swiglu.py
+++ b/benchmark/gemm/frost/benchmark_moe_grouped_matmul_swiglu.py
@@ -11,9 +11,7 @@ split, S=G*M).
 from __future__ import annotations
 
 import argparse
-import re
 import sys
-from typing import Callable
 
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  (installs hook)
@@ -22,9 +20,10 @@ import torch
 from types import SimpleNamespace
 
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
-from cudnn.gemm.frost.tile_config import by_name as _by_name
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.kernel_registry import candidates as _registry_candidates
+
+from benchmark_utils import add_sweep_args, group_offsets, report_pool, resolve_nbuf, rotating, select_configs, set_bytes, spec_for, time_ms
 
 
 def _build_plan(g, cfg, cta_group, sched):
@@ -122,11 +121,6 @@ def _graph_swiglu(S: int, N: int, K: int, E: int):
     )
 
 
-def _offsets(S: int, E: int) -> torch.Tensor:
-    group_m = S // E
-    return torch.arange(E, dtype=torch.int32, device="cuda") * group_m
-
-
 def _mkdata(S, N, K, E):
     torch.manual_seed(0)
     tok = torch.randn(1, S, K, device="cuda", dtype=torch.bfloat16) * 0.4
@@ -135,6 +129,12 @@ def _mkdata(S, N, K, E):
     out = torch.empty(1, S, N, device="cuda", dtype=torch.bfloat16)
     scale = torch.tensor([[[0.5]]], device="cuda", dtype=torch.float32)
     return tok, w0, w1, out, scale
+
+
+def _mkdata_pool(S, N, K, E, nbuf):
+    """`nbuf` independent (tok, w0, w1, out, scale) sets at distinct GMEM addresses."""
+    base = _mkdata(S, N, K, E)
+    return [base] + [tuple(t.clone() for t in base) for _ in range(max(0, nbuf - 1))]
 
 
 def _reference(tok, w0, w1, scale, S, N, K, E):
@@ -147,8 +147,9 @@ def _reference(tok, w0, w1, scale, S, N, K, E):
     return out.reshape(S, N).to(torch.bfloat16)
 
 
-def _unfused_launch(tok, w0, w1, scale, out, S, N, K, E):
+def _unfused_launch(dset, S, N, K, E):
     """Unfused baseline: 2 cuBLAS batched GEMMs + pointwise."""
+    tok, w0, w1, out, scale = dset
     group_m = S // E
     tok_g = tok.view(E, group_m, K)
     c0 = torch.bmm(tok_g, w0.transpose(-1, -2))
@@ -157,27 +158,9 @@ def _unfused_launch(tok, w0, w1, scale, out, S, N, K, E):
     out.view(E, group_m, N).copy_(res.to(out.dtype))
 
 
-# Timing. delayed mode queues a torch.cuda._sleep first so the host can enqueue
-# every launch behind it → kernels run back-to-back (kernel-only, matches nsys).
-
-
-def _time_ms(timed_fn: Callable, *, warmup: int, iters: int, delayed: bool) -> float:
-    for _ in range(warmup):
-        timed_fn()
-    torch.cuda.synchronize()
-    if delayed:
-        delay_cycles = max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6))
-        torch.cuda._sleep(delay_cycles)
-        for _ in range(max(5, warmup)):
-            timed_fn()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    start.record()
-    for _ in range(iters):
-        timed_fn()
-    end.record()
-    torch.cuda.synchronize()
-    return start.elapsed_time(end) / iters
+def _fused_launch(plan, handles, dset, fto):
+    tok, w0, w1, out, scale = dset
+    plan(_vp_moe_mg(handles, [(tok, w0), (tok, w1)], fto, out, scale))
 
 
 # Config candidates — MoE templates only (1ctamma cluster1x1, 2ctamma cluster2x1)
@@ -199,47 +182,13 @@ def _build_spec_map():
 
 _SPEC_MAP = _build_spec_map()
 
-_LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
-
-
-def _spec_for(name):
-    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
-
-    The sweep set comes from the registry funnel over CATALOG; a label naming a
-    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
-    still runnable, so parse it rather than reporting it unsweepable."""
-    spec = _SPEC_MAP.get(name)
-    if spec is not None:
-        return spec
-    m = _LABEL_RE.match(name)
-    if m is None:
-        return None
-    try:
-        cfg = _by_name(m.group(1))
-    except (KeyError, NotImplementedError):
-        return None
-    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
-
-
 # Main
 
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--shape", default="8,512,4096,4096", help="G,M,N,K (even split)")
-    p.add_argument("--warmup", type=int, default=10)
-    p.add_argument("--iters", type=int, default=20)  # CLAUDE.md: <= 20
-    p.add_argument(
-        "--configs",
-        default=None,
-        help="comma-separated CONFIG_..._Nctamma labels (default: sweep all)",
-    )
-    p.add_argument("--timing", choices=("delayed", "events"), default="delayed")
-    p.add_argument(
-        "--stream",
-        action="store_true",
-        help="accepted for CLI parity with benchmark_moe_grouped_matmul.py; " "results already print inline as each config finishes",
-    )
+    add_sweep_args(p, nsys=False)
     p.add_argument("--rtol", type=float, default=5e-2)
     p.add_argument("--atol", type=float, default=2e-1)
     args = p.parse_args()
@@ -254,59 +203,70 @@ def main() -> int:
     G, M, N, K = parts
     E = G
     S = G * M
-    delayed = args.timing == "delayed"
 
     flops = 2 * (2 * S * N * K)  # 2 grouped GEMMs, each 2*S*N*K
     print(f"\n=== MoE dual grouped-matmul SwiGLU  G={G} groups × M={M}  " f"(S={S}) {N}x{K}  (~{flops / 1e9:.1f} GFLOP, 2 GEMMs) ===")
-    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]\n")
+    print(f"  [timing: {args.timing}, warmup={args.warmup}, iters={args.iters}]")
 
-    tok, w0, w1, out, scale = _mkdata(S, N, K, E)
-    offsets = _offsets(S, E)
+    wset = _mkdata(S, N, K, E)  # dedicated warmup set; also what gets verified
+    tok, w0, w1, out, scale = wset
+    per_set = set_bytes(wset)
+    nbuf = resolve_nbuf(args.rotate_buffers, per_set)
+    report_pool(nbuf, per_set)
+    print()
+    pool = _mkdata_pool(S, N, K, E, nbuf)
+
+    offsets = group_offsets(S, E)
     ref = _reference(tok, w0, w1, scale, S, N, K, E)
 
     # baseline: unfused 2×cuBLAS batched GEMM + pointwise
-    out_bl = torch.empty_like(out)
-    bl_ms = _time_ms(
-        lambda: _unfused_launch(tok, w0, w1, scale, out_bl, S, N, K, E),
+    if args.stream:
+        print("  ▶ running unfused baseline ...", flush=True)
+    bl_ms = time_ms(
+        rotating(lambda s: _unfused_launch(s, S, N, K, E), pool),
+        lambda: _unfused_launch(wset, S, N, K, E),
         warmup=args.warmup,
         iters=args.iters,
-        delayed=delayed,
+        timing=args.timing,
     )
     bl_tflops = flops / (bl_ms * 1e-3) / 1e12
     print(f"  {'unfused 2xcuBLAS batched + pointwise':54s} {bl_tflops:8.2f} TFLOP/s  " f"{bl_ms:8.3f} ms   {'1.00×':>8s}")
 
-    config_names = [c.strip() for c in args.configs.split(",")] if args.configs else list(_SPEC_MAP)
+    config_names = select_configs(args.configs, _SPEC_MAP)
 
     best = None
     for label in config_names:
-        spec = _spec_for(label)
+        spec = spec_for(label, _SPEC_MAP)
         if spec is None:
             print(f"  {label:64s} UNKNOWN (not a sweepable MoE swiglu strategy)")
             continue
         cfg, cta_group, sched = spec
+        if args.stream:
+            print(f"  ▶ running {label} ...", flush=True)
         try:
             g, h = _graph_swiglu(S, N, K, E)
             plan = _build_plan(g, cfg, cta_group, sched)
         except (NotImplementedError, ValueError):
             continue
         try:
-            plan(_vp_moe_mg(h, [(tok, w0), (tok, w1)], offsets, out, scale))
+            _fused_launch(plan, h, wset, offsets)
             torch.cuda.synchronize()
         except Exception as e:  # noqa: BLE001
             print(f"  {label:64s} LAUNCH FAIL: {type(e).__name__}: {str(e)[:30]}")
             continue
         err = (out.float() - ref.float()).abs().max().item()
         ok = torch.allclose(out.float(), ref.float(), rtol=args.rtol, atol=args.atol)
-        ms = _time_ms(
-            lambda: plan(_vp_moe_mg(h, [(tok, w0), (tok, w1)], offsets, out, scale)),
+        ms = time_ms(
+            rotating(lambda s, _plan=plan, _h=h: _fused_launch(_plan, _h, s, offsets), pool),
+            lambda _plan=plan, _h=h: _fused_launch(_plan, _h, wset, offsets),
             warmup=args.warmup,
             iters=args.iters,
-            delayed=delayed,
+            timing=args.timing,
         )
         tflops = flops / (ms * 1e-3) / 1e12
         ratio = bl_ms / ms if ms > 0 else 0.0
         flag = "" if ok else f"  !! maxerr={err:.3g}"
-        print(f"  {label:64s} {tflops:8.2f} TFLOP/s  {ms:8.3f} ms   " f"{ratio:>7.2f}×{flag}")
+        print(f"  {label:64s} {tflops:8.2f} TFLOP/s  {ms:8.3f} ms   " f"{ratio:>7.2f}×{flag}", flush=True)
         if ok and (best is None or ms < best[1]):
             best = (label, ms, tflops, ratio)
 

--- a/benchmark/gemm/frost/benchmark_utils.py
+++ b/benchmark/gemm/frost/benchmark_utils.py
@@ -238,10 +238,14 @@ def parse_nsys_stats(text: str) -> dict[str, float]:
         sys.exit("could not find the cuda_gpu_kern_sum CSV header in nsys stats output:\n  " + "\n  ".join(lines[:60]))
 
     cols = next(csv.reader([lines[header_i]]))
-    med_i = next(i for i, c in enumerate(cols) if c.startswith("Med ("))
-    name_i = cols.index("Name")
-    unit = re.search(r"Med \((\w+)\)", cols[med_i]).group(1)
-    per_ms = {"ns": 1e6, "us": 1e3, "ms": 1.0, "s": 1e-3}[unit]
+    med = next((i for i, c in enumerate(cols) if re.fullmatch(r"Med \(\w+\)", c)), None)
+    if med is None or "Name" not in cols:
+        sys.exit(f"cuda_gpu_kern_sum CSV header has no Med (<unit>) / Name column: {lines[header_i]!r}")
+    med_i, name_i = med, cols.index("Name")
+    unit = re.fullmatch(r"Med \((\w+)\)", cols[med_i]).group(1)
+    per_ms = {"ns": 1e6, "us": 1e3, "ms": 1.0, "s": 1e-3}.get(unit)
+    if per_ms is None:
+        sys.exit(f"unsupported time unit {unit!r} in the cuda_gpu_kern_sum CSV header: {lines[header_i]!r}")
     out: dict[str, float] = {}
     for row in csv.reader(io.StringIO("\n".join(lines[header_i + 1 :]))):
         if len(row) <= max(med_i, name_i):

--- a/benchmark/gemm/frost/benchmark_utils.py
+++ b/benchmark/gemm/frost/benchmark_utils.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers shared by the gemm/frost benchmark scripts.
+
+Each script builds its own `spec_map` (label -> (geometry cfg, cta_group,
+scheduler)) from the registry funnel and its own graph / data, but the way they
+select configs, rotate buffers, time launches and read an nsys report is the
+same everywhere. That part lives here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import fnmatch
+import io
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Callable
+
+import torch
+
+from cudnn.gemm.frost.tile_config import by_name as _by_name
+
+# Config selection
+
+LABEL_RE = re.compile(r"^(CONFIG_sm\d+_\d+x\d+x\d+_\d+x\d+x\d+_cluster\d+x\d+)_([12])ctamma(_static)?$")
+
+
+def spec_for(label, spec_map):
+    """(geometry cfg, cta_group, scheduler) for a --configs label, or None.
+
+    The sweep map comes from the registry funnel over CATALOG; a label naming a
+    geometry outside it (e.g. a num_mma_m > 1 tile, which `by_name` synthesizes) is
+    still runnable, so parse it rather than calling it unsweepable."""
+    spec = spec_map.get(label)
+    if spec is not None:
+        return spec
+    m = LABEL_RE.match(label)
+    if m is None:
+        return None
+    try:
+        cfg = _by_name(m.group(1))
+    except (KeyError, NotImplementedError):
+        return None
+    return cfg, int(m.group(2)), "static" if m.group(3) else "clc"
+
+
+def select_configs(arg, spec_map):
+    """--configs value -> concrete label list. A token carrying a glob
+    (`CONFIG_sm107_*`) is expanded against the sweep map; anything else is kept
+    verbatim so `spec_for` can still synthesize an off-catalog geometry."""
+    if not arg:
+        return list(spec_map)
+    out = []
+    for tok in (t.strip() for t in arg.split(",")):
+        if not tok:
+            continue
+        if any(ch in tok for ch in "*?["):
+            hits = [n for n in spec_map if fnmatch.fnmatchcase(n, tok)]
+            if not hits:
+                sys.exit(f"--configs pattern {tok!r} matched no config")
+            out += hits
+        else:
+            out.append(tok)
+    return list(dict.fromkeys(out))
+
+
+# Argument surface
+
+CONFIGS_HELP = "comma-separated config names or globs, e.g. 'CONFIG_sm107_*' (default: sweep all)"
+
+ROTATE_HELP = (
+    "allocate N independent copies of every tensor and rotate the timed launches "
+    "across them so a kernel doesn't re-read the previous launch's data from a hot "
+    "L2 (inflates small-shape TFLOPS). Warmup uses a separate dedicated buffer. "
+    "Default 'auto': size the pool to exceed the L2 (large shapes -> 2, small -> "
+    "scaled up), capped at 4 GB. Pass an integer to override; 1 disables."
+)
+
+STREAM_HELP = "print each config's result as soon as it finishes (the last 'running' line points at a hang)."
+
+
+def add_sweep_args(parser, *, nsys: bool = True, warmup: int = 10, iters: int = 20):
+    """The knobs every sweep script exposes. `nsys=False` for the fused benches,
+    whose baseline is several kernels so a median-kernel-time mode is meaningless."""
+    parser.add_argument("--warmup", type=int, default=warmup)
+    # CLAUDE.md: keep iters <= 20 — more just lengthens the run / holds the GPU.
+    parser.add_argument("--iters", type=int, default=iters)
+    parser.add_argument("--configs", default=None, help=CONFIGS_HELP)
+    parser.add_argument(
+        "--timing",
+        choices=("delayed", "events", "nsys") if nsys else ("delayed", "events"),
+        default="delayed",
+        help="delayed (default) hides host-launch overhead behind a _sleep; events is raw wall clock"
+        + ("; nsys is per-kernel median from a profile" if nsys else ""),
+    )
+    parser.add_argument("--stream", action="store_true", help=STREAM_HELP)
+    parser.add_argument("--rotate-buffers", default="auto", metavar="N", help=ROTATE_HELP)
+    if nsys:
+        parser.add_argument("--_nsys-worker", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+# Buffer rotation (defeat a hot L2 on small shapes)
+
+L2_BYTES = 126 * 1024 * 1024  # B200 class
+_AUTO_POOL_BUDGET_BYTES = 4 * 1024 * 1024 * 1024
+_AUTO_NBUF_CAP = 1024
+
+
+def set_bytes(tensors) -> int:
+    """GMEM footprint of one tensor set (packed FP4 counts as 1 byte per pair)."""
+    return sum(t.numel() * t.element_size() for t in tensors)
+
+
+def auto_nbuf(per_set_bytes: int, *, free_divisor: int = 2) -> int:
+    """Smallest buffer count whose pool exceeds L2 (1.5x margin), clamped to a
+    memory budget. Large shapes -> 2; small shapes -> scaled up until L2-cold."""
+    nbuf = max(2, -(-int(1.5 * L2_BYTES) // per_set_bytes))
+    budget = _AUTO_POOL_BUDGET_BYTES
+    if torch.cuda.is_available():
+        free, _total = torch.cuda.mem_get_info()
+        budget = min(budget, free // free_divisor)
+    return max(1, min(nbuf, max(1, budget // per_set_bytes), _AUTO_NBUF_CAP))
+
+
+def resolve_nbuf(spec, per_set_bytes: int, *, free_divisor: int = 2) -> int:
+    """Resolve --rotate-buffers: 'auto' -> shape-sized count, else the integer
+    (1 = rotation disabled)."""
+    if str(spec).strip().lower() == "auto":
+        return auto_nbuf(per_set_bytes, free_divisor=free_divisor)
+    return max(1, int(spec))
+
+
+def rotating(fn_of_set: Callable, pool: list) -> Callable:
+    """Wrap a `set -> None` callable into `i -> pool[i % len(pool)]`."""
+    n = len(pool)
+    return lambda i: fn_of_set(pool[i % n])
+
+
+def report_pool(nbuf: int, per_set_bytes: int) -> None:
+    """The one-line pool banner, plus the warning when the pool still fits in L2."""
+    if nbuf <= 1:
+        print("  [rotate-buffers: 1 (disabled) — small shapes read a hot L2 and over-report TFLOPS]")
+        return
+    footprint = per_set_bytes * nbuf
+    print(f"  [rotate-buffers: {nbuf} copies/tensor, {footprint / 1024 / 1024:.0f} MB pool — defeats hot-L2 on small shapes]")
+    if footprint < L2_BYTES:
+        print(
+            f"  [WARNING: pool ({footprint / 1024 / 1024:.0f} MB) < L2 (~{L2_BYTES / 1024 / 1024:.0f} MB) — "
+            f"it fits in cache, so launches stay warm after one rotation. Bump --rotate-buffers.]"
+        )
+
+
+# Timing
+
+
+def time_ms_events(timed_fn: Callable, warmup_fn: Callable, *, warmup: int, iters: int) -> float:
+    """Wall-clock CUDA Event timing around a python loop. Inflated by
+    Python+TVM-FFI dispatch overhead (~50us/call). `timed_fn(i)` rotates
+    buffers; `warmup_fn()` uses a separate dedicated buffer."""
+    for _ in range(warmup):
+        warmup_fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for i in range(iters):
+        timed_fn(i)
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+def time_ms_delayed(timed_fn: Callable, warmup_fn: Callable, *, warmup: int, iters: int) -> float:
+    """Kernel-only timing: queue a long `_sleep` first so the host enqueues
+    every launch behind it -> kernels run back-to-back with no host gaps.
+    `timed_fn(i)` rotates buffers; `warmup_fn()` uses a separate buffer.
+
+    The post-sleep warmup ramps SM clocks (DVFS) back up before timing —
+    without it the first fast-config measurement inflates ~2x."""
+    for _ in range(warmup):
+        warmup_fn()
+    torch.cuda.synchronize()
+    # Delay must outlast iters x ~50us host overhead. B200 ~1.7 GHz; floor 1e8.
+    torch.cuda._sleep(max(int(1e8), int((iters * 0.05 + 20.0) * 1.7e6)))
+    for _ in range(max(5, warmup)):
+        warmup_fn()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for i in range(iters):
+        timed_fn(i)
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+def time_ms(timed_fn: Callable, warmup_fn: Callable | None = None, *, warmup: int, iters: int, timing: str) -> float:
+    """Dispatch on --timing. `timed_fn(i)` takes the rotation index (pass
+    `lambda _i: ...` when there is nothing to rotate); `warmup_fn()` defaults to
+    `timed_fn(0)`."""
+    wf = warmup_fn if warmup_fn is not None else (lambda: timed_fn(0))
+    fn = time_ms_delayed if timing == "delayed" else time_ms_events
+    return fn(timed_fn, wf, warmup=warmup, iters=iters)
+
+
+# nsys mode
+
+
+def kernel_match_token(cfg, cta_group: int, scheduler: str = "clc") -> str:
+    """The substring the demangled symbol carries. `compiler` names the kernel
+    `<template_file_stem>_<geometry_name>`, so a static config reads
+    `..._1ctamma_static_128x256x128_...` — the scheduler sits BETWEEN the
+    cta_group token and the geometry and has to be part of the match.
+    The --configs LABEL is not usable here at all: it spells the pipeline before
+    the geometry and the cta_group after it, so it is never a substring."""
+    return f"{cta_group}ctamma{'_static' if scheduler == 'static' else ''}_{cfg.geometry_name}"
+
+
+def parse_nsys_stats(text: str) -> dict[str, float]:
+    """Parse `nsys stats --report cuda_gpu_kern_sum --format csv` into
+    {kernel_name: median_ms}. CSV, not the console table: the column format
+    truncates the symbol at 100 chars with an ellipsis, which cuts the geometry
+    off the longer template names."""
+    lines = text.splitlines()
+    for i, ln in enumerate(lines):
+        if ln.startswith("Time (%),") and ln.rstrip().endswith(",Name"):
+            header_i = i
+            break
+    else:
+        sys.exit("could not find the cuda_gpu_kern_sum CSV header in nsys stats output:\n  " + "\n  ".join(lines[:60]))
+
+    cols = next(csv.reader([lines[header_i]]))
+    med_i = next(i for i, c in enumerate(cols) if c.startswith("Med ("))
+    name_i = cols.index("Name")
+    unit = re.search(r"Med \((\w+)\)", cols[med_i]).group(1)
+    per_ms = {"ns": 1e6, "us": 1e3, "ms": 1.0, "s": 1e-3}[unit]
+    out: dict[str, float] = {}
+    for row in csv.reader(io.StringIO("\n".join(lines[header_i + 1 :]))):
+        if len(row) <= max(med_i, name_i):
+            continue
+        try:
+            out[row[name_i]] = float(row[med_i].replace(",", "")) / per_ms
+        except ValueError:
+            continue
+    return out
+
+
+FROST_SYMBOL_MARKER = "cudnn_frost_"
+
+
+def find_cublas_time(kern_times: dict[str, float]) -> tuple[str, float] | None:
+    """The reference GEMM in the report: cuBLAS's `nvjet_*` if present, else the
+    heaviest kernel that is neither one of ours nor a torch helper. The
+    block-scale reference goes through `F.scaled_mm`, which dispatches to a
+    `cutlass3x_sm100_bstensorop_*` kernel rather than nvjet."""
+    cands = [(k, v) for k, v in kern_times.items() if k.startswith("nvjet_")]
+    if not cands:
+        cands = [(k, v) for k, v in kern_times.items() if FROST_SYMBOL_MARKER not in k and "at::" not in k]
+    if not cands:
+        return None
+    return max(cands, key=lambda x: x[1])
+
+
+def nsys_run_and_parse(script: str, inner_args: list[str], *, tag: str) -> dict[str, float]:
+    """Re-exec `script` under nsys with `--_nsys-worker` + `inner_args`, then parse
+    `cuda_gpu_kern_sum` for the median kernel time (ms). Returns {kernel_name: ms}."""
+    nsys = "/usr/local/bin/nsys" if os.path.exists("/usr/local/bin/nsys") else shutil.which("nsys")
+    if nsys is None:
+        sys.exit("nsys not found — install nsight-systems or use the default events mode.")
+
+    workdir = os.path.join(os.environ.get("TMPDIR", tempfile.gettempdir()), f"{tag}_nsys_{os.getpid()}")
+    os.makedirs(workdir, exist_ok=True)
+    report_prefix = os.path.join(workdir, "report")
+
+    # Redirect nsys's default /tmp/nvidia path (root-owned on some hosts) via env.
+    nsys_env = os.environ.copy()
+    nsys_env.setdefault("TMPDIR", os.environ.get("TMPDIR", tempfile.gettempdir()))
+
+    inner = [sys.executable, "-u", os.path.abspath(script), "--_nsys-worker"] + inner_args
+    profile_cmd = [
+        nsys,
+        "profile",
+        "-o",
+        report_prefix,
+        "--force-overwrite=true",
+        "--cuda-um-cpu-page-faults=false",
+        "--cuda-um-gpu-page-faults=false",
+        "--trace=cuda",
+    ] + inner
+    print(f"  + {' '.join(profile_cmd)}\n")
+    proc = subprocess.run(profile_cmd, capture_output=True, text=True, env=nsys_env)
+    if proc.returncode != 0:
+        print("nsys stdout:\n" + proc.stdout)
+        print("nsys stderr:\n" + proc.stderr, file=sys.stderr)
+        sys.exit(f"nsys profile exited {proc.returncode}")
+
+    stats_cmd = [nsys, "stats", "--report", "cuda_gpu_kern_sum", "--format", "csv", "--force-export=true", report_prefix + ".nsys-rep"]
+    proc = subprocess.run(stats_cmd, capture_output=True, text=True, env=nsys_env)
+    if proc.returncode != 0:
+        print("nsys stats stdout:\n" + proc.stdout)
+        print("nsys stats stderr:\n" + proc.stderr, file=sys.stderr)
+        sys.exit(f"nsys stats exited {proc.returncode}")
+    return parse_nsys_stats(proc.stdout)
+
+
+# Block-scale / MoE data helpers
+
+
+def ceil_div(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def to_blocked(x: torch.Tensor) -> torch.Tensor:
+    """(rows, cols) scale tensor -> the flat F8_128x4 reordered blob, rows padded
+    to 128 and cols to 4."""
+    rows, cols = x.shape
+    nrb, ncb = ceil_div(rows, 128), ceil_div(cols, 4)
+    pad = torch.zeros(nrb * 128, ncb * 4, dtype=x.dtype, device=x.device)
+    pad[:rows, :cols] = x
+    blocks = pad.view(nrb, 128, ncb, 4).permute(0, 2, 1, 3)
+    return blocks.reshape(-1, 4, 32, 4).transpose(1, 2).reshape(-1, 32, 16).flatten()
+
+
+def rand_e8m0(shape, dev):
+    """Random E8M0 scale bytes centred on 2^0 (biased exponent 127). The graph
+    declares the SF as FP8_E8M0, so the blob must carry that dtype."""
+    return torch.randint(125, 129, shape, dtype=torch.uint8, device=dev).view(torch.float8_e8m0fnu)
+
+
+def group_offsets(S: int, E: int) -> torch.Tensor:
+    """Even split, remainder absorbed by the last group: group g starts at
+    g * (S // E). This is the `first_token_offset` tensor."""
+    return torch.arange(E, dtype=torch.int32, device="cuda") * (S // E)
+
+
+def even_offsets(S: int, E: int) -> list[int]:
+    """Routed-group start offsets for ``S`` tokens spread as evenly as possible
+    over ``E`` experts — the first ``S % E`` groups take one extra token.
+    ``S=10, E=3`` -> group sizes 4, 3, 3 -> ``[0, 4, 7]``."""
+    if E < 1:
+        raise ValueError(f"expert count must be >= 1, got {E}")
+    base, rem = divmod(S, E)
+    offsets, start = [], 0
+    for i in range(E):
+        offsets.append(start)
+        start += base + (1 if i < rem else 0)
+    return offsets

--- a/python/cudnn/gemm/frost/tile_config.py
+++ b/python/cudnn/gemm/frost/tile_config.py
@@ -449,15 +449,18 @@ def _geom_sm103(cta_m: int, cta_n: int, cgrp_m: int, cgrp_n: int) -> ConfigSm103
     )
 
 
-def _geom_sm107(cta_m: int, cta_n: int, cgrp_m: int, cgrp_n: int) -> ConfigSm107:
-    """Build one sm107 config (the 64-byte MMA-inst K is the family's, not ours)."""
+def _geom_sm107(num_mma_m: int, cta_n: int, cgrp_m: int, cgrp_n: int) -> ConfigSm107:
+    """Build one sm107 config (the 64-byte MMA-inst K is the family's, not ours).
+    mma_inst_m is pinned to 128 — the block-scale F8_128x4 SF swizzle needs
+    mma_inst_m % 128 == 0, so 64 is not an axis here."""
     return ConfigSm107(
-        cta_tile_m=cta_m,
+        cta_tile_m=_CTA_TILE_M_MAX * num_mma_m,
         cta_tile_n=cta_n,
         cta_tile_k_bytes=128,
         cgrp_size_m=cgrp_m,
         cgrp_size_n=cgrp_n,
-        epi_tile_mn=(cta_m, 32),
+        mma_inst_m=_CTA_TILE_M_MAX,
+        epi_tile_mn=(_CTA_TILE_M_MAX, 32),
         threads_per_cta=256,
         pipeline="sm107",
         acc_stages=2,
@@ -481,9 +484,10 @@ def _build_catalog() -> tuple[TileConfig, ...]:
     # sm107 block-scale geometries: the sm100 axes narrowed to what the F8_128x4
     # SF swizzle admits (M/N multiples of 128, K-tile 128 B) — the rest of the
     # sm100 enumeration would only be rejected by validate_block_scale_config.
-    for cta_n in (256, 128):
-        for cgrp_m, cgrp_n in _CLUSTERS:
-            cfgs.append(_geom_sm107(128, cta_n, cgrp_m, cgrp_n))
+    for num_mma_m in (1, 2):
+        for cta_n in (256, 128):
+            for cgrp_m, cgrp_n in _CLUSTERS:
+                cfgs.append(_geom_sm107(num_mma_m, cta_n, cgrp_m, cgrp_n))
     return tuple(cfgs)
 
 

--- a/python/cudnn/gemm/frost/tile_config.py
+++ b/python/cudnn/gemm/frost/tile_config.py
@@ -385,14 +385,17 @@ def config_class_for_pipeline(pipeline: str) -> type[TileConfig]:
 # ---------------------------------------------------------------------------
 # Catalog — pure-geometry enumeration. cta_group / static / mainloop are NOT
 # enumerated here; the registry expands each geometry across accepting templates.
-# Axes: cta_m ∈ {128,64}, cta_n ∈ {8..256 step 8}, K_bytes ∈ {128,64}, cluster ∈
-# _CLUSTERS. N < 8 / N % 8 rejected by __post_init__ (tcgen05 idesc n_dim is a
-# multiple of 8). 2-CTA templates accept only cgrp_size_m % 2 == 0 (registry
-# predicate). Every catalog entry has num_mma_m == 1 (mma_inst tile == cta tile);
-# geometries that split the tile across several MMA instructions along M are
-# reached by `by_name` synthesis, so they stay out of the funnel's candidate set
-# and out of the benchmark / full-sweep enumerations.
+# Axes: M ∈ _M_AXES (the UTCMMA instruction M and how many of them the CTA tile
+# spans — cta_tile_m is the PRODUCT, not an axis), cta_n ∈ {8..256 step 8},
+# K_bytes ∈ {128,64}, cluster ∈ _CLUSTERS. N < 8 / N % 8 rejected by
+# __post_init__ (tcgen05 idesc n_dim is a multiple of 8). 2-CTA templates accept
+# only cgrp_size_m % 2 == 0 (registry predicate).
 # ---------------------------------------------------------------------------
+
+# (mma_inst_m, num_mma_m) — the UTCMMA instruction M and how many of them one CTA
+# tile spans; cta_tile_m is their product. num_mma_m == 1 first, so a lookup like
+# `next(c for c in CATALOG if c.cta_tile_m == 128)` still lands on the unsplit tile.
+_M_AXES: tuple[tuple[int, int], ...] = ((128, 1), (64, 1), (128, 2), (64, 2))
 
 _CLUSTERS: tuple[tuple[int, int], ...] = (
     (1, 1),
@@ -413,15 +416,17 @@ _CLUSTERS: tuple[tuple[int, int], ...] = (
 )
 
 
-def _geom_sm100(cta_m: int, cta_n: int, k_bytes: int, cgrp_m: int, cgrp_n: int) -> ConfigSm100:
-    """Build one sm100 pure-geometry config."""
+def _geom_sm100(mma_m: int, num_mma_m: int, cta_n: int, k_bytes: int, cgrp_m: int, cgrp_n: int) -> ConfigSm100:
+    """Build one sm100 pure-geometry config from the MMA-instruction M and the
+    number of them the CTA tile spans."""
     return ConfigSm100(
-        cta_tile_m=cta_m,
+        cta_tile_m=mma_m * num_mma_m,
         cta_tile_n=cta_n,
         cta_tile_k_bytes=k_bytes,
         cgrp_size_m=cgrp_m,
         cgrp_size_n=cgrp_n,
-        epi_tile_mn=(cta_m, 32),
+        mma_inst_m=mma_m,
+        epi_tile_mn=(mma_m, 32),
         threads_per_cta=256,
         pipeline="sm100",
         acc_stages=2,
@@ -462,11 +467,11 @@ def _geom_sm107(cta_m: int, cta_n: int, cgrp_m: int, cgrp_n: int) -> ConfigSm107
 
 def _build_catalog() -> tuple[TileConfig, ...]:
     cfgs: list[TileConfig] = []
-    for cta_m in (128, 64):
+    for mma_m, num_mma_m in _M_AXES:
         for cta_n in range(256, 0, -8):
             for k_bytes in (128, 64):
                 for cgrp_m, cgrp_n in _CLUSTERS:
-                    cfgs.append(_geom_sm100(cta_m, cta_n, k_bytes, cgrp_m, cgrp_n))
+                    cfgs.append(_geom_sm100(mma_m, num_mma_m, cta_n, k_bytes, cgrp_m, cgrp_n))
     # sm103 block-scale geometries: M pinned to 128 by the 1-CTA MMA atom;
     # clusters share the sm100 enumeration (the templates use the same generic
     # rank-decomposition multicast masks for data + SF).

--- a/test/python/gemm/frost/test_block_scale_matmul.py
+++ b/test/python/gemm/frost/test_block_scale_matmul.py
@@ -1850,13 +1850,15 @@ def _sm107_kw(config_name, cta_group=1):
 
 def test_catalog_has_sm107_geometries():
     sm107 = [c for c in CATALOG if c.pipeline == "sm107"]
-    # 2 cta_n × the shared 15-cluster enumeration.
-    assert len(sm107) == 30
-    pat = re.compile(r"^CONFIG_sm107_128x(128|256)x128_128x(128|256)x64_cluster\d+x\d+$")
+    # num_mma_m {1,2} × 2 cta_n × the shared 15-cluster enumeration.
+    assert len(sm107) == 60
+    pat = re.compile(r"^CONFIG_sm107_(128|256)x(128|256)x128_128x(128|256)x64_cluster\d+x\d+$")
     for c in sm107:
         assert pat.match(c.name), c.name
         assert isinstance(c, ConfigSm107)
-        assert c.cta_tile_m == 128 and c.cta_tile_k_bytes == 128
+        # mma_inst_m is pinned: the block-scale F8_128x4 SF swizzle needs % 128 == 0.
+        assert c.mma_inst_m == 128 and c.cta_tile_k_bytes == 128
+        assert c.cta_tile_m == 128 * c.num_mma_m
         assert c.mma_inst_k_bytes == 64
     assert by_name(_SM107_128).geometry_name == "128x128x128_128x128x64_cluster1x1"
 

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -2359,8 +2359,11 @@ def test_catalog_enumerates_the_mma_m_axis() -> None:
     sm100 = [c for c in CATALOG if c.pipeline == "sm100"]
     assert {(c.mma_inst_m, c.num_mma_m) for c in sm100} == set(_M_AXES)
     assert all(c.cta_tile_m == c.mma_inst_m * c.num_mma_m for c in CATALOG)
-    # sm103 / sm107 pin M: the block-scale SF 128x4 swizzle needs mma_inst_m % 128 == 0.
-    assert {(c.mma_inst_m, c.num_mma_m) for c in CATALOG if c.pipeline != "sm100"} == {(128, 1)}
+    # sm103 / sm107 pin the INSTRUCTION M (the block-scale SF 128x4 swizzle needs
+    # mma_inst_m % 128 == 0); sm107 still splits, sm103 does not (supports_multi_mma_m=False).
+    assert {c.mma_inst_m for c in CATALOG if c.pipeline != "sm100"} == {128}
+    assert {c.num_mma_m for c in CATALOG if c.pipeline == "sm107"} == {1, 2}
+    assert {c.num_mma_m for c in CATALOG if c.pipeline == "sm103"} == {1}
     # cta_tile_m=128 is the one value two axes produce (128x1 and 64x2).
     assert next(c for c in sm100 if c.cta_tile_m == 128).num_mma_m == 1
 

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -2346,21 +2346,29 @@ def test_illegal_mma_decomposition_rejected(name: str, reason: str) -> None:
     assert reason in str(e.value)
 
 
-def test_split_tiles_are_by_name_only() -> None:
-    """Split geometries are reachable only through `by_name` synthesis, so they
-    stay out of the funnel's candidate set, the CUDNN_GEMM_TEST_FULL sweep and the
-    benchmarks' default config set (which is built from the funnel). They are still
-    measurable by name: `benchmark_matmul.py --configs` resolves an unknown label
-    through `by_name`."""
+def test_catalog_enumerates_the_mma_m_axis() -> None:
+    """M is enumerated as (mma_inst_m, num_mma_m); `cta_tile_m` is their PRODUCT,
+    not an axis. So a split tile is an ordinary catalog geometry and reaches the
+    funnel, the CUDNN_GEMM_TEST_FULL sweep and the benchmarks' default config set.
+    `num_mma_m == 1` is enumerated first, so an unqualified `cta_tile_m` lookup
+    still lands on the unsplit tile — several suites rely on that."""
     from cudnn.gemm.frost.graph_analyzer import analyze
     from cudnn.gemm.frost.kernel_registry import candidates
+    from cudnn.gemm.frost.tile_config import _M_AXES
 
-    assert all(c.num_mma_m == 1 for c in CATALOG)
+    sm100 = [c for c in CATALOG if c.pipeline == "sm100"]
+    assert {(c.mma_inst_m, c.num_mma_m) for c in sm100} == set(_M_AXES)
+    assert all(c.cta_tile_m == c.mma_inst_m * c.num_mma_m for c in CATALOG)
+    # sm103 / sm107 pin M: the block-scale SF 128x4 swizzle needs mma_inst_m % 128 == 0.
+    assert {(c.mma_inst_m, c.num_mma_m) for c in CATALOG if c.pipeline != "sm100"} == {(128, 1)}
+    # cta_tile_m=128 is the one value two axes produce (128x1 and 64x2).
+    assert next(c for c in sm100 if c.cta_tile_m == 128).num_mma_m == 1
+
     g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
     A = g.tensor(name="A", dim=[1, 256, 128], stride=[256 * 128, 128, 1])
     B = g.tensor(name="B", dim=[1, 128, 256], stride=[128 * 256, 1, 128])
     g.matmul(A=A, B=B, name="mm").set_output(True)
-    assert all(cfg.num_mma_m == 1 for _t, cfg in candidates(analyze(g)))
+    assert {cfg.num_mma_m for _t, cfg in candidates(analyze(g))} == {1, 2}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Unify the function and sweeping logic for benchmark scripts

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unified options for configuration sweeps, timing modes, profiling, progress output, and rotating input buffers.
  - Added pooled benchmark data with automatic, memory-aware buffer sizing.
  - Expanded split and unsplit matrix geometry coverage across supported GPU architectures.
  - Improved block-scale, FP4, FP8, and MoE data preparation.

- **Improvements**
  - Standardized benchmark results, memory reporting, configuration selection, and profiling output.
  - Enhanced validation and filtering of compatible configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->