### PR TITLE
test: import torch directly in wgrad Rubin quantization validation test

### DIFF
--- a/test/python/fe_api/test_rubin_kernel_dispatch.py
+++ b/test/python/fe_api/test_rubin_kernel_dispatch.py
@@ -215,8 +215,9 @@ def test_grouped_gemm_wgrad_rubin_quantization_validation(
     sf_vec_size,
     expected,
 ):
+    import torch
+
     api_mod = _import_api_module("cudnn.gemm.cutedsl.grouped.wgrad.api")
-    torch = api_mod.torch
 
     assert (
         api_mod._is_supported_rubin_quantization(


### PR DESCRIPTION
## Problem

All 7 parametrizations of `test_grouped_gemm_wgrad_rubin_quantization_validation` fail with:

```
E   AttributeError: module 'cudnn.gemm.cutedsl.grouped.wgrad.api' has no attribute 'torch'
```

The test pulls torch off the API module (`torch = api_mod.torch`), but `wgrad/api.py` never binds `torch` at module scope: its `torch.Tensor` annotations are strings under `from __future__ import annotations`, and `_is_supported_rubin_quantization` (defined in `_blockscaled_api.py`) imports torch function-locally.

## Fix

Import torch directly in the test, matching the file's existing local-import style.

## Verification

```
pytest test/python/fe_api/test_rubin_kernel_dispatch.py -k quantization_validation -q
7 passed, 20 deselected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated quantization validation coverage to use the standard PyTorch import directly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->