### PR TITLE
Add SM100 MXFP8 SDPA support for d192/d128

### DIFF
--- a/python/cudnn/engines/manifest.py
+++ b/python/cudnn/engines/manifest.py
@@ -184,6 +184,7 @@ MANIFEST: Tuple[EngineFamily, ...] = (
             "sdpa_fwd_prefill_sm100_d192_d128": EngineSlot(6, opt_in=True),
             "sdpa_fwd_prefill_sm120_fp8": EngineSlot(7, opt_in=True),
             "sdpa_fwd_prefill_sm80": EngineSlot(8, opt_in=True),
+            "sdpa_fwd_prefill_sm100_d192_d128_fp8": EngineSlot(9, opt_in=True),
         },
         analyzer=("cudnn.sdpa.graph_analyzer", "analyze"),
         heuristics=("cudnn.sdpa.fwd.heuristics", "recommend"),

--- a/python/cudnn/engines/manifest.py
+++ b/python/cudnn/engines/manifest.py
@@ -185,6 +185,7 @@ MANIFEST: Tuple[EngineFamily, ...] = (
             "sdpa_fwd_prefill_sm120_fp8": EngineSlot(7, opt_in=True),
             "sdpa_fwd_prefill_sm80": EngineSlot(8, opt_in=True),
             "sdpa_fwd_prefill_sm100_d192_d128_fp8": EngineSlot(9, opt_in=True),
+            "sdpa_fwd_prefill_sm100_d192_d128_mxfp8": EngineSlot(10, opt_in=True),
         },
         analyzer=("cudnn.sdpa.graph_analyzer", "analyze"),
         heuristics=("cudnn.sdpa.fwd.heuristics", "recommend"),

--- a/python/cudnn/frost/tile_dsl/mma.py
+++ b/python/cudnn/frost/tile_dsl/mma.py
@@ -93,18 +93,7 @@ def mma_m16n8k32_f32(
 
 
 @cute.jit
-def mma_ss(
-    desc,
-    desc_a_base,
-    desc_b_base,
-    tmem_c,
-    tmem_sf_a=None,
-    tmem_sf_b=None,
-    accumulate: bool = False,
-    k_start: int = 0,
-    k_count=None,
-    fence_code: cutlass.Constexpr[bool] = False,
-):
+def mma_ss(desc, desc_a_base, desc_b_base, tmem_c, tmem_sf_a=None, tmem_sf_b=None, accumulate: bool = False, k_start: int = 0, k_count=None):
     if cutlass.const_expr(desc.cta_group == 1):
         cta_group_kind = nvvm.CTAGroup.CTA_1
     else:
@@ -152,8 +141,6 @@ def mma_ss(
                 )
             else:
                 nvvm.tcgen05_mma(desc.kind, cta_group_kind, tmem_c, da, db, desc.idesc, enable_input_d)
-        if cutlass.const_expr(fence_code):
-            cute.arch.inline_ptx('.pragma "next knob FenceCode";')
         enable_input_d = True
 
 
@@ -202,17 +189,7 @@ def mma_ts(desc, tmem_a_base, desc_b_base, tmem_c, tmem_sf_a=None, tmem_sf_b=Non
 
 
 @cute.jit
-def mma_ts_step(
-    desc,
-    tmem_a_base,
-    desc_b_base,
-    tmem_c,
-    k_idx: int,
-    accumulate,
-    tmem_sf_a=None,
-    tmem_sf_b=None,
-    fence_code: cutlass.Constexpr[bool] = False,
-):
+def mma_ts_step(desc, tmem_a_base, desc_b_base, tmem_c, k_idx: int, accumulate, tmem_sf_a=None, tmem_sf_b=None):
     if cutlass.const_expr(desc.cta_group == 1):
         cta_group_kind = nvvm.CTAGroup.CTA_1
     else:
@@ -244,8 +221,6 @@ def mma_ts_step(
             )
         else:
             nvvm.tcgen05_mma(desc.kind, cta_group_kind, tmem_c, dp, db, desc.idesc, accumulate)
-    if cutlass.const_expr(fence_code):
-        cute.arch.inline_ptx('.pragma "next knob FenceCode";')
 
 
 @cute.jit

--- a/python/cudnn/frost/tile_dsl/mma.py
+++ b/python/cudnn/frost/tile_dsl/mma.py
@@ -93,7 +93,18 @@ def mma_m16n8k32_f32(
 
 
 @cute.jit
-def mma_ss(desc, desc_a_base, desc_b_base, tmem_c, tmem_sf_a=None, tmem_sf_b=None, accumulate: bool = False, k_start: int = 0, k_count=None):
+def mma_ss(
+    desc,
+    desc_a_base,
+    desc_b_base,
+    tmem_c,
+    tmem_sf_a=None,
+    tmem_sf_b=None,
+    accumulate: bool = False,
+    k_start: int = 0,
+    k_count=None,
+    fence_code: cutlass.Constexpr[bool] = False,
+):
     if cutlass.const_expr(desc.cta_group == 1):
         cta_group_kind = nvvm.CTAGroup.CTA_1
     else:
@@ -141,6 +152,8 @@ def mma_ss(desc, desc_a_base, desc_b_base, tmem_c, tmem_sf_a=None, tmem_sf_b=Non
                 )
             else:
                 nvvm.tcgen05_mma(desc.kind, cta_group_kind, tmem_c, da, db, desc.idesc, enable_input_d)
+        if cutlass.const_expr(fence_code):
+            cute.arch.inline_ptx('.pragma "next knob FenceCode";')
         enable_input_d = True
 
 
@@ -189,7 +202,17 @@ def mma_ts(desc, tmem_a_base, desc_b_base, tmem_c, tmem_sf_a=None, tmem_sf_b=Non
 
 
 @cute.jit
-def mma_ts_step(desc, tmem_a_base, desc_b_base, tmem_c, k_idx: int, accumulate, tmem_sf_a=None, tmem_sf_b=None):
+def mma_ts_step(
+    desc,
+    tmem_a_base,
+    desc_b_base,
+    tmem_c,
+    k_idx: int,
+    accumulate,
+    tmem_sf_a=None,
+    tmem_sf_b=None,
+    fence_code: cutlass.Constexpr[bool] = False,
+):
     if cutlass.const_expr(desc.cta_group == 1):
         cta_group_kind = nvvm.CTAGroup.CTA_1
     else:
@@ -221,6 +244,8 @@ def mma_ts_step(desc, tmem_a_base, desc_b_base, tmem_c, k_idx: int, accumulate, 
             )
         else:
             nvvm.tcgen05_mma(desc.kind, cta_group_kind, tmem_c, dp, db, desc.idesc, accumulate)
+    if cutlass.const_expr(fence_code):
+        cute.arch.inline_ptx('.pragma "next knob FenceCode";')
 
 
 @cute.jit

--- a/python/cudnn/frost/tile_dsl/tma.py
+++ b/python/cudnn/frost/tile_dsl/tma.py
@@ -41,7 +41,16 @@ def cp_async_bulk_shared_cluster_shared_cta(dst_mem, src_mem, mbar, size, *, pre
 
 
 @cute.jit
-def tma_load_tile(smem_tile, gmem_slice, mbar, *, cta_group: int = 1, mcast_mask=None, acquire: cutlass.Constexpr[bool] = True):
+def tma_load_tile(
+    smem_tile,
+    gmem_slice,
+    mbar,
+    *,
+    cta_group: int = 1,
+    mcast_mask=None,
+    acquire: cutlass.Constexpr[bool] = True,
+    l2_cache_hint=None,
+):
     num_iters = smem_tile.tma_loads_per_tile
     granu_elems = smem_tile.tma_granu_elems
     sub_stride = smem_tile.tma_subtile_stride_elems
@@ -70,6 +79,7 @@ def tma_load_tile(smem_tile, gmem_slice, mbar, *, cta_group: int = 1, mcast_mask
                     tma_desc_ptr,
                     coords,
                     mbar,
+                    l2_cache_hint=l2_cache_hint,
                 )
             else:
                 nvvm.cp_async_bulk_tensor_shared_cluster_global(
@@ -80,6 +90,7 @@ def tma_load_tile(smem_tile, gmem_slice, mbar, *, cta_group: int = 1, mcast_mask
                     [],
                     multicast_mask=mcast_mask,
                     group=nvvm.CTAGroup.CTA_2,
+                    l2_cache_hint=l2_cache_hint,
                 )
 
 

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -74,12 +74,15 @@ _SM100_DTYPE_QKV_CODE = {
     torch.float16: DTYPE_FP16,
 }
 _SM100_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
-# d128 FP8 kernels (E4M3/E5M2 in, BF16/FP16/FP8 out). Block-scale MXFP8 (per-32-block
-# E8M0 SF) vs per-tensor FP8 (scalar descales). Selected by the graph op (sdpa_mxfp8 vs
-# sdpa_fp8); the f16/bf16 flavors use _SM100_KERNEL_FILES.
+# FP8 kernels use E4M3/E5M2 inputs and BF16/FP16/FP8 outputs. Block-scale
+# MXFP8 remains d128-only; per-tensor FP8 has exact d128/d128 and d192/d128
+# kernels.
 _SM100_MXFP8_KERNEL_FILE = "prefill_d128_mxfp8_sm100.py"
-_SM100_FP8_KERNEL_FILE = "prefill_d128_fp8_sm100.py"
 _SM107_FP8_KERNEL_FILE = "prefill_d128_fp8_sm107.py"
+_SM100_FP8_KERNEL_FILES = {
+    (128, 128): "prefill_d128_fp8_sm100.py",
+    (192, 128): "prefill_d192_d128_fp8_sm100.py",
+}
 # Both flavors tile KV in TILE_N=128 columns; the KV tail is only masked when
 # the padded/causal mask paths are active (see check_support).
 _SM100_TILE_N = 128
@@ -204,7 +207,7 @@ def _pick_flavor(d_qk: int, d_v: int) -> tuple[int, int]:
     the tile box stays the compile-time D, so loads past d_qk / d_v hardware
     zero-fill (adding exact zero terms to every QK^T dot product — S, softmax
     and P·V are bit-identical to the unpadded problem) and O stores past d_v
-    are OOB-clipped. FP8/MXFP8 stays exact-match d128 (gated in
+    are OOB-clipped. FP8/MXFP8 uses exact native shapes (gated in
     check_support); alignment (d % 8, the TMA 16-byte global-stride rule at
     2 bytes/elem) is also gated in check_support / engines.mismatch.
     """
@@ -231,11 +234,11 @@ def _load_sm100_kernel_module(flavor: tuple[int, int], params: Sm100TemplatePara
     dense K=64 FP8 path baked in — see prefill_d128_fp8_sm107.py)."""
 
     tag = _flavor_tag(flavor)
-    if fp8 and pertensor and rubin:
+    if fp8 and pertensor and rubin and flavor == (128, 128):
         filename = _SM107_FP8_KERNEL_FILE
         tag = f"sdpa_fwd_sm107_fp8_{tag}"
     elif fp8:
-        filename = _SM100_FP8_KERNEL_FILE if pertensor else _SM100_MXFP8_KERNEL_FILE
+        filename = _SM100_FP8_KERNEL_FILES[flavor] if pertensor else _SM100_MXFP8_KERNEL_FILE
         tag = f"sdpa_fwd_sm100_{'fp8' if pertensor else 'mxfp8'}_{tag}"
     else:
         filename = _SM100_KERNEL_FILES[flavor]
@@ -782,11 +785,14 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             f"SdpaFwdDslSm100 requires {_allowed_msg}; found SM{major}{minor} on {device}",
         )
 
-        # FP8/MXFP8: exact-match d128 only — the FP8 kernels' SF plumbing and
-        # QMMA geometry are not audited for envelope zero-padding.
+        # FP8 paths use exact native shapes. Per-tensor FP8 also has the
+        # d192/d128 flavor; MXFP8 remains d128-only until its scale-factor
+        # descriptors and pipeline are extended.
+        fp8_shapes = {(128, 128), (192, 128)} if self._pertensor else {(128, 128)}
         self._value_error_if(
-            self._fp8 and (int(d_qk), int(d_v)) != (128, 128),
-            f"FP8/MXFP8 (E4M3/E5M2 inputs) requires exact D_QK=D_V=128 (no envelope padding); got (D_QK={d_qk}, D_V={d_v})",
+            self._fp8 and (int(d_qk), int(d_v)) not in fp8_shapes,
+            f"{'FP8' if self._pertensor else 'MXFP8'} (E4M3/E5M2 inputs) requires an exact native shape in {sorted(fp8_shapes)} "
+            f"(no envelope padding); got (D_QK={d_qk}, D_V={d_v})",
         )
         # Envelope alignment gate: the TMA descriptors are built from the
         # actual tensor extents, and cuTensorMapEncodeTiled requires every
@@ -936,6 +942,18 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 d_v=d_v_sched,
                 elem_bytes=1 if self._fp8 else 2,
             )
+        lpt_head_group = 1
+        if (
+            self._fp8
+            and self._pertensor
+            and self.flavor == (192, 128)
+            and not self.thd
+            and (self.batch_size * self.h_q) % 16 == 0
+        ):
+            lpt_head_group = 16
+        lpt_q_tiles = 0
+        if self._fp8 and self._pertensor and self.flavor == (192, 128) and not self.thd:
+            lpt_q_tiles = (self.s_q_max + 511) // 512
         params = Sm100TemplateParams(
             dtype_qkv=_SM100_DTYPE_QKV_CODE[self.dtype],
             dtype_o=_SM100_DTYPE_QKV_CODE[self.dtype_o],
@@ -946,6 +964,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             seq_kv_lens_present=self.seq_kv_lens_present,
             seq_q_lens_present=self.seq_q_lens_present,
             sched_policy=sched_policy,
+            lpt_head_group=lpt_head_group,
+            lpt_q_tiles=lpt_q_tiles,
             thd_varlen=self.thd,
             fused_ldtm_stat=fused_ldtm_stat,
         )
@@ -960,7 +980,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # f16-only.
             self._compiled_kernel = self._k_mod.compile(**self._thd_compile_kwargs())
         elif self._fp8:
-            # FP8/MXFP8 kernels are exact-match d128 (gated in check_support);
+            # FP8/MXFP8 kernels use exact native shapes (gated in check_support);
             # their compile() has no envelope head-dim parameters. has_lse=False
             # (no Stats output) compiles the LSE store out — no dummy buffer at
             # any level (the amax_o atomicMax write is independent).

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -943,22 +943,29 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 elem_bytes=1 if self._fp8 else 2,
             )
         lpt_head_group = 1
-        if (
-            self._fp8
-            and self._pertensor
-            and self.flavor == (192, 128)
-            and not self.thd
-            and (self.batch_size * self.h_q) % 16 == 0
-        ):
+        if self._fp8 and self._pertensor and self.flavor == (192, 128) and not self.thd and (self.batch_size * self.h_q) % 16 == 0:
             lpt_head_group = 16
         lpt_q_tiles = 0
         if self._fp8 and self._pertensor and self.flavor == (192, 128) and not self.thd:
             lpt_q_tiles = (self.s_q_max + 511) // 512
+        template_window_right = self.window_right
+        if (
+            self._fp8
+            and self._pertensor
+            and self.flavor == (192, 128)
+            and self.window_left is None
+            and self.window_right is None
+            and not self.seq_kv_lens_present
+        ):
+            # CUTLASS DSL 4.7 does not finish lowering the large-shape FP8
+            # MASK_NONE x32 path. A right bound of S_kv removes no valid K but
+            # selects the equivalent masked-interior lowering.
+            template_window_right = self.s_k_max
         params = Sm100TemplateParams(
             dtype_qkv=_SM100_DTYPE_QKV_CODE[self.dtype],
             dtype_o=_SM100_DTYPE_QKV_CODE[self.dtype_o],
             window_left=self.window_left,
-            window_right=self.window_right,
+            window_right=template_window_right,
             bottom_right=self.causal_bottom_right,
             has_sink=self.has_sink,
             seq_kv_lens_present=self.seq_kv_lens_present,

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -83,6 +83,14 @@ _SM100_FP8_KERNEL_FILES = {
     (128, 128): "prefill_d128_fp8_sm100.py",
     (192, 128): "prefill_d192_d128_fp8_sm100.py",
 }
+
+
+def _sm100_fp8_shapes(pertensor: bool, device_cc: tuple[int, int]) -> frozenset[tuple[int, int]]:
+    if not pertensor or device_cc == (10, 7):
+        return frozenset({(128, 128)})
+    return frozenset({(128, 128), (192, 128)})
+
+
 # Both flavors tile KV in TILE_N=128 columns; the KV tail is only masked when
 # the padded/causal mask paths are active (see check_support).
 _SM100_TILE_N = 128
@@ -788,7 +796,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # FP8 paths use exact native shapes. Per-tensor FP8 also has the
         # d192/d128 flavor; MXFP8 remains d128-only until its scale-factor
         # descriptors and pipeline are extended.
-        fp8_shapes = {(128, 128), (192, 128)} if self._pertensor else {(128, 128)}
+        fp8_shapes = _sm100_fp8_shapes(self._pertensor, self._device_cc)
         self._value_error_if(
             self._fp8 and (int(d_qk), int(d_v)) not in fp8_shapes,
             f"{'FP8' if self._pertensor else 'MXFP8'} (E4M3/E5M2 inputs) requires an exact native shape in {sorted(fp8_shapes)} "

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -66,7 +66,7 @@ _SM100_KERNEL_FILES = {
     (128, 128): "prefill_d128_f16_sm100.py",
 }
 # DTYPE_* codes: E4M3=0, E5M2=1, BF16=2, FP16=3. FP8 inputs (0/1) route to the
-# block-scale MXFP8 kernel (d128 only); the output dtype is encoded the same way.
+# FP8 kernel family; the output dtype is encoded the same way.
 _SM100_DTYPE_QKV_CODE = {
     torch.float8_e4m3fn: DTYPE_E4M3,
     torch.float8_e5m2: DTYPE_E5M2,
@@ -75,9 +75,11 @@ _SM100_DTYPE_QKV_CODE = {
 }
 _SM100_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 # FP8 kernels use E4M3/E5M2 inputs and BF16/FP16/FP8 outputs. Block-scale
-# MXFP8 remains d128-only; per-tensor FP8 has exact d128/d128 and d192/d128
-# kernels.
-_SM100_MXFP8_KERNEL_FILE = "prefill_d128_mxfp8_sm100.py"
+# Both FP8 paths have exact d128/d128 and d192/d128 kernels.
+_SM100_MXFP8_KERNEL_FILES = {
+    (128, 128): "prefill_d128_mxfp8_sm100.py",
+    (192, 128): "prefill_d192_d128_mxfp8_sm100.py",
+}
 _SM107_FP8_KERNEL_FILE = "prefill_d128_fp8_sm107.py"
 _SM100_FP8_KERNEL_FILES = {
     (128, 128): "prefill_d128_fp8_sm100.py",
@@ -86,7 +88,7 @@ _SM100_FP8_KERNEL_FILES = {
 
 
 def _sm100_fp8_shapes(pertensor: bool, device_cc: tuple[int, int]) -> frozenset[tuple[int, int]]:
-    if not pertensor or device_cc == (10, 7):
+    if device_cc == (10, 7):
         return frozenset({(128, 128)})
     return frozenset({(128, 128), (192, 128)})
 
@@ -246,7 +248,7 @@ def _load_sm100_kernel_module(flavor: tuple[int, int], params: Sm100TemplatePara
         filename = _SM107_FP8_KERNEL_FILE
         tag = f"sdpa_fwd_sm107_fp8_{tag}"
     elif fp8:
-        filename = _SM100_FP8_KERNEL_FILES[flavor] if pertensor else _SM100_MXFP8_KERNEL_FILE
+        filename = _SM100_FP8_KERNEL_FILES[flavor] if pertensor else _SM100_MXFP8_KERNEL_FILES[flavor]
         tag = f"sdpa_fwd_sm100_{'fp8' if pertensor else 'mxfp8'}_{tag}"
     else:
         filename = _SM100_KERNEL_FILES[flavor]
@@ -793,9 +795,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             f"SdpaFwdDslSm100 requires {_allowed_msg}; found SM{major}{minor} on {device}",
         )
 
-        # FP8 paths use exact native shapes. Per-tensor FP8 also has the
-        # d192/d128 flavor; MXFP8 remains d128-only until its scale-factor
-        # descriptors and pipeline are extended.
+        # FP8 paths use exact native shapes. SM100 supports d128/d128 and
+        # d192/d128; Rubin currently supports only per-tensor FP8 d128.
         fp8_shapes = _sm100_fp8_shapes(self._pertensor, self._device_cc)
         self._value_error_if(
             self._fp8 and (int(d_qk), int(d_v)) not in fp8_shapes,
@@ -951,10 +952,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 elem_bytes=1 if self._fp8 else 2,
             )
         lpt_head_group = 1
-        if self._fp8 and self._pertensor and self.flavor == (192, 128) and not self.thd and (self.batch_size * self.h_q) % 16 == 0:
-            lpt_head_group = 16
+        if self._fp8 and self.flavor == (192, 128) and not self.thd and (self.batch_size * self.h_q) % 8 == 0:
+            lpt_head_group = 8
         lpt_q_tiles = 0
-        if self._fp8 and self._pertensor and self.flavor == (192, 128) and not self.thd:
+        if self._fp8 and self.flavor == (192, 128) and not self.thd:
             lpt_q_tiles = (self.s_q_max + 511) // 512
         template_window_right = self.window_right
         if (
@@ -1518,7 +1519,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         import cutlass
 
         if self.thd:
-            raise NotImplementedError("Frost MXFP8: the legacy THD leg was removed (dense d128 only); see issue #552")
+            raise NotImplementedError("Frost MXFP8: the legacy THD leg was removed (dense only); see issue #552")
         if sf_q is None or sf_k is None or sf_v is None:
             raise ValueError("Frost MXFP8 execute requires sf_q/sf_k/sf_v (block-scale descale tensors)")
 

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -814,8 +814,7 @@ def _validate_cfg_d192(cfg: CfgD192) -> None:
         (cfg.CGA_M == cfg.CTA_MMA and cfg.CTA_MMA in (1, 2), "d192 SM100: CGA_M must equal CTA_MMA, and CTA_MMA must be 1 (cga1) or 2 (cga2)"),
         (
             cfg.STAGES_KV == (2 if fp8 else 1) * cfg.CTA_MMA,
-            "d192: STAGES_KV must scale with input dtype and cluster width "
-            "(FP8: 2/4 at cga1/cga2; half: 1/2)",
+            "d192: STAGES_KV must scale with input dtype and cluster width " "(FP8: 2/4 at cga1/cga2; half: 1/2)",
         ),
         (
             _d192_smem_bytes(cfg) <= _SM100_MAX_DYN_SMEM,
@@ -837,8 +836,7 @@ def _validate_cfg_d192(cfg: CfgD192) -> None:
             "d192: Q/K swizzle must be 64B for FP8 and 128B for BF16/FP16",
         ),
         (
-            cfg.V_SWZ_BYTES == v_swz_bytes(128, cfg.CTA_MMA, cfg.BPE)
-            and cfg.O_SWZ_BYTES in ((64, 128) if fp8 else (128,)),
+            cfg.V_SWZ_BYTES == v_swz_bytes(128, cfg.CTA_MMA, cfg.BPE) and cfg.O_SWZ_BYTES in ((64, 128) if fp8 else (128,)),
             "d192: V/O swizzle is inconsistent with the input/output dtype",
         ),
     )

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -87,6 +87,12 @@ class TemplateParams:
     # cu_seqlens instead.
     seq_q_lens_present: bool = False
     sched_policy: int = SCHED_NATURAL
+    # Compile-time LPT head/batch grouping. Keep 1 unless the selected kernel
+    # and concrete graph shape opt into a divisor of B*Hq.
+    lpt_head_group: int = 1
+    # Dense D192 FP8 may specialize the reverse-row LPT decoder to its exact
+    # number of query tiles. Zero keeps the existing runtime derivation.
+    lpt_q_tiles: int = 0
     thd_varlen: bool = False
     # KV split: each Q tile's KV loop range is cut into ``split_kv`` contiguous
     # chunks, each run as its own persistent tile writing a partial (O, LSE)
@@ -125,8 +131,8 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
     if k.dtype_qkv not in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16):
         raise ValueError(f"{flavor}: DTYPE_QKV must be E4M3/E5M2/BF16/FP16 (0..3); got {k.dtype_qkv}")
     fp8 = k.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
-    if fp8 and flavor != "d128":
-        raise ValueError(f"{flavor}: FP8/MXFP8 inputs (DTYPE_QKV 0/1) are only supported on d128")
+    if fp8 and flavor not in ("d128", "d192"):
+        raise ValueError(f"{flavor}: FP8/MXFP8 inputs (DTYPE_QKV 0/1) are only supported on d128 and d192")
     dtype_o = k.dtype_qkv if k.dtype_o < 0 else k.dtype_o
     if dtype_o not in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16):
         raise ValueError(f"{flavor}: DTYPE_O must be 0..3; got {dtype_o}")
@@ -173,6 +179,10 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
             # The sink logit is folded into the softmax denominator in the
             # per-tile epilogue, so every split would add its own copy of it.
             raise ValueError(f"{flavor}: split_kv > 1 with attention sink is not supported (the sink would be counted once per split)")
+    if k.lpt_head_group not in (1, 16):
+        raise ValueError(f"{flavor}: LPT_HEAD_GROUP must be 1 or 16; got {k.lpt_head_group}")
+    if fp8 and flavor == "d192" and k.split_kv != 1:
+        raise ValueError("d192: split_kv is not implemented by the per-tensor FP8 kernel")
 
 
 def _mask_flags_from(params: TemplateParams) -> int:
@@ -773,7 +783,7 @@ class CfgD192(CfgD128):
 
 
 def _d192_smem_bytes(cfg) -> int:
-    """Data-buffer SMEM for the d192 pipeline (Q/O always aliased).
+    """Data-buffer SMEM for the d192 pipeline.
 
     Same shape as _d128_smem_bytes, but d_qk = 192 makes the Q and K slabs 1.5x
     the d128 ones, which is why this flavor needs a shallower KV pipeline:
@@ -792,32 +802,45 @@ def _d192_smem_bytes(cfg) -> int:
 
 def _validate_cfg_d192(cfg: CfgD192) -> None:
     """Consistency checks on the native DSv3 d192/d128 geometry."""
+    fp8 = cfg.DTYPE_QKV in (DTYPE_E4M3, DTYPE_E5M2)
     checks = (
-        (cfg.DTYPE_QKV in (DTYPE_BF16, DTYPE_FP16), "d192: only BF16/FP16 inputs are supported"),
-        (cfg.DTYPE_O == cfg.DTYPE_QKV, "d192: DTYPE_O must equal DTYPE_QKV"),
+        (
+            cfg.DTYPE_O in (DTYPE_E4M3, DTYPE_E5M2, DTYPE_BF16, DTYPE_FP16) if fp8 else cfg.DTYPE_O == cfg.DTYPE_QKV,
+            "d192: DTYPE_O must equal DTYPE_QKV for half input; FP8 allows an independent output dtype",
+        ),
         (cfg.MMA_REGS == cfg.TMALDG_REGS == cfg.TMASTG_REGS == cfg.SCHEDULER_REGS, "d192: MMA/TMALDG/TMASTG/SCHEDULER regs must match"),
         (cfg.MMA_REGS + cfg.CORRECTION_REGS + cfg.SOFTMAX_WARPGROUPS * cfg.SOFTMAX_REGS <= 512, "d192: register budget over 512"),
         (cfg.MMA_REGS % 8 == 0 and cfg.CORRECTION_REGS % 8 == 0 and cfg.SOFTMAX_REGS % 8 == 0, "d192: per-role regs must be multiples of 8"),
         (cfg.CGA_M == cfg.CTA_MMA and cfg.CTA_MMA in (1, 2), "d192 SM100: CGA_M must equal CTA_MMA, and CTA_MMA must be 1 (cga1) or 2 (cga2)"),
         (
-            cfg.STAGES_KV == (1 if cfg.CTA_MMA == 1 else 2),
-            "d192: STAGES_KV must scale with the cluster width (2 at cga2, 1 at cga1) — cga1 doubles per-CTA K/V, "
-            "and cuDNN's own d192 kernel uses stages_kv = 1 * CTA_MMA for exactly this reason",
+            cfg.STAGES_KV == (2 if fp8 else 1) * cfg.CTA_MMA,
+            "d192: STAGES_KV must scale with input dtype and cluster width "
+            "(FP8: 2/4 at cga1/cga2; half: 1/2)",
         ),
         (
             _d192_smem_bytes(cfg) <= _SM100_MAX_DYN_SMEM,
             f"d192: SMEM {_d192_smem_bytes(cfg) // 1024} KiB over the SM100 {_SM100_MAX_DYN_SMEM // 1024} KiB per-CTA cap",
         ),
         (cfg.TILE_K == 192 and cfg.TILE_O == 128, "d192: expected D_QK tile 192 and D_V tile 128"),
-        (cfg.QO_ALIAS == 1, "d192: Q/O SMEM alias is required to stay within SM100 SMEM budget"),
+        (cfg.QO_ALIAS == (0 if fp8 else 1), "d192: Q/O SMEM alias must be disabled for FP8 and enabled for half input"),
         (cfg.TILES_Q == 2, "d192: TILES_Q must be 2"),
         (cfg.SOFTMAX_WARPGROUPS == 2, "d192: SOFTMAX_WARPGROUPS must be 2"),
         (cfg.CORRECTION_WARPS == 4, "d192: CORRECTION_WARPS must be 4"),
         (cfg.TOTAL_WARPS == 16 and cfg.THREADS_PER_CTA == 512, "d192: 16 warps / 512 threads"),
         (cfg.READ_TILE_ARRIVERS == 15, f"d192: expected READ_TILE_ARRIVERS=15, got {cfg.READ_TILE_ARRIVERS}"),
-        (cfg.TILE_K_HW_BMM1 == 16 and cfg.TILE_K_HW_BMM2 == 16, "d192: TILE_K_HW must be 16 for BF16/FP16 on SM10x"),
-        (cfg.Q_SWZ_BYTES == 128 and cfg.K_SWZ_BYTES == 128, "d192: Q/K swizzle must be 128B"),
-        (cfg.V_SWZ_BYTES == 128 and cfg.O_SWZ_BYTES == 128, "d192: V/O swizzle must be 128B"),
+        (
+            cfg.TILE_K_HW_BMM1 == (32 if fp8 else 16) and cfg.TILE_K_HW_BMM2 == (32 if fp8 else 16),
+            "d192: TILE_K_HW must be 32 for FP8 and 16 for BF16/FP16",
+        ),
+        (
+            cfg.Q_SWZ_BYTES == (64 if fp8 else 128) and cfg.K_SWZ_BYTES == (64 if fp8 else 128),
+            "d192: Q/K swizzle must be 64B for FP8 and 128B for BF16/FP16",
+        ),
+        (
+            cfg.V_SWZ_BYTES == v_swz_bytes(128, cfg.CTA_MMA, cfg.BPE)
+            and cfg.O_SWZ_BYTES in ((64, 128) if fp8 else (128,)),
+            "d192: V/O swizzle is inconsistent with the input/output dtype",
+        ),
     )
     for ok, msg in checks:
         if not ok:
@@ -827,32 +850,34 @@ def _validate_cfg_d192(cfg: CfgD192) -> None:
 def make_cfg_d192(params: TemplateParams) -> Tuple[CfgD192, TmaIters]:
     _validate_params("d192", params)
     b = bpe(params.dtype_qkv)
+    fp8 = params.dtype_qkv in (DTYPE_E4M3, DTYPE_E5M2)
+    dtype_o = params.dtype_qkv if params.dtype_o < 0 else params.dtype_o
+    b_o = bpe(dtype_o)
     cfg = CfgD192(
         DTYPE_QKV=params.dtype_qkv,
-        DTYPE_O=params.dtype_qkv,
+        DTYPE_O=dtype_o,
         BPE=b,
-        BPE_O=b,
+        BPE_O=b_o,
         SPLIT_KV=int(params.split_kv),
+        QO_ALIAS=0 if fp8 else 1,
         Q_SWZ_BYTES=q_swz_bytes(192, b),
         K_SWZ_BYTES=q_swz_bytes(192, b),
         CGA_M=params.cta_mma,
         CTA_MMA=params.cta_mma,
-        # cuDNN's d192 kernel uses stages_kv = 1 * CTA_MMA; cga1 doubles per-CTA
-        # K/V, so the stage count has to halve to keep the CTA inside the cap.
-        STAGES_KV=1 if params.cta_mma == 1 else 2,
         V_SWZ_BYTES=v_swz_bytes(128, params.cta_mma, b),
-        O_SWZ_BYTES=o_swz_bytes(128, b),
+        O_SWZ_BYTES=o_swz_bytes(128, b_o),
         RESCALE_THRESHOLD=rescale_threshold(params.dtype_qkv),
-        TILE_K_HW_BMM1=tile_k_hw(params.dtype_qkv),
-        TILE_K_HW_BMM2=tile_k_hw(params.dtype_qkv),
+        TILE_K_HW_BMM1=32 if fp8 else tile_k_hw(params.dtype_qkv),
+        TILE_K_HW_BMM2=32 if fp8 else tile_k_hw(params.dtype_qkv),
+        STAGES_KV=(2 if fp8 else 1) * params.cta_mma,
         MASK_FLAGS=_mask_flags_from(params),
         WINDOW_LEFT=params.window_left or 0,
         WINDOW_RIGHT=params.window_right or 0,
         HAS_SINK=int(params.has_sink),
         BOTTOM_RIGHT=int(params.bottom_right),
         SCHEDULER_POLICY=1,
-        SOFTMAX_REGS=216 if _mask_flags_from(params) == MASK_NONE else 192,
-        CORRECTION_REGS=40 if _mask_flags_from(params) == MASK_NONE else 88,
+        SOFTMAX_REGS=184 if fp8 else 216 if _mask_flags_from(params) == MASK_NONE else 192,
+        CORRECTION_REGS=104 if fp8 else 40 if _mask_flags_from(params) == MASK_NONE else 88,
         SEQ_KV_LENS_PRESENT=1 if (params.thd_varlen or params.seq_kv_lens_present) else 0,
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
         THD_VARLEN=int(params.thd_varlen),

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -179,8 +179,8 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
             # The sink logit is folded into the softmax denominator in the
             # per-tile epilogue, so every split would add its own copy of it.
             raise ValueError(f"{flavor}: split_kv > 1 with attention sink is not supported (the sink would be counted once per split)")
-    if k.lpt_head_group not in (1, 16):
-        raise ValueError(f"{flavor}: LPT_HEAD_GROUP must be 1 or 16; got {k.lpt_head_group}")
+    if k.lpt_head_group not in (1, 8, 16):
+        raise ValueError(f"{flavor}: LPT_HEAD_GROUP must be 1, 8, or 16; got {k.lpt_head_group}")
     if fp8 and flavor == "d192" and k.split_kv != 1:
         raise ValueError("d192: split_kv is not implemented by the per-tensor FP8 kernel")
 

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -1038,7 +1038,7 @@ ENGINE_SPECS = (
     _sm100_fp8_spec(
         192,
         d_v=128,
-        dtypes=frozenset({cudnn.data_type.FP8_E4M3}),
+        dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
     ),
     _sm120_spec(),
     _sm120_fp8_spec(),

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -150,6 +150,10 @@ class Capabilities:
     swa: bool = False
     padded: bool = False
     sink: bool = False
+    # Optional dtype subset for sink support. None means every dtype served by
+    # the engine; a subset lets one exact-shape flavor decline an unsupported
+    # low-precision sink path without affecting its non-sink coverage.
+    sink_dtypes: Optional[frozenset] = None
     stats: bool = False
     # The adapter accepts lse_tensor=None (its kernel None-specializes the LSE
     # store), so a stats-less graph needs no dummy-LSE workspace chunk. Every
@@ -339,6 +343,9 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
         if fact and not cap:
             return f"graph uses {label}, which this engine does not support"
 
+    if facts.has_sink and capabilities.sink_dtypes is not None and facts.dtype not in capabilities.sink_dtypes:
+        return f"sink token with dtype {facts.dtype} not in {sorted(str(d) for d in capabilities.sink_dtypes)}"
+
     if facts.right_band_widening and facts.right_bound is not None and facts.right_bound < 0:
         return f"negative diagonal_band_right_bound ({facts.right_bound}) is not supported"
 
@@ -486,6 +493,7 @@ def _sm100_fp8_spec(
     d_v: Optional[int] = None,
     *,
     dtypes: Optional[frozenset] = None,
+    sink_dtypes: Optional[frozenset] = None,
 ) -> EngineSpec:
     """Exact-shape per-tensor FP8 engine with scalar descales.
 
@@ -517,6 +525,7 @@ def _sm100_fp8_spec(
             swa=True,
             padded=True,
             sink=True,
+            sink_dtypes=sink_dtypes,
             stats=True,
             lse_optional=True,
             # The fp8 kernel lacks the SEQ_Q_LENS_PRESENT epilogue trim, but its
@@ -1039,6 +1048,9 @@ ENGINE_SPECS = (
         192,
         d_v=128,
         dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
+        # The D192 E5M2 sink path has a distinct FP8 online-softmax rounding
+        # trajectory that exceeds the frontend tolerance on sparse CI seeds.
+        sink_dtypes=frozenset({cudnn.data_type.FP8_E4M3}),
     ),
     _sm120_spec(),
     _sm120_fp8_spec(),

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -481,8 +481,13 @@ def _sm100_mxfp8_spec(d: int) -> EngineSpec:
     )
 
 
-def _sm100_fp8_spec(d: int) -> EngineSpec:
-    """d128 per-tensor FP8 engine (E4M3/E5M2 in + scalar descales, half/FP8 out).
+def _sm100_fp8_spec(
+    d: int,
+    d_v: Optional[int] = None,
+    *,
+    dtypes: Optional[frozenset] = None,
+) -> EngineSpec:
+    """Exact-shape per-tensor FP8 engine with scalar descales.
 
     Padding mask (per-batch ``seq_len_kv`` → KV-side masking) is supported: KV-only
     padding leaves every query row real, so each row's total_sum > 0 and the
@@ -491,15 +496,19 @@ def _sm100_fp8_spec(d: int) -> EngineSpec:
     (dense execute only for v1), so thd=False.
     """
 
+    d_v = d if d_v is None else d_v
+    suffix = f"d{d}" if d_v == d else f"d{d}_d{d_v}"
+    if dtypes is None:
+        dtypes = frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2})
     return EngineSpec(
-        name=f"sdpa_fwd_prefill_sm100_d{d}_fp8",
+        name=f"sdpa_fwd_prefill_sm100_{suffix}_fp8",
         capabilities=Capabilities(
             sm_lo=_BLACKWELL[0],
             sm_hi=_BLACKWELL[1],
             phase="prefill",
             d_qk=frozenset({d}),
-            d_v=frozenset({d}),
-            dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
+            d_v=frozenset({d_v}),
+            dtypes=dtypes,
             out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             is_fp8=True,
             causal=True,
@@ -1026,6 +1035,11 @@ ENGINE_SPECS = (
     _sm100_spec(512),
     _sm100_mxfp8_spec(128),
     _sm100_fp8_spec(128),
+    _sm100_fp8_spec(
+        192,
+        d_v=128,
+        dtypes=frozenset({cudnn.data_type.FP8_E4M3}),
+    ),
     _sm120_spec(),
     _sm120_fp8_spec(),
     _sm80_spec(),

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -453,21 +453,23 @@ def _sm100_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
     )
 
 
-def _sm100_mxfp8_spec(d: int) -> EngineSpec:
-    """d128 block-scale MXFP8 engine (E4M3/E5M2 in + per-32-block E8M0 SF, half out).
+def _sm100_mxfp8_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
+    """Block-scale MXFP8 engine (E4M3/E5M2 + per-32-block E8M0 SF).
 
     THD/varlen is deferred (dense execute only for v1), so thd=False here even
     though the kernel itself supports it.
     """
 
+    d_v = d if d_v is None else d_v
+    suffix = f"d{d}" if d_v == d else f"d{d}_d{d_v}"
     return EngineSpec(
-        name=f"sdpa_fwd_prefill_sm100_d{d}_mxfp8",
+        name=f"sdpa_fwd_prefill_sm100_{suffix}_mxfp8",
         capabilities=Capabilities(
             sm_lo=_BLACKWELL[0],
             sm_hi=_BLACKWELL[1],
             phase="prefill",
             d_qk=frozenset({d}),
-            d_v=frozenset({d}),
+            d_v=frozenset({d_v}),
             dtypes=frozenset({cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             out_dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16, cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E5M2}),
             is_mxfp8=True,
@@ -1043,6 +1045,7 @@ ENGINE_SPECS = (
     _sm100_spec(256),
     _sm100_spec(512),
     _sm100_mxfp8_spec(128),
+    _sm100_mxfp8_spec(192, d_v=128),
     _sm100_fp8_spec(128),
     _sm100_fp8_spec(
         192,

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -456,8 +456,8 @@ def _sm100_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
 def _sm100_mxfp8_spec(d: int, d_v: Optional[int] = None) -> EngineSpec:
     """Block-scale MXFP8 engine (E4M3/E5M2 + per-32-block E8M0 SF).
 
-    THD/varlen is deferred (dense execute only for v1), so thd=False here even
-    though the kernel itself supports it.
+    THD/varlen is not supported by the current MXFP8 kernels, so this engine is
+    intentionally dense-only.
     """
 
     d_v = d if d_v is None else d_v

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -28,8 +28,6 @@ class Bars(NamedTuple):
     mb_bmm1_done: object
     mb_bmm2_done: object
     mb_bmm2_ready: object
-    mb_s_empty: object
-    mb_s_consumed: object
 
     mb_stat_full: object
     mb_stat_empty: object
@@ -143,18 +141,6 @@ def make_classic_bars(CFG) -> Bars:
             init_count=tuple(SOFTMAX_PLUS_CORR_TOTAL if (s % N_BMM2_CHUNKS) == 0 else SOFTMAX_LANES_TOTAL for s in range(CFG.TILES_Q * N_BMM2_CHUNKS)),
             producer=Producer.LEADER,
             scope=Scope.LEADER,
-        ),
-        mb_s_consumed=MBarrier(
-            _alloc(CFG.TILES_Q),
-            stages=CFG.TILES_Q,
-            init_count=CFG.SOFTMAX_LANES,
-            producer=Producer.THREAD,
-        ),
-        mb_s_empty=MBarrier(
-            _alloc(CFG.TILES_Q),
-            stages=CFG.TILES_Q,
-            init_count=CFG.SOFTMAX_LANES,
-            producer=Producer.THREAD,
         ),
         mb_stat_full=MBarrier(_alloc(CFG.TILES_Q), stages=CFG.TILES_Q, init_count=CFG.SOFTMAX_LANES, producer=Producer.THREAD),
         mb_stat_empty=MBarrier(_alloc(CFG.TILES_Q), stages=CFG.TILES_Q, init_count=CFG.CORR_LANES, producer=Producer.THREAD),
@@ -545,6 +531,7 @@ class SdpaHelpers(NamedTuple):
 def make_sdpa_helpers(
     CFG,
     lpt_q_tiles_in_cga_units: bool = False,
+    grouped_lpt: bool = False,
     lpt_head_group: int = 1,
     lpt_q_tiles: int = 0,
 ) -> SdpaHelpers:
@@ -615,21 +602,36 @@ def make_sdpa_helpers(
             return _lpt_q_super(row, cta_in_pair), head, batch
 
     else:
-        if lpt_q_tiles > 0:
+        if grouped_lpt:
+            if lpt_q_tiles > 0:
 
-            @cute.jit
-            def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
-                row, head, batch = decode_linear_tile_lpt_grouped(
-                    _lpt_linear(bidx), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group
-                )
-                return _lpt_q_super(row, cta_in_pair), head, batch
+                @cute.jit
+                def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+                    row, head, batch = decode_linear_tile_lpt_grouped(
+                        _lpt_linear(bidx), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group
+                    )
+                    return _lpt_q_super(row, cta_in_pair), head, batch
 
-            @cute.jit
-            def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
-                row, head, batch = decode_linear_tile_lpt_grouped(
-                    _lpt_linear(t0), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group
-                )
-                return _lpt_q_super(row, cta_in_pair), head, batch
+                @cute.jit
+                def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+                    row, head, batch = decode_linear_tile_lpt_grouped(
+                        _lpt_linear(t0), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group
+                    )
+                    return _lpt_q_super(row, cta_in_pair), head, batch
+
+            else:
+
+                @cute.jit
+                def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+                    q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
+                    row, head, batch = decode_linear_tile_lpt_grouped(_lpt_linear(bidx), n_qh, n_batch, q_tiles, lpt_head_group)
+                    return _lpt_q_super(row, cta_in_pair), head, batch
+
+                @cute.jit
+                def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+                    q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
+                    row, head, batch = decode_linear_tile_lpt_grouped(_lpt_linear(t0), n_qh, n_batch, q_tiles, lpt_head_group)
+                    return _lpt_q_super(row, cta_in_pair), head, batch
 
         else:
 
@@ -688,7 +690,7 @@ def make_sdpa_helpers(
             cga_base_super = q_super_idx - cta_in_pair
             q_row_coord = cga_base_super * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
             arr = cutlass.make_array_view(seq_q_lens_tensor)
-            q_len_b = cutlass.Int32(arr[cutlass.Int32(batch_idx)])
+            q_len_b = cutlass.Int32(arr[batch_idx])
             tile_dead = q_row_coord >= q_len_b
             dead_lo = cutlass.Int32(arith.select(tile_dead.ir_value(), b.left.ir_value(), b.unmasked_lo.ir_value()))
             dead_hi = cutlass.Int32(arith.select(tile_dead.ir_value(), b.left.ir_value(), b.unmasked_hi.ir_value()))
@@ -700,7 +702,7 @@ def make_sdpa_helpers(
     def _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, scalar_seqlen_kv):
         if cutlass.const_expr(CFG.SEQ_KV_LENS_PRESENT == 1):
             arr = cutlass.make_array_view(seq_kv_lens_tensor)
-            return cutlass.Int32(arr[cutlass.Int32(batch_idx)])
+            return cutlass.Int32(arr[batch_idx])
         return scalar_seqlen_kv
 
     @cute.jit

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -28,6 +28,8 @@ class Bars(NamedTuple):
     mb_bmm1_done: object
     mb_bmm2_done: object
     mb_bmm2_ready: object
+    mb_s_empty: object
+    mb_s_consumed: object
 
     mb_stat_full: object
     mb_stat_empty: object
@@ -141,6 +143,18 @@ def make_classic_bars(CFG) -> Bars:
             init_count=tuple(SOFTMAX_PLUS_CORR_TOTAL if (s % N_BMM2_CHUNKS) == 0 else SOFTMAX_LANES_TOTAL for s in range(CFG.TILES_Q * N_BMM2_CHUNKS)),
             producer=Producer.LEADER,
             scope=Scope.LEADER,
+        ),
+        mb_s_consumed=MBarrier(
+            _alloc(CFG.TILES_Q),
+            stages=CFG.TILES_Q,
+            init_count=CFG.SOFTMAX_LANES,
+            producer=Producer.THREAD,
+        ),
+        mb_s_empty=MBarrier(
+            _alloc(CFG.TILES_Q),
+            stages=CFG.TILES_Q,
+            init_count=CFG.SOFTMAX_LANES,
+            producer=Producer.THREAD,
         ),
         mb_stat_full=MBarrier(_alloc(CFG.TILES_Q), stages=CFG.TILES_Q, init_count=CFG.SOFTMAX_LANES, producer=Producer.THREAD),
         mb_stat_empty=MBarrier(_alloc(CFG.TILES_Q), stages=CFG.TILES_Q, init_count=CFG.CORR_LANES, producer=Producer.THREAD),
@@ -500,6 +514,20 @@ def make_split_helpers(CFG, *, bounds_for_tile, dispatch_decode_initial, dispatc
     )
 
 
+@cute.jit
+def decode_linear_tile_lpt_grouped(linear, q_h, batch, q_tiles, lpt_head_group: cutlass.Constexpr[int]):
+    head_group = cutlass.Int32(lpt_head_group)
+    group_span = q_tiles * head_group
+    group_idx = linear // group_span
+    group_offset = linear % group_span
+    row_rank = group_offset // head_group
+    within = group_idx * head_group + group_offset % head_group
+    row = (q_tiles - cutlass.Int32(1)) - row_rank
+    head = within % q_h
+    batch_idx = within // q_h
+    return row, head, batch_idx
+
+
 class SdpaHelpers(NamedTuple):
     decode_initial: object
     decode_payload: object
@@ -514,7 +542,12 @@ class SdpaHelpers(NamedTuple):
     thd_sf_tile_bases: object
 
 
-def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelpers:
+def make_sdpa_helpers(
+    CFG,
+    lpt_q_tiles_in_cga_units: bool = False,
+    lpt_head_group: int = 1,
+    lpt_q_tiles: int = 0,
+) -> SdpaHelpers:
     cga_tile_m = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 
     _cga_m = getattr(CFG, "CGA_M", 1)
@@ -582,20 +615,37 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             return _lpt_q_super(row, cta_in_pair), head, batch
 
     else:
+        if lpt_q_tiles > 0:
 
-        @cute.jit
-        def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
-            linear = _lpt_linear(bidx)
-            q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
-            row, head, batch = lpt_tile_coords(linear, n_qh, n_batch, q_tiles)
-            return _lpt_q_super(row, cta_in_pair), head, batch
+            @cute.jit
+            def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+                row, head, batch = decode_linear_tile_lpt_grouped(
+                    _lpt_linear(bidx), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group
+                )
+                return _lpt_q_super(row, cta_in_pair), head, batch
 
-        @cute.jit
-        def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
-            linear = _lpt_linear(t0)
-            q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
-            row, head, batch = lpt_tile_coords(linear, n_qh, n_batch, q_tiles)
-            return _lpt_q_super(row, cta_in_pair), head, batch
+            @cute.jit
+            def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+                row, head, batch = decode_linear_tile_lpt_grouped(
+                    _lpt_linear(t0), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group
+                )
+                return _lpt_q_super(row, cta_in_pair), head, batch
+
+        else:
+
+            @cute.jit
+            def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+                linear = _lpt_linear(bidx)
+                q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
+                row, head, batch = lpt_tile_coords(linear, n_qh, n_batch, q_tiles)
+                return _lpt_q_super(row, cta_in_pair), head, batch
+
+            @cute.jit
+            def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
+                linear = _lpt_linear(t0)
+                q_tiles = n_q_supers // cutlass.Int32(_cta_mma) if lpt_q_tiles_in_cga_units else n_q_supers
+                row, head, batch = lpt_tile_coords(linear, n_qh, n_batch, q_tiles)
+                return _lpt_q_super(row, cta_in_pair), head, batch
 
     @cute.jit
     def _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair):
@@ -638,7 +688,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
             cga_base_super = q_super_idx - cta_in_pair
             q_row_coord = cga_base_super * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
             arr = cutlass.make_array_view(seq_q_lens_tensor)
-            q_len_b = cutlass.Int32(arr[batch_idx])
+            q_len_b = cutlass.Int32(arr[cutlass.Int32(batch_idx)])
             tile_dead = q_row_coord >= q_len_b
             dead_lo = cutlass.Int32(arith.select(tile_dead.ir_value(), b.left.ir_value(), b.unmasked_lo.ir_value()))
             dead_hi = cutlass.Int32(arith.select(tile_dead.ir_value(), b.left.ir_value(), b.unmasked_hi.ir_value()))
@@ -650,7 +700,7 @@ def make_sdpa_helpers(CFG, lpt_q_tiles_in_cga_units: bool = False) -> SdpaHelper
     def _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, scalar_seqlen_kv):
         if cutlass.const_expr(CFG.SEQ_KV_LENS_PRESENT == 1):
             arr = cutlass.make_array_view(seq_kv_lens_tensor)
-            return cutlass.Int32(arr[batch_idx])
+            return cutlass.Int32(arr[cutlass.Int32(batch_idx)])
         return scalar_seqlen_kv
 
     @cute.jit

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -607,16 +607,12 @@ def make_sdpa_helpers(
 
                 @cute.jit
                 def _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
-                    row, head, batch = decode_linear_tile_lpt_grouped(
-                        _lpt_linear(bidx), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group
-                    )
+                    row, head, batch = decode_linear_tile_lpt_grouped(_lpt_linear(bidx), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group)
                     return _lpt_q_super(row, cta_in_pair), head, batch
 
                 @cute.jit
                 def _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh=None, seqlen_kv=None):
-                    row, head, batch = decode_linear_tile_lpt_grouped(
-                        _lpt_linear(t0), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group
-                    )
+                    row, head, batch = decode_linear_tile_lpt_grouped(_lpt_linear(t0), n_qh, n_batch, cutlass.Int32(lpt_q_tiles), lpt_head_group)
                     return _lpt_q_super(row, cta_in_pair), head, batch
 
             else:

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -142,11 +142,19 @@ def _max_abs_reduction(vec):
     return cute.math.max(maxima[0], -minima[0], ftz=True)
 
 
-def _exp2_mixed_conservative(vec):
-    """Use E5M2-safe coverage while retaining the E4M3 performance mix."""
+def _exp2_chunk0_mask_aware(vec, apply_mask):
+    """Evaluate softmax chunk 0 with the precision required by each static path.
+
+    E5M2 mask-boundary tiles use native EXP2 because degree-2 emulation can
+    exceed the output tolerance there. The repeated unmasked path retains its
+    tuned emulation mix, while the E4M3 instruction mix remains unchanged.
+    """
     values = []
     for i in range(0, int(vec.shape[0]), 2):
-        if CFG.DTYPE_QKV == 1 and i < 32:
+        if CFG.DTYPE_QKV == 1 and apply_mask:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        elif CFG.DTYPE_QKV == 1 and i < 32:
             x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=2)
         elif CFG.DTYPE_QKV == 0 and i < 32 and i % 10 < 4:
             x, y = ex2_emulation_2(vec[i], vec[i + 1])
@@ -1532,7 +1540,7 @@ def _softmax_kv_body(
     reg_S = reg_S * scale_log2 - new_total_max
 
     chunk_S_0 = reg_S[0:CHUNK].vec
-    chunk_P_0 = _exp2_mixed_conservative(chunk_S_0)
+    chunk_P_0 = _exp2_chunk0_mask_aware(chunk_S_0, apply_mask)
     # Hoist chunk-0 sum before cast to overlap with cast's FFMA chain.
     hoisted_sum = row_reduction_pair(chunk_P_0)
     chunk_P_0_fp8 = _pack_fp8_vec(chunk_P_0)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -1,0 +1,2331 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""
+DSL prefill SDPA kernel — per-tensor FP8 (E4M3 / E5M2), d_qk=192, d_v=128, SM100.
+
+Classic 2-sub-tile pipeline (TILES_Q=2, two softmax warpgroups, four correction
+warps, persistent try_cancel scheduler).  Per-tensor descales fold into
+scale_softmax_log2; o_scale_fused feeds the correction epilogue's threshold_beta.
+Optional output dtype (DTYPE_O): FP8 in → E4M3 / E5M2 / BF16 / FP16 O. The
+initial implementation extends the d128 per-tensor FP8 pipeline to exact
+d_qk=192/d_v=128 while preserving the FP8-on-Blackwell K-path:
+  1. **cga2-only, STAGES_KV=4** (config; FP8 BPE=1).
+  2. **512-col TMEM** with per-sub-tile stats on the S_acc heads (col 0/128;
+     FP8 P is 4:1-packed at the S_acc tails 96/224, so the heads are free).
+  3. **Manual row-max** (no LDTM.STAT).
+  4. **FP8 MMA uses the Blackwell K=32 QMMA path** — idesc ``k_dim=0`` +
+     ``TILE_K_HW=32`` (config).  ``NUM_KPHASES_PV`` derives from
+     ``CFG.TILE_K_HW_BMM2`` (→ 4 k-steps at TILE_K_HW=32).  Confirmed by the
+     cuDNN f8 reference (UTCMMA_TILE_K=32, BMM_XMMAS_K=4, kind::f8f6f4).
+
+THD / varlen (``CFG.THD_VARLEN=1``) is supported (E4M3/E5M2) — FP8 is
+element-addressed (no block-scale SF), so it rides the same THD path as f16:
+packed ``[1,T,H,D]`` + ``cu_seqlens`` coord offset (both Q slabs under
+TILES_Q=2), per-batch O TMA-descriptor array (shared
+``kernels/dsl/common/sdpa/thd.py``), packed ``[1,QH,T]`` LSE.  Dense path
+byte-identical.  Public-API quantize→attention(layout="thd") glue is a
+follow-up (needs a THD-aware quantizer); drive via the kernel / the DSL backend.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+
+from cutlass.base_dsl.typing import Pointer  # was the legacy DSL Pointer pre-DKG-bump
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass.experimental.cuda import tensor_map as tmap
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+import cuda.bindings.driver as _cuda_driver  # noqa: F401  (cute.compile pulls cuda)
+
+from dataclasses import dataclass
+
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d192
+
+# The template loader (api_dsl._load_kernel_module) injects FROST_TEMPLATE_PARAMS
+# as a module global before this body runs; the default keeps direct import usable.
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d192(PARAMS)
+Cfg = type(CFG)
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# O's TMA box follows O's swizzle, not V's (under cga2 V may drop to a narrower swizzle).
+# Sized in BPE_O (output dtype) — O may be written at BF16/FP16 when DTYPE_O != DTYPE_QKV.
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+from typing import NamedTuple
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    arrive_expect_tx,
+    cga_arrive,
+    cga_wait,
+    # `wait` (free fn) — still used for sched.mb_* (Sched not in Bars).
+    wait,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    # SM100: no LDTM.STAT — the MASK_NONE fast path uses manual tcgen05_ld +
+    # row_max_reduction (see _softmax_kv_body); tmem_load_max_reduction_tile
+    # is not imported.
+    row_reduction_pair,
+    row_max_reduction,
+    vec_scale_pair,
+    fp32_to_fp8_pack,
+)
+from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+from cudnn.block_sparse_attention.csrc.utils.kernel_utils import ex2_emulation_2
+
+
+@cute.jit
+def _wait_ptr(mb, phase):
+    while not nvvm.mbarrier_wait_parity(mb, phase, nvvm.MBarrierWait.TRY):
+        pass
+
+
+@cute.jit
+def _wait_mbarrier(mb, phase):
+    _wait_ptr(mb.smem_ptr, phase)
+
+
+def _max_abs_reduction(vec):
+    """Balanced max(abs(vec)) without materializing an abs vector."""
+    n = int(vec.shape[0])
+    maxima = [vec[i] for i in range(n)]
+    minima = list(maxima)
+    while len(maxima) > 1:
+        next_maxima = []
+        next_minima = []
+        for i in range(0, len(maxima), 3):
+            max_group = maxima[i : i + 3]
+            min_group = minima[i : i + 3]
+            max_acc = max_group[0]
+            min_acc = min_group[0]
+            for value in max_group[1:]:
+                max_acc = cute.math.max(max_acc, value, ftz=True)
+            for value in min_group[1:]:
+                min_acc = cute.math.min(min_acc, value, ftz=True)
+            next_maxima.append(max_acc)
+            next_minima.append(min_acc)
+        maxima = next_maxima
+        minima = next_minima
+    return cute.math.max(maxima[0], -minima[0], ftz=True)
+
+
+def _exp2_mixed_conservative(vec):
+    """Use E5M2-safe coverage while retaining the E4M3 performance mix."""
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        if CFG.DTYPE_QKV == 1 and i < 32:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=2)
+        elif CFG.DTYPE_QKV == 0 and i < 32 and i % 10 < 4:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1])
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+def _exp2_mixed_late(vec):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        if i >= 56:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=2)
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+def _exp2_emulated_scalar(x):
+    value, _ = ex2_emulation_2(x, x, poly_degree=2)
+    return value
+
+
+# Storage dtype + MMA kind dispatch keyed off CFG.DTYPE_QKV.
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+    MMA_KIND = nvvm.Tcgen05MMAKind.F8F6F4
+else:
+    raise ValueError(
+        f"prefill_sdpa_fp8: DTYPE_QKV={CFG.DTYPE_QKV} not supported "
+        f"(expected 0=E4M3 or 1=E5M2; use the DSL backend with --bf16/--fp16 "
+        f"for the f16 kernel, or extend this dispatch for new fp8 variants)"
+    )
+
+_P_FP8_TAG = "e4m3" if CFG.DTYPE_QKV == 0 else "e5m2"
+
+
+def _fp32x4_to_fp8_word(v0, v1, v2, v3):
+    return nvvm.inline_ptx(
+        "{ .reg .b16 lo, hi;\n"
+        f"cvt.rn.satfinite.{_P_FP8_TAG}x2.f32 lo, $2, $1;\n"
+        f"cvt.rn.satfinite.{_P_FP8_TAG}x2.f32 hi, $4, $3;\n"
+        "mov.b32 $0, {lo, hi}; }",
+        write_only_types=[cutlass.Int32],
+        read_only_args=[v0, v1, v2, v3],
+    )
+
+
+def _pack_fp8_vec(vec):
+    words = [
+        _fp32x4_to_fp8_word(vec[i], vec[i + 1], vec[i + 2], vec[i + 3])
+        for i in range(0, int(vec.shape[0]), 4)
+    ]
+    return cutlass.Vector.from_elements(tuple(words), cutlass.Int32).bitcast(
+        STORAGE_DTYPE
+    )
+
+# DTYPE_O is independent of DTYPE_QKV (mirrors C++ Cfg::DTYPE_O — defaults to
+# DTYPE_QKV but may be promoted to BF16/FP16 so a downstream consumer skips a
+# dequant).  BPE_O ∈ {1, 2}.  The epilogue keeps the bit-identical hand-rolled
+# 16:4 FP8 pack for DTYPE_O ∈ {0, 1}; BF16/FP16 take a generic cast + swizzled
+# store (see _correction_warp_group).
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_fp8: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    Bars,
+    KvLoopBounds,
+    make_classic_bars,
+    compute_kv_loop_bounds,
+    decode_linear_tile_lpt,
+    make_sdpa_helpers,
+)
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+# K (split along seq rows) and V (split along d_v cols) shrink by CTA_MMA;
+# Q / O are per-CTA full.  At cga2 leader's expect_tx = per-CTA bytes × CTA_MMA.
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+
+# SM100 llama is always cga2 → LPT reverse-row count in CGA-tile units.
+_sdpa_h = make_sdpa_helpers(
+    CFG,
+    lpt_q_tiles_in_cga_units=True,
+    lpt_head_group=PARAMS.lpt_head_group,
+    lpt_q_tiles=PARAMS.lpt_q_tiles,
+)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+# THD / varlen — shared helpers (FP8 element-addressed like f16, per-tensor
+# dequant scalars, no block-scale SF).  Gated by CFG.THD_VARLEN (folds out).
+# TILES_Q=2: q_seq_off applies to BOTH Q slabs + both O-store slabs.
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_o_descs_kernel as _build_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+_sdpa_h_mma_runtime = make_sdpa_helpers(
+    CFG,
+    lpt_q_tiles_in_cga_units=True,
+    lpt_head_group=PARAMS.lpt_head_group,
+)
+_dispatch_decode_initial_mma = _sdpa_h_mma_runtime.dispatch_decode_initial
+_dispatch_decode_payload_mma = _sdpa_h_mma_runtime.dispatch_decode_payload
+
+
+class _PredecodedSched(NamedTuple):
+    mb_scheduler: object
+    mb_read_tile_id: object
+    mb_decoded: object
+    tile_id_smem: object
+    initial_decoded_smem: object
+    bidx_init: object
+    bidy_init: object
+    bidz_init: object
+
+
+@cute.jit
+def _scheduler_warp_loop_predecode(
+    sched,
+    sched_stages,
+    is_cga_first_cta,
+    cta_in_pair,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    seq_kv_lens_tensor,
+):
+    state = PipelineState.start()
+    is_valid = cutlass.Int32(1)
+
+    while is_valid > cutlass.Int32(0):
+        wait(sched.mb_read_tile_id.subview(state.idx), state.phase)
+
+        if nvvm.elect_sync():
+            arrive_expect_tx(sched.mb_scheduler.subview(state.idx), 16)
+
+        if nvvm.elect_sync() and is_cga_first_cta:
+            nvvm.clusterlaunchcontrol_try_cancel(
+                sched.tile_id_smem.subview(state.idx * cutlass.Int32(8)),
+                sched.mb_scheduler.subview(state.idx),
+                multicast=1,
+            )
+        nvvm.fence_proxy("async.shared", space="cta")
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(state.idx), state.phase)
+        payload_base = state.idx * cutlass.Int32(8)
+        nxt_q = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base).load())
+        nxt_hb = cute.arch.make_warp_uniform(
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(1)).load()
+        )
+        nxt_v = cute.arch.make_warp_uniform(
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
+        )
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid = nxt_v & cutlass.Int32(1)
+
+        if nvvm.elect_sync():
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(4)).store(q_super_idx)
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(5)).store(head_idx)
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(6)).store(batch_idx)
+            sched.tile_id_smem.subview(payload_base + cutlass.Int32(7)).store(is_valid)
+            nvvm.mbarrier_arrive(sched.mb_decoded.subview(state.idx))
+
+        state = advance(state, sched_stages)
+
+
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    """Column offsets for the cross-inplace 2-sub-tile FP8 pipeline.
+
+    P0 aliases the tail of S1 and P1 aliases the tail of S0.  Statistics use
+    independent SMEM because the lookahead BMM1 overwrites the next S slot
+    before correction consumes the previous iteration's alpha.
+    """
+
+    # Blackwell SM10.0 512-col TMEM cap.
+    TOTAL_COLS: int = 512
+
+    S0_OFF: int = 0
+    S1_OFF: int = 128
+
+    O0_OFF: int = 256
+    O1_OFF: int = 384
+
+    # P (FP8 4:1 packed, 32 cols each) rotates onto the peer S tail.
+    P0_OFF: int = 224
+    P1_OFF: int = 96
+
+    # SM100: stats ride the head of sub-tile qs's S_acc slot (col 0 / 128); FP8
+    # P is 4:1-packed at the tails (96 / 224), so the heads are free after S is
+    # read.  stats_off = STATS_OFF + qs*STATS_STRIDE.
+    STATS_OFF: int = 0
+    STATS_STRIDE: int = 128
+
+
+LAYOUT = KernelTmemLayout()
+
+
+# === Kernel ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    amax_s_tensor: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+) -> None:
+
+    cute.arch.inline_ptx('.pragma "global knob SchedLDSLatency=50";')
+    cute.arch.inline_ptx('.pragma "global knob MaxCumuWaitSinceEndGroup=0";')
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    # Q/K/V/O order matters: Tcgen05SmemDesc.build truncates start_address past
+    # ~256 KiB so high-offset tiles alias to low SMEM in BMM2.
+    sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * qBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sO_raw = cutlass.Array(OUT_STORAGE_DTYPE, CFG.TILES_Q * oBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sStats_raw = cutlass.Array(
+        cutlass.Float32,
+        CFG.TILES_Q * 2 * CFG.TILE_M,
+        alignment=128,
+        space=cutlass.AddressSpace.smem,
+    )
+
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=1,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        # V split along d_v under cga2 → tma_loads_per_tile shrinks by CTA_MMA.
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    bars = make_classic_bars(CFG)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    # tile_id_smem stride 8 Int32/stage: 16 B try_cancel.async payload + 16 B padding.
+    sched = _PredecodedSched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_decoded": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "initial_decoded_smem": cutlass.Array(cutlass.Int32, 4, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # CGA-aware mbar init counts; at CTA_MMA=1 collapse to cga1 baselines.
+    READ_TILE_ARRIVERS_TOTAL = ((CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS) + CFG.CORRECTION_WARPS + 1 + 1) * CGA_SIZE + (CFG.CGA_M // CFG.CTA_MMA)
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+
+    if warp_idx == 0:
+        initial_q, initial_head, initial_batch = _dispatch_decode_initial(
+            bidx,
+            bidy,
+            bidz,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        if nvvm.elect_sync():
+            # range_constexpr → Python-int loop var (required for the
+            # mb_bmm2_ready tuple-init lookup).  Bounds are small —
+            # unroll is free.
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_q_full[qs].init()
+                bars.mb_q_empty[qs].init()
+                bars.mb_bmm1_done[qs].init()
+                bars.mb_bmm2_done[qs].init()
+                bars.mb_s_empty[qs].init()
+                bars.mb_s_consumed[qs].init()
+                bars.mb_stat_full[qs].init()
+                bars.mb_stat_empty[qs].init()
+                bars.mb_stats_read[qs].init()
+                bars.mb_o_full[qs].init()
+                bars.mb_o_empty[qs].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + c].init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+                nvvm.mbarrier_init(sched.mb_decoded.subview(s), CFG.ONE_LANE)
+            bars.mb_tmem_dealloc.init()
+            bars.mb_empty_mainloop.init()
+            sched.initial_decoded_smem.subview(0).store(initial_q)
+            sched.initial_decoded_smem.subview(1).store(initial_head)
+            sched.initial_decoded_smem.subview(2).store(initial_batch)
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    # P4 cluster fence — gates cga2 cross-CTA arrives on peer init.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    # const_expr wrap — without it the DSL stages if/else and post-branch reads NameError.
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    # tma_mcast_mask = 1 << cta_rank — cta_group::2 routing strips bit-24 onto leader.
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=0,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            sStats_raw=sStats_raw,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            sStats_raw=sStats_raw,
+            bars=bars,
+            sched=sched,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            sStats_raw=sStats_raw,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+            o_scale_fused=o_scale_fused,
+            amax_s_tensor=amax_s_tensor,
+            amax_o_tensor=amax_o_tensor,
+        )
+
+    # cga2 non-leader runs quiet body (alloc+dealloc only); cga1 folds to full path.
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(tmem_ptr_i32, bars)
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        # Warm descriptor cache.
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        # try_cancel.multicast::cluster::all — only CGA's (0,0,0) CTA issues.
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        _scheduler_warp_loop_predecode(
+            sched,
+            CFG.SCHEDULER_STAGES,
+            is_cga_first_cta,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+
+
+# === TMA-LDG warp ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    sQ,
+    sK,
+    sV,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+):
+    """Unified TMA-LDG warp — cga1/cga2 × MASK_NONE/PADDED/CAUSAL/SWA.
+
+    Spill-free in OTHER_REGS (40) via the q_row_base trick: pre-multiplying
+    q_super_idx into q_row_base after each scheduler decode keeps the LDS.128
+    result in uniform registers instead of getting STL'd to local stack.
+    """
+    q_empty_phase = cutlass.Int32(1)
+    kv_state = PipelineState.start(phase=1)
+
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+    kv_l2_hint = nvvm.inline_ptx(
+        "createpolicy.fractional.L2::evict_last.b64 {$w0}, 1.0;",
+        write_only_types=[cutlass.Int64],
+    )
+
+    q_super_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(0).load())
+    head_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(1).load())
+    batch_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(2).load())
+    # GQA: K/V are indexed by kv-head.
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    # The DSL TMA descriptor coord is in ELEMENTS, not bytes (C++ uses UINT8 desc).
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            # Prologue interleave: Q[0] → K[first] → Q[1] → V[first] → mainloop.
+            kv_row_base = kv_left * CFG.TILE_N
+
+            _wait_mbarrier(bars.mb_q_empty[0], q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[0].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            _wait_mbarrier(bars.mb_k_empty[kv_state.idx], kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sK[kv_state.idx],
+                # THD: prologue K load MUST apply the per-sequence kv offset
+                # (kv_seq_off) + packed batch coord (tma_batch), like the mainloop
+                # K load + the V loads.  The old `+ K_ROW_OFFSET_PEER, batch_idx`
+                # is byte-identical for dense but reads the wrong packed location
+                # for THD batch>=1 (see the f16 kernel's prologue K-load fix).
+                tma_k(
+                    cutlass.Int32(0),
+                    kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off,
+                    cutlass.Int32(0),
+                    kv_head_idx,
+                    tma_batch,
+                ),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+                l2_cache_hint=kv_l2_hint,
+            )
+
+            _wait_mbarrier(bars.mb_q_empty[1], q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sQ[1],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[1].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            q_empty_phase = q_empty_phase ^ 1
+
+            _wait_mbarrier(bars.mb_v_empty[kv_state.idx], kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+            else:
+                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+            tma_load_tile(
+                sV[kv_state.idx],
+                tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+                l2_cache_hint=kv_l2_hint,
+            )
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=3):
+                kv_row_base = kv_loop * CFG.TILE_N
+
+                _wait_mbarrier(bars.mb_k_empty[kv_state.idx], kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(
+                        cutlass.Int32(0),
+                        kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off,
+                        cutlass.Int32(0),
+                        kv_head_idx,
+                        tma_batch,
+                    ),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    l2_cache_hint=kv_l2_hint,
+                )
+
+                _wait_mbarrier(bars.mb_v_empty[kv_state.idx], kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
+                else:
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes, pred=nvvm.elect_sync())
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                    l2_cache_hint=kv_l2_hint,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_decoded.subview(sched_state.idx), sched_state.phase)
+        decoded_base = sched_state.idx * cutlass.Int32(8) + cutlass.Int32(4)
+        q_super_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base).load())
+        head_idx = cute.arch.make_warp_uniform(
+            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load()
+        )
+        batch_idx = cute.arch.make_warp_uniform(
+            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load()
+        )
+        is_valid_tile = cute.arch.make_warp_uniform(
+            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load()
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        # q_row_base after decode drives ptxas R2UR (keeps nxt_q live before back-edge).
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2: drain trailing empty mbar arrives before SMEM teardown.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _qs in cutlass.range_constexpr(CFG.TILES_Q):
+            _wait_mbarrier(bars.mb_q_empty[_qs], q_empty_phase)
+        q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            _wait_mbarrier(bars.mb_k_empty[kv_state.idx], kv_state.phase)
+            _wait_mbarrier(bars.mb_v_empty[kv_state.idx], kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+# === TMA-STG warp ===
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """Persistent O-store warp; tiles claimed via scheduler's try_cancel.async."""
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx = sched.initial_decoded_smem.subview(0).load()
+    head_idx = sched.initial_decoded_smem.subview(1).load()
+    batch_idx = sched.initial_decoded_smem.subview(2).load()
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            _wait_mbarrier(bars.mb_o_full[qs], o_full_phase)
+
+            # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (seq extent = S_q_b → box past S_q_b OOB-clipped).  q_row coord
+                # sequence-local; batch → 0.  Both slabs share one descriptor.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                )
+
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_o_empty[qs].arrive()
+
+        o_full_phase = o_full_phase ^ 1
+
+        wait(sched.mb_decoded.subview(sched_state.idx), sched_state.phase)
+        decoded_base = sched_state.idx * cutlass.Int32(8) + cutlass.Int32(4)
+        q_super_idx = sched.tile_id_smem.subview(decoded_base).load()
+        head_idx = sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load()
+        batch_idx = sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load()
+        is_valid_tile = sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load()
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+# Swizzle byte width → nvvm.Tcgen05SmemSwizzle enum.
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+# O SMEM Swizzle preset (B, 4, 3): Swz128B=(3,4,3) etc.  Third param is XOR shift, NOT B.
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+LEADING_BYTE_OFFSET_QK = 0
+# SM100/Blackwell FP8: K=32 QMMA path.  Derive from
+# CFG.TILE_K_HW_BMM2 (=32) so NUM_KPHASES_PV = TILE_N/32 = 4 k-steps; a hardcoded
+# 64 would issue only 2 steps and silently drop half of V's K (cf. rules §16).
+_MMA_K_FP8 = CFG.TILE_K_HW_BMM2
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES.
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+NUM_KPHASES_PV = CFG.TILE_N // _MMA_K_FP8
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+@cute.jit
+def _mma_warp_quiet(tmem_ptr_i32, bars):
+    """Non-leader CTA's MMA-warp body under cga2: alloc + named-bar arrive +
+    tmem_dealloc wait + dealloc.  Peer's TMEM stays allocated because leader
+    reads through the cluster crossbar during collective MMA.
+    """
+    # All-lanes warp-collective ops — NO elect_sync gating.
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    # Must match lead MMA's +1 arrive on softmax (id=1) and correction (id=2) bars.
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    _wait_mbarrier(bars.mb_tmem_dealloc, cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Unified MMA warp (cga1 / cga2-leader; MASK_NONE/PADDED/CAUSAL/SWA).
+
+    Spill-free in OTHER_REGS (40).  Non-leader cga2 CTA uses _mma_warp_quiet.
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    # SM100/Blackwell FP8: k_dim=0 = K=32 QMMA path (NOT the k_dim=1 K=64
+    # fast path, which is silently WRONG on Blackwell — cuda-kernels rules §16).
+    idesc_qk = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=0,
+    )
+    idesc_pv = prims.Tcgen05InstrDesc.build(
+        c_dtype=cutlass.Float32,
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=0,
+    )
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM1,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk,
+        kind=MMA_KIND,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=CFG.TILE_K_HW_BMM2,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv,
+        kind=MMA_KIND,
+    )
+
+    desc_Q0 = sQ[0].desc()
+    desc_Q1 = sQ[1].desc()
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial_mma(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=0)
+    bmm2_ready_phase = cutlass.Int32(0)
+    s0_empty_phase = cutlass.Int32(1)
+    s1_empty_phase = cutlass.Int32(1)
+    # Init unconditionally so type stays stable across const_expr branches.
+    empty_mainloop_phase = cutlass.Int32(0)
+    # Stats-consumed gate (one flip per tile per sub-tile): the prologue BMM1
+    # overwrites the S_acc HEAD where the PREVIOUS tile's final
+    # (total_max, total_sum) stats live until the correction epilogue has read
+    # them.  q_full/k_full alone do NOT order that read before the BMM1 (Q/K
+    # can be resident well before correction finishes its epilogue — the fp8
+    # epilogue's amax reductions + LSE/O gmem stores widen the window on
+    # multi-wave grids, corrupting the next tile's stats/O nondeterministically).
+    # Bootstrap phase 1: the first tile has no prior stats to protect, so the
+    # wait passes immediately.
+    stats_read_phase = cutlass.Int32(1)
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            # Empty-kv tile: fire bmm2_done so softmax/corr phases stay in lockstep.
+            _wait_mbarrier(bars.mb_empty_mainloop, empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            # Keep the stats-read gate in lockstep — correction's epilogue
+            # (and its mb_stats_read arrive) runs for empty tiles too.
+            _wait_mbarrier(bars.mb_stats_read[0], stats_read_phase)
+            _wait_mbarrier(bars.mb_stats_read[1], stats_read_phase)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+        else:
+            # mb_stats_read[qs] gates each prologue BMM1 on the correction
+            # epilogue having READ the previous tile's final stats from the
+            # S_acc head this BMM1 is about to overwrite (q_full/k_full don't
+            # order that).
+            _wait_mbarrier(bars.mb_q_full[0], q_full_phase)
+            _wait_mbarrier(bars.mb_k_full[kv_state.idx], kv_state.phase)
+            _wait_mbarrier(bars.mb_stats_read[0], stats_read_phase)
+            _wait_mbarrier(bars.mb_s_empty[0], s0_empty_phase)
+            s0_empty_phase = s0_empty_phase ^ cutlass.Int32(1)
+            desc_K = sK[kv_state.idx].desc()
+            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), fence_code=True)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            _wait_mbarrier(bars.mb_q_full[1], q_full_phase)
+            _wait_mbarrier(bars.mb_stats_read[1], stats_read_phase)
+            _wait_mbarrier(bars.mb_s_empty[1], s1_empty_phase)
+            s1_empty_phase = s1_empty_phase ^ cutlass.Int32(1)
+            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), fence_code=True)
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            q_full_phase = q_full_phase ^ 1
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                old_state = kv_state
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+                # Rotated steady state: S0[i], P0[i-1], S1[i], P1[i-1].
+                # P1[i-1] is produced only after softmax0 consumes S0[i], so
+                # this lookahead cannot overwrite a live probability tile.
+                _wait_mbarrier(bars.mb_k_full[kv_state.idx], kv_state.phase)
+                _wait_mbarrier(bars.mb_s_empty[0], s0_empty_phase)
+                s0_empty_phase = s0_empty_phase ^ cutlass.Int32(1)
+                desc_K = sK[kv_state.idx].desc()
+                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), fence_code=True)
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                _wait_mbarrier(bars.mb_v_full[old_state.idx], old_state.phase)
+                desc_V = sV[old_state.idx].desc()
+                is_not_first_bmm2 = cutlass.Boolean(kv_loop != (kv_left + cutlass.Int32(1)))
+
+                _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2, fence_code=True)
+                    accum_b2 = cutlass.Boolean(True)
+                # Chunk 1 folds out at N_BMM2_CHUNKS=1 (full NUM_KPHASES_PV in chunk 0).
+                if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                    _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
+                    for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                        mma_ts_step(
+                            bmm2_desc,
+                            (tmem_raw.subview(LAYOUT.P0_OFF)),
+                            desc_V,
+                            (tmem_raw.subview(LAYOUT.O0_OFF)),
+                            NUM_KPHASES_PV_PER_CHUNK + local_k,
+                            cutlass.Boolean(True),
+                            fence_code=True,
+                        )
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                _wait_mbarrier(bars.mb_s_empty[1], s1_empty_phase)
+                s1_empty_phase = s1_empty_phase ^ cutlass.Int32(1)
+                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), fence_code=True)
+                bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
+                desc_V = sV[old_state.idx].desc()
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2, fence_code=True)
+                    accum_b2 = cutlass.Boolean(True)
+                if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                    _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
+                    for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                        mma_ts_step(
+                            bmm2_desc,
+                            (tmem_raw.subview(LAYOUT.P1_OFF)),
+                            desc_V,
+                            (tmem_raw.subview(LAYOUT.O1_OFF)),
+                            NUM_KPHASES_PV_PER_CHUNK + local_k,
+                            cutlass.Boolean(True),
+                            fence_code=True,
+                        )
+                elect_p = nvvm.elect_sync()
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+                bars.mb_v_empty[old_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+                bmm2_ready_phase = bmm2_ready_phase ^ 1
+
+            # Epilogue BMM2 always runs (n_kv >= 1).
+            elect_p = nvvm.elect_sync()
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_q_empty[qs].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            _wait_mbarrier(bars.mb_v_full[kv_state.idx], kv_state.phase)
+            desc_V = sV[kv_state.idx].desc()
+            is_not_first_bmm2_epi = cutlass.Boolean((kv_right - kv_left) != cutlass.Int32(1))
+
+            _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2, fence_code=True)
+                accum_b2 = cutlass.Boolean(True)
+            if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                        fence_code=True,
+                    )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2, fence_code=True)
+                accum_b2 = cutlass.Boolean(True)
+            if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
+                _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P1_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O1_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                        fence_code=True,
+                    )
+            elect_p = nvvm.elect_sync()
+            bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+            bars.mb_v_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
+
+            bmm2_ready_phase = bmm2_ready_phase ^ 1
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        # One correction-epilogue arrive per tile per sub-tile — flip once per tile.
+        stats_read_phase = stats_read_phase ^ 1
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+            nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+            nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload_mma(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    _wait_mbarrier(bars.mb_tmem_dealloc, cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _softmax_kv_body(
+    apply_mask: cutlass.Constexpr[bool],
+    sub_tile_id: cutlass.Constexpr[int],
+    kv_loop,
+    tmem_base,
+    sStats_raw,
+    bars,
+    tid_in_wg,
+    q_abs,
+    eff_seqlen_kv,
+    seqlen_q,
+    scale_log2,
+    total_max,
+    total_sum,
+    inplace_phase,
+    leader_cta_id,
+):
+    """Per-kv-iter softmax body with rotated S/P ownership.
+
+    Compile-time apply_mask picks the load+max strategy:
+    - False: tcgen05.ld.red.f32.max fast path (fused HW row-max).
+    - True: chunked load + apply_mask_chunk + sw row_max_reduction.
+    HW max can't observe NEG_INFINITY written after the load, so masked
+    iters fall back; 3-segment kv-loop keeps the fast path on interior iters.
+
+    Phase tracking for mb_bmm1_done / mb_stat_empty is hoisted to the caller
+    so ptxas places phases in URs (lowers to USYNCS.PHASECHK.TRANS64 instead
+    of per-thread SYNCS+NANOSLEEP).
+    """
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+    CHUNK = 64
+    P_COLS_PER_CHUNK = CHUNK // 4
+    N_CHUNKS = CFG.N_BMM2_CHUNKS
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+    RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+    # tcgen05.ld/st auto-derives row from warp_id; address needs col only.
+    s_addr_base = tmem_base + cutlass.Int32(tmem_S_off)
+    p_addr_base = tmem_base + cutlass.Int32(tmem_P_off)
+    stats_base = cutlass.Int32(sub_tile_id * 2 * CFG.TILE_M)
+
+    # const_expr wrap — without it MLIR cf.if NameErrors reg_S_vec post-branch.
+    if cutlass.const_expr(apply_mask):
+        # Comprehensions (not for+append) so the tracer sees fully-formed lists.
+        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
+                num=CHUNK,
+            )
+            for c in range(N_CHUNKS)
+        ]
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        chunks_S = [
+            apply_mask_chunk(
+                raw_chunks[c],
+                q_abs - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                cutlass.Int32(0),
+                eff_seqlen_kv - (kv_col_base + cutlass.Int32(c * CHUNK)),
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                N=CHUNK,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+            )
+            for c in range(N_CHUNKS)
+        ]
+        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
+        reg_S_vec = vec_concat(chunks_S)
+        current_max_unscaled = chunks_max[0]
+        for m in chunks_max[1:]:
+            current_max_unscaled = cute.math.max(current_max_unscaled, m)
+    else:
+        # Use short TMEM score loads on the unmasked steady-state path, then
+        # reduce one full row so the max tree can span all four chunks.
+        UNMASKED_CHUNK = 32
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * UNMASKED_CHUNK), cutlass.Float32),
+                num=UNMASKED_CHUNK,
+            )
+            for c in range(CFG.TILE_N // UNMASKED_CHUNK)
+        ]
+        reg_S_vec = vec_concat(raw_chunks)
+        current_max_unscaled = row_max_reduction(reg_S_vec)
+
+    # size= explicit — Vector.shape[0] is MLIR-typed after vec_concat.
+    reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+    current_max = current_max_unscaled * scale_log2
+
+    # The peer P store may now reuse this S region.  Publish ownership only
+    # after every score load has reached registers.
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+    bars.mb_s_empty[sub_tile_id].arrive()
+    bars.mb_s_consumed[sub_tile_id].arrive()
+
+    # cfence pins ptxas scheduler from hoisting stat-store across the wg sync.
+    if sub_tile_id == 1:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    # Online softmax with RESCALE_THRESHOLD skip.
+    old_total_max = total_max
+    is_first = total_max == NEG_INF
+    update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    exp_input = cutlass.Float32(
+        arith.select(
+            is_first.ir_value(),
+            NEG_INF.ir_value(),
+            (old_total_max - total_max).ir_value(),
+        )
+    )
+    alpha = _exp2_emulated_scalar(exp_input)
+    new_total_max = total_max
+
+    sStats_raw.subview(stats_base + tid_in_wg).store(alpha)
+    bars.mb_stat_full[sub_tile_id].arrive()
+
+    # Manual unroll — tracer intercepts range_constexpr in ways that break
+    # slice.indices() inside RegTile[]; N_CHUNKS ∈ {1,2} so explicit is cleaner.
+    reg_S = reg_S * scale_log2 - new_total_max
+
+    chunk_S_0 = reg_S[0:CHUNK].vec
+    chunk_P_0 = _exp2_mixed_conservative(chunk_S_0)
+    # Hoist chunk-0 sum before cast to overlap with cast's FFMA chain.
+    hoisted_sum = row_reduction_pair(chunk_P_0)
+    chunk_P_0_fp8 = _pack_fp8_vec(chunk_P_0)
+
+    # P0[j] waits for S1[j]; P1[j] waits for S0[j+1].  WG1 discards the
+    # S0[j] event at the start of each persistent tile to create that shift.
+    _wait_mbarrier(bars.mb_s_consumed[1 - sub_tile_id], inplace_phase)
+    inplace_phase = inplace_phase ^ cutlass.Int32(1)
+    nvvm.tcgen05_st(
+        "32x32b",
+        nvvm.make_tmem_ptr(p_addr_base, cutlass.Float32),
+        chunk_P_0_fp8,
+    )
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    deferred_P_1 = None
+    deferred_sum_1 = None
+    if cutlass.const_expr(N_CHUNKS == 2):
+        chunk_S_1 = reg_S[CHUNK : 2 * CHUNK].vec
+        cute.arch.inline_ptx('.pragma "set knob SchedResBusyXU64=1";')
+        deferred_P_1 = _exp2_mixed_late(chunk_S_1)
+        deferred_sum_1 = row_reduction_pair(deferred_P_1)
+        chunk_P_1_fp8 = _pack_fp8_vec(deferred_P_1)
+        nvvm.tcgen05_st(
+            "32x32b",
+            nvvm.make_tmem_ptr(
+                p_addr_base + cutlass.Int32(P_COLS_PER_CHUNK),
+                cutlass.Float32,
+            ),
+            chunk_P_1_fp8,
+        )
+        if sub_tile_id == 0:
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+        cute.arch.inline_ptx('.pragma "reset knob SchedResBusyXU64=1";')
+        nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+        bars.mb_bmm2_ready[sub_tile_id * N_CHUNKS + 1].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    new_p_sum_pair = hoisted_sum
+    if cutlass.const_expr(N_CHUNKS == 2):
+        new_p_sum_pair = new_p_sum_pair + deferred_sum_1
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+    return total_max, total_sum, inplace_phase
+
+
+@cute.jit
+def _softmax_warp_group(
+    sub_tile_id: cutlass.Constexpr[int],
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    sQ,
+    sStats_raw,
+    bars,
+    sched,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Softmax warp group: online softmax per kv iter, one lane per S_acc row.
+
+    Tracks (total_max, total_sum) with RESCALE_THRESHOLD skip, publishes alpha
+    to corr, writes P at S_acc tail, fires bmm2_ready[sub][chunk].
+    """
+    # Wait on MMA's TMEM-publish bar BEFORE tmem_ptr_i32.load() — else stale base.
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base = tmem_ptr_i32.load()
+
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+
+    # Phase trackers persist (XOR) across tile boundaries.
+    bmm1_phase = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes
+    inplace_phase = cutlass.Int32(0)
+    # BOTH softmax wgs wait on mb_o_empty[0]; init phase=1, XOR after.
+    epilogue_state = cutlass.Int32(1)
+
+    # total_sum is Vector[Float32, 2] (even/odd partials) so per-iter update
+    # lowers to packed FMUL2+FADD2; folded to scalar once outside the kv loop.
+    total_max = NEG_INF
+    total_sum = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    q_super_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(0).load())
+    head_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(1).load())
+    batch_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(2).load())
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        _wait_mbarrier(bars.mb_o_empty[0], epilogue_state)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        total_max = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # Bootstrap stat_empty wait lifts wait off per-iter critical path so
+        # α publish + stat_full fire back-to-back.
+        _wait_mbarrier(bars.mb_stat_empty[sub_tile_id], stat_empty_phase)
+        stat_empty_phase = stat_empty_phase ^ 1
+        if cutlass.const_expr(sub_tile_id == 1):
+            # Discard S0[first] so P1[j] consumes the S0[j+1] ownership event.
+            _wait_mbarrier(bars.mb_s_consumed[0], inplace_phase)
+            inplace_phase = inplace_phase ^ cutlass.Int32(1)
+        # 3-segment kv loop: LEFT-masked | unmasked (fast HW max) | RIGHT-masked.
+        # MASK_NONE folds masked sub-loops out at trace time.
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                _wait_mbarrier(bars.mb_bmm1_done[sub_tile_id], bmm1_phase)
+                bmm1_phase = bmm1_phase ^ 1
+                total_max, total_sum, inplace_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_base,
+                    sStats_raw,
+                    bars,
+                    tid_in_wg,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    inplace_phase,
+                    leader_cta_id,
+                )
+                _wait_mbarrier(bars.mb_stat_empty[sub_tile_id], stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ 1
+        else:
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                _wait_mbarrier(bars.mb_bmm1_done[sub_tile_id], bmm1_phase)
+                bmm1_phase = bmm1_phase ^ 1
+                total_max, total_sum, inplace_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_base,
+                    sStats_raw,
+                    bars,
+                    tid_in_wg,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    inplace_phase,
+                    leader_cta_id,
+                )
+                _wait_mbarrier(bars.mb_stat_empty[sub_tile_id], stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ 1
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                _wait_mbarrier(bars.mb_bmm1_done[sub_tile_id], bmm1_phase)
+                bmm1_phase = bmm1_phase ^ 1
+                total_max, total_sum, inplace_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_base,
+                    sStats_raw,
+                    bars,
+                    tid_in_wg,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    inplace_phase,
+                    leader_cta_id,
+                )
+                _wait_mbarrier(bars.mb_stat_empty[sub_tile_id], stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ 1
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                _wait_mbarrier(bars.mb_bmm1_done[sub_tile_id], bmm1_phase)
+                bmm1_phase = bmm1_phase ^ 1
+                total_max, total_sum, inplace_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_base,
+                    sStats_raw,
+                    bars,
+                    tid_in_wg,
+                    q_abs,
+                    eff_seqlen_kv,
+                    seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    inplace_phase,
+                    leader_cta_id,
+                )
+                _wait_mbarrier(bars.mb_stat_empty[sub_tile_id], stat_empty_phase)
+                stat_empty_phase = stat_empty_phase ^ 1
+
+        if cutlass.const_expr(sub_tile_id == 0):
+            # No S0[last+1] exists; release P1[last] with one synthetic event.
+            bars.mb_s_consumed[0].arrive()
+
+        # End-of-kv: publish (total_max, total_sum_final) — corr does LSE.
+        total_sum_scalar = total_sum[0] + total_sum[1]
+        stats_base = cutlass.Int32(sub_tile_id * 2 * CFG.TILE_M)
+        sStats_raw.subview(stats_base + tid_in_wg).store(total_max)
+        sStats_raw.subview(stats_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).store(total_sum_scalar)
+        bars.mb_stat_full[sub_tile_id].arrive()
+
+        # make_warp_uniform keeps scheduler payload in URs across the back-edge.
+        wait(sched.mb_decoded.subview(sched_state.idx), sched_state.phase)
+        decoded_base = sched_state.idx * cutlass.Int32(8) + cutlass.Int32(4)
+        q_super_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base).load())
+        head_idx = cute.arch.make_warp_uniform(
+            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load()
+        )
+        batch_idx = cute.arch.make_warp_uniform(
+            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load()
+        )
+        is_valid_tile = cute.arch.make_warp_uniform(
+            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load()
+        )
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    sStats_raw,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+    o_scale_fused,
+    amax_s_tensor,
+    amax_o_tensor,
+):
+    """Correction warp group: 4 warps × 32 lanes = 128, one lane per O row.
+
+    Per-kv rescales O by α (skipped via all_alpha_one ballot).  Per-tile
+    epilogue normalizes O by 1/total_sum, casts to fp8, swizzled-stores to sO,
+    fires o_full.  Holds the P14 end-of-tile catch-up flip on bmm2_done_phase.
+    """
+    # Wait on MMA TMEM-publish bar BEFORE tmem_ptr_i32.load() — else stale base.
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    # O_CHUNK=16 keeps live range short — O_CHUNK=32 spilled correction-warp regs.
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    O_CHUNK_EPI = 64
+    N_CHUNKS_O_EPI = CFG.TILE_O // O_CHUNK_EPI
+    # D_BLOCK_SIZE must use O_SWZ_B not V_SWZ_B (under cga2 V may drop swizzle).
+    # Sized in BPE_O so it stays consistent with the BPE_O-derived O_SWZ_BYTES
+    # (these feed the FP8 store branch only; the BF16/FP16 branch is self-contained).
+    TMA_O_ITERS = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS
+    TMA_O_GRANU_ELEMS = CFG.TILE_M * D_BLOCK_SIZE
+
+    stat_full_phase = cutlass.Int32(0)
+    # bmm2_done starts at phase=0; iter 0 skipped — first wait at kv_loop=1.
+    bmm2_done_phase = cutlass.Int32(0)
+    o_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes
+
+    q_super_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(0).load())
+    head_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(1).load())
+    batch_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(2).load())
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        # Iter-0 skip: MMA's iter-0 BMM2 uses init_d=False so α-rescale is unneeded.
+        if bounds.right > bounds.left:
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                _wait_mbarrier(bars.mb_stat_full[qs], stat_full_phase)
+                bars.mb_stat_empty[qs].arrive()
+            stat_full_phase = stat_full_phase ^ 1
+        else:
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            tmem_base_iter = tmem_ptr_i32.load()
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+                _wait_mbarrier(bars.mb_stat_full[qs], stat_full_phase)
+                stats_base = cutlass.Int32(qs * 2 * CFG.TILE_M)
+                alpha = sStats_raw.subview(stats_base + tid_in_wg).load()
+
+                # all_alpha_one ballot: rescale skipped once softmax stops bumping max.
+                alpha_is_one = alpha == cutlass.Float32(1.0)
+                all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                bars.mb_stat_empty[qs].arrive()
+
+                _wait_mbarrier(bars.mb_bmm2_done[qs], bmm2_done_phase)
+
+                # Split O_CHUNK=16 into 2× O_HALF=8 LDTM/STTM issued back-to-back —
+                # distinct scoreboard slots overlap second LDTM with first's wait.
+                # vec_scale_pair emits mul_packed_f32x2 → SASS FMUL2.
+                O_HALF = O_CHUNK // 2
+                if ~all_alpha_one:
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr_a = tmem_base_iter + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_addr_b = tmem_base_iter + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK + O_HALF)
+                        o_a = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr_a, cutlass.Float32),
+                            num=O_HALF,
+                        )
+                        o_b = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr_b, cutlass.Float32),
+                            num=O_HALF,
+                        )
+                        s_a = vec_scale_pair(o_a, alpha, O_HALF)
+                        s_b = vec_scale_pair(o_b, alpha, O_HALF)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr_a, cutlass.Float32), s_a)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr_b, cutlass.Float32), s_b)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_full_phase = stat_full_phase ^ 1
+            bmm2_done_phase = bmm2_done_phase ^ 1
+
+        tmem_base_epi = tmem_ptr_i32.load()
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+            _wait_mbarrier(bars.mb_bmm2_done[qs], bmm2_done_phase)
+
+            # softmax fires stat_full once more after kv loop for (total_max, total_sum_final).
+            _wait_mbarrier(bars.mb_stat_full[qs], stat_full_phase)
+
+            stats_base = cutlass.Int32(qs * 2 * CFG.TILE_M)
+            total_max_scaled = sStats_raw.subview(stats_base + tid_in_wg).load()
+            total_sum = sStats_raw.subview(
+                stats_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg
+            ).load()
+
+            bars.mb_stat_empty[qs].arrive()
+            # Preserve the persistent-tile phase protocol used by the MMA
+            # prologue; stats now live in SMEM rather than the S accumulator.
+            bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
+            beta = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
+            lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
+            LN2 = cutlass.Float32(0.6931471805599453)
+            total_max_nat = total_max_scaled * LN2
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                new_max = cute.math.max(total_max_nat, sink_logit)
+                scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+                new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+                lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+                inv_sum = (scale * o_scale_fused) / new_sum
+                beta = inv_sum / o_scale_fused
+            else:
+                lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
+                # Safe inverse: avoid div by 0 on fully-masked rows.
+                beta = cute.arch.rcp_approx(
+                    cute.math.max(total_sum, cutlass.Float32(1e-30))
+                )
+                inv_sum = o_scale_fused * beta
+
+            # amax_s = max over valid rows of the softmax normalization (1/total_sum),
+            # o_scale_fused divided back out so it is the pure softmax-prob amax (cuDNN
+            # FP8 ref: `beta = 1/total_sum`). atomicrmw MAX has no fp variant, so — like
+            # the reference — reinterpret the (always-positive) float as int32 and MAX on
+            # the bits (IEEE754 positive floats are monotonic in their int encoding).
+            _amax_s_ptr = Pointer(amax_s_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+
+            # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: sequence-local row; LSE packed [1,QH,T] → [0, head, cu_q[b]+local].
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                _row_valid = q_row_global < _s_q_b
+                if _row_valid:
+                    if cutlass.const_expr(lse_tensor is not None):
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                _row_valid = q_row_global < seqlen_q
+                if _row_valid:
+                    if cutlass.const_expr(lse_tensor is not None):
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse_val
+
+            _amax_s_local = beta if _row_valid else cutlass.Float32(0.0)
+            _amax_s_warp = cute.arch.warp_redux_sync(_amax_s_local, "fmax")
+
+            # amax_o is defined over the fp32 pre-cast output.
+            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+            _amax_o_local = cutlass.Float32(0.0)
+
+            sO_sub_base = sO[qs].base
+
+            if cutlass.const_expr(CFG.DTYPE_O <= 1):
+                # FP8 output (DTYPE_O ∈ {0,1}): hand-rolled 16:4 fp8 pack +
+                # STS.128 — forces F2FP outputs into a register quad so STS.128
+                # needs no PRMT to gather them (vs the DSL store_swizzled which
+                # folds the swizzle XOR via byte-level PRMT).  Bit-identical to
+                # the DTYPE_O == DTYPE_QKV path.
+                _SWZ_BYTES_C = CFG.O_SWZ_BYTES
+                _SWZ_SHIFT_C = 3 - _O_SWZ_B
+                _SWZ_MASK_C = (1 << _O_SWZ_B) - 1
+                _SUBTILE_BYTES_C = CFG.TILE_M * _SWZ_BYTES_C
+                _FP8_TAG = "e4m3" if cutlass.const_expr(CFG.DTYPE_O == 0) else "e5m2"
+
+                row_base_bytes = tid_in_wg * cutlass.Int32(_SWZ_BYTES_C)
+                row_xor_field = ((tid_in_wg >> cutlass.Int32(_SWZ_SHIFT_C)) & cutlass.Int32(_SWZ_MASK_C)) << cutlass.Int32(4)
+
+                for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                    o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                    o_chunk = nvvm.tcgen05_ld(
+                        "32x32b",
+                        nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                        num=O_CHUNK,
+                    )
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                    o_scaled = o_chunk * inv_sum
+
+                    for _i in cutlass.range_constexpr(O_CHUNK):
+                        _e = o_scaled[_i]
+                        _amax_o_local = cute.math.max(_amax_o_local, cute.math.max(_e, -_e))
+
+                    # Plain range (not range_constexpr) — extraction at Python trace time.
+                    o_packed_v = fp32_to_fp8_pack(
+                        [o_scaled[i] for i in range(16)],
+                        dtype_tag=_FP8_TAG,
+                    )
+
+                    col_elems = chunk_idx * O_CHUNK
+                    block_idx = col_elems // D_BLOCK_SIZE
+                    col_in_block_bytes = (col_elems % D_BLOCK_SIZE) * CFG.BPE_O
+                    block_off_bytes = block_idx * _SUBTILE_BYTES_C
+
+                    swizzled_in_row = row_xor_field ^ cutlass.Int32(col_in_block_bytes)
+                    addr_off_bytes = cutlass.Int32(block_off_bytes) + row_base_bytes + swizzled_in_row
+
+                    # Re-type pointer to Int32 so 4-i32 store maps to one st.shared.v4.b32.
+                    fp8_ptr = sO_sub_base.subview(addr_off_bytes).data_ptr()
+                    i32_ptr = Pointer(fp8_ptr, dtype=cutlass.Int32)
+                    if chunk_idx == 0:
+                        _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
+                    i32_ptr.store(o_packed_v, alignment=16)
+            else:
+                # BF16 / FP16 output (DTYPE_O ∈ {2,3}): the 16:4 fp8 pack does
+                # not apply — cast fp32 → OUT_STORAGE_DTYPE and swizzled-store,
+                # matching the BPE_O-sized TMA-O box.  Mirrors the dsv4 d512 fp8
+                # generic epilogue (prefill_sdpa_d512_fp8.py).
+                O_EPI_BLOCK_SIZE = 64 // CFG.BPE_O  # 32 elems (half-out)
+                O_D_BLOCK = CFG.O_SWZ_BYTES // CFG.BPE_O  # TMA chunk elems
+                O_TMA_GRANU_ELEMS = CFG.TILE_M * O_D_BLOCK
+                o_addr0 = tmem_base_epi + cutlass.Int32(tmem_O_off)
+                o_addr1 = tmem_base_epi + cutlass.Int32(tmem_O_off + O_EPI_BLOCK_SIZE)
+                o_addr2 = tmem_base_epi + cutlass.Int32(tmem_O_off + 2 * O_EPI_BLOCK_SIZE)
+                o_addr3 = tmem_base_epi + cutlass.Int32(tmem_O_off + 3 * O_EPI_BLOCK_SIZE)
+
+                o_chunk0 = nvvm.tcgen05_ld(
+                    "32x32b", nvvm.make_tmem_ptr(o_addr0, cutlass.Float32), num=O_EPI_BLOCK_SIZE
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+
+                o_chunk1 = nvvm.tcgen05_ld(
+                    "32x32b", nvvm.make_tmem_ptr(o_addr1, cutlass.Float32), num=O_EPI_BLOCK_SIZE
+                )
+                o_scaled0 = o_chunk0 * inv_sum
+                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled0), ftz=True)
+                o_half0 = o_scaled0.to(OUT_STORAGE_DTYPE)
+                _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
+                sO_sub_base.subview(tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
+                    o_half0, alignment=64, swizzle=_O_SMEM_SWIZZLE
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+
+                o_chunk2 = nvvm.tcgen05_ld(
+                    "32x32b", nvvm.make_tmem_ptr(o_addr2, cutlass.Float32), num=O_EPI_BLOCK_SIZE
+                )
+                o_scaled1 = o_chunk1 * inv_sum
+                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled1), ftz=True)
+                o_half1 = o_scaled1.to(OUT_STORAGE_DTYPE)
+                sO_sub_base.subview(cutlass.Int32(O_EPI_BLOCK_SIZE) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
+                    o_half1, alignment=64, swizzle=_O_SMEM_SWIZZLE
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+
+                o_chunk3 = nvvm.tcgen05_ld(
+                    "32x32b", nvvm.make_tmem_ptr(o_addr3, cutlass.Float32), num=O_EPI_BLOCK_SIZE
+                )
+                o_scaled2 = o_chunk2 * inv_sum
+                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled2), ftz=True)
+                o_half2 = o_scaled2.to(OUT_STORAGE_DTYPE)
+                sO_sub_base.subview(cutlass.Int32(O_TMA_GRANU_ELEMS) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
+                    o_half2, alignment=64, swizzle=_O_SMEM_SWIZZLE
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+
+                o_scaled3 = o_chunk3 * inv_sum
+                o_half3 = o_scaled3.to(OUT_STORAGE_DTYPE)
+                sO_sub_base.subview(cutlass.Int32(O_TMA_GRANU_ELEMS + O_EPI_BLOCK_SIZE) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
+                    o_half3, alignment=64, swizzle=_O_SMEM_SWIZZLE
+                )
+
+            # fence_proxy needed before TMA reads SMEM written by stores above.
+            nvvm.fence_proxy("async.shared", space="cta")
+
+            bars.mb_o_full[qs].arrive()
+
+            if cutlass.const_expr(CFG.DTYPE_O > 1):
+                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled3), ftz=True)
+
+            if (tid_in_wg & cutlass.Int32(31)) == cutlass.Int32(0):
+                nvvm.atomicrmw(
+                    nvvm.AtomicOp.MAX,
+                    _amax_s_ptr,
+                    _amax_s_warp.bitcast(cutlass.Int32),
+                )
+
+            if _row_valid:
+                nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+        stat_full_phase = stat_full_phase ^ 1
+        o_empty_phase = o_empty_phase ^ 1
+        # P14 catch-up flip — bmm2_done_phase ^= 1 AFTER epilogue wait.
+        # n_kv=1 multi-wave deadlocks on the 2nd tile without this.
+        bmm2_done_phase = bmm2_done_phase ^ 1
+
+        wait(sched.mb_decoded.subview(sched_state.idx), sched_state.phase)
+        decoded_base = sched_state.idx * cutlass.Int32(8) + cutlass.Int32(4)
+        q_super_idx = sched.tile_id_smem.subview(decoded_base).load()
+        head_idx = sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load()
+        batch_idx = sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load()
+        is_valid_tile = sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load()
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    # tmem_dealloc fan-out: fire one arrive per lane; cga2 also DSMEM-arrives
+    # on the peer so peer's local mbar accumulates the full CGA count.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    o_scale_fused: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    amax_s_tensor: cute.Tensor,
+    amax_o_tensor: cute.Tensor,
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    # K box rows are per-CTA (TILE_N/CTA_MMA); O box inner must match O's swizzle, not V's.
+    # O box sized in BPE_O — O may be written at BF16/FP16 (DTYPE_O != DTYPE_QKV).
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    # Expose D192 as three contiguous chunks so one rank-5 K TMA covers a tile.
+    k_rank5_layout = cute.make_layout(
+        (
+            k_tensor.shape[0],
+            k_tensor.shape[2],
+            TMA_QK_ITERS,
+            k_tensor.shape[1],
+            TMA_QK_GRANU_ELEMS,
+        ),
+        stride=(
+            k_tensor.shape[1] * k_tensor.shape[2] * CFG.TILE_K,
+            CFG.TILE_K,
+            TMA_QK_GRANU_ELEMS,
+            k_tensor.shape[2] * CFG.TILE_K,
+            1,
+        ),
+    )
+    k_rank5_tensor = cute.make_tensor(k_tensor.iterator, k_rank5_layout)
+    qk_box_k = (1, 1, TMA_QK_ITERS, CFG.TILE_N // CFG.CTA_MMA, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_rank5_tensor,
+        box_dims=qk_box_k,
+        stride_order=(4, 3, 2, 1, 0),
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    # V TMA swizzle tracks per-CTA inner bytes.
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+
+    # Cluster-wide divisor mandatory: without it cga2 over-launches and OOB
+    # clusters collide with valid clusters' GMEM slots at all but smallest SQ.
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array, then launch the exact
+        # flat batch-outermost grid (n_thd_units host-computed); grid_x = units*CGA_M.
+        # Works at cga1 (CGA_M=1) and cga2.
+        # Use packed O's per-token element stride (QH * d_v), not TILE_O.
+        _build_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(o_tensor.stride[1]),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        lse_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+        o_scale_fused,
+        amax_s_tensor,
+        amax_o_tensor,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128, has_lse: bool = True) -> Callable:  # noqa: A001
+    """Compile with ALL dims concrete — pins TMA strides at compile time.
+
+    THD/varlen: q/k/v/o/lse PACKED with batch dim 1; ``b`` = logical batch.
+    ``has_lse=False`` specializes the LSE argument to ``None`` and removes
+    the Stats store while retaining the independent amax writes."""
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, CFG.TILE_K),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, CFG.TILE_K),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, CFG.TILE_O),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, CFG.TILE_O),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_lse = (
+        cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+        if has_lse
+        else None
+    )
+    # Always part of the ABI; unread when CFG.HAS_SINK == 0 (compile-time fold).
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Always part of the ABI; unread when CFG.SEQ_KV_LENS_PRESENT == 0.  THD
+    # overloads it as [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] (len 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot.
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # amax_s output (scalar): max softmax prob (1/total_sum) via atomicMax. Always
+    # part of the ABI; api pre-zeros it and reads it back (Amax_S output).
+    fake_amax_s = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_lse,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        fake_amax_s,
+        fake_amax_o,
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi --ptxas-options -uumn",
+    )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -67,7 +67,9 @@ TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
 from typing import NamedTuple
 
 from cudnn.frost.tile_dsl.barrier import (
+    MBarrier,
     PipelineState,
+    Producer,
     advance,
     arrive_expect_tx,
     cga_arrive,
@@ -203,13 +205,9 @@ def _fp32x4_to_fp8_word(v0, v1, v2, v3):
 
 
 def _pack_fp8_vec(vec):
-    words = [
-        _fp32x4_to_fp8_word(vec[i], vec[i + 1], vec[i + 2], vec[i + 3])
-        for i in range(0, int(vec.shape[0]), 4)
-    ]
-    return cutlass.Vector.from_elements(tuple(words), cutlass.Int32).bitcast(
-        STORAGE_DTYPE
-    )
+    words = [_fp32x4_to_fp8_word(vec[i], vec[i + 1], vec[i + 2], vec[i + 3]) for i in range(0, int(vec.shape[0]), 4)]
+    return cutlass.Vector.from_elements(tuple(words), cutlass.Int32).bitcast(STORAGE_DTYPE)
+
 
 # DTYPE_O is independent of DTYPE_QKV (mirrors C++ Cfg::DTYPE_O — defaults to
 # DTYPE_QKV but may be promoted to BF16/FP16 so a downstream consumer skips a
@@ -260,6 +258,7 @@ CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
 _sdpa_h = make_sdpa_helpers(
     CFG,
     lpt_q_tiles_in_cga_units=True,
+    grouped_lpt=True,
     lpt_head_group=PARAMS.lpt_head_group,
     lpt_q_tiles=PARAMS.lpt_q_tiles,
 )
@@ -281,6 +280,7 @@ _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 _sdpa_h_mma_runtime = make_sdpa_helpers(
     CFG,
     lpt_q_tiles_in_cga_units=True,
+    grouped_lpt=True,
     lpt_head_group=PARAMS.lpt_head_group,
 )
 _dispatch_decode_initial_mma = _sdpa_h_mma_runtime.dispatch_decode_initial
@@ -296,6 +296,31 @@ class _PredecodedSched(NamedTuple):
     bidx_init: object
     bidy_init: object
     bidz_init: object
+
+
+class _ScoreOwnershipBars(NamedTuple):
+    mb_s_empty: object
+    mb_s_consumed: object
+
+
+def _make_score_ownership_bars() -> _ScoreOwnershipBars:
+    def _alloc():
+        return cutlass.Array(cutlass.Int64, CFG.TILES_Q, alignment=16, space=cutlass.AddressSpace.smem)
+
+    return _ScoreOwnershipBars(
+        mb_s_empty=MBarrier(
+            _alloc(),
+            stages=CFG.TILES_Q,
+            init_count=CFG.SOFTMAX_LANES,
+            producer=Producer.THREAD,
+        ),
+        mb_s_consumed=MBarrier(
+            _alloc(),
+            stages=CFG.TILES_Q,
+            init_count=CFG.SOFTMAX_LANES,
+            producer=Producer.THREAD,
+        ),
+    )
 
 
 @cute.jit
@@ -330,12 +355,8 @@ def _scheduler_warp_loop_predecode(
         wait(sched.mb_scheduler.subview(state.idx), state.phase)
         payload_base = state.idx * cutlass.Int32(8)
         nxt_q = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base).load())
-        nxt_hb = cute.arch.make_warp_uniform(
-            sched.tile_id_smem.subview(payload_base + cutlass.Int32(1)).load()
-        )
-        nxt_v = cute.arch.make_warp_uniform(
-            sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load()
-        )
+        nxt_hb = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(1)).load())
+        nxt_v = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(payload_base + cutlass.Int32(2)).load())
         q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
             nxt_q,
             nxt_hb,
@@ -484,6 +505,7 @@ def _kernel(
     )
 
     bars = make_classic_bars(CFG)
+    score_bars = _make_score_ownership_bars()
 
     tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
 
@@ -527,8 +549,8 @@ def _kernel(
                 bars.mb_q_empty[qs].init()
                 bars.mb_bmm1_done[qs].init()
                 bars.mb_bmm2_done[qs].init()
-                bars.mb_s_empty[qs].init()
-                bars.mb_s_consumed[qs].init()
+                score_bars.mb_s_empty[qs].init()
+                score_bars.mb_s_consumed[qs].init()
                 bars.mb_stat_full[qs].init()
                 bars.mb_stat_empty[qs].init()
                 bars.mb_stats_read[qs].init()
@@ -577,6 +599,7 @@ def _kernel(
             sQ=sQ,
             sStats_raw=sStats_raw,
             bars=bars,
+            score_bars=score_bars,
             sched=sched,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             n_q_supers=n_q_supers,
@@ -597,6 +620,7 @@ def _kernel(
             sQ=sQ,
             sStats_raw=sStats_raw,
             bars=bars,
+            score_bars=score_bars,
             sched=sched,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             n_q_supers=n_q_supers,
@@ -644,6 +668,7 @@ def _kernel(
                     sV=sV,
                     tmem_ptr_i32=tmem_ptr_i32,
                     bars=bars,
+                    score_bars=score_bars,
                     sched=sched,
                     seq_kv_lens_tensor=seq_kv_lens_tensor,
                     n_q_supers=n_q_supers,
@@ -663,6 +688,7 @@ def _kernel(
                 sV=sV,
                 tmem_ptr_i32=tmem_ptr_i32,
                 bars=bars,
+                score_bars=score_bars,
                 sched=sched,
                 seq_kv_lens_tensor=seq_kv_lens_tensor,
                 n_q_supers=n_q_supers,
@@ -915,15 +941,9 @@ def _tmaldg_warp_group(
         wait(sched.mb_decoded.subview(sched_state.idx), sched_state.phase)
         decoded_base = sched_state.idx * cutlass.Int32(8) + cutlass.Int32(4)
         q_super_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base).load())
-        head_idx = cute.arch.make_warp_uniform(
-            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load()
-        )
-        batch_idx = cute.arch.make_warp_uniform(
-            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load()
-        )
-        is_valid_tile = cute.arch.make_warp_uniform(
-            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load()
-        )
+        head_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load())
+        batch_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load())
+        is_valid_tile = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load())
         kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
         # q_row_base after decode drives ptxas R2UR (keeps nxt_q live before back-edge).
         q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
@@ -1065,6 +1085,7 @@ def _mma_warp_group(
     sV,
     tmem_ptr_i32,
     bars,
+    score_bars,
     sched,
     seq_kv_lens_tensor,
     n_q_supers,
@@ -1193,7 +1214,7 @@ def _mma_warp_group(
             _wait_mbarrier(bars.mb_q_full[0], q_full_phase)
             _wait_mbarrier(bars.mb_k_full[kv_state.idx], kv_state.phase)
             _wait_mbarrier(bars.mb_stats_read[0], stats_read_phase)
-            _wait_mbarrier(bars.mb_s_empty[0], s0_empty_phase)
+            _wait_mbarrier(score_bars.mb_s_empty[0], s0_empty_phase)
             s0_empty_phase = s0_empty_phase ^ cutlass.Int32(1)
             desc_K = sK[kv_state.idx].desc()
             mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), fence_code=True)
@@ -1202,7 +1223,7 @@ def _mma_warp_group(
 
             _wait_mbarrier(bars.mb_q_full[1], q_full_phase)
             _wait_mbarrier(bars.mb_stats_read[1], stats_read_phase)
-            _wait_mbarrier(bars.mb_s_empty[1], s1_empty_phase)
+            _wait_mbarrier(score_bars.mb_s_empty[1], s1_empty_phase)
             s1_empty_phase = s1_empty_phase ^ cutlass.Int32(1)
             mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), fence_code=True)
             elect_p = nvvm.elect_sync()
@@ -1219,7 +1240,7 @@ def _mma_warp_group(
                 # P1[i-1] is produced only after softmax0 consumes S0[i], so
                 # this lookahead cannot overwrite a live probability tile.
                 _wait_mbarrier(bars.mb_k_full[kv_state.idx], kv_state.phase)
-                _wait_mbarrier(bars.mb_s_empty[0], s0_empty_phase)
+                _wait_mbarrier(score_bars.mb_s_empty[0], s0_empty_phase)
                 s0_empty_phase = s0_empty_phase ^ cutlass.Int32(1)
                 desc_K = sK[kv_state.idx].desc()
                 mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), fence_code=True)
@@ -1250,7 +1271,7 @@ def _mma_warp_group(
                         )
                 bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
 
-                _wait_mbarrier(bars.mb_s_empty[1], s1_empty_phase)
+                _wait_mbarrier(score_bars.mb_s_empty[1], s1_empty_phase)
                 s1_empty_phase = s1_empty_phase ^ cutlass.Int32(1)
                 mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), fence_code=True)
                 bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
@@ -1374,6 +1395,7 @@ def _softmax_kv_body(
     tmem_base,
     sStats_raw,
     bars,
+    score_bars,
     tid_in_wg,
     q_abs,
     eff_seqlen_kv,
@@ -1466,8 +1488,8 @@ def _softmax_kv_body(
     # The peer P store may now reuse this S region.  Publish ownership only
     # after every score load has reached registers.
     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-    bars.mb_s_empty[sub_tile_id].arrive()
-    bars.mb_s_consumed[sub_tile_id].arrive()
+    score_bars.mb_s_empty[sub_tile_id].arrive()
+    score_bars.mb_s_consumed[sub_tile_id].arrive()
 
     # cfence pins ptxas scheduler from hoisting stat-store across the wg sync.
     if sub_tile_id == 1:
@@ -1509,7 +1531,7 @@ def _softmax_kv_body(
 
     # P0[j] waits for S1[j]; P1[j] waits for S0[j+1].  WG1 discards the
     # S0[j] event at the start of each persistent tile to create that shift.
-    _wait_mbarrier(bars.mb_s_consumed[1 - sub_tile_id], inplace_phase)
+    _wait_mbarrier(score_bars.mb_s_consumed[1 - sub_tile_id], inplace_phase)
     inplace_phase = inplace_phase ^ cutlass.Int32(1)
     nvvm.tcgen05_st(
         "32x32b",
@@ -1560,6 +1582,7 @@ def _softmax_warp_group(
     sQ,
     sStats_raw,
     bars,
+    score_bars,
     sched,
     seq_kv_lens_tensor,
     n_q_supers,
@@ -1625,7 +1648,7 @@ def _softmax_warp_group(
         stat_empty_phase = stat_empty_phase ^ 1
         if cutlass.const_expr(sub_tile_id == 1):
             # Discard S0[first] so P1[j] consumes the S0[j+1] ownership event.
-            _wait_mbarrier(bars.mb_s_consumed[0], inplace_phase)
+            _wait_mbarrier(score_bars.mb_s_consumed[0], inplace_phase)
             inplace_phase = inplace_phase ^ cutlass.Int32(1)
         # 3-segment kv loop: LEFT-masked | unmasked (fast HW max) | RIGHT-masked.
         # MASK_NONE folds masked sub-loops out at trace time.
@@ -1640,6 +1663,7 @@ def _softmax_warp_group(
                     tmem_base,
                     sStats_raw,
                     bars,
+                    score_bars,
                     tid_in_wg,
                     q_abs,
                     eff_seqlen_kv,
@@ -1663,6 +1687,7 @@ def _softmax_warp_group(
                     tmem_base,
                     sStats_raw,
                     bars,
+                    score_bars,
                     tid_in_wg,
                     q_abs,
                     eff_seqlen_kv,
@@ -1685,6 +1710,7 @@ def _softmax_warp_group(
                     tmem_base,
                     sStats_raw,
                     bars,
+                    score_bars,
                     tid_in_wg,
                     q_abs,
                     eff_seqlen_kv,
@@ -1707,6 +1733,7 @@ def _softmax_warp_group(
                     tmem_base,
                     sStats_raw,
                     bars,
+                    score_bars,
                     tid_in_wg,
                     q_abs,
                     eff_seqlen_kv,
@@ -1722,7 +1749,7 @@ def _softmax_warp_group(
 
         if cutlass.const_expr(sub_tile_id == 0):
             # No S0[last+1] exists; release P1[last] with one synthetic event.
-            bars.mb_s_consumed[0].arrive()
+            score_bars.mb_s_consumed[0].arrive()
 
         # End-of-kv: publish (total_max, total_sum_final) — corr does LSE.
         total_sum_scalar = total_sum[0] + total_sum[1]
@@ -1735,15 +1762,9 @@ def _softmax_warp_group(
         wait(sched.mb_decoded.subview(sched_state.idx), sched_state.phase)
         decoded_base = sched_state.idx * cutlass.Int32(8) + cutlass.Int32(4)
         q_super_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base).load())
-        head_idx = cute.arch.make_warp_uniform(
-            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load()
-        )
-        batch_idx = cute.arch.make_warp_uniform(
-            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load()
-        )
-        is_valid_tile = cute.arch.make_warp_uniform(
-            sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load()
-        )
+        head_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load())
+        batch_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load())
+        is_valid_tile = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load())
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
@@ -1880,9 +1901,7 @@ def _correction_warp_group(
 
             stats_base = cutlass.Int32(qs * 2 * CFG.TILE_M)
             total_max_scaled = sStats_raw.subview(stats_base + tid_in_wg).load()
-            total_sum = sStats_raw.subview(
-                stats_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg
-            ).load()
+            total_sum = sStats_raw.subview(stats_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).load()
 
             bars.mb_stat_empty[qs].arrive()
             # Preserve the persistent-tile phase protocol used by the MMA
@@ -1906,9 +1925,7 @@ def _correction_warp_group(
             else:
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
                 # Safe inverse: avoid div by 0 on fully-masked rows.
-                beta = cute.arch.rcp_approx(
-                    cute.math.max(total_sum, cutlass.Float32(1e-30))
-                )
+                beta = cute.arch.rcp_approx(cute.math.max(total_sum, cutlass.Float32(1e-30)))
                 inv_sum = o_scale_fused * beta
 
             # amax_s = max over valid rows of the softmax normalization (1/total_sum),
@@ -2010,26 +2027,18 @@ def _correction_warp_group(
                 o_addr2 = tmem_base_epi + cutlass.Int32(tmem_O_off + 2 * O_EPI_BLOCK_SIZE)
                 o_addr3 = tmem_base_epi + cutlass.Int32(tmem_O_off + 3 * O_EPI_BLOCK_SIZE)
 
-                o_chunk0 = nvvm.tcgen05_ld(
-                    "32x32b", nvvm.make_tmem_ptr(o_addr0, cutlass.Float32), num=O_EPI_BLOCK_SIZE
-                )
+                o_chunk0 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr0, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
 
-                o_chunk1 = nvvm.tcgen05_ld(
-                    "32x32b", nvvm.make_tmem_ptr(o_addr1, cutlass.Float32), num=O_EPI_BLOCK_SIZE
-                )
+                o_chunk1 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr1, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
                 o_scaled0 = o_chunk0 * inv_sum
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled0), ftz=True)
                 o_half0 = o_scaled0.to(OUT_STORAGE_DTYPE)
                 _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
-                sO_sub_base.subview(tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
-                    o_half0, alignment=64, swizzle=_O_SMEM_SWIZZLE
-                )
+                sO_sub_base.subview(tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(o_half0, alignment=64, swizzle=_O_SMEM_SWIZZLE)
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
 
-                o_chunk2 = nvvm.tcgen05_ld(
-                    "32x32b", nvvm.make_tmem_ptr(o_addr2, cutlass.Float32), num=O_EPI_BLOCK_SIZE
-                )
+                o_chunk2 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr2, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
                 o_scaled1 = o_chunk1 * inv_sum
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled1), ftz=True)
                 o_half1 = o_scaled1.to(OUT_STORAGE_DTYPE)
@@ -2038,9 +2047,7 @@ def _correction_warp_group(
                 )
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
 
-                o_chunk3 = nvvm.tcgen05_ld(
-                    "32x32b", nvvm.make_tmem_ptr(o_addr3, cutlass.Float32), num=O_EPI_BLOCK_SIZE
-                )
+                o_chunk3 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr3, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
                 o_scaled2 = o_chunk2 * inv_sum
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled2), ftz=True)
                 o_half2 = o_scaled2.to(OUT_STORAGE_DTYPE)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -19,13 +19,9 @@ d_qk=192/d_v=128 while preserving the FP8-on-Blackwell K-path:
      ``CFG.TILE_K_HW_BMM2`` (→ 4 k-steps at TILE_K_HW=32).  Confirmed by the
      cuDNN f8 reference (UTCMMA_TILE_K=32, BMM_XMMAS_K=4, kind::f8f6f4).
 
-THD / varlen (``CFG.THD_VARLEN=1``) is supported (E4M3/E5M2) — FP8 is
-element-addressed (no block-scale SF), so it rides the same THD path as f16:
-packed ``[1,T,H,D]`` + ``cu_seqlens`` coord offset (both Q slabs under
-TILES_Q=2), per-batch O TMA-descriptor array (shared
-``kernels/dsl/common/sdpa/thd.py``), packed ``[1,QH,T]`` LSE.  Dense path
-byte-identical.  Public-API quantize→attention(layout="thd") glue is a
-follow-up (needs a THD-aware quantizer); drive via the kernel / the DSL backend.
+THD / varlen is not supported here: the legacy THD leg was removed by #622
+because it predates the device-built-metadata plus plan-time-envelope design.
+The adapter rejects FP8 THD, and ``CFG.THD_VARLEN=1`` fails at trace time.
 """
 
 import os
@@ -95,7 +91,7 @@ from cudnn.frost.tile_dsl.pointwise import (
 from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
 from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
 from cudnn.frost.tile_dsl.tma import tma_load_tile, tma_store_tile, tma_store_commit, tma_store_wait
-from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma
 from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
 from cudnn.frost.tile_dsl.mask import (
     apply_mask_chunk,
@@ -239,7 +235,6 @@ from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     make_classic_bars,
     compute_kv_loop_bounds,
-    decode_linear_tile_lpt,
     make_sdpa_helpers,
 )
 
@@ -283,12 +278,8 @@ def _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, scalar_seqlen_kv):
     return scalar_seqlen_kv
 
 
-# THD / varlen — shared helpers (FP8 element-addressed like f16, per-tensor
-# dequant scalars, no block-scale SF).  Gated by CFG.THD_VARLEN (folds out).
-# TILES_Q=2: q_seq_off applies to BOTH Q slabs + both O-store slabs.
-from cudnn.sdpa.fwd.kernels.thd_sm100 import build_o_descs_kernel as _build_o_descs_kernel, TENSOR_MAP_QWORDS
-
-_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+# Flat-grid decode dispatch + seq-offset helper from the shared factory. The
+# latter folds to dense identity because the legacy THD leg is unsupported.
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
@@ -438,7 +429,6 @@ def _kernel(
     lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
-    o_desc_words: cute.Tensor,
     seqlen_q: cutlass.Int32,
     seqlen_kv: cutlass.Int32,
     n_q_supers: cutlass.Int32,
@@ -447,6 +437,10 @@ def _kernel(
     qh_per_kh: cutlass.Int32,
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
 ) -> None:
 
@@ -603,6 +597,16 @@ def _kernel(
     tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
     is_leader = cta_in_pair == cutlass.Int32(0)
 
+    # Keep quantization scales on device. The adapter supplies the attention
+    # scale in log2 units and a unit output scale; fold Q/K and V/O factors in
+    # here without host readback.
+    _dsc_q = cutlass.Float32(cutlass.make_array_view(descale_q_t)[0])
+    _dsc_k = cutlass.Float32(cutlass.make_array_view(descale_k_t)[0])
+    _dsc_v = cutlass.Float32(cutlass.make_array_view(descale_v_t)[0])
+    _scl_o = cutlass.Float32(cutlass.make_array_view(scale_o_t)[0])
+    scale_softmax_log2 = scale_softmax_log2 * _dsc_q * _dsc_k
+    o_scale_fused = o_scale_fused * _dsc_v * _scl_o
+
     if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
         nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
         _softmax_warp_group(
@@ -751,7 +755,6 @@ def _kernel(
             n_batch=n_batch,
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
-            o_desc_words=o_desc_words,
         )
 
     else:  # warp_idx == CFG.SCHED_WARP_ID
@@ -995,7 +998,6 @@ def _tmastg_warp_group(
     n_batch,
     cta_in_pair,
     seq_kv_lens_tensor,
-    o_desc_words,
 ):
     """Persistent O-store warp; tiles claimed via scheduler's try_cancel.async."""
     o_full_phase = cutlass.Int32(0)
@@ -1017,18 +1019,10 @@ def _tmastg_warp_group(
             _wait_mbarrier(bars.mb_o_full[qs], o_full_phase)
 
             # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: store each Q slab through this batch's pre-built descriptor
-                # (seq extent = S_q_b → box past S_q_b OOB-clipped).  q_row coord
-                # sequence-local; batch → 0.  Both slabs share one descriptor.
-                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
-                tma_store_tile(sO[qs], o_slice)
-            else:
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
-                )
+            tma_store_tile(
+                sO[qs],
+                tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+            )
 
             tma_store_commit()
             tma_store_wait(0)
@@ -1959,24 +1953,12 @@ def _correction_warp_group(
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: sequence-local row; LSE packed [1,QH,T] → [0, head, cu_q[b]+local].
-                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
-                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
-                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
-                _row_valid = q_row_global < _s_q_b
-                if _row_valid:
-                    if cutlass.const_expr(lse_tensor is not None):
-                        lse_arr = cutlass.make_array_view(lse_tensor)
-                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
-                        lse_row[_cu_q_b + q_row_global] = lse_val
-            else:
-                _row_valid = q_row_global < seqlen_q
-                if _row_valid:
-                    if cutlass.const_expr(lse_tensor is not None):
-                        lse_arr = cutlass.make_array_view(lse_tensor)
-                        lse_row = lse_arr[batch_idx, head_idx, :]
-                        lse_row[q_row_global] = lse_val
+            _row_valid = q_row_global < seqlen_q
+            if _row_valid:
+                if cutlass.const_expr(lse_tensor is not None):
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[batch_idx, head_idx, :]
+                    lse_row[q_row_global] = lse_val
 
             # amax_o is defined over the fp32 pre-cast output.
             _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
@@ -1994,7 +1976,6 @@ def _correction_warp_group(
                 _SWZ_SHIFT_C = 3 - _O_SWZ_B
                 _SWZ_MASK_C = (1 << _O_SWZ_B) - 1
                 _SUBTILE_BYTES_C = CFG.TILE_M * _SWZ_BYTES_C
-                _FP8_TAG = "e4m3" if cutlass.const_expr(CFG.DTYPE_O == 0) else "e5m2"
 
                 row_base_bytes = tid_in_wg * cutlass.Int32(_SWZ_BYTES_C)
                 row_xor_field = ((tid_in_wg >> cutlass.Int32(_SWZ_SHIFT_C)) & cutlass.Int32(_SWZ_MASK_C)) << cutlass.Int32(4)
@@ -2016,7 +1997,7 @@ def _correction_warp_group(
                     # Plain range (not range_constexpr) — extraction at Python trace time.
                     o_packed_v = fp32_to_fp8_pack(
                         [o_scaled[i] for i in range(16)],
-                        dtype_tag=_FP8_TAG,
+                        dtype=OUT_STORAGE_DTYPE,
                     )
 
                     col_elems = chunk_idx * O_CHUNK
@@ -2128,14 +2109,18 @@ def _host(
     lse_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
-    o_desc_words: cute.Tensor,
     problem_size: Tuple[int, int, int, int, int, int],
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
-    n_thd_units: cutlass.Int32,
+    descale_q_t: cute.Tensor,
+    descale_k_t: cute.Tensor,
+    descale_v_t: cute.Tensor,
+    scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        raise NotImplementedError("prefill_d192_d128_fp8_sm100: THD is unsupported; port the write_thd_meta envelope design first")
     B, QH, KH, SQ, SKV, _ = problem_size
 
     # K box rows are per-CTA (TILE_N/CTA_MMA); O box inner must match O's swizzle, not V's.
@@ -2204,23 +2189,7 @@ def _host(
     q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
-    if cutlass.const_expr(CFG.THD_VARLEN):
-        # THD: build the per-batch O descriptor array, then launch the exact
-        # flat batch-outermost grid (n_thd_units host-computed); grid_x = units*CGA_M.
-        # Works at cga1 (CGA_M=1) and cga2.
-        # Use packed O's per-token element stride (QH * d_v), not TILE_O.
-        _build_o_descs_kernel(
-            o_tensor,
-            tma_o_desc,
-            o_desc_words,
-            seq_kv_lens_tensor,
-            cutlass.Int32(QH),
-            cutlass.Int32(B),
-            cutlass.Int32(o_tensor.stride[1]),
-        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
-        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
-    else:
-        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
     _kernel(
         tma_q_desc,
         tma_k_desc,
@@ -2229,7 +2198,6 @@ def _host(
         lse_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
-        o_desc_words,
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
@@ -2238,6 +2206,10 @@ def _host(
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
         o_scale_fused,
+        descale_q_t,
+        descale_k_t,
+        descale_v_t,
+        scale_o_t,
         amax_o_tensor,
     ).launch(
         grid=grid_shape,
@@ -2251,10 +2223,9 @@ def _host(
 def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128, has_lse: bool = True) -> Callable:  # noqa: A001
     """Compile with ALL dims concrete — pins TMA strides at compile time.
 
-    THD/varlen: q/k/v/o/lse PACKED with batch dim 1; ``b`` = logical batch.
     ``has_lse=False`` specializes the LSE argument to ``None`` and removes
     the Stats store while retaining the independent amax writes."""
-    _fake_batch = 1 if CFG.THD_VARLEN else b
+    _fake_batch = b
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
         (_fake_batch, sq, qh, CFG.TILE_K),
@@ -2296,20 +2267,9 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         stride_order=(0,),
         assumed_align=16,
     )
-    # Always part of the ABI; unread when CFG.SEQ_KV_LENS_PRESENT == 0.  THD
-    # overloads it as [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] (len 3B+2).
-    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
     fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (_skv_len,),
-        stride_order=(0,),
-        assumed_align=16,
-    )
-    # Per-batch O TMA-descriptor array (16 int64 = 128 B each) + 1 pad slot.
-    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
-    fake_o_desc = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int64,
-        (_odesc_len,),
+        (b,),
         stride_order=(0,),
         assumed_align=16,
     )
@@ -2319,6 +2279,15 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         stride_order=(0,),
         assumed_align=16,
     )
+
+    def _fake_scale():
+        return cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (1,),
+            stride_order=(0,),
+            assumed_align=4,
+        )
+
     return cute.compile(
         _host,
         fake_q,
@@ -2328,11 +2297,13 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         fake_lse,
         fake_sinks,
         fake_seq_kv_lens,
-        fake_o_desc,
         (b, qh, kh, sq, skv, 0),
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),
-        cutlass.Int32(0),
+        _fake_scale(),
+        _fake_scale(),
+        _fake_scale(),
+        _fake_scale(),
         fake_amax_o,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi --ptxas-options -uumn",

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -265,7 +265,15 @@ _sdpa_h = make_sdpa_helpers(
 _decode_initial = _sdpa_h.decode_initial
 _decode_payload = _sdpa_h.decode_payload
 _bounds_for_tile = _sdpa_h.bounds_for_tile
-_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+
+
+@cute.jit
+def _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, scalar_seqlen_kv):
+    if cutlass.const_expr(CFG.SEQ_KV_LENS_PRESENT == 1):
+        arr = cutlass.make_array_view(seq_kv_lens_tensor)
+        return cutlass.Int32(arr[cutlass.Int32(batch_idx)])
+    return scalar_seqlen_kv
+
 
 # THD / varlen — shared helpers (FP8 element-addressed like f16, per-tensor
 # dequant scalars, no block-scale SF).  Gated by CFG.THD_VARLEN (folds out).
@@ -1926,6 +1934,22 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
                 # Safe inverse: avoid div by 0 on fully-masked rows.
                 beta = cute.arch.rcp_approx(cute.math.max(total_sum, cutlass.Float32(1e-30)))
+                if cutlass.const_expr((CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.BOTTOM_RIGHT):
+                    row_dead = total_sum <= cutlass.Float32(0.0)
+                    beta = cutlass.Float32(
+                        arith.select(
+                            row_dead.ir_value(),
+                            cutlass.Float32(0.0).ir_value(),
+                            beta.ir_value(),
+                        )
+                    )
+                    lse_val = cutlass.Float32(
+                        arith.select(
+                            row_dead.ir_value(),
+                            cutlass.Float32(float("-inf")).ir_value(),
+                            lse_val.ir_value(),
+                        )
+                    )
                 inv_sum = o_scale_fused * beta
 
             # amax_s = max over valid rows of the softmax normalization (1/total_sum),

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -447,7 +447,6 @@ def _kernel(
     qh_per_kh: cutlass.Int32,
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
-    amax_s_tensor: cute.Tensor,
     amax_o_tensor: cute.Tensor,
 ) -> None:
 
@@ -667,7 +666,6 @@ def _kernel(
             cta_in_pair=cta_in_pair,
             cta_id_x=cta_id_x,
             o_scale_fused=o_scale_fused,
-            amax_s_tensor=amax_s_tensor,
             amax_o_tensor=amax_o_tensor,
         )
 
@@ -1806,7 +1804,6 @@ def _correction_warp_group(
     cta_in_pair,
     cta_id_x,
     o_scale_fused,
-    amax_s_tensor,
     amax_o_tensor,
 ):
     """Correction warp group: 4 warps × 32 lanes = 128, one lane per O row.
@@ -1960,13 +1957,6 @@ def _correction_warp_group(
                     )
                 inv_sum = o_scale_fused * beta
 
-            # amax_s = max over valid rows of the softmax normalization (1/total_sum),
-            # o_scale_fused divided back out so it is the pure softmax-prob amax (cuDNN
-            # FP8 ref: `beta = 1/total_sum`). atomicrmw MAX has no fp variant, so — like
-            # the reference — reinterpret the (always-positive) float as int32 and MAX on
-            # the bits (IEEE754 positive floats are monotonic in their int encoding).
-            _amax_s_ptr = Pointer(amax_s_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
-
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
             if cutlass.const_expr(CFG.THD_VARLEN):
@@ -1987,9 +1977,6 @@ def _correction_warp_group(
                         lse_arr = cutlass.make_array_view(lse_tensor)
                         lse_row = lse_arr[batch_idx, head_idx, :]
                         lse_row[q_row_global] = lse_val
-
-            _amax_s_local = beta if _row_valid else cutlass.Float32(0.0)
-            _amax_s_warp = cute.arch.warp_redux_sync(_amax_s_local, "fmax")
 
             # amax_o is defined over the fp32 pre-cast output.
             _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
@@ -2102,13 +2089,6 @@ def _correction_warp_group(
             if cutlass.const_expr(CFG.DTYPE_O > 1):
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled3), ftz=True)
 
-            if (tid_in_wg & cutlass.Int32(31)) == cutlass.Int32(0):
-                nvvm.atomicrmw(
-                    nvvm.AtomicOp.MAX,
-                    _amax_s_ptr,
-                    _amax_s_warp.bitcast(cutlass.Int32),
-                )
-
             if _row_valid:
                 nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
 
@@ -2153,7 +2133,6 @@ def _host(
     scale_softmax_log2: cutlass.Float32,
     o_scale_fused: cutlass.Float32,
     n_thd_units: cutlass.Int32,
-    amax_s_tensor: cute.Tensor,
     amax_o_tensor: cute.Tensor,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
@@ -2259,7 +2238,6 @@ def _host(
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
         o_scale_fused,
-        amax_s_tensor,
         amax_o_tensor,
     ).launch(
         grid=grid_shape,
@@ -2335,14 +2313,6 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         stride_order=(0,),
         assumed_align=16,
     )
-    # amax_s output (scalar): max softmax prob (1/total_sum) via atomicMax. Always
-    # part of the ABI; api pre-zeros it and reads it back (Amax_S output).
-    fake_amax_s = cute.runtime.make_fake_compact_tensor(
-        cutlass.Float32,
-        (1,),
-        stride_order=(0,),
-        assumed_align=16,
-    )
     fake_amax_o = cute.runtime.make_fake_compact_tensor(
         cutlass.Float32,
         (1,),
@@ -2363,7 +2333,6 @@ def compile(b: int = 1, qh: int = 1, kh: int = 1, sq: int = 256, skv: int = 128,
         cutlass.Float32(0.0),
         cutlass.Float32(0.0),
         cutlass.Int32(0),
-        fake_amax_s,
         fake_amax_o,
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi --ptxas-options -uumn",

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -1225,7 +1225,7 @@ def _mma_warp_group(
             _wait_mbarrier(score_bars.mb_s_empty[0], s0_empty_phase)
             s0_empty_phase = s0_empty_phase ^ cutlass.Int32(1)
             desc_K = sK[kv_state.idx].desc()
-            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), fence_code=True)
+            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)))
             elect_p = nvvm.elect_sync()
             bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
 
@@ -1233,7 +1233,7 @@ def _mma_warp_group(
             _wait_mbarrier(bars.mb_stats_read[1], stats_read_phase)
             _wait_mbarrier(score_bars.mb_s_empty[1], s1_empty_phase)
             s1_empty_phase = s1_empty_phase ^ cutlass.Int32(1)
-            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), fence_code=True)
+            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)))
             elect_p = nvvm.elect_sync()
             bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
             bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
@@ -1251,7 +1251,7 @@ def _mma_warp_group(
                 _wait_mbarrier(score_bars.mb_s_empty[0], s0_empty_phase)
                 s0_empty_phase = s0_empty_phase ^ cutlass.Int32(1)
                 desc_K = sK[kv_state.idx].desc()
-                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), fence_code=True)
+                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)))
                 elect_p = nvvm.elect_sync()
                 bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
 
@@ -1262,7 +1262,7 @@ def _mma_warp_group(
                 _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
                 accum_b2 = is_not_first_bmm2
                 for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
-                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2, fence_code=True)
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2)
                     accum_b2 = cutlass.Boolean(True)
                 # Chunk 1 folds out at N_BMM2_CHUNKS=1 (full NUM_KPHASES_PV in chunk 0).
                 if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
@@ -1275,13 +1275,12 @@ def _mma_warp_group(
                             (tmem_raw.subview(LAYOUT.O0_OFF)),
                             NUM_KPHASES_PV_PER_CHUNK + local_k,
                             cutlass.Boolean(True),
-                            fence_code=True,
                         )
                 bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
 
                 _wait_mbarrier(score_bars.mb_s_empty[1], s1_empty_phase)
                 s1_empty_phase = s1_empty_phase ^ cutlass.Int32(1)
-                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), fence_code=True)
+                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)))
                 bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
                 bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
 
@@ -1289,7 +1288,7 @@ def _mma_warp_group(
                 desc_V = sV[old_state.idx].desc()
                 accum_b2 = is_not_first_bmm2
                 for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
-                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2, fence_code=True)
+                    mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2)
                     accum_b2 = cutlass.Boolean(True)
                 if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
                     _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
@@ -1301,7 +1300,6 @@ def _mma_warp_group(
                             (tmem_raw.subview(LAYOUT.O1_OFF)),
                             NUM_KPHASES_PV_PER_CHUNK + local_k,
                             cutlass.Boolean(True),
-                            fence_code=True,
                         )
                 elect_p = nvvm.elect_sync()
                 bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
@@ -1321,7 +1319,7 @@ def _mma_warp_group(
             _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
             accum_b2 = is_not_first_bmm2_epi
             for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
-                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2, fence_code=True)
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P0_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O0_OFF)), local_k, accum_b2)
                 accum_b2 = cutlass.Boolean(True)
             if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
                 _wait_mbarrier(bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
@@ -1333,7 +1331,6 @@ def _mma_warp_group(
                         (tmem_raw.subview(LAYOUT.O0_OFF)),
                         NUM_KPHASES_PV_PER_CHUNK + local_k,
                         cutlass.Boolean(True),
-                        fence_code=True,
                     )
             elect_p = nvvm.elect_sync()
             bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
@@ -1341,7 +1338,7 @@ def _mma_warp_group(
             _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0], bmm2_ready_phase)
             accum_b2 = is_not_first_bmm2_epi
             for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
-                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2, fence_code=True)
+                mma_ts_step(bmm2_desc, (tmem_raw.subview(LAYOUT.P1_OFF)), desc_V, (tmem_raw.subview(LAYOUT.O1_OFF)), local_k, accum_b2)
                 accum_b2 = cutlass.Boolean(True)
             if cutlass.const_expr(CFG.N_BMM2_CHUNKS == 2):
                 _wait_mbarrier(bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1], bmm2_ready_phase)
@@ -1353,7 +1350,6 @@ def _mma_warp_group(
                         (tmem_raw.subview(LAYOUT.O1_OFF)),
                         NUM_KPHASES_PV_PER_CHUNK + local_k,
                         cutlass.Boolean(True),
-                        fence_code=True,
                     )
             elect_p = nvvm.elect_sync()
             bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA, pred=elect_p)
@@ -1499,7 +1495,7 @@ def _softmax_kv_body(
     score_bars.mb_s_empty[sub_tile_id].arrive()
     score_bars.mb_s_consumed[sub_tile_id].arrive()
 
-    # cfence pins ptxas scheduler from hoisting stat-store across the wg sync.
+    # Synchronize both consumer warp groups before updating shared statistics.
     if sub_tile_id == 1:
         nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
@@ -63,6 +63,9 @@ TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
 TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
 TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+# Merging the masked softmax callsites cuts code size; no-mask keeps static
+# callsites because runtime TMEM offsets regress its compiler schedule.
+MERGE_SOFTMAX_WGS = CFG.MASK_FLAGS != 0
 
 # O TMA box params follow O's swizzle, not V's — required when V_SWZ_B != O_SWZ_B.
 # Sized in BPE_O — O may be written at BF16/FP16 when DTYPE_O != DTYPE_QKV.
@@ -594,10 +597,19 @@ def _kernel(
     sf_mcast_mask = cutlass.Int16(3) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
     is_leader = cta_in_pair == cutlass.Int32(0)
 
-    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+    softmax_first_end = (
+        CFG.CORR_WARP_BASE
+        if cutlass.const_expr(MERGE_SOFTMAX_WGS)
+        else CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS
+    )
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < softmax_first_end:
         nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        if cutlass.const_expr(MERGE_SOFTMAX_WGS):
+            sub_tile_id = (warp_idx - cutlass.Int32(CFG.SOFTMAX_WG0_BASE)) // cutlass.Int32(CFG.SOFTMAX_WG_WARPS)
+        else:
+            sub_tile_id = 0
         _softmax_warp_group(
-            sub_tile_id=0,
+            sub_tile_id=sub_tile_id,
             seqlen_q=seqlen_q,
             seqlen_kv=seqlen_kv,
             scale_log2=scale_softmax_log2,
@@ -615,7 +627,7 @@ def _kernel(
             cta_in_pair=cta_in_pair,
         )
 
-    elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+    elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.CORR_WARP_BASE:
         nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
         _softmax_warp_group(
             sub_tile_id=1,
@@ -1634,7 +1646,7 @@ def _mma_warp_group(
 @cute.jit
 def _softmax_kv_body(
     apply_mask: bool,
-    sub_tile_id: int,
+    sub_tile_id,
     kv_loop,
     tmem_base,
     sStats_raw,
@@ -1659,8 +1671,12 @@ def _softmax_kv_body(
     split into LEFT/unmasked/RIGHT segments to keep the fast path on
     every interior iter.
     """
-    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
-    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+    if cutlass.const_expr(MERGE_SOFTMAX_WGS):
+        tmem_S_off = cutlass.Int32(LAYOUT.S0_OFF) + sub_tile_id * cutlass.Int32(LAYOUT.S1_OFF - LAYOUT.S0_OFF)
+        tmem_P_off = cutlass.Int32(LAYOUT.P0_OFF) + sub_tile_id * cutlass.Int32(LAYOUT.P1_OFF - LAYOUT.P0_OFF)
+    else:
+        tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+        tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
     CHUNK = 64
     P_COLS_PER_CHUNK = CHUNK // 4
     NEG_INF = cutlass.Float32(-3.4028235e38)
@@ -1814,8 +1830,9 @@ def _softmax_kv_body(
     reg_S_a = reg_S_a * scale_log2 - new_total_max
     reg_S_b = reg_S_b * scale_log2 - new_total_max
     reg_P_a = _exp2_chunk0_mask_aware(reg_S_a, apply_mask)
-    sum_a_pair = row_reduction_pair_64(reg_P_a)
+    # Expose conversion and row reduction as independent chains before the P store.
     p_a_fp16 = reg_P_a.to(STORAGE_DTYPE)
+    sum_a_pair = row_reduction_pair_64(reg_P_a)
     nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_a, cutlass.Float32), p_a_fp16)
     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
     bars.mb_bmm2_ready[sub_tile_id * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
@@ -1842,7 +1859,7 @@ def _softmax_kv_body(
 
 @cute.jit
 def _softmax_warp_group(
-    sub_tile_id: int,
+    sub_tile_id,
     seqlen_q,
     seqlen_kv,
     scale_log2: cutlass.Float32,
@@ -1864,8 +1881,12 @@ def _softmax_warp_group(
     nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
     tmem_base = tmem_ptr_i32.load()
 
-    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
-    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+    if cutlass.const_expr(MERGE_SOFTMAX_WGS):
+        tmem_S_off = cutlass.Int32(LAYOUT.S0_OFF) + sub_tile_id * cutlass.Int32(LAYOUT.S1_OFF - LAYOUT.S0_OFF)
+        tmem_P_off = cutlass.Int32(LAYOUT.P0_OFF) + sub_tile_id * cutlass.Int32(LAYOUT.P1_OFF - LAYOUT.P0_OFF)
+    else:
+        tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+        tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
 
     NEG_INF = cutlass.Float32(-3.4028235e38)
 
@@ -1901,8 +1922,14 @@ def _softmax_warp_group(
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
     bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
-    softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
-    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
+    if cutlass.const_expr(MERGE_SOFTMAX_WGS):
+        softmax_wg_base = cutlass.Int32(CFG.SOFTMAX_WG0_BASE) + sub_tile_id * cutlass.Int32(
+            CFG.SOFTMAX_WG1_BASE - CFG.SOFTMAX_WG0_BASE
+        )
+        tid_in_wg = cute.arch.thread_idx()[0] - softmax_wg_base * cutlass.Int32(32)
+    else:
+        softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
+        tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
 
     while is_valid_tile > cutlass.Int32(0):
         if cutlass.const_expr(not (CFG.MASK_FLAGS & MASK_CAUSAL)):

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
@@ -1,0 +1,2601 @@
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+"""DSL prefill SDPA kernel - block-scale MXFP8, d_qk=192/d_v=128, SM100.
+
+Classic 2-sub-tile pipeline (TILES_Q=2, two softmax warpgroups, four correction
+warps, persistent try_cancel scheduler); combines the production SM100 MXFP8
+scale-factor pipeline with the native D192/D128 geometry:
+plus the MXFP8 TMEM scale-factor (SF) relayout:
+  1. **cga2-only, STAGES_KV=4** (config).
+  2. **512-col TMEM.**  S(256)+O(256) fill the cap, so the SF operands cannot
+     park above 512; instead they are reloaded every BMM1 into transiently-free
+     S_acc scratch — prologue BMM1 uses the O region (O not yet accumulated),
+     steady-state BMM1 ping-pongs into the *other* sub-tile's S_acc lower region,
+     gated on that tile's softmax-LDTM-done (``mb_softmax_ldtm_done``).  BMM2
+     SF_P/V ride the existing bmm2_ready wait.  Alpha and final softmax stats
+     use a dedicated shared-memory array, so they do not constrain S_acc reuse.
+  3. **MXFP8 MMA uses the Blackwell K=32 QMMA path** — ``_MXFP8_K_DIM=0`` +
+     TILE_K_HW=32.
+  4. **Row-max**: cc10.0 uses a manual tcgen05_ld + software reduction; cc10.3+
+     (FUSED_LDTM_STAT, set from the device capability) fuses load + row-max into
+     one tcgen05.ld.red.f32.max for unmasked tiles.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Callable, Optional, Tuple
+
+from cutlass.experimental import primitives as nvvm
+from cutlass.experimental.primitives import vote_sync, VoteSync
+from cutlass.experimental.cuda import tensor_map as tmap
+from cutlass._mlir.dialects import arith
+
+import cutlass
+from cutlass.base_dsl.typing import Pointer
+from cutlass.experimental import primitives as prims
+import cutlass.cute as cute
+import cuda.bindings.driver as _cuda_driver  # noqa: F401
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams, make_cfg_d192
+
+# The template loader (api_dsl._load_kernel_module) injects FROST_TEMPLATE_PARAMS
+# as a module global before this body runs; the default keeps direct import usable.
+PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams())
+CFG, _TMA = make_cfg_d192(PARAMS)
+Cfg = type(CFG)
+# LDTM.STAT — fused `tcgen05.ld.red.f32.max` (S_acc load + row-max in one op) — is a
+# cc10.3+ capability; cc10.0 lacks it and uses the manual tcgen05_ld + software
+# row_max_reduction_64 (default 0). api_dsl sets this from the device capability at
+# compile time; a distinct value yields a distinct kernel specialization (cache key).
+FUSED_LDTM_STAT = int(PARAMS.fused_ldtm_stat)
+# MXFP8 THD / varlen is supported via a packed, per-sequence-TILE-padded SF
+# layout (the shared MXFP8 quantizer writes SF tiles at cu_sf[b] + local_tile;
+# this kernel reads them with the matching tile base from _thd_sf_tile_bases).
+# Q/K/V data ride the f16/fp8 packed [1,T,H,D] + cu_seqlens coord path; the SF
+# tensors use B=1 + total_*_sf_tiles descriptors.  Gated on CFG.THD_VARLEN so
+# the dense [B,S,H,D] path stays byte-identical.
+TMA_QK_ITERS = _TMA.QK_ITERS
+TMA_VO_ITERS = _TMA.VO_ITERS
+TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
+TMA_VO_GRANU_ELEMS = _TMA.VO_GRANU_ELEMS
+
+# O TMA box params follow O's swizzle, not V's — required when V_SWZ_B != O_SWZ_B.
+# Sized in BPE_O — O may be written at BF16/FP16 when DTYPE_O != DTYPE_QKV.
+TMA_O_GRANU_ELEMS_HOST = CFG.O_SWZ_BYTES // CFG.BPE_O
+TMA_O_ITERS_HOST = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+
+from cudnn.frost.tile_dsl.barrier import (
+    PipelineState,
+    advance,
+    cga_arrive,
+    cga_wait,
+    # `wait` (free fn) — still used for sched.mb_* + mb_softmax_ldtm (not in Bars).
+    wait,
+    arrive_on_leader,
+)
+from cudnn.frost.tile_dsl.scheduler import (
+    Sched,
+    scheduler_warp_loop,
+    read_tile_id_arrive,
+    SCHED_NATURAL,
+    SCHED_LPT,
+    SCHED_LPT_L2,
+)
+from cudnn.frost.tile_dsl.pointwise import (
+    # cc10.0: the MASK_NONE fast path uses manual tcgen05_ld + row_max_reduction_64.
+    # cc10.3+ (FUSED_LDTM_STAT) fuses load + row-max into tmem_load_max_reduction_x64.
+    row_reduction_pair_64,
+    row_max_reduction_64,
+    tmem_load_max_reduction_x64,
+    vec_scale_pair,
+)
+from cudnn.frost.tile_dsl.mma import mma_ss, mma_ts_step
+from cudnn.frost.tile_dsl.tma import (
+    tma_load_tile,
+    tma_store_tile,
+    tma_store_commit,
+    tma_store_wait,
+    bulk_copy,
+    bulk_copy_multicast,
+)
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, GmemTileLinear, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
+from cudnn.frost.tile_dsl.mask import (
+    apply_mask_chunk,
+    MASK_NONE,
+    MASK_PADDED,
+    MASK_CAUSAL,
+    MASK_SWA,
+)
+from cudnn.block_sparse_attention.csrc.utils.kernel_utils import ex2_emulation_2
+
+
+def _max_abs_reduction(vec):
+    maxima = [vec[i] for i in range(int(vec.shape[0]))]
+    minima = list(maxima)
+    while len(maxima) > 1:
+        next_maxima = []
+        next_minima = []
+        for i in range(0, len(maxima), 4):
+            max_group = maxima[i : i + 4]
+            min_group = minima[i : i + 4]
+            max_acc = max_group[0]
+            min_acc = min_group[0]
+            for value in max_group[1:]:
+                max_acc = cute.math.max(max_acc, value, ftz=True)
+            for value in min_group[1:]:
+                min_acc = cute.math.min(min_acc, value, ftz=True)
+            next_maxima.append(max_acc)
+            next_minima.append(min_acc)
+        maxima = next_maxima
+        minima = next_minima
+    return cute.math.max(maxima[0], -minima[0], ftz=True)
+
+
+def _exp2_chunk0_mask_aware(vec, apply_mask):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        if CFG.DTYPE_QKV == 1 and apply_mask:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        elif CFG.DTYPE_QKV == 1 and i < 32:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=2)
+        elif CFG.DTYPE_QKV == 0 and i < 32 and i % 10 < 4:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1])
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+def _exp2_mixed_late(vec):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        if i >= 48:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1], poly_degree=2)
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
+def _exp2_emulated_scalar(x):
+    value, _ = ex2_emulation_2(x, x, poly_degree=2)
+    return value
+
+
+# MXFP8 storage dtype dispatch — keyed off CFG.DTYPE_QKV (0=E4M3, 1=E5M2).
+if CFG.DTYPE_QKV == 0:
+    STORAGE_DTYPE = cutlass.Float8E4M3FN
+    P_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_QKV == 1:
+    STORAGE_DTYPE = cutlass.Float8E5M2
+    P_STORAGE_DTYPE = cutlass.Float8E5M2
+else:
+    raise ValueError(f"prefill_sdpa_mxfp8: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 0=E4M3 or 1=E5M2)")
+
+MMA_KIND = nvvm.MMABlockScaleKind.MXF8F6F4
+SCALE_VEC_SIZE = nvvm.Tcgen05MMAScaleVecSize.BLOCK32
+
+# SM100/Blackwell MXFP8: k_dim=0 = K=32 QMMA path (NOT the k_dim=1 K=64
+# fast path, which is silently WRONG on Blackwell — cuda-kernels rules §16).
+# BMM1 = TILE_K/32 k-steps, BMM2 = TILE_N/32 (both derive from _MXFP8_TILE_K_HW).
+_MXFP8_K_DIM = 0
+_MXFP8_TILE_K_HW = 32 if _MXFP8_K_DIM == 0 else 64
+
+# DTYPE_O is independent of DTYPE_QKV — MXFP8 input may write BF16/FP16 O so a
+# downstream consumer skips a dequant.  BPE_O ∈ {1, 2}; the epilogue already
+# casts via .to(OUT_STORAGE_DTYPE) + store_swizzled (dtype-generic), so only the
+# O-buffer / TMA-box sizing needs to follow BPE_O.
+if CFG.DTYPE_O == 0:
+    OUT_STORAGE_DTYPE = cutlass.Float8E4M3FN
+elif CFG.DTYPE_O == 1:
+    OUT_STORAGE_DTYPE = cutlass.Float8E5M2
+elif CFG.DTYPE_O == 2:
+    OUT_STORAGE_DTYPE = cutlass.BFloat16
+elif CFG.DTYPE_O == 3:
+    OUT_STORAGE_DTYPE = cutlass.Float16
+else:
+    raise ValueError(f"prefill_sdpa_mxfp8: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+
+
+# MXFP8 SF constants — E8M0 scale factor, 32 elems share one SF.
+BITS_PER_SF_ELEMENT = 8
+BLOCK_SCALE_BLOCK_SIZE = 32
+SF_BLOCK_DIM_NON_K = 128
+SF_BLOCK_DIM_K = 4
+SF_SWIZZLED_BLOCK_DIM_K = 16
+SF_BYTES_PER_BLOCK = SF_BLOCK_DIM_NON_K * SF_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 8
+
+
+def _round_up(a: int, b: int) -> int:
+    return (a + b - 1) // b * b
+
+
+# SF_NUM_BLOCKS_K: 2 (TILE_K=192 rounds to 256 in the SF layout).
+SF_NUM_BLOCKS_M = CFG.TILE_M // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_N = CFG.TILE_N // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_K = _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K
+
+SF_REGISTERS_PER_BLOCK = SF_SWIZZLED_BLOCK_DIM_K * BITS_PER_SF_ELEMENT // 32
+
+SF_TMEM_COLS_Q = SF_NUM_BLOCKS_M * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK
+SF_TMEM_COLS_K = SF_NUM_BLOCKS_N * SF_NUM_BLOCKS_K * SF_REGISTERS_PER_BLOCK
+
+SF_SMEM_SIZE_Q = CFG.TILE_M * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE
+SF_SMEM_SIZE_K = CFG.TILE_N * _round_up(CFG.TILE_K, 128) // BLOCK_SCALE_BLOCK_SIZE
+
+# BMM2 SF: P is constant 1.0 (softmax doesn't scale P); V comes from GMEM.
+SF_NUM_BLOCKS_P = CFG.TILE_M // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_V = _round_up(CFG.TILE_O, 128) // SF_BLOCK_DIM_NON_K
+SF_NUM_BLOCKS_K_BMM2 = CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE // SF_BLOCK_DIM_K
+SF_TMEM_COLS_P = SF_NUM_BLOCKS_P * SF_NUM_BLOCKS_K_BMM2 * SF_REGISTERS_PER_BLOCK
+SF_SMEM_SIZE_P = _round_up(CFG.TILE_M, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE
+SF_SMEM_SIZE_V = _round_up(CFG.TILE_O, 128) * CFG.TILE_N // BLOCK_SCALE_BLOCK_SIZE
+
+# 0x7F = E8M0 representation of 2^0 = 1.0.
+SF_CONST_VALUE = 0x7F
+
+
+from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    Bars,
+    KvLoopBounds,
+    make_classic_bars,
+    compute_kv_loop_bounds,
+    decode_linear_tile_lpt,
+    make_sdpa_helpers,
+    assert_tile_n_supported,
+)
+
+assert_tile_n_supported(CFG)
+
+
+CGA_SIZE = CFG.CGA_M * CFG.CGA_N
+CTA_GROUP_KIND = nvvm.CTAGroup.CTA_2 if CFG.CTA_MMA == 2 else nvvm.CTAGroup.CTA_1
+
+qBufferElems = CFG.TILE_M * CFG.TILE_K
+kBufferElems = CFG.TILE_N * CFG.TILE_K // CFG.CTA_MMA
+vBufferElems = CFG.TILE_O * CFG.TILE_N // CFG.CTA_MMA
+oBufferElems = CFG.TILE_M * CFG.TILE_O
+
+qTmaTransactionBytes = qBufferElems * CFG.BPE * CFG.CTA_MMA
+kTmaTransactionBytes = kBufferElems * CFG.BPE * CFG.CTA_MMA
+vTmaTransactionBytes = vBufferElems * CFG.BPE * CFG.CTA_MMA
+
+CGA_TILE_M = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+
+
+# SM100 is always cga2 → LPT reverse-row count in CGA-tile units.
+_sdpa_h = make_sdpa_helpers(
+    CFG,
+    lpt_q_tiles_in_cga_units=True,
+    grouped_lpt=True,
+    lpt_head_group=PARAMS.lpt_head_group,
+    lpt_q_tiles=PARAMS.lpt_q_tiles,
+)
+_decode_initial = _sdpa_h.decode_initial
+_decode_payload = _sdpa_h.decode_payload
+_bounds_for_tile = _sdpa_h.bounds_for_tile
+_resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
+_resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
+
+# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
+# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
+# kernels/dsl/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
+# Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
+# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
+#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
+# MXFP8-only: _thd_sf_tile_bases returns the per-sequence SF-tile prefix bases
+# (cu_sf_q_base / cu_sf_k_base) for the packed scale-factor layout.
+from cudnn.sdpa.fwd.kernels.thd_sm100 import build_o_descs_kernel as _build_o_descs_kernel, TENSOR_MAP_QWORDS
+
+_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+_dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
+_dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
+_thd_tma_offsets = _sdpa_h.thd_tma_offsets
+_thd_sf_tile_bases = _sdpa_h.thd_sf_tile_bases
+
+
+# Kernel TMEM layout: P aliases each S_acc tail (4:1 FP8 pack), while block
+# scale operands reuse transiently dead regions within the 512-column limit.
+@dataclass(frozen=True)
+class KernelTmemLayout:
+    # Blackwell SM10.0 512-col TMEM cap.
+    TOTAL_COLS: int = 512
+
+    S0_OFF: int = 0
+    S1_OFF: int = 128
+
+    O0_OFF: int = 256
+    O1_OFF: int = 384
+
+    # FP8 P is 4:1-packed at the S_acc tails (96 / 224); the lower halves of each
+    # S_acc slot (< P) are free for reloaded SF operands.
+    P0_OFF: int = 96
+    P1_OFF: int = 224
+
+    SF_HEAD_OFFSET: int = 8
+    SF_AFTER_P_OFFSET: int = 32
+
+    # --- MXFP8 SF operands.  512-col cap leaves no room above S∪O, so SF is
+    # RELOADED every MMA into transiently-free scratch (all offsets derive from
+    # SF_TMEM_COLS_*).
+    #
+    # Steady-state BMM1: SF_Q/K ping-pong into the OTHER sub-tile's S_acc lower
+    # region, gated on that tile's softmax-LDTM-done (mb_softmax_ldtm_done):
+    #   sub0 (writes S_acc_0) -> hides SF in S_acc_1 head; sub1 -> S_acc_0 head.
+    SF_Q0_OFF: int = 128 + SF_HEAD_OFFSET  # 136
+    SF_K0_OFF: int = 128 + SF_HEAD_OFFSET + SF_TMEM_COLS_Q  # 144
+    SF_Q1_OFF: int = SF_HEAD_OFFSET  # 8
+    SF_K1_OFF: int = SF_HEAD_OFFSET + SF_TMEM_COLS_Q  # 16
+    # Prologue BMM1: O not yet accumulated -> O_0 region is dead scratch (the
+    # first BMM2 overwrites it with accumulate=False).  No LDTM wait needed.
+    SF_Q0_PRO_OFF: int = 256  # O_0 head
+    SF_K0_PRO_OFF: int = 256 + SF_TMEM_COLS_Q  # 264
+    SF_Q1_PRO_OFF: int = 256 + SF_TMEM_COLS_Q + SF_TMEM_COLS_K  # 272
+    SF_K1_PRO_OFF: int = 256 + 2 * SF_TMEM_COLS_Q + SF_TMEM_COLS_K  # 280
+    # BMM2 SF_P/V per sub-tile (S_acc region + SF_AFTER_P_OFFSET); the existing
+    # bmm2_ready wait already proves softmax read all of S_acc, so no extra gate.
+    SF_P0_OFF: int = SF_AFTER_P_OFFSET  # 32
+    SF_V0_OFF: int = SF_AFTER_P_OFFSET + SF_TMEM_COLS_P  # 36
+    SF_P1_OFF: int = 128 + SF_AFTER_P_OFFSET  # 160
+    SF_V1_OFF: int = 128 + SF_AFTER_P_OFFSET + SF_TMEM_COLS_P  # 164
+
+
+LAYOUT = KernelTmemLayout()
+
+
+_SWZ_ENUM = {128: 2, 64: 4, 32: 6}
+SMEM_LAYOUT_Q = _SWZ_ENUM[CFG.Q_SWZ_BYTES]
+SMEM_LAYOUT_K = _SWZ_ENUM[CFG.K_SWZ_BYTES]
+SMEM_LAYOUT_V = _SWZ_ENUM[CFG.V_SWZ_BYTES]
+SMEM_LAYOUT_O = _SWZ_ENUM[CFG.O_SWZ_BYTES]
+SMEM_LAYOUT_QKO = SMEM_LAYOUT_Q
+
+# SF SmemDesc layout: NONE=0 is real no-swizzle (NOT value 1 which is SWIZZLE_128B_ATOM_32B).
+SMEM_LAYOUT_SF = 0
+SF_LEADING_BYTE_OFFSET = 16
+SF_STRIDE_BYTE_OFFSET = 128
+
+_O_SWZ_B = {128: 3, 64: 2, 32: 1}[CFG.O_SWZ_BYTES]
+_O_SMEM_SWIZZLE = cutlass.Swizzle(_O_SWZ_B, 4, 3)
+LEADING_BYTE_OFFSET_QK = 0
+
+_MMA_K_FP8 = _MXFP8_TILE_K_HW
+STRIDE_BYTE_OFFSET_QK = 8 * CFG.Q_SWZ_BYTES
+
+# leading_byte_offset = 0 when (TILE_O/CTA_MMA)/8 <= 8 else TILE_N*V_SWZ_BYTES
+_CORE_MATRIX_ROWS = 8
+_V_PC_COLS = CFG.TILE_O // CFG.CTA_MMA
+LEADING_BYTE_OFFSET_PV = 0 if (_V_PC_COLS // _CORE_MATRIX_ROWS) <= 8 else CFG.TILE_N * CFG.V_SWZ_BYTES
+STRIDE_BYTE_OFFSET_PV = 8 * CFG.V_SWZ_BYTES
+
+NUM_KPHASES_PV = CFG.TILE_N // _MMA_K_FP8
+NUM_KPHASES_PV_PER_CHUNK = NUM_KPHASES_PV // CFG.N_BMM2_CHUNKS
+
+
+# === Kernel ===
+
+
+@cute.kernel
+def _kernel(
+    tma_q_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
+    # SF rides cta_group=CFG.CTA_MMA TMA → bytes route through mb_q/k/v_full like Q/K/V; no peer Q_SF DSMEM forward.
+    tma_q_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_k_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    tma_v_sf_desc: cutlass.GridConstant[tmap.TensorMap],
+    lse_tensor: Optional[cute.Tensor],
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    seqlen_q: cutlass.Int32,
+    seqlen_kv: cutlass.Int32,
+    n_q_supers: cutlass.Int32,
+    n_qh: cutlass.Int32,
+    n_batch: cutlass.Int32,
+    qh_per_kh: cutlass.Int32,  # GQA group size = n_qh / n_kh.
+    scale_softmax_log2: cutlass.Float32,
+) -> None:
+
+    warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+    tidx, _, _ = cute.arch.thread_idx()
+
+    bidx = cute.arch.block_idx()[0]
+    bidy = cute.arch.block_idx()[1]
+    bidz = cute.arch.block_idx()[2]
+
+    sQ_raw = cutlass.Array(STORAGE_DTYPE, CFG.TILES_Q * qBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * kBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_raw = cutlass.Array(STORAGE_DTYPE, CFG.STAGES_KV * vBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sO_raw = cutlass.Array(OUT_STORAGE_DTYPE, CFG.TILES_Q * oBufferElems, alignment=1024, space=cutlass.AddressSpace.smem)
+    sStats_raw = cutlass.Array(
+        cutlass.Float32,
+        CFG.TILES_Q * 2 * CFG.TILE_M,
+        alignment=128,
+        space=cutlass.AddressSpace.smem,
+    )
+
+    # SF buffers sized in BYTES (uint8 storage).
+    sQ_SF_raw = cutlass.Array(cutlass.Int8, CFG.TILES_Q * SF_SMEM_SIZE_Q, alignment=1024, space=cutlass.AddressSpace.smem)
+    sK_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_K, alignment=1024, space=cutlass.AddressSpace.smem)
+    sP_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_P, alignment=1024, space=cutlass.AddressSpace.smem)
+    sV_SF_raw = cutlass.Array(cutlass.Int8, CFG.STAGES_KV * SF_SMEM_SIZE_V, alignment=1024, space=cutlass.AddressSpace.smem)
+
+    sQ = SmemTile(
+        base=sQ_raw,
+        elems_per_stage=qBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_QK_ITERS,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_QK_GRANU_ELEMS,
+    )
+    sK = SmemTile(
+        base=sK_raw,
+        elems_per_stage=kBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_QK,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_QK,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=1,
+        tma_granu_elems=TMA_QK_GRANU_ELEMS,
+        tma_subtile_stride_elems=(CFG.TILE_N // CFG.CTA_MMA) * TMA_QK_GRANU_ELEMS,
+    )
+    sV = SmemTile(
+        base=sV_raw,
+        elems_per_stage=vBufferElems,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=LEADING_BYTE_OFFSET_PV,
+        stride_byte_offset=STRIDE_BYTE_OFFSET_PV,
+        layout=SMEM_LAYOUT_V,
+        tma_loads_per_tile=TMA_VO_ITERS // CFG.CTA_MMA,
+        tma_granu_elems=TMA_VO_GRANU_ELEMS,
+        tma_subtile_stride_elems=CFG.TILE_N * TMA_VO_GRANU_ELEMS,
+    )
+    sO = SmemTile(
+        base=sO_raw,
+        elems_per_stage=oBufferElems,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=0,
+        stride_byte_offset=0,
+        layout=SMEM_LAYOUT_QKO,
+        tma_loads_per_tile=TMA_O_ITERS_HOST,
+        tma_granu_elems=TMA_O_GRANU_ELEMS_HOST,
+        tma_subtile_stride_elems=CFG.TILE_M * TMA_O_GRANU_ELEMS_HOST,
+    )
+
+    # SF SmemTiles: no-swizzle, leading=16, stride=128. TMA-LDG warp issues one 5-D bulk.tensor per slab.
+    K_SF_BYTES_PER_PEER = SF_SMEM_SIZE_K // CFG.CTA_MMA
+    V_SF_BYTES_PER_PEER = SF_SMEM_SIZE_V // CFG.CTA_MMA
+    sQ_SF = SmemTile(
+        base=sQ_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_Q,
+        stages=CFG.TILES_Q,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sK_SF = SmemTile(
+        base=sK_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_K,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sP_SF = SmemTile(
+        base=sP_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_P,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+    sV_SF = SmemTile(
+        base=sV_SF_raw,
+        elems_per_stage=SF_SMEM_SIZE_V,
+        stages=CFG.STAGES_KV,
+        leading_byte_offset=SF_LEADING_BYTE_OFFSET,
+        stride_byte_offset=SF_STRIDE_BYTE_OFFSET,
+        layout=SMEM_LAYOUT_SF,
+    )
+
+    bars = make_classic_bars(CFG)
+
+    # SM100 mxfp8-only cross-CTA barrier (not in the shared Bars NamedTuple):
+    # softmax[sub] signals "S_acc[sub] LDTM into registers is done" so the leader
+    # MMA may reload SF_Q/K into that tile's S_acc scratch (steady-state ping-pong).
+    # Leader-waited (P8): both CTAs' softmax arrive_on_leader → init = CTA_MMA.
+    mb_softmax_ldtm = cutlass.Array(cutlass.Int64, CFG.TILES_Q, alignment=16, space=cutlass.AddressSpace.smem)
+
+    tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
+
+    sched = Sched(
+        **{
+            "mb_scheduler": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "mb_read_tile_id": cutlass.Array(cutlass.Int64, CFG.SCHEDULER_STAGES, alignment=16, space=cutlass.AddressSpace.smem),
+            "tile_id_smem": cutlass.Array(cutlass.Int32, CFG.SCHEDULER_STAGES * 8, alignment=16, space=cutlass.AddressSpace.smem),
+            "bidx_init": bidx,
+            "bidy_init": bidy,
+            "bidz_init": bidz,
+        }
+    )
+
+    # READ_TILE_ARRIVERS = 15 × CGA_M × CGA_N (softmax(8) + corr(4) + MMA + TMALDG + TMASTG).
+    READ_TILE_ARRIVERS_TOTAL = ((CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS) + CFG.CORRECTION_WARPS + 1 + 1 + 1) * CGA_SIZE
+
+    if warp_idx == 0:
+        if nvvm.elect_sync():
+            # mb_q_full init=1: leader's arrive_expect_tx covers Q TMA + both peers' Q_SF TMA via cta_group::2.
+            # range_constexpr → Python-int loop var (required for the
+            # mb_bmm2_ready tuple-init lookup).  Bounds are small —
+            # unroll is free.
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_q_full[qs].init()
+                bars.mb_q_empty[qs].init()
+                bars.mb_bmm1_done[qs].init()
+                bars.mb_bmm2_done[qs].init()
+                bars.mb_stat_full[qs].init()
+                bars.mb_stat_empty[qs].init()
+                bars.mb_stats_read[qs].init()
+                bars.mb_o_full[qs].init()
+                bars.mb_o_empty[qs].init()
+                for c in cutlass.range_constexpr(CFG.N_BMM2_CHUNKS):
+                    bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + c].init()
+            for ks in cutlass.range_constexpr(CFG.STAGES_KV):
+                bars.mb_k_full[ks].init()
+                bars.mb_k_empty[ks].init()
+                bars.mb_v_full[ks].init()
+                bars.mb_v_empty[ks].init()
+            for s in range(CFG.SCHEDULER_STAGES):
+                nvvm.mbarrier_init(sched.mb_scheduler.subview(s), CFG.ONE_LANE)
+                nvvm.mbarrier_init(sched.mb_read_tile_id.subview(s), READ_TILE_ARRIVERS_TOTAL)
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                # Leader-waited (P8): each softmax warp elect-arrives after its own
+                # S_acc LDTM+wait → SOFTMAX_WG_WARPS arrives per CTA × CTA_MMA CTAs.
+                nvvm.mbarrier_init(mb_softmax_ldtm.subview(qs), CFG.SOFTMAX_WG_WARPS * CFG.CTA_MMA)
+            bars.mb_tmem_dealloc.init()
+            bars.mb_empty_mainloop.init()
+
+    # P_SF SMEM fill 0x7F (constant 1.0); MUST happen BEFORE cga_arrive so both peers see filled SMEM.
+    SF_TOTAL_BYTES_P = SF_SMEM_SIZE_P * CFG.STAGES_KV
+    _SF_P_ITERS = (SF_TOTAL_BYTES_P + CFG.THREADS_PER_CTA - 1) // CFG.THREADS_PER_CTA
+    for _i in cutlass.range_constexpr(_SF_P_ITERS):
+        _off = tidx + cutlass.Int32(_i * CFG.THREADS_PER_CTA)
+        if _off < cutlass.Int32(SF_TOTAL_BYTES_P):
+            sP_SF_raw.subview(_off).store(cutlass.Int8(0x7F))
+
+    nvvm.fence_mbarrier_init()
+    nvvm.barrier_cta_sync()
+
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        cga_arrive()
+        cga_wait()
+
+    cta_id_x = cute.arch.block_idx_in_cluster() if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    cta_in_pair = (cta_id_x & cutlass.Int32(1)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    leader_cta_id = (cta_id_x & cutlass.Int32(~1 & 0xFFFFFFFF)) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    mcast_mask = (cutlass.Int32(3) << leader_cta_id) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int32(0)
+    tma_mcast_mask = (cutlass.Int16(1) << cta_in_pair) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    # 0b11 delivers each peer's K_SF/V_SF half to BOTH peers' SMEM.
+    sf_mcast_mask = cutlass.Int16(3) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
+    is_leader = cta_in_pair == cutlass.Int32(0)
+
+    if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=0,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            sStats_raw=sStats_raw,
+            bars=bars,
+            sched=sched,
+            mb_softmax_ldtm=mb_softmax_ldtm,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.SOFTMAX_WG1_BASE + CFG.SOFTMAX_WG_WARPS:
+        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        _softmax_warp_group(
+            sub_tile_id=1,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            scale_log2=scale_softmax_log2,
+            tmem_ptr_i32=tmem_ptr_i32,
+            sQ=sQ,
+            sStats_raw=sStats_raw,
+            bars=bars,
+            sched=sched,
+            mb_softmax_ldtm=mb_softmax_ldtm,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+        )
+
+    elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
+        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _correction_warp_group(
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            sO=sO,
+            sStats_raw=sStats_raw,
+            tmem_ptr_i32=tmem_ptr_i32,
+            tidx=tidx,
+            bars=bars,
+            sched=sched,
+            lse_tensor=lse_tensor,
+            amax_o_tensor=amax_o_tensor,
+            sinks_tensor=sinks_tensor,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            leader_cta_id=leader_cta_id,
+            cta_in_pair=cta_in_pair,
+            cta_id_x=cta_id_x,
+        )
+
+    elif warp_idx == CFG.MMA_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.CTA_MMA == 2):
+            if is_leader:
+                _mma_warp_group(
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    sQ=sQ,
+                    sK=sK,
+                    sV=sV,
+                    sQ_SF=sQ_SF,
+                    sK_SF=sK_SF,
+                    sP_SF=sP_SF,
+                    sV_SF=sV_SF,
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    mb_softmax_ldtm=mb_softmax_ldtm,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    mcast_mask=mcast_mask,
+                    cta_in_pair=cta_in_pair,
+                )
+            else:
+                _mma_warp_quiet(
+                    tmem_ptr_i32=tmem_ptr_i32,
+                    bars=bars,
+                    sched=sched,
+                    seqlen_q=seqlen_q,
+                    seqlen_kv=seqlen_kv,
+                    seq_kv_lens_tensor=seq_kv_lens_tensor,
+                    n_q_supers=n_q_supers,
+                    n_qh=n_qh,
+                    n_batch=n_batch,
+                    cta_in_pair=cta_in_pair,
+                    cta_id_x=cta_id_x,
+                )
+        else:
+            _mma_warp_group(
+                seqlen_q=seqlen_q,
+                seqlen_kv=seqlen_kv,
+                sQ=sQ,
+                sK=sK,
+                sV=sV,
+                sQ_SF=sQ_SF,
+                sK_SF=sK_SF,
+                sP_SF=sP_SF,
+                sV_SF=sV_SF,
+                tmem_ptr_i32=tmem_ptr_i32,
+                bars=bars,
+                sched=sched,
+                mb_softmax_ldtm=mb_softmax_ldtm,
+                seq_kv_lens_tensor=seq_kv_lens_tensor,
+                n_q_supers=n_q_supers,
+                n_qh=n_qh,
+                n_batch=n_batch,
+                mcast_mask=mcast_mask,
+                cta_in_pair=cta_in_pair,
+            )
+
+    elif warp_idx == CFG.TMALDG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        nvvm.prefetch_tensormap(tma_q_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_q_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_k_sf_desc.get_ptr())
+        nvvm.prefetch_tensormap(tma_v_sf_desc.get_ptr())
+        _tmaldg_warp_group(
+            tma_q_desc=tma_q_desc,
+            tma_k_desc=tma_k_desc,
+            tma_v_desc=tma_v_desc,
+            tma_q_sf_desc=tma_q_sf_desc,
+            tma_k_sf_desc=tma_k_sf_desc,
+            tma_v_sf_desc=tma_v_sf_desc,
+            sQ=sQ,
+            sK=sK,
+            sV=sV,
+            sQ_SF=sQ_SF,
+            sK_SF=sK_SF,
+            sV_SF=sV_SF,
+            bars=bars,
+            sched=sched,
+            seqlen_q=seqlen_q,
+            seqlen_kv=seqlen_kv,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            qh_per_kh=qh_per_kh,
+            is_leader=is_leader,
+            cta_in_pair=cta_in_pair,
+            tma_mcast_mask=tma_mcast_mask,
+            sf_mcast_mask=sf_mcast_mask,
+        )
+
+    elif warp_idx == CFG.TMASTG_WARP_ID:
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        _tmastg_warp_group(
+            tma_o_desc=tma_o_desc,
+            sO=sO,
+            bars=bars,
+            sched=sched,
+            n_q_supers=n_q_supers,
+            n_qh=n_qh,
+            n_batch=n_batch,
+            cta_in_pair=cta_in_pair,
+            seq_kv_lens_tensor=seq_kv_lens_tensor,
+            o_desc_words=o_desc_words,
+        )
+
+    else:  # warp_idx == CFG.SCHED_WARP_ID
+        nvvm.setmaxregister(CFG.OTHER_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        is_cga_first_cta = cta_id_x == cutlass.Int32(0)
+        scheduler_warp_loop(sched, CFG.SCHEDULER_STAGES, is_cga_first_cta)
+
+
+# === Warp-group functions ===
+
+
+@cute.jit
+def _tmaldg_warp_group(
+    tma_q_desc,
+    tma_k_desc,
+    tma_v_desc,
+    tma_q_sf_desc,
+    tma_k_sf_desc,
+    tma_v_sf_desc,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sV_SF,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    qh_per_kh,
+    is_leader,
+    cta_in_pair,
+    tma_mcast_mask,
+    sf_mcast_mask,
+):
+    """TMA-LDG warp — Q/K/V TMA loads + per-iter SF TMA loads.
+
+    Under cga2: Q_SF — each peer pulls its own M-half (one peer in mcast),
+    bytes route to leader via cta_group::2.  K_SF/V_SF — both peers
+    cooperatively load HALF the slab each at peer-offset with sf_mcast_mask=3.
+    """
+    q_empty_phase = cutlass.Int32(1)
+    kv_state = PipelineState.start(phase=1)
+
+    # SF TMA handles 5-D (innermost = 128-B row); tma_load_tile auto-selects on coord_0.
+    tma_q = GmemTileTma(tma_q_desc)
+    tma_k = GmemTileTma(tma_k_desc)
+    tma_v = GmemTileTma(tma_v_desc)
+    tma_q_sf = GmemTileTma(tma_q_sf_desc)
+    tma_k_sf = GmemTileTma(tma_k_sf_desc)
+    tma_v_sf = GmemTileTma(tma_v_sf_desc)
+
+    # cga2 split-half offsets fold to 0 under cga1.
+    SF_TMA_ROW_BYTES = 128
+    K_SF_BYTES_PER_PEER = SF_SMEM_SIZE_K // CFG.CTA_MMA
+    V_SF_BYTES_PER_PEER = SF_SMEM_SIZE_V // CFG.CTA_MMA
+    K_SF_ROWS_PER_PEER = K_SF_BYTES_PER_PEER // SF_TMA_ROW_BYTES
+    V_SF_ROWS_PER_PEER = V_SF_BYTES_PER_PEER // SF_TMA_ROW_BYTES
+    k_sf_peer_off = cta_in_pair * cutlass.Int32(K_SF_BYTES_PER_PEER)
+    v_sf_peer_off = cta_in_pair * cutlass.Int32(V_SF_BYTES_PER_PEER)
+    k_sf_peer_row = cta_in_pair * cutlass.Int32(K_SF_ROWS_PER_PEER)
+    v_sf_peer_row = cta_in_pair * cutlass.Int32(V_SF_ROWS_PER_PEER)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    # GQA: K/V indexed by kv-head.
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # THD packed-tensor seq offsets (fold to (0,0,batch_idx) dense); SF-tile bases
+    # fold to (0,0) dense.
+    q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+    cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    K_ROW_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_N // CFG.CTA_MMA)
+    V_COL_OFFSET_PEER = cta_in_pair * cutlass.Int32(CFG.TILE_O // CFG.CTA_MMA)
+
+    # SF expect_tx scales by CTA_MMA under cga2 (2× SMEM size on leader); cga1 → SF_SMEM_SIZE.
+    Q_SF_EXPECT_BYTES = SF_SMEM_SIZE_Q * CFG.CTA_MMA
+    K_SF_EXPECT_BYTES = SF_SMEM_SIZE_K * CFG.CTA_MMA
+    V_SF_EXPECT_BYTES = SF_SMEM_SIZE_V * CFG.CTA_MMA
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Empty-kv tile: MMA's empty-mainloop branch handles the matching mbar phases.
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            pass
+        else:
+            q_sf_tile_base = q_row_base // cutlass.Int32(CFG.TILE_M)
+            kv_row_base = kv_left * CFG.TILE_N
+
+            # Prologue: Q[0] / K[first] / Q[1] / V[first] interleaved.
+            bars.mb_q_empty[0].wait(q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                if is_leader:
+                    if nvvm.elect_sync():
+                        bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES)
+            else:
+                if nvvm.elect_sync():
+                    bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES)
+            tma_load_tile(
+                sQ[0],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[0].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sQ_SF[0],
+                tma_q_sf(cutlass.Int32(0), cu_sf_q_base + q_sf_tile_base + cutlass.Int32(0), head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_q_full[0].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                if is_leader:
+                    if nvvm.elect_sync():
+                        bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+            else:
+                if nvvm.elect_sync():
+                    bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+            tma_load_tile(
+                sK[kv_state.idx],
+                tma_k(
+                    cutlass.Int32(0),
+                    kv_row_base + K_ROW_OFFSET_PEER + kv_seq_off,
+                    cutlass.Int32(0),
+                    kv_head_idx,
+                    tma_batch,
+                ),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sK_SF[kv_state.idx].shifted(k_sf_peer_off),
+                tma_k_sf(k_sf_peer_row, cu_sf_k_base + kv_left, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_k_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=sf_mcast_mask,
+            )
+
+            bars.mb_q_empty[1].wait(q_empty_phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                if is_leader:
+                    if nvvm.elect_sync():
+                        bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES)
+            else:
+                if nvvm.elect_sync():
+                    bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes + Q_SF_EXPECT_BYTES)
+            tma_load_tile(
+                sQ[1],
+                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                bars.mb_q_full[1].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sQ_SF[1],
+                tma_q_sf(cutlass.Int32(0), cu_sf_q_base + q_sf_tile_base + cutlass.Int32(1), head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_q_full[1].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            q_empty_phase = q_empty_phase ^ 1
+
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            if cutlass.const_expr(CFG.CTA_MMA == 2):
+                if is_leader:
+                    if nvvm.elect_sync():
+                        bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+            else:
+                if nvvm.elect_sync():
+                    bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+            tma_load_tile(
+                sV[kv_state.idx],
+                tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base + kv_seq_off, tma_batch),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=tma_mcast_mask,
+            )
+            tma_load_tile(
+                sV_SF[kv_state.idx].shifted(v_sf_peer_off),
+                tma_v_sf(v_sf_peer_row, cu_sf_k_base + kv_left, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                bars.mb_v_full[kv_state.idx].smem_ptr,
+                cta_group=CFG.CTA_MMA,
+                mcast_mask=sf_mcast_mask,
+            )
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=2):
+                kv_row_base_iter = kv_loop * CFG.TILE_N
+
+                bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    if is_leader:
+                        if nvvm.elect_sync():
+                            bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+                else:
+                    if nvvm.elect_sync():
+                        bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+                tma_load_tile(
+                    sK[kv_state.idx],
+                    tma_k(
+                        cutlass.Int32(0),
+                        kv_row_base_iter + K_ROW_OFFSET_PEER + kv_seq_off,
+                        cutlass.Int32(0),
+                        kv_head_idx,
+                        tma_batch,
+                    ),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+                tma_load_tile(
+                    sK_SF[kv_state.idx].shifted(k_sf_peer_off),
+                    tma_k_sf(k_sf_peer_row, cu_sf_k_base + kv_loop, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                    bars.mb_k_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=sf_mcast_mask,
+                )
+
+                bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+                if cutlass.const_expr(CFG.CTA_MMA == 2):
+                    if is_leader:
+                        if nvvm.elect_sync():
+                            bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+                else:
+                    if nvvm.elect_sync():
+                        bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+                tma_load_tile(
+                    sV[kv_state.idx],
+                    tma_v(V_COL_OFFSET_PEER, kv_head_idx, kv_row_base_iter + kv_seq_off, tma_batch),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=tma_mcast_mask,
+                )
+                tma_load_tile(
+                    sV_SF[kv_state.idx].shifted(v_sf_peer_off),
+                    tma_v_sf(v_sf_peer_row, cu_sf_k_base + kv_loop, kv_head_idx, tma_batch, coord_0=cutlass.Int32(0)),
+                    bars.mb_v_full[kv_state.idx].smem_ptr,
+                    cta_group=CFG.CTA_MMA,
+                    mcast_mask=sf_mcast_mask,
+                )
+
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
+        cu_sf_q_base, cu_sf_k_base = _thd_sf_tile_bases(seq_kv_lens_tensor, batch_idx, n_batch)
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+
+    # cga2 drain — TMA warp cga2 drain at kernel exit (cga2-mma.md).
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        for _qs in cutlass.range_constexpr(CFG.TILES_Q):
+            bars.mb_q_empty[_qs].wait(q_empty_phase)
+        q_empty_phase = q_empty_phase ^ cutlass.Int32(1)
+        for _ks in cutlass.range_constexpr(CFG.STAGES_KV):
+            bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
+            bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+
+@cute.jit
+def _tmastg_warp_group(
+    tma_o_desc,
+    sO,
+    bars,
+    sched,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    seq_kv_lens_tensor,
+    o_desc_words,
+):
+    """TMA-STG warp — O SMEM→GMEM store."""
+    o_full_phase = cutlass.Int32(0)
+
+    tma_o = GmemTileTma(tma_o_desc)
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            bars.mb_o_full[qs].wait(o_full_phase)
+
+            # O TMA params follow O's swizzle, NOT V's — required when V_SWZ_B != O_SWZ_B.
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: store each Q slab through this batch's pre-built descriptor
+                # (base at the sequence's packed row, seq extent = S_q_b → a box
+                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
+                # batch coord collapses to 0.  Both slabs share one descriptor.
+                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                tma_store_tile(sO[qs], o_slice)
+            else:
+                tma_store_tile(
+                    sO[qs],
+                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                )
+
+            tma_store_commit()
+            tma_store_wait(0)
+
+            bars.mb_o_empty[qs].arrive()
+
+        o_full_phase = o_full_phase ^ 1
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+
+@cute.jit
+def _mma_warp_quiet(
+    tmem_ptr_i32,
+    bars,
+    sched,
+    seqlen_q,
+    seqlen_kv,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Quiet MMA warp — non-leader CTA's MMA slot under cga2.
+
+    Persistent loop keeps peer's mb_read_tile_id contribution + scheduler
+    advance in lockstep with leader (MXFP8 quiet warp counts in
+    READ_TILE_ARRIVERS=15×CGA, unlike FP8).
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _mma_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sQ,
+    sK,
+    sV,
+    sQ_SF,
+    sK_SF,
+    sP_SF,
+    sV_SF,
+    tmem_ptr_i32,
+    bars,
+    sched,
+    mb_softmax_ldtm,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    mcast_mask,
+    cta_in_pair,
+):
+    """Leader MMA warp — block-scale MMA stream for BMM1 + BMM2.
+
+    Per-iter copy_sf into SF TMEM tiles ahead of each mma; P_SF tile is
+    populated once at warp start (constant 1.0).  The inner loop covers
+    SF_NUM_BLOCKS_K K-blocks.
+    """
+    tmem_alloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+    nvvm.barrier_cta_arrive(1, 32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    nvvm.barrier_cta_arrive(2, 32 * (CFG.CORRECTION_WARPS + 1))
+
+    tmem_raw = nvvm.make_tmem_ptr(tmem_ptr_i32.load(), cutlass.Int8)
+
+    idesc_qk_bs = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_N,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        k_dim=_MXFP8_K_DIM,
+    )
+    idesc_pv_bs = prims.Tcgen05MxInstrDesc.build(
+        a_dtype=STORAGE_DTYPE,
+        b_dtype=STORAGE_DTYPE,
+        n_dim=CFG.TILE_O,
+        m_dim=CFG.TILE_M * CFG.CTA_MMA,
+        b_major=1,
+        k_dim=_MXFP8_K_DIM,
+    )
+    # sf_blocks_per_step = TILE_K_HW/32 (SF cols per MMA k-step); NOT SF_NUM_BLOCKS_K (total across K-tile).
+    _MXFP8_SF_BLOCKS_PER_STEP = _MXFP8_TILE_K_HW // 32
+    bmm1_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_N,
+        K=CFG.TILE_K,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=False,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_qk_bs,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=_MXFP8_SF_BLOCKS_PER_STEP,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+    bmm2_desc = MmaDesc(
+        M=CFG.TILE_M * CFG.CTA_MMA,
+        N=CFG.TILE_O,
+        K=CFG.TILE_N,
+        bpe_a=CFG.BPE,
+        bpe_b=CFG.BPE,
+        tile_k_hw=_MXFP8_TILE_K_HW,
+        btranspose=True,
+        k_subtile=CFG.V_SWZ_BYTES // CFG.BPE,
+        cta_group=CFG.CTA_MMA,
+        idesc=idesc_pv_bs,
+        kind=MMA_KIND,
+        is_block_scale=True,
+        sf_blocks_per_step=_MXFP8_SF_BLOCKS_PER_STEP,
+        scale_vec_size=SCALE_VEC_SIZE,
+    )
+
+    desc_Q0 = sQ[0].desc()
+    desc_Q1 = sQ[1].desc()
+
+    desc_Q_SF_0 = sQ_SF[0].desc()
+    desc_Q_SF_1 = sQ_SF[1].desc()
+    desc_P_SF_0 = sP_SF[0].desc()
+
+    # SF TMEM scratch (Blackwell 512-col cap → SF reloaded every MMA, cuDNN
+    # ping-pong): steady BMM1 SF_Q/K in the OTHER sub-tile's S_acc lower region;
+    # prologue BMM1 SF_Q/K in the (dead) O region; BMM2 SF_P/V per sub-tile.
+    tmem_SF_Q0 = tmem_raw.subview(LAYOUT.SF_Q0_OFF)  # sub0 steady (S_acc_1)
+    tmem_SF_K0 = tmem_raw.subview(LAYOUT.SF_K0_OFF)
+    tmem_SF_Q1 = tmem_raw.subview(LAYOUT.SF_Q1_OFF)  # sub1 steady (S_acc_0)
+    tmem_SF_K1 = tmem_raw.subview(LAYOUT.SF_K1_OFF)
+    tmem_SF_Q0_pro = tmem_raw.subview(LAYOUT.SF_Q0_PRO_OFF)  # prologue (O_0, dead)
+    tmem_SF_K0_pro = tmem_raw.subview(LAYOUT.SF_K0_PRO_OFF)
+    tmem_SF_Q1_pro = tmem_raw.subview(LAYOUT.SF_Q1_PRO_OFF)
+    tmem_SF_K1_pro = tmem_raw.subview(LAYOUT.SF_K1_PRO_OFF)
+    tmem_SF_P0 = tmem_raw.subview(LAYOUT.SF_P0_OFF)
+    tmem_SF_V0 = tmem_raw.subview(LAYOUT.SF_V0_OFF)
+    tmem_SF_P1 = tmem_raw.subview(LAYOUT.SF_P1_OFF)
+    tmem_SF_V1 = tmem_raw.subview(LAYOUT.SF_V1_OFF)
+
+    # Trace-time UTCCP macros (emit IR at the call site; caller elect-gates).
+    def _utccp_bmm1_sf(tmem_sf_q, tmem_sf_k, smem_desc_q, smem_desc_k):
+        # D192 has two 128-wide SF blocks after padding the K extent to 256.
+        for _sf_k in cutlass.range_constexpr(SF_NUM_BLOCKS_K):
+            nvvm.tcgen05_cp(
+                nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                tmem_sf_q.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                smem_desc_q + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                group=CTA_GROUP_KIND,
+                multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+            )
+            nvvm.tcgen05_cp(
+                nvvm.Tcgen05CpShape.SHAPE_32X128B,
+                tmem_sf_k.subview(_sf_k * SF_REGISTERS_PER_BLOCK),
+                smem_desc_k + _sf_k * (SF_BYTES_PER_BLOCK // 16),
+                group=CTA_GROUP_KIND,
+                multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+            )
+
+    def _utccp_bmm2_sf(tmem_sf_p, tmem_sf_v, smem_desc_p, smem_desc_v):
+        # SF_P is the constant P_SF; SF_V is per-kv-tile.  Both single-block (llama).
+        # desc_P_SF_0 passed explicitly (DSL-value closure capture is unstaged).
+        nvvm.tcgen05_cp(nvvm.Tcgen05CpShape.SHAPE_32X128B, tmem_sf_p, smem_desc_p, group=CTA_GROUP_KIND, multicast=nvvm.Tcgen05CpMulticast.WARPX4)
+        nvvm.tcgen05_cp(nvvm.Tcgen05CpShape.SHAPE_32X128B, tmem_sf_v, smem_desc_v, group=CTA_GROUP_KIND, multicast=nvvm.Tcgen05CpMulticast.WARPX4)
+
+    if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+        kv_left = cutlass.Int32(0)
+        kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
+    else:
+        q_super_idx, _hd, batch_idx = _dispatch_decode_initial(
+            sched.bidx_init,
+            sched.bidy_init,
+            sched.bidz_init,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+        kv_left = bounds_init.left
+        kv_right = bounds_init.right
+
+    q_full_phase = cutlass.Int32(0)
+    kv_state = PipelineState.start(phase=0)
+    bmm2_ready_phase = cutlass.Int32(0)
+    empty_mainloop_phase = cutlass.Int32(0)
+    # Steady-state BMM1[sub_i] waits mb_softmax_ldtm[1-sub_i] before reloading
+    # SF_Q/K into that tile's S_acc scratch (one iter behind softmax).  Per tile
+    # softmax fires n_kv arrives on EACH sub-tile's ldtm mbar: [0] is consumed
+    # n_kv times (prologue + steady loop), [1] only n_kv-1 times (steady loop
+    # only) — the epilogue P14 drain (below) consumes the last [1] so neither
+    # phase accumulates across persistent-loop wraps (else: multi-wave deadlock).
+    ldtm_phase0 = cutlass.Int32(0)  # consumes softmax[0] arrives (for BMM1[sub1])
+    ldtm_phase1 = cutlass.Int32(0)  # consumes softmax[1] arrives (for BMM1[sub0])
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
+            # Empty mainloop — keep softmax/correction phase trackers in lockstep with non-empty path.
+            bars.mb_empty_mainloop.wait(empty_mainloop_phase)
+            empty_mainloop_phase = empty_mainloop_phase ^ cutlass.Int32(1)
+            if nvvm.elect_sync():
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+        else:
+            # Prologue: BMM1[sub0] + BMM1[sub1] for kv=kv_left.  SF_Q/K land in
+            # the O_0 region (O not yet accumulated → dead scratch; the first BMM2
+            # overwrites it with accumulate=False).  No softmax-LDTM wait needed.
+            bars.mb_q_full[0].wait(q_full_phase)
+            bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+            desc_K = sK[kv_state.idx].desc()
+            desc_K_SF = sK_SF[kv_state.idx].desc()
+            if nvvm.elect_sync():
+                _utccp_bmm1_sf(tmem_SF_Q0_pro, tmem_SF_K0_pro, desc_Q_SF_0, desc_K_SF)
+            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), tmem_sf_a=tmem_SF_Q0_pro, tmem_sf_b=tmem_SF_K0_pro)
+            if nvvm.elect_sync():
+                bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            bars.mb_q_full[1].wait(q_full_phase)
+            # Consume softmax[0]'s prologue-iter LDTM arrive so the steady-state
+            # BMM1[sub1] ldtm[0] waits align to the SAME-iter softmax[0] (cuDNN:
+            # "tile 1 waits for tile 0's softmax; tile 0 starts immediately").
+            # Prologue SF is O-region-dead, so this wait is alignment-only.
+            wait(mb_softmax_ldtm.subview(0), ldtm_phase0)
+            ldtm_phase0 = ldtm_phase0 ^ 1
+            if nvvm.elect_sync():
+                _utccp_bmm1_sf(tmem_SF_Q1_pro, tmem_SF_K1_pro, desc_Q_SF_1, desc_K_SF)
+            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), tmem_sf_a=tmem_SF_Q1_pro, tmem_sf_b=tmem_SF_K1_pro)
+            if nvvm.elect_sync():
+                bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            q_full_phase = q_full_phase ^ 1
+
+            for kv_loop in cutlass.range(kv_left + cutlass.Int32(1), kv_right, 1, unroll=1):
+                old_state = kv_state
+                kv_state = advance(kv_state, CFG.STAGES_KV)
+
+                bars.mb_v_full[old_state.idx].wait(old_state.phase)
+                desc_V = sV[old_state.idx].desc()
+                desc_V_SF = sV_SF[old_state.idx].desc()
+                is_not_first_bmm2 = cutlass.Boolean(kv_loop != (kv_left + cutlass.Int32(1)))
+
+                # BMM2[sub0] → O_0.  SF_P0/V0 reload into S_acc_0 scratch (32/36);
+                # the bmm2_ready wait already proves softmax[0] read all of S_acc_0.
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                if nvvm.elect_sync():
+                    _utccp_bmm2_sf(tmem_SF_P0, tmem_SF_V0, desc_P_SF_0, desc_V_SF)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        local_k,
+                        accum_b2,
+                        tmem_sf_a=tmem_SF_P0,
+                        tmem_sf_b=tmem_SF_V0,
+                    )
+                    accum_b2 = cutlass.Boolean(True)
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                        tmem_sf_a=tmem_SF_P0,
+                        tmem_sf_b=tmem_SF_V0,
+                    )
+                if nvvm.elect_sync():
+                    bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                # BMM1[sub0] next-kv → S_acc_0.  SF_Q0/K0 ping-pong into S_acc_1
+                # scratch (136/140); wait tile1's softmax LDTM (ONE-behind) so its
+                # read of S_acc_1 completed before the leader-broadcast UTCCP
+                # (cta_group::2 self-fills both CTAs) overwrites it.
+                bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+                desc_K = sK[kv_state.idx].desc()
+                desc_K_SF = sK_SF[kv_state.idx].desc()
+                wait(mb_softmax_ldtm.subview(1), ldtm_phase1)
+                ldtm_phase1 = ldtm_phase1 ^ 1
+                if nvvm.elect_sync():
+                    _utccp_bmm1_sf(tmem_SF_Q0, tmem_SF_K0, desc_Q_SF_0, desc_K_SF)
+                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), tmem_sf_a=tmem_SF_Q0, tmem_sf_b=tmem_SF_K0)
+                if nvvm.elect_sync():
+                    bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                # BMM2[sub1] → O_1.  SF_P1/V1 reload into S_acc_1 scratch (160/164).
+                bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                if nvvm.elect_sync():
+                    _utccp_bmm2_sf(tmem_SF_P1, tmem_SF_V1, desc_P_SF_0, desc_V_SF)
+                accum_b2 = is_not_first_bmm2
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P1_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O1_OFF)),
+                        local_k,
+                        accum_b2,
+                        tmem_sf_a=tmem_SF_P1,
+                        tmem_sf_b=tmem_SF_V1,
+                    )
+                    accum_b2 = cutlass.Boolean(True)
+                bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P1_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O1_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                        tmem_sf_a=tmem_SF_P1,
+                        tmem_sf_b=tmem_SF_V1,
+                    )
+                if nvvm.elect_sync():
+                    bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                    bars.mb_v_empty[old_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                # BMM1[sub1] next-kv → S_acc_1.  SF_Q1/K1 ping-pong into S_acc_0
+                # scratch (8/12); wait tile0's softmax LDTM (SAME-iter — BMM1[sub0]
+                # above just wrote this iter's S_acc_0, which softmax[0] must read).
+                wait(mb_softmax_ldtm.subview(0), ldtm_phase0)
+                ldtm_phase0 = ldtm_phase0 ^ 1
+                if nvvm.elect_sync():
+                    _utccp_bmm1_sf(tmem_SF_Q1, tmem_SF_K1, desc_Q_SF_1, desc_K_SF)
+                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), tmem_sf_a=tmem_SF_Q1, tmem_sf_b=tmem_SF_K1)
+                if nvvm.elect_sync():
+                    bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                    bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                bmm2_ready_phase = bmm2_ready_phase ^ 1
+
+            # Epilogue: BMM2 for last kv (always runs — n_kv >= 1).
+            if nvvm.elect_sync():
+                for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                    bars.mb_q_empty[qs].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            bars.mb_v_full[kv_state.idx].wait(kv_state.phase)
+            desc_V = sV[kv_state.idx].desc()
+            desc_V_SF = sV_SF[kv_state.idx].desc()
+            is_not_first_bmm2_epi = cutlass.Boolean((kv_right - kv_left) != cutlass.Int32(1))
+
+            # Epilogue BMM2[sub0] → O_0.  SF_P0/V0 reload into S_acc_0 scratch.
+            bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+            if nvvm.elect_sync():
+                _utccp_bmm2_sf(tmem_SF_P0, tmem_SF_V0, desc_P_SF_0, desc_V_SF)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(
+                    bmm2_desc,
+                    (tmem_raw.subview(LAYOUT.P0_OFF)),
+                    desc_V,
+                    (tmem_raw.subview(LAYOUT.O0_OFF)),
+                    local_k,
+                    accum_b2,
+                    tmem_sf_a=tmem_SF_P0,
+                    tmem_sf_b=tmem_SF_V0,
+                )
+                accum_b2 = cutlass.Boolean(True)
+            bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(
+                    bmm2_desc,
+                    (tmem_raw.subview(LAYOUT.P0_OFF)),
+                    desc_V,
+                    (tmem_raw.subview(LAYOUT.O0_OFF)),
+                    NUM_KPHASES_PV_PER_CHUNK + local_k,
+                    cutlass.Boolean(True),
+                    tmem_sf_a=tmem_SF_P0,
+                    tmem_sf_b=tmem_SF_V0,
+                )
+            if nvvm.elect_sync():
+                bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            # Epilogue BMM2[sub1] → O_1.  SF_P1/V1 reload into S_acc_1 scratch.
+            bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+            if nvvm.elect_sync():
+                _utccp_bmm2_sf(tmem_SF_P1, tmem_SF_V1, desc_P_SF_0, desc_V_SF)
+            accum_b2 = is_not_first_bmm2_epi
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(
+                    bmm2_desc,
+                    (tmem_raw.subview(LAYOUT.P1_OFF)),
+                    desc_V,
+                    (tmem_raw.subview(LAYOUT.O1_OFF)),
+                    local_k,
+                    accum_b2,
+                    tmem_sf_a=tmem_SF_P1,
+                    tmem_sf_b=tmem_SF_V1,
+                )
+                accum_b2 = cutlass.Boolean(True)
+            bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
+            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                mma_ts_step(
+                    bmm2_desc,
+                    (tmem_raw.subview(LAYOUT.P1_OFF)),
+                    desc_V,
+                    (tmem_raw.subview(LAYOUT.O1_OFF)),
+                    NUM_KPHASES_PV_PER_CHUNK + local_k,
+                    cutlass.Boolean(True),
+                    tmem_sf_a=tmem_SF_P1,
+                    tmem_sf_b=tmem_SF_V1,
+                )
+            if nvvm.elect_sync():
+                bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                bars.mb_v_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+            # P14 drain — rebalance mb_softmax_ldtm[1].  softmax fires one
+            # arrive_on_leader(mb_softmax_ldtm[1]) per kv-iter (= n_kv/tile), but the
+            # consumer flips ldtm_phase1 only n_kv-1 times (steady loop; the prologue
+            # consumes softmax[0] not [1], and the epilogue has no BMM1).  ldtm_phase1
+            # lives OUTSIDE the persistent tile loop, so that +1/tile surplus
+            # ACCUMULATES across waves and laps the 1-bit phase -> circular NANOSLEEP
+            # deadlock at high tile-count (multi-wave; small single-wave problems never
+            # trip it).  This catch-up wait returns immediately — softmax's last [1]
+            # arrive precedes the mb_bmm2_ready[1] arrives already awaited above — and
+            # balances [1] to n_kv.  Non-empty else only (empty tiles fire/consume 0).
+            wait(mb_softmax_ldtm.subview(1), ldtm_phase1)
+            ldtm_phase1 = ldtm_phase1 ^ 1
+
+            bmm2_ready_phase = bmm2_ready_phase ^ 1
+            kv_state = advance(kv_state, CFG.STAGES_KV)
+
+        nvvm.bar_warp_sync(cute.arch.FULL_MASK)
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        if cutlass.const_expr(CFG.MASK_FLAGS == 0):
+            nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+        else:
+            nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+            nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+            nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+            q_super_idx, _hd, batch_idx = _dispatch_decode_payload(
+                nxt_q,
+                nxt_hb,
+                cta_in_pair,
+                n_q_supers,
+                n_qh,
+                n_batch,
+                seq_kv_lens_tensor,
+            )
+            is_valid_tile = nxt_v & cutlass.Int32(1)
+            eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+            eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+            kv_left = bounds_next.left
+            kv_right = bounds_next.right
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+
+    bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
+    tmem_dealloc(tmem_ptr_i32, LAYOUT.TOTAL_COLS, CTA_GROUP_KIND)
+
+
+@cute.jit
+def _softmax_kv_body(
+    apply_mask: bool,
+    sub_tile_id: int,
+    kv_loop,
+    tmem_base,
+    sStats_raw,
+    bars,
+    mb_softmax_ldtm,
+    tid_in_wg,
+    q_abs,
+    eff_seqlen_kv,
+    eff_seqlen_q,
+    scale_log2,
+    total_max,
+    total_sum,
+    bmm1_phase,
+    stat_empty_phase,
+    leader_cta_id,
+):
+    """Per-iter softmax body — returns (total_max, total_sum, bmm1_phase, stat_empty_phase).
+
+    Compile-time apply_mask picks fast HW max (tcgen05.ld.red.f32.max)
+    vs slow path (load → apply_mask_chunk → software row_max).  The HW
+    max can't observe NEG_INF written after load, so the kv-loop is
+    split into LEFT/unmasked/RIGHT segments to keep the fast path on
+    every interior iter.
+    """
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+    CHUNK = 64
+    P_COLS_PER_CHUNK = CHUNK // 4
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+    RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
+
+    bars.mb_bmm1_done[sub_tile_id].wait(bmm1_phase)
+    bmm1_phase = bmm1_phase ^ 1
+
+    # TMEM allocation is stable for the lifetime of the persistent kernel.
+    s_addr_a = tmem_base + cutlass.Int32(tmem_S_off + 0)
+    s_addr_b = tmem_base + cutlass.Int32(tmem_S_off + CHUNK)
+    p_addr_a = tmem_base + cutlass.Int32(tmem_P_off + 0)
+    p_addr_b = tmem_base + cutlass.Int32(tmem_P_off + P_COLS_PER_CHUNK)
+    stats_base = cutlass.Int32(sub_tile_id * 2 * CFG.TILE_M)
+
+    # Pre-declare reg_S_*/max_* — without it MLIR cf.if NameErrors the tracer post-branch.
+    reg_S_a = cutlass.Vector.from_elements(
+        tuple(cutlass.Float32(0.0) for _ in range(CHUNK)),
+        cutlass.Float32,
+    )
+    reg_S_b = reg_S_a
+    max_a = cutlass.Float32(0.0)
+    max_b = cutlass.Float32(0.0)
+
+    if apply_mask:
+        # Masked slow path — load, mask, software row-max.
+        reg_S_a = nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(s_addr_a, cutlass.Float32),
+            num=CHUNK,
+        )
+        reg_S_b = nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(s_addr_b, cutlass.Float32),
+            num=CHUNK,
+        )
+        # No tcgen05_wait(LOAD) — reg consumers chain through deps; no downstream mbar arrive depends on it.
+
+        kv_col_base_a = kv_loop * cutlass.Int32(CFG.TILE_N)
+        kv_col_base_b = kv_col_base_a + cutlass.Int32(CHUNK)
+        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
+        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+        reg_S_a = apply_mask_chunk(
+            reg_S_a,
+            q_abs - kv_col_base_a,
+            cutlass.Int32(0),
+            eff_seqlen_kv - kv_col_base_a,
+            CFG.WINDOW_LEFT,
+            CFG.MASK_FLAGS,
+            N=CHUNK,
+            bottom_right=CFG.BOTTOM_RIGHT,
+            causal_diag=causal_diag,
+            window_right=CFG.WINDOW_RIGHT,
+        )
+        reg_S_b = apply_mask_chunk(
+            reg_S_b,
+            q_abs - kv_col_base_b,
+            cutlass.Int32(0),
+            eff_seqlen_kv - kv_col_base_b,
+            CFG.WINDOW_LEFT,
+            CFG.MASK_FLAGS,
+            N=CHUNK,
+            bottom_right=CFG.BOTTOM_RIGHT,
+            causal_diag=causal_diag,
+            window_right=CFG.WINDOW_RIGHT,
+        )
+
+        max_a = row_max_reduction_64(reg_S_a)
+        max_b = row_max_reduction_64(reg_S_b)
+    elif cutlass.const_expr(FUSED_LDTM_STAT != 0):
+        # cc10.3+: fused HW row-max — one tcgen05.ld.red.f32.max does the S_acc
+        # load AND the row-max in one op, returning 64 data regs + the max at
+        # index CHUNK. Unmasked tiles only (the fused .max reduces before the
+        # mask would be applied; masked tiles took the software path above).
+        res_a = tmem_load_max_reduction_x64(s_addr_a)
+        res_b = tmem_load_max_reduction_x64(s_addr_b)
+        reg_S_a = cutlass.Vector.from_elements(
+            tuple(res_a[:CHUNK]),
+            cutlass.Int32,
+        ).bitcast(cutlass.Float32)
+        reg_S_b = cutlass.Vector.from_elements(
+            tuple(res_b[:CHUNK]),
+            cutlass.Int32,
+        ).bitcast(cutlass.Float32)
+        max_a = cutlass.Vector.from_elements(
+            (res_a[CHUNK],),
+            cutlass.Int32,
+        ).bitcast(
+            cutlass.Float32
+        )[0]
+        max_b = cutlass.Vector.from_elements(
+            (res_b[CHUNK],),
+            cutlass.Int32,
+        ).bitcast(
+            cutlass.Float32
+        )[0]
+    else:
+        # cc10.0: no fused LDTM.STAT (tmem_load_max_reduction_x64) — manual
+        # tcgen05_ld + software row_max_reduction_64 (masked path sans mask).
+        reg_S_a = nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(s_addr_a, cutlass.Float32),
+            num=CHUNK,
+        )
+        reg_S_b = nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(s_addr_b, cutlass.Float32),
+            num=CHUNK,
+        )
+        max_a = row_max_reduction_64(reg_S_a)
+        max_b = row_max_reduction_64(reg_S_b)
+
+    # SM100 mxfp8: S_acc[sub] is fully LDTM'd into registers now.  Each softmax
+    # warp elect-arrives on the leader (cross-CTA, P8) so the leader MMA may
+    # reload SF_Q/K into this tile's S_acc scratch (steady-state ping-pong);
+    # tcgen05_wait(LOAD) proves the TMEM read drained before MMA overwrites it.
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+    if nvvm.elect_sync():
+        arrive_on_leader(mb_softmax_ldtm.subview(sub_tile_id), leader_cta_id, CFG.CTA_MMA)
+
+    current_max = cute.math.max(max_a, max_b) * scale_log2
+
+    # sync the two softmax warpgroups before the stat-store.
+    if sub_tile_id == 1:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    old_total_max = total_max
+    is_first = total_max == NEG_INF
+    update_cond = is_first | ((current_max - total_max) > RESCALE_THRESHOLD)
+    total_max = cutlass.Float32(
+        arith.select(
+            update_cond.ir_value(),
+            current_max.ir_value(),
+            total_max.ir_value(),
+        )
+    )
+    exp_input = cutlass.Float32(
+        arith.select(
+            is_first.ir_value(),
+            NEG_INF.ir_value(),
+            (old_total_max - total_max).ir_value(),
+        )
+    )
+    alpha = _exp2_emulated_scalar(exp_input)
+    new_total_max = total_max
+
+    sStats_raw.subview(stats_base + tid_in_wg).store(alpha)
+    bars.mb_stat_full[sub_tile_id].arrive()
+
+    reg_S_a = reg_S_a * scale_log2 - new_total_max
+    reg_S_b = reg_S_b * scale_log2 - new_total_max
+    reg_P_a = _exp2_chunk0_mask_aware(reg_S_a, apply_mask)
+    sum_a_pair = row_reduction_pair_64(reg_P_a)
+    p_a_fp16 = reg_P_a.to(STORAGE_DTYPE)
+    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_a, cutlass.Float32), p_a_fp16)
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_bmm2_ready[sub_tile_id * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    reg_P_b = _exp2_mixed_late(reg_S_b)
+    p_b_fp16 = reg_P_b.to(STORAGE_DTYPE)
+    nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_b, cutlass.Float32), p_b_fp16)
+    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+    bars.mb_bmm2_ready[sub_tile_id * CFG.N_BMM2_CHUNKS + 1].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+    if sub_tile_id == 0:
+        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+
+    sum_b_pair = row_reduction_pair_64(reg_P_b)
+    new_p_sum_pair = sum_a_pair + sum_b_pair
+    alpha_pair = cutlass.Vector.from_elements((alpha, alpha), cutlass.Float32)
+    total_sum = total_sum * alpha_pair + new_p_sum_pair
+
+    bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
+    stat_empty_phase = stat_empty_phase ^ 1
+
+    return total_max, total_sum, bmm1_phase, stat_empty_phase
+
+
+@cute.jit
+def _softmax_warp_group(
+    sub_tile_id: int,
+    seqlen_q,
+    seqlen_kv,
+    scale_log2: cutlass.Float32,
+    tmem_ptr_i32,
+    sQ,
+    sStats_raw,
+    bars,
+    sched,
+    mb_softmax_ldtm,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+):
+    """Softmax warp group — online softmax + α publish (LSE write owned by correction)."""
+    # Wait on MMA's TMEM-publish named barrier BEFORE tmem_ptr_i32.load() — else stale base pointer.
+    nvvm.barrier_cta_sync(barrier_id=1, thread_count=32 * (CFG.SOFTMAX_WARPGROUPS * CFG.SOFTMAX_WG_WARPS + 1))
+    tmem_base = tmem_ptr_i32.load()
+
+    tmem_S_off = LAYOUT.S0_OFF if sub_tile_id == 0 else LAYOUT.S1_OFF
+    tmem_P_off = LAYOUT.P0_OFF if sub_tile_id == 0 else LAYOUT.P1_OFF
+
+    NEG_INF = cutlass.Float32(-3.4028235e38)
+
+    CHUNK = 64
+    P_COLS_PER_CHUNK = CHUNK // 4
+
+    bmm1_phase = cutlass.Int32(0)
+    stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+    epilogue_state = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+
+    # total_sum kept as Vector[Float32,2] so per-iter update lowers to packed FMUL2 + FADD2.
+    total_max = NEG_INF
+    total_sum = cutlass.Vector.from_elements(
+        (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+        cutlass.Float32,
+    )
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
+    tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
+
+    while is_valid_tile > cutlass.Int32(0):
+        if cutlass.const_expr(not (CFG.MASK_FLAGS & MASK_CAUSAL)):
+            read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+
+        # Both softmax wgs wait on slot [0]; without this softmax races ahead while TMA-STG drains prior tile.
+        bars.mb_o_empty[0].wait(epilogue_state)
+        epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        total_max = NEG_INF
+        total_sum = cutlass.Vector.from_elements(
+            (cutlass.Float32(0.0), cutlass.Float32(0.0)),
+            cutlass.Float32,
+        )
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # Bootstrap stat_empty wait lifts the wait out of per-iter critical path.
+        bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
+        stat_empty_phase = stat_empty_phase ^ 1
+        # 3-segment kv loop: LEFT-masked / unmasked (fast HW max) / RIGHT-masked.
+        # MASK_NONE: bounds collapse so masked sub-loops fold out at trace time.
+        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
+            for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_base,
+                    sStats_raw,
+                    bars,
+                    mb_softmax_ldtm,
+                    tid_in_wg,
+                    q_abs,
+                    eff_seqlen_kv,
+                    eff_seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+        else:
+            for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_base,
+                    sStats_raw,
+                    bars,
+                    mb_softmax_ldtm,
+                    tid_in_wg,
+                    q_abs,
+                    eff_seqlen_kv,
+                    eff_seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    False,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_base,
+                    sStats_raw,
+                    bars,
+                    mb_softmax_ldtm,
+                    tid_in_wg,
+                    q_abs,
+                    eff_seqlen_kv,
+                    eff_seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+            if cutlass.const_expr(CFG.MASK_FLAGS & MASK_CAUSAL):
+                read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+            for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
+                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                    True,
+                    sub_tile_id,
+                    kv_loop,
+                    tmem_base,
+                    sStats_raw,
+                    bars,
+                    mb_softmax_ldtm,
+                    tid_in_wg,
+                    q_abs,
+                    eff_seqlen_kv,
+                    eff_seqlen_q,
+                    scale_log2,
+                    total_max,
+                    total_sum,
+                    bmm1_phase,
+                    stat_empty_phase,
+                    leader_cta_id,
+                )
+
+        # Per-tile balance: softmax 1 bootstrap + n_kv end-of-body waits = n_kv+1 = corr fires.
+        total_sum_scalar = total_sum[0] + total_sum[1]
+
+        stats_base = cutlass.Int32(sub_tile_id * 2 * CFG.TILE_M)
+        sStats_raw.subview(stats_base + tid_in_wg).store(total_max)
+        sStats_raw.subview(stats_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).store(total_sum_scalar)
+        bars.mb_stat_full[sub_tile_id].arrive()
+
+        # make_warp_uniform on scheduler loads keeps payload in uniform regs across back-edge (no STL spill).
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load())
+        nxt_hb = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load())
+        nxt_v = cute.arch.make_warp_uniform((sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load())
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+
+@cute.jit
+def _correction_warp_group(
+    seqlen_q,
+    seqlen_kv,
+    sO,
+    sStats_raw,
+    tmem_ptr_i32,
+    tidx,
+    bars,
+    sched,
+    lse_tensor: Optional[cute.Tensor],
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor,
+    n_q_supers,
+    n_qh,
+    n_batch,
+    leader_cta_id,
+    cta_in_pair,
+    cta_id_x,
+):
+    """Correction warp group — α-rescale O + epilogue cast/store + LSE.
+
+    P14 catch-up flip on bmm2_done_phase at end of tile is REQUIRED for
+    multi-wave at n_kv=1.
+    """
+    # Wait on MMA's TMEM-publish named barrier BEFORE tmem_ptr_i32.load() — else stale base pointer.
+    nvvm.barrier_cta_sync(barrier_id=2, thread_count=32 * (CFG.CORRECTION_WARPS + 1))
+
+    tid_raw = cute.arch.thread_idx()[0]
+    tid_in_wg = tid_raw - cutlass.Int32(CFG.CORR_WARP_BASE * 32)
+
+    # O_CHUNK=16 keeps live range short enough to avoid spilling (O_CHUNK=32 spilled correction regs).
+    O_CHUNK = 16
+    N_CHUNKS_O = CFG.TILE_O // O_CHUNK
+    # D_BLOCK_SIZE must use O_SWZ_B not V_SWZ_B — fp8 V drops to Swz64B while half O stays Swz128B.
+    # Sized in BPE_O so it stays consistent with the BPE_O-derived O_SWZ_BYTES (BF16/FP16 O).
+    TMA_O_ITERS = (CFG.TILE_O * CFG.BPE_O) // CFG.O_SWZ_BYTES
+    D_BLOCK_SIZE = CFG.TILE_O // TMA_O_ITERS
+    TMA_O_GRANU_ELEMS = CFG.TILE_M * D_BLOCK_SIZE
+
+    stat_full_phase = cutlass.Int32(0)
+    bmm2_done_phase = cutlass.Int32(0)
+    o_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+
+    q_super_idx, head_idx, batch_idx = _dispatch_decode_initial(
+        sched.bidx_init,
+        sched.bidy_init,
+        sched.bidz_init,
+        cta_in_pair,
+        n_q_supers,
+        n_qh,
+        n_batch,
+        seq_kv_lens_tensor,
+    )
+    is_valid_tile = cutlass.Int32(1)
+    sched_state = PipelineState.start()
+
+    eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+
+    eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    while is_valid_tile > cutlass.Int32(0):
+        read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
+        # Iter-0 skip — MMA's iter-0 BMM2 uses init_d=False to overwrite O, no α-rescale needed.
+        if bounds.right > bounds.left:
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                bars.mb_stat_full[qs].wait(stat_full_phase)
+                bars.mb_stat_empty[qs].arrive()
+            stat_full_phase = stat_full_phase ^ 1
+        else:
+            bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+        for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
+            tmem_base_iter = tmem_ptr_i32.load()
+            for qs in cutlass.range_constexpr(CFG.TILES_Q):
+                tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+                bars.mb_stat_full[qs].wait(stat_full_phase)
+
+                stats_base = cutlass.Int32(qs * 2 * CFG.TILE_M)
+                alpha = sStats_raw.subview(stats_base + tid_in_wg).load()
+
+                # all_alpha_one ballot skips α-rescale once softmax stops bumping total_max.
+                alpha_is_one = alpha == cutlass.Float32(1.0)
+                all_alpha_one = vote_sync(0xFFFFFFFF, alpha_is_one, VoteSync.ALL)
+
+                bars.mb_stat_empty[qs].arrive()
+
+                bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+
+                # vec_scale_pair emits mul_packed_f32x2; without it the DSL lowers to scalar FMUL inside this runtime-if.
+                if ~all_alpha_one:
+                    for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                        o_addr = tmem_base_iter + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_chunk = nvvm.tcgen05_ld(
+                            "32x32b",
+                            nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                            num=O_CHUNK,
+                        )
+                        o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
+                        nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+
+                bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
+
+            stat_full_phase = stat_full_phase ^ 1
+            bmm2_done_phase = bmm2_done_phase ^ 1
+
+        tmem_base_epi = tmem_ptr_i32.load()
+        for qs in cutlass.range_constexpr(CFG.TILES_Q):
+            tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
+
+            bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+
+            bars.mb_stat_full[qs].wait(stat_full_phase)
+
+            stats_base = cutlass.Int32(qs * 2 * CFG.TILE_M)
+            total_max_scaled = sStats_raw.subview(stats_base + tid_in_wg).load()
+            total_sum = sStats_raw.subview(stats_base + cutlass.Int32(CFG.TILE_M) + tid_in_wg).load()
+
+            bars.mb_stat_empty[qs].arrive()
+
+            # Pre-declare inv_sum/lse_val — without it MLIR cf.if NameErrors the tracer post-branch.
+            inv_sum = cutlass.Float32(0.0)
+            lse_val = cutlass.Float32(0.0)
+            LN2 = cutlass.Float32(0.6931471805599453)
+            total_max_nat = total_max_scaled * LN2
+            if cutlass.const_expr(CFG.HAS_SINK):
+                sinks_arr = cutlass.make_array_view(sinks_tensor)
+                sink_logit = sinks_arr[head_idx]
+                new_max = cute.math.max(total_max_nat, sink_logit)
+                scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
+                new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
+                lse_val = new_max + cute.math.log(new_sum, fastmath=True)
+                inv_sum = scale / new_sum
+            else:
+                lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
+                # Safe inverse: avoid div by 0 (rows fully masked).
+                inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+
+            # OOB-row guard: under cga2 cluster Q rows can exceed seqlen_q (else write aliases next head's LSE slot).
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
+            if cutlass.const_expr(CFG.THD_VARLEN):
+                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
+                # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
+                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
+                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
+                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
+                _row_valid = q_row_global < _s_q_b
+                # has_lse=False: the Stats store is compiled out; the amax_o
+                # atomicMax below is independent of it and always live.
+                if cutlass.const_expr(lse_tensor is not None):
+                    if _row_valid:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
+                        lse_row[_cu_q_b + q_row_global] = lse_val
+            else:
+                _row_valid = q_row_global < seqlen_q
+                if cutlass.const_expr(lse_tensor is not None):
+                    if _row_valid:
+                        lse_arr = cutlass.make_array_view(lse_tensor)
+                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row[q_row_global] = lse_val
+
+            sO_sub_base = sO[qs].base
+
+            _amax_o_ptr = Pointer(amax_o_tensor.iterator.raw_ptr(), dtype=cutlass.Int32)
+            _amax_o_local = cutlass.Float32(0.0)
+
+            for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
+                o_addr = tmem_base_epi + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                o_chunk = nvvm.tcgen05_ld(
+                    "32x32b",
+                    nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
+                    num=O_CHUNK,
+                )
+                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
+                o_scaled = o_chunk * inv_sum
+                _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
+                o_out = o_scaled.to(OUT_STORAGE_DTYPE)
+
+                col_offset_const = (chunk_idx * O_CHUNK) % D_BLOCK_SIZE
+                block_idx_const = (chunk_idx * O_CHUNK) // D_BLOCK_SIZE
+                block_offset_const = block_idx_const * TMA_O_GRANU_ELEMS
+                smem_offset = cutlass.Int32(block_offset_const + col_offset_const) + tid_in_wg * cutlass.Int32(D_BLOCK_SIZE)
+
+                smem_ptr = sO_sub_base.subview(smem_offset).data_ptr()
+                # Gate FIRST SMEM store (not earlier TMEM-load loop) — keeps load/FFMA/cast overlapped with prior TMA-STG drain.
+                if chunk_idx == 0:
+                    bars.mb_o_empty[qs].wait(o_empty_phase)
+                smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
+
+            # One atomic per valid row (invalid/OOB rows must not poison the global amax).
+            if _row_valid:
+                nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
+
+            # fence_proxy needed before TMA reads SMEM written by tcgen05_st.
+            nvvm.fence_proxy("async.shared", space="cta")
+
+            bars.mb_o_full[qs].arrive()
+
+        stat_full_phase = stat_full_phase ^ 1
+        o_empty_phase = o_empty_phase ^ 1
+        # P14 catch-up flip — bmm2_done_phase ^= 1 AFTER epilogue wait (else n_kv=1 multi-wave deadlocks on tile 2).
+        bmm2_done_phase = bmm2_done_phase ^ 1
+
+        wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
+        nxt_q = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(0))).load()
+        nxt_hb = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(1))).load()
+        nxt_v = (sched.tile_id_smem.subview(sched_state.idx * cutlass.Int32(8) + cutlass.Int32(2))).load()
+        q_super_idx, head_idx, batch_idx = _dispatch_decode_payload(
+            nxt_q,
+            nxt_hb,
+            cta_in_pair,
+            n_q_supers,
+            n_qh,
+            n_batch,
+            seq_kv_lens_tensor,
+        )
+        is_valid_tile = nxt_v & cutlass.Int32(1)
+        sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
+        eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
+        eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+
+    # mb_tmem_dealloc fan-out — all-lanes arrive + DSMEM-arrive on cross-pair peer under cga2.
+    if cutlass.const_expr(CFG.CTA_MMA == 2):
+        peer_cta = cta_id_x ^ cutlass.Int32(1)
+        bars.mb_tmem_dealloc.arrive_on_peer(peer_cta)
+    bars.mb_tmem_dealloc.arrive()
+
+
+# === Host launcher ===
+
+
+@cute.jit
+def _host(
+    q_tensor: cute.Tensor,
+    k_tensor: cute.Tensor,
+    v_tensor: cute.Tensor,
+    o_tensor: cute.Tensor,
+    sf_q_tensor: cute.Tensor,
+    sf_k_tensor: cute.Tensor,
+    sf_v_tensor: cute.Tensor,
+    lse_tensor: Optional[cute.Tensor],
+    amax_o_tensor: cute.Tensor,
+    sinks_tensor: cute.Tensor,
+    seq_kv_lens_tensor: cute.Tensor,
+    o_desc_words: cute.Tensor,
+    problem_size: Tuple[int, int, int, int, int, int],
+    scale_softmax_log2: cutlass.Float32,
+    n_thd_units: cutlass.Int32,
+    total_q_sf_tiles: cutlass.Int32,
+    total_kv_sf_tiles: cutlass.Int32,
+    stream: _cuda_driver.CUstream = None,
+) -> None:
+    """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors.
+
+    THD/varlen: q/k/v/o/lse/SF are PACKED with batch dim 1; the SF descriptors use
+    B=1 + total_*_sf_tiles (per-sequence-TILE-padded SF layout); O uses a per-batch
+    descriptor array (build_o_descs_kernel)."""
+    B, QH, KH, SQ, SKV, _ = problem_size
+
+    _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O  # O box sized in BPE_O (BF16/FP16 O)
+    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    k_rank5_layout = cute.make_layout(
+        (
+            k_tensor.shape[0],
+            k_tensor.shape[2],
+            TMA_QK_ITERS,
+            k_tensor.shape[1],
+            TMA_QK_GRANU_ELEMS,
+        ),
+        stride=(
+            k_tensor.shape[1] * k_tensor.shape[2] * CFG.TILE_K,
+            CFG.TILE_K,
+            TMA_QK_GRANU_ELEMS,
+            k_tensor.shape[2] * CFG.TILE_K,
+            1,
+        ),
+    )
+    k_rank5_tensor = cute.make_tensor(k_tensor.iterator, k_rank5_layout)
+    qk_box_k = (1, 1, TMA_QK_ITERS, CFG.TILE_N // CFG.CTA_MMA, TMA_QK_GRANU_ELEMS)
+    vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    stride_order = (3, 2, 1, 0)
+
+    # SF TMA: 5-D, box=(128, num_rows, 1, 1, 1); cga2 K_SF/V_SF narrows to (128, num_rows//CTA_MMA, ...).
+    # The D192 Q/K tile contains two adjacent 512-B SF blocks. Reinterpreting
+    # the tile as flat 128-B rows keeps both blocks contiguous in this 5-D map.
+    SF_TMA_ROW_BYTES = 128
+    SF_NUM_ROWS_Q = SF_SMEM_SIZE_Q // SF_TMA_ROW_BYTES
+    SF_NUM_ROWS_K = SF_SMEM_SIZE_K // SF_TMA_ROW_BYTES
+    SF_NUM_ROWS_V = SF_SMEM_SIZE_V // SF_TMA_ROW_BYTES
+
+    def _tma_swz(byte_w: int):
+        return tmap.TensorMapSwizzle.s128b if byte_w == 128 else tmap.TensorMapSwizzle.s64b if byte_w == 64 else tmap.TensorMapSwizzle.s32b
+
+    tma_q_desc = tmap.create_tensor_map_tiled_from_view(
+        q_tensor,
+        box_dims=qk_box_q,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.Q_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_k_desc = tmap.create_tensor_map_tiled_from_view(
+        k_rank5_tensor,
+        box_dims=qk_box_k,
+        stride_order=(4, 3, 2, 1, 0),
+        swizzle=_tma_swz(CFG.K_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_v_desc = tmap.create_tensor_map_tiled_from_view(
+        v_tensor,
+        box_dims=vo_box_v,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.V_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    tma_o_desc = tmap.create_tensor_map_tiled_from_view(
+        o_tensor,
+        box_dims=vo_box_o,
+        stride_order=stride_order,
+        swizzle=_tma_swz(CFG.O_SWZ_BYTES),
+        l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+    )
+    # SF TMA strides in 16-B units (TMA convention); reinterpret 4-D runner SF tensor as 5-D split-byte view.
+    # Dense: per-batch tile counts (SQ/TILE_M, SKV/TILE_N), B-extent = B.  THD:
+    # the SF tensor is PACKED (batch dim 1) and per-sequence-TILE-padded, so the
+    # descriptor uses num_tiles = total_*_sf_tiles (Σ_b ceil(S/TILE)) and B = 1.
+    # _B_SF folds to the const 1 under THD so the descriptor's batch extent is correct.
+    sq_sf_tiles = (SQ + CFG.TILE_M - 1) // CFG.TILE_M
+    skv_sf_tiles = (SKV + CFG.TILE_N - 1) // CFG.TILE_N
+    _B_SF = 1 if cutlass.const_expr(CFG.THD_VARLEN) else B
+    _q_sf_num_tiles = total_q_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else sq_sf_tiles
+    _kv_sf_num_tiles = total_kv_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else skv_sf_tiles
+
+    def _build_sf_desc(sf_tensor, num_tiles, sf_smem_size, num_rows_box, num_heads):
+        sf_base = cutlass.Int64(sf_tensor.iterator.toint())
+        tile_stride_16 = sf_smem_size // 16
+        return tmap.create_tensor_map_tiled(
+            global_address=sf_base,
+            dtype=cutlass.Uint8,
+            global_dims=[
+                SF_TMA_ROW_BYTES,
+                sf_smem_size // SF_TMA_ROW_BYTES,
+                num_tiles,
+                num_heads,
+                _B_SF,
+            ],
+            global_strides=[
+                SF_TMA_ROW_BYTES // 16,
+                tile_stride_16,
+                num_tiles * tile_stride_16,
+                num_heads * num_tiles * tile_stride_16,
+            ],
+            box_dims=[SF_TMA_ROW_BYTES, num_rows_box, 1, 1, 1],
+            swizzle=tmap.TensorMapSwizzle.none,
+            l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
+        )
+
+    tma_q_sf_desc = _build_sf_desc(sf_q_tensor, _q_sf_num_tiles, SF_SMEM_SIZE_Q, SF_NUM_ROWS_Q, QH)
+    tma_k_sf_desc = _build_sf_desc(sf_k_tensor, _kv_sf_num_tiles, SF_SMEM_SIZE_K, SF_NUM_ROWS_K // CFG.CTA_MMA, KH)
+    tma_v_sf_desc = _build_sf_desc(sf_v_tensor, _kv_sf_num_tiles, SF_SMEM_SIZE_V, SF_NUM_ROWS_V // CFG.CTA_MMA, KH)
+
+    rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
+    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    grid_q_supers = q_clusters * CFG.CTA_MMA
+    q_supers = grid_q_supers
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
+        # packed [1,T,QH,D_v] O as base), then launch the exact flat
+        # batch-outermost grid (n_thd_units = Σ_b ceil(S_q_b/CGA_TILE_M)*QH,
+        # host-computed); grid_x = n_thd_units * CGA_M.  Works at cga1 (CGA_M=1).
+        _build_o_descs_kernel(
+            o_tensor,
+            tma_o_desc,
+            o_desc_words,
+            seq_kv_lens_tensor,
+            cutlass.Int32(QH),
+            cutlass.Int32(B),
+            cutlass.Int32(CFG.TILE_O),
+        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
+        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
+    else:
+        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    _kernel(
+        tma_q_desc,
+        tma_k_desc,
+        tma_v_desc,
+        tma_o_desc,
+        tma_q_sf_desc,
+        tma_k_sf_desc,
+        tma_v_sf_desc,
+        lse_tensor,
+        amax_o_tensor,
+        sinks_tensor,
+        seq_kv_lens_tensor,
+        o_desc_words,
+        cutlass.Int32(SQ),
+        cutlass.Int32(SKV),
+        cutlass.Int32(q_supers),
+        cutlass.Int32(QH),
+        cutlass.Int32(B),
+        cutlass.Int32(QH // KH),
+        scale_softmax_log2,
+    ).launch(
+        grid=grid_shape,
+        block=[CFG.THREADS_PER_CTA, 1, 1],
+        cluster=(CFG.CTA_MMA, 1, 1),
+        stream=stream,
+    )
+
+
+@lru_cache(maxsize=None)
+def compile(  # noqa: A001
+    b: int = 1,
+    qh: int = 1,
+    kh: int = 1,
+    sq: int = 256,
+    skv: int = 128,
+    total_q_sf_tiles: int = 0,
+    total_kv_sf_tiles: int = 0,
+    has_lse: bool = True,
+) -> Callable:
+    """Compile a kernel with concrete dims; 3 SF tensors layout [B, H, num_seq_tiles, SF_SMEM_SIZE_*].
+
+    ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
+    ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
+    at all; the amax_o atomicMax write is independent and unchanged.
+
+    THD/varlen: q/k/v/o/lse + SF tensors are PACKED with batch dim 1; ``b`` is the
+    LOGICAL batch (sequence count).  The SF tensors are per-sequence-TILE-padded so
+    their packed tile extent is ``total_q_sf_tiles`` / ``total_kv_sf_tiles`` (=
+    Σ_b ceil(S/TILE)); pass those (they vary with the cu_seqlens partition, hence
+    part of the lru_cache key).  Default 0 → fall back to the dense per-batch
+    tile counts so the dense path is unaffected."""
+    _fake_batch = 1 if CFG.THD_VARLEN else b
+
+    # Q SF tiles TILE_M-row wide → num_tiles = SQ/TILE_M; K/V SF TILE_N-row wide → num_tiles = SKV/TILE_N.
+    # THD: packed (batch dim 1) + per-sequence-TILE-padded → total_*_sf_tiles tiles.
+    sq_tiles = (sq + CFG.TILE_M - 1) // CFG.TILE_M
+    skv_tiles = (skv + CFG.TILE_N - 1) // CFG.TILE_N
+    if CFG.THD_VARLEN:
+        _q_sf_tiles = total_q_sf_tiles if total_q_sf_tiles > 0 else b * sq_tiles
+        _kv_sf_tiles = total_kv_sf_tiles if total_kv_sf_tiles > 0 else b * skv_tiles
+    else:
+        _q_sf_tiles = sq_tiles
+        _kv_sf_tiles = skv_tiles
+
+    fake_q = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, sq, qh, CFG.TILE_K),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_k = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, CFG.TILE_K),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_v = cute.runtime.make_fake_compact_tensor(
+        STORAGE_DTYPE,
+        (_fake_batch, skv, kh, CFG.TILE_O),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_o = cute.runtime.make_fake_compact_tensor(
+        OUT_STORAGE_DTYPE,
+        (_fake_batch, sq, qh, CFG.TILE_O),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    fake_sf_q = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, qh, _q_sf_tiles, SF_SMEM_SIZE_Q),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_sf_k = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_K),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+    fake_sf_v = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int8,
+        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_V),
+        stride_order=(3, 2, 1, 0),
+        assumed_align=16,
+    )
+
+    if not has_lse:
+        # No Stats output: the LSE argument is None-specialized and the store
+        # is compiled out entirely — no dummy buffer exists at any level.
+        fake_lse = None
+    else:
+        fake_lse = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (_fake_batch, qh, sq),
+            stride_order=(2, 1, 0),
+            assumed_align=16,
+        )
+    fake_amax_o = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (1,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    fake_sinks = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32,
+        (qh,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # seq_kv_lens always part of the ABI; THD overloads it as the
+    # [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] metadata buffer (length 3B+2).
+    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (_skv_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    # Per-batch O TMA-descriptor array (TENSOR_MAP_QWORDS int64 = 128 B each) + 1
+    # pad slot; dummy 1-elem when THD off (kernel never reads it).
+    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
+    fake_o_desc = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int64,
+        (_odesc_len,),
+        stride_order=(0,),
+        assumed_align=16,
+    )
+    return cute.compile(
+        _host,
+        fake_q,
+        fake_k,
+        fake_v,
+        fake_o,
+        fake_sf_q,
+        fake_sf_k,
+        fake_sf_v,
+        fake_lse,
+        fake_amax_o,
+        fake_sinks,
+        fake_seq_kv_lens,
+        fake_o_desc,
+        (b, qh, kh, sq, skv, 0),
+        cutlass.Float32(0.0),
+        cutlass.Int32(0),
+        cutlass.Int32(_q_sf_tiles),
+        cutlass.Int32(_kv_sf_tiles),
+        stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
+        options="--enable-tvm-ffi",
+    )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
@@ -53,12 +53,9 @@ Cfg = type(CFG)
 # row_max_reduction_64 (default 0). api_dsl sets this from the device capability at
 # compile time; a distinct value yields a distinct kernel specialization (cache key).
 FUSED_LDTM_STAT = int(PARAMS.fused_ldtm_stat)
-# MXFP8 THD / varlen is supported via a packed, per-sequence-TILE-padded SF
-# layout (the shared MXFP8 quantizer writes SF tiles at cu_sf[b] + local_tile;
-# this kernel reads them with the matching tile base from _thd_sf_tile_bases).
-# Q/K/V data ride the f16/fp8 packed [1,T,H,D] + cu_seqlens coord path; the SF
-# tensors use B=1 + total_*_sf_tiles descriptors.  Gated on CFG.THD_VARLEN so
-# the dense [B,S,H,D] path stays byte-identical.
+# THD / varlen is NOT supported here: the legacy THD leg was removed upstream
+# (issue #552). A future port must use the device-built-metadata plus plan-time
+# envelope design used by the f16 kernels; CFG.THD_VARLEN=1 fails at trace time.
 TMA_QK_ITERS = _TMA.QK_ITERS
 TMA_VO_ITERS = _TMA.VO_ITERS
 TMA_QK_GRANU_ELEMS = _TMA.QK_GRANU_ELEMS
@@ -106,7 +103,7 @@ from cudnn.frost.tile_dsl.tma import (
     bulk_copy,
     bulk_copy_multicast,
 )
-from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, GmemTileLinear, tma_slice_runtime_desc
+from cudnn.frost.tile_dsl.handles import MmaDesc, SmemTile, GmemTileTma, GmemTileLinear
 from cudnn.frost.tile_dsl.tmem import tmem_alloc, tmem_dealloc
 from cudnn.frost.tile_dsl.mask import (
     apply_mask_chunk,
@@ -264,7 +261,6 @@ from cudnn.sdpa.fwd.kernels._common_sm100 import (
     KvLoopBounds,
     make_classic_bars,
     compute_kv_loop_bounds,
-    decode_linear_tile_lpt,
     make_sdpa_helpers,
     assert_tile_n_supported,
 )
@@ -301,17 +297,9 @@ _bounds_for_tile = _sdpa_h.bounds_for_tile
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
 _resolve_seqlen_q = _sdpa_h.resolve_seqlen_q
 
-# THD / varlen — flat-grid decode + tma-offset closures (CFG-bound) from the
-# factory; O-descriptor builder + TENSOR_MAP_QWORDS from the shared
-# kernels/dsl/common/sdpa/thd.py.  Gated by CFG.THD_VARLEN (folds out otherwise).
-# Supported at cga1 and cga2 (TILES_Q=2 → two Q slabs / O stores per tile).
-# seq_kv_lens overloaded as the THD metadata buffer (int32 len 3B+2):
-#   [0..B-1]=seq_kv_lens  [B..2B]=cu_q(B+1)  [2B+1..3B+1]=cu_k(B+1)
-# MXFP8-only: _thd_sf_tile_bases returns the per-sequence SF-tile prefix bases
-# (cu_sf_q_base / cu_sf_k_base) for the packed scale-factor layout.
-from cudnn.sdpa.fwd.kernels.thd_sm100 import build_o_descs_kernel as _build_o_descs_kernel, TENSOR_MAP_QWORDS
-
-_TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
+# Flat-grid decode dispatch + seq-offset helpers from the shared factory. The
+# legacy THD leg was removed; these helpers fold to dense identity at
+# THD_VARLEN=0, preserving the existing TMA coordinates.
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
@@ -413,7 +401,6 @@ def _kernel(
     amax_o_tensor: cute.Tensor,
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
-    o_desc_words: cute.Tensor,
     seqlen_q: cutlass.Int32,
     seqlen_kv: cutlass.Int32,
     n_q_supers: cutlass.Int32,
@@ -616,11 +603,7 @@ def _kernel(
     sf_mcast_mask = cutlass.Int16(3) if cutlass.const_expr(CFG.CTA_MMA == 2) else cutlass.Int16(0)
     is_leader = cta_in_pair == cutlass.Int32(0)
 
-    softmax_first_end = (
-        CFG.CORR_WARP_BASE
-        if cutlass.const_expr(MERGE_SOFTMAX_WGS)
-        else CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS
-    )
+    softmax_first_end = CFG.CORR_WARP_BASE if cutlass.const_expr(MERGE_SOFTMAX_WGS) else CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS
     if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < softmax_first_end:
         if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == 0):
             nvvm.setmaxregister(200, nvvm.SetMaxRegisterAction.INCREASE)
@@ -817,7 +800,6 @@ def _kernel(
             n_batch=n_batch,
             cta_in_pair=cta_in_pair,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
-            o_desc_words=o_desc_words,
         )
 
     else:  # warp_idx == CFG.SCHED_WARP_ID
@@ -1161,7 +1143,6 @@ def _tmastg_warp_group(
     n_batch,
     cta_in_pair,
     seq_kv_lens_tensor,
-    o_desc_words,
 ):
     """TMA-STG warp — O SMEM→GMEM store."""
     o_full_phase = cutlass.Int32(0)
@@ -1190,19 +1171,10 @@ def _tmastg_warp_group(
             bars.mb_o_full[qs].wait(o_full_phase)
 
             # O TMA params follow O's swizzle, NOT V's — required when V_SWZ_B != O_SWZ_B.
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: store each Q slab through this batch's pre-built descriptor
-                # (base at the sequence's packed row, seq extent = S_q_b → a box
-                # past S_q_b is OOB-clipped).  q_row coord is sequence-local; the
-                # batch coord collapses to 0.  Both slabs share one descriptor.
-                o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
-                tma_store_tile(sO[qs], o_slice)
-            else:
-                tma_store_tile(
-                    sO[qs],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
-                )
+            tma_store_tile(
+                sO[qs],
+                tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+            )
 
             tma_store_commit()
             tma_store_wait(0)
@@ -1423,9 +1395,7 @@ def _mma_warp_group(
         smem_desc_v_sf=None,
     ):
         if cutlass.const_expr(SF_NUM_BLOCKS_K == 2):
-            first_k_count = (
-                1 if cutlass.const_expr(CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS != 0) else SF_BLOCK_DIM_K
-            )
+            first_k_count = 1 if cutlass.const_expr(CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS != 0) else SF_BLOCK_DIM_K
             # Block 0 covers the first four K steps.  E4 causal gives block 1
             # extra lead time; other paths delay it to the exact-use frontier.
             if nvvm.elect_sync():
@@ -1525,9 +1495,7 @@ def _mma_warp_group(
             # Recompute for every persistent tile: scheduler payload, effective
             # sequence lengths, and therefore the causal tail all change.
             cga_q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
-            s0_last_q = cga_q_row_base + cutlass.Int32(
-                (CFG.CTA_MMA - 1) * CFG.TILES_Q * CFG.TILE_M + CFG.TILE_M - 1
-            )
+            s0_last_q = cga_q_row_base + cutlass.Int32((CFG.CTA_MMA - 1) * CFG.TILES_Q * CFG.TILE_M + CFG.TILE_M - 1)
             causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else cutlass.Int32(0)
             s0_last_valid_k = s0_last_q + causal_diag + cutlass.Int32(CFG.WINDOW_RIGHT)
             tail_k_begin = (kv_right - cutlass.Int32(1)) * cutlass.Int32(CFG.TILE_N)
@@ -2165,9 +2133,7 @@ def _softmax_warp_group(
     bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
 
     if cutlass.const_expr(MERGE_SOFTMAX_WGS):
-        softmax_wg_base = cutlass.Int32(CFG.SOFTMAX_WG0_BASE) + sub_tile_id * cutlass.Int32(
-            CFG.SOFTMAX_WG1_BASE - CFG.SOFTMAX_WG0_BASE
-        )
+        softmax_wg_base = cutlass.Int32(CFG.SOFTMAX_WG0_BASE) + sub_tile_id * cutlass.Int32(CFG.SOFTMAX_WG1_BASE - CFG.SOFTMAX_WG0_BASE)
         tid_in_wg = cute.arch.thread_idx()[0] - softmax_wg_base * cutlass.Int32(32)
     else:
         softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
@@ -2477,27 +2443,14 @@ def _correction_warp_group(
 
             # OOB-row guard: under cga2 cluster Q rows can exceed seqlen_q (else write aliases next head's LSE slot).
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
-            if cutlass.const_expr(CFG.THD_VARLEN):
-                # THD: q_row_global is sequence-local; LSE is packed [1,QH,T] →
-                # index [0, head, cu_q[b] + local], bound by per-sequence Q len S_q_b.
-                _cu = cutlass.make_array_view(seq_kv_lens_tensor)
-                _cu_q_b = cutlass.Int32(_cu[n_batch + batch_idx])
-                _s_q_b = cutlass.Int32(_cu[n_batch + batch_idx + cutlass.Int32(1)]) - _cu_q_b
-                _row_valid = q_row_global < _s_q_b
-                # has_lse=False: the Stats store is compiled out; the amax_o
-                # atomicMax below is independent of it and always live.
-                if cutlass.const_expr(lse_tensor is not None):
-                    if _row_valid:
-                        lse_arr = cutlass.make_array_view(lse_tensor)
-                        lse_row = lse_arr[cutlass.Int32(0), head_idx, :]
-                        lse_row[_cu_q_b + q_row_global] = lse_val
-            else:
-                _row_valid = q_row_global < seqlen_q
-                if cutlass.const_expr(lse_tensor is not None):
-                    if _row_valid:
-                        lse_arr = cutlass.make_array_view(lse_tensor)
-                        lse_row = lse_arr[batch_idx, head_idx, :]
-                        lse_row[q_row_global] = lse_val
+            _row_valid = q_row_global < seqlen_q
+            # has_lse=False: the Stats store is compiled out; the amax_o
+            # atomicMax below is independent of it and always live.
+            if cutlass.const_expr(lse_tensor is not None):
+                if _row_valid:
+                    lse_arr = cutlass.make_array_view(lse_tensor)
+                    lse_row = lse_arr[batch_idx, head_idx, :]
+                    lse_row[q_row_global] = lse_val
 
             sO_sub_base = sO[qs].base
 
@@ -2591,19 +2544,15 @@ def _host(
     amax_o_tensor: cute.Tensor,
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
-    o_desc_words: cute.Tensor,
     problem_size: Tuple[int, int, int, int, int, int],
     scale_softmax_log2: cutlass.Float32,
-    n_thd_units: cutlass.Int32,
-    total_q_sf_tiles: cutlass.Int32,
-    total_kv_sf_tiles: cutlass.Int32,
     stream: _cuda_driver.CUstream = None,
 ) -> None:
-    """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors.
-
-    THD/varlen: q/k/v/o/lse/SF are PACKED with batch dim 1; the SF descriptors use
-    B=1 + total_*_sf_tiles (per-sequence-TILE-padded SF layout); O uses a per-batch
-    descriptor array (build_o_descs_kernel)."""
+    """MXFP8 host launcher — builds TMA descriptors for Q/K/V/O + SF tensors."""
+    if cutlass.const_expr(CFG.THD_VARLEN):
+        raise NotImplementedError(
+            "prefill_d192_d128_mxfp8_sm100: the legacy THD leg was removed; " "port the write_thd_meta envelope design (issue #552) instead"
+        )
     B, QH, KH, SQ, SKV, _ = problem_size
 
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O  # O box sized in BPE_O (BF16/FP16 O)
@@ -2669,16 +2618,13 @@ def _host(
         swizzle=_tma_swz(CFG.O_SWZ_BYTES),
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
-    # SF TMA strides in 16-B units (TMA convention); reinterpret 4-D runner SF tensor as 5-D split-byte view.
-    # Dense: per-batch tile counts (SQ/TILE_M, SKV/TILE_N), B-extent = B.  THD:
-    # the SF tensor is PACKED (batch dim 1) and per-sequence-TILE-padded, so the
-    # descriptor uses num_tiles = total_*_sf_tiles (Σ_b ceil(S/TILE)) and B = 1.
-    # _B_SF folds to the const 1 under THD so the descriptor's batch extent is correct.
+    # SF TMA strides in 16-B units (TMA convention); reinterpret the 4-D runner
+    # SF tensor as a 5-D split-byte view with per-batch tile counts.
     sq_sf_tiles = (SQ + CFG.TILE_M - 1) // CFG.TILE_M
     skv_sf_tiles = (SKV + CFG.TILE_N - 1) // CFG.TILE_N
-    _B_SF = 1 if cutlass.const_expr(CFG.THD_VARLEN) else B
-    _q_sf_num_tiles = total_q_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else sq_sf_tiles
-    _kv_sf_num_tiles = total_kv_sf_tiles if cutlass.const_expr(CFG.THD_VARLEN) else skv_sf_tiles
+    _B_SF = B
+    _q_sf_num_tiles = sq_sf_tiles
+    _kv_sf_num_tiles = skv_sf_tiles
 
     def _build_sf_desc(sf_tensor, num_tiles, sf_smem_size, num_rows_box, num_heads):
         sf_base = cutlass.Int64(sf_tensor.iterator.toint())
@@ -2712,23 +2658,7 @@ def _host(
     q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
-    if cutlass.const_expr(CFG.THD_VARLEN):
-        # THD: build the per-batch O descriptor array (reuse tma_o_desc over the
-        # packed [1,T,QH,D_v] O as base), then launch the exact flat
-        # batch-outermost grid (n_thd_units = Σ_b ceil(S_q_b/CGA_TILE_M)*QH,
-        # host-computed); grid_x = n_thd_units * CGA_M.  Works at cga1 (CGA_M=1).
-        _build_o_descs_kernel(
-            o_tensor,
-            tma_o_desc,
-            o_desc_words,
-            seq_kv_lens_tensor,
-            cutlass.Int32(QH),
-            cutlass.Int32(B),
-            cutlass.Int32(CFG.TILE_O),
-        ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
-        grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
-    else:
-        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
     _kernel(
         tma_q_desc,
         tma_k_desc,
@@ -2741,7 +2671,6 @@ def _host(
         amax_o_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
-        o_desc_words,
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
@@ -2764,75 +2693,60 @@ def compile(  # noqa: A001
     kh: int = 1,
     sq: int = 256,
     skv: int = 128,
-    total_q_sf_tiles: int = 0,
-    total_kv_sf_tiles: int = 0,
     has_lse: bool = True,
 ) -> Callable:
     """Compile a kernel with concrete dims; 3 SF tensors layout [B, H, num_seq_tiles, SF_SMEM_SIZE_*].
 
     ``has_lse=False`` compiles the LSE store out (the kernel specializes on a
     ``None`` LSE argument) — callers without a Stats output pass no LSE buffer
-    at all; the amax_o atomicMax write is independent and unchanged.
-
-    THD/varlen: q/k/v/o/lse + SF tensors are PACKED with batch dim 1; ``b`` is the
-    LOGICAL batch (sequence count).  The SF tensors are per-sequence-TILE-padded so
-    their packed tile extent is ``total_q_sf_tiles`` / ``total_kv_sf_tiles`` (=
-    Σ_b ceil(S/TILE)); pass those (they vary with the cu_seqlens partition, hence
-    part of the lru_cache key).  Default 0 → fall back to the dense per-batch
-    tile counts so the dense path is unaffected."""
-    _fake_batch = 1 if CFG.THD_VARLEN else b
+    at all; the amax_o atomicMax write is independent and unchanged."""
 
     # Q SF tiles TILE_M-row wide → num_tiles = SQ/TILE_M; K/V SF TILE_N-row wide → num_tiles = SKV/TILE_N.
-    # THD: packed (batch dim 1) + per-sequence-TILE-padded → total_*_sf_tiles tiles.
     sq_tiles = (sq + CFG.TILE_M - 1) // CFG.TILE_M
     skv_tiles = (skv + CFG.TILE_N - 1) // CFG.TILE_N
-    if CFG.THD_VARLEN:
-        _q_sf_tiles = total_q_sf_tiles if total_q_sf_tiles > 0 else b * sq_tiles
-        _kv_sf_tiles = total_kv_sf_tiles if total_kv_sf_tiles > 0 else b * skv_tiles
-    else:
-        _q_sf_tiles = sq_tiles
-        _kv_sf_tiles = skv_tiles
+    _q_sf_tiles = sq_tiles
+    _kv_sf_tiles = skv_tiles
 
     fake_q = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (_fake_batch, sq, qh, CFG.TILE_K),
+        (b, sq, qh, CFG.TILE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_k = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (_fake_batch, skv, kh, CFG.TILE_K),
+        (b, skv, kh, CFG.TILE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_v = cute.runtime.make_fake_compact_tensor(
         STORAGE_DTYPE,
-        (_fake_batch, skv, kh, CFG.TILE_O),
+        (b, skv, kh, CFG.TILE_O),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_o = cute.runtime.make_fake_compact_tensor(
         OUT_STORAGE_DTYPE,
-        (_fake_batch, sq, qh, CFG.TILE_O),
+        (b, sq, qh, CFG.TILE_O),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
 
     fake_sf_q = cute.runtime.make_fake_compact_tensor(
         cutlass.Int8,
-        (_fake_batch, qh, _q_sf_tiles, SF_SMEM_SIZE_Q),
+        (b, qh, _q_sf_tiles, SF_SMEM_SIZE_Q),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_sf_k = cute.runtime.make_fake_compact_tensor(
         cutlass.Int8,
-        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_K),
+        (b, kh, _kv_sf_tiles, SF_SMEM_SIZE_K),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
     fake_sf_v = cute.runtime.make_fake_compact_tensor(
         cutlass.Int8,
-        (_fake_batch, kh, _kv_sf_tiles, SF_SMEM_SIZE_V),
+        (b, kh, _kv_sf_tiles, SF_SMEM_SIZE_V),
         stride_order=(3, 2, 1, 0),
         assumed_align=16,
     )
@@ -2844,7 +2758,7 @@ def compile(  # noqa: A001
     else:
         fake_lse = cute.runtime.make_fake_compact_tensor(
             cutlass.Float32,
-            (_fake_batch, qh, sq),
+            (b, qh, sq),
             stride_order=(2, 1, 0),
             assumed_align=16,
         )
@@ -2860,21 +2774,10 @@ def compile(  # noqa: A001
         stride_order=(0,),
         assumed_align=16,
     )
-    # seq_kv_lens always part of the ABI; THD overloads it as the
-    # [seq_kv_lens(B)|cu_q(B+1)|cu_k(B+1)] metadata buffer (length 3B+2).
-    _skv_len = (3 * b + 2) if CFG.THD_VARLEN else b
+    # seq_kv_lens is always part of the ABI; unread when absent.
     fake_seq_kv_lens = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (_skv_len,),
-        stride_order=(0,),
-        assumed_align=16,
-    )
-    # Per-batch O TMA-descriptor array (TENSOR_MAP_QWORDS int64 = 128 B each) + 1
-    # pad slot; dummy 1-elem when THD off (kernel never reads it).
-    _odesc_len = (b * _TENSOR_MAP_QWORDS + _TENSOR_MAP_QWORDS) if CFG.THD_VARLEN else 1
-    fake_o_desc = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int64,
-        (_odesc_len,),
+        (b,),
         stride_order=(0,),
         assumed_align=16,
     )
@@ -2891,12 +2794,8 @@ def compile(  # noqa: A001
         fake_amax_o,
         fake_sinks,
         fake_seq_kv_lens,
-        fake_o_desc,
         (b, qh, kh, sq, skv, 0),
         cutlass.Float32(0.0),
-        cutlass.Int32(0),
-        cutlass.Int32(_q_sf_tiles),
-        cutlass.Int32(_kv_sf_tiles),
         stream=cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=False),
         options="--enable-tvm-ffi",
     )

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
@@ -157,6 +157,18 @@ def _exp2_chunk0_mask_aware(vec, apply_mask):
     return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
 
 
+def _exp2_chunk0_e4_6pairs(vec):
+    values = []
+    for i in range(0, int(vec.shape[0]), 2):
+        if i < 30 and i % 10 < 4:
+            x, y = ex2_emulation_2(vec[i], vec[i + 1])
+        else:
+            x = cute.math.exp2(vec[i], fastmath=True)
+            y = cute.math.exp2(vec[i + 1], fastmath=True)
+        values.extend((x, y))
+    return cutlass.Vector.from_elements(tuple(values), cutlass.Float32)
+
+
 def _exp2_mixed_late(vec):
     values = []
     for i in range(0, int(vec.shape[0]), 2):
@@ -306,8 +318,10 @@ _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 _thd_sf_tile_bases = _sdpa_h.thd_sf_tile_bases
 
 
-# Kernel TMEM layout: P aliases each S_acc tail (4:1 FP8 pack), while block
-# scale operands reuse transiently dead regions within the 512-column limit.
+# Kernel TMEM layout: each logical P cross-inplaces the opposite S_acc tail
+# (4:1 FP8 pack), while block-scale operands reuse transiently dead regions
+# within the 512-column limit.  This lets the next score MMA issue before the
+# preceding PV MMA, guarded by the softmax score-loaded handoff.
 @dataclass(frozen=True)
 class KernelTmemLayout:
     # Blackwell SM10.0 512-col TMEM cap.
@@ -319,10 +333,9 @@ class KernelTmemLayout:
     O0_OFF: int = 256
     O1_OFF: int = 384
 
-    # FP8 P is 4:1-packed at the S_acc tails (96 / 224); the lower halves of each
-    # S_acc slot (< P) are free for reloaded SF operands.
-    P0_OFF: int = 96
-    P1_OFF: int = 224
+    # Logical P0 occupies physical S_acc_1; logical P1 occupies S_acc_0.
+    P0_OFF: int = 224
+    P1_OFF: int = 96
 
     SF_HEAD_OFFSET: int = 8
     SF_AFTER_P_OFFSET: int = 32
@@ -344,12 +357,11 @@ class KernelTmemLayout:
     SF_K0_PRO_OFF: int = 256 + SF_TMEM_COLS_Q  # 264
     SF_Q1_PRO_OFF: int = 256 + SF_TMEM_COLS_Q + SF_TMEM_COLS_K  # 272
     SF_K1_PRO_OFF: int = 256 + 2 * SF_TMEM_COLS_Q + SF_TMEM_COLS_K  # 280
-    # BMM2 SF_P/V per sub-tile (S_acc region + SF_AFTER_P_OFFSET); the existing
-    # bmm2_ready wait already proves softmax read all of S_acc, so no extra gate.
-    SF_P0_OFF: int = SF_AFTER_P_OFFSET  # 32
-    SF_V0_OFF: int = SF_AFTER_P_OFFSET + SF_TMEM_COLS_P  # 36
-    SF_P1_OFF: int = 128 + SF_AFTER_P_OFFSET  # 160
-    SF_V1_OFF: int = 128 + SF_AFTER_P_OFFSET + SF_TMEM_COLS_P  # 164
+    # BMM2 SF_P/V follow their cross-inplaced logical P operands.
+    SF_P0_OFF: int = 128 + SF_AFTER_P_OFFSET  # 160
+    SF_V0_OFF: int = 128 + SF_AFTER_P_OFFSET + SF_TMEM_COLS_P  # 164
+    SF_P1_OFF: int = SF_AFTER_P_OFFSET  # 32
+    SF_V1_OFF: int = SF_AFTER_P_OFFSET + SF_TMEM_COLS_P  # 36
 
 
 LAYOUT = KernelTmemLayout()
@@ -524,6 +536,12 @@ def _kernel(
     # Leader-waited (P8): both CTAs' softmax arrive_on_leader → init = CTA_MMA.
     mb_softmax_ldtm = cutlass.Array(cutlass.Int64, CFG.TILES_Q, alignment=16, space=cutlass.AddressSpace.smem)
 
+    # Per-CTA one-way handoffs guarding cross-inplaced P stores.  Each score
+    # stream publishes one token after its four softmax warps have completed
+    # TMEM->register loads.  P0 consumes S1 tokens; P1 consumes S0 tokens one
+    # phase later so next-S0 can issue before prior-P0V.
+    mb_p_inplace = cutlass.Array(cutlass.Int64, CFG.TILES_Q, alignment=16, space=cutlass.AddressSpace.smem)
+
     tmem_ptr_i32 = cutlass.Array(cutlass.Int32, 1, alignment=16, space=cutlass.AddressSpace.smem)
 
     sched = Sched(
@@ -570,6 +588,7 @@ def _kernel(
                 # Leader-waited (P8): each softmax warp elect-arrives after its own
                 # S_acc LDTM+wait → SOFTMAX_WG_WARPS arrives per CTA × CTA_MMA CTAs.
                 nvvm.mbarrier_init(mb_softmax_ldtm.subview(qs), CFG.SOFTMAX_WG_WARPS * CFG.CTA_MMA)
+                nvvm.mbarrier_init(mb_p_inplace.subview(qs), CFG.SOFTMAX_WG_WARPS)
             bars.mb_tmem_dealloc.init()
             bars.mb_empty_mainloop.init()
 
@@ -603,7 +622,12 @@ def _kernel(
         else CFG.SOFTMAX_WG0_BASE + CFG.SOFTMAX_WG_WARPS
     )
     if warp_idx >= CFG.SOFTMAX_WG0_BASE and warp_idx < softmax_first_end:
-        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == 0):
+            nvvm.setmaxregister(200, nvvm.SetMaxRegisterAction.INCREASE)
+        elif cutlass.const_expr(CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS != 0):
+            nvvm.setmaxregister(192, nvvm.SetMaxRegisterAction.INCREASE)
+        else:
+            nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
         if cutlass.const_expr(MERGE_SOFTMAX_WGS):
             sub_tile_id = (warp_idx - cutlass.Int32(CFG.SOFTMAX_WG0_BASE)) // cutlass.Int32(CFG.SOFTMAX_WG_WARPS)
         else:
@@ -619,6 +643,7 @@ def _kernel(
             bars=bars,
             sched=sched,
             mb_softmax_ldtm=mb_softmax_ldtm,
+            mb_p_inplace=mb_p_inplace,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             n_q_supers=n_q_supers,
             n_qh=n_qh,
@@ -628,7 +653,12 @@ def _kernel(
         )
 
     elif warp_idx >= CFG.SOFTMAX_WG1_BASE and warp_idx < CFG.CORR_WARP_BASE:
-        nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
+        if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == 0):
+            nvvm.setmaxregister(200, nvvm.SetMaxRegisterAction.INCREASE)
+        elif cutlass.const_expr(CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS != 0):
+            nvvm.setmaxregister(192, nvvm.SetMaxRegisterAction.INCREASE)
+        else:
+            nvvm.setmaxregister(CFG.SOFTMAX_REGS, nvvm.SetMaxRegisterAction.INCREASE)
         _softmax_warp_group(
             sub_tile_id=1,
             seqlen_q=seqlen_q,
@@ -640,6 +670,7 @@ def _kernel(
             bars=bars,
             sched=sched,
             mb_softmax_ldtm=mb_softmax_ldtm,
+            mb_p_inplace=mb_p_inplace,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             n_q_supers=n_q_supers,
             n_qh=n_qh,
@@ -649,7 +680,12 @@ def _kernel(
         )
 
     elif warp_idx >= CFG.CORR_WARP_BASE and warp_idx < CFG.CORR_WARP_BASE + CFG.CORRECTION_WARPS:
-        nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
+        if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == 0):
+            nvvm.setmaxregister(72, nvvm.SetMaxRegisterAction.DECREASE)
+        elif cutlass.const_expr(CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS != 0):
+            nvvm.setmaxregister(88, nvvm.SetMaxRegisterAction.DECREASE)
+        else:
+            nvvm.setmaxregister(CFG.CORRECTION_REGS, nvvm.SetMaxRegisterAction.DECREASE)
         _correction_warp_group(
             seqlen_q=seqlen_q,
             seqlen_kv=seqlen_kv,
@@ -924,9 +960,15 @@ def _tmaldg_warp_group(
 
             bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
             if cutlass.const_expr(CFG.CTA_MMA == 2):
-                if is_leader:
-                    if nvvm.elect_sync():
-                        bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+                if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == MASK_NONE):
+                    bars.mb_k_full[kv_state.idx].arrive(
+                        n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES,
+                        pred=is_leader & nvvm.elect_sync(),
+                    )
+                else:
+                    if is_leader:
+                        if nvvm.elect_sync():
+                            bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
             else:
                 if nvvm.elect_sync():
                     bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
@@ -1004,9 +1046,15 @@ def _tmaldg_warp_group(
 
                 bars.mb_k_empty[kv_state.idx].wait(kv_state.phase)
                 if cutlass.const_expr(CFG.CTA_MMA == 2):
-                    if is_leader:
-                        if nvvm.elect_sync():
-                            bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
+                    if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == MASK_NONE):
+                        bars.mb_k_full[kv_state.idx].arrive(
+                            n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES,
+                            pred=is_leader & nvvm.elect_sync(),
+                        )
+                    else:
+                        if is_leader:
+                            if nvvm.elect_sync():
+                                bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
                 else:
                     if nvvm.elect_sync():
                         bars.mb_k_full[kv_state.idx].arrive(n_bytes=kTmaTransactionBytes + K_SF_EXPECT_BYTES)
@@ -1033,9 +1081,15 @@ def _tmaldg_warp_group(
 
                 bars.mb_v_empty[kv_state.idx].wait(kv_state.phase)
                 if cutlass.const_expr(CFG.CTA_MMA == 2):
-                    if is_leader:
-                        if nvvm.elect_sync():
-                            bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
+                    if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == MASK_NONE):
+                        bars.mb_v_full[kv_state.idx].arrive(
+                            n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES,
+                            pred=is_leader & nvvm.elect_sync(),
+                        )
+                    else:
+                        if is_leader:
+                            if nvvm.elect_sync():
+                                bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
                 else:
                     if nvvm.elect_sync():
                         bars.mb_v_full[kv_state.idx].arrive(n_bytes=vTmaTransactionBytes + V_SF_EXPECT_BYTES)
@@ -1336,10 +1390,96 @@ def _mma_warp_group(
                 multicast=nvvm.Tcgen05CpMulticast.WARPX4,
             )
 
+    def _utccp_bmm1_sf_block(tmem_sf_q, tmem_sf_k, smem_desc_q, smem_desc_k, sf_block: int):
+        nvvm.tcgen05_cp(
+            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+            tmem_sf_q.subview(sf_block * SF_REGISTERS_PER_BLOCK),
+            smem_desc_q + sf_block * (SF_BYTES_PER_BLOCK // 16),
+            group=CTA_GROUP_KIND,
+            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+        )
+        nvvm.tcgen05_cp(
+            nvvm.Tcgen05CpShape.SHAPE_32X128B,
+            tmem_sf_k.subview(sf_block * SF_REGISTERS_PER_BLOCK),
+            smem_desc_k + sf_block * (SF_BYTES_PER_BLOCK // 16),
+            group=CTA_GROUP_KIND,
+            multicast=nvvm.Tcgen05CpMulticast.WARPX4,
+        )
+
+    def _launch_bmm1(
+        bmm1_desc_arg,
+        desc_q,
+        desc_k,
+        tmem_s,
+        tmem_sf_q,
+        tmem_sf_k,
+        smem_desc_q_sf,
+        smem_desc_k_sf,
+        interleave_bmm2_sf=False,
+        interleave_bmm2_p_sf=False,
+        tmem_sf_p=None,
+        tmem_sf_v=None,
+        smem_desc_p_sf=None,
+        smem_desc_v_sf=None,
+    ):
+        if cutlass.const_expr(SF_NUM_BLOCKS_K == 2):
+            first_k_count = (
+                1 if cutlass.const_expr(CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS != 0) else SF_BLOCK_DIM_K
+            )
+            # Block 0 covers the first four K steps.  E4 causal gives block 1
+            # extra lead time; other paths delay it to the exact-use frontier.
+            if nvvm.elect_sync():
+                _utccp_bmm1_sf_block(tmem_sf_q, tmem_sf_k, smem_desc_q_sf, smem_desc_k_sf, 0)
+            mma_ss(
+                bmm1_desc_arg,
+                desc_q,
+                desc_k,
+                tmem_s,
+                tmem_sf_a=tmem_sf_q,
+                tmem_sf_b=tmem_sf_k,
+                k_count=first_k_count,
+            )
+            if cutlass.const_expr(interleave_bmm2_sf):
+                if nvvm.elect_sync():
+                    _utccp_bmm2_sf(tmem_sf_p, tmem_sf_v, smem_desc_p_sf, smem_desc_v_sf)
+            if cutlass.const_expr(interleave_bmm2_p_sf):
+                if nvvm.elect_sync():
+                    _utccp_bmm2_p_sf(tmem_sf_p, smem_desc_p_sf)
+            if nvvm.elect_sync():
+                _utccp_bmm1_sf_block(tmem_sf_q, tmem_sf_k, smem_desc_q_sf, smem_desc_k_sf, 1)
+            mma_ss(
+                bmm1_desc_arg,
+                desc_q,
+                desc_k,
+                tmem_s,
+                tmem_sf_a=tmem_sf_q,
+                tmem_sf_b=tmem_sf_k,
+                accumulate=True,
+                k_start=first_k_count,
+                k_count=bmm1_desc_arg.num_k_steps - first_k_count,
+            )
+        else:
+            if nvvm.elect_sync():
+                _utccp_bmm1_sf(tmem_sf_q, tmem_sf_k, smem_desc_q_sf, smem_desc_k_sf)
+            mma_ss(
+                bmm1_desc_arg,
+                desc_q,
+                desc_k,
+                tmem_s,
+                tmem_sf_a=tmem_sf_q,
+                tmem_sf_b=tmem_sf_k,
+            )
+
     def _utccp_bmm2_sf(tmem_sf_p, tmem_sf_v, smem_desc_p, smem_desc_v):
         # SF_P is the constant P_SF; SF_V is per-kv-tile.  Both single-block (llama).
         # desc_P_SF_0 passed explicitly (DSL-value closure capture is unstaged).
         nvvm.tcgen05_cp(nvvm.Tcgen05CpShape.SHAPE_32X128B, tmem_sf_p, smem_desc_p, group=CTA_GROUP_KIND, multicast=nvvm.Tcgen05CpMulticast.WARPX4)
+        nvvm.tcgen05_cp(nvvm.Tcgen05CpShape.SHAPE_32X128B, tmem_sf_v, smem_desc_v, group=CTA_GROUP_KIND, multicast=nvvm.Tcgen05CpMulticast.WARPX4)
+
+    def _utccp_bmm2_p_sf(tmem_sf_p, smem_desc_p):
+        nvvm.tcgen05_cp(nvvm.Tcgen05CpShape.SHAPE_32X128B, tmem_sf_p, smem_desc_p, group=CTA_GROUP_KIND, multicast=nvvm.Tcgen05CpMulticast.WARPX4)
+
+    def _utccp_bmm2_v_sf(tmem_sf_v, smem_desc_v):
         nvvm.tcgen05_cp(nvvm.Tcgen05CpShape.SHAPE_32X128B, tmem_sf_v, smem_desc_v, group=CTA_GROUP_KIND, multicast=nvvm.Tcgen05CpMulticast.WARPX4)
 
     if cutlass.const_expr(CFG.MASK_FLAGS == 0):
@@ -1380,6 +1520,19 @@ def _mma_warp_group(
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
 
+        skip_s0_tail = cutlass.Boolean(False)
+        if cutlass.const_expr(CFG.MASK_FLAGS & MASK_CAUSAL):
+            # Recompute for every persistent tile: scheduler payload, effective
+            # sequence lengths, and therefore the causal tail all change.
+            cga_q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+            s0_last_q = cga_q_row_base + cutlass.Int32(
+                (CFG.CTA_MMA - 1) * CFG.TILES_Q * CFG.TILE_M + CFG.TILE_M - 1
+            )
+            causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else cutlass.Int32(0)
+            s0_last_valid_k = s0_last_q + causal_diag + cutlass.Int32(CFG.WINDOW_RIGHT)
+            tail_k_begin = (kv_right - cutlass.Int32(1)) * cutlass.Int32(CFG.TILE_N)
+            skip_s0_tail = ((kv_right - kv_left) > cutlass.Int32(1)) & (tail_k_begin > s0_last_valid_k)
+
         if cutlass.const_expr(CFG.MASK_FLAGS != 0) and (kv_right <= kv_left):
             # Empty mainloop — keep softmax/correction phase trackers in lockstep with non-empty path.
             bars.mb_empty_mainloop.wait(empty_mainloop_phase)
@@ -1395,9 +1548,16 @@ def _mma_warp_group(
             bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
             desc_K = sK[kv_state.idx].desc()
             desc_K_SF = sK_SF[kv_state.idx].desc()
-            if nvvm.elect_sync():
-                _utccp_bmm1_sf(tmem_SF_Q0_pro, tmem_SF_K0_pro, desc_Q_SF_0, desc_K_SF)
-            mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), tmem_sf_a=tmem_SF_Q0_pro, tmem_sf_b=tmem_SF_K0_pro)
+            _launch_bmm1(
+                bmm1_desc,
+                desc_Q0,
+                desc_K,
+                tmem_raw.subview(LAYOUT.S0_OFF),
+                tmem_SF_Q0_pro,
+                tmem_SF_K0_pro,
+                desc_Q_SF_0,
+                desc_K_SF,
+            )
             if nvvm.elect_sync():
                 bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
 
@@ -1408,9 +1568,16 @@ def _mma_warp_group(
             # Prologue SF is O-region-dead, so this wait is alignment-only.
             wait(mb_softmax_ldtm.subview(0), ldtm_phase0)
             ldtm_phase0 = ldtm_phase0 ^ 1
-            if nvvm.elect_sync():
-                _utccp_bmm1_sf(tmem_SF_Q1_pro, tmem_SF_K1_pro, desc_Q_SF_1, desc_K_SF)
-            mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), tmem_sf_a=tmem_SF_Q1_pro, tmem_sf_b=tmem_SF_K1_pro)
+            _launch_bmm1(
+                bmm1_desc,
+                desc_Q1,
+                desc_K,
+                tmem_raw.subview(LAYOUT.S1_OFF),
+                tmem_SF_Q1_pro,
+                tmem_SF_K1_pro,
+                desc_Q_SF_1,
+                desc_K_SF,
+            )
             if nvvm.elect_sync():
                 bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
                 bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
@@ -1421,16 +1588,44 @@ def _mma_warp_group(
                 old_state = kv_state
                 kv_state = advance(kv_state, CFG.STAGES_KV)
 
+                # Cross-inplace schedule: next S0 precedes prior P0V.  P0 lives
+                # in physical S1, so softmax1's LDTM token proves both that the
+                # Q/K-SF scratch is free and that P0 may be stored there.
+                bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
+                desc_K = sK[kv_state.idx].desc()
+                desc_K_SF = sK_SF[kv_state.idx].desc()
+                wait(mb_softmax_ldtm.subview(1), ldtm_phase1)
+                ldtm_phase1 = ldtm_phase1 ^ 1
+                _launch_bmm1(
+                    bmm1_desc,
+                    desc_Q0,
+                    desc_K,
+                    tmem_raw.subview(LAYOUT.S0_OFF),
+                    tmem_SF_Q0,
+                    tmem_SF_K0,
+                    desc_Q_SF_0,
+                    desc_K_SF,
+                    interleave_bmm2_p_sf=(CFG.MASK_FLAGS == 0),
+                    tmem_sf_p=tmem_SF_P0,
+                    smem_desc_p_sf=desc_P_SF_0,
+                )
+                if nvvm.elect_sync():
+                    bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+
+                # Keep the masked-path P-SF copy ahead of the V wait.
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                if cutlass.const_expr(CFG.MASK_FLAGS != 0):
+                    if nvvm.elect_sync():
+                        _utccp_bmm2_p_sf(tmem_SF_P0, desc_P_SF_0)
+
                 bars.mb_v_full[old_state.idx].wait(old_state.phase)
                 desc_V = sV[old_state.idx].desc()
                 desc_V_SF = sV_SF[old_state.idx].desc()
                 is_not_first_bmm2 = cutlass.Boolean(kv_loop != (kv_left + cutlass.Int32(1)))
 
-                # BMM2[sub0] → O_0.  SF_P0/V0 reload into S_acc_0 scratch (32/36);
-                # the bmm2_ready wait already proves softmax[0] read all of S_acc_0.
-                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                # Prior P0V consumes cross-inplaced P0/SF from physical S1.
                 if nvvm.elect_sync():
-                    _utccp_bmm2_sf(tmem_SF_P0, tmem_SF_V0, desc_P_SF_0, desc_V_SF)
+                    _utccp_bmm2_v_sf(tmem_SF_V0, desc_V_SF)
                 accum_b2 = is_not_first_bmm2
                 for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
                     mma_ts_step(
@@ -1459,25 +1654,41 @@ def _mma_warp_group(
                 if nvvm.elect_sync():
                     bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
 
-                # BMM1[sub0] next-kv → S_acc_0.  SF_Q0/K0 ping-pong into S_acc_1
-                # scratch (136/140); wait tile1's softmax LDTM (ONE-behind) so its
-                # read of S_acc_1 completed before the leader-broadcast UTCCP
-                # (cta_group::2 self-fills both CTAs) overwrites it.
-                bars.mb_k_full[kv_state.idx].wait(kv_state.phase)
-                desc_K = sK[kv_state.idx].desc()
-                desc_K_SF = sK_SF[kv_state.idx].desc()
-                wait(mb_softmax_ldtm.subview(1), ldtm_phase1)
-                ldtm_phase1 = ldtm_phase1 ^ 1
+                # Next S1 follows prior P0V.  It waits until softmax0 has read
+                # next S0; that same token lets P1 overwrite physical S0.
+                wait(mb_softmax_ldtm.subview(0), ldtm_phase0)
+                ldtm_phase0 = ldtm_phase0 ^ 1
+                _launch_bmm1(
+                    bmm1_desc,
+                    desc_Q1,
+                    desc_K,
+                    tmem_raw.subview(LAYOUT.S1_OFF),
+                    tmem_SF_Q1,
+                    tmem_SF_K1,
+                    desc_Q_SF_1,
+                    desc_K_SF,
+                    interleave_bmm2_sf=(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == 0),
+                    tmem_sf_p=tmem_SF_P1,
+                    tmem_sf_v=tmem_SF_V1,
+                    smem_desc_p_sf=desc_P_SF_0,
+                    smem_desc_v_sf=desc_V_SF,
+                )
                 if nvvm.elect_sync():
-                    _utccp_bmm1_sf(tmem_SF_Q0, tmem_SF_K0, desc_Q_SF_0, desc_K_SF)
-                mma_ss(bmm1_desc, desc_Q0, desc_K, (tmem_raw.subview(LAYOUT.S0_OFF)), tmem_sf_a=tmem_SF_Q0, tmem_sf_b=tmem_SF_K0)
-                if nvvm.elect_sync():
-                    bars.mb_bmm1_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                    bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
+                    bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
 
-                # BMM2[sub1] → O_1.  SF_P1/V1 reload into S_acc_1 scratch (160/164).
+                if cutlass.const_expr(CFG.DTYPE_QKV == 0):
+                    if nvvm.elect_sync():
+                        _utccp_bmm2_sf(tmem_SF_P1, tmem_SF_V1, desc_P_SF_0, desc_V_SF)
+
+                # E5 causal has already consumed S0 and V is resident.  Stage
+                # both disjoint P1/V1 scale operands while softmax produces P1.
+                if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS != 0):
+                    if nvvm.elect_sync():
+                        _utccp_bmm2_sf(tmem_SF_P1, tmem_SF_V1, desc_P_SF_0, desc_V_SF)
+
+                # Prior P1V consumes cross-inplaced P1/SF from physical S0.
                 bars.mb_bmm2_ready[1 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
-                if nvvm.elect_sync():
-                    _utccp_bmm2_sf(tmem_SF_P1, tmem_SF_V1, desc_P_SF_0, desc_V_SF)
                 accum_b2 = is_not_first_bmm2
                 for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
                     mma_ts_step(
@@ -1507,18 +1718,6 @@ def _mma_warp_group(
                     bars.mb_bmm2_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
                     bars.mb_v_empty[old_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
 
-                # BMM1[sub1] next-kv → S_acc_1.  SF_Q1/K1 ping-pong into S_acc_0
-                # scratch (8/12); wait tile0's softmax LDTM (SAME-iter — BMM1[sub0]
-                # above just wrote this iter's S_acc_0, which softmax[0] must read).
-                wait(mb_softmax_ldtm.subview(0), ldtm_phase0)
-                ldtm_phase0 = ldtm_phase0 ^ 1
-                if nvvm.elect_sync():
-                    _utccp_bmm1_sf(tmem_SF_Q1, tmem_SF_K1, desc_Q_SF_1, desc_K_SF)
-                mma_ss(bmm1_desc, desc_Q1, desc_K, (tmem_raw.subview(LAYOUT.S1_OFF)), tmem_sf_a=tmem_SF_Q1, tmem_sf_b=tmem_SF_K1)
-                if nvvm.elect_sync():
-                    bars.mb_bmm1_done[1].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
-                    bars.mb_k_empty[kv_state.idx].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
-
                 bmm2_ready_phase = bmm2_ready_phase ^ 1
 
             # Epilogue: BMM2 for last kv (always runs — n_kv >= 1).
@@ -1526,40 +1725,53 @@ def _mma_warp_group(
                 for qs in cutlass.range_constexpr(CFG.TILES_Q):
                     bars.mb_q_empty[qs].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
 
+            if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS != 0):
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                if ~skip_s0_tail:
+                    if nvvm.elect_sync():
+                        _utccp_bmm2_p_sf(tmem_SF_P0, desc_P_SF_0)
             bars.mb_v_full[kv_state.idx].wait(kv_state.phase)
             desc_V = sV[kv_state.idx].desc()
             desc_V_SF = sV_SF[kv_state.idx].desc()
             is_not_first_bmm2_epi = cutlass.Boolean((kv_right - kv_left) != cutlass.Int32(1))
 
             # Epilogue BMM2[sub0] → O_0.  SF_P0/V0 reload into S_acc_0 scratch.
-            bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
-            if nvvm.elect_sync():
-                _utccp_bmm2_sf(tmem_SF_P0, tmem_SF_V0, desc_P_SF_0, desc_V_SF)
+            if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS != 0):
+                if ~skip_s0_tail:
+                    if nvvm.elect_sync():
+                        _utccp_bmm2_v_sf(tmem_SF_V0, desc_V_SF)
+            else:
+                bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 0].wait(bmm2_ready_phase)
+                if ~skip_s0_tail:
+                    if nvvm.elect_sync():
+                        _utccp_bmm2_sf(tmem_SF_P0, tmem_SF_V0, desc_P_SF_0, desc_V_SF)
             accum_b2 = is_not_first_bmm2_epi
-            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
-                mma_ts_step(
-                    bmm2_desc,
-                    (tmem_raw.subview(LAYOUT.P0_OFF)),
-                    desc_V,
-                    (tmem_raw.subview(LAYOUT.O0_OFF)),
-                    local_k,
-                    accum_b2,
-                    tmem_sf_a=tmem_SF_P0,
-                    tmem_sf_b=tmem_SF_V0,
-                )
-                accum_b2 = cutlass.Boolean(True)
+            if ~skip_s0_tail:
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        local_k,
+                        accum_b2,
+                        tmem_sf_a=tmem_SF_P0,
+                        tmem_sf_b=tmem_SF_V0,
+                    )
+                    accum_b2 = cutlass.Boolean(True)
             bars.mb_bmm2_ready[0 * CFG.N_BMM2_CHUNKS + 1].wait(bmm2_ready_phase)
-            for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
-                mma_ts_step(
-                    bmm2_desc,
-                    (tmem_raw.subview(LAYOUT.P0_OFF)),
-                    desc_V,
-                    (tmem_raw.subview(LAYOUT.O0_OFF)),
-                    NUM_KPHASES_PV_PER_CHUNK + local_k,
-                    cutlass.Boolean(True),
-                    tmem_sf_a=tmem_SF_P0,
-                    tmem_sf_b=tmem_SF_V0,
-                )
+            if ~skip_s0_tail:
+                for local_k in cutlass.range_constexpr(NUM_KPHASES_PV_PER_CHUNK):
+                    mma_ts_step(
+                        bmm2_desc,
+                        (tmem_raw.subview(LAYOUT.P0_OFF)),
+                        desc_V,
+                        (tmem_raw.subview(LAYOUT.O0_OFF)),
+                        NUM_KPHASES_PV_PER_CHUNK + local_k,
+                        cutlass.Boolean(True),
+                        tmem_sf_a=tmem_SF_P0,
+                        tmem_sf_b=tmem_SF_V0,
+                    )
             if nvvm.elect_sync():
                 bars.mb_bmm2_done[0].arrive(mcast_mask=mcast_mask, cta_group=CFG.CTA_MMA)
 
@@ -1652,6 +1864,7 @@ def _softmax_kv_body(
     sStats_raw,
     bars,
     mb_softmax_ldtm,
+    mb_p_inplace,
     tid_in_wg,
     q_abs,
     eff_seqlen_kv,
@@ -1661,9 +1874,10 @@ def _softmax_kv_body(
     total_sum,
     bmm1_phase,
     stat_empty_phase,
+    p_inplace_phase,
     leader_cta_id,
 ):
-    """Per-iter softmax body — returns (total_max, total_sum, bmm1_phase, stat_empty_phase).
+    """Per-iter softmax body with cross-inplaced P ownership handoff.
 
     Compile-time apply_mask picks fast HW max (tcgen05.ld.red.f32.max)
     vs slow path (load → apply_mask_chunk → software row_max).  The HW
@@ -1684,6 +1898,8 @@ def _softmax_kv_body(
 
     bars.mb_bmm1_done[sub_tile_id].wait(bmm1_phase)
     bmm1_phase = bmm1_phase ^ 1
+    if cutlass.const_expr(CFG.DTYPE_QKV == 1 and CFG.MASK_FLAGS == MASK_NONE):
+        bmm1_phase = cute.arch.make_warp_uniform(bmm1_phase)
 
     # TMEM allocation is stable for the lifetime of the persistent kernel.
     s_addr_a = tmem_base + cutlass.Int32(tmem_S_off + 0)
@@ -1797,12 +2013,20 @@ def _softmax_kv_body(
     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
     if nvvm.elect_sync():
         arrive_on_leader(mb_softmax_ldtm.subview(sub_tile_id), leader_cta_id, CFG.CTA_MMA)
+        nvvm.mbarrier_arrive(mb_p_inplace.subview(sub_tile_id))
 
     current_max = cute.math.max(max_a, max_b) * scale_log2
 
-    # sync the two softmax warpgroups before the stat-store.
-    if sub_tile_id == 1:
-        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+    # Serialize the two E5M2 probability bursts with a one-way ping-pong.
+    # Other specializations retain the original symmetric rendezvous.
+    if cutlass.const_expr(CFG.DTYPE_QKV == 1):
+        if sub_tile_id == 0:
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+        else:
+            nvvm.barrier_cta_sync(barrier_id=9, thread_count=256)
+    else:
+        if sub_tile_id == 1:
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
 
     old_total_max = total_max
     is_first = total_max == NEG_INF
@@ -1829,10 +2053,20 @@ def _softmax_kv_body(
 
     reg_S_a = reg_S_a * scale_log2 - new_total_max
     reg_S_b = reg_S_b * scale_log2 - new_total_max
-    reg_P_a = _exp2_chunk0_mask_aware(reg_S_a, apply_mask)
-    # Expose conversion and row reduction as independent chains before the P store.
-    p_a_fp16 = reg_P_a.to(STORAGE_DTYPE)
+    if cutlass.const_expr(CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS == MASK_NONE and sub_tile_id == 1):
+        reg_P_a = _exp2_chunk0_e4_6pairs(reg_S_a)
+    else:
+        reg_P_a = _exp2_chunk0_mask_aware(reg_S_a, apply_mask)
     sum_a_pair = row_reduction_pair_64(reg_P_a)
+    p_a_fp16 = reg_P_a.to(STORAGE_DTYPE)
+    # P0 writes physical S1 after S1 is read.  P1 is deliberately one S0
+    # token behind, so P1(i) waits for the read of next S0(i+1).
+    if cutlass.const_expr(MERGE_SOFTMAX_WGS):
+        p_inplace_slot = cutlass.Int32(1) - sub_tile_id
+    else:
+        p_inplace_slot = 1 if sub_tile_id == 0 else 0
+    wait(mb_p_inplace.subview(p_inplace_slot), p_inplace_phase)
+    p_inplace_phase = p_inplace_phase ^ 1
     nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(p_addr_a, cutlass.Float32), p_a_fp16)
     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
     bars.mb_bmm2_ready[sub_tile_id * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
@@ -1843,8 +2077,14 @@ def _softmax_kv_body(
     nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
     bars.mb_bmm2_ready[sub_tile_id * CFG.N_BMM2_CHUNKS + 1].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 
-    if sub_tile_id == 0:
-        nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
+    if cutlass.const_expr(CFG.DTYPE_QKV == 1):
+        if sub_tile_id == 0:
+            nvvm.barrier_cta_arrive(9, 256)
+        else:
+            nvvm.barrier_cta_arrive(8, 256)
+    else:
+        if sub_tile_id == 0:
+            nvvm.barrier_cta_sync(barrier_id=8, thread_count=256)
 
     sum_b_pair = row_reduction_pair_64(reg_P_b)
     new_p_sum_pair = sum_a_pair + sum_b_pair
@@ -1854,7 +2094,7 @@ def _softmax_kv_body(
     bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
     stat_empty_phase = stat_empty_phase ^ 1
 
-    return total_max, total_sum, bmm1_phase, stat_empty_phase
+    return total_max, total_sum, bmm1_phase, stat_empty_phase, p_inplace_phase
 
 
 @cute.jit
@@ -1869,6 +2109,7 @@ def _softmax_warp_group(
     bars,
     sched,
     mb_softmax_ldtm,
+    mb_p_inplace,
     seq_kv_lens_tensor,
     n_q_supers,
     n_qh,
@@ -1895,6 +2136,7 @@ def _softmax_warp_group(
 
     bmm1_phase = cutlass.Int32(0)
     stat_empty_phase = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
+    p_inplace_phase = cutlass.Int32(0)
     epilogue_state = cutlass.Int32(1)  # bootstrap pre-armed at phase 1 so first wait passes immediately
 
     # total_sum kept as Vector[Float32,2] so per-iter update lowers to packed FMUL2 + FADD2.
@@ -1931,6 +2173,10 @@ def _softmax_warp_group(
         softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
         tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
 
+    if cutlass.const_expr(CFG.DTYPE_QKV == 1):
+        if sub_tile_id == 1:
+            nvvm.barrier_cta_arrive(8, 256)
+
     while is_valid_tile > cutlass.Int32(0):
         if cutlass.const_expr(not (CFG.MASK_FLAGS & MASK_CAUSAL)):
             read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1938,6 +2184,12 @@ def _softmax_warp_group(
         # Both softmax wgs wait on slot [0]; without this softmax races ahead while TMA-STG drains prior tile.
         bars.mb_o_empty[0].wait(epilogue_state)
         epilogue_state = epilogue_state ^ cutlass.Int32(1)
+
+        # Seed P1 one S0 token behind.  Empty tiles produce no score tokens.
+        if bounds.right > bounds.left:
+            if sub_tile_id == 1:
+                wait(mb_p_inplace.subview(0), p_inplace_phase)
+                p_inplace_phase = p_inplace_phase ^ 1
 
         total_max = NEG_INF
         total_sum = cutlass.Vector.from_elements(
@@ -1953,7 +2205,7 @@ def _softmax_warp_group(
         # MASK_NONE: bounds collapse so masked sub-loops fold out at trace time.
         if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
             for kv_loop in cutlass.range(bounds.left, bounds.right, 1, unroll=1):
-                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                total_max, total_sum, bmm1_phase, stat_empty_phase, p_inplace_phase = _softmax_kv_body(
                     False,
                     sub_tile_id,
                     kv_loop,
@@ -1961,6 +2213,7 @@ def _softmax_warp_group(
                     sStats_raw,
                     bars,
                     mb_softmax_ldtm,
+                    mb_p_inplace,
                     tid_in_wg,
                     q_abs,
                     eff_seqlen_kv,
@@ -1970,11 +2223,12 @@ def _softmax_warp_group(
                     total_sum,
                     bmm1_phase,
                     stat_empty_phase,
+                    p_inplace_phase,
                     leader_cta_id,
                 )
         else:
             for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
-                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                total_max, total_sum, bmm1_phase, stat_empty_phase, p_inplace_phase = _softmax_kv_body(
                     True,
                     sub_tile_id,
                     kv_loop,
@@ -1982,6 +2236,7 @@ def _softmax_warp_group(
                     sStats_raw,
                     bars,
                     mb_softmax_ldtm,
+                    mb_p_inplace,
                     tid_in_wg,
                     q_abs,
                     eff_seqlen_kv,
@@ -1991,10 +2246,11 @@ def _softmax_warp_group(
                     total_sum,
                     bmm1_phase,
                     stat_empty_phase,
+                    p_inplace_phase,
                     leader_cta_id,
                 )
             for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
-                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                total_max, total_sum, bmm1_phase, stat_empty_phase, p_inplace_phase = _softmax_kv_body(
                     False,
                     sub_tile_id,
                     kv_loop,
@@ -2002,6 +2258,7 @@ def _softmax_warp_group(
                     sStats_raw,
                     bars,
                     mb_softmax_ldtm,
+                    mb_p_inplace,
                     tid_in_wg,
                     q_abs,
                     eff_seqlen_kv,
@@ -2011,12 +2268,13 @@ def _softmax_warp_group(
                     total_sum,
                     bmm1_phase,
                     stat_empty_phase,
+                    p_inplace_phase,
                     leader_cta_id,
                 )
             if cutlass.const_expr(CFG.MASK_FLAGS & MASK_CAUSAL):
                 read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
             for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
-                total_max, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
+                total_max, total_sum, bmm1_phase, stat_empty_phase, p_inplace_phase = _softmax_kv_body(
                     True,
                     sub_tile_id,
                     kv_loop,
@@ -2024,6 +2282,7 @@ def _softmax_warp_group(
                     sStats_raw,
                     bars,
                     mb_softmax_ldtm,
+                    mb_p_inplace,
                     tid_in_wg,
                     q_abs,
                     eff_seqlen_kv,
@@ -2033,8 +2292,16 @@ def _softmax_warp_group(
                     total_sum,
                     bmm1_phase,
                     stat_empty_phase,
+                    p_inplace_phase,
                     leader_cta_id,
                 )
+
+        # Equal-sized score streams need one final S0 token for the last P1.
+        # This balances stage1's seed plus one cross-store wait per KV.
+        if bounds.right > bounds.left:
+            if sub_tile_id == 0:
+                if nvvm.elect_sync():
+                    nvvm.mbarrier_arrive(mb_p_inplace.subview(0))
 
         # Per-tile balance: softmax 1 bootstrap + n_kv end-of-body waits = n_kv+1 = corr fires.
         total_sum_scalar = total_sum[0] + total_sum[1]
@@ -2142,7 +2409,6 @@ def _correction_warp_group(
             bars.mb_empty_mainloop.arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 
         for kv_loop in cutlass.range(bounds.left + cutlass.Int32(1), bounds.right, 1, unroll=1):
-            tmem_base_iter = tmem_ptr_i32.load()
             for qs in cutlass.range_constexpr(CFG.TILES_Q):
                 tmem_O_off = LAYOUT.O0_OFF if qs == 0 else LAYOUT.O1_OFF
 
@@ -2157,12 +2423,12 @@ def _correction_warp_group(
 
                 bars.mb_stat_empty[qs].arrive()
 
-                bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
-
                 # vec_scale_pair emits mul_packed_f32x2; without it the DSL lowers to scalar FMUL inside this runtime-if.
                 if ~all_alpha_one:
+                    bars.mb_bmm2_done[qs].wait(bmm2_done_phase)
+                    tmem_base_rescale = tmem_ptr_i32.load()
                     for chunk_idx in cutlass.range_constexpr(N_CHUNKS_O):
-                        o_addr = tmem_base_iter + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
+                        o_addr = tmem_base_rescale + cutlass.Int32(tmem_O_off + chunk_idx * O_CHUNK)
                         o_chunk = nvvm.tcgen05_ld(
                             "32x32b",
                             nvvm.make_tmem_ptr(o_addr, cutlass.Float32),
@@ -2170,7 +2436,7 @@ def _correction_warp_group(
                         )
                         o_scaled = vec_scale_pair(o_chunk, alpha, O_CHUNK)
                         nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(o_addr, cutlass.Float32), o_scaled)
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
+                    nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
 
                 bars.mb_bmm2_ready[qs * CFG.N_BMM2_CHUNKS + 0].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 
@@ -2261,14 +2527,22 @@ def _correction_warp_group(
                     bars.mb_o_empty[qs].wait(o_empty_phase)
                 smem_ptr.store_swizzled(o_out, alignment=64, swizzle=_O_SMEM_SWIZZLE)
 
-            # One atomic per valid row (invalid/OOB rows must not poison the global amax).
-            if _row_valid:
-                nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
-
             # fence_proxy needed before TMA reads SMEM written by tcgen05_st.
             nvvm.fence_proxy("async.shared", space="cta")
-
             bars.mb_o_full[qs].arrive()
+
+            # The global amax is independent of the O TMA store.  Publish O
+            # first so the store warp can overlap this atomic and the next qs.
+            if cutlass.const_expr(CFG.DTYPE_QKV == 0 and CFG.MASK_FLAGS == 0):
+                _amax_o_warp_input = cutlass.Float32(0.0)
+                if _row_valid:
+                    _amax_o_warp_input = _amax_o_local
+                _amax_o_warp = cute.arch.warp_redux_sync(_amax_o_warp_input, "fmax")
+                if (tid_in_wg & cutlass.Int32(31)) == 0:
+                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_warp.bitcast(cutlass.Int32))
+            else:
+                if _row_valid:
+                    nvvm.atomicrmw(nvvm.AtomicOp.MAX, _amax_o_ptr, _amax_o_local.bitcast(cutlass.Int32))
 
         stat_full_phase = stat_full_phase ^ 1
         o_empty_phase = o_empty_phase ^ 1

--- a/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
+++ b/test/python/sdpa/frost/test_sdpa_fp8_sm107.py
@@ -16,6 +16,7 @@ import pytest
 
 from frost_test_utils import requires_dsl
 
+from cudnn.sdpa.fwd.api_dsl import _sm100_fp8_shapes
 from cudnn.sdpa.fwd.config_sm100 import TemplateParams
 
 pytestmark = [pytest.mark.L0, requires_dsl]
@@ -50,3 +51,8 @@ def test_sm100_module_unchanged():
     assert (mod.CFG.TILE_K_HW_BMM1, mod.CFG.TILE_K_HW_BMM2) == (32, 32)
     assert mod.CFG.STAGES_KV == 4
     assert mod.NUM_KPHASES_PV == 4
+
+
+def test_sm107_per_tensor_fp8_advertises_only_d128():
+    assert _sm100_fp8_shapes(pertensor=True, device_cc=(10, 7)) == frozenset({(128, 128)})
+    assert (192, 128) in _sm100_fp8_shapes(pertensor=True, device_cc=(10, 0))

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -241,10 +241,10 @@ def test_fp8_output_dtypes(in_key, out_key):
 
 @pytest.mark.L0
 @pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
-@pytest.mark.parametrize("in_key", ["e4m3"])
+@pytest.mark.parametrize("in_key", ["e4m3", "e5m2"])
 @torch_fork_set_rng(seed=0)
 def test_fp8_d192_d128_output_dtypes(in_key, out_key):
-    """Exact DSv3 shape: E4M3 Q/K use d192 while V and O use d128."""
+    """Exact DSv3 shape: FP8 Q/K use d192 while V and O use d128."""
     scale = 1.0 / math.sqrt(192)
     out, o_ref, a_o, a_o_ref = _run(
         1,

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -68,7 +68,9 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
         col = sinks.view(1, h_q, 1, 1).float().expand(b, h_q, s_q, 1).to(dev)
         probs = torch.softmax(torch.cat([scores, col], dim=-1), dim=-1)
         return torch.matmul(probs[..., :s_kv], v_e)
+    row_has_kv = torch.isfinite(scores).any(dim=-1, keepdim=True)
     probs = torch.softmax(scores, dim=-1)
+    probs = torch.where(row_has_kv, probs, torch.zeros_like(probs))
     return torch.matmul(probs, v_e)
 
 
@@ -266,9 +268,10 @@ def test_fp8_d192_d128_output_dtypes(in_key, out_key):
 @pytest.mark.parametrize("mask", ["none", "causal_br", "swa"])
 @torch_fork_set_rng(seed=0)
 def test_fp8_d192_d128_masks(mask):
+    # B*H_q=16 selects the grouped LPT decoder used by the target workload.
     scale = 1.0 / math.sqrt(192)
     out, o_ref, a_o, a_o_ref = _run(
-        1,
+        2,
         8,
         8,
         256,
@@ -277,6 +280,28 @@ def test_fp8_d192_d128_masks(mask):
         torch.float16,
         scale=scale,
         sdpa_kwargs=_MASKS[mask],
+        d_qk=192,
+        d_v=128,
+    )
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_d192_d128_zero_length_kv():
+    """A zero-length KV batch must produce a finite zero output."""
+    scale = 1.0 / math.sqrt(192)
+    out, o_ref, a_o, a_o_ref = _run(
+        2,
+        8,
+        8,
+        256,
+        256,
+        "e4m3",
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs={},
+        seq_lens_kv=[256, 0],
         d_qk=192,
         d_v=128,
     )

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -4,9 +4,9 @@
 """End-to-end tests for the FROST SM100 DSL per-tensor FP8 SDPA-forward engine.
 
 Drives ``graph.sdpa_fp8`` (FP8 E4M3/E5M2 Q/K/V + scalar per-tensor descales) routed to
-the ``sdpa_fwd_prefill_sm100_d128_fp8`` engine, and validates O against an fp32-dequant
-reference. ``Amax_O`` is produced in-kernel (atomicMax over the
-pre-cast fp32 values); both are checked.
+the exact d128/d128 or d192/d128 engine, and validates O against an fp32-dequant
+reference. ``Amax_O`` is produced in-kernel (atomicMax over the pre-cast fp32 values)
+and checked.
 
 cuDNN's ``sdpa_fp8`` op exposes causal / bottom-right / sliding-window masks, attention
 sink, and a padding mask (per-batch ``seq_len_kv`` → KV-side masking, tested here). THD /
@@ -73,15 +73,31 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
 
 
 def _run(
-    B, H_q, H_kv, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, seq_lens_kv=None, s_scale=1.0, s_descale_gain=1.0, stats=True, sync_debug=False
+    B,
+    H_q,
+    H_kv,
+    S_q,
+    S_kv,
+    in_key,
+    out_dt,
+    *,
+    scale,
+    sdpa_kwargs,
+    sink=None,
+    seq_lens_kv=None,
+    s_scale=1.0,
+    s_descale_gain=1.0,
+    stats=True,
+    sync_debug=False,
+    d_qk=128,
+    d_v=128,
 ):
     import cudnn
 
     dev = "cuda"
-    D = 128
-    Qf = torch.randn(B, H_q, S_q, D, device=dev) * 0.5
-    Kf = torch.randn(B, H_kv, S_kv, D, device=dev) * 0.5
-    Vf = torch.randn(B, H_kv, S_kv, D, device=dev) * 0.5
+    Qf = torch.randn(B, H_q, S_q, d_qk, device=dev) * 0.5
+    Kf = torch.randn(B, H_kv, S_kv, d_qk, device=dev) * 0.5
+    Vf = torch.randn(B, H_kv, S_kv, d_v, device=dev) * 0.5
     Q8, dq = _quant(Qf, in_key)
     K8, dk = _quant(Kf, in_key)
     V8, dv = _quant(Vf, in_key)
@@ -90,7 +106,7 @@ def _run(
         return x8.permute(0, 2, 1, 3).contiguous().transpose(1, 2)
 
     Qb, Kb, Vb = bshd(Q8), bshd(K8), bshd(V8)
-    Ob = torch.empty(B, S_q, H_q, D, device=dev, dtype=out_dt).transpose(1, 2)
+    Ob = torch.empty(B, S_q, H_q, d_v, device=dev, dtype=out_dt).transpose(1, 2)
     lse = torch.empty(B, H_q, S_q, 1, device=dev, dtype=torch.float32)
     amax_o = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
 
@@ -137,7 +153,7 @@ def _run(
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(128, fp8=True))
+    _select_engine(g, engine_name(d_qk, d_v=d_v, fp8=True))
     g.check_support()
     g.build_plans()
     if not stats:
@@ -221,6 +237,50 @@ def test_fp8_output_dtypes(in_key, out_key):
     scale = 1.0 / math.sqrt(128)
     out, o_ref, a_o, a_o_ref = _run(1, 8, 8, 512, 512, in_key, _OUT[out_key], scale=scale, sdpa_kwargs=dict(use_causal_mask=True))
     _check(out, o_ref, _OUT[out_key], in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
+@pytest.mark.parametrize("in_key", ["e4m3"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_d192_d128_output_dtypes(in_key, out_key):
+    """Exact DSv3 shape: E4M3 Q/K use d192 while V and O use d128."""
+    scale = 1.0 / math.sqrt(192)
+    out, o_ref, a_o, a_o_ref = _run(
+        1,
+        8,
+        8,
+        512,
+        512,
+        in_key,
+        _OUT[out_key],
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask=True),
+        d_qk=192,
+        d_v=128,
+    )
+    _check(out, o_ref, _OUT[out_key], in_key, a_o, a_o_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mask", ["none", "causal_br", "swa"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_d192_d128_masks(mask):
+    scale = 1.0 / math.sqrt(192)
+    out, o_ref, a_o, a_o_ref = _run(
+        1,
+        8,
+        8,
+        256,
+        256,
+        "e4m3",
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=_MASKS[mask],
+        d_qk=192,
+        d_v=128,
+    )
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -4,7 +4,7 @@
 """End-to-end tests for the FROST SM100 DSL block-scale MXFP8 SDPA-forward engine.
 
 Drives ``graph.sdpa_mxfp8`` (FP8 E4M3/E5M2 Q/K/V + per-32-block E8M0 scale factors)
-routed to the ``sdpa_fwd_prefill_sm100_d128_mxfp8`` engine, and validates the output
+routed to the native D128/D128 or D192/D128 MXFP8 engine, and validates the output
 against an fp32-dequant reference. Inputs are quantized with the torch-only
 MXFP8 quantizer in ``test/python/sdpa/mxfp8_quant.py`` (TE-equivalent semantics
 — the same layout cuDNN's own mxfp8 path uses), so the scale-factor tensors
@@ -89,26 +89,25 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     return torch.matmul(torch.softmax(scores, dim=-1), v_e)
 
 
-def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, stats=True):
+def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, stats=True, d_qk=128, d_v=128):
     """Quantize, build the sdpa_mxfp8 graph, route to the frost engine, execute.
     Returns (O_frost [B,H,S,D] on device, O_ref fp32 [B,H,S,D])."""
     import cudnn
 
     dev = "cuda"
-    D = 128
     fp8 = _FP8[in_key]
-    Qf = torch.randn(B, H_q, S, D, device=dev) * 0.5
-    Kf = torch.randn(B, H_kv, S, D, device=dev) * 0.5
-    Vf = torch.randn(B, H_kv, S, D, device=dev) * 0.5
-    Q8, sfq, dqq, (sqp, dsc) = _quantize(Qf, B, H_q, S, D, fp8, columnwise=False)
-    K8, sfk, dqk, (skp, _) = _quantize(Kf, B, H_kv, S, D, fp8, columnwise=False)
-    V8, sfv, dqv, (ssc, dvp) = _quantize(Vf, B, H_kv, S, D, fp8, columnwise=True)
+    Qf = torch.randn(B, H_q, S, d_qk, device=dev) * 0.5
+    Kf = torch.randn(B, H_kv, S, d_qk, device=dev) * 0.5
+    Vf = torch.randn(B, H_kv, S, d_v, device=dev) * 0.5
+    Q8, sfq, dqq, (sqp, dsc) = _quantize(Qf, B, H_q, S, d_qk, fp8, columnwise=False)
+    K8, sfk, dqk, (skp, _) = _quantize(Kf, B, H_kv, S, d_qk, fp8, columnwise=False)
+    V8, sfv, dqv, (ssc, dvp) = _quantize(Vf, B, H_kv, S, d_v, fp8, columnwise=True)
 
     def bshd(x8):
         return x8.permute(0, 2, 1, 3).contiguous().transpose(1, 2)
 
     Qb, Kb, Vb = bshd(Q8), bshd(K8), bshd(V8)
-    Ob = torch.empty(B, S, H_q, D, device=dev, dtype=out_dt).transpose(1, 2)
+    Ob = torch.empty(B, S, H_q, d_v, device=dev, dtype=out_dt).transpose(1, 2)
     lse = torch.empty(B, H_q, S, 1, device=dev, dtype=torch.float32)
     amax = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
     sfq_g = sfq.view(torch.uint8).reshape(B, H_q, sqp, dsc)
@@ -149,7 +148,7 @@ def _run(B, H_q, H_kv, S, in_key, out_dt, *, scale, sdpa_kwargs, sink=None, stat
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(128, mxfp8=True))
+    _select_engine(g, engine_name(d_qk, d_v=d_v, mxfp8=True))
     g.check_support()
     g.build_plans()
     if not stats:
@@ -183,13 +182,15 @@ def _ref_from_sdpa(sdpa_kwargs):
     return out
 
 
-def _check(O, O_ref, out_dt, in_key=None):
+def _check(O, O_ref, out_dt, in_key=None, d_qk=128):
     """Compare frost output to fp32 ref; for FP8 output, gauge against the fp8-quant floor.
 
     E5M2 inputs (2-bit mantissa) are noisier than E4M3 (3-bit), so the half-output
     tolerance is widened for them.
     """
-    atol_half = 7e-2 if in_key == "e5m2" else 5e-2
+    # D192 accumulates 50% more QK products than D128. Keep the existing D128
+    # threshold unchanged while allowing the measured E5M2 accumulation floor.
+    atol_half = 8e-2 if in_key == "e5m2" and d_qk > 128 else 7e-2 if in_key == "e5m2" else 5e-2
     diff = (O.float() - O_ref).abs().max().item()
     if out_dt in (torch.float8_e4m3fn, torch.float8_e5m2):
         floor = (O_ref - O_ref.to(out_dt).float()).abs().max().item()
@@ -234,6 +235,93 @@ def test_mxfp8_masks(in_key, mask):
     scale = 1.0 / math.sqrt(128)
     O, O_ref, _ = _run(B, H, H, S, in_key, torch.float16, scale=scale, sdpa_kwargs=_MASKS[mask])
     _check(O, O_ref, torch.float16, in_key)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("in_key", _INS)
+@pytest.mark.parametrize("mask", list(_MASKS))
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d192_d128(in_key, mask):
+    """Native D192/D128 path, including the grouped-LPT scheduler geometry."""
+    d_qk, d_v = 192, 128
+    O, O_ref, _ = _run(
+        2,
+        16,
+        16,
+        256,
+        in_key,
+        torch.bfloat16,
+        scale=1.0 / math.sqrt(d_qk),
+        sdpa_kwargs=_MASKS[mask],
+        d_qk=d_qk,
+        d_v=d_v,
+    )
+    _check(O, O_ref, torch.bfloat16, in_key, d_qk=d_qk)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("out_key", ["fp16", "bf16", "e4m3", "e5m2"])
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d192_d128_output_dtypes(out_key):
+    """D192/D128 E4M3 input to each supported output dtype."""
+    d_qk, d_v = 192, 128
+    O, O_ref, amax = _run(
+        1,
+        8,
+        8,
+        256,
+        "e4m3",
+        _OUT[out_key],
+        scale=1.0 / math.sqrt(d_qk),
+        sdpa_kwargs=dict(use_causal_mask=True),
+        d_qk=d_qk,
+        d_v=d_v,
+    )
+    _check(O, O_ref, _OUT[out_key], "e4m3", d_qk=d_qk)
+    assert amax.item() > 0.0
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d192_d128_gqa_sink():
+    """D192/D128 GQA with an attention sink exercises head sharing."""
+    d_qk, d_v = 192, 128
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    O, O_ref, _ = _run(
+        1,
+        8,
+        2,
+        256,
+        "e5m2",
+        torch.float16,
+        scale=1.0 / math.sqrt(d_qk),
+        sdpa_kwargs=dict(use_causal_mask=True),
+        sink=sink,
+        d_qk=d_qk,
+        d_v=d_v,
+    )
+    _check(O, O_ref, torch.float16, "e5m2", d_qk=d_qk)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d192_d128_stats_less():
+    """D192/D128 supports compiling out the optional stats output."""
+    d_qk, d_v = 192, 128
+    O, O_ref, _ = _run(
+        1,
+        8,
+        8,
+        256,
+        "e4m3",
+        torch.bfloat16,
+        scale=1.0 / math.sqrt(d_qk),
+        sdpa_kwargs=dict(use_causal_mask=True),
+        stats=False,
+        d_qk=d_qk,
+        d_v=d_v,
+    )
+    _check(O, O_ref, torch.bfloat16, "e4m3", d_qk=d_qk)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -278,7 +278,9 @@ def test_mxfp8_d192_d128_output_dtypes(out_key):
         d_v=d_v,
     )
     _check(O, O_ref, _OUT[out_key], "e4m3", d_qk=d_qk)
-    assert amax.item() > 0.0
+    amax_value = amax.item()
+    amax_ref = O_ref.abs().max().item()
+    assert abs(amax_value - amax_ref) <= 0.03, f"amax {amax_value:.4f} vs ref {amax_ref:.4f}"
 
 
 @pytest.mark.L0
@@ -360,36 +362,47 @@ def test_mxfp8_gqa(in_key):
 
 
 @pytest.mark.L0
+@pytest.mark.parametrize("d_qk,d_v", [(128, 128), (192, 128)])
 @torch_fork_set_rng(seed=0)
-def test_mxfp8_bottom_right_rectangular():
+def test_mxfp8_bottom_right_rectangular(d_qk, d_v):
     """Bottom-right causal with S_q != S_kv (the case where it differs from top-left)."""
-    scale = 1.0 / math.sqrt(128)
+    scale = 1.0 / math.sqrt(d_qk)
     # S must be a multiple of TILE_N (128) for the non-padded path; use S_q=128, S_kv=256.
     import cudnn  # noqa: F401
 
-    O, O_ref, _ = _run_rect(2, 8, 128, 256, "e4m3", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask_bottom_right=True))
-    _check(O, O_ref, torch.float16, "e4m3")
+    O, O_ref, _ = _run_rect(
+        2,
+        8,
+        128,
+        256,
+        "e4m3",
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask_bottom_right=True),
+        d_qk=d_qk,
+        d_v=d_v,
+    )
+    _check(O, O_ref, torch.float16, "e4m3", d_qk=d_qk)
 
 
-def _run_rect(B, H, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs):
+def _run_rect(B, H, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs, d_qk=128, d_v=128):
     """_run variant allowing S_q != S_kv (bottom-right causal)."""
     import cudnn
 
     dev = "cuda"
-    D = 128
     fp8 = _FP8[in_key]
-    Qf = torch.randn(B, H, S_q, D, device=dev) * 0.5
-    Kf = torch.randn(B, H, S_kv, D, device=dev) * 0.5
-    Vf = torch.randn(B, H, S_kv, D, device=dev) * 0.5
-    Q8, sfq, dqq, (sqp, dsc) = _quantize(Qf, B, H, S_q, D, fp8, columnwise=False)
-    K8, sfk, dqk, (skp, _) = _quantize(Kf, B, H, S_kv, D, fp8, columnwise=False)
-    V8, sfv, dqv, (ssc, dvp) = _quantize(Vf, B, H, S_kv, D, fp8, columnwise=True)
+    Qf = torch.randn(B, H, S_q, d_qk, device=dev) * 0.5
+    Kf = torch.randn(B, H, S_kv, d_qk, device=dev) * 0.5
+    Vf = torch.randn(B, H, S_kv, d_v, device=dev) * 0.5
+    Q8, sfq, dqq, (sqp, dsc) = _quantize(Qf, B, H, S_q, d_qk, fp8, columnwise=False)
+    K8, sfk, dqk, (skp, _) = _quantize(Kf, B, H, S_kv, d_qk, fp8, columnwise=False)
+    V8, sfv, dqv, (ssc, dvp) = _quantize(Vf, B, H, S_kv, d_v, fp8, columnwise=True)
 
     def bshd(x8):
         return x8.permute(0, 2, 1, 3).contiguous().transpose(1, 2)
 
     Qb, Kb, Vb = bshd(Q8), bshd(K8), bshd(V8)
-    Ob = torch.empty(B, S_q, H, D, device=dev, dtype=out_dt).transpose(1, 2)
+    Ob = torch.empty(B, S_q, H, d_v, device=dev, dtype=out_dt).transpose(1, 2)
     lse = torch.empty(B, H, S_q, 1, device=dev, dtype=torch.float32)
     amax = torch.zeros(1, 1, 1, 1, device=dev, dtype=torch.float32)
     g = cudnn.pygraph(
@@ -417,7 +430,7 @@ def _run_rect(B, H, S_q, S_kv, in_key, out_dt, *, scale, sdpa_kwargs):
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(128, mxfp8=True))
+    _select_engine(g, engine_name(d_qk, d_v=d_v, mxfp8=True))
     g.check_support()
     g.build_plans()
     g.execute(

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -166,6 +166,31 @@ def test_probe_envelope_mixed_dims_pick_covering_flavor():
     assert ordered[0] == engines.engine_name(192, d_v=128)
 
 
+def test_d192_fp8_sink_dtype_gate():
+    spec = next(s for s in engines.ENGINE_SPECS if s.name == engines.engine_name(192, d_v=128, fp8=True))
+
+    def facts(dtype, *, sink):
+        return ga.SdpaGraphFacts(
+            b=1,
+            h_q=8,
+            h_kv=8,
+            s_q=256,
+            s_kv=256,
+            d_qk=192,
+            d_v=128,
+            dtype=dtype,
+            dtype_o=cudnn.data_type.HALF,
+            is_fp8=True,
+            has_sink=sink,
+            device_cc=(10, 0),
+        )
+
+    assert engines.mismatch(spec.capabilities, facts(cudnn.data_type.FP8_E4M3, sink=True)) is None
+    assert engines.mismatch(spec.capabilities, facts(cudnn.data_type.FP8_E5M2, sink=False)) is None
+    reason = engines.mismatch(spec.capabilities, facts(cudnn.data_type.FP8_E5M2, sink=True))
+    assert "sink token with dtype" in reason
+
+
 def test_probe_rejects_wrong_device_family(monkeypatch):
     monkeypatch.setattr(ga, "_device_cc", lambda: (8, 0))
     g = _mk_graph()


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

FE OSS kernels or CuTeDSL

## Summary

This PR adds a native SM100/Blackwell FROST DSL block-scale MXFP8 SDPA
forward kernel for the asymmetric prefill shape:

- `D_QK = 192`
- `D_V = 128`
- E4M3 or E5M2 Q/K/V with per-32-element E8M0 scale factors
- FP16, BF16, E4M3, or E5M2 output
- Dense prefill with no mask, top-left or bottom-right causal masks,
  sliding-window attention, GQA, sinks, optional statistics, and Amax_O

The implementation adds an exact `192/128` MXFP8 flavor and engine. Existing
`128/128` MXFP8 routing and kernels are unchanged.

This is a stacked PR based on the current head of #594. **#594 must merge
first.** After #594 merges, this branch will be rebased onto `develop` and CI
will be rerun before this PR is merged.

## Why

The existing SM100 MXFP8 FROST path supports only `D_QK=D_V=128`. The new
specialization extends block-scaled attention to the asymmetric `192/128`
shape used by prefill workloads without changing sibling kernel routes.

For the primary E4M3-input/BF16-output top-left causal 8K workload, the first
correct native D192/D128 MXFP8 implementation took `9.038960 ms`; the final
kernel takes `5.475392 ms` using the same base-clock NCU method, a `39.42%`
duration reduction.

## Related issues

Depends on #594.

## API and compatibility impact

- No new public Python or C++ API.
- Adds an internal FROST engine for exact `D_QK=192, D_V=128` MXFP8 on SM100.
- Existing D128 MXFP8 and existing per-tensor FP8/half-precision routes are
  unchanged.
- THD/varlen remains unsupported for MXFP8; unsupported shapes continue to
  fall through to other eligible engines.
- Performance measurements used CUTLASS DSL `4.7.0a0`.

## Testing

Formatting:

```bash
pre-commit run --from-ref 7fe91fd43b499cd8bf213365c1cf485afa7d7bd8 --to-ref HEAD
```

Result: passed.

Complete SM100 MXFP8 FROST file:

```bash
pytest -q test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
```

Result: `37 passed`.

Full Blackwell FROST suite on the rebased source:

```bash
pytest -q test/python/sdpa/frost
```

Result: `736 passed, 237 skipped, 53 deselected, 0 failed`.

The final-format focused D192/D128 selection, covering both input formats and
all mask families, was rerun after the SM100 ToT ABI adaptation:
`14 passed, 23 deselected`.

## Performance

Methodology:

- GPU: GB100, SM100, 148 SMs.
- Workload: `B=2`, `Hq=Hkv=128`, `D_QK=192`, `D_V=128`, BF16 output.
- Nsight Compute 2026.2: base clock control, launch skip 3, five measured
  launches per case.
- Observed SM clock: approximately `844-846 MHz` across the D192 matrix.
- Kernel duration was the acceptance metric; Compute SOL was used only for
  bottleneck diagnosis.
- GPU/JIT/test/profiling commands were serialized with a host file lock.

### Duration by mask, sequence size, and input format

| Mask | Sq x Skv | E4M3 duration | E5M2 duration | E5M2 delta |
|---|---:|---:|---:|---:|
| top-left | 2048x2048 | 0.507712 ms | 0.500352 ms | -1.450% |
| top-left | 4096x4096 | 1.569088 ms | 1.532704 ms | -2.319% |
| top-left | 4096x8192 | 1.568736 ms | 1.532416 ms | -2.315% |
| top-left | 8192x8192 | 5.474592 ms | 5.314144 ms | -2.931% |
| bottom-right | 2048x2048 | 0.518944 ms | 0.501984 ms | -3.268% |
| bottom-right | 4096x4096 | 1.599296 ms | 1.538720 ms | -3.788% |
| bottom-right | 4096x8192 | 4.039168 ms | 3.854080 ms | -4.582% |
| bottom-right | 8192x8192 | 5.584128 ms | 5.337984 ms | -4.408% |
| no-mask | 2048x2048 | 0.671168 ms | 0.680320 ms | +1.364% |
| no-mask | 4096x4096 | 2.488032 ms | 2.462144 ms | -1.041% |
| no-mask | 4096x8192 | 4.855456 ms | 4.788896 ms | -1.371% |
| no-mask | 8192x8192 | 9.668000 ms | 9.506848 ms | -1.667% |

No-mask is expected to take longer than causal at 8K because it evaluates the
full attention square while causal paths skip the masked triangle.

### Current D128 MXFP8 8K reference

The existing D128/D128 MXFP8 kernel was remeasured in the same profiler run
and environment. The comparison is between different exact-shape pipelines,
not a single-variable head-dimension microbenchmark.

| Input | Mask | D192/D128 MXFP8 | D128/D128 MXFP8 | D192 duration reduction |
|---|---|---:|---:|---:|
| E4M3 | top-left | 5.475392 ms | 7.348672 ms | **25.491%** |
| E5M2 | top-left | 5.314816 ms | 7.346304 ms | **27.653%** |
| E4M3 | no-mask | 9.666848 ms | 12.458304 ms | **22.406%** |
| E5M2 | no-mask | 9.508032 ms | 12.458176 ms | **23.680%** |

### Retained optimization mechanisms

The final kernel retains only changes that survived repeated paired A/B and
final-context component checks. The effects are coupled and are therefore not
presented as additive percentages.

- Cross-inplaced score/probability TMEM ownership with score-before-PV issue.
- Exact-first-use Q/K scale-factor staging and path-specific P/V scale-copy
  placement.
- E5 correction wait/address work sunk into the rare rescale path.
- E5 softmax named-barrier ping-pong to stagger EXP2 work.
- Dtype/path/warp-group-specific EXP2 and register scheduling.
- Removal of fully masked causal-tail P0V work.
- Early O publication before independent output-amax work, with an E4
  no-mask warp-reduced amax.
- A minimized E5 no-mask predicate-form K/V TMA publication sequence.

All final 8K paths use 128 registers per thread and 210.432 KiB shared memory
per block. InstructionStats reports zero local/shared spill requests for the
two causal paths and E4M3 no-mask. E5M2 no-mask executes local-memory
instructions, but the spill-request counters remain zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SM100 FP8 and MXFP8 attention support for D192/D128 head dimensions.
  * Added support for multiple FP8 input and output dtype combinations, masking, attention sinks, and zero-length key/value batches.
  * Added optional L2 cache hints for asynchronous tile loads.
* **Bug Fixes**
  * Improved validation and engine selection for device-specific FP8 shapes and sink dtypes.
* **Tests**
  * Expanded coverage for FP8/MXFP8 D192/D128 execution and compatibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->