### PR TITLE
test: fix Rubin dispatch test paths; skip glu_hadamard_quant on cutlass-dsl < 4.8

### DIFF
--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
@@ -17,6 +17,17 @@ from fe_api.test_fe_api_utils import (
     ue5m3_bytes_to_fp32,
 )
 
+import cutlass
+
+# The glu_hadamard_quant kernel references cutlass.FloatNV8E5M3FNU
+# unconditionally at compile time (moe_blockscaled_grouped_gemm_glu_hadamard_quant.py),
+# and that dtype only exists in cutlass-dsl >= 4.8. Skip the whole file on
+# older builds instead of failing every test with an AttributeError.
+pytestmark = pytest.mark.skipif(
+    not hasattr(cutlass, "FloatNV8E5M3FNU"),
+    reason="glu_hadamard_quant kernels require cutlass-dsl >= 4.8 (cutlass.FloatNV8E5M3FNU)",
+)
+
 FP4_EXECUTION_CASES = [
     (torch.float4_e2m1fn_x2, torch.float8_e4m3fn, 16),
     (torch.float4_e2m1fn_x2, torch.float8_e8m0fnu, 16),

--- a/test/python/fe_api/test_rubin_kernel_dispatch.py
+++ b/test/python/fe_api/test_rubin_kernel_dispatch.py
@@ -184,8 +184,8 @@ def test_grouped_gemm_quant_has_rubin_compile_branches():
 @pytest.mark.parametrize(
     "kernel_path",
     [
-        "grouped_gemm_quant/grouped_gemm_quant.py",
-        "grouped_gemm_quant/moe_blockscaled_grouped_gemm_quant_rubin.py",
+        "quant/grouped_gemm_quant.py",
+        "quant/moe_blockscaled_grouped_gemm_quant_rubin.py",
     ],
 )
 def test_grouped_gemm_quant_kernels_support_optional_prob(kernel_path):


### PR DESCRIPTION
Two test-only fixes for failures seen in the L0 fe_api suite (e.g. cudnn_frontend CI job on Blackwell with cutlass-dsl 4.5.1):

**1. Stale quant kernel paths in the Rubin dispatch test.** The Gemm fusion reorganization (#459) moved the grouped quant kernels to `python/cudnn/gemm/cutedsl/grouped/quant/`, but `test_grouped_gemm_quant_kernels_support_optional_prob` in `test/python/fe_api/test_rubin_kernel_dispatch.py` still looked for them under `grouped_gemm_quant/`, so both parametrizations fail with `FileNotFoundError`. This updates the two `kernel_path` params to `quant/grouped_gemm_quant.py` and `quant/moe_blockscaled_grouped_gemm_quant_rubin.py`. Verified locally: both tests pass, and both asserted source snippets (`self.has_prob = prob is not None`, `if cutlass.const_expr(self.has_prob):`) are present in the relocated kernel files.

**2. Skip `test_grouped_gemm_glu_hadamard_quant.py` on cutlass-dsl < 4.8.** The glu_hadamard_quant kernel references `cutlass.FloatNV8E5M3FNU` unconditionally at compile time, and that dtype only exists in cutlass-dsl >= 4.8, so every test in the file failed with `AttributeError: module 'cutlass' has no attribute 'FloatNV8E5M3FNU'` on older builds (13 failures on a 4.5.1 lane) — even when the scale-factor dtype under test is e4m3/e8m0. This gates the module with the same `hasattr` check `_skip_unless_e5m3_supported` already uses. Verified on an SM100 box: cutlass-dsl 4.7.0 without the gate reproduces the AttributeError; with the gate all 23 tests skip; on 4.8.0a0 the file runs 17 passed / 6 skipped (the pre-existing Rubin-only e5m3 skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated quantized grouped GEMM kernel test paths to match the current layout for Blackwell and Rubin kernels.
  * Added compatibility handling so grouped GEMM GLU Hadamard quantization tests are skipped in environments lacking required NV8E5M3 support, preventing compilation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->