### PR TITLE
[CuTeDSL] Fix SiTU-GLU Hadamard API contracts

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/api.py
@@ -586,10 +586,6 @@ class GroupedGemmGluHadamardSm100(APIBase):
             situ_beta1 = self.situ_beta1
         if situ_beta2 is None:
             situ_beta2 = self.situ_beta2
-        if a_tensor.shape[0] == 0:
-            return
-        if current_stream is None:
-            current_stream = cuda.CUstream(torch.cuda.current_stream(a_tensor.device).cuda_stream)
         if self.act_func == "situglu":
             self._value_error_if(
                 not math.isfinite(situ_beta1) or situ_beta1 <= 0.0,
@@ -603,6 +599,10 @@ class GroupedGemmGluHadamardSm100(APIBase):
                 float(situ_beta1) != self.situ_beta1,
                 "situ_beta1 is specialized at compile time; construct and compile " f"the API with situ_beta1={situ_beta1}",
             )
+        if a_tensor.shape[0] == 0:
+            return
+        if current_stream is None:
+            current_stream = cuda.CUstream(torch.cuda.current_stream(a_tensor.device).cuda_stream)
         if hadamard_tensor is None:
             hadamard_tensor = self.hadamard_tensor
         else:

--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/api.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/api.py
@@ -573,8 +573,8 @@ class GroupedGemmGluHadamardSm100(APIBase):
         amax_tensor: Optional[torch.Tensor] = None,
         post_rht_amax_tensor: Optional[torch.Tensor] = None,
         bias_tensor: Optional[torch.Tensor] = None,
-        situ_beta1: float = 4.0,
-        situ_beta2: float = 25.0,
+        situ_beta1: Optional[float] = None,
+        situ_beta2: Optional[float] = None,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         import torch
@@ -582,6 +582,10 @@ class GroupedGemmGluHadamardSm100(APIBase):
         self._ensure_support_checked()
         if self._compiled_kernel is None:
             raise RuntimeError("Kernel has not been compiled")
+        if situ_beta1 is None:
+            situ_beta1 = self.situ_beta1
+        if situ_beta2 is None:
+            situ_beta2 = self.situ_beta2
         if a_tensor.shape[0] == 0:
             return
         if current_stream is None:
@@ -699,6 +703,11 @@ def grouped_gemm_glu_hadamard_wrapper_sm100(
         c_dtype = torch.bfloat16
     if d_dtype is None:
         d_dtype = torch.bfloat16
+    if act_func == "situglu":
+        if not math.isfinite(situ_beta1) or situ_beta1 <= 0.0:
+            raise ValueError(f"situ_beta1 must be finite and positive, got {situ_beta1}")
+        if not math.isfinite(situ_beta2) or situ_beta2 <= 0.0:
+            raise ValueError(f"situ_beta2 must be finite and positive, got {situ_beta2}")
 
     valid_m = a_tensor.shape[0]
     is_dense = b_tensor is not None

--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/moe_blockscaled_grouped_gemm_glu_hadamard.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard/moe_blockscaled_grouped_gemm_glu_hadamard.py
@@ -565,7 +565,7 @@ class BlockScaledMoEGroupedGemmGluHadamardKernel:
 
         ``situ_beta1`` and ``situ_beta2`` configure SiTU-GLU:
 
-            out = beta1 * tanh(gate / beta1) * sigmoid(gate)
+            out = prob * beta1 * tanh(gate / beta1) * sigmoid(gate)
                   * beta2 * tanh(up / beta2)
 
         They are ignored unless ``act_func == "situglu"``.

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard.py
@@ -256,7 +256,16 @@ def _run_compile_execute(
 
     if execute_empty_input:
         return
-    _check_reference(inputs, outputs, cfg, act_func=act_func, situ_beta1=situ_beta1, situ_beta2=situ_beta2)
+    reference_situ_beta1 = situ_beta1 if execute_situ_beta1 is None else execute_situ_beta1
+    reference_situ_beta2 = situ_beta2 if execute_situ_beta2 is None else execute_situ_beta2
+    _check_reference(
+        inputs,
+        outputs,
+        cfg,
+        act_func=act_func,
+        situ_beta1=reference_situ_beta1,
+        situ_beta2=reference_situ_beta2,
+    )
 
 
 def _run_wrapper(
@@ -413,6 +422,22 @@ def test_grouped_gemm_glu_hadamard_execute_uses_compiled_situglu_betas(request):
         act_func="situglu",
         situ_beta1=2.0,
         situ_beta2=8.0,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_glu_hadamard_execute_uses_runtime_situglu_beta2(request):
+    # beta2 is a runtime scalar, so execute() may override the value stored by
+    # the compiled API object. Verify both the launch and numerical reference
+    # use the explicit execution-time value.
+    _run_compile_execute(
+        request,
+        ab_dtype=torch.float4_e2m1fn_x2,
+        sf_dtype=torch.float8_e8m0fnu,
+        sf_vec_size=16,
+        act_func="situglu",
+        execute_situ_beta2=8.0,
     )
 
 

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard.py
@@ -191,6 +191,9 @@ def _run_compile_execute(
     enable_bias=False,
     situ_beta1=4.0,
     situ_beta2=25.0,
+    execute_empty_input=False,
+    execute_situ_beta1=None,
+    execute_situ_beta2=None,
 ):
     cfg = _make_cfg(request, ab_dtype=ab_dtype, sf_dtype=sf_dtype, sf_vec_size=sf_vec_size, enable_bias=enable_bias)
     inputs = allocate_grouped_gemm_input_tensors(
@@ -235,7 +238,7 @@ def _run_compile_execute(
     api.check_support()
     api.compile()
     api.execute(
-        a_tensor=inputs["a_tensor"],
+        a_tensor=inputs["a_tensor"][:0] if execute_empty_input else inputs["a_tensor"],
         b_tensor=inputs["b_tensor"],
         c_tensor=outputs["c_tensor"],
         d_tensor=outputs["d_tensor"],
@@ -247,8 +250,12 @@ def _run_compile_execute(
         amax_tensor=outputs["amax_tensor"],
         post_rht_amax_tensor=outputs["post_rht_amax_tensor"],
         bias_tensor=inputs["bias_tensor"],
+        situ_beta1=execute_situ_beta1,
+        situ_beta2=execute_situ_beta2,
     )
 
+    if execute_empty_input:
+        return
     _check_reference(inputs, outputs, cfg, act_func=act_func, situ_beta1=situ_beta1, situ_beta2=situ_beta2)
 
 
@@ -407,6 +414,31 @@ def test_grouped_gemm_glu_hadamard_execute_uses_compiled_situglu_betas(request):
         situ_beta1=2.0,
         situ_beta2=8.0,
     )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@pytest.mark.parametrize(
+    ("execute_situ_beta1", "execute_situ_beta2", "match"),
+    [(0.0, None, "situ_beta1"), (None, float("nan"), "situ_beta2")],
+)
+def test_grouped_gemm_glu_hadamard_execute_empty_input_validates_situglu_betas(
+    request,
+    execute_situ_beta1,
+    execute_situ_beta2,
+    match,
+):
+    with pytest.raises(ValueError, match=match):
+        _run_compile_execute(
+            request,
+            ab_dtype=torch.float4_e2m1fn_x2,
+            sf_dtype=torch.float8_e8m0fnu,
+            sf_vec_size=16,
+            act_func="situglu",
+            execute_empty_input=True,
+            execute_situ_beta1=execute_situ_beta1,
+            execute_situ_beta2=execute_situ_beta2,
+        )
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard.py
@@ -181,7 +181,17 @@ def _allocate_outputs(inputs: Dict, cfg: Dict) -> Dict:
     }
 
 
-def _run_compile_execute(request, *, ab_dtype, sf_dtype, sf_vec_size, act_func="swiglu", enable_bias=False):
+def _run_compile_execute(
+    request,
+    *,
+    ab_dtype,
+    sf_dtype,
+    sf_vec_size,
+    act_func="swiglu",
+    enable_bias=False,
+    situ_beta1=4.0,
+    situ_beta2=25.0,
+):
     cfg = _make_cfg(request, ab_dtype=ab_dtype, sf_dtype=sf_dtype, sf_vec_size=sf_vec_size, enable_bias=enable_bias)
     inputs = allocate_grouped_gemm_input_tensors(
         n=cfg["n"],
@@ -219,6 +229,8 @@ def _run_compile_execute(request, *, ab_dtype, sf_dtype, sf_vec_size, act_func="
         vector_f32=cfg["vector_f32"],
         m_aligned=cfg["m_aligned"],
         act_func=act_func,
+        situ_beta1=situ_beta1,
+        situ_beta2=situ_beta2,
     )
     api.check_support()
     api.compile()
@@ -237,7 +249,7 @@ def _run_compile_execute(request, *, ab_dtype, sf_dtype, sf_vec_size, act_func="
         bias_tensor=inputs["bias_tensor"],
     )
 
-    _check_reference(inputs, outputs, cfg, act_func=act_func)
+    _check_reference(inputs, outputs, cfg, act_func=act_func, situ_beta1=situ_beta1, situ_beta2=situ_beta2)
 
 
 def _run_wrapper(
@@ -377,6 +389,72 @@ def test_grouped_gemm_glu_hadamard_wrapper_situglu_fp4(request, situ_beta1, situ
         situ_beta1=situ_beta1,
         situ_beta2=situ_beta2,
     )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_grouped_gemm_glu_hadamard_execute_uses_compiled_situglu_betas(request):
+    # Construct and compile for non-default beta values, then intentionally omit
+    # them from execute(). The launch must inherit the values stored by the API
+    # object so both the compile-time beta1 specialization and runtime beta2
+    # scalar match the numerical reference.
+    _run_compile_execute(
+        request,
+        ab_dtype=torch.float4_e2m1fn_x2,
+        sf_dtype=torch.float8_e8m0fnu,
+        sf_vec_size=16,
+        act_func="situglu",
+        situ_beta1=2.0,
+        situ_beta2=8.0,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+@pytest.mark.parametrize(
+    ("situ_beta1", "situ_beta2", "match"),
+    [(0.0, 25.0, "situ_beta1"), (4.0, float("nan"), "situ_beta2")],
+)
+def test_grouped_gemm_glu_hadamard_empty_input_validates_situglu_betas(
+    request,
+    situ_beta1,
+    situ_beta2,
+    match,
+):
+    from cudnn import grouped_gemm_glu_hadamard_wrapper_sm100
+
+    cfg = _make_cfg(
+        request,
+        ab_dtype=torch.float4_e2m1fn_x2,
+        sf_dtype=torch.float8_e8m0fnu,
+        sf_vec_size=16,
+    )
+    inputs = allocate_grouped_gemm_input_tensors(
+        n=cfg["n"],
+        k=cfg["k"],
+        l=cfg["l"],
+        group_m_list=cfg["group_m_list"],
+        ab_dtype=cfg["ab_dtype"],
+        sf_dtype=cfg["sf_dtype"],
+        sf_vec_size=cfg["sf_vec_size"],
+        m_aligned=cfg["m_aligned"],
+        b_major=cfg["b_major"],
+        enable_bias=False,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        grouped_gemm_glu_hadamard_wrapper_sm100(
+            a_tensor=inputs["a_tensor"][:0],
+            b_tensor=inputs["b_tensor"],
+            sfa_tensor=inputs["sfa_tensor"],
+            sfb_tensor=inputs["sfb_tensor"],
+            padded_offsets=inputs["padded_offsets_tensor"],
+            alpha_tensor=inputs["alpha_tensor"],
+            prob_tensor=inputs["prob_tensor"][:0],
+            act_func="situglu",
+            situ_beta1=situ_beta1,
+            situ_beta2=situ_beta2,
+        )
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)). Fork authors cannot apply upstream labels; requested labels are `cat-bugfix`, `mod-cutedsl`, and `orig-nv-eng`.

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Follow up on [PR 645](https://github.com/NVIDIA/cudnn-frontend/pull/645) with three API-contract corrections for the NVFP4 grouped GEMM + SiTU-GLU + Hadamard path:

- make omitted `GroupedGemmGluHadamardSm100.execute()` beta arguments inherit the values stored in the compiled API object;
- validate positive, finite SiTU beta values before the high-level wrapper's empty-input fast return;
- include the routing-probability factor in the CuTe kernel's documented SiTU-GLU equation.

The tests add a numerical non-default-beta compile/execute case and empty-input validation cases for zero and NaN beta values.

## Why

`situ_beta1` specializes the compiled kernel, while `situ_beta2` is a runtime scalar. The merged implementation gave `execute()` hard-coded `(4, 25)` defaults even when the API object had been constructed and compiled for another valid pair such as `(2, 8)`. Omitting execute-time values could therefore reject a valid compiled object or launch with the wrong runtime `beta2`.

Separately, the high-level wrapper returned zero-token outputs before constructing the API object, bypassing the documented positive-finite beta validation. The kernel docstring also omitted `prob` even though the epilogue multiplies by it.

## Related issues

Follow-up to [NVIDIA/cudnn-frontend#645](https://github.com/NVIDIA/cudnn-frontend/pull/645).

## API and compatibility impact

- No kernel-math, layout, quantization, or performance-path change.
- Existing callers that explicitly pass beta values are unchanged.
- Callers that omit execute-time beta values now consistently reuse the values with which the API object was constructed.
- Invalid SiTU beta values are rejected consistently for empty and non-empty high-level wrapper inputs.
- Tested with cuDNN Frontend 1.27.0, cuDNN backend 9.23.1, and PyTorch 2.12 development builds on NVIDIA B200.

## Testing

- `python3 -m py_compile` on all three changed Python files: passed.
- `pre-commit run` on the staged files: passed.
- CuTe DSL 4.5.2, B200:
  - full L0 grouped GLU/dGLU/GLU-Hadamard matrix: **818 passed, 692 skipped**;
  - focused GLU-Hadamard file: **22 passed**.
- CuTe DSL 4.6.2, B200:
  - full L0 grouped GLU/dGLU/GLU-Hadamard matrix: **818 passed, 692 skipped**;
  - focused GLU-Hadamard file: **22 passed**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional SiT-GLU beta parameters during execution, with automatic fallback to configured values.
  * Added validation requiring beta values to be finite and positive.

* **Documentation**
  * Clarified the SiTU-GLU formula to include the probability term.

* **Bug Fixes**
  * Invalid beta values are now detected consistently, including when processing empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->