### PR TITLE
test(grouped_gemm): skip the GLU sf_fp8 override test off SM100

### DIFF
--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu.py
@@ -2195,6 +2195,9 @@ def test_grouped_gemm_glu_bf16_rejects_sf_fp8_dtype_override(request):
     This is what the None default buys: with an "e4m3" default the value would
     always be non-None and could not be distinguished from an explicit request.
     """
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("Requires SM100+ for grouped GEMM GLU BF16 kernel.")
+
     try:
         from cudnn import grouped_gemm_glu_wrapper_sm100
     except ImportError:


### PR DESCRIPTION
OSS CI fix.

`test_grouped_gemm_glu_bf16_rejects_sf_fp8_dtype_override` calls `grouped_gemm_glu_wrapper_sm100` without the SM100 guard every other test in the file carries, so on pre-Blackwell GPUs it fails with

```
RuntimeError: GroupedGemmGluSm100 requires SM100+, found SM80
```

from the wrapper's own arch check, before reaching the `ValueError` it means to assert. Adds the same skip the siblings use.

@coderabbitai ignore