### PR TITLE
Fix SM107 (Rubin) grouped GEMM quant: read TMEM accumulator before releasing the overlapping stage

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py
@@ -2254,6 +2254,9 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                         if reverse_subtile:
                             real_subtile_idx = self.cta_tile_shape_mnk[1] // self.epi_tile_n_required - 1 - subtile_idx
 
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
                     # C1 fix: fence + early release for overlapping_accum
                     if cutlass.const_expr(self.overlapping_accum):
                         if subtile_idx == self.iter_acc_early_release_in_epilogue:
@@ -2261,9 +2264,6 @@ class BlockScaledMoEGroupedGemmQuantKernel:
                             with cute.arch.elect_one():
                                 acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
-
-                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
-                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
 
                     # For breuse, update mProb based on which M half this subtile belongs to.
                     # With transform, subtiles interleave M groups: even = bkeep, odd = breuse.


### PR DESCRIPTION
## Summary

Follow-up to #654, which fixed the SM100 grouped GEMM kernels to read the TMEM accumulator before releasing the overlapping accumulator stage. As noted in https://github.com/NVIDIA/cudnn-frontend/pull/654#issuecomment-5334702125, the Rubin (SM107) kernel `moe_blockscaled_grouped_gemm_quant_rubin.py` has the identical pattern.

With `overlapping_accum` enabled, the epilogue released the accumulator stage (`acc_pipeline.consumer_release`) **before** performing the TMEM→register copy of that stage's subtile. Once released, the MMA warp can start overwriting the accumulator while the epilogue is still reading it, corrupting results. This PR applies the same reorder as #654: move the `t2r` copy ahead of the fence + early-release block.

## Scope

Checked all Rubin kernels containing the `iter_acc_early_release_in_epilogue` early-release pattern:

| Kernel | Status |
|---|---|
| `grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py` | **Fixed here** (release preceded copy) |
| `grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py` | Already correct (copy before release) |
| `grouped/glu_hadamard_quant/moe_blockscaled_grouped_gemm_glu_hadamard_quant_rubin.py` | Already correct (copy before release) |
| `grouped/dglu/moe_blockscaled_grouped_gemm_dglu_rubin.py` | Already correct (copy before release) |
| `grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad_rubin.py` | Not affected (`overlapping_accum = False`) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of grouped quantized matrix multiplication by ensuring accumulated results are captured before pipeline resources are released.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->