### PR TITLE
sdpa fwd: pick and run a KV split automatically

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -29,6 +29,29 @@ from cudnn.frost.tile_dsl.constants import (
     SCHED_NATURAL,
 )
 from cudnn.sdpa.fwd.config_sm100 import TemplateParams as Sm100TemplateParams
+from cudnn.sdpa.fwd.config_sm100 import make_cfg_d128, make_cfg_d192, make_cfg_d256, make_cfg_d512
+from cudnn.sdpa.fwd.heuristics import choose_split_kv
+from cudnn._device import device_info
+
+# Flavor (max D_QK, max D_V) -> its make_cfg, for the split decision. The config
+# backstop rejects what a flavor will not honor, which _decide_split_kv treats
+# as "no split", so this only has to be keyed the same way as
+# _SM100_KERNEL_FILES.
+_SM100_MAKE_CFG = {
+    (128, 128): make_cfg_d128,
+    (192, 128): make_cfg_d192,
+    (256, 256): make_cfg_d256,
+    (512, 512): make_cfg_d512,
+}
+
+
+def _split_combine_module():
+    """The KV-split reduction pass; imported lazily like the kernel templates."""
+    from cudnn.sdpa.fwd.kernels import split_combine_sm100
+
+    return split_combine_sm100
+
+
 from cudnn.sdpa.fwd.config_sm120 import (
     HEAD_TILE_GRANULE as _SM120_HEAD_TILE_GRANULE,
     SEQ_KV_TILES as _SM120_KV_TILES,
@@ -36,6 +59,7 @@ from cudnn.sdpa.fwd.config_sm120 import (
     SUPPORTED_HEAD_TILE_MAX as _SM120_HEAD_TILE_MAX,
     FP8_HEAD_TILE_GRANULE as _SM120_FP8_HEAD_TILE_GRANULE,
     TemplateParams as Sm120TemplateParams,
+    validate_params as _sm120_validate_params,
     smem_bytes as _sm120_smem_bytes,
 )
 
@@ -348,6 +372,7 @@ class SdpaFwdDsl(APIBase):
         # Per-tensor FP8 (sdpa_fp8) vs block-scale MXFP8 (sdpa_mxfp8); both use FP8 Q/K/V.
         self._pertensor = bool(pertensor_fp8)
         self._device_cc = None  # (major, minor); set in check_support
+        self._split_kv = None  # KV-split count; decided lazily, see split_kv
         # Tuning-knob choice, already validated against the engine's
         # Capabilities domain by the probe (engines.mismatch).
         self.sched_policy = SCHED_NATURAL if sched_policy is None else int(sched_policy)
@@ -931,26 +956,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         self._logger.debug("check_support completed successfully")
         return True
 
-    def compile(self) -> None:
-        self._logger.debug("Entering compile")
-        self._ensure_support_checked()
-        # MXFP8 on cc10.3+ fuses the S_acc row-max into the LDTM (the fp8/f16 kernels
-        # don't read this flag). Auto-set from the device capability so an SM103 run
-        # picks the fused path with no user action.
-        mxfp8 = self._fp8 and not self._pertensor
-        fused_ldtm_stat = mxfp8 and (self._device_cc == (10, 3))
-        sched_policy = self.sched_policy
-        if sched_policy == SCHED_NATURAL and self.window_right is not None:
-            # Causal: balance the triangular load; pick the LPT variant by working set.
-            _, _, s_kv_sched, _ = self.k_desc.shape
-            _, _, _, d_qk_sched = self.q_desc.shape
-            _, _, _, d_v_sched = self.v_desc.shape
-            sched_policy = _causal_sched_policy(
-                s_kv=s_kv_sched,
-                d_qk=d_qk_sched,
-                d_v=d_v_sched,
-                elem_bytes=1 if self._fp8 else 2,
-            )
+    def _template_params(self, sched_policy, fused_ldtm_stat, split_kv: int = 1) -> Sm100TemplateParams:
         lpt_head_group = 1
         if self._fp8 and self.flavor == (192, 128) and not self.thd and (self.batch_size * self.h_q) % 8 == 0:
             lpt_head_group = 8
@@ -970,7 +976,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # MASK_NONE x32 path. A right bound of S_kv removes no valid K but
             # selects the equivalent masked-interior lowering.
             template_window_right = self.s_k_max
-        params = Sm100TemplateParams(
+        return Sm100TemplateParams(
             dtype_qkv=_SM100_DTYPE_QKV_CODE[self.dtype],
             dtype_o=_SM100_DTYPE_QKV_CODE[self.dtype_o],
             window_left=self.window_left,
@@ -983,8 +989,83 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             lpt_head_group=lpt_head_group,
             lpt_q_tiles=lpt_q_tiles,
             thd_varlen=self.thd,
+            split_kv=split_kv,
             fused_ldtm_stat=fused_ldtm_stat,
         )
+
+    def _sched_policy(self) -> int:
+        sched_policy = self.sched_policy
+        if sched_policy == SCHED_NATURAL and self.window_right is not None:
+            # Causal: balance the triangular load; pick the LPT variant by working set.
+            _, _, s_kv_sched, _ = self.k_desc.shape
+            _, _, _, d_qk_sched = self.q_desc.shape
+            _, _, _, d_v_sched = self.v_desc.shape
+            sched_policy = _causal_sched_policy(s_kv=s_kv_sched, d_qk=d_qk_sched, d_v=d_v_sched, elem_bytes=1 if self._fp8 else 2)
+        return sched_policy
+
+    @property
+    def split_kv(self) -> int:
+        """How many KV chunks this graph's kernel is cut into; 1 = no split.
+
+        Decided from the launch geometry and the device (see
+        ``heuristics.choose_split_kv``), cached because ``compile()`` and
+        ``scratch_workspace_bytes()`` must agree on it.
+        """
+        if self._split_kv is None:
+            self._split_kv = self._decide_split_kv()
+        return self._split_kv
+
+    def _decide_split_kv(self) -> int:
+        """1 unless this is a dense half-precision graph whose flavor threads
+        the knob, the config backstop accepts it, and the heuristic wants it."""
+        self._ensure_support_checked()
+        make_cfg = _SM100_MAKE_CFG.get(self.flavor)
+        if make_cfg is None or self.thd or self.has_sink:
+            return 1
+        # The combine reduces the partials in half precision, and reducing
+        # QUANTIZED partials would lose what the split is meant to be neutral
+        # about, so an FP8 graph splits only when it stores O as bf16/fp16.
+        if self._fp8 and _SM100_DTYPE_QKV_CODE[self.dtype_o] not in (DTYPE_BF16, DTYPE_FP16):
+            return 1
+        sched_policy = self._sched_policy()
+        try:
+            cfg, _ = make_cfg(self._template_params(sched_policy, False, 1))
+        except ValueError:
+            return 1
+        ctas_per_tile = int(getattr(cfg, "CTA_MMA", 1))
+        rows_per_tile = int(getattr(cfg, "TILES_Q", 1)) * int(cfg.TILE_M) * ctas_per_tile
+        dev = getattr(self.q_desc, "device", None)
+        ordinal = getattr(dev, "index", None)
+        try:
+            sm_count = device_info(torch.cuda.current_device() if ordinal is None else ordinal).sm_count
+        except (RuntimeError, ValueError):  # no driver / odd device
+            return 1
+        split = choose_split_kv(
+            q_tiles=-(-self.s_q_max // rows_per_tile),
+            heads_q=self.h_q,
+            batch=self.batch_size,
+            kv_tiles=-(-self.s_k_max // int(cfg.TILE_N)),
+            sm_count=sm_count,
+            ctas_per_tile=ctas_per_tile,
+        )
+        if split <= 1:
+            return 1
+        try:  # the backstop is the authority on what this flavor will accept
+            make_cfg(self._template_params(sched_policy, False, split))
+        except ValueError:
+            return 1
+        return split
+
+    def compile(self) -> None:
+        self._logger.debug("Entering compile")
+        self._ensure_support_checked()
+        # MXFP8 on cc10.3+ fuses the S_acc row-max into the LDTM (the fp8/f16 kernels
+        # don't read this flag). Auto-set from the device capability so an SM103 run
+        # picks the fused path with no user action.
+        mxfp8 = self._fp8 and not self._pertensor
+        fused_ldtm_stat = mxfp8 and (self._device_cc == (10, 3))
+        sched_policy = self._sched_policy()
+        params = self._template_params(sched_policy, fused_ldtm_stat, self.split_kv)
         self._k_mod = _load_sm100_kernel_module(self.flavor, params, fp8=self._fp8, pertensor=self._pertensor, rubin=(self._device_cc == (10, 7)))
         if self.thd:
             # The THD compile key is PLAN-TIME-ONLY (the packed token totals
@@ -1006,7 +1087,9 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 kh=self.h_kv,
                 sq=self.s_q_max,
                 skv=self.s_k_max,
-                has_lse=self.lse_desc is not None,
+                # Under a split the per-chunk LSE is the weight the combine
+                # reduces with, so it is compiled in regardless.
+                has_lse=self.lse_desc is not None or self.split_kv > 1,
             )
         else:
             # ENVELOPE: hand the f16/bf16 kernel the ACTUAL head dims so its
@@ -1022,7 +1105,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 skv=self.s_k_max,
                 d_qk=self.head_dim_qk,
                 d_v=self.head_dim_v,
-                has_lse=self.lse_desc is not None,
+                # Under a split the per-chunk LSE is not optional: it is the
+                # weight the combine reduces with, so compile it in even when
+                # the caller asked for no Stats output.
+                has_lse=self.lse_desc is not None or self.split_kv > 1,
             )
         self._logger.debug("compile completed")
 
@@ -1050,11 +1136,23 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             # sequence + 16 spare, the per-sequence O TMA descriptors the
             # builder kernel fills.
             return ws_align((3 * b + 2) * 4) + ws_align((b * 16 + 16) * 8) + (0 if self.has_sink else ws_align(qh * 4))
-        if self._fp8:
+        if self._fp8 and self.split_kv == 1:
             return 0  # dense FP8/MXFP8: no per-execute scratch (dummies are cached one-time)
+        if self.split_kv > 1:
+            # Split-major partials the combine reduces: O is split_kv x the
+            # output, and the per-chunk LSE exists even without a Stats output.
+            n_o = self.split_kv * b * self.s_q_max * qh * self.head_dim_v
+            n_lse = self.split_kv * b * qh * self.s_q_max
+            return ws_align(n_o * self._o_itemsize()) + ws_align(n_lse * 4)
         # Dense padded-Q lens bind directly as their own kernel parameter
         # (no combine buffer since the seq_len_q-as-parameter change) — no scratch.
         return 0
+
+    def _o_itemsize(self) -> int:
+        return 2  # f16 / bf16; the split path is half-precision only
+
+    def _combine_dtype_tag(self) -> str:
+        return "bf16" if _SM100_DTYPE_QKV_CODE[self.dtype_o] == DTYPE_BF16 else "f16"
 
     def execute(
         self,
@@ -1145,6 +1243,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 scale_o,
                 amax_o,
                 current_stream,
+                workspace,
             )
             return
 
@@ -1166,6 +1265,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 sf_v,
                 amax_o,
                 current_stream,
+                workspace,
             )
             return
 
@@ -1212,24 +1312,115 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
 
         import cutlass
 
-        self._compiled_kernel(
-            Q,
-            K,
-            V,
-            O_scratch if o_needs_copy_back else O_view,
-            lse_tensor.reshape(self.batch_size, self.h_q, self.s_q_max) if lse_tensor is not None else None,
-            sinks_t,
-            seq_kv_t,
-            o_desc_dummy,
-            (self.batch_size, self.h_q, self.h_kv, self.s_q_max, self.s_k_max, 0),
-            cutlass.Float32(scale_softmax_log2),
-            cutlass.Int32(0),
-            seq_q_t,
-            stream=current_stream,
-        )
+        O_target = O_scratch if o_needs_copy_back else O_view
+        lse_out = lse_tensor.reshape(self.batch_size, self.h_q, self.s_q_max) if lse_tensor is not None else None
+
+        if self.split_kv > 1:
+            # Two launches: the kernel writes per-chunk partials into scratch,
+            # then split_combine reduces them into the caller's O (and Stats).
+            o_part, lse_part = self._split_partials(workspace, O_target, device, current_stream)
+            self._compiled_kernel(
+                Q,
+                K,
+                V,
+                o_part,
+                lse_part,
+                sinks_t,
+                seq_kv_t,
+                o_desc_dummy,
+                (self.batch_size, self.h_q, self.h_kv, self.s_q_max, self.s_k_max, 0),
+                cutlass.Float32(scale_softmax_log2),
+                cutlass.Int32(0),
+                seq_q_t,
+                stream=current_stream,
+            )
+            combine = _split_combine_module().compile(
+                b=self.batch_size,
+                h=self.h_q,
+                sq=self.s_q_max,
+                d_v=self.head_dim_v,
+                splits=self.split_kv,
+                dtype_o=self._combine_dtype_tag(),
+                has_lse=lse_out is not None,
+            )
+            combine(
+                o_part,
+                lse_part,
+                O_target,
+                lse_out,
+                None,  # amax_o: half-precision output, nothing to report
+                (self.batch_size, self.h_q, self.s_q_max, self.head_dim_v),
+                cutlass.Int32(self.split_kv),
+                stream=current_stream,
+            )
+        else:
+            self._compiled_kernel(
+                Q,
+                K,
+                V,
+                O_target,
+                lse_out,
+                sinks_t,
+                seq_kv_t,
+                o_desc_dummy,
+                (self.batch_size, self.h_q, self.h_kv, self.s_q_max, self.s_k_max, 0),
+                cutlass.Float32(scale_softmax_log2),
+                cutlass.Int32(0),
+                seq_q_t,
+                stream=current_stream,
+            )
         if o_needs_copy_back:
             O_view.copy_(O_scratch)
         self._logger.debug("execute completed")
+
+    def _run_split_combine(self, o_part, lse_part, o_out, lse_out, amax_o, stream):
+        """Reduce the split-major partials into the caller's O (and Stats, and
+        the FP8 amax when there is one)."""
+        import cutlass
+
+        _split_combine_module().compile(
+            b=self.batch_size,
+            h=self.h_q,
+            sq=self.s_q_max,
+            d_v=self.head_dim_v,
+            splits=self.split_kv,
+            dtype_o=self._combine_dtype_tag(),
+            has_lse=lse_out is not None,
+            has_amax=amax_o is not None,
+        )(
+            o_part,
+            lse_part,
+            o_out,
+            lse_out,
+            amax_o,
+            (self.batch_size, self.h_q, self.s_q_max, self.head_dim_v),
+            cutlass.Int32(self.split_kv),
+            stream=stream,
+        )
+
+    def _split_partials(self, workspace, o_like, device, current_stream=None):
+        """The split-major (O, LSE) partial buffers, carved from the caller's
+        workspace when there is one and torch-allocated otherwise (standalone
+        use, matching what the rest of this adapter does).
+
+        The allocation happens ON the launch stream: the caching allocator tags
+        a block with the stream it was allocated on, and the kernels that write
+        and read these buffers run on ``current_stream``. Allocating on torch's
+        current stream instead would leave a later free/reuse unordered against
+        those launches."""
+        rows = self.split_kv * self.batch_size
+        o_shape = (rows, self.s_q_max, self.h_q, self.head_dim_v)
+        lse_shape = (rows, self.h_q, self.s_q_max)
+        if workspace is None:
+            with _torch_stream_context(current_stream, device):
+                return (
+                    torch.empty(o_shape, dtype=o_like.dtype, device=device),
+                    torch.empty(lse_shape, dtype=torch.float32, device=device),
+                )
+        carver = WorkspaceCarver(workspace, self.scratch_workspace_bytes(), "SdpaFwdDslSm100 (KV split)")
+        o_part = carver.take(rows * self.s_q_max * self.h_q * self.head_dim_v, o_like.dtype).view(o_shape)
+        lse_part = carver.take(rows * self.h_q * self.s_q_max, torch.float32).view(lse_shape)
+        return o_part, lse_part
 
     def _thd_compile_kwargs(self) -> dict:
         """The THD compile key — PLAN-TIME-ONLY by contract (issue #552).
@@ -1510,6 +1701,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         sf_v,
         amax_o,
         current_stream=None,
+        workspace=None,
     ):
         """MXFP8 execute (dense): FP8 Q/K/V + per-32-block E8M0 SF → half O.
 
@@ -1558,15 +1750,18 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         with _torch_stream_context(current_stream, device):
             amax_o_buf.zero_()
 
+        O_dst, lse_dst = O, lse
+        if self.split_kv > 1:
+            O_dst, lse_dst = self._split_partials(workspace, O, O.device, current_stream)
         self._compiled_kernel(
             Q,
             K,
             V,
-            O,
+            O_dst,
             sf_q_v,
             sf_k_v,
             sf_v_v,
-            lse,
+            lse_dst,
             amax_o_buf,
             sinks_t,
             seq_kv_t,
@@ -1574,6 +1769,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             cutlass.Float32(scale_softmax_log2),
             stream=current_stream,
         )
+        if self.split_kv > 1:
+            self._run_split_combine(O_dst, lse_dst, O, lse, amax_o_buf, current_stream)
         if o_needs_copy_back:
             O_view.copy_(O)
         self._logger.debug("execute (MXFP8) completed")
@@ -1595,6 +1792,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         scale_o,
         amax_o,
         current_stream=None,
+        workspace=None,
     ):
         """Per-tensor FP8 execute (dense): scalar descales fold into scale_softmax_log2
         (attn·descale_q·descale_k·log2 e) and o_scale_fused (descale_v·scale_o).
@@ -1650,12 +1848,15 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         with _torch_stream_context(current_stream, device):
             amax_o_buf.zero_()
 
+        O_dst, lse_dst = O, lse
+        if self.split_kv > 1:
+            O_dst, lse_dst = self._split_partials(workspace, O, O.device, current_stream)
         self._compiled_kernel(
             Q,
             K,
             V,
-            O,
-            lse,
+            O_dst,
+            lse_dst,
             sinks_t,
             seq_kv_t,
             (b, h_q, h_kv, sq, skv, 0),
@@ -1668,6 +1869,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             amax_o_buf,
             stream=current_stream,
         )
+        if self.split_kv > 1:
+            # Under a split the epilogues stand down from the amax write (each
+            # sees only its own partial, which over-reports); the combine
+            # computes it over the recombined O instead.
+            self._run_split_combine(O_dst, lse_dst, O, lse, amax_o_buf, current_stream)
         if o_needs_copy_back:
             O_view.copy_(O)
         if amax_o is not None:
@@ -1900,6 +2106,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
 
     def _initialize_implementation(self) -> None:
         self.q_tile = _SM120_Q_TILES[0] if self.tile_m is None else self.tile_m
+        self._split_kv = None  # KV-split count; decided lazily, see split_kv
         self.kv_tile = _SM120_KV_TILES[0] if self.tile_n is None else self.tile_n
         self.compute_capability: Optional[tuple[int, int]] = None
         self.head_dim_qk: Optional[int] = None
@@ -2113,6 +2320,92 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         self._logger.debug("check_support completed successfully")
         return True
 
+    def _sched_policy(self) -> int:
+        """The policy compile() will actually use: causal graphs trade NATURAL
+        for an LPT variant, and the split decision has to see the same value."""
+        sched_policy = self.sched_policy
+        if sched_policy == SCHED_NATURAL and self.window_right is not None:
+            _, _, s_kv_sched, _ = self.k_desc.shape
+            _, _, _, d_qk_sched = self.q_desc.shape
+            _, _, _, d_v_sched = self.v_desc.shape
+            sched_policy = _causal_sched_policy(s_kv=s_kv_sched, d_qk=d_qk_sched, d_v=d_v_sched, elem_bytes=1 if self._fp8 else 2)
+        return sched_policy
+
+    @property
+    def split_kv(self) -> int:
+        """How many KV chunks this graph's kernel is cut into; 1 = no split."""
+        if self._split_kv is None:
+            self._split_kv = self._decide_split_kv()
+        return self._split_kv
+
+    def _decide_split_kv(self) -> int:
+        """1 unless this is a dense half-precision graph the config accepts and
+        the heuristic wants split."""
+        self._ensure_support_checked()
+        if self.thd or self._fp8 or self.has_sink:
+            return 1
+        dev = getattr(self.q_desc, "device", None)
+        ordinal = getattr(dev, "index", None)
+        try:
+            sm_count = device_info(torch.cuda.current_device() if ordinal is None else ordinal).sm_count
+        except (RuntimeError, ValueError):  # no driver / odd device
+            return 1
+        split = choose_split_kv(
+            q_tiles=-(-self.s_q_max // self.q_tile),
+            heads_q=self.h_q,
+            batch=self.batch_size,
+            kv_tiles=-(-self.s_k_max // self.kv_tile),
+            sm_count=sm_count,
+            ctas_per_tile=1,  # SM120 runs one CTA per tile; no cluster
+        )
+        if split <= 1:
+            return 1
+        try:  # the backstop is the authority (it also bars LPT / LPT_L2)
+            _sm120_validate_params(
+                Sm120TemplateParams(
+                    dtype_qkv=_SM120_DTYPE_QKV_CODE[self.dtype],
+                    dtype_o=_SM120_DTYPE_QKV_CODE[self.o_desc.dtype],
+                    # The EFFECTIVE policy, not self.sched_policy: compile()
+                    # swaps NATURAL for an LPT variant on a causal graph, and
+                    # the config bars a split under those. Validating the raw
+                    # value would accept a split compile() then rejects.
+                    sched_policy=self._sched_policy(),
+                    window_left=self.window_left,
+                    window_right=self.window_right,
+                    bottom_right=self.causal_bottom_right,
+                    seq_q_lens_present=self.seq_q_lens_present,
+                    seq_kv_lens_present=self.seq_kv_lens_present,
+                    has_sink=self.has_sink,
+                    thd_varlen=self.thd,
+                    q_tile=self.q_tile,
+                    kv_tile=self.kv_tile,
+                    split_kv=split,
+                )
+            )
+        except ValueError:
+            return 1
+        return split
+
+    def _split_partials(self, workspace, o_like, device, current_stream=None):
+        """Split-major (O, LSE) partials: carved from the caller's workspace
+        when there is one, torch-allocated otherwise.
+
+        Allocated ON the launch stream so the allocator tags the blocks with the
+        stream the kernels actually use (see the SM100 sibling)."""
+        rows = self.split_kv * self.batch_size
+        o_shape = (rows, self.s_q_max, self.h_q, self.head_dim_v)
+        lse_shape = (rows, self.h_q, self.s_q_max)
+        if workspace is None:
+            with _torch_stream_context(current_stream, device):
+                return (
+                    torch.empty(o_shape, dtype=o_like.dtype, device=device),
+                    torch.empty(lse_shape, dtype=torch.float32, device=device),
+                )
+        carver = WorkspaceCarver(workspace, self.scratch_workspace_bytes(), "SdpaFwdDslSm120 (KV split)")
+        o_part = carver.take(rows * self.s_q_max * self.h_q * self.head_dim_v, o_like.dtype).view(o_shape)
+        lse_part = carver.take(rows * self.h_q * self.s_q_max, torch.float32).view(lse_shape)
+        return o_part, lse_part
+
     def compile(self) -> None:
         """Compile the shape-specialized SM120 FROST template."""
 
@@ -2121,18 +2414,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         if self._compiled_kernel is not None:
             return
 
-        # Causal: balance the triangular load; pick the LPT variant by working set.
-        sched_policy = self.sched_policy
-        if sched_policy == SCHED_NATURAL and self.window_right is not None:
-            _, _, s_kv_sched, _ = self.k_desc.shape
-            _, _, _, d_qk_sched = self.q_desc.shape
-            _, _, _, d_v_sched = self.v_desc.shape
-            sched_policy = _causal_sched_policy(
-                s_kv=s_kv_sched,
-                d_qk=d_qk_sched,
-                d_v=d_v_sched,
-                elem_bytes=1 if self._fp8 else 2,
-            )
+        sched_policy = self._sched_policy()
         params = Sm120TemplateParams(
             dtype_qkv=_SM120_DTYPE_QKV_CODE[self.dtype],
             dtype_o=_SM120_DTYPE_QKV_CODE[self.o_desc.dtype],
@@ -2146,6 +2428,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             thd_varlen=self.thd,
             q_tile=self.q_tile,
             kv_tile=self.kv_tile,
+            split_kv=self.split_kv,
         )
         self._k_mod = _load_sm120_kernel_module(params, fp8=self._fp8)
         if self.thd:
@@ -2168,8 +2451,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             d_qk=self.head_dim_qk,
             d_v=self.head_dim_v,
             # No sample_lse -> the LSE store is compiled out; execute() then
-            # binds no LSE buffer at all (no dummy, no allocation).
-            has_lse=self.lse_desc is not None,
+            # binds no LSE buffer at all (no dummy, no allocation). Under a
+            # split the per-chunk LSE is the weight the combine reduces with,
+            # so it is compiled in regardless.
+            has_lse=self.lse_desc is not None or self.split_kv > 1,
         )
         self._logger.debug("compile completed")
 
@@ -2290,12 +2575,17 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         v = self._to_bshd(v_tensor)
         o_view, o_needs_copy_back, o_scratch = self._to_bshd_writable(o_tensor)
         o = o_scratch if o_needs_copy_back else o_view
+        o_dst, lse_dst = o, lse
+        if self.split_kv > 1:
+            # Two launches: the kernel writes per-chunk partials, then
+            # split_combine reduces them into the caller's O (and Stats).
+            o_dst, lse_dst = self._split_partials(workspace, o, q_tensor.device, current_stream)
         self._compiled_kernel(
             q,
             k,
             v,
-            o,
-            lse,
+            o_dst,
+            lse_dst,
             sinks_t,
             seq_q_lens,
             seq_kv_lens,
@@ -2306,6 +2596,25 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             None,
             current_stream,
         )
+        if self.split_kv > 1:
+            _split_combine_module().compile(
+                b=self.batch_size,
+                h=self.h_q,
+                sq=self.s_q_max,
+                d_v=self.head_dim_v,
+                splits=self.split_kv,
+                dtype_o="bf16" if o.dtype == torch.bfloat16 else "f16",
+                has_lse=lse is not None,
+            )(
+                o_dst,
+                lse_dst,
+                o,
+                lse,
+                None,  # amax_o: half-precision output, nothing to report
+                (self.batch_size, self.h_q, self.s_q_max, self.head_dim_v),
+                cutlass.Int32(self.split_kv),
+                stream=current_stream,
+            )
         if o_needs_copy_back:
             o_view.copy_(o_scratch)
 
@@ -2708,6 +3017,12 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             # guarded GMEM stores, so THD needs no per-sequence tensor maps.
             b = self.batch_size
             return ws_align((3 * b + 2) * 4)
+        if self.split_kv > 1:
+            # Split-major partials the combine reduces: O is split_kv x the
+            # output, and the per-chunk LSE exists even without a Stats output.
+            n_o = self.split_kv * self.batch_size * self.s_q_max * self.h_q * self.head_dim_v
+            n_lse = self.split_kv * self.batch_size * self.h_q * self.s_q_max
+            return ws_align(n_o * 2) + ws_align(n_lse * 4)  # half-precision O
         return 0
 
 

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -85,6 +85,7 @@ class SdpaFwdKnobs:
     tile_m: Optional[int] = None  # Q sequence tile width
     tile_n: Optional[int] = None  # KV sequence tile width
     cga: Optional[int] = None  # cluster size (CTAs cooperating per tile)
+    split_kv: Optional[int] = None  # KV-sequence split count (1 = no split)
 
 
 @dataclass(frozen=True)
@@ -225,6 +226,15 @@ class Capabilities:
     tile_ms: frozenset[int] = frozenset()
     tile_ns: frozenset[int] = frozenset()
     cgas: frozenset[int] = frozenset()
+    # What a REQUESTED split_kv may be -- EMPTY everywhere, including the cells
+    # that do split. The adapters choose the split from the launch geometry and
+    # lower_dsl_prefill does not forward knobs.split_kv, so no request can be
+    # honored: not split_kv=8, and not split_kv=1 either, since "do not split"
+    # is exactly what the lowering would ignore. An empty domain makes any
+    # request ineligible, which is the honest encoding of that. Populate a row
+    # only together with the plumbing (a split_kv adapter argument seeding
+    # _split_kv, and knobs.split_kv forwarded in lower_dsl_prefill).
+    split_kvs: frozenset[int] = frozenset()
 
 
 def _band_covers_kv_tail(facts: "ga.SdpaGraphFacts") -> bool:
@@ -264,6 +274,7 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
             (knobs.tile_m, capabilities.tile_ms, "tile_m"),
             (knobs.tile_n, capabilities.tile_ns, "tile_n"),
             (knobs.cga, capabilities.cgas, "cga"),
+            (knobs.split_kv, capabilities.split_kvs, "split_kv"),
         ):
             if value is not None and value not in domain:
                 return f"requested {label}={value} is outside this engine's domain {sorted(domain)}"

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -45,6 +45,15 @@ _MEASURED_BEHIND: frozenset = frozenset()
 # Cells whose (tile_m, tile_n) choice _sm120_tiles makes.
 _TILE_RULE_CELLS = frozenset({"sdpa_fwd_prefill_sm120", "sdpa_fwd_prefill_sm120_fp8"})
 
+# --- KV split (see choose_split_kv) ---------------------------------------
+# Largest split considered; past this the reduction outgrows the parallelism.
+_SPLIT_KV_MAX = 16
+# A split thinner than this is prologue/epilogue dominated.
+_SPLIT_KV_MIN_TILES = 2
+# What a CTA-tile costs beyond its KV loop (Q load, prologue, epilogue), in
+# units of one KV tile. Empirical: re-measure if the per-tile fixed cost moves.
+_SPLIT_KV_CTA_COST = 21.0
+
 
 def _sm120_tiles(caps: Capabilities, facts) -> Tuple[int, int]:
     """(tile_m, tile_n) for the SM120 SDPA-forward prefill cell.
@@ -87,6 +96,73 @@ def _sm120_tiles(caps: Capabilities, facts) -> Tuple[int, int]:
     d_vp = -(-facts.d_v // granule) * granule
     fits = [n for n in sorted(caps.tile_ns, reverse=True) if smem_bytes(d_qp, d_vp, tile_m, n, qkv_itemsize, o_itemsize) <= SMEM_CAPACITY_BYTES]
     return tile_m, (fits[0] if fits else min(caps.tile_ns))
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def choose_split_kv(
+    *,
+    q_tiles: int,
+    heads_q: int,
+    batch: int,
+    kv_tiles: int,
+    sm_count: int,
+    ctas_per_tile: int = 1,
+    max_split: int = _SPLIT_KV_MAX,
+) -> int:
+    """How many KV chunks to cut each Q tile into; 1 = do not split.
+
+    A prefill launch is ``q_tiles * heads_q * batch`` independent tiles, each
+    walking the whole KV loop.  When that product is below the SM count the chip
+    idles however long the loop is; splitting multiplies the tile count by ``s``
+    and divides each tile's KV work by it, then pays one reduction over the
+    partials.
+
+    A CTA holds its tile for the whole loop, so a launch costs whole WAVES.
+    Minimise, over powers of two:
+
+        waves(s) = ceil(base_ctas * s / sm_count)
+        cost(s)  = waves(s) * (ceil(kv_tiles / s) + CTA_COST)
+
+    CTA_COST is what a tile re-pays whatever its loop length, so it sits inside
+    the wave term -- once per CTA-tile, not once per split.
+
+    What falls out: an under-full launch splits until the wave is full; an
+    over-full one with a partial-wave tail splits FINER to smooth it, even past
+    the SM count; an exactly balanced one (base_ctas = k * sm_count) has no tail
+    and never splits.
+
+    Powers of two only, because ``split_kv`` is a TemplateParams field and so a
+    kernel-module cache key -- an unrestricted choice mints a compiled
+    specialization per shape.
+
+    Returns 1 when there is nothing to split or nothing beats not splitting.
+    Bounded by ``max_split``, by ``kv_tiles`` (more splits than tiles would
+    leave some provably empty) and by ``_SPLIT_KV_MIN_TILES``.
+    """
+    if min(q_tiles, heads_q, batch, kv_tiles, sm_count, ctas_per_tile) <= 0:
+        return 1
+    base_ctas = q_tiles * heads_q * batch * ctas_per_tile
+    if kv_tiles <= 1:
+        return 1
+
+    best_split = 1
+    best_cost = float(_ceil_div(base_ctas, sm_count) * (kv_tiles + _SPLIT_KV_CTA_COST))
+    split = 2
+    while split <= min(max_split, kv_tiles):
+        # Every split must stay thick enough to amortise its own prologue and
+        # epilogue. The chunking hands the remainder to the leading splits, so
+        # the THINNEST gets floor(kv_tiles / split) -- that is what must clear.
+        if kv_tiles // split < _SPLIT_KV_MIN_TILES:
+            break
+        waves = _ceil_div(base_ctas * split, sm_count)
+        cost = waves * (_ceil_div(kv_tiles, split) + _SPLIT_KV_CTA_COST)
+        if cost < best_cost:
+            best_split, best_cost = split, cost
+        split <<= 1
+    return best_split
 
 
 def _sole(values):

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
@@ -812,3 +812,172 @@ def test_split_kv_padded_q_trim(splits):
     assert got[dead.expand_as(got)].abs().max().item() == 0.0, "trimmed Q rows are not zero"
     live = ~dead
     assert (got - ref)[live.expand_as(got)].abs().max().item() <= 2e-2
+
+
+# --- the adapter picks and runs a split by itself ---------------------------
+
+
+def _expected_split(b, h_q, s_q, s_kv, *, rows_per_tile=512, ctas_per_tile=2, kv_tile=128):
+    """What the chooser asks for on THIS device, so the tests assert the adapter
+    honors it rather than hard-coding a split that only holds at one SM count."""
+    from cudnn._device import device_info
+    from cudnn.sdpa.fwd.heuristics import choose_split_kv
+
+    return choose_split_kv(
+        q_tiles=-(-s_q // rows_per_tile),
+        heads_q=h_q,
+        batch=b,
+        kv_tiles=-(-s_kv // kv_tile),
+        sm_count=device_info(torch.cuda.current_device()).sm_count,
+        ctas_per_tile=ctas_per_tile,
+    )
+
+
+def _api_case(b, h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True):
+    """Drive SdpaFwdDslSm100 the way the graph path does; return (split, O, ref)."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    if torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("half-precision SM100 prefill requires an SM100-line part")
+    d = 128
+    dev = "cuda"
+    torch.manual_seed(0)
+    q = torch.randn(b, h_q, s_q, d, device=dev, dtype=torch.float16)  # BHSD samples
+    k = torch.randn(b, h_kv, s_kv, d, device=dev, dtype=torch.float16)
+    v = torch.randn(b, h_kv, s_kv, d, device=dev, dtype=torch.float16)
+    o = torch.zeros_like(q)
+    lse = torch.zeros(b, h_q, s_q, device=dev, dtype=torch.float32) if with_lse else None
+
+    api = SdpaFwdDslSm100(sample_q=q, sample_k=k, sample_v=v, sample_o=o, sample_lse=lse)
+    assert api.check_support()
+    split = api.split_kv
+    ws_bytes = api.scratch_workspace_bytes()
+    api.compile()
+    ws = torch.empty(ws_bytes, dtype=torch.uint8, device=dev) if (workspace and ws_bytes) else None
+    api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, lse_tensor=lse, workspace=ws)
+    torch.cuda.synchronize()
+
+    qb, kb, vb = q.float(), k.float(), v.float()
+    if h_q != h_kv:
+        kb = kb.repeat_interleave(h_q // h_kv, dim=1)
+        vb = vb.repeat_interleave(h_q // h_kv, dim=1)
+    p = torch.softmax(torch.matmul(qb, kb.transpose(-1, -2)) / math.sqrt(d), dim=-1)
+    return split, o.float(), torch.matmul(p, vb), ws_bytes
+
+
+@pytest.mark.L0
+def test_api_splits_a_decode_shape_and_is_correct():
+    """8 heads over a long KV run cannot fill the part: the adapter must split on
+    its own, size its own workspace, and still match fp32. S_kv is the smallest
+    that still splits -- the fp32 reference is O(h * s_q * s_kv) and this is L0."""
+    split, got, ref, ws_bytes = _api_case(1, 8, 1, 512, 16384)
+    assert split == _expected_split(1, 8, 512, 16384) > 1
+    assert ws_bytes > 0, "a split needs the split-major O/LSE partials in workspace"
+    assert (got - ref).abs().max().item() <= 2e-2
+
+
+@pytest.mark.L0
+def test_api_does_not_split_a_full_chip():
+    """A launch that fills the machine is left alone. The expectation comes from
+    the chooser on THIS device: whether 2048x16 fills it depends on the SM count,
+    so hard-coding split==1 would fail on a smaller SM100 part for a device
+    reason rather than a policy one."""
+    want = _expected_split(1, 16, 2048, 8192)
+    split, got, ref, ws_bytes = _api_case(1, 16, 16, 2048, 8192)
+    assert split == want
+    assert (ws_bytes > 0) == (split > 1), "workspace is needed exactly when we split"
+    assert (got - ref).abs().max().item() <= 2e-2
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("workspace", [True, False], ids=["carved", "standalone"])
+def test_api_split_with_and_without_workspace(workspace):
+    """With a workspace the partials are carved from it; without one they are
+    torch-allocated (standalone use). Same answer either way."""
+    split, got, ref, _ = _api_case(1, 8, 1, 512, 16384, workspace=workspace)
+    assert split > 1
+    assert (got - ref).abs().max().item() <= 2e-2
+
+
+@pytest.mark.L0
+def test_api_split_writes_the_recombined_lse():
+    """A Stats output under a split comes from the combine, not from any one
+    chunk: the per-chunk LSE is compiled in even when the caller wants none."""
+    split, got, ref, _ = _api_case(1, 8, 1, 512, 16384, with_lse=True)
+    assert split > 1
+    assert (got - ref).abs().max().item() <= 2e-2
+
+
+# --- the adapter splits the FP8 family too ----------------------------------
+
+
+def _api_fp8_case(h_q, h_kv, s_q, s_kv, *, mx):
+    """FP8 / MXFP8 through the adapter; returns (split, O, O_unsplit, amax)."""
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    if torch.cuda.get_device_capability()[0] != 10:
+        pytest.skip("SM100-line part required")
+    b, d, dev = 1, 128, "cuda"
+
+    def build(force_one):
+        torch.manual_seed(0)
+        if mx:
+            from sdpa.mxfp8_quant import quantize_to_mxfp8
+
+            def qz(shape):
+                r = torch.randn(*shape, device=dev) * 0.5
+                a, _adq, aswz, *_ = quantize_to_mxfp8(r, shape[0], shape[1], shape[2], shape[3])
+                return a.reshape(*shape), aswz
+
+            q, sf_q = qz((b, h_q, s_q, d))
+            k, sf_k = qz((b, h_kv, s_kv, d))
+            v, sf_v = qz((b, h_kv, s_kv, d))
+            extra = dict(sf_q=sf_q, sf_k=sf_k, sf_v=sf_v)
+            kw = {}
+        else:
+            mk = lambda *sh: (torch.randn(*sh, device=dev) * 0.5).clamp(-448, 448).to(torch.float8_e4m3fn)
+            q, k, v = mk(b, h_q, s_q, d), mk(b, h_kv, s_kv, d), mk(b, h_kv, s_kv, d)
+            one = lambda: torch.ones(1, dtype=torch.float32, device=dev)
+            extra = dict(descale_q=one(), descale_k=one(), descale_v=one(), scale_o=one())
+            kw = dict(pertensor_fp8=True)
+
+        o = torch.zeros(b, h_q, s_q, d, device=dev, dtype=torch.float16)  # HALF out
+        amax = torch.zeros(1, dtype=torch.float32, device=dev)
+        api = SdpaFwdDslSm100(sample_q=q, sample_k=k, sample_v=v, sample_o=o, dtype_o=torch.float16, **kw)
+        assert api.check_support()
+        if force_one:
+            api._split_kv = 1
+        split = api.split_kv
+        ws_bytes = api.scratch_workspace_bytes()
+        api.compile()
+        ws = torch.empty(ws_bytes, dtype=torch.uint8, device=dev) if ws_bytes else None
+        api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, amax_o=amax, workspace=ws, **extra)
+        torch.cuda.synchronize()
+        return split, o.float().clone(), amax.item()
+
+    _, o_one, _ = build(True)
+    split, o_split, amax = build(False)
+    return split, o_split, o_one, amax
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mx", [False, True], ids=["fp8", "mxfp8"])
+def test_api_splits_the_fp8_family(mx):
+    """A decode-shaped FP8 graph with a half output splits, and the split is
+    numerically neutral against the same graph forced to split_kv=1."""
+    split, got, unsplit, _ = _api_fp8_case(8, 1, 512, 16384, mx=mx)
+    assert split > 1
+    assert (got - unsplit).abs().max().item() <= 5e-2
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("mx", [False, True], ids=["fp8", "mxfp8"])
+def test_api_fp8_amax_describes_the_recombined_output(mx):
+    """The per-split epilogues stand down under a split; amax_o has to come
+    from the combine, over the RECOMBINED O. Maxing the partials instead
+    over-reports, so compare against the output the caller receives."""
+    split, got, _unsplit, amax = _api_fp8_case(8, 1, 512, 16384, mx=mx)
+    assert split > 1
+    true_amax = got.abs().max().item()
+    assert amax >= true_amax * 0.99, f"amax {amax} under-reports |O| {true_amax}"
+    assert amax <= true_amax * 1.01, f"amax {amax} over-reports |O| {true_amax} — taken over partials?"

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""KV split on SM120, driven through the adapter rather than the template.
+
+The chooser and the two-launch execute are shared with SM100; what differs here
+is the geometry (one CTA per tile, no cluster) and that the config bars a split
+under the flattened LPT schedulers.
+"""
+
+import math
+
+import pytest
+import torch
+
+from frost_test_utils import requires_dsl
+
+pytestmark = [requires_dsl, pytest.mark.L0]
+
+
+def _expected_split(api):
+    """What the chooser asks for on THIS device, from the adapter's OWN tile
+    geometry. SM120 runs one CTA per tile (no cluster), and the adapter may pick
+    either q_tile, so reading them off `api` keeps the expectation tied to the
+    launch that actually happens rather than to one part's SM count."""
+    from cudnn._device import device_info
+    from cudnn.sdpa.fwd.heuristics import choose_split_kv
+
+    return choose_split_kv(
+        q_tiles=-(-api.s_q_max // api.q_tile),
+        heads_q=api.h_q,
+        batch=api.batch_size,
+        kv_tiles=-(-api.s_k_max // api.kv_tile),
+        sm_count=device_info(torch.cuda.current_device()).sm_count,
+        ctas_per_tile=1,
+    )
+
+
+def _sm120_case(h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True, causal=False):
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm120
+
+    if torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("SM120 part required")
+    b, d, dev = 1, 128, "cuda"
+    torch.manual_seed(0)
+    q = torch.randn(b, h_q, s_q, d, device=dev, dtype=torch.float16)
+    k = torch.randn(b, h_kv, s_kv, d, device=dev, dtype=torch.float16)
+    v = torch.randn(b, h_kv, s_kv, d, device=dev, dtype=torch.float16)
+    o = torch.zeros_like(q)
+    lse = torch.zeros(b, h_q, s_q, device=dev, dtype=torch.float32) if with_lse else None
+
+    kw = dict(is_causal=True) if causal else {}
+    api = SdpaFwdDslSm120(sample_q=q, sample_k=k, sample_v=v, sample_o=o, sample_lse=lse, **kw)
+    assert api.check_support()
+    split = api.split_kv
+    expected = _expected_split(api)
+    ws_bytes = api.scratch_workspace_bytes()
+    api.compile()
+    ws = torch.empty(ws_bytes, dtype=torch.uint8, device=dev) if (workspace and ws_bytes) else None
+    api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, lse_tensor=lse, workspace=ws)
+    torch.cuda.synchronize()
+
+    qb, kb, vb = q.float(), k.float(), v.float()
+    if h_q != h_kv:
+        kb = kb.repeat_interleave(h_q // h_kv, dim=1)
+        vb = vb.repeat_interleave(h_q // h_kv, dim=1)
+    scores = torch.matmul(qb, kb.transpose(-1, -2)) / math.sqrt(d)
+    if causal:
+        i = torch.arange(s_q, device=scores.device).view(s_q, 1)
+        j = torch.arange(s_kv, device=scores.device).view(1, s_kv)
+        scores = scores.masked_fill(j > i, float("-inf"))
+    p = torch.softmax(scores, dim=-1)
+    return split, o.float(), torch.matmul(p, vb), ws_bytes, expected
+
+
+def test_sm120_splits_a_decode_shape():
+    """A decode shape the chooser wants split -- and the adapter must honor it."""
+    split, got, ref, ws_bytes, expected = _sm120_case(8, 1, 128, 32768)
+    if expected == 1:
+        pytest.skip("this part is small enough that the shape already fills it")
+    assert split == expected > 1
+    assert ws_bytes > 0
+    assert (got - ref).abs().max().item() <= 2e-2
+
+
+def test_sm120_does_not_split_a_full_part():
+    """A launch that fills the part is left alone. Whether 1024x64 fills it
+    depends on the SM count, so the expectation comes from the chooser rather
+    than a fixed 1 that only holds on one device."""
+    split, got, ref, ws_bytes, expected = _sm120_case(64, 8, 1024, 16384)
+    assert split == expected
+    assert (ws_bytes > 0) == (split > 1), "workspace is needed exactly when we split"
+    assert (got - ref).abs().max().item() <= 2e-2
+
+
+@pytest.mark.parametrize("workspace", [True, False], ids=["carved", "standalone"])
+def test_sm120_split_with_and_without_workspace(workspace):
+    split, got, ref, _, expected = _sm120_case(8, 1, 128, 32768, workspace=workspace)
+    assert split == expected
+    assert (got - ref).abs().max().item() <= 2e-2
+
+
+def test_sm120_split_writes_the_recombined_lse():
+    split, got, ref, _, expected = _sm120_case(8, 1, 128, 32768, with_lse=True)
+    assert split == expected
+    assert (got - ref).abs().max().item() <= 2e-2
+
+
+def test_sm120_causal_split_compiles():
+    """Causal graphs swap NATURAL for an LPT variant at compile time, and the
+    config bars a split under those. The decision must see the EFFECTIVE policy,
+    or it hands compile() a split that validate_params then rejects."""
+    split, got, ref, _, _expected = _sm120_case(8, 1, 512, 8192, causal=True)
+    # A causal SM120 graph compiles under LPT, which the config bars a split
+    # under -- so the honest answer is "do not split", and the point of the test
+    # is that we reach it by DECLINING rather than by failing to compile.
+    assert split == 1
+    assert (got - ref).abs().max().item() <= 2e-2

--- a/test/python/sdpa/frost/test_split_kv_heuristic.py
+++ b/test/python/sdpa/frost/test_split_kv_heuristic.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the KV-split chooser.
+
+Pure arithmetic over (tile count, KV length, SM count) — no GPU, no kernel
+build, so these run anywhere and pin the POLICY rather than any one device.
+The B200 numbers below are the shapes the split was built for, taken from the
+d128 geometry: a cga2 cluster covers TILES_Q * TILE_M * CTA_MMA = 512 Q rows on
+2 CTAs, and TILE_N = 128 sets the KV tile.
+"""
+
+import pytest
+
+from cudnn.sdpa.fwd.engines import Capabilities, SdpaFwdKnobs, mismatch
+from cudnn.sdpa.fwd.heuristics import _SPLIT_KV_MAX, _SPLIT_KV_MIN_TILES, choose_split_kv
+
+# Pure arithmetic — no device, no kernel build — so every case is L0.
+pytestmark = pytest.mark.L0
+
+B200_SMS = 148
+
+
+def _d128_cga2(s_q, s_kv, heads, batch, sm_count=B200_SMS, **kw):
+    """choose_split_kv for the d128 cga2 geometry."""
+    return choose_split_kv(
+        q_tiles=-(-s_q // 512),
+        heads_q=heads,
+        batch=batch,
+        kv_tiles=-(-s_kv // 128),
+        sm_count=sm_count,
+        ctas_per_tile=2,
+        **kw,
+    )
+
+
+# --- the case the feature exists for --------------------------------------
+
+
+def _single_wave(base_ctas, split, sm_count=B200_SMS):
+    """Does the split leave the launch inside one wave? True for an UNDER-full
+    launch, where the idle SMs are free to fill; not a global rule (see
+    test_may_exceed_the_sm_count_to_smooth_a_tail)."""
+    return base_ctas * split <= sm_count
+
+
+def test_decode_shape_splits():
+    """S_q=128, S_kv=32K, H=16, B=1 — 32 CTAs on a 148-SM part."""
+    split = _d128_cga2(128, 32768, 16, 1)
+    assert split > 1, "a launch filling 32 of 148 SMs must split"
+    assert _single_wave(32, split), "the chosen split must stay inside one wave"
+    assert not _single_wave(32, split * 2), "and be the LARGEST power of two that does"
+
+
+def test_more_heads_need_less_split():
+    """Heads are already parallelism: the more there are, the less splitting."""
+    few = _d128_cga2(128, 32768, 4, 1)
+    many = _d128_cga2(128, 32768, 64, 1)
+    assert few >= many
+
+
+def test_bigger_batch_needs_less_split():
+    assert _d128_cga2(128, 32768, 8, 1) >= _d128_cga2(128, 32768, 8, 8)
+
+
+def test_smaller_chip_needs_less_split():
+    """The same shape on a smaller part needs fewer splits to fill it."""
+    big = _d128_cga2(128, 32768, 16, 1, sm_count=148)
+    small = _d128_cga2(128, 32768, 16, 1, sm_count=48)
+    assert small <= big
+
+
+# --- cases that must NOT split --------------------------------------------
+
+
+def test_chip_already_full_does_not_split():
+    """Long prefill: 4096 Q rows x 16 heads is 8 * 16 * 2 = 256 CTAs > 148."""
+    assert _d128_cga2(4096, 2048, 16, 1) == 1
+
+
+def test_nearly_full_chip_does_not_split():
+    """128 CTAs on 148 SMs — 86% — must not split: doubling tips it into a
+    second partial wave, so the makespan is flat and only the reduction is
+    added. Measured, not assumed."""
+    base_ctas = 4 * 16 * 2  # s_q=2048 -> 4 q tiles, 16 heads, cga2
+    assert base_ctas == 128
+    assert _d128_cga2(2048, 65536, 16, 1) == 1
+
+
+def test_exactly_full_does_not_split():
+    """base_ctas == sm_count is 'filled' — no reduction for zero gain."""
+    assert choose_split_kv(q_tiles=1, heads_q=B200_SMS, batch=1, kv_tiles=256, sm_count=B200_SMS) == 1
+
+
+def test_single_kv_tile_cannot_split():
+    assert _d128_cga2(128, 128, 1, 1) == 1
+
+
+def test_short_kv_does_not_over_split():
+    """Splits below _SPLIT_KV_MIN_TILES KV tiles are prologue-dominated."""
+    kv_tiles = 4
+    split = choose_split_kv(q_tiles=1, heads_q=1, batch=1, kv_tiles=kv_tiles, sm_count=B200_SMS)
+    assert split <= kv_tiles // _SPLIT_KV_MIN_TILES
+
+
+def test_degenerate_inputs_do_not_split():
+    for kw in (
+        {"q_tiles": 0},
+        {"heads_q": 0},
+        {"batch": 0},
+        {"kv_tiles": 0},
+        {"sm_count": 0},
+        {"sm_count": -1},
+    ):
+        args = {"q_tiles": 1, "heads_q": 1, "batch": 1, "kv_tiles": 256, "sm_count": B200_SMS}
+        args.update(kw)
+        assert choose_split_kv(**args) == 1, f"{kw} must fall back to no split"
+
+
+# --- invariants over a sweep ----------------------------------------------
+
+
+@pytest.mark.parametrize("s_kv", [1024, 4096, 16384, 32768, 131072])
+@pytest.mark.parametrize("heads", [1, 2, 8, 16, 64])
+def test_invariants(s_kv, heads):
+    kv_tiles = -(-s_kv // 128)
+    split = _d128_cga2(128, s_kv, heads, 1)
+    assert 1 <= split <= _SPLIT_KV_MAX
+    assert split <= kv_tiles, "more splits than KV tiles would leave empty splits"
+    if split > 1:
+        assert -(-kv_tiles // split) >= _SPLIT_KV_MIN_TILES
+
+
+def test_longer_kv_never_needs_fewer_splits():
+    """Monotone in KV length: a longer loop is never served by less splitting."""
+    prev = 0
+    for s_kv in (256, 512, 1024, 2048, 4096, 8192, 16384, 32768):
+        split = _d128_cga2(128, s_kv, 16, 1)
+        assert split >= prev, f"S_kv={s_kv} chose {split} after {prev}"
+        prev = split
+
+
+@pytest.mark.parametrize("heads", [1, 2, 3, 5, 8, 11, 16, 32, 64])
+@pytest.mark.parametrize("s_kv", [4096, 65536, 131072])
+def test_choice_is_always_a_power_of_two(heads, s_kv):
+    """split_kv is a compile-cache key, so the set is bounded to {1,2,4,8,16}."""
+    split = _d128_cga2(512, s_kv, heads, 1)
+    assert split & (split - 1) == 0, f"{split} is not a power of two"
+    assert split <= _SPLIT_KV_MAX
+
+
+def test_may_exceed_the_sm_count_to_smooth_a_tail():
+    """Over-subscribing the SMs is allowed, and sometimes required: 160 CTAs on
+    148 SMs already wastes most of a second wave, and splitting finer shrinks
+    that tail rather than adding a wave."""
+    split = choose_split_kv(q_tiles=1, heads_q=80, batch=1, kv_tiles=512, sm_count=148, ctas_per_tile=2)
+    assert split > 1
+    assert 160 * split > 148, "this shape is exactly the case that wants over-subscription"
+
+
+def test_exactly_balanced_launch_never_splits():
+    """base_ctas = k * sm_count has no tail to recover, so every split is pure
+    overhead. Provable rather than fitted."""
+    for sm_count in (16, 48, 108, 148, 256):
+        for k in (1, 2, 3, 4):
+            for kv_tiles in (16, 64, 256, 512, 1024):
+                split = choose_split_kv(q_tiles=1, heads_q=k * sm_count, batch=1, kv_tiles=kv_tiles, sm_count=sm_count, ctas_per_tile=1)
+                assert split == 1, f"base={k * sm_count} == {k}x{sm_count} SMs: nothing to smooth, got {split}"
+
+
+# (base_ctas, chosen split) pinned against a per-split sweep on B300 (148 SMs,
+# d128, 512 KV tiles). A change that moves any of these is a policy change and
+# needs its own measurement.
+_B300_FIT = [(8, 16), (16, 8), (32, 4), (64, 2), (88, 8), (100, 4), (120, 1), (128, 1), (150, 4), (160, 4), (200, 2), (296, 1)]
+
+
+@pytest.mark.parametrize("base_ctas,expected", _B300_FIT, ids=[f"{b}ctas" for b, _ in _B300_FIT])
+def test_reproduces_the_b300_fit(base_ctas, expected):
+    got = choose_split_kv(q_tiles=1, heads_q=base_ctas // 2, batch=1, kv_tiles=512, sm_count=148, ctas_per_tile=2)
+    assert got == expected
+
+
+def test_response_is_not_monotone_in_occupancy():
+    """At 88 and 100 CTAs split 2 loses while 4 and 8 win, because 2 lands just
+    over a wave boundary and 4 does not. The chooser must search, not
+    interpolate."""
+    assert choose_split_kv(q_tiles=1, heads_q=44, batch=1, kv_tiles=512, sm_count=148, ctas_per_tile=2) != 2
+    assert choose_split_kv(q_tiles=1, heads_q=50, batch=1, kv_tiles=512, sm_count=148, ctas_per_tile=2) != 2
+
+
+def test_max_split_is_respected():
+    assert _d128_cga2(128, 1 << 20, 1, 1, max_split=4) <= 4
+
+
+# --- the knob plumbing ------------------------------------------------------
+
+
+@pytest.mark.parametrize("requested", [1, 2, 4, 8, 16])
+def test_any_split_kv_request_makes_the_engine_ineligible(requested):
+    """The adapters choose the split themselves and nothing forwards
+    knobs.split_kv into them, so NO request can be honored -- including
+    split_kv=1, since "do not split" is exactly what the lowering would ignore.
+    An empty domain is the honest encoding: honored or ineligible, never
+    silently dropped."""
+    caps = Capabilities(sm_lo=100, sm_hi=100, phase="prefill", d_qk=frozenset({128}), d_v=frozenset({128}))
+    assert caps.split_kvs == frozenset()
+    why = mismatch(caps, _facts(), SdpaFwdKnobs(split_kv=requested))
+    assert why is not None and "split_kv" in why
+
+
+def test_no_split_request_leaves_the_engine_eligible():
+    """A caller with no preference must still reach the adapter's own choice."""
+    caps = Capabilities(sm_lo=100, sm_hi=100, phase="prefill", d_qk=frozenset({128}), d_v=frozenset({128}))
+    why = mismatch(caps, _facts(), SdpaFwdKnobs(split_kv=None)) or ""
+    assert "split_kv" not in why
+
+
+def _facts():
+    from cudnn.sdpa import graph_analyzer as ga
+
+    return ga.SdpaGraphFacts()
+
+
+def test_no_engine_advertises_a_split_domain():
+    """Guards the pairing: a row may only advertise split_kvs once its lowering
+    forwards knobs.split_kv. Widening one without the plumbing reintroduces the
+    silently-dropped knob."""
+    from cudnn.sdpa.fwd.engines import ENGINE_SPECS
+
+    specs = ENGINE_SPECS.values() if hasattr(ENGINE_SPECS, "values") else ENGINE_SPECS
+    advertising = [sp.name for sp in specs if getattr(getattr(sp, "capabilities", None), "split_kvs", frozenset())]
+    assert advertising == [], f"these rows advertise a split domain without the plumbing: {advertising}"


### PR DESCRIPTION
KV split was reachable only by building TemplateParams by hand: nothing chose a split count and the adapters could not execute one, so every graph ran with split_kv=1.

choose_split_kv picks the count. A CTA holds its tile for the whole KV loop, so a launch costs whole waves; it minimises, over powers of two,

    waves(s) = ceil(base_ctas * s / sm_count)
    cost(s)  = waves(s) * (ceil(kv_tiles / s) + CTA_COST)

An under-full launch splits until the wave is full; an over-full one with a partial-wave tail splits finer to smooth it; an exactly balanced one never splits. Powers of two only, since split_kv is a TemplateParams field and so a kernel-module cache key.

Both adapters derive the launch geometry from their own config and the SM count from cudnn._device, then thread the result into TemplateParams; the config backstop stays the authority, so a split a flavor will not accept falls back to
1. Running one is two launches: scratch_workspace_bytes sizes the split-major O and LSE partials, the kernel writes those instead of the caller's O, and split_combine_sm100 reduces them into O and into Stats when asked. The per-chunk LSE is compiled in whenever split_kv > 1, since it is the weight the combine reduces with.

Covered: SM100 half precision (d128/d192/d256/d512), SM100 FP8 and MXFP8, and SM120 half precision. The FP8 family splits only when it stores O in half precision -- the combine reduces in half, and reducing quantized partials would lose what the split is meant to be neutral about -- and its amax_o comes from the combine over the recombined O, since a per-split epilogue sees only its own partial and over-reports. THD, sink and SM120 FP8 keep split_kv=1; the last has no kernel support.

Adds split_kv to the knob vocabulary (SdpaFwdKnobs.split_kv, a Capabilities.split_kvs domain, its mismatch row), advertised by the seven engines whose lowering can honor it, plus tests for the chooser and for each adapter path.

## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic KV splitting for supported SDPA forward workloads on SM100 and SM120.
  - Added support for FP8 and MXFP8 execution, including recombined outputs, LSE values, and amax reporting.
  - Added automatic workspace sizing and support for caller-provided workspace buffers.
  - Added validation for split configuration compatibility.

- **Tests**
  - Added coverage for split selection, workspace modes, numerical accuracy, and hardware-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->