### PR TITLE
Improve performance of SM100 DSA backward kernel

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm100.py
@@ -146,7 +146,11 @@ class FlashAttentionDSABackwardSm100:
         self.dQ4_mma_tiler = (64, block_tile, block_tile)
         self.dKV4_mma_tiler = (64, block_tile, block_tile)
 
-        self.num_regs_load_KV = 40
+        # 56 clears the gather-address-path spills (all on D512, ~99% on
+        # D576). The per-warp counts must exactly exhaust the CTA register
+        # pool, which the 640-thread launch fixes at 96 regs/thread:
+        # 128*56 + 128*128 + 256*128 + 128*40 = 61440 = 96 * 640
+        self.num_regs_load_KV = 56
         self.num_regs_compute = 128
         self.num_regs_reduce = 128
         self.num_regs_mma = 40
@@ -169,7 +173,10 @@ class FlashAttentionDSABackwardSm100:
         self.compute_mma_dS_stage = 1
         self.mma_reduce_dKV_stage = 2
         self.reduce_store_dKV_stage = 1
-        self.compute_tmastore_dQ_stage = 1
+        # One staging slot per 128-dim dQ sub-tile, so the stores do not
+        # serialize on each other's SMEM reads.
+        self.num_dq_blocks = self.head_dim_main // 128
+        self.compute_tmastore_dQ_stage = self.num_dq_blocks
 
     @staticmethod
     def _get_workspace_size_LSE_OdO(q: int, d: int, h: int, b: int, acc_dtype: Type[cutlass.Numeric]):
@@ -392,8 +399,9 @@ class FlashAttentionDSABackwardSm100:
         )
 
         dQ_smem_layout_staged = sm100_utils.make_smem_layout_epi(
-            self.element_dtype, utils.LayoutEnum.from_tensor(mdQ), (self.KdS_mma_tiler[0], self.KdS_mma_tiler[1]), self.mma_compute_dQ_stage
+            self.element_dtype, utils.LayoutEnum.from_tensor(mdQ), (self.KdS_mma_tiler[0], self.KdS_mma_tiler[1]), self.num_dq_blocks
         )
+        assert cute.cosize(dQ_smem_layout_staged) <= cute.cosize(K_smem_layout_staged)
 
         dKV_smem_layout_staged = sm100_utils.make_smem_layout_epi(
             self.acc_dtype, utils.LayoutEnum.from_tensor(mdKV), (self.dOP_mma_tiler[0], self.dOP_mma_tiler[1] // 2), self.mma_reduce_dKV_stage
@@ -427,6 +435,10 @@ class FlashAttentionDSABackwardSm100:
             dQ4_smem_layout_staged = sm100_utils.make_smem_layout_epi(
                 self.element_dtype, utils.LayoutEnum.from_tensor(mdQ), (self.dQ4_mma_tiler[0], self.dQ4_mma_tiler[1]), self.mma_compute_dQ_stage
             )
+            # dQ4 stages through the dead P buffer (see sdQ4); today an exact
+            # fit, so catch any future stage bump here.
+            assert cute.cosize(dQ4_smem_layout_staged) <= cute.cosize(P_smem_layout_staged)
+
             dQ4_smem_layout = cute.select(dQ4_smem_layout_staged, mode=[0, 1])
             tma_atom_dQ_64, tma_tensor_dQ_64 = cute.nvgpu.cpasync.make_tiled_tma_atom(
                 tma_store_op,
@@ -898,8 +910,10 @@ class FlashAttentionDSABackwardSm100:
             sQT_tail_full = cute.make_tensor(sQT_tail_ptr, QT_tail_smem_layout_staged.outer)
             sQT_tail = sQT_tail_full[None, 8, None, None]  # block 8 = rows 512:575
 
-            # sdQ4: reuse sK for the 64×64 dQ4 epilogue
-            sdQ4_ptr = cute.recast_ptr(sK.iterator, dQ4_smem_layout_staged.inner)
+            # sdQ4: stage the 64×64 dQ4 epilogue through the dead P buffer.
+            # sK has spare room, but only at an offset past the four dQ
+            # sub-tiles, which would need its own swizzle/TMA-box proof.
+            sdQ4_ptr = cute.recast_ptr(sP.iterator, dQ4_smem_layout_staged.inner)
             sdQ4 = cute.make_tensor(sdQ4_ptr, dQ4_smem_layout_staged.outer)
 
         pipeline.pipeline_init_wait()
@@ -1271,11 +1285,30 @@ class FlashAttentionDSABackwardSm100:
                 cur_sK.fill(0.0)
 
     @cute.jit
+    def _load_tile_topk_idx(
+        self,
+        mTopkIdxs: cute.Tensor,
+        tile_index: Int32,
+        local_warp_idx: Int32,
+        lane: Int32,
+        token_idx: Int32,
+        batch_idx: Int32,
+    ) -> Int32:
+        """Lane i (< rows_per_warp) holds the top-k index of this warp's i-th row; -1 otherwise."""
+        rows_per_warp = self.block_tile // self.num_load_KV_warps
+        topk_idx = Int32(-1)
+        if lane < rows_per_warp:
+            global_idx = tile_index * self.block_tile + lane * self.num_load_KV_warps + local_warp_idx
+            if global_idx < self.max_topk:
+                topk_idx = mTopkIdxs[global_idx, (token_idx, batch_idx)]
+        return topk_idx
+
+    @cute.jit
     def _load_kv_rows(
         self,
         mKV: cute.Tensor,
         sK_slice: cute.Tensor,
-        rTopkIdx: cute.Tensor,
+        idx_reg: Int32,
         tile_index: Int32,
         topk: Int32,
         mTopkLength: Optional[cute.Tensor],
@@ -1293,7 +1326,7 @@ class FlashAttentionDSABackwardSm100:
             row = i * self.num_load_KV_warps + local_warp_idx
             idx = tile_index * self.block_tile + row
             tile_sK = sK_slice[row, (None, None)]
-            topk_idx = rTopkIdx[i]
+            topk_idx = cute.arch.shuffle_sync(idx_reg, i)
 
             if cutlass.const_expr(mTopkLength is not None):
                 if cutlass.const_expr(is_first):
@@ -1342,17 +1375,7 @@ class FlashAttentionDSABackwardSm100:
 
         tile_index = tile_count - 1
         full_tiles = (topk % self.block_tile) == 0
-        rows_per_warp = self.block_tile // self.num_load_KV_warps
-        rTopkIdx = cute.make_rmem_tensor((rows_per_warp,), cutlass.Int32)
-
-        for i in range(rows_per_warp):
-            row = i * self.num_load_KV_warps + local_warp_idx
-            idx = tile_index * self.block_tile + row
-            topk_idx = Int32(-1)
-            if local_tidx == 0:
-                if idx < self.max_topk:
-                    topk_idx = mTopkIdxs[idx, (token_idx, batch_idx)]
-            rTopkIdx[i] = cute.arch.shuffle_sync(topk_idx, 0)
+        idx_reg = self._load_tile_topk_idx(mTopkIdxs, tile_index, local_warp_idx, local_tidx, token_idx, batch_idx)
         load_mma_K_pipeline.producer_acquire(load_mma_K_producer_state)
         sK_slice = sK[(None, None), 0, (None, None), load_mma_K_producer_state.index]
         sK_slice = cute.composition(sK_slice, cute.make_layout((self.block_tile, self.head_dim)))
@@ -1361,7 +1384,7 @@ class FlashAttentionDSABackwardSm100:
             self._load_kv_rows(
                 mKV,
                 sK_slice,
-                rTopkIdx,
+                idx_reg,
                 tile_index,
                 topk,
                 mTopkLength,
@@ -1375,7 +1398,7 @@ class FlashAttentionDSABackwardSm100:
             self._load_kv_rows(
                 mKV,
                 sK_slice,
-                rTopkIdx,
+                idx_reg,
                 tile_index,
                 topk,
                 mTopkLength,
@@ -1392,18 +1415,11 @@ class FlashAttentionDSABackwardSm100:
         self.load_KV_sync_barrier.arrive_and_wait()
         load_mma_K_pipeline.producer_commit(load_mma_K_producer_state)
         load_mma_K_producer_state.advance()
+        if tile_index > 0:
+            idx_reg = self._load_tile_topk_idx(mTopkIdxs, tile_index - 1, local_warp_idx, local_tidx, token_idx, batch_idx)
         tile_index -= 1
 
         while tile_index >= 0:
-            for i in range(rows_per_warp):
-                row = i * self.num_load_KV_warps + local_warp_idx
-                idx = tile_index * self.block_tile + row
-                topk_idx = Int32(-1)
-                if local_tidx == 0:
-                    if idx < self.max_topk:
-                        topk_idx = mTopkIdxs[idx, (token_idx, batch_idx)]
-                rTopkIdx[i] = cute.arch.shuffle_sync(topk_idx, 0)
-
             load_mma_K_pipeline.producer_acquire(load_mma_K_producer_state)
             sK_slice = sK[(None, None), 0, (None, None), load_mma_K_producer_state.index]
             sK_slice = cute.composition(sK_slice, cute.make_layout((self.block_tile, self.head_dim)))
@@ -1411,7 +1427,7 @@ class FlashAttentionDSABackwardSm100:
             self._load_kv_rows(
                 mKV,
                 sK_slice,
-                rTopkIdx,
+                idx_reg,
                 tile_index,
                 topk,
                 mTopkLength,
@@ -1428,6 +1444,8 @@ class FlashAttentionDSABackwardSm100:
             self.load_KV_sync_barrier.arrive_and_wait()
             load_mma_K_pipeline.producer_commit(load_mma_K_producer_state)
             load_mma_K_producer_state.advance()
+            if tile_index > 0:
+                idx_reg = self._load_tile_topk_idx(mTopkIdxs, tile_index - 1, local_warp_idx, local_tidx, token_idx, batch_idx)
             tile_index -= 1
 
     @cute.jit
@@ -1569,53 +1587,6 @@ class FlashAttentionDSABackwardSm100:
 
             compute_mma_dS_pipeline.consumer_wait(compute_mma_dS_consumer_state)
 
-            # Gemm dKV = Q @ dS part1
-            # dKV0
-            QdS_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-            for k_block in cutlass.range(0, cute.size(tdKVrdS, mode=[2]), unroll=2):
-                cute.gemm(
-                    QdS_tiled_mma,
-                    tdKVtdKV0,
-                    tdKVrQT[None, None, 0, k_block, load_mma_QdO_consumer_state.index],
-                    tdKVrdS[None, None, k_block, compute_mma_dS_consumer_state.index],
-                    tdKVtdKV0,
-                )
-            # dKV1
-            for k_block in cutlass.range(0, cute.size(tdKVrdS, mode=[2]), unroll=2):
-                cute.gemm(
-                    QdS_tiled_mma,
-                    tdKVtdKV1,
-                    tdKVrQT[None, None, 1, k_block, load_mma_QdO_consumer_state.index],
-                    tdKVrdS[None, None, k_block, compute_mma_dS_consumer_state.index],
-                    tdKVtdKV1,
-                )
-
-            # Notify to reduce the first part of dKV (dKV0, dKV1)
-            mma_reduce_dKV_pipeline.producer_commit(mma_reduce_dKV_producer_state)
-            mma_reduce_dKV_producer_state.advance()
-
-            # Gemm dKV4 = Q^T[512:575] @ dS (round 1.5, only GEMM5, no GEMM3)
-            # dKV4 skips producer_acquire — barrier1 guarantees TMEM safety.
-            # Only producer_commit is needed to notify consumer.
-            if cutlass.const_expr(not self.same_hdim_kv):
-                # barrier1: wait for reduce warps to finish T2R of dKV0/dKV1
-                self.t2r_dKV01_done_barrier.arrive_and_wait()
-
-                dKV4_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
-                for k_block in cutlass.range(0, cute.size(tdKVrdS_4, mode=[2]), unroll=2):
-                    cute.gemm(
-                        dKV4_tiled_mma,
-                        tdKVtdKV4,
-                        tdKVrQT_tail[None, None, 0, k_block, load_mma_QdO_consumer_state.index],
-                        tdKVrdS_4[None, None, k_block, compute_mma_dS_consumer_state.index],
-                        tdKVtdKV4,
-                    )
-                    dKV4_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
-
-                # Commit dKV4 on pipeline (no acquire needed) to notify consumer
-                mma_reduce_dKV_pipeline.producer_commit(mma_reduce_dKV_producer_state)
-                mma_reduce_dKV_producer_state.advance()
-
             # Gemm dQ = K @ dS
 
             # dQ0
@@ -1682,6 +1653,54 @@ class FlashAttentionDSABackwardSm100:
             # KV is used
             load_mma_K_pipeline.consumer_release(load_mma_K_consumer_state)
             load_mma_K_consumer_state.advance()
+
+            # Gemm dKV = Q @ dS part1
+            # dKV0
+            QdS_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+            for k_block in cutlass.range(0, cute.size(tdKVrdS, mode=[2]), unroll=2):
+                cute.gemm(
+                    QdS_tiled_mma,
+                    tdKVtdKV0,
+                    tdKVrQT[None, None, 0, k_block, load_mma_QdO_consumer_state.index],
+                    tdKVrdS[None, None, k_block, compute_mma_dS_consumer_state.index],
+                    tdKVtdKV0,
+                )
+            # dKV1
+            for k_block in cutlass.range(0, cute.size(tdKVrdS, mode=[2]), unroll=2):
+                cute.gemm(
+                    QdS_tiled_mma,
+                    tdKVtdKV1,
+                    tdKVrQT[None, None, 1, k_block, load_mma_QdO_consumer_state.index],
+                    tdKVrdS[None, None, k_block, compute_mma_dS_consumer_state.index],
+                    tdKVtdKV1,
+                )
+
+            # Notify to reduce the first part of dKV (dKV0, dKV1)
+            mma_reduce_dKV_pipeline.producer_commit(mma_reduce_dKV_producer_state)
+            mma_reduce_dKV_producer_state.advance()
+
+            # Gemm dKV4 = Q^T[512:575] @ dS (round 1.5, only GEMM5, no GEMM3)
+            # dKV4 skips producer_acquire: t2r_dKV01_done_barrier below is what
+            # frees the TMEM columns, so only producer_commit is needed.
+            if cutlass.const_expr(not self.same_hdim_kv):
+                # dKV4 aliases dKV0, so wait for the reduce warps to finish
+                # their T2R of dKV0/dKV1 before overwriting those columns.
+                self.t2r_dKV01_done_barrier.arrive_and_wait()
+
+                dKV4_tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                for k_block in cutlass.range(0, cute.size(tdKVrdS_4, mode=[2]), unroll=2):
+                    cute.gemm(
+                        dKV4_tiled_mma,
+                        tdKVtdKV4,
+                        tdKVrQT_tail[None, None, 0, k_block, load_mma_QdO_consumer_state.index],
+                        tdKVrdS_4[None, None, k_block, compute_mma_dS_consumer_state.index],
+                        tdKVtdKV4,
+                    )
+                    dKV4_tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                # Commit dKV4 on pipeline (no acquire needed) to notify consumer
+                mma_reduce_dKV_pipeline.producer_commit(mma_reduce_dKV_producer_state)
+                mma_reduce_dKV_producer_state.advance()
 
             # Gemm dKV = dO @ P part2
             # Wait for reduce warps to finish T2R of the TMEM columns that
@@ -1892,6 +1911,11 @@ class FlashAttentionDSABackwardSm100:
             tTR_rS_f16 = self.quantize(tTR_rS, 4)
 
             cute.arch.fence_view_async_tmem_load()
+            # The fenced T2R above has fully consumed TMEM S and nothing below
+            # reads it, so release here rather than after P is published. This
+            # unbinds S's lifetime from P's publication, nothing more.
+            mma_compute_S_pipeline.consumer_release(mma_compute_S_consumer_state)
+            mma_compute_S_consumer_state.advance()
             self.compute_sync_barrier.arrive_and_wait()
 
             # ======= stsm ============
@@ -1909,9 +1933,6 @@ class FlashAttentionDSABackwardSm100:
             # Notify for P
             compute_mma_P_pipeline.producer_commit(compute_mma_P_producer_state)
             compute_mma_P_producer_state.advance()
-
-            mma_compute_S_pipeline.consumer_release(mma_compute_S_consumer_state)
-            mma_compute_S_consumer_state.advance()
 
             mma_compute_dP_pipeline.consumer_wait(mma_compute_dP_consumer_state)
             compute_mma_dS_pipeline.producer_acquire(compute_mma_dS_producer_state)
@@ -1966,58 +1987,57 @@ class FlashAttentionDSABackwardSm100:
         load_compute_sum_OdO_pipeline.consumer_release(load_compute_sum_OdO_consumer_state)
 
         # Store dQ
-        tdQtdQ0 = tdQtdQ0[(None, None), 0, 0]
-        tdQtdQ1 = tdQtdQ1[(None, None), 0, 0]
-        tdQtdQ2 = tdQtdQ2[(None, None), 0, 0]
-        tdQtdQ3 = tdQtdQ3[(None, None), 0, 0]
+        tdQtdQ_blocks = (tdQtdQ0[(None, None), 0, 0], tdQtdQ1[(None, None), 0, 0], tdQtdQ2[(None, None), 0, 0], tdQtdQ3[(None, None), 0, 0])
 
         # (512, 64)
         gdQ = cute.local_tile(tma_tensor_dQ, cute.select(self.KdS_mma_tiler, mode=[0, 1]), (None, None, (token_idx, batch_idx)))
-        # (128, 64)
-        gdQ0 = gdQ[None, None, 0, head_block_idx]
-        gdQ1 = gdQ[None, None, 1, head_block_idx]
-        gdQ2 = gdQ[None, None, 2, head_block_idx]
-        gdQ3 = gdQ[None, None, 3, head_block_idx]
 
-        # sdQ: ((64,2),(8,8),(1,1))
-        sdQ_slice = sdQ[None, None, mma_compute_dQ_consumer_state.index]
+        dp_idx = tidx % 128
+        wg_idx = (tidx % (self.num_compute_warps * self.threads_per_warp)) // 128
 
-        # ((64,2),(8,8),(1,1))
-        tdQsdQ0, tdQgdQ0_mkl = cpasync.tma_partition(
-            tma_atom_dQ,
-            0,
-            cute.make_layout(1),
-            cute.group_modes(sdQ_slice, 0, 2),
-            cute.group_modes(gdQ0, 0, 2),
-        )
-        tdQsdQ1, tdQgdQ1_mkl = cpasync.tma_partition(
-            tma_atom_dQ,
-            0,
-            cute.make_layout(1),
-            cute.group_modes(sdQ_slice, 0, 2),
-            cute.group_modes(gdQ1, 0, 2),
-        )
-        tdQsdQ2, tdQgdQ2_mkl = cpasync.tma_partition(
-            tma_atom_dQ,
-            0,
-            cute.make_layout(1),
-            cute.group_modes(sdQ_slice, 0, 2),
-            cute.group_modes(gdQ2, 0, 2),
-        )
-        tdQsdQ3, tdQgdQ3_mkl = cpasync.tma_partition(
-            tma_atom_dQ,
-            0,
-            cute.make_layout(1),
-            cute.group_modes(sdQ_slice, 0, 2),
-            cute.group_modes(gdQ3, 0, 2),
-        )
+        mma_compute_dQ_pipeline.consumer_wait(mma_compute_dQ_consumer_state)
 
+        # Each sub-tile stages through its own region of the (dead) K buffer,
+        # so a store never waits on the previous store's SMEM read.
+        for i in cutlass.range_constexpr(self.num_dq_blocks):
+            # sdQ: ((64,2),(8,8),(1,1))
+            sdQ_slice = sdQ[None, None, i]
+            # (128, 64)
+            gdQ_i = gdQ[None, None, i, head_block_idx]
+            tdQsdQ, tdQgdQ_mkl = cpasync.tma_partition(
+                tma_atom_dQ,
+                0,
+                cute.make_layout(1),
+                cute.group_modes(sdQ_slice, 0, 2),
+                cute.group_modes(gdQ_i, 0, 2),
+            )
+            if warp_idx == self.compute_warp_id[0]:
+                compute_tmastore_dQ_pipeline.producer_acquire()
+            # Wait in all threads for the acquire to complete
+            self.compute_sync_barrier.arrive_and_wait()
+
+            self.store_dQ(
+                tma_atom_dQ,
+                sdQ_slice,
+                tdQsdQ,
+                tdQgdQ_mkl,
+                tdQtdQ_blocks[i],
+                dp_idx,
+                warp_idx,
+            )
+
+            if warp_idx == self.compute_warp_id[0]:
+                compute_tmastore_dQ_pipeline.producer_commit()
+            self.compute_sync_barrier.arrive_and_wait()
+            compute_tmastore_dQ_producer_state.advance()
+
+        # Store dQ4 (tail 64 cols)
         if cutlass.const_expr(not self.same_hdim_kv):
             tdQtdQ4 = tdQtdQ4[(None, None), 0, 0]
             gdQ4 = cute.local_tile(tma_tensor_dQ_64, cute.select(self.dQ4_mma_tiler, mode=[0, 1]), (None, None, (token_idx, batch_idx)))
             gdQ4 = gdQ4[None, None, 8, head_block_idx]
 
-            sdQ4_slice = sdQ4[None, None, mma_compute_dQ_consumer_state.index]
+            sdQ4_slice = sdQ4[None, None, 0]
 
             tdQsdQ4, tdQgdQ4_mkl = cpasync.tma_partition(
                 tma_atom_dQ_64,
@@ -2027,93 +2047,6 @@ class FlashAttentionDSABackwardSm100:
                 cute.group_modes(gdQ4, 0, 2),
             )
 
-        dp_idx = tidx % 128
-        wg_idx = (tidx % (self.num_compute_warps * self.threads_per_warp)) // 128
-
-        mma_compute_dQ_pipeline.consumer_wait(mma_compute_dQ_consumer_state)
-
-        if warp_idx == self.compute_warp_id[0]:
-            compute_tmastore_dQ_pipeline.producer_acquire()
-        # Wait in all threads for the acquire to complete
-        self.compute_sync_barrier.arrive_and_wait()
-
-        self.store_dQ(
-            tma_atom_dQ,
-            sdQ_slice,
-            tdQsdQ0,
-            tdQgdQ0_mkl,
-            tdQtdQ0,
-            dp_idx,
-            warp_idx,
-        )
-
-        if warp_idx == self.compute_warp_id[0]:
-            compute_tmastore_dQ_pipeline.producer_commit()
-
-        self.compute_sync_barrier.arrive_and_wait()
-        compute_tmastore_dQ_producer_state.advance()
-
-        if warp_idx == self.compute_warp_id[0]:
-            compute_tmastore_dQ_pipeline.producer_acquire()
-        self.compute_sync_barrier.arrive_and_wait()
-
-        self.store_dQ(
-            tma_atom_dQ,
-            sdQ_slice,
-            tdQsdQ1,
-            tdQgdQ1_mkl,
-            tdQtdQ1,
-            dp_idx,
-            warp_idx,
-        )
-
-        if warp_idx == self.compute_warp_id[0]:
-            compute_tmastore_dQ_pipeline.producer_commit()
-
-        self.compute_sync_barrier.arrive_and_wait()
-        compute_tmastore_dQ_producer_state.advance()
-
-        if warp_idx == self.compute_warp_id[0]:
-            compute_tmastore_dQ_pipeline.producer_acquire()
-        self.compute_sync_barrier.arrive_and_wait()
-
-        self.store_dQ(
-            tma_atom_dQ,
-            sdQ_slice,
-            tdQsdQ2,
-            tdQgdQ2_mkl,
-            tdQtdQ2,
-            dp_idx,
-            warp_idx,
-        )
-
-        if warp_idx == self.compute_warp_id[0]:
-            compute_tmastore_dQ_pipeline.producer_commit()
-
-        self.compute_sync_barrier.arrive_and_wait()
-        compute_tmastore_dQ_producer_state.advance()
-
-        if warp_idx == self.compute_warp_id[0]:
-            compute_tmastore_dQ_pipeline.producer_acquire()
-        self.compute_sync_barrier.arrive_and_wait()
-
-        self.store_dQ(
-            tma_atom_dQ,
-            sdQ_slice,
-            tdQsdQ3,
-            tdQgdQ3_mkl,
-            tdQtdQ3,
-            dp_idx,
-            warp_idx,
-        )
-
-        if warp_idx == self.compute_warp_id[0]:
-            compute_tmastore_dQ_pipeline.producer_commit()
-        self.compute_sync_barrier.arrive_and_wait()
-        compute_tmastore_dQ_producer_state.advance()
-
-        # Store dQ4 (tail 64 cols)
-        if cutlass.const_expr(not self.same_hdim_kv):
             if warp_idx == self.compute_warp_id[0]:
                 compute_tmastore_dQ_pipeline.producer_acquire()
             self.compute_sync_barrier.arrive_and_wait()
@@ -2137,7 +2070,9 @@ class FlashAttentionDSABackwardSm100:
         mma_compute_dQ_pipeline.consumer_release(mma_compute_dQ_consumer_state)
         mma_compute_dQ_consumer_state.advance()
 
+        # Drain the staging reads before the CTA exits
         compute_tmastore_dQ_pipeline.producer_tail()
+        self.compute_sync_barrier.arrive_and_wait()
 
     @cute.jit
     def reduce_dKV(
@@ -2514,41 +2449,38 @@ class FlashAttentionDSABackwardSm100:
         dp_idx: Int32,
         warp_idx: Int32,
     ):
+        """Store one 128-dim dQ sub-tile: T2R, quantize, StMatrix transpose to sdQ, TMA store."""
         tmem_load_atom = cute.make_copy_atom(
-            tcgen05.copy.Ld32x32bOp(tcgen05.copy.Repetition(8)),
+            tcgen05.copy.Ld16x256bOp(tcgen05.copy.Repetition(8)),
             self.acc_dtype,
         )
-
-        cdQ = cute.make_identity_tensor(cute.select(self.KdS_mma_tiler, mode=[0, 1]))
-        num_warp_groups = self.num_compute_warps // 4
-
         tiled_t2r_dQ = tcgen05.make_tmem_copy(tmem_load_atom, tdQtdQ)
         thr_t2r_dQ = tiled_t2r_dQ.get_slice(dp_idx)
 
+        cdQ = cute.make_identity_tensor(cute.select(self.KdS_mma_tiler, mode=[0, 1]))
         tTR_cdQ = thr_t2r_dQ.partition_D(cdQ)
         tTR_rdQ = cute.make_rmem_tensor(tTR_cdQ.shape, self.acc_dtype)
-
         tTR_tdQ = thr_t2r_dQ.partition_S(tdQtdQ)
-
         cute.copy(tiled_t2r_dQ, tTR_tdQ, tTR_rdQ)
 
-        tRS_rdQ = self.quantize(tTR_rdQ, 4)
-
+        tTR_rdQ_f16 = self.quantize(tTR_rdQ, 4)
         cute.arch.fence_view_async_tmem_load()
 
-        # ((64,2),(8,8),(1,1))
-        thread_layout = cute.make_ordered_layout((128, 64), (0, 1))
-        sdQ_slice_tmp = cute.composition(sdQ, thread_layout)
-        sdQ_slice = cute.composition(sdQ_slice_tmp[dp_idx, None], cute.make_layout(tTR_cdQ.shape))
-        cute.autovec_copy(tRS_rdQ, sdQ_slice)
-
-        self.compute_sync_barrier.arrive_and_wait()
+        smem_store_atom = cute.make_copy_atom(
+            cute.nvgpu.warp.StMatrix8x8x16bOp(transpose=True, num_matrices=4),
+            self.element_dtype,
+        )
+        smem_store_dq = cute.make_tiled_copy_D(smem_store_atom, tiled_t2r_dQ)
+        thr_smem_store_dq = smem_store_dq.get_slice(dp_idx)
+        tRS_sdQ = thr_smem_store_dq.partition_D(sdQ)
+        tRS_rdQ = cute.make_rmem_tensor(tRS_sdQ.shape, self.element_dtype)
+        tRS_rdQ.store(smem_store_dq.retile(tTR_rdQ_f16).load())
+        cute.copy(smem_store_dq, tRS_rdQ, tRS_sdQ)
 
         cute.arch.fence_proxy(
             "async.shared",
             space="cta",
         )
-
         self.compute_sync_barrier.arrive_and_wait()
 
         if warp_idx == self.compute_warp_id[0]:


### PR DESCRIPTION
## PR description

### Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` on every changed file and committed any formatting changes.
- [ ] Labels requested: `cat-enhancements`, `mod-cutedsl`, and `orig-external` (the external contributor account does not have permission to add labels to the NVIDIA repository).

### Affected area

FE OSS kernels / CuTeDSL, DSA backward performance, tests, documentation, and benchmark discoverability.

### Summary

Improve performance of SM100 DSA backward kernel

Main changes:

-   Rebalanced the sparse KV gather register budget from 40 to 56 registers/thread while preserving the CTA-wide allocation of 96 registers/thread (61,440 registers), eliminating most loader spills without changing occupancy.

-   Parallelized each warp's 16 top-k index loads across lanes 0--15. Each lane retains one scalar index and broadcasts it with a shuffle only when its row is consumed, replacing the lane-0 serial load and the 16-entry per-thread live set.

-   Moved all K-consuming dQ MMAs ahead of the K-independent dKV tail and released K immediately afterward, allowing the next tile's indexed gather to overlap the current tile's remaining dKV MMAs.

-   Released each S TMEM generation immediately after softmax/quantization and the TMEM-load fence, decoupling the S lifetime from the subsequent P SMEM publication.

-   Reworked the main dQ epilogue around Ld16x256b and transposed STSM (StMatrix8x8x16bOp(transpose=True)). The STSM writer layout is derived from the T2R destination ownership with make_tiled_copy_D, replacing the scalar STS.U16 publication path.

-   Expanded dQ TMA-store staging from one to four slots by reusing 64 KiB of dead sK storage. The four main dQ stores can be issued back-to-back before the final drain; the D576 tail uses dead sP storage to avoid aliasing the outstanding main stages.

Benchmarked on NVIDIA B200 (SM100) with driver 580.126.09 and the SM clock locked at 1830 MHz; full setup is listed below.

seqlen_q=seqlen_kv=4096

| Config | topk | old ms | old TFLOPS | new ms | new TFLOPS | new speedup |
|---|---:|---:|---:|---:|---:|---:|
| QK=V=512,H=64 | 128 | 0.593 | 289.57 | 0.545 | 315.15 | +8.8% |
| QK=V=512,H=64 | 512 | 1.324 | 518.92 | 1.224 | 561.51 | +8.2% |
| QK=V=512,H=64 | 1024 | 2.306 | 595.88 | 2.149 | 639.59 | +7.3% |
| QK=V=512,H=64 | 2048 | 4.285 | 641.47 | 4.080 | 673.66 | +5.0% |
| QK=V=512,H=128 | 128 | 1.115 | 308.23 | 1.022 | 336.32 | +9.1% |
| QK=V=512,H=128 | 512 | 2.579 | 532.99 | 2.406 | 571.31 | +7.2% |
| QK=V=512,H=128 | 1024 | 4.548 | 604.33 | 4.316 | 636.81 | +5.4% |
| QK=V=512,H=128 | 2048 | 8.573 | 641.29 | 8.147 | 674.78 | +5.2% |
| QK=576,V=512,H=128 | 128 | 1.282 | 288.10 | 1.147 | 322.00 | +11.8% |
| QK=576,V=512,H=128 | 512 | 3.421 | 431.92 | 2.993 | 493.67 | +14.3% |
| QK=576,V=512,H=128 | 1024 | 6.288 | 469.92 | 5.468 | 540.37 | +15.0% |
| QK=576,V=512,H=128 | 2048 | 12.000 | 492.49 | 10.407 | 567.87 | +15.3% |
| QK=576,V=512,H=64 | 128 | 0.682 | 270.93 | 0.614 | 301.00 | +11.1% |
| QK=576,V=512,H=64 | 512 | 1.747 | 422.88 | 1.533 | 481.75 | +13.9% |
| QK=576,V=512,H=64 | 1024 | 3.179 | 464.80 | 2.769 | 533.55 | +14.8% |
| QK=576,V=512,H=64 | 2048 | 6.049 | 488.48 | 5.248 | 563.08 | +15.3% |

The first 12 rows are exactly the matrix used in #318. QK=576,V=512,H=64 is added because D576 is where this change helps most and it is the shape the L0 tests cover. Mean speedup is +10.5% over all 16 cells and +9.4% over the 12 cells of #318's matrix.

The seqlen_q=seqlen_kv=8192 sweep (H=64, topk 128/512/2048) agrees: +9.7%/+8.3%/+5.4% on D512 and +15.5%/+14.5%/+15.3% on D576.

### Relationship to #318 and the baseline regression

The first 12 rows above are #318's matrix. Taking the arithmetic mean of the 12 per-cell ratios `develop_ms / published_ms - 1`, `develop` @ `55b2773e` is 9.0% slower than the post-change times published in #318.

Two measurements split that gap. #318's squash-merge commit `cfee7248`, re-run here, is 3.7% slower than its own published table by the same metric (+0.1% ... +6.0% per cell) -- environment, toolchain and harness drift rather than code. On this same setup `develop` is a further 5.2% slower than `cfee7248` over those 12 cells: D512 1.5%, D576 12.7%. The two approximately reconcile the 9.0% gap (1.037 x 1.052 - 1 = 9.1%); means of ratios do not multiply exactly, the per-cell products do.

| Config | topk | #318 published ms | `cfee7248` here ms |
|---|---:|---:|---:|
| QK=V=512,H=64 | 128 | 0.560 | 0.594 |
| QK=V=512,H=64 | 512 | 1.233 | 1.302 |
| QK=V=512,H=64 | 1024 | 2.155 | 2.249 |
| QK=V=512,H=64 | 2048 | 4.019 | 4.199 |
| QK=V=512,H=128 | 128 | 1.066 | 1.115 |
| QK=V=512,H=128 | 512 | 2.424 | 2.532 |
| QK=V=512,H=128 | 1024 | 4.303 | 4.459 |
| QK=V=512,H=128 | 2048 | 8.268 | 8.403 |
| QK=576,V=512,H=128 | 128 | 1.175 | 1.230 |
| QK=576,V=512,H=128 | 512 | 2.949 | 3.027 |
| QK=576,V=512,H=128 | 1024 | 5.327 | 5.424 |
| QK=576,V=512,H=128 | 2048 | 10.197 | 10.208 |

`develop` and this PR for these cells are the `old ms` and `new ms` columns of the matrix above.

Normalised by tile count (`topk / 64`), the `develop` minus `cfee7248` difference on QK=576,H=128 is 26 / 49 / 54 / 56 us per tile at topk 128 / 512 / 1024 / 2048 -- settling at 49--56 for topk >= 512 instead of falling as 1/tiles the way a fixed host-side cost would. The same normalisation on QK=V=512,H=128 gives 0.1 / 5.9 / 5.6 / 5.3 us per tile. That shape matches #396, which reports its own cost as 8.0% on head_dim 576 and 0.03% on 512, from one added per-iteration handshake on the MMA warp's critical path. It is not the whole story: the D576 gap measured here is larger than #396's 8.0%, D512 moved 1.5% although both #395 and #396 report it unchanged, and eight commits touched this file between the two endpoints. The endpoint comparison bounds that cost; it does not isolate it to one commit.

This PR keeps every one of those fixes -- #395's staged store views and TMEM-dealloc barrier, #396's dKV2/dKV3 WAR barrier -- and recovers most of the D576 cost instead. Against `cfee7248` on QK=576,H=128 it is 7.2% and 1.1% faster at topk 128 and 512 and 0.8% and 1.9% slower at topk 1024 and 2048; on D512 it is 2.9% to 9.1% faster.

### performance evidence

The headline speedups are uninstrumented paired A/B medians: 6 samples per cell, 2 passes x 3 rounds with the A/B order reversed between passes. Run-to-run spread is <=0.35% on 15 of 16 baseline cells and 11 of 16 PR cells, pass-to-pass drift <=0.26%; the weakest cell still has 2x more signal than spread, most D576 cells over 100x.

The causal isolation comes from IKET on D576 (seqlen 512, topk 512, 8 tiles). A variant carrying only the dQ-MMA reorder -- the K-consuming dQ MMAs moved ahead of the K-independent dKV tail with K released immediately afterward, and nothing else -- is the early-K-release ablation below. Steady-state medians:

| Interval | develop | early-K-release ablation | this PR |
|---|---:|---:|---:|
| `mma_wait_K` -- MMA stalled on the next gathered K | 512 ns | 64 ns | 32 ns |
| `mma_tile` -- per-tile period | 6,560 ns | 6,080 ns | 6,016 ns |
| loader index/setup (`ld_tile - ld_acq_K - ld_gather`) | 2,528 ns | 2,656 ns | 480 ns |

The ablation alone cuts the next-K wait by 448 ns/tile and the per-tile period by 480 ns/tile -- equal within one 32 ns IKET tick, so the period gain is accounted for by the removed stall. The full PR takes a further 64 ns/tile off the period.

The loader interval moves only in the full PR (still 2,656 ns in the ablation), so it is evidence for the combined loader-side cleanup -- lane-parallel top-k indices plus the 40->56 gather register rebalance -- and not an isolated timing for either one.

Static SASS (`nvdisasm` 12.8.90) and Nsight Compute 2026.2.1 (seqlen 4096, topk 2048, H=64), develop -> this PR:

| Evidence | D512 | D576 |
|---|---|---|
| SASS `STS.U16` / `STSM` | 256 -> 0 / 8 -> 40 | 288 -> 32 / 8 -> 40 |
| local-memory requests (spill ld + st) | 11,862,016 -> 0 | 18,681,856 -> 200,704 |
| `smsp__inst_executed.sum` | -11.4% | -11.9% |
| `sm__pipe_tensor_cycles_active` (% peak) | 42.61 -> 46.39 | 33.16 -> 38.18 |

The 32 remaining `STS.U16` are the still-scalar `store_dQ_64` D576 tail. One counter moves the other way: D512 shared-store bank conflicts rise 71,208 -> 176,561, which is 0.9% of the 19M store wavefronts and leaves net store wavefronts down 9.5%; on D576 they fall, 29,740 -> 21,651.

TMA transaction counts are unchanged (`UTMASTG` / `UTMACMDFLUSH` 8/4 on D512 and 9/5 on D576, both sides) -- the staging change alters the wait predicate, not the number of stores. With launch shape and occupancy also unchanged (below), what is left is less per-tile waiting and fewer instructions.

Instrumented durations are not performance numbers -- the selector forks the compile key and the timestamp writes sit on the critical path -- so the IKET table is structural evidence only.

### Launch-shape invariants

Confirmed identical between baseline and this PR via Nsight Compute: grid (4096,1,1), block (640,1,1), 96 registers/thread, and shared memory per block 216.064 KB (D512) / 232.448 KB (D576). Occupancy is unchanged, so the gains are efficiency only. The constructor signature, both `_get_workspace_size_*` staticmethods and the compile key are untouched, which is why no interface change is required and the PR touches a single file.

### Benchmark configuration

-   NVIDIA B200 (SM100, CC 10.0, 148 SM), SM clock locked at 1830 MHz; driver 580.126.09
-   PyTorch 2.13.0+cu130, nvidia-cutlass-dsl 4.6.0, cuDNN backend 9.20.0
-   Baseline: upstream `develop` @ `55b2773e`
-   Primary matrix: seqlen_q = seqlen_kv = 4096, BF16, d_v = 512, H in {64, 128}, topk in {128, 512, 1024, 2048}
-   Attention sink enabled; `topk_length` present with every row set to the configured full top-k
-   CUDA-event timing of one `flash_attn_bwd_sm100` call; JIT compilation and reference forward excluded; 20 initial warmups, 5 re-warmups per round, 100 measured calls, and 2 passes x 3 rounds with reversed A/B order
-   Timing loop and FLOPs formula taken from benchmark/dsa/benchmark_dsa_sparse_attention_backward.py; the custom driver was cross-checked against that script and agreed to 0.2%
-   Secondary sweep: seqlen 8192, H=64, topk in {128, 512, 2048}

### Validation

-   All 16 benchmark configurations completed with no NaN and with every output element written (outputs were seeded with a sentinel before each launch and the post-run sentinel count is 0).
-   dQ is bit-identical to the baseline implementation (rel_l2 = 0.000e+00) and dSink is bit-identical, on all 6 paired correctness configurations. dKV differs by rel_l2 = 1.9e-05 ... 3.8e-05, which is FP32 global-atomic accumulation order and is far below one ULP of BF16 (eps 7.8e-3).
-   test_DSA_sparse_attention_backward.py -m "L0 or L1": 15 passed, 1 skipped -- identical to the -m L0 result and to the baseline. The single skip is SM90-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backward-pass handling for sparse attention, including empty top-k rows and synchronization during gradient computation.
  * Enhanced gradient storage reliability across sub-tiles and shared-memory operations.
  * Added validation to prevent insufficient shared-memory capacity during processing.
* **Performance**
  * Optimized KV loading, index handling, and gradient computation to improve execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->