### PR TITLE
Add an opt-in cuDNN FLA GatedMLP shim

### DIFF
--- a/benchmark/e2e/Qwen3.8/run_model.py
+++ b/benchmark/e2e/Qwen3.8/run_model.py
@@ -203,16 +203,11 @@ MODEL_PRESETS = {
 
 
 def _accelerate_mlp():
-    """Route FLA's GatedMLP through cudnn.gemm.ops.swiglu_mlp (bias-free swish MLP:
-    (silu(x@Wg^T) * (x@Wu^T)) @ Wd^T, exactly what the op computes)."""
-    from cudnn.gemm.ops import swiglu_mlp
-    import fla.modules.mlp as fla_mlp
+    """Opt FLA's supported GatedMLP instances into the production cuDNN shim."""
+    import cudnn.fla as cfla
 
-    def _fwd(self, x, **kwargs):
-        return swiglu_mlp(x, self.gate_proj.weight, self.up_proj.weight, self.down_proj.weight)
-
-    fla_mlp.GatedMLP.forward = _fwd
-    print("[e2e] MLP -> cudnn.gemm.ops.swiglu_mlp (PR #609)")
+    cfla.accelerate_fla(verbose=True, targets="gated_mlp")
+    return cfla.mlp_last_path
 
 
 def _accelerate_attn():
@@ -222,7 +217,7 @@ def _accelerate_attn():
     except ImportError:
         print("[e2e] cudnn.fla not installed (PR #596); linear attention stays on FLA")
         return None
-    cfla.accelerate_fla(verbose=True)
+    cfla.accelerate_fla(verbose=True, targets="gated_delta_rule")
     from cudnn.fla.gated_delta_rule import last_path
 
     return last_path
@@ -337,8 +332,7 @@ def main():
         return
 
     attn_path = _accelerate_attn() if args.accelerate_attn else None
-    if args.accelerate_mlp:
-        _accelerate_mlp()
+    mlp_path = _accelerate_mlp() if args.accelerate_mlp else None
 
     ids = torch.randint(0, shape["vocab"], (args.bs, args.seq), device=dev)
 
@@ -346,6 +340,8 @@ def main():
         paths = [f"full-attn SDPA: {args.full_attn_backend}"]
         if attn_path is not None:
             paths.append(f"linear-attn op path: {attn_path()}")
+        if mlp_path is not None:
+            paths.append(f"MLP op path: {mlp_path()}")
         return ", ".join(paths)
 
     profile_and_report(model, ids, extra_path=extra)

--- a/benchmark/e2e/README.md
+++ b/benchmark/e2e/README.md
@@ -28,6 +28,10 @@ Torch SDPA; it is not an all-eager-Torch implementation. At the benchmark shape,
 Torch 2.13 selects PyTorch FlashAttention rather than cuDNN. Only the MLP axis
 belongs to PR #609.
 
+The formal results below predate this public adapter and used an equivalent
+direct call to `cudnn.gemm.ops.swiglu_mlp`. The adapter itself is validated by
+the focused FLA compatibility suite and a native-route model smoke test.
+
 ## Qwen3.8 proxy result
 
 On a full 148-SM B200 with BF16, batch 4, sequence 2048, and the four-layer

--- a/benchmark/e2e/README.md
+++ b/benchmark/e2e/README.md
@@ -18,8 +18,8 @@ same 16x factor as the depth, retaining the LM-head/layer FLOP ratio.
 The proxy exposes three independent axes:
 
 - stock FLA versus `cudnn.fla` for linear GDN (`--accelerate_attn`, PR #596);
-- stock FLA `GatedMLP` versus `cudnn.gemm.ops.swiglu_mlp`
-  (`--accelerate_mlp`, PR #609); and
+- stock FLA `GatedMLP` versus the opt-in `cudnn.fla` `gated_mlp` target backed
+  by `cudnn.gemm.ops.swiglu_mlp` (`--accelerate_mlp`, PR #609); and
 - vanilla `torch.nn.functional.scaled_dot_product_attention` versus FE's direct
   cuDNN-backend d256 op (`--full_attn_backend`, develop #335).
 
@@ -109,7 +109,9 @@ python benchmark/e2e/Qwen3.8/run_model.py --preset qwen3.5-27b --inspect  # equi
 
 Requires a cuDNN build with the fused GEMM engine and the cuDNN >= 9.23 backend
 d256 SDPA path on an SM100 (Blackwell) device; `flash-linear-attention` provides
-the model. The benchmark rejects the older OSS/CuteDSL d256 SDPA fallback.
+the model. The MLP target requires FLA 0.5.2 and admits its validated plain,
+local, bias-free BF16 `swish` module; unsupported runtime configurations fall
+back to FLA. The benchmark rejects the older OSS/CuteDSL d256 SDPA fallback.
 
 ## Add a model
 

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -66,7 +66,8 @@ release:
 
 ```bash
 pip install flash-linear-attention==0.5.2
+pip install "nvidia-cudnn-frontend[cutedsl]"
 ```
 
-The selected cuDNN kernel may require the optional dependencies documented for
-its FE-OSS API, including the `cutedsl` extra for the fused GEMM path.
+The `cutedsl` extra supplies the optional dependencies required by the fused
+GEMM path used by the native `gated_mlp` target.

--- a/docs/fe-oss-apis/fla.md
+++ b/docs/fe-oss-apis/fla.md
@@ -1,0 +1,72 @@
+# FLA Integration Shims
+
+**The FLA integration APIs are experimental and subject to change.**
+
+`cudnn.fla` can replace selected
+[`flash-linear-attention`](https://github.com/fla-org/flash-linear-attention)
+(FLA) entry points with cuDNN Frontend implementations. The adapters are
+process-wide monkeypatches: they cover modules that already exist as well as
+modules created after activation. Call them before compiling or tracing a
+model.
+
+## Activate targets
+
+```python
+import cudnn.fla
+
+# Backward-compatible default: Gated Delta Rule and KDA.
+cudnn.fla.accelerate_fla()
+
+# Incrementally opt the dense FLA GatedMLP into the fused cuDNN SwiGLU MLP.
+cudnn.fla.accelerate_fla(targets="gated_mlp")
+
+# A string or iterable is accepted; "gdn" and "mlp" are aliases.
+cudnn.fla.accelerate_fla(targets=("gdn", "gated_mlp"))
+```
+
+`accelerate_fla(verbose=True, *, targets=None)` is incremental and idempotent.
+With `targets=None`, it retains the original best-effort behavior and enables
+the `gated_delta_rule` and `kda` targets that exist in the installed FLA. An
+explicit target selection is atomic: if any requested target cannot be
+validated, no new requested target is installed and the raised `ImportError`
+includes the rejection reason.
+
+The `gated_mlp` target currently admits exactly FLA 0.5.2's plain, local,
+bias-free `swish` `GatedMLP` with fused SwiGLU, contiguous BF16 CUDA inputs and
+weights, and an SM100-family device. Unsupported runtime configurations such as
+tensor parallelism or DTensor, quantization, LoRA, parametrizations, hooks,
+custom linears, other dtypes/layouts/devices, or graph compilation execute the
+original FLA method. Typed unsupported-kernel declines also fall back;
+unexpected binding, allocation, or launch errors propagate.
+
+## Inspect and restore
+
+```python
+import cudnn.fla
+
+cudnn.fla.is_accelerated()             # any live cuDNN FLA target
+cudnn.fla.is_accelerated("gated_mlp") # one target ("mlp" also works)
+
+cudnn.fla.mlp_last_path()  # "native", "fallback:<reason>", or "error:<type>"
+cudnn.fla.last_path()      # most recent Gated Delta Rule route
+
+cudnn.fla.restore_fla(targets="gated_mlp") # restore only the MLP target
+cudnn.fla.restore_fla()                    # restore every target owned by cuDNN
+```
+
+`restore_fla(*, targets=None)` restores only patches still owned by
+`cudnn.fla`; it does not overwrite a later third-party replacement. The route
+helpers are diagnostics for tests and benchmarks, not synchronization or
+per-thread state.
+
+## Installation
+
+Install FLA separately. The dense MLP adapter is version-gated to the validated
+release:
+
+```bash
+pip install flash-linear-attention==0.5.2
+```
+
+The selected cuDNN kernel may require the optional dependencies documented for
+its FE-OSS API, including the `cutedsl` extra for the fused GEMM path.

--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -9,6 +9,7 @@ The GEMM CuTeDSL APIs are type-erased and torch-lazy: torch is imported only whe
 - **proj_rope_mxfp8**: JAX eager support on both input paths with `w_out_in=True` (the transposed [in, out] weight view is torch-only), plus the `jax.jit`-compatible `gemm_proj_rope_mxfp8_jax_sm100` entry point.
 
 This folder documents the Python FE APIs implemented under `python/cudnn`. For details on currently implemented operations, see:
+- [FLA Integration Shims](fla.md)
 - [GEMM + Amax](gemm_fusions/gemm_amax.md)
 - [GEMM + RoPE + MXFP8 Projection](gemm_fusions/gemm_proj_rope_mxfp8.md)
 - [GEMM + SwiGLU](gemm_fusions/gemm_swiglu.md)

--- a/python/cudnn/fla/__init__.py
+++ b/python/cudnn/fla/__init__.py
@@ -164,6 +164,7 @@ def accelerate_fla(verbose: bool = True, *, targets: str | Iterable[str] | None 
     available = {target for target in requested if is_accelerated(target)}
     resolved = []
     missing = []
+    rejection_reasons = {}
 
     for target in requested:
         if is_accelerated(target):
@@ -172,29 +173,33 @@ def accelerate_fla(verbose: bool = True, *, targets: str | Iterable[str] | None 
         spec = _TARGETS[target]
         try:
             module = importlib.import_module(spec.module_path)
-        except ImportError:
+        except ImportError as error:
             missing.append(target)
+            rejection_reasons[target] = str(error) or f"cannot import {spec.module_path}"
             continue
         owner = getattr(module, spec.owner_attribute, None) if spec.owner_attribute is not None else module
         if owner is None:
             missing.append(target)
+            rejection_reasons[target] = f"{spec.module_path} has no {spec.owner_attribute} owner"
             continue
         original = getattr(owner, spec.attribute, None)
         if original is None:
             missing.append(target)
+            rejection_reasons[target] = f"the target owner has no {spec.attribute} attribute"
             continue
         try:
             replacement = spec.make_replacement(module, owner, original)
-        except ImportError:
+        except ImportError as error:
             missing.append(target)
+            rejection_reasons[target] = str(error) or "the installed target does not match the supported contract"
             continue
         resolved.append((target, spec, owner, original, replacement))
 
     # An explicit selection is a contract: never silently apply only a subset.
     # The legacy no-target call retains its best-effort GDN/KDA behavior.
     if targets is not None and missing:
-        names = ", ".join(missing)
-        raise ImportError(f"accelerate_fla() could not find supported FLA target(s): {names}")
+        details = ", ".join(f"{target} ({rejection_reasons[target]})" if target in rejection_reasons else target for target in missing)
+        raise ImportError(f"accelerate_fla() could not enable FLA target(s): {details}")
 
     newly_patched = []
     for target, spec, owner, original, replacement in resolved:

--- a/python/cudnn/fla/__init__.py
+++ b/python/cudnn/fla/__init__.py
@@ -3,89 +3,233 @@
 
 """cuDNN drop-in acceleration for flash-linear-attention (FLA).
 
-``accelerate_fla()`` monkeypatches the FLA ops cuDNN can serve so an existing
-``import fla`` training/inference script gets cuDNN's Blackwell kernels with no
-code change, and transparently falls back to FLA where cuDNN has no kernel — so
-results never change. Today: ``gated_delta_rule`` (Gated DeltaNet) and ``kda``
-(Kimi Delta Attention).
+``accelerate_fla()`` monkeypatches FLA entry points cuDNN can serve and
+transparently calls the original implementation for unsupported configurations.
+The backward-compatible no-argument call enables the linear-attention targets
+(``gated_delta_rule`` and ``kda``).  The dense MLP adapter is intentionally
+opt-in because it has a narrower FLA 0.5.2/local-module contract::
 
     import cudnn.fla
-    cudnn.fla.accelerate_fla()   # call before importing FLA layers/models
 
-Correctness is gated by ``test/python/linear_attention/test_fla_compat.py``, which
-requires cuDNN to match FLA within its own bf16 noise on the output and every
-gradient; a config that does not match must fall back rather than run.
+    cudnn.fla.accelerate_fla()                    # GDN + KDA, as before
+    cudnn.fla.accelerate_fla(targets="gated_mlp") # incremental MLP opt-in
+
+Targets can be enabled and restored independently.  Every adapter is
+fail-closed: an incompatible installed FLA target rejects explicit activation,
+while a runtime configuration outside an activated adapter's validated contract
+executes the exact original FLA callable.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import importlib
 import sys
+from typing import Callable, Iterable
 
 from .gated_delta_rule import make_chunk_gated_delta_rule, last_path
+from .gated_mlp import last_path as mlp_last_path
+from .gated_mlp import make_gated_mlp_forward
+from .gated_mlp import _supports_installed_fla
 from .kda import make_chunk_kda
 
-__all__ = ["accelerate_fla", "is_accelerated", "last_path"]
-
-# The FLA ops cuDNN accelerates: (import path, attribute, shim factory).
-_ACCELERATED = [
-    ("fla.ops.gated_delta_rule", "chunk_gated_delta_rule", make_chunk_gated_delta_rule),
-    ("fla.ops.kda", "chunk_kda", make_chunk_kda),
-]
-
-_ORIGINALS: dict = {}
+__all__ = ["accelerate_fla", "is_accelerated", "last_path", "mlp_last_path", "restore_fla"]
 
 
-def is_accelerated() -> bool:
-    return bool(_ORIGINALS)
+@dataclass(frozen=True)
+class _PatchSpec:
+    module_path: str
+    attribute: str
+    make_replacement: Callable
+    owner_attribute: str | None = None
+    default: bool = True
+
+
+@dataclass(frozen=True)
+class _AppliedPatch:
+    spec: _PatchSpec
+    owner: object
+    original: object
+    replacement: object
+
+
+def _function_replacement(factory):
+    def make_replacement(module, owner, original):
+        del module, owner
+        return factory(original)
+
+    return make_replacement
+
+
+def _gated_mlp_replacement(module, owner, original):
+    if not _supports_installed_fla():
+        raise ImportError("the cuDNN GatedMLP shim requires flash-linear-attention==0.5.2")
+    if owner.__module__ != module.__name__ or owner.__dict__.get("forward") is not original:
+        raise ImportError("FLA GatedMLP.forward does not match the expected owning class")
+    if original.__module__ != module.__name__ or original.__qualname__ != "GatedMLP.forward" or hasattr(original, "__wrapped__"):
+        raise ImportError("FLA GatedMLP.forward was replaced before cuDNN acceleration")
+    swiglu_linear_cls = getattr(module, "SwiGLULinear", None)
+    if swiglu_linear_cls is None or swiglu_linear_cls.__module__ != module.__name__:
+        raise ImportError("FLA GatedMLP does not expose the expected SwiGLULinear helper")
+    return make_gated_mlp_forward(original, owner, swiglu_linear_cls)
+
+
+_TARGETS = {
+    "gated_delta_rule": _PatchSpec(
+        "fla.ops.gated_delta_rule",
+        "chunk_gated_delta_rule",
+        _function_replacement(make_chunk_gated_delta_rule),
+    ),
+    "kda": _PatchSpec(
+        "fla.ops.kda",
+        "chunk_kda",
+        _function_replacement(make_chunk_kda),
+    ),
+    "gated_mlp": _PatchSpec(
+        "fla.modules.mlp",
+        "forward",
+        _gated_mlp_replacement,
+        owner_attribute="GatedMLP",
+        default=False,
+    ),
+}
+_ALIASES = {"gdn": "gated_delta_rule", "mlp": "gated_mlp"}
+_DEFAULT_TARGETS = tuple(name for name, spec in _TARGETS.items() if spec.default)
+_ORIGINALS: dict[str, _AppliedPatch] = {}
+
+
+def _canonical_target(target: str) -> str:
+    if not isinstance(target, str):
+        raise TypeError(f"FLA acceleration target must be a string, got {type(target).__name__}")
+    target = _ALIASES.get(target, target)
+    if target not in _TARGETS:
+        choices = ", ".join(_TARGETS)
+        raise ValueError(f"unknown FLA acceleration target {target!r}; expected one of: {choices}")
+    return target
+
+
+def _normalize_targets(targets: str | Iterable[str] | None, *, default: Iterable[str]) -> tuple[str, ...]:
+    if targets is None:
+        requested = tuple(default)
+    elif isinstance(targets, str):
+        requested = (targets,)
+    else:
+        requested = tuple(targets)
+    if not requested:
+        raise ValueError("at least one FLA acceleration target is required")
+    canonical = {_canonical_target(target) for target in requested}
+    # Registry order makes logging/restoration deterministic even if a set was
+    # supplied by the caller.
+    return tuple(target for target in _TARGETS if target in canonical)
+
+
+def is_accelerated(target: str | None = None) -> bool:
+    """Whether any target, or one named target, is currently patched."""
+    if target is None:
+        return any(getattr(applied.owner, applied.spec.attribute, None) is applied.replacement for applied in _ORIGINALS.values())
+    applied = _ORIGINALS.get(_canonical_target(target))
+    return applied is not None and getattr(applied.owner, applied.spec.attribute, None) is applied.replacement
+
+
+def _drop_displaced_patch(target: str) -> None:
+    """Forget a patch whose owner was replaced without clobbering the new owner."""
+    applied = _ORIGINALS.pop(target, None)
+    if applied is None:
+        return
+    if applied.spec.owner_attribute is None:
+        _rebind_everywhere(applied.spec.attribute, applied.replacement, applied.original)
 
 
 def _rebind_everywhere(fn_name: str, original, replacement) -> None:
-    """Rebind ``fn_name`` from ``original`` to ``replacement`` in every module that
-    captured it by reference (e.g. FLA layers that did ``from ... import fn``)."""
-    for mod in list(sys.modules.values()):
-        if mod is None:
+    """Rebind imports that captured a patched module-level function by reference."""
+    for module in list(sys.modules.values()):
+        if module is None:
             continue
         try:
-            if getattr(mod, fn_name, None) is original:
-                setattr(mod, fn_name, replacement)
+            if getattr(module, fn_name, None) is original:
+                setattr(module, fn_name, replacement)
         except Exception:
             # Some modules raise on getattr of arbitrary names; skip them.
             continue
 
 
-def accelerate_fla(verbose: bool = True) -> None:
-    """Patch the FLA ops cuDNN accelerates. Idempotent; call before FLA models load."""
-    if is_accelerated():
-        return
-    import importlib
+def accelerate_fla(verbose: bool = True, *, targets: str | Iterable[str] | None = None) -> None:
+    """Patch selected FLA targets, incrementally and idempotently.
 
-    patched_names = []
-    for mod_path, attr, maker in _ACCELERATED:
-        try:
-            mod = importlib.import_module(mod_path)
-        except ImportError:
-            continue  # this op not present in the installed FLA
-        original = getattr(mod, attr, None)
-        if original is None:
+    ``targets=None`` preserves the original behavior and enables only GDN/KDA.
+    Use ``targets="gated_mlp"`` (or the ``"mlp"`` alias) for the opt-in dense
+    MLP adapter.  A string or iterable of strings is accepted.
+    """
+    requested = _normalize_targets(targets, default=_DEFAULT_TARGETS)
+    available = {target for target in requested if is_accelerated(target)}
+    resolved = []
+    missing = []
+
+    for target in requested:
+        if is_accelerated(target):
             continue
-        _ORIGINALS[attr] = (mod_path, original)
-        _rebind_everywhere(attr, original, maker(original))
-        patched_names.append(attr)
+        _drop_displaced_patch(target)
+        spec = _TARGETS[target]
+        try:
+            module = importlib.import_module(spec.module_path)
+        except ImportError:
+            missing.append(target)
+            continue
+        owner = getattr(module, spec.owner_attribute, None) if spec.owner_attribute is not None else module
+        if owner is None:
+            missing.append(target)
+            continue
+        original = getattr(owner, spec.attribute, None)
+        if original is None:
+            missing.append(target)
+            continue
+        try:
+            replacement = spec.make_replacement(module, owner, original)
+        except ImportError:
+            missing.append(target)
+            continue
+        resolved.append((target, spec, owner, original, replacement))
 
-    if not patched_names:
-        raise ImportError("accelerate_fla() requires flash-linear-attention installed")
-    if verbose:
-        print(f"[cudnn.fla] accelerated FLA {', '.join(patched_names)} with cuDNN (SM100); " "unsupported configs fall back to FLA.")
+    # An explicit selection is a contract: never silently apply only a subset.
+    # The legacy no-target call retains its best-effort GDN/KDA behavior.
+    if targets is not None and missing:
+        names = ", ".join(missing)
+        raise ImportError(f"accelerate_fla() could not find supported FLA target(s): {names}")
+
+    newly_patched = []
+    for target, spec, owner, original, replacement in resolved:
+        if spec.owner_attribute is None:
+            _rebind_everywhere(spec.attribute, original, replacement)
+        else:
+            setattr(owner, spec.attribute, replacement)
+        _ORIGINALS[target] = _AppliedPatch(spec, owner, original, replacement)
+        newly_patched.append(target)
+        available.add(target)
+
+    if not available and not newly_patched:
+        names = ", ".join(requested)
+        raise ImportError(f"accelerate_fla() could not find supported FLA target(s): {names}")
+    if verbose and newly_patched:
+        print(f"[cudnn.fla] accelerated FLA {', '.join(newly_patched)} with cuDNN (SM100); " "unsupported configs fall back to FLA.")
 
 
-def restore_fla() -> None:
-    """Undo :func:`accelerate_fla`."""
-    import importlib
-
-    for attr, (mod_path, original) in list(_ORIGINALS.items()):
-        mod = importlib.import_module(mod_path)
-        current = getattr(mod, attr, None)
-        if current is not None and current is not original:
-            _rebind_everywhere(attr, current, original)
-        setattr(mod, attr, original)  # restore the owning module's attribute explicitly
-    _ORIGINALS.clear()
+def restore_fla(*, targets: str | Iterable[str] | None = None) -> None:
+    """Undo all active patches, or only the selected targets."""
+    if targets is None:
+        requested = tuple(target for target in _TARGETS if target in _ORIGINALS)
+    else:
+        requested = _normalize_targets(targets, default=())
+    for target in requested:
+        applied = _ORIGINALS.pop(target, None)
+        if applied is None:
+            continue
+        spec, owner, original, replacement = (
+            applied.spec,
+            applied.owner,
+            applied.original,
+            applied.replacement,
+        )
+        if spec.owner_attribute is None:
+            _rebind_everywhere(spec.attribute, replacement, original)
+        if getattr(owner, spec.attribute, None) is replacement:
+            setattr(owner, spec.attribute, original)

--- a/python/cudnn/fla/gated_mlp.py
+++ b/python/cudnn/fla/gated_mlp.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""cuDNN-accelerated drop-in for FLA 0.5.2's plain ``GatedMLP``.
+
+The adapter is deliberately narrow.  It replaces only the arithmetic of the
+stock, local, bias-free BF16 ``swish`` module with
+``cudnn.gemm.ops.swiglu_mlp``.  Anything whose semantics may differ -- tensor
+parallelism, tensor/module subclasses, quantization, LoRA, parametrizations,
+hooks, non-compact storage, another FLA version, or graph compilation -- calls
+the original FLA ``forward`` unchanged.
+"""
+
+from __future__ import annotations
+
+import functools
+from importlib import metadata
+
+import torch
+
+import cudnn
+
+_SUPPORTED_FLA_VERSION = "0.5.2"
+_DECLINE_ERRORS = (NotImplementedError, cudnn.cudnnGraphNotSupportedError, ImportError)
+_LAST = {"path": None}
+
+_MODULE_HOOK_ATTRS = (
+    "_backward_hooks",
+    "_backward_pre_hooks",
+    "_forward_hooks",
+    "_forward_pre_hooks",
+)
+_GLOBAL_MODULE_HOOK_ATTRS = (
+    "_global_backward_hooks",
+    "_global_backward_pre_hooks",
+    "_global_forward_hooks",
+    "_global_forward_pre_hooks",
+)
+_TENSOR_HOOK_ATTRS = ("_backward_hooks", "_post_accumulate_grad_hooks")
+
+
+def last_path() -> str | None:
+    """The route the most recent shimmed MLP call took, for telemetry/tests."""
+    return _LAST["path"]
+
+
+def _installed_fla_version() -> str | None:
+    try:
+        return metadata.version("flash-linear-attention")
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _supports_installed_fla() -> bool:
+    return _installed_fla_version() == _SUPPORTED_FLA_VERSION
+
+
+def _is_compiling() -> bool:
+    compiler = getattr(torch, "compiler", None)
+    if compiler is not None and compiler.is_compiling():
+        return True
+    dynamo = getattr(torch, "_dynamo", None)
+    return bool(dynamo is not None and dynamo.is_compiling())
+
+
+def _is_cuda_autocast_enabled() -> bool:
+    try:
+        return torch.is_autocast_enabled("cuda")
+    except TypeError:  # torch versions whose no-argument form means CUDA
+        return torch.is_autocast_enabled()
+
+
+def _cuda_autocast_dtype():
+    if not _is_cuda_autocast_enabled():
+        return None
+    try:
+        return torch.get_autocast_dtype("cuda")
+    except (AttributeError, TypeError):
+        return torch.get_autocast_gpu_dtype()
+
+
+def _is_cuda_tensor(tensor) -> bool:
+    return tensor.is_cuda
+
+
+def _device_capability(device) -> tuple[int, int]:
+    return torch.cuda.get_device_capability(device)
+
+
+def _call_native(x, gate_weight, up_weight, down_weight):
+    # Keep importing cudnn.fla independent of the optional GEMM/CuTeDSL stack;
+    # an unavailable native op is a typed decline to the original FLA method.
+    from cudnn.gemm.ops import swiglu_mlp
+
+    return swiglu_mlp(x, gate_weight, up_weight, down_weight)
+
+
+def _has_hooks(obj, attrs) -> bool:
+    return any(bool(getattr(obj, attr, None)) for attr in attrs)
+
+
+def _has_global_module_hooks() -> bool:
+    module_impl = torch.nn.modules.module
+    return _has_hooks(module_impl, _GLOBAL_MODULE_HOOK_ATTRS)
+
+
+def _is_parametrized(module) -> bool:
+    parametrize = getattr(torch.nn.utils, "parametrize", None)
+    return bool(parametrize is not None and parametrize.is_parametrized(module))
+
+
+def _plain_parameter_decline(parameter, *, shape, device) -> str | None:
+    if type(parameter) is not torch.nn.Parameter:
+        return "tensor-subclass"
+    if type(parameter.data) is not torch.Tensor or parameter.layout is not torch.strided:
+        return "tensor-subclass"
+    if parameter.dtype is not torch.bfloat16:
+        return "non-bf16"
+    if not _is_cuda_tensor(parameter) or parameter.device != device:
+        return "nonlocal-device"
+    if tuple(parameter.shape) != tuple(shape):
+        return "shape"
+    if not parameter.is_contiguous():
+        return "noncontiguous"
+    if not parameter.is_leaf or parameter.grad_fn is not None:
+        return "nonlocal-parameter"
+    if _has_hooks(parameter, _TENSOR_HOOK_ATTRS):
+        return "hooks"
+    return None
+
+
+def _module_decline(module, *, expected_type, expected_parameter_names) -> str | None:
+    if _is_parametrized(module):
+        return "parametrized"
+    if type(module) is not expected_type:
+        return "custom-module"
+    if "forward" in module.__dict__:
+        return "custom-forward"
+    if set(module._parameters) != set(expected_parameter_names) or module._buffers or module._modules:
+        return "custom-module"
+    if _has_hooks(module, _MODULE_HOOK_ATTRS):
+        return "hooks"
+    return None
+
+
+def _decline_reason(self, x, *, gated_mlp_cls, swiglu_linear_cls, fla_version) -> str | None:
+    # This check must precede all tensor/device introspection so torch.compile
+    # traces the incumbent implementation rather than specializing this adapter.
+    if _is_compiling() or torch.jit.is_scripting() or torch.jit.is_tracing():
+        return "compile"
+    if _cuda_autocast_dtype() not in (None, torch.bfloat16):
+        # Stock FLA runs all three Linear modules under autocast.  Entering the
+        # BF16-only fused op would instead bypass a different requested dtype.
+        # BF16 autocast preserves the admitted operands/results and remains fast.
+        return "autocast"
+    if fla_version != _SUPPORTED_FLA_VERSION:
+        return "fla-version"
+    if type(self) is not gated_mlp_cls or "forward" in self.__dict__:
+        return "custom-gated-mlp"
+    if self._parameters or self._buffers or set(self._modules) != {"gate_proj", "up_proj", "down_proj", "swiglu_linear"}:
+        return "custom-gated-mlp"
+    if _is_parametrized(self) or _has_hooks(self, _MODULE_HOOK_ATTRS) or _has_global_module_hooks():
+        return "hooks-or-parametrization"
+    if getattr(self, "hidden_act", None) != "swish" or getattr(self, "fuse_swiglu", None) is not True:
+        return "variant"
+
+    projections = (self.gate_proj, self.up_proj, self.down_proj)
+    for projection in projections:
+        reason = _module_decline(projection, expected_type=torch.nn.Linear, expected_parameter_names=("weight", "bias"))
+        if reason is not None:
+            return reason
+        if projection.bias is not None:
+            return "bias"
+
+    reason = _module_decline(self.swiglu_linear, expected_type=swiglu_linear_cls, expected_parameter_names=())
+    if reason is not None:
+        return reason
+
+    if type(x) is not torch.Tensor or x.layout is not torch.strided:
+        return "tensor-subclass"
+    if x.dtype is not torch.bfloat16:
+        return "non-bf16"
+    if not _is_cuda_tensor(x):
+        return "non-cuda"
+    if x.dim() < 2 or x.numel() == 0 or not x.is_contiguous():
+        return "shape-or-layout"
+    if _has_hooks(x, _TENSOR_HOOK_ATTRS):
+        return "hooks"
+    if _device_capability(x.device)[0] != 10:
+        return "non-sm100"
+
+    hidden = getattr(self, "hidden_size", None)
+    intermediate = getattr(self, "intermediate_size", None)
+    if not isinstance(hidden, int) or not isinstance(intermediate, int) or hidden <= 0 or intermediate <= 0:
+        return "shape"
+    if hidden % 8 or intermediate % 8 or x.shape[-1] != hidden:
+        return "shape"
+    expected_linears = (
+        (self.gate_proj, hidden, intermediate),
+        (self.up_proj, hidden, intermediate),
+        (self.down_proj, intermediate, hidden),
+    )
+    for projection, in_features, out_features in expected_linears:
+        if projection.in_features != in_features or projection.out_features != out_features:
+            return "shape"
+        reason = _plain_parameter_decline(projection.weight, shape=(out_features, in_features), device=x.device)
+        if reason is not None:
+            return reason
+    return None
+
+
+def make_gated_mlp_forward(real_forward, gated_mlp_cls, swiglu_linear_cls):
+    """Wrap FLA's class method with a fail-closed cuDNN SwiGLU-MLP path.
+
+    The wrapper patches the class, so it covers both existing and future
+    instances.  FLA 0.5.2 accepts arbitrary ``**kwargs`` and ignores them; the
+    native path deliberately does the same, while fallback forwards the exact
+    mapping to ``real_forward``.
+    """
+
+    fla_version = _installed_fla_version()
+
+    @functools.wraps(real_forward)
+    def forward(self, x, **kwargs):
+        reason = _decline_reason(
+            self,
+            x,
+            gated_mlp_cls=gated_mlp_cls,
+            swiglu_linear_cls=swiglu_linear_cls,
+            fla_version=fla_version,
+        )
+        if reason is not None:
+            _LAST["path"] = f"fallback:{reason}"
+            return real_forward(self, x, **kwargs)
+        # Mark the selected route before entering the custom autograd op.
+        # Non-reentrant checkpointing deliberately raises an internal
+        # control-flow exception while replaying the op; it must pass through
+        # untouched without being misreported as a native execution failure.
+        _LAST["path"] = "native"
+        try:
+            out = _call_native(x, self.gate_proj.weight, self.up_proj.weight, self.down_proj.weight)
+        except _DECLINE_ERRORS as error:
+            _LAST["path"] = f"fallback:{type(error).__name__}"
+            return real_forward(self, x, **kwargs)
+        except (RuntimeError, ValueError) as error:
+            _LAST["path"] = f"error:{type(error).__name__}"
+            raise
+        return out
+
+    forward.__cudnn_fla_target__ = "gated_mlp"
+    return forward
+
+
+__all__ = ["last_path", "make_gated_mlp_forward"]

--- a/test/python/linear_attention/test_fla_mlp_compat.py
+++ b/test/python/linear_attention/test_fla_mlp_compat.py
@@ -13,6 +13,11 @@ import torch.utils.checkpoint
 
 fla_mlp = pytest.importorskip("fla.modules.mlp")
 
+try:
+    _FLA_VERSION = metadata.version("flash-linear-attention")
+except metadata.PackageNotFoundError:
+    _FLA_VERSION = None
+
 from cudnn.fla import accelerate_fla, is_accelerated, mlp_last_path, restore_fla
 from cudnn.fla.gated_mlp import make_gated_mlp_forward
 
@@ -23,7 +28,7 @@ pytestmark = [
         reason="cuDNN SwiGLU-MLP fusion requires SM100",
     ),
     pytest.mark.skipif(
-        metadata.version("flash-linear-attention") != "0.5.2",
+        _FLA_VERSION != "0.5.2",
         reason="the production GatedMLP shim intentionally supports FLA 0.5.2 exactly",
     ),
 ]

--- a/test/python/linear_attention/test_fla_mlp_compat.py
+++ b/test/python/linear_attention/test_fla_mlp_compat.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""B200 parity/fallback coverage for the production FLA ``GatedMLP`` shim."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+import pytest
+import torch
+import torch.utils.checkpoint
+
+fla_mlp = pytest.importorskip("fla.modules.mlp")
+
+from cudnn.fla import accelerate_fla, is_accelerated, mlp_last_path, restore_fla
+from cudnn.fla.gated_mlp import make_gated_mlp_forward
+
+pytestmark = [
+    pytest.mark.L0,
+    pytest.mark.skipif(
+        not (torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 10),
+        reason="cuDNN SwiGLU-MLP fusion requires SM100",
+    ),
+    pytest.mark.skipif(
+        metadata.version("flash-linear-attention") != "0.5.2",
+        reason="the production GatedMLP shim intentionally supports FLA 0.5.2 exactly",
+    ),
+]
+
+_REAL_FORWARD = fla_mlp.GatedMLP.forward
+_SHIM_FORWARD = make_gated_mlp_forward(_REAL_FORWARD, fla_mlp.GatedMLP, fla_mlp.SwiGLULinear)
+_TOL = 2e-2
+
+
+def _rel_l2(actual, expected):
+    return (actual.float() - expected.float()).norm().item() / max(expected.float().norm().item(), 1e-9)
+
+
+def _module():
+    return fla_mlp.GatedMLP(hidden_size=256, intermediate_size=512, hidden_act="swish", fuse_swiglu=True).cuda().to(torch.bfloat16)
+
+
+def _clone_pair():
+    stock = _module()
+    native = _module()
+    native.load_state_dict(stock.state_dict())
+    return stock, native
+
+
+def _assert_grads(native, stock):
+    for (native_name, native_parameter), (stock_name, stock_parameter) in zip(native.named_parameters(), stock.named_parameters()):
+        assert native_name == stock_name
+        assert native_parameter.grad is not None and stock_parameter.grad is not None
+        assert _rel_l2(native_parameter.grad, stock_parameter.grad) < _TOL, native_name
+
+
+def test_gated_mlp_forward_backward_parity_and_kwargs():
+    torch.manual_seed(10)
+    stock, native = _clone_pair()
+    x_stock = torch.randn(2, 128, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    x_native = x_stock.detach().clone().requires_grad_(True)
+    dout = torch.randn_like(x_stock)
+
+    out_stock = _REAL_FORWARD(stock, x_stock, ignored_by_fla=object())
+    out_native = _SHIM_FORWARD(native, x_native, ignored_by_fla=object())
+    assert mlp_last_path() == "native"
+    out_stock.backward(dout)
+    out_native.backward(dout)
+
+    assert _rel_l2(out_native, out_stock) < _TOL
+    assert _rel_l2(x_native.grad, x_stock.grad) < _TOL
+    _assert_grads(native, stock)
+
+
+@pytest.mark.parametrize("use_reentrant", [True, False], ids=["reentrant", "non-reentrant"])
+def test_gated_mlp_checkpoint_parity(use_reentrant):
+    torch.manual_seed(11)
+    stock, native = _clone_pair()
+    x_stock = torch.randn(1, 128, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+    x_native = x_stock.detach().clone().requires_grad_(True)
+    dout = torch.randn_like(x_stock)
+
+    out_stock = torch.utils.checkpoint.checkpoint(lambda value: _REAL_FORWARD(stock, value), x_stock, use_reentrant=use_reentrant)
+    out_native = torch.utils.checkpoint.checkpoint(lambda value: _SHIM_FORWARD(native, value), x_native, use_reentrant=use_reentrant)
+    out_stock.backward(dout)
+    out_native.backward(dout)
+
+    assert mlp_last_path() == "native"
+    assert _rel_l2(out_native, out_stock) < _TOL
+    assert _rel_l2(x_native.grad, x_stock.grad) < _TOL
+    _assert_grads(native, stock)
+
+
+@pytest.mark.parametrize(
+    "autocast_dtype,expected_path",
+    [(torch.bfloat16, "native"), (torch.float16, "fallback:autocast")],
+    ids=["bf16-native", "fp16-fallback"],
+)
+def test_gated_mlp_autocast_preserves_fla_semantics(autocast_dtype, expected_path):
+    module = _module()
+    x = torch.randn(1, 128, 256, device="cuda", dtype=torch.bfloat16)
+    calls = []
+
+    def recording_original(self, value, **kwargs):
+        calls.append(kwargs)
+        return _REAL_FORWARD(self, value, **kwargs)
+
+    shim = make_gated_mlp_forward(recording_original, fla_mlp.GatedMLP, fla_mlp.SwiGLULinear)
+    with torch.autocast("cuda", dtype=autocast_dtype):
+        out = shim(module, x, opaque=object())
+
+    assert out.shape == x.shape
+    assert out.dtype is autocast_dtype
+    assert mlp_last_path() == expected_path
+    assert len(calls) == (1 if autocast_dtype is torch.float16 else 0)
+
+
+@pytest.mark.parametrize("variant", ["noncontiguous", "fp16", "hook", "custom-linear"], ids=str)
+def test_gated_mlp_unsupported_variant_calls_original(variant):
+    module = _module()
+    x = torch.randn(2, 128, 256, device="cuda", dtype=torch.bfloat16)
+    calls = []
+
+    def recording_original(self, value, **kwargs):
+        calls.append(kwargs)
+        return _REAL_FORWARD(self, value, **kwargs)
+
+    shim = make_gated_mlp_forward(recording_original, fla_mlp.GatedMLP, fla_mlp.SwiGLULinear)
+    hook_calls = []
+    if variant == "noncontiguous":
+        x = torch.randn(2, 256, 128, device="cuda", dtype=torch.bfloat16).transpose(1, 2)
+    elif variant == "fp16":
+        module = module.half()
+        x = x.half()
+    elif variant == "hook":
+        module.gate_proj.register_forward_hook(lambda *args: hook_calls.append(True))
+    elif variant == "custom-linear":
+
+        class CustomLinear(torch.nn.Linear):
+            pass
+
+        replacement = CustomLinear(256, 512, bias=False, device="cuda", dtype=torch.bfloat16)
+        replacement.weight.data.copy_(module.gate_proj.weight)
+        module.gate_proj = replacement
+    else:
+        raise AssertionError(variant)
+
+    out = shim(module, x, opaque=object())
+
+    assert out.shape == x.shape
+    assert len(calls) == 1 and set(calls[0]) == {"opaque"}
+    assert mlp_last_path().startswith("fallback:")
+    assert hook_calls == ([True] if variant == "hook" else [])
+
+
+def test_gated_mlp_api_is_opt_in_and_covers_existing_instances():
+    original = fla_mlp.GatedMLP.forward
+    existing = _module()
+    try:
+        accelerate_fla(verbose=False)
+        assert fla_mlp.GatedMLP.forward is original
+        assert not is_accelerated("gated_mlp")
+
+        accelerate_fla(verbose=False, targets="gated_mlp")
+        replacement = fla_mlp.GatedMLP.forward
+        assert replacement is not original
+        assert existing.forward.__func__ is replacement
+        assert _module().forward.__func__ is replacement
+        assert is_accelerated("mlp")
+
+        accelerate_fla(verbose=False, targets="mlp")
+        assert fla_mlp.GatedMLP.forward is replacement
+
+        x = torch.randn(1, 128, 256, device="cuda", dtype=torch.bfloat16, requires_grad=True)
+        out = existing(x)
+        assert mlp_last_path() == "native"
+        out.float().sum().backward()
+        assert x.grad is not None
+        assert all(parameter.grad is not None for parameter in existing.parameters())
+    finally:
+        restore_fla()
+    assert fla_mlp.GatedMLP.forward is original

--- a/test/python/linear_attention/test_fla_mlp_shim_unit.py
+++ b/test/python/linear_attention/test_fla_mlp_shim_unit.py
@@ -403,7 +403,7 @@ def test_public_mlp_activation_rejects_unsupported_fla_version(monkeypatch):
     monkeypatch.setattr(fla_api, "_supports_installed_fla", lambda: False)
     monkeypatch.setattr(fla_api, "_ORIGINALS", {})
 
-    with pytest.raises(ImportError, match="could not find supported FLA target"):
+    with pytest.raises(ImportError, match="requires flash-linear-attention==0.5.2"):
         fla_api.accelerate_fla(verbose=False, targets="gated_mlp")
 
     assert module.GatedMLP.forward is original
@@ -423,7 +423,7 @@ def test_public_mlp_activation_rejects_prewrapped_class_method(monkeypatch):
     monkeypatch.setattr(fla_api, "_supports_installed_fla", lambda: True)
     monkeypatch.setattr(fla_api, "_ORIGINALS", {})
 
-    with pytest.raises(ImportError, match="could not find supported FLA target"):
+    with pytest.raises(ImportError, match="was replaced before cuDNN acceleration"):
         fla_api.accelerate_fla(verbose=False, targets="gated_mlp")
 
     assert module.GatedMLP.forward is third_party

--- a/test/python/linear_attention/test_fla_mlp_shim_unit.py
+++ b/test/python/linear_attention/test_fla_mlp_shim_unit.py
@@ -1,0 +1,435 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU/mock contract tests for the opt-in FLA ``GatedMLP`` shim."""
+
+from __future__ import annotations
+
+import functools
+import sys
+import types
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import cudnn.fla as fla_api
+import cudnn.fla.gated_mlp as gated_mlp
+
+pytestmark = pytest.mark.L0
+
+
+class _FakeSwiGLULinear(torch.nn.Module):
+    def forward(self, gate, up, weight, bias):
+        return F.linear(F.silu(gate) * up, weight, bias)
+
+
+class _FakeGatedMLP(torch.nn.Module):
+    def __init__(self, *, hidden=16, intermediate=32, dtype=torch.bfloat16):
+        super().__init__()
+        self.hidden_size = hidden
+        self.hidden_ratio = 4
+        self.intermediate_size = intermediate
+        self.hidden_act = "swish"
+        self.fuse_swiglu = True
+        self.powglu_power = 3.0
+        self.gate_proj = torch.nn.Linear(hidden, intermediate, bias=False, dtype=dtype)
+        self.up_proj = torch.nn.Linear(hidden, intermediate, bias=False, dtype=dtype)
+        self.down_proj = torch.nn.Linear(intermediate, hidden, bias=False, dtype=dtype)
+        self.swiglu_linear = _FakeSwiGLULinear()
+        self.fallback_calls = 0
+        self.fallback_kwargs = None
+
+    def forward(self, x, **kwargs):
+        self.fallback_calls += 1
+        self.fallback_kwargs = kwargs
+        gate, up = self.gate_proj(x), self.up_proj(x)
+        return self.swiglu_linear(gate, up, self.down_proj.weight, self.down_proj.bias)
+
+
+@pytest.fixture
+def mock_sm100(monkeypatch):
+    monkeypatch.setattr(gated_mlp, "_installed_fla_version", lambda: "0.5.2")
+    monkeypatch.setattr(gated_mlp, "_is_cuda_tensor", lambda tensor: True)
+    monkeypatch.setattr(gated_mlp, "_device_capability", lambda device: (10, 0))
+    monkeypatch.setattr(gated_mlp, "_has_global_module_hooks", lambda: False)
+
+
+def _wrapped():
+    return gated_mlp.make_gated_mlp_forward(_FakeGatedMLP.forward, _FakeGatedMLP, _FakeSwiGLULinear)
+
+
+def _input(dtype=torch.bfloat16):
+    return torch.randn(2, 3, 16, dtype=dtype)
+
+
+def test_native_path_uses_exact_weights_and_preserves_ignored_kwargs(mock_sm100, monkeypatch):
+    module = _FakeGatedMLP()
+    x = _input()
+    calls = []
+
+    def native(input_, gate, up, down):
+        calls.append((input_, gate, up, down))
+        return input_.clone()
+
+    monkeypatch.setattr(gated_mlp, "_call_native", native)
+    out = _wrapped()(module, x, arbitrary_object=object())
+
+    assert torch.equal(out, x)
+    assert calls == [(x, module.gate_proj.weight, module.up_proj.weight, module.down_proj.weight)]
+    assert module.fallback_calls == 0
+    assert gated_mlp.last_path() == "native"
+
+
+@pytest.mark.parametrize(
+    "case,reason",
+    [
+        ("fla-version", "fla-version"),
+        ("compile", "compile"),
+        ("fp16-autocast", "autocast"),
+        ("cpu", "non-cuda"),
+        ("pre-sm100", "non-sm100"),
+        ("non-bf16", "non-bf16"),
+        ("noncontiguous-input", "shape-or-layout"),
+        ("dtensor-like-input", "tensor-subclass"),
+        ("tensor-parallel-module", "custom-gated-mlp"),
+        ("instance-forward", "custom-gated-mlp"),
+        ("bias", "bias"),
+        ("lora-linear", "custom-module"),
+        ("quantized-linear", "custom-module"),
+        ("parametrized", "parametrized"),
+        ("extra-parameter", "custom-module"),
+        ("noncontiguous-weight", "noncontiguous"),
+        ("parameter-hook", "hooks"),
+    ],
+)
+def test_unsupported_variants_call_original_fla(mock_sm100, monkeypatch, case, reason):
+    module = _FakeGatedMLP()
+    x = _input()
+
+    if case == "fla-version":
+        monkeypatch.setattr(gated_mlp, "_installed_fla_version", lambda: "0.5.3")
+    elif case == "compile":
+        monkeypatch.setattr(gated_mlp, "_is_compiling", lambda: True)
+    elif case == "fp16-autocast":
+        monkeypatch.setattr(gated_mlp, "_cuda_autocast_dtype", lambda: torch.float16)
+    elif case == "cpu":
+        monkeypatch.setattr(gated_mlp, "_is_cuda_tensor", lambda tensor: False)
+    elif case == "pre-sm100":
+        monkeypatch.setattr(gated_mlp, "_device_capability", lambda device: (9, 0))
+    elif case == "non-bf16":
+        module = module.float()
+        x = x.float()
+    elif case == "noncontiguous-input":
+        x = torch.randn(2, 16, 3, dtype=torch.bfloat16).transpose(1, 2)
+    elif case == "dtensor-like-input":
+
+        class DTensorLike(torch.Tensor):
+            pass
+
+        x = x.as_subclass(DTensorLike)
+    elif case == "tensor-parallel-module":
+
+        class TensorParallelGatedMLP(_FakeGatedMLP):
+            pass
+
+        module = TensorParallelGatedMLP()
+    elif case == "instance-forward":
+        module.forward = types.MethodType(_FakeGatedMLP.forward, module)
+    elif case == "bias":
+        module.gate_proj = torch.nn.Linear(16, 32, bias=True, dtype=torch.bfloat16)
+    elif case == "lora-linear":
+
+        class LoraLinear(torch.nn.Linear):
+            pass
+
+        module.gate_proj = LoraLinear(16, 32, bias=False, dtype=torch.bfloat16)
+    elif case == "quantized-linear":
+
+        class QuantizedLinear(torch.nn.Linear):
+            pass
+
+        module.gate_proj = QuantizedLinear(16, 32, bias=False, dtype=torch.bfloat16)
+    elif case == "parametrized":
+
+        class Identity(torch.nn.Module):
+            def forward(self, weight):
+                return weight
+
+        torch.nn.utils.parametrize.register_parametrization(module.gate_proj, "weight", Identity())
+    elif case == "extra-parameter":
+        module.gate_proj.register_parameter("lora_A", torch.nn.Parameter(torch.zeros(1, dtype=torch.bfloat16)))
+    elif case == "noncontiguous-weight":
+        module.gate_proj.weight = torch.nn.Parameter(torch.randn(16, 32, dtype=torch.bfloat16).t())
+    elif case == "parameter-hook":
+        module.gate_proj.weight.register_hook(lambda grad: grad)
+    else:
+        raise AssertionError(case)
+
+    def must_not_run(*args):
+        raise AssertionError("native path should have declined")
+
+    monkeypatch.setattr(gated_mlp, "_call_native", must_not_run)
+    kwargs = {"opaque": object()}
+    out = _wrapped()(module, x, **kwargs)
+
+    assert out.shape == x.shape
+    assert module.fallback_calls == 1
+    assert module.fallback_kwargs == kwargs
+    assert gated_mlp.last_path() == f"fallback:{reason}"
+
+
+def test_bf16_autocast_remains_on_native_path(mock_sm100, monkeypatch):
+    module = _FakeGatedMLP()
+    x = _input()
+    monkeypatch.setattr(gated_mlp, "_cuda_autocast_dtype", lambda: torch.bfloat16)
+    monkeypatch.setattr(gated_mlp, "_call_native", lambda *args: x.clone())
+
+    out = _wrapped()(module, x)
+
+    assert torch.equal(out, x)
+    assert module.fallback_calls == 0
+    assert gated_mlp.last_path() == "native"
+
+
+def test_projection_hook_forces_fallback_and_still_runs(mock_sm100, monkeypatch):
+    module = _FakeGatedMLP()
+    seen = []
+    module.gate_proj.register_forward_hook(lambda *args: seen.append(True))
+    monkeypatch.setattr(gated_mlp, "_call_native", lambda *args: pytest.fail("native path should have declined"))
+
+    _wrapped()(module, _input())
+
+    assert module.fallback_calls == 1
+    assert seen == [True]
+    assert gated_mlp.last_path() == "fallback:hooks"
+
+
+@pytest.mark.parametrize(
+    "error",
+    [NotImplementedError, gated_mlp.cudnn.cudnnGraphNotSupportedError, ImportError],
+    ids=["not-implemented", "graph-not-supported", "optional-dependency"],
+)
+def test_typed_native_decline_falls_back(mock_sm100, monkeypatch, error):
+    module = _FakeGatedMLP()
+
+    def decline(*args):
+        raise error("decline")
+
+    monkeypatch.setattr(gated_mlp, "_call_native", decline)
+    _wrapped()(module, _input())
+
+    assert module.fallback_calls == 1
+    assert gated_mlp.last_path() == f"fallback:{error.__name__}"
+
+
+def test_unexpected_native_error_propagates(mock_sm100, monkeypatch):
+    module = _FakeGatedMLP()
+
+    def fail(*args):
+        raise RuntimeError("synthetic launch failure")
+
+    monkeypatch.setattr(gated_mlp, "_call_native", fail)
+    with pytest.raises(RuntimeError, match="synthetic launch failure"):
+        _wrapped()(module, _input())
+    assert module.fallback_calls == 0
+    assert gated_mlp.last_path() == "error:RuntimeError"
+
+
+def test_native_control_flow_exception_propagates_without_overwriting_route(mock_sm100, monkeypatch):
+    module = _FakeGatedMLP()
+
+    class ControlFlow(Exception):
+        pass
+
+    def stop_recomputation(*args):
+        raise ControlFlow("synthetic checkpoint control flow")
+
+    monkeypatch.setattr(gated_mlp, "_call_native", stop_recomputation)
+    with pytest.raises(ControlFlow, match="synthetic checkpoint control flow"):
+        _wrapped()(module, _input())
+    assert module.fallback_calls == 0
+    assert gated_mlp.last_path() == "native"
+
+
+def test_target_registry_is_incremental_idempotent_and_restorable(monkeypatch):
+    function_module = types.ModuleType("_cudnn_fla_test_function_target")
+
+    def original_function():
+        return "original-function"
+
+    function_module.test_function_target = original_function
+
+    method_module = types.ModuleType("_cudnn_fla_test_method_target")
+
+    class Owner:
+        def forward(self):
+            return "original-method"
+
+    method_module.Owner = Owner
+    method_module.test_method_target = object()
+    original_method = Owner.forward
+
+    def make_function(module, owner, original):
+        del module, owner
+
+        def replacement():
+            return "patched-" + original()
+
+        return replacement
+
+    def make_method(module, owner, original):
+        del module, owner
+
+        def replacement(self):
+            return "patched-" + original(self)
+
+        return replacement
+
+    targets = {
+        "default": fla_api._PatchSpec(function_module.__name__, "test_function_target", make_function),
+        "gated_mlp": fla_api._PatchSpec(method_module.__name__, "forward", make_method, owner_attribute="Owner", default=False),
+    }
+    monkeypatch.setitem(sys.modules, function_module.__name__, function_module)
+    monkeypatch.setitem(sys.modules, method_module.__name__, method_module)
+    monkeypatch.setattr(fla_api, "_TARGETS", targets)
+    monkeypatch.setattr(fla_api, "_ALIASES", {"mlp": "gated_mlp"})
+    monkeypatch.setattr(fla_api, "_DEFAULT_TARGETS", ("default",))
+    monkeypatch.setattr(fla_api, "_ORIGINALS", {})
+
+    existing = Owner()
+    fla_api.accelerate_fla(verbose=False)
+    assert function_module.test_function_target() == "patched-original-function"
+    assert existing.forward() == "original-method"
+    assert fla_api.is_accelerated("default")
+    assert not fla_api.is_accelerated("mlp")
+
+    fla_api.accelerate_fla(verbose=False, targets="mlp")
+    replacement = Owner.forward
+    assert existing.forward() == "patched-original-method"
+    assert Owner().forward() == "patched-original-method"
+    assert fla_api.is_accelerated("gated_mlp")
+
+    fla_api.accelerate_fla(verbose=False, targets=("gated_mlp", "default"))
+    assert Owner.forward is replacement
+
+    fla_api.restore_fla(targets="mlp")
+    assert Owner.forward is original_method
+    assert existing.forward() == "original-method"
+    assert fla_api.is_accelerated("default")
+
+    fla_api.accelerate_fla(verbose=False, targets="mlp")
+
+    def third_party(self):
+        return "third-party-method"
+
+    Owner.forward = third_party
+    assert not fla_api.is_accelerated("mlp")
+    fla_api.restore_fla(targets="mlp")
+    assert Owner.forward is third_party
+
+    # A generic registry target can be claimed again after displacement; its
+    # eventual restore belongs to the callable that was live at re-activation.
+    fla_api.accelerate_fla(verbose=False, targets="mlp")
+    assert fla_api.is_accelerated("mlp")
+    assert Owner().forward() == "patched-third-party-method"
+    fla_api.restore_fla(targets="mlp")
+    assert Owner.forward is third_party
+
+    fla_api.restore_fla()
+    assert function_module.test_function_target is original_function
+    assert not fla_api.is_accelerated()
+
+
+def test_displaced_unavailable_default_target_does_not_report_stale_success(monkeypatch):
+    method_module = types.ModuleType("_cudnn_fla_test_displaced_target")
+
+    class Owner:
+        def forward(self):
+            return "original"
+
+    method_module.Owner = Owner
+
+    def make_method(module, owner, original):
+        del module, owner
+
+        def replacement(self):
+            return "patched-" + original(self)
+
+        return replacement
+
+    target = fla_api._PatchSpec(method_module.__name__, "forward", make_method, owner_attribute="Owner")
+    monkeypatch.setitem(sys.modules, method_module.__name__, method_module)
+    monkeypatch.setattr(fla_api, "_TARGETS", {"default": target})
+    monkeypatch.setattr(fla_api, "_ALIASES", {})
+    monkeypatch.setattr(fla_api, "_DEFAULT_TARGETS", ("default",))
+    monkeypatch.setattr(fla_api, "_ORIGINALS", {})
+
+    fla_api.accelerate_fla(verbose=False)
+    Owner.forward = lambda self: "third-party"
+    assert not fla_api.is_accelerated("default")
+    monkeypatch.delitem(sys.modules, method_module.__name__)
+
+    with pytest.raises(ImportError, match="could not find supported FLA target"):
+        fla_api.accelerate_fla(verbose=False)
+    assert not fla_api.is_accelerated()
+    assert Owner().forward() == "third-party"
+
+
+def _fake_fla_mlp_module():
+    module = types.ModuleType("fla.modules.mlp")
+
+    class SwiGLULinear:
+        pass
+
+    class GatedMLP:
+        def forward(self, x, **kwargs):
+            del kwargs
+            return x
+
+    SwiGLULinear.__module__ = module.__name__
+    GatedMLP.__module__ = module.__name__
+    GatedMLP.forward.__module__ = module.__name__
+    GatedMLP.forward.__qualname__ = "GatedMLP.forward"
+    module.SwiGLULinear = SwiGLULinear
+    module.GatedMLP = GatedMLP
+    return module
+
+
+def test_public_mlp_activation_rejects_unsupported_fla_version(monkeypatch):
+    module = _fake_fla_mlp_module()
+    original = module.GatedMLP.forward
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(fla_api, "_supports_installed_fla", lambda: False)
+    monkeypatch.setattr(fla_api, "_ORIGINALS", {})
+
+    with pytest.raises(ImportError, match="could not find supported FLA target"):
+        fla_api.accelerate_fla(verbose=False, targets="gated_mlp")
+
+    assert module.GatedMLP.forward is original
+    assert not fla_api.is_accelerated("gated_mlp")
+
+
+def test_public_mlp_activation_rejects_prewrapped_class_method(monkeypatch):
+    module = _fake_fla_mlp_module()
+    stock = module.GatedMLP.forward
+
+    @functools.wraps(stock)
+    def third_party(self, x, **kwargs):
+        return stock(self, x, **kwargs)
+
+    module.GatedMLP.forward = third_party
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(fla_api, "_supports_installed_fla", lambda: True)
+    monkeypatch.setattr(fla_api, "_ORIGINALS", {})
+
+    with pytest.raises(ImportError, match="could not find supported FLA target"):
+        fla_api.accelerate_fla(verbose=False, targets="gated_mlp")
+
+    assert module.GatedMLP.forward is third_party
+    assert not fla_api.is_accelerated("gated_mlp")
+
+
+def test_unknown_target_is_rejected():
+    with pytest.raises(ValueError, match="unknown FLA acceleration target"):
+        fla_api.accelerate_fla(verbose=False, targets="does-not-exist")

--- a/test/python/linear_attention/test_fla_mlp_shim_unit.py
+++ b/test/python/linear_attention/test_fla_mlp_shim_unit.py
@@ -403,7 +403,7 @@ def test_public_mlp_activation_rejects_unsupported_fla_version(monkeypatch):
     monkeypatch.setattr(fla_api, "_supports_installed_fla", lambda: False)
     monkeypatch.setattr(fla_api, "_ORIGINALS", {})
 
-    with pytest.raises(ImportError, match="requires flash-linear-attention==0.5.2"):
+    with pytest.raises(ImportError, match=r"requires flash-linear-attention==0\.5\.2"):
         fla_api.accelerate_fla(verbose=False, targets="gated_mlp")
 
     assert module.GatedMLP.forward is original


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

Python API or bindings; benchmarks or performance.

## Summary

- Add an opt-in `cudnn.fla` adapter for FLA 0.5.2 `GatedMLP` backed by `cudnn.gemm.ops.swiglu_mlp`.
- Make the FLA patch registry target-selective, incremental, idempotent, and independently restorable while preserving the existing no-argument GDN+KDA behavior.
- Route the Qwen3.8 benchmark through the production MLP adapter and report its selected path.

## Why

PR #609 added the fused dense BF16 SwiGLU MLP op, but FLA users still needed a benchmark-local monkeypatch to reach it. This change exposes the same integration style as the existing GDN/KDA shim while failing closed for configurations whose semantics are not covered.

The native path is deliberately narrow: exact FLA 0.5.2, plain local bias-free `swish` `GatedMLP`, BF16 contiguous CUDA tensors and weights, and SM100. Tensor-parallel/DTensor, custom or quantized linears, LoRA/parametrization/hooks, unsupported dtype/layout/device/shape, and graph compilation use the original FLA method. Typed unsupported declines fall back; unexpected runtime or launch errors remain visible.

## Related issues

Related to #609 and #596.

## API and compatibility impact

New explicit opt-in:

```python
import cudnn.fla
cudnn.fla.accelerate_fla(targets="gated_mlp")
```

`targets="mlp"` is an alias. `restore_fla(targets=...)` and `is_accelerated(target)` allow selective lifecycle management. The existing `accelerate_fla()` call remains backward-compatible and still enables only GDN and KDA; it does not opt users into the MLP adapter.

The class-method patch covers both existing and future FLA `GatedMLP` instances. An incompatible installed FLA version rejects explicit activation instead of silently installing an unvalidated adapter.

## Testing

- Pre-commit Black and Black-Jupyter hooks on all changed files: passed.
- Mock-contract registry, admission, fallback, error propagation, hook, autocast, and lifecycle suite: **30 passed**.
- Full B200 focused suite (`test_fla_mlp_shim_unit.py` + `test_fla_mlp_compat.py`), Torch 2.13.0+cu130 / cuDNN 9.26 / FLA 0.5.2: **40 passed, 1 warning in 42.42 s**. This includes forward/backward parity, reentrant and non-reentrant checkpointing, BF16/FP16 autocast, fallback variants, and the public existing-instance path.
- Existing B200 GDN/KDA registry lifecycle regression, `test_fla_compat.py::test_accelerate_fla_patches_and_restores`: **1 passed in 30.17 s**.
- Qwen3.8 four-layer smoke (`H=5120`, `I=17408`, `B=1`, `S=128`): completed forward+backward and reported `MLP op path: native`.

The exact all-gradient MLP benchmark from #609 measured 9.848 ms for the cuDNN op versus 10.943 ms for stock FLA 0.5.2 at `M=8192, H=5120, I=17408` (1.111x, 40/40 paired wins). This PR changes integration, not that kernel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added opt-in accelerated Gated MLP execution for supported BF16 CUDA configurations.
  - Added independent controls for enabling, checking, and restoring acceleration targets.
  - Added execution-path reporting for native acceleration and fallback processing.
- **Bug Fixes**
  - Unsupported configurations now safely use the standard implementation.
  - Preserved expected behavior across checkpointing, autocast, hooks, and gradients.
  - Improved handling of existing and newly created model instances.
- **Documentation**
  - Added guidance for FLA integration, installation requirements, supported configurations, validation status, and fallback behavior.
  - Updated benchmark documentation with acceleration and execution-path details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->