### PR TITLE
Add reproducible Qwen3.8 and Qwen-Image end-to-end benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ cover/
 
 # Local end-to-end benchmark artifacts
 qwen3.8-factorial-results/
+qwen-image-bf16-results/
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ coverage.xml
 .pytest_cache/
 cover/
 
+# Local end-to-end benchmark artifacts
+qwen3.8-factorial-results/
+
 # Translations
 *.mo
 *.pot

--- a/benchmark/e2e/Qwen-Image/requirements.txt
+++ b/benchmark/e2e/Qwen-Image/requirements.txt
@@ -1,0 +1,2 @@
+# Benchmark-only dependency; not part of cudnn-frontend's runtime package.
+diffusers @ git+https://github.com/huggingface/diffusers.git@2f7e0154a9db246e95c9ede43edba7db5b130805

--- a/benchmark/e2e/Qwen-Image/run_bf16.py
+++ b/benchmark/e2e/Qwen-Image/run_bf16.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Balanced BF16 Qwen-Image joint-attention A/B benchmark.
+
+This is one numerical-recipe leaf: conservative BF16. It compares explicitly
+forced PyTorch FlashAttention with the FE public cuDNN backend graph while keeping Diffusers'
+Q/K/V projections, QK norm, RoPE, output projections, AdaLN, GELU FFNs, and all
+other transformer work identical.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import statistics
+import subprocess
+import sys
+import time
+
+THIS_DIR = Path(__file__).resolve().parent
+E2E_DIR = THIS_DIR.parent
+REPO_ROOT = THIS_DIR.parents[2]
+MODEL_PATH = THIS_DIR / "run_model.py"
+FACTORIAL_PATH = E2E_DIR / "_factorial.py"
+sys.path.insert(0, str(E2E_DIR))
+
+from _factorial import config_fingerprint, paired_stats, percentile, williams_orders  # noqa: E402
+
+PROTOCOL_DEFAULTS = {
+    "smoke": {"warmup": 1, "rounds": 8, "repeats": 1},
+    "formal": {"warmup": 3, "rounds": 40, "repeats": 3},
+}
+VARIANTS = (("0", "torch_flash"), ("1", "cudnn"))
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as source:
+        for chunk in iter(lambda: source.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_record(path):
+    path = Path(path).resolve()
+    try:
+        display = str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        display = str(path)
+    return {"path": display, "sha256": _sha256(path)}
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git_provenance():
+    def run(*arguments):
+        return subprocess.run(arguments, cwd=REPO_ROOT, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout.strip()
+
+    return {
+        "commit": run("git", "rev-parse", "HEAD"),
+        "branch": run("git", "branch", "--show-current") or "detached",
+        "dirty": bool(run("git", "status", "--porcelain")),
+    }
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=PROTOCOL_DEFAULTS, default="smoke")
+    parser.add_argument("--layers", type=int)
+    parser.add_argument("--image-tokens", type=int)
+    parser.add_argument("--text-tokens", type=int)
+    parser.add_argument("--warmup", type=int)
+    parser.add_argument("--rounds", type=int)
+    parser.add_argument("--repeats", type=int)
+    parser.add_argument("--output-dir", type=Path, default=REPO_ROOT / "qwen-image-bf16-results")
+    parser.add_argument("--tag", default="")
+    parser.add_argument("--compare", type=Path)
+    return parser.parse_args()
+
+
+def _resolve_protocol(args):
+    protocol = dict(PROTOCOL_DEFAULTS[args.mode])
+    for name in protocol:
+        value = getattr(args, name)
+        if value is not None:
+            protocol[name] = value
+    if any(not isinstance(value, int) or value <= 0 for value in protocol.values()):
+        raise ValueError(f"protocol values must be positive integers, got {protocol}")
+    if protocol["rounds"] % 2:
+        raise ValueError("rounds must be a multiple of 2 for the complete two-treatment Williams design")
+    return protocol
+
+
+def _pick_device(torch, mode):
+    candidates = []
+    for index in range(torch.cuda.device_count()):
+        properties = torch.cuda.get_device_properties(index)
+        candidates.append(f"cuda:{index}={properties.name}/{properties.multi_processor_count}SM")
+        if properties.major == 10 and (mode != "formal" or (properties.name == "NVIDIA B200" and properties.multi_processor_count == 148)):
+            return torch.device(f"cuda:{index}"), properties
+    requirement = "a full 148-SM NVIDIA B200" if mode == "formal" else "an SM100-family GPU"
+    raise RuntimeError(f"{mode} mode requires {requirement}; visible: {', '.join(candidates)}")
+
+
+def _rel_l2(actual, expected):
+    return float((actual.float() - expected.float()).norm() / expected.float().norm().clamp_min(1e-12))
+
+
+def _focused_padding_check(torch, qwen_module, model_api, device):
+    text_tokens, image_tokens, heads, head_dim, batch = 64, 128, 4, 128, 2
+    generator = torch.Generator(device=device).manual_seed(2026)
+    shape = (batch, text_tokens + image_tokens, heads, head_dim)
+    q, k, v = (torch.randn(shape, device=device, dtype=torch.bfloat16, generator=generator) for _ in range(3))
+    text_mask = torch.arange(text_tokens, device=device).unsqueeze(0) < torch.tensor([64, 37], device=device).unsqueeze(1)
+    mask = torch.cat([text_mask, torch.ones(batch, image_tokens, dtype=torch.bool, device=device)], dim=1)[:, None, None]
+    select, restore, _, _ = model_api.install_joint_attention_dispatch(qwen_module, text_tokens=text_tokens)
+    try:
+        with torch.inference_mode():
+            select("torch_reference")
+            expected = qwen_module.dispatch_attention_fn(q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False)
+            select("cudnn")
+            actual = qwen_module.dispatch_attention_fn(q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False)
+        torch.cuda.synchronize(device)
+    finally:
+        restore()
+    rel = _rel_l2(actual, expected)
+    if not math.isfinite(rel) or rel > 0.01:
+        raise RuntimeError(f"right-padded joint-attention adapter mismatch: rel_l2={rel}")
+    return {
+        "shape": list(shape),
+        "text_valid_lengths": [64, 37],
+        "rel_l2": rel,
+        "role": "official [text,pad,image] boolean mask vs permuted [image,text,pad] cuDNN seq_len path",
+    }
+
+
+def _load_comparison(path):
+    def reject(value):
+        raise ValueError(f"non-finite JSON constant {value}")
+
+    return json.loads(Path(path).read_text(encoding="utf-8"), parse_constant=reject)
+
+
+def _compare(current, previous):
+    current_fp = current["config"]["comparability_fingerprint"]["sha256"]
+    previous_fp = previous["config"]["comparability_fingerprint"]["sha256"]
+    if current_fp != previous_fp:
+        raise ValueError(f"comparison fingerprint mismatch: current={current_fp}, previous={previous_fp}")
+    arms = {}
+    for bits in ("0", "1"):
+        new = float(current["summary"][bits]["p50_ms"])
+        old = float(previous["summary"][bits]["p50_ms"])
+        if not all(math.isfinite(value) and value > 0 for value in (new, old)):
+            raise ValueError("comparison p50 values must be finite and positive")
+        arms[bits] = {"previous_p50_ms": old, "current_p50_ms": new, "change_percent": (new / old - 1.0) * 100.0}
+    return {
+        "paired_across_runs": False,
+        "arms": arms,
+        "previous_within_run_ratio": previous["comparison_within_run"]["paired_ratio_p50"],
+        "current_within_run_ratio": current["comparison_within_run"]["paired_ratio_p50"],
+    }
+
+
+def _render_markdown(metadata, raw_name, raw_hash):
+    config = metadata["config"]
+    paired = metadata["comparison_within_run"]
+    smoke = config["mode"] == "smoke"
+    lines = [
+        "# Qwen-Image BF16 joint-attention benchmark",
+        "",
+        f"Generated: `{metadata['completed_utc']}`  ",
+        f"Mode: `{config['mode']}`  ",
+        f"Comparability fingerprint: `{config['comparability_fingerprint']['sha256']}`  ",
+        f"Build/provenance fingerprint: `{config['build_fingerprint']['sha256']}`  ",
+        f"Raw JSON: [`{raw_name}`]({raw_name}) (`sha256:{raw_hash}`)",
+        "",
+    ]
+    if smoke:
+        lines += [
+            "## Smoke validation",
+            "",
+            "**Validation only; these reduced-token timings are not a performance headline.**",
+            "",
+        ]
+    else:
+        ratio = paired["paired_ratio_p50"]
+        lines += [
+            "## Result",
+            "",
+            f"Direct FE/cuDNN is `{ratio:.5f}x` the paired forced-PyTorch-Flash elapsed time "
+            f"({(1 - ratio) * 100:.2f}% lower, `{1 / ratio:.3f}x` speedup; {paired['wins']}/{paired['batches']} wins).",
+            "",
+        ]
+    lines += [
+        "| transformer forward (SDPA treatment) | p10 | p50 | p90 | paired ratio vs PyTorch Flash |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for bits, label in VARIANTS:
+        value = metadata["summary"][bits]
+        ratio = 1.0 if bits == "0" else value["paired_ratio_p50"]
+        lines.append(f"| {label} | {value['p10_ms']:.3f} ms | {value['p50_ms']:.3f} ms | {value['p90_ms']:.3f} ms | {ratio:.5f} |")
+    shape = config["shape"]
+    lines += [
+        "",
+        "## Scope and gates",
+        "",
+        f"- Shape: B={shape['bs']}, image/text/joint tokens={shape['image_tokens']}/{shape['text_tokens']}/{shape['joint_tokens']}, "
+        f"H={shape['hidden']}, heads={shape['heads']}x{shape['head_dim']}, FFN={shape['ffn']}, repeated layers={shape['layers']}/60.",
+        f"- Recipe: `{config['numerical_recipe']['id']}` ({config['numerical_recipe']['parameter_dtype']} parameters and activations).",
+        f"- Workload: `{config['workload']}`. One conditional transformer forward; no text encoder, VAE, scheduler, checkpoint weights, or full denoising loop.",
+        f"- PyTorch route: natural `{metadata['route']['torch_probe']['natural_choice_name']}`, timed treatment forced "
+        f"`{metadata['route']['torch_probe']['forced_choice_name']}`; calls Flash/cuDNN: "
+        f"`{metadata['route']['calls']['torch_flash']}/{metadata['route']['calls']['cudnn']}`.",
+        f"- Full-model output relative L2: `{metadata['correctness']['model_output_rel_l2']:.6g}`; "
+        f"right-padded B=2 mask adapter relative L2: `{metadata['correctness']['padding_adapter']['rel_l2']:.6g}`.",
+        "- Joint mask semantics: every query sees valid text and every image token; only padded text key columns are rejected.",
+        "",
+        "## Anchors",
+        "",
+        f"- Model: [`{config['model_anchor']['id']}@{config['model_anchor']['revision']}`]({config['model_anchor']['config_url']})",
+        f"- Implementation: [`diffusers@{config['diffusers_anchor']['commit']}`]({config['diffusers_anchor']['url']})",
+        "",
+        "This is a random-weight, depth-reduced transformer-shape proxy, not image-quality evidence or complete Qwen-Image pipeline throughput.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main():
+    started_utc = _utc_now()
+    args = _parse_args()
+    protocol = _resolve_protocol(args)
+    model_api = _load_module("qwen_image_model", MODEL_PATH)
+    shape = model_api.resolve_shape(args.mode, layers=args.layers, image_tokens=args.image_tokens, text_tokens=args.text_tokens)
+    if os.environ.get("CUDNN_FRONTEND_ENABLE_FROST_ENGINES", "0").lower() in ("1", "true", "yes", "on"):
+        raise RuntimeError("disable global FROST engines: the FE arm is defined as the cuDNN backend graph")
+    torch, _, cudnn, sdpamod, diffusers, qwen_module = model_api.load_runtime()
+    loaded_diffusers_source = _source_record(qwen_module.__file__)
+    expected_diffusers_sha = model_api.DIFFUSERS_ANCHOR["source_sha256"]
+    if loaded_diffusers_source["sha256"] != expected_diffusers_sha:
+        raise RuntimeError(
+            "loaded Diffusers Qwen-Image source does not match the pinned implementation: "
+            f"got {loaded_diffusers_source['sha256']}, expected {expected_diffusers_sha}"
+        )
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device, properties = _pick_device(torch, args.mode)
+    with torch.cuda.device(device):
+        if any(hasattr(sdpamod, name) for name in ("sdpa_fwd_d256", "sdpa_bwd_d256")):
+            raise RuntimeError("loaded FE SDPA predates backend-only #682")
+        padding_check = _focused_padding_check(torch, qwen_module, model_api, device)
+        model = model_api.build_model(torch, qwen_module, device, layers=shape["layers"])
+        inputs = model_api.make_inputs(torch, device, shape)
+        calls = {"torch_flash": 0, "cudnn": 0}
+        torch_probe = {}
+        select, restore, calls, torch_probe = model_api.install_joint_attention_dispatch(
+            qwen_module, text_tokens=shape["text_tokens"], counters=calls, torch_probe=torch_probe
+        )
+
+        def step(backend):
+            select(backend)
+            with torch.inference_mode():
+                return model_api.forward(model, inputs)
+
+        try:
+            for bits, backend in VARIANTS:
+                before = dict(calls)
+                for _ in range(protocol["warmup"]):
+                    step(backend)
+                torch.cuda.synchronize(device)
+                delta = calls[backend] - before[backend]
+                expected = protocol["warmup"] * shape["layers"]
+                other = "cudnn" if backend == "torch_flash" else "torch_flash"
+                if delta != expected or calls[other] != before[other]:
+                    raise RuntimeError(f"{backend} warm route mismatch: delta={delta}, expected={expected}, calls={calls}, before={before}")
+
+            expected_output = step("torch_flash")
+            actual_output = step("cudnn")
+            torch.cuda.synchronize(device)
+            if not bool(torch.isfinite(expected_output).all()) or not bool(torch.isfinite(actual_output).all()):
+                raise RuntimeError("non-finite model output")
+            model_rel_l2 = _rel_l2(actual_output, expected_output)
+            if not math.isfinite(model_rel_l2) or model_rel_l2 > 0.02:
+                raise RuntimeError(f"model output mismatch: rel_l2={model_rel_l2}")
+
+            orders = williams_orders(2)
+            raw = {bits: [] for bits, _ in VARIANTS}
+            batches = {bits: [] for bits, _ in VARIANTS}
+            timing_started = time.time()
+            for batch in range(protocol["rounds"]):
+                for variant_index in orders[batch % len(orders)]:
+                    bits, backend = VARIANTS[variant_index]
+                    samples = []
+                    for _ in range(protocol["repeats"]):
+                        select(backend)
+                        start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+                        start.record()
+                        with torch.inference_mode():
+                            output = model_api.forward(model, inputs)
+                        end.record()
+                        end.synchronize()
+                        elapsed = start.elapsed_time(end)
+                        if not math.isfinite(elapsed) or elapsed <= 0:
+                            raise RuntimeError(f"invalid timing {elapsed}")
+                        samples.append(elapsed)
+                    raw[bits].append(samples)
+                    batches[bits].append(statistics.median(samples))
+                print(f"BATCH {batch + 1}/{protocol['rounds']} elapsed_s={time.time() - timing_started:.1f}", flush=True)
+
+            paired = paired_stats(batches["1"], batches["0"])
+            summary = {}
+            for bits, _ in VARIANTS:
+                values = batches[bits]
+                result = {
+                    "p10_ms": percentile(values, 0.1),
+                    "p50_ms": percentile(values, 0.5),
+                    "p90_ms": percentile(values, 0.9),
+                    "mean_ms": statistics.mean(values),
+                    "batches": len(values),
+                }
+                arm_paired = paired_stats(values, batches["0"])
+                result.update(arm_paired)
+                summary[bits] = result
+
+            calls_per_backend = protocol["warmup"] + 1 + protocol["rounds"] * protocol["repeats"]
+            expected_calls = calls_per_backend * shape["layers"]
+            if calls != {"torch_reference": 0, "torch_flash": expected_calls, "cudnn": expected_calls}:
+                raise RuntimeError(f"final attention route mismatch: calls={calls}, expected_each={expected_calls}")
+            if torch_probe.get("forced_choice_name") != "FLASH_ATTENTION":
+                raise RuntimeError(f"forced PyTorch FlashAttention treatment route changed: {torch_probe}")
+        finally:
+            restore()
+
+    sources = {
+        "runner": _source_record(Path(__file__)),
+        "model_adapter": _source_record(MODEL_PATH),
+        "statistics": _source_record(FACTORIAL_PATH),
+        "diffusers_qwen_image": loaded_diffusers_source,
+        "cudnn_sdpa": _source_record(sdpamod.__file__),
+    }
+    config = {
+        "schema_version": 1,
+        "mode": args.mode,
+        "timing_role": "validation_only" if args.mode == "smoke" else "formal_performance",
+        "performance_claim_eligible": args.mode == "formal",
+        "device": properties.name,
+        "device_id": str(device),
+        "sm_arch": f"sm_{properties.major}{properties.minor}",
+        "sm_count": properties.multi_processor_count,
+        "python": platform.python_version(),
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda or "unknown",
+        "cudnn_frontend": cudnn.__version__,
+        "cudnn_backend": cudnn.backend_version(),
+        "diffusers": getattr(diffusers, "__version__", "unknown"),
+        "shape": shape,
+        "protocol": protocol,
+        "workload": "single_conditional_transformer_forward_no_checkpoint",
+        "weights": "random_init_seed_0",
+        "inputs": "random_latents_and_precomputed_text_embeddings_seed_1234",
+        "numerical_claim_eligible": False,
+        "numerical_recipe": dict(model_api.NUMERICAL_RECIPE),
+        "model_anchor": dict(model_api.OFFICIAL_MODEL),
+        "diffusers_anchor": dict(model_api.DIFFUSERS_ANCHOR),
+        "variants": [{"bits": bits, "backend": backend} for bits, backend in VARIANTS],
+        "williams_orders": orders,
+    }
+    comparable = {
+        key: config[key]
+        for key in (
+            "schema_version",
+            "mode",
+            "timing_role",
+            "performance_claim_eligible",
+            "device",
+            "sm_arch",
+            "sm_count",
+            "python",
+            "torch",
+            "torch_cuda",
+            "cudnn_backend",
+            "diffusers",
+            "shape",
+            "protocol",
+            "workload",
+            "weights",
+            "inputs",
+            "numerical_recipe",
+            "model_anchor",
+            "diffusers_anchor",
+            "variants",
+            "williams_orders",
+        )
+    }
+    build = {"schema_version": 1, "git": _git_provenance(), "sources": {name: value["sha256"] for name, value in sorted(sources.items())}}
+    config["comparability_fingerprint"] = {"inputs": comparable, "sha256": config_fingerprint(comparable)}
+    config["build_fingerprint"] = {"inputs": build, "sha256": config_fingerprint(build)}
+    metadata = {
+        "schema_version": 1,
+        "started_utc": started_utc,
+        "completed_utc": _utc_now(),
+        "arguments": {name: str(value) if isinstance(value, Path) else value for name, value in vars(args).items()},
+        "config": config,
+        "correctness": {"model_output_rel_l2": model_rel_l2, "padding_adapter": padding_check},
+        "summary": summary,
+        "comparison_within_run": paired,
+        "batch_medians_ms": batches,
+        "raw_ms": raw,
+        "route": {"calls": calls, "expected_calls_each": expected_calls, "torch_probe": torch_probe},
+        "provenance": {"git": build["git"], "sources": sources},
+    }
+    if args.compare is not None:
+        if args.mode != "formal":
+            raise ValueError("--compare is formal-only")
+        metadata["comparison_across_runs"] = _compare(metadata, _load_comparison(args.compare))
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    suffix = f"-{args.tag}" if args.tag else ""
+    raw_path = args.output_dir / f"qwen-image-bf16-{args.mode}-{stamp}{suffix}.json"
+    report_path = raw_path.with_suffix(".md")
+    if raw_path.exists() or report_path.exists():
+        raise FileExistsError(f"refusing to overwrite existing artifact {raw_path} or {report_path}")
+    metadata["artifacts"] = {"raw_json": str(raw_path), "markdown": str(report_path)}
+    raw_path.write_text(json.dumps(metadata, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8")
+    raw_hash = _sha256(raw_path)
+    report_path.write_text(_render_markdown(metadata, raw_path.name, raw_hash), encoding="utf-8")
+    print("RESULT " + json.dumps({"torch_flash_p50_ms": summary["0"]["p50_ms"], "cudnn_p50_ms": summary["1"]["p50_ms"], **paired}, sort_keys=True))
+    print(f"RAW_JSON {raw_path} sha256={raw_hash}")
+    print(f"MARKDOWN {report_path} sha256={_sha256(report_path)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/e2e/Qwen-Image/run_model.py
+++ b/benchmark/e2e/Qwen-Image/run_model.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen-Image transformer-shape proxy and switchable BF16 joint attention.
+
+The proxy instantiates Diffusers' real ``QwenImageTransformer2DModel`` class
+with the published hidden/head/FFN dimensions.  It reduces only the repeated
+60-block depth and uses random weights/precomputed text embeddings, so this is
+a transformer-backbone performance proxy rather than image-quality or complete
+pipeline inference.
+
+Qwen-Image's joint Q/K/V order is ``[text, image]``.  Its mask only rejects
+padded text *key columns*; all valid text and all image columns are visible to
+every query.  Canonical single-prompt inference trims text padding and uses no
+mask.  For a batch with right-padded text, the cuDNN adapter temporarily
+permutes Q/K/V to ``[image, text]`` so padding becomes a suffix representable by
+``seq_len_kv``.  Full non-causal attention is permutation-equivariant, and the
+output is permuted back before Diffusers splits the two streams.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import statistics
+import sys
+
+OFFICIAL_MODEL = {
+    "id": "Qwen/Qwen-Image",
+    "revision": "75e0b4be04f60ec59a75f475837eced720f823b6",
+    "config": "transformer/config.json",
+    "config_url": ("https://huggingface.co/Qwen/Qwen-Image/blob/" "75e0b4be04f60ec59a75f475837eced720f823b6/transformer/config.json"),
+}
+DIFFUSERS_ANCHOR = {
+    "project": "huggingface/diffusers",
+    "commit": "2f7e0154a9db246e95c9ede43edba7db5b130805",
+    "path": "src/diffusers/models/transformers/transformer_qwenimage.py",
+    "source_sha256": "cea921e2dd8bba5fcd86ae99054d7320b2773cc653c04c218983d54e737e2cc5",
+    "url": (
+        "https://github.com/huggingface/diffusers/blob/"
+        "2f7e0154a9db246e95c9ede43edba7db5b130805/"
+        "src/diffusers/models/transformers/transformer_qwenimage.py"
+    ),
+}
+NUMERICAL_RECIPE = {
+    "id": "qwen-image-conservative-bf16-v1",
+    "parameter_dtype": "bfloat16",
+    "activation_dtype": "bfloat16",
+    "internal_math": "upstream Diffusers defaults, including explicit FP32 RoPE",
+    "scope": "inference_transformer_forward",
+    "anchor": None,
+    "alignment": "local_baseline",
+}
+PUBLISHED_SHAPE = {
+    "full_layers": 60,
+    "hidden": 3072,
+    "heads": 24,
+    "head_dim": 128,
+    "ffn": 12288,
+    "joint_attention_dim": 3584,
+    "in_channels": 64,
+    "out_channels": 16,
+    "patch_size": 2,
+}
+MODE_DEFAULTS = {
+    "smoke": {"layers": 1, "image_tokens": 256, "text_tokens": 64},
+    "formal": {"layers": 4, "image_tokens": 4096, "text_tokens": 512},
+}
+
+
+def resolve_shape(mode, *, layers=None, image_tokens=None, text_tokens=None, bs=1):
+    if mode not in MODE_DEFAULTS:
+        raise ValueError(f"unknown mode {mode!r}; expected one of {tuple(MODE_DEFAULTS)}")
+    shape = dict(MODE_DEFAULTS[mode])
+    for name, value in (("layers", layers), ("image_tokens", image_tokens), ("text_tokens", text_tokens)):
+        if value is not None:
+            shape[name] = value
+    shape["bs"] = bs
+    if any(not isinstance(shape[name], int) or shape[name] <= 0 for name in ("layers", "image_tokens", "text_tokens", "bs")):
+        raise ValueError(f"all resolved dimensions must be positive integers, got {shape}")
+    image_side = math.isqrt(shape["image_tokens"])
+    if image_side * image_side != shape["image_tokens"]:
+        raise ValueError("image_tokens must be a perfect square for Qwen-Image RoPE")
+    shape["image_side"] = image_side
+    shape["joint_tokens"] = shape["image_tokens"] + shape["text_tokens"]
+    shape.update({name: PUBLISHED_SHAPE[name] for name in ("hidden", "heads", "head_dim", "ffn", "joint_attention_dim")})
+    return shape
+
+
+def is_right_padded(mask):
+    """Return whether every row is a True prefix followed by only False values."""
+    if mask.ndim != 2 or mask.dtype is not __import__("torch").bool:
+        return False
+    lengths = mask.sum(dim=-1)
+    expected = __import__("torch").arange(mask.shape[1], device=mask.device).unsqueeze(0) < lengths.unsqueeze(1)
+    return bool(__import__("torch").equal(mask, expected))
+
+
+def load_runtime():
+    import cudnn
+    import cudnn.experimental.ops.sdpa as cudnn_sdpa_module
+    import diffusers
+    import diffusers.models.transformers.transformer_qwenimage as qwen_module
+    import torch
+    import torch.nn.functional as F
+
+    return torch, F, cudnn, cudnn_sdpa_module, diffusers, qwen_module
+
+
+def install_joint_attention_dispatch(qwen_module, *, text_tokens, counters=None, torch_probe=None):
+    """Install Torch/cuDNN dispatchers and return ``(select, restore)``.
+
+    Diffusers keeps projection, QK norm, RoPE, stream split, and output
+    projections around this function.  The treatment therefore changes only
+    the joint SDPA core (plus the exact padding-layout adapter when needed).
+    """
+    import cudnn.experimental.ops.sdpa as cudnn_sdpa_module
+    import torch
+    import torch.nn.functional as F
+
+    if counters is None:
+        counters = {}
+    for name in ("torch_reference", "torch_flash", "cudnn"):
+        counters.setdefault(name, 0)
+    if torch_probe is None:
+        torch_probe = {}
+    original = qwen_module.dispatch_attention_fn
+    cudnn_sdpa = cudnn_sdpa_module.scaled_dot_product_attention
+
+    def _validate(q, k, v, attn_mask, dropout_p, is_causal, parallel_config):
+        if q.ndim != 4 or k.shape != q.shape or v.shape != q.shape:
+            raise ValueError(f"expected equal BLHD Q/K/V, got {q.shape}, {k.shape}, {v.shape}")
+        if q.shape[1] <= text_tokens:
+            raise ValueError(f"joint sequence {q.shape[1]} must exceed text_tokens={text_tokens}")
+        if dropout_p != 0.0 or is_causal:
+            raise NotImplementedError("Qwen-Image proxy requires non-causal attention with dropout_p=0")
+        if parallel_config is not None:
+            raise NotImplementedError("context-parallel attention is outside this single-GPU proxy")
+        if attn_mask is not None and tuple(attn_mask.shape) != (q.shape[0], 1, 1, q.shape[1]):
+            raise ValueError(f"expected broadcast joint key mask [B,1,1,S], got {attn_mask.shape}")
+
+    def _torch_inputs(q, k, v):
+        return tuple(tensor.transpose(1, 2) for tensor in (q, k, v))
+
+    def torch_reference_dispatch(
+        q,
+        k,
+        v,
+        *,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=None,
+        backend=None,
+        parallel_config=None,
+        **kwargs,
+    ):
+        del backend, kwargs
+        _validate(q, k, v, attn_mask, dropout_p, is_causal, parallel_config)
+        counters["torch_reference"] += 1
+        qt, kt, vt = _torch_inputs(q, k, v)
+        out = F.scaled_dot_product_attention(qt, kt, vt, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=is_causal, scale=scale)
+        return out.transpose(1, 2)
+
+    def torch_flash_dispatch(
+        q,
+        k,
+        v,
+        *,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=None,
+        backend=None,
+        parallel_config=None,
+        **kwargs,
+    ):
+        del backend, kwargs
+        _validate(q, k, v, attn_mask, dropout_p, is_causal, parallel_config)
+        if attn_mask is not None:
+            raise NotImplementedError("the timed PyTorch FlashAttention treatment is dense; use torch_reference for mask parity")
+        counters["torch_flash"] += 1
+        qt, kt, vt = _torch_inputs(q, k, v)
+        names = {int(value): name for name, value in torch.nn.attention.SDPBackend.__members__.items()}
+        if not torch_probe:
+            natural_choice = int(torch._fused_sdp_choice(qt, kt, vt, None, dropout_p, is_causal, scale=scale, enable_gqa=False))
+            with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.FLASH_ATTENTION):
+                forced_choice = int(torch._fused_sdp_choice(qt, kt, vt, None, dropout_p, is_causal, scale=scale, enable_gqa=False))
+            torch_probe.update(
+                {
+                    "natural_choice": natural_choice,
+                    "natural_choice_name": names.get(natural_choice, f"unknown:{natural_choice}"),
+                    "forced_choice": forced_choice,
+                    "forced_choice_name": names.get(forced_choice, f"unknown:{forced_choice}"),
+                    "shape": list(qt.shape),
+                }
+            )
+        with torch.nn.attention.sdpa_kernel(torch.nn.attention.SDPBackend.FLASH_ATTENTION):
+            out = F.scaled_dot_product_attention(qt, kt, vt, dropout_p=dropout_p, is_causal=is_causal, scale=scale)
+        return out.transpose(1, 2)
+
+    def cudnn_dispatch(
+        q,
+        k,
+        v,
+        *,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=None,
+        backend=None,
+        parallel_config=None,
+        **kwargs,
+    ):
+        del backend, kwargs
+        _validate(q, k, v, attn_mask, dropout_p, is_causal, parallel_config)
+        counters["cudnn"] += 1
+        image_tokens = q.shape[1] - text_tokens
+        seq_len_q = seq_len_kv = None
+        reordered = False
+        if attn_mask is not None:
+            if attn_mask.dtype is not torch.bool:
+                raise NotImplementedError("the Qwen-Image cuDNN adapter accepts only the canonical boolean key mask")
+            valid = attn_mask[:, 0, 0]
+            text_valid = valid[:, :text_tokens]
+            if not bool(valid[:, text_tokens:].all()) or not is_right_padded(text_valid):
+                raise NotImplementedError("cuDNN Qwen-Image adapter supports only right-padded text and all-valid image tokens")
+            if not bool(text_valid.all()):
+                # [text, pad, image] has an interior hole. Joint full attention
+                # permits a common token permutation, so [image, text, pad]
+                # makes the same mask representable as a valid prefix.
+                q, k, v = (torch.cat([tensor[:, text_tokens:], tensor[:, :text_tokens]], dim=1) for tensor in (q, k, v))
+                batch = q.shape[0]
+                seq_len_q = torch.full((batch, 1, 1, 1), q.shape[1], dtype=torch.int32, device=q.device)
+                seq_len_kv = (image_tokens + text_valid.sum(dim=-1, dtype=torch.int32)).reshape(batch, 1, 1, 1)
+                reordered = True
+        qt, kt, vt = (tensor.transpose(1, 2) for tensor in (q, k, v))
+        out = cudnn_sdpa(
+            qt,
+            kt,
+            vt,
+            dropout_p=dropout_p,
+            is_causal=is_causal,
+            scale=scale,
+            seq_len_q=seq_len_q,
+            seq_len_kv=seq_len_kv,
+        ).transpose(1, 2)
+        if reordered:
+            out = torch.cat([out[:, image_tokens:], out[:, :image_tokens]], dim=1)
+        return out
+
+    dispatchers = {
+        "torch_reference": torch_reference_dispatch,
+        "torch_flash": torch_flash_dispatch,
+        "cudnn": cudnn_dispatch,
+    }
+
+    def select(name):
+        if name not in dispatchers:
+            raise ValueError(f"unknown joint-attention backend {name!r}")
+        qwen_module.dispatch_attention_fn = dispatchers[name]
+
+    def restore():
+        if qwen_module.dispatch_attention_fn in dispatchers.values():
+            qwen_module.dispatch_attention_fn = original
+
+    return select, restore, counters, torch_probe
+
+
+def build_model(torch, qwen_module, device, *, layers):
+    torch.manual_seed(0)
+    with torch.cuda.device(device):
+        model = qwen_module.QwenImageTransformer2DModel(
+            patch_size=PUBLISHED_SHAPE["patch_size"],
+            in_channels=PUBLISHED_SHAPE["in_channels"],
+            out_channels=PUBLISHED_SHAPE["out_channels"],
+            num_layers=layers,
+            attention_head_dim=PUBLISHED_SHAPE["head_dim"],
+            num_attention_heads=PUBLISHED_SHAPE["heads"],
+            joint_attention_dim=PUBLISHED_SHAPE["joint_attention_dim"],
+        )
+        model = model.to(device=device, dtype=torch.bfloat16).eval().requires_grad_(False)
+    return model
+
+
+def make_inputs(torch, device, shape, *, valid_text_lengths=None):
+    generator = torch.Generator(device=device).manual_seed(1234)
+    image = torch.randn(shape["bs"], shape["image_tokens"], PUBLISHED_SHAPE["in_channels"], device=device, dtype=torch.bfloat16, generator=generator)
+    text = torch.randn(shape["bs"], shape["text_tokens"], PUBLISHED_SHAPE["joint_attention_dim"], device=device, dtype=torch.bfloat16, generator=generator)
+    timestep = torch.full((shape["bs"],), 0.5, device=device, dtype=torch.bfloat16)
+    img_shapes = [[(1, shape["image_side"], shape["image_side"])] for _ in range(shape["bs"])]
+    mask = None
+    if valid_text_lengths is not None:
+        lengths = torch.as_tensor(valid_text_lengths, dtype=torch.int64, device=device)
+        if tuple(lengths.shape) != (shape["bs"],) or bool((lengths < 0).any()) or bool((lengths > shape["text_tokens"]).any()):
+            raise ValueError(f"invalid valid_text_lengths={valid_text_lengths}")
+        mask = torch.arange(shape["text_tokens"], device=device).unsqueeze(0) < lengths.unsqueeze(1)
+        if bool(mask.all()):
+            mask = None
+    return {
+        "hidden_states": image,
+        "encoder_hidden_states": text,
+        "encoder_hidden_states_mask": mask,
+        "timestep": timestep,
+        "img_shapes": img_shapes,
+        "return_dict": False,
+    }
+
+
+def forward(model, inputs):
+    return model(**inputs)[0]
+
+
+def _main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=MODE_DEFAULTS, default="smoke")
+    parser.add_argument("--backend", choices=("torch_reference", "torch_flash", "cudnn"), default="cudnn")
+    parser.add_argument("--layers", type=int)
+    parser.add_argument("--image-tokens", type=int)
+    parser.add_argument("--text-tokens", type=int)
+    parser.add_argument("--inspect", action="store_true")
+    args = parser.parse_args()
+    shape = resolve_shape(args.mode, layers=args.layers, image_tokens=args.image_tokens, text_tokens=args.text_tokens)
+    if args.inspect:
+        print(json.dumps({"shape": shape, "model": OFFICIAL_MODEL, "diffusers": DIFFUSERS_ANCHOR, "recipe": NUMERICAL_RECIPE}, indent=2))
+        return
+    torch, _, cudnn, _, _, qwen_module = load_runtime()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda")
+    properties = torch.cuda.get_device_properties(device)
+    if properties.major != 10:
+        raise RuntimeError(f"Qwen-Image proxy requires SM100, got {properties.name}")
+    if cudnn.backend_version() < 92100:
+        raise RuntimeError(f"joint d128 SDPA requires a current cuDNN backend, got {cudnn.backend_version()}")
+    model = build_model(torch, qwen_module, device, layers=shape["layers"])
+    inputs = make_inputs(torch, device, shape)
+    select, restore, counters, probe = install_joint_attention_dispatch(qwen_module, text_tokens=shape["text_tokens"])
+    try:
+        select(args.backend)
+        samples = []
+        with torch.inference_mode():
+            for _ in range(2):
+                forward(model, inputs)
+            torch.cuda.synchronize(device)
+            for _ in range(10):
+                start, end = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+                start.record()
+                output = forward(model, inputs)
+                end.record()
+                end.synchronize()
+                samples.append(start.elapsed_time(end))
+        if not bool(torch.isfinite(output).all()):
+            raise RuntimeError("non-finite output")
+        print(
+            json.dumps(
+                {
+                    "backend": args.backend,
+                    "p50_ms": statistics.median(samples),
+                    "shape": shape,
+                    "calls": counters,
+                    "torch_probe": probe,
+                },
+                sort_keys=True,
+            )
+        )
+    finally:
+        restore()
+
+
+if __name__ == "__main__":
+    _main()

--- a/benchmark/e2e/Qwen3.8/run_matrix.py
+++ b/benchmark/e2e/Qwen3.8/run_matrix.py
@@ -1,0 +1,951 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Balanced 2^3 Qwen3.8 proxy benchmark for GDN, SwiGLU, and SDPA.
+
+The three bits in every treatment are GDN / MLP / full-attention SDPA:
+
+* 0: stock FLA GDN, stock FLA MLP, or vanilla Torch SDPA
+* 1: cuDNN FLA shim, cuDNN SwiGLU MLP, or FE's cuDNN-backend SDPA
+
+All eight arms run in a Williams design.  Compilation, warmup, route checks,
+and aggregate BF16 correctness checks are outside CUDA-event timing.  Every
+successful run writes raw JSON plus a generated Markdown summary with source
+provenance and a deterministic configuration fingerprint.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import importlib
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import statistics
+import subprocess
+import sys
+import time
+
+torch = None  # Imported after argparse so ``--help`` works without GPU dependencies.
+
+THIS_DIR = Path(__file__).resolve().parent
+E2E_DIR = THIS_DIR.parent
+REPO_ROOT = THIS_DIR.parents[2]
+RUN_MODEL = THIS_DIR / "run_model.py"
+FACTORIAL_MODULE = E2E_DIR / "_factorial.py"
+sys.path.insert(0, str(E2E_DIR))
+
+from _factorial import (  # noqa: E402
+    compare_results,
+    config_fingerprint,
+    factorial_main_effects,
+    paired_stats,
+    percentile,
+    render_markdown,
+    shapley_savings,
+    williams_orders,
+)
+
+
+@dataclass(frozen=True)
+class Variant:
+    bits: str
+    label: str
+    gdn: bool
+    mlp: bool
+    attn: bool
+
+    @property
+    def name(self):
+        return f"{self.bits}_{self.label}"
+
+
+# Integer index equals binary G/M/A bits: G=4, M=2, A=1.
+VARIANTS = (
+    Variant("000", "baseline", False, False, False),
+    Variant("001", "attn", False, False, True),
+    Variant("010", "mlp", False, True, False),
+    Variant("011", "mlp_attn", False, True, True),
+    Variant("100", "gdn", True, False, False),
+    Variant("101", "gdn_attn", True, False, True),
+    Variant("110", "gdn_mlp", True, True, False),
+    Variant("111", "all", True, True, True),
+)
+BY_BITS = {variant.bits: variant for variant in VARIANTS}
+
+PAIR_BITS = (
+    ("gdn_on_baseline", "100", "000"),
+    ("gdn_on_attn", "101", "001"),
+    ("gdn_on_mlp", "110", "010"),
+    ("gdn_on_mlp_attn", "111", "011"),
+    ("mlp_on_baseline", "010", "000"),
+    ("mlp_on_attn", "011", "001"),
+    ("mlp_on_gdn", "110", "100"),
+    ("mlp_on_gdn_attn", "111", "101"),
+    ("attn_on_baseline", "001", "000"),
+    ("attn_on_mlp", "011", "010"),
+    ("attn_on_gdn", "101", "100"),
+    ("attn_on_gdn_mlp", "111", "110"),
+    ("all_vs_baseline", "111", "000"),
+)
+
+MODE_DEFAULTS = {
+    # Same kernel dimensions and four-layer 3:1 hybrid period as formal mode;
+    # only token work and the fixed embedding/LM-head allocation are reduced.
+    "smoke": {"seq": 128, "bs": 1, "vocab": 1024, "warmup": 1, "rounds": 8, "repeats": 1},
+    "formal": {"seq": 2048, "bs": 4, "vocab": None, "warmup": 3, "rounds": 40, "repeats": 3},
+}
+DEFAULT_PRESET = "qwen3.8-27b"
+
+ROUTE_CONTRACT = {
+    "torch_full_attention": {
+        "can_use_flash": True,
+        "can_use_cudnn": False,
+        "flash_sdp_enabled": True,
+        "required_grad_fn": "ScaledDotProductFlashAttentionBackward0",
+    },
+    "cudnn_full_attention": {
+        "adapter": "FE direct cuDNN-backend d256 SDPA",
+        "oss_cutedsl_d256_forbidden": True,
+    },
+    "gdn": {
+        "baseline": "stock FLA",
+        "accelerated": "cudnn.fla native gated_delta_net",
+        "successful_native_calls_per_step": "one per GDN layer when enabled, zero when disabled",
+    },
+    "mlp": {
+        "baseline": "stock FLA GatedMLP",
+        "accelerated": "cudnn.gemm.ops.swiglu_mlp",
+        "backward": "FROST dgrad+dSwiGLU",
+        "pointwise_fallback_calls": 0,
+    },
+}
+
+MEASUREMENT_CONTRACT = {
+    "timed_region": "model forward + fused cross entropy + backward",
+    "outside_timed_region": ["backend selection", "zero_grad", "JIT/autotune", "warmup", "correctness"],
+    "per_arm_batch_value": "median of CUDA-event repeats",
+    "schedule": "eight-treatment Williams design",
+}
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as source:
+        for chunk in iter(lambda: source.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _display_path(path):
+    path = Path(path).resolve()
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _source_record(path):
+    path = Path(path).resolve()
+    return {"path": _display_path(path), "sha256": _sha256(path)}
+
+
+def _strict_json_load(path):
+    def reject_constant(value):
+        raise ValueError(f"non-finite JSON constant {value!r} is not allowed")
+
+    path = Path(path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"), parse_constant=reject_constant)
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        raise ValueError(f"cannot load comparison artifact {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError(f"comparison artifact {path} must contain a JSON object")
+    return payload
+
+
+def _git_provenance():
+    def run(*arguments):
+        completed = subprocess.run(
+            arguments,
+            cwd=REPO_ROOT,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    try:
+        commit = run("git", "rev-parse", "HEAD")
+        dirty = bool(run("git", "status", "--porcelain"))
+    except (OSError, subprocess.CalledProcessError):
+        commit, dirty = "unknown", "unknown"
+    return {"commit": commit, "dirty": dirty}
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_run_model():
+    spec = importlib.util.spec_from_file_location("qwen38_run_model_matrix", RUN_MODEL)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load sibling runner {RUN_MODEL}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _grad_fn_names(tensor, limit=64):
+    pending = [tensor.grad_fn]
+    seen = set()
+    names = []
+    while pending and len(seen) < limit:
+        node = pending.pop(0)
+        if node is None or id(node) in seen:
+            continue
+        seen.add(id(node))
+        names.append(type(node).__name__)
+        pending.extend(next_node for next_node, _ in node.next_functions)
+    return names
+
+
+def _validate_torch_baseline_route(probe):
+    contract = ROUTE_CONTRACT["torch_full_attention"]
+    failures = []
+    for name in ("can_use_flash", "can_use_cudnn", "flash_sdp_enabled"):
+        if probe.get(name) is not contract[name]:
+            failures.append(f"{name}={probe.get(name)!r}, expected {contract[name]!r}")
+    required_grad_fn = contract["required_grad_fn"]
+    if required_grad_fn not in probe.get("grad_fn_chain", ()):
+        failures.append(f"grad_fn_chain lacks {required_grad_fn}")
+    if failures:
+        raise RuntimeError("Torch baseline route contract failed: " + "; ".join(failures))
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--mode",
+        choices=MODE_DEFAULTS,
+        default="smoke",
+        help="smoke keeps Qwen kernel dimensions but reduces tokens; formal requires a full 148-SM B200",
+    )
+    parser.add_argument("--preset", default=DEFAULT_PRESET)
+    parser.add_argument("--layers", type=int)
+    parser.add_argument("--hidden", type=int)
+    parser.add_argument("--intermediate", type=int)
+    parser.add_argument("--linear-heads", type=int)
+    parser.add_argument("--linear-v-heads", type=int)
+    parser.add_argument("--linear-head-dim", type=int)
+    parser.add_argument("--attn-heads", type=int)
+    parser.add_argument("--attn-kv-heads", type=int)
+    parser.add_argument("--attn-every", type=int)
+    parser.add_argument("--vocab", type=int)
+    parser.add_argument("--short-conv", type=int, choices=(0, 1))
+    parser.add_argument("--seq", type=int)
+    parser.add_argument("--bs", type=int)
+    parser.add_argument("--warmup", type=int)
+    parser.add_argument("--rounds", type=int)
+    parser.add_argument("--repeats", type=int)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("qwen3.8-factorial-results"),
+        help="directory for timestamped artifacts when explicit paths are omitted",
+    )
+    parser.add_argument("--artifact-name", help="filename stem for default artifact paths")
+    parser.add_argument("--raw-json", type=Path, help="exact raw JSON path")
+    parser.add_argument("--markdown", type=Path, help="exact generated Markdown path")
+    parser.add_argument(
+        "--compare",
+        type=Path,
+        help="previous formal JSON artifact; requires an identical comparability fingerprint",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="replace explicitly colliding artifact paths")
+    args = parser.parse_args()
+
+    defaults = MODE_DEFAULTS[args.mode]
+    for name in ("seq", "bs", "warmup", "rounds", "repeats"):
+        if getattr(args, name) is None:
+            setattr(args, name, defaults[name])
+    if args.vocab is None and defaults["vocab"] is not None:
+        args.vocab = defaults["vocab"]
+
+    if args.rounds <= 0 or args.rounds % len(VARIANTS):
+        raise ValueError(f"--rounds must be a positive multiple of {len(VARIANTS)}")
+    if args.repeats <= 0 or args.warmup < 1:
+        raise ValueError("--repeats must be positive and --warmup must be at least one")
+    if args.seq <= 0 or args.bs <= 0:
+        raise ValueError("--seq and --bs must be positive")
+    if args.artifact_name and Path(args.artifact_name).name != args.artifact_name:
+        raise ValueError("--artifact-name must be a filename stem, not a path")
+    if args.compare is not None and args.mode != "formal":
+        raise ValueError("--compare is formal-only; smoke timings are validation diagnostics, not performance trends")
+    return args
+
+
+def _resolve_shape(args, qwen):
+    if args.preset not in qwen.MODEL_PRESETS:
+        raise ValueError(f"unknown preset {args.preset!r}; choices={tuple(qwen.MODEL_PRESETS)}")
+    shape = qwen.MODEL_PRESETS[args.preset].copy()
+    for argument_name, shape_name in (
+        ("layers", "layers"),
+        ("hidden", "hidden"),
+        ("intermediate", "intermediate"),
+        ("linear_heads", "linear_heads"),
+        ("linear_v_heads", "linear_v_heads"),
+        ("linear_head_dim", "linear_head_dim"),
+        ("attn_heads", "attn_heads"),
+        ("attn_kv_heads", "attn_kv_heads"),
+        ("attn_every", "attn_every"),
+        ("vocab", "vocab"),
+        ("short_conv", "short_conv"),
+    ):
+        value = getattr(args, argument_name)
+        if value is not None:
+            shape[shape_name] = bool(value) if shape_name == "short_conv" else value
+    return shape
+
+
+def _mode_overrides(args, qwen, shape):
+    expected_shape = qwen.MODEL_PRESETS[args.preset].copy()
+    default_vocab = MODE_DEFAULTS[args.mode]["vocab"]
+    if default_vocab is not None:
+        expected_shape["vocab"] = default_vocab
+
+    overrides = {}
+    if args.preset != DEFAULT_PRESET:
+        overrides["preset"] = {"mode_default": DEFAULT_PRESET, "actual": args.preset}
+    shape_changes = {name: {"mode_default": expected_shape[name], "actual": value} for name, value in shape.items() if value != expected_shape[name]}
+    if shape_changes:
+        overrides["shape"] = shape_changes
+    measurement_changes = {
+        name: {"mode_default": MODE_DEFAULTS[args.mode][name], "actual": getattr(args, name)}
+        for name in ("seq", "bs", "warmup", "rounds", "repeats")
+        if getattr(args, name) != MODE_DEFAULTS[args.mode][name]
+    }
+    if measurement_changes:
+        overrides["measurement"] = measurement_changes
+    return overrides
+
+
+def _prepare_artifacts(args, fingerprint):
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    stem = args.artifact_name or f"qwen38_{args.mode}_{stamp}_{fingerprint[:12]}"
+    raw_path = args.raw_json or args.output_dir / f"{stem}.json"
+    markdown_path = args.markdown or args.output_dir / f"{stem}.md"
+    raw_path = Path(raw_path)
+    markdown_path = Path(markdown_path)
+    if raw_path.resolve() == markdown_path.resolve():
+        raise ValueError("raw JSON and Markdown paths must be different")
+    if not args.overwrite:
+        collisions = [str(path) for path in (raw_path, markdown_path) if path.exists()]
+        if collisions:
+            raise FileExistsError(f"artifact path already exists; pass --overwrite to replace: {collisions}")
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    return raw_path, markdown_path
+
+
+def _serializable_args(args):
+    return {name: str(value) if isinstance(value, Path) else value for name, value in vars(args).items()}
+
+
+def _pick_device(mode):
+    visible = []
+    smoke_candidate = None
+    for index in range(torch.cuda.device_count()):
+        properties = torch.cuda.get_device_properties(index)
+        visible.append(f"cuda:{index}={properties.name}/{properties.multi_processor_count}SM")
+        if properties.name == "NVIDIA B200" and properties.multi_processor_count == 148:
+            if mode == "formal":
+                return torch.device(f"cuda:{index}")
+            smoke_candidate = smoke_candidate or torch.device(f"cuda:{index}")
+        elif 100 <= properties.major * 10 + properties.minor < 120 and smoke_candidate is None:
+            smoke_candidate = torch.device(f"cuda:{index}")
+    if mode == "smoke" and smoke_candidate is not None:
+        return smoke_candidate
+    requirement = "a full 148-SM NVIDIA B200" if mode == "formal" else "an SM100-family Blackwell GPU"
+    raise RuntimeError(f"{mode} mode requires {requirement}; visible devices: " + ", ".join(visible))
+
+
+def _run_experiment(args, qwen, device, properties, orders, started_utc):
+    import cudnn
+    from cudnn import _env as cudnn_env
+    import cudnn.experimental.ops.sdpa as sdpamod
+    import cudnn.fla as cfla
+    import fla
+    import fla.layers.attn as fla_attn
+    import fla.modules.mlp as fla_mlp
+
+    if not hasattr(qwen, "_set_full_attention_backend"):
+        raise RuntimeError(f"{RUN_MODEL} lacks _set_full_attention_backend")
+    for sentinel_name in ("sdpa_fwd_d256", "sdpa_bwd_d256"):
+        sentinel = getattr(sdpamod, sentinel_name, None)
+        if sentinel is None or getattr(sentinel, "__name__", "") != "_forbid_oss_d256":
+            raise RuntimeError(f"run_model did not install the expected OSS d256 sentinel for {sentinel_name}")
+    supports_backend_d256 = getattr(sdpamod, "_cudnn_backend_supports_d256", None)
+    backend_floor = getattr(sdpamod, "_CUDNN_BACKEND_D256_VERSION", None)
+    if supports_backend_d256 is None or backend_floor is None:
+        raise RuntimeError("FE SDPA op lacks the cuDNN-backend d256 route check")
+    if cudnn.backend_version() < backend_floor or not supports_backend_d256():
+        raise RuntimeError("d256 FE arm must route through the cuDNN backend; got backend " f"version {cudnn.backend_version()}, required {backend_floor}")
+
+    from cudnn.gemm.ops import swiglu_mlp as public_swiglu_mlp
+
+    opmod = sys.modules[public_swiglu_mlp.__module__]
+    gdnmod = importlib.import_module("cudnn.fla.gated_delta_rule")
+    real_native_gdn = gdnmod.gated_delta_net
+    native_gdn_module = sys.modules[real_native_gdn.__module__]
+    frost_compiler_module = importlib.import_module("cudnn.gemm.frost.compiler")
+    frost_tile_config_module = importlib.import_module("cudnn.gemm.frost.tile_config")
+    frost_kernel_registry_module = importlib.import_module("cudnn.gemm.frost.kernel_registry")
+    shape = _resolve_shape(args, qwen)
+    mode_overrides = _mode_overrides(args, qwen, shape)
+
+    torch.manual_seed(0)
+    model, attn_layers = qwen.build_model(device, **shape)
+    if not attn_layers:
+        raise RuntimeError("the three-axis benchmark requires at least one full-attention layer")
+    linear_layers = [index for index in range(shape["layers"]) if index not in attn_layers]
+    if not linear_layers:
+        raise RuntimeError("the three-axis benchmark requires at least one GDN layer")
+    ids = torch.randint(0, shape["vocab"], (args.bs, args.seq), device=device)
+
+    original_mlp_forward = fla_mlp.GatedMLP.forward
+
+    def cudnn_mlp_forward(self, x, **kwargs):
+        return opmod.swiglu_mlp(
+            x,
+            self.gate_proj.weight,
+            self.up_proj.weight,
+            self.down_proj.weight,
+        )
+
+    qwen._set_full_attention_backend("torch")
+    torch_attn_adapter = fla_attn.flash_attn_func
+    qwen._set_full_attention_backend("cudnn")
+    cudnn_attn_adapter = fla_attn.flash_attn_func
+    if torch_attn_adapter is cudnn_attn_adapter:
+        raise RuntimeError("Torch and FE attention selectors resolved to the same adapter")
+
+    attn_calls = {"torch": 0, "cudnn": 0}
+    torch_sdpa_probe = {}
+
+    def counted_torch_attn(
+        q,
+        k,
+        v,
+        dropout_p=0.0,
+        softmax_scale=None,
+        causal=False,
+        window_size=(-1, -1),
+        **kwargs,
+    ):
+        attn_calls["torch"] += 1
+        if dropout_p != 0.0:
+            raise RuntimeError("the balanced backend A/B requires full-attention dropout_p=0")
+        if not torch_sdpa_probe:
+            qt, kt, vt = (tensor.transpose(1, 2) for tensor in (q, k, v))
+            enable_gqa = qt.shape[1] != kt.shape[1]
+            params = torch.backends.cuda.SDPAParams(
+                qt,
+                kt,
+                vt,
+                None,
+                float(dropout_p),
+                bool(causal),
+                enable_gqa,
+            )
+            torch_sdpa_probe.update(
+                {
+                    "can_use_cudnn": torch.backends.cuda.can_use_cudnn_attention(params),
+                    "can_use_flash": torch.backends.cuda.can_use_flash_attention(params),
+                    "can_use_efficient": torch.backends.cuda.can_use_efficient_attention(params),
+                    "cudnn_sdp_enabled": torch.backends.cuda.cudnn_sdp_enabled(),
+                    "flash_sdp_enabled": torch.backends.cuda.flash_sdp_enabled(),
+                    "mem_efficient_sdp_enabled": torch.backends.cuda.mem_efficient_sdp_enabled(),
+                    "math_sdp_enabled": torch.backends.cuda.math_sdp_enabled(),
+                    "shape_q": tuple(qt.shape),
+                    "shape_k": tuple(kt.shape),
+                    "shape_v": tuple(vt.shape),
+                    "enable_gqa": enable_gqa,
+                }
+            )
+            if torch_sdpa_probe["can_use_cudnn"]:
+                raise RuntimeError("vanilla Torch now admits cuDNN attention for this d256 GQA shape; " "the intended dispatcher-gap axis has collapsed")
+        output = torch_attn_adapter(
+            q,
+            k,
+            v,
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            **kwargs,
+        )
+        if "grad_fn_chain" not in torch_sdpa_probe:
+            torch_sdpa_probe["grad_fn_chain"] = _grad_fn_names(output)
+        return output
+
+    def counted_cudnn_attn(
+        q,
+        k,
+        v,
+        dropout_p=0.0,
+        softmax_scale=None,
+        causal=False,
+        window_size=(-1, -1),
+        **kwargs,
+    ):
+        attn_calls["cudnn"] += 1
+        if dropout_p != 0.0:
+            raise RuntimeError("the balanced backend A/B requires full-attention dropout_p=0")
+        return cudnn_attn_adapter(
+            q,
+            k,
+            v,
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size=window_size,
+            **kwargs,
+        )
+
+    counted_attn_adapters = {"torch": counted_torch_attn, "cudnn": counted_cudnn_attn}
+
+    frost_calls = 0
+    pointwise_calls = 0
+    native_gdn_calls = 0
+    real_frost = opmod._frost_dswiglu
+    real_pointwise = opmod._dswiglu
+
+    def counted_frost(*arguments, **kwargs):
+        nonlocal frost_calls
+        frost_calls += 1
+        return real_frost(*arguments, **kwargs)
+
+    def counted_pointwise(*arguments, **kwargs):
+        nonlocal pointwise_calls
+        pointwise_calls += 1
+        return real_pointwise(*arguments, **kwargs)
+
+    def counted_native_gdn(*arguments, **kwargs):
+        nonlocal native_gdn_calls
+        result = real_native_gdn(*arguments, **kwargs)
+        # Count only a successful native call. A pre-native decline or an
+        # exception followed by FLA fallback must leave a deficit.
+        native_gdn_calls += 1
+        return result
+
+    opmod._frost_dswiglu = counted_frost
+    opmod._dswiglu = counted_pointwise
+    gdnmod.gated_delta_net = counted_native_gdn
+
+    def select(variant):
+        cfla.restore_fla()
+        if variant.gdn:
+            cfla.accelerate_fla(verbose=False)
+        fla_mlp.GatedMLP.forward = cudnn_mlp_forward if variant.mlp else original_mlp_forward
+        attention_backend = "cudnn" if variant.attn else "torch"
+        qwen._set_full_attention_backend(attention_backend)
+        # Keep run_model's selector authoritative, then add symmetric telemetry.
+        fla_attn.flash_attn_func = counted_attn_adapters[attention_backend]
+
+    def step(variant):
+        select(variant)
+        model.zero_grad(set_to_none=True)
+        output = model(input_ids=ids, labels=ids)
+        output.loss.backward()
+        return output
+
+    frost_template_dir = Path(frost_compiler_module.__file__).resolve().parent / "kernel_templates"
+    sources = {
+        "factorial_runner": _source_record(Path(__file__)),
+        "factorial_statistics": _source_record(FACTORIAL_MODULE),
+        "qwen_run_model": _source_record(RUN_MODEL),
+        "swiglu_mlp": _source_record(opmod.__file__),
+        "frost_dswiglu": _source_record(opmod.__file__),
+        "frost_compiler": _source_record(frost_compiler_module.__file__),
+        "frost_tile_config": _source_record(frost_tile_config_module.__file__),
+        "frost_kernel_registry": _source_record(frost_kernel_registry_module.__file__),
+        "frost_kernel_template_1ctamma": _source_record(frost_template_dir / "sm100_matmul_1ctamma.py"),
+        "frost_kernel_template_2ctamma": _source_record(frost_template_dir / "sm100_matmul_2ctamma.py"),
+        "frost_mainloop_template_1ctamma": _source_record(frost_template_dir / "sm100_matmul_mainloop_1ctamma.py"),
+        "frost_mainloop_template_2ctamma": _source_record(frost_template_dir / "sm100_matmul_mainloop_2ctamma.py"),
+        "cudnn_fla": _source_record(cfla.__file__),
+        "cudnn_fla_gdn_adapter": _source_record(gdnmod.__file__),
+        "native_gdn": _source_record(native_gdn_module.__file__),
+        "sdpa": _source_record(sdpamod.__file__),
+        "cudnn_init": _source_record(cudnn.__file__),
+        "fla_init": _source_record(fla.__file__),
+        "fla_mlp": _source_record(fla_mlp.__file__),
+        "fla_attn": _source_record(fla_attn.__file__),
+    }
+    provenance = {
+        "git": _git_provenance(),
+        "sources": sources,
+        "oss_d256_sentinels": {name: getattr(getattr(sdpamod, name), "__name__", "") for name in ("sdpa_fwd_d256", "sdpa_bwd_d256")},
+    }
+    device_index = device.index if device.index is not None else torch.cuda.current_device()
+    config = {
+        "schema_version": 2,
+        "mode": args.mode,
+        "timing_role": "validation_only" if args.mode == "smoke" else "formal_performance",
+        "performance_claim_eligible": args.mode == "formal",
+        "device": properties.name,
+        "device_id": f"cuda:{device_index}",
+        "sm_arch": f"sm_{properties.major}{properties.minor}",
+        "sm_count": properties.multi_processor_count,
+        "python": platform.python_version(),
+        "torch": torch.__version__,
+        "torch_cuda": torch.version.cuda or "unknown",
+        "cuda_driver": cudnn_env.driver_version(),
+        "cuda_runtime": cudnn_env.runtime_version(),
+        "cudnn_frontend": cudnn.__version__,
+        "cudnn_backend": cudnn.backend_version(),
+        "fla": getattr(fla, "__version__", "unknown"),
+        "preset": args.preset,
+        "seq": args.seq,
+        "bs": args.bs,
+        "resolved_shape": shape,
+        "attn_layers": attn_layers,
+        "params": sum(parameter.numel() for parameter in model.parameters()),
+        "warmup": args.warmup,
+        "rounds": args.rounds,
+        "repeats": args.repeats,
+        "mode_overrides": mode_overrides,
+        "variants": [asdict(variant) | {"name": variant.name} for variant in VARIANTS],
+        "williams_orders": orders,
+        "route_contract": ROUTE_CONTRACT,
+        "measurement_contract": MEASUREMENT_CONTRACT,
+        "provenance": provenance,
+    }
+    comparability_inputs = {
+        key: config[key]
+        for key in (
+            "schema_version",
+            "mode",
+            "timing_role",
+            "performance_claim_eligible",
+            "device",
+            "sm_arch",
+            "sm_count",
+            "python",
+            "torch",
+            "torch_cuda",
+            "cuda_driver",
+            "cuda_runtime",
+            "cudnn_backend",
+            "fla",
+            "preset",
+            "seq",
+            "bs",
+            "resolved_shape",
+            "attn_layers",
+            "params",
+            "warmup",
+            "rounds",
+            "repeats",
+            "mode_overrides",
+            "variants",
+            "williams_orders",
+            "route_contract",
+            "measurement_contract",
+        )
+    }
+    build_inputs = {
+        "schema_version": 1,
+        "git": provenance["git"],
+        "cudnn_frontend": config["cudnn_frontend"],
+        "source_sha256": {name: source["sha256"] for name, source in sorted(sources.items())},
+    }
+    config["comparability_fingerprint"] = {
+        "inputs": comparability_inputs,
+        "sha256": config_fingerprint(comparability_inputs),
+    }
+    config["build_fingerprint"] = {
+        "inputs": build_inputs,
+        "sha256": config_fingerprint(build_inputs),
+    }
+    previous_metadata = _strict_json_load(args.compare) if args.compare is not None else None
+    if previous_metadata is not None:
+        try:
+            previous_fingerprint = previous_metadata["config"]["comparability_fingerprint"]["sha256"]
+        except (KeyError, TypeError) as error:
+            raise ValueError(f"comparison artifact {args.compare} lacks a comparability fingerprint") from error
+        current_fingerprint = config["comparability_fingerprint"]["sha256"]
+        if previous_fingerprint != current_fingerprint:
+            raise ValueError("comparison artifact is not comparable: " f"current={current_fingerprint}, previous={previous_fingerprint}")
+    raw_path, markdown_path = _prepare_artifacts(args, config["build_fingerprint"]["sha256"])
+    print("CONFIG " + json.dumps(config, sort_keys=True, allow_nan=False))
+
+    # Warm every combination outside timing. Per-arm deltas prove that selecting
+    # one axis does not accidentally mutate another.
+    for variant in VARIANTS:
+        before_attn = dict(attn_calls)
+        before_frost = frost_calls
+        before_pointwise = pointwise_calls
+        before_native_gdn = native_gdn_calls
+        for _ in range(args.warmup):
+            step(variant)
+        torch.cuda.synchronize(device)
+        attention_backend = "cudnn" if variant.attn else "torch"
+        expected_attn = args.warmup * len(attn_layers)
+        for backend in ("torch", "cudnn"):
+            observed = attn_calls[backend] - before_attn[backend]
+            expected = expected_attn if backend == attention_backend else 0
+            if observed != expected:
+                raise RuntimeError(f"{variant.name}: {backend} attention calls {observed}, expected {expected}")
+        expected_frost = args.warmup * shape["layers"] if variant.mlp else 0
+        if frost_calls - before_frost != expected_frost:
+            raise RuntimeError(f"{variant.name}: FROST calls {frost_calls - before_frost}, expected {expected_frost}")
+        if pointwise_calls != before_pointwise:
+            raise RuntimeError(f"{variant.name}: unexpected pointwise dSwiGLU fallback")
+        expected_native_gdn = args.warmup * len(linear_layers) if variant.gdn else 0
+        observed_native_gdn = native_gdn_calls - before_native_gdn
+        if observed_native_gdn != expected_native_gdn:
+            raise RuntimeError(f"{variant.name}: successful native GDN calls {observed_native_gdn}, expected {expected_native_gdn}")
+        gdn_path = gdnmod.last_path() if variant.gdn else "off"
+        if variant.gdn and gdn_path != "native":
+            raise RuntimeError(f"{variant.name}: expected native GDN, got {gdn_path}")
+        print(
+            f"WARM {variant.name} gdn_path={gdn_path} native_gdn_delta={observed_native_gdn} "
+            f"full_attn={attention_backend} frost_delta={frost_calls - before_frost}"
+        )
+
+    if not torch_sdpa_probe:
+        raise RuntimeError("Torch SDPA route probe did not run")
+    _validate_torch_baseline_route(torch_sdpa_probe)
+    print("TORCH_SDPA_PROBE " + json.dumps(torch_sdpa_probe, sort_keys=True))
+
+    named_parameters = dict(model.named_parameters())
+    linear_layer = linear_layers[0]
+    full_attn_layer = attn_layers[0]
+    grad_names = (
+        f"model.layers.{linear_layer}.mlp.gate_proj.weight",
+        f"model.layers.{linear_layer}.mlp.down_proj.weight",
+        f"model.layers.{linear_layer}.attn.q_proj.weight",
+        f"model.layers.{linear_layer}.attn.v_proj.weight",
+        f"model.layers.{full_attn_layer}.attn.q_proj.weight",
+        f"model.layers.{full_attn_layer}.attn.v_proj.weight",
+        f"model.layers.{full_attn_layer}.attn.o_proj.weight",
+    )
+    downstream_full_attn_grad_names = frozenset(grad_names[-3:])
+    missing_grad_names = [name for name in grad_names if name not in named_parameters]
+    if missing_grad_names:
+        raise RuntimeError(f"model parameter names changed; missing correctness samples {missing_grad_names}")
+
+    correctness = {}
+    reference = None
+    for variant in VARIANTS:
+        torch.manual_seed(1234)
+        output = step(variant)
+        loss_value = float(output.loss.detach())
+        grad_values = {name: named_parameters[name].grad.detach().reshape(-1)[: 1 << 20].float().cpu() for name in grad_names}
+        current = {
+            "loss": loss_value,
+            "grads": grad_values,
+        }
+        torch.cuda.synchronize(device)
+        if not math.isfinite(loss_value):
+            raise RuntimeError(f"{variant.name}: non-finite correctness loss {loss_value}")
+        nonfinite_grads = [name for name, value in grad_values.items() if not bool(torch.isfinite(value).all())]
+        if nonfinite_grads:
+            raise RuntimeError(f"{variant.name}: non-finite correctness gradients {nonfinite_grads}")
+        if reference is None:
+            reference = current
+        rel_loss = abs(current["loss"] - reference["loss"]) / max(abs(reference["loss"]), 1e-12)
+        if not math.isfinite(rel_loss):
+            raise RuntimeError(f"{variant.name}: non-finite relative loss {rel_loss}")
+        rel_grads = {}
+        for name in grad_names:
+            actual, expected = current["grads"][name], reference["grads"][name]
+            rel_grads[name] = float((actual - expected).norm() / expected.norm().clamp_min(1e-12))
+            if not math.isfinite(rel_grads[name]):
+                raise RuntimeError(f"{variant.name}: non-finite relative gradient for {name}: {rel_grads[name]}")
+        # This multi-layer BF16 comparison is a composition diagnostic. Focused
+        # op/full-block tests remain the primary numerical gates.
+        grad_tolerances = {name: (0.07 if variant.gdn and name in downstream_full_attn_grad_names else 0.05 if variant.gdn else 0.03) for name in grad_names}
+        if rel_loss > 0.02 or any(value > grad_tolerances[name] for name, value in rel_grads.items()):
+            raise RuntimeError(
+                f"{variant.name}: correctness outside aggregate BF16 tolerance: " f"loss={rel_loss}, grads={rel_grads}, grad_tolerances={grad_tolerances}"
+            )
+        correctness[variant.bits] = {
+            "rel_loss": rel_loss,
+            "rel_grads": rel_grads,
+            "grad_tolerances": grad_tolerances,
+        }
+        print(
+            f"CORRECT {variant.name} rel_loss={rel_loss:.6g} "
+            f"grad_tolerances={json.dumps(grad_tolerances, sort_keys=True)} "
+            f"rel_grads={json.dumps(rel_grads, sort_keys=True)}"
+        )
+    del reference
+
+    raw = {variant.bits: [] for variant in VARIANTS}
+    batches = {variant.bits: [] for variant in VARIANTS}
+    timing_started = time.time()
+    for batch in range(args.rounds):
+        for variant_index in orders[batch % len(orders)]:
+            variant = VARIANTS[variant_index]
+            samples = []
+            for _ in range(args.repeats):
+                select(variant)
+                model.zero_grad(set_to_none=True)
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                output = model(input_ids=ids, labels=ids)
+                output.loss.backward()
+                end.record()
+                end.synchronize()
+                elapsed_ms = start.elapsed_time(end)
+                if not math.isfinite(elapsed_ms) or elapsed_ms <= 0.0:
+                    raise RuntimeError(f"{variant.name}: invalid CUDA-event timing {elapsed_ms}")
+                samples.append(elapsed_ms)
+            raw[variant.bits].append(samples)
+            batches[variant.bits].append(statistics.median(samples))
+        print(f"BATCH {batch + 1}/{args.rounds} elapsed_s={time.time() - timing_started:.1f}", flush=True)
+
+    baseline = batches["000"]
+    summary = {}
+    for variant in VARIANTS:
+        values = batches[variant.bits]
+        result = {
+            "p10_ms": percentile(values, 0.1),
+            "p50_ms": percentile(values, 0.5),
+            "p90_ms": percentile(values, 0.9),
+            "mean_ms": statistics.mean(values),
+            "batches": len(values),
+        }
+        result.update(paired_stats(values, baseline))
+        result["wins_vs_baseline"] = result.pop("wins")
+        summary[variant.bits] = result
+        print(f"RESULT {variant.name} " + json.dumps(result, sort_keys=True))
+
+    comparisons = {}
+    for label, numerator_bits, denominator_bits in PAIR_BITS:
+        result = paired_stats(batches[numerator_bits], batches[denominator_bits])
+        result.update(
+            {
+                "numerator": BY_BITS[numerator_bits].name,
+                "denominator": BY_BITS[denominator_bits].name,
+            }
+        )
+        comparisons[label] = result
+        print("COMPARISON " + label + " " + json.dumps(result, sort_keys=True))
+
+    batch_times_by_mask = {mask: batches[f"{mask:03b}"] for mask in range(8)}
+    main_effects = factorial_main_effects(batch_times_by_mask)
+    shapley = shapley_savings(batch_times_by_mask)
+    print("MAIN_EFFECTS " + json.dumps(main_effects, sort_keys=True))
+    print(
+        "SHAPLEY "
+        + json.dumps(
+            {
+                "saving_ms": shapley["saving_ms"],
+                "combined_saving_ms": shapley["combined_saving_ms"],
+            },
+            sort_keys=True,
+        )
+    )
+
+    calls_per_variant = args.warmup + 1 + args.rounds * args.repeats
+    expected_frost_calls = sum(variant.mlp for variant in VARIANTS) * calls_per_variant * shape["layers"]
+    expected_attn_calls = sum(not variant.attn for variant in VARIANTS) * calls_per_variant * len(attn_layers)
+    expected_native_gdn_calls = sum(variant.gdn for variant in VARIANTS) * calls_per_variant * len(linear_layers)
+    if frost_calls != expected_frost_calls or pointwise_calls != 0:
+        raise RuntimeError(f"final dSwiGLU route mismatch: frost={frost_calls}/{expected_frost_calls}, " f"pointwise={pointwise_calls}/0")
+    if attn_calls != {"torch": expected_attn_calls, "cudnn": expected_attn_calls}:
+        raise RuntimeError(f"final full-attention route mismatch: calls={attn_calls}, expected_each={expected_attn_calls}")
+    if native_gdn_calls != expected_native_gdn_calls:
+        raise RuntimeError(f"final native GDN route mismatch: calls={native_gdn_calls}/{expected_native_gdn_calls}")
+    if gdnmod.last_path() != "native":
+        raise RuntimeError(f"unexpected final GDN route: {gdnmod.last_path()}")
+
+    route = {
+        "frost_calls": frost_calls,
+        "expected_frost_calls": expected_frost_calls,
+        "pointwise_calls": pointwise_calls,
+        "native_gdn_calls": native_gdn_calls,
+        "expected_native_gdn_calls": expected_native_gdn_calls,
+        "last_gdn_path": gdnmod.last_path(),
+        "full_attention_calls": attn_calls,
+        "expected_full_attention_calls_each": expected_attn_calls,
+        "torch_sdpa_probe": torch_sdpa_probe,
+        "torch_baseline_route_contract": ROUTE_CONTRACT["torch_full_attention"],
+        "torch_baseline_route_contract_passed": True,
+    }
+    completed_utc = _utc_now()
+    metadata = {
+        "schema_version": 2,
+        "started_utc": started_utc,
+        "completed_utc": completed_utc,
+        "arguments": _serializable_args(args),
+        "config": config,
+        "correctness_role": ("multi-layer BF16 composition diagnostic; focused op and full-block " "parity tests are the primary correctness gates"),
+        "correctness": correctness,
+        "summary": summary,
+        "comparisons": comparisons,
+        "main_effects": main_effects,
+        "shapley": shapley,
+        "batch_medians_ms": batches,
+        "raw_ms": raw,
+        "route": route,
+        "artifacts": {"raw_json": str(raw_path), "markdown": str(markdown_path)},
+    }
+    if previous_metadata is not None:
+        comparison = compare_results(metadata, previous_metadata)
+        comparison["previous_artifact"] = _source_record(args.compare)
+        comparison["current_build_fingerprint_sha256"] = config["build_fingerprint"]["sha256"]
+        comparison["previous_build_fingerprint_sha256"] = previous_metadata.get("config", {}).get("build_fingerprint", {}).get("sha256", "unknown")
+        metadata["comparison"] = comparison
+    raw_path.write_text(json.dumps(metadata, indent=2, sort_keys=True, allow_nan=False) + "\n", encoding="utf-8")
+    raw_hash = _sha256(raw_path)
+    raw_link = os.path.relpath(raw_path.resolve(), markdown_path.resolve().parent)
+    report = render_markdown(metadata, raw_json_link=raw_link, raw_json_sha256=raw_hash)
+    markdown_path.write_text(report, encoding="utf-8")
+    print("ROUTE " + json.dumps(route, sort_keys=True, allow_nan=False))
+    print(f"RAW_JSON {raw_path} sha256={raw_hash}")
+    print(f"MARKDOWN {markdown_path} sha256={_sha256(markdown_path)}")
+
+
+def main():
+    args = _parse_args()
+    # Keep ``--help`` and static inspection usable in a CPU-only environment;
+    # the actual benchmark still requires the normal Torch/CUDA dependencies.
+    global torch
+    torch = importlib.import_module("torch")
+    orders = williams_orders()
+    if os.environ.get("CUDNN_FRONTEND_ENABLE_FROST_ENGINES", "0").lower() in ("1", "true", "yes", "on"):
+        raise RuntimeError("global FROST opt-in must be disabled: FE d256 must use the cuDNN backend " "while the MLP calls its direct FROST dSwiGLU kernel")
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+
+    device = _pick_device(args.mode)
+    with torch.cuda.device(device):
+        # Load under the selected device context. The sibling model installs
+        # persistent sentinels that reject FE's older OSS/CuteDSL d256 fallback
+        # and exposes the canonical backend selector.
+        qwen = _load_run_model()
+        properties = torch.cuda.get_device_properties(device)
+        if args.mode == "formal" and (properties.name != "NVIDIA B200" or properties.multi_processor_count != 148):
+            raise RuntimeError("formal mode requires a full 148-SM NVIDIA B200, got " f"{properties.name}, {properties.multi_processor_count} SMs on {device}")
+        _run_experiment(args, qwen, device, properties, orders, _utc_now())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/e2e/Qwen3.8/run_matrix.py
+++ b/benchmark/e2e/Qwen3.8/run_matrix.py
@@ -113,7 +113,8 @@ ROUTE_CONTRACT = {
     },
     "cudnn_full_attention": {
         "adapter": "FE direct cuDNN-backend d256 SDPA",
-        "oss_cutedsl_d256_forbidden": True,
+        "route": "backend graph only after FE #682",
+        "minimum_cudnn_backend": 92300,
     },
     "gdn": {
         "baseline": "stock FLA",
@@ -392,16 +393,11 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
 
     if not hasattr(qwen, "_set_full_attention_backend"):
         raise RuntimeError(f"{RUN_MODEL} lacks _set_full_attention_backend")
-    for sentinel_name in ("sdpa_fwd_d256", "sdpa_bwd_d256"):
-        sentinel = getattr(sdpamod, sentinel_name, None)
-        if sentinel is None or getattr(sentinel, "__name__", "") != "_forbid_oss_d256":
-            raise RuntimeError(f"run_model did not install the expected OSS d256 sentinel for {sentinel_name}")
-    supports_backend_d256 = getattr(sdpamod, "_cudnn_backend_supports_d256", None)
-    backend_floor = getattr(sdpamod, "_CUDNN_BACKEND_D256_VERSION", None)
-    if supports_backend_d256 is None or backend_floor is None:
-        raise RuntimeError("FE SDPA op lacks the cuDNN-backend d256 route check")
-    if cudnn.backend_version() < backend_floor or not supports_backend_d256():
-        raise RuntimeError("d256 FE arm must route through the cuDNN backend; got backend " f"version {cudnn.backend_version()}, required {backend_floor}")
+    backend_floor = 92300
+    if cudnn.backend_version() < backend_floor:
+        raise RuntimeError("d256 FE arm requires cuDNN backend " f">= {backend_floor}; got {cudnn.backend_version()}")
+    if any(hasattr(sdpamod, name) for name in ("sdpa_fwd_d256", "sdpa_bwd_d256")):
+        raise RuntimeError("loaded FE SDPA module predates #682 and still exposes the legacy standalone d256 stacks")
 
     from cudnn.gemm.ops import swiglu_mlp as public_swiglu_mlp
 
@@ -412,6 +408,7 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
     frost_compiler_module = importlib.import_module("cudnn.gemm.frost.compiler")
     frost_tile_config_module = importlib.import_module("cudnn.gemm.frost.tile_config")
     frost_kernel_registry_module = importlib.import_module("cudnn.gemm.frost.kernel_registry")
+    gated_mlp_adapter_module = importlib.import_module("cudnn.fla.gated_mlp")
     shape = _resolve_shape(args, qwen)
     mode_overrides = _mode_overrides(args, qwen, shape)
 
@@ -423,16 +420,6 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
     if not linear_layers:
         raise RuntimeError("the three-axis benchmark requires at least one GDN layer")
     ids = torch.randint(0, shape["vocab"], (args.bs, args.seq), device=device)
-
-    original_mlp_forward = fla_mlp.GatedMLP.forward
-
-    def cudnn_mlp_forward(self, x, **kwargs):
-        return opmod.swiglu_mlp(
-            x,
-            self.gate_proj.weight,
-            self.up_proj.weight,
-            self.down_proj.weight,
-        )
 
     qwen._set_full_attention_backend("torch")
     torch_attn_adapter = fla_attn.flash_attn_func
@@ -555,10 +542,14 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
     gdnmod.gated_delta_net = counted_native_gdn
 
     def select(variant):
-        cfla.restore_fla()
+        cfla.restore_fla(targets=("gated_delta_rule", "gated_mlp"))
+        selected_fla_targets = []
         if variant.gdn:
-            cfla.accelerate_fla(verbose=False)
-        fla_mlp.GatedMLP.forward = cudnn_mlp_forward if variant.mlp else original_mlp_forward
+            selected_fla_targets.append("gated_delta_rule")
+        if variant.mlp:
+            selected_fla_targets.append("gated_mlp")
+        if selected_fla_targets:
+            cfla.accelerate_fla(verbose=False, targets=selected_fla_targets)
         attention_backend = "cudnn" if variant.attn else "torch"
         qwen._set_full_attention_backend(attention_backend)
         # Keep run_model's selector authoritative, then add symmetric telemetry.
@@ -587,6 +578,7 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
         "frost_mainloop_template_2ctamma": _source_record(frost_template_dir / "sm100_matmul_mainloop_2ctamma.py"),
         "cudnn_fla": _source_record(cfla.__file__),
         "cudnn_fla_gdn_adapter": _source_record(gdnmod.__file__),
+        "cudnn_fla_gated_mlp_adapter": _source_record(gated_mlp_adapter_module.__file__),
         "native_gdn": _source_record(native_gdn_module.__file__),
         "sdpa": _source_record(sdpamod.__file__),
         "cudnn_init": _source_record(cudnn.__file__),
@@ -597,11 +589,11 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
     provenance = {
         "git": _git_provenance(),
         "sources": sources,
-        "oss_d256_sentinels": {name: getattr(getattr(sdpamod, name), "__name__", "") for name in ("sdpa_fwd_d256", "sdpa_bwd_d256")},
+        "d256_route_contract": "FE public backend graph only; legacy standalone stacks absent after #682",
     }
     device_index = device.index if device.index is not None else torch.cuda.current_device()
     config = {
-        "schema_version": 2,
+        "schema_version": 3,
         "mode": args.mode,
         "timing_role": "validation_only" if args.mode == "smoke" else "formal_performance",
         "performance_claim_eligible": args.mode == "formal",
@@ -631,6 +623,7 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
         "williams_orders": orders,
         "route_contract": ROUTE_CONTRACT,
         "measurement_contract": MEASUREMENT_CONTRACT,
+        "numerical_recipe": dict(qwen.NUMERICAL_RECIPE),
         "provenance": provenance,
     }
     comparability_inputs = {
@@ -664,6 +657,7 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
             "williams_orders",
             "route_contract",
             "measurement_contract",
+            "numerical_recipe",
         )
     }
     build_inputs = {
@@ -721,8 +715,13 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
         gdn_path = gdnmod.last_path() if variant.gdn else "off"
         if variant.gdn and gdn_path != "native":
             raise RuntimeError(f"{variant.name}: expected native GDN, got {gdn_path}")
+        mlp_path = cfla.mlp_last_path() if variant.mlp else "off"
+        if cfla.is_accelerated("gated_mlp") != variant.mlp:
+            raise RuntimeError(f"{variant.name}: gated_mlp registry state does not match the selected arm")
+        if variant.mlp and mlp_path != "native":
+            raise RuntimeError(f"{variant.name}: expected native MLP, got {mlp_path}")
         print(
-            f"WARM {variant.name} gdn_path={gdn_path} native_gdn_delta={observed_native_gdn} "
+            f"WARM {variant.name} gdn_path={gdn_path} mlp_path={mlp_path} native_gdn_delta={observed_native_gdn} "
             f"full_attn={attention_backend} frost_delta={frost_calls - before_frost}"
         )
 
@@ -883,6 +882,8 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
         "native_gdn_calls": native_gdn_calls,
         "expected_native_gdn_calls": expected_native_gdn_calls,
         "last_gdn_path": gdnmod.last_path(),
+        "last_mlp_path": cfla.mlp_last_path(),
+        "uses_public_gated_mlp_adapter": True,
         "full_attention_calls": attn_calls,
         "expected_full_attention_calls_each": expected_attn_calls,
         "torch_sdpa_probe": torch_sdpa_probe,
@@ -891,7 +892,7 @@ def _run_experiment(args, qwen, device, properties, orders, started_utc):
     }
     completed_utc = _utc_now()
     metadata = {
-        "schema_version": 2,
+        "schema_version": 3,
         "started_utc": started_utc,
         "completed_utc": completed_utc,
         "arguments": _serializable_args(args),
@@ -937,9 +938,9 @@ def main():
 
     device = _pick_device(args.mode)
     with torch.cuda.device(device):
-        # Load under the selected device context. The sibling model installs
-        # persistent sentinels that reject FE's older OSS/CuteDSL d256 fallback
-        # and exposes the canonical backend selector.
+        # Load under the selected device context. After FE #682 the public d256
+        # operator is backend-graph-only; the sibling exposes the canonical
+        # Torch-versus-FE selector used by this matrix.
         qwen = _load_run_model()
         properties = torch.cuda.get_device_properties(device)
         if args.mode == "formal" and (properties.name != "NVIDIA B200" or properties.multi_processor_count != 148):

--- a/benchmark/e2e/Qwen3.8/run_model.py
+++ b/benchmark/e2e/Qwen3.8/run_model.py
@@ -24,9 +24,8 @@ Full-attention layers use a Torch-SDPA-compatible flash-attn stand-in, so no
 flash-attn install is needed.  The default calls the cuDNN Frontend op directly,
 bypassing the tested Torch 2.13 dispatch guard that does not select cuDNN for
 head-dim 256; ``--full_attn_backend torch`` restores the vanilla dispatcher for
-an exact A/B.  The cuDNN arm requires the cuDNN >= 9.23 backend d256 path and
-explicitly forbids FE's older OSS/CuteDSL d256 fallback.  Requires an SM100
-(Blackwell) device.
+an exact A/B.  The cuDNN arm requires cuDNN backend >= 9.23; after FE #682 the
+public d256 op is backend-graph-only.  Requires an SM100 (Blackwell) device.
 
     python benchmark/e2e/Qwen3.8/run_model.py --accelerate_mlp 1 --accelerate_attn 1
 """
@@ -44,12 +43,12 @@ from _perfshare import pick_sm100, profile_and_report  # noqa: E402
 def _wire_sdpa_attention():
     """Build switchable Torch/cuDNN SDPA adapters for FLA full attention.
 
-    FE #335 routes d256 through the backend graph on cuDNN >= 9.23 and otherwise
-    falls back to Sdpafwd/SdpabwdSm100D256, which are OSS/CuteDSL kernels.  This
-    perf benchmark rejects the latter rather than silently measuring it.  Both
-    adapters receive the same projected/rotated Q/K/V and return the same packed
-    BLHD layout.  Thus QKV/RoPE/O remain common code and are included in module
-    and model timings; only the SDPA core changes across this axis.
+    FE #682 removed the legacy standalone d256 OSS/CuteDSL stacks, so the public
+    op below is backend-graph-only.  cuDNN 9.23 is the first backend release with
+    d256 forward and backward support.  Both adapters receive the same
+    projected/rotated Q/K/V and return the same packed BLHD layout.  Thus
+    QKV/RoPE/O remain common code and are included in module and model timings;
+    only the SDPA core changes across this axis.
     """
     import cudnn
     import cudnn.experimental.ops.sdpa as cudnn_sdpa_module
@@ -68,20 +67,10 @@ def _wire_sdpa_attention():
             "would also replace the intended cuDNN-backend d256 SDPA plan"
         )
 
-    backend_floor = getattr(cudnn_sdpa_module, "_CUDNN_BACKEND_D256_VERSION", None)
-    if backend_floor is None:
-        raise RuntimeError("FE SDPA op lacks the cuDNN-backend d256 bypass from #335; " "refusing to benchmark the OSS/CuteDSL fallback")
+    backend_floor = 92300
     backend_version = cudnn.backend_version()
     if backend_version < backend_floor:
-        raise RuntimeError(f"cuDNN backend {backend_version} < required {backend_floor}; " "refusing to benchmark the OSS/CuteDSL d256 fallback")
-
-    def _forbid_oss_d256(*args, **kwargs):
-        raise RuntimeError("unexpected OSS/CuteDSL d256 SDPA route; this benchmark requires " "the cuDNN backend implementation")
-
-    # Mirror #335's routing test with persistent sentinels: both the forward and
-    # autograd backward must fail instead of silently selecting the OSS kernels.
-    cudnn_sdpa_module.sdpa_fwd_d256 = _forbid_oss_d256
-    cudnn_sdpa_module.sdpa_bwd_d256 = _forbid_oss_d256
+        raise RuntimeError(f"d256 SDPA requires cuDNN backend >= {backend_floor}; got {backend_version}")
     cudnn_sdpa = cudnn_sdpa_module.scaled_dot_product_attention
 
     def _prepare(q, k, v, window_size):
@@ -201,6 +190,24 @@ MODEL_PRESETS = {
     },
 }
 
+# Numerical policy is deliberately data, not another implementation bit. A
+# future FP8/FP4 leaf gets its own runner/record rather than branching throughout
+# this BF16 benchmark.
+NUMERICAL_RECIPE = {
+    "id": "conservative-bf16-v1",
+    "parameter_dtype": "bfloat16",
+    "activation_dtype": "bfloat16",
+    "scope": "forward_backward_no_optimizer",
+    "anchor": {
+        "project": "NVIDIA-NeMo/Megatron-Bridge",
+        "commit": "2e77041c194d106beb7462e226d7ca06b33ea63f",
+        "path": "src/megatron/bridge/training/mixed_precision.py",
+        "symbol": "bf16_mixed",
+        "aligned_scope": "single-GPU BF16 parameter/activation policy only; no distributed or optimizer claim",
+    },
+    "alignment": "upstream_anchored_subset",
+}
+
 
 def _accelerate_mlp():
     """Opt FLA's supported GatedMLP instances into the production cuDNN shim."""
@@ -284,7 +291,7 @@ def main():
         "--accelerate_mlp",
         type=int,
         default=1,
-        help="route the SwiGLU MLP through cuDNN (PR #609)",
+        help="route the SwiGLU MLP through the cudnn.fla shim backed by PR #609",
     )
     ap.add_argument(
         "--accelerate_attn",

--- a/benchmark/e2e/README.md
+++ b/benchmark/e2e/README.md
@@ -1,12 +1,13 @@
 # End-to-end model perf-share benchmarks
 
 One folder per model family. Each `<Model>/run_model.py` keeps the published
-kernel-relevant layer dimensions and one minimal repeated layer period, swaps in
-the cuDNN ops that exist today, runs a fwd+bwd training step, and prints where the
-GPU kernel time goes — by **category**
-(linear-attn / full-attn / gemm / norm / misc) and by **backend** (cuDNN / cuBLAS
-/ torch). The point is the *support gap*: what fraction of a real training step
-cuDNN already owns, and which un-owned op is next. Layer count and vocabulary may
+kernel-relevant layer dimensions and one minimal repeated layer period, while a
+separate precision leaf (for example `run_matrix.py` or `run_bf16.py`) declares
+the workload and implementation treatments. Single-arm profiles can break GPU
+kernel time down by **category** (linear-attn / full-attn / gemm / norm / misc)
+and **backend** (cuDNN / cuBLAS / torch); matrix leaves report paired end-to-end
+treatment effects. The point is the *support gap*: what fraction of a real
+training step cuDNN already owns, and which un-owned op is next. Layer count and vocabulary may
 be reduced to avoid repeating identical work; every such reduction or stand-in is
 printed and documented rather than described as a full-model benchmark.
 
@@ -20,17 +21,18 @@ The proxy exposes three independent axes:
 - stock FLA versus `cudnn.fla` for linear GDN (`--accelerate_attn`, PR #596);
 - stock FLA `GatedMLP` versus the opt-in `cudnn.fla` `gated_mlp` target backed
   by `cudnn.gemm.ops.swiglu_mlp` (`--accelerate_mlp`, PR #609); and
-- vanilla `torch.nn.functional.scaled_dot_product_attention` versus FE's direct
-  cuDNN-backend d256 op (`--full_attn_backend`, develop #335).
+- vanilla `torch.nn.functional.scaled_dot_product_attention` versus FE's public
+  backend-graph d256 op (`--full_attn_backend`, #335; legacy standalone stacks
+  removed by #682).
 
 The model-level true-vanilla arm means stock FLA GDN + stock FLA MLP + vanilla
 Torch SDPA; it is not an all-eager-Torch implementation. At the benchmark shape,
 Torch 2.13 selects PyTorch FlashAttention rather than cuDNN. Only the MLP axis
 belongs to PR #609.
 
-The formal results below predate this public adapter and used an equivalent
-direct call to `cudnn.gemm.ops.swiglu_mlp`. The adapter itself is validated by
-the focused FLA compatibility suite and a native-route model smoke test.
+The formal results below exercise the merged public `cudnn.fla` MLP adapter,
+the merged packed-QKV GDN adapter, and FE's backend-only d256 SDPA path. Every
+accelerated arm fails unless the requested native route is observed.
 
 ## Qwen3.8 proxy result
 
@@ -45,16 +47,17 @@ fingerprint, and a separate build/provenance fingerprint.
 
 | bits (G/M/A) | GDN | MLP | full-attn core | p50 step | paired ratio vs `000` | wins vs `000` |
 |---|---|---|---|---:|---:|---:|
-| `000` | stock FLA | stock FLA | Torch FlashAttention | 75.075 ms | 1.00000 | -- |
-| `001` | stock FLA | stock FLA | cuDNN backend | 73.326 ms | 0.98280 | 29/40 |
-| `010` | stock FLA | PR #609 | Torch FlashAttention | 72.483 ms | 0.96579 | 34/40 |
-| `011` | stock FLA | PR #609 | cuDNN backend | 71.180 ms | 0.94548 | 38/40 |
-| `100` | cuDNN shim | stock FLA | Torch FlashAttention | 64.178 ms | 0.85348 | 40/40 |
-| `101` | cuDNN shim | stock FLA | cuDNN backend | 62.788 ms | 0.83878 | 40/40 |
-| `110` | cuDNN shim | PR #609 | Torch FlashAttention | 62.394 ms | 0.83025 | 40/40 |
-| `111` | cuDNN shim | PR #609 | cuDNN backend | 61.230 ms | **0.81533** | **40/40** |
+| `000` | stock FLA | stock FLA | Torch FlashAttention | 75.427 ms | 1.00000 | -- |
+| `001` | stock FLA | stock FLA | cuDNN backend | 74.516 ms | 0.98939 | 27/40 |
+| `010` | stock FLA | cuDNN shim (#609) | Torch FlashAttention | 73.673 ms | 0.96456 | 32/40 |
+| `011` | stock FLA | cuDNN shim (#609) | cuDNN backend | 71.378 ms | 0.94218 | 38/40 |
+| `100` | cuDNN shim | stock FLA | Torch FlashAttention | 65.016 ms | 0.86099 | 40/40 |
+| `101` | cuDNN shim | stock FLA | cuDNN backend | 63.801 ms | 0.84558 | 40/40 |
+| `110` | cuDNN shim | cuDNN shim (#609) | Torch FlashAttention | 63.729 ms | 0.84446 | 40/40 |
+| `111` | cuDNN shim | cuDNN shim (#609) | cuDNN backend | 62.544 ms | **0.82759** | **40/40** |
 
-The directly paired `111/000` result is 18.47% lower elapsed time, or 1.226x.
+The directly paired `111/000` result is 17.24% lower elapsed time, or 1.208x.
+Raw artifact SHA-256: `65654ec5c55f7e900f1351c60d8f835b2d7e427613b8d1df18dd7f3d9b1b2757`.
 The three ratios below average each axis over all four contexts within every
 batch, so interactions are measured instead of multiplying isolated speedups.
 Shapley savings are mean per-batch attribution values and are not module-time
@@ -62,9 +65,9 @@ shares.
 
 | axis | conditional paired ratio | conditional speedup | mean Shapley saving |
 |---|---:|---:|---:|
-| GDN | 0.85468 | 1.170x | 10.54 ms |
-| MLP | 0.97036 | 1.031x | 1.92 ms |
-| d256 full attention | 0.97836 | 1.022x | 1.42 ms |
+| GDN | 0.86005 | 1.163x | 10.13 ms |
+| MLP | 0.96876 | 1.032x | 1.90 ms |
+| d256 full attention | 0.98280 | 1.017x | 1.18 ms |
 
 An independently attributed true-vanilla CUDA profile gives the approximate,
 mutually exclusive GPU active-time shares below. Generic GEMM kernels account
@@ -87,25 +90,43 @@ Focused A/Bs establish the smaller-axis signal outside model-level noise:
   1.198 ms (2.188x). The full attention block including common QKV, RoPE, layout,
   O projection, and backward is 5.147 versus 3.432 ms (1.494x, 40/40).
 
-The recorded GDN arm included the packed-QKV stride fix from #685: FLA
-short-conv produces strided views, which the shim compacts before the native
-kernel; that copy is inside the timed region. #685 is not yet merged into
-`develop`, so the default `short_conv=true` smoke and formal configurations
-currently require a build containing that fix. The runner does not pin a
-private checkout or require the fix by source hash. Instead it records the
-loaded source hashes and requires exact successful native-GDN call counts plus
-the end-to-end correctness gate; an incompatible shim fails explicitly. These
-are single-job results for a four-layer shape proxy, not full 64-layer Qwen
-throughput.
+The GDN arm includes the packed-QKV stride fix from #685: FLA short-conv
+produces strided views, which the shim compacts before the native kernel; that
+copy is inside the timed region. The runner records the loaded source hashes and
+requires exact successful native-GDN call counts plus the end-to-end correctness
+gate; an incompatible shim fails explicitly. These are single-job results for a
+four-layer shape proxy, not full 64-layer Qwen throughput.
+
+## Qwen-Image BF16 proxy result
+
+On the same full B200, the Qwen-Image proxy uses the published H=3072,
+24x128-head and FFN=12288 dimensions, B=1, 4096 image plus 512 text tokens, and
+four of the 60 repeated transformer blocks. Forty balanced batches with three
+repeats compare an explicitly forced PyTorch FlashAttention treatment with the
+FE public cuDNN backend graph; all projections, QK norm, RoPE, AdaLN, biased
+GELU FFNs, residuals, and output work are common and remain inside the timed
+transformer forward.
+
+| SDPA treatment | p50 transformer forward | paired ratio | latency reduction | speedup | wins |
+|---|---:|---:|---:|---:|---:|
+| forced PyTorch FlashAttention | 9.943 ms | 1.00000 | -- | -- | -- |
+| direct FE/cuDNN backend | 7.883 ms | **0.79640** | **20.36%** | **1.256x** | **40/40** |
+
+The unforced public Torch call already selects `CUDNN_ATTENTION` at this d128
+shape, so this is an implementation A/B rather than a claim of an additional
+dispatcher-level user speedup. The complete four-block output matched within
+0.141% relative L2. The focused B=2 unequal-text mask case matched within 0.300%
+relative L2. Raw artifact SHA-256: `288ce0415c0cfd6564fde99debe0273a2304c07e7810547bd5da8b25cda0fbba`.
 
 The shared, model-agnostic harness lives in [`_perfshare.py`](_perfshare.py); a
 model file only builds its model, applies the swaps, and calls `profile_and_report`.
 
 ## Models
 
-| folder | proxy of | MLP swap | notes |
+| folder | proxy of | current precision leaf | notes |
 |---|---|---|---|
-| [`Qwen3.8/`](Qwen3.8/) | Qwen3.8/3.6/3.5-27B dense hybrid Gated DeltaNet LM | `swiglu_mlp` | exact MLP/GDN dimensions; 4-layer period; selectable Torch FlashAttention or cuDNN-backend d256 GQA at 20Q/4KV instead of gated 24Q/4KV |
+| [`Qwen3.8/`](Qwen3.8/) | Qwen3.8/3.6/3.5-27B dense hybrid Gated DeltaNet LM | BF16 fwd+CE+bwd, 2^3 GDN/MLP/SDPA | exact MLP/GDN dimensions; 4-layer period; selectable Torch FlashAttention or cuDNN-backend d256 GQA at 20Q/4KV instead of gated 24Q/4KV |
+| [`Qwen-Image/`](Qwen-Image/) | Qwen-Image diffusion transformer | BF16 transformer forward, forced PyTorch Flash-vs-cuDNN joint SDPA | exact H=3072, 24x128 and FFN=12288; 4/60 repeated blocks; 4096 image + 512 text tokens |
 
 Planned: Kimi Linear (KDA), DeepSeek-V3.
 
@@ -148,23 +169,58 @@ python benchmark/e2e/Qwen3.8/run_model.py --bs 4 --accelerate_mlp 0 --accelerate
 python benchmark/e2e/Qwen3.8/run_model.py --bs 4 --accelerate_mlp 1 --accelerate_attn 1 --full_attn_backend cudnn
 
 python benchmark/e2e/Qwen3.8/run_model.py --preset qwen3.5-27b --inspect  # equivalent older preset
+
+# Qwen-Image uses the pinned benchmark-only Diffusers implementation.
+python -m pip install -r benchmark/e2e/Qwen-Image/requirements.txt
+
+# Validation-only reduced-token mask/route/correctness smoke.
+python benchmark/e2e/Qwen-Image/run_bf16.py \
+  --mode smoke --output-dir qwen-image-bf16-results/smoke
+
+# Formal one-forward BF16 transformer proxy: B=1, 4096 image + 512 text tokens,
+# four real-shape blocks, 40 balanced batches x 3 repeats on a full B200.
+python benchmark/e2e/Qwen-Image/run_bf16.py \
+  --mode formal --output-dir qwen-image-bf16-results/formal
 ```
 
-Requires a cuDNN build with the fused GEMM engine and the cuDNN >= 9.23 backend
-d256 SDPA path on an SM100 (Blackwell) device; `flash-linear-attention` provides
-the model. The MLP target requires FLA 0.5.2 and admits its validated plain,
-local, bias-free BF16 `swish` module; unsupported runtime configurations fall
-back to FLA. The default `short_conv=true` GDN axis uses the packed-QKV support
-landed in #685. The benchmark rejects the older OSS/CuteDSL d256 SDPA fallback.
-Formal mode additionally rejects anything other than a full 148-SM NVIDIA B200. Both modes verify exact
+The Qwen3.8 runner requires a cuDNN build with the fused GEMM engine and the
+cuDNN >= 9.23 backend d256 SDPA path on an SM100 (Blackwell) device;
+`flash-linear-attention` provides the model. The MLP target requires FLA 0.5.2
+and admits its validated plain, local, bias-free BF16 `swish` module;
+unsupported runtime configurations fall back to FLA. The default
+`short_conv=true` GDN axis uses the packed-QKV support landed in #685. After
+#682, the FE public d256 SDPA operator is backend-graph-only. Formal mode
+additionally rejects anything other than a full 148-SM NVIDIA B200. Both modes verify exact
 GDN/MLP/full-attention routes and explicit finite correctness before reporting.
 Formal shape/timing overrides are allowed but are listed prominently and
 included in the comparability fingerprint. The default
 `qwen3.8-factorial-results/` output directory is gitignored wherever the runner
 is launched inside the checkout.
 
+### Qwen-Image joint mask
+
+Qwen-Image performs non-causal joint attention in `[text, image]` order. Every
+query can see every valid text token and every image token; only padded text key
+columns are masked. Canonical batch-1 inference trims text padding and therefore
+uses the dense no-mask path. For unequal right-padded prompts, the cuDNN adapter
+temporarily permutes the joint sequence to `[image, text]`, where the padding is
+a suffix representable by `seq_len_kv`, then restores output order. Every run
+checks this path against the official boolean-mask semantics with a focused B=2
+case. Arbitrary masks with holes fail closed.
+
+The Qwen-Image result is one random-weight conditional transformer forward. It
+does not include checkpoint loading, text encoding, VAE, scheduler work, or the
+complete denoising loop and is not image-quality evidence. The model/config and
+Diffusers implementation are pinned in the artifact. The A/B explicitly forces
+PyTorch FlashAttention versus direct FE/cuDNN; the artifact also reports the
+unforced public Torch dispatch choice (Torch 2.13 on B200 already selects cuDNN
+for this d128 shape). This BF16 leaf has no
+ModelOpt claim; a future ModelOpt-anchored NVFP4+FP8 experiment belongs in a
+separate `run_nvfp4_fp8.py`.
+
 ## Add a model
 
-1. `mkdir benchmark/e2e/<Model>` and add `run_model.py`.
-2. Build the model, apply the cuDNN swaps, then call `profile_and_report(model, ids, ...)`.
-3. Add a row to the table above.
+1. `mkdir benchmark/e2e/<Model>` and put topology plus backend adapters in `run_model.py`.
+2. Add one workload/precision leaf such as `run_bf16.py`; add FP8/FP4 as sibling files rather than dtype branches throughout the model.
+3. Record immutable upstream model/implementation/recipe anchors and the resolved shape in every artifact.
+4. Add CPU spec tests, a target-GPU route/correctness smoke, and a row above.

--- a/benchmark/e2e/README.md
+++ b/benchmark/e2e/README.md
@@ -37,20 +37,24 @@ the focused FLA compatibility suite and a native-route model smoke test.
 On a full 148-SM B200 with BF16, batch 4, sequence 2048, and the four-layer
 Qwen3.8 period, a 2^3 Williams-balanced experiment used 40 batches and three
 repeats per arm. JIT/autotune, correctness, warmup, and gradient clearing were
-outside the CUDA-event region.
+outside the CUDA-event region. [`Qwen3.8/run_matrix.py`](Qwen3.8/run_matrix.py)
+reproduces that design and emits both raw JSON and a generated Markdown report.
+Each report includes the fully resolved shape, software/device provenance,
+loaded source hashes, route/correctness results, a stable comparability
+fingerprint, and a separate build/provenance fingerprint.
 
 | bits (G/M/A) | GDN | MLP | full-attn core | p50 step | paired ratio vs `000` | wins vs `000` |
 |---|---|---|---|---:|---:|---:|
-| `000` | stock FLA | stock FLA | Torch FlashAttention | 76.047 ms | 1.00000 | -- |
-| `001` | stock FLA | stock FLA | cuDNN backend | 75.120 ms | 0.98555 | 25/40 |
-| `010` | stock FLA | PR #609 | Torch FlashAttention | 74.619 ms | 0.97806 | 29/40 |
-| `011` | stock FLA | PR #609 | cuDNN backend | 73.035 ms | 0.95995 | 38/40 |
-| `100` | cuDNN shim | stock FLA | Torch FlashAttention | 66.075 ms | 0.86980 | 40/40 |
-| `101` | cuDNN shim | stock FLA | cuDNN backend | 65.174 ms | 0.85522 | 40/40 |
-| `110` | cuDNN shim | PR #609 | Torch FlashAttention | 65.071 ms | 0.85309 | 40/40 |
-| `111` | cuDNN shim | PR #609 | cuDNN backend | 64.090 ms | **0.83686** | **40/40** |
+| `000` | stock FLA | stock FLA | Torch FlashAttention | 75.075 ms | 1.00000 | -- |
+| `001` | stock FLA | stock FLA | cuDNN backend | 73.326 ms | 0.98280 | 29/40 |
+| `010` | stock FLA | PR #609 | Torch FlashAttention | 72.483 ms | 0.96579 | 34/40 |
+| `011` | stock FLA | PR #609 | cuDNN backend | 71.180 ms | 0.94548 | 38/40 |
+| `100` | cuDNN shim | stock FLA | Torch FlashAttention | 64.178 ms | 0.85348 | 40/40 |
+| `101` | cuDNN shim | stock FLA | cuDNN backend | 62.788 ms | 0.83878 | 40/40 |
+| `110` | cuDNN shim | PR #609 | Torch FlashAttention | 62.394 ms | 0.83025 | 40/40 |
+| `111` | cuDNN shim | PR #609 | cuDNN backend | 61.230 ms | **0.81533** | **40/40** |
 
-The directly paired `111/000` result is 16.31% lower elapsed time, or 1.195x.
+The directly paired `111/000` result is 18.47% lower elapsed time, or 1.226x.
 The three ratios below average each axis over all four contexts within every
 batch, so interactions are measured instead of multiplying isolated speedups.
 Shapley savings are mean per-batch attribution values and are not module-time
@@ -58,9 +62,9 @@ shares.
 
 | axis | conditional paired ratio | conditional speedup | mean Shapley saving |
 |---|---:|---:|---:|
-| GDN | 0.86793 | 1.152x | 9.76 ms |
-| MLP | 0.98154 | 1.019x | 1.26 ms |
-| d256 full attention | 0.98315 | 1.017x | 1.16 ms |
+| GDN | 0.85468 | 1.170x | 10.54 ms |
+| MLP | 0.97036 | 1.031x | 1.92 ms |
+| d256 full attention | 0.97836 | 1.022x | 1.42 ms |
 
 An independently attributed true-vanilla CUDA profile gives the approximate,
 mutually exclusive GPU active-time shares below. Generic GEMM kernels account
@@ -83,10 +87,16 @@ Focused A/Bs establish the smaller-axis signal outside model-level noise:
   1.198 ms (2.188x). The full attention block including common QKV, RoPE, layout,
   O projection, and backward is 5.147 versus 3.432 ms (1.494x, 40/40).
 
-The GDN arm includes a pending packed-QKV stride fix: FLA short-conv produces
-strided views, which the shim compacts before the native kernel; that copy is
-inside the timed region. These are single-job results for a four-layer shape
-proxy, not full 64-layer Qwen throughput.
+The recorded GDN arm included the packed-QKV stride fix from #685: FLA
+short-conv produces strided views, which the shim compacts before the native
+kernel; that copy is inside the timed region. #685 is not yet merged into
+`develop`, so the default `short_conv=true` smoke and formal configurations
+currently require a build containing that fix. The runner does not pin a
+private checkout or require the fix by source hash. Instead it records the
+loaded source hashes and requires exact successful native-GDN call counts plus
+the end-to-end correctness gate; an incompatible shim fails explicitly. These
+are single-job results for a four-layer shape proxy, not full 64-layer Qwen
+throughput.
 
 The shared, model-agnostic harness lives in [`_perfshare.py`](_perfshare.py); a
 model file only builds its model, applies the swaps, and calls `profile_and_report`.
@@ -102,6 +112,35 @@ Planned: Kimi Linear (KDA), DeepSeek-V3.
 ## Run
 
 ```bash
+# The factorial math/reporting tests are CPU-only and do not import Torch.
+python -m unittest discover -s benchmark/e2e/tests -v
+
+# Validation-only smoke test. It preserves H/I/head dimensions and the four-layer
+# 3:1 period, but M=bs*seq=128 (versus formal M=8192), so fixed overhead dominates.
+# Do not use smoke timing for performance trends, headlines, or speedup claims.
+python benchmark/e2e/Qwen3.8/run_matrix.py \
+  --mode smoke --output-dir qwen3.8-factorial-results/smoke
+
+# Formal 8-arm Williams run: full 148-SM B200, bs=4, seq=2048,
+# 40 balanced batches, 3 repeats. Produces timestamped .json and .md artifacts.
+python benchmark/e2e/Qwen3.8/run_matrix.py \
+  --mode formal --output-dir qwen3.8-factorial-results/formal
+
+# CI/job wrappers may request stable artifact names explicitly.
+python benchmark/e2e/Qwen3.8/run_matrix.py \
+  --mode formal \
+  --raw-json qwen3.8-factorial-results/qwen38.json \
+  --markdown qwen3.8-factorial-results/qwen38.md
+
+# Compare a new formal run with an independently collected prior formal artifact.
+# The command rejects mismatched comparability fingerprints. The report labels
+# per-arm p50 and headline changes as cross-run, non-paired comparisons.
+python benchmark/e2e/Qwen3.8/run_matrix.py \
+  --mode formal \
+  --compare qwen3.8-factorial-results/previous.json \
+  --output-dir qwen3.8-factorial-results/comparison
+
+# A single-arm profile remains available for support-share inspection.
 # Three-axis true vanilla: stock FLA GDN/MLP + vanilla Torch SDPA.
 python benchmark/e2e/Qwen3.8/run_model.py --bs 4 --accelerate_mlp 0 --accelerate_attn 0 --full_attn_backend torch
 
@@ -115,7 +154,14 @@ Requires a cuDNN build with the fused GEMM engine and the cuDNN >= 9.23 backend
 d256 SDPA path on an SM100 (Blackwell) device; `flash-linear-attention` provides
 the model. The MLP target requires FLA 0.5.2 and admits its validated plain,
 local, bias-free BF16 `swish` module; unsupported runtime configurations fall
-back to FLA. The benchmark rejects the older OSS/CuteDSL d256 SDPA fallback.
+back to FLA. The default `short_conv=true` GDN axis uses the packed-QKV support
+landed in #685. The benchmark rejects the older OSS/CuteDSL d256 SDPA fallback.
+Formal mode additionally rejects anything other than a full 148-SM NVIDIA B200. Both modes verify exact
+GDN/MLP/full-attention routes and explicit finite correctness before reporting.
+Formal shape/timing overrides are allowed but are listed prominently and
+included in the comparability fingerprint. The default
+`qwen3.8-factorial-results/` output directory is gitignored wherever the runner
+is launched inside the checkout.
 
 ## Add a model
 

--- a/benchmark/e2e/_factorial.py
+++ b/benchmark/e2e/_factorial.py
@@ -1,0 +1,444 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure statistics and reporting helpers for balanced factorial benchmarks.
+
+This module intentionally has no torch, CUDA, or model dependencies.  Keeping
+the design validation and analysis here makes the experiment math inexpensive
+to test on CPU and reusable by other end-to-end model benchmarks.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import hashlib
+import json
+import math
+import statistics
+
+AXIS_MASKS = {"gdn": 4, "mlp": 2, "attn": 1}
+
+
+def percentile(values, q):
+    """Return a linearly interpolated quantile for a non-empty sample."""
+    values = [float(value) for value in values]
+    if not values:
+        raise ValueError("percentile requires at least one value")
+    if not 0.0 <= q <= 1.0:
+        raise ValueError(f"percentile q must be in [0, 1], got {q}")
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("percentile values must be finite")
+
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * q
+    lo, hi = math.floor(position), math.ceil(position)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] * (hi - position) + ordered[hi] * (position - lo)
+
+
+def distribution(values):
+    """Summarize a non-empty numeric sample without external dependencies."""
+    values = [float(value) for value in values]
+    if not values:
+        raise ValueError("distribution requires at least one value")
+    return {
+        "p10": percentile(values, 0.1),
+        "p50": percentile(values, 0.5),
+        "p90": percentile(values, 0.9),
+        "mean": statistics.mean(values),
+        "count": len(values),
+    }
+
+
+def paired_stats(numerator, denominator):
+    """Compute paired ratios/deltas for aligned treatment batches."""
+    numerator = [float(value) for value in numerator]
+    denominator = [float(value) for value in denominator]
+    if not numerator or len(numerator) != len(denominator):
+        raise ValueError("paired samples must be non-empty and have equal lengths")
+    if any(value <= 0.0 or not math.isfinite(value) for value in numerator + denominator):
+        raise ValueError("paired timing samples must be finite and positive")
+
+    ratios = [new / old for new, old in zip(numerator, denominator)]
+    deltas = [new - old for new, old in zip(numerator, denominator)]
+    return {
+        "paired_ratio_p10": percentile(ratios, 0.1),
+        "paired_ratio_p50": percentile(ratios, 0.5),
+        "paired_ratio_p90": percentile(ratios, 0.9),
+        "paired_delta_p10_ms": percentile(deltas, 0.1),
+        "paired_delta_p50_ms": percentile(deltas, 0.5),
+        "paired_delta_p90_ms": percentile(deltas, 0.9),
+        "wins": sum(new < old for new, old in zip(numerator, denominator)),
+        "batches": len(numerator),
+    }
+
+
+def williams_orders(treatments=8):
+    """Return a standard even-treatment Williams carryover design."""
+    if treatments < 2 or treatments % 2:
+        raise ValueError("Williams design requires an even treatment count >= 2")
+
+    base = [0]
+    for offset in range(1, treatments // 2 + 1):
+        base.append(offset)
+        if offset != treatments // 2:
+            base.append(treatments - offset)
+    orders = tuple(tuple((value + shift) % treatments for value in base) for shift in range(treatments))
+    validate_design(orders)
+    return orders
+
+
+def validate_design(orders):
+    """Assert positional and first-order carryover balance."""
+    orders = tuple(tuple(order) for order in orders)
+    treatments = len(orders)
+    if treatments < 2 or any(len(order) != treatments for order in orders):
+        raise ValueError(f"expected a square Williams design, got {orders}")
+    expected = set(range(treatments))
+    if any(set(order) != expected for order in orders):
+        raise ValueError(f"each Williams row must contain treatments {sorted(expected)} exactly once")
+
+    positions = Counter((position, treatment) for order in orders for position, treatment in enumerate(order))
+    adjacency = Counter(pair for order in orders for pair in zip(order, order[1:]))
+    if set(positions.values()) != {1} or len(positions) != treatments * treatments:
+        raise ValueError(f"unbalanced treatment positions: {positions}")
+    expected_adjacencies = treatments * (treatments - 1)
+    if set(adjacency.values()) != {1} or len(adjacency) != expected_adjacencies:
+        raise ValueError(f"unbalanced ordered carryover: {adjacency}")
+
+
+def _validated_batch_times(batch_times, axis_masks):
+    masks = list(axis_masks.values())
+    expected_masks = [1 << bit for bit in range(len(masks))]
+    if sorted(masks) != expected_masks:
+        raise ValueError(f"axis masks must be unique one-bit masks {expected_masks}, got {masks}")
+
+    expected_keys = set(range(1 << len(masks)))
+    if set(batch_times) != expected_keys:
+        raise ValueError(f"batch_times keys must be {sorted(expected_keys)}, got {sorted(batch_times)}")
+
+    normalized = {}
+    batch_count = None
+    for mask in sorted(expected_keys):
+        values = [float(value) for value in batch_times[mask]]
+        if not values or any(value <= 0.0 or not math.isfinite(value) for value in values):
+            raise ValueError(f"treatment {mask} timings must be finite and positive")
+        if batch_count is None:
+            batch_count = len(values)
+        elif len(values) != batch_count:
+            raise ValueError("every treatment must have the same number of batches")
+        normalized[mask] = values
+    return normalized, batch_count
+
+
+def factorial_main_effects(batch_times, axis_masks=AXIS_MASKS):
+    """Average each axis's conditional effects within every paired batch.
+
+    Deltas use accelerated-minus-incumbent milliseconds.  Ratios are averaged
+    in log space so reciprocal speedups are treated symmetrically.
+    """
+    batch_times, batch_count = _validated_batch_times(batch_times, axis_masks)
+    treatment_count = len(batch_times)
+    results = {}
+    for axis, mask in axis_masks.items():
+        delta_samples = []
+        ratio_samples = []
+        for batch in range(batch_count):
+            conditional_deltas = []
+            conditional_logs = []
+            for incumbent in range(treatment_count):
+                if incumbent & mask:
+                    continue
+                accelerated = incumbent | mask
+                old = batch_times[incumbent][batch]
+                new = batch_times[accelerated][batch]
+                conditional_deltas.append(new - old)
+                conditional_logs.append(math.log(new / old))
+            delta_samples.append(statistics.mean(conditional_deltas))
+            ratio_samples.append(math.exp(statistics.mean(conditional_logs)))
+        results[axis] = {
+            "conditional_delta_ms": distribution(delta_samples),
+            "conditional_geomean_ratio": distribution(ratio_samples),
+        }
+    return results
+
+
+def shapley_savings(batch_times, axis_masks=AXIS_MASKS):
+    """Allocate baseline-minus-all savings to every axis, including interactions."""
+    batch_times, batch_count = _validated_batch_times(batch_times, axis_masks)
+    axis_count = len(axis_masks)
+    all_mask = (1 << axis_count) - 1
+    samples = {axis: [] for axis in axis_masks}
+    totals = []
+
+    for batch in range(batch_count):
+        times = {mask: values[batch] for mask, values in batch_times.items()}
+        per_axis = {}
+        for axis, axis_mask in axis_masks.items():
+            contribution = 0.0
+            for incumbent in range(all_mask + 1):
+                if incumbent & axis_mask:
+                    continue
+                # ``int.bit_count`` is Python 3.10+, while the package still
+                # supports Python 3.9.
+                subset_size = bin(incumbent).count("1")
+                weight = math.factorial(subset_size) * math.factorial(axis_count - subset_size - 1) / math.factorial(axis_count)
+                contribution += weight * (times[incumbent] - times[incumbent | axis_mask])
+            per_axis[axis] = contribution
+            samples[axis].append(contribution)
+        total = times[0] - times[all_mask]
+        if not math.isclose(sum(per_axis.values()), total, rel_tol=1e-10, abs_tol=1e-8):
+            raise AssertionError(f"Shapley additivity failed at batch {batch}: {per_axis}, total={total}")
+        totals.append(total)
+
+    return {
+        "saving_ms": {axis: distribution(values) for axis, values in samples.items()},
+        "combined_saving_ms": distribution(totals),
+        "raw_saving_ms": samples,
+    }
+
+
+def config_fingerprint(config):
+    """Hash a JSON-compatible resolved configuration using canonical encoding."""
+    encoded = json.dumps(config, sort_keys=True, separators=(",", ":"), ensure_ascii=True, allow_nan=False).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def compare_results(current, previous):
+    """Compare two independent formal runs with the same experiment contract.
+
+    Each run's ``111/000`` headline remains internally paired by batch.  Samples
+    are not paired *across* runs, so this function compares arm-level p50s and
+    the two within-run paired headline estimates without claiming cross-run
+    pairing or significance.
+    """
+
+    def comparability_fingerprint(metadata, label):
+        try:
+            value = metadata["config"]["comparability_fingerprint"]["sha256"]
+        except (KeyError, TypeError) as error:
+            raise ValueError(f"{label} artifact lacks a comparability fingerprint") from error
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{label} artifact has an invalid comparability fingerprint")
+        return value
+
+    current_fingerprint = comparability_fingerprint(current, "current")
+    previous_fingerprint = comparability_fingerprint(previous, "previous")
+    if current_fingerprint != previous_fingerprint:
+        raise ValueError(
+            "cannot compare artifacts with different comparability fingerprints: " f"current={current_fingerprint}, previous={previous_fingerprint}"
+        )
+
+    current_summary = current.get("summary", {})
+    previous_summary = previous.get("summary", {})
+    if set(current_summary) != set(previous_summary) or not current_summary:
+        raise ValueError("current and previous artifacts must contain the same non-empty treatment summaries")
+
+    arms = {}
+    for bits in sorted(current_summary):
+        current_p50 = float(current_summary[bits]["p50_ms"])
+        previous_p50 = float(previous_summary[bits]["p50_ms"])
+        if not all(math.isfinite(value) and value > 0.0 for value in (current_p50, previous_p50)):
+            raise ValueError(f"{bits} p50 values must be finite and positive")
+        arms[bits] = {
+            "previous_p50_ms": previous_p50,
+            "current_p50_ms": current_p50,
+            "p50_change_ms": current_p50 - previous_p50,
+            "p50_change_percent": (current_p50 / previous_p50 - 1.0) * 100.0,
+            "p50_ratio_current_over_previous": current_p50 / previous_p50,
+            "paired_across_runs": False,
+        }
+
+    try:
+        current_headline = float(current["comparisons"]["all_vs_baseline"]["paired_ratio_p50"])
+        previous_headline = float(previous["comparisons"]["all_vs_baseline"]["paired_ratio_p50"])
+    except (KeyError, TypeError) as error:
+        raise ValueError("artifacts lack the within-run paired all_vs_baseline headline") from error
+    if not all(math.isfinite(value) and value > 0.0 for value in (current_headline, previous_headline)):
+        raise ValueError("within-run paired headline ratios must be finite and positive")
+
+    return {
+        "comparability_fingerprint_sha256": current_fingerprint,
+        "paired_across_runs": False,
+        "note": (
+            "Runs are independent: arm p50 changes and the change between the two within-run paired "
+            "111/000 estimates are cross-run comparisons, not paired samples."
+        ),
+        "arms": arms,
+        "headline": {
+            "metric": "within_run_paired_111_over_000_ratio_p50",
+            "previous": previous_headline,
+            "current": current_headline,
+            "change": current_headline - previous_headline,
+            "change_percentage_points": (current_headline - previous_headline) * 100.0,
+            "relative_change_percent": (current_headline / previous_headline - 1.0) * 100.0,
+            "paired_across_runs": False,
+        },
+    }
+
+
+def _format_path(path):
+    return str(path).replace("|", "\\|")
+
+
+def render_markdown(metadata, *, raw_json_link, raw_json_sha256):
+    """Render a compact, self-contained Markdown report from a result payload."""
+    config = metadata["config"]
+    summary = metadata["summary"]
+    effects = metadata["main_effects"]
+    shapley = metadata["shapley"]
+    route = metadata["route"]
+    variants = {variant["bits"]: variant for variant in config["variants"]}
+    all_vs_baseline = metadata["comparisons"]["all_vs_baseline"]
+    ratio = all_vs_baseline["paired_ratio_p50"]
+    is_smoke = config["mode"] == "smoke"
+
+    lines = [
+        "# Qwen3.8 2^3 factorial benchmark",
+        "",
+        f"Generated: `{metadata['completed_utc']}`  ",
+        f"Mode: `{config['mode']}`  ",
+        f"Comparability fingerprint: `{config['comparability_fingerprint']['sha256']}`  ",
+        f"Build/provenance fingerprint: `{config['build_fingerprint']['sha256']}`  ",
+        f"Raw JSON: [`{raw_json_link}`]({_format_path(raw_json_link)}) (`sha256:{raw_json_sha256}`)",
+        "",
+    ]
+    if is_smoke:
+        lines.extend(
+            [
+                "## Smoke validation",
+                "",
+                "**Validation only. Do not use smoke timings for performance trends, headlines, or model-speedup claims.** "
+                f"Smoke uses M=bs*seq={config['bs'] * config['seq']} instead of formal M=8192, so fixed launch/dispatch overheads and small-M effects dominate.",
+                "",
+                "The route, correctness, and artifact plumbing gates passed. The p50 values below are diagnostics only.",
+                "",
+                "| bits (G/M/A) | GDN | MLP | full attention | diagnostic p50 step |",
+                "|---|---|---|---|---:|",
+            ]
+        )
+        for bits in sorted(summary):
+            result = summary[bits]
+            variant = variants[bits]
+            lines.append(
+                f"| `{bits}` | {'cuDNN' if variant['gdn'] else 'stock FLA'} | "
+                f"{'cuDNN' if variant['mlp'] else 'stock FLA'} | "
+                f"{'cuDNN backend' if variant['attn'] else 'Torch'} | {result['p50_ms']:.3f} ms |"
+            )
+    else:
+        lines.extend(
+            [
+                "## Result",
+                "",
+                f"The all-cuDNN arm is `{ratio:.5f}x` the paired baseline elapsed time "
+                f"({(1.0 - ratio) * 100.0:.2f}% lower, `{1.0 / ratio:.3f}x` speedup; "
+                f"{all_vs_baseline['wins']}/{all_vs_baseline['batches']} paired wins).",
+                "",
+                "| bits (G/M/A) | GDN | MLP | full attention | p50 step | paired ratio vs 000 | wins vs 000 |",
+                "|---|---|---|---|---:|---:|---:|",
+            ]
+        )
+        for bits in sorted(summary):
+            result = summary[bits]
+            variant = variants[bits]
+            wins = "--" if bits == "000" else f"{result['wins_vs_baseline']}/{result['batches']}"
+            lines.append(
+                f"| `{bits}` | {'cuDNN' if variant['gdn'] else 'stock FLA'} | "
+                f"{'cuDNN' if variant['mlp'] else 'stock FLA'} | "
+                f"{'cuDNN backend' if variant['attn'] else 'Torch'} | "
+                f"{result['p50_ms']:.3f} ms | {result['paired_ratio_p50']:.5f} | {wins} |"
+            )
+        lines.extend(
+            [
+                "",
+                "## Factorial attribution",
+                "",
+                "Conditional ratios average each axis over its four paired contexts in log space. "
+                "Shapley savings allocate baseline-minus-all elapsed time, including interactions; "
+                "they are not module-time shares.",
+                "",
+                "| axis | conditional ratio (p50) | conditional speedup | conditional delta (p50) | Shapley saving (p50) |",
+                "|---|---:|---:|---:|---:|",
+            ]
+        )
+        for axis in AXIS_MASKS:
+            axis_ratio = effects[axis]["conditional_geomean_ratio"]["p50"]
+            axis_delta = effects[axis]["conditional_delta_ms"]["p50"]
+            axis_shapley = shapley["saving_ms"][axis]["p50"]
+            lines.append(f"| {axis} | {axis_ratio:.5f} | {1.0 / axis_ratio:.3f}x | {axis_delta:+.3f} ms | {axis_shapley:.3f} ms |")
+
+    comparison = metadata.get("comparison")
+    if comparison is not None:
+        headline = comparison["headline"]
+        lines.extend(
+            [
+                "",
+                "## Cross-run comparison",
+                "",
+                f"**Not paired across runs.** {comparison['note']}",
+            ]
+        )
+        if "previous_artifact" in comparison:
+            previous_artifact = comparison["previous_artifact"]
+            lines.append(f"Previous artifact: `{_format_path(previous_artifact['path'])}` (`sha256:{previous_artifact['sha256']}`).")
+        lines.extend(
+            [
+                "",
+                f"The within-run paired `111/000` ratio changed from `{headline['previous']:.5f}` to "
+                f"`{headline['current']:.5f}` ({headline['change_percentage_points']:+.3f} percentage points).",
+                "",
+                "| bits | previous p50 | current p50 | non-paired change | change |",
+                "|---|---:|---:|---:|---:|",
+            ]
+        )
+        for bits, arm in sorted(comparison["arms"].items()):
+            lines.append(
+                f"| `{bits}` | {arm['previous_p50_ms']:.3f} ms | {arm['current_p50_ms']:.3f} ms | "
+                f"{arm['p50_change_ms']:+.3f} ms | {arm['p50_change_percent']:+.2f}% |"
+            )
+
+    mode_overrides = config.get("mode_overrides", {})
+    override_text = json.dumps(mode_overrides, sort_keys=True) if mode_overrides else "none"
+    lines.extend(
+        [
+            "",
+            "## Configuration and gates",
+            "",
+            f"- Device: `{config['device']}` ({config['sm_count']} SMs, `{config['device_id']}`)",
+            f"- Software: Python `{config['python']}`, PyTorch `{config['torch']}` / CUDA `{config['torch_cuda']}`, "
+            f"CUDA driver/runtime `{config['cuda_driver']}/{config['cuda_runtime']}`, cuDNN FE `{config['cudnn_frontend']}`, "
+            f"cuDNN backend `{config['cudnn_backend']}`, FLA `{config['fla']}`",
+            f"- Model: `{config['preset']}`, shape `{json.dumps(config['resolved_shape'], sort_keys=True)}`, attention layers `{config['attn_layers']}`",
+            f"- Input/timing: batch `{config['bs']}`, sequence `{config['seq']}`, warmup `{config['warmup']}`, "
+            f"batches `{config['rounds']}`, repeats `{config['repeats']}`",
+            f"- Mode overrides: `{override_text}`",
+            "- Correctness: every arm passed explicit finite-value checks and the recorded aggregate BF16 loss/gradient gate.",
+            f"- Native GDN calls: `{route['native_gdn_calls']}/{route['expected_native_gdn_calls']}`; "
+            f"FROST dSwiGLU calls: `{route['frost_calls']}/{route['expected_frost_calls']}`; pointwise fallback: `{route['pointwise_calls']}`.",
+            f"- Full-attention calls: `{json.dumps(route['full_attention_calls'], sort_keys=True)}`; Torch baseline contract passed.",
+        ]
+    )
+    lines.extend(
+        [
+            "",
+            "## Provenance",
+            "",
+            f"Repository commit: `{config['provenance']['git']['commit']}`; dirty: `{config['provenance']['git']['dirty']}`.",
+            "",
+            "| source | path | sha256 |",
+            "|---|---|---|",
+        ]
+    )
+    for name, source in sorted(config["provenance"]["sources"].items()):
+        lines.append(f"| {name} | `{_format_path(source['path'])}` | `{source['sha256']}` |")
+    lines.extend(
+        [
+            "",
+            "The source hashes above are provenance only; the runner does not pin a private checkout or require a particular GDN source hash.",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/benchmark/e2e/_factorial.py
+++ b/benchmark/e2e/_factorial.py
@@ -405,6 +405,11 @@ def render_markdown(metadata, *, raw_json_link, raw_json_sha256):
 
     mode_overrides = config.get("mode_overrides", {})
     override_text = json.dumps(mode_overrides, sort_keys=True) if mode_overrides else "none"
+    recipe_anchor = config["numerical_recipe"].get("anchor")
+    if recipe_anchor is None:
+        recipe_anchor_text = "none (local policy)"
+    else:
+        recipe_anchor_text = f"{recipe_anchor['project']}@{recipe_anchor['commit']}:" f"{recipe_anchor['path']}::{recipe_anchor['symbol']}"
     lines.extend(
         [
             "",
@@ -415,6 +420,10 @@ def render_markdown(metadata, *, raw_json_link, raw_json_sha256):
             f"CUDA driver/runtime `{config['cuda_driver']}/{config['cuda_runtime']}`, cuDNN FE `{config['cudnn_frontend']}`, "
             f"cuDNN backend `{config['cudnn_backend']}`, FLA `{config['fla']}`",
             f"- Model: `{config['preset']}`, shape `{json.dumps(config['resolved_shape'], sort_keys=True)}`, attention layers `{config['attn_layers']}`",
+            f"- Numerical recipe: `{config['numerical_recipe']['id']}`; parameters/activations "
+            f"`{config['numerical_recipe']['parameter_dtype']}`/`{config['numerical_recipe']['activation_dtype']}`; "
+            f"scope `{config['numerical_recipe']['scope']}`; alignment `{config['numerical_recipe']['alignment']}`",
+            f"- Numerical anchor: `{recipe_anchor_text}`",
             f"- Input/timing: batch `{config['bs']}`, sequence `{config['seq']}`, warmup `{config['warmup']}`, "
             f"batches `{config['rounds']}`, repeats `{config['repeats']}`",
             f"- Mode overrides: `{override_text}`",

--- a/benchmark/e2e/_factorial.py
+++ b/benchmark/e2e/_factorial.py
@@ -242,7 +242,7 @@ def compare_results(current, previous):
         try:
             current_p50 = float(current_summary[bits]["p50_ms"])
             previous_p50 = float(previous_summary[bits]["p50_ms"])
-        except (KeyError, TypeError, ValueError) as error:
+        except (KeyError, TypeError, ValueError, OverflowError) as error:
             raise ValueError(f"{bits} treatment summaries must contain numeric p50_ms values") from error
         if not all(math.isfinite(value) and value > 0.0 for value in (current_p50, previous_p50)):
             raise ValueError(f"{bits} p50 values must be finite and positive")

--- a/benchmark/e2e/_factorial.py
+++ b/benchmark/e2e/_factorial.py
@@ -239,8 +239,11 @@ def compare_results(current, previous):
 
     arms = {}
     for bits in sorted(current_summary):
-        current_p50 = float(current_summary[bits]["p50_ms"])
-        previous_p50 = float(previous_summary[bits]["p50_ms"])
+        try:
+            current_p50 = float(current_summary[bits]["p50_ms"])
+            previous_p50 = float(previous_summary[bits]["p50_ms"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError(f"{bits} treatment summaries must contain numeric p50_ms values") from error
         if not all(math.isfinite(value) and value > 0.0 for value in (current_p50, previous_p50)):
             raise ValueError(f"{bits} p50 values must be finite and positive")
         arms[bits] = {

--- a/benchmark/e2e/_perfshare.py
+++ b/benchmark/e2e/_perfshare.py
@@ -87,27 +87,33 @@ def profile_and_report(model, ids, *, step=_default_step, warmup=3, iters=10, ex
     separately — their difference is only an approximate host/overhead gap (they
     come from different iterations), so it is shown only when positive.
     """
-    for _ in range(warmup):
-        model.zero_grad(set_to_none=True)
-        step(model, ids)
-    torch.cuda.synchronize()
+    if ids.device.type != "cuda":
+        raise ValueError(f"profile_and_report requires CUDA input ids, got {ids.device}")
+    device = ids.device
+    with torch.cuda.device(device):
+        for _ in range(warmup):
+            model.zero_grad(set_to_none=True)
+            step(model, ids)
+        torch.cuda.synchronize(device)
     if extra_path is not None:
         print(f"op path: {extra_path()}")
 
     best = float("inf")
     for _ in range(iters):
-        model.zero_grad(set_to_none=True)
-        s, e = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
-        s.record()
-        step(model, ids)
-        e.record()
-        torch.cuda.synchronize()
-        best = min(best, s.elapsed_time(e))
+        with torch.cuda.device(device):
+            model.zero_grad(set_to_none=True)
+            s, e = torch.cuda.Event(enable_timing=True), torch.cuda.Event(enable_timing=True)
+            s.record()
+            step(model, ids)
+            e.record()
+            torch.cuda.synchronize(device)
+            best = min(best, s.elapsed_time(e))
 
-    model.zero_grad(set_to_none=True)
-    with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
-        step(model, ids)
-        torch.cuda.synchronize()
+    with torch.cuda.device(device):
+        model.zero_grad(set_to_none=True)
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]) as prof:
+            step(model, ids)
+            torch.cuda.synchronize(device)
 
     cat, be, total = collections.defaultdict(float), collections.defaultdict(float), 0.0
     for ev in prof.key_averages():

--- a/benchmark/e2e/tests/test_factorial.py
+++ b/benchmark/e2e/tests/test_factorial.py
@@ -194,7 +194,7 @@ class FactorialStatisticsTest(unittest.TestCase):
             compare_results(current, previous)
 
     def test_cross_run_comparison_labels_missing_or_nonnumeric_p50(self):
-        for invalid in (None, "not-a-number"):
+        for invalid in (None, "not-a-number", 10**10000):
             with self.subTest(invalid=invalid):
                 previous = self._metadata()
                 current = self._metadata()

--- a/benchmark/e2e/tests/test_factorial.py
+++ b/benchmark/e2e/tests/test_factorial.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+E2E_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(E2E_DIR))
+
+from _factorial import (  # noqa: E402
+    compare_results,
+    config_fingerprint,
+    factorial_main_effects,
+    paired_stats,
+    render_markdown,
+    shapley_savings,
+    validate_design,
+    williams_orders,
+)
+
+RUN_MATRIX_PATH = E2E_DIR / "Qwen3.8" / "run_matrix.py"
+RUN_MATRIX_SPEC = importlib.util.spec_from_file_location("qwen38_run_matrix_cpu_test", RUN_MATRIX_PATH)
+if RUN_MATRIX_SPEC is None or RUN_MATRIX_SPEC.loader is None:
+    raise RuntimeError(f"cannot load {RUN_MATRIX_PATH}")
+RUN_MATRIX = importlib.util.module_from_spec(RUN_MATRIX_SPEC)
+sys.modules[RUN_MATRIX_SPEC.name] = RUN_MATRIX
+RUN_MATRIX_SPEC.loader.exec_module(RUN_MATRIX)
+
+
+class FactorialStatisticsTest(unittest.TestCase):
+    def setUp(self):
+        savings = {1: 2.0, 2: 5.0, 4: 10.0}
+        self.batch_times = {
+            mask: [baseline - sum(value for bit, value in savings.items() if mask & bit) for baseline in (100.0, 110.0, 120.0)] for mask in range(8)
+        }
+
+    def _metadata(self, *, mode="formal", fingerprint="comparable", scale=1.0):
+        effects = factorial_main_effects(self.batch_times)
+        shapley = shapley_savings(self.batch_times)
+        variants = []
+        summary = {}
+        for mask in range(8):
+            bits = f"{mask:03b}"
+            variants.append(
+                {
+                    "bits": bits,
+                    "name": bits,
+                    "gdn": bool(mask & 4),
+                    "mlp": bool(mask & 2),
+                    "attn": bool(mask & 1),
+                }
+            )
+            paired = paired_stats(self.batch_times[mask], self.batch_times[0])
+            summary[bits] = {
+                "p50_ms": sorted(self.batch_times[mask])[1] * scale,
+                "paired_ratio_p50": paired["paired_ratio_p50"],
+                "wins_vs_baseline": paired["wins"],
+                "batches": paired["batches"],
+            }
+        all_comparison = paired_stats(self.batch_times[7], self.batch_times[0])
+        return {
+            "completed_utc": "2026-08-20T12:00:00Z",
+            "config": {
+                "mode": mode,
+                "comparability_fingerprint": {"sha256": fingerprint, "inputs": {}},
+                "build_fingerprint": {"sha256": "build123", "inputs": {}},
+                "device": "NVIDIA B200",
+                "device_id": "cuda:2",
+                "sm_count": 148,
+                "python": "3.10",
+                "torch": "test",
+                "torch_cuda": "13.0",
+                "cuda_driver": 13020,
+                "cuda_runtime": 13000,
+                "cudnn_frontend": "test",
+                "cudnn_backend": 92300,
+                "fla": "test",
+                "preset": "qwen3.8-27b",
+                "resolved_shape": {"hidden": 5120},
+                "attn_layers": [3],
+                "bs": 4,
+                "seq": 2048,
+                "warmup": 3,
+                "rounds": 8,
+                "repeats": 1,
+                "mode_overrides": {},
+                "variants": variants,
+                "provenance": {
+                    "git": {"commit": "deadbeef", "dirty": False},
+                    "sources": {"runner": {"path": "benchmark/e2e/Qwen3.8/run_matrix.py", "sha256": "face"}},
+                },
+            },
+            "summary": summary,
+            "comparisons": {"all_vs_baseline": all_comparison},
+            "main_effects": effects,
+            "shapley": shapley,
+            "route": {
+                "native_gdn_calls": 100,
+                "expected_native_gdn_calls": 100,
+                "frost_calls": 100,
+                "expected_frost_calls": 100,
+                "pointwise_calls": 0,
+                "full_attention_calls": {"torch": 10, "cudnn": 10},
+            },
+        }
+
+    def test_williams_design_balances_positions_and_carryover(self):
+        orders = williams_orders()
+        self.assertEqual(orders[0], (0, 1, 7, 2, 6, 3, 5, 4))
+        validate_design(orders)
+        with self.assertRaises(ValueError):
+            validate_design(orders[:-1])
+        with self.assertRaises(ValueError):
+            williams_orders(7)
+
+    def test_paired_statistics_are_batch_aligned(self):
+        result = paired_stats([8.0, 18.0], [10.0, 20.0])
+        self.assertAlmostEqual(result["paired_ratio_p50"], 0.85)
+        self.assertAlmostEqual(result["paired_delta_p50_ms"], -2.0)
+        self.assertEqual(result["wins"], 2)
+        with self.assertRaises(ValueError):
+            paired_stats([1.0], [1.0, 2.0])
+
+    def test_main_effects_and_shapley_recover_additive_savings(self):
+        effects = factorial_main_effects(self.batch_times)
+        self.assertAlmostEqual(effects["gdn"]["conditional_delta_ms"]["p50"], -10.0)
+        self.assertAlmostEqual(effects["mlp"]["conditional_delta_ms"]["p50"], -5.0)
+        self.assertAlmostEqual(effects["attn"]["conditional_delta_ms"]["p50"], -2.0)
+
+        shapley = shapley_savings(self.batch_times)
+        self.assertAlmostEqual(shapley["saving_ms"]["gdn"]["p50"], 10.0)
+        self.assertAlmostEqual(shapley["saving_ms"]["mlp"]["p50"], 5.0)
+        self.assertAlmostEqual(shapley["saving_ms"]["attn"]["p50"], 2.0)
+        self.assertAlmostEqual(shapley["combined_saving_ms"]["p50"], 17.0)
+
+    def test_config_fingerprint_is_canonical_and_sensitive(self):
+        first = {"shape": {"hidden": 5120, "layers": 4}, "mode": "formal"}
+        reordered = {"mode": "formal", "shape": {"layers": 4, "hidden": 5120}}
+        self.assertEqual(config_fingerprint(first), config_fingerprint(reordered))
+        changed = copy.deepcopy(first)
+        changed["shape"]["layers"] = 8
+        self.assertNotEqual(config_fingerprint(first), config_fingerprint(changed))
+        with self.assertRaises(ValueError):
+            config_fingerprint({"invalid": float("nan")})
+
+    def test_markdown_contains_result_configuration_and_provenance(self):
+        metadata = self._metadata()
+        report = render_markdown(metadata, raw_json_link="result.json", raw_json_sha256="cafe")
+        self.assertIn("Comparability fingerprint: `comparable`", report)
+        self.assertIn("Build/provenance fingerprint: `build123`", report)
+        self.assertIn("## Factorial attribution", report)
+        self.assertIn("benchmark/e2e/Qwen3.8/run_matrix.py", report)
+        self.assertIn("provenance only", report)
+
+    def test_smoke_markdown_is_validation_only_without_speedup_headline(self):
+        metadata = self._metadata(mode="smoke")
+        metadata["config"]["bs"] = 1
+        metadata["config"]["seq"] = 128
+        report = render_markdown(metadata, raw_json_link="result.json", raw_json_sha256="cafe")
+        self.assertIn("Validation only", report)
+        self.assertIn("M=bs*seq=128", report)
+        self.assertNotIn("The all-cuDNN arm", report)
+        self.assertNotIn("## Factorial attribution", report)
+
+    def test_cross_run_comparison_is_nonpaired_and_requires_fingerprint_match(self):
+        previous = self._metadata(scale=1.0)
+        current = self._metadata(scale=0.9)
+        current["config"]["build_fingerprint"]["sha256"] = "new-build"
+        current["config"]["provenance"]["sources"]["runner"]["sha256"] = "new-source"
+        previous["comparisons"]["all_vs_baseline"]["paired_ratio_p50"] = 0.90
+        current["comparisons"]["all_vs_baseline"]["paired_ratio_p50"] = 0.85
+
+        comparison = compare_results(current, previous)
+        self.assertFalse(comparison["paired_across_runs"])
+        self.assertAlmostEqual(comparison["arms"]["000"]["p50_change_percent"], -10.0)
+        self.assertAlmostEqual(comparison["headline"]["change_percentage_points"], -5.0)
+        current["comparison"] = comparison
+        report = render_markdown(current, raw_json_link="result.json", raw_json_sha256="cafe")
+        self.assertIn("Not paired across runs", report)
+        self.assertIn("within-run paired `111/000`", report)
+
+        incompatible = self._metadata(fingerprint="different")
+        with self.assertRaisesRegex(ValueError, "different comparability fingerprints"):
+            compare_results(current, incompatible)
+
+    def test_cross_run_comparison_rejects_nonfinite_p50(self):
+        previous = self._metadata()
+        current = self._metadata()
+        current["summary"]["111"]["p50_ms"] = float("nan")
+        with self.assertRaisesRegex(ValueError, "finite and positive"):
+            compare_results(current, previous)
+
+    def test_torch_baseline_route_contract_is_strict(self):
+        valid = {
+            "can_use_flash": True,
+            "can_use_cudnn": False,
+            "flash_sdp_enabled": True,
+            "grad_fn_chain": ["TransposeBackward0", "ScaledDotProductFlashAttentionBackward0"],
+        }
+        RUN_MATRIX._validate_torch_baseline_route(valid)
+        for name, invalid_value in (
+            ("can_use_flash", False),
+            ("can_use_cudnn", True),
+            ("flash_sdp_enabled", False),
+            ("grad_fn_chain", ["SomeOtherBackward0"]),
+        ):
+            with self.subTest(name=name), self.assertRaisesRegex(RuntimeError, "route contract failed"):
+                invalid = copy.deepcopy(valid)
+                invalid[name] = invalid_value
+                RUN_MATRIX._validate_torch_baseline_route(invalid)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmark/e2e/tests/test_factorial.py
+++ b/benchmark/e2e/tests/test_factorial.py
@@ -87,6 +87,19 @@ class FactorialStatisticsTest(unittest.TestCase):
                 "rounds": 8,
                 "repeats": 1,
                 "mode_overrides": {},
+                "numerical_recipe": {
+                    "id": "conservative-bf16-v1",
+                    "parameter_dtype": "bfloat16",
+                    "activation_dtype": "bfloat16",
+                    "scope": "forward_backward_no_optimizer",
+                    "anchor": {
+                        "project": "NVIDIA-NeMo/Megatron-Bridge",
+                        "commit": "2e77041c194d106beb7462e226d7ca06b33ea63f",
+                        "path": "src/megatron/bridge/training/mixed_precision.py",
+                        "symbol": "bf16_mixed",
+                    },
+                    "alignment": "upstream_anchored_subset",
+                },
                 "variants": variants,
                 "provenance": {
                     "git": {"commit": "deadbeef", "dirty": False},
@@ -143,6 +156,9 @@ class FactorialStatisticsTest(unittest.TestCase):
         changed = copy.deepcopy(first)
         changed["shape"]["layers"] = 8
         self.assertNotEqual(config_fingerprint(first), config_fingerprint(changed))
+        recipe_changed = copy.deepcopy(first)
+        recipe_changed["numerical_recipe"] = {"id": "future-low-precision-v1"}
+        self.assertNotEqual(config_fingerprint(first), config_fingerprint(recipe_changed))
         with self.assertRaises(ValueError):
             config_fingerprint({"invalid": float("nan")})
 
@@ -152,6 +168,8 @@ class FactorialStatisticsTest(unittest.TestCase):
         self.assertIn("Comparability fingerprint: `comparable`", report)
         self.assertIn("Build/provenance fingerprint: `build123`", report)
         self.assertIn("## Factorial attribution", report)
+        self.assertIn("Numerical recipe: `conservative-bf16-v1`", report)
+        self.assertIn("NVIDIA-NeMo/Megatron-Bridge@2e77041c", report)
         self.assertIn("benchmark/e2e/Qwen3.8/run_matrix.py", report)
         self.assertIn("provenance only", report)
 

--- a/benchmark/e2e/tests/test_factorial.py
+++ b/benchmark/e2e/tests/test_factorial.py
@@ -193,6 +193,18 @@ class FactorialStatisticsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "finite and positive"):
             compare_results(current, previous)
 
+    def test_cross_run_comparison_labels_missing_or_nonnumeric_p50(self):
+        for invalid in (None, "not-a-number"):
+            with self.subTest(invalid=invalid):
+                previous = self._metadata()
+                current = self._metadata()
+                if invalid is None:
+                    del previous["summary"]["111"]["p50_ms"]
+                else:
+                    previous["summary"]["111"]["p50_ms"] = invalid
+                with self.assertRaisesRegex(ValueError, "111 treatment summaries must contain numeric p50_ms values"):
+                    compare_results(current, previous)
+
     def test_torch_baseline_route_contract_is_strict(self):
         valid = {
             "can_use_flash": True,

--- a/benchmark/e2e/tests/test_qwen_image_spec.py
+++ b/benchmark/e2e/tests/test_qwen_image_spec.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+import sys
+import unittest
+
+E2E_DIR = Path(__file__).resolve().parents[1]
+MODEL_PATH = E2E_DIR / "Qwen-Image" / "run_model.py"
+SPEC = importlib.util.spec_from_file_location("qwen_image_model_cpu_test", MODEL_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"cannot load {MODEL_PATH}")
+MODEL = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODEL
+SPEC.loader.exec_module(MODEL)
+
+
+class QwenImageSpecTest(unittest.TestCase):
+    def test_formal_shape_preserves_published_kernel_dimensions(self):
+        shape = MODEL.resolve_shape("formal")
+        self.assertEqual(shape["image_tokens"], 4096)
+        self.assertEqual(shape["text_tokens"], 512)
+        self.assertEqual(shape["joint_tokens"], 4608)
+        self.assertEqual((shape["hidden"], shape["heads"], shape["head_dim"], shape["ffn"]), (3072, 24, 128, 12288))
+        self.assertEqual(shape["layers"], 4)
+        self.assertEqual(MODEL.PUBLISHED_SHAPE["full_layers"], 60)
+
+    def test_smoke_changes_only_repeated_and_token_work(self):
+        shape = MODEL.resolve_shape("smoke")
+        self.assertEqual((shape["layers"], shape["image_tokens"], shape["text_tokens"]), (1, 256, 64))
+        self.assertEqual((shape["hidden"], shape["heads"], shape["head_dim"], shape["ffn"]), (3072, 24, 128, 12288))
+
+    def test_invalid_image_token_grid_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "perfect square"):
+            MODEL.resolve_shape("smoke", image_tokens=255)
+
+    def test_bf16_leaf_has_immutable_upstream_anchors(self):
+        self.assertEqual(len(MODEL.OFFICIAL_MODEL["revision"]), 40)
+        self.assertEqual(len(MODEL.DIFFUSERS_ANCHOR["commit"]), 40)
+        self.assertEqual(len(MODEL.DIFFUSERS_ANCHOR["source_sha256"]), 64)
+        self.assertEqual(MODEL.NUMERICAL_RECIPE["id"], "qwen-image-conservative-bf16-v1")
+        self.assertEqual(MODEL.NUMERICAL_RECIPE["scope"], "inference_transformer_forward")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`.

## Affected area

Benchmarks or performance; documentation or samples.

## Summary

- Add a reusable Qwen3.8 2^3 layer-period benchmark for independent GDN, SwiGLU MLP, and d256 full-attention treatments, with an eight-treatment Williams design, paired effects, and Shapley attribution.
- Exercise the merged production paths: packed-QKV GDN from #685, the public opt-in `cudnn.fla` GatedMLP shim from #686 (backed by #609), and FE's backend-only public d256 SDPA after #682.
- Add a pinned Qwen-Image BF16 transformer proxy using Diffusers' real `QwenImageTransformer2DModel`, comparing forced PyTorch FlashAttention with direct FE/cuDNN joint SDPA while keeping projections, QK norm, RoPE, AdaLN, FFN, residuals, and output work common.
- Emit raw JSON and generated Markdown with resolved shapes, raw samples, route/correctness gates, immutable upstream anchors, numerical-recipe records, source hashes, and separate comparability and build/provenance fingerprints.
- Keep each model's precision/workload policy in a separate leaf (`run_matrix.py` or `run_bf16.py`) so future FP8/FP4 recipes do not become branches throughout the model definition.

## Why

The goal is to measure cuDNN kernel speedups against the actual vanilla Torch/FLA routes in representative model-shaped work, without multiplying isolated microbenchmark gains or calling a depth-reduced proxy full-model throughput. Smoke mode is validation-only; only full-B200 formal mode is eligible for performance headlines or history comparison.

## Related issues

Built on merged #682, #685, and #686. Related to #609, #596, and #335.

## API and compatibility impact

None for the cuDNN runtime API. New benchmark entry points:

```bash
python benchmark/e2e/Qwen3.8/run_matrix.py --mode smoke
python benchmark/e2e/Qwen3.8/run_matrix.py --mode formal
python benchmark/e2e/Qwen-Image/run_bf16.py --mode smoke
python benchmark/e2e/Qwen-Image/run_bf16.py --mode formal
```

Qwen3.8 formal mode requires a full 148-SM NVIDIA B200, FLA 0.5.2, and cuDNN backend >= 9.23. Its vanilla d256 GQA arm must select PyTorch FlashAttention, while the FE arm must enter the public cuDNN backend graph. The runner also requires exact successful public GDN/MLP native-route counts.

Qwen-Image pins its model config and Diffusers implementation. Its official joint sequence is `[text, image]`: every query can see every valid text token and every image token, and only padded text key columns are masked. Batch-1 trimmed inference uses the dense no-mask path. For unequal right-padded prompts, the adapter permutes Q/K/V to `[image, text]`, represents the now-suffix padding with `seq_len_kv`, and restores output order; masks with arbitrary holes fail closed.

## Testing

- `python3 -m unittest discover -s benchmark/e2e/tests -v`: **14 passed**.
- `py_compile` for both runners/model adapters and tests, Black check, pre-commit, and `git diff --check`: passed.
- Qwen3.8 B200 smoke and formal runs passed finite/correctness, artifact, and strict GDN/MLP/SDPA route gates.
- Qwen-Image B200 smoke and formal runs passed forced-Flash/direct-cuDNN route gates, full-output correctness, and the focused B=2 unequal-text mask parity gate.

### Qwen3.8 formal result

Four-layer Qwen3.8-27B shape proxy, BF16 fwd+CE+bwd, B=4, S=2048, 40 Williams-balanced batches x 3 repeats:

- `000` stock FLA/Torch: **75.427 ms** p50.
- `111` all accelerated: **62.544 ms** p50.
- Direct paired `111/000`: **0.82759**, 17.24% lower / **1.208x**, 40/40 wins.
- Conditional ratios: GDN **0.86005**, MLP **0.96876**, d256 attention **0.98280**.
- Raw artifact SHA-256: `65654ec5c55f7e900f1351c60d8f835b2d7e427613b8d1df18dd7f3d9b1b2757`.

This is a single-job four-layer proxy result, not full 64-layer Qwen throughput. The artifact records its runtime worktree as dirty, while its per-file hashes match the committed benchmark and cuDNN sources exactly.

### Qwen-Image BF16 formal result

Four of 60 blocks, B=1, 4096 image + 512 text tokens, H=3072, 24x128 heads, FFN=12288, 40 balanced batches x 3 repeats, transformer forward only:

- Forced PyTorch FlashAttention: **9.943 ms** p50.
- Direct FE/cuDNN backend: **7.883 ms** p50.
- Paired ratio: **0.79640**, 20.36% lower / **1.256x**, 40/40 wins.
- Full four-block output relative L2: **0.141%**; focused B=2 unequal-text mask relative L2: **0.300%**.
- Raw artifact SHA-256: `288ce0415c0cfd6564fde99debe0273a2304c07e7810547bd5da8b25cda0fbba`.

This is a controlled cuDNN-off/on comparison: the off arm forces PyTorch FlashAttention, while the on arm uses direct FE/cuDNN. The unforced public Torch call already selects `CUDNN_ATTENTION` for this d128 B200 shape, so stock Torch users already receive this cuDNN benefit by default; the result does not claim an additional 1.256x from bypassing Torch dispatch. It uses random weights and precomputed text embeddings and excludes checkpoint loading, text encoding, VAE, scheduler work, and the full denoising loop; it is not image-quality evidence. The artifact records its runtime worktree as dirty, while its per-file hashes match the committed benchmark and cuDNN sources exactly.
