### PR TITLE
Fix three Rubin (sm_107) compile/launch failures in the CuTeDSL kernels

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/utils/compiler.py
+++ b/python/cudnn/deepseek_sparse_attention/utils/compiler.py
@@ -31,7 +31,9 @@ _ARCH_MAP = {
     (9, 0): "sm_90a",  # Hopper H100
     (10, 0): "sm_100a",  # Blackwell B200
     (10, 3): "sm_103a",  # Blackwell Ultra B300
-    (10, 7): "sm_100f",
+    # Rubin needs the arch-specific target: the MXFP8 kernels emit block-scaled
+    # MMAs (.scale_vec::1X) that ptxas rejects on the sm_100f family target.
+    (10, 7): "sm_107a",
 }
 
 

--- a/python/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/dglu/moe_blockscaled_grouped_gemm_dglu_rubin.py
@@ -3908,12 +3908,11 @@ class BlockScaledMoEGroupedGemmDgluKernel:
             1,
         )
 
-        ab_bytes_per_stage = (
-            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
-            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
-            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
-            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
-        )
+        a_bytes_per_stage = cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+        b_bytes_per_stage = cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+        sfa_bytes_per_stage = cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+        sfb_bytes_per_stage = cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        ab_bytes_per_stage = a_bytes_per_stage + b_bytes_per_stage + sfa_bytes_per_stage + sfb_bytes_per_stage
         # Mbar bytes
         mbar_helpers_bytes = 1024
         # Sinfo bytes
@@ -3938,6 +3937,35 @@ class BlockScaledMoEGroupedGemmDgluKernel:
         # Divide remaining by bytes needed per A/B stage
         num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes + sinfo_bytes)) // ab_bytes_per_stage
 
-        total_bytes = occupancy * (ab_bytes_per_stage * num_ab_stage + epi_bytes + sinfo_bytes + mbar_helpers_bytes)
+        # The byte-sum model above ignores the 1024-B alignment padding of the
+        # SharedStorage buffers, so a tight config can produce a struct that
+        # exceeds the sm_107 SMEM cap and CUDA rejects the launch
+        # (CUDA_LAUNCH_INVALID_CONFIG). Mirror the struct layout exactly and shed
+        # A/B stages until it genuinely fits.
+        buffer_align_bytes = 1024
+
+        def round_align(nbytes):
+            return (nbytes + buffer_align_bytes - 1) // buffer_align_bytes * buffer_align_bytes
+
+        d_is_quantized = d_dtype == cutlass.Float8E5M2 or d_dtype == cutlass.Float8E4M3FN
+
+        def shared_storage_bytes(n_ab):
+            # Exact size of the SharedStorage struct in __call__ for these stage
+            # counts: mbars/scheduler head padded to the first 1024-B-aligned
+            # buffer, one aligned extent per MemRange, and the sAmax + 128-B-aligned
+            # sDbias tail plus the trailing padding that rounds the struct itself
+            # up to 1024 B.
+            total = mbar_helpers_bytes
+            total += round_align(c_bytes_per_stage * num_c_stage)
+            total += round_align(d_bytes_per_stage * num_d_stage) * (2 if d_is_quantized else 1)  # sD (+ sD_col)
+            total += round_align(a_bytes_per_stage * n_ab)
+            total += round_align(b_bytes_per_stage * n_ab)
+            total += round_align(sfa_bytes_per_stage * n_ab)
+            total += round_align(sfb_bytes_per_stage * n_ab)
+            total += round_align(dbias_bytes + 128)  # sAmax + sDbias alignment + trailing padding
+            return total
+
+        while num_ab_stage > 1 and shared_storage_bytes(num_ab_stage) > num_smem_capacity // occupancy:
+            num_ab_stage -= 1
 
         return num_acc_stage, num_ab_stage, num_c_stage, num_d_stage, num_tile_stage

--- a/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py
@@ -2398,6 +2398,19 @@ class BlockScaledMoEGroupedGemmGluKernel:
                     expert_idx = tile_info[0]
 
                     gBias_tile = gBias_nl[(None, mma_n_coord, expert_idx)]
+
+                    # For dynamic MNKL, cuteDSL drops the 128bit alignment requirement
+                    # but we know that during runtime the alignment is always 16 bytes.
+                    gBias_tile = cute.make_tensor(
+                        cute.make_ptr(
+                            gBias_tile.element_type,
+                            gBias_tile.iterator.toint(),
+                            AddressSpace.gmem,
+                            assumed_align=16,
+                        ),
+                        gBias_tile.layout,
+                    )
+
                     tBs_gBias = thr_bias_g2s.partition_S(gBias_tile)
 
                     # Predicate: check if this thread's chunk is within N

--- a/python/cudnn/gemm/cutedsl/grouped/glu_hadamard_quant/moe_blockscaled_grouped_gemm_glu_hadamard_quant_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu_hadamard_quant/moe_blockscaled_grouped_gemm_glu_hadamard_quant_rubin.py
@@ -1516,12 +1516,11 @@ class BlockScaledMoEGroupedGemmGluHadamardQuantKernel:
         c_smem_layout_one = sm100_utils.make_smem_layout_epi(c_dtype, c_layout, epi_tile_c, 1)
         d_smem_layout_one = sm100_utils.make_smem_layout_epi(d_dtype, d_layout, epi_tile, 1)
 
-        ab_bytes_per_stage = (
-            cute.size_in_bytes(a_dtype, a_smem_layout_one)
-            + cute.size_in_bytes(b_dtype, b_smem_layout_one)
-            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_one)
-            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_one)
-        )
+        a_bytes_per_stage = cute.size_in_bytes(a_dtype, a_smem_layout_one)
+        b_bytes_per_stage = cute.size_in_bytes(b_dtype, b_smem_layout_one)
+        sfa_bytes_per_stage = cute.size_in_bytes(sf_dtype, sfa_smem_layout_one)
+        sfb_bytes_per_stage = cute.size_in_bytes(sf_dtype, sfb_smem_layout_one)
+        ab_bytes_per_stage = a_bytes_per_stage + b_bytes_per_stage + sfa_bytes_per_stage + sfb_bytes_per_stage
         mbar_helpers_bytes = 1024
 
         # One fp8 scale byte per (1,16) feature block, one row per thread (128 threads).
@@ -1530,19 +1529,24 @@ class BlockScaledMoEGroupedGemmGluHadamardQuantKernel:
         # sInfo is in SchedulerStorage, not here, so use 4-int sInfo
         sinfo_bytes = 4 * 4 * num_tile_stage
         c_bytes = cute.size_in_bytes(c_dtype, c_smem_layout_one) * num_c_stage
-        d_bytes = cute.size_in_bytes(d_dtype, d_smem_layout_one) * num_d_stage
+        d_main_bytes = cute.size_in_bytes(d_dtype, d_smem_layout_one) * num_d_stage
+        d_bytes = d_main_bytes
 
+        d_bf16_bytes = 0
         if d_quant:
             # sD staging stays bf16 (the RHT/quant warps' source); the gmem-dtype (fp4)
             # staging above becomes the TMA source, and sfd rows are staged per thread.
             bf16_smem_layout_one = sm100_utils.make_smem_layout_epi(cutlass.BFloat16, d_layout, epi_tile, 1)
-            d_bytes += cute.size_in_bytes(cutlass.BFloat16, bf16_smem_layout_one) * num_d_stage
+            d_bf16_bytes = cute.size_in_bytes(cutlass.BFloat16, bf16_smem_layout_one) * num_d_stage
+            d_bytes += d_bf16_bytes
             d_bytes += quant_sf_bytes
 
         rht_bytes = 0
+        rht_main_bytes = 0
         if rht_dtype is not None:
             rht_smem_layout_one = sm100_utils.make_smem_layout_epi(rht_dtype, d_layout, epi_tile, 1)
-            rht_bytes = cute.size_in_bytes(rht_dtype, rht_smem_layout_one) * num_d_stage
+            rht_main_bytes = cute.size_in_bytes(rht_dtype, rht_smem_layout_one) * num_d_stage
+            rht_bytes = rht_main_bytes
         if rht_quant:
             rht_bytes += quant_sf_bytes
 
@@ -1556,6 +1560,43 @@ class BlockScaledMoEGroupedGemmGluHadamardQuantKernel:
         epi_bytes = c_bytes + d_bytes + rht_bytes + bias_bytes
 
         num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes + sinfo_bytes)) // ab_bytes_per_stage
+
+        # The byte-sum model above ignores the 1024-B alignment padding of the
+        # SharedStorage buffers, so a tight config can produce a struct that
+        # exceeds the sm_107 SMEM cap and CUDA rejects the launch
+        # (CUDA_LAUNCH_INVALID_CONFIG). Mirror the struct layout exactly and shed
+        # A/B stages until it genuinely fits.
+        buffer_align_bytes = 1024
+
+        def round_align(nbytes):
+            return (nbytes + buffer_align_bytes - 1) // buffer_align_bytes * buffer_align_bytes
+
+        def shared_storage_bytes(n_ab):
+            # Exact size of the SharedStorage struct in __call__ for these stage
+            # counts: mbars/scheduler head padded to the first 1024-B-aligned
+            # buffer, one aligned extent per MemRange (the 16-B-aligned sSfd /
+            # sSfRht rows are each followed by a 1024-B-aligned buffer, so they
+            # round up to it), and the sBias tail plus the trailing padding that
+            # rounds the struct itself up to 1024 B.
+            total = mbar_helpers_bytes
+            total += round_align(c_bytes)
+            total += round_align(d_main_bytes if not d_quant else d_bf16_bytes)  # sD
+            if d_quant:
+                total += round_align(d_main_bytes)  # sDq (fp4 TMA staging)
+                total += round_align(quant_sf_bytes)  # sSfd
+            if rht_dtype is not None:
+                total += round_align(rht_main_bytes)  # sRht
+            if rht_quant:
+                total += round_align(quant_sf_bytes)  # sSfRht
+            total += round_align(a_bytes_per_stage * n_ab)
+            total += round_align(b_bytes_per_stage * n_ab)
+            total += round_align(sfa_bytes_per_stage * n_ab)
+            total += round_align(sfb_bytes_per_stage * n_ab)
+            total += round_align(bias_bytes)  # sBias + trailing padding
+            return total
+
+        while num_ab_stage > 1 and shared_storage_bytes(num_ab_stage) > num_smem_capacity // occupancy:
+            num_ab_stage -= 1
 
         return num_acc_stage, num_ab_stage, num_c_stage, num_d_stage, num_tile_stage, num_bias_stage, num_pingpong_stage
 

--- a/python/cudnn/gemm/cutedsl/grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/quant/moe_blockscaled_grouped_gemm_quant_rubin.py
@@ -540,12 +540,11 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(c_dtype, c_layout, epi_tile, 1)
         d_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(d_dtype, d_layout, epi_tile, 1)
 
-        ab_bytes_per_stage = (
-            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
-            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
-            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
-            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
-        )
+        a_bytes_per_stage = cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+        b_bytes_per_stage = cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+        sfa_bytes_per_stage = cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+        sfb_bytes_per_stage = cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        ab_bytes_per_stage = a_bytes_per_stage + b_bytes_per_stage + sfa_bytes_per_stage + sfb_bytes_per_stage
         mbar_helpers_bytes = 1024
         sinfo_bytes = 4 * 4 * num_tile_stage
         c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
@@ -566,14 +565,47 @@ class BlockScaledMoEGroupedGemmQuantKernel:
         num_ab_stage = (num_smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes + sinfo_bytes)) // ab_bytes_per_stage
 
         d_stage_bytes = d_bytes_per_stage * (2 if generate_sfd else 1)
-        # Reserve headroom: the aligned SharedStorage struct consumes ~1.5 KB more than this
-        # byte sum (the sC/sD/sD_col MemRanges are 1024-B aligned, adding padding). Without it
+        # Reserve headroom: the aligned SharedStorage struct consumes more than this
+        # byte sum (the large MemRanges are 1024-B aligned, adding padding). Without it
         # the extra D stage can push tight tiles (e.g. 256x256, which already packs 9 A/B stages)
         # past the sm_107 SMEM cap and fail the launch config. 512x256 keeps its extra stage.
         smem_headroom = 1536
-        leftover = num_smem_capacity // occupancy - (mbar_helpers_bytes + epi_bytes + sinfo_bytes) - ab_bytes_per_stage * num_ab_stage - smem_headroom
-        if leftover > 0:
-            num_d_stage += leftover // d_stage_bytes
+        smem_budget = num_smem_capacity // occupancy
+        base_d_stage = num_d_stage
+
+        def expanded_d_stage(n_ab):
+            leftover = smem_budget - (mbar_helpers_bytes + epi_bytes + sinfo_bytes) - ab_bytes_per_stage * n_ab - smem_headroom
+            return base_d_stage + (leftover // d_stage_bytes if leftover > 0 else 0)
+
+        buffer_align_bytes = 1024
+
+        def round_align(nbytes):
+            return (nbytes + buffer_align_bytes - 1) // buffer_align_bytes * buffer_align_bytes
+
+        def shared_storage_bytes(n_ab, n_d):
+            # Exact size of the SharedStorage struct in __call__ for these stage
+            # counts: mbars/scheduler head padded to the first 1024-B-aligned
+            # buffer, one aligned extent per MemRange, and sBias/sAmax plus the
+            # trailing padding that rounds the struct itself up to 1024 B.
+            total = mbar_helpers_bytes
+            total += round_align(c_bytes_per_stage * num_c_stage)
+            total += round_align(d_bytes_per_stage * n_d) * (2 if generate_sfd else 1)
+            total += round_align(a_bytes_per_stage * n_ab)
+            total += round_align(b_bytes_per_stage * n_ab)
+            total += round_align(sfa_bytes_per_stage * n_ab)
+            total += round_align(sfb_bytes_per_stage * n_ab)
+            total += round_align(bias_bytes + 4 * 4)  # sBias + sAmax (4 epilog warps)
+            return total
+
+        num_d_stage = expanded_d_stage(num_ab_stage)
+        # The byte-sum estimate above ignores the per-buffer alignment padding, so a
+        # tight config (fp8 256x256: 9 A/B stages with only 480 B of modeled slack)
+        # can produce a struct that exceeds the sm_107 SMEM cap by the padding bytes
+        # and CUDA rejects the launch (CUDA_LAUNCH_INVALID_CONFIG). Shed A/B stages
+        # until the exact struct fits.
+        while num_ab_stage > 1 and shared_storage_bytes(num_ab_stage, num_d_stage) > smem_budget:
+            num_ab_stage -= 1
+            num_d_stage = expanded_d_stage(num_ab_stage)
 
         return num_acc_stage, num_ab_stage, num_c_stage, num_d_stage, num_tile_stage, num_bias_stage
 


### PR DESCRIPTION
## Problem

All 26 fp8-path `test_grouped_gemm_quant` tests fail on Rubin (sm_107) with a deterministic pre-flight launch rejection:

```
error[CUDA_LAUNCH_INVALID_CONFIG]: CUDA launch failed: cudaErrorInvalidValue (1)
kernel '...moe_blockscaled_grouped_gemm_quant_rubin...' launch shared memory exceeds
current GPU arch sm_107a allowed. Allocated: 335872 bytes. Max: 334848 bytes.
```

## Root cause

`_compute_stages` picks the A/B pipeline stage count from a byte-sum model (`1024 mbar + epi_bytes + sinfo`) that ignores the 1024-B alignment padding of the `SharedStorage` buffers. For the fp8 256x256 quant configs the model chooses **9 A/B stages with only 480 B of modeled slack**, but the real struct needs ~1.5 KiB of padding (sSFA 4608→5120 B, plus the trailing padding that rounds the struct itself up to 1024 B). The launch then requests 335872 B of dynamic SMEM — exactly 1 KiB over sm_107's 334848 B per-block cap — and the driver rejects it.

fp4 configs fit only because their per-stage sizes happen to leave enough slack, and the identical math on sm100 lands *exactly at* the 232448 B cap, which is why only Rubin fp8 fails.

## Fix

`_compute_stages` in the three Rubin kernels that own a private copy of this logic (grouped GEMM **quant**, **dglu**, **glu_hadamard_quant**) now mirrors its kernel's `SharedStorage` layout exactly — per-buffer 1024-B aligned extents, mbar/scheduler head, tail buffers plus trailing struct padding — and sheds A/B stages until the struct genuinely fits, re-running the leftover-based D-stage expansion where one exists. **Configs that already fit keep identical stage counts** (the clamp only engages on overflow).

The shared `grouped/moe_kernel_helpers.py::compute_stages` (used by the glu Rubin kernel and several sm100 kernels) carries the same modeling gap but no observed overflow; it is intentionally left unchanged here to avoid touching the sm100 kernels' sizing, and can be hardened the same way in a follow-up.

## Verification

- **quant fp8 on sm107 hardware**: all previously failing tests pass (internal CI run: 389 tests, 0 failures, 0 errors). fp8 256x256 lands on 8 A/B + 6 D stages = 333824 B ≤ 334848 B.
- **quant fp4**: stage counts and SMEM sizes byte-identical before/after.
- **dglu / glu_hadamard_quant**: a 152-config sweep of `_compute_stages` (dtypes x tilers x CTA modes x feature flags) produces identical stage counts before/after at the real sm_107 capacity; a capacity scan confirms the clamp engages and sheds exactly one A/B stage at overflow boundaries.

Internal tracking: NVBugs 6645929.

## Second commit: DSA arch-target selection on Rubin (NVBugs 6645933)

A second Rubin compile failure with the same flavor of root cause (target selection, not codegen): the DSA arch map compiled compute-capability-10.7 kernels for the **`sm_100f` family target**, but the MXFP8 indexer kernels emit block-scaled MMAs (`.scale_vec::1X`) that ptxas only accepts on arch-specific targets, so every DSA mxfp8 test on Rubin failed at compile with `ptxas error: Feature '.scale_vec::1X' not supported on .target 'sm_100f'`. The family entry predates CuTeDSL wheels that know the Rubin arch; current wheels carry `sm_107a`, so `_ARCH_MAP` now maps `(10, 7)` to it.

Verified with `nvidia-cutlass-dsl 4.8.0a0`: the `sm_100f` mapping reproduces the exact ptxas failure; with `sm_107a`, all 39 DSA test parametrizations (mxfp8 **and** bf16) compile cleanly.

Internal tracking: NVBugs 6645933.

## Third commit: bias GMEM pointer alignment in the Rubin GLU kernel (NVBugs 6645919)

Every `with_bias` grouped GEMM GLU test on Rubin (~170 parametrizations) failed at `cute.compile` with an IR-verification ICE: `'cute.copy' op src ptr alignment (16 bits) does not meet requirement (128 bits) of atom '!cute_nvgpu.atom.simt_async_copy<bf16, cache = always, 128 b>'`. The kernel's bias GMEM→SMEM `cp.async` path partitions the `gBias` tile directly into a 128-bit copy atom; with dynamic MNKL the tile's provable alignment is only the bf16 element width. The Blackwell kernel (`moe_blockscaled_grouped_gemm_glu_bias.py`) already rewraps the tile with `assumed_align=16` before `partition_S` — this commit applies the identical rewrap to the Rubin kernel (the runtime allocation is genuinely 16-byte aligned, same guarantee the Blackwell path relies on).

Verified: all **172** `with_bias` GLU parametrizations compile cleanly for sm_107a with the change; before it, every sampled config reproduced the ICE. The glu_hadamard_quant kernel has the same textual pattern but its bias compile is clean (its API carries the alignment through), so it is deliberately left untouched.

Internal tracking: NVBugs 6645919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared-memory allocation calculations for grouped GEMM operations.
  * Accounts for buffer alignment, staging requirements, synchronization storage, and reserved capacity.
  * Dynamically adjusts processing stages to stay within available accelerator memory, improving reliability and occupancy.
  * Corrected architecture targeting for Rubin-based workloads.
  * Improved bias data handling to support required memory alignment and more reliable execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
