### PR TITLE
Fix bias GMEM pointer alignment in the Rubin grouped GEMM GLU kernel

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py
+++ b/python/cudnn/gemm/cutedsl/grouped/glu/moe_blockscaled_grouped_gemm_glu_rubin.py
@@ -2398,6 +2398,19 @@ class BlockScaledMoEGroupedGemmGluKernel:
                     expert_idx = tile_info[0]
 
                     gBias_tile = gBias_nl[(None, mma_n_coord, expert_idx)]
+
+                    # For dynamic MNKL, cuteDSL drops the 128bit alignment requirement
+                    # but we know that during runtime the alignment is always 16 bytes.
+                    gBias_tile = cute.make_tensor(
+                        cute.make_ptr(
+                            gBias_tile.element_type,
+                            gBias_tile.iterator.toint(),
+                            AddressSpace.gmem,
+                            assumed_align=16,
+                        ),
+                        gBias_tile.layout,
+                    )
+
                     tBs_gBias = thr_bias_g2s.partition_S(gBias_tile)
 
                     # Predicate: check if this thread's chunk is within N


### PR DESCRIPTION
## Problem

Every `with_bias` grouped GEMM GLU test on Rubin (sm_107) — 170 parametrizations in the nightly `oss:rubin` run — fails at `cute.compile` with an IR-verification ICE:

```
DSLRuntimeError: ICE IR Verification Failed
error: 'cute.copy' op src ptr alignment (16 bits) does not meet requirement (128 bits)
       of atom '!cute_nvgpu.atom.simt_async_copy<bf16, cache = always, 128 b>'
```

## Root cause

The Rubin GLU kernel's bias GMEM→SMEM `cp.async` path builds a 128-bit copy atom (`num_bits_per_copy=128`) but partitions the `gBias` tile directly:

```python
gBias_tile = gBias_nl[(None, mma_n_coord, expert_idx)]
tBs_gBias = thr_bias_g2s.partition_S(gBias_tile)
```

With dynamic MNKL, the tile's provable alignment is only the bf16 element width (16 bits), so the verifier rejects the copy. The generated source memref carries no `align<>` attribute at all (the SMEM destination right next to it does, which is what makes the omission visible).

## Fix

The Blackwell kernel (`moe_blockscaled_grouped_gemm_glu_bias.py`) already handles this — it rewraps the tile with `assumed_align=16` before `partition_S`, with a comment noting that dynamic MNKL drops the provable alignment but the runtime allocation is always 16-byte aligned. This PR applies the identical rewrap to the Rubin kernel (`moe_blockscaled_grouped_gemm_glu_rubin.py`). The alignment guarantee is the same one the Blackwell path already relies on for the same tensors.

The other Rubin kernels were audited for the same pattern: the glu_hadamard_quant kernel's bias path compiles cleanly (its API carries the alignment through), and the quant kernel's bias path goes through the scheduler-extension tensor reconstruction — neither needs a change.

## Verification

All **172** `with_bias` GLU parametrizations (fp4 + fp8, both MMA tilers, both cluster shapes, wrapper + compile_execute) now compile cleanly for sm_107a with the internal CuTeDSL wheel; before the change, every sampled config reproduced the ICE at `cute.compile`. Non-bias GLU paths are untouched.

Internal tracking: NVBugs 6645919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bias data during grouped GEMM GLU operations.
  * Preserved existing bias layout and data type while enabling reliable asynchronous transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->