### PR TITLE
frost(sdpa): support pack_gqa

### DIFF
--- a/docs/python_graph_and_execution_backends.md
+++ b/docs/python_graph_and_execution_backends.md
@@ -553,7 +553,7 @@ defaulting to device 0 is how an SM100 suite silently skips in full.
 
 - More per-family tuning rules on top of the ranking frame, each with the
   measurements behind it. `sdpa/fwd/heuristics.py::_sm120_tiles` and
-  `_sm100_pack_gqa` are the two today; every other cell falls back to its
+  `_pack_gqa_wins` are the two today; every other cell falls back to its
   capability row's sole point per axis, which is the honest answer while
   nobody has timed it.
 - FALLBACK is one config per cell today — the smallest tile the row admits, the

--- a/docs/python_graph_and_execution_backends.md
+++ b/docs/python_graph_and_execution_backends.md
@@ -552,9 +552,10 @@ defaulting to device 0 is how an SM100 suite silently skips in full.
 ## Follow-ups (separate MRs)
 
 - More per-family tuning rules on top of the ranking frame, each with the
-  measurements behind it. `sdpa/fwd/heuristics.py::_sm120_tiles` is the only
-  one today; every other cell falls back to its capability row's sole point per
-  axis, which is the honest answer while nobody has timed it.
+  measurements behind it. `sdpa/fwd/heuristics.py::_sm120_tiles` and
+  `_sm100_pack_gqa` are the two today; every other cell falls back to its
+  capability row's sole point per axis, which is the honest answer while
+  nobody has timed it.
 - FALLBACK is one config per cell today — the smallest tile the row admits, the
   config that asks least of the device. Picking the handful that between them
   cover the plane needs measurements; the TODO is in `_mode_fallback`.

--- a/python/cudnn/frost/README.md
+++ b/python/cudnn/frost/README.md
@@ -528,13 +528,13 @@ levels, with no shared vocabulary at all:
 
 - **Vocabulary per operation.** Each op defines a typed, frozen dataclass:
   `cudnn.sdpa.fwd.engines.SdpaFwdKnobs(sched_policy=None, tile_m=None,
-  tile_n=None, cga=None)`, where `None` means "no preference". SDPA's knobs
-  cannot collide with GEMM's; fields have real types instead of
-  enum-plus-int64.
+  tile_n=None, cga=None, pack_gqa=None)`, where `None` means "no
+  preference". SDPA's knobs cannot collide with GEMM's; fields have real
+  types instead of enum-plus-int64.
 - **Domains per engine.** Each `Capabilities` row advertises the values its
   lowering honors: `sched_policies = {NATURAL}`, `tile_ms = {128}`,
-  `tile_ns = {128}`, `cgas = {2}`. Two engines of the same op may honor
-  different subsets.
+  `tile_ns = {128}`, `cgas = {2}`, `pack_gqas = {False}`. Two engines of the
+  same op may honor different subsets.
 - **Per plan, not per graph.** A knob set rides on `PlanConfig.knobs`, so a
   tuning choice is part of the plan's identity: a family that wants several
   tunings ranked emits several `PlanConfig`s from `recommend()`, each with its

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -28,7 +28,7 @@ from cudnn.frost.tile_dsl.constants import (
     SCHED_LPT_L2,
     SCHED_NATURAL,
 )
-from cudnn.sdpa.fwd.config_sm100 import TemplateParams as Sm100TemplateParams
+from cudnn.sdpa.fwd.config_sm100 import TemplateParams as Sm100TemplateParams, pack_gqa_supported
 from cudnn.sdpa.fwd.config_sm120 import (
     HEAD_TILE_GRANULE as _SM120_HEAD_TILE_GRANULE,
     SEQ_KV_TILES as _SM120_KV_TILES,
@@ -301,6 +301,7 @@ class SdpaFwdDsl(APIBase):
         cga: Optional[int] = None,
         split_kv: Optional[int] = None,
         softmax_precision: Optional[int] = None,
+        pack_gqa: Optional[bool] = None,
     ) -> None:
         """Capture the common SDPA operation and tuning contract.
 
@@ -375,6 +376,7 @@ class SdpaFwdDsl(APIBase):
         # Framework axis: no forward kernel serves a softmax-precision choice
         # yet, so anything non-None is rejected in check_support.
         self.softmax_precision = softmax_precision
+        self.pack_gqa = bool(pack_gqa) if pack_gqa is not None else False
 
         self.batch_size: Optional[int] = None
         self.s_q_max: Optional[int] = None
@@ -803,10 +805,26 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             f"H_q ({h_qo}) must be divisible by H_kv ({h_kv}) for GQA / MQA",
         )
 
+        if self.pack_gqa:
+            self._not_implemented_error_if(
+                self.thd,
+                "PackGQA is dense-only (THD/ragged runs unpacked)",
+            )
+            self._value_error_if(
+                not pack_gqa_supported(int(h_qo), int(h_kv)),
+                f"PackGQA requires h_q/h_kv to divide the kernel tile_m; got h_q/h_kv = {int(h_qo)}/{int(h_kv)}",
+            )
+
         # Q/K/V dtype: half (BF16/FP16, DTYPE_O == input) or FP8 (E4M3/E5M2 → MXFP8,
         # d128 only, DTYPE_O independent — typically BF16/FP16).
         self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16, *_SM100_FP8_DTYPES], name="Q")
         self._fp8 = self.dtype in _SM100_FP8_DTYPES
+        self._not_implemented_error_if(
+            self.pack_gqa and self._fp8 and not self._pertensor,
+            "PackGQA is not supported for MXFP8: the F8_128x4 sf_q scale-factor atom "
+            "bundles 128 rows of ONE head and is not TMA-gatherable at token granularity "
+            "(see the SF layout note in prefill_d128_mxfp8_sm100.py)",
+        )
         for desc in [self.k_desc, self.v_desc]:
             self._check_dtype(desc, self.dtype, name=desc.name, extra_error_msg=f"{desc.name} must match Q dtype")
         if self._fp8:
@@ -1079,9 +1097,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             lpt_head_group=lpt_head_group,
             lpt_q_tiles=lpt_q_tiles,
             thd_varlen=self.thd,
+            pack_gqa=self.pack_gqa,
+            qh_per_kh=int(self.q_desc.shape[1]) // int(self.k_desc.shape[1]),
+            split_kv=self.split_kv,
             fused_ldtm_stat=fused_ldtm_stat,
             softmax_f16=self.softmax_precision == _cudnn_dtype.HALF,
-            split_kv=self.split_kv,
         )
         self._k_mod = _load_sm100_kernel_module(self.flavor, params, fp8=self._fp8, pertensor=self._pertensor, rubin=(self._device_cc == (10, 7)))
         if self.thd:
@@ -2396,6 +2416,15 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
 
         self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16, *_SM100_FP8_DTYPES], name="Q")
         self._fp8 = self.dtype in _SM100_FP8_DTYPES
+        if self.pack_gqa:
+            self._not_implemented_error_if(
+                self.thd,
+                "PackGQA is dense-only (THD/ragged runs unpacked)",
+            )
+            self._value_error_if(
+                not pack_gqa_supported(int(h_q), int(h_kv), int(self.q_tile)),
+                f"PackGQA requires h_q/h_kv to divide q_tile ({self.q_tile}); got h_q/h_kv = {int(h_q)}/{int(h_kv)}",
+            )
         for desc in (self.k_desc, self.v_desc, self.o_desc):
             if self._fp8 and desc is self.o_desc:
                 # SDPA_FP8's O dtype is independent of QKV: fp16/bf16 ride the
@@ -2564,6 +2593,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             thd_varlen=self.thd,
             q_tile=self.q_tile,
             kv_tile=self.kv_tile,
+            pack_gqa=self.pack_gqa,
             split_kv=self.split_kv,
         )
         self._k_mod = _load_sm120_kernel_module(params, fp8=self._fp8)

--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -1063,12 +1063,13 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                     d_v=d_v_sched,
                     elem_bytes=1 if self._fp8 else 2,
                 )
+        _pack_g = (self.h_q // self.h_kv) if self.pack_gqa else 1
         lpt_head_group = 1
-        if self._fp8 and self.flavor == (192, 128) and not self.thd and (self.batch_size * self.h_q) % 8 == 0:
+        if self._fp8 and self.flavor == (192, 128) and not self.thd and (self.batch_size * self.h_q // _pack_g) % 8 == 0:
             lpt_head_group = 8
         lpt_q_tiles = 0
         if self._fp8 and self.flavor == (192, 128) and not self.thd:
-            lpt_q_tiles = (self.s_q_max + 511) // 512
+            lpt_q_tiles = (self.s_q_max * _pack_g + 511) // 512
         template_window_right = self.window_right
         if (
             self._fp8

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -94,6 +94,11 @@ class TemplateParams:
     # number of query tiles. Zero keeps the existing runtime derivation.
     lpt_q_tiles: int = 0
     thd_varlen: bool = False
+    # PackGQA: pack Q rows from the G query heads sharing one KV head into a
+    # single TILE_M tile, token-major (row r ↔ token r // G, head r % G), so
+    # tiles stay full for GQA/MQA.
+    pack_gqa: bool = False
+    qh_per_kh: int = 1
     # KV split: each Q tile's KV loop range is cut into ``split_kv`` contiguous
     # chunks, each run as its own persistent tile writing a partial (O, LSE)
     # that kernels/split_combine_sm100.py reduces.  1 = off (byte-identical
@@ -191,6 +196,11 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
         raise ValueError(f"{flavor}: LPT_HEAD_GROUP must be 1, 8, or 16; got {k.lpt_head_group}")
     if fp8 and flavor == "d192" and k.split_kv != 1:
         raise ValueError("d192: split_kv is not implemented by the per-tensor FP8 kernel")
+    if k.qh_per_kh < 1:
+        raise ValueError(f"{flavor}: qh_per_kh ({k.qh_per_kh}) must be >= 1")
+    if k.pack_gqa:
+        if k.thd_varlen:
+            raise ValueError(f"{flavor}: pack_gqa is not supported for THD-varlen")
 
 
 def _mask_flags_from(params: TemplateParams) -> int:
@@ -245,6 +255,20 @@ def o_swz_bytes(tile_o: int, bpe_o: int) -> int:
 
 def rescale_threshold(dtype_qkv: int) -> float:
     return 4.0 if dtype_qkv <= 1 else 8.0
+
+
+def pack_gqa_supported(h_q: int, h_kv: int, tile_m: int = 128) -> bool:
+    return h_q > 0 and h_kv > 0 and h_q % h_kv == 0 and tile_m % (h_q // h_kv) == 0
+
+
+def cga_tile_m(d_qk: int) -> int:
+    """Q rows one cluster covers for a flavor: TILES_Q * TILE_M * CTA_MMA.
+
+    The tile-count denominator the pack_gqa heuristic needs (d128/d192: 512;
+    d256/d512: 256), computed from the flavor Cfg classes, not literals.
+    """
+    cls = {128: CfgD128, 192: CfgD192, 256: CfgD256, 512: CfgD512}[d_qk]
+    return cls.TILES_Q * cls.TILE_M * cls.CTA_MMA
 
 
 def _tma_iters_for(d_elems: int, bpe_val: int, swz_b: int) -> int:
@@ -363,6 +387,10 @@ class CfgD256:
     # KV split; 1 = off.  See TemplateParams.split_kv.
     SPLIT_KV: int = 1
 
+    PACK_GQA: int = 0
+
+    QH_PER_KH: int = 1
+
 
 def _validate_cfg_d256(cfg: CfgD256) -> None:
     """Consistency checks on the (mostly hardcoded) d256 geometry."""
@@ -409,8 +437,12 @@ def make_cfg_d256(params: TemplateParams) -> Tuple[CfgD256, TmaIters]:
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
         THD_VARLEN=int(params.thd_varlen),
         SPLIT_KV=int(params.split_kv),
+        PACK_GQA=int(params.pack_gqa),
+        QH_PER_KH=int(params.qh_per_kh),
     )
     _validate_cfg_d256(cfg)
+    if cfg.PACK_GQA and cfg.TILE_M % cfg.QH_PER_KH != 0:
+        raise ValueError(f"qh_per_kh ({cfg.QH_PER_KH}) must divide TILE_M ({cfg.TILE_M}) when PACK_GQA is enabled")
     return cfg, _tma_iters(cfg)
 
 
@@ -506,6 +538,10 @@ class CfgD512:
     # KV split; 1 = off.  See TemplateParams.split_kv.
     SPLIT_KV: int = 1
 
+    PACK_GQA: int = 0
+
+    QH_PER_KH: int = 1
+
 
 def _validate_cfg_d512(cfg: CfgD512) -> None:
     """Consistency checks on the (mostly hardcoded) d512 geometry."""
@@ -556,8 +592,12 @@ def make_cfg_d512(params: TemplateParams) -> Tuple[CfgD512, TmaIters]:
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
         THD_VARLEN=int(params.thd_varlen),
         SPLIT_KV=int(params.split_kv),
+        PACK_GQA=int(params.pack_gqa),
+        QH_PER_KH=int(params.qh_per_kh),
     )
     _validate_cfg_d512(cfg)
+    if cfg.PACK_GQA and cfg.TILE_M % cfg.QH_PER_KH != 0:
+        raise ValueError(f"qh_per_kh ({cfg.QH_PER_KH}) must divide TILE_M ({cfg.TILE_M}) when PACK_GQA is enabled")
     return cfg, _tma_iters(cfg)
 
 
@@ -655,6 +695,10 @@ class CfgD128:
 
     # KV split; 1 = off.  See TemplateParams.split_kv.
     SPLIT_KV: int = 1
+
+    PACK_GQA: int = 0
+
+    QH_PER_KH: int = 1
 
 
 # Blackwell SM100 per-CTA dynamic SMEM cap (228 KiB physical, 227 KiB usable).
@@ -771,8 +815,12 @@ def make_cfg_d128(params: TemplateParams) -> Tuple[CfgD128, TmaIters]:
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
         THD_VARLEN=int(params.thd_varlen),
         SPLIT_KV=int(params.split_kv),
+        PACK_GQA=int(params.pack_gqa),
+        QH_PER_KH=int(params.qh_per_kh),
     )
     _validate_cfg_d128(cfg)
+    if cfg.PACK_GQA and cfg.TILE_M % cfg.QH_PER_KH != 0:
+        raise ValueError(f"qh_per_kh ({cfg.QH_PER_KH}) must divide TILE_M ({cfg.TILE_M}) when PACK_GQA is enabled")
     return cfg, _tma_iters(cfg)
 
 
@@ -887,8 +935,12 @@ def make_cfg_d192(params: TemplateParams) -> Tuple[CfgD192, TmaIters]:
         SEQ_KV_LENS_PRESENT=1 if (params.thd_varlen or params.seq_kv_lens_present) else 0,
         SEQ_Q_LENS_PRESENT=int(params.seq_q_lens_present),
         THD_VARLEN=int(params.thd_varlen),
+        PACK_GQA=int(params.pack_gqa),
+        QH_PER_KH=int(params.qh_per_kh),
     )
     _validate_cfg_d192(cfg)
+    if cfg.PACK_GQA and cfg.TILE_M % cfg.QH_PER_KH != 0:
+        raise ValueError(f"qh_per_kh ({cfg.QH_PER_KH}) must divide TILE_M ({cfg.TILE_M}) when PACK_GQA is enabled")
     return cfg, _tma_iters(cfg)
 
 

--- a/python/cudnn/sdpa/fwd/config_sm120.py
+++ b/python/cudnn/sdpa/fwd/config_sm120.py
@@ -71,6 +71,7 @@ class TemplateParams:
     sched_policy: int = SCHED_NATURAL
     q_tile: int = SEQ_Q_TILES[0]
     kv_tile: int = SEQ_KV_TILES[0]
+    pack_gqa: bool = False
     # KV split: each Q tile's KV-tile range [min_kv_tile, num_kv_tiles) is cut
     # into ``split_kv`` contiguous chunks, each run by its own CTA writing a
     # partial (O, LSE) that kernels/split_combine_sm100.py reduces.  1 = off.
@@ -132,3 +133,5 @@ def validate_params(
             raise ValueError("SM120 SDPA: thd_varlen requires seq_kv_lens_present (the THD metadata tensor)")
         if params.seq_q_lens_present:
             raise ValueError("SM120 SDPA: seq_q_lens_present is dense-only (THD carries per-sequence Q lengths via cu_seqlens)")
+    if params.pack_gqa and params.thd_varlen:
+        raise ValueError("SM120 SDPA: pack_gqa is not supported with thd_varlen")

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -36,6 +36,7 @@ import cudnn
 from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
 from cudnn.frost.buffers import CUTEDSL_MIN_VERSION, cutedsl_state, cutedsl_too_old
 from cudnn.sdpa import graph_analyzer as ga
+from cudnn.sdpa.fwd.config_sm100 import pack_gqa_supported
 
 # The DSL adapters (api_dsl) and cuda.bindings are LOWERING dependencies, not
 # support-check ones: importing them here would drag the CuTe DSL (~1.0 s, 357
@@ -87,6 +88,7 @@ class SdpaFwdKnobs:
     tile_m: Optional[int] = None  # Q sequence tile width
     tile_n: Optional[int] = None  # KV sequence tile width
     cga: Optional[int] = None  # cluster size (CTAs cooperating per tile)
+    pack_gqa: Optional[bool] = None  # Head packing for GQA/MQA
     # KV-split count: each Q tile's KV range cut into this many chunks, each
     # run by its own CTA, recombined by the split_combine pass. 1 = off.
     split_kv: Optional[int] = None
@@ -239,6 +241,7 @@ class Capabilities:
     tile_ms: frozenset[int] = frozenset()
     tile_ns: frozenset[int] = frozenset()
     cgas: frozenset[int] = frozenset()
+    pack_gqas: frozenset[bool] = frozenset({False})
     # Split-KV domain. {1} = the axis exists but only "off" is served; rows
     # whose kernels wire the split path AND whose adapter launches the combine
     # widen this (the SM100 f16 rows today).
@@ -293,6 +296,7 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
             (knobs.tile_m, capabilities.tile_ms, "tile_m"),
             (knobs.tile_n, capabilities.tile_ns, "tile_n"),
             (knobs.cga, capabilities.cgas, "cga"),
+            (knobs.pack_gqa, capabilities.pack_gqas, "pack_gqa"),
             (knobs.split_kv, capabilities.split_kvs, "split_kv"),
             (knobs.softmax_precision, capabilities.softmax_precisions, "softmax_precision"),
         ):
@@ -323,6 +327,12 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
                 return (
                     f"split_kv > 1 is wired only in the {sorted(capabilities.split_d_shapes)} kernel " f"flavors; graph has D_QK={facts.d_qk}/D_V={facts.d_v}"
                 )
+        if knobs.pack_gqa:
+            if facts.thd:
+                return "PackGQA is currently not supported for THD/ragged graphs"
+            _pg_tile_m = knobs.tile_m if knobs.tile_m is not None else max(capabilities.tile_ms)
+            if not pack_gqa_supported(facts.h_q, facts.h_kv, _pg_tile_m):
+                return f"PackGQA requires h_q/h_kv to divide tile_m: h_q/h_kv = {facts.h_q}/{facts.h_kv} does not tile at tile_m={_pg_tile_m}"
     cc = facts.device_cc
     sm = None if cc is None else cc[0] * 10 + cc[1]
     if sm is None or not (capabilities.sm_lo <= sm <= capabilities.sm_hi):
@@ -517,6 +527,7 @@ def _sm100_spec() -> EngineSpec:
             # carves the partial slabs + launches split_combine_sm100 when
             # split_kv > 1 (dense f16 only; see mismatch's facts x knobs gate).
             split_kvs=frozenset({1, 2, 4}),
+            pack_gqas=frozenset({False, True}),
         ),
         lower=partial(lower_dsl_prefill, api_type=_SM100),
     )
@@ -567,6 +578,11 @@ def _sm100_mxfp8_spec() -> EngineSpec:
             # The split path also needs a half-precision O (mismatch's
             # facts x knobs gate) and rides the d128 flavor (split_d_shapes).
             split_kvs=frozenset({1, 2, 4}),
+            # PackGQA is currently not supported for the MXFP8 SDPA engine:
+            # the F8_128x4 sf_q scale-factor atom bundles 128 rows of ONE
+            # head, so a packed tile's interleaved (token, head) rows cannot
+            # gather their scale factors at token granularity.
+            pack_gqas=frozenset({False}),
         ),
         lower=partial(lower_dsl_prefill, api_type=_SM100),
     )
@@ -664,6 +680,7 @@ def _sm100_fp8_spec(*, arch: str = "sm100") -> EngineSpec:
             # quantized rows; split_d_shapes pins it to the d128 flavor.
             split_kvs=frozenset({1}) if rubin_row else frozenset({1, 2, 4}),
             split_d_shapes=frozenset({(128, 128)}),
+            pack_gqas=frozenset({False, True}),
         ),
         lower=partial(lower_dsl_prefill, api_type=_SM100),
     )
@@ -753,6 +770,7 @@ def _sm120_spec() -> EngineSpec:
             tile_ms=frozenset({64, 128}),
             tile_ns=frozenset({64, 128}),
             cgas=frozenset({1}),
+            pack_gqas=frozenset({False, True}),
         ),
         lower=partial(lower_dsl_prefill, api_type=_SM120),
     )
@@ -847,6 +865,7 @@ def lower_dsl_prefill(
         tile_m=knobs.tile_m if knobs is not None else None,
         tile_n=knobs.tile_n if knobs is not None else None,
         cga=knobs.cga if knobs is not None else None,
+        pack_gqa=knobs.pack_gqa if knobs is not None else None,
         split_kv=knobs.split_kv if knobs is not None else None,
         softmax_precision=knobs.softmax_precision if knobs is not None else None,
         # SM80-only PLAN-TIME axes (bias presence/dtype are compile-time
@@ -1109,6 +1128,7 @@ def _sm120_fp8_spec() -> EngineSpec:
             tile_ms=frozenset({64, 128}),
             tile_ns=frozenset({64, 128}),
             cgas=frozenset({1}),
+            pack_gqas=frozenset({False, True}),
         ),
         lower=partial(lower_dsl_prefill, api_type=_SM120),
     )

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -263,16 +263,12 @@ def _sched_points(caps: Capabilities, facts) -> List[Optional[int]]:
 # --- pack_gqa (GQA head packing) --------------------------------------------
 
 
-def _pack_gqa_choices(caps: Capabilities, facts, tile_m: int):
-    if True in caps.pack_gqas and not facts.thd and facts.h_q != facts.h_kv and pack_gqa_supported(facts.h_q, facts.h_kv, tile_m):
-        return (False, True)
-    return (False,)
-
-
 def _pack_gqa_wins(facts, tile_q: int) -> bool:
     """Pack when the Q sequence cannot fit in a single tile, then we can further
-    apply split_kv on top of GQA packing. We may enhance this heuristic logic in
-    the future by considering more factors such as the device SM count.
+    apply split_kv on top of GQA packing.
+
+    TODO: we may enhance this heuristic logic in the future by considering more
+    factors such as the device SM count.
     """
     return facts.s_q < tile_q
 
@@ -293,6 +289,16 @@ def _pack_gqa_tile_q(caps: Capabilities, facts, tile_m: Optional[int]) -> int:
     if facts.d_qk <= 256 and facts.d_v <= 256:
         return cga_tile_m(256)
     return cga_tile_m(512)
+
+
+def _pack_gqa_points(caps: Capabilities, facts, tile_m: int) -> Tuple[bool, ...]:
+    """The pack_gqa axis, best first: ``(True, False)`` when packing wins,
+    ``(False, True)`` when it is only eligible, ``(False,)`` when it is not."""
+    if not (True in caps.pack_gqas and not facts.thd and facts.h_q != facts.h_kv and pack_gqa_supported(facts.h_q, facts.h_kv, tile_m)):
+        return (False,)
+    if _pack_gqa_wins(facts, _pack_gqa_tile_q(caps, facts, tile_m)):
+        return (True, False)
+    return (False, True)
 
 
 def _split_points(caps: Capabilities, facts, tile_m: Optional[int], tile_n: Optional[int], cga: Optional[int], pack_g: int = 1) -> List[Optional[int]]:
@@ -395,10 +401,10 @@ def _knob_sets(spec: EngineSpec, facts) -> List[SdpaFwdKnobs]:
     # small tiles exist for, and a bigger tile admits a bigger G (G must
     # divide it) — while an unpacked set keeps the tile rule's choice.
     pack_tile = next(
-        ((m, n) for m, n in sorted(tiles, key=lambda mn: (-(mn[0] or 0), mn[1] != 128)) if True in _pack_gqa_choices(caps, facts, m or 128)),
+        ((m, n) for m, n in sorted(tiles, key=lambda mn: (-(mn[0] or 0), mn[1] != 128)) if True in _pack_gqa_points(caps, facts, m or 128)),
         None,
     )
-    packed_first = pack_tile is not None and _pack_gqa_wins(facts, _pack_gqa_tile_q(caps, facts, pack_tile[0]))
+    packed_first = pack_tile is not None and _pack_gqa_points(caps, facts, pack_tile[0] or 128)[0]
     unpacked_pack = False if True in caps.pack_gqas else _sole(caps.pack_gqas)
     base_tile = pack_tile if packed_first else tiles[0]
     # The split model sees the launch geometry of the set it rides — the
@@ -418,7 +424,7 @@ def _knob_sets(spec: EngineSpec, facts) -> List[SdpaFwdKnobs]:
         # A packed baseline's tile runners keep the packing, so tiles the
         # ratio cannot ride are skipped — emitted, they would only spend
         # set-cap slots for mismatch to drop.
-        if base.pack_gqa is True and True not in _pack_gqa_choices(caps, facts, tile_m or 128):
+        if base.pack_gqa is True and True not in _pack_gqa_points(caps, facts, tile_m or 128):
             continue
         out.append(replace(base, tile_m=tile_m, tile_n=tile_n))
     for policy in scheds[1:]:

--- a/python/cudnn/sdpa/fwd/heuristics.py
+++ b/python/cudnn/sdpa/fwd/heuristics.py
@@ -47,6 +47,7 @@ import cudnn
 
 from cudnn.engines.base import PlanConfig
 from cudnn.frost.tile_dsl.constants import SCHED_LPT, SCHED_LPT_L2, SCHED_NATURAL
+from cudnn.sdpa.fwd.config_sm100 import cga_tile_m, pack_gqa_supported
 from cudnn.sdpa.fwd.config_sm120 import FP8_HEAD_TILE_GRANULE, HEAD_TILE_GRANULE, SMEM_CAPACITY_BYTES, smem_bytes
 from cudnn.sdpa.fwd.engines import ENGINE_SPECS, Capabilities, EngineSpec, SdpaFwdKnobs, _band_covers_kv_tail, mismatch
 
@@ -259,8 +260,48 @@ def _sched_points(caps: Capabilities, facts) -> List[Optional[int]]:
     return [primary if primary in domain else _sole(domain) or SCHED_NATURAL] + runners
 
 
-def _split_points(caps: Capabilities, facts, tile_m: Optional[int], tile_n: Optional[int], cga: Optional[int]) -> List[Optional[int]]:
+# --- pack_gqa (GQA head packing) --------------------------------------------
+
+
+def _pack_gqa_choices(caps: Capabilities, facts, tile_m: int):
+    if True in caps.pack_gqas and not facts.thd and facts.h_q != facts.h_kv and pack_gqa_supported(facts.h_q, facts.h_kv, tile_m):
+        return (False, True)
+    return (False,)
+
+
+def _pack_gqa_wins(facts, tile_q: int) -> bool:
+    """Pack when the Q sequence cannot fit in a single tile, then we can further
+    apply split_kv on top of GQA packing. We may enhance this heuristic logic in
+    the future by considering more factors such as the device SM count.
+    """
+    return facts.s_q < tile_q
+
+
+def _pack_gqa_tile_q(caps: Capabilities, facts, tile_m: Optional[int]) -> int:
+    """The Q rows one grid tile covers, for :func:`_pack_gqa_wins`.
+
+    The SM100 family runs CGA tiles — ``cga_tile_m`` of the flavor the envelope
+    lowering picks for the graph's head dims (d128/d192: 512; d256/d512:
+    256). SM120 launches one CTA per tile, so it is ``tile_m`` itself.
+    """
+    if caps.sm_lo >= 120 and caps.sm_hi < 130:
+        return tile_m or 128
+    if facts.d_qk <= 128 and facts.d_v <= 128:
+        return cga_tile_m(128)
+    if facts.d_qk <= 192 and facts.d_v <= 128:
+        return cga_tile_m(192)
+    if facts.d_qk <= 256 and facts.d_v <= 256:
+        return cga_tile_m(256)
+    return cga_tile_m(512)
+
+
+def _split_points(caps: Capabilities, facts, tile_m: Optional[int], tile_n: Optional[int], cga: Optional[int], pack_g: int = 1) -> List[Optional[int]]:
     """Ordered split-KV candidates for the chosen tile geometry.
+
+    ``pack_g`` is the pack_gqa group of the set the split rides (1 =
+    unpacked): packing multiplies each head-group's Q rows by G and divides
+    the head count by it, so the wave-cost model must see the PACKED launch
+    — the packed grid is smaller, which is exactly when splitting pays.
 
     The value comes from :func:`choose_split_kv`'s wave-cost model, fed the
     facts-level launch geometry (``tile_m*cga`` rows per tile — the recommend
@@ -293,8 +334,8 @@ def _split_points(caps: Capabilities, facts, tile_m: Optional[int], tile_n: Opti
         return [no_split]
     rows_per_tile = (tile_m or 128) * (cga or 1)
     split = choose_split_kv(
-        q_tiles=_ceil_div(facts.s_q, rows_per_tile),
-        heads_q=facts.h_q,
+        q_tiles=_ceil_div(facts.s_q * pack_g, rows_per_tile),
+        heads_q=facts.h_q // pack_g,
         batch=facts.b,
         kv_tiles=_ceil_div(facts.s_kv, tile_n or 128),
         sm_count=sm_count,
@@ -338,29 +379,57 @@ def _knob_sets(spec: EngineSpec, facts) -> List[SdpaFwdKnobs]:
     """The cell's ordered COMPLETE knob assignments.
 
     The baseline takes the best value on every axis; runners-up deviate on ONE
-    axis at a time in impact order (tiles, sched, split) with the other axes
-    held at their best, capped at ``_MAX_SETS_PER_ENGINE``. Axis interactions
-    the kernels cannot serve are the generators'/mismatch's job — nothing here
-    multiplies domains together.
+    axis at a time in impact order (tiles, sched, pack_gqa, split) with the
+    other axes held at their best, capped at ``_MAX_SETS_PER_ENGINE``. Two
+    axes carry a structural coupling: a packed set rides the largest tile
+    that admits the ratio, and a split set rides the plain scheduler. Axis
+    interactions the kernels cannot serve are the generators'/mismatch's job
+    — nothing here multiplies domains together.
     """
     caps = spec.capabilities
     tiles = _tile_points(spec, facts)
     scheds = _sched_points(caps, facts)
     cga = _cga_points(caps)[0]
-    splits = _split_points(caps, facts, tiles[0][0], tiles[0][1], cga)
+    # pack_gqa couples with the tile axis: a packed set rides the LARGEST
+    # SMEM-fitting tile that admits the ratio — packing fixes the underfill
+    # small tiles exist for, and a bigger tile admits a bigger G (G must
+    # divide it) — while an unpacked set keeps the tile rule's choice.
+    pack_tile = next(
+        ((m, n) for m, n in sorted(tiles, key=lambda mn: (-(mn[0] or 0), mn[1] != 128)) if True in _pack_gqa_choices(caps, facts, m or 128)),
+        None,
+    )
+    packed_first = pack_tile is not None and _pack_gqa_wins(facts, _pack_gqa_tile_q(caps, facts, pack_tile[0]))
+    unpacked_pack = False if True in caps.pack_gqas else _sole(caps.pack_gqas)
+    base_tile = pack_tile if packed_first else tiles[0]
+    # The split model sees the launch geometry of the set it rides — the
+    # packed grid when the baseline packs.
+    splits = _split_points(caps, facts, base_tile[0], base_tile[1], cga, pack_g=(facts.h_q // facts.h_kv) if packed_first else 1)
     base = SdpaFwdKnobs(
         sched_policy=scheds[0],
-        tile_m=tiles[0][0],
-        tile_n=tiles[0][1],
+        tile_m=base_tile[0],
+        tile_n=base_tile[1],
         cga=cga,
+        pack_gqa=True if packed_first else unpacked_pack,
         split_kv=splits[0],
         softmax_precision=_softmax_points(caps)[0],
     )
     out = [base]
     for tile_m, tile_n in tiles[1:]:
+        # A packed baseline's tile runners keep the packing, so tiles the
+        # ratio cannot ride are skipped — emitted, they would only spend
+        # set-cap slots for mismatch to drop.
+        if base.pack_gqa is True and True not in _pack_gqa_choices(caps, facts, tile_m or 128):
+            continue
         out.append(replace(base, tile_m=tile_m, tile_n=tile_n))
     for policy in scheds[1:]:
         out.append(replace(base, sched_policy=policy))
+    # The opposite pack_gqa leg, riding its own tile (packed: the largest
+    # admitting tile; unpacked: the tile rule's best).
+    if pack_tile is not None:
+        if packed_first:
+            out.append(replace(base, pack_gqa=unpacked_pack, tile_m=tiles[0][0], tile_n=tiles[0][1]))
+        else:
+            out.append(replace(base, pack_gqa=True, tile_m=pack_tile[0], tile_n=pack_tile[1]))
     for split in splits[1:]:
         # Split sets ride the plain scheduler: the SM120 config bars a split
         # under the LPT remaps, and in the underfilled regime a split targets
@@ -386,6 +455,7 @@ def _fallback_knobs(caps: Capabilities) -> SdpaFwdKnobs:
         tile_m=min(caps.tile_ms, default=None),
         tile_n=min(caps.tile_ns, default=None),
         cga=_sole(caps.cgas),
+        pack_gqa=False if False in caps.pack_gqas else _sole(caps.pack_gqas),
         split_kv=1 if 1 in caps.split_kvs else _sole(caps.split_kvs),
         softmax_precision=_sole(caps.softmax_precisions),
     )

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -322,9 +322,13 @@ def make_split_helpers(CFG, *, bounds_for_tile, dispatch_decode_initial, dispatc
 
     ``bounds_for_tile`` is the caller's own bounds closure, taking
     ``(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor,
-    batch_idx)`` — flavors differ in whether they apply the dead-Q-tile trim, so
-    the split narrowing composes on top of whatever they already do.
-
+    batch_idx, qh_per_kh)`` — flavors differ in whether they apply the
+    dead-Q-tile trim, so the split narrowing composes on top of whatever they
+    already do.  ``qh_per_kh`` (trailing, default 1) is the graph's GQA
+    ratio; with CFG.PACK_GQA it is the packing group
+    size: the split chunks the tile's PACKED token-span bounds, so packing
+    and KV split compose; without CFG.PACK_GQA the bounds fold to the classic
+    single-head-per-tile form.
     At SPLIT_KV == 1 every closure below folds away and the traced code is the
     classic single-pass kernel.
     """
@@ -440,17 +444,19 @@ def make_split_helpers(CFG, *, bounds_for_tile, dispatch_decode_initial, dispatc
         return q, h, b % n_batch, b // n_batch
 
     @cute.jit
-    def _bounds_for_tile_split(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx):
-        """The flavor's bounds, narrowed to this split's slice of the KV range.
+    def _bounds_for_tile_split(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, qh_per_kh: int = 1):
+        """The flavor's (possibly packed) bounds, narrowed to this split's slice
+        of the KV range.
 
         Splitting the ALREADY-masked ``[left, right)`` rather than the raw KV
         extent is what keeps causal / SWA correct AND balanced: each split gets
-        an equal share of the tile's real work, not of the sequence.  The
-        unmasked band is clamped into the slice, which preserves the
-        ``left <= unmasked_lo <= unmasked_hi <= right`` invariant the mainloop
-        relies on, because clamping is monotone.
+        an equal share of the tile's real work, not of the sequence — and under
+        PackGQA that range is already in packed token-span units, so the two
+        features compose.  The unmasked band is clamped into the slice, which
+        preserves the ``left <= unmasked_lo <= unmasked_hi <= right`` invariant
+        the mainloop relies on, because clamping is monotone.
         """
-        b = bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx)
+        b = bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, qh_per_kh)
         if cutlass.const_expr(SPLIT_KV == 1):
             return b
         lo, hi = _split_chunk(b.left, b.right, split_idx)
@@ -646,9 +652,12 @@ def make_sdpa_helpers(
                 return _lpt_q_super(row, cta_in_pair), head, batch
 
     @cute.jit
-    def _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair):
+    def _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, qh_per_kh: int = 1):
+        # Token capacity of one CGA super-tile: TILES_Q * TILE_M rows hold
+        # rows/G tokens when packing (CFG.PACK_GQA), else one token per row.
+        tokens_per_super = (CFG.TILES_Q * CFG.TILE_M) // qh_per_kh if CFG.PACK_GQA else CFG.TILES_Q * CFG.TILE_M
         cga_base_super = q_super_idx - cta_in_pair
-        q_row_coord = cga_base_super * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_row_coord = cga_base_super * cutlass.Int32(tokens_per_super)
         return compute_kv_loop_bounds(
             q_row_coord,
             seqlen_q,
@@ -656,13 +665,13 @@ def make_sdpa_helpers(
             CFG.WINDOW_LEFT,
             CFG.MASK_FLAGS,
             CFG.TILE_N,
-            cga_tile_m,
+            cga_tile_m // qh_per_kh if CFG.PACK_GQA else cga_tile_m,
             bottom_right=bool(CFG.BOTTOM_RIGHT),
             window_right=int(CFG.WINDOW_RIGHT),
         )
 
     @cute.jit
-    def _bounds_for_tile_qtrim(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx):
+    def _bounds_for_tile_qtrim(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, qh_per_kh: int = 1):
         """bounds_for_tile + cuDNN-style dead-Q-tile KV-loop collapse.
 
         Mirrors cuDNN fort (mma_pipeline_op_native_sdpa_prefill_sm100_nonfp8
@@ -674,17 +683,21 @@ def make_sdpa_helpers(
         empty (right := left, matching the SWA empty-tile machinery) — the
         grid stays padded-sized and a dead tile costs prologue+epilogue only.
         q_len_b == 0 (whole batch dead) collapses every tile since the base
-        row coord is always >= 0.  The row coord is the SAME cga-base value
-        _bounds_for_tile uses, and q lens are per-batch constants, so every
-        warp group calling this helper sees identical (collapsed) bounds and
-        the barrier handshakes stay in lockstep.  The epilogue's
-        SEQ_Q_LENS_PRESENT trim (applied after the sink fold) already forces
-        O := 0 / LSE := -inf for every row of a collapsed tile.
+        row coord is always >= 0.  Under PackGQA the dead-tile
+        compare is the tile's base TOKEN (rows // G) against the per-batch
+        Q length — the same token-space value the packed bounds use.  Either way
+        the row coord is the SAME cga-base value _bounds_for_tile uses and q
+        lens are per-batch constants, so every warp group calling this helper
+        sees identical (collapsed) bounds and the barrier handshakes stay in
+        lockstep.  The epilogue's SEQ_Q_LENS_PRESENT trim (applied after the
+        sink fold) already forces O := 0 / LSE := -inf for every row of a
+        collapsed tile.
         """
-        b = _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair)
+        b = _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, qh_per_kh)
         if cutlass.const_expr(int(getattr(CFG, "SEQ_Q_LENS_PRESENT", 0)) == 1):
+            tokens_per_super = (CFG.TILES_Q * CFG.TILE_M) // qh_per_kh if CFG.PACK_GQA else CFG.TILES_Q * CFG.TILE_M
             cga_base_super = q_super_idx - cta_in_pair
-            q_row_coord = cga_base_super * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+            q_row_coord = cga_base_super * cutlass.Int32(tokens_per_super)
             arr = cutlass.make_array_view(seq_q_lens_tensor)
             q_len_b = cutlass.Int32(arr[batch_idx])
             tile_dead = q_row_coord >= q_len_b
@@ -762,12 +775,16 @@ def make_sdpa_helpers(
     def _dispatch_decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None):
         if cutlass.const_expr(_thd_on):
             return _thd_decode(bidx, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
+        if cutlass.const_expr(CFG.PACK_GQA):
+            qh_per_kh = cutlass.Int32(1)
         return _decode_initial(bidx, bidy, bidz, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh, seqlen_kv)
 
     @cute.jit
     def _dispatch_decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, seq_kv_lens_t, qh_per_kh=None, seqlen_kv=None):
         if cutlass.const_expr(_thd_on):
             return _thd_decode(t0, seq_kv_lens_t, n_batch, n_qh, cta_in_pair)
+        if cutlass.const_expr(CFG.PACK_GQA):
+            qh_per_kh = cutlass.Int32(1)
         return _decode_payload(t0, t1, cta_in_pair, n_q_supers, n_qh, n_batch, qh_per_kh, seqlen_kv)
 
     @cute.jit

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
@@ -158,7 +158,7 @@ elif CFG.DTYPE_QKV == 3:
 else:
     # SM100: f16/bf16 only.  FP8 needs the dedicated prefill_d128_fp8_sm100
     # kernel.  The config already asserts DTYPE_QKV ∈ {2,3}.
-    raise ValueError(f"prefill_sdpa_f16_sm100: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16 or 3=FP16)")
+    raise ValueError(f"prefill_sdpa_f16_sm100: DTYPE_QKV={CFG.DTYPE_QKV} not supported (expected 2=BF16 or 3=FP16)")
 
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
@@ -228,6 +228,9 @@ _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
+# === PackGQA ===
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
 
 # === KV split ===
 #
@@ -322,7 +325,6 @@ def _kernel(
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
 ) -> None:
-
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
 
@@ -680,9 +682,12 @@ def _tmaldg_warp_group(
         qh_per_kh,
         seqlen_kv,
     )
-    # GQA: K/V are indexed by kv-head, not Q-head.
-    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # GQA: K/V are indexed by kv-head, not Q-head; with PackGQA the decoded
+    # head_idx is the PACKED head (Q head base = head_idx * G) and q_row_base is
+    # in TOKEN units (rows // G).
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
     q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
 
     if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
@@ -693,7 +698,7 @@ def _tmaldg_warp_group(
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -721,7 +726,12 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[0],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(
+                    cutlass.Int32(0),
+                    q_head_idx,
+                    q_row_base + cutlass.Int32(0 * TOKENS_PER_TILE) + q_seq_off,
+                    tma_batch,
+                ),
                 bars.mb_q_full[0].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -755,7 +765,12 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[1],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(
+                    cutlass.Int32(0),
+                    q_head_idx,
+                    q_row_base + cutlass.Int32(1 * TOKENS_PER_TILE) + q_seq_off,
+                    tma_batch,
+                ),
                 bars.mb_q_full[1].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -824,9 +839,10 @@ def _tmaldg_warp_group(
             qh_per_kh,
             seqlen_kv,
         )
-        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
         # q_row_base compute right after decode drives ptxas R2UR.
-        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
         q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -835,7 +851,7 @@ def _tmaldg_warp_group(
         elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -895,7 +911,8 @@ def _tmastg_warp_group(
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
 
-        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
         # KV split: partials are stacked split-major on the BATCH axis of the
         # workspace (extent B*SPLIT_KV), so the store needs no new descriptor —
         # only a shifted batch coord.  Folds to batch_idx at SPLIT_KV == 1.
@@ -915,12 +932,18 @@ def _tmastg_warp_group(
                 # skip the store; the barrier protocol below still runs.
                 if batch_idx < n_batch:
                     o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                    o_slice = tma_slice_runtime_desc(
+                        o_desc_ptr,
+                        cutlass.Int32(0),
+                        q_head_idx,
+                        q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE),
+                        cutlass.Int32(0),
+                    )
                     tma_store_tile(sO[qs], o_slice)
             else:
                 tma_store_tile(
                     sO[qs],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
+                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
                 )
 
             tma_store_commit()
@@ -1104,7 +1127,7 @@ def _mma_warp_group(
         else:
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_init.left
             kv_right = bounds_init.right
 
@@ -1312,7 +1335,9 @@ def _mma_warp_group(
             else:
                 eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
                 eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-                bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+                bounds_next = _bounds_for_tile_split(
+                    q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH
+                )
                 kv_left = bounds_next.left
                 kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1594,7 +1619,7 @@ def _softmax_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1613,8 +1638,11 @@ def _softmax_warp_group(
             (cutlass.Float32(0.0), cutlass.Float32(0.0)),
             cutlass.Float32,
         )
-        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
-        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # PackGQA: q_abs is the row's TOKEN index (row // G): every mask
+        # predicate downstream is a token-space compare, and all G rows of one
+        # token share it.
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
         # Bootstrap stat_empty wait BEFORE kv loop — lifts wait off per-iter
         # critical path so alpha publish + stat_full fire happen back-to-back.
         bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
@@ -1726,7 +1754,7 @@ def _softmax_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
 
 @cute.jit
@@ -1798,7 +1826,7 @@ def _correction_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1891,12 +1919,16 @@ def _correction_warp_group(
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
             lse_val = cutlass.Float32(0.0)
+            q_row_global = (
+                q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+            )
+            row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
             # With sinks: fold the lift-the-max rescale into threshold_beta so O is scaled by scale/new_sum in one FMUL.
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
-                sink_logit = sinks_arr[head_idx]
+                sink_logit = sinks_arr[row_head_idx]
                 new_max = cute.math.max(total_max_nat, sink_logit)
                 scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
                 new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
@@ -1915,7 +1947,6 @@ def _correction_warp_group(
 
             # OOB-row guard: under cga2 the cluster's Q rows can exceed seqlen_q;
             # without the guard the write aliases the next head's LSE slot.
-            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
             if cutlass.const_expr(CFG.SEQ_Q_LENS_PRESENT):
                 # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b]
                 # write O := 0 / LSE := -inf.  Applied AFTER the sink branch on
@@ -1956,7 +1987,7 @@ def _correction_warp_group(
                     # the chunk's O.  The pair (O_s, lse_s) is everything the
                     # combine needs.  Folds to batch_idx at SPLIT_KV == 1.
                     lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
-                    lse_row = lse_arr[lse_batch, head_idx, :]
+                    lse_row = lse_arr[lse_batch, row_head_idx, :]
                     lse_row[q_row_global] = lse_val
 
             sO_sub_base = sO[qs].base
@@ -2021,7 +2052,7 @@ def _correction_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     # End-of-warp tmem_dealloc: under cga2 each corr lane ALSO DSMEM-arrives
     # on the peer so the peer's local mbar accumulates the full CGA-total count.
@@ -2072,10 +2103,12 @@ def _host(
     # K is split along seq under cga2 — box rows are per-CTA.  V is split along d_v
     # (plumbed via num_iters//CTA_MMA).  O's TMA box inner dim follows O's swizzle, NOT V's.
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE
-    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
     qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
     vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
-    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
 
     # Per-tensor TMA swizzle tracks per-CTA inner bytes (derived from CFG.*_SWZ_BYTES).
@@ -2117,8 +2150,9 @@ def _host(
 
     # Each cluster pair (CTA_MMA CTAs) collectively covers TILE_M*TILES_Q*CTA_MMA Q rows;
     # without the cluster-wide divisor cga2 over-launches and OOB clusters collide in GMEM.
+    # PackGQA: SQ*G packed rows per packed head, and QH/G packed heads.
     rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
-    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
     if cutlass.const_expr(CFG.THD_VARLEN):
@@ -2154,7 +2188,9 @@ def _host(
         # scheduler-handout paths, so the split travels with it for free.  SPLIT_KV > 1 is
         # gated to SCHED_NATURAL by the config validator.
         grid_shape = (
-            (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+            (grid_q_supers, QH // HEADS_PER_TILE, B * SPLIT_KV)
+            if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+            else (grid_q_supers * (QH // HEADS_PER_TILE) * B * SPLIT_KV, 1, 1)
         )
     _kernel(
         tma_q_desc,
@@ -2168,7 +2204,7 @@ def _host(
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
-        cutlass.Int32(QH),
+        cutlass.Int32(QH // HEADS_PER_TILE),
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm100.py
@@ -155,7 +155,7 @@ elif CFG.DTYPE_O == 2:
 elif CFG.DTYPE_O == 3:
     OUT_STORAGE_DTYPE = cutlass.Float16
 else:
-    raise ValueError(f"prefill_sdpa_fp8: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+    raise ValueError(f"prefill_sdpa_fp8: DTYPE_O={CFG.DTYPE_O} not supported (expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
 
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
@@ -211,6 +211,9 @@ _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
+# === PackGQA ===
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
 
 # === KV split ===
 #
@@ -223,13 +226,13 @@ _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
 
 @cute.jit
-def _bounds_for_tile_uniform(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx):
-    """Uniform 6-arg bounds signature for make_split_helpers.
+def _bounds_for_tile_uniform(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, qh_per_kh: int = 1):
+    """Uniform bounds signature for make_split_helpers.
 
     This flavor has no dead-Q-tile trim, so the trailing two args are
     accepted and ignored — callers pass None for them.
     """
-    return _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair)
+    return _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, qh_per_kh)
 
 
 _split_h = make_split_helpers(
@@ -310,7 +313,6 @@ def _kernel(
     scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
 ) -> None:
-
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
 
@@ -669,9 +671,12 @@ def _tmaldg_warp_group(
         qh_per_kh,
         seqlen_kv,
     )
-    # GQA: K/V are indexed by kv-head.
-    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # GQA: K/V are indexed by kv-head, not Q-head; with PackGQA the decoded
+    # head_idx is the PACKED head (Q head base = head_idx * G) and q_row_base is
+    # in TOKEN units (rows // G).
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
     q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
 
     if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
@@ -682,7 +687,7 @@ def _tmaldg_warp_group(
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -709,7 +714,12 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[0],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(
+                    cutlass.Int32(0),
+                    q_head_idx,
+                    q_row_base + cutlass.Int32(0 * TOKENS_PER_TILE) + q_seq_off,
+                    tma_batch,
+                ),
                 bars.mb_q_full[0].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -738,7 +748,12 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[1],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(
+                    cutlass.Int32(0),
+                    q_head_idx,
+                    q_row_base + cutlass.Int32(1 * TOKENS_PER_TILE) + q_seq_off,
+                    tma_batch,
+                ),
                 bars.mb_q_full[1].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -807,9 +822,10 @@ def _tmaldg_warp_group(
             qh_per_kh,
             seqlen_kv,
         )
-        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
         # q_row_base after decode drives ptxas R2UR (keeps nxt_q live before back-edge).
-        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
         q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -818,7 +834,7 @@ def _tmaldg_warp_group(
         elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -875,7 +891,8 @@ def _tmastg_warp_group(
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
 
-        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
         # KV split: partials are stacked split-major on the workspace BATCH axis
         # (extent B*SPLIT_KV), so the store needs no new descriptor — only a
         # shifted batch coord.  Folds to batch_idx at SPLIT_KV == 1.
@@ -903,7 +920,7 @@ def _tmastg_warp_group(
             else:
                 tma_store_tile(
                     sO[qs],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
+                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
                 )
 
             tma_store_commit()
@@ -1073,7 +1090,7 @@ def _mma_warp_group(
         else:
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx)
+            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_init.left
             kv_right = bounds_init.right
 
@@ -1274,7 +1291,7 @@ def _mma_warp_group(
             else:
                 eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
                 eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-                bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx)
+                bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx, CFG.QH_PER_KH)
                 kv_left = bounds_next.left
                 kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1525,7 +1542,7 @@ def _softmax_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx)
+    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx, CFG.QH_PER_KH)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1541,8 +1558,11 @@ def _softmax_warp_group(
             (cutlass.Float32(0.0), cutlass.Float32(0.0)),
             cutlass.Float32,
         )
-        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
-        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # PackGQA: q_abs is the row's TOKEN index (row // G): every mask
+        # predicate downstream is a token-space compare, and all G rows of one
+        # token share it.
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
         # Bootstrap stat_empty wait lifts wait off per-iter critical path so
         # α publish + stat_full fire back-to-back.
         bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
@@ -1657,7 +1677,7 @@ def _softmax_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx)
+        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx, CFG.QH_PER_KH)
 
 
 @cute.jit
@@ -1729,7 +1749,7 @@ def _correction_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx)
+    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx, CFG.QH_PER_KH)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1827,6 +1847,10 @@ def _correction_warp_group(
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
+            q_row_global = (
+                q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+            )
+            row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
             # Dead row (no valid KV column at all): O := 0 in BOTH branches
@@ -1836,7 +1860,7 @@ def _correction_warp_group(
             row_dead = total_sum <= cutlass.Float32(0.0)
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
-                sink_logit = sinks_arr[head_idx]
+                sink_logit = sinks_arr[row_head_idx]
                 new_max = cute.math.max(total_max_nat, sink_logit)
                 scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
                 # total_sum is in 2^P_CAST_LOG2_SCALE units — lift the sink term
@@ -1855,7 +1879,6 @@ def _correction_warp_group(
                 inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
-            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
             if cutlass.const_expr(CFG.THD_VARLEN):
                 # THD: q_row_global is sequence-local; the row is valid against
                 # the per-sequence Q length from the device metadata (negative
@@ -1887,7 +1910,7 @@ def _correction_warp_group(
                         # TMA-STG put the chunk's O.  The pair (O_s, lse_s) is everything
                         # the combine needs.  Folds to batch_idx at SPLIT_KV == 1.
                         lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
-                        lse_row = lse_arr[lse_batch, head_idx, :]
+                        lse_row = lse_arr[lse_batch, row_head_idx, :]
                         lse_row[q_row_global] = lse_val
 
             # amax_o = max over valid rows of |o_scaled| (the fp32 pre-cast output). Divided
@@ -2028,7 +2051,7 @@ def _correction_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx)
+        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, None, None, split_idx, CFG.QH_PER_KH)
 
     # tmem_dealloc fan-out: fire one arrive per lane; cga2 also DSMEM-arrives
     # on the peer so peer's local mbar accumulates the full CGA count.
@@ -2082,10 +2105,12 @@ def _host(
     # K box rows are per-CTA (TILE_N/CTA_MMA); O box inner must match O's swizzle, not V's.
     # O box sized in BPE_O — O may be written at BF16/FP16 (DTYPE_O != DTYPE_QKV).
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
-    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
     qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
     vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
-    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
 
     def _tma_swz(byte_w: int):
@@ -2123,8 +2148,9 @@ def _host(
 
     # Cluster-wide divisor mandatory: without it cga2 over-launches and OOB
     # clusters collide with valid clusters' GMEM slots at all but smallest SQ.
+    # PackGQA: SQ*G packed rows per packed head, and QH/G packed heads.
     rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
-    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
     if cutlass.const_expr(CFG.THD_VARLEN):
@@ -2162,7 +2188,9 @@ def _host(
         # already recovers the batch coord on both the blockIdx and the
         # scheduler-handout paths, so the split travels with it for free.
         grid_shape = (
-            (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+            (grid_q_supers, QH // HEADS_PER_TILE, B * SPLIT_KV)
+            if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+            else (grid_q_supers * (QH // HEADS_PER_TILE) * B * SPLIT_KV, 1, 1)
         )
     _kernel(
         tma_q_desc,
@@ -2176,7 +2204,7 @@ def _host(
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
-        cutlass.Int32(QH),
+        cutlass.Int32(QH // HEADS_PER_TILE),
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_fp8_sm107.py
@@ -194,7 +194,7 @@ elif CFG.DTYPE_O == 2:
 elif CFG.DTYPE_O == 3:
     OUT_STORAGE_DTYPE = cutlass.Float16
 else:
-    raise ValueError(f"prefill_sdpa_fp8: DTYPE_O={CFG.DTYPE_O} not supported " f"(expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
+    raise ValueError(f"prefill_sdpa_fp8: DTYPE_O={CFG.DTYPE_O} not supported (expected 0=E4M3 / 1=E5M2 / 2=BF16 / 3=FP16)")
 
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
@@ -248,6 +248,10 @@ _TENSOR_MAP_QWORDS = TENSOR_MAP_QWORDS
 _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
+
+# === PackGQA ===
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
 
 
 @dataclass(frozen=True)
@@ -339,7 +343,6 @@ def _kernel(
     scale_o_t: cute.Tensor,
     amax_o_tensor: cute.Tensor,
 ) -> None:
-
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
 
@@ -705,9 +708,12 @@ def _tmaldg_warp_group(
         n_batch,
         seq_kv_lens_tensor,
     )
-    # GQA: K/V are indexed by kv-head.
-    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # GQA: K/V are indexed by kv-head, not Q-head; with PackGQA the decoded
+    # head_idx is the PACKED head (Q head base = head_idx * G) and q_row_base is
+    # in TOKEN units (rows // G).
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
     q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
 
     if cutlass.const_expr(CFG.MASK_FLAGS == 0):
@@ -716,7 +722,7 @@ def _tmaldg_warp_group(
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -743,7 +749,12 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[0],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(
+                    cutlass.Int32(0),
+                    q_head_idx,
+                    q_row_base + cutlass.Int32(0 * TOKENS_PER_TILE) + q_seq_off,
+                    tma_batch,
+                ),
                 bars.mb_q_full[0].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -771,7 +782,12 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[1],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(
+                    cutlass.Int32(0),
+                    q_head_idx,
+                    q_row_base + cutlass.Int32(1 * TOKENS_PER_TILE) + q_seq_off,
+                    tma_batch,
+                ),
                 bars.mb_q_full[1].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -838,16 +854,17 @@ def _tmaldg_warp_group(
             n_batch,
             seq_kv_lens_tensor,
         )
-        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
         # q_row_base after decode drives ptxas R2UR (keeps nxt_q live before back-edge).
-        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
         q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -900,7 +917,8 @@ def _tmastg_warp_group(
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
 
-        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
 
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             bars.mb_o_full[qs].wait(o_full_phase)
@@ -922,7 +940,7 @@ def _tmastg_warp_group(
             else:
                 tma_store_tile(
                     sO[qs],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), batch_idx),
                 )
 
             tma_store_commit()
@@ -1153,7 +1171,7 @@ def _mma_warp_group(
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+        bounds_init = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1353,7 +1371,7 @@ def _mma_warp_group(
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+            bounds_next = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1610,7 +1628,7 @@ def _softmax_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1626,8 +1644,11 @@ def _softmax_warp_group(
             (cutlass.Float32(0.0), cutlass.Float32(0.0)),
             cutlass.Float32,
         )
-        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
-        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # PackGQA: q_abs is the row's TOKEN index (row // G): every mask
+        # predicate downstream is a token-space compare, and all G rows of one
+        # token share it.
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
         # Bootstrap stat_empty wait lifts wait off per-iter critical path so
         # α publish + stat_full fire back-to-back.
         bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
@@ -1740,7 +1761,7 @@ def _softmax_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
 
 
 @cute.jit
@@ -1813,7 +1834,7 @@ def _correction_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+    bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1929,6 +1950,10 @@ def _correction_warp_group(
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
+            q_row_global = (
+                q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+            )
+            row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
             # Dead row (no valid KV column at all): O := 0 in BOTH branches
@@ -1938,7 +1963,7 @@ def _correction_warp_group(
             row_dead = total_sum <= cutlass.Float32(0.0)
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
-                sink_logit = sinks_arr[head_idx]
+                sink_logit = sinks_arr[row_head_idx]
                 new_max = cute.math.max(total_max_nat, sink_logit)
                 scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
                 # total_sum is in 2^P_CAST_LOG2_SCALE units — lift the sink term
@@ -1957,7 +1982,6 @@ def _correction_warp_group(
                 inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
-            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
             if cutlass.const_expr(CFG.THD_VARLEN):
                 # THD: q_row_global is sequence-local; the row is valid against
                 # the per-sequence Q length from the device metadata (negative
@@ -1985,7 +2009,7 @@ def _correction_warp_group(
                 if _row_valid:
                     if cutlass.const_expr(lse_tensor is not None):
                         lse_arr = cutlass.make_array_view(lse_tensor)
-                        lse_row = lse_arr[batch_idx, head_idx, :]
+                        lse_row = lse_arr[batch_idx, row_head_idx, :]
                         lse_row[q_row_global] = lse_val
 
             # amax_o = max over valid rows of |o_scaled| (the fp32 pre-cast output). Divided
@@ -2118,7 +2142,7 @@ def _correction_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch)
-        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair)
+        bounds = _bounds_for_tile(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
 
     # tmem_dealloc fan-out: fire one arrive per lane; cga2 also DSMEM-arrives
     # on the peer so peer's local mbar accumulates the full CGA count.
@@ -2169,13 +2193,16 @@ def _host(
         SQ = q_tensor.shape[1]
         SKV = k_tensor.shape[1]
 
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+
     # K box rows are per-CTA (TILE_N/CTA_MMA); O box inner must match O's swizzle, not V's.
     # O box sized in BPE_O — O may be written at BF16/FP16 (DTYPE_O != DTYPE_QKV).
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
-    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
     qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
     vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
-    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
 
     def _tma_swz(byte_w: int):
@@ -2213,8 +2240,9 @@ def _host(
 
     # Cluster-wide divisor mandatory: without it cga2 over-launches and OOB
     # clusters collide with valid clusters' GMEM slots at all but smallest SQ.
+    # PackGQA: SQ*G packed rows per packed head, and QH/G packed heads.
     rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
-    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
     if cutlass.const_expr(CFG.THD_VARLEN):
@@ -2248,7 +2276,11 @@ def _host(
         ).launch(grid=(1, 1, 1), block=(32, 1, 1), stream=stream)
         grid_shape = (n_thd_units * cutlass.Int32(CFG.CGA_M), cutlass.Int32(1), cutlass.Int32(1))
     else:
-        grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+        grid_shape = (
+            (grid_q_supers, QH // HEADS_PER_TILE, B)
+            if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+            else (grid_q_supers * (QH // HEADS_PER_TILE) * B, 1, 1)
+        )
     _kernel(
         tma_q_desc,
         tma_k_desc,
@@ -2261,7 +2293,7 @@ def _host(
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
-        cutlass.Int32(QH),
+        cutlass.Int32(QH // HEADS_PER_TILE),
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_mxfp8_sm100.py
@@ -257,6 +257,19 @@ _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
+# === PackGQA ===
+# PackGQA is not supported for MXFP8 with the current SF contract: sf_q arrives
+# as one opaque 512-byte F8_128x4 atom per (batch, head, 128-row tile) with
+# intra-atom byte order (r%32)*16 + (r//32)*4 + c. The finest TMA-addressable
+# unit inside an atom (16 B) bundles source rows {m, m+32, m+64, m+96} of one
+# head, while a packed tile row j needs token j//G of head j%G — expressing that
+# gather needs a 4-byte-stride dim (illegal: TMA global strides are 16-B units)
+# and 6 dims (> the 5-dim TMA max).
+# Unblock options (all change the contract or add a pass): a packed upstream SF
+# layout, a device-side repack kernel, or an in-kernel quadrant gather + SMEM
+# permute.
+if CFG.PACK_GQA:
+    raise ValueError("prefill_d128_mxfp8_sm100: PACK_GQA is unsupported (F8_128x4 sf_q atom is not TMA-gatherable at token granularity)")
 
 # === KV split ===
 #
@@ -269,13 +282,13 @@ _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
 
 @cute.jit
-def _bounds_for_tile_uniform(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx):
-    """Uniform 6-arg bounds signature for make_split_helpers.
+def _bounds_for_tile_uniform(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, qh_per_kh: int = 1):
+    """Uniform bounds signature for make_split_helpers.
 
-    This flavor has no dead-Q-tile trim, so the trailing two args are
-    accepted and ignored — callers pass None for them.
+    This flavor has no dead-Q-tile trim, so the seq-lens args are accepted
+    and ignored (callers pass None for them).
     """
-    return _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair)
+    return _bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, qh_per_kh)
 
 
 _split_h = make_split_helpers(

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -133,7 +133,7 @@ elif CFG.DTYPE_QKV == 3:
 else:
     # SM100 d192/d128: f16/bf16 only. The config already asserts
     # DTYPE_QKV in {2, 3}.
-    raise ValueError(f"prefill_sdpa_d192_d128_f16_sm100: DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16 or 3=FP16)")
+    raise ValueError(f"prefill_sdpa_d192_d128_f16_sm100: DTYPE_QKV={CFG.DTYPE_QKV} not supported (expected 2=BF16 or 3=FP16)")
 
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
@@ -185,10 +185,11 @@ def _bounds_for_tile(
     cta_in_pair,
     seq_q_lens_tensor,
     batch_idx,
+    qh_per_kh: int = 1,
 ):
     # Keep the KV pipeline active for padded-Q tail tiles; the epilogue trims
     # rows beyond the per-batch Q length before storing O and LSE.
-    return _sdpa_h.bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair)
+    return _sdpa_h.bounds_for_tile(q_super_idx, seqlen_q, seqlen_kv, cta_in_pair, qh_per_kh)
 
 
 _resolve_seqlen_kv = _sdpa_h.resolve_seqlen_kv
@@ -211,6 +212,9 @@ _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
+# === PackGQA ===
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
 
 # === KV split ===
 #
@@ -716,9 +720,12 @@ def _tmaldg_warp_group(
         qh_per_kh,
         seqlen_kv,
     )
-    # GQA: K/V are indexed by kv-head, not Q-head.
-    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # GQA: K/V are indexed by kv-head, not Q-head; with PackGQA the decoded
+    # head_idx is the PACKED head (Q head base = head_idx * G) and q_row_base is
+    # in TOKEN units (rows // G).
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
     q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
 
     if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
@@ -729,7 +736,7 @@ def _tmaldg_warp_group(
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -772,7 +779,12 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[0],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(
+                    cutlass.Int32(0),
+                    q_head_idx,
+                    q_row_base + cutlass.Int32(0 * TOKENS_PER_TILE) + q_seq_off,
+                    tma_batch,
+                ),
                 bars.mb_q_full[0].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -808,7 +820,12 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[1],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(
+                    cutlass.Int32(0),
+                    q_head_idx,
+                    q_row_base + cutlass.Int32(1 * TOKENS_PER_TILE) + q_seq_off,
+                    tma_batch,
+                ),
                 bars.mb_q_full[1].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -876,9 +893,10 @@ def _tmaldg_warp_group(
             qh_per_kh,
             seqlen_kv,
         )
-        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
         # q_row_base compute right after decode drives ptxas R2UR.
-        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
         q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -887,7 +905,7 @@ def _tmaldg_warp_group(
         elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -950,7 +968,8 @@ def _tmastg_warp_group(
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
 
-        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
         # KV split: partials are stacked split-major on the workspace BATCH axis
         # (extent B*SPLIT_KV), so the store needs no new descriptor — only a
         # shifted batch coord.  Folds to batch_idx at SPLIT_KV == 1.
@@ -970,12 +989,18 @@ def _tmastg_warp_group(
                 # the store; the barrier protocol below still runs.
                 if batch_idx < n_batch:
                     o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), cutlass.Int32(0))
+                    o_slice = tma_slice_runtime_desc(
+                        o_desc_ptr,
+                        cutlass.Int32(0),
+                        q_head_idx,
+                        q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE),
+                        cutlass.Int32(0),
+                    )
                     tma_store_tile(sO[qs], o_slice)
             else:
                 tma_store_tile(
                     sO[qs],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), o_batch),
+                    tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), o_batch),
                 )
 
             tma_store_commit()
@@ -1168,7 +1193,7 @@ def _mma_warp_group(
         else:
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_init.left
             kv_right = bounds_init.right
 
@@ -1375,7 +1400,9 @@ def _mma_warp_group(
             else:
                 eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
                 eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-                bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+                bounds_next = _bounds_for_tile_split(
+                    q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH
+                )
                 kv_left = bounds_next.left
                 kv_right = bounds_next.right
 
@@ -1682,7 +1709,7 @@ def _softmax_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1700,8 +1727,11 @@ def _softmax_warp_group(
             (cutlass.Float32(0.0), cutlass.Float32(0.0)),
             cutlass.Float32,
         )
-        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
-        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # PackGQA: q_abs is the row's TOKEN index (row // G): every mask
+        # predicate downstream is a token-space compare, and all G rows of one
+        # token share it.
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
         # 3-segment kv loop: LEFT-masked / fully-unmasked / RIGHT-masked.
         # At MASK_NONE bounds collapse so the two masked sub-loops have empty range and fold out.
         if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
@@ -1817,7 +1847,7 @@ def _softmax_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
 
 @cute.jit
@@ -1889,7 +1919,7 @@ def _correction_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1983,12 +2013,16 @@ def _correction_warp_group(
 
             inv_sum = cutlass.Float32(0.0)  # pre-declare for DSL if-staging
             lse_val = cutlass.Float32(0.0)
+            q_row_global = (
+                q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+            )
+            row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
             # With sinks: fold the lift-the-max rescale into threshold_beta so O is scaled by scale/new_sum in one FMUL.
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
-                sink_logit = sinks_arr[head_idx]
+                sink_logit = sinks_arr[row_head_idx]
                 new_max = cute.math.max(total_max_nat, sink_logit)
                 scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
                 new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
@@ -2009,7 +2043,6 @@ def _correction_warp_group(
 
             # OOB-row guard: under cga2 the cluster's Q rows can exceed seqlen_q;
             # without the guard the write aliases the next head's LSE slot.
-            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
             if cutlass.const_expr(CFG.SEQ_Q_LENS_PRESENT):
                 # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b]
                 # write O := 0 / LSE := -inf.  Applied AFTER the sink branch on
@@ -2048,7 +2081,7 @@ def _correction_warp_group(
                     # where TMA-STG put the chunk's O.  The pair (O_s, lse_s) is
                     # everything the combine needs.
                     lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
-                    lse_row = lse_arr[lse_batch, head_idx, :]
+                    lse_row = lse_arr[lse_batch, row_head_idx, :]
                     lse_row[q_row_global] = lse_val
 
             sO_sub_base = sO[qs].base
@@ -2116,7 +2149,7 @@ def _correction_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     # End-of-warp tmem_dealloc: under cga2 each corr lane ALSO DSMEM-arrives
     # on the peer so the peer's local mbar accumulates the full CGA-total count.
@@ -2167,10 +2200,12 @@ def _host(
     # K is split along seq under cga2 — box rows are per-CTA.  V is split along d_v
     # (plumbed via num_iters//CTA_MMA).  O's TMA box inner dim follows O's swizzle, NOT V's.
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE
-    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
     qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
     vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
-    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
 
     # Per-tensor TMA swizzle tracks per-CTA inner bytes (derived from CFG.*_SWZ_BYTES).
@@ -2212,8 +2247,9 @@ def _host(
 
     # Each cluster pair (CTA_MMA CTAs) collectively covers TILE_M*TILES_Q*CTA_MMA Q rows;
     # without the cluster-wide divisor cga2 over-launches and OOB clusters collide in GMEM.
+    # PackGQA: SQ*G packed rows per packed head, and QH/G packed heads.
     rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
-    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
     if cutlass.const_expr(CFG.THD_VARLEN):
@@ -2246,7 +2282,9 @@ def _host(
         # already recovers the batch coord on both the blockIdx and the
         # scheduler-handout paths, so the split travels with it for free.
         grid_shape = (
-            (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+            (grid_q_supers, QH // HEADS_PER_TILE, B * SPLIT_KV)
+            if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+            else (grid_q_supers * (QH // HEADS_PER_TILE) * B * SPLIT_KV, 1, 1)
         )
     _kernel(
         tma_q_desc,
@@ -2260,7 +2298,7 @@ def _host(
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
-        cutlass.Int32(QH),
+        cutlass.Int32(QH // HEADS_PER_TILE),
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -287,6 +287,12 @@ _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
+# PackGQA geometry: query heads sharing one Q tile and the tokens the tile
+# covers.  At HEADS_PER_TILE == 1 (unpacked) packed arithmetic (//, %, *)
+# is the identity.
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
+
 _sdpa_h_mma_runtime = make_sdpa_helpers(
     CFG,
     lpt_q_tiles_in_cga_units=True,
@@ -822,9 +828,12 @@ def _tmaldg_warp_group(
     q_super_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(0).load())
     head_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(1).load())
     batch_idx = cute.arch.make_warp_uniform(sched.initial_decoded_smem.subview(2).load())
-    # GQA: K/V are indexed by kv-head.
-    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # GQA: K/V are indexed by kv-head, not Q-head.  Under PackGQA the decoded
+    # head_idx is the PACKED head (Q head base = head_idx * G) and q_row_base is
+    # in TOKEN units.
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
     q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
 
     if cutlass.const_expr(CFG.MASK_FLAGS == 0):
@@ -832,7 +841,7 @@ def _tmaldg_warp_group(
         kv_right = seqlen_kv // cutlass.Int32(CFG.TILE_N)
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -859,7 +868,7 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[0].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[0],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(0 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(0 * TOKENS_PER_TILE) + q_seq_off, tma_batch),
                 bars.mb_q_full[0].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -897,7 +906,7 @@ def _tmaldg_warp_group(
                 bars.mb_q_full[1].arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[1],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(1 * CFG.TILE_M) + q_seq_off, tma_batch),
+                tma_q(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(1 * TOKENS_PER_TILE) + q_seq_off, tma_batch),
                 bars.mb_q_full[1].smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -966,14 +975,15 @@ def _tmaldg_warp_group(
         head_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(1)).load())
         batch_idx = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(2)).load())
         is_valid_tile = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load())
-        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
         # q_row_base after decode drives ptxas R2UR (keeps nxt_q live before back-edge).
-        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
         q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         if cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -1018,7 +1028,8 @@ def _tmastg_warp_group(
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
 
-        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_row_base = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
 
         for qs in cutlass.range_constexpr(CFG.TILES_Q):
             _wait_mbarrier(bars.mb_o_full[qs], o_full_phase)
@@ -1026,7 +1037,7 @@ def _tmastg_warp_group(
             # O TMA params follow O's swizzle, not V's (V and O swizzles may differ).
             tma_store_tile(
                 sO[qs],
-                tma_o(cutlass.Int32(0), head_idx, q_row_base + cutlass.Int32(qs * CFG.TILE_M), batch_idx),
+                tma_o(cutlass.Int32(0), q_head_idx, q_row_base + cutlass.Int32(qs * TOKENS_PER_TILE), batch_idx),
             )
 
             tma_store_commit()
@@ -1180,7 +1191,7 @@ def _mma_warp_group(
             seq_kv_lens_tensor,
         )
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        bounds_init = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1387,7 +1398,7 @@ def _mma_warp_group(
             )
             is_valid_tile = nxt_v & cutlass.Int32(1)
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+            bounds_next = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1638,7 +1649,7 @@ def _softmax_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
 
     softmax_wg_base_const = CFG.SOFTMAX_WG0_BASE if sub_tile_id == 0 else CFG.SOFTMAX_WG1_BASE
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(softmax_wg_base_const * 32)
@@ -1657,14 +1668,18 @@ def _softmax_warp_group(
             cutlass.Float32,
         )
         if cutlass.const_expr(_E5_SINK):
-            sink_log2 = cutlass.Float32(sinks_arr[head_idx]) * cutlass.Float32(1.4426950408889634)
+            sink_log2 = cutlass.Float32(sinks_arr[head_idx * cutlass.Int32(HEADS_PER_TILE) + tid_in_wg % cutlass.Int32(HEADS_PER_TILE)]) * cutlass.Float32(
+                1.4426950408889634
+            )
             total_max = sink_log2
             total_sum = cutlass.Vector.from_elements(
                 (cutlass.Float32(1.0), cutlass.Float32(0.0)),
                 cutlass.Float32,
             )
-        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
-        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * CFG.TILE_M) + tid_in_wg
+        # PackGQA: token-unit row base; the row's token index feeds the mask
+        # compares (all G rows of one token share it).
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_abs = q_row_coord + cutlass.Int32(sub_tile_id * TOKENS_PER_TILE) + tid_in_wg // cutlass.Int32(HEADS_PER_TILE)
         # Bootstrap stat_empty wait lifts wait off per-iter critical path so
         # α publish + stat_full fire back-to-back.
         _wait_mbarrier(bars.mb_stat_empty[sub_tile_id], stat_empty_phase)
@@ -1794,7 +1809,7 @@ def _softmax_warp_group(
         is_valid_tile = cute.arch.make_warp_uniform(sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load())
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
 
 
 @cute.jit
@@ -1855,7 +1870,7 @@ def _correction_warp_group(
     sched_state = PipelineState.start()
 
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+    bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
 
     while is_valid_tile > cutlass.Int32(0):
         read_tile_id_arrive(sched.mb_read_tile_id.subview(sched_state.idx), CGA_SIZE)
@@ -1940,13 +1955,21 @@ def _correction_warp_group(
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
+            # Row identity (PackGQA): this lane's row decodes to (token,
+            # head-in-group) — q_row_global is the TOKEN index and
+            # row_head_idx the row's true query head (lane-varying under
+            # packing; do NOT make_warp_uniform it).
+            q_row_global = (
+                q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + cutlass.Int32(qs * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+            )
+            row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
             if cutlass.const_expr(_E5_SINK):
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
                 beta = cute.arch.rcp_approx(cute.math.max(total_sum, cutlass.Float32(1e-30)))
                 inv_sum = o_scale_fused * beta
             elif cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
-                sink_logit = sinks_arr[head_idx]
+                sink_logit = sinks_arr[row_head_idx]
                 new_max = cute.math.max(total_max_nat, sink_logit)
                 scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
                 new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
@@ -1976,12 +1999,11 @@ def _correction_warp_group(
                 inv_sum = o_scale_fused * beta
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
-            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
             _row_valid = q_row_global < seqlen_q
             if _row_valid:
                 if cutlass.const_expr(lse_tensor is not None):
                     lse_arr = cutlass.make_array_view(lse_tensor)
-                    lse_row = lse_arr[batch_idx, head_idx, :]
+                    lse_row = lse_arr[batch_idx, row_head_idx, :]
                     lse_row[q_row_global] = lse_val
 
             # amax_o is defined over the fp32 pre-cast output.
@@ -2116,7 +2138,7 @@ def _correction_warp_group(
         is_valid_tile = sched.tile_id_smem.subview(decoded_base + cutlass.Int32(3)).load()
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
-        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair)
+        bounds = _bounds_for_tile(q_super_idx, seqlen_q, eff_seqlen_kv, cta_in_pair, CFG.QH_PER_KH)
 
     # tmem_dealloc fan-out: fire one arrive per lane; cga2 also DSMEM-arrives
     # on the peer so peer's local mbar accumulates the full CGA count.
@@ -2163,7 +2185,9 @@ def _host(
     # K box rows are per-CTA (TILE_N/CTA_MMA); O box inner must match O's swizzle, not V's.
     # O box sized in BPE_O — O may be written at BF16/FP16 (DTYPE_O != DTYPE_QKV).
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
-    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
     # Expose D192 as three contiguous chunks so one rank-5 K TMA covers a tile.
     k_rank5_layout = cute.make_layout(
         (
@@ -2184,7 +2208,7 @@ def _host(
     k_rank5_tensor = cute.make_tensor(k_tensor.iterator, k_rank5_layout)
     qk_box_k = (1, 1, TMA_QK_ITERS, CFG.TILE_N // CFG.CTA_MMA, TMA_QK_GRANU_ELEMS)
     vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
-    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
 
     def _tma_swz(byte_w: int):
@@ -2223,10 +2247,14 @@ def _host(
     # Cluster-wide divisor mandatory: without it cga2 over-launches and OOB
     # clusters collide with valid clusters' GMEM slots at all but smallest SQ.
     rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
-    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
-    grid_shape = (grid_q_supers, QH, B) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B, 1, 1)
+    grid_shape = (
+        (grid_q_supers, QH // HEADS_PER_TILE, B)
+        if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+        else (grid_q_supers * (QH // HEADS_PER_TILE) * B, 1, 1)
+    )
     _kernel(
         tma_q_desc,
         tma_k_desc,
@@ -2238,7 +2266,7 @@ def _host(
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
-        cutlass.Int32(QH),
+        cutlass.Int32(QH // HEADS_PER_TILE),
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
@@ -78,7 +78,7 @@ elif CFG.DTYPE_QKV == 3:
     MMA_KIND = nvvm.Tcgen05MMAKind.F16
 
 if CFG.DTYPE_O != CFG.DTYPE_QKV:
-    raise NotImplementedError(f"prefill_sdpa_d256_f16: DTYPE_O={CFG.DTYPE_O} != DTYPE_QKV=" f"{CFG.DTYPE_QKV} not yet supported.")
+    raise NotImplementedError(f"prefill_sdpa_d256_f16: DTYPE_O={CFG.DTYPE_O} != DTYPE_QKV={CFG.DTYPE_QKV} not yet supported.")
 OUT_STORAGE_DTYPE = STORAGE_DTYPE
 
 
@@ -131,6 +131,9 @@ _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
+# === PackGQA ===
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
 
 # === KV split ===
 #
@@ -220,7 +223,6 @@ def _kernel(
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
 ) -> None:
-
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
 
@@ -496,7 +498,6 @@ def _tmaldg_warp_group(
     cta_in_pair,
     tma_mcast_mask,
 ):
-
     q_o_alias_phase = cutlass.Int32(0)
     kv_state = PipelineState.start(phase=1)
 
@@ -516,8 +517,12 @@ def _tmaldg_warp_group(
         qh_per_kh,
         seqlen_kv,
     )
-    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # GQA: K/V are indexed by kv-head, not Q-head; with PackGQA the decoded
+    # head_idx is the PACKED head (Q head base = head_idx * G) and q_row_base is
+    # in TOKEN units (rows // G).
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
     q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
 
     if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
@@ -528,7 +533,7 @@ def _tmaldg_warp_group(
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -553,7 +558,7 @@ def _tmaldg_warp_group(
                 bars.mb_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=nvvm.elect_sync())
             tma_load_tile(
                 sQ[0],
-                tma_q(cutlass.Int32(0), head_idx, q_row_base + q_seq_off, tma_batch),
+                tma_q(cutlass.Int32(0), q_head_idx, q_row_base + q_seq_off, tma_batch),
                 bars.mb_q_full.smem_ptr,
                 cta_group=CFG.CTA_MMA,
                 mcast_mask=tma_mcast_mask,
@@ -609,8 +614,9 @@ def _tmaldg_warp_group(
             qh_per_kh,
             seqlen_kv,
         )
-        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
         q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -619,7 +625,7 @@ def _tmaldg_warp_group(
         elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -646,7 +652,6 @@ def _tmastg_warp_group(
     seqlen_kv,
     qh_per_kh,
 ):
-
     tmastg_go_phase = cutlass.Int32(0)
     o_full_phase = cutlass.Int32(0)
 
@@ -676,7 +681,8 @@ def _tmastg_warp_group(
         for chunk in cutlass.range_constexpr(N_O_CHUNKS):
             bars.mb_o_full[chunk].wait(o_full_phase)
 
-        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
         # KV split: partials are stacked split-major on the workspace BATCH
         # axis (extent B*SPLIT_KV), so the store needs no new descriptor —
         # only a shifted batch coord.  Folds to batch_idx at SPLIT_KV == 1.
@@ -688,12 +694,12 @@ def _tmastg_warp_group(
             # the store; the barrier protocol below still runs.
             if batch_idx < n_batch:
                 o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_coord, cutlass.Int32(0))
+                o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
                 tma_store_tile(sO[0], o_slice)
         else:
             tma_store_tile(
                 sO[0],
-                tma_o(cutlass.Int32(0), head_idx, q_row_coord, o_batch),
+                tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
             )
         tma_store_commit()
         tma_store_wait(0)
@@ -824,7 +830,7 @@ def _mma_warp_group(
         else:
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_init.left
             kv_right = bounds_init.right
 
@@ -972,7 +978,9 @@ def _mma_warp_group(
             else:
                 eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
                 eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-                bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+                bounds_next = _bounds_for_tile_split(
+                    q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH
+                )
                 kv_left = bounds_next.left
                 kv_right = bounds_next.right
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1026,7 +1034,7 @@ def _softmax_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     tid_in_wg = cute.arch.thread_idx()[0] - cutlass.Int32(CFG.SOFTMAX_WG0_BASE * 32)
 
@@ -1039,8 +1047,11 @@ def _softmax_warp_group(
             (cutlass.Float32(0.0), cutlass.Float32(0.0)),
             cutlass.Float32,
         )
-        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
-        q_abs = q_row_coord + tid_in_wg
+        # PackGQA: q_abs is the row's TOKEN index (row // G): every mask
+        # predicate downstream is a token-space compare, and all G rows of one
+        # token share it.
+        q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+        q_abs = q_row_coord + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
 
         bars.mb_o_empty.wait(epilogue_state)
         bars.mb_stat_empty.wait(stat_empty_phase)
@@ -1391,7 +1402,7 @@ def _softmax_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
 
 @cute.jit
@@ -1442,7 +1453,7 @@ def _correction_warp_group(
     eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
 
     eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+    bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     O_CHUNK = 16
     N_CHUNKS_O = CFG.TILE_O // O_CHUNK
@@ -1540,9 +1551,11 @@ def _correction_warp_group(
         total_max_nat = total_max_scaled * LN2
         lse_val = cutlass.Float32(0.0)
         inv_sum = cutlass.Float32(0.0)
+        q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+        row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
         if cutlass.const_expr(CFG.HAS_SINK):
             sinks_arr = cutlass.make_array_view(sinks_tensor)
-            sink_logit = sinks_arr[head_idx]
+            sink_logit = sinks_arr[row_head_idx]
             new_max = cute.math.max(total_max_nat, sink_logit)
             scale = cute.math.exp(total_max_nat - new_max, fastmath=True)
             new_sum = total_sum * scale + cute.math.exp(sink_logit - new_max, fastmath=True)
@@ -1559,7 +1572,6 @@ def _correction_warp_group(
             lse_val = cutlass.Float32(arith.select(row_dead.ir_value(), neg_inf_lse.ir_value(), lse_val.ir_value()))
             inv_sum = cutlass.Float32(arith.select(row_dead.ir_value(), cutlass.Float32(0.0).ir_value(), inv_sum.ir_value()))
 
-        q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
         if cutlass.const_expr(CFG.SEQ_Q_LENS_PRESENT):
             # Dense padded-Q trim (cuDNN >= 9.14): q rows >= seq_len_q[b] write
             # O := 0 / LSE := -inf.  Applied AFTER the sink branch on purpose —
@@ -1594,7 +1606,7 @@ def _correction_warp_group(
                 # TMA-STG put the chunk's O.  The pair (O_s, lse_s) is everything
                 # the combine needs.
                 lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
-                lse_row = lse_arr[lse_batch, head_idx, :]
+                lse_row = lse_arr[lse_batch, row_head_idx, :]
                 lse_row[q_row_global] = lse_val
 
         parity_last_rt = cutlass.Int32(0)
@@ -1664,7 +1676,7 @@ def _correction_warp_group(
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
 
     if cutlass.const_expr(CFG.CTA_MMA == 2):
         peer_cta = cta_id_x ^ cutlass.Int32(1)
@@ -1707,10 +1719,12 @@ def _host(
         SKV = k_tensor.shape[1]
 
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
-    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
     qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
     vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
-    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
 
     def _tma_swz(byte_w: int):
@@ -1745,8 +1759,9 @@ def _host(
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
 
+    # PackGQA: SQ*G packed rows per packed head, and QH/G packed heads.
     rows_per_cluster = CFG.TILES_Q * CFG.TILE_M * CFG.CTA_MMA
-    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CTA_MMA
     q_supers = grid_q_supers
     if cutlass.const_expr(CFG.THD_VARLEN):
@@ -1771,7 +1786,9 @@ def _host(
         # already recovers the batch coord on both the blockIdx and the
         # scheduler-handout paths, so the split travels with it for free.
         grid_shape = (
-            (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+            (grid_q_supers, (QH // HEADS_PER_TILE), B * SPLIT_KV)
+            if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+            else (grid_q_supers * (QH // HEADS_PER_TILE) * B * SPLIT_KV, 1, 1)
         )
     _kernel(
         tma_q_desc,
@@ -1785,7 +1802,7 @@ def _host(
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
-        cutlass.Int32(QH),
+        cutlass.Int32(QH // HEADS_PER_TILE),
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,
@@ -1992,11 +2009,11 @@ def _main():
     parser.add_argument("--iters", type=int, default=0)
     args = parser.parse_args()
 
-    print(f"[d256_f16_sm100] compile b={args.b} qh={args.hq} kh={args.hk} " f"sq={args.sq} skv={args.skv}", flush=True)
+    print(f"[d256_f16_sm100] compile b={args.b} qh={args.hq} kh={args.hk} sq={args.sq} skv={args.skv}", flush=True)
     fn = compile(args.b, args.hq, args.hk, args.sq, args.skv)
     print(f"[d256_f16_sm100] compile OK: {fn}", flush=True)
     if args.validate:
-        print("[d256_f16_sm100] compiled — run validation via the " "frost SDPA test suite (see test/python/frost/sdpa/).")
+        print("[d256_f16_sm100] compiled — run validation via the frost SDPA test suite (see test/python/frost/sdpa/).")
     return 0
 
 

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
@@ -108,7 +108,7 @@ elif CFG.DTYPE_QKV == 3:
     MMA_KIND = nvvm.Tcgen05MMAKind.F16
 else:
     raise ValueError(
-        f"prefill_sdpa_d512_f16 (SM100): DTYPE_QKV={CFG.DTYPE_QKV} not supported " f"(expected 2=BF16 or 3=FP16; FP8/MXFP8 ship in a separate kernel file)"
+        f"prefill_sdpa_d512_f16 (SM100): DTYPE_QKV={CFG.DTYPE_QKV} not supported (expected 2=BF16 or 3=FP16; FP8/MXFP8 ship in a separate kernel file)"
     )
 OUT_STORAGE_DTYPE = STORAGE_DTYPE
 
@@ -295,7 +295,7 @@ _require(P_TMA_ITERS == P_XFER_HALVES, f"P-xfer split assumes P_TMA_ITERS ({P_TM
 _require(NUM_KPHASES_PV % P_XFER_HALVES == 0, f"NUM_KPHASES_PV ({NUM_KPHASES_PV}) not divisible by P_XFER_HALVES ({P_XFER_HALVES})")
 _require(
     NUM_KPHASES_PV_HALF * CFG.TILE_K_HW_BMM2 == P_D_BLOCK,
-    f"K-split boundary ({NUM_KPHASES_PV_HALF * CFG.TILE_K_HW_BMM2}) must equal " f"P SMEM half width P_D_BLOCK ({P_D_BLOCK})",
+    f"K-split boundary ({NUM_KPHASES_PV_HALF * CFG.TILE_K_HW_BMM2}) must equal P SMEM half width P_D_BLOCK ({P_D_BLOCK})",
 )
 _require(pHalfXferElems == P_BLOCK_BYTES, f"P half ({pHalfXferElems} elems) must equal one TMA chunk P_BLOCK_BYTES ({P_BLOCK_BYTES})")
 
@@ -322,6 +322,9 @@ _dispatch_decode_initial = _sdpa_h.dispatch_decode_initial
 _dispatch_decode_payload = _sdpa_h.dispatch_decode_payload
 _thd_tma_offsets = _sdpa_h.thd_tma_offsets
 
+# === PackGQA ===
+HEADS_PER_TILE = CFG.QH_PER_KH if CFG.PACK_GQA else 1
+TOKENS_PER_TILE = CFG.TILE_M // HEADS_PER_TILE
 
 # === KV split ===
 #
@@ -369,7 +372,6 @@ def _kernel(
     # ABI is unchanged.
     seq_q_lens_tensor: Optional[cute.Tensor] = None,
 ) -> None:
-
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     tidx, _, _ = cute.arch.thread_idx()
 
@@ -861,7 +863,7 @@ def _compute_warp_group(
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_unmasked_lo = bounds_init.unmasked_lo
         kv_unmasked_hi = bounds_init.unmasked_hi
@@ -903,7 +905,10 @@ def _compute_warp_group(
                 cutlass.Float32,
             )
 
-            q_abs = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
+            # PackGQA: q_abs is the row's TOKEN index (row // G): every mask
+            # predicate downstream is a token-space compare, and all G rows of one
+            # token share it.
+            q_abs = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
 
             if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
                 pass
@@ -1117,10 +1122,12 @@ def _compute_warp_group(
 
             bars.mb_stats_xfer_empty.arrive_on_peer(cross_sg_peer, pred=is_lead_warp & nvvm.elect_sync())
 
+            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+            row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
             LN2 = cutlass.Float32(0.6931471805599453)
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
-                sink_logit = sinks_arr[head_idx]
+                sink_logit = sinks_arr[row_head_idx]
                 final_max_nat = final_max * LN2
                 new_max_nat = cute.math.max(final_max_nat, sink_logit)
                 scale_sink = cute.math.exp(final_max_nat - new_max_nat, fastmath=True)
@@ -1143,13 +1150,12 @@ def _compute_warp_group(
                 # write O := 0 / LSE := -inf.  Applied AFTER the sink branch on
                 # purpose — a trimmed row is dead even with a sink.  Per-batch
                 # q lens come in via the dedicated seq_q_lens_tensor parameter.
-                # (q_row_global below is only computed after the O store loop,
-                # so the trim recomputes the row index here — beta feeds the
-                # O normalization in that loop.)
+                # (q_row_global — the row's token index — is computed above,
+                # before the sink fold, which needs the row's head; beta feeds
+                # the O normalization in the store loop below.)
                 _sq_arr = cutlass.make_array_view(seq_q_lens_tensor)
                 _q_len_b = cutlass.Int32(_sq_arr[batch_idx])
-                _q_row_trim = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
-                row_trim = _q_row_trim >= _q_len_b
+                row_trim = q_row_global >= _q_len_b
                 neg_inf_trim = cutlass.Float32(float("-inf"))
                 beta = cutlass.Float32(arith.select(row_trim.ir_value(), cutlass.Float32(0.0).ir_value(), beta.ir_value()))
                 lse = cutlass.Float32(arith.select(row_trim.ir_value(), neg_inf_trim.ir_value(), lse.ir_value()))
@@ -1193,7 +1199,6 @@ def _compute_warp_group(
                     nvvm.fence_proxy("async.shared", space="cta")
                     bars.mb_tma_o_full[chunk].arrive()
 
-            q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + tid_in_wg
             if cutlass.const_expr(lse_tensor is None):
                 pass  # has_lse=False: the Stats store is compiled out
             elif cutlass.const_expr(CFG.THD_VARLEN):
@@ -1214,7 +1219,7 @@ def _compute_warp_group(
                 if q_row_global < seqlen_q:
                     lse_arr = cutlass.make_array_view(lse_tensor)
                     lse_batch = _partial_batch(batch_idx, split_idx, n_batch)
-                    lse_row = lse_arr[lse_batch, head_idx, :]
+                    lse_row = lse_arr[lse_batch, row_head_idx, :]
                     lse_row[q_row_global] = lse
 
         wait(sched.mb_scheduler.subview(sched_state.idx), sched_state.phase)
@@ -1239,7 +1244,7 @@ def _compute_warp_group(
         elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_unmasked_lo = bounds_next.unmasked_lo
             kv_unmasked_hi = bounds_next.unmasked_hi
@@ -1354,7 +1359,7 @@ def _mma_warp_group(
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1505,7 +1510,7 @@ def _mma_warp_group(
         elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -1568,7 +1573,7 @@ def _mma_warp_non_leader(
         else:
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_init.left
             kv_right = bounds_init.right
 
@@ -1612,7 +1617,9 @@ def _mma_warp_non_leader(
             elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
                 eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
                 eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-                bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+                bounds_next = _bounds_for_tile_split(
+                    q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH
+                )
                 kv_left = bounds_next.left
                 kv_right = bounds_next.right
     bars.mb_tmem_dealloc.wait(cutlass.Int32(0))
@@ -1664,8 +1671,12 @@ def _tmaldg_warp_group(
         qh_per_kh,
         seqlen_kv,
     )
-    kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+    # GQA: K/V are indexed by kv-head, not Q-head; with PackGQA the decoded
+    # head_idx is the PACKED head (Q head base = head_idx * G) and q_row_base is
+    # in TOKEN units (rows // G).
+    q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+    kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+    q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
     q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
 
     if cutlass.const_expr(CFG.MASK_FLAGS == 0 and SPLIT_KV == 1):
@@ -1676,7 +1687,7 @@ def _tmaldg_warp_group(
     else:
         eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
         eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+        bounds_init = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
         kv_left = bounds_init.left
         kv_right = bounds_init.right
 
@@ -1709,7 +1720,7 @@ def _tmaldg_warp_group(
                 bars.mb_tma_q_full.arrive(n_bytes=qTmaTransactionBytes, pred=is_leader & nvvm.elect_sync())
                 tma_load_tile(
                     sQ[0],
-                    tma_q(cutlass.Int32(0), head_idx, q_row_base + q_seq_off, tma_batch),
+                    tma_q(cutlass.Int32(0), q_head_idx, q_row_base + q_seq_off, tma_batch),
                     bars.mb_tma_q_full.smem_ptr,
                     cta_group=CFG.CTA_MMA,
                     mcast_mask=tma_mcast_mask,
@@ -1764,8 +1775,9 @@ def _tmaldg_warp_group(
             qh_per_kh,
             seqlen_kv,
         )
-        kv_head_idx = cute.arch.make_warp_uniform(head_idx // qh_per_kh)
-        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M))
+        q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
+        kv_head_idx = cute.arch.make_warp_uniform(head_idx if cutlass.const_expr(CFG.PACK_GQA) else head_idx // qh_per_kh)
+        q_row_base = cute.arch.make_warp_uniform(q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE))
         q_seq_off, kv_seq_off, tma_batch = _thd_tma_offsets(seq_kv_lens_tensor, batch_idx, n_batch)
         is_valid_tile = nxt_v & cutlass.Int32(1)
         sched_state = advance(sched_state, CFG.SCHEDULER_STAGES)
@@ -1774,7 +1786,7 @@ def _tmaldg_warp_group(
         elif cutlass.const_expr(CFG.MASK_FLAGS != 0):
             eff_seqlen_kv = _resolve_seqlen_kv(seq_kv_lens_tensor, batch_idx, seqlen_kv)
             eff_seqlen_q = _resolve_seqlen_q(seq_kv_lens_tensor, batch_idx, seqlen_q, n_batch, seq_q_lens_tensor)
-            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx)
+            bounds_next = _bounds_for_tile_split(q_super_idx, eff_seqlen_q, eff_seqlen_kv, cta_in_pair, seq_q_lens_tensor, batch_idx, split_idx, CFG.QH_PER_KH)
             kv_left = bounds_next.left
             kv_right = bounds_next.right
 
@@ -1833,7 +1845,8 @@ def _tmastg_warp_group(
             for chunk in cutlass.range_constexpr(N_O_CHUNKS):
                 bars.mb_tma_o_full[chunk].wait(o_full_state.phase)
 
-            q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M)
+            q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
+            q_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE)
             # KV split: partials stack split-major on the workspace BATCH axis.
             o_batch = _partial_batch(batch_idx, split_idx, n_batch)
             if cutlass.const_expr(CFG.THD_VARLEN):
@@ -1842,12 +1855,12 @@ def _tmastg_warp_group(
                 # the store; the barrier protocol below still runs.
                 if batch_idx < n_batch:
                     o_desc_ptr = (o_desc_words.iterator.raw_ptr() + batch_idx * cutlass.Int32(_TENSOR_MAP_QWORDS)).tospace(cutlass.AddressSpace.generic)
-                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), head_idx, q_row_coord, cutlass.Int32(0))
+                    o_slice = tma_slice_runtime_desc(o_desc_ptr, cutlass.Int32(0), q_head_idx, q_row_coord, cutlass.Int32(0))
                     tma_store_tile(sO[0], o_slice)
             else:
                 tma_store_tile(
                     sO[0],
-                    tma_o(cutlass.Int32(0), head_idx, q_row_coord, o_batch),
+                    tma_o(cutlass.Int32(0), q_head_idx, q_row_coord, o_batch),
                 )
             tma_store_commit()
             tma_store_wait(0)
@@ -1911,10 +1924,12 @@ def _host(
         SKV = k_tensor.shape[1]
 
     _O_GRANU_ELEMS = CFG.O_SWZ_BYTES // CFG.BPE_O
-    qk_box_q = (1, CFG.TILE_M, 1, TMA_QK_GRANU_ELEMS)
+    if cutlass.const_expr(CFG.PACK_GQA and q_tensor.shape[2] != k_tensor.shape[2] * CFG.QH_PER_KH):
+        raise ValueError(f"CFG.QH_PER_KH ({CFG.QH_PER_KH}) does not match tensor head extents H_q={q_tensor.shape[2]}, H_kv={k_tensor.shape[2]}")
+    qk_box_q = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, TMA_QK_GRANU_ELEMS)
     qk_box_k = (1, CFG.TILE_N // CFG.CTA_MMA, 1, TMA_QK_GRANU_ELEMS)
     vo_box_v = (1, CFG.TILE_N, 1, TMA_VO_GRANU_ELEMS)
-    vo_box_o = (1, CFG.TILE_M, 1, _O_GRANU_ELEMS)
+    vo_box_o = (1, CFG.TILE_M // HEADS_PER_TILE, HEADS_PER_TILE, _O_GRANU_ELEMS)
     stride_order = (3, 2, 1, 0)
 
     def _tma_swz(byte_w: int):
@@ -1949,8 +1964,9 @@ def _host(
         l2_promotion=tmap.TensorMapL2Promotion.l2_128b,
     )
 
+    # PackGQA: SQ*G packed rows per packed head, and QH/G packed heads.
     rows_per_cluster = CGA_TILE_M
-    q_clusters = (SQ + rows_per_cluster - 1) // rows_per_cluster
+    q_clusters = (SQ * HEADS_PER_TILE + rows_per_cluster - 1) // rows_per_cluster
     grid_q_supers = q_clusters * CFG.CGA_M
     q_supers = q_clusters * CFG.CTA_MMA
     if cutlass.const_expr(CFG.THD_VARLEN):
@@ -1973,7 +1989,9 @@ def _host(
     else:
         # KV split rides the BATCH axis: z = batch + split*B.
         grid_shape = (
-            (grid_q_supers, QH, B * SPLIT_KV) if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL) else (grid_q_supers * QH * B * SPLIT_KV, 1, 1)
+            (grid_q_supers, QH // HEADS_PER_TILE, B * SPLIT_KV)
+            if cutlass.const_expr(CFG.SCHEDULER_POLICY == SCHED_NATURAL)
+            else (grid_q_supers * (QH // HEADS_PER_TILE) * B * SPLIT_KV, 1, 1)
         )
     _kernel(
         tma_q_desc,
@@ -1987,7 +2005,7 @@ def _host(
         cutlass.Int32(SQ),
         cutlass.Int32(SKV),
         cutlass.Int32(q_supers),
-        cutlass.Int32(QH),
+        cutlass.Int32(QH // HEADS_PER_TILE),
         cutlass.Int32(B),
         cutlass.Int32(QH // KH),
         scale_softmax_log2,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -217,6 +217,8 @@ class SM120FusedMultiHeadAttentionForward:
         head_tile_v: int = 128,
         kv_tile: int = SEQ_KV_TILES[0],
         q_tile: int = SEQ_Q_TILES[0],
+        pack_gqa: bool = False,
+        qh_per_kh: int = 1,
     ):
         """Initialize the FMHA prefill kernel configuration.
 
@@ -253,10 +255,22 @@ class SM120FusedMultiHeadAttentionForward:
             constraint as ``head_tile_qk``.
         :param q_tile: Query sequence tile size.
         :param kv_tile: Key/value sequence tile size.
+        :param pack_gqa: Enable PackGQA: each Q tile holds ``q_tile/qh_per_kh``
+            tokens x qh_per_kh query heads sharing one KV head, token-major
+            (row r ↔ token ``r // G``, head ``r % G``).
+        :param qh_per_kh: The graph's GQA ratio ``h_q // h_kv``; must divide
+            ``q_tile`` when ``pack_gqa`` is enabled, and is validated against
+            the runtime Q/K head extents at ``__call__``.
         """
 
         if out_dtype != in_dtype:
             raise ValueError("out_dtype must match in_dtype")
+        if qh_per_kh < 1:
+            raise ValueError(f"qh_per_kh ({qh_per_kh}) must be >= 1")
+        if pack_gqa and q_tile % qh_per_kh != 0:
+            raise ValueError(f"qh_per_kh ({qh_per_kh}) must divide q_tile ({q_tile}) when pack_gqa is enabled")
+        if pack_gqa and thd_varlen:
+            raise ValueError("PackGQA is dense-only (THD keeps the unpacked path)")
         if thd_varlen and thd_batch < 1:
             raise ValueError("thd_varlen requires thd_batch >= 1")
         self.in_dtype = in_dtype
@@ -283,6 +297,8 @@ class SM120FusedMultiHeadAttentionForward:
         self.head_tile_v = head_tile_v
         self.q_tile = q_tile
         self.kv_tile = kv_tile
+        self.pack_gqa = pack_gqa
+        self.qh_per_kh = qh_per_kh
         # KV split: SPLIT_KV CTAs per (q_tile, batch, head), each covering a
         # contiguous slice of that tile's KV-tile range.  1 = off (folds away).
         self.split_kv = split_kv
@@ -440,10 +456,13 @@ class SM120FusedMultiHeadAttentionForward:
             )
             for i in cutlass.range_constexpr(4):
                 row_in_cta, col_in_cta = mma_offsets_in_cta[i]
-                cur_q_seq_idx = basic_params.q_seq_idx + row_in_cta
+                cur_q_seq_idx = basic_params.q_seq_idx + (row_in_cta if cutlass.const_expr(not self.pack_gqa) else row_in_cta // self.qh_per_kh)
+                q_row_off = cur_q_seq_idx * basic_params.q_seq_stride
+                if cutlass.const_expr(self.pack_gqa and self.qh_per_kh != 1):
+                    q_row_off = q_row_off + (row_in_cta % self.qh_per_kh) * basic_params.q_head_stride
                 q_packed = cutlass.Int32(0)
                 if cur_q_seq_idx < basic_params.seqlen_q and col_in_cta < basic_params.head_dim_qk:
-                    q_pair = (basic_params.q_ptr + basic_params.q_head_off + cur_q_seq_idx * basic_params.q_seq_stride + col_in_cta).load(count=2, alignment=4)
+                    q_pair = (basic_params.q_ptr + basic_params.q_head_off + q_row_off + col_in_cta).load(count=2, alignment=4)
                     q_packed = q_pair.bitcast(cutlass.Int32)[0]
                 q_regs[q_regs_offset + i] = q_packed
 
@@ -570,7 +589,7 @@ class SM120FusedMultiHeadAttentionForward:
 
             # Resolve mask bounds for this query row. ``valid_cols`` is an
             # exclusive upper bound; ``first_valid_col`` is inclusive.
-            q_position = basic_params.q_seq_idx + q_row_in_cta
+            q_position = basic_params.q_seq_idx + (q_row_in_cta if cutlass.const_expr(not self.pack_gqa) else q_row_in_cta // self.qh_per_kh)
             diagonal_offset = cutlass.Int32(0)
             if cutlass.const_expr(self.bottom_right):
                 diagonal_offset = basic_params.seqlen_k - basic_params.seqlen_q
@@ -848,7 +867,7 @@ class SM120FusedMultiHeadAttentionForward:
             batch_idx = batch_idx % n_batch_real
             o_batch_idx = split_idx * n_batch_real + batch_idx
         if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
-            _n_qh = cutlass.Int32(q.shape[2])
+            _n_qh = cutlass.Int32((q.shape[2] // self.qh_per_kh if self.pack_gqa else q.shape[2]))
             _n_batch = cutlass.Int32(self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0])
             # Host-computed (see __call__): the grid is sized from the same
             # value, so the decode cannot disagree with the launch geometry.
@@ -873,7 +892,7 @@ class SM120FusedMultiHeadAttentionForward:
             # scheduler waves (right-band graphs share the causal shape).
             grid_q, _, _ = cute.arch.grid_dim()
             q_tile_idx = grid_q - q_tile_idx - 1
-        q_seq_idx = q_tile_idx * self.q_tile
+        q_seq_idx = q_tile_idx * (self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile)
 
         lane = tidx % cute.arch.WARP_SIZE
         warp = cute.arch.warp_idx()
@@ -917,16 +936,17 @@ class SM120FusedMultiHeadAttentionForward:
 
         q_batch_stride, q_seq_stride, q_head_stride, _ = q.stride
         o_batch_stride, o_seq_stride, o_head_stride, _ = o.stride
+        q_head_base = head_idx if cutlass.const_expr(not self.pack_gqa) else head_idx * cutlass.Int32(self.qh_per_kh)
         if cutlass.const_expr(self.thd_varlen):
             # Packed view has batch 1: the sequence's token base replaces the
             # batch stride term, and every Q/O row index below stays
             # sequence-local.
-            q_head_off = q_row_base * q_seq_stride + head_idx * q_head_stride
-            o_head_off = q_row_base * o_seq_stride + head_idx * o_head_stride
+            q_head_off = q_row_base * q_seq_stride + q_head_base * q_head_stride
+            o_head_off = q_row_base * o_seq_stride + q_head_base * o_head_stride
         else:
-            q_head_off = batch_idx * q_batch_stride + head_idx * q_head_stride
-            o_head_off = o_batch_idx * o_batch_stride + head_idx * o_head_stride
-        kv_head_idx = head_idx // (num_heads_q // num_heads_kv)
+            q_head_off = batch_idx * q_batch_stride + q_head_base * q_head_stride
+            o_head_off = o_batch_idx * o_batch_stride + q_head_base * o_head_stride
+        kv_head_idx = q_head_base // (num_heads_q // num_heads_kv)
 
         num_kv_tiles = ceil_div(seqlen_k, self.kv_tile)
         if cutlass.const_expr(self.thd_varlen):
@@ -937,7 +957,7 @@ class SM120FusedMultiHeadAttentionForward:
             if q_seq_idx >= seqlen_q:
                 num_kv_tiles = cutlass.Int32(0)
         if cutlass.const_expr(self.is_causal):
-            causal_k_end = q_seq_idx + self.q_tile + self.window_right
+            causal_k_end = q_seq_idx + (self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.window_right
             if cutlass.const_expr(self.bottom_right):
                 causal_k_end += seqlen_k - seqlen_q
             causal_k_end = cute.math.max(cutlass.Int32(0), cute.math.min(causal_k_end, seqlen_k))
@@ -1107,6 +1127,7 @@ class SM120FusedMultiHeadAttentionForward:
                 q_seq_idx=q_seq_idx,
                 q_head_off=q_head_off,
                 q_seq_stride=q_seq_stride,
+                q_head_stride=q_head_stride,
                 q_warp_row0=q_warp_row0,
                 lane=lane,
                 lane_div8=lane_div8,
@@ -1134,16 +1155,16 @@ class SM120FusedMultiHeadAttentionForward:
             # Main attention loop.
             mask_steps = 1
             if cutlass.const_expr(self.is_causal):
-                mask_steps = ceil_div(self.q_tile, self.kv_tile)
+                mask_steps = ceil_div(self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile, self.kv_tile)
                 if cutlass.const_expr(self.diag_shifted):
                     # A translated diagonal (bottom-right anchoring or a right
                     # band) can straddle one additional KV tile; the frontier
                     # width itself is R-independent — the band only translates
                     # the diagonal.
-                    mask_steps = ceil_div(self.q_tile + self.kv_tile - 1, self.kv_tile)
+                    mask_steps = ceil_div((self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.kv_tile - 1, self.kv_tile)
             left_mask_steps = 1
             if cutlass.const_expr(self.window_size_left is not None):
-                left_mask_steps = ceil_div(self.q_tile + self.kv_tile - 1, self.kv_tile)
+                left_mask_steps = ceil_div((self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.kv_tile - 1, self.kv_tile)
 
             kv_tile_idx = num_kv_tiles - 1
             # Phase 1: potentially masked iterations.
@@ -1225,7 +1246,10 @@ class SM120FusedMultiHeadAttentionForward:
                 row_max_nat = row_max[row_half] * softmax_scale_log2 * LN2
                 if cutlass.const_expr(self.has_sink):
                     sinks_arr = cutlass.make_array_view(sinks)
-                    sink_logit = cutlass.Float32(sinks_arr[head_idx])
+                    _sink_head = (
+                        q_head_base if cutlass.const_expr(not self.pack_gqa) else q_head_base + (q_warp_row0 + (lane // 4) + row_half * 8) % self.qh_per_kh
+                    )
+                    sink_logit = cutlass.Float32(sinks_arr[_sink_head])
                     new_max = cute.arch.fmax(row_max_nat, sink_logit)
                     # alpha re-normalizes the loop's accumulator and sum from
                     # row_max_nat to the sink-extended max; it is 0 for a row
@@ -1252,7 +1276,9 @@ class SM120FusedMultiHeadAttentionForward:
                 if lane % 4 == 0:
                     lse_arr = cutlass.make_array_view(lse)
                     for row_half in cutlass.range_constexpr(2):
-                        lse_q_idx = q_seq_idx + q_warp_row0 + (lane // 4) + row_half * 8
+                        _lse_row_in_cta = q_warp_row0 + (lane // 4) + row_half * 8
+                        lse_q_idx = q_seq_idx + (_lse_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _lse_row_in_cta // self.qh_per_kh)
+                        _lse_head = q_head_base if cutlass.const_expr(not self.pack_gqa) else q_head_base + _lse_row_in_cta % self.qh_per_kh
                         lse_out = cutlass.Float32(row_lse[row_half])
                         if cutlass.const_expr(self.thd_varlen):
                             # Packed ragged-Stats LSE, written directly in the
@@ -1263,17 +1289,17 @@ class SM120FusedMultiHeadAttentionForward:
                             # padded region to trim.
                             if lse_q_idx < seqlen_q:
                                 if cutlass.const_expr(self.thd_lse_head_major):
-                                    lse_row = lse_arr[head_idx, :]
+                                    lse_row = lse_arr[_lse_head, :]
                                     lse_row[q_row_base + lse_q_idx] = lse_out
                                 else:
                                     lse_row = lse_arr[q_row_base + lse_q_idx, :]
-                                    lse_row[head_idx] = lse_out
+                                    lse_row[_lse_head] = lse_out
                         else:
                             # Rows at/past this batch's Q length trim to -inf.
                             if lse_q_idx >= seqlen_q:
                                 lse_out = -cutlass.Float32.inf
                             if lse_q_idx < q.shape[1]:
-                                lse_row = lse_arr[o_batch_idx, head_idx, :]
+                                lse_row = lse_arr[o_batch_idx, _lse_head, :]
                                 lse_row[lse_q_idx] = lse_out
 
             prims.barrier_cta_sync(self.bar_compute_sync, thread_count=self.threads_compute)
@@ -1307,7 +1333,11 @@ class SM120FusedMultiHeadAttentionForward:
 
             store_row = lane_mod8 + ((lane_div8) % 2) * 8
             store_col = lane_div16 * 8
-            store_q_seq_idx = q_seq_idx + q_warp_row0 + store_row
+            _store_row_in_cta = q_warp_row0 + store_row
+            store_q_seq_idx = q_seq_idx + (_store_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _store_row_in_cta // self.qh_per_kh)
+            store_head_off = o_head_off
+            if cutlass.const_expr(self.pack_gqa and self.qh_per_kh != 1):
+                store_head_off = store_head_off + (_store_row_in_cta % self.qh_per_kh) * o_head_stride
             for d_frag_pair in cutlass.range_constexpr(self.pv_d_frags // 2):
                 store_col_in_cta = d_frag_pair * 16 + store_col
                 if cutlass.const_expr(self.thd_varlen):
@@ -1315,12 +1345,12 @@ class SM120FusedMultiHeadAttentionForward:
                     # the NEXT sequence's tokens — no store, and never the
                     # dense path's zero-fill.
                     if store_q_seq_idx < seqlen_q and store_col_in_cta < head_dim_v:
-                        gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
+                        gO_ptr = o_ptr + store_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
                         sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * (16 * 16) + lane * 8
                         gO_ptr.store(sO_ptr.load(count=8, alignment=16), alignment=16)
                 else:
                     if store_q_seq_idx < q.shape[1] and store_col_in_cta < head_dim_v:
-                        gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
+                        gO_ptr = o_ptr + store_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
                         if store_q_seq_idx < seqlen_q:
                             sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * (16 * 16) + lane * 8
                             gO_ptr.store(sO_ptr.load(count=8, alignment=16), alignment=16)
@@ -1419,6 +1449,7 @@ class SM120FusedMultiHeadAttentionForward:
             or _static_neq(q.shape[1], o.shape[1])
             or _static_neq(q.shape[2], o.shape[2])
             or q.shape[2] % k.shape[2] != 0
+            or (isinstance(q.shape[2], int) and isinstance(k.shape[2], int) and q.shape[2] != k.shape[2] * self.qh_per_kh)
         ):
             raise ValueError("runtime Q/K/V/O batch, sequence, or head geometry mismatch")
         for name, tensor in (("Q", q), ("K", k), ("V", v), ("O", o)):
@@ -1518,9 +1549,15 @@ class SM120FusedMultiHeadAttentionForward:
         # REAL batch count (the packed view's batch mode is 1); tiles past a shorter
         # sequence's length drain without work. NOTE thd_max_sq is a __call__
         # argument in this base, not a member.
-        n_q_tiles = ceil_div(thd_max_sq, self.q_tile) if cutlass.const_expr(self.thd_varlen) else ceil_div(q.shape[1], self.q_tile)
+        # PackGQA: S_q*G packed rows per packed head, H_q/G packed heads on the
+        # head axis (THD is always unpacked).
+        n_q_tiles = (
+            ceil_div(thd_max_sq, self.q_tile)
+            if cutlass.const_expr(self.thd_varlen)
+            else ceil_div((q.shape[1] * self.qh_per_kh if self.pack_gqa else q.shape[1]), self.q_tile)
+        )
         n_batch = self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
-        n_head = q.shape[2]
+        n_head = q.shape[2] // self.qh_per_kh if self.pack_gqa else q.shape[2]
         # LPT / LPT_L2 flatten the 3-D grid so the decode can order the whole tile
         # set globally (heaviest causal rows first); NATURAL keeps the zero-overhead
         # 3-D grid. The kernel receives n_q_tiles so its decode uses the same value.
@@ -1611,6 +1648,8 @@ def compile(  # noqa: A001
         q_tile=PARAMS.q_tile,
         kv_tile=PARAMS.kv_tile,
         split_kv=PARAMS.split_kv,
+        pack_gqa=PARAMS.pack_gqa,
+        qh_per_kh=qh // kh,
     )
     if PARAMS.split_kv > 1 and not has_lse:
         raise ValueError("SM120 SDPA: split_kv > 1 requires an LSE output (the per-split LSE drives the combine)")

--- a/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_fp8_sm120.py
@@ -246,6 +246,8 @@ class SM120FusedMultiHeadAttentionForward:
         head_tile_v: int = 128,
         kv_tile: int = SEQ_KV_TILES[0],
         q_tile: int = SEQ_Q_TILES[0],
+        pack_gqa: bool = False,
+        qh_per_kh: int = 1,
     ):
         """Initialize the FMHA prefill kernel configuration.
 
@@ -281,12 +283,24 @@ class SM120FusedMultiHeadAttentionForward:
             constraint as ``head_tile_qk``.
         :param q_tile: Query sequence tile size.
         :param kv_tile: Key/value sequence tile size.
+        :param pack_gqa: Enable PackGQA: each Q tile holds ``q_tile/qh_per_kh``
+            tokens x qh_per_kh query heads sharing one KV head, token-major
+            (row r ↔ token ``r // G``, head ``r % G``).
+        :param qh_per_kh: The graph's GQA ratio ``h_q // h_kv``; must divide
+            ``q_tile`` when ``pack_gqa`` is enabled, and is validated against
+            the runtime Q/K head extents at ``__call__``.
         """
 
         if in_dtype not in (cutlass.Float8E4M3FN, cutlass.Float8E5M2):
             raise ValueError("in_dtype must be Float8E4M3FN or Float8E5M2")
         if out_dtype not in (cutlass.Float16, cutlass.BFloat16, cutlass.Float8E4M3FN, cutlass.Float8E5M2):
             raise ValueError("out_dtype must be Float16, BFloat16, Float8E4M3FN, or Float8E5M2")
+        if qh_per_kh < 1:
+            raise ValueError(f"qh_per_kh ({qh_per_kh}) must be >= 1")
+        if pack_gqa and q_tile % qh_per_kh != 0:
+            raise ValueError(f"qh_per_kh ({qh_per_kh}) must divide q_tile ({q_tile}) when pack_gqa is enabled")
+        if pack_gqa and thd_varlen:
+            raise ValueError("PackGQA is dense-only (THD keeps the unpacked path)")
         if thd_varlen and thd_batch < 1:
             raise ValueError("thd_varlen requires thd_batch >= 1")
         for tile_name, tile in (("head_tile_qk", head_tile_qk), ("head_tile_v", head_tile_v)):
@@ -317,6 +331,8 @@ class SM120FusedMultiHeadAttentionForward:
         self.head_tile_v = head_tile_v
         self.q_tile = q_tile
         self.kv_tile = kv_tile
+        self.pack_gqa = pack_gqa
+        self.qh_per_kh = qh_per_kh
 
         # Warp roles
         if self.q_tile == 128:
@@ -474,10 +490,13 @@ class SM120FusedMultiHeadAttentionForward:
             )
             for i in cutlass.range_constexpr(4):
                 row_in_cta, col_in_cta = mma_offsets_in_cta[i]
-                cur_q_seq_idx = basic_params.q_seq_idx + row_in_cta
+                cur_q_seq_idx = basic_params.q_seq_idx + (row_in_cta if cutlass.const_expr(not self.pack_gqa) else row_in_cta // self.qh_per_kh)
+                q_row_off = cur_q_seq_idx * basic_params.q_seq_stride
+                if cutlass.const_expr(self.pack_gqa and self.qh_per_kh != 1):
+                    q_row_off = q_row_off + (row_in_cta % self.qh_per_kh) * basic_params.q_head_stride
                 q_packed = cutlass.Int32(0)
                 if cur_q_seq_idx < basic_params.seqlen_q and col_in_cta < basic_params.head_dim_qk:
-                    q_quad = (basic_params.q_ptr + basic_params.q_head_off + cur_q_seq_idx * basic_params.q_seq_stride + col_in_cta).load(count=4, alignment=4)
+                    q_quad = (basic_params.q_ptr + basic_params.q_head_off + q_row_off + col_in_cta).load(count=4, alignment=4)
                     q_packed = q_quad.bitcast(cutlass.Int32)[0]
                 q_regs[q_regs_offset + i] = q_packed
 
@@ -609,7 +628,7 @@ class SM120FusedMultiHeadAttentionForward:
 
             # Resolve mask bounds for this query row. ``valid_cols`` is an
             # exclusive upper bound; ``first_valid_col`` is inclusive.
-            q_position = basic_params.q_seq_idx + q_row_in_cta
+            q_position = basic_params.q_seq_idx + (q_row_in_cta if cutlass.const_expr(not self.pack_gqa) else q_row_in_cta // self.qh_per_kh)
             diagonal_offset = cutlass.Int32(0)
             if cutlass.const_expr(self.bottom_right):
                 diagonal_offset = basic_params.seqlen_k - basic_params.seqlen_q
@@ -994,7 +1013,7 @@ class SM120FusedMultiHeadAttentionForward:
         tidx, _, _ = cute.arch.thread_idx()
         q_tile_idx, batch_idx, head_idx = cute.arch.block_idx()
         if cutlass.const_expr(self.sched_policy != SCHED_NATURAL):
-            _n_qh = cutlass.Int32(q.shape[2])
+            _n_qh = cutlass.Int32((q.shape[2] // self.qh_per_kh if self.pack_gqa else q.shape[2]))
             _n_batch = cutlass.Int32(self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0])
             # Host-computed (see __call__): the grid is sized from the same
             # value, so the decode cannot disagree with the launch geometry.
@@ -1017,7 +1036,7 @@ class SM120FusedMultiHeadAttentionForward:
             # avoid leaving a few expensive CTAs in the final scheduler waves.
             grid_q, _, _ = cute.arch.grid_dim()
             q_tile_idx = grid_q - q_tile_idx - 1
-        q_seq_idx = q_tile_idx * self.q_tile
+        q_seq_idx = q_tile_idx * (self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile)
 
         lane = tidx % cute.arch.WARP_SIZE
         warp = cute.arch.warp_idx()
@@ -1061,16 +1080,17 @@ class SM120FusedMultiHeadAttentionForward:
 
         q_batch_stride, q_seq_stride, q_head_stride, _ = q.stride
         o_batch_stride, o_seq_stride, o_head_stride, _ = o.stride
+        q_head_base = head_idx if cutlass.const_expr(not self.pack_gqa) else head_idx * cutlass.Int32(self.qh_per_kh)
         if cutlass.const_expr(self.thd_varlen):
             # Packed view has batch 1: the sequence's token base replaces the
             # batch stride term, and every Q/O row index below stays
             # sequence-local.
-            q_head_off = q_row_base * q_seq_stride + head_idx * q_head_stride
-            o_head_off = q_row_base * o_seq_stride + head_idx * o_head_stride
+            q_head_off = q_row_base * q_seq_stride + q_head_base * q_head_stride
+            o_head_off = q_row_base * o_seq_stride + q_head_base * o_head_stride
         else:
-            q_head_off = batch_idx * q_batch_stride + head_idx * q_head_stride
-            o_head_off = batch_idx * o_batch_stride + head_idx * o_head_stride
-        kv_head_idx = head_idx // (num_heads_q // num_heads_kv)
+            q_head_off = batch_idx * q_batch_stride + q_head_base * q_head_stride
+            o_head_off = batch_idx * o_batch_stride + q_head_base * o_head_stride
+        kv_head_idx = q_head_base // (num_heads_q // num_heads_kv)
 
         num_kv_tiles = ceil_div(seqlen_k, self.kv_tile)
         if cutlass.const_expr(self.thd_varlen):
@@ -1081,7 +1101,7 @@ class SM120FusedMultiHeadAttentionForward:
             if q_seq_idx >= seqlen_q:
                 num_kv_tiles = cutlass.Int32(0)
         if cutlass.const_expr(self.is_causal):
-            causal_k_end = q_seq_idx + self.q_tile + self.window_right
+            causal_k_end = q_seq_idx + (self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.window_right
             if cutlass.const_expr(self.bottom_right):
                 causal_k_end += seqlen_k - seqlen_q
             causal_k_end = cute.math.max(cutlass.Int32(0), cute.math.min(causal_k_end, seqlen_k))
@@ -1241,6 +1261,7 @@ class SM120FusedMultiHeadAttentionForward:
                 q_seq_idx=q_seq_idx,
                 q_head_off=q_head_off,
                 q_seq_stride=q_seq_stride,
+                q_head_stride=q_head_stride,
                 q_warp_row0=q_warp_row0,
                 lane=lane,
                 lane_div8=lane_div8,
@@ -1279,18 +1300,18 @@ class SM120FusedMultiHeadAttentionForward:
             # Main attention loop.
             mask_steps = 1
             if cutlass.const_expr(self.is_causal):
-                mask_steps = ceil_div(self.q_tile, self.kv_tile)
+                mask_steps = ceil_div(self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile, self.kv_tile)
                 if cutlass.const_expr(self.diag_shifted):
                     # A translated diagonal (bottom-right anchoring or a right
                     # band) can straddle one additional KV tile; the frontier
                     # width itself is R-independent -- the band only
                     # translates the diagonal.
-                    mask_steps = ceil_div(self.q_tile + self.kv_tile - 1, self.kv_tile)
+                    mask_steps = ceil_div((self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.kv_tile - 1, self.kv_tile)
             elif cutlass.const_expr(not self.seq_kv_lens_present and not self.thd_varlen and k.shape[1] % self.kv_tile == 0):
                 mask_steps = 0
             left_mask_steps = 1
             if cutlass.const_expr(self.window_size_left is not None):
-                left_mask_steps = ceil_div(self.q_tile + self.kv_tile - 1, self.kv_tile)
+                left_mask_steps = ceil_div((self.q_tile // self.qh_per_kh if self.pack_gqa else self.q_tile) + self.kv_tile - 1, self.kv_tile)
 
             kv_tile_idx = num_kv_tiles - 1
             # Phase 1: potentially masked iterations.
@@ -1369,7 +1390,10 @@ class SM120FusedMultiHeadAttentionForward:
                 row_max_nat = row_max[row_half] * softmax_scale_log2 * LN2
                 if cutlass.const_expr(self.has_sink):
                     sinks_arr = cutlass.make_array_view(sinks)
-                    sink_logit = cutlass.Float32(sinks_arr[head_idx])
+                    _sink_head = (
+                        q_head_base if cutlass.const_expr(not self.pack_gqa) else q_head_base + (q_warp_row0 + (lane // 4) + row_half * 8) % self.qh_per_kh
+                    )
+                    sink_logit = cutlass.Float32(sinks_arr[_sink_head])
                     new_max = cute.arch.fmax(row_max_nat, sink_logit)
                     # alpha re-normalizes the loop's accumulator and sum from
                     # row_max_nat to the sink-extended max; it is 0 for a row
@@ -1399,7 +1423,9 @@ class SM120FusedMultiHeadAttentionForward:
                 if lane % 4 == 0:
                     lse_arr = cutlass.make_array_view(lse)
                     for row_half in cutlass.range_constexpr(2):
-                        lse_q_idx = q_seq_idx + q_warp_row0 + (lane // 4) + row_half * 8
+                        _lse_row_in_cta = q_warp_row0 + (lane // 4) + row_half * 8
+                        lse_q_idx = q_seq_idx + (_lse_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _lse_row_in_cta // self.qh_per_kh)
+                        _lse_head = q_head_base if cutlass.const_expr(not self.pack_gqa) else q_head_base + _lse_row_in_cta % self.qh_per_kh
                         lse_out = cutlass.Float32(row_lse[row_half])
                         if cutlass.const_expr(self.thd_varlen):
                             # Packed ragged-Stats LSE, written directly in the
@@ -1410,17 +1436,17 @@ class SM120FusedMultiHeadAttentionForward:
                             # trim.
                             if lse_q_idx < seqlen_q:
                                 if cutlass.const_expr(self.thd_lse_head_major):
-                                    lse_row = lse_arr[head_idx, :]
+                                    lse_row = lse_arr[_lse_head, :]
                                     lse_row[q_row_base + lse_q_idx] = lse_out
                                 else:
                                     lse_row = lse_arr[q_row_base + lse_q_idx, :]
-                                    lse_row[head_idx] = lse_out
+                                    lse_row[_lse_head] = lse_out
                         else:
                             # Rows at/past this batch's Q length trim to -inf.
                             if lse_q_idx >= seqlen_q:
                                 lse_out = -cutlass.Float32.inf
                             if lse_q_idx < q.shape[1]:
-                                lse_row = lse_arr[batch_idx, head_idx, :]
+                                lse_row = lse_arr[batch_idx, _lse_head, :]
                                 lse_row[lse_q_idx] = lse_out
 
             prims.barrier_cta_sync(self.bar_compute_sync, thread_count=self.threads_compute)
@@ -1449,7 +1475,8 @@ class SM120FusedMultiHeadAttentionForward:
             o_block_bytes = 16 * 16 * self.out_dtype.bytes
             row_valid = cutlass.Array(cutlass.Float32, 2, alignment=8)
             for row_half in cutlass.range_constexpr(2):
-                amax_q_idx = q_seq_idx + q_warp_row0 + (lane // 4) + row_half * 8
+                _amax_row_in_cta = q_warp_row0 + (lane // 4) + row_half * 8
+                amax_q_idx = q_seq_idx + (_amax_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _amax_row_in_cta // self.qh_per_kh)
                 row_valid[row_half] = cutlass.Float32(1.0) if amax_q_idx < seqlen_q else cutlass.Float32(0.0)
             lane_amax_half = cutlass.Array(cutlass.Float32, 4, alignment=16)
             for i in cutlass.range_constexpr(4):
@@ -1467,17 +1494,21 @@ class SM120FusedMultiHeadAttentionForward:
                         for row_half in cutlass.range_constexpr(2):
                             e = frag * 4 + row_half * 2
                             o_pair = fp32_to_fp8x2(o_scaled[e], o_scaled[e + 1], dtype=self.out_dtype)
-                            pair_q_seq_idx = q_seq_idx + q_warp_row0 + (lane // 4) + row_half * 8
+                            _pair_row_in_cta = q_warp_row0 + (lane // 4) + row_half * 8
+                            pair_q_seq_idx = q_seq_idx + (_pair_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _pair_row_in_cta // self.qh_per_kh)
+                            pair_head_off = o_head_off
+                            if cutlass.const_expr(self.pack_gqa and self.qh_per_kh != 1):
+                                pair_head_off = pair_head_off + (_pair_row_in_cta % self.qh_per_kh) * o_head_stride
                             pair_col_in_cta = d_frag_pair * 16 + frag * 8 + (lane % 4) * 2
                             if cutlass.const_expr(self.thd_varlen):
                                 if pair_q_seq_idx < seqlen_q and pair_col_in_cta < head_dim_v:
-                                    gO_pair = o_ptr + o_head_off + pair_q_seq_idx * o_seq_stride + pair_col_in_cta
+                                    gO_pair = o_ptr + pair_head_off + pair_q_seq_idx * o_seq_stride + pair_col_in_cta
                                     gO_pair.store(cutlass.Vector.from_elements((o_pair,), cutlass.Uint16).bitcast(self.out_dtype), alignment=2)
                             else:
                                 if pair_q_seq_idx < q.shape[1] and pair_col_in_cta < head_dim_v:
                                     if pair_q_seq_idx >= seqlen_q:
                                         o_pair = cutlass.Uint16(0)
-                                    gO_pair = o_ptr + o_head_off + pair_q_seq_idx * o_seq_stride + pair_col_in_cta
+                                    gO_pair = o_ptr + pair_head_off + pair_q_seq_idx * o_seq_stride + pair_col_in_cta
                                     gO_pair.store(cutlass.Vector.from_elements((o_pair,), cutlass.Uint16).bitcast(self.out_dtype), alignment=2)
                 else:
                     o_packed = o_scaled.to(self.out_dtype).bitcast(cutlass.Int32)
@@ -1501,7 +1532,11 @@ class SM120FusedMultiHeadAttentionForward:
             if cutlass.const_expr(self.out_dtype.bytes != 1):
                 store_row = lane_mod8 + ((lane_div8) % 2) * 8
                 store_col = lane_div16 * 8
-                store_q_seq_idx = q_seq_idx + q_warp_row0 + store_row
+                _store_row_in_cta = q_warp_row0 + store_row
+                store_q_seq_idx = q_seq_idx + (_store_row_in_cta if cutlass.const_expr(not self.pack_gqa) else _store_row_in_cta // self.qh_per_kh)
+                store_head_off = o_head_off
+                if cutlass.const_expr(self.pack_gqa and self.qh_per_kh != 1):
+                    store_head_off = store_head_off + (_store_row_in_cta % self.qh_per_kh) * o_head_stride
                 for d_frag_pair in cutlass.range_constexpr(self.pv_d_frags // 2):
                     store_col_in_cta = d_frag_pair * 16 + store_col
                     if cutlass.const_expr(self.thd_varlen):
@@ -1509,12 +1544,12 @@ class SM120FusedMultiHeadAttentionForward:
                         # the NEXT sequence's tokens — no store, and never the
                         # dense path's zero-fill.
                         if store_q_seq_idx < seqlen_q and store_col_in_cta < head_dim_v:
-                            gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
+                            gO_ptr = o_ptr + store_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
                             sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * o_block_bytes + lane * 16
                             gO_ptr.store(sO_ptr.load(count=16, alignment=16).bitcast(self.out_dtype), alignment=16)
                     else:
                         if store_q_seq_idx < q.shape[1] and store_col_in_cta < head_dim_v:
-                            gO_ptr = o_ptr + o_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
+                            gO_ptr = o_ptr + store_head_off + store_q_seq_idx * o_seq_stride + store_col_in_cta
                             if store_q_seq_idx < seqlen_q:
                                 sO_ptr = sO.data_ptr() + (compute_warp_idx * (self.pv_d_frags // 2) + d_frag_pair) * o_block_bytes + lane * 16
                                 gO_ptr.store(sO_ptr.load(count=16, alignment=16).bitcast(self.out_dtype), alignment=16)
@@ -1620,6 +1655,7 @@ class SM120FusedMultiHeadAttentionForward:
             or _static_neq(q.shape[1], o.shape[1])
             or _static_neq(q.shape[2], o.shape[2])
             or q.shape[2] % k.shape[2] != 0
+            or (isinstance(q.shape[2], int) and isinstance(k.shape[2], int) and q.shape[2] != k.shape[2] * self.qh_per_kh)
         ):
             raise ValueError("runtime Q/K/V/O batch, sequence, or head geometry mismatch")
         for name, tensor in (("Q", q), ("K", k), ("V", v), ("O", o)):
@@ -1705,9 +1741,15 @@ class SM120FusedMultiHeadAttentionForward:
         # REAL batch count (the packed view's batch mode is 1); tiles past a shorter
         # sequence's length drain without work. NOTE thd_max_sq is a __call__
         # argument in this base, not a member.
-        n_q_tiles = ceil_div(thd_max_sq, self.q_tile) if cutlass.const_expr(self.thd_varlen) else ceil_div(q.shape[1], self.q_tile)
+        # PackGQA: S_q*G packed rows per packed head, H_q/G packed heads on the
+        # head axis (THD is always unpacked).
+        n_q_tiles = (
+            ceil_div(thd_max_sq, self.q_tile)
+            if cutlass.const_expr(self.thd_varlen)
+            else ceil_div((q.shape[1] * self.qh_per_kh if self.pack_gqa else q.shape[1]), self.q_tile)
+        )
         n_batch = self.thd_batch if cutlass.const_expr(self.thd_varlen) else q.shape[0]
-        n_head = q.shape[2]
+        n_head = q.shape[2] // self.qh_per_kh if self.pack_gqa else q.shape[2]
         # LPT / LPT_L2 flatten the 3-D grid so the decode can order the whole tile
         # set globally (heaviest causal rows first); NATURAL keeps the zero-overhead
         # 3-D grid. The kernel receives n_q_tiles so its decode uses the same value.
@@ -1797,6 +1839,8 @@ def compile(  # noqa: A001
         head_tile_v=round_up_head_tile(d_v),
         q_tile=PARAMS.q_tile,
         kv_tile=PARAMS.kv_tile,
+        pack_gqa=PARAMS.pack_gqa,
+        qh_per_kh=qh // kh,
     )
     fake_batch = 1 if PARAMS.thd_varlen else b
     if PARAMS.thd_varlen:

--- a/test/python/sdpa/frost/frost_test_utils.py
+++ b/test/python/sdpa/frost/frost_test_utils.py
@@ -77,29 +77,33 @@ def _is_plan_for(plan_name, engine) -> bool:
     return plan_name == engine or plan_name.startswith(engine + "[")
 
 
-def select_engine(graph, name, tiles=None):
+def select_engine(graph, name, tiles=None, pack_gqa=None):
     """Pin the ranked entry for engine ``name`` (graph.plans holds the backend's
     plans and the python engines' in one list). A pin is strict: check_support /
     build_plans raise if that engine declines the graph.
 
     The FIRST entry for that engine is the heuristics' own best guess for this
-    shape. ``tiles`` pins a different one, so a test can run a tile the best
-    guess would not choose.
+    shape. ``tiles`` / ``pack_gqa`` pin a different one, so a test can run a
+    config the best guess would not choose. Filters match the STRUCTURED knobs,
+    not the rendered plan name: substring matching a name would let a request
+    for tile_n=128 select a tile_n=1280 plan, and the test would pass having
+    run something else. Every filter — and each ``tiles`` component — is
+    None-transparent (matches any value), so a test can pin just kv_tile
+    (the auto-tile_m graph_api cases) or nothing at all (the best guess).
     """
     names = [graph.get_plan_name_at_index(i) for i in range(len(graph.plans))]
-    if tiles is None:
-        index = next((i for i, n in enumerate(names) if _is_plan_for(n, name)), None)
-        assert index is not None, f"engine {name!r} did not claim this graph; plans={names}"
-    else:
-        # Against the STRUCTURED knobs, not the rendered plan name: substring
-        # matching a name would let a request for tile_n=128 select a tile_n=1280
-        # plan, and the test would pass having run something else.
-        def _wanted(i):
-            knobs = graph.plans[i].knobs
-            return _is_plan_for(names[i], name) and (getattr(knobs, "tile_m", None), getattr(knobs, "tile_n", None)) == tuple(tiles)
+    want_m, want_n = tiles if tiles is not None else (None, None)
 
-        index = next((i for i in range(len(names)) if _wanted(i)), None)
-        assert index is not None, f"no plan for tiles {tiles}; plans={names}"
+    def _wanted(i):
+        if not _is_plan_for(names[i], name):
+            return False
+        return all(
+            want is None or getattr(graph.plans[i].knobs, field, None) == want
+            for field, want in (("tile_m", want_m), ("tile_n", want_n), ("pack_gqa", pack_gqa))
+        )
+
+    index = next((i for i in range(len(names)) if _wanted(i)), None)
+    assert index is not None, f"no plan for engine {name!r} with tiles={tiles} pack_gqa={pack_gqa}; plans={names}"
     graph.select_plan(index)
     return graph
 

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -169,7 +169,7 @@ def _bhsd(b, h, s, d, dtype, device="cuda"):
     return torch.randn(b, s, h, d, device=device, dtype=dtype).transpose(1, 2)
 
 
-def _run_dsl_graph(q_gpu, k_gpu, v_gpu, *, scale, dtype, sdpa_kwargs, seq_len_kv=None, seq_len_q=None, sink=None):
+def _run_dsl_graph(q_gpu, k_gpu, v_gpu, *, scale, dtype, sdpa_kwargs, seq_len_kv=None, seq_len_q=None, sink=None, pack_gqa=None, return_stats=False):
     """Build the graph, opt into the matching FROST DSL engine, execute, return O (BHSD)."""
     import cudnn
 
@@ -181,37 +181,44 @@ def _run_dsl_graph(q_gpu, k_gpu, v_gpu, *, scale, dtype, sdpa_kwargs, seq_len_kv
     q = g.tensor_like(q_gpu)
     k = g.tensor_like(k_gpu)
     v = g.tensor_like(v_gpu)
-    kw = dict(name="sdpa", q=q, k=k, v=v, generate_stats=False, attn_scale=scale)
+    kw = dict(name="sdpa", q=q, k=k, v=v, generate_stats=return_stats, attn_scale=scale)
     vp = {q: q_gpu, k: k_gpu, v: v_gpu}
     if seq_len_kv is not None:
         slk = g.tensor_like(seq_len_kv)
         kw["seq_len_kv"] = slk
         kw["use_padding_mask"] = True
         vp[slk] = seq_len_kv
-        # padding_mask requires a seq_len_q companion; when the caller passes
-        # none, synthesize full lengths (KV-only trim, every Q row live).
-        if seq_len_q is None:
-            seq_len_q = torch.full((b, 1, 1, 1), s_q, dtype=torch.int32, device="cuda")
-        slq = g.tensor_like(seq_len_q)
+        # padding_mask requires a seq_len_q companion; without a caller-provided
+        # seq_len_q the kernel trims only KV (Q full).
+        slq_t = seq_len_q if seq_len_q is not None else torch.full((b, 1, 1, 1), s_q, dtype=torch.int32, device="cuda")
+        slq = g.tensor_like(slq_t)
         kw["seq_len_q"] = slq
-        vp[slq] = seq_len_q
+        vp[slq] = slq_t
     if sink is not None:
         st = g.tensor_like(sink)
         kw["sink_token"] = st
         vp[st] = sink
     kw.update(sdpa_kwargs)
-    o, _ = g.sdpa(**kw)
+    o, stats = g.sdpa(**kw)
     o.set_output(True).set_dim(o_gpu.shape).set_stride(o_gpu.stride())
+    stats_gpu = None
+    if return_stats:
+        stats_gpu = torch.empty(b, h_q, s_q, dtype=torch.float32, device="cuda")
+        stats.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+        stats.set_dim((b, h_q, s_q, 1)).set_stride((h_q * s_q, s_q, 1, 1))
+        vp[stats] = stats_gpu
 
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name())
+    _select_engine(g, engine_name(), pack_gqa=pack_gqa)
     g.check_support()
     g.build_plans()
     vp[o] = o_gpu
     g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device="cuda", dtype=torch.uint8))
     torch.cuda.synchronize()
+    if return_stats:
+        return o_gpu, stats_gpu
     return o_gpu
 
 
@@ -565,6 +572,250 @@ def test_dsl_sm100_gqa(dtype, d):
     o = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True))
     o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True)
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+# --- PackGQA: TILE_M/G tokens x G query heads per tile -------
+def _pack_gqa_case(d, h_q, h_kv, s_q, s_kv, dtype, *, sdpa_kwargs):
+    q = _bhsd(2, h_q, s_q, d, dtype)
+    k = _bhsd(2, h_kv, s_kv, d, dtype)
+    v = _bhsd(2, h_kv, s_kv, d, dtype)
+    scale = 1.0 / math.sqrt(d)
+    o = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=sdpa_kwargs, pack_gqa=True)
+    return q, k, v, scale, o
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_false_pinned():
+    """pack_gqa=False pinned on a GQA graph runs the classic unpacked kernel
+    and matches the reference — the knob's False side verified numerically,
+    independent of what the auto rule would rank first on this device."""
+    _require_dsl()
+    d, h_q, h_kv = 128, 8, 2
+    q = _bhsd(2, h_q, 40, d, torch.float16)
+    k = _bhsd(2, h_kv, 256, d, torch.float16)
+    v = _bhsd(2, h_kv, 256, d, torch.float16)
+    scale = 1.0 / math.sqrt(d)
+    o = _run_dsl_graph(q, k, v, scale=scale, dtype=torch.float16, sdpa_kwargs=dict(use_causal_mask=True), pack_gqa=False)
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "h_q,h_kv",
+    [(8, 4), (8, 2), (8, 1), (16, 1)],
+    ids=["g2", "g4", "g8_mqa", "g16_mqa"],
+)
+@pytest.mark.parametrize("d", [128, 256], ids=["d128", "d256"])
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_ratios(d, h_q, h_kv):
+    """Packed plans across GQA ratios (incl. MQA), causal, tile-unaligned s_q."""
+    _require_dsl()
+    q, k, v, scale, o = _pack_gqa_case(d, h_q, h_kv, 40, 256, torch.float16, sdpa_kwargs=dict(use_causal_mask=True))
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("h_q,h_kv", [(8, 2), (64, 1), (128, 1)], ids=["g4", "g64_mqa", "g128_mqa"])
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_d512(dtype, h_q, h_kv):
+    """Packed d512 flavor (SPLIT_PIPELINE / cga4; epilogue in the softmax WG).
+
+    G=64 packs 2 tokens per tile and G=128 one token per tile — the whole
+    tile is a single token's head family (MQA decode geometry)."""
+    _require_dsl()
+    q, k, v, scale, o = _pack_gqa_case(512, h_q, h_kv, 40, 256, dtype, sdpa_kwargs=dict(use_causal_mask=True))
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("h_q,s_q", [(64, 1), (64, 3), (128, 4)], ids=["g64_q1", "g64_q3_mtp", "g128_q4_mtp"])
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_d512_mqa_decode(h_q, s_q):
+    """MQA decode/MTP geometry on d512 (single shared KV head, long cache):
+    q_tokens 1-4 against s_kv=2048 with a bottom-right band — the packed
+    tile is dominated by one token's head family, and the whole q span fits
+    inside one packed tile span."""
+    _require_dsl()
+    dtype = torch.bfloat16
+    q = _bhsd(2, h_q, s_q, 512, dtype)
+    k = _bhsd(2, 1, 2048, 512, dtype)
+    v = _bhsd(2, 1, 2048, 512, dtype)
+    scale = 1.0 / math.sqrt(512)
+    kw = dict(use_causal_mask_bottom_right=True) if s_q > 1 else dict()
+    o = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=kw, pack_gqa=True)
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=s_q > 1, bottom_right=s_q > 1)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("dtype", _DTYPES, ids=_DTYPE_IDS)
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_d192_d128(dtype):
+    """Packed native DSv3 shape (d_qk=192 / d_v=128, QO_ALIAS, LPT-only)."""
+    _require_dsl()
+    b, h_q, h_kv, s_q, s_kv = 2, 8, 2, 40, 256
+    scale = 1.0 / math.sqrt(192)
+    q = _bhsd(b, h_q, s_q, 192, dtype)
+    k = _bhsd(b, h_kv, s_kv, 192, dtype)
+    v = _bhsd(b, h_kv, s_kv, 128, dtype)
+    o = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), pack_gqa=True)
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "d,h_q,h_kv,s_q",
+    [
+        # d128: CGA token span 512/G.  G=8: sub-span (8), exact span (64), tail (100).
+        (128, 64, 8, 8),
+        (128, 64, 8, 64),
+        (128, 64, 8, 100),
+        # d256: CGA token span 256/G.  G=16: sub-span (4), exact span (16), tail (25).
+        (256, 32, 2, 4),
+        (256, 32, 2, 16),
+        (256, 32, 2, 25),
+    ],
+    ids=["d128_subspan", "d128_exact", "d128_tail", "d256_subspan", "d256_exact", "d256_tail"],
+)
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_tiles(d, h_q, h_kv, s_q):
+    """Packed tile geometry edges: s_q*G below / at / past the CGA tile span."""
+    _require_dsl()
+    q, k, v, scale, o = _pack_gqa_case(d, h_q, h_kv, s_q, 256, torch.float16, sdpa_kwargs=dict(use_causal_mask=True))
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("s_q", [1, 129, 1023, 2048])
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_tiles_deep(s_q):
+    """Packed multi-wave / odd-length shapes (persistent scheduler wraps)."""
+    _require_dsl()
+    q, k, v, scale, o = _pack_gqa_case(128, 64, 8, s_q, 2048, torch.float16, sdpa_kwargs=dict(use_causal_mask=True))
+    o_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "mask",
+    ["none", "causal", "causal_br", "swa", "band_right", "padded", "sink_swa"],
+)
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_features(mask):
+    """Packed plans x the dense mask/sink/stats envelope, with LSE checked —
+    the packed epilogue scatters LSE across G head rows and reads per-row
+    sinks, so stats are the sharpest probe of the row-identity math."""
+    _require_dsl()
+    d, b, h_q, h_kv, s_q, s_kv = 128, 2, 8, 2, 40, 256
+    dtype = torch.float16
+    scale = 1.0 / math.sqrt(d)
+    q = _bhsd(b, h_q, s_q, d, dtype)
+    k = _bhsd(b, h_kv, s_kv, d, dtype)
+    v = _bhsd(b, h_kv, s_kv, d, dtype)
+    kw = dict()
+    ref = dict()
+    seq_len_kv = None
+    sink = None
+    if mask == "causal":
+        kw, ref = dict(use_causal_mask=True), dict(is_causal=True)
+    elif mask == "causal_br":
+        kw, ref = dict(use_causal_mask_bottom_right=True), dict(is_causal=True, bottom_right=True)
+    elif mask == "swa":
+        kw, ref = dict(use_causal_mask=True, sliding_window_length=17), dict(is_causal=True, swa_window=16)
+    elif mask == "band_right":
+        # diagonal_band_right_bound implies the causal diagonal (the graph API
+        # rejects combining it with use_causal_mask).
+        kw, ref = dict(diagonal_band_right_bound=8), dict(is_causal=True, band_right=8)
+    elif mask == "padded":
+        seq_len_kv = torch.tensor([180, 240], dtype=torch.int32, device="cuda").view(b, 1, 1, 1)
+        ref = dict(seq_kv_lens=seq_len_kv.flatten())
+    elif mask == "sink_swa":
+        sink = torch.randn(1, h_q, 1, 1, dtype=torch.float32, device="cuda")
+        kw, ref = dict(use_causal_mask=True, sliding_window_length=17), dict(is_causal=True, swa_window=16, sinks=sink.flatten())
+    o, lse = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=kw, seq_len_kv=seq_len_kv, sink=sink, pack_gqa=True, return_stats=True)
+    o_ref, lse_ref = _ref_sdpa_full(q, k, v, scale=scale, return_stats=True, **ref)
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+    torch.testing.assert_close(lse, lse_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_qtrim():
+    """Packed dense padded-Q trim: rows past seq_len_q[b] write O := 0 and
+    LSE := -inf — under packing the trim predicate is per-TOKEN, exercised
+    here with per-batch lengths that are not multiples of the token span."""
+    _require_dsl()
+    d, b, h_q, h_kv, s_q, s_kv = 128, 2, 8, 2, 128, 256
+    dtype = torch.float16
+    scale = 1.0 / math.sqrt(d)
+    q = _bhsd(b, h_q, s_q, d, dtype)
+    k = _bhsd(b, h_kv, s_kv, d, dtype)
+    v = _bhsd(b, h_kv, s_kv, d, dtype)
+    q_lens = [37, 90]
+    kv_lens = [180, 240]
+    seq_len_q = torch.tensor(q_lens, dtype=torch.int32, device="cuda").view(b, 1, 1, 1)
+    seq_len_kv = torch.tensor(kv_lens, dtype=torch.int32, device="cuda").view(b, 1, 1, 1)
+    o, lse = _run_dsl_graph(
+        q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), seq_len_kv=seq_len_kv, seq_len_q=seq_len_q, pack_gqa=True, return_stats=True
+    )
+    o_ref, lse_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True, seq_kv_lens=seq_len_kv.flatten(), return_stats=True)
+    for i, ql in enumerate(q_lens):
+        o_ref[i, :, ql:, :] = 0.0
+        lse_ref[i, :, ql:] = float("-inf")
+    torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+    torch.testing.assert_close(lse, lse_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm100_pack_gqa_knob_contract():
+    """pack_gqa is honored-or-ineligible: no packed plan exists for MHA or a
+    ratio that does not divide tile_m, and an unpacked plan always does."""
+    _require_dsl()
+    import cudnn
+
+    def _plans_for(h_q, h_kv, s, b=2):
+        d, dtype = 128, torch.float16
+        g = cudnn.pygraph(io_data_type=cudnn.data_type.HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        q = g.tensor_like(_bhsd(b, h_q, s, d, dtype))
+        k = g.tensor_like(_bhsd(b, h_kv, s, d, dtype))
+        v = g.tensor_like(_bhsd(b, h_kv, s, d, dtype))
+        o, _ = g.sdpa(name="sdpa", q=q, k=k, v=v, generate_stats=False, attn_scale=1.0 / math.sqrt(d), use_causal_mask=True)
+        o.set_output(True).set_dim((b, h_q, s, d)).set_stride((s * h_q * d, d, h_q * d, 1))
+        g.validate()
+        g.build_operation_graph()
+        g.create_execution_plans([cudnn.heur_mode.A])
+        name = engine_name()
+        out = []
+        for i in range(len(g.plans)):
+            pn = g.get_plan_name_at_index(i)
+            if pn == name or pn.startswith(name + "["):
+                out.append(getattr(g.plans[i].knobs, "pack_gqa", None))
+        return out
+
+    # MHA: only unpacked plans.
+    pg = _plans_for(8, 8, 64)
+    assert pg and True not in pg, f"MHA graph must not rank a packed plan; got {pg}"
+    # ratios that do not divide tile_m (full-ratio contract): only unpacked plans.
+    pg = _plans_for(6, 2, 64)
+    assert pg and True not in pg, f"ratio-3 graph must not rank a packed plan; got {pg}"
+    pg = _plans_for(12, 2, 64)
+    assert pg and True not in pg, f"ratio-6 graph must not rank a packed plan; got {pg}"
+    # GQA small s_q (s_q < the CGA tile): both variants ranked, packed
+    # first — the rule is shape-only, so no batch/SM-count staging needed.
+    pg = _plans_for(64, 8, 64)
+    assert pg[0] is True and False in pg, f"small-s_q GQA should rank packed first with unpacked runner-up; got {pg}"
+    # GQA full prefill: both variants ranked, unpacked first.
+    pg = _plans_for(64, 8, 8192)
+    assert pg[0] is False and True in pg, f"full-prefill GQA should rank unpacked first with packed runner-up; got {pg}"
 
 
 # THD/varlen: packed [T,H,D] + per-operand ragged_offset (exclusive-prefix-sum of

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
@@ -1433,11 +1433,11 @@ def test_dsl_sm120_pack_gqa_features(mask: str):
 
 @pytest.mark.L1
 @pytest.mark.parametrize("dtype", [torch.bfloat16], ids=["bf16"])
-@pytest.mark.parametrize("s_q", [1, 129, 1023])
+@pytest.mark.parametrize("s_q, h_kv", [(1, 8), (127, 8), (127, 1)], ids=["s1-g8", "s127-g8", "s127-mqa64"])
 @torch_fork_set_rng(seed=4)
-def test_dsl_sm120_pack_gqa_deep(dtype: torch.dtype, s_q: int):
-    """Packed multi-tile / odd-length shapes, bf16."""
-    _run_case(batch=1, h_q=64, h_kv=8, s_q=s_q, s_kv=2048, head_dim=128, dtype=dtype, is_causal=True, pack_gqa=True)
+def test_dsl_sm120_pack_gqa_deep(dtype: torch.dtype, s_q: int, h_kv: int):
+    """Packed multi-tile / odd-length row spaces, bf16."""
+    _run_case(batch=1, h_q=64, h_kv=h_kv, s_q=s_q, s_kv=2048, head_dim=128, dtype=dtype, is_causal=True, pack_gqa=True)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
@@ -168,6 +168,7 @@ def _run_case(
     scale: float | None = None,
     with_sink: bool = False,
     check_stats: bool = False,
+    pack_gqa: bool | None = None,
 ) -> None:
     q = _bhsd(batch, h_q, s_q, head_dim, dtype)
     k = _bhsd(batch, h_kv, s_kv, head_dim, dtype)
@@ -189,6 +190,7 @@ def _run_case(
         v,
         q_tile=q_tile,
         kv_tile=kv_tile,
+        pack_gqa=pack_gqa,
         scale=scale,
         return_stats=check_stats,
         **mask_kwargs,
@@ -240,6 +242,7 @@ def _run_dsl_graph(
     sinks: torch.Tensor | None = None,
     q_tile: int | None = None,
     kv_tile: int | None = None,
+    pack_gqa: bool | None = None,
     return_stats: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """Build, select, and execute the SM120 FROST graph engine.
@@ -312,17 +315,14 @@ def _run_dsl_graph(
         stats.set_output(True).set_dim(stats_gpu.shape).set_stride(stats_gpu.stride())
         stats.set_data_type(cudnn.data_type.FLOAT)
         variant_pack[stats] = stats_gpu
+    tiles = None
     if q_tile is not None or kv_tile is not None:
-        pytest.skip(
-            "graph.set_engine_knobs() was removed with the monkey-patch dispatch layer and has no replacement in "
-            "this MR: knobs now ride on the plan (engines.base.PlanConfig.knobs), one ranked entry per knob set, "
-            "picked with select_plan(). Re-enable once the SDPA fwd family proposes its tile domain as plans."
-        )
+        tiles = (q_tile, kv_tile)
 
     graph.validate()
     graph.build_operation_graph()
     graph.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(graph, engine_name(arch="sm120"))
+    _select_engine(graph, engine_name(arch="sm120"), tiles=tiles, pack_gqa=pack_gqa)
     graph.check_support()
     graph.build_plans()
     # Honest workspace: the SM120 kernel None-specializes the LSE store, so a
@@ -1373,6 +1373,71 @@ def test_dsl_sm120_thd_mixed_head_dims_sink(stats_layout: str):
 @torch_fork_set_rng(seed=3)
 def test_dsl_sm120_grouped_query_attention(h_q: int, h_kv: int):
     _run_case(batch=2, h_q=h_q, h_kv=h_kv, s_q=256, s_kv=256, head_dim=64)
+
+
+# --- PackGQA: q_tile/G tokens x G query heads per tile -------
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "h_q,h_kv",
+    [(8, 4), (8, 2), (8, 1), (16, 1)],
+    ids=["g2", "g4", "g8_mqa", "g16_mqa"],
+)
+@torch_fork_set_rng(seed=0)
+def test_dsl_sm120_pack_gqa_ratios(h_q: int, h_kv: int):
+    """Packed plans across GQA ratios (incl. MQA)."""
+    _run_case(batch=2, h_q=h_q, h_kv=h_kv, s_q=40, s_kv=256, head_dim=128, is_causal=True, pack_gqa=True, check_stats=True)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("s_q", [4, 16, 25], ids=["subspan", "exact_span", "tail"])
+@torch_fork_set_rng(seed=1)
+def test_dsl_sm120_pack_gqa_tiles(s_q: int):
+    """Packed tile-geometry edges at G=8, q_tile=128 (token span 16/tile)."""
+    _run_case(batch=1, h_q=64, h_kv=8, s_q=s_q, s_kv=256, head_dim=128, is_causal=True, q_tile=128, kv_tile=128, pack_gqa=True, check_stats=True)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=2)
+def test_dsl_sm120_pack_gqa_tile64():
+    """Packed at q_tile=64 (G must divide the smaller tile: 8/2 -> G=4)."""
+    _run_case(batch=2, h_q=8, h_kv=2, s_q=24, s_kv=192, head_dim=64, is_causal=True, q_tile=64, kv_tile=64, pack_gqa=True, check_stats=True)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "mask",
+    ["none", "causal", "causal_br", "swa", "band_right", "padded_qtrim", "sink_swa"],
+)
+@torch_fork_set_rng(seed=3)
+def test_dsl_sm120_pack_gqa_features(mask: str):
+    """Packed plans x the dense mask/sink/trim envelope, stats checked."""
+    kw: dict = dict(batch=2, h_q=8, h_kv=2, s_q=40, s_kv=256, head_dim=128, pack_gqa=True, check_stats=True)
+    if mask == "causal":
+        kw.update(is_causal=True)
+    elif mask == "causal_br":
+        kw.update(is_causal=True, causal_bottom_right=True, window_size_right=0)
+    elif mask == "swa":
+        kw.update(is_causal=True, window_size_left=16)
+    elif mask == "band_right":
+        kw.update(window_size_right=8)
+    elif mask == "padded_qtrim":
+        kw.update(
+            s_q=128,
+            seq_q_lens=torch.tensor([37, 90], dtype=torch.int32, device="cuda"),
+            seq_kv_lens=torch.tensor([180, 240], dtype=torch.int32, device="cuda"),
+        )
+    elif mask == "sink_swa":
+        kw.update(is_causal=True, window_size_left=16, with_sink=True)
+    _run_case(**kw)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("dtype", [torch.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize("s_q", [1, 129, 1023])
+@torch_fork_set_rng(seed=4)
+def test_dsl_sm120_pack_gqa_deep(dtype: torch.dtype, s_q: int):
+    """Packed multi-tile / odd-length shapes, bf16."""
+    _run_case(batch=1, h_q=64, h_kv=8, s_q=s_q, s_kv=2048, head_dim=128, dtype=dtype, is_causal=True, pack_gqa=True)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -517,7 +517,19 @@ def test_fp8_pack_gqa_d192_d128_ratios(h_q, h_kv):
     """Packed d192xd128 flavor across GQA ratios, causal, tile-unaligned s_q."""
     scale = 1.0 / math.sqrt(192)
     out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
-        2, h_q, h_kv, 40, 256, "e4m3", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), d_qk=192, d_v=128, pack_gqa=True, return_lse=True
+        2,
+        h_q,
+        h_kv,
+        40,
+        256,
+        "e4m3",
+        torch.float16,
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask=True),
+        d_qk=192,
+        d_v=128,
+        pack_gqa=True,
+        return_lse=True,
     )
     _check(out, o_ref, torch.float16, "e4m3", a_o, a_ref)
     torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)
@@ -533,7 +545,19 @@ def test_fp8_pack_gqa_d192_d128_grouped_lpt():
     reverse-row CGA tiles."""
     scale = 1.0 / math.sqrt(192)
     out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
-        8, 8, 4, 300, 512, "e4m3", torch.bfloat16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), d_qk=192, d_v=128, pack_gqa=True, return_lse=True
+        8,
+        8,
+        4,
+        300,
+        512,
+        "e4m3",
+        torch.bfloat16,
+        scale=scale,
+        sdpa_kwargs=dict(use_causal_mask=True),
+        d_qk=192,
+        d_v=128,
+        pack_gqa=True,
+        return_lse=True,
     )
     _check(out, o_ref, torch.bfloat16, "e4m3", a_o, a_ref)
     torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -52,7 +52,7 @@ def _quant(x, in_key):
     return (x / dq).clamp(-fmax, fmax).to(fp8), dq
 
 
-def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=None, sinks=None, seq_lens_kv=None):
+def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=None, sinks=None, seq_lens_kv=None, return_stats=False):
     b, h_q, s_q, _ = qd.shape
     _, h_kv, s_kv, _ = vd.shape
     dev = qd.device
@@ -75,12 +75,19 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
     scores = scores.masked_fill(masked, float("-inf"))
     if sinks is not None:
         col = sinks.view(1, h_q, 1, 1).float().expand(b, h_q, s_q, 1).to(dev)
-        probs = torch.softmax(torch.cat([scores, col], dim=-1), dim=-1)
-        return torch.matmul(probs[..., :s_kv], v_e)
+        ext = torch.cat([scores, col], dim=-1)
+        probs = torch.softmax(ext, dim=-1)
+        o = torch.matmul(probs[..., :s_kv], v_e)
+        if return_stats:
+            return o, torch.logsumexp(ext, dim=-1)
+        return o
     row_has_kv = torch.isfinite(scores).any(dim=-1, keepdim=True)
     probs = torch.softmax(scores, dim=-1)
     probs = torch.where(row_has_kv, probs, torch.zeros_like(probs))
-    return torch.matmul(probs, v_e)
+    o = torch.matmul(probs, v_e)
+    if return_stats:
+        return o, torch.logsumexp(scores, dim=-1)
+    return o
 
 
 def _run(
@@ -102,6 +109,8 @@ def _run(
     sync_debug=False,
     d_qk=128,
     d_v=128,
+    pack_gqa=None,
+    return_lse=False,
 ):
     import cudnn
 
@@ -166,7 +175,7 @@ def _run(
     g.create_execution_plans([cudnn.heur_mode.A])
     # ONE fp8 engine per arch line — kernel-flavor choice (d128 vs d192xd128,
     # and the head-dim envelope) happens inside the lowering.
-    _select_engine(g, engine_name(arch=_D128_ARCH, fp8=True))
+    _select_engine(g, engine_name(arch=_D128_ARCH, fp8=True), pack_gqa=pack_gqa)
     g.check_support()
     g.build_plans()
     if not stats:
@@ -192,6 +201,10 @@ def _run(
     ref_kw = _ref_kwargs(sdpa_kwargs)
     if sink is not None:
         ref_kw["sinks"] = sink.flatten()
+    if return_lse:
+        assert stats, "return_lse requires stats=True"
+        o_ref, lse_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, return_stats=True, **ref_kw)
+        return Ob, o_ref, amax_o.item(), o_ref.abs().max().item(), lse.view(B, H_q, S_q), lse_ref
     o_ref = _ref(Q8.float() * dq, K8.float() * dk, V8.float() * dv, scale=scale, seq_lens_kv=seq_lens_kv, **ref_kw)
     return Ob, o_ref, amax_o.item(), o_ref.abs().max().item()
 
@@ -423,6 +436,77 @@ def test_fp8_gqa(in_key):
     scale = 1.0 / math.sqrt(128)
     out, o_ref, a_o, a_o_ref = _run(2, 8, 2, 256, 256, in_key, torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True))
     _check(out, o_ref, torch.float16, in_key, a_o, a_o_ref)
+
+
+# --- PackGQA: TILE_M/G tokens x G query heads per tile -------
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "h_q,h_kv",
+    [(8, 4), (8, 2), (8, 1), (16, 1)],
+    ids=["g2", "g4", "g8_mqa", "g16_mqa"],
+)
+@torch_fork_set_rng(seed=0)
+def test_fp8_pack_gqa_ratios(h_q, h_kv):
+    """Packed plans across GQA ratios, causal, tile-unaligned s_q, LSE checked."""
+    scale = 1.0 / math.sqrt(128)
+    out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
+        2, h_q, h_kv, 40, 256, "e4m3", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), pack_gqa=True, return_lse=True
+    )
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_ref)
+    torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("s_q", [8, 64, 100], ids=["subspan", "exact_span", "tail"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_pack_gqa_tiles(s_q):
+    """Packed tile-geometry edges at G=8 (s_q*G below / at / past the 512-row CGA span)."""
+    scale = 1.0 / math.sqrt(128)
+    out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
+        1, 64, 8, s_q, 256, "e4m3", torch.bfloat16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), pack_gqa=True, return_lse=True
+    )
+    _check(out, o_ref, torch.bfloat16, "e4m3", a_o, a_ref)
+    torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("out_dt", [torch.float16, torch.float8_e4m3fn], ids=["f16_out", "e4m3_out"])
+@pytest.mark.parametrize(
+    "mask",
+    ["none_padded", "causal", "causal_br", "swa", "sink_causal"],
+)
+@torch_fork_set_rng(seed=0)
+def test_fp8_pack_gqa_features(mask, out_dt):
+    """Packed plans x the fp8 mask/sink envelope x both output dtypes."""
+    scale = 1.0 / math.sqrt(128)
+    kw = dict()
+    sink = None
+    seq_lens_kv = None
+    if mask == "none_padded":
+        seq_lens_kv = [180, 240]
+    elif mask == "causal":
+        kw = dict(use_causal_mask=True)
+    elif mask == "causal_br":
+        kw = dict(use_causal_mask_bottom_right=True)
+    elif mask == "swa":
+        kw = dict(use_causal_mask=True, left_bound=17)
+    elif mask == "sink_causal":
+        kw = dict(use_causal_mask=True)
+        sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
+        2, 8, 2, 40, 256, "e4m3", out_dt, scale=scale, sdpa_kwargs=kw, sink=sink, seq_lens_kv=seq_lens_kv, pack_gqa=True, return_lse=True
+    )
+    _check(out, o_ref, out_dt, "e4m3", a_o, a_ref)
+    torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_fp8_pack_gqa_e5m2():
+    """Packed e5m2 input path."""
+    scale = 1.0 / math.sqrt(128)
+    out, o_ref, a_o, a_ref = _run(2, 8, 2, 40, 256, "e5m2", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), pack_gqa=True)
+    _check(out, o_ref, torch.float16, "e5m2", a_o, a_ref)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -509,6 +509,50 @@ def test_fp8_pack_gqa_e5m2():
     _check(out, o_ref, torch.float16, "e5m2", a_o, a_ref)
 
 
+@_skip_on_rubin
+@pytest.mark.L0
+@pytest.mark.parametrize("h_q,h_kv", [(8, 4), (8, 2), (16, 2)], ids=["g2", "g4", "g8"])
+@torch_fork_set_rng(seed=0)
+def test_fp8_pack_gqa_d192_d128_ratios(h_q, h_kv):
+    """Packed d192xd128 flavor across GQA ratios, causal, tile-unaligned s_q."""
+    scale = 1.0 / math.sqrt(192)
+    out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
+        2, h_q, h_kv, 40, 256, "e4m3", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), d_qk=192, d_v=128, pack_gqa=True, return_lse=True
+    )
+    _check(out, o_ref, torch.float16, "e4m3", a_o, a_ref)
+    torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)
+
+
+@_skip_on_rubin
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_fp8_pack_gqa_d192_d128_grouped_lpt():
+    """Packed d192xd128 through the grouped-LPT decoder: the head-group and
+    reverse-row (lpt_q_tiles) knobs must see the PACKED launch geometry —
+    B * (h_q/G) = 32 selects the group-of-8 decoder, and s_q*G spans two
+    reverse-row CGA tiles."""
+    scale = 1.0 / math.sqrt(192)
+    out, o_ref, a_o, a_ref, lse_v, lse_ref = _run(
+        8, 8, 4, 300, 512, "e4m3", torch.bfloat16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), d_qk=192, d_v=128, pack_gqa=True, return_lse=True
+    )
+    _check(out, o_ref, torch.bfloat16, "e4m3", a_o, a_ref)
+    torch.testing.assert_close(lse_v, lse_ref, atol=5e-2, rtol=3e-2)
+
+
+@_skip_on_rubin
+@pytest.mark.L1
+@torch_fork_set_rng(seed=0)
+def test_fp8_pack_gqa_d192_d128_e5m2_sink():
+    """Packed d192xd128 E5M2 + sink: the sink logit seeds the softmax per
+    ROW, so under packing the seed is lane-varying (row's true query head)."""
+    scale = 1.0 / math.sqrt(192)
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    out, o_ref, a_o, a_ref = _run(
+        2, 8, 2, 40, 256, "e5m2", torch.float16, scale=scale, sdpa_kwargs=dict(use_causal_mask=True), sink=sink, d_qk=192, d_v=128, pack_gqa=True
+    )
+    _check(out, o_ref, torch.float16, "e5m2", a_o, a_ref)
+
+
 @pytest.mark.L0
 @torch_fork_set_rng(seed=0)
 def test_fp8_bottom_right_rectangular():

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
@@ -96,6 +96,7 @@ def _run(
     seq_lens_kv=None,
     seq_lens_q=None,
     tiles=None,
+    pack_gqa=None,
     s_descale_gain=1.0,
     sync_debug=False,
     D=128,
@@ -196,7 +197,7 @@ def _run(
     g.validate()
     g.build_operation_graph()
     g.create_execution_plans([cudnn.heur_mode.A])
-    _select_engine(g, engine_name(arch="sm120", fp8=True), tiles=tiles)
+    _select_engine(g, engine_name(arch="sm120", fp8=True), tiles=tiles, pack_gqa=pack_gqa)
     g.check_support()
     g.build_plans()
     vp.update({o: Ob, stats: lse, amx_o: amax_o})
@@ -248,6 +249,71 @@ def _check(out, o_ref, amax_o, amax_o_ref, lse=None, lse_ref=None, tol_o=5e-2):
         assert torch.equal(torch.isfinite(lse), finite), "LSE -inf pattern differs from the reference"
         d = (lse[finite] - lse_ref[finite]).abs().max().item() if finite.any() else 0.0
         assert d <= 3e-2, f"max|LSE-ref|={d:.4f} > 0.03"
+
+
+# --- PackGQA: q_tile/G tokens x G query heads per tile -------
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    "h_q,h_kv",
+    [(8, 4), (8, 2), (8, 1), (16, 1)],
+    ids=["g2", "g4", "g8_mqa", "g16_mqa"],
+)
+@torch_fork_set_rng(seed=0)
+def test_fp8_sm120_pack_gqa_ratios(h_q, h_kv):
+    """Packed plans across GQA ratios (incl. MQA)."""
+    out, o_ref, a_o, a_ref, lse, lse_ref = _run(2, h_q, h_kv, 40, 256, scale=1.0 / math.sqrt(128), sdpa_kwargs=dict(use_causal_mask=True), pack_gqa=True)
+    _check(out, o_ref, a_o, a_ref, lse, lse_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("s_q", [4, 16, 25], ids=["subspan", "exact_span", "tail"])
+@torch_fork_set_rng(seed=1)
+def test_fp8_sm120_pack_gqa_tiles(s_q):
+    """Packed tile-geometry edges at G=8, q_tile=128 (token span 16/tile)."""
+    out, o_ref, a_o, a_ref, lse, lse_ref = _run(
+        1, 64, 8, s_q, 256, scale=1.0 / math.sqrt(128), sdpa_kwargs=dict(use_causal_mask=True), tiles=(128, 128), pack_gqa=True
+    )
+    _check(out, o_ref, a_o, a_ref, lse, lse_ref)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("o_dtype", [torch.bfloat16, torch.float8_e4m3fn], ids=["bf16_out", "e4m3_out"])
+@pytest.mark.parametrize("mask", ["none_padded", "causal", "causal_br", "swa", "sink_causal"])
+@torch_fork_set_rng(seed=2)
+def test_fp8_sm120_pack_gqa_features(mask, o_dtype):
+    """Packed plans x the fp8 mask/sink envelope x both output-dtype epilogues."""
+    kw = dict()
+    sinks = None
+    seq_lens_kv = None
+    if mask == "none_padded":
+        seq_lens_kv = [180, 240]
+    elif mask == "causal":
+        kw = dict(use_causal_mask=True)
+    elif mask == "causal_br":
+        kw = dict(use_causal_mask_bottom_right=True)
+    elif mask == "swa":
+        kw = dict(use_causal_mask=True, left_bound=17)
+    elif mask == "sink_causal":
+        kw = dict(use_causal_mask=True)
+        sinks = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda")
+    out, o_ref, a_o, a_ref, lse, lse_ref = _run(
+        2, 8, 2, 40, 256, scale=1.0 / math.sqrt(128), sdpa_kwargs=kw, seq_lens_kv=seq_lens_kv, sinks=sinks, o_dtype=o_dtype, pack_gqa=True
+    )
+    tol_o = 5e-2
+    if o_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+        floor = (o_ref - o_ref.to(o_dtype).float()).abs().max().item()
+        tol_o = max(tol_o, 3 * floor)
+    _check(out, o_ref, a_o, a_ref, lse, lse_ref, tol_o=tol_o)
+
+
+@pytest.mark.L1
+@torch_fork_set_rng(seed=3)
+def test_fp8_sm120_pack_gqa_tile64():
+    """Packed at q_tile=64 (G must divide the smaller tile: 8/2 -> G=4)."""
+    out, o_ref, a_o, a_ref, lse, lse_ref = _run(
+        2, 8, 2, 24, 192, scale=1.0 / math.sqrt(128), sdpa_kwargs=dict(use_causal_mask=True), tiles=(64, 64), pack_gqa=True
+    )
+    _check(out, o_ref, a_o, a_ref, lse, lse_ref)
 
 
 _MASKS = {

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
@@ -45,19 +45,19 @@ def _ref_sdpa(q, k, v, scale, is_causal, kh):
     return torch.matmul(p, vb).permute(0, 2, 1, 3)
 
 
-def _kernel_module(splits, dtype_qkv, causal, cta_mma=2):
+def _kernel_module(splits, dtype_qkv, causal, cta_mma=2, pack_gqa=False, qh_per_kh=1):
     from cudnn.frost.template_loader import load_template
     from cudnn.sdpa.fwd import api_dsl
     from cudnn.sdpa.fwd.config_sm100 import TemplateParams
 
     path = os.path.join(os.path.dirname(os.path.abspath(api_dsl.__file__)), "kernels", "prefill_d128_f16_sm100.py")
-    kw = {"dtype_qkv": dtype_qkv, "split_kv": splits, "cta_mma": cta_mma}
+    kw = {"dtype_qkv": dtype_qkv, "split_kv": splits, "cta_mma": cta_mma, "pack_gqa": pack_gqa, "qh_per_kh": qh_per_kh}
     if causal:
         kw["window_right"] = 0
-    return load_template(path, TemplateParams(**kw), tag=f"splitkv{splits}_d{dtype_qkv}_{'caus' if causal else 'dense'}_cga{cta_mma}")
+    return load_template(path, TemplateParams(**kw), tag=f"splitkv{splits}_d{dtype_qkv}_{'caus' if causal else 'dense'}_cga{cta_mma}_pg{int(pack_gqa)}")
 
 
-def _run(splits, B, H, KH, SQ, SKV, dtype, causal, cta_mma=2):
+def _run(splits, B, H, KH, SQ, SKV, dtype, causal, cta_mma=2, pack_gqa=False):
     """Launch the split kernel + DSL combine; returns the recombined O (BSHD fp32)."""
     import cutlass
     import cuda.bindings.driver as cuda_driver
@@ -71,7 +71,7 @@ def _run(splits, B, H, KH, SQ, SKV, dtype, causal, cta_mma=2):
     k = torch.randn(B, SKV, KH, D, device=dev, dtype=dtype)
     v = torch.randn(B, SKV, KH, D, device=dev, dtype=dtype)
 
-    mod = _kernel_module(splits, 3 if dtype == torch.float16 else 2, causal, cta_mma=cta_mma)
+    mod = _kernel_module(splits, 3 if dtype == torch.float16 else 2, causal, cta_mma=cta_mma, pack_gqa=pack_gqa, qh_per_kh=H // KH)
     fn = mod.compile(b=B, qh=H, kh=KH, sq=SQ, skv=SKV, d_qk=D, d_v=D, has_lse=True)
 
     o_p = torch.zeros(splits * B, SQ, H, D, device=dev, dtype=dtype)
@@ -148,6 +148,22 @@ def test_split_kv_gqa(splits):
     got, (q, k, v, scale) = _run(splits, B, H, KH, SQ, SKV, torch.float16, causal=False)
     ref = _ref_sdpa(q, k, v, scale, is_causal=False, kh=KH)
     assert (got - ref).abs().max().item() <= 2e-2
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("splits", [2, 4])
+def test_split_kv_pack_gqa(splits):
+    """KV split x PackGQA: the split chunks the PACKED tile's KV range
+    (_bounds_for_tile_split's trailing pack_g), the partial epilogue scatters
+    rows to their logical (batch', head, token) slots, and the combine — which
+    reads logical positions — is packing-agnostic.  Tile-unaligned s_q on
+    purpose; GQA 8:2 -> G=4."""
+    o, (q, k, v, scale) = _run(splits, 2, 8, 2, 40, 512, torch.float16, causal=True, pack_gqa=True)
+    ref = _ref_sdpa(q, k, v, scale, True, 2)
+    torch.testing.assert_close(o, ref, atol=5e-2, rtol=3e-2)
+    # And the packed split result must match the packed UNSPLIT kernel.
+    o1, _ = _run(1, 2, 8, 2, 40, 512, torch.float16, causal=True, pack_gqa=True)
+    torch.testing.assert_close(o, o1, atol=2e-2, rtol=2e-2)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -599,6 +599,54 @@ def test_knob_request_none_fields_are_no_preference():
     assert engines.engine_name() in _eligible(g, engines.SdpaFwdKnobs())
 
 
+def _mk_gqa_graph(h_q, h_kv, d=128):
+    """Causal GQA graph (BSHD-physical strides) for the pack_gqa knob tests."""
+    g = _mk_graph()
+    dims_q, strides_q = (B, h_q, S, d), (S * h_q * d, d, h_q * d, 1)
+    dims_kv, strides_kv = (B, h_kv, S, d), (S * h_kv * d, d, h_kv * d, 1)
+    q = g.tensor(dim=dims_q, stride=strides_q, data_type=DTYPE, name="q")
+    k = g.tensor(dim=dims_kv, stride=strides_kv, data_type=DTYPE, name="k")
+    v = g.tensor(dim=dims_kv, stride=strides_kv, data_type=DTYPE, name="v")
+    o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, use_causal_mask=True)
+    _finish_output(o, dims_q, strides_q)
+    return g
+
+
+def test_knob_request_pack_gqa_eligible_on_gqa():
+    # The f16 SM100 rows declare pack_gqas={False, True}; a dense GQA graph
+    # with a power-of-2 group admits the packed request.
+    g = _mk_gqa_graph(8, 2)
+    assert engines.engine_name() in _eligible(g, engines.SdpaFwdKnobs(pack_gqa=True))
+
+
+def test_knob_request_pack_gqa_on_mha_is_identity():
+    # MHA: G == 1 compiles the identity (bit-exact unpacked fold), so an
+    # explicit pack_gqa=True is honorable and the engine stays eligible.
+    g = _mk_eligible_graph()
+    assert engines.engine_name() in _eligible(g, engines.SdpaFwdKnobs(pack_gqa=True))
+
+
+def test_knob_request_pack_gqa_no_pow2_group_rejects_engine():
+    # GQA ratio 3 does not divide tile_m (128) so pack_gqa_supported is False.
+    g = _mk_gqa_graph(6, 2)
+    assert not _eligible(g, engines.SdpaFwdKnobs(pack_gqa=True))
+
+
+def test_knob_request_pack_gqa_false_always_eligible():
+    # Running unpacked is trivially honorable — on MHA graphs too.
+    assert engines.engine_name() in _eligible(_mk_eligible_graph(), engines.SdpaFwdKnobs(pack_gqa=False))
+    assert engines.engine_name() in _eligible(_mk_gqa_graph(8, 2), engines.SdpaFwdKnobs(pack_gqa=False))
+
+
+def test_knob_request_pack_gqa_outside_domain_rejects_row():
+    # The mxfp8/SM80 rows keep the default {False} domain, so an explicit
+    # packed request must never make them eligible; the packable set is
+    # pinned exactly by test_pack_gqa_capability_domains.
+    g = _mk_gqa_graph(8, 2)
+    eligible = _eligible(g, engines.SdpaFwdKnobs(pack_gqa=True))
+    assert eligible <= {s.name for s in engines.ENGINE_SPECS if True in s.capabilities.pack_gqas}, eligible
+
+
 # ---------------------------------------------------------------------------
 # SM120 engine row (sdpa_fwd_prefill_sm120) — same probes under a faked
 # SM120/SM121 device. Executable coverage lives in test_sdpa_fwd_dsl_sm120.py.


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

- FE OSS kernels or CuTeDSL

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

Add **PackGQA** to the FROST SDPA forward prefill engines.

- For GQA/MQA (`h_q = G·h_kv`), one Q tile packs `TILE_M/G` tokens × the G query heads sharing one KV head. Row `r` maps to token `r // G`, head `r % G`
- Covered kernels:
    - SM100f: f16/bf16 (d128, d256, d512, d192×128), per-tensor fp8 (SM100, SM107)
    - SM120f: f16 and fp8
- Mechanism
    - SM100f: a Q/O TMA box reshape `(1, TILE_M, 1, granule) → (1, TILE_M/G, G, granule)` plus index algebra. Transaction bytes are invariant; the mask/softmax code is untouched
    - SM120f: the same token/head split in the LDG/STG address math
- Contract: `G` is always the full ratio `h_q // h_kv` and must divide the tile size
- New knob: `SdpaFwdKnobs.pack_gqa` (True / False / None-auto), with `Capabilities.pack_gqas` domains and `mismatch()` clauses. A knob is honored or the engine is ineligible
- Simple heuristic: pack iff eligible and `s_q < tile_q` (the CGA tile on SM100, `tile_m` on SM120). Shape-only, device-independent
- Composes with KV split: the split chunks the packed token-span bounds, and the split heuristic sees the packed launch geometry


#### Engines without pack_gqa support
- SM100 MXFP8: the F8_128x4 `sf_q` scale-factor atom bundles 128 rows of one head and is not TMA-gatherable at token granularity
- SM80: the APIs seem under refactoring; needs follow-up
- SDPA backward engines

#### Limitations on the supported engines

- THD/ragged layouts currently not supported; needs follow-up
- Non-dividing GQA ratios: currently we require `qh_per_kh | tile_m`, so qh_per_kh like 3/6/7/12 and 96-head MQA (Kimi K3) run unpacked: needs follow-up

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

- Chunked prefill and speculative-decode verification run small `s_q`
  Unpacked, each query head gets its own mostly-empty tile, and the G tiles of one KV-head family re-stream the same K/V
- Packing fills one tile with the whole head family, so K/V is read once per KV head instead of once per query head

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

Related to #379 and #381

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

- Additive API: `SdpaFwdKnobs.pack_gqa`, `Capabilities.pack_gqas`, and the `pack_gqa` / `qh_per_kh` template-record fields

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->

- SM100 (B200-class, cuDNN 9.26): frost fwd suites incl. mxfp8, L0–L2 — 710 passed / 18 failed vs base 646/18. 
Failures: the THD `cu_seq_len` family (5) and the mxfp8 suite (13), both pre-existing upstream.
- SM120 (RTX 5090, cuDNN 9.26): frost fwd suites, L0–L4 — 219 passed / 4 failed vs base 175/4.
Failures: f16 THD `cu_seq_len` (4, pre-existing upstream).
- Device-free planning suites (`test_sdpa_graph_analyzer.py`, `test_sm120_tile_rule.py`) — **112 passed**.
- `test_mhas_v2.py` decode family (128 seeded configs, FROST enabled, SM100): 128/128 route to FROST, **19 execute a packed plan**, all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added packed grouped-query attention (PackGQA) for supported dense SDPA workloads on SM100 and SM120 hardware, including FP16, BF16, and FP8 paths.
  - Added automatic selection of compatible packing modes, head ratios, and tile configurations.
  - Preserved correct masking, sinks, statistics, split-KV execution, and output addressing with packed queries.

- **Bug Fixes**
  - Added validation for supported head ratios, data types, layouts, and sequence modes, with clear rejection of unsupported configurations.

- **Documentation**
  - Updated tuning, capability, and SDPA knob documentation to describe PackGQA support and constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->