### PR TITLE
Add stale-PR automation: mark stale at 3 weeks, close at 6 weeks of inactivity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: Mark and close stale PRs
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  # PR labels and comments go through the issues API
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # PRs only — leave issues untouched
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 21
+          days-before-pr-close: 21
+          stale-pr-label: stale
+          close-pr-label: closed-stale
+          stale-pr-message: >
+            This PR has been inactive for 3 weeks and is now marked stale.
+            It will be closed in 3 more weeks unless there is new activity
+            (a comment, a push, or removal of the stale label).
+          close-pr-message: >
+            Closing this PR after 6 weeks of inactivity. Feel free to reopen
+            or open a new PR when you're ready to continue.
+          remove-stale-when-updated: true


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

CI or test infrastructure

## Summary

Adds `.github/workflows/stale.yml` — the repository's first GitHub Actions workflow on the code branches — using [`actions/stale@v9`](https://github.com/actions/stale) on a daily schedule (02:30 UTC) plus `workflow_dispatch` for manual runs:

- A PR with **no activity for 3 weeks (21 days)** gets the `stale` label and an explanatory comment.
- If there is still no activity **3 weeks after that (6 weeks total inactivity)**, the PR is closed with a comment and labeled `closed-stale` (reusing the repo's existing label).
- Any activity resets the clock: a comment, a push, or a maintainer simply **removing the `stale` label** (an unlabel event counts as an update, and `remove-stale-when-updated: true` also auto-drops the label on new activity).
- **Issues are not affected** (`days-before-issue-stale/close: -1`).

The workflow carries an explicit `permissions:` block (`issues: write`, `pull-requests: write` — PR labels/comments go through the issues API) since the repo has no workflow-permissions baseline yet.

## Why

PRs accumulate without activity and there is currently no lifecycle policy or automation. This keeps the PR queue reflective of active work while giving authors a 3-week warning and an easy reset (any comment/push, or a maintainer removing the label).

Note: `schedule`/`workflow_dispatch` run from the default branch (`develop`), so the automation goes live as soon as this merges. Review activity that happens only on the internal GitLab mirror does not reset the timer — a GitHub-side comment or label removal does.

## Related issues

None.

## API and compatibility impact

None. CI-only change; no code, build, or packaging impact.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/stale.yml'))"` — parses cleanly.
- `pre-commit run --files .github/workflows/stale.yml` — all hooks skipped/pass (no hooks target workflow YAML).
- The workflow itself cannot run pre-merge (scheduled/dispatch workflows execute from the default branch). After merge it can be exercised via **Actions → Mark and close stale PRs → Run workflow**; the first run will label PRs already ≥21 days inactive. If a no-op trial is preferred, temporarily add `debug-only: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated handling for inactive pull requests.
  * Pull requests are marked stale after 21 days of inactivity and closed after an additional 21 days.
  * Status labels and notifications are applied automatically, with stale status removed when activity resumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->