### PR TITLE
benchmark: add the Ampere (sm80) row to the peak-MMA table

### DIFF
--- a/benchmark/attention_training/benchmark_single_sdpa.py
+++ b/benchmark/attention_training/benchmark_single_sdpa.py
@@ -52,6 +52,10 @@ _FLOPS_PER_CLOCK_PER_SM = {
     # Hopper (sm90): H100 SXM lists 989.5 dense BF16 TFLOPS (FP32 accumulate;
     # 1979 is the sparsity figure) = 132 SMs x 1.83 GHz x 4096 FLOPs/clk/SM;
     # FP8 dense is 2x. (No mxfp8 entry: Hopper has no MXFP8 datapath.)
+    # Ampere (sm80): A100 lists 312 dense BF16/FP16 TFLOPS (FP32 accumulate;
+    # 624 is the sparsity figure) = 108 SMs x 1.41 GHz x 2048 FLOPs/clk/SM.
+    # (No fp8/mxfp8 entries: Ampere has neither datapath.)
+    8: {"bfloat16": 2048, "float16": 2048},
     9: {"bfloat16": 4096, "float16": 4096, "fp8": 8192},
     10: {"bfloat16": 8192, "float16": 8192, "fp8": 16384, "mxfp8": 16384},
     12: {"bfloat16": 1024, "float16": 1024, "fp8": 2048, "mxfp8": 2048},

--- a/benchmark/attention_training/benchmark_single_sdpa.py
+++ b/benchmark/attention_training/benchmark_single_sdpa.py
@@ -67,6 +67,30 @@ def _peak_flops_per_clock_per_sm(dtype_str):
     return _FLOPS_PER_CLOCK_PER_SM.get(props.major, {}).get(dtype_str)
 
 
+def _nvml_handle_for_torch_device(pynvml, cuda_index):
+    """NVML handle for the PHYSICAL device backing torch device ``cuda_index``.
+
+    NVML enumerates physical GPUs and ignores CUDA_VISIBLE_DEVICES, while torch
+    indexes only the visible subset: under ``CUDA_VISIBLE_DEVICES=3`` the
+    benchmark runs on physical GPU 3 but ``torch.cuda.current_device()`` is 0,
+    so indexing NVML with the torch index samples GPU 0's clock. When several
+    single-GPU shards run side by side on a multi-GPU node (each pinned via
+    CUDA_VISIBLE_DEVICES), a shard whose neighbor GPU 0 has gone idle then
+    records the IDLE clock as its "peak", collapsing the SOL ceiling by the
+    idle-vs-boost ratio (>10x on aggressively-downclocking parts).
+    """
+    cvd = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if cvd:
+        entries = [e.strip() for e in cvd.split(",") if e.strip()]
+        if cuda_index < len(entries):
+            entry = entries[cuda_index]
+            if entry.isdigit():
+                return pynvml.nvmlDeviceGetHandleByIndex(int(entry))
+            # UUID ("GPU-...") or MIG ("MIG-...") form.
+            return pynvml.nvmlDeviceGetHandleByUUID(entry.encode())
+    return pynvml.nvmlDeviceGetHandleByIndex(cuda_index)
+
+
 class _SmClockSampler:
     """Background thread that polls SM clock via NVML at ~1 kHz.
 
@@ -89,7 +113,7 @@ class _SmClockSampler:
 
             pynvml.nvmlInit()
             self._pynvml = pynvml
-            self._handle = pynvml.nvmlDeviceGetHandleByIndex(torch.cuda.current_device())
+            self._handle = _nvml_handle_for_torch_device(pynvml, torch.cuda.current_device())
         except Exception:
             self._pynvml = None
             return


### PR DESCRIPTION
Follow-up to #699 (which fixed WHICH GPU the clock sampler reads; this fixes a peak that was never computed at all): `_FLOPS_PER_CLOCK_PER_SM` has sm90/sm100/sm12x entries only, so A100 runs compute no `peak_mma_tflops` and their charts draw no MMA-throughput max line.

A100: 312 dense BF16/FP16 TFLOPS (FP32 accumulate; 624 is the sparsity figure) = 108 SMs × 1.41 GHz × 2048 FLOPs/clk/SM. No fp8/mxfp8 entries — Ampere has neither datapath, and those cases already record unsupported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU monitoring during attention training benchmarks when device visibility is configured.
  * Added support for accurately sampling clocks across numeric, UUID, and MIG device identifiers.
  * Added peak performance data for Ampere GPUs using BF16 and FP16 precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->