### PR TITLE
Tmastg with multi gemm

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -41,6 +41,8 @@ def _as_custream(stream):
 
 from .dtypes import (
     DTYPE_BITS,
+    _TMA_SLOTS_0,
+    tma_slots_of,
     DTYPE_BYTES,
     DTYPE_TO_CUTLASS,
     DTYPE_TO_MMA_KIND,
@@ -234,7 +236,7 @@ def _aux_call_block(aux_tensors: list[TensorRef], prefix: str = "") -> str:
 
 
 def _tma_c_plumbing(chain: FusionChain) -> dict[str, str]:
-    n_out = len(chain.output_specs)
+    n_out = len(_TMA_SLOTS_0)
     return {
         "INJECT_KERNEL_TMA_C_PARAMS": ",\n".join(f"tma_c_desc_{i}: cutlass.GridConstant[_tma.TensorMap]" for i in range(n_out)) + ",",
         "INJECT_TMA_C_LISTS": "tma_c_descs = [" + ", ".join(f"tma_c_desc_{i}" for i in range(n_out)) + "]",
@@ -458,6 +460,20 @@ def _epi_vec_bytes(chain: FusionChain, config: TileConfig, cta_group: int) -> in
     return _compute_output_vec_bytes(chain, tile_cols=_epi_tile_cols(config, cta_group))
 
 
+def _epi_chunk_elems(chain: FusionChain, config: TileConfig, cta_group: int, use_tma_store: bool) -> int:
+    if not use_tma_store:
+        return _epi_vec_bytes(chain, config, cta_group) // DTYPE_BYTES[chain.output_dtype]
+    epi_n = _epi_n(config, cta_group, chain.output_dtype)
+    # The M-major arm transposes, so its `tcgen05_ld(SHAPE_16X256B, num=epi_n // 8)`
+    # hands a lane 4*num = epi_n/2 elements and the stmatrix ledger consumes exactly
+    # that (`range(epi_n // 16)` x 4 Int32). The N-major arm hands the whole subtile.
+    return epi_n // 2 if chain.out_major == "m" else epi_n
+
+
+def _epi_chunk_bytes(chain: FusionChain, config: TileConfig, cta_group: int, use_tma_store: bool) -> int:
+    return _epi_chunk_elems(chain, config, cta_group, use_tma_store) * DTYPE_BYTES[chain.output_dtype]
+
+
 def _mainloop_chain_zero_preserving(ops) -> bool:
     """True iff applying this mainloop op chain to 0 provably yields 0.
 
@@ -656,21 +672,18 @@ def _render_tile_constants(
             )
         acc_stages = min(cfg.acc_stages, 2 if 2 * acc_region_cols <= total_tmem else 1)
     lines.append(f"acc_stages = {acc_stages}  # {acc_region_cols} acc cols/stage")
+    # Multi-GEMM holds one SMEM buffer per DISTINCT operand, not the single A+B
+    # `smem_max_ab_stages` assumes. Carry that as a per-stage surcharge so the
+    # ONE override below decides ab_stages -- computing it here would be silently
+    # clobbered by that override, which sizes a single A+B (SMEM overflow at
+    # launch once multi-GEMM can also take the TMA-store epilogue).
+    mg_extra_per_stage = 0
     if chain.is_multi_gemm:
-        # ab_stages: one SMEM buffer per DISTINCT operand (num_a A + num_b B per
-        # stage), not the single A+B that smem_max_ab_stages assumes.
-        from .tile_config import _sm_smem_ab_budget_bytes, _AB_STAGES_CAP
-
         # Per-CTA SMEM B-tile N is halved under 2-CTA MMA (the pair splits B's N).
         smem_n = cfg.cta_tile_n // cta_group
-        per_stage = (chain.num_a_operands * cfg.cta_tile_m + chain.num_b_operands * smem_n) * cfg.cta_tile_k_bytes
-        avail = _sm_smem_ab_budget_bytes(cfg.pipeline, moe=chain.has_moe)
-        ab_stages_mg = min(avail // per_stage, _AB_STAGES_CAP)
-        if ab_stages_mg < 1:
-            raise NotImplementedError(
-                f"multi-GEMM: {chain.num_a_operands} A + {chain.num_b_operands} B " f"operand tiles per stage exceed SMEM budget at this geometry"
-            )
-        lines.append(f"ab_stages = {ab_stages_mg}  # multi-GEMM: {chain.num_a_operands}A+{chain.num_b_operands}B per stage")
+        base_mn = cfg.cta_tile_m + smem_n
+        mg_mn = chain.num_a_operands * cfg.cta_tile_m + chain.num_b_operands * smem_n
+        mg_extra_per_stage = (mg_mn - base_mn) * cfg.cta_tile_k_bytes
     # MoE grouped matmul: grouped persistent scheduler launches a FIXED cluster
     # count (≈ NUM_SMS / cluster_size); host grid and kernel stride share it.
     if chain.has_moe:
@@ -721,6 +734,7 @@ def _render_tile_constants(
     # (fallback). See _use_tma_store_epi() for gating.
     use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, cfg, vec_bytes_epi, cta_group)
     lines.append(f"use_tma_store_epi = {use_tma}")
+    lines.append(f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma)}")
     # Final ab_stages override: account for the TMA-D SMEM buffer (fixed, when
     # TMA-store is active) AND a mixed-input mainloop's narrow LOAD buffer
     # (per-stage). Otherwise leave the plain max.
@@ -733,14 +747,23 @@ def _render_tile_constants(
             cast_extra_per_stage += cfg.cta_tile_m * k_elems * DTYPE_BYTES[chain.mainloop_a_load_dtype]
         if chain.mainloop_b_cast:
             cast_extra_per_stage += smem_n * k_elems * DTYPE_BYTES[chain.mainloop_b_load_dtype]
-    if smem_d_bytes > 0 or cast_extra_per_stage > 0:
-        new_ab = cfg.max_ab_stages(
-            cta_group,
-            extra_smem_bytes=smem_d_bytes,
-            extra_per_stage_bytes=cast_extra_per_stage,
-            moe=chain.has_moe,
+    if smem_d_bytes > 0 or cast_extra_per_stage > 0 or mg_extra_per_stage > 0:
+        try:
+            new_ab = cfg.max_ab_stages(
+                cta_group,
+                extra_smem_bytes=smem_d_bytes,
+                extra_per_stage_bytes=cast_extra_per_stage + mg_extra_per_stage,
+                moe=chain.has_moe,
+            )
+        except ValueError as exc:
+            if chain.is_multi_gemm:
+                raise NotImplementedError(
+                    f"multi-GEMM: {chain.num_a_operands} A + {chain.num_b_operands} B " f"operand tiles per stage exceed SMEM budget at this geometry"
+                ) from exc
+            raise
+        lines.append(
+            f"ab_stages = {new_ab}  # SMEM-D {smem_d_bytes}B fixed" f" + cast LOAD {cast_extra_per_stage}B/stage" f" + multi-GEMM {mg_extra_per_stage}B/stage"
         )
-        lines.append(f"ab_stages = {new_ab}  # SMEM-D {smem_d_bytes}B fixed" f" + cast LOAD {cast_extra_per_stage}B/stage")
     lines.extend(_quant_device_imports(chain))
     lines.extend(_mixed_cga_constants(cfg, cta_group, fallback_cluster))
     return "\n".join(lines)
@@ -1412,6 +1435,7 @@ def _render_block_scale_tile_constants(
         f"vec_bytes_epi = {vec_bytes_epi}",
         f"frost_compile_options = {_frost_compile_options()!r}",
         f"use_tma_store_epi = {use_tma_store_epi}",
+        f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma_store_epi)}",
         f"cd_out_is_m_major = {chain.out_major == 'm'}",
         f"cd_fake_n_div = {2 if out_dt == 'fp4_e2m1' else 1}",
         # M-major TMA-store C-descriptor inner-M box = 128 B swizzle span / elem_bytes.
@@ -1631,7 +1655,7 @@ def _render_template(
     compile_aux_fakes = _aux_fake_block(
         aux_tensors,
         dynamic_strides=True,
-        align_reqs=_aux_align_reqs(chain, vec_bytes=vec_bytes_epi),
+        align_reqs=_aux_align_reqs(chain, vec_bytes=_epi_chunk_bytes(chain, config, cta_group, use_tma)),
     )
     compile_aux_pass = _aux_call_block(aux_tensors, prefix="fake_")
     tile_constants = _render_tile_constants(config, chain, cta_group, use_tma, fallback_cluster=fallback_cluster)
@@ -1758,7 +1782,9 @@ def _render_block_scale_template(
     kernel_aux_params = _aux_signature_block(aux_tensors)
     host_aux_params = _aux_signature_block(aux_tensors)
     host_aux_pass = _aux_call_block(aux_tensors)
-    compile_aux_fakes = _aux_fake_block(aux_tensors, dynamic_strides=True, align_reqs=_aux_align_reqs(chain, vec_bytes=vec_bytes_epi))
+    compile_aux_fakes = _aux_fake_block(
+        aux_tensors, dynamic_strides=True, align_reqs=_aux_align_reqs(chain, vec_bytes=_epi_chunk_bytes(chain, config, cta_group, use_tma))
+    )
     compile_aux_pass = _aux_call_block(aux_tensors, prefix="fake_")
     tile_constants = _render_block_scale_tile_constants(config, chain, cta_group, use_tma_store_epi=use_tma, fallback_cluster=fallback_cluster)
     if snippets.tap_constants:
@@ -2719,7 +2745,24 @@ def _check_input_alignment(chain: FusionChain) -> None:
 _EPI_SMEM_STAGES = 2
 
 
-_EPI_SWIZZLE_BY_ROW_BYTES = {32: (1, "s32b"), 64: (2, "s64b"), 128: (3, "s128b")}
+# A 16-byte staging row needs no swizzle: the XOR exists to spread a WIDE row
+# across the banks, and at 16 B/thread an STS.128 warp already covers all 32
+# banks conflict-free per phase. `Swizzle(0, ...)` has a zero-width mask, so
+# `store_swizzled` degenerates to a plain store and the descriptor declares
+# `none`, which is the one mode the DSL exempts from the box-width check.
+_EPI_SWIZZLE_BY_ROW_BYTES = {16: (0, "none"), 32: (1, "s32b"), 64: (2, "s64b"), 128: (3, "s128b")}
+
+# The N-major arm stages with `store_swizzled`, an XOR on SMEM BYTE addresses,
+# and hands the C descriptor an element type -- both are a function of the
+# element WIDTH, not of the dtype. Sub-byte output is the one exception: the
+# descriptor is byte-typed there, so its n and the store coordinate would have
+# to be the PACKED ones (`cd_fake_n_div`), which the host arm does not do.
+# The M-major arm transposes with `stmatrix.m8n8`, which moves a b16 payload
+# and has no b32 form in PTX -- that one IS a dtype-width lock at exactly 16.
+_TMA_STORE_MIN_OUT_BITS = 8
+_TMA_STORE_M_MAJOR_OUT_BITS = 16
+_TMA_STORE_M_MAJOR_MIN_EPI_N = 16
+
 _EPI_ROW_BYTES_MAX = 128  # widest TMA store swizzle
 _EPI_N_BASE = 32  # drain width when the epilogue is already hidden behind the MMA
 _EPI_N_MAX = 64  # per-lane fp32 registers the drain can hold
@@ -2734,18 +2777,21 @@ def _epi_n(cfg, cta_group: int, out_dt: str) -> int:
     return 1 << (n.bit_length() - 1)
 
 
+def _epi_swizzle_ok(cfg, cta_group: int, out_dt: str) -> bool:
+    """Does the TMA-store staging row have a swizzle? A subtile row outside
+    {32,64,128} bytes has none, which makes the tmastg SMEM stage inexpressible
+    -- a store-stage predicate, so it declines the TMA arm rather than the whole
+    render (the STG arm never touches the swizzle)."""
+    return _epi_n(cfg, cta_group, out_dt) * DTYPE_BYTES[out_dt] in _EPI_SWIZZLE_BY_ROW_BYTES
+
+
 def _epi_swizzle_lines(cfg, cta_group: int, out_dt: str) -> list[str]:
     epi_n = _epi_n(cfg, cta_group, out_dt)
     row_bytes = epi_n * DTYPE_BYTES[out_dt]
-    if row_bytes not in _EPI_SWIZZLE_BY_ROW_BYTES:
-        raise NotImplementedError(
-            f"{cfg.name!r}: epilogue subtile row is {row_bytes} bytes "
-            f"(epi_n={epi_n} x {DTYPE_BYTES[out_dt]}B {out_dt}); "
-            f"the TMA store swizzle only spans {sorted(_EPI_SWIZZLE_BY_ROW_BYTES)}"
-        )
-    b, tma = _EPI_SWIZZLE_BY_ROW_BYTES[row_bytes]
+    b, tma = _EPI_SWIZZLE_BY_ROW_BYTES.get(row_bytes, _EPI_SWIZZLE_BY_ROW_BYTES[min(_EPI_SWIZZLE_BY_ROW_BYTES)])
     return [
         f"epi_n = {epi_n}",
+        f"epi_smem_row_bytes = {row_bytes}",
         f"epi_smem_swizzle = cutlass.Swizzle({b}, 4, 3)",
         f"epi_tma_swizzle = _tma.TensorMapSwizzle.{tma}",
     ]
@@ -2760,60 +2806,107 @@ def _smem_d_bytes(cfg, chain, cta_group: int) -> int:
     return _EPI_SMEM_STAGES * cfg.epi_tile_mn[0] * _epi_n(cfg, cta_group, out_dt) * DTYPE_BYTES[out_dt] + 16
 
 
-def _use_tma_store_epi(chain, cfg, vec_bytes_epi: int, cta_group: int) -> bool:
-    """Gate for the TMA-store epilogue path. Requires:
-    - single tensor output (no aux): aux ops load at STG vsize, misaligned
-      with the full t2r_inst_repx vector the TMA path stages to SMEM.
-    - N-major output row stride ≥ 16 bytes: cp.async.bulk.tensor needs the
-      SMEM source aligned to the descriptor swizzle (else undeclarable).
-    - mma_inst_m == 128: only the 128-rows-per-MMA-block thread→row layout is
-      wired (an M=64 MMA block drains through the packed lane<16 layout).
-    - out dtype ∈ {bf16, fp16}: the drain widens to epi_n only for 2-byte output.
-    - M-major output: 16B-aligned M (16x256b TMEM-load + stmatrix.trans + tma_store),
-      and not MoE: the six MoE templates carry only the N-major TMA store.
-    """
-    if chain.is_multi_gemm:
-        # No multi-accumulator hook in the TMA-store path → STG only.
-        return False
-    if chain.aux_tensors:
-        return False
-    if any(op.op == "gen_index" for op in chain.ops):
-        # gen_index emits an iota at the STG vsize; the TMA path stages full
-        # t2r_inst_repx vectors.
-        return False
-    if len(chain.output_specs) > 1:
-        # Extra dense outputs store in the per-vector inner loop; the TMA path
-        # stages full t2r_inst_repx subtiles with no tap hook.
-        return False
-    if chain.reductions:
-        # Reduction taps are per-element atomic updates from the STG epilogue.
-        return False
-    if chain.quants:
-        # Quant scales are per-vector side outputs from the STG epilogue.
-        return False
-    if chain.out_major == "n" and vec_bytes_epi < 16:
-        return False
+def _tma_store_geometry_ok(chain, cfg, cta_group: int) -> bool:
+    """The store rules that hold on BOTH arms -- pure geometry and output width,
+    nothing about the chain's shape."""
+    # Only the 128-rows-per-MMA-block thread->row layout is wired; an M=64 MMA
+    # block drains through the packed lane<16 layout.
     if cfg.mma_inst_m != 128:
         return False
-    if chain.output_dtype not in ("bf16", "fp16"):
+    # WIDTH, not dtype: store_swizzled and the descriptor are width-functions.
+    if DTYPE_BITS[chain.output_dtype] < _TMA_STORE_MIN_OUT_BITS:
+        return False
+    # The SMEM staging row must be a width the swizzle table can express.
+    if not _epi_swizzle_ok(cfg, cta_group, chain.output_dtype):
         return False
     # An N-tile that is not a whole number of subtiles would TMA-store an
     # epi_n-wide box past the tile edge into the neighbouring tile (TMA clamps
-    # only at the GLOBAL extent) — fall back to STG. The N-major arm's span walk
-    # would halve to fit, but the M-major arm drains a fixed epi_n.
+    # only at the GLOBAL extent).
     if _epi_tile_cols(cfg, cta_group) % _epi_n(cfg, cta_group, chain.output_dtype) != 0:
         return False
-    # Under cta_group=2 each CTA holds cta_tile_n//2 cols, so cta_tile_n<64
-    # (per-CTA n<32) would split a subtile across CTAs — unsupported by the
-    # TMA path, fall back to STG.
-    if cta_group == 2 and cfg.cta_tile_n < 64:
+    return True
+
+
+def _tma_store_n_major_ok(chain, cfg, cta_group: int, vec_bytes_epi: int) -> bool:
+    """What still keeps an N-major graph off the TMA-store arm.
+
+    One of these is a real store rule; the other two are unfinished work, and
+        both need the same missing piece -- a per-element mask INSIDE the trailing
+        chunk. The arm exists precisely to serve a tile that overhangs N, and a
+        chunk-granular guard would silently drop the valid prefix of a straddling
+        subtile (a missed atomic / a missing scale byte, not a fault). Taps escape
+        that because `_tap_store_elems` divides both N and `col_j`."""
+    # REAL: the C descriptor encodes its global row stride in 16-BYTE units, so a
+    # row that is not a whole number of them is silently misaddressed (N=255 bf16:
+    # 510 // 16 = 31 -> rows read at 496 bytes). `_epi_vec_bytes` is the output's
+    # own row alignment clamped to the subtile spans, and the clamp never binds
+    # here -- `_tma_store_geometry_ok` already forces a >= 16-byte staging row that
+    # divides the N-tile. Measured: 0 over-rejections over 5400 (config, cta_group)
+    # pairs x 5 values of N. The SMEM side is `_epi_swizzle_ok`, not this.
+    if vec_bytes_epi < 16:
+        return False
+    # TODO(gate 5): reductions are atomic RMWs -- one folded per chunk when N is
+    # the reduced axis, one per element otherwise. A clamp is inadmissible for a
+    # read-modify-write, so they wait for the in-chunk mask.
+    if chain.reductions:
+        return False
+    # TODO(gate 6): the quant VALUE transform is already arm-correct, but the
+    # scale store is a per-chunk side effect, and a straddling chunk's amax would
+    # fold in columns past N -- so even the surviving columns' scale is wrong.
+    # Also needs `.to_vector()` on the two block-quant emitters first.
+    if chain.quants:
+        return False
+    return True
+
+
+def _tma_store_m_major_ok(chain, cfg, cta_group: int) -> bool:
+    """The M-major arm is `tcgen05.ld 16x256b -> stmatrix.trans -> utmastg`. It
+    re-reads TMEM itself, runs the snippet TWICE under `for _h in range(2)`, and
+    `row` / `col_j` are the subtile base rather than the coordinates of the
+    fragment a lane holds -- so everything coordinate-reading or side-effecting
+    is out by construction, not pending."""
+    # stmatrix.m8n8 has no b32 payload form.
+    if DTYPE_BITS[chain.output_dtype] != _TMA_STORE_M_MAJOR_OUT_BITS:
+        return False
+    # The transpose ledger is `for _blk in range(epi_n // 16)` over 4-register
+    # stmatrix tiles, so a narrower drain emits ZERO stores and the output keeps
+    # whatever the buffer held -- silent, not a fault.
+    if _epi_n(cfg, cta_group, chain.output_dtype) < _TMA_STORE_M_MAJOR_MIN_EPI_N:
+        return False
+    # The six MoE templates carry only the N-major TMA store.
+    if chain.has_moe:
+        return False
+    # This arm skips the pre-split accumulator load, so there is no `vec_f32_<g>`
+    # to bind for the extra GEMMs.
+    if chain.is_multi_gemm:
+        return False
+    # Coordinate-reading pointwise inputs and side effects: wrong coordinates,
+    # and the double pass would fire each side effect twice.
+    if any(a.bcast_mode != "scalar" for a in chain.aux_tensors):
+        return False
+    if any(op.op == "gen_index" for op in chain.ops):
+        return False
+    if len(chain.output_specs) > 1 or chain.reductions or chain.quants:
+        return False
+    # 16x256b TMEM-load + stmatrix.trans + tma_store all move 16-byte units of M.
+    return chain.matmul.M % (16 // DTYPE_BYTES[chain.output_dtype]) == 0
+
+
+def _use_tma_store_epi(chain, cfg, vec_bytes_epi: int, cta_group: int) -> bool:
+    """Gate for the TMA-store epilogue path: the geometry rules both arms share,
+    then the arm's own. Split by output major because the two arms have almost
+    nothing in common past the staging buffer -- see the two helpers."""
+    if not chain.output_specs:
+        # A reduction/amax-only chain has no dense output to bind the TMA-C
+        # slot, and `chain.output_dtype` / `out_major` then answer for a slot
+        # that does not exist -- it would report slot 0 and bind reduction_0 to
+        # the C descriptor. Do not rely on the reduction/quant rules for this.
+        return False
+    if not _tma_store_geometry_ok(chain, cfg, cta_group):
         return False
     if chain.out_major == "m":
-        if chain.has_moe:
-            return False
-        m_align = 16 // DTYPE_BYTES[chain.output_dtype]
-        return chain.matmul.M % m_align == 0
-    return True
+        return _tma_store_m_major_ok(chain, cfg, cta_group)
+    return _tma_store_n_major_ok(chain, cfg, cta_group, vec_bytes_epi)
 
 
 def _check_block_quant_supported(
@@ -2937,19 +3030,137 @@ def _check_executable(chain: FusionChain) -> None:
         raise NotImplementedError("a norm2 reduction takes a square root after the kernel, which is a device operation this engine does not own")
 
 
+def plan_config(chain: FusionChain) -> "tuple[TileConfig, int]":
+    from .kernel_registry import preferred_pipeline
+    from .tile_config import as_pipeline, select_config
+
+    tile_m = chain.matmul.M
+    if chain.moe is not None:
+        tile_m = (chain.matmul.M + chain.moe.num_groups - 1) // chain.moe.num_groups
+    config, cta_group = select_config(
+        tile_m,
+        chain.matmul.N,
+        chain.num_gemms,
+        K=chain.matmul.K,
+        block_scale=chain.has_block_scale,
+        b_n_major=chain.matmul.b_major == "n",
+        b_elem_bytes=DTYPE_BYTES[chain.matmul.b_dtype],
+    )
+    return as_pipeline(config, preferred_pipeline(chain)), cta_group
+
+
+def _precheck_plain(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
+    from .kernel_registry import select_template
+
+    _check_supported(chain, config)
+    _arch_reason = select_template(chain, config, cta_group).active_reject(config)
+    if _arch_reason is not None:
+        raise NotImplementedError(_arch_reason)
+    _check_dtype_config_compat(chain, config, cta_group)
+    _check_input_alignment(chain)
+    _compute_output_vec_bytes(chain)
+    _check_block_quant_supported(chain, _epi_vec_bytes(chain, config, cta_group), config, cta_group)
+
+
+def _precheck_moe(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
+    from .kernel_registry import GraphType, mma_arch_reject, select_template
+
+    reason = mma_arch_reject(chain, GraphType.MOE, config.pipeline)
+    if reason is not None:
+        raise NotImplementedError(reason)
+    if chain.matmul.a_major != "k":
+        raise NotImplementedError(
+            "MoE grouped matmul supports only K-major token: the per-group A "
+            "descriptor patch walks the token rows by their M stride "
+            f"(got token {chain.matmul.a_major}-major)"
+        )
+    _arch_reason = select_template(chain, config, cta_group).active_reject(config)
+    if _arch_reason is not None:
+        raise NotImplementedError(_arch_reason)
+    _check_dtype_config_compat(chain, config, cta_group)
+    _check_input_alignment(chain)
+    _compute_output_vec_bytes(chain)
+    _check_block_quant_supported(chain, _epi_vec_bytes(chain, config, cta_group), config, cta_group)
+
+
+def _precheck_block_scale(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
+    from .kernel_registry import select_template
+
+    _check_block_scale_supported(chain, config.pipeline)
+    _check_input_alignment(chain)
+    _epi_pipelines = ("sm100", "sm107")
+    if chain.reductions:
+        if config.pipeline not in _epi_pipelines:
+            raise NotImplementedError(f"block-scale reduction is not supported on {config.pipeline} templates")
+        for red in chain.reductions:
+            if red.compute_dtype != "fp32" or red.dtype != "fp32":
+                raise NotImplementedError("block-scale reduction supports only fp32 compute/output")
+    if chain.quants and config.pipeline not in _epi_pipelines:
+        raise NotImplementedError(f"block-scale quant epilogue is not supported on {config.pipeline} " "templates (not yet validated on sm103)")
+    _tmpl = select_template(chain, config, cta_group)
+    if chain.is_multi_gemm and not _tmpl.supports_multi_gemm:
+        raise NotImplementedError(f"block-scale multi-GEMM ({chain.num_gemms} GEMMs) is not supported by " f"{_tmpl.file} (cta_group={cta_group}).")
+    _arch_reason = _tmpl.active_reject(config)
+    if _arch_reason is not None:
+        raise NotImplementedError(_arch_reason)
+    _compute_output_vec_bytes(chain)
+    _check_block_quant_supported(chain, _epi_vec_bytes(chain, config, cta_group), config, cta_group)
+
+
+def _precheck_moe_block_scale(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
+    from .kernel_registry import GraphType, mma_arch_reject, select_template
+
+    reason = mma_arch_reject(chain, GraphType.MOE_BLOCK_SCALE, config.pipeline)
+    if reason is not None:
+        raise NotImplementedError(reason)
+    if chain.matmul.a_major != "k":
+        raise NotImplementedError(
+            "MoE block-scale matmul supports only K-major token: the per-group A "
+            "descriptor patch walks the token rows by their M stride "
+            f"(got token {chain.matmul.a_major}-major)"
+        )
+    if chain.reductions:
+        for red in chain.reductions:
+            if red.compute_dtype != "fp32" or red.dtype != "fp32":
+                raise NotImplementedError("MoE block-scale reduction supports only fp32 compute/output")
+    _check_input_alignment(chain)
+    _arch_reason = select_template(chain, config, cta_group).active_reject(config)
+    if _arch_reason is not None:
+        raise NotImplementedError(_arch_reason)
+    _compute_output_vec_bytes(chain)
+    _check_block_quant_supported(chain, _epi_vec_bytes(chain, config, cta_group), config, cta_group)
+
+
+def precheck_path(chain: FusionChain, config: TileConfig, cta_group: int) -> None:
+    """Every gate the matching ``_jit_*`` path runs before it renders anything.
+    ``probe_supported`` calls this so a graph the build will decline is never
+    reported eligible -- otherwise the engine is listed, ``build_plans`` drops
+    it, native cuDNN serves the graph and no test fails."""
+    if chain.has_moe and chain.has_block_scale:
+        _precheck_moe_block_scale(chain, config, cta_group)
+    elif chain.has_block_scale:
+        _precheck_block_scale(chain, config, cta_group)
+    elif chain.has_moe:
+        _precheck_moe(chain, config, cta_group)
+    else:
+        _precheck_plain(chain, config, cta_group)
+
+
 def probe_supported(
     graph: cudnn.pygraph,
-    config: TileConfig = DEFAULT_CONFIG,
+    config: "TileConfig | None" = None,
     *,
-    cta_group: int = 2,
+    cta_group: "int | None" = None,
 ) -> None:
     """Cheap eligibility check — the :func:`jit_from_cudnn_graph` gates WITHOUT
     ``cute.compile``. Raises if the engine can't run the graph. This is
     ``FrostGemmEngine.check_support`` (see ``cudnn/gemm/frost/engine.py``), so it
     runs for every candidate graph and must stay cheap.
 
-    Block-scale / MoE gate inside their ``_jit_*`` compile paths; here a
-    successful analysis is treated as eligible (full validation at compile)."""
+    With no explicit config it probes the (config, cta_group) ``build_gemm_plan``
+    will pick, and runs the same gate prefix that path runs -- probe and build
+    must agree or an ineligible graph is listed, dropped at build, and silently
+    served by native cuDNN."""
     # frost is written in the cutedsl these kernels compile through; below its
     # floor the engine cannot build (same gate the linear-attention engines
     # apply). Decline early so a too-old wheel falls back to the backend instead
@@ -2967,9 +3178,11 @@ def probe_supported(
     if _dtype_reason is not None:
         raise NotImplementedError(_dtype_reason)
     _check_executable(chain)
-    if chain.has_moe or chain.has_block_scale:
-        return  # specialized paths validate at compile
-    if chain.is_multi_gemm:
+    if config is None or cta_group is None:
+        _cfg, _cg = plan_config(chain)
+        config = _cfg if config is None else config
+        cta_group = _cg if cta_group is None else cta_group
+    if chain.is_multi_gemm and not (chain.has_moe or chain.has_block_scale):
         from .kernel_registry import select_template
 
         tmpl = select_template(chain, config, cta_group)
@@ -2979,14 +3192,7 @@ def probe_supported(
                 f"by the 1ctamma CLC template this pass; got cta_group={cta_group}, "
                 f"→ {tmpl.file}."
             )
-    _check_supported(chain, config)
-    from .kernel_registry import select_template as _sel_tmpl
-
-    _arch_reason = _sel_tmpl(chain, config, cta_group).active_reject(config)
-    if _arch_reason is not None:
-        raise NotImplementedError(_arch_reason)
-    _check_dtype_config_compat(chain, config, cta_group)
-    _check_input_alignment(chain)
+    precheck_path(chain, config, cta_group)
 
 
 def jit_from_cudnn_graph(
@@ -3019,17 +3225,23 @@ def jit_from_cudnn_graph(
         raise NotImplementedError(_dtype_reason)
     _check_cta_group_geometry(config, cta_group)
     _check_mma_n_dim(chain, config, cta_group)
-    # MoE grouped block-scale = both matches at once (dequant + moe_grouped);
-    # check BEFORE the single-feature gates.
-    if chain.has_moe and chain.has_block_scale:
-        return _jit_moe_block_scale(chain, config, cta_group, binding=binding)
-    # Block-scale is gated independently (own per-side case table).
-    if chain.has_block_scale:
-        return _jit_block_scale(chain, config, cta_group, binding=binding)
-    # MoE grouped matmul: own template (grouped persistent scheduler + per-group
-    # A TMA descriptor replacement).
-    if chain.has_moe:
-        return _jit_moe(chain, config, cta_group, binding=binding)
+    global _FORCE_STG_EPI
+    prev_force = _FORCE_STG_EPI
+    _FORCE_STG_EPI = force_stg_epi
+    try:
+        # MoE grouped block-scale = both matches at once (dequant + moe_grouped);
+        # check BEFORE the single-feature gates.
+        if chain.has_moe and chain.has_block_scale:
+            return _jit_moe_block_scale(chain, config, cta_group, binding=binding)
+        # Block-scale is gated independently (own per-side case table).
+        if chain.has_block_scale:
+            return _jit_block_scale(chain, config, cta_group, binding=binding)
+        # MoE grouped matmul: own template (grouped persistent scheduler + per-group
+        # A TMA descriptor replacement).
+        if chain.has_moe:
+            return _jit_moe(chain, config, cta_group, binding=binding)
+    finally:
+        _FORCE_STG_EPI = prev_force
     # Multi-GEMM is only in the 1ctamma CLC template. select_template skips
     # capability gates, so reject unsupported strategy here with a clear message
     # rather than fault deep in cute on a missing vec_f32_<g> binding.
@@ -3045,29 +3257,17 @@ def jit_from_cudnn_graph(
             )
     # Plain-matmul (pipeline × input/acc dtype combo [× GPU for the rare
     # special-case combos]) gate, then the template family's active-GPU gate.
-    _check_supported(chain, config)
-    from .kernel_registry import select_template as _sel_tmpl
-
-    _arch_reason = _sel_tmpl(chain, config, cta_group).active_reject(config)
-    if _arch_reason is not None:
-        raise NotImplementedError(_arch_reason)
-    _check_dtype_config_compat(chain, config, cta_group)
-    _check_input_alignment(chain)
-    # Eager: also raises if output alignment < 4 bytes (PTX st.b32 floor), so
-    # callers see the rejection at JIT time.
-    _compute_output_vec_bytes(chain)
-    global _FORCE_STG_EPI
+    _precheck_plain(chain, config, cta_group)
     prev_force = _FORCE_STG_EPI
     _FORCE_STG_EPI = force_stg_epi
     try:
         vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-        _check_block_quant_supported(chain, vec_bytes_epi, config, cta_group)
         use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
         snippets = generate(
             chain,
-            vec_bytes_epi=vec_bytes_epi,
+            vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
             output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
-            use_tma_store=use_tma,
+            tma_slots=tma_slots_of(use_tma),
         )
         src = _render_template(chain, snippets, config, cta_group)
     finally:
@@ -3083,7 +3283,7 @@ def jit_from_cudnn_graph(
         _launchable=mod.compile(),  # one-shot cute.compile (lru_cached in mod)
         binding=binding,
         use_tma_store=use_tma,
-        vec_bytes_epi=vec_bytes_epi,
+        vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
     )
 
 
@@ -3224,6 +3424,7 @@ class CompiledMoeGemm:
     # output descriptor when the TMA-store epilogue is on (re-dimensioned per
     # routed group so the hardware clips the ragged tail).
     _desc_slots_per_cta: int = 0
+    use_tma_store: bool = False
     accepts_stream: ClassVar[bool] = True  # stream-aware dispatch (see CompiledFusedGemm)
 
     @property
@@ -3318,13 +3519,13 @@ class CompiledMoeGemm:
             workspace,
             a,
             b,
-            *cs,
+            *_moe_launch_tail(cs, use_tma_store=self.use_tma_store),
             stream=_as_custream(stream),
         )
 
     def _call_variant_pack(self, variant_pack: dict, workspace=None, stream=None):
         a_bufs, b_bufs, out_bufs, aux_bufs, fto, _sfa, _sfb, snk = _resolve_moe_variant_pack(self, variant_pack)
-        _out_reqs = _output_align_reqs(self.chain, False, vec_bytes=self.vec_bytes_epi)
+        _out_reqs = _output_align_reqs(self.chain, tma_slots_of(self.use_tma_store), vec_bytes=self.vec_bytes_epi)
         _aux_reqs = _aux_align_reqs(self.chain, vec_bytes=self.vec_bytes_epi)
         _named = (
             [("token", x, 16, "ptr") for x in a_bufs]
@@ -3439,10 +3640,21 @@ class CompiledMoeGemm:
             workspace,
             *a_wrapped,
             *b_wrapped,
-            *cs,
-            *aux,
+            *_moe_launch_tail(cs, aux, use_tma_store=self.use_tma_store),
             stream=_as_custream(stream),
         )
+
+
+def _moe_launch_tail(cs, aux=(), *, use_tma_store: bool) -> tuple:
+    """Outputs + auxes in the host signature's order -- TAP, AUX, then the
+    trailing TMA-C slot. Under STG every dense output rides a tap slot; under
+    TMA-store slot 0 binds the TMA-only parameter and so goes LAST. MoE has no
+    recipe (``_check_executable`` returns early for it), so this is the only
+    place that order is written down."""
+    cs = list(cs)
+    if use_tma_store and cs:
+        return (*cs[1:], *aux, cs[0])
+    return (*cs, *aux)
 
 
 def _jit_moe(
@@ -3453,33 +3665,14 @@ def _jit_moe(
     binding: "GemmBinding | None" = None,
 ) -> CompiledMoeGemm:
     """JIT path for a MoE grouped matmul forward pass (mode=NONE)."""
-    from .kernel_registry import GraphType, mma_arch_reject
-
-    reason = mma_arch_reject(chain, GraphType.MOE, config.pipeline)
-    if reason is not None:
-        raise NotImplementedError(reason)
-    if chain.matmul.a_major != "k":
-        raise NotImplementedError(
-            "MoE grouped matmul supports only K-major token: the per-group A "
-            "descriptor patch walks the token rows by their M stride "
-            f"(got token {chain.matmul.a_major}-major)"
-        )
-    from .kernel_registry import select_template as _sel_tmpl
-
-    _arch_reason = _sel_tmpl(chain, config, cta_group).active_reject(config)
-    if _arch_reason is not None:
-        raise NotImplementedError(_arch_reason)
-    _check_dtype_config_compat(chain, config, cta_group)
-    _check_input_alignment(chain)
-    _compute_output_vec_bytes(chain)
+    _precheck_moe(chain, config, cta_group)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    _check_block_quant_supported(chain, vec_bytes_epi, config, cta_group)
     use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
     snippets = generate(
         chain,
-        vec_bytes_epi=vec_bytes_epi,
+        vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
-        use_tma_store=use_tma,
+        tma_slots=tma_slots_of(use_tma),
     )
     src = _render_template(chain, snippets, config, cta_group)
     mod = _import_kernel(src)
@@ -3495,8 +3688,9 @@ def _jit_moe(
         _grid_ctas=grid_ctas,
         aux_names=[aux.name for aux in chain.aux_tensors],
         binding=binding,
-        vec_bytes_epi=vec_bytes_epi,
+        vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         _desc_slots_per_cta=chain.num_a_operands + (1 if use_tma else 0),
+        use_tma_store=use_tma,
     )
 
 
@@ -3514,38 +3708,17 @@ def _jit_block_scale(
     tile-constant renderer (``validate_block_scale_config``)."""
     # Exact per-side match against the supported cases (+ arch); subsumes the
     # both-sided requirement (single-sided matches no case).
-    _check_block_scale_supported(chain, config.pipeline)
-    _check_input_alignment(chain)
-    # The sm107 templates carry the sm100 epilogue verbatim, so reductions and
-    # the quant epilogue ride it unchanged; sm103's own pipeline does not.
-    _epi_pipelines = ("sm100", "sm107")
-    if chain.reductions:
-        if config.pipeline not in _epi_pipelines:
-            raise NotImplementedError(f"block-scale reduction is not supported on {config.pipeline} templates")
-        for red in chain.reductions:
-            if red.compute_dtype != "fp32" or red.dtype != "fp32":
-                raise NotImplementedError("block-scale reduction supports only fp32 compute/output")
-    if chain.quants and config.pipeline not in _epi_pipelines:
-        raise NotImplementedError(f"block-scale quant epilogue is not supported on {config.pipeline} " "templates (not yet validated on sm103)")
-    # Per-template active-GPU SM gate (no-op when no GPU is visible).
     from .kernel_registry import select_template
 
-    _tmpl = select_template(chain, config, cta_group)
-    if chain.is_multi_gemm and not _tmpl.supports_multi_gemm:
-        raise NotImplementedError(f"block-scale multi-GEMM ({chain.num_gemms} GEMMs) is not supported by " f"{_tmpl.file} (cta_group={cta_group}).")
-    _arch_reason = _tmpl.active_reject(config)
-    if _arch_reason is not None:
-        raise NotImplementedError(_arch_reason)
-    fallback_cluster = _mixed_cga_fallback(config, cta_group, _tmpl.file)
-    _compute_output_vec_bytes(chain)  # eager: rejects bad output alignment
+    _precheck_block_scale(chain, config, cta_group)
+    fallback_cluster = _mixed_cga_fallback(config, cta_group, select_template(chain, config, cta_group).file)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    _check_block_quant_supported(chain, vec_bytes_epi, config, cta_group)
     use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
     snippets = generate(
         chain,
-        vec_bytes_epi=vec_bytes_epi,
+        vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
-        use_tma_store=use_tma,
+        tma_slots=tma_slots_of(use_tma),
     )
     src = _render_block_scale_template(chain, snippets, config, cta_group, fallback_cluster=fallback_cluster)
     mod = _import_kernel(src)
@@ -3560,7 +3733,7 @@ def _jit_block_scale(
         use_tma_store=use_tma,
         block_scale=True,
         binding=binding,
-        vec_bytes_epi=vec_bytes_epi,
+        vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
     )
 
 
@@ -3599,6 +3772,7 @@ class CompiledMoeBlockScaleGemm:
     # (its base carries start_sf_block_m and its m extent bounds the group), plus
     # the output descriptor when the TMA-store epilogue re-dimensions it per group.
     _desc_slots_per_cta: int = 0
+    use_tma_store: bool = False
     accepts_stream: ClassVar[bool] = True  # stream-aware dispatch (see CompiledFusedGemm)
 
     @property
@@ -3703,13 +3877,13 @@ class CompiledMoeBlockScaleGemm:
             b,
             msfa,
             msfb,
-            *cs,
+            *_moe_launch_tail(cs, use_tma_store=self.use_tma_store),
             stream=_as_custream(stream),
         )
 
     def _call_variant_pack(self, variant_pack: dict, workspace=None, stream=None):
         a_bufs, b_bufs, out_bufs, aux_bufs, fto, sfa, sfb, snk = _resolve_moe_variant_pack(self, variant_pack)
-        _out_reqs = _output_align_reqs(self.chain, False, vec_bytes=self.vec_bytes_epi)
+        _out_reqs = _output_align_reqs(self.chain, tma_slots_of(self.use_tma_store), vec_bytes=self.vec_bytes_epi)
         _aux_reqs = _aux_align_reqs(self.chain, vec_bytes=self.vec_bytes_epi)
         _named = (
             [("token", x, 16, "ptr") for x in a_bufs]
@@ -3838,8 +4012,7 @@ class CompiledMoeBlockScaleGemm:
             *b_wrapped,
             *sfa_wrapped,
             *sfb_wrapped,
-            *cs,
-            *aux,
+            *_moe_launch_tail(cs, aux, use_tma_store=self.use_tma_store),
             stream=_as_custream(stream),
         )
 
@@ -3861,34 +4034,15 @@ def _jit_moe_block_scale(
         select_template,
     )
 
-    reason = mma_arch_reject(chain, GraphType.MOE_BLOCK_SCALE, config.pipeline)
-    if reason is not None:
-        raise NotImplementedError(reason)
-    if chain.matmul.a_major != "k":
-        raise NotImplementedError(
-            "MoE block-scale matmul supports only K-major token: the per-group A "
-            "descriptor patch walks the token rows by their M stride "
-            f"(got token {chain.matmul.a_major}-major)"
-        )
-    if chain.reductions:
-        for red in chain.reductions:
-            if red.compute_dtype != "fp32" or red.dtype != "fp32":
-                raise NotImplementedError("MoE block-scale reduction supports only fp32 compute/output")
-    _check_input_alignment(chain)
-    # Per-template active-GPU SM gate (no-op when no GPU is visible).
+    _precheck_moe_block_scale(chain, config, cta_group)
     _tmpl = select_template(chain, config, cta_group)
-    _arch_reason = _tmpl.active_reject(config)
-    if _arch_reason is not None:
-        raise NotImplementedError(_arch_reason)
-    _compute_output_vec_bytes(chain)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
     use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
-    _check_block_quant_supported(chain, vec_bytes_epi, config, cta_group)
     snippets = generate(
         chain,
-        vec_bytes_epi=vec_bytes_epi,
+        vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
-        use_tma_store=use_tma,
+        tma_slots=tma_slots_of(use_tma),
     )
     src = _render_block_scale_template(chain, snippets, config, cta_group, fallback_cluster=_mixed_cga_fallback(config, cta_group, _tmpl.file))
     mod = _import_kernel(src)
@@ -3903,6 +4057,7 @@ def _jit_moe_block_scale(
         _launchable=mod.compile(),
         _grid_ctas=grid_ctas,
         binding=binding,
-        vec_bytes_epi=vec_bytes_epi,
+        vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         _desc_slots_per_cta=chain.num_a_operands * 2 + (1 if use_tma else 0),
+        use_tma_store=use_tma,
     )

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -1551,7 +1551,10 @@ def _render_block_scale_tile_constants(
         f"vec_bytes_epi = {vec_bytes_epi}",
         f"frost_compile_options = {_frost_compile_options()!r}",
         f"use_tma_store_epi = {use_tma_store_epi}",
-        f"n_tma_outputs = {1 if use_tma_store_epi else 0}",
+        # The COUNT, not the flag: a block-scale graph can put more than one
+        # output on the TMA-C surface, and on MoE this number also sizes the
+        # tensormap scratch and the per-CTA workspace stride.
+        f"n_tma_outputs = {len(_tma_slots_for(chain, cfg, cta_group, vec_bytes_epi))}",
         f"epi_slot_widen = {_epi_slot_widen(chain)}",
         f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma_store_epi)}",
         f"cd_out_is_m_major = {chain.out_major == 'm'}",

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -2860,11 +2860,14 @@ def _tma_store_n_major_ok(chain, cfg, cta_group: int, vec_bytes_epi: int) -> boo
 
 
 def _tma_store_m_major_ok(chain, cfg, cta_group: int) -> bool:
-    """The M-major arm is `tcgen05.ld 16x256b -> stmatrix.trans -> utmastg`. It
-    re-reads TMEM itself, runs the snippet TWICE under `for _h in range(2)`, and
-    `row` / `col_j` are the subtile base rather than the coordinates of the
-    fragment a lane holds -- so everything coordinate-reading or side-effecting
-    is out by construction, not pending."""
+    """The M-major arm is `tcgen05.ld 16x256b -> stmatrix.trans -> utmastg`: it
+    re-reads TMEM itself and each lane owns a TRANSPOSED patch, so `row` /
+    `col_j` are the subtile base rather than this element's coordinates.
+
+    Coordinate-READING pointwise inputs are served by `_mmajor_elem_coord` and do
+    not appear here. What is left splits three ways: real properties of the
+    transpose (output width, drain width, M alignment), a template gap (MoE), and
+    side effects that still have no per-register form."""
     # stmatrix.m8n8 has no b32 payload form.
     if DTYPE_BITS[chain.output_dtype] != _TMA_STORE_M_MAJOR_OUT_BITS:
         return False
@@ -2880,12 +2883,10 @@ def _tma_store_m_major_ok(chain, cfg, cta_group: int) -> bool:
     # to bind for the extra GEMMs.
     if chain.is_multi_gemm:
         return False
-    # Coordinate-reading pointwise inputs and side effects: wrong coordinates,
-    # and the double pass would fire each side effect twice.
-    if any(a.bcast_mode != "scalar" for a in chain.aux_tensors):
-        return False
-    if any(op.op == "gen_index" for op in chain.ops):
-        return False
+    # Side effects still wait: an extra dense output goes through
+    # `_emit_mmajor_scatter`, which has no per-register arm, and reductions /
+    # quants have no in-chunk mask. Coordinate-READING pointwise inputs are
+    # served by `_mmajor_elem_coord` and no longer gate this arm.
     if len(chain.output_specs) > 1 or chain.reductions or chain.quants:
         return False
     # 16x256b TMEM-load + stmatrix.trans + tma_store all move 16-byte units of M.

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -41,8 +41,6 @@ def _as_custream(stream):
 
 from .dtypes import (
     DTYPE_BITS,
-    _TMA_SLOTS_0,
-    tma_slots_of,
     DTYPE_BYTES,
     DTYPE_TO_CUTLASS,
     DTYPE_TO_MMA_KIND,
@@ -56,7 +54,7 @@ from .dtypes import (
     dtype_arch_reject,
     tensor_alignment,
 )
-from .epilogue_codegen import EpilogueSnippets, generate
+from .epilogue_codegen import EpilogueSnippets, generate, tma_out_value
 from .fusion_ir import ZERO_PRESERVING_OPS, FusionChain, TensorRef
 from .recipe import (
     CONST,
@@ -235,17 +233,133 @@ def _aux_call_block(aux_tensors: list[TensorRef], prefix: str = "") -> str:
     return ",\n".join(f"{prefix}{aux.name}" for aux in aux_tensors) + ","
 
 
-def _tma_c_plumbing(chain: FusionChain) -> dict[str, str]:
-    n_out = len(_TMA_SLOTS_0)
+def _tma_c_plumbing(chain: FusionChain, tma_slots: "frozenset[int]" = frozenset({0})) -> dict[str, str]:
+    """Kernel / host / compile plumbing for the outputs on the TMA-C surface.
+
+    One C descriptor per TMA slot, numbered 0..k-1 in SLOT order -- the kernel
+    never sees the slot number, only its own index into `tma_c_descs`. The count
+    is a property of the STORE PLAN, not of the chain: an output that takes STG
+    passes as an ordinary tap instead."""
+    n_out = max(1, len(tma_slots))
     return {
         "INJECT_KERNEL_TMA_C_PARAMS": ",\n".join(f"tma_c_desc_{i}: cutlass.GridConstant[_tma.TensorMap]" for i in range(n_out)) + ",",
         "INJECT_TMA_C_LISTS": "tma_c_descs = [" + ", ".join(f"tma_c_desc_{i}" for i in range(n_out)) + "]",
         "INJECT_HOST_TMA_C_PARAMS": ",\n".join(f"c_{i}: cute.Tensor" for i in range(n_out)) + ",",
         "INJECT_HOST_TMA_C_LISTS": "_tma_c_outputs = [" + ", ".join(f"c_{i}" for i in range(n_out)) + "]",
         "INJECT_HOST_TMA_C_PASS": ",\n".join(f"tma_c_desc_list[{i}]" for i in range(n_out)) + ",",
-        "INJECT_COMPILE_TMA_C_FAKES": "\n".join(f"fake_c_{i} = _make_fake_c()" for i in range(n_out)),
+        "INJECT_COMPILE_TMA_C_FAKES": "\n".join(
+            f"fake_c_{j} = _make_fake_c({_cd_cutlass(dt)}, {2 if dt == 'fp4_e2m1' else 1})"
+            for j, (_slot, dt) in enumerate(_tma_out_dtypes(chain, tma_slots) or [(0, chain.output_dtype)])
+        ),
         "INJECT_COMPILE_TMA_C_PASS": ",\n".join(f"fake_c_{i}" for i in range(n_out)) + ",",
     }
+
+
+def _tma_out_dtypes(chain: FusionChain, tma_slots: "frozenset[int]") -> "list[tuple[int, str]]":
+    """(dense slot, dtype) for each output on the TMA-C surface, in slot order."""
+    return [(i, chain.output_specs[i].dtype) for i in sorted(tma_slots) if i < len(chain.output_specs)]
+
+
+def _cd_cutlass(dt: str) -> str:
+    return "cutlass.Int8" if dt == "fp4_e2m1" else DTYPE_TO_CUTLASS[dt]
+
+
+def _tma_store_sequence(chain, cfg, cta_group: int, tma_slots: "frozenset[int]", epi_n: int) -> str:
+    """The N-major TMA arm, unrolled once per TMA-stored output.
+
+    All of them walk the SAME SMEM ring: the slot is sized for the widest, and
+    each output takes its OWN typed view of it (`Array(base=...)`), so N outputs
+    cost no extra SMEM. `epi_n` is a COLUMN count and is shared; what differs per
+    output is the row BYTES, and with them the swizzle. Unrolling here rather
+    than looping in the template keeps the dtypes and swizzles compile-time
+    without a const_expr-indexed table."""
+    rows = cfg.epi_tile_mn[0]
+    lines: list[str] = []
+    for j, (slot, dt) in enumerate(_tma_out_dtypes(chain, tma_slots)):
+        row_bytes = epi_n * DTYPE_BYTES[dt]
+        b, _tma_sw = _EPI_SWIZZLE_BY_ROW_BYTES[row_bytes]
+        v = f"_tsv_{j}"
+        lines += [
+            "epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES",
+            f"{v} = cutlass.Array(base=smem_d_ptr.data_ptr(epi_stage_idx * epi_subtile_elems), shape={rows * epi_n}, dtype={_cd_cutlass(dt)})",
+            f"{v}.data_ptr(tidx * subtile_w).store_swizzled({tma_out_value(j)}, alignment={row_bytes}, swizzle=cutlass.Swizzle({b}, 4, 3))",
+            "cute.arch.fence_view_async_shared()",
+            "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
+            "if warp_idx == 0:",
+            "    if elect_one:",
+            "        nvvm.cp_async_bulk_tensor_global_shared_cta(",
+            # MoE re-dimensions D per routed group, so it issues through the
+            # patched workspace copy rather than the static kernel parameter.
+            f"            {f'd_desc_ptr_list[{j}]' if chain.has_moe else f'tma_c_descs[{j}].get_ptr()'},",
+            f"            {v}.data_ptr(),",
+            "            (col, coord_m, tile_l),",
+            "        )",
+            "    if elect_one:",
+            "        nvvm.cp_async_bulk_commit_group()",
+            "    nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)",
+            "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
+        ]
+    return "\n".join(lines) if lines else "pass"
+
+
+def _host_tma_c_descs(chain, cfg, cta_group: int, tma_slots: "frozenset[int]", epi_n: int) -> str:
+    """Build one C descriptor per TMA-stored output. Each carries its OWN dtype,
+    strides and swizzle; the M-major arm is single-output by construction (its
+    gate rejects extra dense outputs), so it keeps the transposed box."""
+    outs = _tma_out_dtypes(chain, tma_slots)
+    lines: list[str] = []
+    for j, (slot, dt) in enumerate(outs):
+        width = DTYPE_BITS[dt]
+        cud = _cd_cutlass(dt)
+        row_bytes = epi_n * DTYPE_BYTES[dt]
+        _b, tma_sw = _EPI_SWIZZLE_BY_ROW_BYTES[row_bytes]
+        if chain.has_moe:
+            lines += [
+                f"_c{j} = _tma_c_outputs[{j}]",
+                f"tma_c_desc_{j} = _tma.create_tensor_map_tiled(",
+                f"    global_address=_c{j}.iterator.toint(),",
+                f"    dtype={cud},",
+                "    global_dims=[n, m, 1],",
+                "    global_strides=[",
+                f"        out_stride_m_{slot} * {width} // 128,",
+                f"        out_stride_l_{slot} * {width} // 128,",
+                "    ],",
+                f"    box_dims=[{epi_n}, epi_tile_mn[0], 1],",
+                f"    swizzle=_tma.TensorMapSwizzle.{tma_sw},",
+                ")",
+            ]
+        elif chain.out_major == "m":
+            lines += [
+                f"_c{j} = _tma_c_outputs[{j}]",
+                f"tma_c_desc_{j} = _tma.create_tensor_map_tiled(",
+                f"    global_address=_c{j}.iterator.toint(),",
+                f"    dtype={cud},",
+                "    global_dims=[m, n, batch],",
+                "    global_strides=[",
+                f"        out_stride_n_{slot} * {width} // 128,",
+                f"        out_stride_l_{slot} * {width} // 128,",
+                "    ],",
+                "    box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],",
+                "    swizzle=_tma.TensorMapSwizzle.s128b,",
+                ")",
+            ]
+        else:
+            lines += [
+                f"_c{j} = _tma_c_outputs[{j}]",
+                f"tma_c_desc_{j} = _tma.create_tensor_map_tiled(",
+                f"    global_address=_c{j}.iterator.toint(),",
+                f"    dtype={cud},",
+                "    global_dims=[n, m, batch],",
+                "    global_strides=[",
+                f"        out_stride_m_{slot} * {width} // 128,",
+                f"        out_stride_l_{slot} * {width} // 128,",
+                "    ],",
+                f"    box_dims=[{epi_n}, epi_tile_mn[0], 1],",
+                f"    swizzle=_tma.TensorMapSwizzle.{tma_sw},",
+                ")",
+            ]
+    lines.append("tma_c_desc_list = [" + ", ".join(f"tma_c_desc_{j}" for j in range(len(outs))) + "]")
+    return "\n".join(lines)
 
 
 def _reduction_stride_kernel_params(chain: FusionChain) -> str:
@@ -732,8 +846,10 @@ def _render_tile_constants(
     lines.append(f"frost_compile_options = {_frost_compile_options()!r}")
     # Epilogue store mode: TMA-store-via-SMEM (preferred) vs per-thread STG
     # (fallback). See _use_tma_store_epi() for gating.
-    use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, cfg, vec_bytes_epi, cta_group)
+    use_tma = _use_tma_store_epi(chain, cfg, vec_bytes_epi, cta_group)
     lines.append(f"use_tma_store_epi = {use_tma}")
+    lines.append(f"n_tma_outputs = {len(_tma_slots_for(chain, cfg, cta_group, vec_bytes_epi))}")
+    lines.append(f"epi_slot_widen = {_epi_slot_widen(chain)}")
     lines.append(f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma)}")
     # Final ab_stages override: account for the TMA-D SMEM buffer (fixed, when
     # TMA-store is active) AND a mixed-input mainloop's narrow LOAD buffer
@@ -1435,6 +1551,8 @@ def _render_block_scale_tile_constants(
         f"vec_bytes_epi = {vec_bytes_epi}",
         f"frost_compile_options = {_frost_compile_options()!r}",
         f"use_tma_store_epi = {use_tma_store_epi}",
+        f"n_tma_outputs = {1 if use_tma_store_epi else 0}",
+        f"epi_slot_widen = {_epi_slot_widen(chain)}",
         f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma_store_epi)}",
         f"cd_out_is_m_major = {chain.out_major == 'm'}",
         f"cd_fake_n_div = {2 if out_dt == 'fp4_e2m1' else 1}",
@@ -1609,7 +1727,9 @@ def _render_template(
     # Strip the unused epilogue path FIRST so its @@INJECT_EPILOGUE@@ marker
     # doesn't survive into the marker-replacement step.
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
+    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    tma_slots = frozenset(i for i, m in enumerate(store_modes) if m == "tma")
+    use_tma = bool(tma_slots)
     src = _resolve_path_blocks(src, use_tma)
 
     aux_tensors = chain.aux_tensors
@@ -1725,7 +1845,11 @@ def _render_template(
             }
         )
     if "@@INJECT_KERNEL_TMA_C_PARAMS@@" in src:
-        replacements.update(_tma_c_plumbing(chain))
+        replacements.update(_tma_c_plumbing(chain, tma_slots))
+    if "@@INJECT_TMA_STORE_SEQUENCE@@" in src:
+        _epi = _epi_n(config, cta_group, chain.output_dtype)
+        replacements["INJECT_TMA_STORE_SEQUENCE"] = _tma_store_sequence(chain, config, cta_group, tma_slots, _epi)
+        replacements["INJECT_HOST_TMA_C_DESCS"] = _host_tma_c_descs(chain, config, cta_group, tma_slots, _epi)
     # Per-GEMM STG vector bindings — on every STG-epilogue template (mainloop
     # included; single-GEMM → `pass`).
     if "@@INJECT_STG_VEC_BINDINGS@@" in src:
@@ -1775,7 +1899,9 @@ def _render_block_scale_template(
     template_path = _TEMPLATE_DIR / tmpl.file
     src = template_path.read_text()
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
+    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    tma_slots = frozenset(i for i, m in enumerate(store_modes) if m == "tma")
+    use_tma = bool(tma_slots)
     src = _resolve_path_blocks(src, use_tma_store_epi=use_tma)
 
     aux_tensors = chain.aux_tensors
@@ -1932,7 +2058,11 @@ def _render_block_scale_template(
     if "@@INJECT_STG_VEC_BINDINGS@@" in src:
         replacements["INJECT_STG_VEC_BINDINGS"] = stg_vec_bindings
     if "@@INJECT_KERNEL_TMA_C_PARAMS@@" in src:
-        replacements.update(_tma_c_plumbing(chain))
+        replacements.update(_tma_c_plumbing(chain, tma_slots))
+    if "@@INJECT_TMA_STORE_SEQUENCE@@" in src:
+        _epi = _epi_n(config, cta_group, chain.output_dtype)
+        replacements["INJECT_TMA_STORE_SEQUENCE"] = _tma_store_sequence(chain, config, cta_group, tma_slots, _epi)
+        replacements["INJECT_HOST_TMA_C_DESCS"] = _host_tma_c_descs(chain, config, cta_group, tma_slots, _epi)
     # MoE block-scale raw-A-tensor plumbing (per-routed-group descriptor patch).
     if "@@INJECT_MOE_KERNEL_MA_PARAMS@@" in src:
         replacements.update(
@@ -2206,13 +2336,22 @@ class CompiledFusedGemm:
     block_scale: bool = False  # block-scaled matmul (FP4/FP8 + SF)
     device: int = 0  # CUDA device this plan's baked constants describe
     binding: "GemmBinding | None" = None  # role -> cuDNN tensor (variant-pack call)
-    # TMA-store mode: the single dense output binds the template's trailing
-    # TMA-only params (passed LAST); STG passes every output as a tap.
+    # Per-dense-output store mode ("tma" | "stg"). `use_tma_store` is the derived
+    # "did the kernel render the TMA arm" -- the template question, not the
+    # output's. A TMA slot binds the template's trailing TMA-only params (passed
+    # LAST); every other output passes as a tap.
+    store_modes: tuple = ()
     use_tma_store: bool = False
     # The epilogue chunk width (bytes) the kernel was RENDERED with (tile-
     # clamped); drives the runtime output/aux alignment requirements. None →
     # fall back to the chain-derived width.
     vec_bytes_epi: "int | None" = None
+
+    @property
+    def tma_slots(self) -> "frozenset[int]":
+        """Which dense output slots ride the TMA-C surface."""
+        return frozenset(i for i, m in enumerate(self.store_modes) if m == "tma")
+
     # Opt in to stream-aware dispatch: frost/dispatch.py resolves the stream
     # from the execute-time cuDNN handle and forwards it as `stream=`. Engines
     # that do not carry the param stay on the default stream (see dispatch).
@@ -2777,12 +2916,14 @@ def _epi_n(cfg, cta_group: int, out_dt: str) -> int:
     return 1 << (n.bit_length() - 1)
 
 
-def _epi_swizzle_ok(cfg, cta_group: int, out_dt: str) -> bool:
+def _epi_swizzle_ok(cfg, cta_group: int, out_dt: str, epi_n: "int | None" = None) -> bool:
     """Does the TMA-store staging row have a swizzle? A subtile row outside
     {32,64,128} bytes has none, which makes the tmastg SMEM stage inexpressible
     -- a store-stage predicate, so it declines the TMA arm rather than the whole
     render (the STG arm never touches the swizzle)."""
-    return _epi_n(cfg, cta_group, out_dt) * DTYPE_BYTES[out_dt] in _EPI_SWIZZLE_BY_ROW_BYTES
+    if epi_n is None:
+        epi_n = _epi_n(cfg, cta_group, out_dt)
+    return epi_n * DTYPE_BYTES[out_dt] in _EPI_SWIZZLE_BY_ROW_BYTES
 
 
 def _epi_swizzle_lines(cfg, cta_group: int, out_dt: str) -> list[str]:
@@ -2797,69 +2938,53 @@ def _epi_swizzle_lines(cfg, cta_group: int, out_dt: str) -> list[str]:
     ]
 
 
+def _epi_slot_widen(chain) -> int:
+    """The ring is TYPED as the primary slot's dtype but SHARED by every
+    TMA-stored output, so one slot has to span the WIDEST of them. `epi_n` (a
+    column count) is common; the element width is not."""
+    if not chain.output_specs:
+        return 1
+    widest = max(DTYPE_BYTES[o.dtype] for o in chain.output_specs)
+    return max(1, widest // DTYPE_BYTES[chain.output_dtype])
+
+
 def _smem_d_bytes(cfg, chain, cta_group: int) -> int:
     """SMEM-D buffer bytes for the TMA-store epilogue: `_EPI_SMEM_STAGES` slots of
     one epilogue subtile (one MMA-M block x epi_n) + a 16-byte alignment pad. With
     num_mma_m > 1 the M blocks reuse the same slots. epi_n MUST be the same value
     the kernel renders, or the reserve under-counts and the launch is rejected."""
     out_dt = chain.output_dtype
-    return _EPI_SMEM_STAGES * cfg.epi_tile_mn[0] * _epi_n(cfg, cta_group, out_dt) * DTYPE_BYTES[out_dt] + 16
+    return _EPI_SMEM_STAGES * cfg.epi_tile_mn[0] * _epi_n(cfg, cta_group, out_dt) * DTYPE_BYTES[out_dt] * _epi_slot_widen(chain) + 16
 
 
-def _tma_store_geometry_ok(chain, cfg, cta_group: int) -> bool:
-    """The store rules that hold on BOTH arms -- pure geometry and output width,
-    nothing about the chain's shape."""
+def _tma_store_geometry_ok(spec, cfg, cta_group: int, epi_n: int) -> bool:
+    """The store rules that hold on BOTH arms -- pure geometry and this output's
+    width, nothing about the chain's shape."""
     # Only the 128-rows-per-MMA-block thread->row layout is wired; an M=64 MMA
     # block drains through the packed lane<16 layout.
     if cfg.mma_inst_m != 128:
         return False
     # WIDTH, not dtype: store_swizzled and the descriptor are width-functions.
-    if DTYPE_BITS[chain.output_dtype] < _TMA_STORE_MIN_OUT_BITS:
+    if DTYPE_BITS[spec.dtype] < _TMA_STORE_MIN_OUT_BITS:
         return False
     # The SMEM staging row must be a width the swizzle table can express.
-    if not _epi_swizzle_ok(cfg, cta_group, chain.output_dtype):
+    if not _epi_swizzle_ok(cfg, cta_group, spec.dtype, epi_n):
         return False
     # An N-tile that is not a whole number of subtiles would TMA-store an
     # epi_n-wide box past the tile edge into the neighbouring tile (TMA clamps
     # only at the GLOBAL extent).
-    if _epi_tile_cols(cfg, cta_group) % _epi_n(cfg, cta_group, chain.output_dtype) != 0:
+    if _epi_tile_cols(cfg, cta_group) % epi_n != 0:
         return False
     return True
 
 
-def _tma_store_n_major_ok(chain, cfg, cta_group: int, vec_bytes_epi: int) -> bool:
-    """What still keeps an N-major graph off the TMA-store arm.
-
-    One of these is a real store rule; the other two are unfinished work, and
-        both need the same missing piece -- a per-element mask INSIDE the trailing
-        chunk. The arm exists precisely to serve a tile that overhangs N, and a
-        chunk-granular guard would silently drop the valid prefix of a straddling
-        subtile (a missed atomic / a missing scale byte, not a fault). Taps escape
-        that because `_tap_store_elems` divides both N and `col_j`."""
-    # REAL: the C descriptor encodes its global row stride in 16-BYTE units, so a
-    # row that is not a whole number of them is silently misaddressed (N=255 bf16:
-    # 510 // 16 = 31 -> rows read at 496 bytes). `_epi_vec_bytes` is the output's
-    # own row alignment clamped to the subtile spans, and the clamp never binds
-    # here -- `_tma_store_geometry_ok` already forces a >= 16-byte staging row that
-    # divides the N-tile. Measured: 0 over-rejections over 5400 (config, cta_group)
-    # pairs x 5 values of N. The SMEM side is `_epi_swizzle_ok`, not this.
+def _tma_store_n_major_ok(chain, spec, cfg, cta_group: int, vec_bytes_epi: int) -> bool:
     if vec_bytes_epi < 16:
         return False
-    # TODO(gate 5): reductions are atomic RMWs -- one folded per chunk when N is
-    # the reduced axis, one per element otherwise. A clamp is inadmissible for a
-    # read-modify-write, so they wait for the in-chunk mask.
-    if chain.reductions:
-        return False
-    # TODO(gate 6): the quant VALUE transform is already arm-correct, but the
-    # scale store is a per-chunk side effect, and a straddling chunk's amax would
-    # fold in columns past N -- so even the surviving columns' scale is wrong.
-    # Also needs `.to_vector()` on the two block-quant emitters first.
-    if chain.quants:
-        return False
     return True
 
 
-def _tma_store_m_major_ok(chain, cfg, cta_group: int) -> bool:
+def _tma_store_m_major_ok(chain, spec, cfg, cta_group: int, epi_n: int) -> bool:
     """The M-major arm is `tcgen05.ld 16x256b -> stmatrix.trans -> utmastg`: it
     re-reads TMEM itself and each lane owns a TRANSPOSED patch, so `row` /
     `col_j` are the subtile base rather than this element's coordinates.
@@ -2869,12 +2994,12 @@ def _tma_store_m_major_ok(chain, cfg, cta_group: int) -> bool:
     transpose (output width, drain width, M alignment), a template gap (MoE), and
     side effects that still have no per-register form."""
     # stmatrix.m8n8 has no b32 payload form.
-    if DTYPE_BITS[chain.output_dtype] != _TMA_STORE_M_MAJOR_OUT_BITS:
+    if DTYPE_BITS[spec.dtype] != _TMA_STORE_M_MAJOR_OUT_BITS:
         return False
     # The transpose ledger is `for _blk in range(epi_n // 16)` over 4-register
     # stmatrix tiles, so a narrower drain emits ZERO stores and the output keeps
     # whatever the buffer held -- silent, not a fault.
-    if _epi_n(cfg, cta_group, chain.output_dtype) < _TMA_STORE_M_MAJOR_MIN_EPI_N:
+    if epi_n < _TMA_STORE_M_MAJOR_MIN_EPI_N:
         return False
     # The six MoE templates carry only the N-major TMA store.
     if chain.has_moe:
@@ -2890,24 +3015,104 @@ def _tma_store_m_major_ok(chain, cfg, cta_group: int) -> bool:
     if len(chain.output_specs) > 1 or chain.reductions or chain.quants:
         return False
     # 16x256b TMEM-load + stmatrix.trans + tma_store all move 16-byte units of M.
-    return chain.matmul.M % (16 // DTYPE_BYTES[chain.output_dtype]) == 0
+    return chain.matmul.M % (16 // DTYPE_BYTES[spec.dtype]) == 0
+
+
+def _output_chunk_ok(chain, cfg, cta_group: int) -> bool:
+    """Can EVERY output be produced at the TMA arm's chunk width?
+
+    The store is per-output, but the chunk is shared geometry -- one LDTM feeds
+    them all -- so an output whose correctness depends on the chunk constrains
+    the arm for everyone. Two do:
+
+    * a block-quantized output folds an amax over whole blocks of the chunk and
+      emits one scale per block, so the block size must divide the chunk;
+    * a reduction folds the chunk (when N is the reduced axis) or walks it
+      element-wise, and an atomic RMW cannot be clamped -- so a chunk straddling
+      N would fold real columns together with OOB ones.
+
+    Both were checked against the STG chunk, which `_compute_output_vec_bytes`
+    pins to the quant block size. The TMA arm's chunk is `epi_n` instead, so the
+    same facts have to hold there. `N % chunk == 0` is what lets the emitters
+    bound a whole chunk at a time instead of masking inside one.
+    """
+    if not chain.output_specs:
+        return True
+    epi = _epi_n(cfg, cta_group, chain.output_dtype)
+    if chain.reductions and chain.matmul.N % epi != 0:
+        return False
+    for spec in chain.output_specs:
+        if spec.quant_idx is None:
+            continue
+        if chain.matmul.N % epi != 0:
+            return False
+        if epi % chain.quants[spec.quant_idx].block_size != 0:
+            return False
+    return True
+
+
+def _output_store_mode(out, chain, cfg, cta_group: int, vec_bytes_epi: int) -> str:
+    """How is THIS output stored? Decided from the output itself plus the
+    geometry it is stored with -- never from what the OTHER outputs need.
+
+    A reduction and a quant's scale factor are not dense surfaces: the first is
+    an atomic RMW, the second a per-chunk side store, and neither has a C
+    descriptor to bind. They take STG, which says nothing about the dense
+    outputs beside them -- a quant's DATA output is an ordinary dense output.
+    """
+    if out.is_reduction or out.is_quant_scale:
+        return "stg"
+    # The kernel renders ONE arm and it follows slot 0's layout, so an output laid
+    # out the other way has no store sequence to ride. Every non-virtual output is
+    # meant to carry the SAME layout, so this should be unreachable -- but nothing
+    # enforces it yet, and without the guard the odd one out would take a TMA slot
+    # and be stored by the wrong arm.
+    # TODO: the M-major output path is due a refactor that supports MIXED
+    # m/n-major alongside tmastg; this conjunct goes away with it.
+    if out.major != chain.out_major:
+        return "stg"
+    # ONE rendered column count for the whole epilogue: `epi_n` is a COLUMN count
+    # and comes from the primary slot's dtype. What differs per output is the ROW
+    # BYTES, `epi_n * its own element width`, and with them the swizzle.
+    epi_n = _epi_n(cfg, cta_group, chain.output_dtype)
+    if not _tma_store_geometry_ok(out, cfg, cta_group, epi_n):
+        return "stg"
+    if not _output_chunk_ok(chain, cfg, cta_group):
+        return "stg"
+    if out.major == "m":
+        return "tma" if _tma_store_m_major_ok(chain, out, cfg, cta_group, epi_n) else "stg"
+    return "tma" if _tma_store_n_major_ok(chain, out, cfg, cta_group, vec_bytes_epi) else "stg"
+
+
+def _store_modes(chain, cfg, cta_group: int, vec_bytes_epi: int) -> tuple[str, ...]:
+    """One store mode per output, in `chain.outputs` slot order.
+
+    Every TMA-stored output shares ONE SMEM ring -- the slot is sized for the
+    widest of them and each takes its own typed view -- so there is no budget to
+    spend: an output takes the surface iff it is eligible. MoE additionally gives
+    each one a workspace slot and a scratch copy of the D descriptor, which it
+    re-dimensions per routed group. What still follows SLOT 0 is the arm the
+    kernel renders, and with it the TMEM load shape (`cd_out_is_m_major`).
+    """
+    outs = chain.outputs
+    if _FORCE_STG_EPI:
+        return ("stg",) * len(outs)
+    modes = ["stg"] * len(outs)
+    for i in range(len(chain.output_specs)):
+        modes[i] = _output_store_mode(outs[i], chain, cfg, cta_group, vec_bytes_epi)
+    return tuple(modes)
+
+
+def _tma_slots_for(chain, cfg, cta_group: int, vec_bytes_epi: int) -> "frozenset[int]":
+    return frozenset(i for i, m in enumerate(_store_modes(chain, cfg, cta_group, vec_bytes_epi)) if m == "tma")
 
 
 def _use_tma_store_epi(chain, cfg, vec_bytes_epi: int, cta_group: int) -> bool:
-    """Gate for the TMA-store epilogue path: the geometry rules both arms share,
-    then the arm's own. Split by output major because the two arms have almost
-    nothing in common past the staging buffer -- see the two helpers."""
-    if not chain.output_specs:
-        # A reduction/amax-only chain has no dense output to bind the TMA-C
-        # slot, and `chain.output_dtype` / `out_major` then answer for a slot
-        # that does not exist -- it would report slot 0 and bind reduction_0 to
-        # the C descriptor. Do not rely on the reduction/quant rules for this.
-        return False
-    if not _tma_store_geometry_ok(chain, cfg, cta_group):
-        return False
-    if chain.out_major == "m":
-        return _tma_store_m_major_ok(chain, cfg, cta_group)
-    return _tma_store_n_major_ok(chain, cfg, cta_group, vec_bytes_epi)
+    """Does the kernel render the TMA-store arm at all? True iff some output
+    takes it -- the renderer deletes one of `@@STG_ONLY@@` / `@@TMA_STORE_ONLY@@`,
+    so this is a property of the TEMPLATE, while `_store_modes` is the per-output
+    answer the emitters consume."""
+    return "tma" in _store_modes(chain, cfg, cta_group, vec_bytes_epi)
 
 
 def _check_block_quant_supported(
@@ -3263,12 +3468,13 @@ def jit_from_cudnn_graph(
     _FORCE_STG_EPI = force_stg_epi
     try:
         vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-        use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
+        store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+        use_tma = "tma" in store_modes
         snippets = generate(
             chain,
             vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
             output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
-            tma_slots=tma_slots_of(use_tma),
+            tma_slots=frozenset(i for i, m in enumerate(store_modes) if m == "tma"),
         )
         src = _render_template(chain, snippets, config, cta_group)
     finally:
@@ -3283,6 +3489,7 @@ def jit_from_cudnn_graph(
         generated_path=_cache_dir() / f"gen_{digest}" / "generated_kernel.py",
         _launchable=mod.compile(),  # one-shot cute.compile (lru_cached in mod)
         binding=binding,
+        store_modes=store_modes,
         use_tma_store=use_tma,
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
     )
@@ -3425,8 +3632,14 @@ class CompiledMoeGemm:
     # output descriptor when the TMA-store epilogue is on (re-dimensioned per
     # routed group so the hardware clips the ragged tail).
     _desc_slots_per_cta: int = 0
+    store_modes: tuple = ()
     use_tma_store: bool = False
     accepts_stream: ClassVar[bool] = True  # stream-aware dispatch (see CompiledFusedGemm)
+
+    @property
+    def tma_slots(self) -> "frozenset[int]":
+        """Which dense output slots ride the TMA-C surface."""
+        return frozenset(i for i, m in enumerate(self.store_modes) if m == "tma")
 
     @property
     def workspace_bytes(self) -> int:
@@ -3520,13 +3733,13 @@ class CompiledMoeGemm:
             workspace,
             a,
             b,
-            *_moe_launch_tail(cs, use_tma_store=self.use_tma_store),
+            *_moe_launch_tail(cs, tma_slots=self.tma_slots),
             stream=_as_custream(stream),
         )
 
     def _call_variant_pack(self, variant_pack: dict, workspace=None, stream=None):
         a_bufs, b_bufs, out_bufs, aux_bufs, fto, _sfa, _sfb, snk = _resolve_moe_variant_pack(self, variant_pack)
-        _out_reqs = _output_align_reqs(self.chain, tma_slots_of(self.use_tma_store), vec_bytes=self.vec_bytes_epi)
+        _out_reqs = _output_align_reqs(self.chain, self.tma_slots, vec_bytes=self.vec_bytes_epi)
         _aux_reqs = _aux_align_reqs(self.chain, vec_bytes=self.vec_bytes_epi)
         _named = (
             [("token", x, 16, "ptr") for x in a_bufs]
@@ -3641,21 +3854,21 @@ class CompiledMoeGemm:
             workspace,
             *a_wrapped,
             *b_wrapped,
-            *_moe_launch_tail(cs, aux, use_tma_store=self.use_tma_store),
+            *_moe_launch_tail(cs, aux, tma_slots=self.tma_slots),
             stream=_as_custream(stream),
         )
 
 
-def _moe_launch_tail(cs, aux=(), *, use_tma_store: bool) -> tuple:
-    """Outputs + auxes in the host signature's order -- TAP, AUX, then the
-    trailing TMA-C slot. Under STG every dense output rides a tap slot; under
-    TMA-store slot 0 binds the TMA-only parameter and so goes LAST. MoE has no
-    recipe (``_check_executable`` returns early for it), so this is the only
-    place that order is written down."""
+def _moe_launch_tail(cs, aux=(), *, tma_slots: "frozenset[int]" = frozenset()) -> tuple:
+    """Outputs + auxes in the host signature's order -- TAPS, AUX, then the
+    trailing TMA-C slots in slot order. An output on the TMA surface binds a
+    TMA-only parameter and so goes LAST; every other one rides a tap slot. MoE
+    has no recipe (``_check_executable`` returns early for it), so this is the
+    only place that order is written down."""
     cs = list(cs)
-    if use_tma_store and cs:
-        return (*cs[1:], *aux, cs[0])
-    return (*cs, *aux)
+    taps = [c for i, c in enumerate(cs) if i not in tma_slots]
+    tmas = [cs[i] for i in sorted(tma_slots) if i < len(cs)]
+    return (*taps, *aux, *tmas)
 
 
 def _jit_moe(
@@ -3668,12 +3881,13 @@ def _jit_moe(
     """JIT path for a MoE grouped matmul forward pass (mode=NONE)."""
     _precheck_moe(chain, config, cta_group)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
+    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    use_tma = "tma" in store_modes
     snippets = generate(
         chain,
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
-        tma_slots=tma_slots_of(use_tma),
+        tma_slots=frozenset(i for i, m in enumerate(store_modes) if m == "tma"),
     )
     src = _render_template(chain, snippets, config, cta_group)
     mod = _import_kernel(src)
@@ -3690,7 +3904,8 @@ def _jit_moe(
         aux_names=[aux.name for aux in chain.aux_tensors],
         binding=binding,
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
-        _desc_slots_per_cta=chain.num_a_operands + (1 if use_tma else 0),
+        _desc_slots_per_cta=chain.num_a_operands + len([m for m in store_modes if m == "tma"]),
+        store_modes=store_modes,
         use_tma_store=use_tma,
     )
 
@@ -3714,12 +3929,13 @@ def _jit_block_scale(
     _precheck_block_scale(chain, config, cta_group)
     fallback_cluster = _mixed_cga_fallback(config, cta_group, select_template(chain, config, cta_group).file)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
+    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    use_tma = "tma" in store_modes
     snippets = generate(
         chain,
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
-        tma_slots=tma_slots_of(use_tma),
+        tma_slots=frozenset(i for i, m in enumerate(store_modes) if m == "tma"),
     )
     src = _render_block_scale_template(chain, snippets, config, cta_group, fallback_cluster=fallback_cluster)
     mod = _import_kernel(src)
@@ -3731,6 +3947,7 @@ def _jit_block_scale(
         aux_names=[aux.name for aux in chain.aux_tensors],
         generated_path=_cache_dir() / f"gen_{digest}" / "generated_kernel.py",
         _launchable=mod.compile(),
+        store_modes=store_modes,
         use_tma_store=use_tma,
         block_scale=True,
         binding=binding,
@@ -3773,8 +3990,14 @@ class CompiledMoeBlockScaleGemm:
     # (its base carries start_sf_block_m and its m extent bounds the group), plus
     # the output descriptor when the TMA-store epilogue re-dimensions it per group.
     _desc_slots_per_cta: int = 0
+    store_modes: tuple = ()
     use_tma_store: bool = False
     accepts_stream: ClassVar[bool] = True  # stream-aware dispatch (see CompiledFusedGemm)
+
+    @property
+    def tma_slots(self) -> "frozenset[int]":
+        """Which dense output slots ride the TMA-C surface."""
+        return frozenset(i for i, m in enumerate(self.store_modes) if m == "tma")
 
     @property
     def workspace_bytes(self) -> int:
@@ -3878,13 +4101,13 @@ class CompiledMoeBlockScaleGemm:
             b,
             msfa,
             msfb,
-            *_moe_launch_tail(cs, use_tma_store=self.use_tma_store),
+            *_moe_launch_tail(cs, tma_slots=self.tma_slots),
             stream=_as_custream(stream),
         )
 
     def _call_variant_pack(self, variant_pack: dict, workspace=None, stream=None):
         a_bufs, b_bufs, out_bufs, aux_bufs, fto, sfa, sfb, snk = _resolve_moe_variant_pack(self, variant_pack)
-        _out_reqs = _output_align_reqs(self.chain, tma_slots_of(self.use_tma_store), vec_bytes=self.vec_bytes_epi)
+        _out_reqs = _output_align_reqs(self.chain, self.tma_slots, vec_bytes=self.vec_bytes_epi)
         _aux_reqs = _aux_align_reqs(self.chain, vec_bytes=self.vec_bytes_epi)
         _named = (
             [("token", x, 16, "ptr") for x in a_bufs]
@@ -4013,7 +4236,7 @@ class CompiledMoeBlockScaleGemm:
             *b_wrapped,
             *sfa_wrapped,
             *sfb_wrapped,
-            *_moe_launch_tail(cs, aux, use_tma_store=self.use_tma_store),
+            *_moe_launch_tail(cs, aux, tma_slots=self.tma_slots),
             stream=_as_custream(stream),
         )
 
@@ -4038,12 +4261,13 @@ def _jit_moe_block_scale(
     _precheck_moe_block_scale(chain, config, cta_group)
     _tmpl = select_template(chain, config, cta_group)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    use_tma = (not _FORCE_STG_EPI) and _use_tma_store_epi(chain, config, vec_bytes_epi, cta_group)
+    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    use_tma = "tma" in store_modes
     snippets = generate(
         chain,
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
-        tma_slots=tma_slots_of(use_tma),
+        tma_slots=frozenset(i for i, m in enumerate(store_modes) if m == "tma"),
     )
     src = _render_block_scale_template(chain, snippets, config, cta_group, fallback_cluster=_mixed_cga_fallback(config, cta_group, _tmpl.file))
     mod = _import_kernel(src)
@@ -4059,6 +4283,7 @@ def _jit_moe_block_scale(
         _grid_ctas=grid_ctas,
         binding=binding,
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
-        _desc_slots_per_cta=chain.num_a_operands * 2 + (1 if use_tma else 0),
+        _desc_slots_per_cta=chain.num_a_operands * 2 + len([m for m in store_modes if m == "tma"]),
+        store_modes=store_modes,
         use_tma_store=use_tma,
     )

--- a/python/cudnn/gemm/frost/dtypes.py
+++ b/python/cudnn/gemm/frost/dtypes.py
@@ -267,16 +267,6 @@ def _aux_align_reqs(chain: FusionChain, vec_bytes: "int | None" = None) -> dict:
     return reqs
 
 
-# Only dense slot 0 is ever put on the TMA-C surface: the templates build ONE
-# C descriptor and one SMEM-D ring. The store mode is nonetheless carried as a
-# SET so the slot numbering never has to ask "which mode is the kernel in".
-_TMA_SLOTS_0 = frozenset({0})
-
-
-def tma_slots_of(use_tma_store: bool) -> "frozenset[int]":
-    return _TMA_SLOTS_0 if use_tma_store else frozenset()
-
-
 def _output_align_reqs(chain: FusionChain, tma_slots: "frozenset[int]", vec_bytes: "int | None" = None) -> "list[int]":
     """Per-output required byte alignment, one per ``chain.outputs`` slot (dense
     specs, then reductions, then quant scales) = the width its store uses

--- a/python/cudnn/gemm/frost/dtypes.py
+++ b/python/cudnn/gemm/frost/dtypes.py
@@ -114,11 +114,10 @@ CUDNN_FROM_DTYPE: dict[Dtype, Any] = {v: k for k, v in DTYPE_FROM_CUDNN.items()}
 
 MAX_MEM_ACCESS_BYTES = 32
 
-# Widest epilogue chunk in ELEMENTS (not bytes). The epilogue drains the
-# accumulator in <= 32-column subtiles (tcgen05_ld SHAPE_32X32B, num <= 32) and
-# the codegen walks a chunk with `range(32)` + `const_expr(i < vsize)` guards,
-# so a chunk can never hold more elements than this. It CAN span more than
-# MAX_MEM_ACCESS_BYTES: a wide dtype splits its chunk into several stores.
+# Widest STG epilogue chunk in ELEMENTS (not bytes). Only the STG arm is capped
+# here -- the TMA-store arm's chunk is the staged subtile (`epi_n`), which
+# reaches 64. A chunk CAN span more than MAX_MEM_ACCESS_BYTES: every output
+# splits it into its own <= MAX_MEM_ACCESS_BYTES-wide stores.
 MAX_EPI_CHUNK_ELEMS = 32
 
 
@@ -268,12 +267,22 @@ def _aux_align_reqs(chain: FusionChain, vec_bytes: "int | None" = None) -> dict:
     return reqs
 
 
-def _output_align_reqs(chain: FusionChain, use_tma_store: bool, vec_bytes: "int | None" = None) -> "list[int]":
+# Only dense slot 0 is ever put on the TMA-C surface: the templates build ONE
+# C descriptor and one SMEM-D ring. The store mode is nonetheless carried as a
+# SET so the slot numbering never has to ask "which mode is the kernel in".
+_TMA_SLOTS_0 = frozenset({0})
+
+
+def tma_slots_of(use_tma_store: bool) -> "frozenset[int]":
+    return _TMA_SLOTS_0 if use_tma_store else frozenset()
+
+
+def _output_align_reqs(chain: FusionChain, tma_slots: "frozenset[int]", vec_bytes: "int | None" = None) -> "list[int]":
     """Per-output required byte alignment, one per ``chain.outputs`` slot (dense
     specs, then reductions, then quant scales) = the width its store uses
     (matches the epilogue): reduction / quant-scale side outputs store scalar
-    (1); an M-major dense output uses 16 on the TMA path, else a scalar scatter;
-    the TMA-store dense output needs 16; fp4 data packs 2/byte; everything else
+    (1); a slot on the TMA-C surface needs 16 (M-major included); every other
+    slot uses its own store width -- fp4 data packs 2/byte, and everything else
     stores ``vsize`` elements. Major is read per slot — ``chain.out_major`` only
     governs the shared epilogue chunk, and a tap may carry the other major.
     ``vec_bytes`` overrides the chain-derived chunk width (pass the tile-clamped
@@ -287,8 +296,8 @@ def _output_align_reqs(chain: FusionChain, use_tma_store: bool, vec_bytes: "int 
         if out.is_reduction or out.is_quant_scale:
             reqs.append(1)
         elif chain.output_specs[i].major == "m":
-            reqs.append(16 if use_tma_store else eb)
-        elif use_tma_store and i == 0:
+            reqs.append(16 if i in tma_slots else eb)
+        elif i in tma_slots:
             reqs.append(16)
         elif out.dtype == "fp4_e2m1":
             reqs.append(max(vsize // 2, 4))

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from .dtypes import DTYPE_BYTES, DTYPE_TO_CUTLASS, MAX_EPI_CHUNK_ELEMS, _output_align_reqs, allowed_store_vsize, dense_output_layout, tensor_alignment
+from .dtypes import DTYPE_BYTES, DTYPE_TO_CUTLASS, _output_align_reqs, allowed_store_vsize, dense_output_layout, tensor_alignment
 from .fusion_ir import (
     BlockQuantizeSpec,
     Dtype,
@@ -74,22 +74,22 @@ def _index_term(var: str, stride: int) -> str:
     return f"{var} * {stride}"
 
 
-def _aux_index_expr(aux: TensorRef) -> str:
+def _aux_index_expr(aux: TensorRef, *, row_var: str = "row", col_var: str = "col_j") -> str:
     """Linear element offset for the current epilogue location. Extent-1
     dims are broadcast and don't contribute to the offset."""
     if len(aux.dim) == 1:
-        axes = ((aux.dim[0], aux.stride[0], "col_j"),)
+        axes = ((aux.dim[0], aux.stride[0], col_var),)
     elif len(aux.dim) == 2:
         axes = (
-            (aux.dim[0], aux.stride[0], "row"),
-            (aux.dim[1], aux.stride[1], "col_j"),
+            (aux.dim[0], aux.stride[0], row_var),
+            (aux.dim[1], aux.stride[1], col_var),
         )
     elif len(aux.dim) == 3:
         lead_var = "group_idx" if aux.grouped_by_moe else "tile_l"
         axes = (
             (aux.dim[0], aux.stride[0], lead_var),
-            (aux.dim[1], aux.stride[1], "row"),
-            (aux.dim[2], aux.stride[2], "col_j"),
+            (aux.dim[1], aux.stride[1], row_var),
+            (aux.dim[2], aux.stride[2], col_var),
         )
     else:
         raise ValueError(f"unsupported aux rank {len(aux.dim)} for {aux.name!r}")
@@ -98,7 +98,47 @@ def _aux_index_expr(aux: TensorRef) -> str:
     return " + ".join(terms) if terms else "0"
 
 
-def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str) -> str:
+def _aux_reads_row(aux: TensorRef) -> bool:
+    return len(aux.dim) >= 2 and aux.dim[-2] != 1
+
+
+def _bounded_aux_prelude(chain: FusionChain) -> list[str]:
+    """The TMA arm hands the snippet a SUBTILE base with neither an N nor an M
+    bound -- the store is clipped by the descriptor's global extent, so nothing
+    downstream needs one, but a `per_col` / `per_elem` LDG at `col_j + k` is a
+    real read past the aux allocation (N=144, cta_tile_n=128, epi_n=32: the
+    subtile at col=224 reads columns 224..255, and at row M-1 that is 80
+    elements past a `per_elem` tensor's end). Take the whole-chunk vector load
+    when the window is inside both extents -- the case on every subtile but the
+    last -- and otherwise read element-wise at a CLAMPED coordinate: the lanes
+    past the extent land on the last valid element, whose value is never stored."""
+    lines: list[str] = []
+    for aux in chain.aux_tensors:
+        if aux.bcast_mode not in ("per_col", "per_elem"):
+            continue
+        n, ptr = aux.name, _aux_ptr_var(aux.name)
+        lines.append(f"_auxt_{n} = cute.make_rmem_tensor(vsize, {DTYPE_TO_CUTLASS[aux.dtype]})")
+        lines.append(f"_auxv_{n} = _auxt_{n}.load().to_vector()")
+        cond = ["col_j + vsize <= N"]
+        if _aux_reads_row(aux):
+            cond.append("row < M")
+        lines.append(f"if {' & '.join(f'({c})' for c in cond)}:")
+        lines.append(f"    _auxv_{n} = ({ptr} + {_aux_index_expr(aux)}).load(count=vsize, alignment=ALIGN_AUX_{n})")
+        lines.append("else:")
+        row_var = f"_auxr_{n}"
+        if _aux_reads_row(aux):
+            lines.append(f"    {row_var} = cute.math.min(cutlass.Int32(row), cutlass.Int32(M) - 1)")
+        else:
+            row_var = "row"
+        lines.append("    for _auxk in cutlass.range_constexpr(vsize):")
+        lines.append(f"        _auxc_{n} = cute.math.min(cutlass.Int32(col_j) + _auxk, cutlass.Int32(N) - 1)")
+        idx = _aux_index_expr(aux, row_var=row_var, col_var=f"_auxc_{n}")
+        lines.append(f"        _auxt_{n}[_auxk] = ({ptr} + {idx}).load()")
+        lines.append(f"    _auxv_{n} = _auxt_{n}.load().to_vector()")
+    return lines
+
+
+def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str, *, bounded: bool = False) -> str:
     """Expression yielding aux value(s) as a length-`vsize` vector in the op's
     compute dtype, matching ``like_var``'s dtype."""
     idx = _aux_index_expr(aux)
@@ -109,11 +149,9 @@ def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str) -> str:
     if aux.bcast_mode == "per_row":
         # per-row scalar prefetched in aux_views, broadcast to vec
         return f"cutlass.full_like({like_var}, {_aux_prefetch_var(aux.name)}.to({cast}))"
-    if aux.bcast_mode == "per_col":
-        # vector load of vsize elements from aux_ptr[col_j]
-        return f"({_aux_ptr_var(aux.name)} + {idx}).load(count=vsize, " f"alignment=ALIGN_AUX_{aux.name}).to({cast})"
-    if aux.bcast_mode == "per_elem":
-        # vector load of vsize elements from aux_ptr[row*N + col_j]
+    if aux.bcast_mode in ("per_col", "per_elem"):
+        if bounded:
+            return f"_auxv_{aux.name}.to({cast})"
         return f"({_aux_ptr_var(aux.name)} + {idx}).load(count=vsize, " f"alignment=ALIGN_AUX_{aux.name}).to({cast})"
     raise AssertionError(f"unknown bcast_mode {aux.bcast_mode!r}")
 
@@ -371,7 +409,7 @@ def _emit_op(
             return [f"{new} = cutlass.full_like({prev}, cutlass.Float32(row))"], new
         gl = [f"_gi{idx} = cute.make_rmem_tensor({vsize}, cutlass.Float32)"]
         gl += [f"_gi{idx}[{k}] = cutlass.Float32(col_j + {k})" for k in range(vsize)]
-        gl.append(f"{new} = _gi{idx}.load()")
+        gl.append(f"{new} = _gi{idx}.load().to_vector()")
         return gl, new
 
     if op.op == "binary_select":
@@ -546,19 +584,23 @@ def _dense_store_offset(i: int, is_fp4: bool, batch: int) -> str:
     return f"(tile_l * out_stride_l_{i} + {base})" if batch > 1 else f"({base})"
 
 
-def _emit_mmajor_scatter(tap_idx: int, i: int, source_var: str, dtype: Dtype, batch: int) -> list[str]:
+def _emit_mmajor_scatter(tap_idx: int, i: int, source_var: str, dtype: Dtype, batch: int, vsize: int, *, row_bound: str | None = None) -> list[str]:
     """Per-element scatter for an M-major (or arbitrarily strided) dense
     output: vsize scalar stores through the output's own runtime strides."""
     tap_var = f"_tap_{tap_idx}"
     l_term = f"tile_l * out_stride_l_{i} + " if batch > 1 else ""
     lines = [f"{tap_var} = {_store_cast_expr(source_var, dtype)}"]
-    for e in range(32):
-        lines.append(f"if cutlass.const_expr({e} < vsize):")
-        lines.append(
-            f"    (gC_tap_{tap_idx}_ptr + {l_term}row * out_stride_m_{i} + "
+    for e in range(vsize):
+        store = (
+            f"(gC_tap_{tap_idx}_ptr + {l_term}row * out_stride_m_{i} + "
             f"(col_j + {e}) * out_stride_n_{i}).store({tap_var}[{e} : {e} + 1], "
             f"alignment={DTYPE_BYTES[dtype]})"
         )
+        if row_bound is not None:
+            lines.append(f"if (row < {row_bound}) & (col_j + {e} < N):")
+            lines.append(f"    {store}")
+        else:
+            lines.append(store)
     return lines
 
 
@@ -581,7 +623,17 @@ def _tap_vec_bytes(chain: FusionChain, dtype: Dtype, dim, stride, vsize: int) ->
 
 
 def _emit_tap_store(
-    tap_idx: int, source_var: str, tap_dtype: Dtype, chain: FusionChain, dim, stride, vsize: int, offset_expr: str = "linear_idx", spec_idx: int = 0
+    tap_idx: int,
+    source_var: str,
+    tap_dtype: Dtype,
+    chain: FusionChain,
+    dim,
+    stride,
+    vsize: int,
+    offset_expr: str = "linear_idx",
+    spec_idx: int = 0,
+    *,
+    row_bound: str | None = None,
 ) -> list[str]:
     """Store one tap vector. M-major TMA taps scatter the 16x256b fragment;
     all other paths store ``offset_expr`` in ``_tap_store_elems``-wide chunks (a
@@ -600,13 +652,20 @@ def _emit_tap_store(
         f"{tap_var}[_tr_{tap_idx} : _tr_{tap_idx} + 1], alignment=VEC_BYTES_TAP_{tap_idx})",
         f"else:",
     ]
-    if store_elems >= vsize:
-        lines.append(f"    (gC_tap_{tap_idx}_ptr + {offset_expr}).store({tap_var}, alignment=VEC_BYTES_TAP_{tap_idx})")
-    else:
-        for _s in range(0, vsize, store_elems):
-            lines.append(
-                f"    (gC_tap_{tap_idx}_ptr + {offset_expr} + {_s}).store(" f"{tap_var}[{_s} : {_s + store_elems}], alignment=VEC_BYTES_TAP_{tap_idx})"
-            )
+    # The STG arm sits inside `row < M` / `col_j + vsize <= N`; the TMA arm has
+    # neither -- its store is clipped by the descriptor's global extent instead.
+    # `_tap_store_elems` divides both N and `col_j`, so a sub-chunk is wholly
+    # inside N or wholly outside: the whole-chunk predicate loses no column.
+    for _s in range(0, vsize, store_elems) if store_elems < vsize else (None,):
+        span = f"{tap_var}" if _s is None else f"{tap_var}[{_s} : {_s + store_elems}]"
+        off = f"{offset_expr}" if _s is None else f"{offset_expr} + {_s}"
+        width = vsize if _s is None else store_elems
+        store = f"(gC_tap_{tap_idx}_ptr + {off}).store({span}, alignment=VEC_BYTES_TAP_{tap_idx})"
+        if row_bound is not None:
+            lines.append(f"    if (row < {row_bound}) & (col_j + {(_s or 0) + width} <= N):")
+            lines.append(f"        {store}")
+        else:
+            lines.append(f"    {store}")
     return lines
 
 
@@ -627,6 +686,7 @@ def _emit_reduction_local_combine(
     red_idx: int,
     red: ReductionSpec,
     src: str,
+    vsize: int,
 ) -> tuple[list[str], str]:
     """Combine the vector's elements into one register value so a single
     atomic per vector covers the whole chunk (valid only when every element
@@ -655,22 +715,21 @@ def _emit_reduction_local_combine(
 
     lines = [f"{acc} = {init}"]
     start = 0 if combine in ("add", "mul") else 1
-    for i in range(start, 32):
-        lines.append(f"if cutlass.const_expr({i} < vsize):")
+    for i in range(start, vsize):
         if combine == "add":
-            lines.append(f"    {acc} = {acc} + {elem(i)}")
+            lines.append(f"{acc} = {acc} + {elem(i)}")
         elif combine == "mul":
             if red.mode == "mul_no_zeros":
-                lines.append(f"    if {src}[{i}] != cutlass.Float32(0.0):")
-                lines.append(f"        {acc} = {acc} * {src}[{i}]")
-            else:
+                lines.append(f"if {src}[{i}] != cutlass.Float32(0.0):")
                 lines.append(f"    {acc} = {acc} * {src}[{i}]")
+            else:
+                lines.append(f"{acc} = {acc} * {src}[{i}]")
         elif is_int:
             op = ">" if combine == "max" else "<"
-            lines.append(f"    if {elem(i)} {op} {acc}:")
-            lines.append(f"        {acc} = {elem(i)}")
+            lines.append(f"if {elem(i)} {op} {acc}:")
+            lines.append(f"    {acc} = {elem(i)}")
         else:
-            lines.append(f"    {acc} = cute.math.{combine}({acc}, {elem(i)})")
+            lines.append(f"{acc} = cute.math.{combine}({acc}, {elem(i)})")
     return lines, acc
 
 
@@ -680,6 +739,7 @@ def _emit_reduction_atomic(
     red: ReductionSpec,
     source_var: str,
     matmul: "MatmulSpec",
+    vsize: int,
 ) -> list[str]:
     src = f"_red_{red_idx}_src"
     lines = [f"{src} = ({source_var}).to({DTYPE_TO_CUTLASS[red.compute_dtype]})"]
@@ -696,7 +756,7 @@ def _emit_reduction_atomic(
             count = n_factor * (matmul.M if red.dim[1] == 1 else 1) * (matmul.batch if red.dim[0] == 1 else 1)
             lines.append(f"_red_{red_idx}_inv = cutlass.Float32({1.0 / count})")
     if red.dim[2] == 1:
-        combine_lines, acc = _emit_reduction_local_combine(red_idx, red, src)
+        combine_lines, acc = _emit_reduction_local_combine(red_idx, red, src, vsize)
         lines.extend(combine_lines)
         offset = _reduction_output_offset_expr(red_idx, red, "0")
         ptr = f"gC_tap_{tap_idx}_ptr + {offset}"
@@ -739,9 +799,7 @@ def _emit_reduction_atomic(
             val = f"{acc} * _red_{red_idx}_inv" if red.mode == "avg" else acc
             lines.append(f'nvvm.atomicrmw("add", {ptr}, {val}, mem_order="relaxed", syncscope="gpu")')
         return lines
-    for i in range(32):
-        # const_expr(i < vsize) keeps emitted code valid for every vsize, no dynamic index
-        lines.append(f"if cutlass.const_expr({i} < vsize):")
+    for i in range(vsize):
         val = f"{src}[{i}]"
         offset = _reduction_output_offset_expr(red_idx, red, str(i))
         ptr = f"gC_tap_{tap_idx}_ptr + {offset}"
@@ -756,26 +814,26 @@ def _emit_reduction_atomic(
                 op = red.mode
             else:
                 raise AssertionError(f"unhandled int32 reduction mode {red.mode!r}")
-            lines.append(f'    nvvm.atomicrmw("{op}", {ptr}, ' f'{val}, mem_order="relaxed", syncscope="gpu")')
+            lines.append(f'nvvm.atomicrmw("{op}", {ptr}, ' f'{val}, mem_order="relaxed", syncscope="gpu")')
             continue
         if red.mode == "amax":
-            lines.append(f"    cute.arch.atomic_fmax({ptr}, " f'cute.math.abs({val}), sign_bit=False, sem="relaxed", scope="gpu")')
+            lines.append(f"cute.arch.atomic_fmax({ptr}, " f'cute.math.abs({val}), sign_bit=False, sem="relaxed", scope="gpu")')
             continue
         if red.mode == "norm1":
-            lines.append(f'    nvvm.atomicrmw("add", {ptr}, cute.math.abs({val}), mem_order="relaxed", syncscope="gpu")')
+            lines.append(f'nvvm.atomicrmw("add", {ptr}, cute.math.abs({val}), mem_order="relaxed", syncscope="gpu")')
             continue
         if red.mode == "norm2":
-            lines.append(f'    nvvm.atomicrmw("add", {ptr}, {val} * {val}, mem_order="relaxed", syncscope="gpu")')
+            lines.append(f'nvvm.atomicrmw("add", {ptr}, {val} * {val}, mem_order="relaxed", syncscope="gpu")')
             continue
         if red.mode == "avg":
-            lines.append(f'    nvvm.atomicrmw("add", {ptr}, {val} * _red_{red_idx}_inv, mem_order="relaxed", syncscope="gpu")')
+            lines.append(f'nvvm.atomicrmw("add", {ptr}, {val} * _red_{red_idx}_inv, mem_order="relaxed", syncscope="gpu")')
             continue
         if red.mode in ("mul", "mul_no_zeros"):
             t = f"_red_{red_idx}_{i}"
-            pad = "    "
+            pad = ""
             if red.mode == "mul_no_zeros":
-                lines.append(f"    if {val} != cutlass.Float32(0.0):")
-                pad = "        "
+                lines.append(f"if {val} != cutlass.Float32(0.0):")
+                pad = "    "
             lines.extend(
                 [
                     f"{pad}{t}_mo = (({ptr})).load().bitcast(cutlass.Int32)",
@@ -791,24 +849,24 @@ def _emit_reduction_atomic(
             )
             continue
         if red.mode == "max":
-            lines.append(f'    cute.arch.atomic_fmax({ptr}, {val}, sem="relaxed", scope="gpu")')
+            lines.append(f'cute.arch.atomic_fmax({ptr}, {val}, sem="relaxed", scope="gpu")')
             continue
         if red.mode == "min":
             bits = f"_red_{red_idx}_{i}_bits"
             lines.extend(
                 [
-                    f"    {bits} = ({val}).bitcast(cutlass.Int32)",
-                    f"    if {bits} < cutlass.Int32(0):",
-                    f"        cute.arch.atomic_max({ptr}, cutlass.Uint32({bits}), " f'sem="relaxed", scope="gpu")',
-                    "    else:",
-                    f"        cute.arch.atomic_min({ptr}, {bits}, " f'sem="relaxed", scope="gpu")',
+                    f"{bits} = ({val}).bitcast(cutlass.Int32)",
+                    f"if {bits} < cutlass.Int32(0):",
+                    f"    cute.arch.atomic_max({ptr}, cutlass.Uint32({bits}), " f'sem="relaxed", scope="gpu")',
+                    "else:",
+                    f"    cute.arch.atomic_min({ptr}, {bits}, " f'sem="relaxed", scope="gpu")',
                 ]
             )
             continue
         else:
             assert red.mode == "add"
             op = "add"
-        lines.append(f'    nvvm.atomicrmw("{op}", {ptr}, ' f'{val}, mem_order="relaxed", syncscope="gpu")')
+        lines.append(f'nvvm.atomicrmw("{op}", {ptr}, ' f'{val}, mem_order="relaxed", syncscope="gpu")')
     return lines
 
 
@@ -1162,27 +1220,17 @@ def generate(
     *,
     vec_bytes_epi: int = 32,
     output_elem_bytes: int = 2,
-    use_tma_store: bool = False,
+    tma_slots: "frozenset[int]" = frozenset(),
 ) -> EpilogueSnippets:
     """Produce the two hook-site snippets, the extra kernel param list, and
     all per-tap plumbing. ``vec_bytes_epi`` / ``output_elem_bytes`` (from the
     compiler) fix the inner-loop chunk size: each tap stores
     ``vsize = vec_bytes_epi // output_elem_bytes`` elements per chunk."""
     vsize = vec_bytes_epi // output_elem_bytes
-    if vsize > MAX_EPI_CHUNK_ELEMS:
-        raise NotImplementedError(
-            f"epilogue chunk of {vsize} elements exceeds the {MAX_EPI_CHUNK_ELEMS}-element "
-            f"drain subtile (vec_bytes_epi={vec_bytes_epi}, output_elem_bytes={output_elem_bytes})"
-        )
     # aux_views snippet. `row` is defined by the template just before this hook
     # (M-aware: differs for MMA_M=64 vs MMA_M>=128) — we just consume it.
     aux_lines: list[str] = []
     for aux in chain.aux_tensors:
-        if aux.grouped_by_moe and aux.bcast_mode == "per_col" and aux.stride[0] % vsize != 0:
-            raise NotImplementedError(
-                f"per-group per-col aux {aux.name!r}: group stride {aux.stride[0]} must be "
-                f"a multiple of the epilogue chunk ({vsize} elements) for aligned vector loads"
-            )
         aux_lines.append(f"{_aux_ptr_var(aux.name)} = {aux.name}.iterator.raw_ptr()")
         if aux.bcast_mode == "scalar":
             aux_lines.append(f"{_aux_prefetch_var(aux.name)} = " f"({_aux_ptr_var(aux.name)} + {_aux_index_expr(aux)}).load()")
@@ -1193,7 +1241,16 @@ def generate(
     aux_views = "\n".join(aux_lines) if aux_lines else "pass"
 
     # epilogue snippet (interleaves op chain with tap stores)
-    body_lines: list[str] = []
+    on_tma_arm = 0 in tma_slots
+    # The template binds `vec_f32_<g>` in the STG arm only, where the chunk is a
+    # slice of the subtile. The TMA arm takes the whole subtile, and when it is
+    # rendered the STG arm is deleted outright -- so emit the bindings here
+    # rather than adding a second template marker to all 8 parity groups.
+    tma_vec_bindings = [f"vec_f32_{g} = c_rmem_vecs[{g}]" for g in range(1, chain.num_gemms)] if on_tma_arm else []
+    # The TMA arm carries no row bound of its own; reuse the one its STG
+    # sibling applies -- the routed group's end on MoE, the problem M elsewhere.
+    store_row_bound = ("group_end" if chain.has_moe else "M") if on_tma_arm else None
+    body_lines: list[str] = tma_vec_bindings + (_bounded_aux_prelude(chain) if on_tma_arm else [])
 
     # Per-op result var name lookup (handles `identity` pass-throughs).
     result_var: dict[int, str] = {}
@@ -1218,7 +1275,7 @@ def generate(
     for i, op in enumerate(chain.ops):
         if op.op == "aux_load":
             aux_ref = chain.aux_by_name(op.aux)
-            body_lines.append(f"_op_{i} = {_aux_load_expr(aux_ref, op.compute_dtype, 'vec_f32')}")
+            body_lines.append(f"_op_{i} = {_aux_load_expr(aux_ref, op.compute_dtype, 'vec_f32', bounded=on_tma_arm)}")
             round_lines, cur = _emit_round(f"_op_{i}", op.out_dtype, str(i))
             body_lines.extend(round_lines)
             result_var[i] = cur
@@ -1227,7 +1284,7 @@ def generate(
         parent_raw = _parent_value(parent)
         cast_lines, parent_var = _compute_cast(parent_raw, op.compute_dtype, f"{i}_a")
         body_lines.extend(cast_lines)
-        aux_loads = {aux.name: _aux_load_expr(aux, op.compute_dtype, parent_var) for aux in chain.aux_tensors}
+        aux_loads = {aux.name: _aux_load_expr(aux, op.compute_dtype, parent_var, bounded=on_tma_arm) for aux in chain.aux_tensors}
         other_in_chain = _parent_value(op.parent_idx_b) if op.parent_idx_b is not None else None
         if other_in_chain is not None:
             cast_lines, other_in_chain = _compute_cast(other_in_chain, op.compute_dtype, f"{i}_b")
@@ -1244,22 +1301,27 @@ def generate(
         body_lines.extend(round_lines)
         result_var[i] = cur
 
-    # Dense outputs, uniform in slot order. STG mode: every dense output rides
-    # a tap slot (dense spec i -> tap i; the template has no C output). TMA
-    # mode: spec 0 binds the template's ``vec_out`` (the TMA staging consumes
-    # it), specs 1.. -> taps i-1. A quant-carrying spec emits the
-    # block-quantize (quantized vector + scale byte) in place of a plain cast.
+    # Dense outputs, uniform in slot order. The store MODE is per slot: a slot
+    # in ``tma_slots`` binds the template's ``vec_out`` (the TMA staging consumes
+    # it) and occupies the trailing TMA-C parameter; every other output rides a
+    # tap slot. `_tap_of` is the ONE place that numbering is decided -- the tap
+    # index, the reduction index and the quant-scale index all read it, so they
+    # cannot drift apart. A quant-carrying spec emits the block-quantize
+    # (quantized vector + scale byte) in place of a plain cast.
     specs = chain.output_specs
     quant_batch_expr = "0" if chain.has_moe else "tile_l"
-    dense_tap_shift = -1 if use_tma_store else 0
-    n_dense_taps = max(len(specs) + dense_tap_shift, 0)
+    _tap_of: dict[int, int] = {}
+    for _oi in range(len(chain.outputs)):
+        if _oi not in tma_slots:
+            _tap_of[_oi] = len(_tap_of)
+    n_dense_taps = sum(1 for si in range(len(specs)) if si not in tma_slots)
 
     def _scale_tap_idx(qi: int) -> int:
-        return n_dense_taps + len(chain.reductions) + qi
+        return _tap_of[len(specs) + len(chain.reductions) + qi]
 
     for si, spec in enumerate(specs):
         src = _parent_value(spec.source_ref)
-        if use_tma_store and si == 0:
+        if si in tma_slots:
             if spec.quant_idx is not None:
                 body_lines.extend(
                     _emit_block_quant(
@@ -1277,9 +1339,9 @@ def generate(
             else:
                 body_lines.append(f"vec_out = {_store_cast_expr(src, spec.dtype)}")
             continue
-        tap_idx = si + dense_tap_shift
+        tap_idx = _tap_of[si]
         if spec.major == "m":
-            body_lines.extend(_emit_mmajor_scatter(tap_idx, si, src, spec.dtype, chain.matmul.batch))
+            body_lines.extend(_emit_mmajor_scatter(tap_idx, si, src, spec.dtype, chain.matmul.batch, vsize, row_bound=store_row_bound))
             continue
         offset_expr = _dense_store_offset(si, spec.dtype == "fp4_e2m1", chain.matmul.batch)
         if spec.quant_idx is not None:
@@ -1303,11 +1365,11 @@ def generate(
             else:
                 body_lines.append(f"(gC_tap_{tap_idx}_ptr + {offset_expr}).store({qv}, alignment=VEC_BYTES_TAP_{tap_idx})")
         else:
-            body_lines.extend(_emit_tap_store(tap_idx, src, spec.dtype, chain, spec.dim, spec.stride, vsize, offset_expr, si))
+            body_lines.extend(_emit_tap_store(tap_idx, src, spec.dtype, chain, spec.dim, spec.stride, vsize, offset_expr, si, row_bound=store_row_bound))
 
     for red_idx, red in enumerate(chain.reductions):
         red_source = _parent_value(red.source_ref)
-        body_lines.extend(_emit_reduction_atomic(n_dense_taps + red_idx, red_idx, red, red_source, chain.matmul))
+        body_lines.extend(_emit_reduction_atomic(_tap_of[len(specs) + red_idx], red_idx, red, red_source, chain.matmul, vsize))
 
     epilogue = "\n".join(body_lines)
 
@@ -1315,17 +1377,16 @@ def generate(
     kernel_params = [f"{aux.name}: cute.Tensor" for aux in chain.aux_tensors]
     host_args = [aux.name for aux in chain.aux_tensors]
 
-    # tap plumbing (STG: every output; TMA: all but the first)
-    # STG mode: the tap list IS the full output list (dense, reductions,
-    # scales). TMA mode: outputs[0] rides the template's C params instead.
-    taps = list(chain.outputs) if not use_tma_store else chain.taps
+    # tap plumbing: every output that is NOT on the TMA-C surface, in tap order.
+    _slot_of = {t: o for o, t in _tap_of.items()}
+    taps = [chain.outputs[_slot_of[i]] for i in range(len(_tap_of))]
     tap_kernel_params = [f"mC_tap_{i}: cute.Tensor" for i in range(len(taps))]
     tap_host_params = [f"c_tap_{i}: cute.Tensor" for i in range(len(taps))]
     tap_host_pass = [f"c_tap_{i}" for i in range(len(taps))]
     tap_compile_fakes: list[str] = []
     # Per-slot true store alignment (matches _alignment_reject's contract); 16 is
     # a false claim for reduction / quant-scale / M-major taps.
-    _out_reqs = _output_align_reqs(chain, use_tma_store, vec_bytes=vec_bytes_epi)
+    _out_reqs = _output_align_reqs(chain, tma_slots, vec_bytes=vec_bytes_epi)
     for i, tap in enumerate(taps):
         # Byte-carrier taps: packed FP4 data, and an E5M3 scale (the DSL has no
         # E5M3 float type, and a raw_ptr store to a Uint8 tensor is rejected —
@@ -1337,9 +1398,9 @@ def generate(
         # contract is stride_n == 1 on an N-major DENSE tap (_dense_store_offset).
         # M-major dense scatters, and reductions / quant scales index purely by
         # runtime strides (and legitimately carry stride 0 for broadcast modes).
-        # Tap i is output slot i - dense_tap_shift; a slot outside chain.outputs
-        # would silently wrap the _out_reqs lookup.
-        _si = i - dense_tap_shift
+        # Tap i is output slot _slot_of[i]; a slot outside chain.outputs would
+        # silently wrap the _out_reqs lookup.
+        _si = _slot_of[i]
         assert 0 <= _si < len(_out_reqs), f"tap {i} maps to output slot {_si}, outside chain.outputs ({len(_out_reqs)})"
         _n_major_dense = (not tap.is_reduction) and (not tap.is_quant_scale) and _si < len(specs) and specs[_si].major == "n"
         _stride = "(cute.sym_int64(), 1, cute.sym_int64())" if _n_major_dense else "(cute.sym_int64(), cute.sym_int64(), cute.sym_int64())"

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -98,8 +98,62 @@ def _aux_index_expr(aux: TensorRef, *, row_var: str = "row", col_var: str = "col
     return " + ".join(terms) if terms else "0"
 
 
+def _mmajor_elem_coord(e: int) -> tuple[str, str]:
+    """Which (row, col) does element ``e`` of the M-major TMA arm's fragment hold?
+
+    That arm loads `tcgen05_ld(SHAPE_16X256B)` and its lane holds a TRANSPOSED
+    patch, so the `row` / `col_j` the drain sets just before the hook are the
+    subtile base, not this element's coordinates -- anything that asks "which row
+    / column am I" has to come through here. The two `_h` passes cover disjoint
+    row halves (the `16 * _h` term), so a side effect placed on this arm fires
+    once per element, not twice.
+
+    Element ``e`` contributes `8 * bit1` to M and `bit0 + 8 * (bits 2..)` to N,
+    which is what makes a lane's 2 rows x vsize/2 columns tile the subtile."""
+    return (
+        f"(coord_m + warp_idx * 32 + (lane // 4) + {8 * ((e >> 1) & 1)} + 16 * _h)",
+        f"(col + 2 * (lane % 4) + {(e & 1) + 8 * (e >> 2)})",
+    )
+
+
+def _elem_coord(e: int, mmajor_tma: bool) -> tuple[str, str]:
+    """The (row, col) of element ``e``: the N-major arms hand the snippet the
+    fragment's own coordinates, the M-major TMA arm does not."""
+    return _mmajor_elem_coord(e) if mmajor_tma else ("row", f"col_j + {e}")
+
+
 def _aux_reads_row(aux: TensorRef) -> bool:
     return len(aux.dim) >= 2 and aux.dim[-2] != 1
+
+
+def _mmajor_aux_prelude(chain: FusionChain, vsize: int) -> list[str]:
+    """Coordinate-reading aux on the M-major TMA arm. A lane's columns are not
+    contiguous there (`_tn` steps by 8 every 4 elements) and its rows come in two
+    halves, so there is no vector load to have -- each element reads at its own
+    CLAMPED coordinate. Out-of-extent elements land on the last valid one; the
+    TMA store clips them at the global extent, so their value is never used.
+    `per_row` joins the list here: `row` is uniform on the N-major arms, not on
+    this one."""
+    lines: list[str] = []
+    for aux in chain.aux_tensors:
+        if aux.bcast_mode == "scalar":
+            continue
+        n, ptr = aux.name, _aux_ptr_var(aux.name)
+        lines.append(f"_auxt_{n} = cute.make_rmem_tensor({vsize}, {DTYPE_TO_CUTLASS[aux.dtype]})")
+        wants_row = _aux_reads_row(aux)
+        for k in range(vsize):
+            row_e, col_e = _mmajor_elem_coord(k)
+            row_var, col_var = "row", "col_j"
+            if wants_row:
+                row_var = f"_auxr_{n}"
+                lines.append(f"{row_var} = cute.math.min(cutlass.Int32({row_e}), cutlass.Int32(M) - 1)")
+            if aux.dim[-1] != 1:
+                col_var = f"_auxc_{n}"
+                lines.append(f"{col_var} = cute.math.min(cutlass.Int32({col_e}), cutlass.Int32(N) - 1)")
+            idx = _aux_index_expr(aux, row_var=row_var, col_var=col_var)
+            lines.append(f"_auxt_{n}[{k}] = ({ptr} + {idx}).load()")
+        lines.append(f"_auxv_{n} = _auxt_{n}.load().to_vector()")
+    return lines
 
 
 def _bounded_aux_prelude(chain: FusionChain) -> list[str]:
@@ -138,7 +192,7 @@ def _bounded_aux_prelude(chain: FusionChain) -> list[str]:
     return lines
 
 
-def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str, *, bounded: bool = False) -> str:
+def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str, *, bounded: bool = False, mmajor_tma: bool = False) -> str:
     """Expression yielding aux value(s) as a length-`vsize` vector in the op's
     compute dtype, matching ``like_var``'s dtype."""
     idx = _aux_index_expr(aux)
@@ -147,10 +201,12 @@ def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str, *, bound
         # scalar prefetched in aux_views, broadcast to vec
         return f"cutlass.full_like({like_var}, {_aux_prefetch_var(aux.name)}.to({cast}))"
     if aux.bcast_mode == "per_row":
+        if mmajor_tma:
+            return f"_auxv_{aux.name}.to({cast})"
         # per-row scalar prefetched in aux_views, broadcast to vec
         return f"cutlass.full_like({like_var}, {_aux_prefetch_var(aux.name)}.to({cast}))"
     if aux.bcast_mode in ("per_col", "per_elem"):
-        if bounded:
+        if bounded or mmajor_tma:
             return f"_auxv_{aux.name}.to({cast})"
         return f"({_aux_ptr_var(aux.name)} + {idx}).load(count=vsize, " f"alignment=ALIGN_AUX_{aux.name}).to({cast})"
     raise AssertionError(f"unknown bcast_mode {aux.bcast_mode!r}")
@@ -347,6 +403,7 @@ def _emit_op(
     other_in_chain: str | None = None,
     third_in_chain: str | None = None,
     vsize: int = 32,
+    mmajor_tma: bool = False,
 ) -> tuple[list[str], str]:
     """Emit lines computing this op, given the previous-step var name.
     ``other_in_chain`` = second operand var for fan-in binary ops (else None).
@@ -405,10 +462,14 @@ def _emit_op(
 
     if op.op == "gen_index":
         axis = dict(op.attrs).get("axis")
-        if axis == 1:
+        # Row index is uniform across the vector on the N-major arms only -- the
+        # M-major TMA fragment holds two row halves, so it needs the map too.
+        if axis == 1 and not mmajor_tma:
             return [f"{new} = cutlass.full_like({prev}, cutlass.Float32(row))"], new
         gl = [f"_gi{idx} = cute.make_rmem_tensor({vsize}, cutlass.Float32)"]
-        gl += [f"_gi{idx}[{k}] = cutlass.Float32(col_j + {k})" for k in range(vsize)]
+        for k in range(vsize):
+            _row, _col = _elem_coord(k, mmajor_tma)
+            gl.append(f"_gi{idx}[{k}] = cutlass.Float32({_row if axis == 1 else _col})")
         gl.append(f"{new} = _gi{idx}.load().to_vector()")
         return gl, new
 
@@ -643,7 +704,7 @@ def _emit_tap_store(
     lines = [
         f"{tap_var} = {_store_cast_expr(source_var, tap_dtype)}",
         f"if cutlass.const_expr(cd_out_is_m_major and use_tma_store_epi):",
-        f"    for _tr_{tap_idx} in cutlass.range_constexpr(16):",
+        f"    for _tr_{tap_idx} in cutlass.range_constexpr({vsize}):",
         f"        _tm_{tap_idx} = coord_m + warp_idx * 32 + (lane // 4)" f" + 8 * ((_tr_{tap_idx} >> 1) & 1) + 16 * _h",
         f"        _tn_{tap_idx} = col + 2 * (lane % 4)" f" + (_tr_{tap_idx} & 1) + 8 * (_tr_{tap_idx} >> 2)",
         f"        if _tm_{tap_idx} < M and _tn_{tap_idx} < N:",
@@ -1242,6 +1303,10 @@ def generate(
 
     # epilogue snippet (interleaves op chain with tap stores)
     on_tma_arm = 0 in tma_slots
+    # The M-major TMA arm's `row` / `col_j` are the subtile base, not the
+    # fragment's coordinates -- everything that asks "which row / column am I"
+    # goes through `_elem_coord` there. See `_mmajor_elem_coord`.
+    mmajor_tma = on_tma_arm and chain.out_major == "m"
     # The template binds `vec_f32_<g>` in the STG arm only, where the chunk is a
     # slice of the subtile. The TMA arm takes the whole subtile, and when it is
     # rendered the STG arm is deleted outright -- so emit the bindings here
@@ -1250,7 +1315,8 @@ def generate(
     # The TMA arm carries no row bound of its own; reuse the one its STG
     # sibling applies -- the routed group's end on MoE, the problem M elsewhere.
     store_row_bound = ("group_end" if chain.has_moe else "M") if on_tma_arm else None
-    body_lines: list[str] = tma_vec_bindings + (_bounded_aux_prelude(chain) if on_tma_arm else [])
+    _aux_pre = _mmajor_aux_prelude(chain, vsize) if mmajor_tma else (_bounded_aux_prelude(chain) if on_tma_arm else [])
+    body_lines: list[str] = tma_vec_bindings + _aux_pre
 
     # Per-op result var name lookup (handles `identity` pass-throughs).
     result_var: dict[int, str] = {}
@@ -1275,7 +1341,7 @@ def generate(
     for i, op in enumerate(chain.ops):
         if op.op == "aux_load":
             aux_ref = chain.aux_by_name(op.aux)
-            body_lines.append(f"_op_{i} = {_aux_load_expr(aux_ref, op.compute_dtype, 'vec_f32', bounded=on_tma_arm)}")
+            body_lines.append(f"_op_{i} = {_aux_load_expr(aux_ref, op.compute_dtype, 'vec_f32', bounded=on_tma_arm, mmajor_tma=mmajor_tma)}")
             round_lines, cur = _emit_round(f"_op_{i}", op.out_dtype, str(i))
             body_lines.extend(round_lines)
             result_var[i] = cur
@@ -1284,7 +1350,7 @@ def generate(
         parent_raw = _parent_value(parent)
         cast_lines, parent_var = _compute_cast(parent_raw, op.compute_dtype, f"{i}_a")
         body_lines.extend(cast_lines)
-        aux_loads = {aux.name: _aux_load_expr(aux, op.compute_dtype, parent_var, bounded=on_tma_arm) for aux in chain.aux_tensors}
+        aux_loads = {aux.name: _aux_load_expr(aux, op.compute_dtype, parent_var, bounded=on_tma_arm, mmajor_tma=mmajor_tma) for aux in chain.aux_tensors}
         other_in_chain = _parent_value(op.parent_idx_b) if op.parent_idx_b is not None else None
         if other_in_chain is not None:
             cast_lines, other_in_chain = _compute_cast(other_in_chain, op.compute_dtype, f"{i}_b")
@@ -1293,7 +1359,7 @@ def generate(
         if third_in_chain is not None:
             cast_lines, third_in_chain = _compute_cast(third_in_chain, op.compute_dtype, f"{i}_c")
             body_lines.extend(cast_lines)
-        lines, cur = _emit_op(op, parent_var, i, aux_loads, other_in_chain, third_in_chain, vsize=vec_bytes_epi // output_elem_bytes)
+        lines, cur = _emit_op(op, parent_var, i, aux_loads, other_in_chain, third_in_chain, vsize=vec_bytes_epi // output_elem_bytes, mmajor_tma=mmajor_tma)
         body_lines.extend(lines)
         # Round to the op's out_dtype (no-op for fp32) so every consumer —
         # downstream ops and outputs alike — sees the declared-dtype value.

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -122,6 +122,12 @@ def _elem_coord(e: int, mmajor_tma: bool) -> tuple[str, str]:
     return _mmajor_elem_coord(e) if mmajor_tma else ("row", f"col_j + {e}")
 
 
+def tma_out_value(j: int) -> str:
+    """The variable holding the j-th TMA-stored output's value. Slot 0 keeps the
+    legacy `vec_out`, so a single-TMA-output render is unchanged."""
+    return "vec_out" if j == 0 else f"_tma_out_{j}"
+
+
 def _aux_reads_row(aux: TensorRef) -> bool:
     return len(aux.dim) >= 2 and aux.dim[-2] != 1
 
@@ -801,6 +807,28 @@ def _emit_reduction_atomic(
     source_var: str,
     matmul: "MatmulSpec",
     vsize: int,
+    row_bound: str | None = None,
+) -> list[str]:
+    """A reduction is an atomic RMW, so an out-of-extent element cannot be
+    clamped onto a valid one -- it has to be SKIPPED. The STG arm inherits
+    `row < M` / `col_j + vsize <= N` from the drain; the TMA arm has neither, so
+    it re-applies them here. `_output_chunk_ok` forces N % chunk == 0 whenever a
+    reduction is present, which is what makes the chunk-level column test exact:
+    a chunk is wholly inside N or wholly past it, so the fold over it never mixes
+    real columns with OOB ones."""
+    body = _emit_reduction_atomic_body(tap_idx, red_idx, red, source_var, matmul, vsize)
+    if row_bound is None:
+        return body
+    return [f"if (row < {row_bound}) & (col_j + {vsize} <= N):"] + [f"    {ln}" for ln in body]
+
+
+def _emit_reduction_atomic_body(
+    tap_idx: int,
+    red_idx: int,
+    red: ReductionSpec,
+    source_var: str,
+    matmul: "MatmulSpec",
+    vsize: int,
 ) -> list[str]:
     src = f"_red_{red_idx}_src"
     lines = [f"{src} = ({source_var}).to({DTYPE_TO_CUTLASS[red.compute_dtype]})"]
@@ -998,6 +1026,7 @@ def _emit_block_quant_col(
     batch_index_expr: str,
     matmul_m: int,
     vsize: int,
+    row_bound: str | None = None,
 ) -> list[str]:
     """Emit M-axis (col) block quantize for one epilogue vector. A warp
     (block 32) or half-warp (block 16) of lanes holds one block of rows, so
@@ -1056,7 +1085,7 @@ def _emit_block_quant_col(
             )
     lines.extend(
         [
-            f"{p}_vec = {p}_out.load()",
+            f"{p}_vec = {p}_out.load().to_vector()",
             (
                 f"{p}_clamped = cute.math.min(cute.math.max({p}_vec, "
                 f"cutlass.full_like({p}_vec, {_quant_output_min(output_dtype)})), "
@@ -1094,7 +1123,16 @@ def _emit_block_quant_col(
                 f"{p}_sidx{k} = {batch_index_expr} * quant_scale_stride_l_{quant_idx} + "
                 f"{p}_mb * quant_scale_stride_m_{quant_idx} + {p}_n{k} * quant_scale_stride_n_{quant_idx}"
             )
-        lines.append(f"(gC_tap_{scale_tap_idx}_ptr + {p}_sidx{k}).store({p}_scale_mine_{k}, alignment=1)")
+        # The scale byte is a SIDE STORE: the STG arm sits inside `row < M`,
+        # the TMA arm has no row bound of its own.
+        _st = f"(gC_tap_{scale_tap_idx}_ptr + {p}_sidx{k}).store({p}_scale_mine_{k}, alignment=1)"
+        if row_bound is None:
+            lines.append(_st)
+        else:
+            # `_quant_output_chunk_ok` forces N % chunk == 0, so a chunk is wholly
+            # inside N or wholly past it -- the chunk-level column test is exact.
+            lines.append(f"if (row < {row_bound}) & (col_j + {vsize} <= N):")
+            lines.append(f"    {_st}")
     return lines
 
 
@@ -1108,6 +1146,7 @@ def _emit_block_quant(
     batch_index_expr: str = "tile_l",
     matmul_m: int = 0,
     vsize: int = 32,
+    row_bound: str | None = None,
 ) -> list[str]:
     """Emit block quantize for one epilogue vector, binding the quantized
     vector to ``out_var`` and storing the scale byte(s) through the
@@ -1126,6 +1165,7 @@ def _emit_block_quant(
             batch_index_expr,
             matmul_m,
             vsize,
+            row_bound,
         )
     p = f"_q{quant_idx}"
     bs = quant.block_size
@@ -1150,7 +1190,7 @@ def _emit_block_quant(
             lines.append(f"{p}_out[{base + e}] = {p}_src[{base + e}] * {p}_inv{k}")
     lines.extend(
         [
-            f"{p}_vec = {p}_out.load()",
+            f"{p}_vec = {p}_out.load().to_vector()",
             (
                 f"{p}_clamped = cute.math.min(cute.math.max({p}_vec, "
                 f"cutlass.full_like({p}_vec, {_quant_output_min(output_dtype)})), "
@@ -1181,7 +1221,16 @@ def _emit_block_quant(
                 f"{p}_sidx{k} = {batch_index_expr} * quant_scale_stride_l_{quant_idx} + "
                 f"row * quant_scale_stride_m_{quant_idx} + {p}_scol{k} * quant_scale_stride_n_{quant_idx}"
             )
-        lines.append(f"(gC_tap_{scale_tap_idx}_ptr + {p}_sidx{k}).store({p}_scale{k}, alignment=1)")
+        # The scale byte is a SIDE STORE: the STG arm sits inside `row < M`,
+        # the TMA arm has no row bound of its own.
+        _st = f"(gC_tap_{scale_tap_idx}_ptr + {p}_sidx{k}).store({p}_scale{k}, alignment=1)"
+        if row_bound is None:
+            lines.append(_st)
+        else:
+            # `_quant_output_chunk_ok` forces N % chunk == 0, so a chunk is wholly
+            # inside N or wholly past it -- the chunk-level column test is exact.
+            lines.append(f"if (row < {row_bound}) & (col_j + {vsize} <= N):")
+            lines.append(f"    {_st}")
     return lines
 
 
@@ -1388,6 +1437,7 @@ def generate(
     for si, spec in enumerate(specs):
         src = _parent_value(spec.source_ref)
         if si in tma_slots:
+            _ov = tma_out_value(sorted(tma_slots).index(si))
             if spec.quant_idx is not None:
                 body_lines.extend(
                     _emit_block_quant(
@@ -1395,15 +1445,16 @@ def generate(
                         spec.quant_idx,
                         src,
                         spec.dtype,
-                        "vec_out",
+                        _ov,
                         _scale_tap_idx(spec.quant_idx),
                         quant_batch_expr,
                         chain.matmul.M,
                         vsize,
+                        store_row_bound,
                     )
                 )
             else:
-                body_lines.append(f"vec_out = {_store_cast_expr(src, spec.dtype)}")
+                body_lines.append(f"{_ov} = {_store_cast_expr(src, spec.dtype)}")
             continue
         tap_idx = _tap_of[si]
         if spec.major == "m":
@@ -1423,19 +1474,27 @@ def generate(
                     quant_batch_expr,
                     chain.matmul.M,
                     vsize,
+                    store_row_bound,
                 )
             )
-            if spec.dtype == "fp4_e2m1":
-                # packed 2-per-byte: the tap tensor is Int8 (B, M, N/2)
-                body_lines.append(f"(gC_tap_{tap_idx}_ptr + {offset_expr}).store({qv}, alignment={max(vsize // 2, 4)})")
+            _align = max(vsize // 2, 4) if spec.dtype == "fp4_e2m1" else f"VEC_BYTES_TAP_{tap_idx}"
+            # fp4 is packed 2-per-byte, so its tap tensor is Int8 (B, M, N/2).
+            _st = f"(gC_tap_{tap_idx}_ptr + {offset_expr}).store({qv}, alignment={_align})"
+            # A quant tap's DATA store does not go through `_emit_tap_store`, so it
+            # needs the arm's row bound applied here too. Without it a MoE tile,
+            # which overhangs its routed group into the NEXT one, writes rows that
+            # group's own tile also writes -- two tiles racing on the same bytes.
+            if store_row_bound is None:
+                body_lines.append(_st)
             else:
-                body_lines.append(f"(gC_tap_{tap_idx}_ptr + {offset_expr}).store({qv}, alignment=VEC_BYTES_TAP_{tap_idx})")
+                body_lines.append(f"if (row < {store_row_bound}) & (col_j + {vsize} <= N):")
+                body_lines.append(f"    {_st}")
         else:
             body_lines.extend(_emit_tap_store(tap_idx, src, spec.dtype, chain, spec.dim, spec.stride, vsize, offset_expr, si, row_bound=store_row_bound))
 
     for red_idx, red in enumerate(chain.reductions):
         red_source = _parent_value(red.source_ref)
-        body_lines.extend(_emit_reduction_atomic(_tap_of[len(specs) + red_idx], red_idx, red, red_source, chain.matmul, vsize))
+        body_lines.extend(_emit_reduction_atomic(_tap_of[len(specs) + red_idx], red_idx, red, red_source, chain.matmul, vsize, store_row_bound))
 
     epilogue = "\n".join(body_lines)
 

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -1351,7 +1351,11 @@ def generate(
     aux_views = "\n".join(aux_lines) if aux_lines else "pass"
 
     # epilogue snippet (interleaves op chain with tap stores)
-    on_tma_arm = 0 in tma_slots
+    # ANY slot on the TMA surface means the kernel renders the TMA arm, so the
+    # bounds the arm does not supply have to be emitted -- keying this on slot 0
+    # leaves them off whenever slot 0 is the one that fell back (an fp4 data
+    # output beside a bf16 one, say).
+    on_tma_arm = bool(tma_slots)
     # The M-major TMA arm's `row` / `col_j` are the subtile base, not the
     # fragment's coordinates -- everything that asks "which row / column am I"
     # goes through `_elem_coord` there. See `_mmajor_elem_coord`.

--- a/python/cudnn/gemm/frost/fusion_ir.py
+++ b/python/cudnn/gemm/frost/fusion_ir.py
@@ -166,6 +166,7 @@ class ChainOutput:
     is_reduction: bool = False
     is_quant_scale: bool = False
     quant_block_size: int | None = None
+    major: "OutMajor" = "n"
 
 
 @dataclass(frozen=True)
@@ -774,7 +775,7 @@ class FusionChain:
         then one quant scale per ``quants`` entry. Callers must pass runtime
         output tensors in this order."""
         outs: list[ChainOutput] = [
-            ChainOutput(source=self._output_label(spec), dtype=spec.dtype, dim=spec.dim, stride=spec.stride) for spec in self.output_specs
+            ChainOutput(source=self._output_label(spec), dtype=spec.dtype, dim=spec.dim, stride=spec.stride, major=spec.major) for spec in self.output_specs
         ]
         for i, red in enumerate(self.reductions):
             outs.append(

--- a/python/cudnn/gemm/frost/graph_analyzer.py
+++ b/python/cudnn/gemm/frost/graph_analyzer.py
@@ -562,27 +562,9 @@ def build_gemm_plan(graph: cudnn.pygraph):
     ``ValueError`` (type + message preserved) on rejection."""
     if not _graph_has_gemm(graph):
         raise ValueError("cudnn.gemm.frost: graph has no matmul / moe_grouped_matmul node; nothing to compile")
-    from .compiler import jit_from_cudnn_graph
-    from .kernel_registry import preferred_pipeline
-    from .tile_config import as_pipeline, select_config
+    from .compiler import jit_from_cudnn_graph, plan_config
 
-    chain = analyze(graph)
-    tile_m = chain.matmul.M
-    if chain.moe is not None:
-        groups = chain.moe.num_groups
-        tile_m = (chain.matmul.M + groups - 1) // groups
-    from .dtypes import DTYPE_BYTES
-
-    config, cta_group = select_config(
-        tile_m,
-        chain.matmul.N,
-        chain.num_gemms,
-        K=chain.matmul.K,
-        block_scale=chain.has_block_scale,
-        b_n_major=chain.matmul.b_major == "n",
-        b_elem_bytes=DTYPE_BYTES[chain.matmul.b_dtype],
-    )
-    config = as_pipeline(config, preferred_pipeline(chain))
+    config, cta_group = plan_config(analyze(graph))
     return jit_from_cudnn_graph(graph, config=config, cta_group=cta_group)
 
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
@@ -356,7 +356,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1132,7 +1132,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
@@ -128,7 +128,6 @@ def _kernel(
     # @@INJECT_AB_DESC_LISTS@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -192,7 +191,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -302,7 +302,7 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -1089,11 +1089,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1125,6 +1124,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1132,38 +1151,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1386,32 +1374,7 @@ def _host(
         )
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1515,10 +1478,10 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
@@ -128,7 +128,6 @@ def _kernel(
     # @@INJECT_AB_DESC_LISTS@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -199,7 +198,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -296,7 +296,7 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -1175,11 +1175,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1211,6 +1210,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1218,38 +1237,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1473,32 +1461,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1602,10 +1565,10 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
@@ -361,7 +361,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1218,7 +1218,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
@@ -334,7 +334,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -961,7 +961,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
@@ -112,7 +112,6 @@ def _kernel(
     # @@INJECT_AB_DESC_LISTS@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -174,7 +173,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_b_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -265,7 +265,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -915,11 +915,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -954,6 +953,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -961,38 +980,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1175,32 +1163,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1284,10 +1247,10 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
@@ -339,7 +339,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
     M = m
     N = n
     num_k_tiles = cute.ceil_div(k, cgrp_tile_mnk[2])
@@ -1026,7 +1026,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
@@ -110,7 +110,6 @@ def _kernel(
     # @@INJECT_AB_DESC_LISTS@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -179,7 +178,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_b_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -259,7 +259,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -980,11 +980,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1019,6 +1018,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1026,38 +1045,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1240,32 +1228,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1349,10 +1312,10 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
@@ -112,7 +112,6 @@ def _kernel(
     tma_b_desc = tma_b_descs[0]
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -173,7 +172,8 @@ def _kernel(
         nvvm.prefetch_tensormap(tma_b_desc.get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -264,7 +264,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -1128,11 +1128,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1167,6 +1166,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1174,38 +1193,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1369,32 +1357,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1478,10 +1441,10 @@ def compile() -> Callable:
 
     # @@INJECT_COMPILE_AB_FAKES@@
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
@@ -340,7 +340,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1174,7 +1174,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
@@ -114,7 +114,6 @@ def _kernel(
     tma_b_desc = tma_b_descs[0]
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -182,7 +181,8 @@ def _kernel(
         nvvm.prefetch_tensormap(tma_b_desc.get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -261,7 +261,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -1265,11 +1265,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1304,6 +1303,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1311,38 +1330,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1507,32 +1495,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1616,10 +1579,10 @@ def compile() -> Callable:
 
     # @@INJECT_COMPILE_AB_FAKES@@
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
@@ -352,7 +352,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1311,7 +1311,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -47,7 +47,7 @@ from cuda.bindings import driver as _cuda
 
 # Tensormap workspace slots per CTA: the A operands, plus the output descriptor
 # when the TMA-store epilogue re-dimensions it per routed group.
-moe_desc_slots = num_a_operands * 2 + (1 if use_tma_store_epi else 0)
+moe_desc_slots = num_a_operands * 2 + n_tma_outputs
 
 if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_per_mma_m, epi_n)):
     raise NotImplementedError(f"{__name__}: acc overlap reverses subtiles by index, which needs a uniform drain width")
@@ -121,7 +121,6 @@ def _kernel(
     # @@INJECT_MOE_MSFA_LIST@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -160,7 +159,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     cluster_linear_init = bidx // cluster_m
@@ -226,7 +226,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -235,7 +235,7 @@ def _kernel(
     )
     tma_c_desc_smem = cutlass.Array(
         cutlass.Int64,
-        TENSOR_MAP_QWORDS,
+        TENSOR_MAP_QWORDS * n_tma_outputs,
         space=cutlass.AddressSpace.smem,
         alignment=128,
     )
@@ -1040,16 +1040,16 @@ def _kernel(
         # The routed output is a single (1, S, N) tensor, so the batch coord is fixed.
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
-        d_desc_base = a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2) * TENSOR_MAP_QWORDS
-        d_desc_tma_ptr = cute.make_ptr(
-            cutlass.Int64,
-            d_desc_base.toint(),
-            mem_space=cute.AddressSpace.generic,
-        )
+        d_desc_base_list = [
+            a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2 + _di) * TENSOR_MAP_QWORDS
+            for _di in range(n_tma_outputs)
+        ]
+        d_desc_ptr_list = [cute.make_ptr(cutlass.Int64, _b.toint(), mem_space=cute.AddressSpace.generic) for _b in d_desc_base_list]
         previous_group_end = cutlass.Int32(-1)
         if warp_idx == 0:
-            if elect_one:
-                _copy_tensormap_to_workspace(tma_c_desc.get_ptr(), tma_c_desc_smem)
+            for _di in cutlass.range_constexpr(n_tma_outputs):
+                if elect_one:
+                    _copy_tensormap_to_workspace(tma_c_descs[_di].get_ptr(), tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS))
             nvvm.bar_warp_sync(0xFFFFFFFF)
         # @@TMA_STORE_ONLY:END@@
 
@@ -1082,14 +1082,18 @@ def _kernel(
                 if warp_idx == 0:
                     if group_end != previous_group_end:
                         previous_group_end = group_end
+                        # One drain retires the in-flight stores of EVERY descriptor,
+                        # so it does not repeat per output.
                         nvvm.cp_async_bulk_wait_group(0, read=True)
-                        _fence_tensormap_acquire(d_desc_tma_ptr)
-                        if elect_one:
-                            _replace_tensormap_global_dim_1(tma_c_desc_smem, group_end)
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
-                        if lane < TENSOR_MAP_QWORDS:
-                            (d_desc_base + lane).store((tma_c_desc_smem.subview(lane)).load())
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
+                        for _di in cutlass.range_constexpr(n_tma_outputs):
+                            _scratch = tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS)
+                            _fence_tensormap_acquire(d_desc_ptr_list[_di])
+                            if elect_one:
+                                _replace_tensormap_global_dim_1(_scratch, group_end)
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
+                            if lane < TENSOR_MAP_QWORDS:
+                                (d_desc_base_list[_di] + lane).store((_scratch.subview(lane)).load())
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
                         _fence_tensormap_release()
                 # @@TMA_STORE_ONLY:END@@
                 # @@EPILOGUE_DRAIN:BEGIN@@
@@ -1154,39 +1158,13 @@ def _kernel(
                         col = coord_n_c + subtile_col_offset
 
                         # @@TMA_STORE_ONLY:BEGIN@@
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                         vec_f32 = c_rmem_vec
                         col_j = col
                         linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-
-                        if warp_idx == 0:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    d_desc_tma_ptr,
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                         # @@TMA_STORE_ONLY:END@@
 
                         # @@STG_ONLY:BEGIN@@
@@ -1259,19 +1237,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    tma_c_desc = _tma.create_tensor_map_tiled(
-        global_address=c.iterator.toint(),
-        dtype=cd_tma_dtype,
-        global_dims=[n, m, 1],
-        global_strides=[
-            out_stride_m_0 * cd_dtype.width // 128,
-            out_stride_l_0 * cd_dtype.width // 128,
-        ],
-        box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-        swizzle=epi_tma_swizzle,
-    )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     tma_a_desc_list = []
@@ -1485,10 +1451,10 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, 1),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
             stride_order=(1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -326,7 +326,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1164,7 +1164,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                         cute.arch.fence_view_async_shared()
                         nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -331,7 +331,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1230,7 +1230,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                         cute.arch.fence_view_async_shared()
                         nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -49,7 +49,7 @@ from cuda.bindings import driver as _cuda
 
 # Tensormap workspace slots per CTA: the A operands, plus the output descriptor
 # when the TMA-store epilogue re-dimensions it per routed group.
-moe_desc_slots = num_a_operands * 2 + (1 if use_tma_store_epi else 0)
+moe_desc_slots = num_a_operands * 2 + n_tma_outputs
 
 if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_per_mma_m, epi_n)):
     raise NotImplementedError(f"{__name__}: acc overlap reverses subtiles by index, which needs a uniform drain width")
@@ -123,7 +123,6 @@ def _kernel(
     # @@INJECT_MOE_MSFA_LIST@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -168,7 +167,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     a_pattern = 0
@@ -226,7 +226,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -235,7 +235,7 @@ def _kernel(
     )
     tma_c_desc_smem = cutlass.Array(
         cutlass.Int64,
-        TENSOR_MAP_QWORDS,
+        TENSOR_MAP_QWORDS * n_tma_outputs,
         space=cutlass.AddressSpace.smem,
         alignment=128,
     )
@@ -1098,16 +1098,16 @@ def _kernel(
         # The routed output is a single (1, S, N) tensor, so the batch coord is fixed.
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
-        d_desc_base = a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2) * TENSOR_MAP_QWORDS
-        d_desc_tma_ptr = cute.make_ptr(
-            cutlass.Int64,
-            d_desc_base.toint(),
-            mem_space=cute.AddressSpace.generic,
-        )
+        d_desc_base_list = [
+            a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2 + _di) * TENSOR_MAP_QWORDS
+            for _di in range(n_tma_outputs)
+        ]
+        d_desc_ptr_list = [cute.make_ptr(cutlass.Int64, _b.toint(), mem_space=cute.AddressSpace.generic) for _b in d_desc_base_list]
         previous_group_end = cutlass.Int32(-1)
         if warp_idx == 0:
-            if elect_one:
-                _copy_tensormap_to_workspace(tma_c_desc.get_ptr(), tma_c_desc_smem)
+            for _di in cutlass.range_constexpr(n_tma_outputs):
+                if elect_one:
+                    _copy_tensormap_to_workspace(tma_c_descs[_di].get_ptr(), tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS))
             nvvm.bar_warp_sync(0xFFFFFFFF)
         # @@TMA_STORE_ONLY:END@@
 
@@ -1140,14 +1140,18 @@ def _kernel(
                 if warp_idx == 0:
                     if group_end != previous_group_end:
                         previous_group_end = group_end
+                        # One drain retires the in-flight stores of EVERY descriptor,
+                        # so it does not repeat per output.
                         nvvm.cp_async_bulk_wait_group(0, read=True)
-                        _fence_tensormap_acquire(d_desc_tma_ptr)
-                        if elect_one:
-                            _replace_tensormap_global_dim_1(tma_c_desc_smem, group_end)
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
-                        if lane < TENSOR_MAP_QWORDS:
-                            (d_desc_base + lane).store((tma_c_desc_smem.subview(lane)).load())
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
+                        for _di in cutlass.range_constexpr(n_tma_outputs):
+                            _scratch = tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS)
+                            _fence_tensormap_acquire(d_desc_ptr_list[_di])
+                            if elect_one:
+                                _replace_tensormap_global_dim_1(_scratch, group_end)
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
+                            if lane < TENSOR_MAP_QWORDS:
+                                (d_desc_base_list[_di] + lane).store((_scratch.subview(lane)).load())
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
                         _fence_tensormap_release()
                 # @@TMA_STORE_ONLY:END@@
                 # @@EPILOGUE_DRAIN:BEGIN@@
@@ -1220,39 +1224,13 @@ def _kernel(
                         col = coord_n_c + subtile_col_offset
 
                         # @@TMA_STORE_ONLY:BEGIN@@
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                         vec_f32 = c_rmem_vec
                         col_j = col
                         linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-
-                        if warp_idx == 0:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    d_desc_tma_ptr,
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                         # @@TMA_STORE_ONLY:END@@
 
                         # @@STG_ONLY:BEGIN@@
@@ -1327,19 +1305,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    tma_c_desc = _tma.create_tensor_map_tiled(
-        global_address=c.iterator.toint(),
-        dtype=cd_tma_dtype,
-        global_dims=[n, m, 1],
-        global_strides=[
-            out_stride_m_0 * cd_dtype.width // 128,
-            out_stride_l_0 * cd_dtype.width // 128,
-        ],
-        box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-        swizzle=epi_tma_swizzle,
-    )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     tma_a_desc_list = []
@@ -1556,10 +1522,10 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, 1),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
             stride_order=(1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
@@ -48,7 +48,7 @@ from cuda.bindings import driver as _cuda
 
 # Tensormap workspace slots per CTA: the A operands, plus the output descriptor
 # when the TMA-store epilogue re-dimensions it per routed group.
-moe_desc_slots = num_a_operands + (1 if use_tma_store_epi else 0)
+moe_desc_slots = num_a_operands + n_tma_outputs
 
 
 SCHED_STAGES = 2
@@ -109,7 +109,6 @@ def _kernel(
     # @@INJECT_MOE_MA_LIST@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -148,7 +147,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_b_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     a_pattern = 0
@@ -222,7 +222,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -231,7 +231,7 @@ def _kernel(
     )
     tma_c_desc_smem = cutlass.Array(
         cutlass.Int64,
-        TENSOR_MAP_QWORDS,
+        TENSOR_MAP_QWORDS * n_tma_outputs,
         space=cutlass.AddressSpace.smem,
         alignment=128,
     )
@@ -765,16 +765,15 @@ def _kernel(
         # The routed output is a single (1, S, N) tensor, so the batch coord is fixed.
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
-        d_desc_base = a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands) * TENSOR_MAP_QWORDS
-        d_desc_tma_ptr = cute.make_ptr(
-            cutlass.Int64,
-            d_desc_base.toint(),
-            mem_space=cute.AddressSpace.generic,
-        )
+        d_desc_base_list = [
+            a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands + _di) * TENSOR_MAP_QWORDS for _di in range(n_tma_outputs)
+        ]
+        d_desc_ptr_list = [cute.make_ptr(cutlass.Int64, _b.toint(), mem_space=cute.AddressSpace.generic) for _b in d_desc_base_list]
         previous_group_end = cutlass.Int32(-1)
         if warp_idx == 0:
-            if elect_one:
-                _copy_tensormap_to_workspace(tma_c_desc.get_ptr(), tma_c_desc_smem)
+            for _di in cutlass.range_constexpr(n_tma_outputs):
+                if elect_one:
+                    _copy_tensormap_to_workspace(tma_c_descs[_di].get_ptr(), tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS))
             nvvm.bar_warp_sync(0xFFFFFFFF)
         # @@TMA_STORE_ONLY:END@@
 
@@ -802,14 +801,18 @@ def _kernel(
             if warp_idx == 0:
                 if group_end != previous_group_end:
                     previous_group_end = group_end
+                    # One drain retires the in-flight stores of EVERY descriptor,
+                    # so it does not repeat per output.
                     nvvm.cp_async_bulk_wait_group(0, read=True)
-                    _fence_tensormap_acquire(d_desc_tma_ptr)
-                    if elect_one:
-                        _replace_tensormap_global_dim_1(tma_c_desc_smem, group_end)
-                    nvvm.bar_warp_sync(0xFFFFFFFF)
-                    if lane < TENSOR_MAP_QWORDS:
-                        (d_desc_base + lane).store((tma_c_desc_smem.subview(lane)).load())
-                    nvvm.bar_warp_sync(0xFFFFFFFF)
+                    for _di in cutlass.range_constexpr(n_tma_outputs):
+                        _scratch = tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS)
+                        _fence_tensormap_acquire(d_desc_ptr_list[_di])
+                        if elect_one:
+                            _replace_tensormap_global_dim_1(_scratch, group_end)
+                        nvvm.bar_warp_sync(0xFFFFFFFF)
+                        if lane < TENSOR_MAP_QWORDS:
+                            (d_desc_base_list[_di] + lane).store((_scratch.subview(lane)).load())
+                        nvvm.bar_warp_sync(0xFFFFFFFF)
                     _fence_tensormap_release()
             # @@TMA_STORE_ONLY:END@@
             # @@EPILOGUE_DRAIN:BEGIN@@
@@ -862,39 +865,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     vec_f32 = c_rmem_vec
                     col_j = col
                     linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
                     # @@INJECT_EPILOGUE@@
 
-                    smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if elect_one:
-                            nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                d_desc_tma_ptr,
-                                smem_subtile_ptr,
-                                (col, coord_m, tile_l),
-                            )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -981,19 +958,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    tma_c_desc = _tma.create_tensor_map_tiled(
-        global_address=c.iterator.toint(),
-        dtype=cd_tma_dtype,
-        global_dims=[n, m, 1],
-        global_strides=[
-            out_stride_m_0 * cd_dtype.width // 128,
-            out_stride_l_0 * cd_dtype.width // 128,
-        ],
-        box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-        swizzle=epi_tma_swizzle,
-    )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     tma_a_desc_list = []
@@ -1133,10 +1098,10 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, 1),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
             stride_order=(1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
@@ -291,7 +291,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -872,7 +872,7 @@ def _kernel(
 
                     # @@INJECT_EPILOGUE@@
 
-                    smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                    smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
@@ -304,7 +304,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -941,7 +941,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                         cute.arch.fence_view_async_shared()
                         nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
@@ -50,7 +50,7 @@ from cuda.bindings import driver as _cuda
 
 # Tensormap workspace slots per CTA: the A operands, plus the output descriptor
 # when the TMA-store epilogue re-dimensions it per routed group.
-moe_desc_slots = num_a_operands + (1 if use_tma_store_epi else 0)
+moe_desc_slots = num_a_operands + n_tma_outputs
 
 
 # Scheduler ring depth.
@@ -114,7 +114,6 @@ def _kernel(
     # @@INJECT_MOE_MA_LIST@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -157,7 +156,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_b_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     a_pattern = 0
@@ -227,7 +227,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -236,7 +236,7 @@ def _kernel(
     )
     tma_c_desc_smem = cutlass.Array(
         cutlass.Int64,
-        TENSOR_MAP_QWORDS,
+        TENSOR_MAP_QWORDS * n_tma_outputs,
         space=cutlass.AddressSpace.smem,
         alignment=128,
     )
@@ -823,16 +823,15 @@ def _kernel(
         # The routed output is a single (1, S, N) tensor, so the batch coord is fixed.
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
-        d_desc_base = a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands) * TENSOR_MAP_QWORDS
-        d_desc_tma_ptr = cute.make_ptr(
-            cutlass.Int64,
-            d_desc_base.toint(),
-            mem_space=cute.AddressSpace.generic,
-        )
+        d_desc_base_list = [
+            a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands + _di) * TENSOR_MAP_QWORDS for _di in range(n_tma_outputs)
+        ]
+        d_desc_ptr_list = [cute.make_ptr(cutlass.Int64, _b.toint(), mem_space=cute.AddressSpace.generic) for _b in d_desc_base_list]
         previous_group_end = cutlass.Int32(-1)
         if warp_idx == 0:
-            if elect_one:
-                _copy_tensormap_to_workspace(tma_c_desc.get_ptr(), tma_c_desc_smem)
+            for _di in cutlass.range_constexpr(n_tma_outputs):
+                if elect_one:
+                    _copy_tensormap_to_workspace(tma_c_descs[_di].get_ptr(), tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS))
             nvvm.bar_warp_sync(0xFFFFFFFF)
         # @@TMA_STORE_ONLY:END@@
 
@@ -865,14 +864,18 @@ def _kernel(
                 if warp_idx == 0:
                     if group_end != previous_group_end:
                         previous_group_end = group_end
+                        # One drain retires the in-flight stores of EVERY descriptor,
+                        # so it does not repeat per output.
                         nvvm.cp_async_bulk_wait_group(0, read=True)
-                        _fence_tensormap_acquire(d_desc_tma_ptr)
-                        if elect_one:
-                            _replace_tensormap_global_dim_1(tma_c_desc_smem, group_end)
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
-                        if lane < TENSOR_MAP_QWORDS:
-                            (d_desc_base + lane).store((tma_c_desc_smem.subview(lane)).load())
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
+                        for _di in cutlass.range_constexpr(n_tma_outputs):
+                            _scratch = tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS)
+                            _fence_tensormap_acquire(d_desc_ptr_list[_di])
+                            if elect_one:
+                                _replace_tensormap_global_dim_1(_scratch, group_end)
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
+                            if lane < TENSOR_MAP_QWORDS:
+                                (d_desc_base_list[_di] + lane).store((_scratch.subview(lane)).load())
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
                         _fence_tensormap_release()
                 # @@TMA_STORE_ONLY:END@@
                 # @@EPILOGUE_DRAIN:BEGIN@@
@@ -931,39 +934,13 @@ def _kernel(
                         col = coord_n_c + subtile_col_offset
 
                         # @@TMA_STORE_ONLY:BEGIN@@
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                         vec_f32 = c_rmem_vec
                         col_j = col
                         linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-
-                        if warp_idx == 0:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    d_desc_tma_ptr,
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                         # @@TMA_STORE_ONLY:END@@
 
                         # @@STG_ONLY:BEGIN@@
@@ -1032,19 +1009,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    tma_c_desc = _tma.create_tensor_map_tiled(
-        global_address=c.iterator.toint(),
-        dtype=cd_tma_dtype,
-        global_dims=[n, m, 1],
-        global_strides=[
-            out_stride_m_0 * cd_dtype.width // 128,
-            out_stride_l_0 * cd_dtype.width // 128,
-        ],
-        box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-        swizzle=epi_tma_swizzle,
-    )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     tma_a_desc_list = []
@@ -1184,10 +1149,10 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, 1),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
             stride_order=(1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
@@ -425,7 +425,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1327,7 +1327,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
@@ -192,7 +192,6 @@ def _kernel(
     # @@INJECT_AB_DESC_LISTS@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -257,7 +256,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -368,7 +368,7 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -1284,11 +1284,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1320,6 +1319,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1327,38 +1346,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1548,32 +1536,7 @@ def _host(
         )
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1677,10 +1640,10 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
@@ -192,7 +192,6 @@ def _kernel(
     # @@INJECT_AB_DESC_LISTS@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -264,7 +263,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -362,7 +362,7 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -1366,11 +1366,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1402,6 +1401,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1409,38 +1428,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1631,32 +1619,7 @@ def _host(
         )
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1760,10 +1723,10 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
@@ -432,7 +432,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1409,7 +1409,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_1ctamma.py
@@ -145,7 +145,6 @@ def _kernel(
     # @@INJECT_AB_DESC_LISTS@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -212,7 +211,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -322,7 +322,7 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -1148,11 +1148,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1184,6 +1183,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1191,38 +1210,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1445,32 +1433,7 @@ def _host(
         )
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1574,10 +1537,10 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_1ctamma.py
@@ -376,7 +376,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1191,7 +1191,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_2ctamma.py
@@ -145,7 +145,6 @@ def _kernel(
     # @@INJECT_AB_DESC_LISTS@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -216,7 +215,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     init_raw_m = bidx >> _preferred_cluster_m_shift
@@ -313,7 +313,7 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -1232,11 +1232,10 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                    smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                    smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                     if cutlass.const_expr(cd_out_is_m_major):
+                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
+                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
+                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
                         ld_col = mi_col_base + subtile_col_offset
                         for _h in cutlass.range(2, unroll_full=True):
                             ld_row = base_row_id + warp_idx * 32 + _h * 16
@@ -1268,6 +1267,26 @@ def _kernel(
                                     nvvm.MMALayout.COL,
                                     shape=nvvm.StoreShape.M8N8,
                                 )
+                        cute.arch.fence_view_async_shared()
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
+                        if warp_idx == 0:
+                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
+                                if elect_one:
+                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
+                                        tma_c_descs[0].get_ptr(),
+                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
+                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
+                                    )
+                            if elect_one:
+                                nvvm.cp_async_bulk_commit_group()
+                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
+                        nvvm.barrier_cta_sync(
+                            barrier_id=EPI_SYNC_BAR_ID,
+                            thread_count=num_epilogue_warps * 32,
+                        )
                     else:
                         vec_f32 = c_rmem_vec
                         col_j = col
@@ -1275,38 +1294,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                    cute.arch.fence_view_async_shared()
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
-
-                    if warp_idx == 0:
-                        if cutlass.const_expr(cd_out_is_m_major):
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_desc.get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                        else:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    tma_c_desc.get_ptr(),
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                        if elect_one:
-                            nvvm.cp_async_bulk_commit_group()
-                        nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                    nvvm.barrier_cta_sync(
-                        barrier_id=EPI_SYNC_BAR_ID,
-                        thread_count=num_epilogue_warps * 32,
-                    )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1530,32 +1518,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    if cutlass.const_expr(cd_out_is_m_major):
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[m, n, batch],
-            global_strides=[
-                out_stride_n_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],
-            swizzle=(_tma.TensorMapSwizzle.s128b if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    else:
-        tma_c_desc = _tma.create_tensor_map_tiled(
-            global_address=c.iterator.toint(),
-            dtype=cd_tma_dtype,
-            global_dims=[n, m, batch],
-            global_strides=[
-                out_stride_m_0 * cd_dtype.width // 128,
-                out_stride_l_0 * cd_dtype.width // 128,
-            ],
-            box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-            swizzle=(epi_tma_swizzle if cutlass.const_expr(use_tma_store_epi) else _tma.TensorMapSwizzle.none),
-        )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     cluster_m = cluster_shape_mnk[0]
@@ -1659,10 +1622,10 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, sym_l),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
             stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_2ctamma.py
@@ -378,7 +378,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1275,7 +1275,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                     cute.arch.fence_view_async_shared()
                     nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -344,7 +344,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1221,7 +1221,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                         cute.arch.fence_view_async_shared()
                         nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -66,7 +66,7 @@ from cuda.bindings import driver as _cuda
 
 # Tensormap workspace slots per CTA: the A operands, plus the output descriptor
 # when the TMA-store epilogue re-dimensions it per routed group.
-moe_desc_slots = num_a_operands * 2 + (1 if use_tma_store_epi else 0)
+moe_desc_slots = num_a_operands * 2 + n_tma_outputs
 
 if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_per_mma_m, epi_n)):
     raise NotImplementedError(f"{__name__}: acc overlap reverses subtiles by index, which needs a uniform drain width")
@@ -139,7 +139,6 @@ def _kernel(
     # @@INJECT_MOE_MSFA_LIST@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -178,7 +177,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     cluster_linear_init = bidx // cluster_m
@@ -244,7 +244,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -253,7 +253,7 @@ def _kernel(
     )
     tma_c_desc_smem = cutlass.Array(
         cutlass.Int64,
-        TENSOR_MAP_QWORDS,
+        TENSOR_MAP_QWORDS * n_tma_outputs,
         space=cutlass.AddressSpace.smem,
         alignment=128,
     )
@@ -1097,16 +1097,16 @@ def _kernel(
         # The routed output is a single (1, S, N) tensor, so the batch coord is fixed.
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
-        d_desc_base = a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2) * TENSOR_MAP_QWORDS
-        d_desc_tma_ptr = cute.make_ptr(
-            cutlass.Int64,
-            d_desc_base.toint(),
-            mem_space=cute.AddressSpace.generic,
-        )
+        d_desc_base_list = [
+            a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2 + _di) * TENSOR_MAP_QWORDS
+            for _di in range(n_tma_outputs)
+        ]
+        d_desc_ptr_list = [cute.make_ptr(cutlass.Int64, _b.toint(), mem_space=cute.AddressSpace.generic) for _b in d_desc_base_list]
         previous_group_end = cutlass.Int32(-1)
         if warp_idx == 0:
-            if elect_one:
-                _copy_tensormap_to_workspace(tma_c_desc.get_ptr(), tma_c_desc_smem)
+            for _di in cutlass.range_constexpr(n_tma_outputs):
+                if elect_one:
+                    _copy_tensormap_to_workspace(tma_c_descs[_di].get_ptr(), tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS))
             nvvm.bar_warp_sync(0xFFFFFFFF)
         # @@TMA_STORE_ONLY:END@@
 
@@ -1139,14 +1139,18 @@ def _kernel(
                 if warp_idx == 0:
                     if group_end != previous_group_end:
                         previous_group_end = group_end
+                        # One drain retires the in-flight stores of EVERY descriptor,
+                        # so it does not repeat per output.
                         nvvm.cp_async_bulk_wait_group(0, read=True)
-                        _fence_tensormap_acquire(d_desc_tma_ptr)
-                        if elect_one:
-                            _replace_tensormap_global_dim_1(tma_c_desc_smem, group_end)
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
-                        if lane < TENSOR_MAP_QWORDS:
-                            (d_desc_base + lane).store((tma_c_desc_smem.subview(lane)).load())
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
+                        for _di in cutlass.range_constexpr(n_tma_outputs):
+                            _scratch = tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS)
+                            _fence_tensormap_acquire(d_desc_ptr_list[_di])
+                            if elect_one:
+                                _replace_tensormap_global_dim_1(_scratch, group_end)
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
+                            if lane < TENSOR_MAP_QWORDS:
+                                (d_desc_base_list[_di] + lane).store((_scratch.subview(lane)).load())
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
                         _fence_tensormap_release()
                 # @@TMA_STORE_ONLY:END@@
                 # @@EPILOGUE_DRAIN:BEGIN@@
@@ -1211,39 +1215,13 @@ def _kernel(
                         col = coord_n_c + subtile_col_offset
 
                         # @@TMA_STORE_ONLY:BEGIN@@
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                         vec_f32 = c_rmem_vec
                         col_j = col
                         linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-
-                        if warp_idx == 0:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    d_desc_tma_ptr,
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                         # @@TMA_STORE_ONLY:END@@
 
                         # @@STG_ONLY:BEGIN@@
@@ -1316,19 +1294,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    tma_c_desc = _tma.create_tensor_map_tiled(
-        global_address=c.iterator.toint(),
-        dtype=cd_tma_dtype,
-        global_dims=[n, m, 1],
-        global_strides=[
-            out_stride_m_0 * cd_dtype.width // 128,
-            out_stride_l_0 * cd_dtype.width // 128,
-        ],
-        box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-        swizzle=epi_tma_swizzle,
-    )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     tma_a_desc_list = []
@@ -1542,10 +1508,10 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, 1),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
             stride_order=(1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -349,7 +349,7 @@ def _kernel(
     # @@INJECT_TAP_PTRS@@
 
     VEC_BYTES = vec_bytes_epi
-    vsize = (VEC_BYTES * 8) // cd_dtype.width
+    vsize = epi_chunk_elems
 
     M = m
     N = n
@@ -1288,7 +1288,7 @@ def _kernel(
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=64, swizzle=epi_smem_swizzle)
+                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
 
                         cute.arch.fence_view_async_shared()
                         nvvm.barrier_cta_sync(

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -68,7 +68,7 @@ from cuda.bindings import driver as _cuda
 
 # Tensormap workspace slots per CTA: the A operands, plus the output descriptor
 # when the TMA-store epilogue re-dimensions it per routed group.
-moe_desc_slots = num_a_operands * 2 + (1 if use_tma_store_epi else 0)
+moe_desc_slots = num_a_operands * 2 + n_tma_outputs
 
 if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_per_mma_m, epi_n)):
     raise NotImplementedError(f"{__name__}: acc overlap reverses subtiles by index, which needs a uniform drain width")
@@ -141,7 +141,6 @@ def _kernel(
     # @@INJECT_MOE_MSFA_LIST@@
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_TMA_C_LISTS@@
-    tma_c_desc = tma_c_descs[0]
     # @@TMA_STORE_ONLY:END@@
 
     mma_warp_id = 4
@@ -186,7 +185,8 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_sfb_descs[_j].get_ptr())
 
         # @@TMA_STORE_ONLY:BEGIN@@
-        nvvm.prefetch_tensormap(tma_c_desc.get_ptr())
+        for _ci in cutlass.range_constexpr(n_tma_outputs):
+            nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
     a_pattern = 0
@@ -244,7 +244,7 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1]
+    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -253,7 +253,7 @@ def _kernel(
     )
     tma_c_desc_smem = cutlass.Array(
         cutlass.Int64,
-        TENSOR_MAP_QWORDS,
+        TENSOR_MAP_QWORDS * n_tma_outputs,
         space=cutlass.AddressSpace.smem,
         alignment=128,
     )
@@ -1156,16 +1156,16 @@ def _kernel(
         # The routed output is a single (1, S, N) tensor, so the batch coord is fixed.
         tile_l = cutlass.Int32(0)
         epi_block_linear = bidx + bidy * gridx
-        d_desc_base = a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2) * TENSOR_MAP_QWORDS
-        d_desc_tma_ptr = cute.make_ptr(
-            cutlass.Int64,
-            d_desc_base.toint(),
-            mem_space=cute.AddressSpace.generic,
-        )
+        d_desc_base_list = [
+            a_tma_workspace.iterator.raw_ptr() + (epi_block_linear * moe_desc_slots + num_a_operands * 2 + _di) * TENSOR_MAP_QWORDS
+            for _di in range(n_tma_outputs)
+        ]
+        d_desc_ptr_list = [cute.make_ptr(cutlass.Int64, _b.toint(), mem_space=cute.AddressSpace.generic) for _b in d_desc_base_list]
         previous_group_end = cutlass.Int32(-1)
         if warp_idx == 0:
-            if elect_one:
-                _copy_tensormap_to_workspace(tma_c_desc.get_ptr(), tma_c_desc_smem)
+            for _di in cutlass.range_constexpr(n_tma_outputs):
+                if elect_one:
+                    _copy_tensormap_to_workspace(tma_c_descs[_di].get_ptr(), tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS))
             nvvm.bar_warp_sync(0xFFFFFFFF)
         # @@TMA_STORE_ONLY:END@@
 
@@ -1198,14 +1198,18 @@ def _kernel(
                 if warp_idx == 0:
                     if group_end != previous_group_end:
                         previous_group_end = group_end
+                        # One drain retires the in-flight stores of EVERY descriptor,
+                        # so it does not repeat per output.
                         nvvm.cp_async_bulk_wait_group(0, read=True)
-                        _fence_tensormap_acquire(d_desc_tma_ptr)
-                        if elect_one:
-                            _replace_tensormap_global_dim_1(tma_c_desc_smem, group_end)
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
-                        if lane < TENSOR_MAP_QWORDS:
-                            (d_desc_base + lane).store((tma_c_desc_smem.subview(lane)).load())
-                        nvvm.bar_warp_sync(0xFFFFFFFF)
+                        for _di in cutlass.range_constexpr(n_tma_outputs):
+                            _scratch = tma_c_desc_smem.subview(_di * TENSOR_MAP_QWORDS)
+                            _fence_tensormap_acquire(d_desc_ptr_list[_di])
+                            if elect_one:
+                                _replace_tensormap_global_dim_1(_scratch, group_end)
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
+                            if lane < TENSOR_MAP_QWORDS:
+                                (d_desc_base_list[_di] + lane).store((_scratch.subview(lane)).load())
+                            nvvm.bar_warp_sync(0xFFFFFFFF)
                         _fence_tensormap_release()
                 # @@TMA_STORE_ONLY:END@@
                 # @@EPILOGUE_DRAIN:BEGIN@@
@@ -1278,39 +1282,13 @@ def _kernel(
                         col = coord_n_c + subtile_col_offset
 
                         # @@TMA_STORE_ONLY:BEGIN@@
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-
                         vec_f32 = c_rmem_vec
                         col_j = col
                         linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
                         # @@INJECT_EPILOGUE@@
 
-                        smem_thr_ptr.data_ptr().store_swizzled(vec_out, alignment=epi_smem_row_bytes, swizzle=epi_smem_swizzle)
-
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-
-                        if warp_idx == 0:
-                            if elect_one:
-                                nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                    d_desc_tma_ptr,
-                                    smem_subtile_ptr,
-                                    (col, coord_m, tile_l),
-                                )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
+                        # @@INJECT_TMA_STORE_SEQUENCE@@
                         # @@TMA_STORE_ONLY:END@@
 
                         # @@STG_ONLY:BEGIN@@
@@ -1385,19 +1363,7 @@ def _host(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # @@INJECT_HOST_TMA_C_LISTS@@
-    c = _tma_c_outputs[0]
-    tma_c_desc = _tma.create_tensor_map_tiled(
-        global_address=c.iterator.toint(),
-        dtype=cd_tma_dtype,
-        global_dims=[n, m, 1],
-        global_strides=[
-            out_stride_m_0 * cd_dtype.width // 128,
-            out_stride_l_0 * cd_dtype.width // 128,
-        ],
-        box_dims=[epi_tile_mn[1], epi_tile_mn[0], 1],
-        swizzle=epi_tma_swizzle,
-    )
-    tma_c_desc_list = [tma_c_desc]
+    # @@INJECT_HOST_TMA_C_DESCS@@
     # @@TMA_STORE_ONLY:END@@
 
     tma_a_desc_list = []
@@ -1614,10 +1580,10 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c():
+    def _make_fake_c(_dt=None, _div=None):
         return make_fake_compact_tensor(
-            cd_dtype,
-            (sym_m, sym_n // cd_fake_n_div, 1),
+            cd_dtype if _dt is None else _dt,
+            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
             stride_order=(1, 0, 2),
             assumed_align=16,
         )

--- a/python/cudnn/gemm/frost/recipe.py
+++ b/python/cudnn/gemm/frost/recipe.py
@@ -35,7 +35,7 @@ from typing import Any
 
 from cudnn.frost.buffers import init_word, is_contiguous, strided_fill_plan
 
-from .dtypes import DTYPE_BYTES, _aux_align_reqs, _output_align_reqs, _pow2_floor, tensor_alignment, tma_slots_of
+from .dtypes import DTYPE_BYTES, _aux_align_reqs, _output_align_reqs, _pow2_floor, tensor_alignment
 from .fusion_ir import FusionChain
 
 # An operand's three axes, named by role rather than by position.
@@ -489,7 +489,7 @@ def build(compiled) -> GemmRecipe:
         _operand(order[id(t)], f"B operand[{i}]", t, major=mm.b_major, dtype=mm.b_dtype, batch=mm.b_batch, is_b=True) for i, t in enumerate(binding.b_operands)
     ]
 
-    out_reqs = _output_align_reqs(chain, tma_slots_of(compiled.use_tma_store), vec_bytes=compiled.vec_bytes_epi)
+    out_reqs = _output_align_reqs(chain, compiled.tma_slots, vec_bytes=compiled.vec_bytes_epi)
     aux_reqs = _aux_align_reqs(chain, vec_bytes=compiled.vec_bytes_epi)
     outputs, seeds = [], []
     for i, (spec, t) in enumerate(zip(chain.outputs, binding.outputs)):
@@ -530,8 +530,12 @@ def build(compiled) -> GemmRecipe:
     heads = [(op.index, None) for op in inputs] + [(s.index, None) for s in sf]
     outs = [(o.index, None) for o in outputs]
     auxs = [(x.index, x.ref) for x in aux]
-    tma = bool(compiled.use_tma_store)
-    arg_plan = tuple(heads + (outs[1:] + auxs + outs[:1] if tma else outs + auxs))
+    # Taps, aux, then the TMA-C slots in slot order -- an output on the TMA
+    # surface binds a trailing TMA-only kernel parameter.
+    slots = compiled.tma_slots
+    taps = [o for i, o in enumerate(outs) if i not in slots]
+    tmas = [outs[i] for i in sorted(slots) if i < len(outs)]
+    arg_plan = tuple(heads + taps + auxs + tmas)
 
     # Block-scale multi-GEMM sends ONE A and ONE B stride triple and requires the
     # rest to match it; every other flavor sends each operand's own.

--- a/python/cudnn/gemm/frost/recipe.py
+++ b/python/cudnn/gemm/frost/recipe.py
@@ -35,7 +35,7 @@ from typing import Any
 
 from cudnn.frost.buffers import init_word, is_contiguous, strided_fill_plan
 
-from .dtypes import DTYPE_BYTES, _aux_align_reqs, _output_align_reqs, _pow2_floor, tensor_alignment
+from .dtypes import DTYPE_BYTES, _aux_align_reqs, _output_align_reqs, _pow2_floor, tensor_alignment, tma_slots_of
 from .fusion_ir import FusionChain
 
 # An operand's three axes, named by role rather than by position.
@@ -489,7 +489,7 @@ def build(compiled) -> GemmRecipe:
         _operand(order[id(t)], f"B operand[{i}]", t, major=mm.b_major, dtype=mm.b_dtype, batch=mm.b_batch, is_b=True) for i, t in enumerate(binding.b_operands)
     ]
 
-    out_reqs = _output_align_reqs(chain, compiled.use_tma_store, vec_bytes=compiled.vec_bytes_epi)
+    out_reqs = _output_align_reqs(chain, tma_slots_of(compiled.use_tma_store), vec_bytes=compiled.vec_bytes_epi)
     aux_reqs = _aux_align_reqs(chain, vec_bytes=compiled.vec_bytes_epi)
     outputs, seeds = [], []
     for i, (spec, t) in enumerate(zip(chain.outputs, binding.outputs)):
@@ -530,8 +530,8 @@ def build(compiled) -> GemmRecipe:
     heads = [(op.index, None) for op in inputs] + [(s.index, None) for s in sf]
     outs = [(o.index, None) for o in outputs]
     auxs = [(x.index, x.ref) for x in aux]
-    tma = bool(compiled.use_tma_store) and not chain.is_multi_gemm
-    arg_plan = tuple(heads + (auxs + outs[:1] if tma else outs + auxs))
+    tma = bool(compiled.use_tma_store)
+    arg_plan = tuple(heads + (outs[1:] + auxs + outs[:1] if tma else outs + auxs))
 
     # Block-scale multi-GEMM sends ONE A and ONE B stride triple and requires the
     # rest to match it; every other flavor sends each operand's own.

--- a/test/python/gemm/frost/test_frontend_integration.py
+++ b/test/python/gemm/frost/test_frontend_integration.py
@@ -359,6 +359,71 @@ def test_ineligible_graph_not_listed():
     assert not any(is_python_engine(p.engine_id) for p in g.plans)
 
 
+def _bf16_graph(m, n, k, *, epi=None, out_dt=None, b_major="k", ntap=0):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    A = g.tensor(name="A", dim=[1, m, k], stride=[m * k, k, 1])
+    bs = [k * n, 1, k] if b_major == "k" else [k * n, n, 1]
+    B = g.tensor(name="B", dim=[1, k, n], stride=bs)
+    C = g.matmul(A=A, B=B, name="mm")
+    if ntap:
+        C.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    T = getattr(g, epi)(input=C, name="e") if epi else C
+    T.set_output(True).set_data_type(out_dt or cudnn.data_type.BFLOAT16)
+    return g
+
+
+def _moe_graph(s, n, k, e, *, token_major="k"):
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    ts = [s * k, k, 1] if token_major == "k" else [s * k, 1, s]
+    tok = g.tensor(name="token", dim=[1, s, k], stride=ts, data_type=cudnn.data_type.BFLOAT16)
+    w = g.tensor(name="weight", dim=[e, k, n], stride=[k * n, 1, k], data_type=cudnn.data_type.BFLOAT16)
+    fto = g.tensor(name="first_token_offset", dim=[e, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
+    out = g.moe_grouped_matmul(tok, w, fto, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=cudnn.data_type.FLOAT, name="moe")
+    out.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+    return g
+
+
+_AGREEMENT_GRAPHS = {
+    "plain": lambda: _bf16_graph(256, 256, 256),
+    "relu": lambda: _bf16_graph(256, 256, 256, epi="relu"),
+    "tap": lambda: _bf16_graph(256, 256, 256, epi="relu", ntap=1),
+    "fp32_out": lambda: _bf16_graph(256, 256, 256, out_dt=cudnn.data_type.FLOAT),
+    "b_n_major": lambda: _bf16_graph(256, 256, 256, b_major="n"),
+    "tall_narrow": lambda: _bf16_graph(4096, 64, 256),
+    "moe": lambda: _moe_graph(2048, 256, 256, 8),
+    "moe_token_m_major": lambda: _moe_graph(2048, 256, 256, 8, token_major="m"),
+}
+
+
+@_GPU
+@pytest.mark.parametrize("name", sorted(_AGREEMENT_GRAPHS))
+def test_probe_and_build_agree(name):
+    """``probe_gemm_plan`` is what puts frost_gemm in the ranked list, and
+    ``build_gemm_plan`` is what has to honour it. When the probe is the more
+    permissive of the two, the engine is listed, ``build_plans`` drops it and
+    native cuDNN silently serves the graph -- a rejection with NO test failure.
+    This pins them equal, which is the only regression signal the epilogue gates
+    have on the public path."""
+    from cudnn.gemm.frost.graph_analyzer import build_gemm_plan, probe_gemm_plan
+
+    g = _AGREEMENT_GRAPHS[name]()
+    probed = probe_gemm_plan(g)
+    try:
+        build_gemm_plan(_AGREEMENT_GRAPHS[name]())
+        built, why = True, ""
+    except (NotImplementedError, ValueError) as exc:
+        built, why = False, str(exc)
+    assert probed == built, f"probe={probed} but build={built}" + (f" ({why})" if why else "")
+
+
 @_GPU
 def test_wrapper_graph_path():
     """wrapper.Graph(heuristics=[A]) plans and executes the fused graph."""

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -37,7 +37,7 @@ pytestmark = [pytest.mark.L0, requires_sm100]
 
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  — installs the cudnn.pygraph recorder hook
-from cudnn.gemm.frost.compiler import _current_arch, _epi_vec_bytes
+from cudnn.gemm.frost.compiler import _current_arch, _epi_chunk_elems, _epi_vec_bytes
 from cudnn.gemm.frost.tile_config import CATALOG, by_name
 
 _TORCH_DTYPE = {
@@ -845,6 +845,140 @@ def test_matmul(
         f"\n  max|ref|:  {max_ref:.4g}"
         f"\n  hint:      sample c[0,0,:8]   = {c[0, 0, :8].to(torch.float32).tolist()}"
         f"\n             sample ref[0,0,:8] = {ref[0, 0, :8].to(torch.float32).tolist()}"
+    )
+
+
+# Every N in _WEIRD_SHAPES is a multiple of 256, so the epilogue's last chunk of
+# a tile is always whole and the partial-chunk store predicate is never exercised.
+# These two straddle it — the valid column count inside the final N tile is not a
+# multiple of the chunk — while M keeps a tail. N still clears the row-stride rule
+# (_compatible: N * out_eb % 32 == 0), so this is chunk overhang, not N-OOB.
+_N_CHUNK_STRADDLE_SHAPES: tuple[tuple[int, int, int], ...] = (
+    (200, 144, 256),
+    (255, 208, 240),
+)
+
+_STRADDLE_CONFIGS: tuple[str, ...] = (
+    "CONFIG_sm100_128x128x128_128x128x32_cluster1x1_1ctamma",
+    "CONFIG_sm100_128x256x128_128x256x32_cluster1x1_1ctamma",
+    # cta_group=2 with a per-CTA n of 16: the only TMA-store coverage of the
+    # narrow-N pair, which no _QUICK_CONFIGS entry reaches.
+    "CONFIG_sm100_128x32x128_128x32x32_cluster2x1_2ctamma",
+)
+
+
+def _straddle_graph(kind: str, M: int, N: int, K: int) -> cudnn.pygraph:
+    g = cudnn.pygraph(
+        io_data_type=_BF16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    C = g.matmul(A=A, B=B, name="mm")
+    if kind == "plain":
+        Y = C
+    elif kind == "relu":
+        Y = g.relu(input=C, name="r")
+    elif kind == "scalar_aux":
+        s = g.tensor(name="s", dim=[1, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.FLOAT)
+        Y = g.mul(a=C, b=s, name="sc")
+    elif kind == "row_aux":
+        r = g.tensor(name="r", dim=[1, M, 1], stride=[M, 1, 1], data_type=cudnn.data_type.FLOAT)
+        Y = g.mul(a=C, b=r, name="rw")
+    elif kind == "gen_index_axis1":
+        Y = g.add(a=C, b=g.gen_index(input=C, axis=1, name="gi"), name="ad")
+    elif kind == "per_col_aux":
+        xc = g.tensor(name="xc", dim=[1, 1, N], stride=[N, N, 1], data_type=cudnn.data_type.FLOAT)
+        Y = g.mul(a=C, b=xc, name="cw")
+    elif kind == "per_elem_aux":
+        xe = g.tensor(name="xe", dim=[1, M, N], stride=[M * N, N, 1], data_type=cudnn.data_type.FLOAT)
+        Y = g.mul(a=C, b=xe, name="ew")
+    elif kind == "matmul_tap":
+        C.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+        Y = g.relu(input=C, name="r")
+    elif kind == "two_taps":
+        C.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+        R = g.relu(input=C, name="r")
+        R.set_output(True).set_data_type(cudnn.data_type.HALF)
+        Y = g.gelu_approx_tanh(input=R, name="ge")
+    else:
+        raise AssertionError(kind)
+    Y.set_output(True)
+    return g
+
+
+# _TORCH_DTYPE covers the INPUT dtypes; a tap may also be fp32 / int32.
+_TAP_TORCH_DTYPE = {**_TORCH_DTYPE, "fp32": torch.float32, "int32": torch.int32}
+
+
+def _straddle_outs(plan, M: int, N: int) -> list[torch.Tensor]:
+    return [torch.full((1, M, N), float("nan"), dtype=_TAP_TORCH_DTYPE[o.dtype], device="cuda") for o in plan.chain.outputs]
+
+
+def _straddle_aux(plan, M: int, N: int) -> list[torch.Tensor]:
+    out = []
+    for t in plan.chain.aux_tensors:
+        if t.name == "s":
+            out.append(torch.full((1, 1, 1), 2.0, device="cuda"))
+        elif t.name == "r":
+            out.append(torch.arange(M, dtype=torch.float32, device="cuda").reshape(1, M, 1) % 3 + 1)
+        elif t.name == "xc":
+            out.append(torch.arange(N, dtype=torch.float32, device="cuda").reshape(1, 1, N) % 5 + 1)
+        elif t.name == "xe":
+            out.append(torch.arange(M * N, dtype=torch.float32, device="cuda").reshape(1, M, N) % 7 + 1)
+        else:
+            raise AssertionError(t.name)
+    return out
+
+
+@pytest.mark.parametrize(
+    "kind",
+    ("plain", "relu", "scalar_aux", "row_aux", "gen_index_axis1", "per_col_aux", "per_elem_aux", "matmul_tap", "two_taps"),
+)
+@pytest.mark.parametrize(
+    "shape",
+    _N_CHUNK_STRADDLE_SHAPES,
+    ids=[_shape_id(s) for s in _N_CHUNK_STRADDLE_SHAPES],
+)
+@pytest.mark.parametrize("config_name", _STRADDLE_CONFIGS, ids=[_config_id(n) for n in _STRADDLE_CONFIGS])
+def test_partial_n_chunk_store_matches_stg(config_name: str, shape: tuple[int, int, int], kind: str) -> None:
+    """The two store paths are bit-identical when the last chunk of the N tile is
+    partial. Guards the gate-relaxation work: a store rule that only holds for a
+    whole chunk passes every other shape in the suite."""
+    cfg, cta_group = _resolve(config_name)
+    M, N, K = shape
+    ok, reason = _compatible(cfg, M, N, K, "bf16", "bf16", cta_group=cta_group)
+    if not ok:
+        pytest.skip(reason)
+
+    tma = _plan(_straddle_graph(kind, M, N, K), config=cfg, cta_group=cta_group)
+    if not tma._compiled.use_tma_store:
+        pytest.skip(f"{kind} does not take the TMA-store path on {config_name}")
+
+    chunk = _epi_chunk_elems(tma.chain, cfg, cta_group, True)
+    assert N % chunk != 0, f"shape {shape} no longer straddles the {chunk}-element chunk — the test is vacuous"
+
+    stg = _plan(_straddle_graph(kind, M, N, K), config=cfg, cta_group=cta_group, force_stg_epi=True)
+    assert not stg._compiled.use_tma_store
+
+    a, b, _ = _mkdata(M, N, K, "bf16", "bf16")
+    outs_tma = _straddle_outs(tma, M, N)
+    outs_stg = _straddle_outs(stg, M, N)
+    tma(_vp(tma, a, b, outs_tma, *_straddle_aux(tma, M, N)))
+    stg(_vp(stg, a, b, outs_stg, *_straddle_aux(stg, M, N)))
+    torch.cuda.synchronize()
+
+    assert len(outs_tma) == len(tma.chain.outputs)
+    unwritten = sum(int(torch.isnan(o.float()).sum()) for o in outs_tma)
+    assert unwritten == 0, f"TMA store left {unwritten} cells unwritten across {len(outs_tma)} slots"
+    bad = sum(int((x.float() != y.float()).sum()) for x, y in zip(outs_tma, outs_stg))
+    assert bad == 0, (
+        f"\n  config: {config_name}"
+        f"\n  shape:  {M}x{N}x{K}  (chunk={chunk}, tail={N % chunk})"
+        f"\n  kind:   {kind}"
+        f"\n  slots:  {[o.dtype for o in tma.chain.outputs]}"
+        f"\n  TMA != STG at {bad} cells"
     )
 
 
@@ -2370,6 +2504,53 @@ def test_drain_width_keys_on_the_mma_block_height(name: str, cta_group: int, wan
     assert _epi_tile_cols(by_name(name), cta_group) == want
 
 
+@pytest.mark.parametrize("out_major,want", (("n", True), ("m", False)))
+def test_extra_dense_outputs_take_the_tma_store_only_when_n_major(out_major: str, want: bool) -> None:
+    """Extra dense outputs land through the STG emitters, which read `row` /
+    `col_j`. The N-major TMA arm hands them the same coordinates the STG arm
+    does, so they only need bounding. Under an M-major slot 0 they are the
+    subtile base and the drain runs the snippet twice — a scatter there would
+    double-fire at the wrong coordinates, so that stays on STG."""
+    from cudnn.gemm.frost.compiler import _use_tma_store_epi
+    from cudnn.gemm.frost.graph_analyzer import analyze
+
+    M = N = K = 256
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    C = g.matmul(A=A, B=B, name="mm")
+    # Slot order is set_output order, and the gate keys on SLOT 0's majorness.
+    R = g.relu(input=C, name="r")
+    if out_major == "m":
+        R.set_stride([M * N, 1, M])
+    R.set_output(True)
+    g.gelu_approx_tanh(input=R, name="ge").set_output(True)
+
+    chain = analyze(g)
+    assert len(chain.output_specs) == 2
+    assert chain.out_major == out_major
+    cfg = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1")
+    assert _use_tma_store_epi(chain, cfg, 16, 1) is want
+
+
+@pytest.mark.parametrize("name", ["CONFIG_sm100_128x16x128_128x16x32_cluster2x1", "CONFIG_sm100_128x32x128_128x32x32_cluster2x1"])
+def test_narrow_n_under_two_cta_mma_still_takes_the_tma_store(name: str) -> None:
+    """`cta_group == 2 and cta_tile_n < 64` used to fall back to STG on the
+    theory that a subtile would split across the MMA pair. It does not: each
+    CTA drains its own half and the subtile span walk already halves to fit.
+    Measured bit-identical to STG on 16 (config, cta_group) pairs."""
+    from cudnn.gemm.frost.compiler import _use_tma_store_epi
+    from cudnn.gemm.frost.graph_analyzer import analyze
+
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, 256, 128], stride=[256 * 128, 128, 1])
+    B = g.tensor(name="B", dim=[1, 128, 256], stride=[128 * 256, 1, 128])
+    g.matmul(A=A, B=B, name="mm").set_output(True)
+    cfg = by_name(name)
+    assert cfg.cta_tile_n < 64
+    assert _use_tma_store_epi(analyze(g), cfg, 16, 2) is True
+
+
 @pytest.mark.parametrize(
     "name",
     [
@@ -2389,6 +2570,117 @@ def test_tma_store_gate_follows_the_mma_block_height(name: str) -> None:
     g.matmul(A=A, B=B, name="mm").set_output(True)
     cfg = by_name(name)
     assert _use_tma_store_epi(analyze(g), cfg, 16, 1) == (cfg.mma_inst_m == 128)
+
+
+@pytest.mark.parametrize(
+    "name,cta_group,out_dt,want",
+    [
+        ("CONFIG_sm100_128x16x128_128x16x32_cluster1x1", 1, "bf16", 32),
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1", 1, "bf16", 64),
+        ("CONFIG_sm100_128x256x128_128x256x32_cluster2x1", 2, "bf16", 64),
+        ("CONFIG_sm100_256x256x128_128x256x32_cluster2x1", 1, "bf16", 128),
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1", 1, "fp32", 128),
+    ],
+)
+def test_epi_smem_row_bytes_is_the_real_staging_alignment(name: str, cta_group: int, out_dt: str, want: int) -> None:
+    """The TMA-store SMEM stage is written at `smem_subtile_ptr + tidx * epi_n`,
+    so the tightest true alignment is one subtile row -- `epi_n * elem_bytes`,
+    attained at odd tidx. It was a hardcoded 64, which over-claims at
+    cta_tile_n=16 (a 32-byte row) and under-claims at epi_n=64 / 4-byte output.
+    `store_swizzled` forwards it as `assumed_align`, so an over-claim is a false
+    promise the backend may exploit."""
+    from cudnn.gemm.frost.compiler import _epi_n, _epi_swizzle_lines
+    from cudnn.gemm.frost.dtypes import DTYPE_BYTES
+
+    cfg = by_name(name)
+    assert _epi_n(cfg, cta_group, out_dt) * DTYPE_BYTES[out_dt] == want
+    assert f"epi_smem_row_bytes = {want}" in _epi_swizzle_lines(cfg, cta_group, out_dt)
+
+
+def test_no_template_hardcodes_the_staging_alignment() -> None:
+    """Every template must read the rendered constant; a literal would silently
+    go stale the next time `_epi_n` moves."""
+    import pathlib
+
+    tmpl_dir = pathlib.Path(cudnn.__file__).parent / "gemm" / "frost" / "kernel_templates"
+    files = sorted(p for p in tmpl_dir.glob("sm*.py"))
+    assert len(files) == 16, [p.name for p in files]
+    for path in files:
+        src = path.read_text()
+        assert "alignment=epi_smem_row_bytes" in src, path.name
+        assert "alignment=64" not in src, path.name
+
+
+@pytest.mark.parametrize(
+    "name,cta_group",
+    [
+        ("CONFIG_sm100_128x16x128_128x16x32_cluster1x1", 1),
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1", 1),
+        ("CONFIG_sm100_128x256x128_128x256x32_cluster2x1", 2),
+        ("CONFIG_sm100_256x256x128_128x256x32_cluster2x1", 1),
+    ],
+)
+def test_epilogue_chunk_is_the_width_the_arm_hands_the_snippet(name: str, cta_group: int) -> None:
+    """The injected snippet is handed the whole staged subtile on the TMA arm
+    and one store-vector slice on the STG arm, and the codegen must be told
+    which. Getting it wrong is silent: every `vsize`-keyed emitter (aux loads,
+    gen_index, the reduction unrolls, the quant block) then walks the wrong
+    number of elements."""
+    from cudnn.gemm.frost.compiler import _epi_chunk_elems, _epi_n, _epi_vec_bytes
+    from cudnn.gemm.frost.dtypes import DTYPE_BYTES
+    from cudnn.gemm.frost.graph_analyzer import analyze
+
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, 256, 128], stride=[256 * 128, 128, 1])
+    B = g.tensor(name="B", dim=[1, 128, 256], stride=[128 * 256, 1, 128])
+    g.matmul(A=A, B=B, name="mm").set_output(True)
+    chain = analyze(g)
+    cfg = by_name(name)
+    assert _epi_chunk_elems(chain, cfg, cta_group, True) == _epi_n(cfg, cta_group, chain.output_dtype)
+    assert _epi_chunk_elems(chain, cfg, cta_group, False) == _epi_vec_bytes(chain, cfg, cta_group) // DTYPE_BYTES[chain.output_dtype]
+
+
+@pytest.mark.parametrize(
+    "name,want_tma",
+    [
+        ("CONFIG_sm100_128x8x128_128x8x32_cluster1x1", False),
+        ("CONFIG_sm100_128x16x128_128x16x32_cluster1x1", True),
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1", True),
+    ],
+)
+def test_m_major_tma_store_needs_a_whole_stmatrix_block(name: str, want_tma: bool) -> None:
+    """The M-major arm transposes with `for _blk in range(epi_n // 16)` over
+    4-register stmatrix tiles, so `epi_n < 16` emits ZERO stores and the output
+    keeps whatever the buffer held. It is silent -- nothing faults, the shapes
+    are right, the values are stale. Found by the full suite the day
+    `_epi_swizzle_lines` stopped raising and this geometry started rendering."""
+    from cudnn.gemm.frost.compiler import _epi_n, _use_tma_store_epi
+    from cudnn.gemm.frost.graph_analyzer import analyze
+
+    m, n, k = 256, 256, 256
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, m, k], stride=[m * k, k, 1])
+    B = g.tensor(name="B", dim=[1, k, n], stride=[k * n, 1, k])
+    C = g.matmul(A=A, B=B, name="mm")
+    C.set_output(True).set_data_type(_BF16)
+    C.set_stride([m * n, 1, m])
+    chain = analyze(g)
+    assert chain.out_major == "m"
+    cfg = by_name(name)
+    assert _use_tma_store_epi(chain, cfg, 16, 1) is want_tma
+    assert (_epi_n(cfg, 1, "bf16") >= 16) is want_tma
+
+
+def test_templates_take_the_chunk_from_the_rendered_constant() -> None:
+    """`vsize` is the fusion chunk, not a memory-access width -- it must come
+    from `epi_chunk_elems`, which differs per store arm."""
+    import pathlib
+
+    tmpl_dir = pathlib.Path(cudnn.__file__).parent / "gemm" / "frost" / "kernel_templates"
+    for path in sorted(tmpl_dir.glob("sm*.py")):
+        src = path.read_text()
+        assert "vsize = epi_chunk_elems" in src, path.name
+        assert "vsize = (VEC_BYTES" not in src, path.name
 
 
 # --- cutlass-dsl version-gated kwargs ----------------------------------------

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -909,7 +909,7 @@ def _straddle_graph(kind: str, M: int, N: int, K: int) -> cudnn.pygraph:
 
 
 # _TORCH_DTYPE covers the INPUT dtypes; a tap may also be fp32 / int32.
-_TAP_TORCH_DTYPE = {**_TORCH_DTYPE, "fp32": torch.float32, "int32": torch.int32}
+_TAP_TORCH_DTYPE = {**_TORCH_DTYPE, "fp32": torch.float32, "int32": torch.int32, "fp8_e8m0": torch.float8_e8m0fnu}
 
 
 def _straddle_outs(plan, M: int, N: int) -> list[torch.Tensor]:
@@ -2573,6 +2573,51 @@ def test_m_major_tma_store_serves_coordinate_reading_pointwise(config_name: str,
     assert bad == 0, f"\n  {config_name}\n  m-major {M}x{N}x{K}  {kind}\n  wrong at {bad}/{c.numel()}"
 
 
+def test_tma_arm_never_writes_past_the_output_rows() -> None:
+    """The TMA arm runs the epilogue for the whole tile and clips only its OWN
+    store; every other store must re-apply the row bound. A missed one is
+    INVISIBLE in the output tensor -- it writes past the last row, into whatever
+    the allocator put next -- so this test gives each output slack and poisons it.
+
+    The shape matters: M must not be a multiple of the CLUSTER tile height, or
+    there are no overhang rows to write. 384 with cluster2x1 x cta_tile_m=128
+    (cgrp_tile_m=256) leaves 128."""
+    M, N, K = 384, 256, 256
+    cfg, cta_group = _resolve("CONFIG_sm100_128x256x128_128x256x32_cluster2x1_2ctamma")
+    assert M % (cfg.cta_tile_m * cfg.cgrp_size_m) != 0
+
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    R = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+    R.set_output(True)
+    q, sc = g.block_scale_quantize(input=R, block_size=32, axis=-1, name="qr")
+    q.set_output(True).set_data_type(cudnn.data_type.FP8_E4M3)
+    sc.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+
+    plan = _plan(g, config=cfg, cta_group=cta_group)
+    if not plan._compiled.use_tma_store:
+        pytest.skip("this graph does not take the TMA-store arm")
+
+    a, b, _ = _mkdata(M, N, K, "bf16", "bf16")
+    slack = 256
+    backing, views = [], []
+    for o in plan.chain.outputs:
+        shape = o.dim if o.dim is not None else (1, M, N)
+        buf = torch.empty(shape[0], shape[1] + slack, shape[2], dtype=_TAP_TORCH_DTYPE[o.dtype], device="cuda")
+        buf.view(torch.uint8).fill_(0xAB)
+        backing.append(buf)
+        views.append(buf[:, : shape[1]])
+    plan(_vp(plan, a, b, views))
+    torch.cuda.synchronize()
+
+    for o, buf in zip(plan.chain.outputs, backing):
+        rows = (o.dim if o.dim is not None else (1, M, N))[1]
+        tail = buf[:, rows:].view(torch.uint8)
+        touched = int((tail != 0xAB).sum())
+        assert touched == 0, f"{o.source}: the epilogue wrote {touched} bytes past its {rows} rows"
+
+
 @pytest.mark.parametrize("out_major,want", (("n", True), ("m", False)))
 def test_extra_dense_outputs_take_the_tma_store_only_when_n_major(out_major: str, want: bool) -> None:
     """Extra dense outputs land through the STG emitters, which read `row` /
@@ -2588,12 +2633,15 @@ def test_extra_dense_outputs_take_the_tma_store_only_when_n_major(out_major: str
     A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
     B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
     C = g.matmul(A=A, B=B, name="mm")
-    # Slot order is set_output order, and the gate keys on SLOT 0's majorness.
+    # Every non-virtual output carries the same layout, so vary them together;
+    # the gate keys on SLOT 0's majorness because that is the arm the kernel
+    # renders.
     R = g.relu(input=C, name="r")
-    if out_major == "m":
-        R.set_stride([M * N, 1, M])
-    R.set_output(True)
-    g.gelu_approx_tanh(input=R, name="ge").set_output(True)
+    Y = g.gelu_approx_tanh(input=R, name="ge")
+    for t in (R, Y):
+        if out_major == "m":
+            t.set_stride([M * N, 1, M])
+        t.set_output(True)
 
     chain = analyze(g)
     assert len(chain.output_specs) == 2
@@ -2667,17 +2715,37 @@ def test_epi_smem_row_bytes_is_the_real_staging_alignment(name: str, cta_group: 
 
 
 def test_no_template_hardcodes_the_staging_alignment() -> None:
-    """Every template must read the rendered constant; a literal would silently
-    go stale the next time `_epi_n` moves."""
+    """The staging alignment is the SMEM row width, which is per output
+    (`epi_n * its own element width`), so no template carries it: every one hands
+    its store sequence to `@@INJECT_TMA_STORE_SEQUENCE@@` and the renderer
+    unrolls it per output with that output's own width. A LITERAL in a template
+    would go stale the next time `_epi_n` moves."""
     import pathlib
+
+    from cudnn.gemm.frost.compiler import _epi_n, _tma_store_sequence
+    from cudnn.gemm.frost.graph_analyzer import analyze
+    from cudnn.gemm.frost.tile_config import by_name
 
     tmpl_dir = pathlib.Path(cudnn.__file__).parent / "gemm" / "frost" / "kernel_templates"
     files = sorted(p for p in tmpl_dir.glob("sm*.py"))
     assert len(files) == 16, [p.name for p in files]
     for path in files:
         src = path.read_text()
-        assert "alignment=epi_smem_row_bytes" in src, path.name
         assert "alignment=64" not in src, path.name
+        assert "@@INJECT_TMA_STORE_SEQUENCE@@" in src, path.name
+        assert "alignment=epi_smem_row_bytes" not in src, path.name
+
+    # The renderer emits the row width the output's OWN dtype implies.
+    M = N = K = 256
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    g.matmul(A=A, B=B, name="mm").set_output(True)
+    chain = analyze(g)
+    cfg = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1")
+    epi_n = _epi_n(cfg, 1, chain.output_dtype)
+    seq = _tma_store_sequence(chain, cfg, 1, frozenset({0}), epi_n)
+    assert f"alignment={epi_n * 2}" in seq, seq  # bf16
 
 
 @pytest.mark.parametrize(

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -2504,6 +2504,75 @@ def test_drain_width_keys_on_the_mma_block_height(name: str, cta_group: int, wan
     assert _epi_tile_cols(by_name(name), cta_group) == want
 
 
+_MMAJOR_COORD_KINDS = ("gen_index_axis1", "gen_index_axis2", "per_row", "per_col", "per_elem")
+
+
+def _mmajor_coord_graph(kind: str, M: int, N: int, K: int) -> tuple[cudnn.pygraph, str | None]:
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    C = g.matmul(A=A, B=B, name="mm")
+    aux = None
+    if kind.startswith("gen_index"):
+        axis = int(kind[-1])
+        Y = g.add(a=C, b=g.gen_index(input=C, axis=axis, name="gi"), name="ad")
+    else:
+        dim, stride = {
+            "per_row": ([1, M, 1], [M, 1, 1]),
+            "per_col": ([1, 1, N], [N, N, 1]),
+            "per_elem": ([1, M, N], [M * N, N, 1]),
+        }[kind]
+        x = g.tensor(name="x", dim=dim, stride=stride, data_type=cudnn.data_type.FLOAT)
+        Y = g.mul(a=C, b=x, name="w")
+        aux = "x"
+    Y.set_stride([M * N, 1, M])
+    Y.set_output(True)
+    return g, aux
+
+
+@pytest.mark.parametrize("kind", _MMAJOR_COORD_KINDS)
+@pytest.mark.parametrize("shape", ((256, 256, 256), (512, 128, 256)), ids=("256x256x256", "512x128x256"))
+@pytest.mark.parametrize("config_name", _STRADDLE_CONFIGS[:2], ids=[_config_id(n) for n in _STRADDLE_CONFIGS[:2]])
+def test_m_major_tma_store_serves_coordinate_reading_pointwise(config_name: str, shape: tuple[int, int, int], kind: str) -> None:
+    """`row` / `col_j` on the M-major TMA arm are the subtile base, not the
+    coordinates of the fragment a lane holds -- that arm loads 16x256b and each
+    lane owns a TRANSPOSED patch. Anything asking "which row / column am I"
+    (gen_index, per_row / per_col / per_elem aux) goes through
+    `_mmajor_elem_coord`; before it did not, and gen_index measured wrong on
+    BOTH axes here while being exact through STG."""
+    cfg, cta_group = _resolve(config_name)
+    M, N, K = shape
+    ok, reason = _compatible(cfg, M, N, K, "bf16", "bf16", cta_group=cta_group, out_major="m")
+    if not ok:
+        pytest.skip(reason)
+
+    g, aux_name = _mmajor_coord_graph(kind, M, N, K)
+    plan = _plan(g, config=cfg, cta_group=cta_group)
+    if not plan._compiled.use_tma_store:
+        pytest.skip(f"{kind} does not take the M-major TMA-store path on {config_name}")
+
+    a, b, c = _mkdata(M, N, K, "bf16", "bf16", out_major="m")
+    args = []
+    if aux_name is not None:
+        n = {"per_row": M, "per_col": N, "per_elem": M * N}[kind]
+        shape3 = {"per_row": (1, M, 1), "per_col": (1, 1, N), "per_elem": (1, M, N)}[kind]
+        args.append((torch.arange(n, dtype=torch.float32, device="cuda") % 5 + 1).reshape(shape3))
+    plan(_vp(plan, a, b, [c], *args))
+    torch.cuda.synchronize()
+
+    ref = torch.einsum("bmk,bnk->bmn", a.to(torch.float32), b.to(torch.float32))
+    if kind == "gen_index_axis1":
+        ref = ref + torch.arange(M, device="cuda", dtype=torch.float32).reshape(1, M, 1)
+    elif kind == "gen_index_axis2":
+        ref = ref + torch.arange(N, device="cuda", dtype=torch.float32).reshape(1, 1, N)
+    else:
+        ref = ref * args[0]
+    ref = ref.to(torch.bfloat16)
+
+    bad = int((c.to(torch.float32) != ref.to(torch.float32)).sum())
+    assert bad == 0, f"\n  {config_name}\n  m-major {M}x{N}x{K}  {kind}\n  wrong at {bad}/{c.numel()}"
+
+
 @pytest.mark.parametrize("out_major,want", (("n", True), ("m", False)))
 def test_extra_dense_outputs_take_the_tma_store_only_when_n_major(out_major: str, want: bool) -> None:
     """Extra dense outputs land through the STG emitters, which read `row` /

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -12,7 +12,10 @@ Runs as a script too (forwards argv to pytest on this file).
 
 from __future__ import annotations
 
+import inspect
+import pathlib
 import sys
+import textwrap
 from dataclasses import dataclass
 from typing import Callable
 
@@ -32,6 +35,8 @@ pytestmark = [pytest.mark.L0, requires_sm100]
 
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  — installs the cudnn.pygraph recorder hook
+from cudnn.gemm.frost import compiler, epilogue_codegen
+from cudnn.gemm.frost.epilogue_codegen import generate
 from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.tile_config import by_name
 
@@ -2268,6 +2273,71 @@ if __name__ == "__main__":
 
 
 # --- full cuDNN pointwise-mode coverage (new ops, 2026-07-20) ---------------
+
+
+@pytest.mark.parametrize("mode,dims", (("per_col", [1, 1, 128]), ("per_elem", [1, 128, 128])))
+def test_coordinate_reading_aux_is_clamped_on_the_tma_arm(mode: str, dims: list[int]) -> None:
+    """The TMA arm hands the snippet a subtile base with no N or M bound, so a
+    `per_col` / `per_elem` LDG at `col_j + k` reads past the aux allocation.
+    The clamped fallback keeps every address inside both extents; the STG arm
+    already carries `col_j + vsize <= N` and must stay byte-identical."""
+    M = N = K = 128
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    C = g.matmul(A=A, B=B, name="mm")
+    stride = [dims[1] * dims[2], dims[2], 1]
+    x = g.tensor(name="x", dim=dims, stride=stride, data_type=cudnn.data_type.FLOAT)
+    g.mul(a=C, b=x, name="w").set_output(True)
+    chain = analyze(g)
+
+    stg = generate(chain, tma_slots=frozenset()).epilogue
+    tma = generate(chain, tma_slots=frozenset({0})).epilogue
+
+    assert "_auxv_x" not in stg, "the STG arm's own predicate already bounds the read — no fallback wanted"
+    assert ".load(count=vsize, alignment=ALIGN_AUX_x)" in stg
+
+    assert "cute.math.min(cutlass.Int32(col_j) + _auxk, cutlass.Int32(N) - 1)" in tma
+    assert ("cute.math.min(cutlass.Int32(row), cutlass.Int32(M) - 1)" in tma) == (mode == "per_elem")
+    # The whole-chunk load is still the fast path; the clamp is the tail only.
+    assert "if (col_j + vsize <= N)" in tma
+    assert ".load(count=vsize, alignment=ALIGN_AUX_x)" in tma
+
+
+def test_tma_staged_values_reach_the_store_as_vectors() -> None:
+    """`store_swizzled` picks its path by sniffing whether the value's `.shape`
+    is a tuple: a `cutlass.Vector` reports `(N,)` and gets the per-16-byte-granule
+    scatter the SMEM swizzle needs, while `cute.make_rmem_tensor(N, ...).load()`
+    is a `TensorSSA` whose `.shape` is the bare int `N` -- taken for a scalar,
+    XORed once on the row base and written CONTIGUOUSLY, so each row's tail
+    spills into the next. Every emitter that can reach the TMA arm must hand on
+    a Vector; the ones that cannot must stay behind the gate that says so."""
+    src = pathlib.Path(epilogue_codegen.__file__).read_text()
+    gate = "".join(
+        textwrap.dedent(inspect.getsource(fn)) for fn in (compiler._use_tma_store_epi, compiler._tma_store_n_major_ok, compiler._tma_store_m_major_ok)
+    )
+
+    sites = src.count("cute.make_rmem_tensor(")
+    converted = src.count(".load().to_vector()")
+    assert sites == 4, (
+        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 4. A new one either "
+        f"converts with .load().to_vector() or its feature stays gated off the TMA arm — "
+        f"decide which, then update this test."
+    )
+    assert converted == 3, f"expected exactly 3 converted rmem loads, found {converted}"
+
+    # The two unconverted sites are the row/col block-quantize emitters.
+    assert src.count("_out = cute.make_rmem_tensor(") == 2
+    assert "if chain.quants:" in gate, (
+        "the block-quantize emitters build their result in an rmem tensor and hand it on as a "
+        "TensorSSA; they are only safe because quant graphs never take the TMA arm. Relaxing "
+        "that gate requires converting them first."
+    )
+
 
 _PW_M, _PW_N, _PW_K = 128, 128, 128
 

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -12,6 +12,7 @@ Runs as a script too (forwards argv to pytest on this file).
 
 from __future__ import annotations
 
+import ast
 import inspect
 import pathlib
 import sys
@@ -2308,13 +2309,170 @@ def test_coordinate_reading_aux_is_clamped_on_the_tma_arm(mode: str, dims: list[
     assert ".load(count=vsize, alignment=ALIGN_AUX_x)" in tma
 
 
+@pytest.mark.parametrize(
+    "cfg_name,dts,want",
+    [
+        ("CONFIG_sm100_128x256x128_128x256x32_cluster1x1", ["bf16", "bf16"], ("tma", "tma")),
+        ("CONFIG_sm100_128x256x128_128x256x32_cluster1x1", ["bf16", "fp32"], ("tma", "tma")),
+        # epi_n is 64 only on this family, and 64 fp32 columns is a 256-byte row --
+        # wider than any swizzle in the table, so the fp32 output falls back alone.
+        ("CONFIG_sm100_256x256x128_128x256x32_cluster1x1", ["bf16", "fp32"], ("tma", "stg")),
+        ("CONFIG_sm100_256x256x128_128x256x32_cluster1x1", ["fp32", "bf16"], ("tma", "tma")),
+    ],
+)
+def test_epi_n_is_one_shared_column_count_not_a_per_output_one(cfg_name: str, dts: list[str], want: tuple) -> None:
+    """The kernel renders ONE `epi_n`, from the primary slot's dtype. What is per
+    output is the ROW BYTES (`epi_n * its own element width`) and with them the
+    swizzle -- so a second TMA output is judged against the SHARED column count,
+    not against the one its own dtype would have produced. Asking per output
+    computes a width the kernel never renders, which at the 256x256 family lets
+    an fp32 output onto a 256-byte staging row that has no swizzle."""
+    from cudnn.gemm.frost.compiler import _epi_vec_bytes, _store_modes
+    from cudnn.gemm.frost.tile_config import by_name
+
+    CU = {"bf16": cudnn.data_type.BFLOAT16, "fp32": cudnn.data_type.FLOAT}
+    M = N = K = 256
+    g = cudnn.pygraph(io_data_type=CU["bf16"], intermediate_data_type=CU["fp32"], compute_data_type=CU["fp32"])
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    cur = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+    cur.set_output(True).set_data_type(CU[dts[0]])
+    g.mul(a=cur, b=cur, name="sq").set_output(True).set_data_type(CU[dts[1]])
+
+    chain = analyze(g)
+    cfg = by_name(cfg_name)
+    assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == want
+
+
+@pytest.mark.parametrize("majors,want", [(("n", "m"), ("tma", "stg")), (("m", "n"), ("stg", "stg"))])
+def test_an_output_laid_out_against_the_arm_stays_on_stg(majors: tuple, want: tuple) -> None:
+    """The kernel renders ONE store arm and it follows slot 0's layout, so an
+    output laid out the other way has no sequence to ride -- the M-major arm
+    transposes through stmatrix, the N-major one stages a row-major subtile.
+
+    Every non-virtual output is MEANT to carry the same layout, but nothing
+    enforces that yet -- `analyze` accepts a mixed-major graph, which is why this
+    test can build one.
+
+    The OUTCOME below is currently delivered by other rules, not by the same-arm
+    conjunct: an M-major output beside another dense output is rejected by the
+    M-major arm's single-output rule, and an N-major output under an M-major slot
+    0 is rejected because `_epi_vec_bytes` (a chain-level width taken from slot
+    0's layout) drops below 16 there. So the conjunct is redundant TODAY and this
+    test would pass without it -- it is kept as insurance and pinned separately
+    below, because both of those rejections are coincidental rather than about
+    the arm.
+
+    TODO: the M-major output path is due a refactor that supports MIXED
+    m/n-major alongside tmastg; this test and that conjunct go away with it."""
+    from cudnn.gemm.frost.compiler import _epi_vec_bytes, _store_modes
+    from cudnn.gemm.frost.tile_config import by_name
+
+    M = N = K = 256
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    R = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+    Y = g.gelu_approx_tanh(input=R, name="ge")
+    for t, mj in zip((R, Y), majors):
+        if mj == "m":
+            t.set_stride([M * N, 1, M])
+        t.set_output(True)
+
+    chain = analyze(g)
+    assert [o.major for o in chain.output_specs] == list(majors), "the mixed-major graph must still be buildable"
+    cfg = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster1x1")
+    assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == want
+
+
+def test_the_store_gate_still_guards_against_the_wrong_arm() -> None:
+    """The same-arm conjunct is redundant today (see
+    `test_an_output_laid_out_against_the_arm_stays_on_stg`), so no behavioural
+    test can protect it. Pin it at the source instead: if it is deleted, the
+    protection is gone the moment either of the coincidental rejections moves."""
+    src = inspect.getsource(compiler._output_store_mode)
+    assert "out.major != chain.out_major" in src, "the wrong-arm guard is gone"
+    assert "TODO" in src, "keep the pointer to the M-major refactor that removes it"
+
+
+def test_more_than_one_output_can_take_the_tma_store() -> None:
+    """Every TMA-stored output walks the SAME SMEM ring -- the slot is sized for
+    the widest and each takes its own typed view -- so there is no budget to
+    spend: an output takes the surface iff it is eligible."""
+    from cudnn.gemm.frost.compiler import _epi_slot_widen, _epi_vec_bytes, _store_modes
+    from cudnn.gemm.frost.tile_config import by_name
+    from cudnn.gemm.frost.graph_analyzer import analyze as _an
+
+    CU = {"bf16": cudnn.data_type.BFLOAT16, "fp32": cudnn.data_type.FLOAT}
+    M = N = K = 256
+    g = cudnn.pygraph(io_data_type=CU["bf16"], intermediate_data_type=CU["fp32"], compute_data_type=CU["fp32"])
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    cur = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+    cur.set_output(True).set_data_type(CU["bf16"])
+    g.mul(a=cur, b=cur, name="sq").set_output(True).set_data_type(CU["fp32"])
+    chain = _an(g)
+
+    cfg = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster1x1")
+    assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == ("tma", "tma")
+    # The ring is typed as the primary slot's dtype, so a wider companion widens
+    # the SLOT rather than adding a second ring.
+    assert _epi_slot_widen(chain) == 2
+
+
+def test_every_dense_store_on_the_tma_arm_carries_the_row_bound() -> None:
+    """The TMA arm runs the epilogue body for EVERY row of the tile and clips only
+    its own store (the C descriptor's extent does that in hardware). Every other
+    store in the body has to re-apply the bound itself.
+
+    A quant tap's DATA store is the one that does not go through
+    `_emit_tap_store`, and it was missed: `generate` appends it directly for
+    `spec.quant_idx is not None`. Unguarded it writes the tile's overhang rows,
+    which on a plain matmul run past the output buffer into whatever the
+    allocator put next -- observed as ~55 % of a neighbouring SCALE buffer coming
+    back as zero, and only on the first launch in a fresh process, because a warm
+    allocator lays the buffers out differently."""
+    M, N, K = 384, 256, 256
+    g = cudnn.pygraph(
+        io_data_type=cudnn.data_type.BFLOAT16,
+        intermediate_data_type=cudnn.data_type.FLOAT,
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    R = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+    R.set_output(True)
+    q, sc = g.block_scale_quantize(input=R, block_size=32, axis=-1, name="qr")
+    q.set_output(True).set_data_type(cudnn.data_type.FP8_E4M3)
+    sc.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+    chain = analyze(g)
+
+    # A quant pins the chunk to its block size; slot 0 is bf16 -> 32 * 2 bytes.
+    kw = dict(vec_bytes_epi=64, output_elem_bytes=2)
+    tma = generate(chain, tma_slots=frozenset({0}), **kw).epilogue
+    stg = generate(chain, tma_slots=frozenset(), **kw).epilogue
+
+    guarded = [ln for ln in tma.splitlines() if ln.startswith("    (gC_tap_")]
+    bare = [ln for ln in tma.splitlines() if ln.startswith("(gC_tap_")]
+    assert guarded, "the TMA arm must emit its tap stores under a bound"
+    assert not bare, f"unguarded store(s) on the TMA arm: {bare}"
+    # The STG arm inherits `row < M` / `col_j + vsize <= N` from the drain, so its
+    # stores must stay bare -- a guard there would change every shipping kernel.
+    assert not [ln for ln in stg.splitlines() if ln.strip().startswith("if (row <")]
+
+
 def test_coordinate_reading_pointwise_is_not_a_store_rule() -> None:
     """Neither arm's store rule may consult how a pointwise input reads its
     coordinates. What differs between the arms is the element -> (row, col) MAP,
     and `_elem_coord` publishes it; asking "does this graph read coordinates" in
     the gate is the shape of the bug, not the fix."""
     for fn in (compiler._tma_store_n_major_ok, compiler._tma_store_m_major_ok, compiler._tma_store_geometry_ok):
-        src = inspect.getsource(fn)
+        tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
+        # The prose may name these; the CODE may not.
+        body = tree.body[0].body
+        if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+            body = body[1:]
+        src = "\n".join(ast.unparse(node) for node in body)
         for probe in ("bcast_mode", "grouped_by_moe", "gen_index"):
             assert probe not in src, f"{fn.__name__} consults {probe}: that is a pointwise concern"
 
@@ -2335,28 +2493,21 @@ def test_tma_staged_values_reach_the_store_as_vectors() -> None:
     is a `TensorSSA` whose `.shape` is the bare int `N` -- taken for a scalar,
     XORed once on the row base and written CONTIGUOUSLY, so each row's tail
     spills into the next. Every emitter that can reach the TMA arm must hand on
-    a Vector; the ones that cannot must stay behind the gate that says so."""
+    a Vector."""
     src = pathlib.Path(epilogue_codegen.__file__).read_text()
-    gate = "".join(
-        textwrap.dedent(inspect.getsource(fn)) for fn in (compiler._use_tma_store_epi, compiler._tma_store_n_major_ok, compiler._tma_store_m_major_ok)
-    )
 
     sites = src.count("cute.make_rmem_tensor(")
     converted = src.count(".load().to_vector()")
     assert sites == 5, (
         f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 5. A new one either "
-        f"converts with .load().to_vector() or its feature stays gated off the TMA arm — "
-        f"decide which, then update this test."
+        f"converts with .load().to_vector() or its feature stays off the TMA arm -- decide which, "
+        f"then update this test."
     )
-    assert converted == 4, f"expected exactly 4 converted rmem loads, found {converted}"
-
-    # The two unconverted sites are the row/col block-quantize emitters.
+    assert converted == 6, f"expected exactly 6 converted rmem loads, found {converted}"
+    # The two block-quantize emitters were the last holdouts: their result now
+    # reaches a TMA-stored dense output, so they must convert like the rest.
     assert src.count("_out = cute.make_rmem_tensor(") == 2
-    assert "if chain.quants:" in gate, (
-        "the block-quantize emitters build their result in an rmem tensor and hand it on as a "
-        "TensorSSA; they are only safe because quant graphs never take the TMA arm. Relaxing "
-        "that gate requires converting them first."
-    )
+    assert src.count("_vec = {p}_out.load().to_vector()") == 2, "the block-quantize emitters must hand on a Vector"
 
 
 _PW_M, _PW_N, _PW_K = 128, 128, 128

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -2385,6 +2385,54 @@ def test_an_output_laid_out_against_the_arm_stays_on_stg(majors: tuple, want: tu
     assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == want
 
 
+def test_both_renderers_emit_the_tma_output_COUNT_not_a_flag() -> None:
+    """`n_tma_outputs` sizes the descriptor prefetch, and on MoE also the
+    tensormap scratch and the per-CTA workspace stride. The block-scale renderer
+    used to emit `1 if use_tma_store_epi else 0` -- a FLAG -- which under-counts
+    the moment a block-scale graph puts two outputs on the surface, so the second
+    descriptor's scratch and workspace slot overlap somebody else's."""
+    import re
+
+    from cudnn.gemm.frost.compiler import (
+        _epi_vec_bytes,
+        _render_block_scale_tile_constants,
+        _render_tile_constants,
+        _tma_slots_for,
+    )
+    from cudnn.gemm.frost.tile_config import by_name
+
+    E4, E8, RE = cudnn.data_type.FP8_E4M3, cudnn.data_type.FP8_E8M0, cudnn.tensor_reordering.F8_128x4
+    M = N = K = 256
+    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1], data_type=E4)
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K], data_type=E4)
+    sfa = g.tensor(name="sfa", dim=[1, M, K // 32], stride=[M * K // 32, K // 32, 1], data_type=E8, reordering_type=RE)
+    sfb = g.tensor(name="sfb", dim=[1, K // 32, N], stride=[K * N // 32, 1, K // 32], data_type=E8, reordering_type=RE)
+    c = g.matmul(
+        A=g.block_scale_dequantize(input=A, descale=sfa, block_size=[1, 32], name="dqa"),
+        B=g.block_scale_dequantize(input=B, descale=sfb, block_size=[32, 1], name="dqb"),
+        name="mm",
+        compute_data_type=cudnn.data_type.FLOAT,
+    )
+    R = g.relu(input=c, name="r")
+    R.set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+    g.mul(a=R, b=R, name="sq").set_output(True).set_data_type(cudnn.data_type.BFLOAT16)
+
+    chain = analyze(g)
+    assert chain.has_block_scale
+    cfg = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster1x1")
+    want = len(_tma_slots_for(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)))
+    assert want == 2, "this graph is meant to put BOTH outputs on the surface"
+
+    for render in (
+        _render_block_scale_tile_constants(cfg, chain, 1, use_tma_store_epi=True),
+        _render_tile_constants(cfg, chain, 1),
+    ):
+        m = re.search(r"^n_tma_outputs = (\d+)$", render, re.M)
+        assert m, "every renderer must emit n_tma_outputs"
+        assert int(m.group(1)) == want, f"emitted {m.group(1)}, real TMA slots {want}"
+
+
 def test_the_store_gate_still_guards_against_the_wrong_arm() -> None:
     """The same-arm conjunct is redundant today (see
     `test_an_output_laid_out_against_the_arm_stays_on_stg`), so no behavioural

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -2308,6 +2308,26 @@ def test_coordinate_reading_aux_is_clamped_on_the_tma_arm(mode: str, dims: list[
     assert ".load(count=vsize, alignment=ALIGN_AUX_x)" in tma
 
 
+def test_coordinate_reading_pointwise_is_not_a_store_rule() -> None:
+    """Neither arm's store rule may consult how a pointwise input reads its
+    coordinates. What differs between the arms is the element -> (row, col) MAP,
+    and `_elem_coord` publishes it; asking "does this graph read coordinates" in
+    the gate is the shape of the bug, not the fix."""
+    for fn in (compiler._tma_store_n_major_ok, compiler._tma_store_m_major_ok, compiler._tma_store_geometry_ok):
+        src = inspect.getsource(fn)
+        for probe in ("bcast_mode", "grouped_by_moe", "gen_index"):
+            assert probe not in src, f"{fn.__name__} consults {probe}: that is a pointwise concern"
+
+
+def test_m_major_tap_scatter_covers_the_whole_fragment() -> None:
+    """The M-major TMA scatter walks one register per element, so its trip count
+    is the chunk (`epi_n // 2`), not a constant. It was pinned at 16 -- exact
+    only at epi_n == 32, dropping half the tap at the 64 the wide tiles reach."""
+    src = pathlib.Path(epilogue_codegen.__file__).read_text()
+    assert "cutlass.range_constexpr(16)" not in src, "the M-major scatter trip count must follow vsize"
+    assert "for _tr_{tap_idx} in cutlass.range_constexpr({vsize}):" in src
+
+
 def test_tma_staged_values_reach_the_store_as_vectors() -> None:
     """`store_swizzled` picks its path by sniffing whether the value's `.shape`
     is a tuple: a `cutlass.Vector` reports `(N,)` and gets the per-16-byte-granule
@@ -2323,12 +2343,12 @@ def test_tma_staged_values_reach_the_store_as_vectors() -> None:
 
     sites = src.count("cute.make_rmem_tensor(")
     converted = src.count(".load().to_vector()")
-    assert sites == 4, (
-        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 4. A new one either "
+    assert sites == 5, (
+        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 5. A new one either "
         f"converts with .load().to_vector() or its feature stays gated off the TMA arm — "
         f"decide which, then update this test."
     )
-    assert converted == 3, f"expected exactly 3 converted rmem loads, found {converted}"
+    assert converted == 4, f"expected exactly 4 converted rmem loads, found {converted}"
 
     # The two unconverted sites are the row/col block-quantize emitters.
     assert src.count("_out = cute.make_rmem_tensor(") == 2

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -930,3 +930,56 @@ def test_moe_int8(cta_group):
             ref[0, lo:hi] = a[0, lo:hi].float() @ b[gi].float().t()
     # Small-magnitude integer products are exact in bf16's range → bit-exact.
     torch.testing.assert_close(outb, ref.to(torch.bfloat16), atol=0.0, rtol=0.0)
+
+
+# --- launch ABI -------------------------------------------------------------
+
+# MoE has no recipe (`_check_executable` returns early for it), so its four
+# launch sites are hand-written positional calls and nothing else pins their
+# order against the rendered `_host` signature.
+
+
+def test_moe_launch_tail_puts_the_tma_slot_last():
+    """The host signature is TAP, AUX, then the trailing TMA-C parameter. Under
+    STG every dense output rides a tap slot; under TMA-store slot 0 binds the
+    TMA-only parameter and moves to the END. Passing `*cs, *aux` in both modes
+    keeps the ARITY but shifts the mapping by one, which binds the output buffer
+    to an aux parameter -- both are `cute.Tensor`, so nothing raises."""
+    from cudnn.gemm.frost.compiler import _moe_launch_tail
+
+    assert _moe_launch_tail(["c0"], (), use_tma_store=False) == ("c0",)
+    assert _moe_launch_tail(["c0"], (), use_tma_store=True) == ("c0",)
+    assert _moe_launch_tail(["c0"], ["x"], use_tma_store=False) == ("c0", "x")
+    assert _moe_launch_tail(["c0"], ["x"], use_tma_store=True) == ("x", "c0")
+    assert _moe_launch_tail(["c0", "c1"], ["x"], use_tma_store=False) == ("c0", "c1", "x")
+    assert _moe_launch_tail(["c0", "c1"], ["x"], use_tma_store=True) == ("c1", "x", "c0")
+    assert _moe_launch_tail([], ["x"], use_tma_store=True) == ("x",)
+
+
+@requires_sm100
+@pytest.mark.parametrize("force_stg", [False, True], ids=["tmastg", "stg"])
+def test_moe_host_signature_matches_the_launch_order(force_stg: bool) -> None:
+    """Pin the rendered `_host` parameter list the four launchers feed: every
+    dense output is a `c_tap_<i>`, except the slot-0 output under TMA-store,
+    which becomes the trailing `c_<i>` the TMA-C marker injects."""
+    import re
+
+    from cudnn.gemm.frost.compiler import _moe_launch_tail
+
+    g = _build_graph(E=8, S=2048, N=256, K=256)
+    plan = _plan(g, config=by_name("CONFIG_sm100_128x256x128_128x256x32_cluster2x1"), cta_group=2, force_stg_epi=force_stg)
+    tma = plan._compiled.use_tma_store
+    assert tma is not force_stg
+
+    src = open(plan.generated_path).read()
+    body = re.search(r"^def _host\(\n(.*?)^\) -> None:", src, re.S | re.M).group(1)
+    params = [ln.strip().split(":")[0] for ln in body.splitlines() if ln.strip()]
+    taps = [p for p in params if p.startswith("c_tap_")]
+    tma_c = [p for p in params if re.fullmatch(r"c_\d+", p)]
+    n_out = len(plan.chain.outputs)
+
+    assert len(taps) == n_out - (1 if tma else 0)
+    assert len(tma_c) == (1 if tma else 0)
+    if tma:
+        assert params[-2] == tma_c[0], params
+    assert len(_moe_launch_tail(range(n_out), plan.aux_names, use_tma_store=tma)) == len(taps) + len(plan.aux_names) + len(tma_c)

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -6,6 +6,8 @@ correctness vs a torch group-loop reference (uneven + empty groups)."""
 
 from __future__ import annotations
 
+import pathlib
+
 import cudnn
 import cudnn.gemm.frost  # noqa: F401  (installs hook)
 import pytest
@@ -977,8 +979,10 @@ def test_moe_host_signature_matches_the_launch_order(force_stg: bool) -> None:
     tma = plan._compiled.use_tma_store
     assert tma is not force_stg
 
-    src = open(plan.generated_path).read()
-    body = re.search(r"^def _host\(\n(.*?)^\) -> None:", src, re.S | re.M).group(1)
+    src = pathlib.Path(plan.generated_path).read_text()
+    m = re.search(r"^def _host\(\n(.*?)^\) -> None:", src, re.S | re.M)
+    assert m, f"no _host signature in {plan.generated_path}"
+    body = m.group(1)
     params = [ln.strip().split(":")[0] for ln in body.splitlines() if ln.strip()]
     taps = [p for p in params if p.startswith("c_tap_")]
     tma_c = [p for p in params if re.fullmatch(r"c_\d+", p)]

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -941,19 +941,25 @@ def test_moe_int8(cta_group):
 
 def test_moe_launch_tail_puts_the_tma_slot_last():
     """The host signature is TAP, AUX, then the trailing TMA-C parameter. Under
-    STG every dense output rides a tap slot; under TMA-store slot 0 binds the
-    TMA-only parameter and moves to the END. Passing `*cs, *aux` in both modes
+    STG every dense output rides a tap slot; an output on the TMA surface binds a
+    trailing TMA-only parameter and moves to the END. Passing `*cs, *aux` in both modes
     keeps the ARITY but shifts the mapping by one, which binds the output buffer
     to an aux parameter -- both are `cute.Tensor`, so nothing raises."""
     from cudnn.gemm.frost.compiler import _moe_launch_tail
 
-    assert _moe_launch_tail(["c0"], (), use_tma_store=False) == ("c0",)
-    assert _moe_launch_tail(["c0"], (), use_tma_store=True) == ("c0",)
-    assert _moe_launch_tail(["c0"], ["x"], use_tma_store=False) == ("c0", "x")
-    assert _moe_launch_tail(["c0"], ["x"], use_tma_store=True) == ("x", "c0")
-    assert _moe_launch_tail(["c0", "c1"], ["x"], use_tma_store=False) == ("c0", "c1", "x")
-    assert _moe_launch_tail(["c0", "c1"], ["x"], use_tma_store=True) == ("c1", "x", "c0")
-    assert _moe_launch_tail([], ["x"], use_tma_store=True) == ("x",)
+    NONE, S0, S1, BOTH = frozenset(), frozenset({0}), frozenset({1}), frozenset({0, 1})
+
+    assert _moe_launch_tail(["c0"], (), tma_slots=NONE) == ("c0",)
+    assert _moe_launch_tail(["c0"], (), tma_slots=S0) == ("c0",)
+    assert _moe_launch_tail(["c0"], ["x"], tma_slots=NONE) == ("c0", "x")
+    assert _moe_launch_tail(["c0"], ["x"], tma_slots=S0) == ("x", "c0")
+    assert _moe_launch_tail(["c0", "c1"], ["x"], tma_slots=NONE) == ("c0", "c1", "x")
+    assert _moe_launch_tail(["c0", "c1"], ["x"], tma_slots=S0) == ("c1", "x", "c0")
+    assert _moe_launch_tail([], ["x"], tma_slots=S0) == ("x",)
+    # Which slot takes the surface is a CHOICE, so the order follows the SET, not
+    # the position: slot 1 on the surface leaves slot 0 as the tap.
+    assert _moe_launch_tail(["c0", "c1"], ["x"], tma_slots=S1) == ("c0", "x", "c1")
+    assert _moe_launch_tail(["c0", "c1"], ["x"], tma_slots=BOTH) == ("x", "c0", "c1")
 
 
 @requires_sm100
@@ -982,4 +988,4 @@ def test_moe_host_signature_matches_the_launch_order(force_stg: bool) -> None:
     assert len(tma_c) == (1 if tma else 0)
     if tma:
         assert params[-2] == tma_c[0], params
-    assert len(_moe_launch_tail(range(n_out), plan.aux_names, use_tma_store=tma)) == len(taps) + len(plan.aux_names) + len(tma_c)
+    assert len(_moe_launch_tail(range(n_out), plan.aux_names, tma_slots=plan._compiled.tma_slots)) == len(taps) + len(plan.aux_names) + len(tma_c)

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd_epilogue_fusion.py
@@ -15,7 +15,12 @@ import torch
 from gemm_test_utils import requires_sm100
 from test_matmul import _fp4_quant_ref, _unpack_e2m1, _col_quant_reference
 
+import inspect
+
+from cudnn.gemm.frost import compiler
 from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
+from cudnn.gemm.frost.epilogue_codegen import generate
+from cudnn.gemm.frost.graph_analyzer import analyze
 from cudnn.gemm.frost.tile_config import by_name
 
 pytestmark = [pytest.mark.L0, requires_sm100]
@@ -825,3 +830,54 @@ def test_single_moe_grouped_avg_reduction():
         if b < e:
             ref[gi, 0] = csw[b:e].mean(dim=0)
     torch.testing.assert_close(r, ref, atol=5e-2, rtol=2e-2)
+
+
+def test_moe_tma_arm_bounds_extra_outputs_by_the_routed_group() -> None:
+    """The TMA arm carries no row bound of its own, so an extra dense output's
+    store has to reapply the one its STG sibling uses. On MoE that is the routed
+    group's end, NOT the problem M — `row < M` writes rows belonging to the next
+    group and the result is wrong, not merely unclipped."""
+    g, c, _ = _graph()
+    r = g.relu(input=c, name="r")
+    r.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    g.gelu_approx_tanh(input=r, name="ge").set_output(True)
+    chain = analyze(g)
+    assert chain.has_moe and len(chain.output_specs) == 2
+
+    tma = generate(chain, tma_slots=frozenset({0})).epilogue
+    stg = generate(chain, tma_slots=frozenset()).epilogue
+
+    assert "row < group_end" in tma
+    assert "row < M" not in tma
+    # The STG arm is enclosed by the template's own guard and must stay bare.
+    assert "row < group_end" not in stg and "row < M" not in stg
+
+
+def test_per_group_per_col_aux_group_stride_need_not_divide_the_chunk() -> None:
+    """A per-group per-col aux loads at `group_idx * stride[0] + col_j`, and the
+    group stride used to have to be a whole number of epilogue chunks. It does
+    not: `ALIGN_AUX_<name>` is `min(the aux's OWN layout alignment, the chunk)`,
+    and `tensor_alignment` already folds the group stride in — so the alignment
+    promise degrades on its own. The old check predated that and only bit once
+    the TMA arm widened the chunk from the STG width to `epi_n`."""
+    from cudnn.gemm.frost.compiler import _use_tma_store_epi
+    from cudnn.gemm.frost.dtypes import tensor_alignment
+
+    # 248 * 4 bytes = 992 -> a 32-byte alignment, and 248 % 32 == 24.
+    assert tensor_alignment((_G, 1, 248), (248, 248, 1), 4) == 32
+    assert 248 % 32 != 0
+
+    g, c, _ = _graph()
+    bias = g.tensor(name="bias", dim=[_G, 1, _N], stride=[_N, _N, 1], data_type=cudnn.data_type.FLOAT)
+    g.add(a=c, b=bias, name="bi").set_output(True)
+    chain = analyze(g)
+    aux = chain.aux_tensors[0]
+    assert aux.grouped_by_moe and aux.bcast_mode == "per_col"
+
+    cfg = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1")
+    # `_N` is 256 here, so assert on the rule's shape rather than on this N:
+    # nothing in the gate may consult a per-group aux's stride.
+    assert _use_tma_store_epi(chain, cfg, 16, 1) is True
+    src = inspect.getsource(compiler._tma_store_n_major_ok)
+    for probe in ("grouped_by_moe", "bcast_mode", "aux_tensors"):
+        assert probe not in src, f"{probe}: an aux load's alignment is a pointwise concern, not a store rule"


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Remove most of the tmastg restriction for n-major output layout, improving the performance for most of the epilogue fusion cases

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multiple optimized output transfers in GEMM and MoE workloads.
  - Improved mixed data types, output layouts, partial chunks, and M-major outputs.
  - Enhanced launch configuration and output ordering for complex fused operations.

- **Bug Fixes**
  - Prevented out-of-bounds writes and corrected staging alignment and sizing.
  - Improved auxiliary, quantized, reduction, and per-group output handling.
  - Strengthened validation for transfer eligibility and output geometry.

- **Tests**
  - Added extensive coverage for output correctness, layout combinations, partial writes, and MoE launch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->