### PR TITLE
Change RoPE computation to bf16 precision to match MCore's triton implementation

### DIFF
--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/api.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/api.py
@@ -25,7 +25,6 @@ from .gemm_proj_rope_mxfp8_bf16in import (
 from .gemm_proj_rope_mxfp8_mxfp8in import (
     gemm_proj_rope_mxfp8_host as _mxfp8in_host,
     _as_e8m0 as _mxfp8_as_e8m0,
-    DBG as _MXFP8IN_DBG,
 )
 
 from cuda.bindings import driver as cuda
@@ -290,8 +289,6 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         sample_out_scales_row: torch.Tensor,
         sample_out_fp8_col: torch.Tensor,
         sample_out_scales_col: torch.Tensor,
-        sample_dbg_gemm: torch.Tensor,
-        sample_dbg_rope: torch.Tensor,
     ):
         super().__init__()
         self._warn_experimental_api()
@@ -325,8 +322,6 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
             sample_out_scales_row,
             sample_out_fp8_col,
             sample_out_scales_col,
-            sample_dbg_gemm,
-            sample_dbg_rope,
         )
         self._logger.debug(f"__init__ completed: x_code {self.x_code_desc.shape}, w_code {self.w_code_desc.shape}")
 
@@ -436,7 +431,7 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
             swizzle_size = v
         return grid_m, t2r_x8, swizzle_size
 
-    def _to_cute_tensors(self, x_code, x_scale, w_code, w_scale, cos, sin, out_fp8_row, out_scales_row, out_fp8_col, out_scales_col, dbg_gemm, dbg_rope):
+    def _to_cute_tensors(self, x_code, x_scale, w_code, w_scale, cos, sin, out_fp8_row, out_scales_row, out_fp8_col, out_scales_col):
         """Compile-time sample conversion."""
         mA = from_dlpack(_maybe_detach(x_code), assumed_align=16).mark_layout_dynamic(leading_dim=1)
         mSFA = _mxfp8_as_e8m0(x_scale)
@@ -448,9 +443,7 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         mSrow = from_dlpack(out_scales_row, assumed_align=16).mark_layout_dynamic(leading_dim=2)
         mQcol = from_dlpack(out_fp8_col, assumed_align=16).mark_layout_dynamic(leading_dim=2)
         mScol = from_dlpack(out_scales_col, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        mDbgGemm = from_dlpack(dbg_gemm, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        mDbgRope = from_dlpack(dbg_rope, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        return mA, mSFA, mB, mSFB, mCos, mSin, mQrow, mSrow, mQcol, mScol, mDbgGemm, mDbgRope
+        return mA, mSFA, mB, mSFB, mCos, mSin, mQrow, mSrow, mQcol, mScol
 
     def compile(self) -> None:
         self._logger.debug("Entering compile")
@@ -489,8 +482,6 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         out_scales_row,
         out_fp8_col,
         out_scales_col,
-        dbg_gemm,
-        dbg_rope,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         if current_stream is None:
@@ -515,8 +506,6 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
             out_scales_row,
             out_fp8_col,
             out_scales_col,
-            dbg_gemm,
-            dbg_rope,
             current_stream,
         )
 
@@ -660,13 +649,6 @@ def gemm_proj_rope_mxfp8_wrapper_sm100(
         # kernel body never references these and 1-element placeholders suffice.
         import torch as _torch
 
-        if _MXFP8IN_DBG:
-            dbg_gemm = _torch.empty(tokens, num_heads, HEAD_DIM, dtype=_torch.bfloat16, device=device)
-            dbg_rope = _torch.empty(tokens, num_heads, HEAD_DIM, dtype=_torch.float32, device=device)
-        else:
-            dbg_gemm = _torch.empty(1, 1, 1, dtype=_torch.bfloat16, device=device)
-            dbg_rope = _torch.empty(1, 1, 1, dtype=_torch.float32, device=device)
-
         key = (get_shape(x), get_shape(wc), get_device(x))
         obj = _mxfp8in_obj_cache.get(key)
         if obj is None:
@@ -681,8 +663,6 @@ def gemm_proj_rope_mxfp8_wrapper_sm100(
                 sample_out_scales_row=out_scales_row,
                 sample_out_fp8_col=out_fp8_col,
                 sample_out_scales_col=out_scales_col,
-                sample_dbg_gemm=dbg_gemm,
-                sample_dbg_rope=dbg_rope,
             )
             assert obj.check_support()
             obj.compile()
@@ -698,8 +678,6 @@ def gemm_proj_rope_mxfp8_wrapper_sm100(
             out_scales_row,
             out_fp8_col,
             out_scales_col,
-            dbg_gemm,
-            dbg_rope,
             current_stream=stream,
         )
 
@@ -712,7 +690,4 @@ def gemm_proj_rope_mxfp8_wrapper_sm100(
         out_fp8_col=out_fp8_col,
         out_scales_col=out_scales_col,
     )
-    if _MXFP8IN_DBG and x_cutlass_dtype is cutlass.Float8E4M3FN:
-        outputs["dbg_gemm"] = dbg_gemm
-        outputs["dbg_rope"] = dbg_rope
     return TupleDict(**outputs)

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/api.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/api.py
@@ -25,6 +25,7 @@ from .gemm_proj_rope_mxfp8_bf16in import (
 from .gemm_proj_rope_mxfp8_mxfp8in import (
     gemm_proj_rope_mxfp8_host as _mxfp8in_host,
     _as_e8m0 as _mxfp8_as_e8m0,
+    DBG as _MXFP8IN_DBG,
 )
 
 from cuda.bindings import driver as cuda
@@ -289,6 +290,8 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         sample_out_scales_row: torch.Tensor,
         sample_out_fp8_col: torch.Tensor,
         sample_out_scales_col: torch.Tensor,
+        sample_dbg_gemm: torch.Tensor,
+        sample_dbg_rope: torch.Tensor,
     ):
         super().__init__()
         self._warn_experimental_api()
@@ -322,6 +325,8 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
             sample_out_scales_row,
             sample_out_fp8_col,
             sample_out_scales_col,
+            sample_dbg_gemm,
+            sample_dbg_rope,
         )
         self._logger.debug(f"__init__ completed: x_code {self.x_code_desc.shape}, w_code {self.w_code_desc.shape}")
 
@@ -431,7 +436,7 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
             swizzle_size = v
         return grid_m, t2r_x8, swizzle_size
 
-    def _to_cute_tensors(self, x_code, x_scale, w_code, w_scale, cos, sin, out_fp8_row, out_scales_row, out_fp8_col, out_scales_col):
+    def _to_cute_tensors(self, x_code, x_scale, w_code, w_scale, cos, sin, out_fp8_row, out_scales_row, out_fp8_col, out_scales_col, dbg_gemm, dbg_rope):
         """Compile-time sample conversion."""
         mA = from_dlpack(_maybe_detach(x_code), assumed_align=16).mark_layout_dynamic(leading_dim=1)
         mSFA = _mxfp8_as_e8m0(x_scale)
@@ -443,7 +448,9 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         mSrow = from_dlpack(out_scales_row, assumed_align=16).mark_layout_dynamic(leading_dim=2)
         mQcol = from_dlpack(out_fp8_col, assumed_align=16).mark_layout_dynamic(leading_dim=2)
         mScol = from_dlpack(out_scales_col, assumed_align=16).mark_layout_dynamic(leading_dim=2)
-        return mA, mSFA, mB, mSFB, mCos, mSin, mQrow, mSrow, mQcol, mScol
+        mDbgGemm = from_dlpack(dbg_gemm, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        mDbgRope = from_dlpack(dbg_rope, assumed_align=16).mark_layout_dynamic(leading_dim=2)
+        return mA, mSFA, mB, mSFB, mCos, mSin, mQrow, mSrow, mQcol, mScol, mDbgGemm, mDbgRope
 
     def compile(self) -> None:
         self._logger.debug("Entering compile")
@@ -482,6 +489,8 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
         out_scales_row,
         out_fp8_col,
         out_scales_col,
+        dbg_gemm,
+        dbg_rope,
         current_stream: Optional[cuda.CUstream] = None,
     ) -> None:
         if current_stream is None:
@@ -506,6 +515,8 @@ class GemmProjRopeMxfp8Mxfp8InSm100(APIBase):
             out_scales_row,
             out_fp8_col,
             out_scales_col,
+            dbg_gemm,
+            dbg_rope,
             current_stream,
         )
 
@@ -644,6 +655,18 @@ def gemm_proj_rope_mxfp8_wrapper_sm100(
             wc, ws = w, w_scale
         else:
             wc, ws = w.T.contiguous(), w_scale.T.contiguous()
+
+        # Debug intermediates (NVTE_FUSED_Q_UPROJ_DEBUG). Off by default, in which case the
+        # kernel body never references these and 1-element placeholders suffice.
+        import torch as _torch
+
+        if _MXFP8IN_DBG:
+            dbg_gemm = _torch.empty(tokens, num_heads, HEAD_DIM, dtype=_torch.bfloat16, device=device)
+            dbg_rope = _torch.empty(tokens, num_heads, HEAD_DIM, dtype=_torch.float32, device=device)
+        else:
+            dbg_gemm = _torch.empty(1, 1, 1, dtype=_torch.bfloat16, device=device)
+            dbg_rope = _torch.empty(1, 1, 1, dtype=_torch.float32, device=device)
+
         key = (get_shape(x), get_shape(wc), get_device(x))
         obj = _mxfp8in_obj_cache.get(key)
         if obj is None:
@@ -658,6 +681,8 @@ def gemm_proj_rope_mxfp8_wrapper_sm100(
                 sample_out_scales_row=out_scales_row,
                 sample_out_fp8_col=out_fp8_col,
                 sample_out_scales_col=out_scales_col,
+                sample_dbg_gemm=dbg_gemm,
+                sample_dbg_rope=dbg_rope,
             )
             assert obj.check_support()
             obj.compile()
@@ -673,15 +698,21 @@ def gemm_proj_rope_mxfp8_wrapper_sm100(
             out_scales_row,
             out_fp8_col,
             out_scales_col,
+            dbg_gemm,
+            dbg_rope,
             current_stream=stream,
         )
 
     else:
         raise AssertionError(f"unsupported input dtype {x.dtype}; expected bfloat16 (BF16 GEMM) or float8_e4m3fn (MXFP8 GEMM)")
 
-    return TupleDict(
+    outputs = dict(
         out_fp8_row=out_fp8_row,
         out_scales_row=out_scales_row,
         out_fp8_col=out_fp8_col,
         out_scales_col=out_scales_col,
     )
+    if _MXFP8IN_DBG and x_cutlass_dtype is cutlass.Float8E4M3FN:
+        outputs["dbg_gemm"] = dbg_gemm
+        outputs["dbg_rope"] = dbg_rope
+    return TupleDict(**outputs)

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -124,33 +124,44 @@ def _to_bf16_f32(v):
 # PTX.  The mnemonics are exactly the ones rotary_fwd_q_kernel compiles to (scripts/rope_ptx.py).
 # fma.rn.bf16 is the load-bearing one: it forms its product exactly and rounds the sum once,
 # which is what an fp32 fma followed by a narrow cannot reproduce.
+#
+# The operands are declared Int16 rather than BFloat16.  A bf16 MLIR type on an inline-asm
+# operand makes the NVVM backend fail to compile with no usable diagnostic; the registers are
+# the same .b16 either way, so passing the bit pattern sidesteps it at no cost.
 
 
 @cute.jit
 def _mul_bf16(a, b):
-    return cute.arch.inline_ptx(
+    r = cute.arch.inline_ptx(
         "mul.bf16 {$w0}, {$r0}, {$r1};",
-        write_only_types=[cutlass.BFloat16],
-        read_only_args=[a, b],
+        write_only_types=[cutlass.Int16],
+        read_only_args=[a.bitcast(cutlass.Int16), b.bitcast(cutlass.Int16)],
     )
+    return r.bitcast(cutlass.BFloat16)
 
 
 @cute.jit
 def _fma_bf16(a, b, c):
-    return cute.arch.inline_ptx(
+    r = cute.arch.inline_ptx(
         "fma.rn.bf16 {$w0}, {$r0}, {$r1}, {$r2};",
-        write_only_types=[cutlass.BFloat16],
-        read_only_args=[a, b, c],
+        write_only_types=[cutlass.Int16],
+        read_only_args=[
+            a.bitcast(cutlass.Int16),
+            b.bitcast(cutlass.Int16),
+            c.bitcast(cutlass.Int16),
+        ],
     )
+    return r.bitcast(cutlass.BFloat16)
 
 
 @cute.jit
 def _neg_bf16(a):
-    return cute.arch.inline_ptx(
+    r = cute.arch.inline_ptx(
         "neg.bf16 {$w0}, {$r0};",
-        write_only_types=[cutlass.BFloat16],
-        read_only_args=[a],
+        write_only_types=[cutlass.Int16],
+        read_only_args=[a.bitcast(cutlass.Int16)],
     )
+    return r.bitcast(cutlass.BFloat16)
 
 
 @cute.struct

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fused projection GEMM + per-head YARN RoPE + dual-direction MXFP8 quantize (Blackwell / SM100)."""
 
+import os
+
 import cutlass
 import cutlass.cute as cute
 import cutlass.utils as utils
@@ -69,6 +71,37 @@ assert QK_ROPE == FEATCELL, "the rope occupies exactly one feature cell; QK_ROPE
 assert HALF == QK_ROPE // 2, "HALF must be QK_ROPE // 2"
 assert TILE_M % BLOCK == 0, "TILE_M must be a whole number of MXFP8 blocks"
 assert NUM_EPI_WARPS == COLBLK * N_FEATCELL, "epilogue warp count must equal COLBLK x N_FEATCELL"
+
+# ---- Debug instrumentation (off by default) ----
+# When on, the epilogue also writes its two intermediates to GMEM so the fused result can be
+# bisected against the unfused GEMM -> RoPE -> quantize chain:
+#   DbgGemm  bf16 [tokens, NUM_HEADS, HEAD_DIM]  post-GEMM, post-bf16-stage, pre-RoPE
+#   DbgRope  fp32 [tokens, NUM_HEADS, HEAD_DIM]  post-RoPE, pre-quantize.  BF16-valued, but
+#            dumped as fp32 so it can also be scored against an exact reference.
+# Guarded with const_expr, so nothing is emitted at all when the flag is off; the buffers are
+# then 1-element placeholders.
+DBG = int(os.environ.get("NVTE_FUSED_Q_UPROJ_DEBUG", "0")) > 0
+
+# ---- RoPE arithmetic ----
+# The unfused path applies RoPE with Megatron's Triton rotary_fwd_q_kernel.  Its element type
+# is BF16, but the arithmetic is not: Triton widens to fp32 registers, contracts one product
+# into an fma, and rounds to BF16 only where a value is materialized.  Scored against an exact
+# fp64 evaluation over 5.0e7 elements, that kernel is exactly
+#
+#   left  = bf16( x1*cos_l - bf16(x2*sin_l) )     (x1*cos_l stays fp32 inside the fma)
+#   right = bf16( bf16(x2*cos_r) + x1*sin_r )     (x1*sin_r stays fp32 inside the fma)
+#
+# so the epilogue below reproduces that form, product for product and rounding for rounding.
+# Two nearby alternatives were measured and both diverge from Triton: keeping everything in
+# fp32 and rounding once at the store misses on 3.6e6 of those elements, and doing genuine
+# all-BF16 multiplies and adds misses on 3.8e6.  Matching the fma contraction is what makes
+# the fused and unfused queries agree bit for bit.
+
+
+@cute.jit
+def _to_bf16_f32(v):
+    """Round an fp32 value through BF16 and back, matching the unfused RoPE's storage."""
+    return v.to(cutlass.BFloat16).to(cutlass.Float32)
 
 
 @cute.struct
@@ -202,6 +235,8 @@ def gemm_proj_rope_mxfp8_kernel(
     mSrow: cute.Tensor,
     mQcol: cute.Tensor,
     mScol: cute.Tensor,
+    mDbgGemm: cute.Tensor,
+    mDbgRope: cute.Tensor,
     epi_tile: cute.Tile,
     cta_layout_vmnk: cute.Layout,
     tile_sched_params: utils.PersistentTileSchedulerParams,
@@ -436,6 +471,13 @@ def gemm_proj_rope_mxfp8_kernel(
             b = fc * 2 + (lane // HALFW)  # 32-feature row-block 0..5
             col_amax0 = cutlass.Float32(0.0)
             col_amax1 = cutlass.Float32(0.0)
+            if cutlass.const_expr(DBG):
+                # P1: raw GEMM tile straight out of sACC, before any rope. The (f0, f1) pairs
+                # over 12 warps x 32 lanes x 32 tokens tile TILE_M x HEAD_DIM exactly once, so
+                # this dumps every column in natural (nope | interleaved-rope) order.
+                for r in cutlass.range_constexpr(BLOCK):
+                    mDbgGemm[token_base + tok0 + r, head, f0] = sACC[tok0 + r, f0]
+                    mDbgGemm[token_base + tok0 + r, head, f1] = sACC[tok0 + r, f1]
             # TE weight layout: NOPE at features 0..127, ROPE at features 128..191 (last cell)
             is_rope = fc == (N_FEATCELL - 1)
             if is_rope:
@@ -463,8 +505,14 @@ def gemm_proj_rope_mxfp8_kernel(
                         s0 = ts[0].to(cutlass.Float32)
                         c1 = tc[1].to(cutlass.Float32)
                         s1 = ts[1].to(cutlass.Float32)
-                        ps0, ps1 = cute.arch.mul_packed_f32x2((p0, p1), (s0, s1))
-                        v0, v1 = cute.arch.fma_packed_f32x2((q0, q1), (c0, c1), (ps0, ps1))
+                        # Triton emits bf16( bf16(q*c) + p*s ): q*c is materialized, p*s
+                        # is the multiply the compiler folds into the fma.
+                        qc0, qc1 = cute.arch.mul_packed_f32x2((q0, q1), (c0, c1))
+                        qc0 = _to_bf16_f32(qc0)
+                        qc1 = _to_bf16_f32(qc1)
+                        v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (s0, s1), (qc0, qc1))
+                        v0 = _to_bf16_f32(v0)
+                        v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
@@ -482,9 +530,14 @@ def gemm_proj_rope_mxfp8_kernel(
                         s0 = ts[0].to(cutlass.Float32)
                         c1 = tc[1].to(cutlass.Float32)
                         s1 = ts[1].to(cutlass.Float32)
-                        pc0, pc1 = cute.arch.mul_packed_f32x2((p0, p1), (c0, c1))
+                        # Triton emits bf16( p*c - bf16(q*s) ): q*s is materialized, p*c
+                        # is the multiply the compiler folds into the fma.
                         qs0, qs1 = cute.arch.mul_packed_f32x2((q0, q1), (s0, s1))
-                        v0, v1 = cute.arch.fma_packed_f32x2((qs0, qs1), (cutlass.Float32(-1.0), cutlass.Float32(-1.0)), (pc0, pc1))
+                        qs0 = _to_bf16_f32(qs0)
+                        qs1 = _to_bf16_f32(qs1)
+                        v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (c0, c1), (-qs0, -qs1))
+                        v0 = _to_bf16_f32(v0)
+                        v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
@@ -497,6 +550,12 @@ def gemm_proj_rope_mxfp8_kernel(
                     buf1[r] = v1
                     col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
                     col_amax1 = cute.arch.fmax(col_amax1, cute.arch.fmax(v1, -v1))
+            if cutlass.const_expr(DBG):
+                # P2: post-rope values, still fp32, before amax/quantize. buf0/buf1 map to the
+                # output features f0/f1 in both the rope and non-rope branches.
+                for r in cutlass.range_constexpr(BLOCK):
+                    mDbgRope[token_base + tok0 + r, head, f0] = buf0[r]
+                    mDbgRope[token_base + tok0 + r, head, f1] = buf1[r]
             invc0, sbc0, invc1, sbc1 = _e8m0_pair(col_amax0, col_amax1)
             scol_row = m_idx * COLBLK + cb
             mScol[scol_row, head, f0] = cutlass.Uint8(sbc0)
@@ -566,6 +625,8 @@ def gemm_proj_rope_mxfp8_host(
     mSrow: cute.Tensor,
     mQcol: cute.Tensor,
     mScol: cute.Tensor,
+    mDbgGemm: cute.Tensor,
+    mDbgRope: cute.Tensor,
     grid_m: cutlass.Constexpr,
     num_heads: cutlass.Constexpr,
     max_active_clusters: cutlass.Constexpr,
@@ -634,6 +695,8 @@ def gemm_proj_rope_mxfp8_host(
         mSrow,
         mQcol,
         mScol,
+        mDbgGemm,
+        mDbgRope,
         epi_tile,
         cta_layout_vmnk,
         tile_sched_params,

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -579,11 +579,7 @@ def gemm_proj_rope_mxfp8_kernel(
                             c1 = tc[1].to(cutlass.Float32)
                             s1 = ts[1].to(cutlass.Float32)
                             qc0, qc1 = cute.arch.mul_packed_f32x2((q0, q1), (c0, c1))
-                            qc0 = _to_bf16_f32(qc0)
-                            qc1 = _to_bf16_f32(qc1)
                             v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (s0, s1), (qc0, qc1))
-                            v0 = _to_bf16_f32(v0)
-                            v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
@@ -615,11 +611,7 @@ def gemm_proj_rope_mxfp8_kernel(
                             c1 = tc[1].to(cutlass.Float32)
                             s1 = ts[1].to(cutlass.Float32)
                             qs0, qs1 = cute.arch.mul_packed_f32x2((q0, q1), (s0, s1))
-                            qs0 = _to_bf16_f32(qs0)
-                            qs1 = _to_bf16_f32(qs1)
                             v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (c0, c1), (-qs0, -qs1))
-                            v0 = _to_bf16_f32(v0)
-                            v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -72,31 +72,7 @@ assert HALF == QK_ROPE // 2, "HALF must be QK_ROPE // 2"
 assert TILE_M % BLOCK == 0, "TILE_M must be a whole number of MXFP8 blocks"
 assert NUM_EPI_WARPS == COLBLK * N_FEATCELL, "epilogue warp count must equal COLBLK x N_FEATCELL"
 
-# ---- RoPE arithmetic ----
-# The unfused path applies RoPE with Megatron's Triton rotary_fwd_q_kernel.  Reading the PTX
-# that kernel compiles to (scripts/rope_ptx.py) it contains no fp32 instruction at all: per
-# output element it emits one mul.bf16, one neg.bf16, and one fma.rn.bf16.  So Triton computes
-#
-#   left  = fma.rn.bf16( x1, cos_l, -mul.bf16(x2, sin_l) )
-#   right = fma.rn.bf16( x1, sin_r,  mul.bf16(x2, cos_r) )
-#
-# where the fma forms its product exactly and rounds the sum exactly once.
-#
-# Two evaluations of that expression are implemented below and selected by
-# NVTE_FUSED_Q_UPROJ_ROPE_BF16_FMA:
-#
-#   0 (default): reproduce the *shape* -- which product is materialized, which is folded into
-#     the fma -- but evaluate in fp32 with packed-f32x2 ops and narrow at the end.  That is a
-#     double rounding: when the fp32 result lands exactly on a BF16 midpoint, the second
-#     rounding breaks a tie that a single rounding would never have seen, and the result is one
-#     ULP off the correctly rounded value.  Measured at 1 element in 1e8 (README T21).
-#
-#   1: emit the same bf16 instructions Triton does, via inline PTX.  Single rounding, so it is
-#     both correctly rounded and bit-identical to the unfused path.  Costs the packed-f32x2
-#     throughput on the rope cell (1 of 3 feature cells).
-#
-# Both agree on all but ~1e-8 of elements; the flag exists to measure that difference and the
-# cost of closing it.
+
 ROPE_BF16_FMA = int(os.environ.get("NVTE_FUSED_Q_UPROJ_ROPE_BF16_FMA", "0")) > 0
 
 @cute.jit
@@ -104,26 +80,6 @@ def _to_bf16_f32(v):
     """Round an fp32 value through BF16 and back, matching the unfused RoPE's storage."""
     return v.to(cutlass.BFloat16).to(cutlass.Float32)
 
-
-# ---- Native BF16 rope, packed ----
-# cute.arch exposes packed-f32x2 arithmetic but no bf16 arithmetic, so this goes through inline
-# PTX.  Two details are load-bearing:
-#
-#   fma.rn.bf16x2 forms its products exactly and rounds each half once, which is what an fp32
-#   fma followed by a narrow cannot reproduce.  Its per-half rounding is identical to the scalar
-#   fma.rn.bf16 that rotary_fwd_q_kernel emits, so the packed form is not an approximation of
-#   the scalar one -- it is the same function, verified elementwise in scripts/probe_bf16_ptx.py.
-#
-#   The whole pair goes in *one* asm block.  A first cut used one block per instruction, six per
-#   pair, and cost 5.2x on the kernel (README T24).  Halving the instruction count by packing is
-#   the small part of the win: an inline_ptx block is opaque to ptxas, so six of them per pair
-#   with BLOCK=32 unrolled put up to 192 barriers through an epilogue that has to overlap this
-#   arithmetic with the quantize, the amax reduction and the stores.
-#
-# Operands are raw bit patterns, not BFloat16: a bf16 MLIR type on an inline-asm operand makes
-# the NVVM backend fail to compile with no usable diagnostic.  Everything arrives as a 16-bit
-# value and gets packed here; an earlier version fetched the adjacent cos/sin as one 32-bit load
-# instead, which saves two loads but reintroduces that same silent compile failure.
 _ROPE_PROLOGUE = (
     "{\n"
     " .reg .b32 pp, qq, cc, ss, tq;\n"
@@ -575,11 +531,7 @@ def gemm_proj_rope_mxfp8_kernel(
                             c1 = tc[1].to(cutlass.Float32)
                             s1 = ts[1].to(cutlass.Float32)
                             qc0, qc1 = cute.arch.mul_packed_f32x2((q0, q1), (c0, c1))
-                            qc0 = _to_bf16_f32(qc0)
-                            qc1 = _to_bf16_f32(qc1)
                             v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (s0, s1), (qc0, qc1))
-                            v0 = _to_bf16_f32(v0)
-                            v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
@@ -611,11 +563,7 @@ def gemm_proj_rope_mxfp8_kernel(
                             c1 = tc[1].to(cutlass.Float32)
                             s1 = ts[1].to(cutlass.Float32)
                             qs0, qs1 = cute.arch.mul_packed_f32x2((q0, q1), (s0, s1))
-                            qs0 = _to_bf16_f32(qs0)
-                            qs1 = _to_bf16_f32(qs1)
                             v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (c0, c1), (-qs0, -qs1))
-                            v0 = _to_bf16_f32(v0)
-                            v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -83,25 +83,74 @@ assert NUM_EPI_WARPS == COLBLK * N_FEATCELL, "epilogue warp count must equal COL
 DBG = int(os.environ.get("NVTE_FUSED_Q_UPROJ_DEBUG", "0")) > 0
 
 # ---- RoPE arithmetic ----
-# The unfused path applies RoPE with Megatron's Triton rotary_fwd_q_kernel.  Its element type
-# is BF16, but the arithmetic is not: Triton widens to fp32 registers, contracts one product
-# into an fma, and rounds to BF16 only where a value is materialized.  Scored against an exact
-# fp64 evaluation over 5.0e7 elements, that kernel is exactly
+# The unfused path applies RoPE with Megatron's Triton rotary_fwd_q_kernel.  Reading the PTX
+# that kernel compiles to (scripts/rope_ptx.py) it contains no fp32 instruction at all: per
+# output element it emits one mul.bf16, one neg.bf16, and one fma.rn.bf16.  So Triton computes
 #
-#   left  = bf16( x1*cos_l - bf16(x2*sin_l) )     (x1*cos_l stays fp32 inside the fma)
-#   right = bf16( bf16(x2*cos_r) + x1*sin_r )     (x1*sin_r stays fp32 inside the fma)
+#   left  = fma.rn.bf16( x1, cos_l, -mul.bf16(x2, sin_l) )
+#   right = fma.rn.bf16( x1, sin_r,  mul.bf16(x2, cos_r) )
 #
-# so the epilogue below reproduces that form, product for product and rounding for rounding.
-# Two nearby alternatives were measured and both diverge from Triton: keeping everything in
-# fp32 and rounding once at the store misses on 3.6e6 of those elements, and doing genuine
-# all-BF16 multiplies and adds misses on 3.8e6.  Matching the fma contraction is what makes
-# the fused and unfused queries agree bit for bit.
+# where the fma forms its product exactly and rounds the sum exactly once.
+#
+# Two evaluations of that expression are implemented below and selected by
+# NVTE_FUSED_Q_UPROJ_ROPE_BF16_FMA:
+#
+#   0 (default): reproduce the *shape* -- which product is materialized, which is folded into
+#     the fma -- but evaluate in fp32 with packed-f32x2 ops and narrow at the end.  That is a
+#     double rounding: when the fp32 result lands exactly on a BF16 midpoint, the second
+#     rounding breaks a tie that a single rounding would never have seen, and the result is one
+#     ULP off the correctly rounded value.  Measured at 1 element in 1e8 (README T21).
+#
+#   1: emit the same bf16 instructions Triton does, via inline PTX.  Single rounding, so it is
+#     both correctly rounded and bit-identical to the unfused path.  Costs the packed-f32x2
+#     throughput on the rope cell (1 of 3 feature cells).
+#
+# Both agree on all but ~1e-8 of elements; the flag exists to measure that difference and the
+# cost of closing it.
+ROPE_BF16_FMA = int(os.environ.get("NVTE_FUSED_Q_UPROJ_ROPE_BF16_FMA", "0")) > 0
+
+if DBG or ROPE_BF16_FMA:
+    print(f"[proj_rope_mxfp8] DBG={DBG} ROPE_BF16_FMA={ROPE_BF16_FMA}", flush=True)
 
 
 @cute.jit
 def _to_bf16_f32(v):
     """Round an fp32 value through BF16 and back, matching the unfused RoPE's storage."""
     return v.to(cutlass.BFloat16).to(cutlass.Float32)
+
+
+# ---- Native BF16 scalar ops ----
+# cute.arch exposes packed-f32x2 arithmetic but no bf16 arithmetic, so these go through inline
+# PTX.  The mnemonics are exactly the ones rotary_fwd_q_kernel compiles to (scripts/rope_ptx.py).
+# fma.rn.bf16 is the load-bearing one: it forms its product exactly and rounds the sum once,
+# which is what an fp32 fma followed by a narrow cannot reproduce.
+
+
+@cute.jit
+def _mul_bf16(a, b):
+    return cute.arch.inline_ptx(
+        "mul.bf16 {$w0}, {$r0}, {$r1};",
+        write_only_types=[cutlass.BFloat16],
+        read_only_args=[a, b],
+    )
+
+
+@cute.jit
+def _fma_bf16(a, b, c):
+    return cute.arch.inline_ptx(
+        "fma.rn.bf16 {$w0}, {$r0}, {$r1}, {$r2};",
+        write_only_types=[cutlass.BFloat16],
+        read_only_args=[a, b, c],
+    )
+
+
+@cute.jit
+def _neg_bf16(a):
+    return cute.arch.inline_ptx(
+        "neg.bf16 {$w0}, {$r0};",
+        write_only_types=[cutlass.BFloat16],
+        read_only_args=[a],
+    )
 
 
 @cute.struct
@@ -493,51 +542,73 @@ def gemm_proj_rope_mxfp8_kernel(
                 cos_base = mCos[token_base + tok0, None].iterator.toint() + cidx0 * 2
                 sin_base = mSin[token_base + tok0, None].iterator.toint() + cidx0 * 2
                 if is_second_half:
-                    # lanes 16..31: v = p*s + q*c
+                    # lanes 16..31: v = p*s + q*c.  Triton materializes q*c and folds p*s
+                    # into the fma.
                     for r in cutlass.range_constexpr(BLOCK):
-                        p0 = sACC[tok0 + r, pcol0].to(cutlass.Float32)
-                        q0 = sACC[tok0 + r, pcol0 + 1].to(cutlass.Float32)
-                        p1 = sACC[tok0 + r, pcol1].to(cutlass.Float32)
-                        q1 = sACC[tok0 + r, pcol1 + 1].to(cutlass.Float32)
                         tc = cute.make_tensor(cute.make_ptr(cutlass.BFloat16, cos_base + r * cs_row_bytes, cute.AddressSpace.gmem, assumed_align=2), (2,))
                         ts = cute.make_tensor(cute.make_ptr(cutlass.BFloat16, sin_base + r * cs_row_bytes, cute.AddressSpace.gmem, assumed_align=2), (2,))
-                        c0 = tc[0].to(cutlass.Float32)
-                        s0 = ts[0].to(cutlass.Float32)
-                        c1 = tc[1].to(cutlass.Float32)
-                        s1 = ts[1].to(cutlass.Float32)
-                        # Triton emits bf16( bf16(q*c) + p*s ): q*c is materialized, p*s
-                        # is the multiply the compiler folds into the fma.
-                        qc0, qc1 = cute.arch.mul_packed_f32x2((q0, q1), (c0, c1))
-                        qc0 = _to_bf16_f32(qc0)
-                        qc1 = _to_bf16_f32(qc1)
-                        v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (s0, s1), (qc0, qc1))
-                        v0 = _to_bf16_f32(v0)
-                        v1 = _to_bf16_f32(v1)
+                        if cutlass.const_expr(ROPE_BF16_FMA):
+                            v0 = _fma_bf16(
+                                sACC[tok0 + r, pcol0],
+                                ts[0],
+                                _mul_bf16(sACC[tok0 + r, pcol0 + 1], tc[0]),
+                            ).to(cutlass.Float32)
+                            v1 = _fma_bf16(
+                                sACC[tok0 + r, pcol1],
+                                ts[1],
+                                _mul_bf16(sACC[tok0 + r, pcol1 + 1], tc[1]),
+                            ).to(cutlass.Float32)
+                        else:
+                            p0 = sACC[tok0 + r, pcol0].to(cutlass.Float32)
+                            q0 = sACC[tok0 + r, pcol0 + 1].to(cutlass.Float32)
+                            p1 = sACC[tok0 + r, pcol1].to(cutlass.Float32)
+                            q1 = sACC[tok0 + r, pcol1 + 1].to(cutlass.Float32)
+                            c0 = tc[0].to(cutlass.Float32)
+                            s0 = ts[0].to(cutlass.Float32)
+                            c1 = tc[1].to(cutlass.Float32)
+                            s1 = ts[1].to(cutlass.Float32)
+                            qc0, qc1 = cute.arch.mul_packed_f32x2((q0, q1), (c0, c1))
+                            qc0 = _to_bf16_f32(qc0)
+                            qc1 = _to_bf16_f32(qc1)
+                            v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (s0, s1), (qc0, qc1))
+                            v0 = _to_bf16_f32(v0)
+                            v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
                         col_amax1 = cute.arch.fmax(col_amax1, cute.arch.fmax(v1, -v1))
                 else:
-                    # lanes 0..15: v = p*c - q*s
+                    # lanes 0..15: v = p*c - q*s.  Triton materializes q*s, negates it, and
+                    # folds p*c into the fma.
                     for r in cutlass.range_constexpr(BLOCK):
-                        p0 = sACC[tok0 + r, pcol0].to(cutlass.Float32)
-                        q0 = sACC[tok0 + r, pcol0 + 1].to(cutlass.Float32)
-                        p1 = sACC[tok0 + r, pcol1].to(cutlass.Float32)
-                        q1 = sACC[tok0 + r, pcol1 + 1].to(cutlass.Float32)
                         tc = cute.make_tensor(cute.make_ptr(cutlass.BFloat16, cos_base + r * cs_row_bytes, cute.AddressSpace.gmem, assumed_align=2), (2,))
                         ts = cute.make_tensor(cute.make_ptr(cutlass.BFloat16, sin_base + r * cs_row_bytes, cute.AddressSpace.gmem, assumed_align=2), (2,))
-                        c0 = tc[0].to(cutlass.Float32)
-                        s0 = ts[0].to(cutlass.Float32)
-                        c1 = tc[1].to(cutlass.Float32)
-                        s1 = ts[1].to(cutlass.Float32)
-                        # Triton emits bf16( p*c - bf16(q*s) ): q*s is materialized, p*c
-                        # is the multiply the compiler folds into the fma.
-                        qs0, qs1 = cute.arch.mul_packed_f32x2((q0, q1), (s0, s1))
-                        qs0 = _to_bf16_f32(qs0)
-                        qs1 = _to_bf16_f32(qs1)
-                        v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (c0, c1), (-qs0, -qs1))
-                        v0 = _to_bf16_f32(v0)
-                        v1 = _to_bf16_f32(v1)
+                        if cutlass.const_expr(ROPE_BF16_FMA):
+                            v0 = _fma_bf16(
+                                sACC[tok0 + r, pcol0],
+                                tc[0],
+                                _neg_bf16(_mul_bf16(sACC[tok0 + r, pcol0 + 1], ts[0])),
+                            ).to(cutlass.Float32)
+                            v1 = _fma_bf16(
+                                sACC[tok0 + r, pcol1],
+                                tc[1],
+                                _neg_bf16(_mul_bf16(sACC[tok0 + r, pcol1 + 1], ts[1])),
+                            ).to(cutlass.Float32)
+                        else:
+                            p0 = sACC[tok0 + r, pcol0].to(cutlass.Float32)
+                            q0 = sACC[tok0 + r, pcol0 + 1].to(cutlass.Float32)
+                            p1 = sACC[tok0 + r, pcol1].to(cutlass.Float32)
+                            q1 = sACC[tok0 + r, pcol1 + 1].to(cutlass.Float32)
+                            c0 = tc[0].to(cutlass.Float32)
+                            s0 = ts[0].to(cutlass.Float32)
+                            c1 = tc[1].to(cutlass.Float32)
+                            s1 = ts[1].to(cutlass.Float32)
+                            qs0, qs1 = cute.arch.mul_packed_f32x2((q0, q1), (s0, s1))
+                            qs0 = _to_bf16_f32(qs0)
+                            qs1 = _to_bf16_f32(qs1)
+                            v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (c0, c1), (-qs0, -qs1))
+                            v0 = _to_bf16_f32(v0)
+                            v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -72,16 +72,6 @@ assert HALF == QK_ROPE // 2, "HALF must be QK_ROPE // 2"
 assert TILE_M % BLOCK == 0, "TILE_M must be a whole number of MXFP8 blocks"
 assert NUM_EPI_WARPS == COLBLK * N_FEATCELL, "epilogue warp count must equal COLBLK x N_FEATCELL"
 
-# ---- Debug instrumentation (off by default) ----
-# When on, the epilogue also writes its two intermediates to GMEM so the fused result can be
-# bisected against the unfused GEMM -> RoPE -> quantize chain:
-#   DbgGemm  bf16 [tokens, NUM_HEADS, HEAD_DIM]  post-GEMM, post-bf16-stage, pre-RoPE
-#   DbgRope  fp32 [tokens, NUM_HEADS, HEAD_DIM]  post-RoPE, pre-quantize.  BF16-valued, but
-#            dumped as fp32 so it can also be scored against an exact reference.
-# Guarded with const_expr, so nothing is emitted at all when the flag is off; the buffers are
-# then 1-element placeholders.
-DBG = int(os.environ.get("NVTE_FUSED_Q_UPROJ_DEBUG", "0")) > 0
-
 # ---- RoPE arithmetic ----
 # The unfused path applies RoPE with Megatron's Triton rotary_fwd_q_kernel.  Reading the PTX
 # that kernel compiles to (scripts/rope_ptx.py) it contains no fp32 instruction at all: per
@@ -108,10 +98,6 @@ DBG = int(os.environ.get("NVTE_FUSED_Q_UPROJ_DEBUG", "0")) > 0
 # Both agree on all but ~1e-8 of elements; the flag exists to measure that difference and the
 # cost of closing it.
 ROPE_BF16_FMA = int(os.environ.get("NVTE_FUSED_Q_UPROJ_ROPE_BF16_FMA", "0")) > 0
-
-if DBG or ROPE_BF16_FMA:
-    print(f"[proj_rope_mxfp8] DBG={DBG} ROPE_BF16_FMA={ROPE_BF16_FMA}", flush=True)
-
 
 @cute.jit
 def _to_bf16_f32(v):
@@ -295,8 +281,6 @@ def gemm_proj_rope_mxfp8_kernel(
     mSrow: cute.Tensor,
     mQcol: cute.Tensor,
     mScol: cute.Tensor,
-    mDbgGemm: cute.Tensor,
-    mDbgRope: cute.Tensor,
     epi_tile: cute.Tile,
     cta_layout_vmnk: cute.Layout,
     tile_sched_params: utils.PersistentTileSchedulerParams,
@@ -531,13 +515,7 @@ def gemm_proj_rope_mxfp8_kernel(
             b = fc * 2 + (lane // HALFW)  # 32-feature row-block 0..5
             col_amax0 = cutlass.Float32(0.0)
             col_amax1 = cutlass.Float32(0.0)
-            if cutlass.const_expr(DBG):
-                # P1: raw GEMM tile straight out of sACC, before any rope. The (f0, f1) pairs
-                # over 12 warps x 32 lanes x 32 tokens tile TILE_M x HEAD_DIM exactly once, so
-                # this dumps every column in natural (nope | interleaved-rope) order.
-                for r in cutlass.range_constexpr(BLOCK):
-                    mDbgGemm[token_base + tok0 + r, head, f0] = sACC[tok0 + r, f0]
-                    mDbgGemm[token_base + tok0 + r, head, f1] = sACC[tok0 + r, f1]
+            
             # TE weight layout: NOPE at features 0..127, ROPE at features 128..191 (last cell)
             is_rope = fc == (N_FEATCELL - 1)
             if is_rope:
@@ -624,12 +602,7 @@ def gemm_proj_rope_mxfp8_kernel(
                     buf1[r] = v1
                     col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
                     col_amax1 = cute.arch.fmax(col_amax1, cute.arch.fmax(v1, -v1))
-            if cutlass.const_expr(DBG):
-                # P2: post-rope values, still fp32, before amax/quantize. buf0/buf1 map to the
-                # output features f0/f1 in both the rope and non-rope branches.
-                for r in cutlass.range_constexpr(BLOCK):
-                    mDbgRope[token_base + tok0 + r, head, f0] = buf0[r]
-                    mDbgRope[token_base + tok0 + r, head, f1] = buf1[r]
+            
             invc0, sbc0, invc1, sbc1 = _e8m0_pair(col_amax0, col_amax1)
             scol_row = m_idx * COLBLK + cb
             mScol[scol_row, head, f0] = cutlass.Uint8(sbc0)
@@ -699,8 +672,6 @@ def gemm_proj_rope_mxfp8_host(
     mSrow: cute.Tensor,
     mQcol: cute.Tensor,
     mScol: cute.Tensor,
-    mDbgGemm: cute.Tensor,
-    mDbgRope: cute.Tensor,
     grid_m: cutlass.Constexpr,
     num_heads: cutlass.Constexpr,
     max_active_clusters: cutlass.Constexpr,
@@ -769,8 +740,6 @@ def gemm_proj_rope_mxfp8_host(
         mSrow,
         mQcol,
         mScol,
-        mDbgGemm,
-        mDbgRope,
         epi_tile,
         cta_layout_vmnk,
         tile_sched_params,

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -105,49 +105,67 @@ def _to_bf16_f32(v):
     return v.to(cutlass.BFloat16).to(cutlass.Float32)
 
 
-# ---- Native BF16 scalar ops ----
-# cute.arch exposes packed-f32x2 arithmetic but no bf16 arithmetic, so these go through inline
-# PTX.  The mnemonics are exactly the ones rotary_fwd_q_kernel compiles to (scripts/rope_ptx.py).
-# fma.rn.bf16 is the load-bearing one: it forms its product exactly and rounds the sum once,
-# which is what an fp32 fma followed by a narrow cannot reproduce.
+# ---- Native BF16 rope, packed ----
+# cute.arch exposes packed-f32x2 arithmetic but no bf16 arithmetic, so this goes through inline
+# PTX.  Two details are load-bearing:
 #
-# The operands are declared Int16 rather than BFloat16.  A bf16 MLIR type on an inline-asm
-# operand makes the NVVM backend fail to compile with no usable diagnostic; the registers are
-# the same .b16 either way, so passing the bit pattern sidesteps it at no cost.
+#   fma.rn.bf16x2 forms its products exactly and rounds each half once, which is what an fp32
+#   fma followed by a narrow cannot reproduce.  Its per-half rounding is identical to the scalar
+#   fma.rn.bf16 that rotary_fwd_q_kernel emits, so the packed form is not an approximation of
+#   the scalar one -- it is the same function, verified elementwise in scripts/probe_bf16_ptx.py.
+#
+#   The whole pair goes in *one* asm block.  A first cut used one block per instruction, six per
+#   pair, and cost 5.2x on the kernel (README T24).  Halving the instruction count by packing is
+#   the small part of the win: an inline_ptx block is opaque to ptxas, so six of them per pair
+#   with BLOCK=32 unrolled put up to 192 barriers through an epilogue that has to overlap this
+#   arithmetic with the quantize, the amax reduction and the stores.
+#
+# Operands are raw bit patterns, not BFloat16: a bf16 MLIR type on an inline-asm operand makes
+# the NVVM backend fail to compile with no usable diagnostic.  Everything arrives as a 16-bit
+# value and gets packed here; an earlier version fetched the adjacent cos/sin as one 32-bit load
+# instead, which saves two loads but reintroduces that same silent compile failure.
+_ROPE_PROLOGUE = (
+    "{\n"
+    " .reg .b32 pp, qq, cc, ss, tq;\n"
+    " .reg .b16 h0, h1;\n"
+    " mov.b32 pp, {{$r0}, {$r1}};\n"
+    " mov.b32 qq, {{$r2}, {$r3}};\n"
+    " mov.b32 cc, {{$r4}, {$r5}};\n"
+    " mov.b32 ss, {{$r6}, {$r7}};\n"
+)
+_ROPE_EPILOGUE = (
+    " mov.b32 {h0, h1}, pp;\n"
+    " cvt.f32.bf16 {$w0}, h0;\n"
+    " cvt.f32.bf16 {$w1}, h1;\n"
+    "}\n"
+)
 
 
 @cute.jit
-def _mul_bf16(a, b):
-    r = cute.arch.inline_ptx(
-        "mul.bf16 {$w0}, {$r0}, {$r1};",
-        write_only_types=[cutlass.Int16],
-        read_only_args=[a.bitcast(cutlass.Int16), b.bitcast(cutlass.Int16)],
+def _rope_lo_bf16(p0, p1, q0, q1, c0, c1, s0, s1):
+    """Low rotated half: v_k = fma.rn.bf16(p_k, c_k, -mul.bf16(q_k, s_k)), two features at once."""
+    return cute.arch.inline_ptx(
+        _ROPE_PROLOGUE
+        + " mul.bf16x2 tq, qq, ss;\n"
+        + " neg.bf16x2 tq, tq;\n"
+        + " fma.rn.bf16x2 pp, pp, cc, tq;\n"
+        + _ROPE_EPILOGUE,
+        write_only_types=[cutlass.Float32, cutlass.Float32],
+        read_only_args=[p0, p1, q0, q1, c0, c1, s0, s1],
     )
-    return r.bitcast(cutlass.BFloat16)
 
 
 @cute.jit
-def _fma_bf16(a, b, c):
-    r = cute.arch.inline_ptx(
-        "fma.rn.bf16 {$w0}, {$r0}, {$r1}, {$r2};",
-        write_only_types=[cutlass.Int16],
-        read_only_args=[
-            a.bitcast(cutlass.Int16),
-            b.bitcast(cutlass.Int16),
-            c.bitcast(cutlass.Int16),
-        ],
+def _rope_hi_bf16(p0, p1, q0, q1, c0, c1, s0, s1):
+    """High rotated half: v_k = fma.rn.bf16(p_k, s_k, mul.bf16(q_k, c_k)), two features at once."""
+    return cute.arch.inline_ptx(
+        _ROPE_PROLOGUE
+        + " mul.bf16x2 tq, qq, cc;\n"
+        + " fma.rn.bf16x2 pp, pp, ss, tq;\n"
+        + _ROPE_EPILOGUE,
+        write_only_types=[cutlass.Float32, cutlass.Float32],
+        read_only_args=[p0, p1, q0, q1, c0, c1, s0, s1],
     )
-    return r.bitcast(cutlass.BFloat16)
-
-
-@cute.jit
-def _neg_bf16(a):
-    r = cute.arch.inline_ptx(
-        "neg.bf16 {$w0}, {$r0};",
-        write_only_types=[cutlass.Int16],
-        read_only_args=[a.bitcast(cutlass.Int16)],
-    )
-    return r.bitcast(cutlass.BFloat16)
 
 
 @cute.struct
@@ -537,16 +555,16 @@ def gemm_proj_rope_mxfp8_kernel(
                         tc = cute.make_tensor(cute.make_ptr(cutlass.BFloat16, cos_base + r * cs_row_bytes, cute.AddressSpace.gmem, assumed_align=2), (2,))
                         ts = cute.make_tensor(cute.make_ptr(cutlass.BFloat16, sin_base + r * cs_row_bytes, cute.AddressSpace.gmem, assumed_align=2), (2,))
                         if cutlass.const_expr(ROPE_BF16_FMA):
-                            v0 = _fma_bf16(
-                                sACC[tok0 + r, pcol0],
-                                ts[0],
-                                _mul_bf16(sACC[tok0 + r, pcol0 + 1], tc[0]),
-                            ).to(cutlass.Float32)
-                            v1 = _fma_bf16(
-                                sACC[tok0 + r, pcol1],
-                                ts[1],
-                                _mul_bf16(sACC[tok0 + r, pcol1 + 1], tc[1]),
-                            ).to(cutlass.Float32)
+                            v0, v1 = _rope_hi_bf16(
+                                sACC[tok0 + r, pcol0].bitcast(cutlass.Int16),
+                                sACC[tok0 + r, pcol1].bitcast(cutlass.Int16),
+                                sACC[tok0 + r, pcol0 + 1].bitcast(cutlass.Int16),
+                                sACC[tok0 + r, pcol1 + 1].bitcast(cutlass.Int16),
+                                tc[0].bitcast(cutlass.Int16),
+                                tc[1].bitcast(cutlass.Int16),
+                                ts[0].bitcast(cutlass.Int16),
+                                ts[1].bitcast(cutlass.Int16),
+                            )
                         else:
                             p0 = sACC[tok0 + r, pcol0].to(cutlass.Float32)
                             q0 = sACC[tok0 + r, pcol0 + 1].to(cutlass.Float32)
@@ -557,7 +575,11 @@ def gemm_proj_rope_mxfp8_kernel(
                             c1 = tc[1].to(cutlass.Float32)
                             s1 = ts[1].to(cutlass.Float32)
                             qc0, qc1 = cute.arch.mul_packed_f32x2((q0, q1), (c0, c1))
+                            qc0 = _to_bf16_f32(qc0)
+                            qc1 = _to_bf16_f32(qc1)
                             v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (s0, s1), (qc0, qc1))
+                            v0 = _to_bf16_f32(v0)
+                            v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
@@ -569,16 +591,16 @@ def gemm_proj_rope_mxfp8_kernel(
                         tc = cute.make_tensor(cute.make_ptr(cutlass.BFloat16, cos_base + r * cs_row_bytes, cute.AddressSpace.gmem, assumed_align=2), (2,))
                         ts = cute.make_tensor(cute.make_ptr(cutlass.BFloat16, sin_base + r * cs_row_bytes, cute.AddressSpace.gmem, assumed_align=2), (2,))
                         if cutlass.const_expr(ROPE_BF16_FMA):
-                            v0 = _fma_bf16(
-                                sACC[tok0 + r, pcol0],
-                                tc[0],
-                                _neg_bf16(_mul_bf16(sACC[tok0 + r, pcol0 + 1], ts[0])),
-                            ).to(cutlass.Float32)
-                            v1 = _fma_bf16(
-                                sACC[tok0 + r, pcol1],
-                                tc[1],
-                                _neg_bf16(_mul_bf16(sACC[tok0 + r, pcol1 + 1], ts[1])),
-                            ).to(cutlass.Float32)
+                            v0, v1 = _rope_lo_bf16(
+                                sACC[tok0 + r, pcol0].bitcast(cutlass.Int16),
+                                sACC[tok0 + r, pcol1].bitcast(cutlass.Int16),
+                                sACC[tok0 + r, pcol0 + 1].bitcast(cutlass.Int16),
+                                sACC[tok0 + r, pcol1 + 1].bitcast(cutlass.Int16),
+                                tc[0].bitcast(cutlass.Int16),
+                                tc[1].bitcast(cutlass.Int16),
+                                ts[0].bitcast(cutlass.Int16),
+                                ts[1].bitcast(cutlass.Int16),
+                            )
                         else:
                             p0 = sACC[tok0 + r, pcol0].to(cutlass.Float32)
                             q0 = sACC[tok0 + r, pcol0 + 1].to(cutlass.Float32)
@@ -589,7 +611,11 @@ def gemm_proj_rope_mxfp8_kernel(
                             c1 = tc[1].to(cutlass.Float32)
                             s1 = ts[1].to(cutlass.Float32)
                             qs0, qs1 = cute.arch.mul_packed_f32x2((q0, q1), (s0, s1))
+                            qs0 = _to_bf16_f32(qs0)
+                            qs1 = _to_bf16_f32(qs1)
                             v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (c0, c1), (-qs0, -qs1))
+                            v0 = _to_bf16_f32(v0)
+                            v1 = _to_bf16_f32(v1)
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))

--- a/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
+++ b/python/cudnn/gemm/cutedsl/dense/proj_rope_mxfp8/gemm_proj_rope_mxfp8_mxfp8in.py
@@ -530,8 +530,8 @@ def gemm_proj_rope_mxfp8_kernel(
                             s0 = ts[0].to(cutlass.Float32)
                             c1 = tc[1].to(cutlass.Float32)
                             s1 = ts[1].to(cutlass.Float32)
-                            qc0, qc1 = cute.arch.mul_packed_f32x2((q0, q1), (c0, c1))
-                            v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (s0, s1), (qc0, qc1))
+                            ps0, ps1 = cute.arch.mul_packed_f32x2((p0, p1), (s0, s1))
+                            v0, v1 = cute.arch.fma_packed_f32x2((q0, q1), (c0, c1), (ps0, ps1))
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))
@@ -562,8 +562,9 @@ def gemm_proj_rope_mxfp8_kernel(
                             s0 = ts[0].to(cutlass.Float32)
                             c1 = tc[1].to(cutlass.Float32)
                             s1 = ts[1].to(cutlass.Float32)
+                            pc0, pc1 = cute.arch.mul_packed_f32x2((p0, p1), (c0, c1))
                             qs0, qs1 = cute.arch.mul_packed_f32x2((q0, q1), (s0, s1))
-                            v0, v1 = cute.arch.fma_packed_f32x2((p0, p1), (c0, c1), (-qs0, -qs1))
+                            v0, v1 = cute.arch.fma_packed_f32x2((qs0, qs1), (cutlass.Float32(-1.0), cutlass.Float32(-1.0)), (pc0, pc1))
                         buf0[r] = v0
                         buf1[r] = v1
                         col_amax0 = cute.arch.fmax(col_amax0, cute.arch.fmax(v0, -v0))


### PR DESCRIPTION
## Before submitting

- [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [ ] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

<!-- What changed? Keep the scope concise. -->

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional BF16-optimized RoPE computation path for supported workloads.
  - The path can be enabled through the `NVTE_FUSED_Q_UPROJ_ROPE_BF16_FMA` environment setting.
  - Existing FP32 behavior remains available when the setting is disabled or unavailable.

- **Bug Fixes**
  - Improved intermediate-output handling during MXFP8 dispatch without changing existing execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->