### PR TITLE
Restore pre-1.27 module paths as deprecated aliases; clearer lazy-import errors

### DIFF
--- a/docs/fe-oss-apis/overview.md
+++ b/docs/fe-oss-apis/overview.md
@@ -52,6 +52,12 @@ pip install --group jax     # jax >= 0.5 (XLA entry points via cutlass.jax, ship
 
 After installation, you can import the APIs directly from the `cudnn` package, i.e. `from cudnn import {your_operation}`
 
+### Import paths
+
+`from cudnn import {your_operation}` is the supported entry point and has been stable across releases. The modules behind it were reorganized in 1.27: the GEMM fusion packages now live under `cudnn.gemm.cutedsl.{dense,grouped,discrete_grouped}` (e.g. `cudnn.gemm.cutedsl.grouped.wgrad` instead of `cudnn.grouped_gemm.grouped_gemm_wgrad`). The pre-1.27 module paths — `cudnn.grouped_gemm`, `cudnn.discrete_grouped_gemm`, `cudnn.gemm_amax`, `cudnn.gemm_swiglu`, `cudnn.gemm_srelu`, `cudnn.gemm_dsrelu`, `cudnn.gemm_proj_rope_mxfp8`, and their submodules — remain importable as deprecated aliases of the new packages (a `DeprecationWarning` is emitted on first use). New code should use the top-level symbols.
+
+Note that a failed optional-dependency import surfaces as `ImportError: {your_operation} requires optional dependencies ...` when accessing the symbol; the underlying cause is chained onto the error (`raise ... from`), so run with the full traceback to see what is actually missing.
+
 ## API Usage
 
 Each operation exposes two APIs:

--- a/python/cudnn/__init__.py
+++ b/python/cudnn/__init__.py
@@ -307,6 +307,13 @@ __all__ = [*_EAGER_PUBLIC_NAMES, "Graph", "wrapper"]
 
 _OPTIONAL_DEPENDENCY_INSTALL_HINT = "Install with 'pip install nvidia-cudnn-frontend[cutedsl]'"
 
+# Pre-1.27 module paths (cudnn.grouped_gemm, cudnn.gemm_amax, ...) keep
+# working as deprecated sys.modules aliases of the cudnn.gemm.cutedsl.*
+# packages. Lazy (a meta-path finder) so `import cudnn` stays framework-free.
+from . import _legacy_aliases
+
+_legacy_aliases.install()
+
 _LAZY_OPTIONAL_IMPORTS = {
     "gnn": (".gnn", None),
     "BSA": (".block_sparse_attention", "BSA"),
@@ -381,8 +388,23 @@ def _load_optional_symbol(name: str) -> Any:
     try:
         module = importlib.import_module(module_name, package=__name__)
         value = module if attr_name is None else getattr(module, attr_name)
-    except Exception as e:
+    except ImportError as e:
+        # A cudnn-internal module that cannot be found is a packaging or
+        # lazy-table bug, not a missing optional dependency; saying "pip
+        # install ...[cutedsl]" for it sends users chasing the wrong fix.
+        missing = getattr(e, "name", None)
+        if isinstance(e, ModuleNotFoundError) and missing and missing.startswith(__name__):
+            raise ImportError(
+                f"cudnn.{name} could not be imported: internal module {missing!r} is missing. "
+                f"This is a cudnn-frontend packaging bug, not a missing optional dependency."
+            ) from e
         raise ImportError(f"{name} requires optional dependencies. {_OPTIONAL_DEPENDENCY_INSTALL_HINT}: {e}") from e
+    except Exception as e:
+        # Anything else is a real failure inside the fusion module (or a stale
+        # table entry): surface it as such instead of blaming optional deps.
+        raise ImportError(
+            f"cudnn.{name} failed to import from {module_name!r} with " f"{type(e).__name__}: {e}. This is not a missing optional dependency."
+        ) from e
 
     globals()[name] = value
     return value

--- a/python/cudnn/_legacy_aliases.py
+++ b/python/cudnn/_legacy_aliases.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Import-system aliases for the pre-1.27 CuTeDSL GEMM module paths.
+
+The 1.27 reorganization ("Reorganize Gemm fusion") moved the CuTeDSL GEMM
+fusion packages under ``cudnn.gemm.cutedsl.*``. The supported entry point —
+``from cudnn import <symbol>`` — never changed, but code importing modules by
+their old dotted paths (``import cudnn.grouped_gemm``,
+``from cudnn.grouped_gemm.grouped_gemm_wgrad.api import ...``) broke: the
+attribute-level aliases in ``cudnn.__getattr__`` cannot satisfy an import
+statement, because ``import a.b`` resolves ``a.b`` through the import system,
+not through ``getattr(a, "b")``.
+
+A table of eager ``sys.modules[legacy] = canonical`` entries can't fix this
+either without importing every CuTeDSL package (and therefore torch and
+nvidia-cutlass-dsl) at ``import cudnn`` time, which
+``test_import_boundaries.py`` forbids. So the aliases are installed as a
+:class:`importlib.abc.MetaPathFinder` that redirects a legacy path to its
+canonical module lazily, at the moment the legacy path is first imported:
+
+* ``sys.modules[legacy_name] is sys.modules[canonical_name]`` after the
+  import, so ``is`` checks and monkeypatching see one module, not a copy;
+* a :class:`DeprecationWarning` names the canonical path on first use;
+* ``import cudnn`` itself stays framework-free.
+
+The loader hands the already-imported canonical module back from
+``create_module``; the import machinery only fills module attributes that are
+unset, so the canonical module keeps its own ``__name__`` / ``__spec__`` /
+``__path__`` and merely gains a second ``sys.modules`` key.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import importlib.util
+import sys
+import warnings
+
+# Legacy package roots mapped to their canonical packages. Descendants follow
+# the root: child modules keep their names, except the per-fusion subpackages,
+# which dropped the redundant family prefix in the move
+# (``grouped_gemm.grouped_gemm_wgrad`` -> ``grouped.wgrad``);
+# _STRIP_CHILD_PREFIX records that rename.
+_LEGACY_ROOTS = {
+    "cudnn.gemm_amax": "cudnn.gemm.cutedsl.dense.amax",
+    "cudnn.gemm_swiglu": "cudnn.gemm.cutedsl.dense.swiglu",
+    "cudnn.gemm_srelu": "cudnn.gemm.cutedsl.dense.srelu",
+    "cudnn.gemm_dsrelu": "cudnn.gemm.cutedsl.dense.dsrelu",
+    "cudnn.gemm_proj_rope_mxfp8": "cudnn.gemm.cutedsl.dense.proj_rope_mxfp8",
+    "cudnn.grouped_gemm": "cudnn.gemm.cutedsl.grouped",
+    "cudnn.discrete_grouped_gemm": "cudnn.gemm.cutedsl.discrete_grouped",
+}
+
+_STRIP_CHILD_PREFIX = {
+    "cudnn.grouped_gemm": "grouped_gemm_",
+    "cudnn.discrete_grouped_gemm": "discrete_grouped_gemm_",
+    # ``from cudnn.grouped_gemm import grouped_gemm_wgrad`` resolves the child
+    # against the parent's __name__, which is already canonical — so the
+    # prefixed child names must also be aliased under the canonical roots.
+    "cudnn.gemm.cutedsl.grouped": "grouped_gemm_",
+    "cudnn.gemm.cutedsl.discrete_grouped": "discrete_grouped_gemm_",
+}
+
+
+def _canonical_name(fullname: str) -> "str | None":
+    """Map a legacy dotted path to its canonical one; None if not legacy."""
+    # The finder sits at sys.meta_path[0] and sees every import in the
+    # process; get non-cudnn names out of the way on one comparison.
+    if not fullname.startswith("cudnn."):
+        return None
+    for root, canonical_root in _LEGACY_ROOTS.items():
+        if fullname == root:
+            return canonical_root
+        if fullname.startswith(root + "."):
+            rest = fullname[len(root) + 1 :].split(".")
+            prefix = _STRIP_CHILD_PREFIX.get(root)
+            if prefix and rest[0].startswith(prefix):
+                rest[0] = rest[0][len(prefix) :]
+            return ".".join([canonical_root, *rest])
+    # Prefixed child names spelled directly under a canonical root.
+    for root in ("cudnn.gemm.cutedsl.grouped", "cudnn.gemm.cutedsl.discrete_grouped"):
+        if fullname.startswith(root + "."):
+            rest = fullname[len(root) + 1 :].split(".")
+            prefix = _STRIP_CHILD_PREFIX[root]
+            if rest[0].startswith(prefix):
+                rest[0] = rest[0][len(prefix) :]
+                return ".".join([root, *rest])
+    return None
+
+
+class _AliasLoader(importlib.abc.Loader):
+    def __init__(self, canonical: str):
+        self._canonical = canonical
+        self._saved = {}
+
+    def create_module(self, spec):
+        # Returning an existing module makes the import machinery bind the
+        # legacy name in sys.modules to the canonical module itself. The
+        # machinery then stamps the legacy spec onto that module
+        # (_init_module_attrs overwrites __spec__/__loader__ and, for a
+        # returned module, __name__/__package__), so snapshot the canonical
+        # metadata here and restore it in exec_module, which runs after.
+        module = importlib.import_module(self._canonical)
+        self._saved = {attr: getattr(module, attr) for attr in ("__name__", "__spec__", "__loader__", "__package__") if hasattr(module, attr)}
+        return module
+
+    def exec_module(self, module):
+        # Already executed under its canonical name; just undo the legacy
+        # metadata stamped between create_module and here.
+        for attr, value in self._saved.items():
+            setattr(module, attr, value)
+
+
+class _LegacyAliasFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        canonical = _canonical_name(fullname)
+        if canonical is None or canonical == fullname:
+            return None
+        warnings.warn(
+            f"'{fullname}' moved to '{canonical}' in cudnn-frontend 1.27; the old"
+            f" path is kept as a deprecated alias. Prefer the top-level"
+            f" 'from cudnn import <symbol>' entry points, which never moved.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return importlib.util.spec_from_loader(fullname, _AliasLoader(canonical))
+
+
+def install() -> None:
+    """Idempotently install the legacy-alias finder on ``sys.meta_path``.
+
+    It must run BEFORE the default PathFinder: an aliased parent package has
+    the canonical ``__path__``, so PathFinder would resolve a legacy child
+    like ``cudnn.grouped_gemm.grouped_gemm_wgrad.api`` to the real ``api.py``
+    and execute it a second time as a distinct module under the legacy name.
+    """
+    if not any(isinstance(finder, _LegacyAliasFinder) for finder in sys.meta_path):
+        sys.meta_path.insert(0, _LegacyAliasFinder())

--- a/python/cudnn/gemm/__init__.py
+++ b/python/cudnn/gemm/__init__.py
@@ -12,7 +12,11 @@ Layout::
     cudnn.gemm.reference                         pure-PyTorch correctness engine
 
 Every public symbol is also re-exported at the top level (``cudnn.<symbol>``),
-which is the supported entry point for users.
+which is the supported entry point for users. The pre-1.27 module paths
+(``cudnn.grouped_gemm``, ``cudnn.discrete_grouped_gemm``, ``cudnn.gemm_amax``,
+``cudnn.gemm_swiglu``, ``cudnn.gemm_srelu``, ``cudnn.gemm_dsrelu``,
+``cudnn.gemm_proj_rope_mxfp8`` and their submodules) remain importable as
+deprecated aliases of these packages — see ``cudnn._legacy_aliases``.
 """
 
 from typing import Any

--- a/test/python/test_legacy_import_aliases.py
+++ b/test/python/test_legacy_import_aliases.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The pre-1.27 module paths must keep importing after the gemm reorg.
+
+The 1.27 reorganization moved the CuTeDSL GEMM packages under
+``cudnn.gemm.cutedsl.*`` while keeping ``from cudnn import <symbol>`` stable.
+``cudnn._legacy_aliases`` is the compatibility layer for the module paths
+themselves: ``import cudnn.grouped_gemm.grouped_gemm_wgrad.api`` must bind the
+canonical module (same object, not a copy) and warn, without making
+``import cudnn`` pull a framework.
+
+Probes that import real fusion modules need the optional deps and run in a
+fresh interpreter (an in-process assertion would pass for the wrong reason
+once modules are cached); mapping tests are pure and run in-process.
+"""
+
+import importlib.util
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.L0
+
+# The eager grouped-gemm import chain needs nvidia-cutlass-dsl and
+# cuda-python at module scope (torch is deferred to call time).
+_HAVE_CUTEDSL = bool(importlib.util.find_spec("cutlass")) and bool(importlib.util.find_spec("cuda"))
+
+
+def _run(probe: str) -> None:
+    run = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True)
+    assert run.returncode == 0, run.stderr
+
+
+def test_legacy_name_mapping():
+    from cudnn._legacy_aliases import _canonical_name
+
+    assert _canonical_name("cudnn.grouped_gemm") == "cudnn.gemm.cutedsl.grouped"
+    assert _canonical_name("cudnn.grouped_gemm.grouped_gemm_wgrad.api") == "cudnn.gemm.cutedsl.grouped.wgrad.api"
+    # Helper modules kept their names in the move.
+    assert _canonical_name("cudnn.grouped_gemm.moe_utils") == "cudnn.gemm.cutedsl.grouped.moe_utils"
+    assert _canonical_name("cudnn.discrete_grouped_gemm.discrete_grouped_gemm_swiglu") == "cudnn.gemm.cutedsl.discrete_grouped.swiglu"
+    assert _canonical_name("cudnn.gemm_amax.api") == "cudnn.gemm.cutedsl.dense.amax.api"
+    # Old-style child names spelled under the canonical root (the fromlist
+    # path of ``from cudnn.grouped_gemm import grouped_gemm_wgrad``).
+    assert _canonical_name("cudnn.gemm.cutedsl.grouped.grouped_gemm_wgrad") == "cudnn.gemm.cutedsl.grouped.wgrad"
+    # Non-legacy paths are left to the normal import machinery.
+    assert _canonical_name("cudnn.sdpa") is None
+    assert _canonical_name("cudnn.gemm.cutedsl.grouped.wgrad") is None
+    assert _canonical_name("numpy") is None
+
+
+def test_finder_installed_by_import_cudnn():
+    _run("""
+import sys
+import cudnn
+from cudnn._legacy_aliases import _LegacyAliasFinder
+assert any(isinstance(f, _LegacyAliasFinder) for f in sys.meta_path)
+import cudnn  # reimport must not stack a second finder
+cudnn._legacy_aliases.install()
+assert sum(isinstance(f, _LegacyAliasFinder) for f in sys.meta_path) == 1
+""")
+
+
+@pytest.mark.skipif(not _HAVE_CUTEDSL, reason="requires nvidia-cutlass-dsl and torch")
+def test_legacy_import_binds_canonical_module_and_warns():
+    _run("""
+import sys
+import warnings
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    import cudnn.grouped_gemm
+    import cudnn.grouped_gemm.grouped_gemm_wgrad.api
+
+import cudnn.gemm.cutedsl.grouped
+
+assert sys.modules["cudnn.grouped_gemm"] is sys.modules["cudnn.gemm.cutedsl.grouped"]
+assert (
+    sys.modules["cudnn.grouped_gemm.grouped_gemm_wgrad.api"]
+    is sys.modules["cudnn.gemm.cutedsl.grouped.wgrad.api"]
+)
+# The canonical module keeps its identity; only sys.modules gains a key.
+assert sys.modules["cudnn.grouped_gemm"].__name__ == "cudnn.gemm.cutedsl.grouped"
+
+from cudnn.grouped_gemm import grouped_gemm_wgrad  # fromlist spelling
+assert grouped_gemm_wgrad is sys.modules["cudnn.gemm.cutedsl.grouped.wgrad"]
+
+from cudnn import grouped_gemm_wgrad_wrapper_sm100  # supported entry point
+assert grouped_gemm_wgrad_wrapper_sm100 is grouped_gemm_wgrad.api.grouped_gemm_wgrad_wrapper_sm100
+
+deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+assert any("cudnn.gemm.cutedsl.grouped" in str(w.message) for w in deprecations), deprecations
+""")
+
+
+def test_optional_dep_failure_names_the_real_cause():
+    _run("""
+import importlib.abc
+import sys
+
+class BlockOptionalDeps(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split(".")[0] in ("torch", "cutlass", "nvidia_cutlass_dsl", "cuda"):
+            raise ImportError(f"blocked {fullname} for legacy-alias test")
+        return None
+
+sys.meta_path.insert(0, BlockOptionalDeps())
+import cudnn
+try:
+    cudnn.grouped_gemm_wgrad_wrapper_sm100
+except ImportError as error:
+    assert "pip install nvidia-cudnn-frontend[cutedsl]" in str(error), error
+    assert "blocked" in str(error), error
+    assert error.__cause__ is not None
+else:
+    raise AssertionError("lazy symbol access unexpectedly succeeded without optional deps")
+""")
+
+
+def test_internal_missing_module_is_not_blamed_on_optional_deps():
+    _run("""
+import cudnn
+cudnn._LAZY_OPTIONAL_IMPORTS["bogus_symbol"] = (".does_not_exist", None)
+try:
+    cudnn.bogus_symbol
+except ImportError as error:
+    assert "packaging bug" in str(error), error
+    assert "pip install" not in str(error), error
+else:
+    raise AssertionError("bogus lazy symbol unexpectedly resolved")
+""")


### PR DESCRIPTION
## Problem

The 1.27 GEMM reorganization kept every public symbol importable as `from cudnn import <symbol>`, but the old dotted module paths broke:

```python
import cudnn.grouped_gemm                                    # ModuleNotFoundError
from cudnn.grouped_gemm.grouped_gemm_wgrad.api import ...    # ModuleNotFoundError
```

The attribute-level aliases in `cudnn.__getattr__` cannot satisfy an import statement (`import a.b` resolves through the import system, not `getattr`). The package-structure design doc called for `sys.modules` compatibility aliases, but they were never implemented.

Separately, `_load_optional_symbol` wrapped **every** failure as `"<name> requires optional dependencies. Install with pip install nvidia-cudnn-frontend[cutedsl]"`, so an internal packaging bug or a real error inside a fusion module masqueraded as a missing optional dependency — which in turn read as "the API was removed".

## Change

- **`cudnn/_legacy_aliases.py`** — a `sys.meta_path` finder lazily maps every legacy path (`cudnn.grouped_gemm*`, `cudnn.discrete_grouped_gemm*`, `cudnn.gemm_amax`, `cudnn.gemm_swiglu`, `cudnn.gemm_srelu`, `cudnn.gemm_dsrelu`, `cudnn.gemm_proj_rope_mxfp8`, and their submodules, including the renamed per-fusion children like `grouped_gemm_wgrad` → `wgrad`) onto its canonical `cudnn.gemm.cutedsl.*` module on first import. After the import, `sys.modules[legacy] is sys.modules[canonical]` — one module, not a copy — and a `DeprecationWarning` names the canonical path. Lazy by construction: `import cudnn` still pulls no framework (the eager-`sys.modules` approach from the design doc would have violated `test_import_boundaries.py`). The finder must sit in front of `PathFinder`, which would otherwise resolve legacy children through the aliased parent's `__path__` and execute the same file twice as two distinct modules.
- **`_load_optional_symbol`** — failure classes are now distinguished: a missing third-party module keeps the `[cutedsl]` install hint (with the underlying error appended), a missing `cudnn.*` internal module is reported as a packaging bug, and any other exception is surfaced as the real failure. All paths chain via `raise ... from`.
- **Docs** — import-path / 1.27-reorg note in `docs/fe-oss-apis/overview.md`; alias note in the `cudnn.gemm` docstring.
- **Tests** — `test/python/test_legacy_import_aliases.py`: fresh-interpreter probes for alias identity, the `from cudnn.grouped_gemm import grouped_gemm_wgrad` fromlist spelling, deprecation warnings, finder idempotence, and both error-message classes.

## Verification

- New suite: 5/5 pass (alias identity verified against real `cutlass`/`cuda-python` imports on a GPU box).
- Existing `test/python/test_import_boundaries.py`: 8/8 pass — `import cudnn` remains framework-free and the gnn/ops optional-dependency guidance is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)