### PR TITLE
Fix -Werror=unused-parameter build failure in python/gnn.cpp against cudnn < 9.26 headers

### DIFF
--- a/python/gnn.cpp
+++ b/python/gnn.cpp
@@ -68,7 +68,7 @@ ensure_cuda_runtime_context() {
 }  // namespace
 
 void
-init_gnn_submodule(py::module_ &m) {
+init_gnn_submodule([[maybe_unused]] py::module_ &m) {
 #if CUDNN_VERSION >= 92600 && !defined(_WIN32)
     py::enum_<cudnnGnnAggOp_t>(m, "gnn_agg_op")
         .value("SUM", CUDNN_GNN_AGG_SUM)


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

(Requesting labels: `cat-bugfix`, `mod-frontend`, `orig-external` — happy to adjust.)

## Affected area

Build, packaging, or installation (python bindings, source build only).

## Summary

One-line fix: mark the `py::module_ &m` parameter of `init_gnn_submodule` as `[[maybe_unused]]` so the python bindings build from source against cuDNN headers older than 9.26.

## Why

`init_gnn_submodule(py::module_ &m)` in `python/gnn.cpp` has its entire body gated on `#if CUDNN_VERSION >= 92600 && !defined(_WIN32)`. When building against older cuDNN headers the gate compiles the body out, `m` becomes unused, and the top-level `add_compile_options(... -Werror ...)` fails the whole python-binding build:

```
python/gnn.cpp: In function 'void cudnn_frontend::python_bindings::init_gnn_submodule(pybind11::module_&)':
python/gnn.cpp:71:33: error: unused parameter 'm' [-Werror=unused-parameter]
   71 | init_gnn_submodule(py::module_ &m) {
      |                    ~~~~~~~~~~~~~^
cc1plus: all warnings being treated as errors
```

Version matrix:

| cuDNN headers at build time | result |
|---|---|
| >= 9.26 | builds fine (gate open, `m` used) |
| < 9.26 (e.g. 9.23, 9.24) | **build fails** as above |
| published wheels | unaffected (built with new cuDNN) |

`[[maybe_unused]]` is already used elsewhere in this codebase (e.g. `include/cudnn_frontend_EngineFallbackList.h`, `include/cudnn_frontend/utils/attn_score_modifiers.h`) and is inert when the gate is open and the parameter is used.

I swept the rest of the tree for the same pattern (a `CUDNN_VERSION` gate compiling out a whole function body and orphaning a parameter): `python/pycudnn.cpp`'s version gates sit inside `PYBIND11_MODULE` where `m` is used unconditionally, and the gated `TEST_CASE` bodies in `samples/` take no parameters — `python/gnn.cpp` is the only instance.

## Related issues

None filed; hit while building the python bindings from source on a machine with cuDNN 9.23.

## API and compatibility impact

None. Attribute-only change; no behavior, API, or ABI impact for any cuDNN version.

## Testing

On Linux x86_64, gcc 13.3.0, CMake 3.31.6, python 3.12, cuDNN 9.23 headers (`/usr/include/x86_64-linux-gnu`), clean environment (no `CXXFLAGS`/`CFLAGS` overrides):

- Before the fix (stock develop @ 139b1546):
  `cmake -S . -B build -GNinja -DCUDNN_FRONTEND_BUILD_PYTHON_BINDINGS=ON -DCUDNN_FRONTEND_BUILD_SAMPLES=OFF -DCUDNN_FRONTEND_BUILD_TESTS=OFF && cmake --build build --target _compiled_module`
  fails with the error above.
- After the fix: same build succeeds.
- `python3 -m pip wheel . --no-deps` (the standard source wheel build) succeeds on the fixed tree against the same 9.23 headers.
- Full default-target build (`CUDNN_FRONTEND_BUILD_SAMPLES=ON`, `CUDNN_FRONTEND_BUILD_TESTS=ON`) also compiles cleanly under `-Werror` against 9.23 headers.
- No >= 9.26 header set was available to me for the open-gate arm; there `[[maybe_unused]]` is attribute-only and inert by construction (it merely suppresses the diagnostic; the parameter is used).
- `pre-commit run --files python/gnn.cpp`: clang-format passed, no reformatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made an internal code-quality adjustment with no changes to runtime behavior or the public Python API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->