### PR TITLE
python: fix -Werror unused-parameter build break in init_gnn_submodule (pre-9.26 headers)

### DIFF
--- a/python/gnn.cpp
+++ b/python/gnn.cpp
@@ -68,7 +68,11 @@ ensure_cuda_runtime_context() {
 }  // namespace
 
 void
-init_gnn_submodule(py::module_ &m) {
+init_gnn_submodule([[maybe_unused]] py::module_ &m) {
+    // maybe_unused: with pre-9.26 cuDNN headers (or on Windows) the #if body
+    // below compiles away entirely and -Werror=unused-parameter breaks the
+    // build (seen with the pip source build inside containers shipping older
+    // cuDNN headers).
 #if CUDNN_VERSION >= 92600 && !defined(_WIN32)
     py::enum_<cudnnGnnAggOp_t>(m, "gnn_agg_op")
         .value("SUM", CUDNN_GNN_AGG_SUM)


### PR DESCRIPTION
`init_gnn_submodule(py::module_ &m)` guards its whole body with `#if CUDNN_VERSION >= 92600 && !defined(_WIN32)` — against pre-9.26 cuDNN headers (or on Windows) the body compiles away, `m` is unused, and the build's `-Werror=unused-parameter` makes every `pip install .` of current develop fail:

```
python/gnn.cpp:71:33: error: unused parameter 'm' [-Werror=unused-parameter]
ERROR: Failed building wheel for nvidia-cudnn-frontend
```

Seen wherever the source build runs inside a container shipping older cuDNN headers (e.g. recent NGC PyTorch images), while environments with 9.26+ headers build fine. Fix: `[[maybe_unused]]` on the parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build compatibility for Windows and environments using older cuDNN headers.
  * Prevented unused-parameter warnings from being treated as build errors.
  * Preserved existing runtime behavior when GNN bindings are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->