### PR TITLE
Map CUDNN_KNOB_TYPE_TILE_CGA so knob queries and explicit plans round-trip

### DIFF
--- a/include/cudnn_frontend/knobs.h
+++ b/include/cudnn_frontend/knobs.h
@@ -36,6 +36,7 @@ enum class KnobType_t {
     SWAP_AB,
     INPUT_TMA_ENABLE,
     OUTPUT_TMA_ENABLE,
+    TILE_CGA,
 };
 
 class Knob {
@@ -159,6 +160,11 @@ convert_to_backend_knob_type(KnobType_t const knob_type, cudnnBackendKnobType_t&
             cudnn_knob_type = CUDNN_KNOB_TYPE_OUTPUT_TMA_ENABLE;
             return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
 #endif
+        case KnobType_t::TILE_CGA:
+            // Deprecated in the backend enum but still reported by some engines'
+            // knob queries; the numeric value avoids the deprecation warning.
+            cudnn_knob_type = (cudnnBackendKnobType_t)26;  // CUDNN_KNOB_TYPE_TILE_CGA
+            return cudnnStatus_t::CUDNN_STATUS_SUCCESS;
 #ifndef NO_DEFAULT_IN_SWITCH
         default:
             return cudnnStatus_t::CUDNN_STATUS_INVALID_VALUE;
@@ -246,6 +252,8 @@ convert_from_backend_knob_type(cudnnBackendKnobType_t cudnn_knob_type) {
         case CUDNN_KNOB_TYPE_OUTPUT_TMA_ENABLE:
             return KnobType_t::OUTPUT_TMA_ENABLE;
 #endif
+        case 26:  // CUDNN_KNOB_TYPE_TILE_CGA (deprecated)
+            return KnobType_t::TILE_CGA;
         default:
             return KnobType_t::NOT_SET;
     }

--- a/python/properties.cpp
+++ b/python/properties.cpp
@@ -238,7 +238,8 @@ init_properties(py::module_& m) {
         .value("WARP_SPEC_CFG", cudnn_frontend::KnobType_t::WARP_SPEC_CFG)
         .value("SWAP_AB", cudnn_frontend::KnobType_t::SWAP_AB)
         .value("INPUT_TMA_ENABLE", cudnn_frontend::KnobType_t::INPUT_TMA_ENABLE)
-        .value("OUTPUT_TMA_ENABLE", cudnn_frontend::KnobType_t::OUTPUT_TMA_ENABLE);
+        .value("OUTPUT_TMA_ENABLE", cudnn_frontend::KnobType_t::OUTPUT_TMA_ENABLE)
+        .value("TILE_CGA", cudnn_frontend::KnobType_t::TILE_CGA);
 
     py::class_<cudnn_frontend::Knob, std::shared_ptr<cudnn_frontend::Knob>>(m, "knob")
         .def(py::init<cudnn_frontend::KnobType_t, int64_t, int64_t, int64_t>(),


### PR DESCRIPTION
`get_knobs_for_engine()` converts backend knob types into `KnobType_t`; a knob the mapping does not carry arrives as `NOT_SET`, and passing that knob back through `create_execution_plan()` fails `convert_to_backend_knob_type` with `CUDNN_STATUS_INVALID_VALUE` for **every** knob combination on that engine — so an engine reporting one unmapped knob becomes impossible to drive through the explicit-plan API at all.

`CUDNN_KNOB_TYPE_TILE_CGA` (id 26) is marked deprecated in the public backend enum but is still reported by some engines' knob queries. This PR:

- adds `KnobType_t::TILE_CGA` and maps it in both conversion directions (`knobs.h`)
- exposes the enum value to the Python bindings (`properties.cpp`)

The backend-side conversion uses the numeric value to avoid the deprecated-enum warning. No behavior change for graphs that never see this knob; round-tripping `get_knobs_for_engine` → `create_execution_plan` now works on engines that report it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `TILE_CGA` knob type to the C++ and Python interfaces.
  * Enabled conversion of this knob type between frontend and backend representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->