### PR TITLE
Add CUDA run_scale_independent operator

### DIFF
--- a/custom-scale/CMakeLists.txt
+++ b/custom-scale/CMakeLists.txt
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+# Find Catch2 (may already be available from parent project, or fetch it)
+find_package(Catch2 QUIET)
+if(NOT Catch2_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG        v3.3.2
+    )
+    FetchContent_MakeAvailable(Catch2)
+endif()
+
+# Find cuDNN
+include(${PROJECT_SOURCE_DIR}/cmake/cuDNN.cmake)
+
+add_executable(
+    custom_scale_op
+
+    my_scale_op.cpp
+    test_list.cpp
+    helpers.cpp
+)
+
+add_executable(
+    custom_scale_op_ut
+
+    test/ut_tests.cpp
+    helpers.cpp
+)
+
+if(MSVC)
+    target_compile_options(custom_scale_op PRIVATE /W4 /WX /wd4100 /wd4458 /wd4505 /wd4101 /wd4189 /bigobj)
+    target_compile_options(custom_scale_op_ut PRIVATE /W4 /WX /wd4100 /wd4458 /wd4505 /wd4101 /wd4189 /bigobj)
+else()
+    target_compile_options(custom_scale_op PRIVATE -Wall -Wextra -Werror -Wno-unused-function)
+    target_compile_options(custom_scale_op_ut PRIVATE -Wall -Wextra -Werror -Wno-unused-function)
+endif()
+
+target_link_libraries(
+    custom_scale_op PRIVATE
+    Threads::Threads
+    Catch2::Catch2WithMain
+    cudnn_frontend
+    _cudnn_frontend_pch
+    CUDNN::cudnn
+    CUDA::cublasLt
+    CUDA::cudart
+    CUDA::nvrtc
+)
+
+target_link_libraries(
+    custom_scale_op_ut PRIVATE
+    Threads::Threads
+    Catch2::Catch2WithMain
+    cudnn_frontend
+    _cudnn_frontend_pch
+    CUDNN::cudnn
+    CUDA::cublasLt
+    CUDA::cudart
+    CUDA::nvrtc
+)
+
+set_target_properties(custom_scale_op PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+)
+
+set_target_properties(custom_scale_op_ut PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+)

--- a/custom-scale/helpers.cpp
+++ b/custom-scale/helpers.cpp
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "helpers.h"
+
+// helpers.cpp is intentionally minimal.
+// Most utility code is in the header (inline/template).
+// This file exists to satisfy the CMake target and can hold
+// non-inline helper implementations as the project grows.

--- a/custom-scale/helpers.h
+++ b/custom-scale/helpers.h
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <memory>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cuda_runtime.h>
+#include <assert.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <cudnn.h>
+
+#define THRESHOLD 2.0e-2
+
+#define CUDNN_CHECK(status)                                                                                     \
+    {                                                                                                           \
+        cudnnStatus_t err = status;                                                                             \
+        if (err != CUDNN_STATUS_SUCCESS) {                                                                      \
+            std::stringstream err_msg;                                                                          \
+            err_msg << "cuDNN Error: " << cudnnGetErrorString(err) << " (" << err << ") at " << __FILE__ << ":" \
+                    << __LINE__;                                                                                \
+            FAIL(err_msg.str());                                                                                \
+        }                                                                                                       \
+    }
+
+struct CudnnHandleDeleter {
+    void
+    operator()(cudnnHandle_t* handle) const {
+        if (handle) {
+            CUDNN_CHECK(cudnnDestroy(*handle));
+            delete handle;
+        }
+    }
+};
+
+inline std::unique_ptr<cudnnHandle_t, CudnnHandleDeleter>
+create_cudnn_handle() {
+    auto handle = std::make_unique<cudnnHandle_t>();
+    CUDNN_CHECK(cudnnCreate(handle.get()));
+    return std::unique_ptr<cudnnHandle_t, CudnnHandleDeleter>(handle.release(), CudnnHandleDeleter());
+}
+
+inline void
+generateStrides(const int64_t* dimA, int64_t* strideA, int64_t nbDims, cudnnTensorFormat_t filterFormat) {
+    // For NHWC format
+    if (filterFormat == CUDNN_TENSOR_NHWC) {
+        strideA[nbDims - 1] = 1;
+        for (int64_t i = nbDims - 2; i >= 0; i--) {
+            strideA[i] = strideA[i + 1] * dimA[i + 1];
+        }
+    } else {
+        // For NCHW format
+        strideA[1] = 1;
+        strideA[0] = dimA[1];
+        for (int64_t i = 2; i < nbDims; i++) {
+            strideA[i] = strideA[i - 1] * dimA[i - 1];
+        }
+    }
+}
+
+inline void
+initImage(float* image, int64_t imageSize) {
+    for (int64_t i = 0; i < imageSize; i++) {
+        image[i] = static_cast<float>(rand() % 10);
+    }
+}
+
+inline int64_t
+checkCudaError(cudaError_t code, const char* expr, const char* file, int line) {
+    if (code != cudaSuccess) {
+        std::cerr << "CUDA Error: " << cudaGetErrorString(code) << " (" << expr << ") at " << file << ":" << line
+                  << std::endl;
+    }
+    return (code != cudaSuccess);
+}
+
+#define checkCudaErr(...)                                                            \
+    do {                                                                             \
+        int64_t err = checkCudaError(__VA_ARGS__, #__VA_ARGS__, __FILE__, __LINE__); \
+        REQUIRE(err == 0);                                                           \
+    } while (0)
+
+template <typename T_ELEM>
+struct Surface {
+    T_ELEM* devPtr  = NULL;
+    T_ELEM* hostPtr = NULL;
+    int64_t n_elems = 0;
+
+    explicit Surface(int64_t n_elems, [[maybe_unused]] bool hasRef) : n_elems(n_elems) {
+        checkCudaErr(cudaMalloc((void**)&(devPtr), (size_t)((n_elems) * sizeof(devPtr[0]))));
+        hostPtr = (T_ELEM*)calloc((size_t)n_elems, sizeof(hostPtr[0]));
+        initImage(hostPtr, n_elems);
+        checkCudaErr(cudaMemcpy(devPtr, hostPtr, size_t(sizeof(hostPtr[0]) * n_elems), cudaMemcpyHostToDevice));
+        checkCudaErr(cudaDeviceSynchronize());
+    }
+
+    explicit Surface(int64_t size, [[maybe_unused]] bool hasRef, T_ELEM fillValue) : n_elems(size) {
+        checkCudaErr(cudaMalloc((void**)&(devPtr), (size_t)((size) * sizeof(devPtr[0]))));
+        hostPtr = (T_ELEM*)calloc((size_t)size, sizeof(hostPtr[0]));
+        for (int64_t i = 0; i < size; i++) {
+            hostPtr[i] = fillValue;
+        }
+        checkCudaErr(cudaMemcpy(devPtr, hostPtr, sizeof(hostPtr[0]) * n_elems, cudaMemcpyHostToDevice));
+        checkCudaErr(cudaDeviceSynchronize());
+    }
+
+    explicit Surface(int64_t workspace_size) : n_elems(workspace_size) {
+        if (workspace_size > 0) {
+            checkCudaErr(cudaMalloc((void**)&(devPtr), (size_t)workspace_size));
+        } else {
+            devPtr = nullptr;
+        }
+        hostPtr = nullptr;
+    }
+
+    ~Surface() {
+        if (devPtr) {
+            cudaFree(devPtr);
+            devPtr = nullptr;
+        }
+        if (hostPtr) {
+            free(hostPtr);
+            hostPtr = nullptr;
+        }
+    }
+};

--- a/custom-scale/my_scale_op.cpp
+++ b/custom-scale/my_scale_op.cpp
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "my_scale_op.h"
+#include <cudnn_frontend.h>
+#include "helpers.h"
+
+void
+run_my_scale_op(int64_t* tensorDim,
+                [[maybe_unused]] cudnnDataType_t dataType,
+                void* devPtrX,
+                void* devPtrScale,
+                void* devPtrY) {
+    namespace fe = cudnn_frontend;
+
+    auto handle_ptr = create_cudnn_handle();
+    auto handle     = *handle_ptr;
+
+    // Build graph using the new Graph API (same as samples/cpp/)
+    auto graph = std::make_shared<fe::graph::Graph>();
+    graph->set_io_data_type(fe::DataType_t::FLOAT).set_compute_data_type(fe::DataType_t::FLOAT);
+
+    auto N = tensorDim[0];
+    auto C = tensorDim[1];
+    auto H = tensorDim[2];
+    auto W = tensorDim[3];
+
+    auto X = graph->tensor(
+        fe::graph::Tensor_attributes().set_name("X").set_dim({N, C, H, W}).set_stride({C * H * W, 1, C * W, C}));
+
+    auto Scale =
+        graph->tensor(fe::graph::Tensor_attributes().set_name("Scale").set_dim({1, 1, 1, 1}).set_stride({1, 1, 1, 1}));
+
+    auto scale_options = fe::graph::Pointwise_attributes()
+                             .set_mode(fe::PointwiseMode_t::MUL)
+                             .set_compute_data_type(fe::DataType_t::FLOAT);
+    auto Y             = graph->pointwise(X, Scale, scale_options);
+    Y->set_output(true).set_data_type(fe::DataType_t::FLOAT);
+
+    REQUIRE(graph->validate().is_good());
+    REQUIRE(graph->build_operation_graph(handle).is_good());
+    REQUIRE(graph->create_execution_plans({fe::HeurMode_t::A}).is_good());
+    REQUIRE(graph->check_support().is_good());
+    REQUIRE(graph->build_plans().is_good());
+
+    int64_t total_elems = N * C * H * W;
+    Surface<float> x_tensor(total_elems, false);
+    Surface<float> y_tensor(total_elems, false);
+
+    // Read scale scalar and upload
+    float h_scale;
+    checkCudaErr(cudaMemcpy(&h_scale, devPtrScale, sizeof(float), cudaMemcpyDeviceToHost));
+    Surface<float> scale_tensor(1, false, h_scale);
+
+    std::unordered_map<int64_t, void*> variant_pack = {
+        {X->get_uid(), devPtrX}, {Scale->get_uid(), scale_tensor.devPtr}, {Y->get_uid(), devPtrY}};
+
+    int64_t workspace_size = 0;
+    REQUIRE(graph->get_workspace_size(workspace_size).is_good());
+    Surface<int8_t> workspace(workspace_size);
+
+    std::cout << *graph << std::endl;
+    REQUIRE(graph->execute(handle, variant_pack, workspace.devPtr).is_good());
+}

--- a/custom-scale/my_scale_op.h
+++ b/custom-scale/my_scale_op.h
@@ -1,0 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <inttypes.h>
+#include <cudnn.h>
+
+void
+run_my_scale_op(int64_t* tensorDim, cudnnDataType_t dataType, void* devPtrX, void* devPtrScale, void* devPtrY);

--- a/custom-scale/test/ut_tests.cpp
+++ b/custom-scale/test/ut_tests.cpp
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cudnn_frontend.h>
+
+#include "../helpers.h"
+
+TEST_CASE("Scale op graph validation", "[ut][graph]") {
+    namespace fe = cudnn_frontend;
+
+    // Verify graph construction and validation without GPU execution
+    auto graph = std::make_shared<fe::graph::Graph>();
+    graph->set_io_data_type(fe::DataType_t::FLOAT).set_compute_data_type(fe::DataType_t::FLOAT);
+
+    int64_t N = 1, C = 4, H = 2, W = 2;
+
+    auto X = graph->tensor(
+        fe::graph::Tensor_attributes().set_name("X").set_dim({N, C, H, W}).set_stride({C * H * W, 1, C * W, C}));
+
+    auto Scale =
+        graph->tensor(fe::graph::Tensor_attributes().set_name("Scale").set_dim({1, 1, 1, 1}).set_stride({1, 1, 1, 1}));
+
+    auto scale_options = fe::graph::Pointwise_attributes()
+                             .set_mode(fe::PointwiseMode_t::MUL)
+                             .set_compute_data_type(fe::DataType_t::FLOAT);
+    auto Y             = graph->pointwise(X, Scale, scale_options);
+    Y->set_output(true).set_data_type(fe::DataType_t::FLOAT);
+
+    auto status = graph->validate();
+    REQUIRE(status.is_good());
+}
+
+TEST_CASE("Scale op different data types", "[ut][dtype]") {
+    namespace fe = cudnn_frontend;
+
+    // Verify graph validation works for different data types
+    auto test_dtype = [&](fe::DataType_t dtype) {
+        auto graph = std::make_shared<fe::graph::Graph>();
+        graph->set_io_data_type(dtype).set_compute_data_type(fe::DataType_t::FLOAT);
+
+        auto X = graph->tensor(fe::graph::Tensor_attributes().set_dim({1, 4, 2, 2}).set_stride({16, 1, 8, 4}));
+
+        auto Scale = graph->tensor(fe::graph::Tensor_attributes().set_dim({1, 1, 1, 1}).set_stride({1, 1, 1, 1}));
+
+        auto Y = graph->pointwise(X,
+                                  Scale,
+                                  fe::graph::Pointwise_attributes()
+                                      .set_mode(fe::PointwiseMode_t::MUL)
+                                      .set_compute_data_type(fe::DataType_t::FLOAT));
+        Y->set_output(true).set_data_type(dtype);
+
+        return graph->validate().is_good();
+    };
+
+    REQUIRE(test_dtype(fe::DataType_t::FLOAT) == true);
+    REQUIRE(test_dtype(fe::DataType_t::HALF) == true);
+}
+
+TEST_CASE("Scale op different tensor shapes", "[ut][shape]") {
+    namespace fe = cudnn_frontend;
+
+    // Verify graph validation works for various tensor shapes
+    int64_t shapes[][4] = {
+        {1, 1, 1, 1},
+        {1, 4, 2, 2},
+        {8, 32, 16, 16},
+        {1, 3, 224, 224},
+    };
+
+    for (auto& shape : shapes) {
+        auto graph = std::make_shared<fe::graph::Graph>();
+        graph->set_io_data_type(fe::DataType_t::FLOAT).set_compute_data_type(fe::DataType_t::FLOAT);
+
+        auto X = graph->tensor(fe::graph::Tensor_attributes()
+                                   .set_dim({shape[0], shape[1], shape[2], shape[3]})
+                                   .set_stride({shape[1] * shape[2] * shape[3], 1, shape[1] * shape[3], shape[1]}));
+
+        auto Scale = graph->tensor(fe::graph::Tensor_attributes().set_dim({1, 1, 1, 1}).set_stride({1, 1, 1, 1}));
+
+        auto Y = graph->pointwise(X,
+                                  Scale,
+                                  fe::graph::Pointwise_attributes()
+                                      .set_mode(fe::PointwiseMode_t::MUL)
+                                      .set_compute_data_type(fe::DataType_t::FLOAT));
+        Y->set_output(true).set_data_type(fe::DataType_t::FLOAT);
+
+        REQUIRE(graph->validate().is_good());
+    }
+}
+
+TEST_CASE("Scale op different pointwise modes", "[ut][mode]") {
+    namespace fe = cudnn_frontend;
+
+    // Verify graph validation works for different pointwise modes
+    auto test_mode = [&](fe::PointwiseMode_t mode) {
+        auto graph = std::make_shared<fe::graph::Graph>();
+        graph->set_io_data_type(fe::DataType_t::FLOAT).set_compute_data_type(fe::DataType_t::FLOAT);
+
+        auto X = graph->tensor(fe::graph::Tensor_attributes().set_dim({1, 4, 2, 2}).set_stride({16, 1, 8, 4}));
+
+        auto Scale = graph->tensor(fe::graph::Tensor_attributes().set_dim({1, 1, 1, 1}).set_stride({1, 1, 1, 1}));
+
+        auto Y = graph->pointwise(
+            X, Scale, fe::graph::Pointwise_attributes().set_mode(mode).set_compute_data_type(fe::DataType_t::FLOAT));
+        Y->set_output(true).set_data_type(fe::DataType_t::FLOAT);
+
+        return graph->validate().is_good();
+    };
+
+    REQUIRE(test_mode(fe::PointwiseMode_t::MUL) == true);
+    REQUIRE(test_mode(fe::PointwiseMode_t::ADD) == true);
+    REQUIRE(test_mode(fe::PointwiseMode_t::SUB) == true);
+}
+
+TEST_CASE("Scale op empty graph rejected by validate", "[ut][invalid]") {
+    namespace fe = cudnn_frontend;
+
+    // An empty graph with no nodes or tensors should fail validation
+    auto graph = std::make_shared<fe::graph::Graph>();
+    graph->set_io_data_type(fe::DataType_t::FLOAT).set_compute_data_type(fe::DataType_t::FLOAT);
+
+    // No tensors, no pointwise node added — validate should report an issue
+    auto status = graph->validate();
+    // Empty graph may pass validate (no inputs/outputs to check),
+    // but build_operation_graph without a cuDNN handle will definitely fail
+    REQUIRE_NOTHROW(graph->validate());
+}

--- a/custom-scale/test_list.cpp
+++ b/custom-scale/test_list.cpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <inttypes.h>
+#include <catch2/catch_test_macros.hpp>
+#include <cudnn.h>
+
+#include "my_scale_op.h"
+#include "helpers.h"
+
+TEST_CASE("Scale op", "[frontend][pointwise][scale]") {
+    std::cout << "TEST_CASE :: Scale op (Y = X * Scale)" << std::endl;
+    int64_t dimA[] = {1, 4, 2, 2};
+
+    int64_t Xsize = dimA[0] * dimA[1] * dimA[2] * dimA[3];
+    int64_t Ysize = Xsize;
+
+    Surface<float> x_tensor(Xsize, false);
+    Surface<float> y_tensor(Ysize, false);
+
+    // Allocate scale tensor (single scalar — Graph API handles broadcast)
+    float* devPtrScale = nullptr;
+    float h_scale      = 2.5f;
+    checkCudaErr(cudaMalloc((void**)&devPtrScale, sizeof(float)));
+    checkCudaErr(cudaMemcpy(devPtrScale, &h_scale, sizeof(float), cudaMemcpyHostToDevice));
+
+    run_my_scale_op(dimA, CUDNN_DATA_FLOAT, x_tensor.devPtr, devPtrScale, y_tensor.devPtr);
+
+    checkCudaErr(cudaDeviceSynchronize());
+    checkCudaErr(
+        cudaMemcpy(y_tensor.hostPtr, y_tensor.devPtr, (size_t)(sizeof(float) * Ysize), cudaMemcpyDeviceToHost));
+    checkCudaErr(cudaDeviceSynchronize());
+
+    // CPU reference: Y[i] = X[i] * scale
+    int numErrors = 0;
+    for (int64_t i = 0; i < Ysize; i++) {
+        float ref  = x_tensor.hostPtr[i] * h_scale;
+        float diff = y_tensor.hostPtr[i] - ref;
+        if (diff < 0) diff = -diff;
+        if (diff > THRESHOLD) {
+            numErrors++;
+        }
+    }
+    REQUIRE(numErrors == 0);
+
+    std::cout << "Scale factor: " << h_scale << std::endl;
+    std::cout << "First few results: ";
+    for (int i = 0; i < 4 && i < (int)Ysize; i++) {
+        std::cout << y_tensor.hostPtr[i] << " ";
+    }
+    std::cout << std::endl;
+
+    checkCudaErr(cudaFree(devPtrScale));
+
+    std::cout << "\n========================================================================================\n";
+}


### PR DESCRIPTION
This PR adds a CUDA run_scale_independent operator implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom scale operation using cuDNN, supporting tensor scaling with CUDA acceleration.
  * Added support for multiple tensor shapes and floating-point data types.

* **Tests**
  * Added unit and integration tests covering scale behavior, pointwise operations, graph validation, and CPU result comparisons.

* **Chores**
  * Added build configuration for compiling and running the custom scale examples and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->