### PR TITLE
samples: skip unsupported test case, remove invalid cudaGraphDestroy

### DIFF
--- a/samples/cpp/misc/cudagraphs.cpp
+++ b/samples/cpp/misc/cudagraphs.cpp
@@ -228,8 +228,7 @@ TEST_CASE("Cuda graphs with matmul add", "[cudagraph][graph]") {
     }
 
     //// Cleanup
-    cudaGraphExecDestroy(cuda_graph_exec);
-    cudaGraphDestroy(main_cuda_graph);
-    cudaGraphDestroy(cudnn_cuda_graph_new);
+    CUDA_CHECK(cudaGraphExecDestroy(cuda_graph_exec));
+    CUDA_CHECK(cudaGraphDestroy(main_cuda_graph));
 #endif  // CUDART_VERSION < 12000
 }

--- a/samples/cpp/sdpa/fp16_bwd.cpp
+++ b/samples/cpp/sdpa/fp16_bwd.cpp
@@ -193,6 +193,11 @@ TEST_CASE("Toy sdpa backward", "[graph][sdpa][flash][backward]") {
         return;
     }
 
+    if (is_blackwell_arch() && cudnnGetVersion() < 91800 && is_deterministic) {
+        SKIP("Deterministic SDPA backward requires cuDNN 9.18.0+ on Blackwell");
+        return;
+    }
+
     // Create a unique_ptr for the cuDNN handle
     auto handle_ptr = create_cudnn_handle();
     auto handle     = *handle_ptr;


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

cat-bugfix mod-frontend orig-external (The UI doesn't appear to let me attach labels)

## Affected area

- Documentation or samples

## Summary

- Skip deterministic SDPA backward in sample when running on Blackwell with tool old cuDNN. This is explicitly [marked as unsupported](https://github.com/NVIDIA/cudnn-frontend/blob/ae8705effeea3804585b6aca554beaca1a76a3da/include/cudnn_frontend/node/scaled_dot_product_flash_attention.h#L1434) in the code.
- Remove invalid `cudaGraphDestroy(cudnn_cuda_graph_new)` in `cudagraphs` sample. As per documentation of `cudaGraphChildGraphNodeGetGraph` it's owned by the parent `main_cuda_graph` and gets destroyed whenever the main one is.

## Why

This makes the samples tests pass on older cuDNN.

## Related issues

None

## API and compatibility impact

None

## Testing

```
cmake -B build -DCMAKE_BUILD_TYPE=Release
cmake --build build -j $(nproc)
build/bin/samples
build/bin/legacy_samples
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during CUDA graph cleanup.
  * Added a compatibility skip for deterministic SDPA backward tests on Blackwell hardware with older cuDNN versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->