### PR TITLE
M major output refactorization

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -52,6 +52,7 @@ from .dtypes import (
     _pow2_floor,
     allowed_store_vsize,
     dtype_arch_reject,
+    dense_output_layout,
     tensor_alignment,
 )
 from .epilogue_codegen import EpilogueSnippets, generate, tma_out_value
@@ -248,8 +249,8 @@ def _tma_c_plumbing(chain: FusionChain, tma_slots: "frozenset[int]" = frozenset(
         "INJECT_HOST_TMA_C_LISTS": "_tma_c_outputs = [" + ", ".join(f"c_{i}" for i in range(n_out)) + "]",
         "INJECT_HOST_TMA_C_PASS": ",\n".join(f"tma_c_desc_list[{i}]" for i in range(n_out)) + ",",
         "INJECT_COMPILE_TMA_C_FAKES": "\n".join(
-            f"fake_c_{j} = _make_fake_c({_cd_cutlass(dt)}, {2 if dt == 'fp4_e2m1' else 1})"
-            for j, (_slot, dt) in enumerate(_tma_out_dtypes(chain, tma_slots) or [(0, chain.output_dtype)])
+            f"fake_c_{j} = _make_fake_c({_cd_cutlass(dt)}, {2 if dt == 'fp4_e2m1' else 1}, {_fake_c_major(chain, slot)})"
+            for j, (slot, dt) in enumerate(_tma_out_dtypes(chain, tma_slots) or [(0, chain.output_dtype)])
         ),
         "INJECT_COMPILE_TMA_C_PASS": ",\n".join(f"fake_c_{i}" for i in range(n_out)) + ",",
     }
@@ -260,104 +261,162 @@ def _tma_out_dtypes(chain: FusionChain, tma_slots: "frozenset[int]") -> "list[tu
     return [(i, chain.output_specs[i].dtype) for i in sorted(tma_slots) if i < len(chain.output_specs)]
 
 
+def _fake_c_major(chain, slot: int) -> bool:
+    return chain.output_specs[slot].major == "m" if slot < len(chain.output_specs) else chain.out_major == "m"
+
+
+def _mmajor_atom_m(dt: str) -> int:
+    """Rows in a 128-byte M-contiguous column. BITS: `128 // DTYPE_BYTES` is 2x off sub-byte."""
+    return 1024 // DTYPE_BITS[dt]
+
+
 def _cd_cutlass(dt: str) -> str:
     return "cutlass.Int8" if dt == "fp4_e2m1" else DTYPE_TO_CUTLASS[dt]
 
 
+def _cd_view_bits(dt: str) -> int:
+    """Width of the carrier the C descriptor is declared with; sub-byte rides Int8."""
+    return 8 if dt == "fp4_e2m1" else DTYPE_BITS[dt]
+
+
+def _epi_row_bytes(dt: str, epi_n: int) -> int:
+    """`epi_n` LOGICAL columns in bytes, packed."""
+    return epi_n * DTYPE_BITS[dt] // 8
+
+
+def _epi_row_elems(dt: str, epi_n: int) -> int:
+    """The same row in carrier elements."""
+    return _epi_row_bytes(dt, epi_n) * 8 // _cd_view_bits(dt)
+
+
+def _tma_store_issue(chain, j: int, coord: str, ptr: str) -> "list[str]":
+    return [
+        "if warp_idx == 0:",
+        "    if elect_one:",
+        "        nvvm.cp_async_bulk_tensor_global_shared_cta(",
+        f"            {f'd_desc_ptr_list[{j}]' if chain.has_moe else f'tma_c_descs[{j}].get_ptr()'},",
+        f"            {ptr},",
+        f"            {coord},",
+        "        )",
+    ]
+
+
+def _tma_store_one(chain, cfg, cta_group: int, epi_n: int, j: int, dt: str, major: str) -> "list[str]":
+    """One TMA-stored output's store stage: stage this lane's fragment into the
+    shared ring slot, then issue from it.
+
+    Both layouts consume the SAME row-per-lane fragment; only the SMEM image
+    differs. N-major stages a row and hands TMA one box. M-major stages a
+    COLUMN -- lane `t` owns row `t`, so its `epi_n` elements land strided by the
+    128-byte column pitch -- and hands TMA one box per M block.
+    """
+    v = f"_tsv_{j}"
+    m_rows = cfg.epi_tile_mn[0]
+    packed = _epi_packed_lanes(cfg, cta_group)
+    lines = [
+        "epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES",
+        f"{v} = cutlass.Array(base=smem_d_ptr.data_ptr(epi_stage_idx * epi_subtile_elems), shape={_epi_stage_rows(cfg, cta_group) * _epi_row_elems(dt, epi_n)}, dtype={_cd_cutlass(dt)})",
+    ]
+    val = tma_out_value(j)
+    if major == "m":
+        atom_m = _mmajor_atom_m(dt)
+        elem_bytes = DTYPE_BYTES[dt]
+        # The s128b XOR lands on bits the COLUMN index alone sets here, so the 8
+        # XORed row bases hoist and every store offset is an immediate.
+        assert 7 * (16 // elem_bytes) < atom_m
+        # As N-major: `tidx` is the slot everywhere but packed. Under 2x2-DP
+        # `tidx // atom_m` happens to name the COLUMN HALF, which is what it needs.
+        slot = "(row - coord_m)" if packed else "tidx"
+        lines += [
+            f"_mrow_{j} = {slot} % {atom_m}",
+            f"_mblk_{j} = ({slot} // {atom_m}) * {atom_m * epi_n}",
+        ]
+        lines += [f"_mx{x}_{j} = _mrow_{j} ^ {x * (16 // elem_bytes)}" for x in range(8)]
+        for k in range(epi_n):
+            st = f"{v}.data_ptr(_mblk_{j} + {k * atom_m} + _mx{k % 8}_{j}).store({val}[{k} : {k + 1}], alignment={elem_bytes})"
+            lines.append(f"if row_active:\n    {st}" if packed else st)
+        lines += [
+            "cute.arch.fence_view_async_shared()",
+            "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
+        ]
+        for mb in range(m_rows // atom_m):
+            lines += _tma_store_issue(chain, j, f"(coord_m + {mb * atom_m}, col, tile_l)", f"{v}.data_ptr({mb * atom_m * epi_n})")
+        if _epi_dp22(cfg, cta_group):
+            # the other COLUMN half, not another M block: same rows, further along N
+            lines += _tma_store_issue(chain, j, "(coord_m, col + epi_cols_per_mma_m, tile_l)", f"{v}.data_ptr({atom_m * epi_n})")
+    else:
+        row_bytes = _epi_row_bytes(dt, epi_n)
+        row_elems = _epi_row_elems(dt, epi_n)
+        b, _tma_sw = _EPI_SWIZZLE_BY_ROW_BYTES[row_bytes]
+        # sub-byte packs 2/byte: ring row and store coordinate are the packed ones.
+        col_c = "col // 2" if DTYPE_BITS[dt] < 8 else "col"
+        # `row - coord_m` is the row within the tile, and is `tidx` except packed.
+        store = f"{v}.data_ptr({'(row - coord_m)' if packed else 'tidx'} * {row_elems}).store_swizzled({val}, alignment={row_bytes}, swizzle=cutlass.Swizzle({b}, 4, 3))"
+        lines += [
+            f"if row_active:\n    {store}" if packed else store,
+            "cute.arch.fence_view_async_shared()",
+            "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
+        ]
+        lines += _tma_store_issue(chain, j, f"({col_c}, coord_m, tile_l)", f"{v}.data_ptr()")
+        if _epi_dp22(cfg, cta_group):
+            # warps 2/3's column half, staged behind the first tile
+            half = "(col + epi_cols_per_mma_m) // 2" if DTYPE_BITS[dt] < 8 else "col + epi_cols_per_mma_m"
+            lines += _tma_store_issue(chain, j, f"({half}, coord_m, tile_l)", f"{v}.data_ptr({m_rows * row_elems})")
+    lines += [
+        "    if elect_one:",
+        "        nvvm.cp_async_bulk_commit_group()",
+        "    nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)",
+        "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
+    ]
+    return lines
+
+
 def _tma_store_sequence(chain, cfg, cta_group: int, tma_slots: "frozenset[int]", epi_n: int) -> str:
-    """The N-major TMA arm, unrolled once per TMA-stored output.
+    """The TMA arm, unrolled once per TMA-stored output.
 
     All of them walk the SAME SMEM ring: the slot is sized for the widest, and
     each output takes its OWN typed view of it (`Array(base=...)`), so N outputs
     cost no extra SMEM. `epi_n` is a COLUMN count and is shared; what differs per
-    output is the row BYTES, and with them the swizzle. Unrolling here rather
-    than looping in the template keeps the dtypes and swizzles compile-time
-    without a const_expr-indexed table."""
-    rows = cfg.epi_tile_mn[0]
+    output is its dtype and its layout, both compile-time here."""
     lines: list[str] = []
     for j, (slot, dt) in enumerate(_tma_out_dtypes(chain, tma_slots)):
-        row_bytes = epi_n * DTYPE_BYTES[dt]
-        b, _tma_sw = _EPI_SWIZZLE_BY_ROW_BYTES[row_bytes]
-        v = f"_tsv_{j}"
-        lines += [
-            "epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES",
-            f"{v} = cutlass.Array(base=smem_d_ptr.data_ptr(epi_stage_idx * epi_subtile_elems), shape={rows * epi_n}, dtype={_cd_cutlass(dt)})",
-            f"{v}.data_ptr(tidx * subtile_w).store_swizzled({tma_out_value(j)}, alignment={row_bytes}, swizzle=cutlass.Swizzle({b}, 4, 3))",
-            "cute.arch.fence_view_async_shared()",
-            "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
-            "if warp_idx == 0:",
-            "    if elect_one:",
-            "        nvvm.cp_async_bulk_tensor_global_shared_cta(",
-            # MoE re-dimensions D per routed group, so it issues through the
-            # patched workspace copy rather than the static kernel parameter.
-            f"            {f'd_desc_ptr_list[{j}]' if chain.has_moe else f'tma_c_descs[{j}].get_ptr()'},",
-            f"            {v}.data_ptr(),",
-            "            (col, coord_m, tile_l),",
-            "        )",
-            "    if elect_one:",
-            "        nvvm.cp_async_bulk_commit_group()",
-            "    nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)",
-            "nvvm.barrier_cta_sync(barrier_id=EPI_SYNC_BAR_ID, thread_count=num_epilogue_warps * 32)",
-        ]
+        lines += _tma_store_one(chain, cfg, cta_group, epi_n, j, dt, chain.output_specs[slot].major)
     return "\n".join(lines) if lines else "pass"
 
 
 def _host_tma_c_descs(chain, cfg, cta_group: int, tma_slots: "frozenset[int]", epi_n: int) -> str:
     """Build one C descriptor per TMA-stored output. Each carries its OWN dtype,
-    strides and swizzle; the M-major arm is single-output by construction (its
-    gate rejects extra dense outputs), so it keeps the transposed box."""
+    strides, box and swizzle, so outputs of different dtypes and different
+    layouts can share one epilogue."""
     outs = _tma_out_dtypes(chain, tma_slots)
+    batch = "1" if chain.has_moe else "batch"
     lines: list[str] = []
     for j, (slot, dt) in enumerate(outs):
-        width = DTYPE_BITS[dt]
-        cud = _cd_cutlass(dt)
-        row_bytes = epi_n * DTYPE_BYTES[dt]
-        _b, tma_sw = _EPI_SWIZZLE_BY_ROW_BYTES[row_bytes]
-        if chain.has_moe:
-            lines += [
-                f"_c{j} = _tma_c_outputs[{j}]",
-                f"tma_c_desc_{j} = _tma.create_tensor_map_tiled(",
-                f"    global_address=_c{j}.iterator.toint(),",
-                f"    dtype={cud},",
-                "    global_dims=[n, m, 1],",
-                "    global_strides=[",
-                f"        out_stride_m_{slot} * {width} // 128,",
-                f"        out_stride_l_{slot} * {width} // 128,",
-                "    ],",
-                f"    box_dims=[{epi_n}, epi_tile_mn[0], 1],",
-                f"    swizzle=_tma.TensorMapSwizzle.{tma_sw},",
-                ")",
-            ]
-        elif chain.out_major == "m":
-            lines += [
-                f"_c{j} = _tma_c_outputs[{j}]",
-                f"tma_c_desc_{j} = _tma.create_tensor_map_tiled(",
-                f"    global_address=_c{j}.iterator.toint(),",
-                f"    dtype={cud},",
-                "    global_dims=[m, n, batch],",
-                "    global_strides=[",
-                f"        out_stride_n_{slot} * {width} // 128,",
-                f"        out_stride_l_{slot} * {width} // 128,",
-                "    ],",
-                "    box_dims=[cd_mmajor_atom_m, epi_tile_mn[1], 1],",
-                "    swizzle=_tma.TensorMapSwizzle.s128b,",
-                ")",
-            ]
+        width = _cd_view_bits(dt)
+        if chain.output_specs[slot].major == "m":
+            dims = f"[m, n, {batch}]"
+            outer = f"out_stride_n_{slot}"
+            box = f"[{_mmajor_atom_m(dt)}, {epi_n}, 1]"
+            sw = "s128b"
         else:
-            lines += [
-                f"_c{j} = _tma_c_outputs[{j}]",
-                f"tma_c_desc_{j} = _tma.create_tensor_map_tiled(",
-                f"    global_address=_c{j}.iterator.toint(),",
-                f"    dtype={cud},",
-                "    global_dims=[n, m, batch],",
-                "    global_strides=[",
-                f"        out_stride_m_{slot} * {width} // 128,",
-                f"        out_stride_l_{slot} * {width} // 128,",
-                "    ],",
-                f"    box_dims=[{epi_n}, epi_tile_mn[0], 1],",
-                f"    swizzle=_tma.TensorMapSwizzle.{tma_sw},",
-                ")",
-            ]
+            dims = f"[{'n // 2' if DTYPE_BITS[dt] < 8 else 'n'}, m, {batch}]"
+            outer = f"out_stride_m_{slot}"
+            box = f"[{_epi_row_elems(dt, epi_n)}, epi_tile_mn[0], 1]"
+            sw = _EPI_SWIZZLE_BY_ROW_BYTES[_epi_row_bytes(dt, epi_n)][1]
+        lines += [
+            f"_c{j} = _tma_c_outputs[{j}]",
+            f"tma_c_desc_{j} = _tma.create_tensor_map_tiled(",
+            f"    global_address=_c{j}.iterator.toint(),",
+            f"    dtype={_cd_cutlass(dt)},",
+            f"    global_dims={dims},",
+            "    global_strides=[",
+            f"        {outer} * {width} // 128,",
+            f"        out_stride_l_{slot} * {width} // 128,",
+            "    ],",
+            f"    box_dims={box},",
+            f"    swizzle=_tma.TensorMapSwizzle.{sw},",
+            ")",
+        ]
     lines.append("tma_c_desc_list = [" + ", ".join(f"tma_c_desc_{j}" for j in range(len(outs))) + "]")
     return "\n".join(lines)
 
@@ -577,11 +636,7 @@ def _epi_vec_bytes(chain: FusionChain, config: TileConfig, cta_group: int) -> in
 def _epi_chunk_elems(chain: FusionChain, config: TileConfig, cta_group: int, use_tma_store: bool) -> int:
     if not use_tma_store:
         return _epi_vec_bytes(chain, config, cta_group) // DTYPE_BYTES[chain.output_dtype]
-    epi_n = _epi_n(config, cta_group, chain.output_dtype)
-    # The M-major arm transposes, so its `tcgen05_ld(SHAPE_16X256B, num=epi_n // 8)`
-    # hands a lane 4*num = epi_n/2 elements and the stmatrix ledger consumes exactly
-    # that (`range(epi_n // 16)` x 4 Int32). The N-major arm hands the whole subtile.
-    return epi_n // 2 if chain.out_major == "m" else epi_n
+    return _epi_n(config, cta_group, chain.output_dtype)
 
 
 def _epi_chunk_bytes(chain: FusionChain, config: TileConfig, cta_group: int, use_tma_store: bool) -> int:
@@ -744,12 +799,7 @@ def _render_tile_constants(
         # ab_tma_dtype: A/B TMA-descriptor element dtype (same for A and B — TMA
         # only cares about element byte width, identical across an a/b pair).
         f"ab_tma_dtype = {DTYPE_TO_CUTLASS[mma_a_dt]}",
-        f"cd_tma_dtype = {'cutlass.Int8' if out_dt == 'fp4_e2m1' else DTYPE_TO_CUTLASS[out_dt]}",
         f"mma_kind = {DTYPE_TO_MMA_KIND[mma_a_dt]}",
-        f"cd_out_is_m_major = {chain.out_major == 'm'}",
-        f"cd_fake_n_div = {2 if out_dt == 'fp4_e2m1' else 1}",
-        # M-major TMA-store C-descriptor inner-M box = 128 B swizzle span / elem_bytes.
-        f"cd_mmajor_atom_m = {128 // DTYPE_BYTES[out_dt]}",
         *_epi_swizzle_lines(cfg, cta_group, out_dt),
     ]
     # Persistent kernel always: double-TMEM + L2 N-super-block swizzle.
@@ -847,9 +897,9 @@ def _render_tile_constants(
     # Epilogue store mode: TMA-store-via-SMEM (preferred) vs per-thread STG
     # (fallback). See _use_tma_store_epi() for gating.
     use_tma = _use_tma_store_epi(chain, cfg, vec_bytes_epi, cta_group)
-    lines.append(f"use_tma_store_epi = {use_tma}")
     lines.append(f"n_tma_outputs = {len(_tma_slots_for(chain, cfg, cta_group, vec_bytes_epi))}")
-    lines.append(f"epi_slot_widen = {_epi_slot_widen(chain)}")
+    lines.append(f"epi_slot_widen = {_epi_slot_widen(chain, cfg, cta_group)}")
+    lines.append(f"epi_stage_rows = {_epi_stage_rows(cfg, cta_group)}")
     lines.append(f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma)}")
     # Final ab_stages override: account for the TMA-D SMEM buffer (fixed, when
     # TMA-store is active) AND a mixed-input mainloop's narrow LOAD buffer
@@ -1547,20 +1597,15 @@ def _render_block_scale_tile_constants(
         "",
         f"# output",
         f"cd_dtype = {'cutlass.Int8' if out_dt == 'fp4_e2m1' else DTYPE_TO_CUTLASS[out_dt]}",
-        f"cd_tma_dtype = {'cutlass.Int8' if out_dt == 'fp4_e2m1' else DTYPE_TO_CUTLASS[out_dt]}",
         f"vec_bytes_epi = {vec_bytes_epi}",
         f"frost_compile_options = {_frost_compile_options()!r}",
-        f"use_tma_store_epi = {use_tma_store_epi}",
         # The COUNT, not the flag: a block-scale graph can put more than one
         # output on the TMA-C surface, and on MoE this number also sizes the
         # tensormap scratch and the per-CTA workspace stride.
         f"n_tma_outputs = {len(_tma_slots_for(chain, cfg, cta_group, vec_bytes_epi))}",
-        f"epi_slot_widen = {_epi_slot_widen(chain)}",
+        f"epi_slot_widen = {_epi_slot_widen(chain, cfg, cta_group)}",
+        f"epi_stage_rows = {_epi_stage_rows(cfg, cta_group)}",
         f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma_store_epi)}",
-        f"cd_out_is_m_major = {chain.out_major == 'm'}",
-        f"cd_fake_n_div = {2 if out_dt == 'fp4_e2m1' else 1}",
-        # M-major TMA-store C-descriptor inner-M box = 128 B swizzle span / elem_bytes.
-        f"cd_mmajor_atom_m = {128 // DTYPE_BYTES[out_dt]}",
         *_epi_swizzle_lines(cfg, cta_group, out_dt),
         "",
         f"# block-scale MMA",
@@ -2894,16 +2939,6 @@ _EPI_SMEM_STAGES = 2
 # `none`, which is the one mode the DSL exempts from the box-width check.
 _EPI_SWIZZLE_BY_ROW_BYTES = {16: (0, "none"), 32: (1, "s32b"), 64: (2, "s64b"), 128: (3, "s128b")}
 
-# The N-major arm stages with `store_swizzled`, an XOR on SMEM BYTE addresses,
-# and hands the C descriptor an element type -- both are a function of the
-# element WIDTH, not of the dtype. Sub-byte output is the one exception: the
-# descriptor is byte-typed there, so its n and the store coordinate would have
-# to be the PACKED ones (`cd_fake_n_div`), which the host arm does not do.
-# The M-major arm transposes with `stmatrix.m8n8`, which moves a b16 payload
-# and has no b32 form in PTX -- that one IS a dtype-width lock at exactly 16.
-_TMA_STORE_MIN_OUT_BITS = 8
-_TMA_STORE_M_MAJOR_OUT_BITS = 16
-_TMA_STORE_M_MAJOR_MIN_EPI_N = 16
 
 _EPI_ROW_BYTES_MAX = 128  # widest TMA store swizzle
 _EPI_N_BASE = 32  # drain width when the epilogue is already hidden behind the MMA
@@ -2915,18 +2950,10 @@ def _epi_n(cfg, cta_group: int, out_dt: str) -> int:
     cap = _EPI_N_BASE
     if cfg.num_mma_m > 1 and 2 * cfg.num_mma_m * cols > _tmem_cols_for_arch():
         cap = _EPI_N_MAX
-    n = min(_EPI_ROW_BYTES_MAX // DTYPE_BYTES[out_dt], cap, cols)
-    return 1 << (n.bit_length() - 1)
-
-
-def _epi_swizzle_ok(cfg, cta_group: int, out_dt: str, epi_n: "int | None" = None) -> bool:
-    """Does the TMA-store staging row have a swizzle? A subtile row outside
-    {32,64,128} bytes has none, which makes the tmastg SMEM stage inexpressible
-    -- a store-stage predicate, so it declines the TMA arm rather than the whole
-    render (the STG arm never touches the swizzle)."""
-    if epi_n is None:
-        epi_n = _epi_n(cfg, cta_group, out_dt)
-    return epi_n * DTYPE_BYTES[out_dt] in _EPI_SWIZZLE_BY_ROW_BYTES
+    # Must DIVIDE `cols`, not floor it: a partial subtile would TMA-store past the
+    # tile edge, which TMA clips only at the GLOBAL extent. No separate gate --
+    # this is the only place that can violate it (test_epi_n_divides_the_drain_width).
+    return min(_EPI_ROW_BYTES_MAX * 8 // DTYPE_BITS[out_dt], cap, _pow2_floor(cols, cap=cols))
 
 
 def _epi_swizzle_lines(cfg, cta_group: int, out_dt: str) -> list[str]:
@@ -2935,20 +2962,41 @@ def _epi_swizzle_lines(cfg, cta_group: int, out_dt: str) -> list[str]:
     b, tma = _EPI_SWIZZLE_BY_ROW_BYTES.get(row_bytes, _EPI_SWIZZLE_BY_ROW_BYTES[min(_EPI_SWIZZLE_BY_ROW_BYTES)])
     return [
         f"epi_n = {epi_n}",
-        f"epi_smem_row_bytes = {row_bytes}",
-        f"epi_smem_swizzle = cutlass.Swizzle({b}, 4, 3)",
-        f"epi_tma_swizzle = _tma.TensorMapSwizzle.{tma}",
+        f"epi_row_elems = {_epi_row_elems(out_dt, epi_n)}",
     ]
 
 
-def _epi_slot_widen(chain) -> int:
-    """The ring is TYPED as the primary slot's dtype but SHARED by every
-    TMA-stored output, so one slot has to span the WIDEST of them. `epi_n` (a
-    column count) is common; the element width is not."""
-    if not chain.output_specs:
+def _epi_slot_widen(chain, cfg, cta_group: int) -> int:
+    """One shared slot spans the widest TMA-stored row. An STG output never
+    touches the ring, so it must not widen it."""
+    epi_n = _epi_n(cfg, cta_group, chain.output_dtype)
+    tma = _tma_slots_for(chain, cfg, cta_group, _epi_vec_bytes(chain, cfg, cta_group))
+    widths = [_epi_row_bytes(chain.output_specs[i].dtype, epi_n) for i in sorted(tma) if i < len(chain.output_specs)]
+    if not widths:
         return 1
-    widest = max(DTYPE_BYTES[o.dtype] for o in chain.output_specs)
-    return max(1, widest // DTYPE_BYTES[chain.output_dtype])
+    return max(1, max(widths) // _epi_row_bytes(chain.output_dtype, epi_n))
+
+
+_EPI_WARPS = 4  # every template's `num_epilogue_warps`
+_EPI_STAGE_ROWS = _EPI_WARPS * 32
+
+
+def _epi_packed_lanes(cfg, cta_group: int) -> bool:
+    """The packed `lane < 16` drain (hardware M=64, foot-gun #18): half the lanes
+    carry nothing and a row is `warp_idx * 16 + lane`, not `tidx`."""
+    return cfg.mma_inst_m == 64 and cta_group == 1
+
+
+def _epi_dp22(cfg, cta_group: int) -> bool:
+    """The 2-CTA 2x2-DP drain: two column halves per stage, so two TMA boxes.
+    Trades short K for long K vs STG (4096^2, `64x128` cluster2x1): +5.8 % at
+    K=512, -2.5 % at 4096."""
+    return cfg.mma_inst_m == 64 and cta_group == 2
+
+
+def _epi_stage_rows(cfg, cta_group: int) -> int:
+    """Distinct row slots per ring stage: one per thread, except packed."""
+    return cfg.epi_tile_mn[0] if _epi_packed_lanes(cfg, cta_group) else _EPI_STAGE_ROWS
 
 
 def _smem_d_bytes(cfg, chain, cta_group: int) -> int:
@@ -2957,134 +3005,53 @@ def _smem_d_bytes(cfg, chain, cta_group: int) -> int:
     num_mma_m > 1 the M blocks reuse the same slots. epi_n MUST be the same value
     the kernel renders, or the reserve under-counts and the launch is rejected."""
     out_dt = chain.output_dtype
-    return _EPI_SMEM_STAGES * cfg.epi_tile_mn[0] * _epi_n(cfg, cta_group, out_dt) * DTYPE_BYTES[out_dt] * _epi_slot_widen(chain) + 16
-
-
-def _tma_store_geometry_ok(spec, cfg, cta_group: int, epi_n: int) -> bool:
-    """The store rules that hold on BOTH arms -- pure geometry and this output's
-    width, nothing about the chain's shape."""
-    # Only the 128-rows-per-MMA-block thread->row layout is wired; an M=64 MMA
-    # block drains through the packed lane<16 layout.
-    if cfg.mma_inst_m != 128:
-        return False
-    # WIDTH, not dtype: store_swizzled and the descriptor are width-functions.
-    if DTYPE_BITS[spec.dtype] < _TMA_STORE_MIN_OUT_BITS:
-        return False
-    # The SMEM staging row must be a width the swizzle table can express.
-    if not _epi_swizzle_ok(cfg, cta_group, spec.dtype, epi_n):
-        return False
-    # An N-tile that is not a whole number of subtiles would TMA-store an
-    # epi_n-wide box past the tile edge into the neighbouring tile (TMA clamps
-    # only at the GLOBAL extent).
-    if _epi_tile_cols(cfg, cta_group) % epi_n != 0:
-        return False
-    return True
-
-
-def _tma_store_n_major_ok(chain, spec, cfg, cta_group: int, vec_bytes_epi: int) -> bool:
-    if vec_bytes_epi < 16:
-        return False
-    return True
-
-
-def _tma_store_m_major_ok(chain, spec, cfg, cta_group: int, epi_n: int) -> bool:
-    """The M-major arm is `tcgen05.ld 16x256b -> stmatrix.trans -> utmastg`: it
-    re-reads TMEM itself and each lane owns a TRANSPOSED patch, so `row` /
-    `col_j` are the subtile base rather than this element's coordinates.
-
-    Coordinate-READING pointwise inputs are served by `_mmajor_elem_coord` and do
-    not appear here. What is left splits three ways: real properties of the
-    transpose (output width, drain width, M alignment), a template gap (MoE), and
-    side effects that still have no per-register form."""
-    # stmatrix.m8n8 has no b32 payload form.
-    if DTYPE_BITS[spec.dtype] != _TMA_STORE_M_MAJOR_OUT_BITS:
-        return False
-    # The transpose ledger is `for _blk in range(epi_n // 16)` over 4-register
-    # stmatrix tiles, so a narrower drain emits ZERO stores and the output keeps
-    # whatever the buffer held -- silent, not a fault.
-    if epi_n < _TMA_STORE_M_MAJOR_MIN_EPI_N:
-        return False
-    # The six MoE templates carry only the N-major TMA store.
-    if chain.has_moe:
-        return False
-    # This arm skips the pre-split accumulator load, so there is no `vec_f32_<g>`
-    # to bind for the extra GEMMs.
-    if chain.is_multi_gemm:
-        return False
-    # Side effects still wait: an extra dense output goes through
-    # `_emit_mmajor_scatter`, which has no per-register arm, and reductions /
-    # quants have no in-chunk mask. Coordinate-READING pointwise inputs are
-    # served by `_mmajor_elem_coord` and no longer gate this arm.
-    if len(chain.output_specs) > 1 or chain.reductions or chain.quants:
-        return False
-    # 16x256b TMEM-load + stmatrix.trans + tma_store all move 16-byte units of M.
-    return chain.matmul.M % (16 // DTYPE_BYTES[spec.dtype]) == 0
-
-
-def _output_chunk_ok(chain, cfg, cta_group: int) -> bool:
-    """Can EVERY output be produced at the TMA arm's chunk width?
-
-    The store is per-output, but the chunk is shared geometry -- one LDTM feeds
-    them all -- so an output whose correctness depends on the chunk constrains
-    the arm for everyone. Two do:
-
-    * a block-quantized output folds an amax over whole blocks of the chunk and
-      emits one scale per block, so the block size must divide the chunk;
-    * a reduction folds the chunk (when N is the reduced axis) or walks it
-      element-wise, and an atomic RMW cannot be clamped -- so a chunk straddling
-      N would fold real columns together with OOB ones.
-
-    Both were checked against the STG chunk, which `_compute_output_vec_bytes`
-    pins to the quant block size. The TMA arm's chunk is `epi_n` instead, so the
-    same facts have to hold there. `N % chunk == 0` is what lets the emitters
-    bound a whole chunk at a time instead of masking inside one.
-    """
-    if not chain.output_specs:
-        return True
-    epi = _epi_n(cfg, cta_group, chain.output_dtype)
-    if chain.reductions and chain.matmul.N % epi != 0:
-        return False
-    for spec in chain.output_specs:
-        if spec.quant_idx is None:
-            continue
-        if chain.matmul.N % epi != 0:
-            return False
-        if epi % chain.quants[spec.quant_idx].block_size != 0:
-            return False
-    return True
+    row_bytes = _epi_row_bytes(out_dt, _epi_n(cfg, cta_group, out_dt))
+    return _EPI_SMEM_STAGES * _epi_stage_rows(cfg, cta_group) * row_bytes * _epi_slot_widen(chain, cfg, cta_group) + 16
 
 
 def _output_store_mode(out, chain, cfg, cta_group: int, vec_bytes_epi: int) -> str:
-    """How is THIS output stored? Decided from the output itself plus the
-    geometry it is stored with -- never from what the OTHER outputs need.
-
-    A reduction and a quant's scale factor are not dense surfaces: the first is
-    an atomic RMW, the second a per-chunk side store, and neither has a C
-    descriptor to bind. They take STG, which says nothing about the dense
-    outputs beside them -- a quant's DATA output is an ordinary dense output.
-    """
+    """Store mode for ONE output, from the output itself plus the geometry it is
+    stored with -- never from what the others need."""
+    # No dense surface, so no C descriptor to bind.
     if out.is_reduction or out.is_quant_scale:
         return "stg"
-    # The kernel renders ONE arm and it follows slot 0's layout, so an output laid
-    # out the other way has no store sequence to ride. Every non-virtual output is
-    # meant to carry the SAME layout, so this should be unreachable -- but nothing
-    # enforces it yet, and without the guard the odd one out would take a TMA slot
-    # and be stored by the wrong arm.
-    # TODO: the M-major output path is due a refactor that supports MIXED
-    # m/n-major alongside tmastg; this conjunct goes away with it.
-    if out.major != chain.out_major:
-        return "stg"
-    # ONE rendered column count for the whole epilogue: `epi_n` is a COLUMN count
-    # and comes from the primary slot's dtype. What differs per output is the ROW
-    # BYTES, `epi_n * its own element width`, and with them the swizzle.
+
+    # TMA addresses its contiguous dim in 16-byte units, and truncates. The next
+    # two rejections are that granule at a different extent.
     epi_n = _epi_n(cfg, cta_group, chain.output_dtype)
-    if not _tma_store_geometry_ok(out, cfg, cta_group, epi_n):
+
+    # The staged SMEM row; transposed stages the 128-byte M column instead. The
+    # ceiling is the widest swizzle, not the granule.
+    row = _epi_row_bytes(out.dtype, _mmajor_atom_m(out.dtype) if out.major == "m" else epi_n)
+    if row < 16 or row % 16 or row > _EPI_ROW_BYTES_MAX:
         return "stg"
-    if not _output_chunk_ok(chain, cfg, cta_group):
+
+    # The strides the descriptor encodes -- never the contiguous dim's.
+    carrier = _cd_view_bits(out.dtype) // 8
+    dim, stride = dense_output_layout(chain, out.dtype, out.dim, out.stride)
+    encoded = [stride[1] if out.major == "n" else stride[2]]
+    if dim[0] > 1:
+        encoded.append(stride[0])
+    if any(x * carrier < 16 or x * carrier % 16 for x in encoded):
         return "stg"
+
+    # The chunk is SHARED, so an output that FOLDS it constrains the arm for all.
+    # The emitters guard a whole chunk, so one straddling N is skipped outright.
+    quants = [chain.quants[q.quant_idx] for q in chain.output_specs if q.quant_idx is not None]
+    if (chain.reductions or quants) and chain.matmul.N % epi_n:
+        return "stg"
+    # One scale per WHOLE block of the chunk.
+    if any(epi_n % q.block_size for q in quants):
+        return "stg"
+
     if out.major == "m":
-        return "tma" if _tma_store_m_major_ok(chain, out, cfg, cta_group, epi_n) else "stg"
-    return "tma" if _tma_store_n_major_ok(chain, out, cfg, cta_group, vec_bytes_epi) else "stg"
+        # Same granule on a RUNTIME bound: MoE clips D per routed group.
+        if chain.has_moe:
+            return "stg"
+        # A block taller than the drain emits ZERO stores.
+        if cfg.epi_tile_mn[0] % _mmajor_atom_m(out.dtype):
+            return "stg"
+    return "tma"
 
 
 def _store_modes(chain, cfg, cta_group: int, vec_bytes_epi: int) -> tuple[str, ...]:
@@ -3094,8 +3061,7 @@ def _store_modes(chain, cfg, cta_group: int, vec_bytes_epi: int) -> tuple[str, .
     widest of them and each takes its own typed view -- so there is no budget to
     spend: an output takes the surface iff it is eligible. MoE additionally gives
     each one a workspace slot and a scratch copy of the D descriptor, which it
-    re-dimensions per routed group. What still follows SLOT 0 is the arm the
-    kernel renders, and with it the TMEM load shape (`cd_out_is_m_major`).
+    re-dimensions per routed group.
     """
     outs = chain.outputs
     if _FORCE_STG_EPI:
@@ -3478,6 +3444,7 @@ def jit_from_cudnn_graph(
             vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
             output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
             tma_slots=frozenset(i for i, m in enumerate(store_modes) if m == "tma"),
+            packed_lanes=_epi_packed_lanes(config, cta_group),
         )
         src = _render_template(chain, snippets, config, cta_group)
     finally:
@@ -3513,6 +3480,11 @@ def _check_block_scale_supported(chain: FusionChain, template_pipeline: str) -> 
     reason = mma_arch_reject(chain, GraphType.BLOCK_SCALE_MATMUL, template_pipeline)
     if reason is not None:
         raise NotImplementedError(reason)
+
+
+def _moe_dense_layout_bad(t) -> bool:
+    """A MoE dense output must be contiguous in one of the two inner dims."""
+    return t.stride(-1) != 1 and t.stride(-2) != 1
 
 
 def _moe_operand_layout_bad(chain, token, weight) -> bool:
@@ -3703,7 +3675,7 @@ class CompiledMoeGemm:
         a_perm = token.permute(1, 2, 0)
         b_perm = weight.permute(1, 2, 0)
         c_perms = [t.permute(1, 2, 0) for t in outputs]
-        dense_bad = self.chain.output_specs and outputs[0].stride(-1) != 1
+        dense_bad = self.chain.output_specs and _moe_dense_layout_bad(outputs[0])
         if _moe_operand_layout_bad(self.chain, token, weight) or dense_bad:
             raise ValueError(
                 "MoE non-packed tensors require contiguous innermost dimensions: "
@@ -3813,7 +3785,7 @@ class CompiledMoeGemm:
                     raise ValueError(
                         f"multi-GEMM MoE {role} must be rank-3 with contiguous " f"innermost dim; got shape {tuple(t.shape)} stride {tuple(t.stride())}"
                     )
-        if out.stride(-1) != 1:
+        if _moe_dense_layout_bad(out):
             raise ValueError("multi-GEMM MoE output requires contiguous innermost dim")
         for spec, ci in zip(outputs_spec, outs):
             if len(ci.shape) != 3 or tuple(ci.shape) != _expected_output_shape(spec, chain, (S, N, K)):
@@ -3891,6 +3863,7 @@ def _jit_moe(
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
         tma_slots=frozenset(i for i, m in enumerate(store_modes) if m == "tma"),
+        packed_lanes=_epi_packed_lanes(config, cta_group),
     )
     src = _render_template(chain, snippets, config, cta_group)
     mod = _import_kernel(src)
@@ -3939,6 +3912,7 @@ def _jit_block_scale(
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
         tma_slots=frozenset(i for i, m in enumerate(store_modes) if m == "tma"),
+        packed_lanes=_epi_packed_lanes(config, cta_group),
     )
     src = _render_block_scale_template(chain, snippets, config, cta_group, fallback_cluster=fallback_cluster)
     mod = _import_kernel(src)
@@ -4068,7 +4042,7 @@ class CompiledMoeBlockScaleGemm:
         a_perm = token.permute(1, 2, 0)
         b_perm = weight.permute(1, 2, 0)
         c_perms = [t.permute(1, 2, 0) for t in outputs]
-        dense_bad = self.chain.output_specs and outputs[0].stride(-1) != 1
+        dense_bad = self.chain.output_specs and _moe_dense_layout_bad(outputs[0])
         if _moe_operand_layout_bad(self.chain, token, weight) or dense_bad:
             raise ValueError(
                 "MoE block-scale non-packed tensors require contiguous innermost "
@@ -4201,7 +4175,7 @@ class CompiledMoeBlockScaleGemm:
         a_stride_perms = [t.permute(1, 2, 0) for (t, _sf) in a_slots]
         b_stride_perms = [t.permute(1, 2, 0) for (t, _sf) in b_slots]
         c_perms = [ci.permute(1, 2, 0) for ci in outs]
-        dense_bad = chain.output_specs and out.stride(-1) != 1
+        dense_bad = chain.output_specs and _moe_dense_layout_bad(out)
         if _moe_operand_layout_bad(chain, a0, b0) or dense_bad:
             raise ValueError("multi-GEMM MoE block-scale tensors require contiguous innermost dim")
         output_strides = tuple(stride for _spec, ci in zip(outputs_spec, c_perms) for stride in ci.stride())
@@ -4271,6 +4245,7 @@ def _jit_moe_block_scale(
         vec_bytes_epi=_epi_chunk_bytes(chain, config, cta_group, use_tma),
         output_elem_bytes=DTYPE_BYTES[chain.output_dtype],
         tma_slots=frozenset(i for i, m in enumerate(store_modes) if m == "tma"),
+        packed_lanes=_epi_packed_lanes(config, cta_group),
     )
     src = _render_block_scale_template(chain, snippets, config, cta_group, fallback_cluster=_mixed_cga_fallback(config, cta_group, _tmpl.file))
     mod = _import_kernel(src)

--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -178,12 +178,6 @@ def _aux_fake_shape_code(aux: TensorRef) -> str:
     raise AssertionError(f"unknown bcast_mode {aux.bcast_mode!r}")
 
 
-def _aux_fake_stride_order(aux: TensorRef) -> str:
-    if len(aux.dim) == 3:
-        return "(2, 1, 0)"
-    return "(1, 0)"
-
-
 def _aux_can_use_explicit_fake_stride(aux: TensorRef) -> bool:
     # Rank-1 aux is represented as a rank-2 broadcastable fake at compile, so
     # its raw rank-1 stride is not a valid fake stride.
@@ -250,7 +244,7 @@ def _tma_c_plumbing(chain: FusionChain, tma_slots: "frozenset[int]" = frozenset(
         "INJECT_HOST_TMA_C_PASS": ",\n".join(f"tma_c_desc_list[{i}]" for i in range(n_out)) + ",",
         "INJECT_COMPILE_TMA_C_FAKES": "\n".join(
             f"fake_c_{j} = _make_fake_c({_cd_cutlass(dt)}, {2 if dt == 'fp4_e2m1' else 1}, {_fake_c_major(chain, slot)})"
-            for j, (slot, dt) in enumerate(_tma_out_dtypes(chain, tma_slots) or [(0, chain.output_dtype)])
+            for j, (slot, dt) in enumerate(_tma_out_dtypes(chain, tma_slots))
         ),
         "INJECT_COMPILE_TMA_C_PASS": ",\n".join(f"fake_c_{i}" for i in range(n_out)) + ",",
     }
@@ -759,7 +753,6 @@ def _render_tile_constants(
         f"epi_tile_mn = {(cfg.epi_tile_mn[0], _epi_n(cfg, cta_group, out_dt))}",
         f"threads_per_cta = {cfg.threads_per_cta}",
         f"cluster_shape_mnk = {cfg.cluster_shape}",
-        f"matmul_batch = {chain.matmul.batch}",
         f"matmul_a_batch = {chain.matmul.a_batch}",
         f"matmul_b_batch = {chain.matmul.b_batch}",
         f"a_is_m_major = {chain.matmul.a_major == 'm'}",
@@ -773,7 +766,6 @@ def _render_tile_constants(
         f"b_mcast_slices = {b_mcast_slices}",
         f"ab_empty_full_mask = {ab_empty_full_mask}",
         f"ab_smem_swizzle = cutlass.experimental.primitives.Tcgen05SmemSwizzle.{smem_swizzle_name}",
-        f"ab_smem_swizzle_bytes = {smem_swizzle_bytes}",
         f"a_smem_desc_leading_byte_offset = {a_lbo}",
         f"a_smem_desc_stride_byte_offset = {a_sbo}",
         f"a_smem_k_step_bytes = {a_k_step}",
@@ -817,7 +809,6 @@ def _render_tile_constants(
     total_tmem = _tmem_cols_for_arch()
     lines.append(f"num_tmem_alloc_cols = {total_tmem}")
     lines.append(f"tmem_alloc_exclusive = {total_tmem > _MAX_NON_EXCLUSIVE_TMEM_COLS}")
-    lines.append(f"b_collector_ok = {_b_collector_supported()}")
     # TMEM accumulator budget. One acc stage holds, per GEMM, one region of
     # `num_mma_m` MMA-M blocks each `_epi_tile_cols` columns wide (the N-direction
     # MMAs subdivide that width, they do not add to it). `total_tmem == 0` means
@@ -896,8 +887,8 @@ def _render_tile_constants(
     lines.append(f"frost_compile_options = {_frost_compile_options()!r}")
     # Epilogue store mode: TMA-store-via-SMEM (preferred) vs per-thread STG
     # (fallback). See _use_tma_store_epi() for gating.
-    use_tma = _use_tma_store_epi(chain, cfg, vec_bytes_epi, cta_group)
-    lines.append(f"n_tma_outputs = {len(_tma_slots_for(chain, cfg, cta_group, vec_bytes_epi))}")
+    use_tma = _use_tma_store_epi(chain, cfg, cta_group)
+    lines.append(f"n_tma_outputs = {len(_tma_slots_for(chain, cfg, cta_group))}")
     lines.append(f"epi_slot_widen = {_epi_slot_widen(chain, cfg, cta_group)}")
     lines.append(f"epi_stage_rows = {_epi_stage_rows(cfg, cta_group)}")
     lines.append(f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma)}")
@@ -1194,8 +1185,6 @@ def _mixed_cga_fallback(cfg: TileConfig, cta_group: int, template_file: str) -> 
     fallback = min_fallback_cluster(cta_group)
     if fallback == (cfg.cgrp_size_m, cfg.cgrp_size_n) or cfg.tile_swizzle_n > 1:
         return None
-    if cfg.cgrp_size_m % fallback[0] or cfg.cgrp_size_n % fallback[1]:
-        return None
     return fallback
 
 
@@ -1442,8 +1431,6 @@ def _render_block_scale_tile_constants(
     # Per-distinct-operand SF word col bases (single-GEMM → length-1 lists).
     sfa_col_bases = [sf_region_base + i * sfa_tmem_cols for i in range(na)]
     sfb_col_bases = [sf_region_base + na * sfa_tmem_cols + j * sfb_tmem_cols for j in range(nb)]
-    sfa_col_base = sfa_col_bases[0]
-    sfb_col_base = sfb_col_bases[0]
     # tcgen05.alloc requires a power-of-2 column count; allocate the full TMEM.
     used_cols = sf_region_base + sf_total_cols
     num_tmem_alloc_cols = total_tmem
@@ -1512,12 +1499,8 @@ def _render_block_scale_tile_constants(
 
     lines = [
         f"# Block-scale config: {cfg.name} data={bs.a_dtype}x{bs.b_dtype} sf={bs.sf_dtype} block={bs.block_size}",
-        f"cta_tile_m = {cta_m}",
-        f"cta_tile_n = {cta_n}",
-        f"cta_tile_k_elems = {cta_k_elems}",
         f"cta_tile_mnk = ({cta_m}, {cta_n // cta_group}, {cta_k_elems})",
         # MMA instruction M = mma_inst_m × cta_group (256 for the 2-CTA pair).
-        f"mma_inst_shape_mnk = ({cfg.mma_inst_m * cta_group}, {cfg.mma_inst_n}, {mma_inst_k_elems})",
         # MMA instructions the CTA tile spans along M.
         f"num_mma_m = {cfg.num_mma_m}",
         f"cgrp_tile_mnk = ({cta_m * cfg.cgrp_size_m}, {cta_n * cfg.cgrp_size_n}, {cta_k_elems})",
@@ -1570,7 +1553,6 @@ def _render_block_scale_tile_constants(
         f"ab_packed_per_row = {ab_packed_per_row}",
         f"sA_packed_elems = {sA_packed_elems}",
         f"sB_packed_elems = {sB_packed_elems}",
-        f"ab_tma_dtype = {DTYPE_TO_CUTLASS[bs.a_dtype]}",
         # TMA-descriptor element dtype. FP4 uses the NATIVE 4-bit Float4E2M1FN
         # (not the packed-pair Float4E2M1FNx2) so cute scales the descriptor by
         # width=4 itself (no manual stride halving). FP8 same as ab_tma_dtype.
@@ -1602,7 +1584,7 @@ def _render_block_scale_tile_constants(
         # The COUNT, not the flag: a block-scale graph can put more than one
         # output on the TMA-C surface, and on MoE this number also sizes the
         # tensormap scratch and the per-CTA workspace stride.
-        f"n_tma_outputs = {len(_tma_slots_for(chain, cfg, cta_group, vec_bytes_epi))}",
+        f"n_tma_outputs = {len(_tma_slots_for(chain, cfg, cta_group))}",
         f"epi_slot_widen = {_epi_slot_widen(chain, cfg, cta_group)}",
         f"epi_stage_rows = {_epi_stage_rows(cfg, cta_group)}",
         f"epi_chunk_elems = {_epi_chunk_elems(chain, cfg, cta_group, use_tma_store_epi)}",
@@ -1623,7 +1605,6 @@ def _render_block_scale_tile_constants(
         f"# scale factors",
         f"block_size = {bs.block_size}",
         f"sf_cutlass_dtype = {DTYPE_TO_CUTLASS[bs.sf_dtype]}",
-        f"sf_k = {sf_k}",
         f"sf_scales_per_inst = {scales_per_inst}",
         f"sf_insts_per_atom = {insts_per_word}",
         f"num_sf_atoms = {num_sf_words}",
@@ -1640,8 +1621,6 @@ def _render_block_scale_tile_constants(
         f"registers_per_atom = {_REGISTERS_PER_ATOM}",
         f"sf_atom_desc_stride = {sf_atom_desc_stride}",
         f"sf_block_desc_stride = {sf_block_desc_stride}",
-        f"sfa_col_base = {sfa_col_base}",
-        f"sfb_col_base = {sfb_col_base}",
         f"num_tmem_alloc_cols = {num_tmem_alloc_cols}",
         f"tmem_alloc_exclusive = {num_tmem_alloc_cols > _MAX_NON_EXCLUSIVE_TMEM_COLS}",
         f"b_collector_ok = {_b_collector_supported()}",
@@ -1698,7 +1677,6 @@ def _render_block_scale_tile_constants(
         # A's per-row byte stride = k * ab_data_elem_bits / 8 (FP4: k/2 bytes);
         # routed-group base offset = group_begin rows × this. NOT ab_dtype.width
         # (that is the packed Float4E2M1FNx2 8-bit type).
-        lines.append(f"ab_data_elem_bits = {data_elem_bits}")
     lines.extend(_mixed_cga_constants(cfg, cta_group, fallback_cluster))
     lines.extend(_quant_device_imports(chain))
     return "\n".join(lines)
@@ -1725,12 +1703,6 @@ def _resolve_path_blocks(src: str, use_tma_store_epi: bool) -> str:
     src = keep_pat.sub(r"\1", src)
     src = drop_pat.sub("", src)
     return src
-
-
-def _mainloop_template_file(base_template_file: str) -> str:
-    """Map a template filename to its mainloop-fusion variant
-    (``sm100_matmul_1ctamma.py`` -> ``sm100_matmul_mainloop_1ctamma.py``)."""
-    return base_template_file.replace("_matmul_", "_matmul_mainloop_")
 
 
 _INJECT_MARKER_LINE = re.compile(r"^([ \t]*)# *@@([A-Z0-9_]+)@@[ \t]*\n", flags=re.MULTILINE)
@@ -1775,7 +1747,7 @@ def _render_template(
     # Strip the unused epilogue path FIRST so its @@INJECT_EPILOGUE@@ marker
     # doesn't survive into the marker-replacement step.
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    store_modes = _store_modes(chain, config, cta_group)
     tma_slots = frozenset(i for i, m in enumerate(store_modes) if m == "tma")
     use_tma = bool(tma_slots)
     src = _resolve_path_blocks(src, use_tma)
@@ -1947,7 +1919,7 @@ def _render_block_scale_template(
     template_path = _TEMPLATE_DIR / tmpl.file
     src = template_path.read_text()
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    store_modes = _store_modes(chain, config, cta_group)
     tma_slots = frozenset(i for i, m in enumerate(store_modes) if m == "tma")
     use_tma = bool(tma_slots)
     src = _resolve_path_blocks(src, use_tma_store_epi=use_tma)
@@ -2958,8 +2930,6 @@ def _epi_n(cfg, cta_group: int, out_dt: str) -> int:
 
 def _epi_swizzle_lines(cfg, cta_group: int, out_dt: str) -> list[str]:
     epi_n = _epi_n(cfg, cta_group, out_dt)
-    row_bytes = epi_n * DTYPE_BYTES[out_dt]
-    b, tma = _EPI_SWIZZLE_BY_ROW_BYTES.get(row_bytes, _EPI_SWIZZLE_BY_ROW_BYTES[min(_EPI_SWIZZLE_BY_ROW_BYTES)])
     return [
         f"epi_n = {epi_n}",
         f"epi_row_elems = {_epi_row_elems(out_dt, epi_n)}",
@@ -2970,7 +2940,7 @@ def _epi_slot_widen(chain, cfg, cta_group: int) -> int:
     """One shared slot spans the widest TMA-stored row. An STG output never
     touches the ring, so it must not widen it."""
     epi_n = _epi_n(cfg, cta_group, chain.output_dtype)
-    tma = _tma_slots_for(chain, cfg, cta_group, _epi_vec_bytes(chain, cfg, cta_group))
+    tma = _tma_slots_for(chain, cfg, cta_group)
     widths = [_epi_row_bytes(chain.output_specs[i].dtype, epi_n) for i in sorted(tma) if i < len(chain.output_specs)]
     if not widths:
         return 1
@@ -3009,13 +2979,9 @@ def _smem_d_bytes(cfg, chain, cta_group: int) -> int:
     return _EPI_SMEM_STAGES * _epi_stage_rows(cfg, cta_group) * row_bytes * _epi_slot_widen(chain, cfg, cta_group) + 16
 
 
-def _output_store_mode(out, chain, cfg, cta_group: int, vec_bytes_epi: int) -> str:
+def _output_store_mode(out, chain, cfg, cta_group: int) -> str:
     """Store mode for ONE output, from the output itself plus the geometry it is
     stored with -- never from what the others need."""
-    # No dense surface, so no C descriptor to bind.
-    if out.is_reduction or out.is_quant_scale:
-        return "stg"
-
     # TMA addresses its contiguous dim in 16-byte units, and truncates. The next
     # two rejections are that granule at a different extent.
     epi_n = _epi_n(cfg, cta_group, chain.output_dtype)
@@ -3036,12 +3002,11 @@ def _output_store_mode(out, chain, cfg, cta_group: int, vec_bytes_epi: int) -> s
         return "stg"
 
     # The chunk is SHARED, so an output that FOLDS it constrains the arm for all.
+    # `epi_n % block_size == 0` needs no check: `_check_block_quant_supported`
+    # already forces it through `_pow2_floor(cols)`.
     # The emitters guard a whole chunk, so one straddling N is skipped outright.
     quants = [chain.quants[q.quant_idx] for q in chain.output_specs if q.quant_idx is not None]
     if (chain.reductions or quants) and chain.matmul.N % epi_n:
-        return "stg"
-    # One scale per WHOLE block of the chunk.
-    if any(epi_n % q.block_size for q in quants):
         return "stg"
 
     if out.major == "m":
@@ -3054,7 +3019,7 @@ def _output_store_mode(out, chain, cfg, cta_group: int, vec_bytes_epi: int) -> s
     return "tma"
 
 
-def _store_modes(chain, cfg, cta_group: int, vec_bytes_epi: int) -> tuple[str, ...]:
+def _store_modes(chain, cfg, cta_group: int) -> tuple[str, ...]:
     """One store mode per output, in `chain.outputs` slot order.
 
     Every TMA-stored output shares ONE SMEM ring -- the slot is sized for the
@@ -3068,20 +3033,20 @@ def _store_modes(chain, cfg, cta_group: int, vec_bytes_epi: int) -> tuple[str, .
         return ("stg",) * len(outs)
     modes = ["stg"] * len(outs)
     for i in range(len(chain.output_specs)):
-        modes[i] = _output_store_mode(outs[i], chain, cfg, cta_group, vec_bytes_epi)
+        modes[i] = _output_store_mode(outs[i], chain, cfg, cta_group)
     return tuple(modes)
 
 
-def _tma_slots_for(chain, cfg, cta_group: int, vec_bytes_epi: int) -> "frozenset[int]":
-    return frozenset(i for i, m in enumerate(_store_modes(chain, cfg, cta_group, vec_bytes_epi)) if m == "tma")
+def _tma_slots_for(chain, cfg, cta_group: int) -> "frozenset[int]":
+    return frozenset(i for i, m in enumerate(_store_modes(chain, cfg, cta_group)) if m == "tma")
 
 
-def _use_tma_store_epi(chain, cfg, vec_bytes_epi: int, cta_group: int) -> bool:
+def _use_tma_store_epi(chain, cfg, cta_group: int) -> bool:
     """Does the kernel render the TMA-store arm at all? True iff some output
     takes it -- the renderer deletes one of `@@STG_ONLY@@` / `@@TMA_STORE_ONLY@@`,
     so this is a property of the TEMPLATE, while `_store_modes` is the per-output
     answer the emitters consume."""
-    return "tma" in _store_modes(chain, cfg, cta_group, vec_bytes_epi)
+    return "tma" in _store_modes(chain, cfg, cta_group)
 
 
 def _check_block_quant_supported(
@@ -3437,7 +3402,7 @@ def jit_from_cudnn_graph(
     _FORCE_STG_EPI = force_stg_epi
     try:
         vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-        store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+        store_modes = _store_modes(chain, config, cta_group)
         use_tma = "tma" in store_modes
         snippets = generate(
             chain,
@@ -3856,7 +3821,7 @@ def _jit_moe(
     """JIT path for a MoE grouped matmul forward pass (mode=NONE)."""
     _precheck_moe(chain, config, cta_group)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    store_modes = _store_modes(chain, config, cta_group)
     use_tma = "tma" in store_modes
     snippets = generate(
         chain,
@@ -3905,7 +3870,7 @@ def _jit_block_scale(
     _precheck_block_scale(chain, config, cta_group)
     fallback_cluster = _mixed_cga_fallback(config, cta_group, select_template(chain, config, cta_group).file)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    store_modes = _store_modes(chain, config, cta_group)
     use_tma = "tma" in store_modes
     snippets = generate(
         chain,
@@ -4238,7 +4203,7 @@ def _jit_moe_block_scale(
     _precheck_moe_block_scale(chain, config, cta_group)
     _tmpl = select_template(chain, config, cta_group)
     vec_bytes_epi = _epi_vec_bytes(chain, config, cta_group)
-    store_modes = _store_modes(chain, config, cta_group, vec_bytes_epi)
+    store_modes = _store_modes(chain, config, cta_group)
     use_tma = "tma" in store_modes
     snippets = generate(
         chain,

--- a/python/cudnn/gemm/frost/dtypes.py
+++ b/python/cudnn/gemm/frost/dtypes.py
@@ -219,7 +219,9 @@ def _compute_output_vec_bytes(chain: FusionChain, tile_cols: "int | None" = None
     """Epilogue chunk width in bytes of the first dense output's dtype. The
     chunk ELEMENT count (vsize) is order-independent: a quant pins vsize to its
     block size; otherwise vsize = the min over every dense output's widest
-    allowed store. M-major output → elem_bytes (scalar / TMA store).
+    allowed store. An M-major output is bounded by N instead: the chunk walks N
+    and the baked ``sym_n`` divisibility IS the chunk, while its own alignment
+    measures the M extent.
 
     The chunk is a shared ELEMENT count, not one memory access — every output
     reads/writes the same columns but splits the chunk into its own
@@ -233,16 +235,19 @@ def _compute_output_vec_bytes(chain: FusionChain, tile_cols: "int | None" = None
     never exceeds the lowest set bit of ``tile_cols``. Without it a chunk wider
     than the N-tile would make interior tiles store into their neighbours."""
     elem_bytes = DTYPE_BYTES[chain.output_dtype]
-    if chain.out_major == "m":
-        return elem_bytes
+    widths = [_allowed_vsize(chain, spec.dtype, spec.dim, spec.stride) for spec in chain.output_specs if spec.dtype != "fp4_e2m1"]
     if chain.quants:
         vsize = max(q.block_size for q in chain.quants)
+    elif chain.out_major == "m" or not widths:
+        # No dense store width to give (M-major scatters, fp4 packs, an
+        # amax-only chain has no dense output). N is the only bound --
+        # `chain.output_dtype` would size it off a FABRICATED bf16 output.
+        vsize = MAX_EPI_CHUNK_ELEMS
     else:
-        vsize = min(
-            (_allowed_vsize(chain, spec.dtype, spec.dim, spec.stride) for spec in chain.output_specs if spec.dtype != "fp4_e2m1"),
-            default=_allowed_vsize(chain, chain.output_dtype),
-        )
+        vsize = min(widths)
     vsize = min(vsize, MAX_EPI_CHUNK_ELEMS)
+    if chain.out_major == "m" or not widths:
+        vsize = min(vsize, _pow2_floor(chain.matmul.N, cap=MAX_EPI_CHUNK_ELEMS))
     if tile_cols is not None:
         vsize = min(vsize, _pow2_floor(tile_cols, cap=MAX_EPI_CHUNK_ELEMS))
     return vsize * elem_bytes
@@ -273,13 +278,13 @@ def _output_align_reqs(chain: FusionChain, tma_slots: "frozenset[int]", vec_byte
     (matches the epilogue): reduction / quant-scale side outputs store scalar
     (1); a slot on the TMA-C surface needs 16 (M-major included); every other
     slot uses its own store width -- fp4 data packs 2/byte, and everything else
-    stores ``vsize`` elements. Major is read per slot — ``chain.out_major`` only
-    governs the shared epilogue chunk, and a tap may carry the other major.
+    stores ``vsize`` elements. Major is read per slot; a tap may carry the other
+    major.
     ``vec_bytes`` overrides the chain-derived chunk width (pass the tile-clamped
     value the kernel was rendered with)."""
     if vec_bytes is None:
         vec_bytes = _compute_output_vec_bytes(chain)
-    vsize = 1 if chain.out_major == "m" else vec_bytes // DTYPE_BYTES[chain.output_dtype]
+    vsize = vec_bytes // DTYPE_BYTES[chain.output_dtype]
     reqs = []
     for i, out in enumerate(chain.outputs):
         eb = DTYPE_BYTES[out.dtype]

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -98,28 +98,10 @@ def _aux_index_expr(aux: TensorRef, *, row_var: str = "row", col_var: str = "col
     return " + ".join(terms) if terms else "0"
 
 
-def _mmajor_elem_coord(e: int) -> tuple[str, str]:
-    """Which (row, col) does element ``e`` of the M-major TMA arm's fragment hold?
-
-    That arm loads `tcgen05_ld(SHAPE_16X256B)` and its lane holds a TRANSPOSED
-    patch, so the `row` / `col_j` the drain sets just before the hook are the
-    subtile base, not this element's coordinates -- anything that asks "which row
-    / column am I" has to come through here. The two `_h` passes cover disjoint
-    row halves (the `16 * _h` term), so a side effect placed on this arm fires
-    once per element, not twice.
-
-    Element ``e`` contributes `8 * bit1` to M and `bit0 + 8 * (bits 2..)` to N,
-    which is what makes a lane's 2 rows x vsize/2 columns tile the subtile."""
-    return (
-        f"(coord_m + warp_idx * 32 + (lane // 4) + {8 * ((e >> 1) & 1)} + 16 * _h)",
-        f"(col + 2 * (lane % 4) + {(e & 1) + 8 * (e >> 2)})",
-    )
-
-
-def _elem_coord(e: int, mmajor_tma: bool) -> tuple[str, str]:
-    """The (row, col) of element ``e``: the N-major arms hand the snippet the
-    fragment's own coordinates, the M-major TMA arm does not."""
-    return _mmajor_elem_coord(e) if mmajor_tma else ("row", f"col_j + {e}")
+def _elem_coord(e: int) -> tuple[str, str]:
+    """The (row, col) of element ``e``. Every arm hands the snippet the SAME
+    row-per-lane fragment, so these are the fragment's own coordinates."""
+    return ("row", f"col_j + {e}")
 
 
 def tma_out_value(j: int) -> str:
@@ -130,36 +112,6 @@ def tma_out_value(j: int) -> str:
 
 def _aux_reads_row(aux: TensorRef) -> bool:
     return len(aux.dim) >= 2 and aux.dim[-2] != 1
-
-
-def _mmajor_aux_prelude(chain: FusionChain, vsize: int) -> list[str]:
-    """Coordinate-reading aux on the M-major TMA arm. A lane's columns are not
-    contiguous there (`_tn` steps by 8 every 4 elements) and its rows come in two
-    halves, so there is no vector load to have -- each element reads at its own
-    CLAMPED coordinate. Out-of-extent elements land on the last valid one; the
-    TMA store clips them at the global extent, so their value is never used.
-    `per_row` joins the list here: `row` is uniform on the N-major arms, not on
-    this one."""
-    lines: list[str] = []
-    for aux in chain.aux_tensors:
-        if aux.bcast_mode == "scalar":
-            continue
-        n, ptr = aux.name, _aux_ptr_var(aux.name)
-        lines.append(f"_auxt_{n} = cute.make_rmem_tensor({vsize}, {DTYPE_TO_CUTLASS[aux.dtype]})")
-        wants_row = _aux_reads_row(aux)
-        for k in range(vsize):
-            row_e, col_e = _mmajor_elem_coord(k)
-            row_var, col_var = "row", "col_j"
-            if wants_row:
-                row_var = f"_auxr_{n}"
-                lines.append(f"{row_var} = cute.math.min(cutlass.Int32({row_e}), cutlass.Int32(M) - 1)")
-            if aux.dim[-1] != 1:
-                col_var = f"_auxc_{n}"
-                lines.append(f"{col_var} = cute.math.min(cutlass.Int32({col_e}), cutlass.Int32(N) - 1)")
-            idx = _aux_index_expr(aux, row_var=row_var, col_var=col_var)
-            lines.append(f"_auxt_{n}[{k}] = ({ptr} + {idx}).load()")
-        lines.append(f"_auxv_{n} = _auxt_{n}.load().to_vector()")
-    return lines
 
 
 def _bounded_aux_prelude(chain: FusionChain) -> list[str]:
@@ -198,7 +150,7 @@ def _bounded_aux_prelude(chain: FusionChain) -> list[str]:
     return lines
 
 
-def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str, *, bounded: bool = False, mmajor_tma: bool = False) -> str:
+def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str, *, bounded: bool = False) -> str:
     """Expression yielding aux value(s) as a length-`vsize` vector in the op's
     compute dtype, matching ``like_var``'s dtype."""
     idx = _aux_index_expr(aux)
@@ -207,12 +159,10 @@ def _aux_load_expr(aux: TensorRef, compute_dtype: Dtype, like_var: str, *, bound
         # scalar prefetched in aux_views, broadcast to vec
         return f"cutlass.full_like({like_var}, {_aux_prefetch_var(aux.name)}.to({cast}))"
     if aux.bcast_mode == "per_row":
-        if mmajor_tma:
-            return f"_auxv_{aux.name}.to({cast})"
         # per-row scalar prefetched in aux_views, broadcast to vec
         return f"cutlass.full_like({like_var}, {_aux_prefetch_var(aux.name)}.to({cast}))"
     if aux.bcast_mode in ("per_col", "per_elem"):
-        if bounded or mmajor_tma:
+        if bounded:
             return f"_auxv_{aux.name}.to({cast})"
         return f"({_aux_ptr_var(aux.name)} + {idx}).load(count=vsize, " f"alignment=ALIGN_AUX_{aux.name}).to({cast})"
     raise AssertionError(f"unknown bcast_mode {aux.bcast_mode!r}")
@@ -409,7 +359,6 @@ def _emit_op(
     other_in_chain: str | None = None,
     third_in_chain: str | None = None,
     vsize: int = 32,
-    mmajor_tma: bool = False,
 ) -> tuple[list[str], str]:
     """Emit lines computing this op, given the previous-step var name.
     ``other_in_chain`` = second operand var for fan-in binary ops (else None).
@@ -468,13 +417,11 @@ def _emit_op(
 
     if op.op == "gen_index":
         axis = dict(op.attrs).get("axis")
-        # Row index is uniform across the vector on the N-major arms only -- the
-        # M-major TMA fragment holds two row halves, so it needs the map too.
-        if axis == 1 and not mmajor_tma:
+        if axis == 1:
             return [f"{new} = cutlass.full_like({prev}, cutlass.Float32(row))"], new
         gl = [f"_gi{idx} = cute.make_rmem_tensor({vsize}, cutlass.Float32)"]
         for k in range(vsize):
-            _row, _col = _elem_coord(k, mmajor_tma)
+            _row, _col = _elem_coord(k)
             gl.append(f"_gi{idx}[{k}] = cutlass.Float32({_row if axis == 1 else _col})")
         gl.append(f"{new} = _gi{idx}.load().to_vector()")
         return gl, new
@@ -651,7 +598,7 @@ def _dense_store_offset(i: int, is_fp4: bool, batch: int) -> str:
     return f"(tile_l * out_stride_l_{i} + {base})" if batch > 1 else f"({base})"
 
 
-def _emit_mmajor_scatter(tap_idx: int, i: int, source_var: str, dtype: Dtype, batch: int, vsize: int, *, row_bound: str | None = None) -> list[str]:
+def _emit_mmajor_scatter(tap_idx: int, i: int, source_var: str, dtype: Dtype, batch: int, vsize: int, *, row_pred: str | None = None) -> list[str]:
     """Per-element scatter for an M-major (or arbitrarily strided) dense
     output: vsize scalar stores through the output's own runtime strides."""
     tap_var = f"_tap_{tap_idx}"
@@ -663,8 +610,8 @@ def _emit_mmajor_scatter(tap_idx: int, i: int, source_var: str, dtype: Dtype, ba
             f"(col_j + {e}) * out_stride_n_{i}).store({tap_var}[{e} : {e} + 1], "
             f"alignment={DTYPE_BYTES[dtype]})"
         )
-        if row_bound is not None:
-            lines.append(f"if (row < {row_bound}) & (col_j + {e} < N):")
+        if row_pred is not None:
+            lines.append(f"if ({row_pred}) & (col_j + {e} < N):")
             lines.append(f"    {store}")
         else:
             lines.append(store)
@@ -700,25 +647,14 @@ def _emit_tap_store(
     offset_expr: str = "linear_idx",
     spec_idx: int = 0,
     *,
-    row_bound: str | None = None,
+    row_pred: str | None = None,
 ) -> list[str]:
-    """Store one tap vector. M-major TMA taps scatter the 16x256b fragment;
-    all other paths store ``offset_expr`` in ``_tap_store_elems``-wide chunks (a
-    wide dtype co-materialized with a block-quant splits into <=32B sub-stores)."""
+    """Store one N-major tap vector: ``offset_expr`` in ``_tap_store_elems``-wide
+    chunks (a wide dtype co-materialized with a block-quant splits into <=32B
+    sub-stores). An M-major output goes through `_emit_mmajor_scatter`."""
     tap_var = f"_tap_{tap_idx}"
     store_elems = _tap_store_elems(chain, tap_dtype, dim, stride, vsize)
-    lines = [
-        f"{tap_var} = {_store_cast_expr(source_var, tap_dtype)}",
-        f"if cutlass.const_expr(cd_out_is_m_major and use_tma_store_epi):",
-        f"    for _tr_{tap_idx} in cutlass.range_constexpr({vsize}):",
-        f"        _tm_{tap_idx} = coord_m + warp_idx * 32 + (lane // 4)" f" + 8 * ((_tr_{tap_idx} >> 1) & 1) + 16 * _h",
-        f"        _tn_{tap_idx} = col + 2 * (lane % 4)" f" + (_tr_{tap_idx} & 1) + 8 * (_tr_{tap_idx} >> 2)",
-        f"        if _tm_{tap_idx} < M and _tn_{tap_idx} < N:",
-        f"            (gC_tap_{tap_idx}_ptr + tile_l * out_stride_l_{spec_idx}"
-        f" + _tm_{tap_idx} * out_stride_m_{spec_idx} + _tn_{tap_idx} * out_stride_n_{spec_idx}).store("
-        f"{tap_var}[_tr_{tap_idx} : _tr_{tap_idx} + 1], alignment=VEC_BYTES_TAP_{tap_idx})",
-        f"else:",
-    ]
+    lines = [f"{tap_var} = {_store_cast_expr(source_var, tap_dtype)}"]
     # The STG arm sits inside `row < M` / `col_j + vsize <= N`; the TMA arm has
     # neither -- its store is clipped by the descriptor's global extent instead.
     # `_tap_store_elems` divides both N and `col_j`, so a sub-chunk is wholly
@@ -728,11 +664,11 @@ def _emit_tap_store(
         off = f"{offset_expr}" if _s is None else f"{offset_expr} + {_s}"
         width = vsize if _s is None else store_elems
         store = f"(gC_tap_{tap_idx}_ptr + {off}).store({span}, alignment=VEC_BYTES_TAP_{tap_idx})"
-        if row_bound is not None:
-            lines.append(f"    if (row < {row_bound}) & (col_j + {(_s or 0) + width} <= N):")
-            lines.append(f"        {store}")
-        else:
+        if row_pred is not None:
+            lines.append(f"if ({row_pred}) & (col_j + {(_s or 0) + width} <= N):")
             lines.append(f"    {store}")
+        else:
+            lines.append(store)
     return lines
 
 
@@ -807,19 +743,19 @@ def _emit_reduction_atomic(
     source_var: str,
     matmul: "MatmulSpec",
     vsize: int,
-    row_bound: str | None = None,
+    row_pred: str | None = None,
 ) -> list[str]:
     """A reduction is an atomic RMW, so an out-of-extent element cannot be
     clamped onto a valid one -- it has to be SKIPPED. The STG arm inherits
     `row < M` / `col_j + vsize <= N` from the drain; the TMA arm has neither, so
-    it re-applies them here. `_output_chunk_ok` forces N % chunk == 0 whenever a
+    it re-applies them here. `_output_store_mode` forces N % chunk == 0 whenever a
     reduction is present, which is what makes the chunk-level column test exact:
     a chunk is wholly inside N or wholly past it, so the fold over it never mixes
     real columns with OOB ones."""
     body = _emit_reduction_atomic_body(tap_idx, red_idx, red, source_var, matmul, vsize)
-    if row_bound is None:
+    if row_pred is None:
         return body
-    return [f"if (row < {row_bound}) & (col_j + {vsize} <= N):"] + [f"    {ln}" for ln in body]
+    return [f"if ({row_pred}) & (col_j + {vsize} <= N):"] + [f"    {ln}" for ln in body]
 
 
 def _emit_reduction_atomic_body(
@@ -1026,7 +962,7 @@ def _emit_block_quant_col(
     batch_index_expr: str,
     matmul_m: int,
     vsize: int,
-    row_bound: str | None = None,
+    row_pred: str | None = None,
 ) -> list[str]:
     """Emit M-axis (col) block quantize for one epilogue vector. A warp
     (block 32) or half-warp (block 16) of lanes holds one block of rows, so
@@ -1126,12 +1062,12 @@ def _emit_block_quant_col(
         # The scale byte is a SIDE STORE: the STG arm sits inside `row < M`,
         # the TMA arm has no row bound of its own.
         _st = f"(gC_tap_{scale_tap_idx}_ptr + {p}_sidx{k}).store({p}_scale_mine_{k}, alignment=1)"
-        if row_bound is None:
+        if row_pred is None:
             lines.append(_st)
         else:
-            # `_quant_output_chunk_ok` forces N % chunk == 0, so a chunk is wholly
+            # `_output_store_mode` forces N % chunk == 0, so a chunk is wholly
             # inside N or wholly past it -- the chunk-level column test is exact.
-            lines.append(f"if (row < {row_bound}) & (col_j + {vsize} <= N):")
+            lines.append(f"if ({row_pred}) & (col_j + {vsize} <= N):")
             lines.append(f"    {_st}")
     return lines
 
@@ -1146,7 +1082,7 @@ def _emit_block_quant(
     batch_index_expr: str = "tile_l",
     matmul_m: int = 0,
     vsize: int = 32,
-    row_bound: str | None = None,
+    row_pred: str | None = None,
 ) -> list[str]:
     """Emit block quantize for one epilogue vector, binding the quantized
     vector to ``out_var`` and storing the scale byte(s) through the
@@ -1165,7 +1101,7 @@ def _emit_block_quant(
             batch_index_expr,
             matmul_m,
             vsize,
-            row_bound,
+            row_pred,
         )
     p = f"_q{quant_idx}"
     bs = quant.block_size
@@ -1224,12 +1160,12 @@ def _emit_block_quant(
         # The scale byte is a SIDE STORE: the STG arm sits inside `row < M`,
         # the TMA arm has no row bound of its own.
         _st = f"(gC_tap_{scale_tap_idx}_ptr + {p}_sidx{k}).store({p}_scale{k}, alignment=1)"
-        if row_bound is None:
+        if row_pred is None:
             lines.append(_st)
         else:
-            # `_quant_output_chunk_ok` forces N % chunk == 0, so a chunk is wholly
+            # `_output_store_mode` forces N % chunk == 0, so a chunk is wholly
             # inside N or wholly past it -- the chunk-level column test is exact.
-            lines.append(f"if (row < {row_bound}) & (col_j + {vsize} <= N):")
+            lines.append(f"if ({row_pred}) & (col_j + {vsize} <= N):")
             lines.append(f"    {_st}")
     return lines
 
@@ -1331,6 +1267,7 @@ def generate(
     vec_bytes_epi: int = 32,
     output_elem_bytes: int = 2,
     tma_slots: "frozenset[int]" = frozenset(),
+    packed_lanes: bool = False,
 ) -> EpilogueSnippets:
     """Produce the two hook-site snippets, the extra kernel param list, and
     all per-tap plumbing. ``vec_bytes_epi`` / ``output_elem_bytes`` (from the
@@ -1356,10 +1293,6 @@ def generate(
     # leaves them off whenever slot 0 is the one that fell back (an fp4 data
     # output beside a bf16 one, say).
     on_tma_arm = bool(tma_slots)
-    # The M-major TMA arm's `row` / `col_j` are the subtile base, not the
-    # fragment's coordinates -- everything that asks "which row / column am I"
-    # goes through `_elem_coord` there. See `_mmajor_elem_coord`.
-    mmajor_tma = on_tma_arm and chain.out_major == "m"
     # The template binds `vec_f32_<g>` in the STG arm only, where the chunk is a
     # slice of the subtile. The TMA arm takes the whole subtile, and when it is
     # rendered the STG arm is deleted outright -- so emit the bindings here
@@ -1367,8 +1300,16 @@ def generate(
     tma_vec_bindings = [f"vec_f32_{g} = c_rmem_vecs[{g}]" for g in range(1, chain.num_gemms)] if on_tma_arm else []
     # The TMA arm carries no row bound of its own; reuse the one its STG
     # sibling applies -- the routed group's end on MoE, the problem M elsewhere.
-    store_row_bound = ("group_end" if chain.has_moe else "M") if on_tma_arm else None
-    _aux_pre = _mmajor_aux_prelude(chain, vsize) if mmajor_tma else (_bounded_aux_prelude(chain) if on_tma_arm else [])
+    # The TMA arm has no row predicate of its own -- the descriptor's global
+    # extent clips the store -- so every SIDE EFFECT placed on it carries one.
+    # Under the packed `lane < 16` layout half the lanes hold nothing, and a
+    # reduction's atomic RMW cannot be clipped after the fact.
+    store_row_pred = None
+    if on_tma_arm:
+        store_row_pred = f"row < {'group_end' if chain.has_moe else 'M'}"
+        if packed_lanes:
+            store_row_pred = f"row_active & ({store_row_pred})"
+    _aux_pre = _bounded_aux_prelude(chain) if on_tma_arm else []
     body_lines: list[str] = tma_vec_bindings + _aux_pre
 
     # Per-op result var name lookup (handles `identity` pass-throughs).
@@ -1394,7 +1335,7 @@ def generate(
     for i, op in enumerate(chain.ops):
         if op.op == "aux_load":
             aux_ref = chain.aux_by_name(op.aux)
-            body_lines.append(f"_op_{i} = {_aux_load_expr(aux_ref, op.compute_dtype, 'vec_f32', bounded=on_tma_arm, mmajor_tma=mmajor_tma)}")
+            body_lines.append(f"_op_{i} = {_aux_load_expr(aux_ref, op.compute_dtype, 'vec_f32', bounded=on_tma_arm)}")
             round_lines, cur = _emit_round(f"_op_{i}", op.out_dtype, str(i))
             body_lines.extend(round_lines)
             result_var[i] = cur
@@ -1403,7 +1344,7 @@ def generate(
         parent_raw = _parent_value(parent)
         cast_lines, parent_var = _compute_cast(parent_raw, op.compute_dtype, f"{i}_a")
         body_lines.extend(cast_lines)
-        aux_loads = {aux.name: _aux_load_expr(aux, op.compute_dtype, parent_var, bounded=on_tma_arm, mmajor_tma=mmajor_tma) for aux in chain.aux_tensors}
+        aux_loads = {aux.name: _aux_load_expr(aux, op.compute_dtype, parent_var, bounded=on_tma_arm) for aux in chain.aux_tensors}
         other_in_chain = _parent_value(op.parent_idx_b) if op.parent_idx_b is not None else None
         if other_in_chain is not None:
             cast_lines, other_in_chain = _compute_cast(other_in_chain, op.compute_dtype, f"{i}_b")
@@ -1412,7 +1353,7 @@ def generate(
         if third_in_chain is not None:
             cast_lines, third_in_chain = _compute_cast(third_in_chain, op.compute_dtype, f"{i}_c")
             body_lines.extend(cast_lines)
-        lines, cur = _emit_op(op, parent_var, i, aux_loads, other_in_chain, third_in_chain, vsize=vec_bytes_epi // output_elem_bytes, mmajor_tma=mmajor_tma)
+        lines, cur = _emit_op(op, parent_var, i, aux_loads, other_in_chain, third_in_chain, vsize=vec_bytes_epi // output_elem_bytes)
         body_lines.extend(lines)
         # Round to the op's out_dtype (no-op for fp32) so every consumer —
         # downstream ops and outputs alike — sees the declared-dtype value.
@@ -1454,7 +1395,7 @@ def generate(
                         quant_batch_expr,
                         chain.matmul.M,
                         vsize,
-                        store_row_bound,
+                        store_row_pred,
                     )
                 )
             else:
@@ -1462,7 +1403,7 @@ def generate(
             continue
         tap_idx = _tap_of[si]
         if spec.major == "m":
-            body_lines.extend(_emit_mmajor_scatter(tap_idx, si, src, spec.dtype, chain.matmul.batch, vsize, row_bound=store_row_bound))
+            body_lines.extend(_emit_mmajor_scatter(tap_idx, si, src, spec.dtype, chain.matmul.batch, vsize, row_pred=store_row_pred))
             continue
         offset_expr = _dense_store_offset(si, spec.dtype == "fp4_e2m1", chain.matmul.batch)
         if spec.quant_idx is not None:
@@ -1478,7 +1419,7 @@ def generate(
                     quant_batch_expr,
                     chain.matmul.M,
                     vsize,
-                    store_row_bound,
+                    store_row_pred,
                 )
             )
             _align = max(vsize // 2, 4) if spec.dtype == "fp4_e2m1" else f"VEC_BYTES_TAP_{tap_idx}"
@@ -1488,17 +1429,17 @@ def generate(
             # needs the arm's row bound applied here too. Without it a MoE tile,
             # which overhangs its routed group into the NEXT one, writes rows that
             # group's own tile also writes -- two tiles racing on the same bytes.
-            if store_row_bound is None:
+            if store_row_pred is None:
                 body_lines.append(_st)
             else:
-                body_lines.append(f"if (row < {store_row_bound}) & (col_j + {vsize} <= N):")
+                body_lines.append(f"if ({store_row_pred}) & (col_j + {vsize} <= N):")
                 body_lines.append(f"    {_st}")
         else:
-            body_lines.extend(_emit_tap_store(tap_idx, src, spec.dtype, chain, spec.dim, spec.stride, vsize, offset_expr, si, row_bound=store_row_bound))
+            body_lines.extend(_emit_tap_store(tap_idx, src, spec.dtype, chain, spec.dim, spec.stride, vsize, offset_expr, si, row_pred=store_row_pred))
 
     for red_idx, red in enumerate(chain.reductions):
         red_source = _parent_value(red.source_ref)
-        body_lines.extend(_emit_reduction_atomic(_tap_of[len(specs) + red_idx], red_idx, red, red_source, chain.matmul, vsize, store_row_bound))
+        body_lines.extend(_emit_reduction_atomic(_tap_of[len(specs) + red_idx], red_idx, red, red_source, chain.matmul, vsize, store_row_pred))
 
     epilogue = "\n".join(body_lines)
 

--- a/python/cudnn/gemm/frost/epilogue_codegen.py
+++ b/python/cudnn/gemm/frost/epilogue_codegen.py
@@ -1374,7 +1374,6 @@ def generate(
     for _oi in range(len(chain.outputs)):
         if _oi not in tma_slots:
             _tap_of[_oi] = len(_tap_of)
-    n_dense_taps = sum(1 for si in range(len(specs)) if si not in tma_slots)
 
     def _scale_tap_idx(qi: int) -> int:
         return _tap_of[len(specs) + len(chain.reductions) + qi]

--- a/python/cudnn/gemm/frost/fusion_ir.py
+++ b/python/cudnn/gemm/frost/fusion_ir.py
@@ -152,6 +152,22 @@ ZERO_PRESERVING_OPS: frozenset[str] = frozenset(
 )
 
 
+def out_major_of(stride: "tuple[int, ...] | None") -> "OutMajor":
+    """A dense output's layout, read off its STRIDE alone.
+
+    Not off `dim`: cuDNN fills a derived tensor's extents only at
+    `build_operation_graph()` time, while its stride is there from the start, so
+    the extents are not available to disambiguate a degenerate N == 1. An unset
+    stride is the default layout."""
+    if not stride:
+        return "n"
+    if stride[-1] == 1:
+        return "n"
+    if stride[-2] == 1:
+        return "m"
+    raise ValueError(f"output must be N-major or M-major in the inner (M,N) plane; got stride={stride!r}")
+
+
 @dataclass(frozen=True)
 class ChainOutput:
     """One materialized GMEM output. ``source`` = where the value is taken from:
@@ -162,11 +178,15 @@ class ChainOutput:
     source: str
     dtype: Dtype
     dim: "tuple[int, int, int] | None" = None
-    stride: "tuple[int, ...] | None" = None
+    stride: "tuple[int, int, int] | None" = None
     is_reduction: bool = False
     is_quant_scale: bool = False
     quant_block_size: int | None = None
-    major: "OutMajor" = "n"
+
+    @property
+    def major(self) -> "OutMajor":
+        """Derived, not stored -- see `out_major_of`."""
+        return out_major_of(self.stride)
 
 
 @dataclass(frozen=True)
@@ -181,18 +201,22 @@ class OutputSpec:
 
     source_ref: int
     dtype: Dtype
-    major: OutMajor = "n"
     quant_idx: int | None = None
-    dim: "tuple[int, ...] | None" = None
-    stride: "tuple[int, ...] | None" = None
+    dim: "tuple[int, int, int] | None" = None
+    stride: "tuple[int, int, int] | None" = None
 
     def __post_init__(self) -> None:
+        for _f, _v in (("dim", self.dim), ("stride", self.stride)):
+            if _v is not None and len(_v) != 3:
+                raise ValueError(f"output {_f} must be rank-3 (got {_v!r})")
         if self.dtype not in SUPPORTED_DTYPES:
             raise ValueError(f"unsupported output dtype {self.dtype!r}")
-        if self.major not in ("n", "m"):
-            raise ValueError(f"output major must be 'n' or 'm' (got {self.major!r})")
-        if self.quant_idx is not None and self.dtype not in ("fp8_e4m3", "fp8_e5m2", "fp4_e2m1"):
-            raise ValueError(f"block quantize output dtype {self.dtype!r} is not supported; " "expected fp8_e4m3, fp8_e5m2, or fp4_e2m1")
+        self.major  # noqa: B018 -- reject an unsupported layout at construction
+
+    @property
+    def major(self) -> OutMajor:
+        """Derived, not stored -- see `out_major_of`."""
+        return out_major_of(self.stride)
 
 
 @dataclass(frozen=True)
@@ -221,6 +245,16 @@ class ReductionSpec:
             raise ValueError(f"reduction compute_dtype {self.compute_dtype!r} is not supported; " f"expected one of {REDUCTION_DTYPES}")
         if self.dtype != self.compute_dtype:
             raise ValueError(f"reduction output dtype {self.dtype!r} must match compute_dtype " f"{self.compute_dtype!r} for direct atomic reduction")
+
+
+# What a block_scale_quantize may emit as DATA. The SCALE half has its own set on
+# `BlockQuantizeSpec.scale_dtype` -- ue5m3 lives there, not here: it is a scale
+# format, carried end to end as an opaque byte.
+QUANT_DATA_DTYPES = ("fp8_e4m3", "fp8_e5m2", "fp4_e2m1")
+
+# A sub-byte dtype packs two adjacent M rows into one byte, and those rows are
+# held by different lanes -- a read-modify-write race, not an implementation gap.
+M_MAJOR_OUT_DTYPES = ("bf16", "fp16", "fp32", "fp8_e4m3", "fp8_e5m2", "fp8_e8m0", "fp8_e5m3", "int8", "uint8", "int32")
 
 
 @dataclass(frozen=True)
@@ -661,6 +695,9 @@ class FusionChain:
                     raise ValueError(f"quants[{qi}] source GEMM {g} out of range for " f"{self.num_gemms} GEMM(s)")
             elif not (0 <= q.source_ref < len(self.ops)):
                 raise ValueError(f"quants[{qi}] source op index {q.source_ref} out of range " f"for {len(self.ops)} op(s)")
+        for i, spec in enumerate(self.output_specs):
+            if spec.major == "m" and spec.dtype not in M_MAJOR_OUT_DTYPES:
+                raise ValueError(f"output_specs[{i}] is M-major, so its dtype must be one of " f"{M_MAJOR_OUT_DTYPES}; got {spec.dtype!r}.")
         quant_refs = []
         for i, spec in enumerate(self.output_specs):
             if spec.quant_idx is None:
@@ -671,6 +708,13 @@ class FusionChain:
                 raise ValueError(
                     f"output_specs[{i}] source ref {spec.source_ref} does not match "
                     f"quants[{spec.quant_idx}] source ref {self.quants[spec.quant_idx].source_ref}"
+                )
+            if spec.dtype not in QUANT_DATA_DTYPES:
+                raise ValueError(
+                    f"output_specs[{i}] carries quants[{spec.quant_idx}], so its value is that "
+                    f"node's quantized DATA and its dtype must be one of {QUANT_DATA_DTYPES}; got "
+                    f"{spec.dtype!r}. The SCALE half is a separate output and its dtype is "
+                    f"`BlockQuantizeSpec.scale_dtype`."
                 )
             quant_refs.append(spec.quant_idx)
         if sorted(quant_refs) != list(range(len(self.quants))):
@@ -775,7 +819,7 @@ class FusionChain:
         then one quant scale per ``quants`` entry. Callers must pass runtime
         output tensors in this order."""
         outs: list[ChainOutput] = [
-            ChainOutput(source=self._output_label(spec), dtype=spec.dtype, dim=spec.dim, stride=spec.stride, major=spec.major) for spec in self.output_specs
+            ChainOutput(source=self._output_label(spec), dtype=spec.dtype, dim=spec.dim, stride=spec.stride) for spec in self.output_specs
         ]
         for i, red in enumerate(self.reductions):
             outs.append(

--- a/python/cudnn/gemm/frost/graph_analyzer.py
+++ b/python/cudnn/gemm/frost/graph_analyzer.py
@@ -20,10 +20,10 @@ import cudnn
 _LOG = logging.getLogger(__name__)
 
 from .fusion_ir import (
+    out_major_of,
     AMajor,
     BMajor,
     BlockQuantizeSpec,
-    OutMajor,
     OutputSpec,
     Dtype,
     FusionChain,
@@ -604,16 +604,6 @@ def _infer_b_major(dim: tuple[int, ...], stride: tuple[int, ...]) -> BMajor:
     if stride[-1] == 1:
         return "n"
     raise ValueError(f"B must be K-major or N-major in the inner (K,N) plane; " f"got dim={dim} stride={stride}")
-
-
-def _infer_out_major(dim: tuple[int, ...], stride: tuple[int, ...]) -> OutMajor:
-    if not stride:
-        return "n"
-    if stride[-1] == 1:
-        return "n"
-    if stride[-2] == 1:
-        return "m"
-    raise ValueError(f"output must be N-major or M-major in the inner (M,N) plane; " f"got dim={dim} stride={stride}")
 
 
 def _resolve_out_dtype(
@@ -1224,7 +1214,7 @@ def _build_multi_moe_chain(
                 _layout["dim"] = tuple(_d_i)
             if _s_i:
                 _layout["stride"] = tuple(_s_i)
-            dense_entries[_di] = (_spec_replace(_spec_i, major=_infer_out_major(_d_i, _s_i), **_layout), _obj_i)
+            dense_entries[_di] = (_spec_replace(_spec_i, **_layout), _obj_i)
     matmul_spec = MatmulSpec(
         M=M,
         N=N,
@@ -1865,7 +1855,6 @@ def _build_multi_gemm_chain(
         elif not reductions:
             raise ValueError("graph materializes no output; mark at least one tensor " "set_output(True)")
 
-    out_major: OutMajor = "n"
     if dense_entries:
         from dataclasses import replace as _spec_replace
 
@@ -1877,9 +1866,6 @@ def _build_multi_gemm_chain(
                 _meta_i = meta.get(quant_recs[_spec_i.quant_idx].output)
                 if _meta_i is not None:
                     _d_i, _s_i = _meta_i.dim, _meta_i.stride
-            _major_i = _infer_out_major(_d_i, _s_i)
-            if _di == 0:
-                out_major = _major_i
             # Recorded independently — a derived tensor carries its stride long
             # before cuDNN fills its dim (only at build_operation_graph time).
             _layout = {}
@@ -1887,7 +1873,7 @@ def _build_multi_gemm_chain(
                 _layout["dim"] = tuple(_d_i)
             if _s_i:
                 _layout["stride"] = tuple(_s_i)
-            dense_entries[_di] = (_spec_replace(_spec_i, major=_major_i, **_layout), _obj_i)
+            dense_entries[_di] = (_spec_replace(_spec_i, **_layout), _obj_i)
     matmul_spec = MatmulSpec(
         M=M,
         N=N,

--- a/python/cudnn/gemm/frost/kernel_registry.py
+++ b/python/cudnn/gemm/frost/kernel_registry.py
@@ -589,10 +589,3 @@ def candidates(chain: FusionChain) -> list[tuple[KernelTemplate, TileConfig]]:
         for cfg in tmpl.candidate_configs(chain):  # stages 0 + 2 + 3 + 4
             out.append((tmpl, cfg))
     return out
-
-
-def enumerate_candidates(
-    chain: FusionChain,
-) -> list[tuple[KernelTemplate, TileConfig]]:
-    """Alias for :func:`candidates` (the four-stage funnel)."""
-    return candidates(chain)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
@@ -32,7 +32,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
@@ -302,7 +301,9 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -355,7 +356,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1064,23 +1064,22 @@ def _kernel(
                         subtile_w = epi_n
                     else:
                         subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if cutlass.const_expr(((not use_acc_overlap) or cd_out_is_m_major) and not (use_tma_store_epi and cd_out_is_m_major)):
+                    if cutlass.const_expr(not use_acc_overlap):
                         if cutlass.const_expr(mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1):
                             nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                             if elect_one:
                                 nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
 
-                    if use_acc_overlap and (not cd_out_is_m_major) and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
+                    if use_acc_overlap and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -1089,69 +1088,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1165,13 +1108,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1478,11 +1414,11 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_1ctamma.py
@@ -794,7 +794,6 @@ def _kernel(
         s2t_shape, s2t_multicast = nvvm.S2TCopyMode.S2T_32x128b_WARPX4
         sfa_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]) for i in range(num_a_operands)]
         sfb_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]) for j in range(num_b_operands)]
-        sfa_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfa_tmem_bases]
         sfb_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfb_tmem_bases]
         sfa_dst_ptrs = [
             [nvvm.make_tmem_ptr(sfa_tmem_bases[i] + m * registers_per_block, cutlass.Float32) for m in range(num_mma_m)] for i in range(num_a_operands)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
@@ -818,7 +818,6 @@ def _kernel(
             sfa_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]) for i in range(num_a_operands)]
             sfb_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]) for j in range(num_b_operands)]
             s2t_shape, s2t_multicast = nvvm.S2TCopyMode.S2T_32x128b_WARPX4
-            sfa_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfa_tmem_bases]
             sfb_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfb_tmem_bases]
             sfa_dst_ptrs = [
                 [nvvm.make_tmem_ptr(sfa_tmem_bases[i] + m * registers_per_block, cutlass.Float32) for m in range(num_mma_m)] for i in range(num_a_operands)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_block_scale_matmul_2ctamma.py
@@ -31,7 +31,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
@@ -296,7 +295,9 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -360,7 +361,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1142,16 +1142,15 @@ def _kernel(
                         subtile_w = epi_n
                     else:
                         subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if cutlass.const_expr(((not use_acc_overlap) or cd_out_is_m_major) and not (use_tma_store_epi and cd_out_is_m_major)):
+                    if cutlass.const_expr(not use_acc_overlap):
                         if cutlass.const_expr(mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1):
                             nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
@@ -1162,7 +1161,7 @@ def _kernel(
                                     relaxed=True,
                                 )
 
-                    if use_acc_overlap and (not cd_out_is_m_major) and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
+                    if use_acc_overlap and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -1175,69 +1174,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1251,14 +1194,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
-                    nvvm.mbarrier_arrive(mbar_pair_ptr, scope=nvvm.MemScope.CLUSTER, relaxed=True)
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1565,11 +1500,11 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_1ctamma.py
@@ -33,7 +33,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_tensor
@@ -265,7 +264,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -333,7 +334,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -892,21 +892,20 @@ def _kernel(
 
                 for subtile_idx in cutlass.range_constexpr(subtile_cnt):
                     subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w, offset=ld_half_off)
-                            # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
-                            if cutlass.const_expr(acc_widen_to_fp32):
-                                _accf = _cv.to(cutlass.Float32)
-                                # `+ 0.0` forces a fresh fp32 register so int32->fp32 isn't folded into an invalid int32->fp8 cast.
-                                _cv = _accf + cutlass.full_like(_accf, 0.0)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w, offset=ld_half_off)
+                        # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
+                        if cutlass.const_expr(acc_widen_to_fp32):
+                            _accf = _cv.to(cutlass.Float32)
+                            # `+ 0.0` forces a fresh fp32 register so int32->fp32 isn't folded into an invalid int32->fp8 cast.
+                            _cv = _accf + cutlass.full_like(_accf, 0.0)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if (not (use_tma_store_epi and cd_out_is_m_major)) and mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1:
+                    if mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -915,72 +914,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            if cutlass.const_expr(acc_widen_to_fp32):
-                                _accf = _lv.to(cutlass.Float32)
-                                _lv = _accf + cutlass.full_like(_accf, 0.0)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -994,13 +934,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1247,11 +1180,11 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_2ctamma.py
@@ -30,7 +30,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor, make_fake_tensor
@@ -259,7 +258,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -338,7 +339,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
     M = m
     N = n
@@ -953,21 +953,20 @@ def _kernel(
 
                 for subtile_idx in cutlass.range_constexpr(subtile_cnt):
                     subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
-                            # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
-                            if cutlass.const_expr(acc_widen_to_fp32):
-                                _accf = _cv.to(cutlass.Float32)
-                                # `+ 0.0` forces a fresh fp32 register so int32->fp32 isn't folded into an invalid int32->fp8 cast.
-                                _cv = _accf + cutlass.full_like(_accf, 0.0)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
+                        if cutlass.const_expr(acc_widen_to_fp32):
+                            _accf = _cv.to(cutlass.Float32)
+                            # `+ 0.0` forces a fresh fp32 register so int32->fp32 isn't folded into an invalid int32->fp8 cast.
+                            _cv = _accf + cutlass.full_like(_accf, 0.0)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if (not (use_tma_store_epi and cd_out_is_m_major)) and mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1:
+                    if mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -980,72 +979,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            if cutlass.const_expr(acc_widen_to_fp32):
-                                _accf = _lv.to(cutlass.Float32)
-                                _lv = _accf + cutlass.full_like(_accf, 0.0)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1059,14 +999,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
-                    nvvm.mbarrier_arrive(mbar_pair_ptr, scope=nvvm.MemScope.CLUSTER, relaxed=True)
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1312,11 +1244,11 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_1ctamma.py
@@ -31,7 +31,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
@@ -264,7 +263,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -339,7 +340,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1105,21 +1105,20 @@ def _kernel(
 
                 for subtile_idx in cutlass.range_constexpr(subtile_cnt):
                     subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w, offset=ld_half_off)
-                            # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
-                            if cutlass.const_expr(acc_widen_to_fp32):
-                                _accf = _cv.to(cutlass.Float32)
-                                # `+ 0.0` forces a fresh fp32 register so int32->fp32 isn't folded into an invalid int32->fp8 cast.
-                                _cv = _accf + cutlass.full_like(_accf, 0.0)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w, offset=ld_half_off)
+                        # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
+                        if cutlass.const_expr(acc_widen_to_fp32):
+                            _accf = _cv.to(cutlass.Float32)
+                            # `+ 0.0` forces a fresh fp32 register so int32->fp32 isn't folded into an invalid int32->fp8 cast.
+                            _cv = _accf + cutlass.full_like(_accf, 0.0)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if (not (use_tma_store_epi and cd_out_is_m_major)) and mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1:
+                    if mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -1128,72 +1127,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            if cutlass.const_expr(acc_widen_to_fp32):
-                                _accf = _lv.to(cutlass.Float32)
-                                _lv = _accf + cutlass.full_like(_accf, 0.0)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1207,13 +1147,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1441,11 +1374,11 @@ def compile() -> Callable:
 
     # @@INJECT_COMPILE_AB_FAKES@@
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_matmul_mainloop_2ctamma.py
@@ -32,7 +32,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
@@ -261,7 +260,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -351,7 +352,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1238,21 +1238,20 @@ def _kernel(
 
                 for subtile_idx in cutlass.range_constexpr(subtile_cnt):
                     subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
-                            # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
-                            if cutlass.const_expr(acc_widen_to_fp32):
-                                _accf = _cv.to(cutlass.Float32)
-                                # `+ 0.0` forces a fresh fp32 register so int32->fp32 isn't folded into an invalid int32->fp8 cast.
-                                _cv = _accf + cutlass.full_like(_accf, 0.0)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        # INT8 int32 accumulate → widen to fp32 (skipped for int32 output).
+                        if cutlass.const_expr(acc_widen_to_fp32):
+                            _accf = _cv.to(cutlass.Float32)
+                            # `+ 0.0` forces a fresh fp32 register so int32->fp32 isn't folded into an invalid int32->fp8 cast.
+                            _cv = _accf + cutlass.full_like(_accf, 0.0)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if (not (use_tma_store_epi and cd_out_is_m_major)) and mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1:
+                    if mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -1265,72 +1264,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            if cutlass.const_expr(acc_widen_to_fp32):
-                                _accf = _lv.to(cutlass.Float32)
-                                _lv = _accf + cutlass.full_like(_accf, 0.0)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1344,14 +1284,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
-                    nvvm.mbarrier_arrive(mbar_pair_ptr, scope=nvvm.MemScope.CLUSTER, relaxed=True)
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1579,11 +1511,11 @@ def compile() -> Callable:
 
     # @@INJECT_COMPILE_AB_FAKES@@
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -138,9 +138,7 @@ def _kernel(
     tidx = cute.arch.thread_idx()[0]
     bidx = cute.arch.block_idx()[0]
     bidy = cute.arch.block_idx()[1]
-    bidz = cute.arch.block_idx()[2]
     gridx = cute.arch.grid_dim()[0]
-    gridy = cute.arch.grid_dim()[1]
 
     cluster_m = cluster_shape_mnk[0]
     cluster_n = cluster_shape_mnk[1]
@@ -798,7 +796,6 @@ def _kernel(
         sfa_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]) for i in range(num_a_operands)]
         sfb_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]) for j in range(num_b_operands)]
         s2t_shape, s2t_multicast = nvvm.S2TCopyMode.S2T_32x128b_WARPX4
-        sfa_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfa_tmem_bases]
         sfb_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfb_tmem_bases]
         sfa_dst_ptrs = [
             [nvvm.make_tmem_ptr(sfa_tmem_bases[i] + m * registers_per_block, cutlass.Float32) for m in range(num_mma_m)] for i in range(num_a_operands)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -226,7 +226,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -325,7 +327,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1451,11 +1452,11 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
-            stride_order=(1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, 1),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -140,9 +140,7 @@ def _kernel(
     tidx = cute.arch.thread_idx()[0]
     bidx = cute.arch.block_idx()[0]
     bidy = cute.arch.block_idx()[1]
-    bidz = cute.arch.block_idx()[2]
     gridx = cute.arch.grid_dim()[0]
-    gridy = cute.arch.grid_dim()[1]
 
     cluster_m = cluster_shape_mnk[0]
     cluster_n = cluster_shape_mnk[1]
@@ -822,7 +820,6 @@ def _kernel(
             sfa_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]) for i in range(num_a_operands)]
             sfb_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]) for j in range(num_b_operands)]
             s2t_shape, s2t_multicast = nvvm.S2TCopyMode.S2T_32x128b_WARPX4
-            sfa_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfa_tmem_bases]
             sfb_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfb_tmem_bases]
             sfa_dst_ptrs = [
                 [nvvm.make_tmem_ptr(sfa_tmem_bases[i] + m * registers_per_block, cutlass.Float32) for m in range(num_mma_m)] for i in range(num_a_operands)

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -226,7 +226,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -330,7 +332,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1522,11 +1523,11 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
-            stride_order=(1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, 1),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
@@ -222,7 +222,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -290,7 +292,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1098,11 +1099,11 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
-            stride_order=(1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, 1),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
@@ -126,9 +126,7 @@ def _kernel(
     tidx = cute.arch.thread_idx()[0]
     bidx = cute.arch.block_idx()[0]
     bidy = cute.arch.block_idx()[1]
-    bidz = cute.arch.block_idx()[2]
     gridx = cute.arch.grid_dim()[0]
-    gridy = cute.arch.grid_dim()[1]
 
     cluster_m = cluster_shape_mnk[0]
     cluster_n = cluster_shape_mnk[1]

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
@@ -227,7 +227,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -303,7 +305,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1149,11 +1150,11 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
-            stride_order=(1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, 1),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
@@ -131,9 +131,7 @@ def _kernel(
     tidx = cute.arch.thread_idx()[0]
     bidx = cute.arch.block_idx()[0]
     bidy = cute.arch.block_idx()[1]
-    bidz = cute.arch.block_idx()[2]
     gridx = cute.arch.grid_dim()[0]
-    gridy = cute.arch.grid_dim()[1]
 
     cluster_m = cluster_shape_mnk[0]
     cluster_n = cluster_shape_mnk[1]

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_1ctamma.py
@@ -53,7 +53,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
@@ -368,7 +367,9 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -424,7 +425,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1259,23 +1259,22 @@ def _kernel(
                         subtile_w = epi_n
                     else:
                         subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if cutlass.const_expr(((not use_acc_overlap) or cd_out_is_m_major) and not (use_tma_store_epi and cd_out_is_m_major)):
+                    if cutlass.const_expr(not use_acc_overlap):
                         if cutlass.const_expr(mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1):
                             nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                             if elect_one:
                                 nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
 
-                    if use_acc_overlap and (not cd_out_is_m_major) and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
+                    if use_acc_overlap and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -1284,69 +1283,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1360,13 +1303,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1640,11 +1576,11 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm103_block_scale_matmul_2ctamma.py
@@ -53,7 +53,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
@@ -362,7 +361,9 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -431,7 +432,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1333,16 +1333,15 @@ def _kernel(
                         subtile_w = epi_n
                     else:
                         subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if cutlass.const_expr(((not use_acc_overlap) or cd_out_is_m_major) and not (use_tma_store_epi and cd_out_is_m_major)):
+                    if cutlass.const_expr(not use_acc_overlap):
                         if cutlass.const_expr(mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1):
                             nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
@@ -1353,7 +1352,7 @@ def _kernel(
                                     relaxed=True,
                                 )
 
-                    if use_acc_overlap and (not cd_out_is_m_major) and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
+                    if use_acc_overlap and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -1366,69 +1365,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1442,14 +1385,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
-                    nvvm.mbarrier_arrive(mbar_pair_ptr, scope=nvvm.MemScope.CLUSTER, relaxed=True)
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1723,11 +1658,11 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_1ctamma.py
@@ -50,7 +50,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
@@ -322,7 +321,9 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -375,7 +376,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1123,23 +1123,22 @@ def _kernel(
                         subtile_w = epi_n
                     else:
                         subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if cutlass.const_expr(((not use_acc_overlap) or cd_out_is_m_major) and not (use_tma_store_epi and cd_out_is_m_major)):
+                    if cutlass.const_expr(not use_acc_overlap):
                         if cutlass.const_expr(mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1):
                             nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                             if elect_one:
                                 nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
 
-                    if use_acc_overlap and (not cd_out_is_m_major) and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
+                    if use_acc_overlap and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -1148,69 +1147,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1224,13 +1167,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    nvvm.mbarrier_arrive(acc_empty_mbar_ptr.subview(acc_stage))
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1537,11 +1473,11 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_1ctamma.py
@@ -835,7 +835,6 @@ def _kernel(
         s2t_shape, s2t_multicast = nvvm.S2TCopyMode.S2T_32x128b_WARPX4
         sfa_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]) for i in range(num_a_operands)]
         sfb_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]) for j in range(num_b_operands)]
-        sfa_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfa_tmem_bases]
         sfb_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfb_tmem_bases]
         # utccp destination per (MN-block, atom within the scale word). SFB is
         # atom-MAJOR across the N-blocks because ONE instruction walks all of

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_2ctamma.py
@@ -49,7 +49,6 @@ from cudnn.gemm.frost.kernel_templates._tile_helpers import (
 )
 import cutlass.experimental.cuda.tensor_map as _tma
 import cutlass._mlir_helpers.vector as _cvec
-from cutlass import apply_swizzle as _apply_smem_swizzle
 import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import make_fake_compact_tensor
@@ -313,7 +312,9 @@ def _kernel(
     ]
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -377,7 +378,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1199,16 +1199,15 @@ def _kernel(
                         subtile_w = epi_n
                     else:
                         subtile_col_offset, subtile_w = epi_spans[subtile_idx]
-                    if cutlass.const_expr(not (use_tma_store_epi and cd_out_is_m_major)):
-                        c_rmem_vecs = []
-                        for g in cutlass.range_constexpr(num_gemms):
-                            subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
-                            tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
-                            _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
-                            c_rmem_vecs.append(_cv)
-                        c_rmem_vec = c_rmem_vecs[0]
+                    c_rmem_vecs = []
+                    for g in cutlass.range_constexpr(num_gemms):
+                        subtile_tmem_addr = tmem_col_addr_gemms[g] + subtile_col_offset
+                        tmem = cutlass.inttoptr(subtile_tmem_addr, 6, mma_c_dtype)
+                        _cv = nvvm.tcgen05_ld(shape, tmem, num=subtile_w)
+                        c_rmem_vecs.append(_cv)
+                    c_rmem_vec = c_rmem_vecs[0]
 
-                    if cutlass.const_expr(((not use_acc_overlap) or cd_out_is_m_major) and not (use_tma_store_epi and cd_out_is_m_major)):
+                    if cutlass.const_expr(not use_acc_overlap):
                         if cutlass.const_expr(mi == num_mma_m - 1 and subtile_idx == subtile_cnt - 1):
                             nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                             nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
@@ -1219,7 +1218,7 @@ def _kernel(
                                     relaxed=True,
                                 )
 
-                    if use_acc_overlap and (not cd_out_is_m_major) and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
+                    if use_acc_overlap and mi * subtile_cnt + subtile_idx == acc_overlap_subtiles - 1:
                         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                         nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
                         if elect_one:
@@ -1232,69 +1231,13 @@ def _kernel(
                     col = coord_n_c + subtile_col_offset
 
                     # @@TMA_STORE_ONLY:BEGIN@@
-                    if cutlass.const_expr(cd_out_is_m_major):
-                        epi_stage_idx = (epi_stage_idx + 1) % EPI_SMEM_STAGES
-                        smem_subtile_ptr = smem_d_ptr.subview(epi_stage_idx * epi_subtile_elems)
-                        smem_thr_ptr = smem_subtile_ptr.subview(tidx * subtile_w)
-                        ld_col = mi_col_base + subtile_col_offset
-                        for _h in cutlass.range(2, unroll_full=True):
-                            ld_row = base_row_id + warp_idx * 32 + _h * 16
-                            ld_addr = (ld_row << 16) | ld_col
-                            ld_tmem = cutlass.inttoptr(ld_addr, 6, mma_c_dtype)
-                            _lv = nvvm.tcgen05_ld(nvvm.Tcgen05LdStShape.SHAPE_16X256B, ld_tmem, num=epi_n // 8)
-                            vec_f32 = _lv
-                            col_j = col
-                            linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
+                    vec_f32 = c_rmem_vec
+                    col_j = col
+                    linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
 
-                            # @@INJECT_EPILOGUE@@
+                    # @@INJECT_EPILOGUE@@
 
-                            _i32 = vec_out.bitcast(cutlass.Int32)
-                            for _blk in cutlass.range_constexpr(epi_n // 16):
-                                _regs = [_i32[_blk * 4 + _j] for _j in range(4)]
-                                _n_full = (lane % 8) + 8 * (lane // 16) + 16 * _blk
-                                _m_base = warp_idx * 32 + _h * 16 + 8 * ((lane // 8) % 2)
-                                _stm_off = (
-                                    (_m_base // cd_mmajor_atom_m) * (cd_mmajor_atom_m * epi_tile_mn[1])
-                                    + (_m_base % cd_mmajor_atom_m)
-                                    + _n_full * cd_mmajor_atom_m
-                                )
-                                nvvm.stmatrix(
-                                    _apply_smem_swizzle(
-                                        smem_subtile_ptr.data_ptr() + _stm_off,
-                                        cutlass.Swizzle(3, 4, 3),
-                                    ),
-                                    _regs,
-                                    nvvm.MMALayout.COL,
-                                    shape=nvvm.StoreShape.M8N8,
-                                )
-                        cute.arch.fence_view_async_shared()
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                        if warp_idx == 0:
-                            for _mb in cutlass.range_constexpr(epi_tile_mn[0] // cd_mmajor_atom_m):
-                                if elect_one:
-                                    nvvm.cp_async_bulk_tensor_global_shared_cta(
-                                        tma_c_descs[0].get_ptr(),
-                                        smem_subtile_ptr.subview(_mb * (cd_mmajor_atom_m * epi_tile_mn[1])),
-                                        (coord_m + _mb * cd_mmajor_atom_m, col, tile_l),
-                                    )
-                            if elect_one:
-                                nvvm.cp_async_bulk_commit_group()
-                            nvvm.cp_async_bulk_wait_group(EPI_SMEM_STAGES - 1, read=True)
-                        nvvm.barrier_cta_sync(
-                            barrier_id=EPI_SYNC_BAR_ID,
-                            thread_count=num_epilogue_warps * 32,
-                        )
-                    else:
-                        vec_f32 = c_rmem_vec
-                        col_j = col
-                        linear_idx = tile_l * out_stride_l_0 + row * out_stride_m_0 + col_j * out_stride_n_0
-
-                        # @@INJECT_EPILOGUE@@
-
-                        # @@INJECT_TMA_STORE_SEQUENCE@@
+                    # @@INJECT_TMA_STORE_SEQUENCE@@
                     # @@TMA_STORE_ONLY:END@@
 
                     # @@STG_ONLY:BEGIN@@
@@ -1308,14 +1251,6 @@ def _kernel(
 
                                 # @@INJECT_EPILOGUE@@
                     # @@STG_ONLY:END@@
-
-            # The M-major TMA path loads its accumulator inside the store loop, so its release cannot move up.
-            if cutlass.const_expr(use_tma_store_epi and cd_out_is_m_major):
-                nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-                nvvm.tcgen05_fence(nvvm.Tcgen05Fence.BEFORE_THREAD_SYNC)
-                if elect_one:
-                    mbar_pair_ptr = nvvm.mapa(acc_empty_mbar_ptr.subview(acc_stage), pair_leader_rank)
-                    nvvm.mbarrier_arrive(mbar_pair_ptr, scope=nvvm.MemScope.CLUSTER, relaxed=True)
 
             # @@EPILOGUE_DRAIN:END@@
             consumer_stage = tile_iter % CLC_SCHED_STAGES
@@ -1622,11 +1557,11 @@ def compile() -> Callable:
         )
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), sym_l),
-            stride_order=(0, 1, 2) if cd_out_is_m_major else (1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, sym_l),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_block_scale_matmul_2ctamma.py
@@ -857,7 +857,6 @@ def _kernel(
             sfa_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]) for i in range(num_a_operands)]
             sfb_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]) for j in range(num_b_operands)]
             s2t_shape, s2t_multicast = nvvm.S2TCopyMode.S2T_32x128b_WARPX4
-            sfa_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfa_tmem_bases]
             sfb_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfb_tmem_bases]
             # utccp destination per (MN-block, atom within the scale word). SFB
             # is atom-MAJOR across the N-blocks because ONE instruction walks

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -156,9 +156,7 @@ def _kernel(
     tidx = cute.arch.thread_idx()[0]
     bidx = cute.arch.block_idx()[0]
     bidy = cute.arch.block_idx()[1]
-    bidz = cute.arch.block_idx()[2]
     gridx = cute.arch.grid_dim()[0]
-    gridy = cute.arch.grid_dim()[1]
 
     cluster_m = cluster_shape_mnk[0]
     cluster_n = cluster_shape_mnk[1]
@@ -837,7 +835,6 @@ def _kernel(
         sfa_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]) for i in range(num_a_operands)]
         sfb_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]) for j in range(num_b_operands)]
         s2t_shape, s2t_multicast = nvvm.S2TCopyMode.S2T_32x128b_WARPX4
-        sfa_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfa_tmem_bases]
         sfb_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfb_tmem_bases]
         # utccp destination per (MN-block, atom within the scale word). SFB is
         # atom-MAJOR across the N-blocks because ONE instruction walks all of

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -244,7 +244,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -343,7 +345,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1508,11 +1509,11 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
-            stride_order=(1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, 1),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -244,7 +244,9 @@ def _kernel(
 
     # @@TMA_STORE_ONLY:BEGIN@@
     # One epilogue subtile = one MMA-M block x 32 cols; the M blocks reuse it.
-    epi_subtile_elems = epi_tile_mn[0] * epi_tile_mn[1] * epi_slot_widen
+    # The ring slot is indexed by `tidx`, so its row count is the EPILOGUE THREAD
+    # count -- which is epi_tile_mn[0] only when the MMA M block is 128.
+    epi_subtile_elems = epi_stage_rows * epi_row_elems * epi_slot_widen
     smem_d_ptr = cutlass.Array(
         cd_dtype,
         epi_subtile_elems * EPI_SMEM_STAGES,
@@ -348,7 +350,6 @@ def _kernel(
 
     # @@INJECT_TAP_PTRS@@
 
-    VEC_BYTES = vec_bytes_epi
     vsize = epi_chunk_elems
 
     M = m
@@ -1580,11 +1581,11 @@ def compile() -> Callable:
     # @@INJECT_COMPILE_TAP_FAKES@@
 
     # @@TMA_STORE_ONLY:BEGIN@@
-    def _make_fake_c(_dt=None, _div=None):
+    def _make_fake_c(_dt, _div, _mm):
         return make_fake_compact_tensor(
-            cd_dtype if _dt is None else _dt,
-            (sym_m, sym_n // (cd_fake_n_div if _div is None else _div), 1),
-            stride_order=(1, 0, 2),
+            _dt,
+            (sym_m, sym_n // _div, 1),
+            stride_order=(0, 1, 2) if _mm else (1, 0, 2),
             assumed_align=16,
         )
 

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -158,9 +158,7 @@ def _kernel(
     tidx = cute.arch.thread_idx()[0]
     bidx = cute.arch.block_idx()[0]
     bidy = cute.arch.block_idx()[1]
-    bidz = cute.arch.block_idx()[2]
     gridx = cute.arch.grid_dim()[0]
-    gridy = cute.arch.grid_dim()[1]
 
     cluster_m = cluster_shape_mnk[0]
     cluster_n = cluster_shape_mnk[1]
@@ -861,7 +859,6 @@ def _kernel(
             sfa_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfa_col_bases[i]) for i in range(num_a_operands)]
             sfb_tmem_bases = [(base_row_id << 16) | (base_col_id_root + sfb_col_bases[j]) for j in range(num_b_operands)]
             s2t_shape, s2t_multicast = nvvm.S2TCopyMode.S2T_32x128b_WARPX4
-            sfa_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfa_tmem_bases]
             sfb_scale_ptrs = [nvvm.make_tmem_ptr(b, cutlass.Float32) for b in sfb_tmem_bases]
             # utccp destination per (MN-block, atom within the scale word). SFB
             # is atom-MAJOR across the N-blocks because ONE instruction walks

--- a/python/cudnn/gemm/frost/tile_config.py
+++ b/python/cudnn/gemm/frost/tile_config.py
@@ -673,8 +673,6 @@ def select_config(
         wide = [c for c in choices if c >= 128]
         if wide:
             choices = wide
-    if not choices:
-        choices = [cta_n_max]
     cta_n = max(choices, key=lambda c: _tile_score(rep_m, N, K, cta_m, c, sm))
 
     if block_scale:
@@ -705,8 +703,6 @@ def select_config(
     pool = [g for g in _CLUSTERS_1D + _CLUSTERS_2D if not _hang_prone(cta_m, cta_n, g[0], g[1])]
     if cta_group == 2:
         pool = [g for g in pool if g[0] % 2 == 0]  # 2-CTA needs cgrp_size_m % 2 == 0
-    if not pool:
-        pool = [(2, 1)] if cta_group == 2 else [(1, 1)]
     cgrp_m, cgrp_n = max(pool, key=lambda g: _cluster_score(M, N, cta_m, cta_n, cta_group, g[0], g[1], sm))
 
     name = f"CONFIG_sm100_{cta_m}x{cta_n}x128_{cta_m}x{cta_n}x{_MMA_INST_K_BYTES}_cluster{cgrp_m}x{cgrp_n}"

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -2633,7 +2633,7 @@ def test_narrow_n_under_two_cta_mma_still_takes_the_tma_store(name: str) -> None
     g.matmul(A=A, B=B, name="mm").set_output(True)
     cfg = by_name(name)
     assert cfg.cta_tile_n < 64
-    assert _use_tma_store_epi(analyze(g), cfg, 16, 2) is True
+    assert _use_tma_store_epi(analyze(g), cfg, 2) is True
 
 
 @pytest.mark.parametrize(
@@ -2667,7 +2667,7 @@ def test_tma_store_serves_every_drain_height(name: str, cta_group: int, shape: t
         return g, A, B, C
 
     g, _, _, _ = build()
-    assert _store_modes(analyze(g), cfg, cta_group, _epi_vec_bytes(analyze(g), cfg, cta_group)) == ("tma",)
+    assert _store_modes(analyze(g), cfg, cta_group) == ("tma",)
 
     torch.manual_seed(0)
     a = torch.randn(1, M, K, device="cuda", dtype=torch.bfloat16)
@@ -2824,7 +2824,7 @@ def test_m_major_tma_store_serves_a_narrow_drain(name: str, cta_group: int) -> N
     g, _, _, _ = build()
     chain = analyze(g)
     assert chain.out_major == "m"
-    assert _store_modes(chain, cfg, cta_group, 16) == ("tma",)
+    assert _store_modes(chain, cfg, cta_group) == ("tma",)
 
     torch.manual_seed(0)
     a = torch.randn(1, m, k, device="cuda", dtype=torch.bfloat16)

--- a/test/python/gemm/frost/test_matmul.py
+++ b/test/python/gemm/frost/test_matmul.py
@@ -2618,38 +2618,6 @@ def test_tma_arm_never_writes_past_the_output_rows() -> None:
         assert touched == 0, f"{o.source}: the epilogue wrote {touched} bytes past its {rows} rows"
 
 
-@pytest.mark.parametrize("out_major,want", (("n", True), ("m", False)))
-def test_extra_dense_outputs_take_the_tma_store_only_when_n_major(out_major: str, want: bool) -> None:
-    """Extra dense outputs land through the STG emitters, which read `row` /
-    `col_j`. The N-major TMA arm hands them the same coordinates the STG arm
-    does, so they only need bounding. Under an M-major slot 0 they are the
-    subtile base and the drain runs the snippet twice — a scatter there would
-    double-fire at the wrong coordinates, so that stays on STG."""
-    from cudnn.gemm.frost.compiler import _use_tma_store_epi
-    from cudnn.gemm.frost.graph_analyzer import analyze
-
-    M = N = K = 256
-    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
-    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
-    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
-    C = g.matmul(A=A, B=B, name="mm")
-    # Every non-virtual output carries the same layout, so vary them together;
-    # the gate keys on SLOT 0's majorness because that is the arm the kernel
-    # renders.
-    R = g.relu(input=C, name="r")
-    Y = g.gelu_approx_tanh(input=R, name="ge")
-    for t in (R, Y):
-        if out_major == "m":
-            t.set_stride([M * N, 1, M])
-        t.set_output(True)
-
-    chain = analyze(g)
-    assert len(chain.output_specs) == 2
-    assert chain.out_major == out_major
-    cfg = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1")
-    assert _use_tma_store_epi(chain, cfg, 16, 1) is want
-
-
 @pytest.mark.parametrize("name", ["CONFIG_sm100_128x16x128_128x16x32_cluster2x1", "CONFIG_sm100_128x32x128_128x32x32_cluster2x1"])
 def test_narrow_n_under_two_cta_mma_still_takes_the_tma_store(name: str) -> None:
     """`cta_group == 2 and cta_tile_n < 64` used to fall back to STG on the
@@ -2669,24 +2637,55 @@ def test_narrow_n_under_two_cta_mma_still_takes_the_tma_store(name: str) -> None
 
 
 @pytest.mark.parametrize(
-    "name",
+    "name,cta_group",
     [
-        "CONFIG_sm100_256x128x128_128x128x32_cluster1x1",
-        "CONFIG_sm100_128x128x128_64x128x32_cluster1x1",
+        ("CONFIG_sm100_256x128x128_128x128x32_cluster1x1", 1),
+        ("CONFIG_sm100_128x128x128_64x128x32_cluster1x1", 1),
+        ("CONFIG_sm100_64x128x128_64x128x32_cluster1x1", 1),
+        ("CONFIG_sm100_64x128x128_64x128x32_cluster2x1", 2),
     ],
 )
-def test_tma_store_gate_follows_the_mma_block_height(name: str) -> None:
-    """The TMA-store epilogue stages one MMA-M block of rows, so its gate is on
-    mma_inst_m — an M=64 MMA block drains through the packed lane<16 layout."""
-    from cudnn.gemm.frost.compiler import _use_tma_store_epi
+@pytest.mark.parametrize("shape", [(4096, 4096, 512), (255, 256, 240)])
+def test_tma_store_serves_every_drain_height(name: str, cta_group: int, shape: tuple) -> None:
+    """`mma_inst_m` is 64 or 128 by construction, and the TMA-store epilogue
+    stages all three drain layouts: the full thread->row one at 128, the 1-CTA
+    packed `lane < 16` one at 64 (half the lanes carry nothing, so the staging
+    indexes by `row` and the side effects carry `row_active`), and the 2-CTA
+    2x2-DP one at 64 (two column halves per stage, one TMA box each)."""
+    from cudnn.gemm.frost.compiler import _epi_vec_bytes, _store_modes, jit_from_cudnn_graph
     from cudnn.gemm.frost.graph_analyzer import analyze
 
-    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
-    A = g.tensor(name="A", dim=[1, 256, 128], stride=[256 * 128, 128, 1])
-    B = g.tensor(name="B", dim=[1, 128, 256], stride=[128 * 256, 1, 128])
-    g.matmul(A=A, B=B, name="mm").set_output(True)
+    M, N, K = shape
     cfg = by_name(name)
-    assert _use_tma_store_epi(analyze(g), cfg, 16, 1) == (cfg.mma_inst_m == 128)
+
+    def build():
+        g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+        B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+        C = g.matmul(A=A, B=B, name="mm")
+        C.set_output(True).set_data_type(_BF16)
+        return g, A, B, C
+
+    g, _, _, _ = build()
+    assert _store_modes(analyze(g), cfg, cta_group, _epi_vec_bytes(analyze(g), cfg, cta_group)) == ("tma",)
+
+    torch.manual_seed(0)
+    a = torch.randn(1, M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(1, N, K, device="cuda", dtype=torch.bfloat16)
+
+    def run(force_stg: bool):
+        slack = 4096
+        raw = torch.full((2 * M * N + slack,), 0xAB, device="cuda", dtype=torch.uint8)
+        c = raw.view(torch.bfloat16)[: M * N].view(1, M, N)
+        c.zero_()
+        tail = raw[2 * M * N :].clone()
+        gg, aa, bb, cc = build()
+        jit_from_cudnn_graph(gg, config=cfg, cta_group=cta_group, force_stg_epi=force_stg)({aa: a, bb: b, cc: c})
+        torch.cuda.synchronize()
+        assert torch.equal(raw[2 * M * N :], tail), "the store ran past the output"
+        return c.clone()
+
+    assert torch.equal(run(False).view(torch.uint8), run(True).view(torch.uint8))
 
 
 @pytest.mark.parametrize(
@@ -2705,13 +2704,25 @@ def test_epi_smem_row_bytes_is_the_real_staging_alignment(name: str, cta_group: 
     attained at odd tidx. It was a hardcoded 64, which over-claims at
     cta_tile_n=16 (a 32-byte row) and under-claims at epi_n=64 / 4-byte output.
     `store_swizzled` forwards it as `assumed_align`, so an over-claim is a false
-    promise the backend may exploit."""
-    from cudnn.gemm.frost.compiler import _epi_n, _epi_swizzle_lines
+    promise the backend may exploit. It is per OUTPUT, not shared: `epi_n` is a
+    column count and only the element width differs."""
+    from cudnn.gemm.frost.compiler import _epi_n, _tma_store_sequence
     from cudnn.gemm.frost.dtypes import DTYPE_BYTES
+    from cudnn.gemm.frost.graph_analyzer import analyze
 
     cfg = by_name(name)
-    assert _epi_n(cfg, cta_group, out_dt) * DTYPE_BYTES[out_dt] == want
-    assert f"epi_smem_row_bytes = {want}" in _epi_swizzle_lines(cfg, cta_group, out_dt)
+    epi_n = _epi_n(cfg, cta_group, out_dt)
+    assert epi_n * DTYPE_BYTES[out_dt] == want
+
+    # The width is no longer a shared constant -- it is per output, so it is a
+    # literal in the store sequence the renderer unrolls.
+    M, N, K = 256, cfg.cta_tile_n, 256
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    g.matmul(A=A, B=B, name="mm").set_output(True).set_data_type(_CUDNN_DTYPE.get(out_dt, cudnn.data_type.FLOAT))
+    seq = _tma_store_sequence(analyze(g), cfg, cta_group, frozenset({0}), epi_n)
+    assert f"alignment={want}" in seq, seq
 
 
 def test_no_template_hardcodes_the_staging_alignment() -> None:
@@ -2778,34 +2789,130 @@ def test_epilogue_chunk_is_the_width_the_arm_hands_the_snippet(name: str, cta_gr
 
 
 @pytest.mark.parametrize(
-    "name,want_tma",
+    "name,cta_group",
     [
-        ("CONFIG_sm100_128x8x128_128x8x32_cluster1x1", False),
-        ("CONFIG_sm100_128x16x128_128x16x32_cluster1x1", True),
-        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1", True),
+        ("CONFIG_sm100_128x8x128_128x8x32_cluster1x1", 1),
+        ("CONFIG_sm100_128x16x128_128x16x32_cluster1x1", 1),
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1", 1),
+        ("CONFIG_sm100_128x256x128_128x256x32_cluster2x1", 2),
+        # the two `mma_inst_m == 64` drains: 1-CTA packed and 2-CTA 2x2-DP
+        ("CONFIG_sm100_64x128x128_64x128x32_cluster1x1", 1),
+        ("CONFIG_sm100_64x128x128_64x128x32_cluster2x1", 2),
     ],
 )
-def test_m_major_tma_store_needs_a_whole_stmatrix_block(name: str, want_tma: bool) -> None:
-    """The M-major arm transposes with `for _blk in range(epi_n // 16)` over
-    4-register stmatrix tiles, so `epi_n < 16` emits ZERO stores and the output
-    keeps whatever the buffer held. It is silent -- nothing faults, the shapes
-    are right, the values are stale. Found by the full suite the day
-    `_epi_swizzle_lines` stopped raising and this geometry started rendering."""
-    from cudnn.gemm.frost.compiler import _epi_n, _use_tma_store_epi
+def test_m_major_tma_store_serves_a_narrow_drain(name: str, cta_group: int) -> None:
+    """The M-major store stages an M-contiguous column with one scalar store per
+    drain column, so a narrow `epi_n` is just fewer stores. The arm it replaced
+    walked `range(epi_n // 16)` stmatrix blocks and emitted ZERO of them below
+    16 -- silent, not a fault -- which is what this geometry used to be rejected
+    for."""
+    from cudnn.gemm.frost.compiler import _store_modes, jit_from_cudnn_graph
     from cudnn.gemm.frost.graph_analyzer import analyze
 
     m, n, k = 256, 256, 256
-    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
-    A = g.tensor(name="A", dim=[1, m, k], stride=[m * k, k, 1])
-    B = g.tensor(name="B", dim=[1, k, n], stride=[k * n, 1, k])
-    C = g.matmul(A=A, B=B, name="mm")
-    C.set_output(True).set_data_type(_BF16)
-    C.set_stride([m * n, 1, m])
+    cfg = by_name(name)
+
+    def build():
+        g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        A = g.tensor(name="A", dim=[1, m, k], stride=[m * k, k, 1])
+        B = g.tensor(name="B", dim=[1, k, n], stride=[k * n, 1, k])
+        C = g.matmul(A=A, B=B, name="mm")
+        C.set_output(True).set_data_type(_BF16)
+        C.set_stride([m * n, 1, m])
+        return g, A, B, C
+
+    g, _, _, _ = build()
     chain = analyze(g)
     assert chain.out_major == "m"
-    cfg = by_name(name)
-    assert _use_tma_store_epi(chain, cfg, 16, 1) is want_tma
-    assert (_epi_n(cfg, 1, "bf16") >= 16) is want_tma
+    assert _store_modes(chain, cfg, cta_group, 16) == ("tma",)
+
+    torch.manual_seed(0)
+    a = torch.randn(1, m, k, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(1, n, k, device="cuda", dtype=torch.bfloat16)
+
+    def run(force_stg: bool):
+        slack = 4096
+        raw = torch.full((2 * n * m + slack,), 0xAB, device="cuda", dtype=torch.uint8)
+        c = raw.view(torch.bfloat16)[: n * m].view(1, n, m).transpose(1, 2)
+        tail = raw[2 * n * m :].clone()
+        gg, aa, bb, cc = build()
+        jit_from_cudnn_graph(gg, config=cfg, cta_group=cta_group, force_stg_epi=force_stg)({aa: a, bb: b, cc: c})
+        torch.cuda.synchronize()
+        assert torch.equal(raw[2 * n * m :], tail), "store ran past the output"
+        return c.contiguous()
+
+    assert torch.equal(run(False).view(torch.uint8), run(True).view(torch.uint8))
+
+
+@pytest.mark.parametrize("N,want_chunk", [(4096, 32), (384, 32), (40, 8), (24, 8), (8, 8)])
+def test_m_major_chunk_follows_n(N: int, want_chunk: int) -> None:
+    """An M-major output stores one element per chunk column through its own
+    strides, so its allowed store width does not bound the chunk -- N does. The
+    chunk walks N and the baked `sym_n` divisibility IS the chunk, so it must be
+    a power of two dividing N. An M-major output's own alignment measures the M
+    extent and says nothing about N, which is why it cannot supply this.
+
+    It used to be pinned at one element, which is always legal but costs ~1.5x on
+    the STG arm (4096^3 bf16 `64x128` 1ctamma: 160.5 -> 105.7 us)."""
+    from cudnn.gemm.frost.compiler import _epi_chunk_elems
+    from cudnn.gemm.frost.graph_analyzer import analyze
+
+    M, K = 256, 256
+    cfg = by_name("CONFIG_sm100_64x128x128_64x128x32_cluster1x1")
+    g = cudnn.pygraph(io_data_type=_BF16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    C = g.matmul(A=A, B=B, name="mm")
+    C.set_output(True).set_data_type(_BF16)
+    C.set_stride([M * N, 1, M])
+    chain = analyze(g)
+    assert chain.out_major == "m"
+    # the STG chunk specifically -- `_epi_chunk_elems(..., use_tma=False)` -- which
+    # is what an M-major scatter walks, whichever arm this config ends up on.
+    assert _epi_chunk_elems(chain, cfg, 1, False) == want_chunk
+
+
+def test_epi_n_divides_the_drain_width() -> None:
+    """`epi_n` is the TMA arm's subtile width, and an N-tile that is not a whole
+    number of subtiles would store a box past the tile edge into its neighbour
+    (TMA clamps only at the GLOBAL extent). So it must DIVIDE the drain width --
+    which is why it is a power of two dividing `cols`, not the power-of-two floor
+    OF `cols`. Flooring by value rejected every 8-multiple that is not a
+    32-multiple (48 -> 32, and 48 % 32 != 0), i.e. 65 % of the catalog."""
+    from cudnn.gemm.frost.compiler import _epi_n, _epi_tile_cols
+    from cudnn.gemm.frost.tile_config import CATALOG
+
+    seen_non_pow2_tile = False
+    for cfg in CATALOG:
+        for cta_group in (1, 2):
+            if cta_group == 2 and (cfg.cgrp_size_m % 2 or cfg.cta_tile_n % 16 or cfg.mma_inst_n % 16):
+                continue
+            cols = _epi_tile_cols(cfg, cta_group)
+            seen_non_pow2_tile |= cols & (cols - 1) != 0
+            for dt in ("bf16", "fp32", "fp8_e4m3", "fp4_e2m1"):
+                n = _epi_n(cfg, cta_group, dt)
+                assert n > 0 and n & (n - 1) == 0, (cfg.name, cta_group, dt, n)
+                assert cols % n == 0, f"{cfg.name} cta_group={cta_group} {dt}: epi_n {n} does not divide {cols}"
+    assert seen_non_pow2_tile, "the catalog no longer carries a non-power-of-2 drain width — the test is vacuous"
+
+
+def test_the_auto_path_never_picks_a_non_power_of_two_tile() -> None:
+    """`select_config` scores N only over {32,64,128,256}, so the widths the
+    divisor rule newly admits are reachable through a forced config, not through
+    the engine's own choice."""
+    from cudnn.gemm.frost.tile_config import select_config
+
+    widths = set()
+    for M in (64, 128, 512, 4096, 16384):
+        for N in (64, 128, 512, 4096, 11008):
+            for num_gemms in (1, 2, 3):
+                for block_scale in (False, True):
+                    try:
+                        widths.add(select_config(M, N, num_gemms=num_gemms, block_scale=block_scale)[0].cta_tile_n)
+                    except NotImplementedError:
+                        pass
+    assert widths, "select_config produced nothing — the sweep is vacuous"
+    assert all(w & (w - 1) == 0 for w in widths), sorted(widths)
 
 
 def test_templates_take_the_chunk_from_the_rendered_constant() -> None:

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -1539,6 +1539,47 @@ def test_matmul_tap_only() -> None:
     torch.testing.assert_close(c_term, torch.relu(mm).to(torch.bfloat16), atol=1e-1, rtol=1e-2)
 
 
+@pytest.mark.parametrize("N,want_chunk", [(256, 32), (384, 32), (40, 8), (24, 8)])
+def test_reduction_only_chain_sizes_its_chunk_from_n(N: int, want_chunk: int) -> None:
+    """A chain whose ONLY output is a reduction has no dense store to size the
+    epilogue chunk. It used to be sized off `chain.output_dtype`, which INVENTS a
+    bf16 output when there are no specs -- so the chunk came from a tensor that
+    does not exist, capped by that tensor's memory-access width. N is the real
+    bound: the chunk walks N and nothing else constrains it.
+
+    Nothing exercised this path before; the whole suite ran with it never taken."""
+    from cudnn.gemm.frost.compiler import _epi_chunk_elems, _store_modes, _epi_vec_bytes
+    from cudnn.gemm.frost.tile_config import by_name
+
+    M, K = 128, 64
+    cfg = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1")
+
+    def build():
+        g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+        B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+        Y = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="relu")
+        R = g.reduction(input=Y, mode=cudnn.reduction_mode.MAX, name="red")
+        R.set_dim([1, 1, 1]).set_stride([1, 1, 1]).set_output(True).set_data_type(cudnn.data_type.FLOAT)
+        return g, A, B, R
+
+    g, _, _, _ = build()
+    chain = analyze(g)
+    assert not chain.output_specs and len(chain.reductions) == 1
+    assert _epi_chunk_elems(chain, cfg, 1, False) == want_chunk
+    assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == ("stg",)
+
+    torch.manual_seed(0)
+    a = torch.randn(1, M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(1, N, K, device="cuda", dtype=torch.bfloat16)
+    r = torch.zeros(1, 1, 1, device="cuda", dtype=torch.float32)
+    gg, aa, bb, rr = build()
+    compiler.jit_from_cudnn_graph(gg, config=cfg, cta_group=1)({aa: a, bb: b, rr: r})
+    torch.cuda.synchronize()
+    ref = torch.relu(torch.einsum("bmk,bnk->bmn", a.float(), b.float())).max()
+    assert abs(r.item() - ref.item()) < 1e-3, (r.item(), ref.item())
+
+
 @pytest.mark.parametrize(
     "mode,ref_fn",
     (
@@ -2344,45 +2385,61 @@ def test_epi_n_is_one_shared_column_count_not_a_per_output_one(cfg_name: str, dt
     assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == want
 
 
-@pytest.mark.parametrize("majors,want", [(("n", "m"), ("tma", "stg")), (("m", "n"), ("stg", "stg"))])
-def test_an_output_laid_out_against_the_arm_stays_on_stg(majors: tuple, want: tuple) -> None:
-    """The kernel renders ONE store arm and it follows slot 0's layout, so an
-    output laid out the other way has no sequence to ride -- the M-major arm
-    transposes through stmatrix, the N-major one stages a row-major subtile.
-
-    Every non-virtual output is MEANT to carry the same layout, but nothing
-    enforces that yet -- `analyze` accepts a mixed-major graph, which is why this
-    test can build one.
-
-    The OUTCOME below is currently delivered by other rules, not by the same-arm
-    conjunct: an M-major output beside another dense output is rejected by the
-    M-major arm's single-output rule, and an N-major output under an M-major slot
-    0 is rejected because `_epi_vec_bytes` (a chain-level width taken from slot
-    0's layout) drops below 16 there. So the conjunct is redundant TODAY and this
-    test would pass without it -- it is kept as insurance and pinned separately
-    below, because both of those rejections are coincidental rather than about
-    the arm.
-
-    TODO: the M-major output path is due a refactor that supports MIXED
-    m/n-major alongside tmastg; this test and that conjunct go away with it."""
-    from cudnn.gemm.frost.compiler import _epi_vec_bytes, _store_modes
+@pytest.mark.parametrize(
+    "majors,want",
+    [
+        (("n", "n"), ("tma", "tma")),
+        (("n", "m"), ("tma", "tma")),
+        (("m", "m"), ("tma", "tma")),
+        (("m", "n"), ("tma", "tma")),
+    ],
+)
+def test_outputs_of_either_layout_share_one_epilogue(majors: tuple, want: tuple) -> None:
+    """Layout and store mode are independent axes: every output rides the same
+    row-per-lane fragment and differs only in how its store stages it, so one
+    epilogue serves any mix of m/n-major and any mix of tma/stg."""
+    from cudnn.gemm.frost.compiler import _epi_vec_bytes, _store_modes, jit_from_cudnn_graph
     from cudnn.gemm.frost.tile_config import by_name
 
     M = N = K = 256
-    g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
-    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
-    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
-    R = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
-    Y = g.gelu_approx_tanh(input=R, name="ge")
-    for t, mj in zip((R, Y), majors):
-        if mj == "m":
-            t.set_stride([M * N, 1, M])
-        t.set_output(True)
-
-    chain = analyze(g)
-    assert [o.major for o in chain.output_specs] == list(majors), "the mixed-major graph must still be buildable"
     cfg = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster1x1")
+
+    def build():
+        g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+        B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+        R = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+        Y = g.gelu_approx_tanh(input=R, name="ge")
+        for t, mj in zip((R, Y), majors):
+            if mj == "m":
+                t.set_stride([M * N, 1, M])
+            t.set_output(True)
+        return g, A, B, R, Y
+
+    g, *_ = build()
+    chain = analyze(g)
     assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == want
+
+    torch.manual_seed(0)
+    a = torch.randn(1, M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(1, N, K, device="cuda", dtype=torch.bfloat16)
+
+    def run(force_stg: bool):
+        slack, outs, raws = 4096, [], []
+        for mj in majors:
+            raw = torch.full((2 * M * N + slack,), 0xAB, device="cuda", dtype=torch.uint8)
+            v = raw.view(torch.bfloat16)[: M * N]
+            outs.append(v.view(1, N, M).transpose(1, 2) if mj == "m" else v.view(1, M, N))
+            raws.append((raw, raw[2 * M * N :].clone()))
+        gg, aa, bb, rr, yy = build()
+        jit_from_cudnn_graph(gg, config=cfg, cta_group=1, force_stg_epi=force_stg)({aa: a, bb: b, rr: outs[0], yy: outs[1]})
+        torch.cuda.synchronize()
+        for raw, tail in raws:
+            assert torch.equal(raw[2 * M * N :], tail), "a store ran past its output"
+        return [o.contiguous() for o in outs]
+
+    for got, ref in zip(run(False), run(True)):
+        assert torch.equal(got.view(torch.uint8), ref.view(torch.uint8))
 
 
 def test_both_renderers_emit_the_tma_output_COUNT_not_a_flag() -> None:
@@ -2433,14 +2490,198 @@ def test_both_renderers_emit_the_tma_output_COUNT_not_a_flag() -> None:
         assert int(m.group(1)) == want, f"emitted {m.group(1)}, real TMA slots {want}"
 
 
-def test_the_store_gate_still_guards_against_the_wrong_arm() -> None:
-    """The same-arm conjunct is redundant today (see
-    `test_an_output_laid_out_against_the_arm_stays_on_stg`), so no behavioural
-    test can protect it. Pin it at the source instead: if it is deleted, the
-    protection is gone the moment either of the coincidental rejections moves."""
-    src = inspect.getsource(compiler._output_store_mode)
-    assert "out.major != chain.out_major" in src, "the wrong-arm guard is gone"
-    assert "TODO" in src, "keep the pointer to the M-major refactor that removes it"
+def test_a_quant_output_must_carry_a_quantized_data_dtype() -> None:
+    """An output holding `quant_idx` IS that node's quantized data, so its dtype
+    has to be one the quantizer emits. The check needs BOTH halves -- the dtype
+    is on the OutputSpec, the quant node is on the chain -- so it lives in
+    `FusionChain.__post_init__` beside the other cross-references, not on either
+    piece alone. ue5m3 is deliberately absent: it is a SCALE format
+    (`BlockQuantizeSpec.scale_dtype`, validated there), carried as an opaque
+    byte, never quantized DATA."""
+    from cudnn.gemm.frost.fusion_ir import (
+        QUANT_DATA_DTYPES,
+        BlockQuantizeSpec,
+        FusionChain,
+        MatmulSpec,
+        OutputSpec,
+        gemm_source,
+    )
+
+    assert "fp8_e5m3" not in QUANT_DATA_DTYPES
+    assert "fp8_e5m3" in BlockQuantizeSpec(source_ref=gemm_source(0), block_size=32, scale_dtype="fp8_e5m3").scale_dtype
+
+    mm = MatmulSpec(M=256, N=256, K=256, batch=1, a_batch=1, b_batch=1)
+    q = BlockQuantizeSpec(source_ref=gemm_source(0), block_size=32)
+
+    def build(dtype: str) -> FusionChain:
+        return FusionChain(matmul=mm, ops=[], quants=[q], output_specs=[OutputSpec(source_ref=gemm_source(0), dtype=dtype, quant_idx=0)])
+
+    for dtype in QUANT_DATA_DTYPES:
+        build(dtype)
+    for dtype in ("bf16", "fp32", "fp8_e5m3"):
+        with pytest.raises(ValueError, match="quantized DATA"):
+            build(dtype)
+    # It is NOT a constraint on an ordinary output of the same dtype.
+    FusionChain(matmul=mm, ops=[], output_specs=[OutputSpec(source_ref=gemm_source(0), dtype="bf16")])
+
+
+@pytest.mark.parametrize(
+    "cfg_name,cta_group",
+    [
+        ("CONFIG_sm100_128x128x128_128x128x32_cluster1x1", 1),
+        ("CONFIG_sm100_128x256x128_128x256x32_cluster2x1", 2),
+        ("CONFIG_sm100_256x256x128_128x256x32_cluster1x1", 1),
+        ("CONFIG_sm100_64x128x128_64x128x32_cluster1x1", 1),
+    ],
+)
+@pytest.mark.parametrize("second", ["bf16", "fp32"])
+def test_smem_d_reserve_matches_what_the_templates_stage(cfg_name: str, cta_group: int, second: str) -> None:
+    """The epilogue ring's per-stage size is computed in THREE places: the host
+    reserve (`_smem_d_bytes`, subtracted from the AB budget), the template's own
+    `epi_subtile_elems`, and each TMA output's typed view of a slot. They must
+    agree -- a reserve that is too small overflows the ring, one that is too large
+    silently costs an `ab_stage`.
+
+    The template's formula is READ here, not restated, so changing it fails this
+    rather than drifting."""
+    import cutlass
+    import cutlass.cute as cute
+    import cutlass.experimental.cuda.tensor_map as _tma
+    import cutlass.experimental.primitives as nvvm
+    from cudnn.gemm.frost.compiler import (
+        _EPI_SMEM_STAGES,
+        _epi_n,
+        _epi_vec_bytes,
+        _epi_stage_rows,
+        _render_tile_constants,
+        _smem_d_bytes,
+        _tma_out_dtypes,
+        _tma_slots_for,
+    )
+    from cudnn.gemm.frost.dtypes import DTYPE_BYTES
+    from cudnn.gemm.frost.tile_config import by_name
+
+    tmpl = pathlib.Path(cudnn.__file__).parent / "gemm" / "frost" / "kernel_templates"
+    formulas = set()
+    for f in sorted(tmpl.glob("sm*.py")):
+        got = [l.strip() for l in f.read_text().split("\n") if l.strip().startswith("epi_subtile_elems = ")]
+        assert len(got) == 1, f.name
+        formulas.add(got[0])
+    assert len(formulas) == 1, f"templates disagree on the ring slot size: {formulas}"
+
+    CU = {"bf16": cudnn.data_type.BFLOAT16, "fp32": cudnn.data_type.FLOAT}
+    M = N = K = 256
+    g = cudnn.pygraph(io_data_type=CU["bf16"], intermediate_data_type=CU["fp32"], compute_data_type=CU["fp32"])
+    A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+    B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+    cur = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+    cur.set_output(True).set_data_type(CU["bf16"])
+    g.mul(a=cur, b=cur, name="sq").set_output(True).set_data_type(CU[second])
+    chain = analyze(g)
+    cfg = by_name(cfg_name)
+
+    ns = {"cutlass": cutlass, "cute": cute, "nvvm": nvvm, "_tma": _tma, "num_epilogue_warps": 4}
+    exec(_render_tile_constants(cfg, chain, cta_group), ns)
+    exec(formulas.pop(), ns)
+    slot_bytes = ns["epi_subtile_elems"] * (ns["cd_dtype"].width // 8)
+
+    assert _EPI_SMEM_STAGES * slot_bytes + 16 == _smem_d_bytes(cfg, chain, cta_group)
+
+    epi_n = _epi_n(cfg, cta_group, chain.output_dtype)
+    slots = _tma_slots_for(chain, cfg, cta_group, _epi_vec_bytes(chain, cfg, cta_group))
+    for _slot, dt in _tma_out_dtypes(chain, slots):
+        view = _epi_stage_rows(cfg, cta_group) * epi_n * DTYPE_BYTES[dt]
+        assert view <= slot_bytes, f"{dt} view {view}B does not fit a {slot_bytes}B slot"
+
+
+@pytest.mark.parametrize("cfg_name,cta_group", [("CONFIG_sm100_128x128x128_128x128x32_cluster1x1", 1), ("CONFIG_sm100_128x256x128_128x256x32_cluster2x1", 2)])
+@pytest.mark.parametrize("block_size", (16, 32))
+def test_sub_byte_output_takes_the_tma_store(cfg_name: str, cta_group: int, block_size: int) -> None:
+    """An fp4 quant DATA output rides the TMA arm. It is the one dtype whose
+    element is narrower than the carrier its descriptor is declared with, so
+    `epi_n` (LOGICAL columns) and the ring row, the box and the store coordinate
+    (all PACKED) part company -- mixing the two is what kept it on STG.
+
+    Measured 4096x4096x4096 nvfp4 out, `128x128` 1ctamma: 83.0 vs 85.5 us."""
+    from cudnn.gemm.frost.compiler import _epi_row_bytes, _epi_vec_bytes, _store_modes, jit_from_cudnn_graph
+    from cudnn.gemm.frost.tile_config import by_name
+
+    M = K = 256
+    N = 256
+    cfg = by_name(cfg_name)
+
+    def build():
+        g = cudnn.pygraph(io_data_type=cudnn.data_type.BFLOAT16, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+        B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+        Y = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+        q, sf = g.block_scale_quantize(input=Y, block_size=block_size, axis=2, name="q")
+        q.set_output(True).set_data_type(cudnn.data_type.FP4_E2M1)
+        sf.set_output(True).set_data_type(cudnn.data_type.FP8_E8M0)
+        return g, A, B, q, sf
+
+    g, _, _, _, _ = build()
+    chain = analyze(g)
+    assert _store_modes(chain, cfg, cta_group, _epi_vec_bytes(chain, cfg, cta_group)) == ("tma", "stg")
+    # the packed row is half the logical column count, in bytes
+    assert _epi_row_bytes("fp4_e2m1", 32) == 16 and _epi_row_bytes("bf16", 32) == 64
+
+    torch.manual_seed(0)
+    a = torch.randn(1, M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(1, N, K, device="cuda", dtype=torch.bfloat16)
+
+    def run(force_stg: bool):
+        nbytes, slack = M * (N // 2), 4096
+        raw = torch.full((nbytes + slack,), 0xAB, device="cuda", dtype=torch.uint8)
+        data = raw[:nbytes].view(1, M, N // 2)
+        data.zero_()
+        tail = raw[nbytes:].clone()
+        scale = torch.zeros(1, M, N // block_size, device="cuda", dtype=torch.float8_e8m0fnu)
+        gg, aa, bb, qq, ss = build()
+        jit_from_cudnn_graph(gg, config=cfg, cta_group=cta_group, force_stg_epi=force_stg)({aa: a, bb: b, qq: data, ss: scale})
+        torch.cuda.synchronize()
+        assert torch.equal(raw[nbytes:], tail), "the store ran past the packed output"
+        return data.clone(), scale.view(torch.uint8).clone()
+
+    got_d, got_s = run(False)
+    ref_d, ref_s = run(True)
+    assert torch.equal(got_d, ref_d)
+    assert torch.equal(got_s, ref_s)
+
+
+def test_only_a_tma_stored_output_widens_the_ring() -> None:
+    """The ring slot spans the widest TMA-stored output's element width. An
+    output that takes STG never touches the ring, so it must not size it -- a
+    wide STG-only output beside a narrow TMA one used to double the reserve and
+    take the bytes straight out of `ab_stages`."""
+    from cudnn.gemm.frost.compiler import _epi_slot_widen, _epi_vec_bytes, _smem_d_bytes, _store_modes
+    from cudnn.gemm.frost.tile_config import by_name
+
+    CU = {"bf16": cudnn.data_type.BFLOAT16, "fp32": cudnn.data_type.FLOAT}
+    M = N = K = 256
+
+    def build(second: str) -> FusionChain:
+        g = cudnn.pygraph(io_data_type=CU["bf16"], intermediate_data_type=CU["fp32"], compute_data_type=CU["fp32"])
+        A = g.tensor(name="A", dim=[1, M, K], stride=[M * K, K, 1])
+        B = g.tensor(name="B", dim=[1, K, N], stride=[K * N, 1, K])
+        cur = g.relu(input=g.matmul(A=A, B=B, name="mm"), name="r")
+        cur.set_output(True).set_data_type(CU["bf16"])
+        g.mul(a=cur, b=cur, name="sq").set_output(True).set_data_type(CU[second])
+        return analyze(g)
+
+    # epi_n = 64 here, so an fp32 output's 256-byte staging row has no swizzle
+    # and it declines the TMA arm.
+    stg = by_name("CONFIG_sm100_256x256x128_128x256x32_cluster1x1")
+    chain = build("fp32")
+    assert _store_modes(chain, stg, 1, _epi_vec_bytes(chain, stg, 1)) == ("tma", "stg")
+    assert _epi_slot_widen(chain, stg, 1) == 1
+    assert _smem_d_bytes(stg, chain, 1) == _smem_d_bytes(stg, build("bf16"), 1)
+
+    # ...but at epi_n = 32 the same fp32 output IS TMA-stored, and then it does.
+    tma = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster1x1")
+    chain = build("fp32")
+    assert _store_modes(chain, tma, 1, _epi_vec_bytes(chain, tma, 1)) == ("tma", "tma")
+    assert _epi_slot_widen(chain, tma, 1) == 2
 
 
 def test_more_than_one_output_can_take_the_tma_store() -> None:
@@ -2465,7 +2706,7 @@ def test_more_than_one_output_can_take_the_tma_store() -> None:
     assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == ("tma", "tma")
     # The ring is typed as the primary slot's dtype, so a wider companion widens
     # the SLOT rather than adding a second ring.
-    assert _epi_slot_widen(chain) == 2
+    assert _epi_slot_widen(chain, cfg, 1) == 2
 
 
 def test_every_dense_store_on_the_tma_arm_carries_the_row_bound() -> None:
@@ -2510,11 +2751,11 @@ def test_every_dense_store_on_the_tma_arm_carries_the_row_bound() -> None:
 
 
 def test_coordinate_reading_pointwise_is_not_a_store_rule() -> None:
-    """Neither arm's store rule may consult how a pointwise input reads its
-    coordinates. What differs between the arms is the element -> (row, col) MAP,
-    and `_elem_coord` publishes it; asking "does this graph read coordinates" in
-    the gate is the shape of the bug, not the fix."""
-    for fn in (compiler._tma_store_n_major_ok, compiler._tma_store_m_major_ok, compiler._tma_store_geometry_ok):
+    """The store rule may not consult how a pointwise input reads its
+    coordinates. Every arm hands the snippet the SAME row-per-lane fragment, so
+    `row` / `col_j` are always its real coordinates; asking "does this graph read
+    coordinates" in the gate is the shape of the bug, not the fix."""
+    for fn in (compiler._output_store_mode,):
         tree = ast.parse(textwrap.dedent(inspect.getsource(fn)))
         # The prose may name these; the CODE may not.
         body = tree.body[0].body
@@ -2525,13 +2766,16 @@ def test_coordinate_reading_pointwise_is_not_a_store_rule() -> None:
             assert probe not in src, f"{fn.__name__} consults {probe}: that is a pointwise concern"
 
 
-def test_m_major_tap_scatter_covers_the_whole_fragment() -> None:
-    """The M-major TMA scatter walks one register per element, so its trip count
-    is the chunk (`epi_n // 2`), not a constant. It was pinned at 16 -- exact
-    only at epi_n == 32, dropping half the tap at the 64 the wide tiles reach."""
-    src = pathlib.Path(epilogue_codegen.__file__).read_text()
-    assert "cutlass.range_constexpr(16)" not in src, "the M-major scatter trip count must follow vsize"
-    assert "for _tr_{tap_idx} in cutlass.range_constexpr({vsize}):" in src
+def test_m_major_scatter_covers_the_whole_chunk() -> None:
+    """An M-major output stores one element per chunk column through its own
+    strides. The trip count must follow the chunk -- it was once pinned at 16,
+    exact only at `epi_n == 32` and dropping half the output at the 64 the wide
+    tiles reach."""
+    from cudnn.gemm.frost.epilogue_codegen import _emit_mmajor_scatter
+
+    for vsize in (8, 16, 32, 64):
+        lines = _emit_mmajor_scatter(0, 0, "vec_out", "bf16", 1, vsize)
+        assert sum(".store(" in l for l in lines) == vsize, vsize
 
 
 def test_tma_staged_values_reach_the_store_as_vectors() -> None:
@@ -2546,12 +2790,12 @@ def test_tma_staged_values_reach_the_store_as_vectors() -> None:
 
     sites = src.count("cute.make_rmem_tensor(")
     converted = src.count(".load().to_vector()")
-    assert sites == 5, (
-        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 5. A new one either "
+    assert sites == 4, (
+        f"epilogue_codegen has {sites} make_rmem_tensor sites, expected 4. A new one either "
         f"converts with .load().to_vector() or its feature stays off the TMA arm -- decide which, "
         f"then update this test."
     )
-    assert converted == 6, f"expected exactly 6 converted rmem loads, found {converted}"
+    assert converted == 5, f"expected exactly 5 converted rmem loads, found {converted}"
     # The two block-quantize emitters were the last holdouts: their result now
     # reaches a TMA-stored dense output, so they must convert like the rest.
     assert src.count("_out = cute.make_rmem_tensor(") == 2

--- a/test/python/gemm/frost/test_matmul_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_matmul_epilogue_fusion.py
@@ -1567,7 +1567,7 @@ def test_reduction_only_chain_sizes_its_chunk_from_n(N: int, want_chunk: int) ->
     chain = analyze(g)
     assert not chain.output_specs and len(chain.reductions) == 1
     assert _epi_chunk_elems(chain, cfg, 1, False) == want_chunk
-    assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == ("stg",)
+    assert _store_modes(chain, cfg, 1) == ("stg",)
 
     torch.manual_seed(0)
     a = torch.randn(1, M, K, device="cuda", dtype=torch.bfloat16)
@@ -2382,7 +2382,7 @@ def test_epi_n_is_one_shared_column_count_not_a_per_output_one(cfg_name: str, dt
 
     chain = analyze(g)
     cfg = by_name(cfg_name)
-    assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == want
+    assert _store_modes(chain, cfg, 1) == want
 
 
 @pytest.mark.parametrize(
@@ -2418,7 +2418,7 @@ def test_outputs_of_either_layout_share_one_epilogue(majors: tuple, want: tuple)
 
     g, *_ = build()
     chain = analyze(g)
-    assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == want
+    assert _store_modes(chain, cfg, 1) == want
 
     torch.manual_seed(0)
     a = torch.randn(1, M, K, device="cuda", dtype=torch.bfloat16)
@@ -2478,7 +2478,7 @@ def test_both_renderers_emit_the_tma_output_COUNT_not_a_flag() -> None:
     chain = analyze(g)
     assert chain.has_block_scale
     cfg = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster1x1")
-    want = len(_tma_slots_for(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)))
+    want = len(_tma_slots_for(chain, cfg, 1))
     assert want == 2, "this graph is meant to put BOTH outputs on the surface"
 
     for render in (
@@ -2588,7 +2588,7 @@ def test_smem_d_reserve_matches_what_the_templates_stage(cfg_name: str, cta_grou
     assert _EPI_SMEM_STAGES * slot_bytes + 16 == _smem_d_bytes(cfg, chain, cta_group)
 
     epi_n = _epi_n(cfg, cta_group, chain.output_dtype)
-    slots = _tma_slots_for(chain, cfg, cta_group, _epi_vec_bytes(chain, cfg, cta_group))
+    slots = _tma_slots_for(chain, cfg, cta_group)
     for _slot, dt in _tma_out_dtypes(chain, slots):
         view = _epi_stage_rows(cfg, cta_group) * epi_n * DTYPE_BYTES[dt]
         assert view <= slot_bytes, f"{dt} view {view}B does not fit a {slot_bytes}B slot"
@@ -2622,7 +2622,7 @@ def test_sub_byte_output_takes_the_tma_store(cfg_name: str, cta_group: int, bloc
 
     g, _, _, _, _ = build()
     chain = analyze(g)
-    assert _store_modes(chain, cfg, cta_group, _epi_vec_bytes(chain, cfg, cta_group)) == ("tma", "stg")
+    assert _store_modes(chain, cfg, cta_group) == ("tma", "stg")
     # the packed row is half the logical column count, in bytes
     assert _epi_row_bytes("fp4_e2m1", 32) == 16 and _epi_row_bytes("bf16", 32) == 64
 
@@ -2673,14 +2673,14 @@ def test_only_a_tma_stored_output_widens_the_ring() -> None:
     # and it declines the TMA arm.
     stg = by_name("CONFIG_sm100_256x256x128_128x256x32_cluster1x1")
     chain = build("fp32")
-    assert _store_modes(chain, stg, 1, _epi_vec_bytes(chain, stg, 1)) == ("tma", "stg")
+    assert _store_modes(chain, stg, 1) == ("tma", "stg")
     assert _epi_slot_widen(chain, stg, 1) == 1
     assert _smem_d_bytes(stg, chain, 1) == _smem_d_bytes(stg, build("bf16"), 1)
 
     # ...but at epi_n = 32 the same fp32 output IS TMA-stored, and then it does.
     tma = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster1x1")
     chain = build("fp32")
-    assert _store_modes(chain, tma, 1, _epi_vec_bytes(chain, tma, 1)) == ("tma", "tma")
+    assert _store_modes(chain, tma, 1) == ("tma", "tma")
     assert _epi_slot_widen(chain, tma, 1) == 2
 
 
@@ -2703,7 +2703,7 @@ def test_more_than_one_output_can_take_the_tma_store() -> None:
     chain = _an(g)
 
     cfg = by_name("CONFIG_sm100_128x256x128_128x256x32_cluster1x1")
-    assert _store_modes(chain, cfg, 1, _epi_vec_bytes(chain, cfg, 1)) == ("tma", "tma")
+    assert _store_modes(chain, cfg, 1) == ("tma", "tma")
     # The ring is typed as the primary slot's dtype, so a wider companion widens
     # the SLOT rather than adding a second ring.
     assert _epi_slot_widen(chain, cfg, 1) == 2

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -561,6 +561,57 @@ def test_moe_grouped_matmul_fwd_auto_config_n_major_small_n() -> None:
     torch.testing.assert_close(output[0], _ref_f32(token, weight_k, offsets, S, N, E).to(torch.bfloat16), atol=1e-1, rtol=1e-2)
 
 
+@pytest.mark.parametrize("cta_group", (1, 2))
+def test_moe_m_major_output(cta_group: int) -> None:
+    """A routed MoE output may be M-major. It takes STG: TMA would clip D to
+    `group_end` on the INNERMOST dim of a transposed descriptor, whose extent TMA
+    requires to be 16-byte aligned, and routed group bounds are runtime data --
+    a group ending at row 100 (200 B) faults, 104 (208 B) does not."""
+    from cudnn.gemm.frost.compiler import _epi_vec_bytes, _store_modes, jit_from_cudnn_graph
+    from cudnn.gemm.frost.graph_analyzer import analyze
+    from cudnn.gemm.frost.tile_config import by_name
+
+    S, N, K, E = 512, 256, 128, 3
+    bounds = [0, 100, 300]  # neither tile- nor 16-byte-aligned
+    BF = cudnn.data_type.BFLOAT16
+    cfg = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1" if cta_group == 1 else "CONFIG_sm100_128x256x128_128x256x32_cluster2x1")
+
+    def build():
+        g = cudnn.pygraph(io_data_type=BF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+        tok = g.tensor(name="token", dim=[1, S, K], stride=[S * K, K, 1], data_type=BF)
+        w = g.tensor(name="weight", dim=[E, K, N], stride=[K * N, 1, K], data_type=BF)
+        fto = g.tensor(name="first_token_offset", dim=[E, 1, 1], stride=[1, 1, 1], data_type=cudnn.data_type.INT32)
+        out = g.moe_grouped_matmul(tok, w, fto, mode=cudnn.moe_grouped_matmul_mode.NONE, compute_data_type=cudnn.data_type.FLOAT, name="moe")
+        out.set_data_type(BF).set_output(True)
+        out.set_stride([S * N, 1, S])
+        return g, tok, w, fto, out
+
+    g, _, _, _, _ = build()
+    chain = analyze(g)
+    assert chain.out_major == "m"
+    assert _store_modes(chain, cfg, cta_group, _epi_vec_bytes(chain, cfg, cta_group)) == ("stg",)
+
+    torch.manual_seed(0)
+    tk = torch.randn(1, S, K, device="cuda", dtype=torch.bfloat16)
+    wt = torch.randn(E, N, K, device="cuda", dtype=torch.bfloat16)
+    ft = torch.tensor(bounds, device="cuda", dtype=torch.int32)
+    slack = 4096
+    raw = torch.full((2 * S * N + slack,), 0xAB, device="cuda", dtype=torch.uint8)
+    out = raw.view(torch.bfloat16)[: S * N].view(1, N, S).transpose(1, 2)
+    out.zero_()
+    tail = raw[2 * S * N :].clone()
+    gg, tt, ww, ff, oo = build()
+    jit_from_cudnn_graph(gg, config=cfg, cta_group=cta_group)({tt: tk, ww: wt, ff: ft, oo: out})
+    torch.cuda.synchronize()
+
+    ref = torch.zeros(1, S, N, device="cuda", dtype=torch.float32)
+    b = bounds + [S]
+    for gi in range(E):
+        ref[0, b[gi] : b[gi + 1]] = tk[0, b[gi] : b[gi + 1]].float() @ wt[gi].float().T
+    assert torch.equal(raw[2 * S * N :], tail), "the store ran past the output"
+    assert (out.float() - ref).abs().max().item() < 0.5
+
+
 def test_moe_grouped_matmul_fwd_rejects_m_major_token() -> None:
     from cudnn.gemm.frost.compiler import jit_from_cudnn_graph
 

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd.py
@@ -589,7 +589,7 @@ def test_moe_m_major_output(cta_group: int) -> None:
     g, _, _, _, _ = build()
     chain = analyze(g)
     assert chain.out_major == "m"
-    assert _store_modes(chain, cfg, cta_group, _epi_vec_bytes(chain, cfg, cta_group)) == ("stg",)
+    assert _store_modes(chain, cfg, cta_group) == ("stg",)
 
     torch.manual_seed(0)
     tk = torch.randn(1, S, K, device="cuda", dtype=torch.bfloat16)

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd_epilogue_fusion.py
@@ -878,6 +878,6 @@ def test_per_group_per_col_aux_group_stride_need_not_divide_the_chunk() -> None:
     # `_N` is 256 here, so assert on the rule's shape rather than on this N:
     # nothing in the gate may consult a per-group aux's stride.
     assert _use_tma_store_epi(chain, cfg, 16, 1) is True
-    src = inspect.getsource(compiler._tma_store_n_major_ok)
+    src = inspect.getsource(compiler._output_store_mode)
     for probe in ("grouped_by_moe", "bcast_mode", "aux_tensors"):
         assert probe not in src, f"{probe}: an aux load's alignment is a pointwise concern, not a store rule"

--- a/test/python/gemm/frost/test_moe_grouped_matmul_fwd_epilogue_fusion.py
+++ b/test/python/gemm/frost/test_moe_grouped_matmul_fwd_epilogue_fusion.py
@@ -877,7 +877,7 @@ def test_per_group_per_col_aux_group_stride_need_not_divide_the_chunk() -> None:
     cfg = by_name("CONFIG_sm100_128x128x128_128x128x32_cluster1x1")
     # `_N` is 256 here, so assert on the rule's shape rather than on this N:
     # nothing in the gate may consult a per-group aux's stride.
-    assert _use_tma_store_epi(chain, cfg, 16, 1) is True
+    assert _use_tma_store_epi(chain, cfg, 1) is True
     src = inspect.getsource(compiler._output_store_mode)
     for probe in ("grouped_by_moe", "bcast_mode", "aux_tensors"):
         assert probe not in src, f"{probe}: an aux load's alignment is a pointwise concern, not a store rule"


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Unify the m-major epilogue logic with n-major, enabling flexible transpose in the epilogue

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-output layouts and data types, including mixed outputs, packed lanes, sub-byte formats, and M-major output handling.
  * Improved grouped and multi-operation workloads with flexible scaling descriptors and runtime workspace support.
  * Expanded output-layout validation and support for varied drain sizes and alignment patterns.

* **Bug Fixes**
  * Improved output-bound safety, staging-size calculations, and store selection across supported layouts.
  * Corrected automatic tile selection and invalid configuration handling.

* **Tests**
  * Added broad coverage for output correctness, quantization, reductions, staging, grouped workloads, and narrow output shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->