### PR TITLE
ci: require Milestone and Projects fields on PRs before merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 - [ ] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
 - [ ] I ran `pre-commit run` and committed any formatting changes.
 - [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
+- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).
 
 ## Affected area
 

--- a/.github/workflows/pr-merge-requirements.yml
+++ b/.github/workflows/pr-merge-requirements.yml
@@ -1,0 +1,92 @@
+name: PR merge requirements
+
+# Blocks merging until the PR has a Milestone and is on at least one Project
+# board. Runs as `pull_request_target` so that PRs from forks get the repo
+# secrets; this is safe because the job never checks out or executes PR code —
+# it only queries PR metadata.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - edited
+      - labeled
+      - unlabeled
+      - milestoned
+      - demilestoned
+
+permissions:
+  pull-requests: read
+
+jobs:
+  merge-requirements:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check milestone and project assignment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fine-grained PAT with organization "Projects: read" access; the
+          # built-in GITHUB_TOKEN cannot read Projects v2.
+          PROJECT_READ_TOKEN: ${{ secrets.PROJECT_READ_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
+        run: |
+          set -u
+
+          # Bot PRs (dependabot, github-actions, ...) are exempt.
+          if [ "${AUTHOR_TYPE}" = "Bot" ]; then
+            echo "PR author is a bot — merge requirements do not apply."
+            exit 0
+          fi
+
+          # Query live PR state rather than the (possibly stale) event
+          # payload, so that re-running this check after fixing the fields
+          # passes without needing a new PR event.
+          pr_json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
+
+          if echo "${pr_json}" | jq -e 'any(.labels[]; .name == "cat-routine-update")' > /dev/null; then
+            echo "PR is labeled cat-routine-update — merge requirements do not apply."
+            exit 0
+          fi
+
+          failed=0
+
+          milestone=$(echo "${pr_json}" | jq -r '.milestone.title // empty')
+          if [ -n "${milestone}" ]; then
+            echo "Milestone: ${milestone}"
+          else
+            echo "::error::This PR has no Milestone."
+            failed=1
+          fi
+
+          if [ -z "${PROJECT_READ_TOKEN:-}" ]; then
+            echo "::error::The PROJECT_READ_TOKEN repository secret is not configured, so the Projects field cannot be verified. Ask a repository admin to set it (a PAT with read access to organization projects)."
+            failed=1
+          else
+            project_count=$(GH_TOKEN="${PROJECT_READ_TOKEN}" gh api graphql \
+              -F owner="${REPO%/*}" -F name="${REPO#*/}" -F number="${PR_NUMBER}" \
+              -f query='query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  pullRequest(number: $number) {
+                    projectItems(first: 1) { totalCount }
+                  }
+                }
+              }' --jq '.data.repository.pullRequest.projectItems.totalCount')
+            if [ "${project_count}" -gt 0 ] 2> /dev/null; then
+              echo "PR is on ${project_count} project board(s)."
+            else
+              echo "::error::This PR is not on any Project board."
+              failed=1
+            fi
+          fi
+
+          if [ "${failed}" -ne 0 ]; then
+            echo ""
+            echo "Set the Milestone and Projects fields in the PR sidebar, then re-run this check from the Checks tab."
+            echo "(Adding a PR to a Project does not automatically re-trigger this check; changing the milestone does.)"
+            exit 1
+          fi
+          echo "All merge requirements satisfied."


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

CI or test infrastructure

## Summary

Adds a `PR merge requirements` workflow whose `merge-requirements` job fails while a PR has no **Milestone** or is not on any **Project** board, plus a PR-template checkbox reminding authors to set both fields. Exemptions: bot-authored PRs (dependabot, github-actions, ...) and PRs labeled `cat-routine-update`.

Design notes:
- Runs as `pull_request_target` so PRs from forks get repository secrets. This is safe: the job never checks out or executes PR code, it only queries PR metadata.
- The Projects lookup requires a `PROJECT_READ_TOKEN` repository secret (PAT with read access to organization projects) because the built-in `GITHUB_TOKEN` cannot read Projects v2. Until the secret is configured the check fails with an explicit message.
- The check queries **live** PR state instead of the event payload, so after setting the fields a manual **Re-run** from the Checks tab turns it green. (Adding a PR to a Project emits no PR event; milestone and label changes do re-trigger.)

## Why

Milestone and Project assignment on merged PRs is currently enforced only by convention, and several PRs land without them. Making this a status check (and later a required one via the branch ruleset) guarantees the fields are filled before merge while keeping bot/routine traffic unaffected.

## Related issues

None.

## API and compatibility impact

None (CI only). Note for rollout: after this merges and is verified on a live PR, a repo admin should (1) set the `PROJECT_READ_TOKEN` secret and (2) add `merge-requirements` as a required status check to the `push-protect` ruleset.

## Testing

- `python3 -c 'yaml.safe_load(...)'` — workflow YAML parses.
- `bash -n` on the embedded script — syntax OK.
- `pre-commit run --files ...` — clean (no hooks apply to YAML/Markdown).
- The workflow cannot run on this PR itself (`pull_request_target` executes the base-branch version), so end-to-end behavior will be verified with a throwaway PR after merge: missing fields → red, fields set + re-run → green, `cat-routine-update` label → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to ensure pull requests have both a Milestone and Project assigned before merging.
  * Added clear guidance when required metadata is missing.

* **Documentation**
  * Updated the pull request checklist to remind contributors to set Milestone and Project fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->