### PR TITLE
ci: report a clear error when the Projects lookup fails in merge-requirements

### DIFF
--- a/.github/workflows/pr-merge-requirements.yml
+++ b/.github/workflows/pr-merge-requirements.yml
@@ -74,9 +74,13 @@ jobs:
                     projectItems(first: 1) { totalCount }
                   }
                 }
-              }' --jq '.data.repository.pullRequest.projectItems.totalCount')
-            if [ "${project_count}" -gt 0 ] 2> /dev/null; then
+              }' --jq '.data.repository.pullRequest.projectItems.totalCount' \
+              2> gh_stderr.txt) || project_count=""
+            if [ -n "${project_count}" ] && [ "${project_count}" -gt 0 ] 2> /dev/null; then
               echo "PR is on ${project_count} project board(s)."
+            elif [ -z "${project_count}" ]; then
+              echo "::error::Could not query the Projects field. Is the PROJECT_READ_TOKEN secret a valid PAT with read access to organization projects? API said: $(tr '\n' ' ' < gh_stderr.txt)"
+              failed=1
             else
               echo "::error::This PR is not on any Project board."
               failed=1


### PR DESCRIPTION
## Summary

Follow-up to #736. If the `PROJECT_READ_TOKEN` PAT is rejected by the API (observed: the NVIDIA enterprise forbids classic PATs with lifetime > 366 days), the GraphQL call aborted the script via errexit, so the check failed with only "Process completed with exit code 1" and the API error buried in the log. Capture the failure and emit an explicit `::error::` including the API message. The check fails closed either way; this only fixes the diagnostics.

## Why

Seen live on the first run of the check (run 32890104163 on test PR #738).

## Testing

YAML parses; `bash -n` clean on the embedded script; will be exercised on throwaway PR #738 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project assignment checks to distinguish between successful responses with no assignments and failed requests.
  - Failed project queries now report the underlying error and correctly mark the check as unsuccessful.
  - Prevented stale project counts from being retained after a request failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->