### PR TITLE
ci: enforce pre-commit style check via GitHub Actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,36 @@
+name: Style check
+
+# Enforces the formatting contract in CONTRIBUTING.md: clang-format for
+# C++/CUDA and black (line length 160) for Python/notebooks, exactly as
+# pinned in .pre-commit-config.yaml — CI runs the same hooks contributors
+# run locally.
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit on all files
+        run: |
+          pip install pre-commit
+          pre-commit run --all-files --show-diff-on-failure --color always

--- a/benchmark/attention_inference/benchmark_single_attention.py
+++ b/benchmark/attention_inference/benchmark_single_attention.py
@@ -240,10 +240,18 @@ def setup_cudnn_fp8(args, cudnn, oss=False):
     q, k, v = graph.tensor_like(q_gpu), graph.tensor_like(k_gpu), graph.tensor_like(v_gpu)
     scalars = {n: graph.tensor_like(t) for n, t in ones.items()}
     kwargs = dict(
-        q=q, k=k, v=v,
-        descale_q=scalars["dq"], descale_k=scalars["dk"], descale_v=scalars["dv"],
-        descale_s=scalars["ds"], scale_s=scalars["ss"], scale_o=scalars["so"],
-        is_inference=True, attn_scale=args.sm_scale, name="sdpa_fp8",
+        q=q,
+        k=k,
+        v=v,
+        descale_q=scalars["dq"],
+        descale_k=scalars["dk"],
+        descale_v=scalars["dv"],
+        descale_s=scalars["ds"],
+        scale_s=scalars["ss"],
+        scale_o=scalars["so"],
+        is_inference=True,
+        attn_scale=args.sm_scale,
+        name="sdpa_fp8",
     )
     if args.phase == "generation" and sq > 1:
         kwargs["use_causal_mask_bottom_right"] = True
@@ -725,12 +733,22 @@ def main():
     ms = time_fn(fn, args.num_warmup_iterations, args.num_iterations)
 
     flops = attention_flops(
-        args.batch_size, args.q_tokens, args.kv_len, args.num_q_heads, args.head_dim_qk, args.head_dim_vo,
+        args.batch_size,
+        args.q_tokens,
+        args.kv_len,
+        args.num_q_heads,
+        args.head_dim_qk,
+        args.head_dim_vo,
         causal_prefill=args.causal and args.phase == "context",
     )
     byts = attention_bytes(
-        args.batch_size, args.q_tokens, args.kv_len, args.num_q_heads, args.num_kv_heads,
-        args.head_dim_qk, args.head_dim_vo,
+        args.batch_size,
+        args.q_tokens,
+        args.kv_len,
+        args.num_q_heads,
+        args.num_kv_heads,
+        args.head_dim_qk,
+        args.head_dim_vo,
         kv_shared=args.kind == "mla_absorbed",
         sliding_window=args.sliding_window_size,
         kv_elt_size=1 if args.kv_cache_dtype == "fp8_e4m3" else 2,
@@ -742,10 +760,7 @@ def main():
     peak = get_peak_bw_gbps()
     sol = f"{gbps / peak * 100.0:.4f}" if peak else ""
 
-    print(
-        f"RESULT,{ms:.6f},{tflops:.3f},{gbps:.3f},{sol},"
-        f"{torch.cuda.get_device_name().replace(',', ';')},{detail.replace(',', ';')}"
-    )
+    print(f"RESULT,{ms:.6f},{tflops:.3f},{gbps:.3f},{sol}," f"{torch.cuda.get_device_name().replace(',', ';')},{detail.replace(',', ';')}")
 
 
 if __name__ == "__main__":

--- a/benchmark/attention_inference/configs/qwen3vl_vit.py
+++ b/benchmark/attention_inference/configs/qwen3vl_vit.py
@@ -34,16 +34,16 @@ CONFIG = InferenceBenchmarkConfig(
     name="qwen3vl_vit",
     models=[QWEN3VL_VIT],
     context_seqlens=[
-        8836,   # 94x94 patch grid
+        8836,  # 94x94 patch grid
         15376,  # 124x124 (most frequent single-image forward)
         24336,  # 156x156
         35344,  # 188x188 (FLOPs-median forward)
         47376,  # non-square grid (e.g. 168x282)
         62500,  # 250x250
     ],
-    context_chunked_shapes=[],   # encoder: no chunked prefill against a cache
-    generation_shapes=[],        # encoder: no decode phase
-    context_causal=False,        # bidirectional ViT self-attention
+    context_chunked_shapes=[],  # encoder: no chunked prefill against a cache
+    generation_shapes=[],  # encoder: no decode phase
+    context_causal=False,  # bidirectional ViT self-attention
     # bf16 only: this suite expresses fp8 solely as the generation-phase
     # kv-cache axis (the fp8 attention graph), and an encoder has no
     # generation phase — the context path has no fp8 route today. The training

--- a/python/cudnn/frost/README.md
+++ b/python/cudnn/frost/README.md
@@ -810,6 +810,6 @@ Asserts:
     frontend-integration test that it appears in `graph.plans` and runs when
     pinned. Mark test modules `pytest.mark.L0` -- the default pytest addopts
     is `-m L0` and unmarked tests silently never run. Run
-    `ci/run_style_check_diff.sh --apply` (black, 160 cols) before pushing.
+    `pre-commit run --all-files` (black, 160 cols) before pushing.
 13. **Keep this document true.** If code and this contract disagree and you
     change the code, change this file in the same commit.

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -249,9 +249,7 @@ def _check_dsl_sm100_strided_stats(d_qk, d_v):
     v = _bhsd(b, h, s, d_v, dtype)
 
     _, contiguous_stats = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), return_stats=True)
-    o, strided_stats = _run_dsl_graph(
-        q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), return_stats=True, stats_layout="strided"
-    )
+    o, strided_stats = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), return_stats=True, stats_layout="strided")
     o_ref, stats_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True, return_stats=True)
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
     torch.testing.assert_close(strided_stats, contiguous_stats, atol=0, rtol=0)


### PR DESCRIPTION
## What

Adds `.github/workflows/pre-commit.yml`: a **Style check** workflow that runs `pre-commit run --all-files` on every PR and on pushes to `develop`/`main`, on a plain `ubuntu-latest` runner (no GPU). Hook environments are cached keyed on the config hash, so steady-state runs take seconds.

This enforces in CI exactly what [CONTRIBUTING.md](../blob/develop/CONTRIBUTING.md) already asks contributors to run locally — clang-format v21.1.6 for C++/CUDA and black 26.3.1 (line length 160) for Python/notebooks, as pinned in `.pre-commit-config.yaml` — replacing the internal `analysis:clang-format` GitLab job (removed separately), which used unpinned tool versions from the CI image and occupied a GPU runner for a pure text check.

## Included cleanup

- One-time black fix for the 3 files the hook currently flags (`benchmark/attention_inference/benchmark_single_attention.py`, `benchmark/attention_inference/configs/qwen3vl_vit.py`, `test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py`) so the check passes from day one. `benchmark/` was never covered by the old script, which is how these drifted.
- Fix a stale frost README reference to the internal-only `ci/run_style_check_diff.sh` (points to `pre-commit run --all-files` now).

## Verification

`pre-commit run --all-files` passes locally on this branch (clang-format, black, black-jupyter all green). The workflow itself will run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated formatting checks for pull requests and pushes to the primary development branches.
  - Formatting checks now provide clear, colorized differences when validation fails.

- **Documentation**
  - Updated contributor guidance to use the current pre-commit formatting workflow.

- **Style**
  - Standardized formatting across attention benchmarks, vision configuration files, and SDPA tests without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->