### PR TITLE
add-dynamic-scheduler-for-moe

### DIFF
--- a/python/cudnn/gemm/frost/compiler.py
+++ b/python/cudnn/gemm/frost/compiler.py
@@ -3497,6 +3497,7 @@ def _resolve_moe_variant_pack(compiled, variant_pack: dict):
 
 
 # One 128-byte TMA tensormap slot per CTA per distinct A operand.
+_MOE_SCHED_COUNTER_SLOTS = 1
 _MOE_DESC_SLOT_BYTES = 128
 
 
@@ -3525,6 +3526,19 @@ def _register_legacy_device_view_adapter() -> None:
         # 128-byte tensormap slot the MoE workspace fake declares.
         ptr = view.data_ptr()
         return from_dlpack(view, assumed_align=min(ptr & -ptr, _MOE_DESC_SLOT_BYTES))
+
+
+def _moe_reset_sched_counter(workspace, desc_slots: int, stream) -> None:
+    """Zero the dynamic tile scheduler's global counter, stream-ordered.
+
+    It lives in the slot past the per-CTA descriptor scratch, so it rides the
+    same buffer and the same stable pointer that makes the plan graph-safe.
+    A 4-byte D32 memset, not a kernel."""
+    buffers.memset_zero_async(
+        workspace.data_ptr() + desc_slots * _MOE_DESC_SLOT_BYTES,
+        4,
+        _as_custream(stream),
+    )
 
 
 def _moe_carve_workspace(caller, n_slots: int, plan: str):
@@ -3586,7 +3600,7 @@ class CompiledMoeGemm:
         """Per-CTA tensormap scratch: one 128-byte slot per CTA per patched
         descriptor. The persistent grid is shape-independent, so this is
         constant for the plan — which is why override-shape needs no re-query."""
-        return self._grid_ctas * self._desc_slots_per_cta * _MOE_DESC_SLOT_BYTES
+        return (self._grid_ctas * self._desc_slots_per_cta + _MOE_SCHED_COUNTER_SLOTS) * _MOE_DESC_SLOT_BYTES
 
     def _make_workspace(self, n_slots, caller=None):
         """The per-CTA tensormap GMEM workspace (16 int64/slot, 128-byte
@@ -3666,7 +3680,8 @@ class CompiledMoeGemm:
             for spec, ci in zip(outputs_spec, c_perms)
         ]
         # Tensormap workspace: one 128-byte slot per CTA per patched descriptor.
-        workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta, workspace)
+        workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta + _MOE_SCHED_COUNTER_SLOTS, workspace)
+        _moe_reset_sched_counter(workspace, self._grid_ctas * self._desc_slots_per_cta, stream)
         return self._launchable(
             problem_size,
             first_token_offset,
@@ -3787,7 +3802,8 @@ class CompiledMoeGemm:
                 )
         aux = tuple(_maybe_wrap_layout(_reshape_aux_to_fake(t, ref), _LEADING_DIM_AUX) for ref, t in zip(chain.aux_tensors, aux))
         # Workspace: one 128-B tensormap slot per patched descriptor per CTA.
-        workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta, workspace)
+        workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta + _MOE_SCHED_COUNTER_SLOTS, workspace)
+        _moe_reset_sched_counter(workspace, self._grid_ctas * self._desc_slots_per_cta, stream)
         return self._launchable(
             problem_size,
             first_token_offset,
@@ -3946,7 +3962,7 @@ class CompiledMoeBlockScaleGemm:
         """Per-CTA A-descriptor scratch: one 128-byte tensormap slot per CTA per
         distinct A operand. The persistent grid is shape-independent, so this is
         constant for the plan — which is why override-shape needs no re-query."""
-        return self._grid_ctas * self._desc_slots_per_cta * _MOE_DESC_SLOT_BYTES
+        return (self._grid_ctas * self._desc_slots_per_cta + _MOE_SCHED_COUNTER_SLOTS) * _MOE_DESC_SLOT_BYTES
 
     def _make_workspace(self, n_slots, caller=None):
         """The per-CTA A-descriptor GMEM workspace (16 int64/slot, 128-byte
@@ -4034,7 +4050,8 @@ class CompiledMoeBlockScaleGemm:
         ]
         msfa = _maybe_wrap_layout(sfa.permute(1, 2, 0), _LEADING_DIM_AUX)
         msfb = _maybe_wrap_layout(sfb.permute(1, 2, 0), _LEADING_DIM_AUX)
-        workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta, workspace)
+        workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta + _MOE_SCHED_COUNTER_SLOTS, workspace)
+        _moe_reset_sched_counter(workspace, self._grid_ctas * self._desc_slots_per_cta, stream)
         return self._launchable(
             problem_size,
             first_token_offset,
@@ -4169,7 +4186,8 @@ class CompiledMoeBlockScaleGemm:
                     f"per-group aux {ref.name!r} must be rank-3 with leading dim " f"{num_groups} (the first_token_offset length); got shape {tuple(t.shape)}"
                 )
         aux = tuple(_maybe_wrap_layout(_reshape_aux_to_fake(t, ref), _LEADING_DIM_AUX) for ref, t in zip(chain.aux_tensors, aux))
-        workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta, workspace)
+        workspace = self._make_workspace(self._grid_ctas * self._desc_slots_per_cta + _MOE_SCHED_COUNTER_SLOTS, workspace)
+        _moe_reset_sched_counter(workspace, self._grid_ctas * self._desc_slots_per_cta, stream)
         return self._launchable(
             problem_size,
             first_token_offset,

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -55,6 +55,7 @@ if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_
 
 # Per-CTA scheduler ring (replaces CLC): 2 stages, 8 int32 slot words.
 SCHED_STAGES = 2
+SCHED_BCAST_STAGES = 2
 SCHED_SLOT_WORDS = 8
 
 USE_PDL = True
@@ -161,7 +162,11 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
-    cluster_linear_init = bidx // cluster_m
+    sched_counter_ptr = cute.make_ptr(
+        cutlass.Int32,
+        (a_tma_workspace.iterator.raw_ptr() + grid_num_clusters * cluster_m * cluster_n * moe_desc_slots * TENSOR_MAP_QWORDS).toint(),
+        mem_space=cute.AddressSpace.generic,
+    )
 
     a_pattern = 0
     for n_idx in cutlass.range_constexpr(cluster_n):
@@ -203,6 +208,9 @@ def _kernel(
     )
     sched_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     sched_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_slot = cutlass.Array(cutlass.Int32, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=16)
+    sched_bcast_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     tma_a_desc_smem_list = [
         cutlass.Array(
             cutlass.Int64,
@@ -306,6 +314,11 @@ def _kernel(
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
             if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
+        for i in range(SCHED_BCAST_STAGES):
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_full_mbar_ptr.subview(i), 1)
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_empty_mbar_ptr.subview(i), cluster_size)
     nvvm.fence_mbarrier_init()
 
     if cutlass.const_expr(cluster_shape_mnk[0] * cluster_shape_mnk[1] > 1):
@@ -342,7 +355,10 @@ def _kernel(
         gemm_s = cutlass.Int32(M)
         sched_stage = cutlass.Int32(0)
         sched_empty_phase = cutlass.Int32(1)
-        linear_idx = cutlass.Int32(cluster_linear_init)
+        bcast_stage = cutlass.Int32(0)
+        bcast_full_phase = cutlass.Int32(0)
+        bcast_empty_phase = cutlass.Int32(1)
+        linear_idx = cutlass.Int32(0)
         start_linear_idx = cutlass.Int32(0)
         total_tiles = cutlass.Int32(0)
         start_sf_block_m = cutlass.Int32(0)
@@ -360,6 +376,44 @@ def _kernel(
             cached_next_begin = tile_lower_bound
 
         while is_tile_valid != 0:
+            # Dynamic tile assignment: the cluster leader claims the next GLOBAL
+            # tile index and broadcasts it, so the clusters live at any instant
+            # sit in one contiguous window of tile space and share L2. Static
+            # striding lets them drift apart and share nothing.
+            if cta_rank_in_cluster == 0:
+                while not nvvm.mbarrier_try_wait_parity(
+                    sched_bcast_empty_mbar_ptr.subview(bcast_stage),
+                    bcast_empty_phase,
+                    time_limit=10_000_000,
+                ):
+                    pass
+                claimed = cutlass.Int32(0)
+                if lane == 0:
+                    claimed = nvvm.atomicrmw(
+                        "add",
+                        sched_counter_ptr,
+                        cutlass.Int32(1),
+                        mem_order="relaxed",
+                        syncscope="gpu",
+                    )
+                claimed = nvvm.shfl_sync(full_warp_mask, claimed, 0, shfl_idx_clamp, nvvm.Shfl.IDX)
+                if lane < cluster_size:
+                    (nvvm.mapa(sched_bcast_slot.subview(bcast_stage), lane)).store(claimed)
+                    nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_full_mbar_ptr.subview(bcast_stage), lane))
+            while not nvvm.mbarrier_try_wait_parity(
+                sched_bcast_full_mbar_ptr.subview(bcast_stage),
+                bcast_full_phase,
+                time_limit=10_000_000,
+            ):
+                pass
+            linear_idx = (sched_bcast_slot.subview(bcast_stage)).load()
+            if lane == 0:
+                nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))
+            bcast_stage += 1
+            if bcast_stage == SCHED_BCAST_STAGES:
+                bcast_stage = cutlass.Int32(0)
+                bcast_full_phase = bcast_full_phase ^ 1
+                bcast_empty_phase = bcast_empty_phase ^ 1
             group_begin = cached_next_begin
             group_end = cached_next_end
 
@@ -522,7 +576,6 @@ def _kernel(
                     _moe_auto_swizzle_w(group_nt_m * cgrp_tile_mnk[0], N, k, clusters_along_n),
                 )
                 coord_expert = group_idx % num_experts
-                linear_idx += grid_num_clusters
 
             while not nvvm.mbarrier_try_wait_parity(
                 sched_empty_mbar_ptr.subview(sched_stage),
@@ -1428,7 +1481,7 @@ def compile() -> Callable:
     grid_ctas = grid_num_clusters * cluster_m * cluster_n
     fake_a_tma_workspace = make_fake_compact_tensor(
         cutlass.Int64,
-        (grid_ctas * moe_desc_slots * 16,),
+        (grid_ctas * moe_desc_slots * 16 + 16,),
         stride_order=(0,),
         assumed_align=128,
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -56,6 +56,7 @@ if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_
 
 
 SCHED_STAGES = 2
+SCHED_BCAST_STAGES = 2
 SCHED_SLOT_WORDS = 8
 
 USE_PDL = True
@@ -154,7 +155,11 @@ def _kernel(
     is_pair_leader = pair_member == 0
     pair_leader_rank = pair_m_idx * 2 + n_rank * cluster_m
 
-    cluster_linear_init = bidx // cluster_m
+    sched_counter_ptr = cute.make_ptr(
+        cutlass.Int32,
+        (a_tma_workspace.iterator.raw_ptr() + grid_num_clusters * cluster_m * cluster_n * moe_desc_slots * TENSOR_MAP_QWORDS).toint(),
+        mem_space=cute.AddressSpace.generic,
+    )
 
     if warp_idx == mma_warp_id:
         for _i in cutlass.range_constexpr(num_a_operands):
@@ -203,6 +208,9 @@ def _kernel(
     )
     sched_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     sched_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_slot = cutlass.Array(cutlass.Int32, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=16)
+    sched_bcast_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     tma_a_desc_smem_list = [
         cutlass.Array(
             cutlass.Int64,
@@ -311,6 +319,11 @@ def _kernel(
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
             if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
+        for i in range(SCHED_BCAST_STAGES):
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_full_mbar_ptr.subview(i), 1)
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_empty_mbar_ptr.subview(i), cluster_size)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
 
@@ -347,7 +360,10 @@ def _kernel(
         gemm_s = cutlass.Int32(M)
         sched_stage = cutlass.Int32(0)
         sched_empty_phase = cutlass.Int32(1)
-        linear_idx = cutlass.Int32(cluster_linear_init)
+        bcast_stage = cutlass.Int32(0)
+        bcast_full_phase = cutlass.Int32(0)
+        bcast_empty_phase = cutlass.Int32(1)
+        linear_idx = cutlass.Int32(0)
         start_linear_idx = cutlass.Int32(0)
         total_tiles = cutlass.Int32(0)
         start_sf_block_m = cutlass.Int32(0)
@@ -365,6 +381,44 @@ def _kernel(
             cached_next_begin = tile_lower_bound
 
         while is_tile_valid != 0:
+            # Dynamic tile assignment: the cluster leader claims the next GLOBAL
+            # tile index and broadcasts it, so the clusters live at any instant
+            # sit in one contiguous window of tile space and share L2. Static
+            # striding lets them drift apart and share nothing.
+            if cta_rank_in_cluster == 0:
+                while not nvvm.mbarrier_try_wait_parity(
+                    sched_bcast_empty_mbar_ptr.subview(bcast_stage),
+                    bcast_empty_phase,
+                    time_limit=10_000_000,
+                ):
+                    pass
+                claimed = cutlass.Int32(0)
+                if lane == 0:
+                    claimed = nvvm.atomicrmw(
+                        "add",
+                        sched_counter_ptr,
+                        cutlass.Int32(1),
+                        mem_order="relaxed",
+                        syncscope="gpu",
+                    )
+                claimed = nvvm.shfl_sync(full_warp_mask, claimed, 0, shfl_idx_clamp, nvvm.Shfl.IDX)
+                if lane < cluster_size:
+                    (nvvm.mapa(sched_bcast_slot.subview(bcast_stage), lane)).store(claimed)
+                    nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_full_mbar_ptr.subview(bcast_stage), lane))
+            while not nvvm.mbarrier_try_wait_parity(
+                sched_bcast_full_mbar_ptr.subview(bcast_stage),
+                bcast_full_phase,
+                time_limit=10_000_000,
+            ):
+                pass
+            linear_idx = (sched_bcast_slot.subview(bcast_stage)).load()
+            if lane == 0:
+                nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))
+            bcast_stage += 1
+            if bcast_stage == SCHED_BCAST_STAGES:
+                bcast_stage = cutlass.Int32(0)
+                bcast_full_phase = bcast_full_phase ^ 1
+                bcast_empty_phase = bcast_empty_phase ^ 1
             group_begin = cached_next_begin
             group_end = cached_next_end
 
@@ -527,7 +581,6 @@ def _kernel(
                     _moe_auto_swizzle_w(group_nt_m * cgrp_tile_mnk[0], N, k, clusters_along_n),
                 )
                 coord_expert = group_idx % num_experts
-                linear_idx += grid_num_clusters
 
             while not nvvm.mbarrier_try_wait_parity(
                 sched_empty_mbar_ptr.subview(sched_stage),
@@ -1496,7 +1549,7 @@ def compile() -> Callable:
     grid_ctas = grid_num_clusters * cluster_m * cluster_n
     fake_a_tma_workspace = make_fake_compact_tensor(
         cutlass.Int64,
-        (grid_ctas * moe_desc_slots * 16,),
+        (grid_ctas * moe_desc_slots * 16 + 16,),
         stride_order=(0,),
         assumed_align=128,
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_1ctamma.py
@@ -52,6 +52,7 @@ moe_desc_slots = num_a_operands + n_tma_outputs
 
 
 SCHED_STAGES = 2
+SCHED_BCAST_STAGES = 2
 SCHED_SLOT_WORDS = 8
 
 # Programmatic Dependent Launch (PDL, sm_90+).
@@ -136,7 +137,11 @@ def _kernel(
     m_rank = cta_rank_in_cluster % cluster_m
     n_rank = cta_rank_in_cluster // cluster_m
 
-    cluster_linear_init = bidx // cluster_m
+    sched_counter_ptr = cute.make_ptr(
+        cutlass.Int32,
+        (a_tma_workspace.iterator.raw_ptr() + grid_num_clusters * cluster_m * cluster_n * moe_desc_slots * TENSOR_MAP_QWORDS).toint(),
+        mem_space=cute.AddressSpace.generic,
+    )
 
     if warp_idx == mma_warp_id:
         for _i in cutlass.range_constexpr(num_a_operands):
@@ -186,6 +191,9 @@ def _kernel(
     )
     sched_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     sched_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_slot = cutlass.Array(cutlass.Int32, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=16)
+    sched_bcast_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
 
     sA_elems = cta_tile_mnk[0] * cta_tile_mnk[2]
     sB_elems = cta_tile_mnk[1] * cta_tile_mnk[2]
@@ -258,6 +266,11 @@ def _kernel(
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
             if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
+        for i in range(SCHED_BCAST_STAGES):
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_full_mbar_ptr.subview(i), 1)
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_empty_mbar_ptr.subview(i), cluster_size)
     nvvm.fence_mbarrier_init()
     if cutlass.const_expr(cluster_shape_mnk[0] * cluster_shape_mnk[1] > 1):
         nvvm.barrier_cluster_arrive_relaxed()
@@ -308,7 +321,10 @@ def _kernel(
         gemm_s = cutlass.Int32(M)
         sched_stage = cutlass.Int32(0)
         sched_empty_phase = cutlass.Int32(1)
-        linear_idx = cutlass.Int32(cluster_linear_init)
+        bcast_stage = cutlass.Int32(0)
+        bcast_full_phase = cutlass.Int32(0)
+        bcast_empty_phase = cutlass.Int32(1)
+        linear_idx = cutlass.Int32(0)
         start_linear_idx = cutlass.Int32(0)
         total_tiles = cutlass.Int32(0)
         scan_base = cutlass.Int32(0)
@@ -318,6 +334,44 @@ def _kernel(
         is_tile_valid = cutlass.Int32(1)
 
         while is_tile_valid != 0:
+            # Dynamic tile assignment: the cluster leader claims the next GLOBAL
+            # tile index and broadcasts it, so the clusters live at any instant
+            # sit in one contiguous window of tile space and share L2. Static
+            # striding lets them drift apart and share nothing.
+            if cta_rank_in_cluster == 0:
+                while not nvvm.mbarrier_try_wait_parity(
+                    sched_bcast_empty_mbar_ptr.subview(bcast_stage),
+                    bcast_empty_phase,
+                    time_limit=10_000_000,
+                ):
+                    pass
+                claimed = cutlass.Int32(0)
+                if lane == 0:
+                    claimed = nvvm.atomicrmw(
+                        "add",
+                        sched_counter_ptr,
+                        cutlass.Int32(1),
+                        mem_order="relaxed",
+                        syncscope="gpu",
+                    )
+                claimed = nvvm.shfl_sync(full_warp_mask, claimed, 0, shfl_idx_clamp, nvvm.Shfl.IDX)
+                if lane < cluster_size:
+                    (nvvm.mapa(sched_bcast_slot.subview(bcast_stage), lane)).store(claimed)
+                    nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_full_mbar_ptr.subview(bcast_stage), lane))
+            while not nvvm.mbarrier_try_wait_parity(
+                sched_bcast_full_mbar_ptr.subview(bcast_stage),
+                bcast_full_phase,
+                time_limit=10_000_000,
+            ):
+                pass
+            linear_idx = (sched_bcast_slot.subview(bcast_stage)).load()
+            if lane == 0:
+                nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))
+            bcast_stage += 1
+            if bcast_stage == SCHED_BCAST_STAGES:
+                bcast_stage = cutlass.Int32(0)
+                bcast_full_phase = bcast_full_phase ^ 1
+                bcast_empty_phase = bcast_empty_phase ^ 1
             if linear_idx >= start_linear_idx + total_tiles:
                 is_search_live = cutlass.Int32(1)
                 while is_search_live != 0:
@@ -386,7 +440,6 @@ def _kernel(
                     _moe_auto_swizzle_w(group_nt_m * cgrp_tile_mnk[0], N, k, clusters_along_n),
                 )
                 coord_expert = group_idx % num_experts
-                linear_idx += grid_num_clusters
 
             while not nvvm.mbarrier_try_wait_parity(
                 sched_empty_mbar_ptr.subview(sched_stage),
@@ -1076,7 +1129,7 @@ def compile() -> Callable:
     grid_ctas = grid_num_clusters * cluster_m * cluster_n
     fake_a_tma_workspace = make_fake_compact_tensor(
         cutlass.Int64,
-        (grid_ctas * moe_desc_slots * 16,),
+        (grid_ctas * moe_desc_slots * 16 + 16,),
         stride_order=(0,),
         assumed_align=128,
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm100_moe_grouped_matmul_fwd_2ctamma.py
@@ -55,6 +55,7 @@ moe_desc_slots = num_a_operands + n_tma_outputs
 
 # Scheduler ring depth.
 SCHED_STAGES = 2
+SCHED_BCAST_STAGES = 2
 
 # Number of i32 slots per scheduler ring stage.
 SCHED_SLOT_WORDS = 8
@@ -145,7 +146,11 @@ def _kernel(
     is_pair_leader = pair_member == 0
     pair_leader_rank = pair_m_idx * 2 + n_rank * cluster_m
 
-    cluster_linear_init = bidx // cluster_m
+    sched_counter_ptr = cute.make_ptr(
+        cutlass.Int32,
+        (a_tma_workspace.iterator.raw_ptr() + grid_num_clusters * cluster_m * cluster_n * moe_desc_slots * TENSOR_MAP_QWORDS).toint(),
+        mem_space=cute.AddressSpace.generic,
+    )
 
     if warp_idx == mma_warp_id:
         for _i in cutlass.range_constexpr(num_a_operands):
@@ -191,6 +196,9 @@ def _kernel(
     )
     sched_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     sched_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_slot = cutlass.Array(cutlass.Int32, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=16)
+    sched_bcast_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
 
     sA_elems = cta_tile_mnk[0] * cgrp_tile_mnk[2]
     sB_elems = cta_tile_mnk[1] * cgrp_tile_mnk[2]
@@ -268,6 +276,11 @@ def _kernel(
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
             if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
+        for i in range(SCHED_BCAST_STAGES):
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_full_mbar_ptr.subview(i), 1)
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_empty_mbar_ptr.subview(i), cluster_size)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
 
@@ -321,7 +334,10 @@ def _kernel(
         gemm_s = cutlass.Int32(M)
         sched_stage = cutlass.Int32(0)
         sched_empty_phase = cutlass.Int32(1)
-        linear_idx = cutlass.Int32(cluster_linear_init)
+        bcast_stage = cutlass.Int32(0)
+        bcast_full_phase = cutlass.Int32(0)
+        bcast_empty_phase = cutlass.Int32(1)
+        linear_idx = cutlass.Int32(0)
         start_linear_idx = cutlass.Int32(0)
         total_tiles = cutlass.Int32(0)
         scan_base = cutlass.Int32(0)
@@ -331,6 +347,44 @@ def _kernel(
         is_tile_valid = cutlass.Int32(1)
 
         while is_tile_valid != 0:
+            # Dynamic tile assignment: the cluster leader claims the next GLOBAL
+            # tile index and broadcasts it, so the clusters live at any instant
+            # sit in one contiguous window of tile space and share L2. Static
+            # striding lets them drift apart and share nothing.
+            if cta_rank_in_cluster == 0:
+                while not nvvm.mbarrier_try_wait_parity(
+                    sched_bcast_empty_mbar_ptr.subview(bcast_stage),
+                    bcast_empty_phase,
+                    time_limit=10_000_000,
+                ):
+                    pass
+                claimed = cutlass.Int32(0)
+                if lane == 0:
+                    claimed = nvvm.atomicrmw(
+                        "add",
+                        sched_counter_ptr,
+                        cutlass.Int32(1),
+                        mem_order="relaxed",
+                        syncscope="gpu",
+                    )
+                claimed = nvvm.shfl_sync(full_warp_mask, claimed, 0, shfl_idx_clamp, nvvm.Shfl.IDX)
+                if lane < cluster_size:
+                    (nvvm.mapa(sched_bcast_slot.subview(bcast_stage), lane)).store(claimed)
+                    nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_full_mbar_ptr.subview(bcast_stage), lane))
+            while not nvvm.mbarrier_try_wait_parity(
+                sched_bcast_full_mbar_ptr.subview(bcast_stage),
+                bcast_full_phase,
+                time_limit=10_000_000,
+            ):
+                pass
+            linear_idx = (sched_bcast_slot.subview(bcast_stage)).load()
+            if lane == 0:
+                nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))
+            bcast_stage += 1
+            if bcast_stage == SCHED_BCAST_STAGES:
+                bcast_stage = cutlass.Int32(0)
+                bcast_full_phase = bcast_full_phase ^ 1
+                bcast_empty_phase = bcast_empty_phase ^ 1
             if linear_idx >= start_linear_idx + total_tiles:
                 is_search_live = cutlass.Int32(1)
                 while is_search_live != 0:
@@ -399,7 +453,6 @@ def _kernel(
                     _moe_auto_swizzle_w(group_nt_m * cgrp_tile_mnk[0], N, k, clusters_along_n),
                 )
                 coord_expert = group_idx % num_experts
-                linear_idx += grid_num_clusters
 
             while not nvvm.mbarrier_try_wait_parity(
                 sched_empty_mbar_ptr.subview(sched_stage),
@@ -1127,7 +1180,7 @@ def compile() -> Callable:
     grid_ctas = grid_num_clusters * cluster_m * cluster_n
     fake_a_tma_workspace = make_fake_compact_tensor(
         cutlass.Int64,
-        (grid_ctas * moe_desc_slots * 16,),
+        (grid_ctas * moe_desc_slots * 16 + 16,),
         stride_order=(0,),
         assumed_align=128,
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_1ctamma.py
@@ -74,6 +74,7 @@ if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_
 
 # Per-CTA scheduler ring (replaces CLC): 2 stages, 8 int32 slot words.
 SCHED_STAGES = 2
+SCHED_BCAST_STAGES = 2
 SCHED_SLOT_WORDS = 8
 
 USE_PDL = True
@@ -179,7 +180,11 @@ def _kernel(
             nvvm.prefetch_tensormap(tma_c_descs[_ci].get_ptr())
         # @@TMA_STORE_ONLY:END@@
 
-    cluster_linear_init = bidx // cluster_m
+    sched_counter_ptr = cute.make_ptr(
+        cutlass.Int32,
+        (a_tma_workspace.iterator.raw_ptr() + grid_num_clusters * cluster_m * cluster_n * moe_desc_slots * TENSOR_MAP_QWORDS).toint(),
+        mem_space=cute.AddressSpace.generic,
+    )
 
     a_pattern = 0
     for n_idx in cutlass.range_constexpr(cluster_n):
@@ -221,6 +226,9 @@ def _kernel(
     )
     sched_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     sched_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_slot = cutlass.Array(cutlass.Int32, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=16)
+    sched_bcast_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     tma_a_desc_smem_list = [
         cutlass.Array(
             cutlass.Int64,
@@ -324,6 +332,11 @@ def _kernel(
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
             if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
+        for i in range(SCHED_BCAST_STAGES):
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_full_mbar_ptr.subview(i), 1)
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_empty_mbar_ptr.subview(i), cluster_size)
     nvvm.fence_mbarrier_init()
 
     if cutlass.const_expr(cluster_shape_mnk[0] * cluster_shape_mnk[1] > 1):
@@ -360,7 +373,10 @@ def _kernel(
         gemm_s = cutlass.Int32(M)
         sched_stage = cutlass.Int32(0)
         sched_empty_phase = cutlass.Int32(1)
-        linear_idx = cutlass.Int32(cluster_linear_init)
+        bcast_stage = cutlass.Int32(0)
+        bcast_full_phase = cutlass.Int32(0)
+        bcast_empty_phase = cutlass.Int32(1)
+        linear_idx = cutlass.Int32(0)
         start_linear_idx = cutlass.Int32(0)
         total_tiles = cutlass.Int32(0)
         start_sf_block_m = cutlass.Int32(0)
@@ -378,6 +394,44 @@ def _kernel(
             cached_next_begin = tile_lower_bound
 
         while is_tile_valid != 0:
+            # Dynamic tile assignment: the cluster leader claims the next GLOBAL
+            # tile index and broadcasts it, so the clusters live at any instant
+            # sit in one contiguous window of tile space and share L2. Static
+            # striding lets them drift apart and share nothing.
+            if cta_rank_in_cluster == 0:
+                while not nvvm.mbarrier_try_wait_parity(
+                    sched_bcast_empty_mbar_ptr.subview(bcast_stage),
+                    bcast_empty_phase,
+                    time_limit=10_000_000,
+                ):
+                    pass
+                claimed = cutlass.Int32(0)
+                if lane == 0:
+                    claimed = nvvm.atomicrmw(
+                        "add",
+                        sched_counter_ptr,
+                        cutlass.Int32(1),
+                        mem_order="relaxed",
+                        syncscope="gpu",
+                    )
+                claimed = nvvm.shfl_sync(full_warp_mask, claimed, 0, shfl_idx_clamp, nvvm.Shfl.IDX)
+                if lane < cluster_size:
+                    (nvvm.mapa(sched_bcast_slot.subview(bcast_stage), lane)).store(claimed)
+                    nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_full_mbar_ptr.subview(bcast_stage), lane))
+            while not nvvm.mbarrier_try_wait_parity(
+                sched_bcast_full_mbar_ptr.subview(bcast_stage),
+                bcast_full_phase,
+                time_limit=10_000_000,
+            ):
+                pass
+            linear_idx = (sched_bcast_slot.subview(bcast_stage)).load()
+            if lane == 0:
+                nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))
+            bcast_stage += 1
+            if bcast_stage == SCHED_BCAST_STAGES:
+                bcast_stage = cutlass.Int32(0)
+                bcast_full_phase = bcast_full_phase ^ 1
+                bcast_empty_phase = bcast_empty_phase ^ 1
             group_begin = cached_next_begin
             group_end = cached_next_end
 
@@ -540,7 +594,6 @@ def _kernel(
                     _moe_auto_swizzle_w(group_nt_m * cgrp_tile_mnk[0], N, k, clusters_along_n),
                 )
                 coord_expert = group_idx % num_experts
-                linear_idx += grid_num_clusters
 
             while not nvvm.mbarrier_try_wait_parity(
                 sched_empty_mbar_ptr.subview(sched_stage),
@@ -1485,7 +1538,7 @@ def compile() -> Callable:
     grid_ctas = grid_num_clusters * cluster_m * cluster_n
     fake_a_tma_workspace = make_fake_compact_tensor(
         cutlass.Int64,
-        (grid_ctas * moe_desc_slots * 16,),
+        (grid_ctas * moe_desc_slots * 16 + 16,),
         stride_order=(0,),
         assumed_align=128,
     )

--- a/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
+++ b/python/cudnn/gemm/frost/kernel_templates/sm107_moe_grouped_block_scale_matmul_fwd_2ctamma.py
@@ -75,6 +75,7 @@ if use_acc_overlap and any(_w != epi_n for _, _w in _epi_subtile_spans(epi_cols_
 
 
 SCHED_STAGES = 2
+SCHED_BCAST_STAGES = 2
 SCHED_SLOT_WORDS = 8
 
 USE_PDL = True
@@ -172,7 +173,11 @@ def _kernel(
     is_pair_leader = pair_member == 0
     pair_leader_rank = pair_m_idx * 2 + n_rank * cluster_m
 
-    cluster_linear_init = bidx // cluster_m
+    sched_counter_ptr = cute.make_ptr(
+        cutlass.Int32,
+        (a_tma_workspace.iterator.raw_ptr() + grid_num_clusters * cluster_m * cluster_n * moe_desc_slots * TENSOR_MAP_QWORDS).toint(),
+        mem_space=cute.AddressSpace.generic,
+    )
 
     if warp_idx == mma_warp_id:
         for _i in cutlass.range_constexpr(num_a_operands):
@@ -221,6 +226,9 @@ def _kernel(
     )
     sched_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     sched_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_slot = cutlass.Array(cutlass.Int32, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=16)
+    sched_bcast_full_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
+    sched_bcast_empty_mbar_ptr = cutlass.Array(cutlass.Int64, SCHED_BCAST_STAGES, space=cutlass.AddressSpace.smem, alignment=8)
     tma_a_desc_smem_list = [
         cutlass.Array(
             cutlass.Int64,
@@ -329,6 +337,11 @@ def _kernel(
                 nvvm.mbarrier_init(sched_full_mbar_ptr.subview(i), 1)
             if elect_one:
                 nvvm.mbarrier_init(sched_empty_mbar_ptr.subview(i), sched_empty_count)
+        for i in range(SCHED_BCAST_STAGES):
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_full_mbar_ptr.subview(i), 1)
+            if elect_one:
+                nvvm.mbarrier_init(sched_bcast_empty_mbar_ptr.subview(i), cluster_size)
     nvvm.fence_mbarrier_init()
     nvvm.barrier_cluster_arrive_relaxed()
 
@@ -365,7 +378,10 @@ def _kernel(
         gemm_s = cutlass.Int32(M)
         sched_stage = cutlass.Int32(0)
         sched_empty_phase = cutlass.Int32(1)
-        linear_idx = cutlass.Int32(cluster_linear_init)
+        bcast_stage = cutlass.Int32(0)
+        bcast_full_phase = cutlass.Int32(0)
+        bcast_empty_phase = cutlass.Int32(1)
+        linear_idx = cutlass.Int32(0)
         start_linear_idx = cutlass.Int32(0)
         total_tiles = cutlass.Int32(0)
         start_sf_block_m = cutlass.Int32(0)
@@ -383,6 +399,45 @@ def _kernel(
             cached_next_begin = tile_lower_bound
 
         while is_tile_valid != 0:
+            # Dynamic tile assignment: the cluster leader claims the next GLOBAL
+            # tile index and broadcasts it, so the clusters that are live at any
+            # instant sit in one contiguous window of tile space and share L2.
+            # Static striding lets them drift apart and share nothing.
+            if cta_rank_in_cluster == 0:
+                while not nvvm.mbarrier_try_wait_parity(
+                    sched_bcast_empty_mbar_ptr.subview(bcast_stage),
+                    bcast_empty_phase,
+                    time_limit=10_000_000,
+                ):
+                    pass
+                claimed = cutlass.Int32(0)
+                if lane == 0:
+                    claimed = nvvm.atomicrmw(
+                        "add",
+                        sched_counter_ptr,
+                        cutlass.Int32(1),
+                        mem_order="relaxed",
+                        syncscope="gpu",
+                    )
+                claimed = nvvm.shfl_sync(full_warp_mask, claimed, 0, shfl_idx_clamp, nvvm.Shfl.IDX)
+                if lane < cluster_size:
+                    (nvvm.mapa(sched_bcast_slot.subview(bcast_stage), lane)).store(claimed)
+                    nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_full_mbar_ptr.subview(bcast_stage), lane))
+            while not nvvm.mbarrier_try_wait_parity(
+                sched_bcast_full_mbar_ptr.subview(bcast_stage),
+                bcast_full_phase,
+                time_limit=10_000_000,
+            ):
+                pass
+            linear_idx = (sched_bcast_slot.subview(bcast_stage)).load()
+            if lane == 0:
+                nvvm.mbarrier_arrive(nvvm.mapa(sched_bcast_empty_mbar_ptr.subview(bcast_stage), 0))
+            bcast_stage += 1
+            if bcast_stage == SCHED_BCAST_STAGES:
+                bcast_stage = cutlass.Int32(0)
+                bcast_full_phase = bcast_full_phase ^ 1
+                bcast_empty_phase = bcast_empty_phase ^ 1
+
             group_begin = cached_next_begin
             group_end = cached_next_end
 
@@ -545,7 +600,6 @@ def _kernel(
                     _moe_auto_swizzle_w(group_nt_m * cgrp_tile_mnk[0], N, k, clusters_along_n),
                 )
                 coord_expert = group_idx % num_experts
-                linear_idx += grid_num_clusters
 
             while not nvvm.mbarrier_try_wait_parity(
                 sched_empty_mbar_ptr.subview(sched_stage),
@@ -1554,7 +1608,7 @@ def compile() -> Callable:
     grid_ctas = grid_num_clusters * cluster_m * cluster_n
     fake_a_tma_workspace = make_fake_compact_tensor(
         cutlass.Int64,
-        (grid_ctas * moe_desc_slots * 16,),
+        (grid_ctas * moe_desc_slots * 16 + 16,),
         stride_order=(0,),
         assumed_align=128,
     )


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [x] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

<!-- Choose one:
- C++ frontend API or graph construction
- Python API or bindings
- FE OSS kernels or CuTeDSL
- Build, packaging, or installation
- CI or test infrastructure
- Documentation or samples
- Benchmarks or performance
- Not sure
-->

## Summary

Add dynamic scheduler for MoE grouped gemm to optimize the performance

## Why

<!-- What problem does this solve, and why is this approach appropriate? -->

## Related issues

<!-- Use "Fixes #123" or "Related to #123" where applicable. -->

## API and compatibility impact

<!-- Note public API, supported GPU/cuDNN/CUDA/Python versions, performance, or backward-compatibility changes. Write "None" if not applicable. -->

## Testing

<!-- List exact commands and results. If something was not tested, explain why. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Mixture-of-Experts (MoE) workload scheduling for grouped and block-scaled matrix operations.
  * Work is now distributed dynamically across GPU execution clusters, helping balance tile processing more effectively.
* **Reliability**
  * Added automatic scheduler-state initialization before supported operations.
  * Updated workspace handling to support the enhanced scheduling mechanism across dense, multi-GEMM, and MoE workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->