### PR TITLE
frost(sdpa): squeeze the 4D dense-LSE buffer in the pack_gqa stats checks

### DIFF
--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -249,9 +249,7 @@ def _check_dsl_sm100_strided_stats(d_qk, d_v):
     v = _bhsd(b, h, s, d_v, dtype)
 
     _, contiguous_stats = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), return_stats=True)
-    o, strided_stats = _run_dsl_graph(
-        q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), return_stats=True, stats_layout="strided"
-    )
+    o, strided_stats = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=True), return_stats=True, stats_layout="strided")
     o_ref, stats_ref = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True, return_stats=True)
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
     torch.testing.assert_close(strided_stats, contiguous_stats, atol=0, rtol=0)
@@ -794,7 +792,7 @@ def test_dsl_sm100_pack_gqa_features(mask):
     o, lse = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=kw, seq_len_kv=seq_len_kv, sink=sink, pack_gqa=True, return_stats=True)
     o_ref, lse_ref = _ref_sdpa_full(q, k, v, scale=scale, return_stats=True, **ref)
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
-    torch.testing.assert_close(lse, lse_ref, atol=5e-2, rtol=3e-2)
+    torch.testing.assert_close(lse.squeeze(-1), lse_ref, atol=5e-2, rtol=3e-2)
 
 
 @pytest.mark.L0
@@ -822,7 +820,7 @@ def test_dsl_sm100_pack_gqa_qtrim():
         o_ref[i, :, ql:, :] = 0.0
         lse_ref[i, :, ql:] = float("-inf")
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
-    torch.testing.assert_close(lse, lse_ref, atol=5e-2, rtol=3e-2)
+    torch.testing.assert_close(lse.squeeze(-1), lse_ref, atol=5e-2, rtol=3e-2)
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).

## Affected area

CI or test infrastructure

## Summary

- Squeeze the trailing singleton of the graph-path stats buffer before
  comparing LSE in `test_dsl_sm100_pack_gqa_features` and
  `test_dsl_sm100_pack_gqa_qtrim` (two one-line changes).
- One extra hunk is the repo black hook collapsing a line from #712 that
  merged formatter-unclean.

## Why

- The 8 tests fail on SM100 CI with
  `shape torch.Size([2, 8, 40, 1]) != torch.Size([2, 8, 40])`.
- Merge race: #712 changed `_run_dsl_graph` to allocate stats via
  `make_dense_stats` — 4D `(B, H, S, 1)` — and squeezed at its own
  comparison sites, but the two stats-checking pack_gqa tests from #709
  were not on its branch and kept comparing against the 3D `(B, H, S)`
  reference.
- Squeezing at the comparison matches #712's own convention in
  `_check_dsl_sm100_strided_stats`.

## Related issues

Fixes the SM100 CI failures from the #709 x #712 merge race.

## API and compatibility impact

None (test-only).

## Testing

- SM100 (cc 10.0):
  `cd test/python && pytest "sdpa/frost/test_sdpa_fwd_dsl_sm100.py::test_dsl_sm100_pack_gqa_features" "sdpa/frost/test_sdpa_fwd_dsl_sm100.py::test_dsl_sm100_pack_gqa_qtrim" -m "L0 or L1 or L2"` — **8 passed** (the exact CI failure set).
- `pre-commit run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)