### PR TITLE
docs(sdpa): clarify O strides in fp16_fwd sample (#184)

### DIFF
--- a/samples/cpp/sdpa/fp16_fwd.cpp
+++ b/samples/cpp/sdpa/fp16_fwd.cpp
@@ -47,6 +47,9 @@ create_sdpa_forward_graph(int64_t const b,
         .set_intermediate_data_type(fe::DataType_t::FLOAT)
         .set_compute_data_type(fe::DataType_t::FLOAT);
 
+    // Dim order is always BHSD. Strides describe the memory layout and may differ
+    // across tensors. Q/K/V below use a head-major layout:
+    //   stride = {h * s * d, s * d, d, 1}
     auto Q = graph->tensor(fe::graph::Tensor_attributes()
                                .set_name("Q")
                                .set_uid(Q_UID)
@@ -93,6 +96,10 @@ create_sdpa_forward_graph(int64_t const b,
 
     auto [O, Stats] = graph->sdpa(Q, K, V, sdpa_options);
 
+    // O keeps BHSD dims but intentionally uses a different valid layout than Q/K/V:
+    //   stride = {h * d, d, b * h * d, 1}
+    // Matching Q/K/V ({h * s * d, s * d, d, 1}) is also valid; pick strides to match
+    // how the caller allocates O (see issue #184).
     O->set_output(true).set_dim({b, h_q, s_q, d_v}).set_stride({h_q * d_v, d_v, b * h_q * d_v, 1}).set_uid(O_UID);
 
     if (generate_stats) {


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

- Documentation or samples

## Summary

Add short comments in `samples/cpp/sdpa/fp16_fwd.cpp` clarifying that tensor dims are always BHSD while strides describe memory layout, and that this sample's `O` intentionally uses a different valid stride pattern than Q/K/V.

## Why

[#184](https://github.com/NVIDIA/cudnn-frontend/issues/184) reported the `O` strides as incorrect. @Anerudhan clarified both layouts are valid; the confusion is sample documentation, not a bug in the strides themselves.

## Related issues

Related to #184

## API and compatibility impact

None

## Testing

Comment-only change in a C++ sample; no runtime behavior change. Did not rebuild samples (no code path change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comments clarifying tensor dimension ordering and memory layouts for attention inputs and outputs.
  * Documented valid output layouts and how they correspond to caller-allocated memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->