### PR TITLE
frost(sdpa): guard empty d192 quantized O TMEM loads

### DIFF
--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_fp8_sm100.py
@@ -1955,6 +1955,12 @@ def _correction_warp_group(
             lse_val = cutlass.Float32(0.0)  # pre-declare; computed in both branches
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
+            # E5M2+sinks seeds total_sum with the sink contribution, so its
+            # empty-numerator predicate must come from the KV bounds instead.
+            if cutlass.const_expr(_E5_SINK):
+                row_dead = bounds.right <= bounds.left
+            else:
+                row_dead = total_sum <= cutlass.Float32(0.0)
             # Row identity (PackGQA): this lane's row decodes to (token,
             # head-in-group) — q_row_global is the TOKEN index and
             # row_head_idx the row's true query head (lane-varying under
@@ -1980,22 +1986,20 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
                 # Safe inverse: avoid div by 0 on fully-masked rows.
                 beta = cute.arch.rcp_approx(cute.math.max(total_sum, cutlass.Float32(1e-30)))
-                if cutlass.const_expr((CFG.MASK_FLAGS & (MASK_PADDED | MASK_SWA)) != 0 or CFG.BOTTOM_RIGHT):
-                    row_dead = total_sum <= cutlass.Float32(0.0)
-                    beta = cutlass.Float32(
-                        arith.select(
-                            row_dead.ir_value(),
-                            cutlass.Float32(0.0).ir_value(),
-                            beta.ir_value(),
-                        )
+                beta = cutlass.Float32(
+                    arith.select(
+                        row_dead.ir_value(),
+                        cutlass.Float32(0.0).ir_value(),
+                        beta.ir_value(),
                     )
-                    lse_val = cutlass.Float32(
-                        arith.select(
-                            row_dead.ir_value(),
-                            cutlass.Float32(float("-inf")).ir_value(),
-                            lse_val.ir_value(),
-                        )
+                )
+                lse_val = cutlass.Float32(
+                    arith.select(
+                        row_dead.ir_value(),
+                        cutlass.Float32(float("-inf")).ir_value(),
+                        lse_val.ir_value(),
                     )
+                )
                 inv_sum = o_scale_fused * beta
 
             # cga2 OOB-row guard: cluster Q rows can exceed seqlen_q.
@@ -2036,6 +2040,11 @@ def _correction_warp_group(
                     if cutlass.const_expr(_E5_SINK and chunk_idx == N_CHUNKS_O - 1):
                         bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
                     o_scaled = o_chunk * inv_sum
+                    _zero_f = cutlass.Float32(0.0)
+                    o_scaled = cutlass.Vector.from_elements(
+                        tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                        cutlass.Float32,
+                    )
 
                     for _i in cutlass.range_constexpr(O_CHUNK):
                         _e = o_scaled[_i]
@@ -2079,6 +2088,11 @@ def _correction_warp_group(
 
                 o_chunk1 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr1, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
                 o_scaled0 = o_chunk0 * inv_sum
+                _zero_f = cutlass.Float32(0.0)
+                o_scaled0 = cutlass.Vector.from_elements(
+                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled0[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
+                    cutlass.Float32,
+                )
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled0), ftz=True)
                 o_half0 = o_scaled0.to(OUT_STORAGE_DTYPE)
                 _wait_mbarrier(bars.mb_o_empty[qs], o_empty_phase)
@@ -2087,6 +2101,10 @@ def _correction_warp_group(
 
                 o_chunk2 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr2, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
                 o_scaled1 = o_chunk1 * inv_sum
+                o_scaled1 = cutlass.Vector.from_elements(
+                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled1[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
+                    cutlass.Float32,
+                )
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled1), ftz=True)
                 o_half1 = o_scaled1.to(OUT_STORAGE_DTYPE)
                 sO_sub_base.subview(cutlass.Int32(O_EPI_BLOCK_SIZE) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
@@ -2096,6 +2114,10 @@ def _correction_warp_group(
 
                 o_chunk3 = nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(o_addr3, cutlass.Float32), num=O_EPI_BLOCK_SIZE)
                 o_scaled2 = o_chunk2 * inv_sum
+                o_scaled2 = cutlass.Vector.from_elements(
+                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled2[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
+                    cutlass.Float32,
+                )
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled2), ftz=True)
                 o_half2 = o_scaled2.to(OUT_STORAGE_DTYPE)
                 sO_sub_base.subview(cutlass.Int32(O_TMA_GRANU_ELEMS) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
@@ -2107,6 +2129,10 @@ def _correction_warp_group(
                     bars.mb_stats_read[qs].arrive(leader_cta_id=leader_cta_id, cta_group=CFG.CTA_MMA)
 
                 o_scaled3 = o_chunk3 * inv_sum
+                o_scaled3 = cutlass.Vector.from_elements(
+                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled3[i].ir_value())) for i in range(O_EPI_BLOCK_SIZE)),
+                    cutlass.Float32,
+                )
                 o_half3 = o_scaled3.to(OUT_STORAGE_DTYPE)
                 sO_sub_base.subview(cutlass.Int32(O_TMA_GRANU_ELEMS + O_EPI_BLOCK_SIZE) + tid_in_wg * cutlass.Int32(O_D_BLOCK)).data_ptr().store_swizzled(
                     o_half3, alignment=64, swizzle=_O_SMEM_SWIZZLE

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_mxfp8_sm100.py
@@ -2428,6 +2428,9 @@ def _correction_warp_group(
             lse_val = cutlass.Float32(0.0)
             LN2 = cutlass.Float32(0.6931471805599453)
             total_max_nat = total_max_scaled * LN2
+            # A dead row must select literal zero after normalization because
+            # multiplying an unwritten TMEM NaN by zero does not sanitize it.
+            row_dead = total_sum <= cutlass.Float32(0.0)
             if cutlass.const_expr(CFG.HAS_SINK):
                 sinks_arr = cutlass.make_array_view(sinks_tensor)
                 sink_logit = sinks_arr[head_idx]
@@ -2440,6 +2443,20 @@ def _correction_warp_group(
                 lse_val = total_max_nat + cute.math.log(total_sum, fastmath=True)
                 # Safe inverse: avoid div by 0 (rows fully masked).
                 inv_sum = cutlass.Float32(1.0) / cute.math.max(total_sum, cutlass.Float32(1e-30))
+                lse_val = cutlass.Float32(
+                    arith.select(
+                        row_dead.ir_value(),
+                        cutlass.Float32(float("-inf")).ir_value(),
+                        lse_val.ir_value(),
+                    )
+                )
+                inv_sum = cutlass.Float32(
+                    arith.select(
+                        row_dead.ir_value(),
+                        cutlass.Float32(0.0).ir_value(),
+                        inv_sum.ir_value(),
+                    )
+                )
 
             # OOB-row guard: under cga2 cluster Q rows can exceed seqlen_q (else write aliases next head's LSE slot).
             q_row_global = q_super_idx * cutlass.Int32(CFG.TILES_Q * CFG.TILE_M) + cutlass.Int32(qs * CFG.TILE_M) + tid_in_wg
@@ -2465,6 +2482,11 @@ def _correction_warp_group(
                 )
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
                 o_scaled = o_chunk * inv_sum
+                _zero_f = cutlass.Float32(0.0)
+                o_scaled = cutlass.Vector.from_elements(
+                    tuple(cutlass.Float32(arith.select(row_dead.ir_value(), _zero_f.ir_value(), o_scaled[i].ir_value())) for i in range(O_CHUNK)),
+                    cutlass.Float32,
+                )
                 _amax_o_local = cute.math.max(_amax_o_local, _max_abs_reduction(o_scaled), ftz=True)
                 o_out = o_scaled.to(OUT_STORAGE_DTYPE)
 

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
@@ -178,13 +178,7 @@ def _blocked_sf_to_flat(sf_tensor: torch.Tensor, rows: int, cols: int) -> torch.
     row_idx = torch.arange(rows, device=sf_tensor.device, dtype=torch.long).view(rows, 1)
     col_idx = torch.arange(sf_cols, device=sf_tensor.device, dtype=torch.long).view(1, sf_cols)
     col_blocks = sf_tensor.shape[1] // 4
-    linear = (
-        (row_idx // 128) * col_blocks * 512
-        + (col_idx // 4) * 512
-        + (row_idx % 32) * 16
-        + ((row_idx // 32) % 4) * 4
-        + (col_idx % 4)
-    )
+    linear = (row_idx // 128) * col_blocks * 512 + (col_idx // 4) * 512 + (row_idx % 32) * 16 + ((row_idx // 32) % 4) * 4 + (col_idx % 4)
     return sf_tensor.flatten()[linear]
 
 
@@ -228,8 +222,7 @@ def _check_nvfp4_output(
         max_abs_err = err[bad].max().item()
         max_rel_err = torch.nanquantile(err[bad] / ref_bf16[bad].abs(), 1.0).item()
         raise RuntimeError(
-            f"{name}: {int(bad.sum())} dequantized elements exceed the quantization error bound "
-            f"(max abs err {max_abs_err:.4f}, max rel err {max_rel_err:.4f})"
+            f"{name}: {int(bad.sum())} dequantized elements exceed the quantization error bound (max abs err {max_abs_err:.4f}, max rel err {max_rel_err:.4f})"
         )
 
 

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -134,6 +134,7 @@ def _run(
     pack_gqa=None,
     stats_layout="contiguous",
     return_lse=False,
+    poison_tmem_before_execute: bool = False,
 ):
     import cudnn
 
@@ -209,6 +210,14 @@ def _run(
     if stats:
         vp[stats_t] = lse
     ws = torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8)
+    if poison_tmem_before_execute:
+        assert seq_lens_kv is not None
+        poison_vp = dict(vp)
+        poison_vp[v] = torch.full_like(Vb, float("nan"))
+        poison_vp[skv_h] = torch.full_like(slk, S_kv)
+        g.execute(poison_vp, ws)
+        torch.cuda.synchronize()
+        amax_o.zero_()
     if sync_debug:
         # Rule 3 pin: execute must not read the scale tensors (or anything
         # else) back to the host.
@@ -386,25 +395,40 @@ def test_fp8_d192_d128_masks(mask):
 
 @_skip_on_rubin
 @pytest.mark.L0
+@pytest.mark.parametrize(
+    ("in_key", "out_key", "with_sink"),
+    [
+        ("e4m3", "fp16", False),
+        ("e4m3", "e4m3", True),
+        ("e5m2", "fp16", True),
+    ],
+    ids=["e4m3-fp16-nosink", "e4m3-fp8-sink", "e5m2-fp16-sink"],
+)
 @torch_fork_set_rng(seed=0)
-def test_fp8_d192_d128_zero_length_kv():
-    """A zero-length KV batch must produce a finite zero output."""
+def test_fp8_d192_d128_leading_zero_length_kv(in_key: str, out_key: str, with_sink: bool):
+    """A leading zero-length KV batch must produce zero O and valid Stats."""
     scale = 1.0 / math.sqrt(192)
-    out, o_ref, a_o, a_o_ref = _run(
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda") if with_sink else None
+    result = _run(
         2,
         8,
         8,
         256,
         256,
-        "e4m3",
-        torch.float16,
+        in_key,
+        _OUT[out_key],
         scale=scale,
         sdpa_kwargs={},
-        seq_lens_kv=[256, 0],
+        sink=sink,
+        seq_lens_kv=[0, 256],
         d_qk=192,
         d_v=128,
+        return_lse=True,
+        poison_tmem_before_execute=True,
     )
-    _check(out, o_ref, torch.float16, "e4m3", a_o, a_o_ref)
+    _check(result.output, result.reference, _OUT[out_key], in_key, result.amax, result.reference_amax)
+    assert (result.output[0] == 0).all()
+    torch.testing.assert_close(result.stats, result.reference_stats, atol=5e-2, rtol=3e-2)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py
@@ -119,7 +119,10 @@ def _ref(qd, kd, vd, *, scale, is_causal=False, bottom_right=False, swa_window=N
         if return_stats:
             return _ReferenceWithStats(o, torch.logsumexp(ext, dim=-1))
         return o
-    o = torch.matmul(torch.softmax(scores, dim=-1), v_e)
+    row_has_kv = torch.isfinite(scores).any(dim=-1, keepdim=True)
+    probs = torch.softmax(scores, dim=-1)
+    probs = torch.where(row_has_kv, probs, torch.zeros_like(probs))
+    o = torch.matmul(probs, v_e)
     if return_stats:
         return _ReferenceWithStats(o, torch.logsumexp(scores, dim=-1))
     return o
@@ -142,6 +145,7 @@ def _run(
     d_v=128,
     stats_layout="contiguous",
     return_lse=False,
+    poison_tmem_before_execute: bool = False,
 ):
     """Quantize, build the sdpa_mxfp8 graph, route to the frost engine, execute.
 
@@ -224,7 +228,16 @@ def _run(
     vp.update({o: Ob, amax_o: amax})
     if stats:
         vp[stats_t] = lse
-    g.execute(vp, torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8))
+    workspace = torch.empty(max(g.get_workspace_size(), 1), device=dev, dtype=torch.uint8)
+    if poison_tmem_before_execute:
+        assert seq_lens_kv is not None
+        poison_vp = dict(vp)
+        poison_vp[v] = torch.full_like(Vb, float("nan"))
+        poison_vp[skv_h] = torch.full_like(slk, S)
+        g.execute(poison_vp, workspace)
+        torch.cuda.synchronize()
+        amax.zero_()
+    g.execute(vp, workspace)
     torch.cuda.synchronize()
 
     ref_kwargs = {k2: v2 for k2, v2 in _ref_from_sdpa(sdpa_kwargs).items()}
@@ -429,6 +442,40 @@ def test_mxfp8_d192_d128_gqa_sink():
         d_v=d_v,
     )
     _check(O, O_ref, torch.float16, "e5m2", d_qk=d_qk)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("out_key", "with_sink"),
+    [("fp16", False), ("e4m3", True)],
+    ids=["fp16-nosink", "fp8-sink"],
+)
+@torch_fork_set_rng(seed=0)
+def test_mxfp8_d192_d128_leading_zero_length_kv(out_key: str, with_sink: bool):
+    """A leading zero-length KV batch must produce zero O and a finite amax."""
+    d_qk, d_v = 192, 128
+    sink = torch.randn(1, 8, 1, 1, dtype=torch.float32, device="cuda") if with_sink else None
+    result = _run(
+        2,
+        8,
+        8,
+        256,
+        "e4m3",
+        _OUT[out_key],
+        scale=1.0 / math.sqrt(d_qk),
+        sdpa_kwargs={},
+        sink=sink,
+        seq_lens_kv=[0, 256],
+        # The MXFP8 engine intentionally declines padding plus Stats; O and
+        # amax exercise the affected epilogue independently of that contract.
+        stats=False,
+        d_qk=d_qk,
+        d_v=d_v,
+        poison_tmem_before_execute=True,
+    )
+    _check(result.output, result.reference, _OUT[out_key], "e4m3", d_qk=d_qk)
+    assert (result.output[0] == 0).all()
+    assert abs(result.amax.item() - result.reference.abs().max().item()) <= 0.03
 
 
 @pytest.mark.L0


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [x] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

- FE OSS kernels or CuTeDSL

## Summary

- Sanitize dead rows in the SM100 d192/d128 per-tensor FP8 and MXFP8 forward epilogues by selecting literal zero before output conversion and `amax_o` accumulation.
- Add deterministic NaN-primed regressions for a leading zero-length KV batch across FP8 and half output types, with and without attention sinks.
- Also fix a style issue introduced by 781e3383b6775b7130dc31cda5228444825dff4e.

## Why

When a row has no visible KV column, BMM2 may leave its output accumulator in TMEM unwritten. Multiplying the loaded value by a zero normalization factor is insufficient because an unwritten value can decode as NaN and `NaN * 0` remains NaN. That can contaminate both O and `amax_o`.

The epilogues now apply a per-element `arith.select` to replace every dead-row value with literal zero before amax reduction, FP8 packing, or half conversion. This also covers dead rows inside otherwise live tiles and preserves the existing TMEM load pipeline and barrier protocol.

## Related issues

Fixes #702.

## API and compatibility impact

No public API or ABI change. Dead rows now produce zero O, retain the expected LSE and sink semantics, and do not affect output amax.

## Testing

On SM100 with cuDNN backend 9.26, all five targeted regression cases passed:

```bash
pytest -q \
  sdpa/frost/test_sdpa_fwd_fp8_sm100.py::test_fp8_d192_d128_leading_zero_length_kv \
  sdpa/frost/test_sdpa_fwd_mxfp8_sm100.py::test_mxfp8_d192_d128_leading_zero_length_kv
```

Also passed:

- `pre-commit run` on the four changed files
- `python -m py_compile` on the two changed kernels and two changed test modules
- `git diff --check`

The full test suite was not run; validation was targeted to the affected SM100 kernels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected scaled dot-product attention handling for rows with empty or invalid key/value ranges.
  * Such rows now reliably produce zero outputs, negative-infinity log-sum-exp values, and valid amax results.
  * Improved behavior across FP8, MXFP8, FP16, BF16, and attention-sink configurations.

* **Tests**
  * Added coverage for leading zero-length key/value sequences, padding-mask scenarios, and declared packed-token totals.
  * Added validation for zero outputs and finite quantization metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->