### PR TITLE
frost(sdpa): fix sm120 split_kv test after #720 combine_rows change

### DIFF
--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
@@ -46,6 +46,8 @@ def _expected_split(api):
         kv_tiles=-(-api.s_k_max // api.kv_tile),
         sm_count=device_info(torch.cuda.current_device()).sm_count,
         ctas_per_tile=1,
+        # The combine's grid is (S_q, H, B) — see choose_split_kv.
+        combine_rows=api.batch_size * api.h_q * api.s_q_max,
     )
 
 


### PR DESCRIPTION
## Summary
- #720 added a required `combine_rows` keyword-only argument to `choose_split_kv` (combine-pass cost term) but the squash-merge dropped the follow-up fix to the sm120 test (yanzhuo607/cudnn-frontend#1), so `develop` currently fails `frost:rel:sdpa:sm120` CI with:

  ```
  TypeError: choose_split_kv() missing 1 required keyword-only argument: 'combine_rows'
  ```
- Passes `combine_rows` in `test_sdpa_fwd_split_kv_sm120.py`'s `_expected_split` helper, matching the pattern already used by its sm100 sibling in `test_sdpa_fwd_split_kv_sm100.py` (`combine_rows=b * h_q * s_q`).

## Test plan
- [x] `py_compile` on the changed file
- [x] `black -l 160` clean
- [ ] CI: `frost:rel:sdpa:sm120` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated split-key/value attention test expectations to match the combine grid dimensions.
  * Improves test accuracy for batched and multi-query attention scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->