### PR TITLE
Avoid copies in BackendDescriptor constructor

### DIFF
--- a/include/cudnn_backend_base.h
+++ b/include/cudnn_backend_base.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <ostream>
+#include <utility>
 
 namespace cudnn_frontend {
 
@@ -134,7 +135,7 @@ class BackendDescriptor {
      * Initializes the member variables as passed.
      */
     BackendDescriptor(ManagedOpaqueDescriptor pointer_, cudnnStatus_t status_, std::string err_msg_)
-        : pointer(pointer_), status(status_), err_msg(err_msg_) {}
+        : pointer(std::move(pointer_)), status(status_), err_msg(std::move(err_msg_)) {}
     BackendDescriptor() = default;
 
     virtual ~BackendDescriptor() {};


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

C++ frontend API or graph construction

## Summary

Move the by-value `ManagedOpaqueDescriptor` and `std::string` constructor parameters into the corresponding `BackendDescriptor` members.

Also include `<utility>` explicitly for `std::move`.

## Why

Named by-value parameters are lvalues inside the constructor. Initializing the members directly from `pointer_` and `err_msg_` therefore invokes their copy constructors.

Moving these parameters into the members avoids:

- An unnecessary `std::shared_ptr` reference-count increment and decrement.
- An unnecessary `std::string` copy and potential allocation.

The parameters are not used afterward, so moving them preserves the intended ownership semantics and does not affect callers.

Ref: https://clang.llvm.org/extra/clang-tidy/checks/modernize/pass-by-value.html

## Related issues

None.

## API and compatibility impact

None.


## Testing

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal descriptor construction efficiency by moving managed data instead of copying it.
  * No user-visible behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->