### PR TITLE
frost(sdpa): support attention bias in SDPA forward engines

### DIFF
--- a/python/cudnn/sdpa/fwd/api_dsl.py
+++ b/python/cudnn/sdpa/fwd/api_dsl.py
@@ -282,6 +282,7 @@ class SdpaFwdDsl(APIBase):
         sample_v: torch.Tensor | TensorDesc,
         sample_o: torch.Tensor | TensorDesc,
         sample_lse: Optional[torch.Tensor | TensorDesc] = None,
+        sample_bias: Optional[torch.Tensor | TensorDesc] = None,
         is_causal: bool = False,
         causal_bottom_right: bool = False,
         window_size_left: Optional[int] = None,
@@ -321,6 +322,8 @@ class SdpaFwdDsl(APIBase):
         self.v_desc = self._make_tensor_desc(sample_v, name="v")
         self.o_desc = self._make_tensor_desc(sample_o, name="o")
         self.lse_desc = self._unpad_tensor_to_ndim(self._make_tensor_desc(sample_lse, name="lse"), 3, "lse")
+        self.bias_desc = self._make_tensor_desc(sample_bias, name="bias")
+        self._bias_stride: Optional[tuple[int, int, int, int]] = None
 
         self.is_causal = bool(is_causal)
         self.causal_bottom_right = bool(causal_bottom_right)
@@ -595,6 +598,24 @@ class SdpaFwdDsl(APIBase):
             self._dummy_cache[cache_key] = tensor
         return tensor
 
+    def _check_bias_desc(self, h_q: int, s_q: int, s_kv: int) -> None:
+        if self.bias_desc is None:
+            return
+        from cudnn.sdpa.graph_analyzer import dense_layout_ok
+
+        self._check_dtype(self.bias_desc, [self.dtype, torch.float32], name="bias")
+        self._check_tensor_shape(self.bias_desc, (1, h_q, s_q, s_kv), name="bias")
+        self._value_error_if(
+            not dense_layout_ok(self.bias_desc.shape, self.bias_desc.stride),
+            "bias must use a dense-compatible H/Q permutation or padded layout "
+            f"with contiguous K and non-broadcast, non-overlapping-by-span strides; got {self.bias_desc.stride}",
+        )
+        self._value_error_if(
+            self.bias_desc.device != self.q_desc.device,
+            f"bias must be on device {self.q_desc.device}; got {self.bias_desc.device}",
+        )
+        self._bias_stride = None if self.bias_desc.is_contiguous() else tuple(int(stride) for stride in self.bias_desc.stride)
+
     def _checked_lse_view(self, lse_tensor: torch.Tensor) -> torch.Tensor:
         """Validate a caller-provided LSE buffer and return the kernel's (B, H_q, S_q) view.
 
@@ -652,6 +673,32 @@ class SdpaFwdDsl(APIBase):
             "sinks must be contiguous (bound to the kernel as a flat (H_q,) view)",
         )
         return sinks.reshape(-1)
+
+    def _checked_bias(self, bias_tensor: torch.Tensor) -> torch.Tensor:
+        """Validate bias storage and return the view declared at compile time.
+
+        Graph variant-pack entries are raw storage: their PyTorch metadata
+        need not match the graph tensor descriptor. Rebuild that descriptor's
+        view here so graph and standalone callers share one normalization
+        path. ``as_strided`` is a view and therefore does not allocate on the
+        execute hot path.
+        """
+        self._value_error_if(
+            bias_tensor.dtype != self.bias_desc.dtype,
+            f"bias dtype must match the compiled specialization ({self.bias_desc.dtype}); got {bias_tensor.dtype}",
+        )
+        self._value_error_if(
+            bias_tensor.device != self.bias_desc.device,
+            f"bias must be on device {self.bias_desc.device}; got {bias_tensor.device}",
+        )
+        shape, stride = self.bias_desc.shape, self.bias_desc.stride
+        if tuple(bias_tensor.shape) != shape or tuple(bias_tensor.stride()) != stride:
+            storage_offset = bias_tensor.storage_offset()
+            try:
+                bias_tensor = bias_tensor.as_strided(shape, stride, storage_offset)
+            except RuntimeError as exc:
+                raise ValueError(f"bias backing storage is too small for declared shape {shape}, stride {stride}, and storage_offset {storage_offset}") from exc
+        return bias_tensor
 
     def _checked_seq_lens(self, seq_lens: torch.Tensor, name: str) -> torch.Tensor:
         """Validate caller-provided per-batch lengths and return the kernel's (B,) int32 view.
@@ -775,6 +822,7 @@ class SdpaFwdDsl(APIBase):
         v_tensor: torch.Tensor,
         o_tensor: torch.Tensor,
         lse_tensor: Optional[torch.Tensor] = None,
+        bias_tensor: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         seq_q_lens: Optional[torch.Tensor] = None,
         seq_kv_lens: Optional[torch.Tensor] = None,
@@ -855,6 +903,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 self._thd_check_strides_packed()
             else:
                 self._thd_check_strides_native()
+            self._not_implemented_error_if(
+                self.bias_desc is not None,
+                "attention bias is dense-only (THD has no single [1, H_q, S_q, S_kv] bias shape)",
+            )
 
         b, h_qo, s_qo, d_qk = self.q_desc.shape
         _, h_kv, s_kv, _ = self.k_desc.shape
@@ -895,6 +947,11 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # d128 only, DTYPE_O independent — typically BF16/FP16).
         self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16, *_SM100_FP8_DTYPES], name="Q")
         self._fp8 = self.dtype in _SM100_FP8_DTYPES
+        self._not_implemented_error_if(
+            self._fp8 and self.bias_desc is not None,
+            "attention bias is not supported by the FP8/MXFP8 SDPA kernels",
+        )
+        self._check_bias_desc(h_qo, s_qo, s_kv)
         self._not_implemented_error_if(
             self.pack_gqa and self._fp8 and not self._pertensor,
             "PackGQA is not supported for MXFP8: the F8_128x4 sf_q scale-factor atom "
@@ -1067,7 +1124,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         # covers direct construction.
         self._not_implemented_error_if(
             self.thd and self._fp8 and (int(d_qk), int(d_v)) != (128, 128),
-            f"THD/varlen on the FP8/MXFP8 path requires D_QK=D_V=128 (the d192/d128 " f"kernels are dense-only); got (D_QK={d_qk}, D_V={d_v})",
+            f"THD/varlen on the FP8/MXFP8 path requires D_QK=D_V=128 (the d192/d128 kernels are dense-only); got (D_QK={d_qk}, D_V={d_v})",
         )
         # Dense padded-Q trim backstops (engines.lower_dsl_prefill never sets
         # these combinations; a direct caller could).
@@ -1172,6 +1229,8 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             window_left=self.window_left,
             window_right=template_window_right,
             bottom_right=self.causal_bottom_right,
+            has_bias=self.bias_desc is not None,
+            bias_is_fp32=self.bias_desc is not None and self.bias_desc.dtype == torch.float32,
             has_sink=self.has_sink,
             seq_kv_lens_present=self.seq_kv_lens_present,
             seq_q_lens_present=self.seq_q_lens_present,
@@ -1237,6 +1296,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 d_v=self.head_dim_v,
                 has_lse=(self.lse_desc is not None) or self.split_kv > 1,
                 lse_stride=None if self.split_kv > 1 else self._lse_stride,
+                bias_stride=self._bias_stride,
             )
         self._combine_kernel = None
         if self.split_kv > 1:
@@ -1310,6 +1370,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         v_tensor: torch.Tensor,
         o_tensor: torch.Tensor,
         lse_tensor: Optional[torch.Tensor] = None,
+        bias_tensor: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         seq_q_lens: Optional[torch.Tensor] = None,
         seq_kv_lens: Optional[torch.Tensor] = None,
@@ -1367,6 +1428,10 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         self._value_error_if(
             self.lse_desc is None and lse_tensor is not None,
             "this specialization was compiled without an LSE output; construct the API with sample_lse",
+        )
+        self._value_error_if(
+            (self.bias_desc is not None) != (bias_tensor is not None),
+            "bias presence must match the compiled specialization",
         )
         if self.thd:
             pass  # bound in _execute_thd (declared packed layout)
@@ -1440,6 +1505,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
         O_view, o_needs_copy_back, O_scratch = self._to_bshd_writable(o_tensor)
 
         device = q_tensor.device
+        bias_t = self._checked_bias(bias_tensor) if bias_tensor is not None else None
         sinks_t = (
             self._checked_sinks_1d(sinks)
             if sinks is not None
@@ -1478,6 +1544,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 V,
                 o_partial,
                 lse_partial,
+                bias_t,
                 sinks_t,
                 seq_kv_t,
                 o_desc_dummy,
@@ -1504,6 +1571,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
                 V,
                 o_arg,
                 lse_arg,
+                bias_t,
                 sinks_t,
                 seq_kv_t,
                 o_desc_dummy,
@@ -1756,6 +1824,7 @@ class SdpaFwdDslSm100(SdpaFwdDsl):
             pack.V,
             pack.O,
             LSE,
+            None,
             pack.sinks_t,
             pack.meta,
             pack.o_desc,
@@ -2409,6 +2478,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         if self.thd:
             self._value_error_if(self.seq_q_lens_present, "seq_q_lens_present is dense-only (THD carries per-sequence Q lengths via cu_seqlens)")
             self.seq_kv_lens_present = True
+            self._not_implemented_error_if(
+                self.bias_desc is not None,
+                "attention bias is dense-only (THD has no single [1, H_q, S_q, S_kv] bias shape)",
+            )
         self._not_implemented_error_if(
             (self.cu_seq_q_lens or self.cu_seq_kv_lens) and not self.thd,
             "cu_seq_len_* is THD-only (the dense kernels have no CU read mode yet)",
@@ -2505,6 +2578,11 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
 
         self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16, *_SM100_FP8_DTYPES], name="Q")
         self._fp8 = self.dtype in _SM100_FP8_DTYPES
+        self._not_implemented_error_if(
+            self._fp8 and self.bias_desc is not None,
+            "attention bias is not supported by the FP8 SDPA kernel",
+        )
+        self._check_bias_desc(h_q, s_q, s_kv)
         if self.pack_gqa:
             self._not_implemented_error_if(
                 self.thd,
@@ -2676,6 +2754,8 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             window_left=self.window_left,
             window_right=self.window_right,
             bottom_right=self.causal_bottom_right,
+            has_bias=self.bias_desc is not None,
+            bias_is_fp32=self.bias_desc is not None and self.bias_desc.dtype == torch.float32,
             seq_q_lens_present=self.seq_q_lens_present,
             seq_kv_lens_present=self.seq_kv_lens_present,
             has_sink=self.has_sink,
@@ -2696,7 +2776,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             self._compiled_kernel = self._k_mod.compile(**self._thd_compile_kwargs())
             self._logger.debug("compile completed (THD, dynamic token extents)")
             return
-        self._compiled_kernel = self._k_mod.compile(
+        compile_kwargs = dict(
             compute_capability=self.compute_capability,
             b=self.batch_size,
             qh=self.h_q,
@@ -2711,6 +2791,9 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             has_lse=(self.lse_desc is not None) or self.split_kv > 1,
             lse_stride=None if self.split_kv > 1 else self._lse_stride,
         )
+        if not self._fp8:
+            compile_kwargs["bias_stride"] = self._bias_stride
+        self._compiled_kernel = self._k_mod.compile(**compile_kwargs)
         self._combine_kernel = None
         if self.split_kv > 1:
             # The recombine pass compiles at PLAN time; execute() only rebinds
@@ -2738,6 +2821,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         v_tensor: torch.Tensor,
         o_tensor: torch.Tensor,
         lse_tensor: Optional[torch.Tensor] = None,
+        bias_tensor: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         seq_q_lens: Optional[torch.Tensor] = None,
         seq_kv_lens: Optional[torch.Tensor] = None,
@@ -2773,6 +2857,10 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
         self._value_error_if(
             self.lse_desc is None and lse_tensor is not None,
             "this specialization was compiled without an LSE output; construct the API with sample_lse",
+        )
+        self._value_error_if(
+            (self.bias_desc is not None) != (bias_tensor is not None),
+            "bias presence must match the compiled specialization",
         )
         scale_val = self.scale_softmax if scale_softmax is None or scale_softmax == 0.0 else float(scale_softmax)
         if self._fp8:
@@ -2816,6 +2904,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             )
             return
         lse = self._checked_lse_view(lse_tensor) if lse_tensor is not None else None
+        bias_t = self._checked_bias(bias_tensor) if bias_tensor is not None else None
         sinks_t = self._checked_sinks_1d(sinks) if sinks is not None else None
         seq_q_lens = (
             self._checked_seq_lens(seq_q_lens, "seq_q_lens")
@@ -2860,6 +2949,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             v,
             o_dst,
             lse_dst,
+            bias_t,
             sinks_t,
             seq_q_lens,
             seq_kv_lens,
@@ -3260,6 +3350,7 @@ class SdpaFwdDslSm120(SdpaFwdDsl):
             pack.V,
             pack.O,
             lse,
+            None,
             sinks_t,
             pack.seq_q_dummy,
             pack.meta,
@@ -3581,10 +3672,8 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
     caller buffers to the cached artifact (a compile-cache miss at execute is
     a bug by contract).
 
-    SM80-only compile axes that have no home in the shared constructor arrive
-    as extra keyword-only arguments (``bias_present`` / ``bias_fp32`` /
-    ``rope_max_s``); the engine lowering forwards them only when the graph
-    declares the operands. ALiBi, block_mask and the score-stat side outputs
+    The SM80-only RoPE compile axis arrives as ``rope_max_s``; dense attention
+    bias uses the shared adapter contract. ALiBi, block_mask and score-stat outputs
     are deliberately NOT served: the capability row declines such graphs and
     the backend takes them.
 
@@ -3595,14 +3684,12 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
     are rescaled to log2 units with one (H,)-element multiply per execute.
     """
 
-    def __init__(self, *args, scheduler: Optional[str] = None, bias_present: bool = False, bias_fp32: bool = False, rope_max_s: int = 0, **kwargs) -> None:
+    def __init__(self, *args, scheduler: Optional[str] = None, rope_max_s: int = 0, **kwargs) -> None:
         # SM80-only plan-time axes (see class docstring). ``scheduler`` is the
         # token override for standalone callers; the graph path leaves it None
         # and carries the heuristic's explicit sched_policy knob instead
         # (None = derive via "auto", explicit ints map to their tokens).
         self._scheduler_token = scheduler
-        self._bias_present = bool(bias_present)
-        self._bias_fp32 = bool(bias_fp32)
         self._rope_max_s = int(rope_max_s)
         super().__init__(*args, **kwargs)
 
@@ -3662,12 +3749,11 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
         max_d_v = max(fdv for _, fdv in _SM80_FLAVOR_DIMS.values())
         self._value_error_if(
             d_qk > max_d_qk or d_v > max_d_v,
-            f"SM80 SDPA: head dim (D_QK={d_qk}, D_V={d_v}) exceeds "
-            f"supported envelope (D_QK<={max_d_qk}, D_V<={max_d_v}).  "
-            f"Larger heads are not yet ported.",
+            f"SM80 SDPA: head dim (D_QK={d_qk}, D_V={d_v}) exceeds supported envelope (D_QK<={max_d_qk}, D_V<={max_d_v}).  Larger heads are not yet ported.",
         )
 
         self.dtype = self._check_dtype(self.q_desc, [torch.float16, torch.bfloat16], name="Q")
+        self._check_bias_desc(h_qo, s_qo, s_kv)
         for desc in (self.k_desc, self.v_desc, self.o_desc):
             self._check_dtype(
                 desc,
@@ -3691,7 +3777,7 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
 
         self._not_implemented_error_if(
             self.thd or self.cu_seq_q_lens or self.cu_seq_kv_lens,
-            "SdpaFwdDslSm80 does not serve packed THD / cu_seq_len graphs; " "sdpa_fwd_wrapper_sm80's varlen path launches them directly",
+            "SdpaFwdDslSm80 does not serve packed THD / cu_seq_len graphs; sdpa_fwd_wrapper_sm80's varlen path launches them directly",
         )
         self._not_implemented_error_if(
             self.window_size_right is not None and not self.is_causal,
@@ -3813,8 +3899,8 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
             has_seq_kv_lens=self.seq_kv_lens_present,
             has_seq_q_lens=self.seq_q_lens_present,
             has_sink=self.has_sink,
-            has_bias=self._bias_present,
-            bias_is_fp32=self._bias_fp32,
+            has_bias=self.bias_desc is not None,
+            bias_is_fp32=self.bias_desc is not None and self.bias_desc.dtype == torch.float32,
             has_rope=self._rope_max_s > 0,
             thd_varlen=False,
             sched_policy=_sm80_sched_policy_int(self.sched_token),
@@ -3836,6 +3922,7 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
             swa_window=int(self.swa_window_runtime),
             rope_max_s=self._rope_max_s,
             lse_stride=self._lse_stride,
+            bias_stride=self._bias_stride,
         )
         self._logger.debug("compile completed")
 
@@ -3850,13 +3937,13 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
         v_tensor: torch.Tensor,
         o_tensor: torch.Tensor,
         lse_tensor: Optional[torch.Tensor] = None,
+        bias_tensor: Optional[torch.Tensor] = None,
         sinks: Optional[torch.Tensor] = None,
         seq_q_lens: Optional[torch.Tensor] = None,
         seq_kv_lens: Optional[torch.Tensor] = None,
         scale_softmax: Optional[float] = None,
         workspace: Optional[torch.Tensor] = None,
         current_stream: Optional[cuda.CUstream] = None,
-        bias_tensor: Optional[torch.Tensor] = None,
         rope_freqs: Optional[torch.Tensor] = None,
     ) -> None:
         self._logger.debug("Entering execute")
@@ -3939,16 +4026,7 @@ class SdpaFwdDslSm80(SdpaFwdDsl):
             else:
                 sinks_b = self._dummy("one_f32", device, lambda: torch.ones(1, dtype=torch.float32, device=device))
             if bias_tensor is not None:
-                self._value_error_if(
-                    bias_tensor.dtype != (torch.float32 if p.bias_is_fp32 else q_tensor.dtype),
-                    f"bias dtype must match the compiled specialization; got {bias_tensor.dtype}",
-                )
-                self._value_error_if(
-                    tuple(bias_tensor.shape[-3:]) != (self.h_q, self.s_q_max, self.s_k_max),
-                    f"bias trailing dims must be (H, SQ, SKV) = ({self.h_q}, {self.s_q_max}, {self.s_k_max}); got {tuple(bias_tensor.shape)}",
-                )
-                bias_b = bias_tensor[:1] if bias_tensor.shape[0] != 1 else bias_tensor
-                self._value_error_if(not bias_b.is_contiguous(), "bias must be contiguous")
+                bias_b = self._checked_bias(bias_tensor)
             else:
                 bias_dt = q_tensor.dtype
                 bias_b = self._dummy(f"one_{bias_dt}", device, lambda: torch.ones(1, dtype=bias_dt, device=device))
@@ -4203,8 +4281,7 @@ def sdpa_fwd_wrapper_sm80(
         seq_kv_lens is not None,
         seq_len_q is not None,
         sinks is not None,
-        bias_tensor is not None,
-        (bias_tensor.dtype if bias_tensor is not None else None),
+        _optional_tensor_signature(bias_tensor),
         rope_max_s,
         q_tensor.device,
     )
@@ -4216,6 +4293,7 @@ def sdpa_fwd_wrapper_sm80(
             sample_v=v_tensor,
             sample_o=o_tensor,
             sample_lse=lse_tensor,
+            sample_bias=bias_tensor,
             is_causal=is_causal,
             causal_bottom_right=causal_bottom_right,
             window_size_left=(wl if wl >= 0 else None),
@@ -4225,8 +4303,6 @@ def sdpa_fwd_wrapper_sm80(
             seq_q_lens_present=seq_len_q is not None,
             has_sink=sinks is not None,
             scheduler=scheduler,
-            bias_present=bias_tensor is not None,
-            bias_fp32=(bias_tensor is not None and bias_tensor.dtype == torch.float32),
             rope_max_s=rope_max_s,
         )
         api.check_support()
@@ -4238,12 +4314,12 @@ def sdpa_fwd_wrapper_sm80(
         v_tensor=v_tensor,
         o_tensor=o_tensor,
         lse_tensor=lse_tensor,
+        bias_tensor=bias_tensor,
         sinks=sinks,
         seq_q_lens=seq_len_q,
         seq_kv_lens=seq_kv_lens,
         scale_softmax=scale_softmax,
         current_stream=current_stream,
-        bias_tensor=bias_tensor,
         rope_freqs=rope_freqs,
     )
     return TupleDict(o_tensor=o_tensor, lse_tensor=lse_tensor)

--- a/python/cudnn/sdpa/fwd/config_sm100.py
+++ b/python/cudnn/sdpa/fwd/config_sm100.py
@@ -77,6 +77,8 @@ class TemplateParams:
     window_left: Optional[int] = None
     window_right: Optional[int] = None
     bottom_right: bool = False
+    has_bias: bool = False
+    bias_is_fp32: bool = False
     has_sink: bool = False
     seq_kv_lens_present: bool = False
     # Dense padded-Q trim: per-batch seq_len_q is a SEPARATE (B,)-int32
@@ -160,6 +162,10 @@ def _validate_params(flavor: str, k: TemplateParams) -> None:
             raise ValueError(f"{flavor}: bottom_right anchors the band's diagonal and requires a right bound (window_right)")
     if k.thd_varlen and not k.seq_kv_lens_present:
         raise ValueError(f"{flavor}: THD/varlen requires SEQ_KV_LENS_PRESENT (per-sequence padded masking)")
+    if k.thd_varlen and k.has_bias:
+        raise ValueError(f"{flavor}: attention bias is dense-only (THD has no single [1, H_q, S_q, S_kv] bias shape)")
+    if k.bias_is_fp32 and not k.has_bias:
+        raise ValueError(f"{flavor}: bias_is_fp32 requires has_bias")
     if k.seq_q_lens_present:
         if k.thd_varlen:
             raise ValueError(f"{flavor}: SEQ_Q_LENS_PRESENT is dense-only (THD carries per-sequence Q lengths via cu_seqlens)")

--- a/python/cudnn/sdpa/fwd/config_sm120.py
+++ b/python/cudnn/sdpa/fwd/config_sm120.py
@@ -64,6 +64,8 @@ class TemplateParams:
     window_left: int | None = None
     window_right: int | None = None
     bottom_right: bool = False
+    has_bias: bool = False
+    bias_is_fp32: bool = False
     seq_q_lens_present: bool = False
     seq_kv_lens_present: bool = False
     has_sink: bool = False
@@ -133,5 +135,9 @@ def validate_params(
             raise ValueError("SM120 SDPA: thd_varlen requires seq_kv_lens_present (the THD metadata tensor)")
         if params.seq_q_lens_present:
             raise ValueError("SM120 SDPA: seq_q_lens_present is dense-only (THD carries per-sequence Q lengths via cu_seqlens)")
+        if params.has_bias:
+            raise ValueError("SM120 SDPA: attention bias is dense-only (THD has no single [1, H_q, S_q, S_kv] bias shape)")
+    if params.bias_is_fp32 and not params.has_bias:
+        raise ValueError("SM120 SDPA: bias_is_fp32 requires has_bias")
     if params.pack_gqa and params.thd_varlen:
         raise ValueError("SM120 SDPA: pack_gqa is not supported with thd_varlen")

--- a/python/cudnn/sdpa/fwd/engines.py
+++ b/python/cudnn/sdpa/fwd/engines.py
@@ -25,7 +25,6 @@ engines may share one template. Neither direction is 1:1.
 
 from __future__ import annotations
 
-import inspect
 import logging
 from dataclasses import dataclass
 from functools import partial
@@ -431,6 +430,19 @@ def mismatch(capabilities: Capabilities, facts: "ga.SdpaGraphFacts", knobs: Opti
         bias_dt = facts.bias_t.get_data_type()
         if bias_dt not in (cudnn.data_type.FLOAT, facts.dtype):
             return f"bias dtype {bias_dt} must be fp32 or match the Q/K/V dtype ({facts.dtype})"
+        if facts.thd:
+            return "attention bias is dense-only (THD has no single [1, H_q, S_q, S_kv] bias shape)"
+        bias_dim = tuple(facts.bias_t.get_dim())
+        expected_dim = (1, facts.h_q, facts.s_q, facts.s_kv)
+        if bias_dim != expected_dim:
+            return f"bias must be [1, H_q, S_q, S_kv] = {expected_dim}; got {bias_dim}"
+        bias_stride = tuple(facts.bias_t.get_stride())
+        if not ga.dense_layout_ok(bias_dim, bias_stride):
+            return (
+                "bias must use a dense-compatible H/Q permutation or padded layout "
+                "with contiguous K and non-broadcast, non-overlapping-by-span strides; "
+                f"got {bias_stride}"
+            )
 
     if facts.right_band_widening and facts.right_bound is not None and facts.right_bound < 0:
         return f"negative diagonal_band_right_bound ({facts.right_bound}) is not supported"
@@ -517,6 +529,7 @@ def _sm100_spec() -> EngineSpec:
             phase="prefill",
             d_shapes=frozenset({(128, 128), (192, 128), (256, 256), (512, 512)}),
             dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
+            bias=True,
             causal=True,
             bottom_right=True,
             right_band_widening=True,
@@ -763,6 +776,7 @@ def _sm120_spec() -> EngineSpec:
             # native shapes are the cross product of the supported tiles.
             d_shapes=frozenset((tq, tv) for tq in SUPPORTED_HEAD_TILES for tv in SUPPORTED_HEAD_TILES),
             dtypes=frozenset({cudnn.data_type.HALF, cudnn.data_type.BFLOAT16}),
+            bias=True,
             causal=True,
             bottom_right=True,
             swa=True,
@@ -861,6 +875,7 @@ def lower_dsl_prefill(
         sample_v=ga.tensor_desc_from_ir(facts.v_t, name="v"),
         sample_o=ga.tensor_desc_from_ir(facts.o_t, name="o"),
         sample_lse=ga.tensor_desc_from_ir(facts.stats_t, "lse") if facts.stats_t is not None else None,
+        sample_bias=ga.tensor_desc_from_ir(facts.bias_t, "bias") if facts.bias_t is not None else None,
         # A right-widened band lowers as the causal mask with a BAND_RIGHT
         # diagonal offset (facts.causal is False when right_bound > 0).
         is_causal=facts.causal or facts.right_band_widening,
@@ -895,18 +910,6 @@ def lower_dsl_prefill(
         pack_gqa=knobs.pack_gqa if knobs is not None else None,
         split_kv=knobs.split_kv if knobs is not None else None,
         softmax_precision=knobs.softmax_precision if knobs is not None else None,
-        # SM80-only PLAN-TIME axes (bias presence/dtype are compile-time
-        # specializations of that template): forwarded only to adapters whose
-        # constructor declares them — every other row's mismatch gated the
-        # operands off already.
-        **(
-            {
-                "bias_present": facts.bias_t is not None,
-                "bias_fp32": facts.bias_t is not None and facts.bias_t.get_data_type() == cudnn.data_type.FLOAT,
-            }
-            if "bias_present" in inspect.signature(_adapter(api_type).__init__).parameters
-            else {}
-        ),
     )
     api.check_support()  # raises ValueError / NotImplementedError if unsupported
     api.compile()
@@ -924,13 +927,6 @@ def lower_dsl_prefill(
     synth_kv_bytes = ws_align(facts.b * 4) if synth_kv_padding else 0
     api_scratch_bytes = api.scratch_workspace_bytes()
     total_workspace_bytes = synth_kv_bytes + api_scratch_bytes
-
-    # SM80-only feature operand (bias): the row's capability gate admitted it,
-    # and the adapter's execute() declares the matching optional keyword —
-    # forwarded below only when both hold. ALiBi / block_mask / score-stats
-    # graphs never reach a FROST row (every capability row declines them, so
-    # the backend serves them).
-    _extra_exec_keys = {"bias_tensor"} & set(inspect.signature(type(api).execute).parameters)
 
     binding = ga.SdpaBinding(
         q=facts.q_t,
@@ -993,9 +989,9 @@ def lower_dsl_prefill(
         # lse_optional (the kernel compiles the LSE store out) — no dummy.
         lse_buf = resolved.get(id(binding.stats)) if binding.stats is not None else None
         # Shared presence-checked resolution (graph_analyzer.resolve_feature_operands);
-        # bias flows only to adapters declaring the keyword (the SM80 row);
-        # every other feature operand is gated off by mismatch for all rows.
+        # Every other feature operand is gated off by mismatch for all rows.
         feature_ops = ga.resolve_feature_operands(facts, resolved)
+        bias_buf = feature_ops.bias
         sinks_buf = feature_ops.sinks
         seq_kv_buf = feature_ops.seq_kv_lens
         if synth_kv_padding and seq_kv_buf is None:
@@ -1033,6 +1029,7 @@ def lower_dsl_prefill(
             v_tensor=v_buf,
             o_tensor=o_buf,
             lse_tensor=lse_buf,
+            bias_tensor=bias_buf,
             scale_softmax=facts.scale,
             sinks=sinks_buf,
             seq_kv_lens=seq_kv_buf,
@@ -1052,10 +1049,6 @@ def lower_dsl_prefill(
                 descale_v=dv_buf,
                 scale_o=so_buf,
             )
-        if _extra_exec_keys:
-            # SM80 feature operand (mismatch admitted it for this row).
-            if feature_ops.bias is not None and "bias_tensor" in _extra_exec_keys:
-                execute_kwargs["bias_tensor"] = feature_ops.bias
         if api_scratch_bytes:
             execute_kwargs["workspace"] = carver.remaining()
         api.execute(**execute_kwargs)

--- a/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/_common_sm100.py
@@ -13,8 +13,10 @@ from cudnn.frost.tile_dsl.scheduler import (
     lpt_tile_coords,
     lpt_l2_tile_coords,
 )
-from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_PADDED, MASK_SWA
+from cudnn.frost.tile_dsl.mask import MASK_CAUSAL, MASK_PADDED, MASK_SWA, apply_mask_chunk
 from cudnn.frost.tile_dsl.barrier import MBarrier, Producer, Scope
+
+_LOG2E = 1.4426950408889634
 
 
 class Bars(NamedTuple):
@@ -825,3 +827,105 @@ def make_sdpa_helpers(
         thd_tma_offsets=_thd_tma_offsets,
         thd_sf_tile_bases=_thd_sf_tile_bases,
     )
+
+
+@cute.jit
+def load_attention_bias_chunk(
+    bias_tensor: cute.Tensor,
+    head_idx,
+    q_idx,
+    kv_col_base,
+    chunk_size: cutlass.Constexpr[int],
+):
+    """Load one score-row chunk from key-contiguous ``[1, H, Sq, Skv]`` bias.
+
+    Rows and columns outside the logical tail clamp to the last physical
+    element. The attention mask overwrites those lanes with ``-inf`` before
+    softmax, so the clamped values are never observed. Keeping every GMEM
+    address in bounds lets arbitrary Sq/Skv tails use the same specialization.
+    """
+
+    bias = cutlass.make_array_view(bias_tensor)
+    sq = cutlass.Int32(bias_tensor.shape[2])
+    skv = cutlass.Int32(bias_tensor.shape[3])
+    q_safe = cutlass.Int32(arith.select((q_idx < sq).ir_value(), q_idx.ir_value(), (sq - cutlass.Int32(1)).ir_value()))
+
+    def _load(i: int):
+        col = kv_col_base + cutlass.Int32(i)
+        col_safe = cutlass.Int32(arith.select((col < skv).ir_value(), col.ir_value(), (skv - cutlass.Int32(1)).ir_value()))
+        return cutlass.Float32(bias[cutlass.Int32(0), head_idx, q_safe, col_safe])
+
+    return cutlass.Vector.from_elements(tuple(_load(i) for i in range(chunk_size)), cutlass.Float32)
+
+
+@cute.jit
+def add_attention_bias_log2(
+    scores,
+    bias_tensor: cute.Tensor,
+    head_idx,
+    q_idx,
+    kv_col_base,
+    scale_log2,
+    tile_n: cutlass.Constexpr[int],
+):
+    """Return ``QK * scale_log2 + bias * log2(e)``."""
+
+    from cudnn.frost.tile_dsl.regtile import vec_concat
+
+    chunk = 64
+    bias_chunks = [
+        load_attention_bias_chunk(
+            bias_tensor,
+            head_idx,
+            q_idx,
+            kv_col_base + cutlass.Int32(i * chunk),
+            chunk,
+        )
+        for i in range(tile_n // chunk)
+    ]
+    return scores * scale_log2 + vec_concat(bias_chunks) * cutlass.Float32(_LOG2E)
+
+
+@cute.jit
+def apply_attention_mask(
+    scores,
+    q_idx,
+    kv_col_base,
+    seq_kv_len,
+    window_left: cutlass.Constexpr[int],
+    mask_flags: cutlass.Constexpr[int],
+    tile_n: cutlass.Constexpr[int],
+    bottom_right: cutlass.Constexpr[int] = 0,
+    causal_diag=None,
+    window_right: cutlass.Constexpr[int] = 0,
+):
+    """Apply the attention mask to already scaled and biased scores.
+
+    Bias must precede masking so masked lanes stay ``-inf`` even when their
+    bias values are nonfinite. The helper also returns the masked row max used
+    by the online softmax update.
+    """
+
+    from cudnn.frost.tile_dsl.pointwise import row_max_reduction
+    from cudnn.frost.tile_dsl.regtile import RegTile, vec_concat
+
+    chunk = 64
+    score_tile = RegTile(scores, size=tile_n)
+    masked_chunks = [
+        apply_mask_chunk(
+            score_tile[i * chunk : (i + 1) * chunk].vec,
+            q_idx,
+            kv_col_base + cutlass.Int32(i * chunk),
+            seq_kv_len,
+            window_left,
+            mask_flags,
+            N=chunk,
+            bottom_right=bottom_right,
+            causal_diag=causal_diag,
+            mask_value=float("-inf"),
+            window_right=window_right,
+        )
+        for i in range(tile_n // chunk)
+    ]
+    masked = vec_concat(masked_chunks)
+    return masked, row_max_reduction(masked)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d128_f16_sm100.py
@@ -162,7 +162,9 @@ else:
 
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    add_attention_bias_log2,
     Bars,
+    apply_attention_mask,
     make_split_helpers,
     KvLoopBounds,
     make_classic_bars,
@@ -309,6 +311,7 @@ def _kernel(
     tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
     tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -475,6 +478,7 @@ def _kernel(
             sQ=sQ,
             bars=bars,
             sched=sched,
+            bias_tensor=bias_tensor,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             seq_q_lens_tensor=seq_q_lens_tensor,
             n_q_supers=n_q_supers,
@@ -496,6 +500,7 @@ def _kernel(
             sQ=sQ,
             bars=bars,
             sched=sched,
+            bias_tensor=bias_tensor,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             seq_q_lens_tensor=seq_q_lens_tensor,
             n_q_supers=n_q_supers,
@@ -1363,13 +1368,15 @@ def _softmax_kv_body(
     bmm1_phase,
     stat_empty_phase,
     leader_cta_id,
+    bias_tensor,
+    row_head_idx,
 ):
     """Per-iter kv body for the softmax warp group.
 
-    Compile-time apply_mask (Python bool) picks the load+max strategy:
-    apply_mask=False uses fused tcgen05.ld.red.f32.max (HW row-max);
-    apply_mask=True uses tcgen05.ld + apply_mask_chunk + software row-max
-    (HW max can't observe NEG_INFINITY written after the load).
+    Without bias, compile-time apply_mask (Python bool) picks whether the raw
+    scores are masked before their row max is computed. With bias, the raw
+    scores are scaled and biased first, then masked once before computing the
+    final row max so the mask remains authoritative for nonfinite bias values.
 
     total_max runs in scaled (log2) units and starts at -inf; total_max_safe
     is its 0-substituted companion (see row_max_for_exp2), carried so alpha
@@ -1397,71 +1404,80 @@ def _softmax_kv_body(
     p_addr_base = tmem_base + cutlass.Int32(tmem_P_off)
     stats_addr = tmem_base + cutlass.Int32(stats_off)
 
-    # apply_mask is a Python bool — wrap in cutlass.const_expr so the DSL folds
-    # at trace time instead of staging cf.if (the two arms produce Vectors
-    # built via different MLIR op sequences and the tracer would error).
-    if cutlass.const_expr(apply_mask):
-        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
-        # Python comprehensions (not for+append) so the tracer sees fully-formed lists.
-        raw_chunks = [
-            nvvm.tcgen05_ld(
-                "32x32b",
-                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
-                num=CHUNK,
-            )
-            for c in range(N_CHUNKS)
-        ]
-        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
-        # CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
-        chunks_S = [
-            apply_mask_chunk(
-                raw_chunks[c],
+    from cudnn.frost.tile_dsl.regtile import vec_concat
+
+    kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+    # Python comprehensions (not for+append) so the tracer sees fully-formed lists.
+    raw_chunks = [
+        nvvm.tcgen05_ld(
+            "32x32b",
+            nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
+            num=CHUNK,
+        )
+        for c in range(N_CHUNKS)
+    ]
+
+    if cutlass.const_expr(PARAMS.has_bias):
+        adjusted_scores = add_attention_bias_log2(
+            vec_concat(raw_chunks),
+            bias_tensor,
+            row_head_idx,
+            q_abs,
+            kv_col_base,
+            scale_log2,
+            CFG.TILE_N,
+        )
+        reg_S = RegTile(adjusted_scores, size=CFG.TILE_N)
+        if cutlass.const_expr(apply_mask):
+            causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+            masked_scores, current_max = apply_attention_mask(
+                reg_S.vec,
                 q_abs,
-                kv_col_base + cutlass.Int32(c * CHUNK),
+                kv_col_base,
                 eff_seqlen_kv,
                 CFG.WINDOW_LEFT,
                 CFG.MASK_FLAGS,
-                N=CHUNK,
+                CFG.TILE_N,
                 bottom_right=CFG.BOTTOM_RIGHT,
                 causal_diag=causal_diag,
-                mask_value=float("-inf"),
                 window_right=CFG.WINDOW_RIGHT,
             )
-            for c in range(N_CHUNKS)
-        ]
-        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
-        from cudnn.frost.tile_dsl.regtile import vec_concat
-
-        # vec_concat handles single-element lists too; keeps tracer Vector type uniform across N_CHUNKS.
-        reg_S_vec = vec_concat(chunks_S)
-        current_max_unscaled = chunks_max[0]
-        for m in chunks_max[1:]:
-            current_max_unscaled = cute.math.max(current_max_unscaled, m)
+            reg_S = RegTile(masked_scores, size=CFG.TILE_N)
+        else:
+            current_max = row_max_reduction(reg_S[0:CHUNK].vec)
+            if cutlass.const_expr(N_CHUNKS == 2):
+                current_max = cute.math.max(current_max, row_max_reduction(reg_S[CHUNK : 2 * CHUNK].vec))
     else:
-        # SM100: manual row-max (no LDTM.STAT / tmem_load_max_reduction_tile).
-        # Load S chunks, reduce per chunk, combine across chunks — the masked
-        # path's pattern sans mask.
-        from cudnn.frost.tile_dsl.regtile import vec_concat
+        if cutlass.const_expr(apply_mask):
+            # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out
+            # when CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+            causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+            score_chunks = [
+                apply_mask_chunk(
+                    raw_chunks[c],
+                    q_abs,
+                    kv_col_base + cutlass.Int32(c * CHUNK),
+                    eff_seqlen_kv,
+                    CFG.WINDOW_LEFT,
+                    CFG.MASK_FLAGS,
+                    N=CHUNK,
+                    bottom_right=CFG.BOTTOM_RIGHT,
+                    causal_diag=causal_diag,
+                    mask_value=float("-inf"),
+                    window_right=CFG.WINDOW_RIGHT,
+                )
+                for c in range(N_CHUNKS)
+            ]
+        else:
+            score_chunks = raw_chunks
 
-        raw_chunks = [
-            nvvm.tcgen05_ld(
-                "32x32b",
-                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
-                num=CHUNK,
-            )
-            for c in range(N_CHUNKS)
-        ]
-        chunks_max = [row_max_reduction(raw_chunks[c]) for c in range(N_CHUNKS)]
-        reg_S_vec = vec_concat(raw_chunks)
+        # SM100: manual row-max (no LDTM.STAT / tmem_load_max_reduction_tile).
+        chunks_max = [row_max_reduction(score_chunks[c]) for c in range(N_CHUNKS)]
+        reg_S = RegTile(vec_concat(score_chunks), size=CFG.TILE_N)
         current_max_unscaled = chunks_max[0]
         for m in chunks_max[1:]:
             current_max_unscaled = cute.math.max(current_max_unscaled, m)
-
-    # Pass size=CFG.TILE_N explicitly — Vector.shape[0] is an MLIR value
-    # (not Python int) for vec_concat-built vectors, so auto-detect can't recover the length.
-    reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
-    current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+        current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
 
     # Named-barrier wg0/wg1 sync: sub_tile_id==1 waits at TOP for sub_tile_id==0's bottom arrive.
     if sub_tile_id == 1:
@@ -1498,7 +1514,10 @@ def _softmax_kv_body(
     bars.mb_stat_full[sub_tile_id].arrive()
 
     # Rescale full reg_S in one vector op — emits same FFMA2 sequence as explicit half-tile rescales.
-    reg_S = reg_S * scale_log2 - total_max_safe
+    if cutlass.const_expr(PARAMS.has_bias):
+        reg_S = reg_S - total_max_safe
+    else:
+        reg_S = reg_S * scale_log2 - total_max_safe
 
     # Chunk 0 manual unroll — the DSL's @cute.jit tracer makes the loop iter an
     # MLIR value, breaking Python slice.indices() math inside RegTile[].
@@ -1558,6 +1577,7 @@ def _softmax_warp_group(
     sQ,
     bars,
     sched,
+    bias_tensor: Optional[cute.Tensor],
     seq_kv_lens_tensor,
     seq_q_lens_tensor,
     n_q_supers,
@@ -1643,6 +1663,7 @@ def _softmax_warp_group(
         # token share it.
         q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
         q_abs = q_row_coord + cutlass.Int32(sub_tile_id * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+        row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
         # Bootstrap stat_empty wait BEFORE kv loop — lifts wait off per-iter
         # critical path so alpha publish + stat_full fire happen back-to-back.
         bars.mb_stat_empty[sub_tile_id].wait(stat_empty_phase)
@@ -1667,6 +1688,8 @@ def _softmax_warp_group(
                     bmm1_phase,
                     stat_empty_phase,
                     leader_cta_id,
+                    bias_tensor,
+                    row_head_idx,
                 )
         else:
             for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
@@ -1686,6 +1709,8 @@ def _softmax_warp_group(
                     bmm1_phase,
                     stat_empty_phase,
                     leader_cta_id,
+                    bias_tensor,
+                    row_head_idx,
                 )
             for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
                 total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
@@ -1704,6 +1729,8 @@ def _softmax_warp_group(
                     bmm1_phase,
                     stat_empty_phase,
                     leader_cta_id,
+                    bias_tensor,
+                    row_head_idx,
                 )
             for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
                 total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
@@ -1722,6 +1749,8 @@ def _softmax_warp_group(
                     bmm1_phase,
                     stat_empty_phase,
                     leader_cta_id,
+                    bias_tensor,
+                    row_head_idx,
                 )
 
         # End-of-kv: publish (total_max, total_sum_final) to TMEM Stats — corr reads it for LSE.
@@ -2071,6 +2100,7 @@ def _host(
     v_tensor: cute.Tensor,
     o_tensor: cute.Tensor,
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -2197,6 +2227,7 @@ def _host(
         tma_v_desc,
         tma_o_desc,
         lse_tensor,
+        bias_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
         o_desc_words,
@@ -2233,6 +2264,7 @@ def compile(  # noqa: A001
     v_stride: Optional[tuple] = None,
     o_stride: Optional[tuple] = None,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    bias_stride: Optional[tuple[int, int, int, int]] = None,
 ) -> Callable:
     """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
 
@@ -2272,6 +2304,8 @@ def compile(  # noqa: A001
         raise ValueError("d128: split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
     if lse_stride is not None and (CFG.THD_VARLEN or SPLIT_KV > 1):
         raise ValueError("dense LSE strides are not valid for THD or split-KV workspaces")
+    if bias_stride is not None and not PARAMS.has_bias:
+        raise ValueError("bias_stride requires a bias-enabled kernel")
     _fake_batch = 1 if CFG.THD_VARLEN else b
     if CFG.THD_VARLEN:
         # Dynamic packed token totals: one symbol per ragged group (Q/O and
@@ -2303,6 +2337,16 @@ def compile(  # noqa: A001
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
     fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=STORAGE_DTYPE)
+    bias_dtype = cutlass.Float32 if PARAMS.bias_is_fp32 else STORAGE_DTYPE
+    fake_bias = (
+        (
+            cute.runtime.make_fake_tensor(bias_dtype, (1, qh, sq, skv), bias_stride, assumed_align=4)
+            if bias_stride is not None
+            else cute.runtime.make_fake_compact_tensor(bias_dtype, (1, qh, sq, skv), stride_order=(3, 2, 1, 0), assumed_align=4)
+        )
+        if PARAMS.has_bias
+        else None
+    )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2410,6 +2454,7 @@ def compile(  # noqa: A001
         fake_v,
         fake_o,
         fake_lse,
+        fake_bias,
         fake_sinks,
         fake_seq_kv_lens,
         fake_o_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d192_d128_f16_sm100.py
@@ -137,6 +137,8 @@ else:
 
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    add_attention_bias_log2,
+    apply_attention_mask,
     make_split_helpers,
     make_classic_bars,
     row_max_for_exp2,
@@ -343,6 +345,7 @@ def _kernel(
     tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
     tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -513,6 +516,7 @@ def _kernel(
             sQ=sQ,
             bars=bars,
             sched=sched,
+            bias_tensor=bias_tensor,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             seq_q_lens_tensor=seq_q_lens_tensor,
             n_q_supers=n_q_supers,
@@ -534,6 +538,7 @@ def _kernel(
             sQ=sQ,
             bars=bars,
             sched=sched,
+            bias_tensor=bias_tensor,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             seq_q_lens_tensor=seq_q_lens_tensor,
             n_q_supers=n_q_supers,
@@ -1431,13 +1436,15 @@ def _softmax_kv_body(
     bmm1_phase,
     stat_empty_phase,
     leader_cta_id,
+    bias_tensor,
+    row_head_idx,
 ):
     """Per-iter kv body for the softmax warp group.
 
-    Compile-time apply_mask (Python bool) picks the load+max strategy:
-    apply_mask=False uses manual tcgen05.ld + software row-max;
-    apply_mask=True uses tcgen05.ld + apply_mask_chunk + software row-max
-    (HW max can't observe NEG_INFINITY written after the load).
+    Without bias, compile-time apply_mask (Python bool) picks whether the raw
+    scores are masked before their row max is computed. With bias, the raw
+    scores are scaled and biased first, then masked once before computing the
+    final row max so the mask remains authoritative for nonfinite bias values.
 
     total_max runs in scaled (log2) units and starts at -inf; total_max_safe
     is its 0-substituted companion (see row_max_for_exp2), carried so alpha
@@ -1452,20 +1459,13 @@ def _softmax_kv_body(
     N_CHUNKS = CFG.N_BMM2_CHUNKS
     RESCALE_THRESHOLD = cutlass.Float32(CFG.RESCALE_THRESHOLD)
 
-    if cutlass.const_expr(apply_mask):
-        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
-        # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out when
-        # CFG.BOTTOM_RIGHT is 0 - top-left masking is unchanged).
-        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
-
     _wait_mbarrier(bars.mb_bmm1_done[sub_tile_id], bmm1_phase)
     bmm1_phase = bmm1_phase ^ 1
 
-    # apply_mask is a Python bool — wrap in cutlass.const_expr so the DSL folds
-    # at trace time instead of staging cf.if (the two arms produce Vectors
-    # built via different MLIR op sequences and the tracer would error).
-    if cutlass.const_expr(apply_mask):
-        # Python comprehensions (not for+append) so the tracer sees fully-formed lists.
+    from cudnn.frost.tile_dsl.regtile import vec_concat
+
+    kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
+    if cutlass.const_expr(apply_mask or CFG.MASK_FLAGS == MASK_NONE):
         raw_chunks = [
             nvvm.tcgen05_ld(
                 "32x32b",
@@ -1474,84 +1474,98 @@ def _softmax_kv_body(
             )
             for c in range(N_CHUNKS)
         ]
-        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0):
-            chunks_S = [
-                _apply_top_left_causal_mask_chunk(
-                    raw_chunks[c],
-                    q_abs,
-                    kv_col_base + cutlass.Int32(c * CHUNK),
-                    N=CHUNK,
-                )
-                for c in range(N_CHUNKS)
-            ]
-        elif cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT != 0):
-            chunks_S = [
-                _apply_bottom_right_causal_mask_chunk(
-                    raw_chunks[c],
-                    q_abs,
-                    kv_col_base + cutlass.Int32(c * CHUNK),
-                    causal_diag,
-                    N=CHUNK,
-                )
-                for c in range(N_CHUNKS)
-            ]
-        else:
-            chunks_S = [
-                apply_mask_chunk(
-                    raw_chunks[c],
-                    q_abs,
-                    kv_col_base + cutlass.Int32(c * CHUNK),
-                    eff_seqlen_kv,
-                    CFG.WINDOW_LEFT,
-                    CFG.MASK_FLAGS,
-                    N=CHUNK,
-                    bottom_right=CFG.BOTTOM_RIGHT,
-                    causal_diag=causal_diag,
-                    mask_value=float("-inf"),
-                    window_right=CFG.WINDOW_RIGHT,
-                )
-                for c in range(N_CHUNKS)
-            ]
-        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
-        from cudnn.frost.tile_dsl.regtile import vec_concat
-
-        # vec_concat handles single-element lists too; keeps tracer Vector type uniform across N_CHUNKS.
-        reg_S_vec = vec_concat(chunks_S)
-        current_max_unscaled = chunks_max[0]
-        for m in chunks_max[1:]:
-            current_max_unscaled = cute.math.max(current_max_unscaled, m)
     else:
-        # SM100: manual row-max (no LDTM.STAT / tmem_load_max_reduction_tile).
-        # Pure MASK_NONE avoids the x32 lowering, which spills under DSL 4.7.
-        # Causal kernels retain x32 for their unmasked middle segment.
-        from cudnn.frost.tile_dsl.regtile import vec_concat
-
-        if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
-            raw_chunks = [
-                nvvm.tcgen05_ld(
-                    "32x32b",
-                    nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32),
-                    num=CHUNK,
-                )
-                for c in range(N_CHUNKS)
-            ]
-        else:
-            LOAD_CHUNK = 32
-            raw_chunks = [
-                nvvm.tcgen05_ld(
-                    "32x32b",
-                    nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * LOAD_CHUNK), cutlass.Float32),
-                    num=LOAD_CHUNK,
-                )
-                for c in range(CFG.TILE_N // LOAD_CHUNK)
-            ]
+        LOAD_CHUNK = 32
+        raw_chunks = [
+            nvvm.tcgen05_ld(
+                "32x32b",
+                nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * LOAD_CHUNK), cutlass.Float32),
+                num=LOAD_CHUNK,
+            )
+            for c in range(CFG.TILE_N // LOAD_CHUNK)
+        ]
+    if cutlass.const_expr(PARAMS.has_bias):
         reg_S_vec = vec_concat(raw_chunks)
-        current_max_unscaled = row_max_reduction(reg_S_vec)
-
-    # Pass size=CFG.TILE_N explicitly — Vector.shape[0] is an MLIR value
-    # (not Python int) for vec_concat-built vectors, so auto-detect can't recover the length.
-    reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
-    current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+        adjusted_scores = add_attention_bias_log2(
+            reg_S_vec,
+            bias_tensor,
+            row_head_idx,
+            q_abs,
+            kv_col_base,
+            scale_log2,
+            CFG.TILE_N,
+        )
+        reg_S = RegTile(adjusted_scores, size=CFG.TILE_N)
+        if cutlass.const_expr(apply_mask):
+            causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+            masked_scores, current_max = apply_attention_mask(
+                reg_S.vec,
+                q_abs,
+                kv_col_base,
+                eff_seqlen_kv,
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                CFG.TILE_N,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+            )
+            reg_S = RegTile(masked_scores, size=CFG.TILE_N)
+        else:
+            current_max = row_max_reduction(reg_S.vec)
+    else:
+        if cutlass.const_expr(apply_mask):
+            # Bottom-right causal: runtime SKV-SQ diagonal offset (folds out
+            # when CFG.BOTTOM_RIGHT is 0 — top-left masking is unchanged).
+            causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+            if cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT == 0):
+                score_chunks = [
+                    _apply_top_left_causal_mask_chunk(
+                        raw_chunks[c],
+                        q_abs,
+                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        N=CHUNK,
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+            elif cutlass.const_expr(CFG.MASK_FLAGS == MASK_CAUSAL and CFG.BOTTOM_RIGHT != 0):
+                score_chunks = [
+                    _apply_bottom_right_causal_mask_chunk(
+                        raw_chunks[c],
+                        q_abs,
+                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        causal_diag,
+                        N=CHUNK,
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+            else:
+                score_chunks = [
+                    apply_mask_chunk(
+                        raw_chunks[c],
+                        q_abs,
+                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        eff_seqlen_kv,
+                        CFG.WINDOW_LEFT,
+                        CFG.MASK_FLAGS,
+                        N=CHUNK,
+                        bottom_right=CFG.BOTTOM_RIGHT,
+                        causal_diag=causal_diag,
+                        mask_value=float("-inf"),
+                        window_right=CFG.WINDOW_RIGHT,
+                    )
+                    for c in range(N_CHUNKS)
+                ]
+            chunks_max = [row_max_reduction(score_chunks[c]) for c in range(N_CHUNKS)]
+            reg_S = RegTile(vec_concat(score_chunks), size=CFG.TILE_N)
+            current_max_unscaled = chunks_max[0]
+            for m in chunks_max[1:]:
+                current_max_unscaled = cute.math.max(current_max_unscaled, m)
+        else:
+            reg_S_vec = vec_concat(raw_chunks)
+            reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
+            current_max_unscaled = row_max_reduction(reg_S_vec)
+        current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
 
     cute.arch.inline_ptx('.pragma "set knob SchedResBusyXU64=1";')
 
@@ -1588,7 +1602,10 @@ def _softmax_kv_body(
     bars.mb_stat_full[sub_tile_id].arrive()
 
     # Rescale full reg_S in one vector op — emits same FFMA2 sequence as explicit half-tile rescales.
-    reg_S = reg_S * scale_log2 - total_max_safe
+    if cutlass.const_expr(PARAMS.has_bias):
+        reg_S = reg_S - total_max_safe
+    else:
+        reg_S = reg_S * scale_log2 - total_max_safe
 
     # Chunk 0 manual unroll — the DSL's @cute.jit tracer makes the loop iter an
     # MLIR value, breaking Python slice.indices() math inside RegTile[].
@@ -1651,6 +1668,7 @@ def _softmax_warp_group(
     sQ,
     bars,
     sched,
+    bias_tensor: Optional[cute.Tensor],
     seq_kv_lens_tensor,
     seq_q_lens_tensor,
     n_q_supers,
@@ -1732,6 +1750,7 @@ def _softmax_warp_group(
         # token share it.
         q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
         q_abs = q_row_coord + cutlass.Int32(sub_tile_id * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+        row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
         # 3-segment kv loop: LEFT-masked / fully-unmasked / RIGHT-masked.
         # At MASK_NONE bounds collapse so the two masked sub-loops have empty range and fold out.
         if cutlass.const_expr(CFG.MASK_FLAGS == MASK_NONE):
@@ -1754,6 +1773,8 @@ def _softmax_warp_group(
                     bmm1_phase,
                     stat_empty_phase,
                     leader_cta_id,
+                    bias_tensor,
+                    row_head_idx,
                 )
         else:
             for kv_loop in cutlass.range(bounds.left, bounds.unmasked_lo, 1, unroll=1):
@@ -1775,6 +1796,8 @@ def _softmax_warp_group(
                     bmm1_phase,
                     stat_empty_phase,
                     leader_cta_id,
+                    bias_tensor,
+                    row_head_idx,
                 )
             for kv_loop in cutlass.range(bounds.unmasked_lo, bounds.unmasked_hi, 1, unroll=1):
                 total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
@@ -1795,6 +1818,8 @@ def _softmax_warp_group(
                     bmm1_phase,
                     stat_empty_phase,
                     leader_cta_id,
+                    bias_tensor,
+                    row_head_idx,
                 )
             for kv_loop in cutlass.range(bounds.unmasked_hi, bounds.right, 1, unroll=1):
                 total_max, total_max_safe, total_sum, bmm1_phase, stat_empty_phase = _softmax_kv_body(
@@ -1815,6 +1840,8 @@ def _softmax_warp_group(
                     bmm1_phase,
                     stat_empty_phase,
                     leader_cta_id,
+                    bias_tensor,
+                    row_head_idx,
                 )
 
         if cutlass.const_expr(not CAN_HAVE_EMPTY_KV) or (bounds.right > bounds.left):
@@ -2168,6 +2195,7 @@ def _host(
     v_tensor: cute.Tensor,
     o_tensor: cute.Tensor,
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -2291,6 +2319,7 @@ def _host(
         tma_v_desc,
         tma_o_desc,
         lse_tensor,
+        bias_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
         o_desc_words,
@@ -2327,6 +2356,7 @@ def compile(  # noqa: A001
     v_stride: Optional[tuple] = None,
     o_stride: Optional[tuple] = None,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    bias_stride: Optional[tuple[int, int, int, int]] = None,
 ) -> Callable:
     """Compile a kernel with ALL dims concrete to pin TMA descriptor strides at compile time.
 
@@ -2358,6 +2388,8 @@ def compile(  # noqa: A001
         raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
     if lse_stride is not None and (CFG.THD_VARLEN or SPLIT_KV > 1):
         raise ValueError("dense LSE strides are not valid for THD or split-KV workspaces")
+    if bias_stride is not None and not PARAMS.has_bias:
+        raise ValueError("bias_stride requires a bias-enabled kernel")
     _fake_batch = 1 if CFG.THD_VARLEN else b
     if CFG.THD_VARLEN:
         # Dynamic packed token totals: one symbol per ragged group (Q/O and
@@ -2388,6 +2420,16 @@ def compile(  # noqa: A001
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
     fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=STORAGE_DTYPE)
+    bias_dtype = cutlass.Float32 if PARAMS.bias_is_fp32 else STORAGE_DTYPE
+    fake_bias = (
+        (
+            cute.runtime.make_fake_tensor(bias_dtype, (1, qh, sq, skv), bias_stride, assumed_align=4)
+            if bias_stride is not None
+            else cute.runtime.make_fake_compact_tensor(bias_dtype, (1, qh, sq, skv), stride_order=(3, 2, 1, 0), assumed_align=4)
+        )
+        if PARAMS.has_bias
+        else None
+    )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2495,6 +2537,7 @@ def compile(  # noqa: A001
         fake_v,
         fake_o,
         fake_lse,
+        fake_bias,
         fake_sinks,
         fake_seq_kv_lens,
         fake_o_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm100.py
@@ -83,6 +83,8 @@ OUT_STORAGE_DTYPE = STORAGE_DTYPE
 
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    apply_attention_mask,
+    add_attention_bias_log2,
     make_split_helpers,
     D256Bars as Bars,
     KvLoopBounds,
@@ -207,6 +209,7 @@ def _kernel(
     tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
     tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -348,6 +351,7 @@ def _kernel(
             bars=bars,
             sched=sched,
             lse_tensor=lse_tensor,
+            bias_tensor=bias_tensor,
             sinks_tensor=sinks_tensor,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             seq_q_lens_tensor=seq_q_lens_tensor,
@@ -998,6 +1002,7 @@ def _softmax_warp_group(
     bars,
     sched,
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor,
     seq_q_lens_tensor,
@@ -1052,6 +1057,7 @@ def _softmax_warp_group(
         # token share it.
         q_row_coord = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE)
         q_abs = q_row_coord + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+        row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
 
         bars.mb_o_empty.wait(epilogue_state)
         bars.mb_stat_empty.wait(stat_empty_phase)
@@ -1085,12 +1091,19 @@ def _softmax_warp_group(
                 raw_chunks = [
                     nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
                 ]
-                chunks_max = [row_max_reduction(raw_chunks[c]) for c in range(N_CHUNKS)]
-                current_max_unscaled = chunks_max[0]
-                for _m in chunks_max[1:]:
-                    current_max_unscaled = cute.math.max(current_max_unscaled, _m)
                 reg_S = RegTile(vec_concat(raw_chunks), size=CFG.TILE_N)
-                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+                if cutlass.const_expr(PARAMS.has_bias):
+                    adjusted_scores = add_attention_bias_log2(
+                        reg_S.vec, bias_tensor, row_head_idx, q_abs, kv_loop * cutlass.Int32(CFG.TILE_N), scale_log2, CFG.TILE_N
+                    )
+                    reg_S = RegTile(adjusted_scores, size=CFG.TILE_N)
+                    current_max = row_max_reduction(reg_S.vec)
+                else:
+                    chunks_max = [row_max_reduction(raw_chunks[c]) for c in range(N_CHUNKS)]
+                    current_max_unscaled = chunks_max[0]
+                    for _m in chunks_max[1:]:
+                        current_max_unscaled = cute.math.max(current_max_unscaled, _m)
+                    current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
 
                 # total_max starts at -inf: a live iteration always clears the
                 # threshold (real - (-inf) = +inf), a fully-masked one never does
@@ -1108,7 +1121,10 @@ def _softmax_warp_group(
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
                 bars.mb_stat_full.arrive()
 
-                reg_S = reg_S * scale_log2 - total_max_safe
+                if cutlass.const_expr(PARAMS.has_bias):
+                    reg_S = reg_S - total_max_safe
+                else:
+                    reg_S = reg_S * scale_log2 - total_max_safe
 
                 chunk_S_0 = reg_S[0:CHUNK].vec
                 chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
@@ -1157,29 +1173,44 @@ def _softmax_warp_group(
                     nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
                 ]
                 causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
-                chunks_S = [
-                    apply_mask_chunk(
-                        raw_chunks[c],
+                if cutlass.const_expr(PARAMS.has_bias):
+                    adjusted_scores = add_attention_bias_log2(vec_concat(raw_chunks), bias_tensor, row_head_idx, q_abs, kv_col_base, scale_log2, CFG.TILE_N)
+                    masked_scores, current_max = apply_attention_mask(
+                        adjusted_scores,
                         q_abs,
-                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        kv_col_base,
                         eff_seqlen_kv,
                         CFG.WINDOW_LEFT,
                         CFG.MASK_FLAGS,
-                        N=CHUNK,
+                        CFG.TILE_N,
                         bottom_right=CFG.BOTTOM_RIGHT,
                         causal_diag=causal_diag,
                         window_right=CFG.WINDOW_RIGHT,
-                        mask_value=float("-inf"),
                     )
-                    for c in range(N_CHUNKS)
-                ]
-                chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
-                reg_S_vec = vec_concat(chunks_S)
-                current_max_unscaled = chunks_max[0]
-                for m in chunks_max[1:]:
-                    current_max_unscaled = cute.math.max(current_max_unscaled, m)
-                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
-                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+                    reg_S = RegTile(masked_scores, size=CFG.TILE_N)
+                else:
+                    score_chunks = [
+                        apply_mask_chunk(
+                            raw_chunks[c],
+                            q_abs,
+                            kv_col_base + cutlass.Int32(c * CHUNK),
+                            eff_seqlen_kv,
+                            CFG.WINDOW_LEFT,
+                            CFG.MASK_FLAGS,
+                            N=CHUNK,
+                            bottom_right=CFG.BOTTOM_RIGHT,
+                            causal_diag=causal_diag,
+                            window_right=CFG.WINDOW_RIGHT,
+                            mask_value=float("-inf"),
+                        )
+                        for c in range(N_CHUNKS)
+                    ]
+                    chunks_max = [row_max_reduction(score_chunks[c]) for c in range(N_CHUNKS)]
+                    reg_S = RegTile(vec_concat(score_chunks), size=CFG.TILE_N)
+                    current_max_unscaled = chunks_max[0]
+                    for m in chunks_max[1:]:
+                        current_max_unscaled = cute.math.max(current_max_unscaled, m)
+                    current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
 
                 # total_max starts at -inf: a live iteration always clears the
                 # threshold (real - (-inf) = +inf), a fully-masked one never does
@@ -1196,7 +1227,10 @@ def _softmax_warp_group(
                 nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
                 bars.mb_stat_full.arrive()
-                reg_S = reg_S * scale_log2 - total_max_safe
+                if cutlass.const_expr(PARAMS.has_bias):
+                    reg_S = reg_S - total_max_safe
+                else:
+                    reg_S = reg_S * scale_log2 - total_max_safe
 
                 chunk_S_0 = reg_S[0:CHUNK].vec
                 chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
@@ -1241,12 +1275,19 @@ def _softmax_warp_group(
                 raw_chunks = [
                     nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
                 ]
-                chunks_max = [row_max_reduction(raw_chunks[c]) for c in range(N_CHUNKS)]
-                current_max_unscaled = chunks_max[0]
-                for _m in chunks_max[1:]:
-                    current_max_unscaled = cute.math.max(current_max_unscaled, _m)
                 reg_S = RegTile(vec_concat(raw_chunks), size=CFG.TILE_N)
-                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+                if cutlass.const_expr(PARAMS.has_bias):
+                    adjusted_scores = add_attention_bias_log2(
+                        reg_S.vec, bias_tensor, row_head_idx, q_abs, kv_loop * cutlass.Int32(CFG.TILE_N), scale_log2, CFG.TILE_N
+                    )
+                    reg_S = RegTile(adjusted_scores, size=CFG.TILE_N)
+                    current_max = row_max_reduction(reg_S.vec)
+                else:
+                    chunks_max = [row_max_reduction(raw_chunks[c]) for c in range(N_CHUNKS)]
+                    current_max_unscaled = chunks_max[0]
+                    for _m in chunks_max[1:]:
+                        current_max_unscaled = cute.math.max(current_max_unscaled, _m)
+                    current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
 
                 # total_max starts at -inf: a live iteration always clears the
                 # threshold (real - (-inf) = +inf), a fully-masked one never does
@@ -1263,7 +1304,10 @@ def _softmax_warp_group(
                 nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
                 bars.mb_stat_full.arrive()
-                reg_S = reg_S * scale_log2 - total_max_safe
+                if cutlass.const_expr(PARAMS.has_bias):
+                    reg_S = reg_S - total_max_safe
+                else:
+                    reg_S = reg_S * scale_log2 - total_max_safe
 
                 chunk_S_0 = reg_S[0:CHUNK].vec
                 chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
@@ -1310,29 +1354,44 @@ def _softmax_warp_group(
                     nvvm.tcgen05_ld("32x32b", nvvm.make_tmem_ptr(s_addr_base + cutlass.Int32(c * CHUNK), cutlass.Float32), num=CHUNK) for c in range(N_CHUNKS)
                 ]
                 causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
-                chunks_S = [
-                    apply_mask_chunk(
-                        raw_chunks[c],
+                if cutlass.const_expr(PARAMS.has_bias):
+                    adjusted_scores = add_attention_bias_log2(vec_concat(raw_chunks), bias_tensor, row_head_idx, q_abs, kv_col_base, scale_log2, CFG.TILE_N)
+                    masked_scores, current_max = apply_attention_mask(
+                        adjusted_scores,
                         q_abs,
-                        kv_col_base + cutlass.Int32(c * CHUNK),
+                        kv_col_base,
                         eff_seqlen_kv,
                         CFG.WINDOW_LEFT,
                         CFG.MASK_FLAGS,
-                        N=CHUNK,
+                        CFG.TILE_N,
                         bottom_right=CFG.BOTTOM_RIGHT,
                         causal_diag=causal_diag,
                         window_right=CFG.WINDOW_RIGHT,
-                        mask_value=float("-inf"),
                     )
-                    for c in range(N_CHUNKS)
-                ]
-                chunks_max = [row_max_reduction(chunks_S[c]) for c in range(N_CHUNKS)]
-                reg_S_vec = vec_concat(chunks_S)
-                current_max_unscaled = chunks_max[0]
-                for m in chunks_max[1:]:
-                    current_max_unscaled = cute.math.max(current_max_unscaled, m)
-                reg_S = RegTile(reg_S_vec, size=CFG.TILE_N)
-                current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
+                    reg_S = RegTile(masked_scores, size=CFG.TILE_N)
+                else:
+                    score_chunks = [
+                        apply_mask_chunk(
+                            raw_chunks[c],
+                            q_abs,
+                            kv_col_base + cutlass.Int32(c * CHUNK),
+                            eff_seqlen_kv,
+                            CFG.WINDOW_LEFT,
+                            CFG.MASK_FLAGS,
+                            N=CHUNK,
+                            bottom_right=CFG.BOTTOM_RIGHT,
+                            causal_diag=causal_diag,
+                            window_right=CFG.WINDOW_RIGHT,
+                            mask_value=float("-inf"),
+                        )
+                        for c in range(N_CHUNKS)
+                    ]
+                    chunks_max = [row_max_reduction(score_chunks[c]) for c in range(N_CHUNKS)]
+                    reg_S = RegTile(vec_concat(score_chunks), size=CFG.TILE_N)
+                    current_max_unscaled = chunks_max[0]
+                    for m in chunks_max[1:]:
+                        current_max_unscaled = cute.math.max(current_max_unscaled, m)
+                    current_max = current_max_unscaled * scale_log2  # -inf when the whole iteration is masked
 
                 # total_max starts at -inf: a live iteration always clears the
                 # threshold (real - (-inf) = +inf), a fully-masked one never does
@@ -1349,7 +1408,10 @@ def _softmax_warp_group(
                 nvvm.tcgen05_st("32x32b", nvvm.make_tmem_ptr(stats_addr, cutlass.Float32), alpha_vec)
                 nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.STORE)
                 bars.mb_stat_full.arrive()
-                reg_S = reg_S * scale_log2 - total_max_safe
+                if cutlass.const_expr(PARAMS.has_bias):
+                    reg_S = reg_S - total_max_safe
+                else:
+                    reg_S = reg_S * scale_log2 - total_max_safe
 
                 chunk_S_0 = reg_S[0:CHUNK].vec
                 chunk_P_0 = cute.math.exp2(chunk_S_0, fastmath=True)
@@ -1690,6 +1752,7 @@ def _host(
     v_tensor: cute.Tensor,
     o_tensor: cute.Tensor,
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -1795,6 +1858,7 @@ def _host(
         tma_v_desc,
         tma_o_desc,
         lse_tensor,
+        bias_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
         o_desc_words,
@@ -1831,6 +1895,7 @@ def compile(  # noqa: A001
     v_stride: Optional[tuple] = None,
     o_stride: Optional[tuple] = None,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    bias_stride: Optional[tuple[int, int, int, int]] = None,
 ) -> Callable:
     """ENVELOPE: ``d_qk`` / ``d_v`` are the ACTUAL head dims (defaults = full
     TILE_K / TILE_O). TMA descriptors carry these extents while the tile box
@@ -1854,6 +1919,8 @@ def compile(  # noqa: A001
         raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
     if lse_stride is not None and (CFG.THD_VARLEN or SPLIT_KV > 1):
         raise ValueError("dense LSE strides are not valid for THD or split-KV workspaces")
+    if bias_stride is not None and not PARAMS.has_bias:
+        raise ValueError("bias_stride requires a bias-enabled kernel")
     _fake_batch = 1 if CFG.THD_VARLEN else b
     if CFG.THD_VARLEN:
         # Dynamic packed token totals: one symbol per ragged group (Q/O and
@@ -1884,6 +1951,16 @@ def compile(  # noqa: A001
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
     fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=OUT_STORAGE_DTYPE, bpe=CFG.BPE_O)
+    bias_dtype = cutlass.Float32 if PARAMS.bias_is_fp32 else STORAGE_DTYPE
+    fake_bias = (
+        (
+            cute.runtime.make_fake_tensor(bias_dtype, (1, qh, sq, skv), bias_stride, assumed_align=4)
+            if bias_stride is not None
+            else cute.runtime.make_fake_compact_tensor(bias_dtype, (1, qh, sq, skv), stride_order=(3, 2, 1, 0), assumed_align=4)
+        )
+        if PARAMS.has_bias
+        else None
+    )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -1985,6 +2062,7 @@ def compile(  # noqa: A001
         fake_v,
         fake_o,
         fake_lse,
+        fake_bias,
         fake_sinks,
         fake_seq_kv_lens,
         fake_o_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm80.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d256_f16_sm80.py
@@ -384,15 +384,17 @@ def _sdpa_kernel(
     heads_per_kv = H // H_kv  # Python int — folds at trace time
     kv_head_idx = head_idx if heads_per_kv == 1 else (head_idx // cutlass.Int32(heads_per_kv))
 
-    # Additive-bias per-head base pointer (element-addressed).  bias is
-    # [1, H, SQ, SKV] (broadcast over batch): head stride = SQ*SKV, q stride =
-    # SKV, col stride = 1.  Materialize the per-head ELEMENT base here; the
+    # Additive-bias per-head base pointer (element-addressed).  Bias is
+    # [1, H, SQ, SKV] (broadcast over batch); its compile-time tensor layout
+    # carries padded/permuted H/Q strides while SKV stays contiguous.  The
     # mainloop loads the per-lane tile frag (overlapped with the QK mma) and
     # the softmax injects it pre-scale.  bias_dt selects the GMEM load width.
     bias_dt = cutlass.Float32 if cutlass.const_expr(bias_is_fp32) else io_dtype
     if cutlass.const_expr(has_bias):
         _bias_ptr0 = cutlass.make_array_view(bias).data_ptr()
-        bias_head_e = cutlass.Int64(head_idx) * cutlass.Int64(SQ) * cutlass.Int64(SKV)
+        bias_head_e = cutlass.Int64(head_idx) * cutlass.Int64(bias.stride[1])
+        bias_q_stride_e = cutlass.Int64(bias.stride[2])
+        bias_k_stride_e = cutlass.Int64(bias.stride[3])
         bias_base = _bias_ptr0 + bias_head_e  # per-head element ptr
 
     # RoPE (cos, sin) table base — shared by all heads/batches (position-only).
@@ -1023,16 +1025,16 @@ def _sdpa_kernel(
                 if cutlass.const_expr(not is_even_mn):
                     bq_top = _imin_i32(bq_top, sq_runtime - cutlass.Int32(1))
                     bq_bot = _imin_i32(bq_bot, sq_runtime - cutlass.Int32(1))
-                bq_top64 = cutlass.Int64(bq_top) * cutlass.Int64(SKV)
-                bq_bot64 = cutlass.Int64(bq_bot) * cutlass.Int64(SKV)
+                bq_top64 = cutlass.Int64(bq_top) * bias_q_stride_e
+                bq_bot64 = cutlass.Int64(bq_bot) * bias_q_stride_e
                 for k in cutlass.range_constexpr(QK_N_FRAGS):
                     bca = bias_kv_col_base + cutlass.Int32(k * 8) + cutlass.Int32(2) * p_lane
                     bcb = bca + cutlass.Int32(1)
                     if cutlass.const_expr(not is_even_mn):
                         bca = _imin_i32(bca, skv_runtime - cutlass.Int32(1))
                         bcb = _imin_i32(bcb, skv_runtime - cutlass.Int32(1))
-                    bca64 = cutlass.Int64(bca)
-                    bcb64 = cutlass.Int64(bcb)
+                    bca64 = cutlass.Int64(bca) * bias_k_stride_e
+                    bcb64 = cutlass.Int64(bcb) * bias_k_stride_e
                     bias_frag[bbase + k * 4 + 0] = bias_pp[bq_top64 + bca64].to(cutlass.Float32) * inv_softmax_scale
                     bias_frag[bbase + k * 4 + 1] = bias_pp[bq_top64 + bcb64].to(cutlass.Float32) * inv_softmax_scale
                     bias_frag[bbase + k * 4 + 2] = bias_pp[bq_bot64 + bca64].to(cutlass.Float32) * inv_softmax_scale
@@ -1694,6 +1696,7 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     rope_max_s: int = 0,
     n_batch_logical: int = 0,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    bias_stride: Optional[tuple[int, int, int, int]] = None,
 ):
     """Compile (or fetch) this template specialization for one shape.
 
@@ -1722,6 +1725,8 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     p = PARAMS
     if p.thd_varlen and p.has_bias:
         raise ValueError("sm80: bias + THD is not supported (varlen has no single [1,H,SQ,SKV] bias shape)")
+    if bias_stride is not None and not p.has_bias:
+        raise ValueError("bias_stride requires a bias-enabled kernel")
     io_dtype = cutlass.BFloat16 if p.io_bf16 else cutlass.Float16
     mask_flags = (MASK_CAUSAL if p.is_causal else MASK_NONE) | (MASK_SWA if p.has_swa else 0)
     sched_l2_bytes = p.sched_l2_mib * 1024 * 1024
@@ -1800,12 +1805,14 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     )
     # Additive bias [1, H, SQ, SKV] in io_dtype or fp32 (or a 1-elem dummy).
     bias_io_dtype = cutlass.Float32 if p.bias_is_fp32 else io_dtype
-    fake_bias = cute.runtime.make_fake_compact_tensor(
-        bias_io_dtype,
-        ((1, h, sq, skv) if p.has_bias else (1,)),
-        stride_order=((3, 2, 1, 0) if p.has_bias else (0,)),
-        assumed_align=16,
-    )
+    if p.has_bias:
+        fake_bias = (
+            cute.runtime.make_fake_tensor(bias_io_dtype, (1, h, sq, skv), bias_stride, assumed_align=16)
+            if bias_stride is not None
+            else cute.runtime.make_fake_compact_tensor(bias_io_dtype, (1, h, sq, skv), stride_order=(3, 2, 1, 0), assumed_align=16)
+        )
+    else:
+        fake_bias = cute.runtime.make_fake_compact_tensor(bias_io_dtype, (1,), stride_order=(0,), assumed_align=16)
     # THD cumulative seqlens [B_logical + 1] int32 (or 1-elem dummies).
     _cu_len = (n_batch_logical + 1) if p.thd_varlen else 1
     fake_cu_q = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (_cu_len,), stride_order=(0,), assumed_align=4)

--- a/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_d512_f16_sm100.py
@@ -91,6 +91,8 @@ from cudnn.frost.tile_dsl.mask import (
 )
 
 from cudnn.sdpa.fwd.kernels._common_sm100 import (
+    apply_attention_mask,
+    add_attention_bias_log2,
     make_split_helpers,
     KvLoopBounds,
     compute_kv_loop_bounds,
@@ -356,6 +358,7 @@ def _kernel(
     tma_v_desc: cutlass.GridConstant[tmap.TensorMap],
     tma_o_desc: cutlass.GridConstant[tmap.TensorMap],
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -542,6 +545,7 @@ def _kernel(
             bars=bars,
             sched=sched,
             lse_tensor=lse_tensor,
+            bias_tensor=bias_tensor,
             sinks_tensor=sinks_tensor,
             seq_kv_lens_tensor=seq_kv_lens_tensor,
             seq_q_lens_tensor=seq_q_lens_tensor,
@@ -671,6 +675,8 @@ def _sg0_softmax_kv_iter(
     eff_seqlen_kv,
     eff_seqlen_q,
     scale_log2,
+    bias_tensor,
+    row_head_idx,
     tid_in_wg,
     is_lead_warp,
     leader_cta_id,
@@ -683,9 +689,9 @@ def _sg0_softmax_kv_iter(
     bmm1_done_state = advance(bmm1_done_state, CFG.XFER_STAGES)
 
     s_addr_base = tmem_base_addr + cur_parity_S * cutlass.Int32(LAYOUT.S_ACC_COLS)
+    kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
 
     if cutlass.const_expr(apply_mask):
-        kv_col_base = kv_loop * cutlass.Int32(CFG.TILE_N)
         raw_chunks = [
             nvvm.tcgen05_ld(
                 "32x32b",
@@ -694,34 +700,66 @@ def _sg0_softmax_kv_iter(
             )
             for c in range(SOFTMAX_N_CHUNKS_LOAD)
         ]
-        causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
-        chunks_S = [
-            apply_mask_chunk(
-                raw_chunks[c],
-                q_abs,
-                kv_col_base + cutlass.Int32(c * SOFTMAX_CHUNK),
-                eff_seqlen_kv,
-                CFG.WINDOW_LEFT,
-                CFG.MASK_FLAGS,
-                N=SOFTMAX_CHUNK,
-                bottom_right=CFG.BOTTOM_RIGHT,
-                causal_diag=causal_diag,
-                window_right=CFG.WINDOW_RIGHT,
-                mask_value=float("-inf"),
-            )
-            for c in range(SOFTMAX_N_CHUNKS_LOAD)
-        ]
-        chunks_max = [row_max_reduction(chunks_S[c]) for c in range(SOFTMAX_N_CHUNKS_LOAD)]
-        reg_S_vec = vec_concat(chunks_S)
-        current_max_raw = chunks_max[0]
-        for m in chunks_max[1:]:
-            current_max_raw = cute.math.max(current_max_raw, m)
-        reg_S_tile = RegTile(reg_S_vec, size=CFG.TILE_N)
+        if cutlass.const_expr(PARAMS.has_bias):
+            reg_S_tile = RegTile(vec_concat(raw_chunks), size=CFG.TILE_N)
+        else:
+            causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+            score_chunks = [
+                apply_mask_chunk(
+                    raw_chunks[c],
+                    q_abs,
+                    kv_col_base + cutlass.Int32(c * SOFTMAX_CHUNK),
+                    eff_seqlen_kv,
+                    CFG.WINDOW_LEFT,
+                    CFG.MASK_FLAGS,
+                    N=SOFTMAX_CHUNK,
+                    bottom_right=CFG.BOTTOM_RIGHT,
+                    causal_diag=causal_diag,
+                    window_right=CFG.WINDOW_RIGHT,
+                    mask_value=float("-inf"),
+                )
+                for c in range(SOFTMAX_N_CHUNKS_LOAD)
+            ]
+            chunks_max = [row_max_reduction(score_chunks[c]) for c in range(SOFTMAX_N_CHUNKS_LOAD)]
+            reg_S_tile = RegTile(vec_concat(score_chunks), size=CFG.TILE_N)
+            current_max_raw = chunks_max[0]
+            for m in chunks_max[1:]:
+                current_max_raw = cute.math.max(current_max_raw, m)
     else:
         reg_S_tile = tmem_load_tile(s_addr_base, num_elems=CFG.TILE_N)
         nvvm.tcgen05_wait(kind=nvvm.Tcgen05Wait.LOAD)
-        current_max_raw = row_max_reduction(reg_S_tile.vec)
-    current_max = current_max_raw * scale_log2  # -inf when the whole iteration is masked
+        if cutlass.const_expr(not PARAMS.has_bias):
+            current_max_raw = row_max_reduction(reg_S_tile.vec)
+    if cutlass.const_expr(PARAMS.has_bias):
+        adjusted_scores = add_attention_bias_log2(
+            reg_S_tile.vec,
+            bias_tensor,
+            row_head_idx,
+            q_abs,
+            kv_col_base,
+            scale_log2,
+            CFG.TILE_N,
+        )
+        reg_S_tile = RegTile(adjusted_scores, size=CFG.TILE_N)
+        if cutlass.const_expr(apply_mask):
+            causal_diag = eff_seqlen_kv - eff_seqlen_q if cutlass.const_expr(CFG.BOTTOM_RIGHT) else None
+            masked_scores, current_max = apply_attention_mask(
+                reg_S_tile.vec,
+                q_abs,
+                kv_col_base,
+                eff_seqlen_kv,
+                CFG.WINDOW_LEFT,
+                CFG.MASK_FLAGS,
+                CFG.TILE_N,
+                bottom_right=CFG.BOTTOM_RIGHT,
+                causal_diag=causal_diag,
+                window_right=CFG.WINDOW_RIGHT,
+            )
+            reg_S_tile = RegTile(masked_scores, size=CFG.TILE_N)
+        else:
+            current_max = row_max_reduction(reg_S_tile.vec)
+    else:
+        current_max = current_max_raw * scale_log2  # -inf when the whole iteration is masked
 
     bars.mb_s_acc_empty[cur_parity_S].arrive(cta_group=CFG.CTA_MMA, leader_cta_id=leader_cta_id)
 
@@ -754,7 +792,10 @@ def _sg0_softmax_kv_iter(
         bars.mb_p_xfer_empty[chunk_slot].wait(cur_phase_S)
 
         reg_S_chunk = reg_S_tile[chunk * P_D_BLOCK : (chunk + 1) * P_D_BLOCK].vec
-        reg_P_fp32_chunk = cute.math.exp2(reg_S_chunk * scale_log2 - total_max_safe, fastmath=True)
+        if cutlass.const_expr(PARAMS.has_bias):
+            reg_P_fp32_chunk = cute.math.exp2(reg_S_chunk - total_max_safe, fastmath=True)
+        else:
+            reg_P_fp32_chunk = cute.math.exp2(reg_S_chunk * scale_log2 - total_max_safe, fastmath=True)
         reg_P_half_chunk = reg_P_fp32_chunk.to(P_STORAGE_DTYPE)
         total_sum_vec = total_sum_vec + row_reduction_pair(reg_P_fp32_chunk)
 
@@ -813,6 +854,7 @@ def _compute_warp_group(
     bars,
     sched,
     lse_tensor,
+    bias_tensor,
     sinks_tensor,
     seq_kv_lens_tensor,
     seq_q_lens_tensor,
@@ -909,6 +951,7 @@ def _compute_warp_group(
             # predicate downstream is a token-space compare, and all G rows of one
             # token share it.
             q_abs = q_super_idx * cutlass.Int32(CFG.TILES_Q * TOKENS_PER_TILE) + (tid_in_wg // cutlass.Int32(HEADS_PER_TILE))
+            row_head_idx = head_idx * cutlass.Int32(HEADS_PER_TILE) + (tid_in_wg % cutlass.Int32(HEADS_PER_TILE))
 
             if cutlass.const_expr(MAY_BE_EMPTY) and (kv_right <= kv_left):
                 pass
@@ -931,6 +974,8 @@ def _compute_warp_group(
                             eff_seqlen_kv,
                             eff_seqlen_q,
                             scale_log2,
+                            bias_tensor,
+                            row_head_idx,
                             tid_in_wg,
                             is_lead_warp,
                             leader_cta_id,
@@ -954,6 +999,8 @@ def _compute_warp_group(
                             eff_seqlen_kv,
                             eff_seqlen_q,
                             scale_log2,
+                            bias_tensor,
+                            row_head_idx,
                             tid_in_wg,
                             is_lead_warp,
                             leader_cta_id,
@@ -976,6 +1023,8 @@ def _compute_warp_group(
                             eff_seqlen_kv,
                             eff_seqlen_q,
                             scale_log2,
+                            bias_tensor,
+                            row_head_idx,
                             tid_in_wg,
                             is_lead_warp,
                             leader_cta_id,
@@ -998,6 +1047,8 @@ def _compute_warp_group(
                             eff_seqlen_kv,
                             eff_seqlen_q,
                             scale_log2,
+                            bias_tensor,
+                            row_head_idx,
                             tid_in_wg,
                             is_lead_warp,
                             leader_cta_id,
@@ -1895,6 +1946,7 @@ def _host(
     v_tensor: cute.Tensor,
     o_tensor: cute.Tensor,
     lse_tensor: Optional[cute.Tensor],
+    bias_tensor: Optional[cute.Tensor],
     sinks_tensor: cute.Tensor,
     seq_kv_lens_tensor: cute.Tensor,
     o_desc_words: cute.Tensor,
@@ -1998,6 +2050,7 @@ def _host(
         tma_v_desc,
         tma_o_desc,
         lse_tensor,
+        bias_tensor,
         sinks_tensor,
         seq_kv_lens_tensor,
         o_desc_words,
@@ -2034,6 +2087,7 @@ def compile(  # noqa: A001
     v_stride: Optional[tuple] = None,
     o_stride: Optional[tuple] = None,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    bias_stride: Optional[tuple[int, int, int, int]] = None,
 ) -> Callable:
     """ENVELOPE: ``d_qk`` / ``d_v`` are the ACTUAL head dims (defaults = full
     TILE_K / TILE_O). TMA descriptors carry these extents while the tile box
@@ -2057,6 +2111,8 @@ def compile(  # noqa: A001
         raise ValueError("split_kv > 1 requires has_lse=True (the per-split LSE drives the combine)")
     if lse_stride is not None and (CFG.THD_VARLEN or SPLIT_KV > 1):
         raise ValueError("dense LSE strides are not valid for THD or split-KV workspaces")
+    if bias_stride is not None and not PARAMS.has_bias:
+        raise ValueError("bias_stride requires a bias-enabled kernel")
     _fake_batch = 1 if CFG.THD_VARLEN else b
     if CFG.THD_VARLEN:
         # Dynamic packed token totals: one symbol per ragged group (Q/O and
@@ -2085,6 +2141,16 @@ def compile(  # noqa: A001
     fake_k = _fake_bshd((_fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((_fake_batch, skv, kh, d_v), v_stride)
     fake_o = _fake_bshd((_o_batch, sq, qh, d_v), o_stride, dtype=OUT_STORAGE_DTYPE, bpe=CFG.BPE_O)
+    bias_dtype = cutlass.Float32 if PARAMS.bias_is_fp32 else STORAGE_DTYPE
+    fake_bias = (
+        (
+            cute.runtime.make_fake_tensor(bias_dtype, (1, qh, sq, skv), bias_stride, assumed_align=4)
+            if bias_stride is not None
+            else cute.runtime.make_fake_compact_tensor(bias_dtype, (1, qh, sq, skv), stride_order=(3, 2, 1, 0), assumed_align=4)
+        )
+        if PARAMS.has_bias
+        else None
+    )
     if not has_lse:
         # No Stats output: the LSE argument is None-specialized and the store
         # is compiled out entirely — no dummy buffer exists at any level.
@@ -2186,6 +2252,7 @@ def compile(  # noqa: A001
         fake_v,
         fake_o,
         fake_lse,
+        fake_bias,
         fake_sinks,
         fake_seq_kv_lens,
         fake_o_desc,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm120.py
@@ -75,6 +75,7 @@ PARAMS: TemplateParams = globals().get("FROST_TEMPLATE_PARAMS", TemplateParams()
 validate_params(PARAMS)
 
 STORAGE_DTYPE = {DTYPE_FP16: cutlass.Float16, DTYPE_BF16: cutlass.BFloat16}[PARAMS.dtype_qkv]
+_LOG2E = 1.4426950408889634
 
 # ---------------------------------------------------------------------------
 # PTX and layout helpers.
@@ -209,6 +210,8 @@ class SM120FusedMultiHeadAttentionForward:
         seq_q_lens_present: bool = False,
         seq_kv_lens_present: bool = False,
         has_sink: bool = False,
+        has_bias: bool = False,
+        bias_is_fp32: bool = False,
         thd_varlen: bool = False,
         split_kv: int = 1,
         thd_batch: int = 1,
@@ -271,6 +274,10 @@ class SM120FusedMultiHeadAttentionForward:
             raise ValueError(f"qh_per_kh ({qh_per_kh}) must divide q_tile ({q_tile}) when pack_gqa is enabled")
         if pack_gqa and thd_varlen:
             raise ValueError("PackGQA is dense-only (THD keeps the unpacked path)")
+        if has_bias and thd_varlen:
+            raise ValueError("attention bias is dense-only")
+        if bias_is_fp32 and not has_bias:
+            raise ValueError("bias_is_fp32 requires has_bias")
         if thd_varlen and thd_batch < 1:
             raise ValueError("thd_varlen requires thd_batch >= 1")
         self.in_dtype = in_dtype
@@ -289,6 +296,8 @@ class SM120FusedMultiHeadAttentionForward:
         self.seq_q_lens_present = seq_q_lens_present
         self.seq_kv_lens_present = seq_kv_lens_present
         self.has_sink = has_sink
+        self.has_bias = has_bias
+        self.bias_is_fp32 = bias_is_fp32
         self.thd_varlen = thd_varlen
         self.thd_batch = thd_batch
         self.thd_lse_head_major = thd_lse_head_major
@@ -579,6 +588,9 @@ class SM120FusedMultiHeadAttentionForward:
         row_max = softmax_params.row_max
         row_sum = softmax_params.row_sum
         softmax_scale_log2 = softmax_params.softmax_scale_log2
+        if cutlass.const_expr(self.has_bias):
+            bias = basic_params.bias
+            bias_arr = cutlass.make_array_view(bias)
 
         # Each lane owns four S registers split across two Q rows after Q@K^T.
         for row_half in cutlass.range_constexpr(2):
@@ -590,6 +602,13 @@ class SM120FusedMultiHeadAttentionForward:
             # Resolve mask bounds for this query row. ``valid_cols`` is an
             # exclusive upper bound; ``first_valid_col`` is inclusive.
             q_position = basic_params.q_seq_idx + (q_row_in_cta if cutlass.const_expr(not self.pack_gqa) else q_row_in_cta // self.qh_per_kh)
+            if cutlass.const_expr(self.has_bias):
+                bias_q = cute.math.min(q_position, cutlass.Int32(bias.shape[2] - 1))
+                bias_head = (
+                    basic_params.q_head_base
+                    if cutlass.const_expr(not self.pack_gqa)
+                    else basic_params.q_head_base + q_row_in_cta % cutlass.Int32(self.qh_per_kh)
+                )
             diagonal_offset = cutlass.Int32(0)
             if cutlass.const_expr(self.bottom_right):
                 diagonal_offset = basic_params.seqlen_k - basic_params.seqlen_q
@@ -617,9 +636,14 @@ class SM120FusedMultiHeadAttentionForward:
                 s_off = k_frag * 4
                 s0 = s_regs[s_off + s_reg_idx_lo]
                 s1 = s_regs[s_off + s_reg_idx_hi]
+                k_col0 = kv_seq_idx + k_frag * 8 + 2 * (lane % 4)
+                k_col1 = k_col0 + 1
+                if cutlass.const_expr(self.has_bias):
+                    bias_k0 = cute.math.min(k_col0, cutlass.Int32(bias.shape[3] - 1))
+                    bias_k1 = cute.math.min(k_col1, cutlass.Int32(bias.shape[3] - 1))
+                    s0 = s0 * softmax_scale_log2 + cutlass.Float32(bias_arr[cutlass.Int32(0), bias_head, bias_q, bias_k0]) * cutlass.Float32(_LOG2E)
+                    s1 = s1 * softmax_scale_log2 + cutlass.Float32(bias_arr[cutlass.Int32(0), bias_head, bias_q, bias_k1]) * cutlass.Float32(_LOG2E)
                 if cutlass.const_expr(in_mask_steps):
-                    k_col0 = kv_seq_idx + k_frag * 8 + 2 * (lane % 4)
-                    k_col1 = k_col0 + 1
                     valid0 = k_col0 >= first_valid_col and k_col0 < valid_cols
                     valid1 = k_col1 >= first_valid_col and k_col1 < valid_cols
                     if not valid0:
@@ -644,10 +668,13 @@ class SM120FusedMultiHeadAttentionForward:
                 if cutlass.const_expr(in_mask_steps):
                     need_correct = new_max > -cutlass.Float32.inf
                 if need_correct:
-                    old_scale = cute.math.exp2(
-                        (row_max_prev - new_max) * softmax_scale_log2,
-                        fastmath=True,
-                    )
+                    if cutlass.const_expr(self.has_bias):
+                        old_scale = cute.math.exp2(row_max_prev - new_max, fastmath=True)
+                    else:
+                        old_scale = cute.math.exp2(
+                            (row_max_prev - new_max) * softmax_scale_log2,
+                            fastmath=True,
+                        )
             row_max[row_half] = new_max
 
             # Compute P, accumulate the per-lane partial sum, and stage P.
@@ -655,17 +682,21 @@ class SM120FusedMultiHeadAttentionForward:
             if cutlass.const_expr(in_mask_steps):
                 if exp_max == -cutlass.Float32.inf:
                     exp_max = cutlass.Float32(0.0)
-            neg_exp_max_scaled = -(exp_max * softmax_scale_log2)
+            neg_exp_max_scaled = -(exp_max if cutlass.const_expr(self.has_bias) else exp_max * softmax_scale_log2)
             tile_sum = cutlass.Float32(0.0)
             for k_frag in cutlass.range_constexpr(self.qk_k_frags):
                 s_off = k_frag * 4
                 s0 = s_regs[s_off + s_reg_idx_lo]
                 s1 = s_regs[s_off + s_reg_idx_hi]
-                in0, in1 = fma2(
-                    (s0, s1),
-                    (softmax_scale_log2, softmax_scale_log2),
-                    (neg_exp_max_scaled, neg_exp_max_scaled),
-                )
+                if cutlass.const_expr(self.has_bias):
+                    in0 = s0 + neg_exp_max_scaled
+                    in1 = s1 + neg_exp_max_scaled
+                else:
+                    in0, in1 = fma2(
+                        (s0, s1),
+                        (softmax_scale_log2, softmax_scale_log2),
+                        (neg_exp_max_scaled, neg_exp_max_scaled),
+                    )
                 p0 = cute.math.exp2(in0, fastmath=True)
                 p1 = cute.math.exp2(in1, fastmath=True)
                 tile_sum = tile_sum + (p0 + p1)
@@ -826,6 +857,7 @@ class SM120FusedMultiHeadAttentionForward:
         v: cute.Tensor,
         o: cute.Tensor,
         lse: Optional[cute.Tensor],
+        bias: Optional[cute.Tensor],
         sinks: Optional[cute.Tensor],
         seq_q_lens: cute.Tensor,
         seq_kv_lens: cute.Tensor,
@@ -844,6 +876,8 @@ class SM120FusedMultiHeadAttentionForward:
             token-major ``(T, H)`` or head-major ``(H, head_stride)`` (per
             ``thd_lse_head_major``) under ``thd_varlen``; or ``None`` to
             compile the LSE store out (the DSL specializes on ``None``).
+        :param bias: Dense additive attention bias, or ``None`` when the
+            kernel is configured without ``has_bias``.
         :param sinks: ``(H,)`` fp32 per-Q-head sink logits; ``None`` iff the
             kernel is configured without ``has_sink``.
         :param seq_q_lens: Per-batch query lengths, or an unused dummy tensor.
@@ -1126,6 +1160,7 @@ class SM120FusedMultiHeadAttentionForward:
                 head_idx=head_idx,
                 q_seq_idx=q_seq_idx,
                 q_head_off=q_head_off,
+                q_head_base=q_head_base,
                 q_seq_stride=q_seq_stride,
                 q_head_stride=q_head_stride,
                 q_warp_row0=q_warp_row0,
@@ -1133,6 +1168,7 @@ class SM120FusedMultiHeadAttentionForward:
                 lane_div8=lane_div8,
                 lane_mod8=lane_mod8,
                 lane_div16=lane_div16,
+                bias=bias,
                 tma_k_desc=tma_k_desc,
                 tma_v_desc=tma_v_desc,
                 k_tma_mbar=k_tma_mbar,
@@ -1243,7 +1279,7 @@ class SM120FusedMultiHeadAttentionForward:
             row_sum_inv = cutlass.Array(cutlass.Float32, 2, alignment=8)
             row_lse = cutlass.Array(cutlass.Float32, 2, alignment=8)
             for row_half in cutlass.range_constexpr(2):
-                row_max_nat = row_max[row_half] * softmax_scale_log2 * LN2
+                row_max_nat = row_max[row_half] * LN2 if cutlass.const_expr(self.has_bias) else row_max[row_half] * softmax_scale_log2 * LN2
                 if cutlass.const_expr(self.has_sink):
                     sinks_arr = cutlass.make_array_view(sinks)
                     _sink_head = (
@@ -1383,6 +1419,7 @@ class SM120FusedMultiHeadAttentionForward:
         v: cute.Tensor,
         o: cute.Tensor,
         lse: Optional[cute.Tensor],
+        bias: Optional[cute.Tensor],
         sinks: Optional[cute.Tensor],
         seq_q_lens: cute.Tensor,
         seq_kv_lens: cute.Tensor,
@@ -1403,6 +1440,8 @@ class SM120FusedMultiHeadAttentionForward:
             token-major ``(T, H)`` or head-major ``(H, head_stride)`` (per
             ``thd_lse_head_major``) under ``thd_varlen``; or ``None`` to
             compile the LSE store out entirely (no dummy buffer needed).
+        :param bias: Dense additive attention bias, or ``None`` when the
+            kernel is configured without ``has_bias``.
         :param sinks: ``(H,)`` fp32 per-Q-head sink logits; must be ``None``
             exactly when the kernel is configured without ``has_sink``.
         :param seq_q_lens: Per-batch query lengths, or an unused dummy tensor.
@@ -1458,6 +1497,13 @@ class SM120FusedMultiHeadAttentionForward:
                     f"and non-overlapping seq/head strides that are multiples of 8 elements "
                     f"(compact or padded); got shape {tuple(tensor.shape)} stride {tuple(tensor.stride)}"
                 )
+        if cutlass.const_expr(self.has_bias != (bias is not None)):
+            raise ValueError("bias must be provided exactly when the kernel is configured with has_bias")
+        if cutlass.const_expr(bias is not None):
+            if cutlass.const_expr(bias.shape != (1, q.shape[2], q.shape[1], k.shape[1])):
+                raise ValueError("bias must have shape (1, H_q, S_q, S_kv)")
+            if cutlass.const_expr(bias.shape[3] != 1 and bias.stride[3] != 1):
+                raise ValueError("bias must be contiguous along S_kv")
         if cutlass.const_expr(lse is not None):
             if cutlass.const_expr(self.thd_varlen):
                 # The packed token total (q.shape[1]) is DYNAMIC under THD, so
@@ -1570,6 +1616,7 @@ class SM120FusedMultiHeadAttentionForward:
             v,
             o,
             lse,
+            bias,
             sinks,
             seq_q_lens,
             seq_kv_lens,
@@ -1603,6 +1650,7 @@ def compile(  # noqa: A001
     v_stride: Optional[tuple[int, int, int, int]] = None,
     o_stride: Optional[tuple[int, int, int, int]] = None,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    bias_stride: Optional[tuple[int, int, int, int]] = None,
 ) -> Callable:
     """Compile and cache one architecture-specific compact BSHD shape.
 
@@ -1640,6 +1688,8 @@ def compile(  # noqa: A001
         seq_q_lens_present=PARAMS.seq_q_lens_present,
         seq_kv_lens_present=PARAMS.seq_kv_lens_present,
         has_sink=PARAMS.has_sink,
+        has_bias=PARAMS.has_bias,
+        bias_is_fp32=PARAMS.bias_is_fp32,
         thd_varlen=PARAMS.thd_varlen,
         thd_batch=b,
         thd_lse_head_major=lse_head_major,
@@ -1655,6 +1705,8 @@ def compile(  # noqa: A001
         raise ValueError("SM120 SDPA: split_kv > 1 requires an LSE output (the per-split LSE drives the combine)")
     if lse_stride is not None and (PARAMS.thd_varlen or PARAMS.split_kv > 1):
         raise ValueError("dense LSE strides are not valid for THD or split-KV workspaces")
+    if bias_stride is not None and not PARAMS.has_bias:
+        raise ValueError("bias_stride requires a bias-enabled kernel")
     fake_batch = 1 if PARAMS.thd_varlen else b
     if PARAMS.thd_varlen:
         # Dynamic packed token totals: one symbol per ragged group (Q/O and
@@ -1680,6 +1732,16 @@ def compile(  # noqa: A001
     fake_k = _fake_bshd((fake_batch, skv, kh, d_qk), k_stride)
     fake_v = _fake_bshd((fake_batch, skv, kh, d_v), v_stride)
     fake_o = _fake_bshd((o_fake_batch, sq, qh, d_v), o_stride)
+    bias_dtype = cutlass.Float32 if PARAMS.bias_is_fp32 else STORAGE_DTYPE
+    fake_bias = (
+        (
+            cute.runtime.make_fake_tensor(bias_dtype, (1, qh, sq, skv), bias_stride, assumed_align=4)
+            if bias_stride is not None
+            else cute.runtime.make_fake_compact_tensor(bias_dtype, (1, qh, sq, skv), stride_order=(3, 2, 1, 0), assumed_align=4)
+        )
+        if PARAMS.has_bias
+        else None
+    )
     if PARAMS.thd_varlen:
         fake_lse_shape = (qh, lse_head_stride) if lse_head_major else (sq, qh)
     else:
@@ -1740,6 +1802,7 @@ def compile(  # noqa: A001
         fake_v,
         fake_o,
         fake_lse,
+        fake_bias,
         fake_sinks,
         fake_seq_q_lens,
         fake_seq_kv_lens,

--- a/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm80.py
+++ b/python/cudnn/sdpa/fwd/kernels/prefill_f16_sm80.py
@@ -411,15 +411,17 @@ def _sdpa_kernel(
     heads_per_kv = H // H_kv  # Python int — folds at trace time
     kv_head_idx = head_idx if heads_per_kv == 1 else (head_idx // cutlass.Int32(heads_per_kv))
 
-    # Additive-bias per-head base pointer (element-addressed).  bias is
-    # [1, H, SQ, SKV] (broadcast over batch): head stride = SQ*SKV, q stride =
-    # SKV, col stride = 1.  Materialize the per-head ELEMENT base here; the
+    # Additive-bias per-head base pointer (element-addressed).  Bias is
+    # [1, H, SQ, SKV] (broadcast over batch); its compile-time tensor layout
+    # carries padded/permuted H/Q strides while SKV stays contiguous.  The
     # mainloop loads the per-lane tile frag (overlapped with the QK mma) and
     # the softmax injects it pre-scale.  bias_dt selects the GMEM load width.
     bias_dt = cutlass.Float32 if cutlass.const_expr(bias_is_fp32) else io_dtype
     if cutlass.const_expr(has_bias):
         _bias_ptr0 = cutlass.make_array_view(bias).data_ptr()
-        bias_head_e = cutlass.Int64(head_idx) * cutlass.Int64(SQ) * cutlass.Int64(SKV)
+        bias_head_e = cutlass.Int64(head_idx) * cutlass.Int64(bias.stride[1])
+        bias_q_stride_e = cutlass.Int64(bias.stride[2])
+        bias_k_stride_e = cutlass.Int64(bias.stride[3])
         bias_base = _bias_ptr0 + bias_head_e  # per-head element ptr
 
     # RoPE (cos, sin) table base — shared by all heads/batches (position-only).
@@ -1029,16 +1031,16 @@ def _sdpa_kernel(
                 if cutlass.const_expr(not is_even_mn):
                     bq_top = _imin_i32(bq_top, sq_runtime - cutlass.Int32(1))
                     bq_bot = _imin_i32(bq_bot, sq_runtime - cutlass.Int32(1))
-                bq_top64 = cutlass.Int64(bq_top) * cutlass.Int64(SKV)
-                bq_bot64 = cutlass.Int64(bq_bot) * cutlass.Int64(SKV)
+                bq_top64 = cutlass.Int64(bq_top) * bias_q_stride_e
+                bq_bot64 = cutlass.Int64(bq_bot) * bias_q_stride_e
                 for k in cutlass.range_constexpr(QK_N_FRAGS):
                     bca = bias_kv_col_base + cutlass.Int32(k * 8) + cutlass.Int32(2) * p_lane
                     bcb = bca + cutlass.Int32(1)
                     if cutlass.const_expr(not is_even_mn):
                         bca = _imin_i32(bca, skv_runtime - cutlass.Int32(1))
                         bcb = _imin_i32(bcb, skv_runtime - cutlass.Int32(1))
-                    bca64 = cutlass.Int64(bca)
-                    bcb64 = cutlass.Int64(bcb)
+                    bca64 = cutlass.Int64(bca) * bias_k_stride_e
+                    bcb64 = cutlass.Int64(bcb) * bias_k_stride_e
                     bias_frag[bbase + k * 4 + 0] = bias_pp[bq_top64 + bca64].to(cutlass.Float32) * inv_softmax_scale
                     bias_frag[bbase + k * 4 + 1] = bias_pp[bq_top64 + bcb64].to(cutlass.Float32) * inv_softmax_scale
                     bias_frag[bbase + k * 4 + 2] = bias_pp[bq_bot64 + bca64].to(cutlass.Float32) * inv_softmax_scale
@@ -1693,6 +1695,7 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     rope_max_s: int = 0,
     n_batch_logical: int = 0,
     lse_stride: Optional[tuple[int, int, int]] = None,
+    bias_stride: Optional[tuple[int, int, int, int]] = None,
 ):
     """Compile (or fetch) this template specialization for one shape.
 
@@ -1721,6 +1724,8 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     p = PARAMS
     if p.thd_varlen and p.has_bias:
         raise ValueError("sm80: bias + THD is not supported (varlen has no single [1,H,SQ,SKV] bias shape)")
+    if bias_stride is not None and not p.has_bias:
+        raise ValueError("bias_stride requires a bias-enabled kernel")
     io_dtype = cutlass.BFloat16 if p.io_bf16 else cutlass.Float16
     mask_flags = (MASK_CAUSAL if p.is_causal else MASK_NONE) | (MASK_SWA if p.has_swa else 0)
     sched_l2_bytes = p.sched_l2_mib * 1024 * 1024
@@ -1799,12 +1804,14 @@ def compile(  # noqa: A001 — the template contract's entry point (matches the 
     )
     # Additive bias [1, H, SQ, SKV] in io_dtype or fp32 (or a 1-elem dummy).
     bias_io_dtype = cutlass.Float32 if p.bias_is_fp32 else io_dtype
-    fake_bias = cute.runtime.make_fake_compact_tensor(
-        bias_io_dtype,
-        ((1, h, sq, skv) if p.has_bias else (1,)),
-        stride_order=((3, 2, 1, 0) if p.has_bias else (0,)),
-        assumed_align=16,
-    )
+    if p.has_bias:
+        fake_bias = (
+            cute.runtime.make_fake_tensor(bias_io_dtype, (1, h, sq, skv), bias_stride, assumed_align=16)
+            if bias_stride is not None
+            else cute.runtime.make_fake_compact_tensor(bias_io_dtype, (1, h, sq, skv), stride_order=(3, 2, 1, 0), assumed_align=16)
+        )
+    else:
+        fake_bias = cute.runtime.make_fake_compact_tensor(bias_io_dtype, (1,), stride_order=(0,), assumed_align=16)
     # THD cumulative seqlens [B_logical + 1] int32 (or 1-elem dummies).
     _cu_len = (n_batch_logical + 1) if p.thd_varlen else 1
     fake_cu_q = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (_cu_len,), stride_order=(0,), assumed_align=4)

--- a/test/python/sdpa/frost/frost_test_utils.py
+++ b/test/python/sdpa/frost/frost_test_utils.py
@@ -125,3 +125,23 @@ def make_dense_stats(batch: int, heads: int, sequence: int, layout: str):
         assert not stats.is_contiguous()
         return stats
     raise ValueError(f"unknown dense Stats layout {layout!r}")
+
+
+def make_dense_bias(heads: int, query_sequence: int, kv_sequence: int, dtype, layout: str):
+    """Allocate additive bias in compact or permuted-and-gapped H/Q storage."""
+    import torch
+
+    if layout == "contiguous":
+        return torch.randn(1, heads, query_sequence, kv_sequence, dtype=dtype, device="cuda") * 0.25
+    if layout == "strided":
+        storage = torch.full(
+            (query_sequence + 7, heads + 2, kv_sequence + 3),
+            float("nan"),
+            dtype=dtype,
+            device="cuda",
+        )
+        bias = storage[:query_sequence, :heads, :kv_sequence].permute(1, 0, 2).unsqueeze(0)
+        bias.normal_().mul_(0.25)
+        assert not bias.is_contiguous() and bias.stride(-1) == 1
+        return bias
+    raise ValueError(f"unknown dense bias layout {layout!r}")

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm100.py
@@ -12,7 +12,7 @@ import torch
 from test_utils import torch_fork_set_rng
 
 from cudnn.sdpa.fwd.engines import engine_name
-from frost_test_utils import make_dense_stats, requires_pre_rubin_blackwell, requires_dsl, _dsl_installed
+from frost_test_utils import make_dense_bias, make_dense_stats, requires_pre_rubin_blackwell, requires_dsl, _dsl_installed
 
 
 from frost_test_utils import select_engine as _select_engine  # noqa: F401
@@ -108,7 +108,20 @@ _THD_SENTINEL = 2048.0
 
 
 def _ref_sdpa_full(
-    q, k, v, *, scale, is_causal=False, bottom_right=False, band_right=0, swa_window=None, seq_q_lens=None, seq_kv_lens=None, sinks=None, return_stats=False
+    q,
+    k,
+    v,
+    *,
+    scale,
+    is_causal=False,
+    bottom_right=False,
+    band_right=0,
+    swa_window=None,
+    seq_q_lens=None,
+    seq_kv_lens=None,
+    sinks=None,
+    bias=None,
+    return_stats=False,
 ):
     """fp32 reference matching the SM100 DSL kernel's mask + sink semantics.
     q/k/v are BHSD; GQA (h_q > h_kv) is handled by expanding K/V. Bottom-right
@@ -124,6 +137,8 @@ def _ref_sdpa_full(
     k_ref = k.repeat_interleave(g, dim=1).float()
     v_ref = v.repeat_interleave(g, dim=1).float()
     scores = torch.matmul(q.float(), k_ref.transpose(-1, -2)) * scale
+    if bias is not None:
+        scores = scores + bias.float()
 
     q_lens = seq_q_lens.flatten().to(device=dev, dtype=torch.int64) if seq_q_lens is not None else torch.full((b,), s_q, dtype=torch.int64, device=dev)
     kv_lens = seq_kv_lens.flatten().to(device=dev, dtype=torch.int64) if seq_kv_lens is not None else torch.full((b,), s_kv, dtype=torch.int64, device=dev)
@@ -180,6 +195,7 @@ def _run_dsl_graph(
     seq_len_kv=None,
     seq_len_q=None,
     sink=None,
+    bias=None,
     pack_gqa=None,
     return_stats=False,
     stats_layout="contiguous",
@@ -212,6 +228,10 @@ def _run_dsl_graph(
         st = g.tensor_like(sink)
         kw["sink_token"] = st
         vp[st] = sink
+    if bias is not None:
+        bt = g.tensor_like(bias)
+        kw["bias"] = bt
+        vp[bt] = bias
     kw.update(sdpa_kwargs)
     o, stats = g.sdpa(**kw)
     o.set_output(True).set_dim(o_gpu.shape).set_stride(o_gpu.stride())
@@ -288,6 +308,147 @@ def test_dsl_sm100_d192_d128(dtype, is_causal):
     o = _run_dsl_graph(q, k, v, scale=scale, dtype=dtype, sdpa_kwargs=dict(use_causal_mask=is_causal))
     o_ref = _ref_sdpa(q, k, v, is_causal=is_causal, scale=scale)
     torch.testing.assert_close(o, o_ref, atol=5e-2, rtol=3e-2)
+
+
+def _check_dsl_sm100_attention_bias(d_qk, d_v, dtype, bias_dtype, bias_layout="contiguous", *, pack_gqa=True, mask_kind="causal"):
+    _require_dsl()
+    if torch.cuda.get_device_capability() == (10, 7):
+        pytest.skip("SM107 serves only the per-tensor FP8 d128 forward path")
+    b, h_q, h_kv, s_q = 2, 4, 2, 96
+    s_kv = 256 if mask_kind in ("dense", "padded") else 144
+    scale = 1.0 / math.sqrt(d_qk)
+    q = _bhsd(b, h_q, s_q, d_qk, dtype)
+    k = _bhsd(b, h_kv, s_kv, d_qk, dtype)
+    v = _bhsd(b, h_kv, s_kv, d_v, dtype)
+    bias = make_dense_bias(h_q, s_q, s_kv, bias_dtype, bias_layout)
+
+    sdpa_kwargs = {}
+    ref_kwargs = {}
+    seq_len_kv = None
+    if mask_kind == "causal":
+        sdpa_kwargs["use_causal_mask"] = True
+        ref_kwargs["is_causal"] = True
+    elif mask_kind == "band_right":
+        band_right = 8
+        sdpa_kwargs["diagonal_band_right_bound"] = band_right
+        ref_kwargs.update(is_causal=True, band_right=band_right)
+    elif mask_kind == "swa":
+        window = 32
+        sdpa_kwargs.update(use_causal_mask=True, sliding_window_length=window + 1)
+        ref_kwargs.update(is_causal=True, swa_window=window)
+    elif mask_kind == "padded":
+        seq_len_kv = torch.tensor([s_kv, 197], dtype=torch.int32, device="cuda").view(b, 1, 1, 1)
+        ref_kwargs["seq_kv_lens"] = seq_len_kv
+    elif mask_kind != "dense":
+        raise ValueError(f"unknown attention-bias mask kind: {mask_kind}")
+
+    o, stats = _run_dsl_graph(
+        q,
+        k,
+        v,
+        scale=scale,
+        dtype=dtype,
+        sdpa_kwargs=sdpa_kwargs,
+        seq_len_kv=seq_len_kv,
+        bias=bias,
+        pack_gqa=pack_gqa,
+        return_stats=True,
+    )
+    o_ref, stats_ref = _ref_sdpa_full(q, k, v, scale=scale, bias=bias, return_stats=True, **ref_kwargs)
+    torch.testing.assert_close(o, o_ref, atol=0.1, rtol=5e-2)
+    torch.testing.assert_close(stats.squeeze(-1), stats_ref, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=67)
+def test_dsl_sm100_attention_bias():
+    """The SM100 half L0 flavor adds broadcast-batch attention bias."""
+
+    _check_dsl_sm100_attention_bias(128, 128, torch.float16, torch.float16)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=68)
+def test_dsl_sm100_strided_attention_bias():
+    """The SM100 L0 flavor reads a permuted, gapped fp32 bias directly."""
+
+    _check_dsl_sm100_attention_bias(128, 128, torch.float16, torch.float32, bias_layout="strided")
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize(
+    ("pack_gqa", "mask_kind"),
+    [
+        (False, "dense"),
+        (False, "swa"),
+        (True, "band_right"),
+        (True, "padded"),
+    ],
+    ids=["gqa-dense", "gqa-swa", "pack-gqa-band-right", "pack-gqa-padded"],
+)
+@torch_fork_set_rng(seed=69)
+def test_dsl_sm100_attention_bias_gqa_mask_combinations(pack_gqa, mask_kind):
+    """Bias composes with ordinary/packed GQA and distinct mask geometries."""
+
+    _check_dsl_sm100_attention_bias(
+        128,
+        128,
+        torch.float16,
+        torch.float32,
+        bias_layout="strided",
+        pack_gqa=pack_gqa,
+        mask_kind=mask_kind,
+    )
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize(
+    ("d_qk", "d_v", "dtype", "bias_dtype"),
+    [
+        (192, 128, torch.bfloat16, torch.float32),
+        (256, 256, torch.float16, torch.float32),
+        (512, 512, torch.bfloat16, torch.bfloat16),
+    ],
+    ids=["d192-bias-fp32", "d256-bias-fp32", "d512-bf16"],
+)
+@torch_fork_set_rng(seed=67)
+def test_dsl_sm100_attention_bias_other_flavors(d_qk, d_v, dtype, bias_dtype):
+    """The remaining SM100 half/BF16 flavors add attention bias."""
+
+    _check_dsl_sm100_attention_bias(d_qk, d_v, dtype, bias_dtype, bias_layout="strided")
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=71)
+def test_dsl_sm100_attention_mask_overrides_nonfinite_bias():
+    """Masked bias values cannot turn authoritative ``-inf`` scores into NaNs."""
+
+    _require_dsl()
+    b, h, s_q, s_kv, d = 1, 2, 96, 144, 128
+    scale = 1.0 / math.sqrt(d)
+    q = _bhsd(b, h, s_q, d, torch.float16)
+    k = _bhsd(b, h, s_kv, d, torch.float16)
+    v = _bhsd(b, h, s_kv, d, torch.float16)
+    bias = torch.randn(1, h, s_q, s_kv, dtype=torch.float32, device="cuda") * 0.25
+    row = torch.arange(s_q, device="cuda").view(1, 1, s_q, 1)
+    col = torch.arange(s_kv, device="cuda").view(1, 1, 1, s_kv)
+    masked = col > row
+    bias.masked_fill_(masked & (col % 2 == 0), float("inf"))
+    bias.masked_fill_(masked & (col % 2 == 1), float("nan"))
+
+    output, stats = _run_dsl_graph(
+        q,
+        k,
+        v,
+        scale=scale,
+        dtype=torch.float16,
+        sdpa_kwargs=dict(use_causal_mask=True),
+        bias=bias,
+        return_stats=True,
+    )
+    expected, expected_stats = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True, bias=bias, return_stats=True)
+    torch.testing.assert_close(output, expected, atol=0.1, rtol=5e-2)
+    torch.testing.assert_close(stats.squeeze(-1), expected_stats, atol=5e-2, rtol=3e-2)
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_dsl_sm120.py
@@ -11,7 +11,7 @@ import pytest
 import torch
 
 from test_utils import torch_fork_set_rng
-from frost_test_utils import make_dense_stats, requires_blackwell_geforce, requires_dsl, _dsl_installed
+from frost_test_utils import make_dense_bias, make_dense_stats, requires_blackwell_geforce, requires_dsl, _dsl_installed
 
 
 def _is_sm120() -> bool:
@@ -102,6 +102,7 @@ def _ref_sdpa_full(
     seq_q_lens: torch.Tensor | None = None,
     seq_kv_lens: torch.Tensor | None = None,
     sinks: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
     return_stats: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """fp32 reference matching the SM120 DSL kernel's mask semantics.
@@ -119,6 +120,8 @@ def _ref_sdpa_full(
     k_ref = k.repeat_interleave(g, dim=1).float()
     v_ref = v.repeat_interleave(g, dim=1).float()
     scores = torch.matmul(q.float(), k_ref.transpose(-1, -2)) * scale
+    if bias is not None:
+        scores = scores + bias.float()
 
     q_lens = seq_q_lens.flatten().to(torch.int64) if seq_q_lens is not None else torch.full((b,), s_q, dtype=torch.int64, device=dev)
     kv_lens = seq_kv_lens.flatten().to(torch.int64) if seq_kv_lens is not None else torch.full((b,), s_kv, dtype=torch.int64, device=dev)
@@ -167,6 +170,8 @@ def _run_case(
     seq_kv_lens: torch.Tensor | None = None,
     scale: float | None = None,
     with_sink: bool = False,
+    bias_dtype: torch.dtype | None = None,
+    bias_layout: str = "contiguous",
     check_stats: bool = False,
     pack_gqa: bool | None = None,
     stats_layout: str = "contiguous",
@@ -176,6 +181,7 @@ def _run_case(
     v = _bhsd(batch, h_kv, s_kv, head_dim if head_dim_v is None else head_dim_v, dtype)
     scale = 1.0 / math.sqrt(head_dim) if scale is None else scale
     sinks = torch.randn(1, h_q, 1, 1, dtype=torch.float32, device="cuda") if with_sink else None
+    bias = make_dense_bias(h_q, s_q, s_kv, bias_dtype, bias_layout) if bias_dtype is not None else None
     mask_kwargs = dict(
         is_causal=is_causal,
         causal_bottom_right=causal_bottom_right,
@@ -184,6 +190,7 @@ def _run_case(
         seq_q_lens=seq_q_lens,
         seq_kv_lens=seq_kv_lens,
         sinks=sinks,
+        bias=bias,
     )
     result = _run_dsl_graph(
         q,
@@ -242,6 +249,7 @@ def _run_dsl_graph(
     seq_q_lens: torch.Tensor | None = None,
     seq_kv_lens: torch.Tensor | None = None,
     sinks: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
     q_tile: int | None = None,
     kv_tile: int | None = None,
     pack_gqa: bool | None = None,
@@ -307,6 +315,10 @@ def _run_dsl_graph(
         sink_t = graph.tensor_like(sinks, name="sink")
         sdpa_kwargs["sink_token"] = sink_t
         variant_pack[sink_t] = sinks
+    if bias is not None:
+        bias_t = graph.tensor_like(bias, name="bias")
+        sdpa_kwargs["bias"] = bias_t
+        variant_pack[bias_t] = bias
 
     o, stats = graph.sdpa(**sdpa_kwargs)
     o.set_output(True).set_dim(o_gpu.shape).set_stride(o_gpu.stride())
@@ -573,6 +585,116 @@ def test_sdpa_fwd_dsl_sm120_graph_api(dtype: torch.dtype, is_causal: bool):
     output = _run_dsl_graph(q, k, v, scale=scale, is_causal=is_causal, kv_tile=64)
     expected = _ref_sdpa_full(q, k, v, scale=scale, is_causal=is_causal)
     torch.testing.assert_close(output.float(), expected, atol=0.1, rtol=5e-2)
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("dtype", "bias_dtype", "bias_layout"),
+    [(torch.float16, torch.float16, "contiguous"), (torch.bfloat16, torch.float32, "strided")],
+    ids=["fp16-bias-fp16", "bf16-bias-fp32-strided"],
+)
+@torch_fork_set_rng(seed=67)
+def test_dsl_sm120_attention_bias(dtype: torch.dtype, bias_dtype: torch.dtype, bias_layout: str):
+    """SM120 applies dense bias for GQA, sequence tails, masking, and LSE."""
+
+    _run_case(
+        batch=2,
+        h_q=8,
+        h_kv=2,
+        s_q=96,
+        s_kv=144,
+        head_dim=64,
+        dtype=dtype,
+        is_causal=True,
+        bias_dtype=bias_dtype,
+        bias_layout=bias_layout,
+        pack_gqa=True,
+        check_stats=True,
+    )
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize(
+    ("pack_gqa", "mask_kind"),
+    [
+        (False, "dense"),
+        (False, "swa"),
+        (True, "band_right"),
+        (True, "padded"),
+    ],
+    ids=["gqa-dense", "gqa-swa", "pack-gqa-band-right", "pack-gqa-padded"],
+)
+@torch_fork_set_rng(seed=69)
+def test_dsl_sm120_attention_bias_gqa_mask_combinations(pack_gqa: bool, mask_kind: str):
+    """Bias composes with ordinary/packed GQA and distinct mask geometries."""
+
+    batch, s_q, s_kv = 2, 96, 256
+    mask_kwargs = {}
+    if mask_kind == "swa":
+        mask_kwargs.update(is_causal=True, window_size_left=32)
+    elif mask_kind == "band_right":
+        mask_kwargs["window_size_right"] = 8
+    elif mask_kind == "padded":
+        mask_kwargs.update(
+            seq_q_lens=torch.tensor([93, 51], dtype=torch.int32, device="cuda").view(batch, 1, 1, 1),
+            seq_kv_lens=torch.tensor([s_kv, 197], dtype=torch.int32, device="cuda").view(batch, 1, 1, 1),
+        )
+
+    _run_case(
+        batch=batch,
+        h_q=8,
+        h_kv=2,
+        s_q=s_q,
+        s_kv=s_kv,
+        head_dim=128,
+        dtype=torch.float16,
+        bias_dtype=torch.float32,
+        bias_layout="strided",
+        pack_gqa=pack_gqa,
+        **mask_kwargs,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=71)
+def test_dsl_sm120_attention_mask_overrides_nonfinite_bias():
+    """Masked bias values cannot turn authoritative ``-inf`` scores into NaNs."""
+
+    batch, heads, s_q, s_kv, head_dim = 1, 2, 96, 144, 128
+    scale = 1.0 / math.sqrt(head_dim)
+    q = _bhsd(batch, heads, s_q, head_dim, torch.float16)
+    k = _bhsd(batch, heads, s_kv, head_dim, torch.float16)
+    v = _bhsd(batch, heads, s_kv, head_dim, torch.float16)
+    bias = torch.randn(1, heads, s_q, s_kv, dtype=torch.float32, device="cuda") * 0.25
+    row = torch.arange(s_q, device="cuda").view(1, 1, s_q, 1)
+    col = torch.arange(s_kv, device="cuda").view(1, 1, 1, s_kv)
+    masked = col > row
+    bias.masked_fill_(masked & (col % 2 == 0), float("inf"))
+    bias.masked_fill_(masked & (col % 2 == 1), float("nan"))
+
+    output, stats = _run_dsl_graph(q, k, v, scale=scale, is_causal=True, bias=bias, return_stats=True)
+    expected, expected_stats = _ref_sdpa_full(q, k, v, scale=scale, is_causal=True, bias=bias, return_stats=True)
+    torch.testing.assert_close(output.float(), expected, atol=0.1, rtol=5e-2)
+    torch.testing.assert_close(stats.squeeze(-1), expected_stats, atol=5e-2, rtol=3e-2)
+
+
+@pytest.mark.L0
+def test_dsl_sm120_thd_attention_bias_is_rejected():
+    """THD has no single dense bias shape shared by all ragged sequences."""
+
+    _require_dsl()
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm120
+
+    batch, heads, sequence, head_dim = 2, 4, 128, 64
+    q = _bhsd(batch, heads, sequence, head_dim, torch.float16)
+    k = _bhsd(batch, heads, sequence, head_dim, torch.float16)
+    v = _bhsd(batch, heads, sequence, head_dim, torch.float16)
+    o = torch.empty_like(q)
+    bias = make_dense_bias(heads, sequence, sequence, torch.float32, "contiguous")
+    api = SdpaFwdDslSm120(sample_q=q, sample_k=k, sample_v=v, sample_o=o, sample_bias=bias, thd=True)
+
+    with pytest.raises(NotImplementedError, match="attention bias is dense-only"):
+        api.check_support()
 
 
 @pytest.mark.L0

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm100.py
@@ -68,6 +68,28 @@ class _RunWithStatsResult(NamedTuple):
     reference_stats: torch.Tensor
 
 
+@pytest.mark.L0
+@pytest.mark.parametrize("pertensor_fp8", [False, True], ids=["mxfp8", "fp8"])
+def test_fp8_standalone_attention_bias_is_declined(pertensor_fp8):
+    """The direct adapter must not silently discard an FP8 bias specialization."""
+
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm100
+
+    q = torch.zeros(1, 2, 64, 128, dtype=torch.float8_e4m3fn, device="cuda")
+    o = torch.empty(1, 2, 64, 128, dtype=torch.float16, device="cuda")
+    api = SdpaFwdDslSm100(
+        sample_q=q,
+        sample_k=q,
+        sample_v=q,
+        sample_o=o,
+        sample_bias=torch.zeros(1, 2, 64, 64, dtype=torch.float32, device="cuda"),
+        dtype_o=torch.float16,
+        pertensor_fp8=pertensor_fp8,
+    )
+    with pytest.raises(NotImplementedError, match="attention bias is not supported"):
+        api.check_support()
+
+
 def _quant(x, in_key):
     fp8, fmax = _FP8[in_key], _FP8_MAX[in_key]
     dq = (x.abs().amax().clamp_min(1e-8) / fmax).item()

--- a/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_fp8_sm120.py
@@ -50,6 +50,27 @@ class _RunResult(NamedTuple):
     reference_stats: torch.Tensor
 
 
+@pytest.mark.L0
+def test_fp8_standalone_attention_bias_is_declined():
+    """The direct adapter must not silently discard an FP8 bias specialization."""
+
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm120
+
+    q = torch.zeros(1, 2, 64, 128, dtype=torch.float8_e4m3fn, device="cuda")
+    o = torch.empty(1, 2, 64, 128, dtype=torch.float16, device="cuda")
+    api = SdpaFwdDslSm120(
+        sample_q=q,
+        sample_k=q,
+        sample_v=q,
+        sample_o=o,
+        sample_bias=torch.zeros(1, 2, 64, 64, dtype=torch.float32, device="cuda"),
+        dtype_o=torch.float16,
+        pertensor_fp8=True,
+    )
+    with pytest.raises(NotImplementedError, match="attention bias is not supported"):
+        api.check_support()
+
+
 def _quant(x, dtype=torch.float8_e4m3fn):
     fmax = _FP8_MAX[dtype]
     dq = (x.abs().amax().clamp_min(1e-8) / fmax).item()

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm100.py
@@ -19,7 +19,7 @@ from typing import NamedTuple, Optional
 import pytest
 import torch
 
-from frost_test_utils import requires_pre_rubin_blackwell, requires_dsl
+from frost_test_utils import make_dense_bias, requires_pre_rubin_blackwell, requires_dsl
 
 pytestmark = [requires_pre_rubin_blackwell, requires_dsl]
 
@@ -92,6 +92,7 @@ def _run(splits, B, H, KH, SQ, SKV, dtype, causal, cta_mma=2, pack_gqa=False):
         v,
         o_p,
         lse_p,
+        None,
         torch.zeros(H, dtype=torch.float32, device=dev),  # sinks (ABI slot)
         torch.zeros(B, dtype=torch.int32, device=dev),  # seq_kv_lens (unused)
         torch.zeros(1, dtype=torch.int64, device=dev),  # o_desc (THD only)
@@ -422,6 +423,7 @@ def test_empty_splits_every_flavor(flavor):
         v,
         o_p,
         lse_p,
+        None,
         torch.zeros(H, dtype=torch.float32, device=dev),
         torch.zeros(B, dtype=torch.int32, device=dev),
         torch.zeros(1, dtype=torch.int64, device=dev),
@@ -642,6 +644,7 @@ def test_combine_lse_matches_reference(splits):
         v,
         o_p,
         lse_p,
+        None,
         torch.zeros(H, dtype=torch.float32, device=dev),
         torch.zeros(B, dtype=torch.int32, device=dev),
         torch.zeros(1, dtype=torch.int64, device=dev),
@@ -712,6 +715,7 @@ def test_even_splits_every_flavor_batched(flavor, dtype):
         v,
         o_p,
         lse_p,
+        None,
         torch.zeros(H, dtype=torch.float32, device=dev),
         torch.zeros(B, dtype=torch.int32, device=dev),
         torch.zeros(1, dtype=torch.int64, device=dev),
@@ -739,8 +743,26 @@ def test_even_splits_every_flavor_batched(flavor, dtype):
 # suite uses to model this kernel's exact mask semantics.
 
 
-def _run_masked(kfile, d_qk, d_v, splits, *, B, H, KH, SQ, SKV, tp_kwargs, seq_kv_lens=None, seq_q_lens=None, dtype=torch.float16, cta_mma=2):
-    """Launch split kernel + combine under an arbitrary mask; returns (got, q, k, v, scale)."""
+def _run_masked(
+    kfile,
+    d_qk,
+    d_v,
+    splits,
+    *,
+    B,
+    H,
+    KH,
+    SQ,
+    SKV,
+    tp_kwargs,
+    seq_kv_lens=None,
+    seq_q_lens=None,
+    dtype=torch.float16,
+    bias_dtype=None,
+    bias_layout="contiguous",
+    cta_mma=2,
+):
+    """Launch a masked split kernel and return its output and reference inputs."""
     import os as _os
 
     import cutlass
@@ -757,11 +779,29 @@ def _run_masked(kfile, d_qk, d_v, splits, *, B, H, KH, SQ, SKV, tp_kwargs, seq_k
     q = torch.randn(B, SQ, H, d_qk, device=dev, dtype=dtype)
     k = torch.randn(B, SKV, KH, d_qk, device=dev, dtype=dtype)
     v = torch.randn(B, SKV, KH, d_v, device=dev, dtype=dtype)
+    bias = make_dense_bias(H, SQ, SKV, bias_dtype, bias_layout) if bias_dtype is not None else None
 
     path = _os.path.join(_os.path.dirname(_os.path.abspath(api_dsl.__file__)), "kernels", kfile)
-    params = TemplateParams(dtype_qkv=3 if dtype == torch.float16 else 2, split_kv=splits, cta_mma=cta_mma, **tp_kwargs)
+    params = TemplateParams(
+        dtype_qkv=3 if dtype == torch.float16 else 2,
+        split_kv=splits,
+        cta_mma=cta_mma,
+        has_bias=bias is not None,
+        bias_is_fp32=bias_dtype == torch.float32,
+        **tp_kwargs,
+    )
     mod = load_template(path, params, tag=f"mask_{kfile[:16]}_{splits}_{cta_mma}_{sorted(tp_kwargs.items())}")
-    fn = mod.compile(b=B, qh=H, kh=KH, sq=SQ, skv=SKV, d_qk=d_qk, d_v=d_v, has_lse=True)
+    fn = mod.compile(
+        b=B,
+        qh=H,
+        kh=KH,
+        sq=SQ,
+        skv=SKV,
+        d_qk=d_qk,
+        d_v=d_v,
+        has_lse=True,
+        bias_stride=tuple(bias.stride()) if bias is not None and not bias.is_contiguous() else None,
+    )
 
     o_p = torch.zeros(splits * B, SQ, H, d_v, device=dev, dtype=dtype)
     lse_p = torch.zeros(splits * B, H, SQ, device=dev, dtype=torch.float32)
@@ -773,6 +813,7 @@ def _run_masked(kfile, d_qk, d_v, splits, *, B, H, KH, SQ, SKV, tp_kwargs, seq_k
         v,
         o_p,
         lse_p,
+        bias,
         torch.zeros(H, dtype=torch.float32, device=dev),
         skv_t,
         torch.zeros(1, dtype=torch.int64, device=dev),
@@ -784,13 +825,13 @@ def _run_masked(kfile, d_qk, d_v, splits, *, B, H, KH, SQ, SKV, tp_kwargs, seq_k
     )
     if splits == 1:
         torch.cuda.synchronize()
-        return o_p.float(), q, k, v, scale
+        return o_p.float(), q, k, v, bias, scale
     o_out = torch.zeros(B, SQ, H, d_v, device=dev, dtype=dtype)
     cfn = comb.compile(b=B, h=H, sq=SQ, d_v=d_v, splits=splits, dtype_o="f16" if dtype == torch.float16 else "bf16", has_lse=False)
     cfn(o_p, lse_p, o_out, None, None, (B, H, SQ, d_v), cutlass.Int32(splits), stream=stream)
     torch.cuda.synchronize()
     assert not torch.isnan(o_out).any(), "NaN under mask+split"
-    return o_out.float(), q, k, v, scale
+    return o_out.float(), q, k, v, bias, scale
 
 
 def _bhsd(t):
@@ -805,11 +846,11 @@ def test_split_kv_swa_causal(splits):
 
     W = 256
     B, H, SQ, SKV = 1, 4, 1024, 1024
-    got, q, k, v, scale = _run_masked(
+    output, q, k, v, _, scale = _run_masked(
         "prefill_d128_f16_sm100.py", 128, 128, splits, B=B, H=H, KH=H, SQ=SQ, SKV=SKV, tp_kwargs=dict(window_right=0, window_left=W)
     )
     ref = _ref_sdpa_full(_bhsd(q), _bhsd(k), _bhsd(v), scale=scale, is_causal=True, swa_window=W)
-    assert (got - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-2
+    assert (output - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-2
 
 
 @pytest.mark.L0
@@ -819,11 +860,91 @@ def test_split_kv_bottom_right_causal(splits):
     from test_sdpa_fwd_dsl_sm100 import _ref_sdpa_full
 
     B, H, SQ, SKV = 1, 4, 128, 2048
-    got, q, k, v, scale = _run_masked(
+    output, q, k, v, _, scale = _run_masked(
         "prefill_d128_f16_sm100.py", 128, 128, splits, B=B, H=H, KH=H, SQ=SQ, SKV=SKV, tp_kwargs=dict(window_right=0, bottom_right=True)
     )
     ref = _ref_sdpa_full(_bhsd(q), _bhsd(k), _bhsd(v), scale=scale, is_causal=True, bottom_right=True)
-    assert (got - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-2
+    assert (output - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-2
+
+
+@pytest.mark.L0
+@pytest.mark.parametrize("bias_dtype", [torch.float16, torch.float32], ids=["bias-fp16", "bias-fp32"])
+def test_split_kv_attention_bias_uses_absolute_kv_columns(bias_dtype):
+    """Every split reads its bias slice at the global, not split-local, KV offset."""
+
+    _check_split_kv_attention_bias("d128", bias_dtype)
+
+
+@pytest.mark.L0
+def test_split_kv_attention_bias_gqa_causal():
+    """Unpacked GQA composes bias, causal masking, and split-KV."""
+
+    _check_split_kv_attention_bias("d128", torch.float32, mask_kind="causal", pack_gqa=False)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("mask_kind", ["causal", "bottom_right", "swa", "padded"], ids=["causal", "bottom-right", "swa", "padded"])
+def test_split_kv_attention_bias_mask_combinations(mask_kind):
+    """Split-KV bias composes with packed GQA and each supported mask shape."""
+
+    _check_split_kv_attention_bias("d128", torch.float32, mask_kind=mask_kind)
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize("flavor", ["d192", "d256", "d512"])
+def test_split_kv_attention_bias_other_flavors(flavor):
+    """Every independently compiled SM100 flavor uses absolute bias columns."""
+
+    _check_split_kv_attention_bias(flavor, torch.float32)
+
+
+def _check_split_kv_attention_bias(flavor, bias_dtype, *, mask_kind="none", pack_gqa=True):
+    """Check one flavor's split-KV bias coordinates and optional masking."""
+
+    from test_sdpa_fwd_dsl_sm100 import _ref_sdpa_full
+
+    kmod, d_qk, d_v = _F16_FLAVORS[flavor]
+    B, H, KH = 2, 4, 2
+    SQ, SKV = 96, 1024
+    tp_kwargs = dict(pack_gqa=pack_gqa, qh_per_kh=H // KH)
+    ref_kwargs = {}
+    seq_kv_lens = None
+    if mask_kind == "causal":
+        SQ = 384
+        tp_kwargs["window_right"] = 0
+        ref_kwargs["is_causal"] = True
+    elif mask_kind == "bottom_right":
+        tp_kwargs.update(window_right=0, bottom_right=True)
+        ref_kwargs.update(is_causal=True, bottom_right=True)
+    elif mask_kind == "swa":
+        SQ, SKV = 512, 512
+        window = 128
+        tp_kwargs.update(window_right=0, window_left=window)
+        ref_kwargs.update(is_causal=True, swa_window=window)
+    elif mask_kind == "padded":
+        tp_kwargs["seq_kv_lens_present"] = True
+        seq_kv_lens = torch.tensor([SKV, 731], dtype=torch.int32, device="cuda")
+        ref_kwargs["seq_kv_lens"] = seq_kv_lens
+    elif mask_kind != "none":
+        raise ValueError(f"unknown split-KV attention-bias mask kind: {mask_kind}")
+
+    output, q, k, v, bias, scale = _run_masked(
+        kmod,
+        d_qk,
+        d_v,
+        4,
+        B=B,
+        H=H,
+        KH=KH,
+        SQ=SQ,
+        SKV=SKV,
+        tp_kwargs=tp_kwargs,
+        seq_kv_lens=seq_kv_lens,
+        bias_dtype=bias_dtype,
+        bias_layout="strided",
+    )
+    ref = _ref_sdpa_full(_bhsd(q), _bhsd(k), _bhsd(v), scale=scale, bias=bias, **ref_kwargs)
+    assert (output - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 3e-2
 
 
 @pytest.mark.L0
@@ -834,11 +955,11 @@ def test_split_kv_padded_kv(splits):
 
     B, H, SQ, SKV = 2, 4, 128, 2048
     lens = torch.tensor([2048, 1531], dtype=torch.int32, device="cuda")  # 2nd ends mid-tile
-    got, q, k, v, scale = _run_masked(
+    output, q, k, v, _, scale = _run_masked(
         "prefill_d128_f16_sm100.py", 128, 128, splits, B=B, H=H, KH=H, SQ=SQ, SKV=SKV, tp_kwargs=dict(seq_kv_lens_present=True), seq_kv_lens=lens
     )
     ref = _ref_sdpa_full(_bhsd(q), _bhsd(k), _bhsd(v), scale=scale, seq_kv_lens=lens)
-    assert (got - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-2
+    assert (output - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-2
 
 
 @pytest.mark.L0
@@ -849,9 +970,9 @@ def test_split_kv_causal_other_flavors(flavor):
 
     kmod, d_qk, d_v = _F16_FLAVORS[flavor]
     B, H, SQ, SKV = 1, 4, 1024, 1024
-    got, q, k, v, scale = _run_masked(kmod, d_qk, d_v, 4, B=B, H=H, KH=H, SQ=SQ, SKV=SKV, tp_kwargs=dict(window_right=0))
+    output, q, k, v, _, scale = _run_masked(kmod, d_qk, d_v, 4, B=B, H=H, KH=H, SQ=SQ, SKV=SKV, tp_kwargs=dict(window_right=0))
     ref = _ref_sdpa_full(_bhsd(q), _bhsd(k), _bhsd(v), scale=scale, is_causal=True)
-    assert (got - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-2
+    assert (output - ref.float().permute(0, 2, 1, 3)).abs().max().item() <= 2e-2
 
 
 @pytest.mark.L0
@@ -874,7 +995,7 @@ def test_split_kv_padded_q_trim(flavor, splits):
     B, H, SQ, SKV = 2, 4, 1024, 2048
     kv_lens = torch.tensor([2048, 2048], dtype=torch.int32, device="cuda")
     q_lens = torch.tensor([1024, 137], dtype=torch.int32, device="cuda")  # 2nd trims mid-tile
-    got, q, k, v, scale = _run_masked(
+    output, q, k, v, _, scale = _run_masked(
         kmod,
         d_qk,
         d_v,
@@ -891,11 +1012,11 @@ def test_split_kv_padded_q_trim(flavor, splits):
     ref = _ref_sdpa_full(_bhsd(q), _bhsd(k), _bhsd(v), scale=scale, seq_kv_lens=kv_lens)
     ref = ref.float().permute(0, 2, 1, 3)  # -> BSHD
     # Rows past the per-batch Q length must be exactly zero.
-    rows = torch.arange(SQ, device=got.device).view(1, SQ, 1, 1)
+    rows = torch.arange(SQ, device=output.device).view(1, SQ, 1, 1)
     dead = rows >= q_lens.view(B, 1, 1, 1)
-    assert got[dead.expand_as(got)].abs().max().item() == 0.0, "trimmed Q rows are not zero"
+    assert output[dead.expand_as(output)].abs().max().item() == 0.0, "trimmed Q rows are not zero"
     live = ~dead
-    assert (got - ref)[live.expand_as(got)].abs().max().item() <= 2e-2
+    assert (output - ref)[live.expand_as(output)].abs().max().item() <= 2e-2
 
 
 # --- the adapter honors the heuristic's split knob ---------------------------

--- a/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
+++ b/test/python/sdpa/frost/test_sdpa_fwd_split_kv_sm120.py
@@ -17,9 +17,9 @@ from typing import NamedTuple, Optional
 import pytest
 import torch
 
-from frost_test_utils import requires_dsl
+from frost_test_utils import make_dense_bias, requires_dsl
 
-pytestmark = [requires_dsl, pytest.mark.L0]
+pytestmark = requires_dsl
 
 
 class _ApiCaseResult(NamedTuple):
@@ -51,7 +51,24 @@ def _expected_split(api):
     )
 
 
-def _sm120_case(h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True, causal=False, lse_layout="contiguous", split_kv=None):
+def _sm120_case(
+    h_q,
+    h_kv,
+    s_q,
+    s_kv,
+    *,
+    with_lse=False,
+    workspace=True,
+    causal=False,
+    causal_bottom_right=False,
+    window_size_left=None,
+    window_size_right=None,
+    lse_layout="contiguous",
+    split_kv=None,
+    bias_dtype=None,
+    bias_layout="contiguous",
+    pack_gqa=None,
+):
     from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm120
 
     if torch.cuda.get_device_capability()[0] != 12:
@@ -61,6 +78,7 @@ def _sm120_case(h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True, causal=
     q = torch.randn(b, h_q, s_q, d, device=dev, dtype=torch.float16)
     k = torch.randn(b, h_kv, s_kv, d, device=dev, dtype=torch.float16)
     v = torch.randn(b, h_kv, s_kv, d, device=dev, dtype=torch.float16)
+    bias = make_dense_bias(h_q, s_q, s_kv, bias_dtype, bias_layout) if bias_dtype is not None else None
     o = torch.zeros_like(q)
     lse_storage = None
     if not with_lse:
@@ -73,7 +91,14 @@ def _sm120_case(h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True, causal=
     else:
         raise ValueError(f"unknown LSE layout {lse_layout!r}")
 
-    kw = dict(is_causal=True) if causal else {}
+    kw = dict(
+        sample_bias=bias,
+        is_causal=causal,
+        causal_bottom_right=causal_bottom_right,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        pack_gqa=pack_gqa,
+    )
     # Probe pass: the chooser reads the adapter's own tile geometry.
     probe = SdpaFwdDslSm120(sample_q=q, sample_k=k, sample_v=v, sample_o=o, sample_lse=lse, **kw)
     assert probe.check_support()
@@ -89,7 +114,7 @@ def _sm120_case(h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True, causal=
     ws_bytes = api.scratch_workspace_bytes()
     api.compile()
     ws = torch.empty(ws_bytes, dtype=torch.uint8, device=dev) if (workspace and ws_bytes) else None
-    api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, lse_tensor=lse, workspace=ws)
+    api.execute(q_tensor=q, k_tensor=k, v_tensor=v, o_tensor=o, lse_tensor=lse, bias_tensor=bias, workspace=ws)
     torch.cuda.synchronize()
 
     qb, kb, vb = q.float(), k.float(), v.float()
@@ -97,10 +122,20 @@ def _sm120_case(h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True, causal=
         kb = kb.repeat_interleave(h_q // h_kv, dim=1)
         vb = vb.repeat_interleave(h_q // h_kv, dim=1)
     scores = torch.matmul(qb, kb.transpose(-1, -2)) / math.sqrt(d)
-    if causal:
+    if bias is not None:
+        scores = scores + bias.float()
+    if causal or window_size_left is not None or window_size_right is not None:
         i = torch.arange(s_q, device=scores.device).view(s_q, 1)
         j = torch.arange(s_kv, device=scores.device).view(1, s_kv)
-        scores = scores.masked_fill(j > i, float("-inf"))
+        diagonal = i + (s_kv - s_q) if causal_bottom_right else i
+        masked = torch.zeros((s_q, s_kv), dtype=torch.bool, device=scores.device)
+        if causal:
+            masked |= j > diagonal
+        if window_size_right is not None:
+            masked |= j > diagonal + window_size_right
+        if window_size_left is not None:
+            masked |= j < diagonal - window_size_left
+        scores = scores.masked_fill(masked, float("-inf"))
     p = torch.softmax(scores, dim=-1)
     if lse is not None:
         torch.testing.assert_close(lse, torch.logsumexp(scores, dim=-1), rtol=3e-2, atol=5e-2)
@@ -111,6 +146,7 @@ def _sm120_case(h_q, h_kv, s_q, s_kv, *, with_lse=False, workspace=True, causal=
     return _ApiCaseResult(split, o.float(), torch.matmul(p, vb), ws_bytes, expected, None if lse is None else lse.clone())
 
 
+@pytest.mark.L0
 def test_sm120_splits_a_decode_shape():
     """A decode shape the chooser wants split -- and the adapter must honor it."""
     result = _sm120_case(8, 1, 128, 32768)
@@ -121,6 +157,7 @@ def test_sm120_splits_a_decode_shape():
     assert (result.output - result.reference).abs().max().item() <= 2e-2
 
 
+@pytest.mark.L0
 def test_sm120_does_not_split_a_full_part():
     """A launch that fills the part is left alone. Whether 1024x64 fills it
     depends on the SM count, so the expectation comes from the chooser rather
@@ -131,6 +168,7 @@ def test_sm120_does_not_split_a_full_part():
     assert (result.output - result.reference).abs().max().item() <= 2e-2
 
 
+@pytest.mark.L0
 @pytest.mark.parametrize("workspace", [True, False], ids=["carved", "standalone"])
 def test_sm120_split_with_and_without_workspace(workspace):
     result = _sm120_case(8, 1, 128, 32768, workspace=workspace)
@@ -138,12 +176,14 @@ def test_sm120_split_with_and_without_workspace(workspace):
     assert (result.output - result.reference).abs().max().item() <= 2e-2
 
 
+@pytest.mark.L0
 def test_sm120_split_writes_the_recombined_lse():
     result = _sm120_case(8, 1, 128, 32768, with_lse=True)
     assert result.split == result.expected_split
     assert (result.output - result.reference).abs().max().item() <= 2e-2
 
 
+@pytest.mark.L0
 def test_sm120_split_writes_strided_recombined_lse():
     contiguous = _sm120_case(8, 1, 128, 1024, with_lse=True, split_kv=2)
     strided = _sm120_case(8, 1, 128, 1024, with_lse=True, lse_layout="strided", split_kv=2)
@@ -152,6 +192,75 @@ def test_sm120_split_writes_strided_recombined_lse():
     torch.testing.assert_close(strided.stats, contiguous.stats, atol=0, rtol=0)
 
 
+@pytest.mark.L0
+@pytest.mark.parametrize("bias_dtype", [torch.float16, torch.float32], ids=["bias-fp16", "bias-fp32"])
+def test_sm120_split_attention_bias_uses_absolute_kv_columns(bias_dtype):
+    result = _sm120_case(8, 2, 96, 1024, with_lse=True, split_kv=2, bias_dtype=bias_dtype, bias_layout="strided")
+    assert result.split == 2
+    assert (result.output - result.reference).abs().max().item() <= 3e-2
+
+
+@pytest.mark.L1
+@pytest.mark.parametrize(
+    ("pack_gqa", "mask_kind"),
+    [(False, "causal"), (True, "bottom_right"), (True, "swa")],
+    ids=["gqa-causal", "pack-gqa-bottom-right", "pack-gqa-swa"],
+)
+def test_sm120_split_attention_bias_mask_combinations(pack_gqa, mask_kind):
+    """Split-KV bias composes with every mask geometry supported by SM120 split-KV."""
+
+    s_q, s_kv = (512, 512) if mask_kind == "swa" else (384, 1024)
+    mask_kwargs = dict(causal=True)
+    if mask_kind == "bottom_right":
+        mask_kwargs["causal_bottom_right"] = True
+    elif mask_kind == "swa":
+        mask_kwargs["window_size_left"] = 128
+
+    result = _sm120_case(
+        8,
+        2,
+        s_q,
+        s_kv,
+        split_kv=2,
+        bias_dtype=torch.float32,
+        bias_layout="strided",
+        pack_gqa=pack_gqa,
+        **mask_kwargs,
+    )
+    assert result.split == 2
+    assert (result.output - result.reference).abs().max().item() <= 3e-2
+
+
+@pytest.mark.L0
+def test_sm120_split_attention_bias_with_padding_is_rejected():
+    """SM120 split-KV currently serves only unpadded dense bias graphs."""
+
+    from cudnn.sdpa.fwd.api_dsl import SdpaFwdDslSm120
+
+    if torch.cuda.get_device_capability()[0] != 12:
+        pytest.skip("SM120 part required")
+    batch, heads, sequence, head_dim = 1, 4, 128, 128
+    q = torch.randn(batch, heads, sequence, head_dim, dtype=torch.float16, device="cuda")
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    o = torch.empty_like(q)
+    bias = make_dense_bias(heads, sequence, sequence, torch.float32, "contiguous")
+    api = SdpaFwdDslSm120(
+        sample_q=q,
+        sample_k=k,
+        sample_v=v,
+        sample_o=o,
+        sample_bias=bias,
+        seq_kv_lens_present=True,
+        split_kv=2,
+        sched_policy=0,
+    )
+
+    with pytest.raises(ValueError, match="serves unpadded dense graphs only"):
+        api.check_support()
+
+
+@pytest.mark.L0
 def test_sm120_causal_split_requires_the_natural_scheduler():
     """The config bars a split under the LPT remaps a causal graph derives.
     Knob-route contract, both directions: a split WITHOUT an explicit

--- a/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
+++ b/test/python/sdpa/frost/test_sdpa_graph_analyzer.py
@@ -199,13 +199,51 @@ def test_probe_rejects_wrong_device_family(monkeypatch):
     assert not _eligible(g)
 
 
-def test_probe_rejects_bias():
+@pytest.mark.parametrize(
+    ("cc", "engine"),
+    [
+        ((8, 0), engines.engine_name(arch="sm80")),
+        ((10, 0), engines.engine_name()),
+        ((12, 0), engines.engine_name(arch="sm120")),
+    ],
+    ids=["sm80", "sm100", "sm120"],
+)
+def test_probe_accepts_dense_attention_bias(monkeypatch, cc, engine):
+    monkeypatch.setattr(ga, "_device_cc", lambda: cc)
     g = _mk_graph()
-    q, k, v, dims, strides = _mk_qkv(g)
+    q, k, v, dims, strides = _mk_qkv(g, d=128)
     bias = g.tensor(dim=(1, H, S, S), stride=(H * S * S, S * S, S, 1), data_type=cudnn.data_type.FLOAT, name="bias")
     o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, bias=bias)
     _finish_output(o, dims, strides)
-    assert not _eligible(g)
+    assert engine in _eligible(g)
+
+
+@pytest.mark.parametrize(
+    ("cc", "engine"),
+    [
+        ((8, 0), engines.engine_name(arch="sm80")),
+        ((10, 0), engines.engine_name()),
+        ((12, 0), engines.engine_name(arch="sm120")),
+    ],
+    ids=["sm80", "sm100", "sm120"],
+)
+def test_probe_accepts_strided_attention_bias(monkeypatch, cc, engine):
+    monkeypatch.setattr(ga, "_device_cc", lambda: cc)
+    g = _mk_graph()
+    q, k, v, dims, strides = _mk_qkv(g, d=128)
+    bias = g.tensor(dim=(1, H, S, S), stride=(H * S * (S + 1), S * (S + 1), S + 1, 1), data_type=cudnn.data_type.FLOAT, name="bias")
+    o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, bias=bias)
+    _finish_output(o, dims, strides)
+    assert engine in _eligible(g)
+
+
+def test_probe_rejects_overlapping_attention_bias():
+    g = _mk_graph()
+    q, k, v, dims, strides = _mk_qkv(g)
+    bias = g.tensor(dim=(1, H, S, S), stride=(H * S * S, S * S, S - 1, 1), data_type=cudnn.data_type.FLOAT, name="bias")
+    o, _ = g.sdpa(name="s", q=q, k=k, v=v, attn_scale=0.1, is_inference=True, bias=bias)
+    _finish_output(o, dims, strides)
+    assert engines.engine_name() not in _eligible(g)
 
 
 def test_probe_rejects_alibi():

--- a/test/python/sdpa/frost/test_sdpa_sm80_frontend_integration.py
+++ b/test/python/sdpa/frost/test_sdpa_sm80_frontend_integration.py
@@ -17,7 +17,7 @@ import torch
 import cudnn
 import cudnn.sdpa  # noqa: F401 — the SM80 capability tables live here
 from cudnn.engines import MANIFEST, is_python_engine
-from frost_test_utils import select_engine
+from frost_test_utils import make_dense_bias, select_engine
 
 from cudnn.sdpa import graph_analyzer as ga
 from cudnn.sdpa.bwd import engines as engines_bwd_sm80
@@ -135,6 +135,58 @@ def test_fwd_engine_end_to_end():
     ref = torch.nn.functional.scaled_dot_product_attention(q_buf.float(), k_buf.float(), v_buf.float(), is_causal=True, scale=_SCALE).to(torch.float16)
     torch.testing.assert_close(o_buf, ref, rtol=1e-2, atol=4e-3)
     assert torch.isfinite(stats_buf).all()
+
+
+def _check_fwd_engine_attention_bias(d, bias_dtype, bias_layout):
+    torch.manual_seed(67)
+    bias_values = make_dense_bias(H, S, S, bias_dtype, bias_layout)
+    g = cudnn.pygraph(io_data_type=_HALF, intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+    st = _bshd_stride(B, H, S, d)
+    q = g.tensor(name="q", dim=(B, H, S, d), stride=st, data_type=_HALF)
+    k = g.tensor(name="k", dim=(B, H, S, d), stride=st, data_type=_HALF)
+    v = g.tensor(name="v", dim=(B, H, S, d), stride=st, data_type=_HALF)
+    bias_type = cudnn.data_type.FLOAT if bias_dtype == torch.float32 else _HALF
+    bias = g.tensor(name="bias", dim=(1, H, S, S), stride=bias_values.stride(), data_type=bias_type)
+    scale = 1.0 / math.sqrt(d)
+    o, stats = g.sdpa(q=q, k=k, v=v, bias=bias, attn_scale=scale, use_causal_mask=True, generate_stats=True)
+    o.set_output(True).set_dim((B, H, S, d)).set_stride(st).set_data_type(_HALF)
+    stats.set_output(True).set_data_type(cudnn.data_type.FLOAT)
+    _native_then_pin(g, _FWD)
+
+    q_buf, k_buf, v_buf = _buf(d), _buf(d), _buf(d)
+    bias_buf = bias_values.view(-1) if bias_values.is_contiguous() else bias_values
+    o_buf = torch.empty_like(q_buf)
+    stats_buf = torch.empty(B, H, S, 1, dtype=torch.float32, device="cuda")
+    g.execute({q: q_buf, k: k_buf, v: v_buf, bias: bias_buf, o: o_buf, stats: stats_buf}, None)
+    torch.cuda.synchronize()
+
+    scores = torch.matmul(q_buf.float(), k_buf.float().transpose(-1, -2)) * scale + bias_values.float()
+    causal_mask = torch.ones(S, S, dtype=torch.bool, device="cuda").triu(diagonal=1)
+    masked_scores = scores.masked_fill(causal_mask, float("-inf"))
+    ref = torch.matmul(torch.softmax(masked_scores, dim=-1), v_buf.float()).to(torch.float16)
+    torch.testing.assert_close(o_buf, ref, rtol=1e-2, atol=4e-3)
+    torch.testing.assert_close(stats_buf.squeeze(-1), torch.logsumexp(masked_scores, dim=-1), rtol=3e-2, atol=5e-2)
+
+
+@_SM80
+@pytest.mark.L0
+@pytest.mark.parametrize(
+    ("bias_dtype", "bias_layout"),
+    [(torch.float16, "contiguous"), (torch.float32, "contiguous"), (torch.float16, "strided")],
+    ids=["bias-fp16", "bias-fp32", "bias-fp16-strided"],
+)
+def test_fwd_engine_attention_bias(bias_dtype, bias_layout):
+    """The shared adapter views raw bias storage through its graph descriptor."""
+
+    _check_fwd_engine_attention_bias(128, bias_dtype, bias_layout)
+
+
+@_SM80
+@pytest.mark.L1
+def test_fwd_engine_strided_attention_bias_d256():
+    """The separate SM80 D256 kernel reads a permuted, gapped bias directly."""
+
+    _check_fwd_engine_attention_bias(256, torch.float32, "strided")
 
 
 def _check_fwd_engine_strided_stats(d):


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [x] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*` (see [label list](https://github.com/NVIDIA/cudnn-frontend/labels)).
- [x] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

FE OSS kernels or CuTeDSL

## Summary

- Add dense additive attention-bias support to the SM80-, SM100-, and SM120-family FROST FP16/BF16 SDPA forward engines.
- Support bias in the Q/K/V dtype or FP32 with dense-compatible, non-contiguous strides described by `bias_stride`.
- Apply bias before masking and softmax while preserving the existing compile-time no-bias fast path.
- Cover GQA, PackGQA, split-KV, causal/bottom-right/sliding-window/band masks, padded sequence lengths, and all SM100 kernel flavors.
- Keep THD and FP8/MXFP8 graphs on their existing paths because those FROST kernels do not support attention bias.

## Why

Dense SDPA graphs with an additive attention-bias tensor were routed to native cuDNN backends even when the corresponding FROST FP16/BF16 engine otherwise supported the graph. This closes that functional coverage gap across the supported SM80, SM100, and SM120 kernel families while retaining arbitrary dense-compatible bias layouts and the existing feature-specific decline behavior.

## Related issues

Related to #379, #381 and #377.

## API and compatibility impact

No public API signature changes. Existing dense SDPA graphs with bias shaped `[1, H_q, S_q, S_kv]` may now select a FROST FP16/BF16 forward engine when the bias dtype is FP32 or matches Q/K/V. Unsupported bias shapes/layouts, THD, and FP8/MXFP8 continue to decline the FROST engine.

## Testing

- A100 PCIe 40 GB / SM80, cuDNN backend 9.26: 14 passed across L0 and L1 (`test_sdpa_sm80_frontend_integration.py`).
- B100 / SM100, cuDNN backend 9.26: 818 passed across L0 and L1 (`test_sdpa_fwd_dsl_sm100.py`, `test_sdpa_fwd_fp8_sm100.py`, `test_sdpa_fwd_split_kv_sm100.py`, and `test_sdpa_graph_analyzer.py`).
- RTX 5090 / SM120, cuDNN backend 9.26: 240 passed across L0 and L1 (`test_sdpa_fwd_dsl_sm120.py`, `test_sdpa_fwd_fp8_sm120.py`, and `test_sdpa_fwd_split_kv_sm120.py`). One unrelated PackGQA case stops at a pre-existing hard-coded zero-workspace assertion when its split-KV plan requests 133120 bytes; allocating the reported workspace makes the same execution and reference check pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dense attention-bias support for SDPA forward operations on SM80, SM100, and SM120.
  * Supports FP16, BF16, and selected FP32 bias configurations, including strided layouts.
  * Bias is applied correctly alongside causal, sliding-window, padded, GQA, and split-KV attention modes.
* **Bug Fixes**
  * Added validation for unsupported THD and FP8 bias configurations, invalid shapes, layouts, dtypes, and strides.
  * Improved handling of masked positions and non-finite bias values.
* **Tests**
  * Expanded coverage across supported architectures, layouts, masks, data types, and sequence configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->