### PR TITLE
Gate the packed-FP4 wgrad layout workaround on cutlass-dsl < 4.8

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -70,9 +70,7 @@ def _using_internal_cutlass_dsl() -> bool:
 def _cutlass_dsl_needs_fp4_layout_workaround() -> bool:
     # Public cutlass-dsl wheels before 4.8 interpret packed sub-byte
     # from_dlpack layouts in byte units, so the FP4 A/B layouts must be
-    # recast to element units. 4.8+ public wheels adopted the internal
-    # wheel's native sub-byte layout semantics, where the recast would
-    # double-correct and corrupt the layout the MMA consumes.
+    # recast to element units.
     if _using_internal_cutlass_dsl():
         return False
     match = re.match(r"(\d+)\.(\d+)", getattr(cutlass, "__version__", "") or "")

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -22,6 +22,7 @@ Scheduler: moe_persistent_scheduler.py (CLC mode, scenario="2Dx2D")
 Extension: moe_sched_extension.py (WgradDense / WgradDiscrete)
 """
 
+import re
 from importlib.metadata import PackageNotFoundError, version
 from typing import Literal, Type, Tuple, Optional
 
@@ -66,7 +67,21 @@ def _using_internal_cutlass_dsl() -> bool:
     return True
 
 
-_USING_INTERNAL_CUTLASS_DSL = _using_internal_cutlass_dsl()
+def _cutlass_dsl_needs_fp4_layout_workaround() -> bool:
+    # Public cutlass-dsl wheels before 4.8 interpret packed sub-byte
+    # from_dlpack layouts in byte units, so the FP4 A/B layouts must be
+    # recast to element units. 4.8+ public wheels adopted the internal
+    # wheel's native sub-byte layout semantics, where the recast would
+    # double-correct and corrupt the layout the MMA consumes.
+    if _using_internal_cutlass_dsl():
+        return False
+    match = re.match(r"(\d+)\.(\d+)", getattr(cutlass, "__version__", "") or "")
+    if match is None:
+        return False
+    return (int(match.group(1)), int(match.group(2))) < (4, 8)
+
+
+_NEEDS_FP4_LAYOUT_WORKAROUND = _cutlass_dsl_needs_fp4_layout_workaround()
 
 
 class BlockScaledMoEGroupedGemmWgradKernel:
@@ -329,10 +344,10 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         out_single_expert: Optional[cute.Tensor] = None,
     ) -> None:
 
-        # Public CUTLASS DSL 4.5 needs the packed-FP4 from_dlpack layout
-        # workaround. Rubin and the internal DSL wheel consume the native
-        # 4-bit layout directly.
-        needs_fp4_layout_workaround = self.architecture != "sm_107" and not _USING_INTERNAL_CUTLASS_DSL
+        # Public CUTLASS DSL < 4.8 needs the packed-FP4 from_dlpack layout
+        # workaround. Rubin, the internal DSL wheel, and public wheels >= 4.8
+        # consume the native 4-bit layout directly.
+        needs_fp4_layout_workaround = self.architecture != "sm_107" and _NEEDS_FP4_LAYOUT_WORKAROUND
         if cutlass.const_expr(needs_fp4_layout_workaround and mat_a.iterator.dtype.width < 8):
             mat_a = cute.make_tensor(
                 mat_a.iterator,

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
@@ -178,13 +178,7 @@ def _blocked_sf_to_flat(sf_tensor: torch.Tensor, rows: int, cols: int) -> torch.
     row_idx = torch.arange(rows, device=sf_tensor.device, dtype=torch.long).view(rows, 1)
     col_idx = torch.arange(sf_cols, device=sf_tensor.device, dtype=torch.long).view(1, sf_cols)
     col_blocks = sf_tensor.shape[1] // 4
-    linear = (
-        (row_idx // 128) * col_blocks * 512
-        + (col_idx // 4) * 512
-        + (row_idx % 32) * 16
-        + ((row_idx // 32) % 4) * 4
-        + (col_idx % 4)
-    )
+    linear = (row_idx // 128) * col_blocks * 512 + (col_idx // 4) * 512 + (row_idx % 32) * 16 + ((row_idx // 32) % 4) * 4 + (col_idx % 4)
     return sf_tensor.flatten()[linear]
 
 


### PR DESCRIPTION
## Problem

The nightly `oss:rel:cutlass_dsl_4.8` [Blackwell] CI jobs fail all fp4 `test_grouped_gemm_wgrad` tests (21 on shard1, e.g. pipeline 64271661 / job 409620600) with ~94% mismatched output — and, run-dependently, an illegal memory access that poisons the CUDA context and cascades into dozens of unrelated test ERRORs. cutlass-dsl 4.7 is green on the same commit.

## Root cause

`BlockScaledMoEGroupedGemmWgradKernel` carries a packed-FP4 `from_dlpack` layout workaround (`cute.recast_layout(4, 8, ...)` on the A/B layouts) that public cutlass-dsl wheels < 4.8 require, gated on the *internal* cutlass-dsl wheel not being installed. The 4.8.0a0 public wheels adopted the internal wheel's native sub-byte layout semantics, so on 4.8 the recast double-corrects: the MMA consumes byte-aliased data (effectively halved-K / wrong strides), producing garbage output, and the corrupted addressing in the discrete-pointer TMA path can cross into unmapped memory (the IMA).

A/B proof matrix from the standalone repro (dense compile_execute fp4 sf_e4m3 vs the torch `scaled_grouped_mm` reference, sm100):

| | workaround ON | workaround OFF |
|---|---|---|
| cutlass-dsl 4.7.0 | pass, bit-exact | fail, ~94% wrong |
| cutlass-dsl 4.8.0a0 dailies | fail, ~94% wrong | pass, bit-exact |

## Fix

Gate the workaround on the cutlass-dsl version (`< 4.8`) instead of only on internal-wheel presence. The sm_107 and internal-wheel exemptions are unchanged.

## Verification

On an sm100 box (torch 2.13, CUDA 13), dense compile_execute fp4 `sf_e4m3`, mma 128x128 and 256x128, cluster 1x1 and 2x1:

- cutlass-dsl **4.7.0** + this fix → gate ON → **0/491520 mismatched (bit-exact)**
- cutlass-dsl **4.8.0a0+20260823210556.ac70faa** (the exact daily the failing CI job installed) + this fix → gate OFF → **0/491520 mismatched (bit-exact)**

A full CI replay (internal MR !2355, `oss:rel` pointed at the 4.8.0a0 prerelease) is running on Blackwell shard0/shard1; results will be posted as a comment here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for grouped GEMM operations across different CUTLASS DSL versions.
  * Newer versions now use native packed-FP4 layouts, while older versions continue using the appropriate compatibility path.
  * Preserved correct scale-factor indexing for grouped GEMM quantization workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->