### PR TITLE
[1.28.0-rc] Gate the packed-FP4 wgrad layout workaround on cutlass-dsl < 4.8

### DIFF
--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -70,9 +70,7 @@ def _using_internal_cutlass_dsl() -> bool:
 def _cutlass_dsl_needs_fp4_layout_workaround() -> bool:
     # Public cutlass-dsl wheels before 4.8 interpret packed sub-byte
     # from_dlpack layouts in byte units, so the FP4 A/B layouts must be
-    # recast to element units. 4.8+ public wheels adopted the internal
-    # wheel's native sub-byte layout semantics, where the recast would
-    # double-correct and corrupt the layout the MMA consumes.
+    # recast to element units.
     if _using_internal_cutlass_dsl():
         return False
     match = re.match(r"(\d+)\.(\d+)", getattr(cutlass, "__version__", "") or "")

--- a/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
+++ b/python/cudnn/gemm/cutedsl/grouped/wgrad/moe_blockscaled_grouped_gemm_wgrad.py
@@ -22,6 +22,7 @@ Scheduler: moe_persistent_scheduler.py (CLC mode, scenario="2Dx2D")
 Extension: moe_sched_extension.py (WgradDense / WgradDiscrete)
 """
 
+import re
 from importlib.metadata import PackageNotFoundError, version
 from typing import Literal, Type, Tuple, Optional
 
@@ -66,7 +67,21 @@ def _using_internal_cutlass_dsl() -> bool:
     return True
 
 
-_USING_INTERNAL_CUTLASS_DSL = _using_internal_cutlass_dsl()
+def _cutlass_dsl_needs_fp4_layout_workaround() -> bool:
+    # Public cutlass-dsl wheels before 4.8 interpret packed sub-byte
+    # from_dlpack layouts in byte units, so the FP4 A/B layouts must be
+    # recast to element units. 4.8+ public wheels adopted the internal
+    # wheel's native sub-byte layout semantics, where the recast would
+    # double-correct and corrupt the layout the MMA consumes.
+    if _using_internal_cutlass_dsl():
+        return False
+    match = re.match(r"(\d+)\.(\d+)", getattr(cutlass, "__version__", "") or "")
+    if match is None:
+        return False
+    return (int(match.group(1)), int(match.group(2))) < (4, 8)
+
+
+_NEEDS_FP4_LAYOUT_WORKAROUND = _cutlass_dsl_needs_fp4_layout_workaround()
 
 
 class BlockScaledMoEGroupedGemmWgradKernel:
@@ -329,10 +344,10 @@ class BlockScaledMoEGroupedGemmWgradKernel:
         out_single_expert: Optional[cute.Tensor] = None,
     ) -> None:
 
-        # Public CUTLASS DSL 4.5 needs the packed-FP4 from_dlpack layout
-        # workaround. Rubin and the internal DSL wheel consume the native
-        # 4-bit layout directly.
-        needs_fp4_layout_workaround = self.architecture != "sm_107" and not _USING_INTERNAL_CUTLASS_DSL
+        # Public CUTLASS DSL < 4.8 needs the packed-FP4 from_dlpack layout
+        # workaround. Rubin, the internal DSL wheel, and public wheels >= 4.8
+        # consume the native 4-bit layout directly.
+        needs_fp4_layout_workaround = self.architecture != "sm_107" and _NEEDS_FP4_LAYOUT_WORKAROUND
         if cutlass.const_expr(needs_fp4_layout_workaround and mat_a.iterator.dtype.width < 8):
             mat_a = cute.make_tensor(
                 mat_a.iterator,

--- a/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
+++ b/test/python/fe_api/grouped_gemm/test_grouped_gemm_glu_hadamard_quant.py
@@ -178,13 +178,7 @@ def _blocked_sf_to_flat(sf_tensor: torch.Tensor, rows: int, cols: int) -> torch.
     row_idx = torch.arange(rows, device=sf_tensor.device, dtype=torch.long).view(rows, 1)
     col_idx = torch.arange(sf_cols, device=sf_tensor.device, dtype=torch.long).view(1, sf_cols)
     col_blocks = sf_tensor.shape[1] // 4
-    linear = (
-        (row_idx // 128) * col_blocks * 512
-        + (col_idx // 4) * 512
-        + (row_idx % 32) * 16
-        + ((row_idx // 32) % 4) * 4
-        + (col_idx % 4)
-    )
+    linear = (row_idx // 128) * col_blocks * 512 + (col_idx // 4) * 512 + (row_idx % 32) * 16 + ((row_idx // 32) % 4) * 4 + (col_idx % 4)
     return sf_tensor.flatten()[linear]
 
 


### PR DESCRIPTION
Cherry-pick of all three commits from #763 onto `1.28.0-rc`: the gate fix, the comment trim, and the black formatting of `test_grouped_gemm_glu_hadamard_quant.py` (so the pre-commit `--all-files` check passes on this branch too).

## Problem / root cause

`BlockScaledMoEGroupedGemmWgradKernel` applies a packed-FP4 `from_dlpack` layout workaround (`cute.recast_layout(4, 8, ...)` on the A/B layouts) gated only on the internal cutlass-dsl wheel not being installed. Public cutlass-dsl wheels < 4.8 need it, but the 4.8.0a0 public wheels adopted native sub-byte layout semantics, so the recast double-corrects: every fp4 wgrad test fails with ~94% mismatched output (21 tests on the Blackwell nightly `oss:rel:cutlass_dsl_4.8` shard1), occasionally escalating to an illegal memory access that cascades into unrelated test ERRORs.

## Fix

Gate the workaround on the cutlass-dsl version (`< 4.8`) instead of only on internal-wheel presence. sm_107 and internal-wheel behavior unchanged; behavior on 4.5–4.7 public wheels unchanged (gate stays ON).

## Verification (done on #763, same patch)

- Local sm100, dense compile_execute fp4 `sf_e4m3`, mma 128x128/256x128, cluster 1x1/2x1: **bit-exact (0/491520 mismatched)** on cutlass-dsl 4.7.0 (gate ON) and 4.8.0a0+20260823210556.ac70faa (gate OFF); without the fix, 4.8 fails at ~94% mismatch.
- Internal CI replay (MR !2355) with `oss:rel` pointed at the 4.8.0a0 prerelease: all four jobs green; Blackwell shard1 went from 21 failed to **910 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
