### PR TITLE
frost(sdpa): SM80 backward native strided-LSE reads + THD max_s_kv grid hint

### DIFF
--- a/python/cudnn/sdpa/bwd/api_dsl.py
+++ b/python/cudnn/sdpa/bwd/api_dsl.py
@@ -975,7 +975,9 @@ def _sm80_bwd_pad_last_dim(t: torch.Tensor, new_last: int) -> torch.Tensor:
     return torch.cat([t, pad], dim=-1).contiguous()
 
 
-def _sm80_thd_backward(q, k, v, o, do, lse, *, cu_q, cu_k, scale_softmax, is_causal, window_size, causal_bottom_right, sinks=None, deterministic=False):
+def _sm80_thd_backward(
+    q, k, v, o, do, lse, *, cu_q, cu_k, scale_softmax, is_causal, window_size, causal_bottom_right, sinks=None, deterministic=False, max_s_kv=None
+):
     """THD / varlen backward: q/k/v/o/do are PACKED ``[1, T, H, D]`` (BSHD,
     B==1 — no transpose), ``lse`` is packed ``[1, H, T_q]`` (head-major,
     matching the kernel's THD LSE layout), and cu_q/cu_k are ``[n_seq+1]``
@@ -985,10 +987,10 @@ def _sm80_thd_backward(q, k, v, o, do, lse, *, cu_q, cu_k, scale_softmax, is_cau
     GQA reduces over the query-head group).  Returns packed ``[1, T, H, D]``
     dQ/dK/dV (BHSD-equivalent for B==1).
 
-    Wrapper-only Rule-3 residual: the grid extents (max seqlen per side, the
-    logical sequence count) are RUNTIME ints read from cu_seqlens on the HOST
-    — a D2H sync this functional wrapper accepts (the graph/engine path never
-    routes THD here without materialized host seqlens).
+    The over-provisioned grid needs the longest per-sequence KV length:
+    pass ``max_s_kv`` (any upper bound works — short tiles early-out) to keep
+    the call fully async; without it the wrapper reads it from ``cu_k`` on
+    the HOST (a D2H sync — the wrapper-only Rule-3 residual).
     """
     if sinks is not None:
         raise NotImplementedError("SM80 THD bprop: attention sinks are dense-only")
@@ -1039,13 +1041,17 @@ def _sm80_thd_backward(q, k, v, o, do, lse, *, cu_q, cu_k, scale_softmax, is_cau
         sched_policy=_BWD_SCHED_NATURAL,  # LPT+THD is a future tweak
     )
     mod = _load_sm80_bwd_module(params)
-    # Host-side grid math (the wrapper-only D2H documented above).
-    cu_q_host = cu_q.to(dtype=torch.int32, device="cpu")
-    cu_k_host = cu_k.to(dtype=torch.int32, device="cpu")
-    n_seq = cu_q_host.numel() - 1
-    assert cu_k_host.numel() == n_seq + 1, "cu_seqlens_q / cu_seqlens_k length mismatch"
-    max_sq = int((cu_q_host[1:] - cu_q_host[:-1]).max())
-    max_skv = int((cu_k_host[1:] - cu_k_host[:-1]).max())
+    # Host-side grid math.  n_seq is shape metadata (no sync); the longest KV
+    # length comes from the caller's max_s_kv hint, or from a host read of
+    # cu_k (the D2H documented above) when no hint is given.
+    n_seq = cu_q.numel() - 1
+    assert cu_k.numel() == n_seq + 1, "cu_seqlens_q / cu_seqlens_k length mismatch"
+    if max_s_kv is not None:
+        max_s_kv = int(max_s_kv)
+        assert max_s_kv > 0, f"max_s_kv must be > 0; got {max_s_kv}"
+    else:
+        cu_k_host = cu_k.to(dtype=torch.int32, device="cpu")
+        max_s_kv = int((cu_k_host[1:] - cu_k_host[:-1]).max())
     c = mod.compile(1, h_q, h_kv, 0, 0, swa_window=swa, n_batch_logical=n_seq)
     t_q = q.shape[1]
     t_kv = k.shape[1]
@@ -1091,7 +1097,7 @@ def _sm80_thd_backward(q, k, v, o, do, lse, *, cu_q, cu_k, scale_softmax, is_cau
         inv_scale=1.0 / float(scale_softmax),
         bias_bstride=0,
         sem_q_stride=0,
-        grid_kv_tiles=(max_skv + params.tile_kv - 1) // params.tile_kv,
+        grid_kv_tiles=(max_s_kv + params.tile_kv - 1) // params.tile_kv,
         grid_batch=n_seq,
         stream=stream,
     )
@@ -1229,10 +1235,10 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
 
     Layouts: any dense layout with the head dim innermost-contiguous is
     served — non-BSHD-compact operands (dense_flex) gather into carved
-    staging, a strided stats input gathers to the packed LSE the kernels
-    read (``Capabilities.strided_stats``), and head dims inside a flavor
-    envelope pad host-side into the same carved buffers (issue #514: with a
-    workspace provided, execute allocates nothing).
+    staging, a strided stats input is READ natively at its declared strides
+    (``Capabilities.strided_stats``; no gather), and head dims inside a
+    flavor envelope pad host-side into the same carved buffers (issue #514:
+    with a workspace provided, execute allocates nothing).
     """
 
     def __init__(
@@ -1254,7 +1260,42 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
         self.mask_token: Optional[str] = None
         self.swa_window_runtime: int = 0
         self.right_bound_runtime: int = 0
+        self._lse_stride: "Optional[tuple[int, int, int]]" = None
         self._dummy_cache: dict = {}
+
+    def _checked_lse_view(self, lse_tensor: torch.Tensor) -> torch.Tensor:
+        """Validate a caller-provided Stats/LSE buffer and return the
+        kernels' (B, H_q, S_q) READ view.
+
+        The logical contract is exactly ``B*H_q*S_q`` fp32 elements.  With a
+        strided plan (``_lse_stride``), rebuild the DECLARED layout over the
+        caller's storage — the kernels' loads were compiled against exactly
+        those strides; a contiguous plan requires a contiguous runtime buffer
+        (the compiled packed fake would misread anything else).
+        """
+        self._value_error_if(
+            lse_tensor.device != self.stats_desc.device,
+            f"stats must be on the plan's device {self.stats_desc.device}; got {lse_tensor.device} (the kernel binds this pointer directly)",
+        )
+        self._value_error_if(lse_tensor.dtype != torch.float32, f"stats must be float32; got {lse_tensor.dtype}")
+        expected = self.batch_size * self.h_q * self.s_q_max
+        self._value_error_if(
+            lse_tensor.numel() != expected,
+            f"stats must have B*H_q*S_q = {expected} elements; got {lse_tensor.numel()}",
+        )
+        shape = (self.batch_size, self.h_q, self.s_q_max)
+        stride = self._lse_stride
+        if stride is None:
+            self._value_error_if(not lse_tensor.is_contiguous(), "stats must be contiguous (the plan declared a packed LSE layout)")
+            return lse_tensor.view(shape)
+        if tuple(lse_tensor.shape) == shape and tuple(lse_tensor.stride()) == stride:
+            return lse_tensor
+        try:
+            return lse_tensor.as_strided(shape, stride, lse_tensor.storage_offset())
+        except RuntimeError as exc:
+            raise ValueError(
+                f"stats backing storage is too small for declared shape {shape}, stride {stride}, and storage_offset {lse_tensor.storage_offset()}"
+            ) from exc
 
     def _dummy(self, key: str, device: torch.device, factory) -> torch.Tensor:
         """A cached device-local dummy for a dead ABI slot (AGENTS.md Rule 1:
@@ -1310,11 +1351,21 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
             stats_shape not in ((b, h_qo, s_qo), (b, h_qo, s_qo, 1)),
             f"stats must be (B, H_q, S_q[, 1]) = ({b}, {h_qo}, {s_qo}[, 1]); got {stats_shape}",
         )
-        # Any stats layout is served: a non-contiguous input gathers into
-        # carved staging (the kernels read a packed natural-log LSE).
-        self._stats_needs_stage = not self.stats_desc.is_contiguous()
+        # Any stats layout is served NATIVELY: the kernels' LSE loads are
+        # stride-aware, compiled against the DECLARED (B, H_q, S_q) strides
+        # (the trailing size-1 dim of a rank-4 Stats contributes no offset).
+        # Contiguous stats keep the packed compact fake (byte-identical).
+        self._lse_stride = None if self.stats_desc.is_contiguous() else tuple(int(st) for st in self.stats_desc.stride[:3])
 
         self._value_error_if(not torch.cuda.is_available(), "CUDA must be available for SM80 BPROP")
+        # Plan-time device parity: the kernels bind the Stats pointer directly
+        # (native strided reads), and execute() validates the runtime LSE
+        # against stats_desc.device — so a host-side or cross-GPU Stats
+        # DECLARATION must be rejected here, before it can anchor that check.
+        self._value_error_if(
+            self.stats_desc.device != self.q_desc.device,
+            f"stats must be on Q's device {self.q_desc.device}; got {self.stats_desc.device}",
+        )
         device = self.q_desc.device
         major, minor = torch.cuda.get_device_capability(device)
         self._value_error_if((major, minor) != (8, 0), f"SdpaBwdDslSm80 requires SM80 (A100); found SM{major}{minor} on {device}")
@@ -1415,7 +1466,9 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
                 bool(self.s_q_max % self._params.tile_q or self.s_k_max % self._params.tile_kv),
                 "SM80 bprop: RoPE requires S_q/S_kv tile-aligned",
             )
-        # d64 fast-path gate: every input is plan-time state now.
+        # d64 fast-path gate: every input is plan-time state now.  The
+        # dedicated kernel keeps legacy PACKED LSE reads, so a strided Stats
+        # declaration routes to the generic (stride-aware) module instead.
         self._use_d64 = _sm80_d64_fast_path_eligible(
             d_qk=self.head_dim_qk,
             d_v=self.head_dim_v,
@@ -1435,6 +1488,8 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
                 deterministic=self.deterministic,
             ),
         )
+        if self._lse_stride is not None:
+            self._use_d64 = False
         if self._use_d64:
             self._kmod = None
             self._compiled_kernel = True  # d64 self-caches on first execute
@@ -1449,6 +1504,7 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
                 swa_window=int(self.swa_window_runtime),
                 rope_max_s=self._rope_max_s,
                 n_batch_logical=0,
+                lse_stride=self._lse_stride,
             )
         self._logger.debug("compile completed")
 
@@ -1489,8 +1545,6 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
                 total += ws_align(int(desc.shape[0]) * s_len * hh * fd * elem)
             else:
                 total += self._bshd_gather_bytes(desc)
-        if self._stats_needs_stage:
-            total += ws_align(b * hq * sq * 4)
         total += _kmod.scratch_bytes(
             B=b,
             SQ=sq,
@@ -1593,14 +1647,12 @@ class SdpaBwdDslSm80(SdpaBwdDsl):
             O = _stage(o_tensor, pad_v, self.flavor_d_v)
             dO = _stage(do_tensor, pad_v, self.flavor_d_v)
 
-            # Stats → packed (B, H, S) LSE; squeeze(-1) is a valid view for
-            # any (B, H, S, 1) strides; strided inputs gather into staging
-            # (the kernels READ a packed LSE — raw-pointer addressing).
+            # Stats → the kernels' (B, H, S) LSE view; squeeze(-1) is a valid
+            # view for any (B, H, S, 1) strides.  A strided declaration binds
+            # the caller's storage directly — the kernels compiled stride-aware
+            # LSE loads against the declared layout (no gather, no copy).
             lse = stats_tensor.squeeze(-1) if stats_tensor.ndim == 4 else stats_tensor
-            if not lse.is_contiguous():
-                lse_stage = _take(lse.numel(), torch.float32, shape=lse.shape)
-                lse_stage.copy_(lse)
-                lse = lse_stage
+            lse = self._checked_lse_view(lse)
 
             # --- d64 fast path: the dedicated plain-dense MHA kernel keeps
             # its legacy self-caching module (dense-only; #604 is THD-only).
@@ -1765,6 +1817,7 @@ def sdpa_bwd_wrapper_sm80(
     cum_seqlen_q_tensor: Optional[torch.Tensor] = None,
     cum_seqlen_k_tensor: Optional[torch.Tensor] = None,
     deterministic: bool = False,
+    max_s_kv: Optional[int] = None,
 ) -> TupleDict:
     """SM80 (A100) SDPA backward.
 
@@ -1774,6 +1827,10 @@ def sdpa_bwd_wrapper_sm80(
     fp32 when ``sinks`` is given (stable order: dq, dk, dv, dbias, dsink).
     ALiBi and block_mask are not supported (use the graph API, which routes
     them to the cuDNN backend); bias/dBias remain fully served.
+
+    THD (``cum_seqlen_*``): pass ``max_s_kv`` (any upper bound on the
+    longest per-sequence KV length) to keep the call fully async; without it
+    the wrapper reads the max from ``cu_k`` on the host (a D2H sync).
     """
     # THD / varlen: q/k/v/o/dO are PACKED [1, T, H, D] (BSHD) + cu_seqlens;
     # lse is packed [1, H, T_q].  Dedicated path that skips the dense BHSD
@@ -1803,7 +1860,10 @@ def sdpa_bwd_wrapper_sm80(
                 causal_bottom_right=causal_bottom_right,
                 sinks=sinks,
                 deterministic=deterministic,
+                max_s_kv=max_s_kv,
             )
+    if max_s_kv is not None:
+        raise ValueError("max_s_kv is a THD grid hint; it requires cum_seqlen_q_tensor/cum_seqlen_k_tensor")
     for nm, t in (("Q", q_tensor), ("V", v_tensor), ("O", o_tensor), ("dO", do_tensor)):
         if t.ndim != 4:
             raise ValueError(f"{nm} must be rank-4 BHSD; got {t.ndim}D")
@@ -1826,6 +1886,11 @@ def sdpa_bwd_wrapper_sm80(
         q_tensor.stride(),
         k_tensor.stride(),
         v_tensor.stride(),
+        # The compiled kernel is SPECIALIZED on the declared LSE layout
+        # (compile()'s lse_stride — native strided reads), so the Stats
+        # geometry is part of the plan identity, not just runtime data.
+        lse_tensor.shape,
+        lse_tensor.stride(),
         q_tensor.dtype,
         is_causal,
         window_size,

--- a/python/cudnn/sdpa/bwd/engines.py
+++ b/python/cudnn/sdpa/bwd/engines.py
@@ -547,9 +547,9 @@ def _sm80_spec() -> EngineSpec:
             sink=True,
             decode=False,  # prefill kernels only
             layouts=frozenset({"bshd", "dense_flex"}),
-            # Served by gathering the strided stats into carved contiguous
-            # staging (issue #514 workspace machinery) — the kernels read a
-            # packed LSE; sm120 reads declared strides natively instead.
+            # The kernels READ the declared stats strides natively (the
+            # #712 analogue for the backward's loads), same as sm120 — no
+            # gather staging.
             strided_stats=True,
         ),
         lower=partial(lower_dsl_bwd, api_type=_SM80),

--- a/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
+++ b/python/cudnn/sdpa/bwd/kernels/bprop_f16_sm80.py
@@ -420,10 +420,20 @@ def _bprop_kernel(
     k_tile_gmem = K_view.data_ptr() + k_tile_base
     v_tile_gmem = V_view.data_ptr() + v_tile_base
 
-    # LSE / do_dot: dense [B,H,SQ] → (batch*H+head)*SQ; THD packed [1,H,T_q]
-    # (T_q == SQ here) → head*T_q + cu_q[b].  Read below at + the in-seq q index.
-    lse_head_base = (head * cutlass.Int32(SQ) + cu_q_b) if cutlass.const_expr(THD_VARLEN) else (batch * cutlass.Int32(H) + head) * cutlass.Int32(SQ)
-    dot_head_base = lse_head_base
+    # LSE: STRIDE-AWARE on the dense path (a graph Stats input may carry any
+    # dense-compatible [B,H,SQ] layout; the compile-time strides come from the
+    # fake — a compact fake folds them to the packed constants, so the packed
+    # case is byte-identical).  THD keeps the packed [1,H,T_q] math (the grid
+    # `batch` is the LOGICAL sequence index, not the tensor's batch-1 dim).
+    # do_dot is an internal packed buffer → packed math always.
+    if cutlass.const_expr(THD_VARLEN):
+        lse_head_base = cutlass.Int64(head * cutlass.Int32(SQ) + cu_q_b)
+        LSE_Q_STRIDE = cutlass.Int64(1)
+        dot_head_base = head * cutlass.Int32(SQ) + cu_q_b
+    else:
+        lse_head_base = cutlass.Int64(batch) * cutlass.Int64(LSE.stride[0]) + cutlass.Int64(head) * cutlass.Int64(LSE.stride[1])
+        LSE_Q_STRIDE = cutlass.Int64(LSE.stride[2])
+        dot_head_base = (batch * cutlass.Int32(H) + head) * cutlass.Int32(SQ)
 
     # ---- SMEM tiles -------------------------------------------------------
     # Q∪dO is MERGED into one array so BMM1/dV/dK's per-sub-group B operand is a
@@ -704,8 +714,8 @@ def _bprop_kernel(
                 # clamped value is dead.
                 qr0 = _clamp_lt(qc0, q_bound) if cutlass.const_expr(GATE_Q) else qc0
                 qr1 = _clamp_lt(qc1, q_bound) if cutlass.const_expr(GATE_Q) else qc1
-                lse0 = Pointer(LSE_view.data_ptr() + lse_head_base + qr0, dtype=cutlass.Float32).load() * cutlass.Float32(_LOG2E)
-                lse1 = Pointer(LSE_view.data_ptr() + lse_head_base + qr1, dtype=cutlass.Float32).load() * cutlass.Float32(_LOG2E)
+                lse0 = Pointer(LSE_view.data_ptr() + lse_head_base + cutlass.Int64(qr0) * LSE_Q_STRIDE, dtype=cutlass.Float32).load() * cutlass.Float32(_LOG2E)
+                lse1 = Pointer(LSE_view.data_ptr() + lse_head_base + cutlass.Int64(qr1) * LSE_Q_STRIDE, dtype=cutlass.Float32).load() * cutlass.Float32(_LOG2E)
                 off = nf * 4
                 # Bias: add bias/scale to UNSCALED acc1 (post-scale → +bias),
                 # matching the forward.  Cells: (kv_a,qc0)(kv_a,qc1)(kv_a8,qc0)(kv_a8,qc1).
@@ -1223,15 +1233,20 @@ def _dsink_kernel(
     if row < n_bh:
         H = SINKS.shape[0]
         h = row % cutlass.Int32(H)
+        b = row // cutlass.Int32(H)
         sink_h = Pointer(cutlass.make_array_view(SINKS).data_ptr() + h, dtype=cutlass.Float32).load()
         base = row * cutlass.Int32(SQ)
+        # LSE is stride-aware (a graph Stats input may be any dense-compatible
+        # layout; compact strides fold to the packed math).  do_dot is an
+        # internal packed buffer.
+        lse_base = cutlass.Int64(b) * cutlass.Int64(LSE.stride[0]) + cutlass.Int64(h) * cutlass.Int64(LSE.stride[1])
         lse_p = cutlass.make_array_view(LSE).data_ptr()
         dot_p = cutlass.make_array_view(DO_DOT).data_ptr()
         acc = cutlass.Float32(0.0)
         for k in cutlass.range_constexpr((SQ + 31) // 32):
             q = lane + cutlass.Int32(k * 32)
             if q < cutlass.Int32(SQ):
-                lse_q = Pointer(lse_p + base + q, dtype=cutlass.Float32).load()
+                lse_q = Pointer(lse_p + lse_base + cutlass.Int64(q) * cutlass.Int64(LSE.stride[2]), dtype=cutlass.Float32).load()
                 dd_q = Pointer(dot_p + base + q, dtype=cutlass.Float32).load()
                 # Padded / fully-masked q-rows have LSE = -inf (forward writes -inf
                 # for an empty softmax denom).  exp2((sink - (-inf))·log2e) = +inf →
@@ -1527,10 +1542,10 @@ def scratch_bytes(
 # there; ``n_batch_logical`` (the logical sequence count) sizes the
 # ``cu_seqlens`` ABI and IS plan-time. Launch marshaling lives in the adapter
 # (``api_dsl._sm80_bwd_call``); this module holds no host runtime logic.
-# The stats input is READ as a packed (B, H, SQ) LSE (raw-pointer packed
-# addressing in the device code) — a strided graph stats input is gathered
-# into carved staging by the adapter, unlike the forward's #712-style native
-# strided WRITES.
+# The stats input is READ stride-aware on the dense path: ``compile()``
+# takes a plan-time ``lse_stride`` and the device code loads through the
+# fake's strides (the #712 analogue for the backward's loads; a contiguous
+# plan keeps the packed compact fake — byte-identical codegen).
 # ===========================================================================
 from typing import NamedTuple  # noqa: E402
 
@@ -1557,6 +1572,7 @@ def compile(  # noqa: A001 — the template contract's entry point
     swa_window: int = 0,
     rope_max_s: int = 0,
     n_batch_logical: int = 0,
+    lse_stride: "Optional[tuple[int, int, int]]" = None,
 ):
     """Compile (or fetch) this template specialization for one shape.
 
@@ -1567,6 +1583,11 @@ def compile(  # noqa: A001 — the template contract's entry point
     ``cute.sym_int`` per ragged group (Q/dO/dQ/LSE/do_dot share t_q; K/V and
     the per-query-head dK/dV write buffers share t_kv), so one artifact
     re-binds any totals.
+
+    ``lse_stride`` (dense only, plan-time): declared (B, H, SQ) strides of a
+    non-contiguous Stats input — the kernels then READ the LSE natively at
+    that layout (the #712 analogue for the backward's loads; ``None`` keeps
+    the packed compact fake, byte-identical codegen).
     """
     p = PARAMS
     io_dtype = cutlass.BFloat16 if p.io_bf16 else cutlass.Float16
@@ -1602,7 +1623,11 @@ def compile(  # noqa: A001 — the template contract's entry point
     # dK/dV WRITE buffers carry H_q heads (per-query-head; GQA reduces after).
     fdk_ws = _fake(io_dtype, (_b, _skv, h, p.d_qk), r4)
     fdv_ws = _fake(io_dtype, (_b, _skv, h, p.d_v), r4)
-    fl = _fake(cutlass.Float32, (_b, h, _sq), (2, 1, 0))
+    fl = (
+        cute.runtime.make_fake_tensor(cutlass.Float32, (_b, h, _sq), lse_stride, assumed_align=4)
+        if lse_stride is not None and not p.thd_varlen
+        else _fake(cutlass.Float32, (_b, h, _sq), (2, 1, 0))
+    )
     fdt = _fake(cutlass.Float32, (_b, h, _sq), (2, 1, 0))
     fsk = _fake(cutlass.Int32, (b if p.has_seq_kv_lens else 1,), (0,), align=4)
     bias_dtype = cutlass.Float32 if p.bias_is_fp32 else io_dtype

--- a/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
+++ b/test/python/fe_api/sdpa/test_sdpa_bwd_sm80.py
@@ -358,3 +358,191 @@ def test_sm80_bwd_thd_compile_key_plan_time_only():
     # call 1's key (n_seqs=2, different token totals) and MUST cache-hit.
     assert misses_1 - misses_0 <= 1, f"THD bprop compile key leaked runtime data: {misses_1 - misses_0} new misses"
     assert hits_1 - hits_0 >= 1, "expected a cache hit on the same-batch-count re-call"
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_sm80_bwd_strided_stats_native_reads():
+    """The kernels read a STRIDED Stats/LSE input natively (the #712 analogue
+    for the backward's loads): an interleaved-stride stats declaration must
+    produce bitwise the same grads as the contiguous run — with no gather
+    staging (the workspace stays exactly the packed plan's size)."""
+    try:
+        from cudnn.sdpa.bwd import api_dsl as api_sm80
+        from cudnn.sdpa.fwd import sdpa_fwd_wrapper_sm80
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+
+    b, h, s, d = 2, 4, 512, 128
+    scale = 1.0 / math.sqrt(d)
+    q = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    k = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    v = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    do = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    fwd = sdpa_fwd_wrapper_sm80(q_tensor=q, k_tensor=k, v_tensor=v, is_causal=True, scale_softmax=scale)
+    lse_c = fwd["lse_tensor"].contiguous()
+
+    # Interleave the (B, H, S) LSE into a doubled-S buffer: stride (2*H*S, 2*S, 2).
+    buf = torch.full((b, h, s, 2), float("nan"), dtype=torch.float32, device="cuda")
+    lse_strided = buf.as_strided((b, h, s), (2 * h * s, 2 * s, 2))
+    lse_strided.copy_(lse_c)
+
+    def run(lse):
+        dq = torch.empty(b, s, h, d, dtype=torch.float16, device="cuda").transpose(1, 2)
+        dk, dv = torch.empty_like(dq), torch.empty_like(dq)
+        eng = api_sm80.SdpaBwdDslSm80(
+            sample_q=q,
+            sample_k=k,
+            sample_v=v,
+            sample_o=fwd["o_tensor"],
+            sample_do=do,
+            sample_stats=lse,
+            sample_dq=dq,
+            sample_dk=dk,
+            sample_dv=dv,
+            is_causal=True,
+            scale_softmax=scale,
+        )
+        assert eng.check_support()
+        eng.compile()
+        ws = torch.empty(eng.scratch_workspace_bytes(), dtype=torch.uint8, device="cuda")
+        eng.execute(
+            q_tensor=q,
+            k_tensor=k,
+            v_tensor=v,
+            o_tensor=fwd["o_tensor"],
+            do_tensor=do,
+            stats_tensor=lse,
+            dq_tensor=dq,
+            dk_tensor=dk,
+            dv_tensor=dv,
+            scale_softmax=scale,
+            workspace=ws,
+        )
+        return eng, dq, dk, dv
+
+    eng_c, dq_c, dk_c, dv_c = run(lse_c)
+    eng_s, dq_s, dk_s, dv_s = run(lse_strided)
+    assert eng_s._lse_stride == (2 * h * s, 2 * s, 2)
+    # Native reads: the strided plan needs NO staging — same scratch as packed.
+    assert eng_s.scratch_workspace_bytes() == eng_c.scratch_workspace_bytes()
+    assert torch.equal(dq_s, dq_c)
+    assert torch.equal(dk_s, dk_c)
+    assert torch.equal(dv_s, dv_c)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_sm80_bwd_thd_max_s_kv_hint():
+    """The THD wrapper's max_s_kv grid hint must (a) produce bitwise the same
+    grads as the hint-less host-read path, including when over-provisioned
+    (short kv-tiles early-out), and (b) be rejected on the dense path."""
+    import itertools
+
+    try:
+        from cudnn.sdpa.bwd.api_dsl import sdpa_bwd_wrapper_sm80
+        from cudnn.sdpa.fwd import sdpa_fwd_wrapper_sm80
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+
+    h, d = 4, 128
+    lens = [96, 320, 160]
+    t = int(sum(lens))
+    cu = torch.tensor([0] + list(itertools.accumulate(lens)), dtype=torch.int32, device="cuda")
+    q = torch.randn(1, t, h, d, dtype=torch.float16, device="cuda")
+    k, v, do = torch.randn_like(q), torch.randn_like(q), torch.randn_like(q)
+    fwd = sdpa_fwd_wrapper_sm80(q, k, v, is_causal=True, cum_seqlen_q_tensor=cu, cum_seqlen_k_tensor=cu, max_s_q=max(lens))
+
+    def run(**kw):
+        return sdpa_bwd_wrapper_sm80(q, k, v, fwd["o_tensor"], do, fwd["lse_tensor"], is_causal=True, cum_seqlen_q_tensor=cu, cum_seqlen_k_tensor=cu, **kw)
+
+    base = run()
+    exact = run(max_s_kv=max(lens))
+    over = run(max_s_kv=t)  # upper bound: extra kv-tiles early-out
+    for key in ("dq_tensor", "dk_tensor", "dv_tensor"):
+        assert torch.equal(exact[key], base[key]), key
+        assert torch.equal(over[key], base[key]), key
+
+    with pytest.raises(ValueError, match="max_s_kv"):
+        sdpa_bwd_wrapper_sm80(
+            _bshd_randn(1, h, 128, d, dtype=torch.float16, device="cuda"),
+            _bshd_randn(1, h, 128, d, dtype=torch.float16, device="cuda"),
+            _bshd_randn(1, h, 128, d, dtype=torch.float16, device="cuda"),
+            _bshd_randn(1, h, 128, d, dtype=torch.float16, device="cuda"),
+            _bshd_randn(1, h, 128, d, dtype=torch.float16, device="cuda"),
+            torch.randn(1, h, 128, dtype=torch.float32, device="cuda"),
+            max_s_kv=128,
+        )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=0)
+def test_sm80_bwd_wrapper_lse_stride_in_cache_key():
+    """The wrapper's plan cache must key on the Stats/LSE geometry: the
+    compiled kernel is SPECIALIZED on the declared LSE strides (native
+    strided reads), so a cache hit across differently-laid-out LSE views
+    would misread the stats — same q/k/v, contiguous-then-strided LSE must
+    produce bitwise-identical gradients."""
+    try:
+        from cudnn.sdpa.bwd import sdpa_bwd_wrapper_sm80
+        from cudnn.sdpa.fwd import sdpa_fwd_wrapper_sm80
+    except ImportError as e:
+        pytest.skip(f"SM80 SDPA API not available: {e}")
+
+    b, h, s, d = 2, 4, 512, 128
+    scale = 1.0 / math.sqrt(d)
+    q = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    k = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    v = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    do = _bshd_randn(b, h, s, d, dtype=torch.float16, device="cuda")
+    fwd = sdpa_fwd_wrapper_sm80(q_tensor=q, k_tensor=k, v_tensor=v, is_causal=True, scale_softmax=scale)
+    lse_c = fwd["lse_tensor"].contiguous()
+
+    # Interleaved-stride view of the SAME values: stride (2*h*s, 2*s, 2).
+    buf = torch.full((b, h, s, 2), float("nan"), dtype=torch.float32, device="cuda")
+    lse_strided = buf.as_strided((b, h, s), (2 * h * s, 2 * s, 2))
+    lse_strided.copy_(lse_c)
+
+    def run(lse):
+        return sdpa_bwd_wrapper_sm80(
+            q_tensor=q,
+            k_tensor=k,
+            v_tensor=v,
+            o_tensor=fwd["o_tensor"],
+            do_tensor=do,
+            lse_tensor=lse,
+            is_causal=True,
+            scale_softmax=scale,
+        )
+
+    base = run(lse_c)  # plan cached with the packed LSE layout
+    strided = run(lse_strided)  # must NOT reuse the packed plan
+    for key in ("dq_tensor", "dk_tensor", "dv_tensor"):
+        assert torch.equal(strided[key], base[key]), key
+
+    # Device guard: a host-side LSE must be rejected loudly, never bound as a
+    # kernel pointer (the plan's cached adapter would otherwise launch on it).
+    with pytest.raises(ValueError, match="device"):
+        run(lse_c.cpu())
+
+    # And at PLAN time: a CPU Stats DECLARATION must fail check_support —
+    # otherwise the execute-time guard (which validates against
+    # stats_desc.device) would anchor to the host device and pass.
+    from cudnn.sdpa.bwd import api_dsl as _api
+
+    dq = torch.empty_like(q)
+    eng = _api.SdpaBwdDslSm80(
+        sample_q=q,
+        sample_k=k,
+        sample_v=v,
+        sample_o=fwd["o_tensor"],
+        sample_do=do,
+        sample_stats=lse_c.cpu(),
+        sample_dq=dq,
+        sample_dk=dq,
+        sample_dv=dq,
+        is_causal=True,
+        scale_softmax=scale,
+    )
+    with pytest.raises(ValueError, match="device"):
+        eng.check_support()


### PR DESCRIPTION
Now a single commit directly on `develop` (#716 and #765 have merged).

Two follow-ups to #765 that finish the zero-copy story on the SM80 backward:

**Native strided-LSE reads (the #712 analogue for the backward's loads)**
- The main-bprop and dSink kernels now read the Stats/LSE input stride-aware: the template module's `compile()` gains a plan-time `lse_stride` key and the device loads go through the fake's declared `(B, H, SQ)` strides. A contiguous plan keeps the packed compact fake — byte-identical codegen. THD keeps packed math (the grid batch index is the logical sequence, not the tensor's batch-1 dim).
- The adapter's strided-stats gather staging is deleted: sizing loses the staging term, and execute binds the caller's storage through a checked declared-layout view (the reader twin of the forward's `_checked_lse_view`, and the SM80 counterpart of the SM120 bwd adapter's existing `_lse_strides` convention).
- The dedicated d=64 fast path keeps legacy packed reads, so a strided Stats declaration routes to the generic (stride-aware) module — a plan-time gate.

**THD `max_s_kv` grid hint**
- The THD functional wrapper's only remaining D2H sync was reading the longest per-sequence KV length from `cu_k` to size the over-provisioned grid. `sdpa_bwd_wrapper_sm80(..., max_s_kv=...)` (any upper bound — short kv-tiles early-out) now removes it; `n_seq` was already shape metadata. Hint-less calls keep the documented host read; the dense path rejects the hint loudly.

## Tests
- `test_sm80_bwd_strided_stats_native_reads`: interleaved-stride stats vs contiguous — bitwise-equal dQ/dK/dV **and** identical `scratch_workspace_bytes()` (proves no staging).
- `test_sm80_bwd_thd_max_s_kv_hint`: exact and over-provisioned hints bitwise-equal to the hint-less path; dense-path rejection.

## Verification (A100, dev backend 9.27)
- The four SM80 suites at L0–L2 on this head: **123/123 passed, 0 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional sequence-length hint for SM80 THD backward operations to reduce unnecessary host reads.
  - Added support for reading dense statistics and LSE tensors directly from strided layouts.
  - Cache handling now distinguishes plans with different LSE layouts.

- **Bug Fixes**
  - Dense operations now reject the THD-only sequence-length hint.
  - Improved strided-statistics support while preserving gradient correctness and workspace sizing.

- **Tests**
  - Added coverage for strided statistics, sequence-length hints, invalid dense inputs, and LSE layout caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->