### PR TITLE
ci: skip PR checks on draft PRs

### DIFF
--- a/.github/workflows/pr-merge-requirements.yml
+++ b/.github/workflows/pr-merge-requirements.yml
@@ -22,6 +22,8 @@ permissions:
 
 jobs:
   merge-requirements:
+    # Draft PRs are skipped; marking one ready for review runs the check.
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Check milestone and project assignment

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,11 @@ name: Style check
 # run locally.
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     branches:
       - develop
@@ -16,6 +21,8 @@ permissions:
 
 jobs:
   pre-commit:
+    # Draft PRs are skipped; marking one ready for review runs the check.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Draft PRs currently run the style check and the merge-requirements gate. That burns CI minutes and puts red checks on work that is not ready for review.

Both `pull_request`-triggered workflows now carry a job-level `if` on `draft == false`. Job-level rather than step-level, so the run reports as skipped instead of green-but-empty.

`pre-commit.yml` also needed an explicit `types` list — the default set for `pull_request` omits `ready_for_review`, so flipping a draft to ready would otherwise never trigger the check. `pr-merge-requirements.yml` already listed that type. Its guard has no `github.event_name` clause because it only fires on `pull_request_target`.

`stale.yml` is cron-only and untouched.

A skipped required check still blocks merge under branch protection, which is fine here: drafts cannot merge anyway, and both checks run on the draft → ready transition.

@coderabbitai ignore