### PR TITLE
Fix benchmark image links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,32 +57,32 @@ Contributor credits for these OSS CuTe DSL kernels are listed in [Acknowledgemen
 
 #### Llama 3.1 style Forward and Bprop with causal masking (GB300)
 <p align="center">
-  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/main/benchmark/attention_training/results/llama3.1/gb300/llama3.1_top_left.png" alt="Llama 3.1 SDPA Benchmark on GB300 (only cuDNN)" width="600"/>
+  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/develop/benchmark/attention_training/results/llama3.1/gb300/llama3.1_top_left.png" alt="Llama 3.1 SDPA Benchmark on GB300 (only cuDNN)" width="600"/>
 </p>
 
 #### Deepseek v3 style Forward and Bprop with causal masking (GB300)
 
 <p align="center">
-  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/main/benchmark/attention_training/results/dsv3/gb300/dsv3_top_left.png" alt="DSv3 SDPA Benchmark on GB300 (only cuDNN)" width="600"/>
+  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/develop/benchmark/attention_training/results/dsv3/gb300/dsv3_top_left.png" alt="DSv3 SDPA Benchmark on GB300 (only cuDNN)" width="600"/>
 </p>
 
 ## New OSS Linear Attention Kernels
 
 #### GDN Forward and Bprop (GB300)
 <p align="center">
-  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/main/benchmark/linear_attention/results/gdn/gb300/gdn_fixed_batch_flops.png" alt="GDN Linear Attention Benchmark on GB300" width="600"/>
+  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/develop/benchmark/linear_attention/results/gdn/gb300/gdn_fixed_batch_flops.png" alt="GDN Linear Attention Benchmark on GB300" width="600"/>
 </p>
 
 #### KDA Forward and Bprop (GB300)
 
 <p align="center">
-  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/main/benchmark/linear_attention/results/kda/gb300/kda_fixed_batch_flops.png" alt="KDA Linear Attention Benchmark on GB300" width="600"/>
+  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/develop/benchmark/linear_attention/results/kda/gb300/kda_fixed_batch_flops.png" alt="KDA Linear Attention Benchmark on GB300" width="600"/>
 </p>
 
 #### GDN-2 Forward and Bprop (GB300)
 
 <p align="center">
-  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/main/benchmark/linear_attention/results/gdn2/gb300/gdn2_fixed_batch_flops.png" alt="GDN-2 Linear Attention Benchmark on GB300" width="600"/>
+  <img src="https://github.com/NVIDIA/cudnn-frontend/blob/develop/benchmark/linear_attention/results/gdn2/gb300/gdn2_fixed_batch_flops.png" alt="GDN-2 Linear Attention Benchmark on GB300" width="600"/>
 </p>
 
 ## Key Features


### PR DESCRIPTION
The five benchmark result images in the README point at blob/main, but the training results directory was renamed to attention_training and the linear_attention results only exist on develop, so all five images render broken. This points them at develop, where the artifact refresh PRs land, so they stay current instead of going stale between releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark image links in the README to reference the `develop` branch for Llama 3.1, DeepSeek v3, GDN, KDA, and GDN-2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->