### PR TITLE
benchmark/e2e: bucket causal_conv1d and the rest of the GDN kernels

### DIFF
--- a/benchmark/e2e/_perfshare.py
+++ b/benchmark/e2e/_perfshare.py
@@ -20,7 +20,24 @@ import torch
 # "cutile" belong in backend() below, not here -- FROST serves the MLP dgrad too, so
 # bucketing it as linear-attention would miscount the headline category shares.
 _CATEGORIES = (
-    ("linear_attn", ("gdn", "delta", "chunk_gated", "wy_fast", "solve", "cumsum", "l2norm", "kda")),
+    ("short_conv", ("causal_conv1d", "conv1d")),
+    (
+        "linear_attn",
+        (
+            "gdn",
+            "delta",
+            "chunk_gated",
+            "chunk_fwd_kernel",
+            "chunk_bwd_kernel",
+            "prepare_wy_repr",
+            "recompute_w_u",
+            "wy_fast",
+            "solve",
+            "cumsum",
+            "l2norm",
+            "kda",
+        ),
+    ),
     ("full_attn", ("flash", "fmha", "sdpa", "scaled_dot", "mha", "_attention")),
     ("gemm", ("gemm", "cutlass", "ampere", "sm100_tst", "nvjet", "cublas", "matmul", "wgrad", "dgrad", "tensorop")),
     ("norm", ("rmsnorm", "layernorm", "layer_norm", "rms_norm", "norm")),
@@ -116,11 +133,15 @@ def profile_and_report(model, ids, *, step=_default_step, warmup=3, iters=10, ex
             torch.cuda.synchronize(device)
 
     cat, be, total = collections.defaultdict(float), collections.defaultdict(float), 0.0
+    uncategorized = collections.defaultdict(float)
     for ev in prof.key_averages():
         t = ev.self_device_time_total
         if t <= 0:
             continue
-        cat[categorize(ev.key)] += t
+        c = categorize(ev.key)
+        cat[c] += t
+        if c == "other":
+            uncategorized[ev.key] += t
         be[backend(ev.key)] += t
         total += t
 
@@ -133,9 +154,15 @@ def profile_and_report(model, ids, *, step=_default_step, warmup=3, iters=10, ex
 
     print(f"\n{'category':12} {'ms':>9} {'share':>7}")
     print("-" * 30)
-    for c in ("linear_attn", "full_attn", "gemm", "norm", "misc", "other"):
+    for c in ("linear_attn", "short_conv", "full_attn", "gemm", "norm", "misc", "other"):
         if cat[c] > 0:
             print(f"{c:12} {cat[c] / 1e3:9.3f} {100 * cat[c] / total:6.1f}%")
+    # A kernel that drifts out of _CATEGORIES lands in "other" and silently deflates the
+    # component it belongs to, so name what is in there rather than reporting only a total.
+    if uncategorized:
+        print(f"\n  \"other\" is {100 * cat['other'] / total:.1f}% -- add any of these to _CATEGORIES if they belong to a component:")
+        for name, t in sorted(uncategorized.items(), key=lambda kv: -kv[1])[:10]:
+            print(f"    {t / 1e3:9.3f} ms {100 * t / total:5.1f}%  {name[:88]}")
     print(f"\n{'backend':12} {'ms':>9} {'share':>7}")
     print("-" * 30)
     for b in ("cuDNN", "cuBLAS", "torch"):

--- a/benchmark/e2e/tests/test_perfshare_categories.py
+++ b/benchmark/e2e/tests/test_perfshare_categories.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pin `categorize()` to real kernel names observed in a Gated DeltaNet training step.
+
+A kernel that no substring matches lands in "other", which silently deflates the
+component it belongs to -- the share table still adds to 100% and looks healthy. This
+guards the name lists against upstream renames; every name below was taken from a
+torch-profiler trace of `Qwen3.8/run_model.py` on SM100 (FLA Triton + cuDNN SDPA).
+"""
+
+from pathlib import Path
+import sys
+import unittest
+
+E2E_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(E2E_DIR))
+
+from _perfshare import categorize  # noqa: E402
+
+OBSERVED = {
+    # FLA short convolution -- both directions.
+    "causal_conv1d_fwd_kernel": "short_conv",
+    "causal_conv1d_bwd_kernel": "short_conv",
+    "causal_conv1d_update_kernel": "short_conv",
+    # FLA chunked Gated DeltaNet. The chunk_*/wy_repr/recompute names carry no "gdn"
+    # or "delta" substring, so they need their own entries.
+    "chunk_gated_delta_rule_fwd_kernel_h_blockdim64": "linear_attn",
+    "chunk_gated_delta_rule_bwd_kernel_dhu_blockdim64": "linear_attn",
+    "chunk_gated_delta_rule_fwd_kernel_kkt_solve": "linear_attn",
+    "chunk_fwd_kernel_o": "linear_attn",
+    "chunk_fwd_kernel_h": "linear_attn",
+    "chunk_bwd_kernel_dqkwg": "linear_attn",
+    "prepare_wy_repr_fwd_kernel": "linear_attn",
+    "prepare_wy_repr_bwd_kernel": "linear_attn",
+    "recompute_w_u_fwd_kernel": "linear_attn",
+    "l2norm_fwd_kernel": "linear_attn",
+    # cuDNN fused Gated DeltaNet (the cudnn.fla arm).
+    "kernel_cutlass_kernel_GdnCfgio_dtype_bfloat16": "linear_attn",
+    "kernel_cutlass_kernel_GdnBwdCfguse_initial_stateFalse": "linear_attn",
+    "kernel_cutlass_kernel_GdnRecomputeCfg_dtype_bfloat16": "linear_attn",
+    # Full attention, both arms of --full_attn_backend.
+    "cudnn_generated_fort_native_sdpa_sm100_flash_fprop_f16_knob_2_128x128x256": "full_attn",
+    "cudnn_generated_fort_native_sdpa_sm100_flash_bprop_f16_knob_2_128x128x128": "full_attn",
+    # GEMM and the SwiGLU MLP.
+    "nvjet_sm100_tst_256x128_64x5_2x4_2cta_h_bz_NTT": "gemm",
+    "swiglu_fwd_kernel": "misc",
+    "swiglu_fwdbwd_kernel": "misc",
+    "layer_norm_bwd_kernel1": "norm",
+}
+
+
+class TestPerfshareCategories(unittest.TestCase):
+    def test_observed_kernels_are_categorized(self):
+        wrong = {k: (categorize(k), want) for k, want in OBSERVED.items() if categorize(k) != want}
+        self.assertEqual(wrong, {}, f"miscategorized (got, want): {wrong}")
+
+    def test_nothing_observed_falls_into_other(self):
+        leaked = sorted(k for k in OBSERVED if categorize(k) == "other")
+        self.assertEqual(leaked, [], f"these land in 'other' and deflate their component: {leaked}")
+
+    def test_unknown_kernels_still_fall_through_to_other(self):
+        self.assertEqual(categorize("some_future_kernel_nobody_has_seen"), "other")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`benchmark/e2e/_perfshare.py`'s `categorize()` matched `chunk_gated` and `wy_fast` against
kernels that are actually named `chunk_fwd_kernel_*`, `chunk_bwd_kernel_*`,
`prepare_wy_repr_*` and `recompute_w_u_*`, and had **no entry for the short convolution at
all**. Nine kernels from a Gated DeltaNet training step land in `other` on `develop`:

```
other  causal_conv1d_fwd_kernel        other  chunk_fwd_kernel_o
other  causal_conv1d_bwd_kernel        other  chunk_fwd_kernel_h
other  causal_conv1d_update_kernel     other  chunk_bwd_kernel_dqkwg
other  prepare_wy_repr_fwd_kernel      other  recompute_w_u_fwd_kernel
other  prepare_wy_repr_bwd_kernel
```

## Why it matters

The share table still sums to 100%, so the under-count is invisible in the output. On a
12-layer GDN proxy the leak was 9.2% of kernel time: `linear_attn` read **15.1%** when the
GDN kernels actually cost **24.0%**, and the short convolution had no row at all. This
benchmark's output is used to rank components for investment, so a component reading low —
or not appearing — is the failure mode that matters most here.

## Changes

- add a `short_conv` category (`causal_conv1d`, `conv1d`) and print it in the table
- complete the `linear_attn` name list: `chunk_fwd_kernel`, `chunk_bwd_kernel`,
  `prepare_wy_repr`, `recompute_w_u`
- make `other` name its contents instead of reporting only a total, so the next upstream
  rename is visible rather than silent
- `benchmark/e2e/tests/test_perfshare_categories.py` pins `categorize()` to kernel names
  taken from a profiler trace (FLA Triton GDN, cuDNN fused GDN, both SDPA arms, GEMM,
  SwiGLU, norm). It fails on the pre-fix table with all nine names above.

No change to timing, model construction, or any measured value — only which bucket a
kernel is counted in.

## Test

```
$ python -m pytest benchmark/e2e/tests/test_perfshare_categories.py -q
3 passed

$ git stash && python -m pytest benchmark/e2e/tests/test_perfshare_categories.py -q
2 failed, 1 passed
FAILED ...::test_observed_kernels_are_categorized
FAILED ...::test_nothing_observed_falls_into_other
```

`black --line-length 160 --fast` (pinned 26.3.1) reports no change; pre-commit passes.

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] The change is covered by a test
- [x] Formatting hooks pass
- [x] License header present on the new file (Apache-2.0)

---
<sub>note to self: claude::473deaf5-2130-4c34-bbf3-9c8099297886 — "causal conv1d for linear attention: perf vs attention-gym" · cwd /home/scratch.yanxu_libs/cudnn_frontend · workspace /home/scratch.yanxu_gpu/conv1d_study</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance reporting for short convolution kernels.
  * Expanded fused attention kernel categorization.
  * Reports uncategorized kernels and highlights their top contributors.
  * Added detailed visibility into kernels classified as “other.”

* **Tests**
  * Added coverage to verify observed profiler kernels are categorized correctly.
  * Preserved fallback handling for unknown kernels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->