### PR TITLE
Fix HSTU TMA store synchronization

### DIFF
--- a/python/cudnn/hstu_attention/_kernels/hstu_fwd.py
+++ b/python/cudnn/hstu_attention/_kernels/hstu_fwd.py
@@ -3121,6 +3121,9 @@ class HSTUAttentionForwardSm100:
                 cute.arch.fence_view_async_tmem_load()
                 pipeline_o.consumer_release(o_consumer_state)
 
+        if const_expr(self.use_tma_O):
+            # Publish regular SMEM writes before the async proxy reads sO for the TMA store.
+            cute.arch.fence_proxy("async.shared", space="cta")
         cute.arch.barrier(barrier_id=EPILOGUE_BARRIER_BASE + stage, number_of_threads=cute.arch.WARP_SIZE * len(self.silu1_warp_ids))
 
         logical_stage_start = m_block * self.kBlockM - offset_dynamic


### PR DESCRIPTION
## Summary

- Publish HSTU epilogue shared-memory writes to the async proxy before issuing the SMEM-to-GMEM TMA store.
- Preserve bitwise-deterministic forward results under Blackwell GPU context contention.
- Keep the exact determinism assertion and the TMA output path enabled.

## Root cause

The epilogue wrote `sO` through the generic shared-memory proxy and then synchronized its warps with a named barrier. The barrier orders the participating threads, but the TMA engine reads through the async proxy and requires an explicit `fence.proxy.async.shared::cta`. Without that fence, CUTLASS DSL 4.5.x could occasionally store partially visible `sO` data.

This was exposed by the four-worker CI job as 120 mismatched BF16 elements between two identical same-stream launches, with a greatest absolute difference of `0.0019073486328125`.

## Validation

- NVIDIA B200, four concurrent processes, 1000 invocations per process of `test_current_stream_and_compile_cache`:
  - CUTLASS DSL 4.5.0: pass, 0 mismatches
  - CUTLASS DSL 4.5.1: pass, 0 mismatches
  - CUTLASS DSL 4.6.1: pass, 0 mismatches
- `python3 -m black --check --line-length 160 python/cudnn/hstu_attention/_kernels/hstu_fwd.py`
- `python3 -m py_compile python/cudnn/hstu_attention/_kernels/hstu_fwd.py`
- `git diff --check`

Follow-up to #487.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization during accelerated attention output operations for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->