### PR TITLE
DSA backward SM90: fix three top-k and attention-sink boundary failures

### DIFF
--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/_interface_sm90.py
@@ -63,8 +63,12 @@ def flash_attn_bwd_sm90(
         dq: pre-allocated (total_S_q, nheads, headdim), optional
         dkv: pre-allocated (total_S_kv, headdim), optional
         d_sink: pre-allocated (nheads,), optional
-        topk_idxs: (total_S_q, topk_max) int32, global indices
-        topk_length: (total_S_q,) int32, per-query valid count, optional
+        topk_idxs: (total_S_q, topk_max) int32, global KV indices.
+            Compact (`topk_length` given): prefix `[0, topk_length)` is valid.
+            Non-compact (`topk_length` is None): a negative entry is padding.
+            Positive indices must be in `[0, S_kv)`; oversized `topk_length`
+            is out of contract.
+        topk_length: (total_S_q,) int32, per-query valid prefix length, optional
         need_d_sink: return and compute d_sink when True
 
     Returns:

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -335,15 +335,12 @@ class _FlashAttentionDSABackwardPreprocessSm90:
                         LOG2_E = math.log2(math.e)
                         lse_log2 = lse_row * LOG2_E
                         sink_log2 = mAttnSink[head_idx] * LOG2_E
-                        # Sigmoid form of the two-way softmax weight; stays finite
-                        # when either operand saturates.
-                        p_sink = Float32(1.0) / (Float32(1.0) + cute.math.exp2(lse_log2 - sink_log2))
-                        # inf == inf is true, so both-saturating operands split
-                        # evenly instead of leaving p_sink as NaN from inf - inf.
-                        if lse_log2 == sink_log2:
-                            p_sink = Float32(0.5)
-                        if lse_row == Float32.inf:
-                            p_sink = Float32(0.0)
+                        # KV LSE +inf keeps the develop convention p_sink = 0.
+                        p_sink = Float32(0.0)
+                        if lse_row != Float32.inf:
+                            p_sink = Float32(1.0) / (Float32(1.0) + cute.math.exp2(lse_log2 - sink_log2))
+                            if lse_log2 == sink_log2:
+                                p_sink = Float32(0.5)
                         if row_valid:
                             atomic_add_fp32(
                                 -p_sink * dP_sum[m],
@@ -390,21 +387,14 @@ class _FlashAttentionDSABackwardPreprocessSm90:
                     if cutlass.const_expr(mAttnSink is not None):
                         sink_log2 = mAttnSink[head_idx] * LOG2_E
                         lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
-                        # Max-shift only while the maximum is finite; an
-                        # infinite max is already the logaddexp result.
-                        # Seed before the staged ifs (CuTeDSL SSA).
-                        lse_with_sink_log2 = lse_max_log2
-                        if lse_max_log2 == Float32.inf:
-                            lse_with_sink_log2 = Float32.inf
+                        # Infinite max is already the logaddexp; shifting it is inf-inf.
+                        if cute.math.isfinite(lse_max_log2):
+                            sum_exp2 = Float32(
+                                cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2)
+                            )
+                            lse_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
                         else:
-                            if lse_max_log2 == -Float32.inf:
-                                lse_with_sink_log2 = -Float32.inf
-                            else:
-                                sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
-                                lse_with_sink_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
-                        if lse == Float32.inf:
-                            lse_with_sink_log2 = Float32.inf
-                        lse_log2 = lse_with_sink_log2
+                            lse_log2 = lse_max_log2
                     gLSElog2[tidx] = lse_log2
 
 
@@ -1164,8 +1154,6 @@ class FlashAttentionDSABackwardSm90:
                 topK = mTopkLength[batch_idx, seq_idx]
             else:
                 topK = self.max_topk
-            n_block_max = (topK + self.tile_n - 1) // self.tile_n
-            topk_tail_rows = topK - (n_block_max - 1) * self.tile_n
 
             mKV_cur = mKV[None, None, head_idx_kv, batch_idx]
             mTopkIdxs_cur = mTopkIdxs[batch_idx, seq_idx, None]
@@ -1178,12 +1166,12 @@ class FlashAttentionDSABackwardSm90:
             load_Q, _, _ = tma_get_copy_fn(tma_atom_Q, 0, cute.make_layout(1), gQ, sQ, single_stage=True)
             load_dO, _, _ = tma_get_copy_fn(tma_atom_dO, 0, cute.make_layout(1), gdO, sdO, single_stage=True)
 
-            # Empty top-k: skip everything WG1 also skips. The 256-thread
-            # barriers (G4_half_ready, sdS_consumed) would otherwise wait on
-            # WG0 alone. The Q/dO TMA lands in sQ, which WG1's epilogue
-            # writes; without the mainloop handshake it races that store.
-            # The epilogue still runs so caller-owned dQ is written.
+            # Skip the WG0 prologue together with WG1 for empty rows.
+            # This avoids asymmetric 256-thread barriers and prevents the Q TMA
+            # from racing with WG1's dQ epilogue in sQ.
             if topK > 0:
+                n_block_max = (topK + self.tile_n - 1) // self.tile_n
+                topk_tail_rows = topK - (n_block_max - 1) * self.tile_n
                 if warp_idx_in_wg == 0:
                     with cute.arch.elect_one():
                         cute.arch.mbarrier_arrive_and_expect_tx(mbar_QdO_ptr, self.tma_copy_bytes["Q"] + self.tma_copy_bytes["dO"])
@@ -1232,7 +1220,8 @@ class FlashAttentionDSABackwardSm90:
 
                 n_block = n_block_max - 1
 
-                # first n_block
+                # Peel the tail block so its validity mask does not enter the
+                # steady-state loop.
                 self._wg0_one_n_block(
                     n_block,
                     wg_tidx,
@@ -1256,12 +1245,10 @@ class FlashAttentionDSABackwardSm90:
                     softmax_scale_log2,
                     softmax_scale,
                     dQ_accumulate=False,
-                    is_first=True,
-                    num_valid_rows=topk_tail_rows,
+                    valid_rows=topk_tail_rows,
                 )
                 n_block -= 1
 
-                # remaining n_blocks
                 while n_block >= 0:
                     self._wg0_one_n_block(
                         n_block,
@@ -1286,8 +1273,7 @@ class FlashAttentionDSABackwardSm90:
                         softmax_scale_log2,
                         softmax_scale,
                         dQ_accumulate=True,
-                        is_first=False,
-                        num_valid_rows=self.tile_n,
+                        valid_rows=self.tile_n,
                     )
                     n_block -= 1
 
@@ -1449,11 +1435,10 @@ class FlashAttentionDSABackwardSm90:
         softmax_scale_log2: Float32,
         softmax_scale: Float32,
         dQ_accumulate: Boolean = False,
-        is_first: Boolean = True,
-        num_valid_rows: Int32 = 64,
+        valid_rows: Int32 = 64,
     ):
         """WG0 one n_block: load KV(cp.async) + GEMM1/2 + softmax/dsoftmax + R2S + GEMM4_WG0(x2)"""
-        if not is_first:
+        if dQ_accumulate:
             cute.arch.barrier(
                 barrier_id=int(NamedBarrierBwd.KV_empty),
                 number_of_threads=self.num_mma_threads,  # 256 = WG0(128) + WG1(128)
@@ -1465,7 +1450,7 @@ class FlashAttentionDSABackwardSm90:
         for r in cutlass.range_constexpr(ROWS_PER_GROUP):
             row = r * NUM_GROUPS + group_idx
             global_topk_row = n_block * self.tile_n + row
-            if row < num_valid_rows or not is_first:
+            if row < valid_rows or dQ_accumulate:
                 if const_expr(self.have_topk_length):
                     self._copy_row(
                         mKV_cur,
@@ -1493,7 +1478,7 @@ class FlashAttentionDSABackwardSm90:
                     else:
                         self._zero_row(sKV, row, idx_in_group)
             else:
-                # clear for OOB rows (only in first n_block)
+                # Tail padding of the peeled n_block.
                 self._zero_row(sKV, row, idx_in_group)
 
         cute.arch.cp_async_commit_group()
@@ -1516,7 +1501,7 @@ class FlashAttentionDSABackwardSm90:
         #
         # Padded columns are zero-filled in sKV, so their score is 0 rather
         # than -inf. Force those lanes to probability zero.
-        # Compact: past the top-k tail (peeled first n_block only).
+        # Compact: past valid_rows on the peeled tail n_block.
         # Non-compact: a negative top-k index. Positive OOB indices and
         # compact entries in [0, topK) are trusted as valid KV rows.
         acc_S_mn = make_acc_tensor_mn_view(acc_S, transpose=self.SdP_swapAB)
@@ -1525,8 +1510,8 @@ class FlashAttentionDSABackwardSm90:
             for c in cutlass.range(cute.size(acc_S_mn, mode=[1]), unroll_full=True):
                 p = cute.math.exp2(acc_S_mn[r, c] * softmax_scale_log2 - tLSErLSE[r], fastmath=True)
                 col = tScS_mn[r, c][COL]
-                if is_first:
-                    p = Float32(0.0) if col >= num_valid_rows else p
+                if not dQ_accumulate:
+                    p = Float32(0.0) if col >= valid_rows else p
                 if const_expr(not self.have_topk_length):
                     # Peeled tile still spans tile_n columns; clamp so a
                     # partial non-compact row is not read past its end.

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -1245,7 +1245,7 @@ class FlashAttentionDSABackwardSm90:
                     softmax_scale_log2,
                     softmax_scale,
                     dQ_accumulate=False,
-                    valid_rows=topk_tail_rows,
+                    num_valid_rows=topk_tail_rows,
                 )
                 n_block -= 1
 
@@ -1273,7 +1273,7 @@ class FlashAttentionDSABackwardSm90:
                         softmax_scale_log2,
                         softmax_scale,
                         dQ_accumulate=True,
-                        valid_rows=self.tile_n,
+                        num_valid_rows=self.tile_n,
                     )
                     n_block -= 1
 
@@ -1435,7 +1435,7 @@ class FlashAttentionDSABackwardSm90:
         softmax_scale_log2: Float32,
         softmax_scale: Float32,
         dQ_accumulate: Boolean = False,
-        valid_rows: Int32 = 64,
+        num_valid_rows: Int32 = 64,
     ):
         """WG0 one n_block: load KV(cp.async) + GEMM1/2 + softmax/dsoftmax + R2S + GEMM4_WG0(x2)"""
         if dQ_accumulate:
@@ -1450,7 +1450,7 @@ class FlashAttentionDSABackwardSm90:
         for r in cutlass.range_constexpr(ROWS_PER_GROUP):
             row = r * NUM_GROUPS + group_idx
             global_topk_row = n_block * self.tile_n + row
-            if row < valid_rows or dQ_accumulate:
+            if row < num_valid_rows or dQ_accumulate:
                 if const_expr(self.have_topk_length):
                     self._copy_row(
                         mKV_cur,
@@ -1501,7 +1501,7 @@ class FlashAttentionDSABackwardSm90:
         #
         # Padded columns are zero-filled in sKV, so their score is 0 rather
         # than -inf. Force those lanes to probability zero.
-        # Compact: past valid_rows on the peeled tail n_block.
+        # Compact: past num_valid_rows on the peeled tail n_block.
         # Non-compact: a negative top-k index. Positive OOB indices and
         # compact entries in [0, topK) are trusted as valid KV rows.
         acc_S_mn = make_acc_tensor_mn_view(acc_S, transpose=self.SdP_swapAB)
@@ -1511,7 +1511,7 @@ class FlashAttentionDSABackwardSm90:
                 p = cute.math.exp2(acc_S_mn[r, c] * softmax_scale_log2 - tLSErLSE[r], fastmath=True)
                 col = tScS_mn[r, c][COL]
                 if not dQ_accumulate:
-                    p = Float32(0.0) if col >= valid_rows else p
+                    p = Float32(0.0) if col >= num_valid_rows else p
                 if const_expr(not self.have_topk_length):
                     # Peeled tile still spans tile_n columns; clamp so a
                     # partial non-compact row is not read past its end.

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -1541,10 +1541,18 @@ class FlashAttentionDSABackwardSm90:
         for r in cutlass.range_constexpr(cute.size(acc_S_mn, mode=[0])):
             for c in cutlass.range(cute.size(acc_S_mn, mode=[1]), unroll_full=True):
                 p = cute.math.exp2(acc_S_mn[r, c] * softmax_scale_log2 - tLSErLSE[r], fastmath=True)
+                col = tScS_mn[r, c][COL]
                 if is_first:
-                    p = Float32(0.0) if tScS_mn[r, c][COL] >= num_valid_rows else p
+                    p = Float32(0.0) if col >= num_valid_rows else p
                 if const_expr(not self.have_topk_length):
-                    if mTopkIdxs_cur[n_block * self.tile_n + tScS_mn[r, c][COL]] < 0:
+                    # `col` still runs to tile_n - 1 in the peeled partial tile,
+                    # and max_topk need not be a multiple of tile_n, so clamp
+                    # before the load or the row is read past its end. Lanes
+                    # past the tail were zeroed just above and this guard only
+                    # ever zeroes, so the clamped entry cannot change the result.
+                    idx = n_block * self.tile_n + col
+                    idx = idx if idx < self.max_topk else Int32(self.max_topk - 1)
+                    if mTopkIdxs_cur[idx] < 0:
                         p = Float32(0.0)
                 acc_S_mn[r, c] = p
 

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -388,11 +388,11 @@ class _FlashAttentionDSABackwardPreprocessSm90:
                         sink_log2 = mAttnSink[head_idx] * LOG2_E
                         lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
                         # Infinite max is already the logaddexp; shifting it is inf-inf.
-                        if cute.math.isfinite(lse_max_log2):
+                        if lse_max_log2 == Float32.inf or lse_max_log2 == -Float32.inf:
+                            lse_log2 = lse_max_log2
+                        else:
                             sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
                             lse_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
-                        else:
-                            lse_log2 = lse_max_log2
                     gLSElog2[tidx] = lse_log2
 
 

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -335,10 +335,21 @@ class _FlashAttentionDSABackwardPreprocessSm90:
                         LOG2_E = math.log2(math.e)
                         lse_log2 = lse_row * LOG2_E
                         sink_log2 = mAttnSink[head_idx] * LOG2_E
-                        lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
-                        sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
-                        lse_with_sink_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
-                        p_sink = cute.math.exp2(sink_log2 - lse_with_sink_log2)
+                        # p_sink is the two-way softmax weight of the sink
+                        # against the KV LSE. Taking it as a sigmoid is
+                        # algebraically the same as
+                        # exp2(sink - logaddexp2(lse, sink)) but stays finite
+                        # when either term saturates: the max-shifted logaddexp
+                        # evaluates inf - inf = NaN, and attn_sink reaches that
+                        # through the log2(e) rescale above already for
+                        # |sink| > 3.4e38 / log2(e).
+                        p_sink = Float32(1.0) / (Float32(1.0) + cute.math.exp2(lse_log2 - sink_log2))
+                        # Equal exponents split the mass evenly; this also
+                        # catches the difference being NaN because both
+                        # saturate the same way, where there is no mass to
+                        # attribute (dP_sum is zero for such a row anyway).
+                        if lse_log2 == sink_log2:
+                            p_sink = Float32(0.5)
                         if lse_row == Float32.inf:
                             p_sink = Float32(0.0)
                         if row_valid:
@@ -387,8 +398,16 @@ class _FlashAttentionDSABackwardPreprocessSm90:
                     if cutlass.const_expr(mAttnSink is not None):
                         sink_log2 = mAttnSink[head_idx] * LOG2_E
                         lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
-                        sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
-                        lse_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
+                        # Shift by the maximum only while it is finite. A
+                        # saturating operand otherwise turns the shift into
+                        # inf - inf = NaN, and this LSE feeds every exp2() in
+                        # the main kernel, so the whole of dQ/dKV goes with it.
+                        # An infinite maximum is already the logaddexp result.
+                        if lse_max_log2 != Float32.inf:
+                            if lse_max_log2 != -Float32.inf:
+                                sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
+                                lse_max_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
+                        lse_log2 = lse_max_log2
                         if lse == Float32.inf:
                             lse_log2 = Float32.inf
                     gLSElog2[tidx] = lse_log2
@@ -1034,6 +1053,12 @@ class FlashAttentionDSABackwardSm90:
         wg_mma_SdP = tiled_mma_SdP.get_slice(wg_tidx)
         thr_mma_SdP = tiled_mma_SdP.get_slice(wg_tidx)
 
+        # KV-column coordinate of each S accumulator element, used to mask the
+        # top-k tail. Loop invariant, so build it once per CTA.
+        S_tile_shape = (self.tile_m, self.tile_n)
+        cS = cute.make_identity_tensor(S_tile_shape if const_expr(not self.SdP_swapAB) else S_tile_shape[::-1])
+        tScS_mn = make_acc_tensor_mn_view(thr_mma_SdP.partition_C(cS), transpose=self.SdP_swapAB)
+
         # GEMM1: S = Q @ KV^T (SS), K dim = tile_hdim (512 or 576)
         tSrQ, tSrKV = mma_partition_fragment_AB(wg_mma_SdP, sQ, sKV, self.SdP_swapAB)
         # GEMM2: dP = dO @ V^T (SS), K dim = tile_hdimv (512)
@@ -1146,7 +1171,6 @@ class FlashAttentionDSABackwardSm90:
                 topK = self.max_topk
             n_block_max = (topK + self.tile_n - 1) // self.tile_n
             topk_tail_rows = topK - (n_block_max - 1) * self.tile_n
-            n_block = n_block_max - 1
 
             mKV_cur = mKV[None, None, head_idx_kv, batch_idx]
             mTopkIdxs_cur = mTopkIdxs[batch_idx, seq_idx, None]
@@ -1159,82 +1183,67 @@ class FlashAttentionDSABackwardSm90:
             load_Q, _, _ = tma_get_copy_fn(tma_atom_Q, 0, cute.make_layout(1), gQ, sQ, single_stage=True)
             load_dO, _, _ = tma_get_copy_fn(tma_atom_dO, 0, cute.make_layout(1), gdO, sdO, single_stage=True)
 
-            if warp_idx_in_wg == 0:
-                with cute.arch.elect_one():
-                    cute.arch.mbarrier_arrive_and_expect_tx(mbar_QdO_ptr, self.tma_copy_bytes["Q"] + self.tma_copy_bytes["dO"])
-                load_Q(tma_bar_ptr=mbar_QdO_ptr)
-                load_dO(tma_bar_ptr=mbar_QdO_ptr)
+            # A nonpositive top-k length means no KV row contributes to this
+            # query, so dQ is exactly zero and WG1 runs zero mainloop
+            # iterations. Skip everything WG1 is not also skipping:
+            #  - the cross-warpgroup named barriers below (G4_half_ready,
+            #    sdS_consumed) would otherwise be waited on by WG0 alone;
+            #  - the Q/dO TMA lands in sQ, which WG1's epilogue writes. On the
+            #    mainloop path the sP_ready/sdS_ready handshake orders that
+            #    load ahead of both epilogues; with the mainloop skipped there
+            #    is no such ordering, and an in-flight Q load would overwrite
+            #    the zeros WG1 already stored to sQ[256:].
+            # The epilogue itself still runs, so caller-owned dQ is written.
+            if topK > 0:
+                if warp_idx_in_wg == 0:
+                    with cute.arch.elect_one():
+                        cute.arch.mbarrier_arrive_and_expect_tx(mbar_QdO_ptr, self.tma_copy_bytes["Q"] + self.tma_copy_bytes["dO"])
+                    load_Q(tma_bar_ptr=mbar_QdO_ptr)
+                    load_dO(tma_bar_ptr=mbar_QdO_ptr)
 
-            # All 128 threads load the query's head values. Rows beyond qhpkv
-            # are neutralized for the 64-row MMA tile.
-            mLSE_cur = mLSE[None, head_idx_kv, seq_idx, batch_idx]
-            mdPsum_cur = mdPsum[None, head_idx_kv, seq_idx, batch_idx]
-            _load_f32_head_to_smem(
-                mLSE_cur,
-                sLSE,
-                self.tile_m,
-                wg_tidx,
-                self.num_threads_per_warp_group,
-                self.qhead_per_kvhead,
-                head_tile,
-                Float32.inf,
-            )
-            _load_f32_head_to_smem(
-                mdPsum_cur,
-                sdPsum,
-                self.tile_m,
-                wg_tidx,
-                self.num_threads_per_warp_group,
-                self.qhead_per_kvhead,
-                head_tile,
-                Float32(0.0),
-            )
+                # All 128 threads load the query's head values. Rows beyond qhpkv
+                # are neutralized for the 64-row MMA tile.
+                mLSE_cur = mLSE[None, head_idx_kv, seq_idx, batch_idx]
+                mdPsum_cur = mdPsum[None, head_idx_kv, seq_idx, batch_idx]
+                _load_f32_head_to_smem(
+                    mLSE_cur,
+                    sLSE,
+                    self.tile_m,
+                    wg_tidx,
+                    self.num_threads_per_warp_group,
+                    self.qhead_per_kvhead,
+                    head_tile,
+                    Float32.inf,
+                )
+                _load_f32_head_to_smem(
+                    mdPsum_cur,
+                    sdPsum,
+                    self.tile_m,
+                    wg_tidx,
+                    self.num_threads_per_warp_group,
+                    self.qhead_per_kvhead,
+                    head_tile,
+                    Float32(0.0),
+                )
 
-            # Fence SMEM writes (LSE/dPsum stores) + barrier to ensure visibility
-            cute.arch.fence_view_async_shared()
-            cute.arch.barrier(
-                barrier_id=int(NamedBarrierBwd.WG0_producer_sync),
-                number_of_threads=self.num_threads_per_warp_group,
-            )
+                # Fence SMEM writes (LSE/dPsum stores) + barrier to ensure visibility
+                cute.arch.fence_view_async_shared()
+                cute.arch.barrier(
+                    barrier_id=int(NamedBarrierBwd.WG0_producer_sync),
+                    number_of_threads=self.num_threads_per_warp_group,
+                )
 
-            # Wait for Q/dO TMA complete
-            cute.arch.mbarrier_wait(mbar_QdO_ptr, mbar_QdO_phase)
-            mbar_QdO_phase = mbar_QdO_phase ^ 1
+                # Wait for Q/dO TMA complete
+                cute.arch.mbarrier_wait(mbar_QdO_ptr, mbar_QdO_phase)
+                mbar_QdO_phase = mbar_QdO_phase ^ 1
 
-            # S2R: LSE and dPsum (SMEM to registers, once per m_block)
-            tLSErLSE = load_s2r(tLSEsLSE)
-            tLSErdPsum = load_s2r(tLSEsdPsum)
+                # S2R: LSE and dPsum (SMEM to registers, once per m_block)
+                tLSErLSE = load_s2r(tLSEsLSE)
+                tLSErdPsum = load_s2r(tLSEsdPsum)
 
-            # first n_block
-            self._wg0_one_n_block(
-                n_block,
-                wg_tidx,
-                mKV_cur,
-                mTopkIdxs_cur,
-                sKV,
-                async_copy_atom,
-                async_thr_copy,
-                idx_in_group,
-                group_idx,
-                mma_qkv_fn,
-                mma_dov_fn,
-                mma_dsk_fn_0,
-                mma_dsk_fn_1,
-                tLSErLSE,
-                tLSErdPsum,
-                tPsP,
-                tdSsdS,
-                smem_thr_copy_PdS,
-                softmax_scale_log2,
-                softmax_scale,
-                dQ_accumulate=False,
-                is_first=True,
-                num_valid_rows=topk_tail_rows,
-            )
-            n_block -= 1
+                n_block = n_block_max - 1
 
-            # remaining n_blocks
-            while n_block >= 0:
+                # first n_block
                 self._wg0_one_n_block(
                     n_block,
                     wg_tidx,
@@ -1253,21 +1262,57 @@ class FlashAttentionDSABackwardSm90:
                     tLSErdPsum,
                     tPsP,
                     tdSsdS,
+                    tScS_mn,
                     smem_thr_copy_PdS,
                     softmax_scale_log2,
                     softmax_scale,
-                    dQ_accumulate=True,
-                    is_first=False,
-                    num_valid_rows=self.tile_n,
+                    dQ_accumulate=False,
+                    is_first=True,
+                    num_valid_rows=topk_tail_rows,
                 )
                 n_block -= 1
 
-            # Wait for WG1 to finish reading sQ (GEMM5 dS^T @ Q uses sQ),
-            # before epilogue_dQ overwrites sQ with dQ output.
-            cute.arch.barrier(
-                barrier_id=int(NamedBarrierBwd.sdS_consumed),
-                number_of_threads=self.num_mma_threads,
-            )
+                # remaining n_blocks
+                while n_block >= 0:
+                    self._wg0_one_n_block(
+                        n_block,
+                        wg_tidx,
+                        mKV_cur,
+                        mTopkIdxs_cur,
+                        sKV,
+                        async_copy_atom,
+                        async_thr_copy,
+                        idx_in_group,
+                        group_idx,
+                        mma_qkv_fn,
+                        mma_dov_fn,
+                        mma_dsk_fn_0,
+                        mma_dsk_fn_1,
+                        tLSErLSE,
+                        tLSErdPsum,
+                        tPsP,
+                        tdSsdS,
+                        tScS_mn,
+                        smem_thr_copy_PdS,
+                        softmax_scale_log2,
+                        softmax_scale,
+                        dQ_accumulate=True,
+                        is_first=False,
+                        num_valid_rows=self.tile_n,
+                    )
+                    n_block -= 1
+
+                # Wait for WG1 to finish reading sQ (GEMM5 dS^T @ Q uses sQ),
+                # before epilogue_dQ overwrites sQ with dQ output.
+                cute.arch.barrier(
+                    barrier_id=int(NamedBarrierBwd.sdS_consumed),
+                    number_of_threads=self.num_mma_threads,
+                )
+            else:
+                # No GEMM4 ran, so the accumulators still hold whatever the
+                # registers happened to contain.
+                acc_dQ_0.fill(0.0)
+                acc_dQ_1.fill(0.0)
 
             # WG0 always writes dQ[0:256] — same as V3.1 for both d=512 and d=576
             self.epilogue_dQ(
@@ -1411,6 +1456,7 @@ class FlashAttentionDSABackwardSm90:
         tLSErdPsum: cute.Tensor,
         tPsP: cute.Tensor,
         tdSsdS: cute.Tensor,
+        tScS_mn: cute.Tensor,
         smem_thr_copy_PdS: cute.TiledCopy,
         softmax_scale_log2: Float32,
         softmax_scale: Float32,
@@ -1479,10 +1525,28 @@ class FlashAttentionDSABackwardSm90:
         acc_dP = mma_dov_fn(B_idx=None, wg_wait=1)
 
         # (3) Softmax: P = exp2(S * scale_log2 - LSE)
+        #
+        # Padded KV columns are zero-filled in sKV rather than masked, so their
+        # score is exactly 0 instead of -inf and the lane's probability comes
+        # out as exp2(-LSE). For a strongly negative LSE that overflows to
+        # +inf, and GEMM4 below multiplies it by the zeroed KV row, turning the
+        # whole dQ tile into NaN. Force those lanes to probability zero.
+        #
+        # A column is padding in two ways, matching how the gather above filled
+        # it: past the top-k tail (only the first n_block can be partial, so
+        # this costs nothing in the steady-state loop), or, in the non-compact
+        # layout, flagged by a negative top-k index.
         acc_S_mn = make_acc_tensor_mn_view(acc_S, transpose=self.SdP_swapAB)
+        COL = const_expr(1 if not self.SdP_swapAB else 0)
         for r in cutlass.range_constexpr(cute.size(acc_S_mn, mode=[0])):
             for c in cutlass.range(cute.size(acc_S_mn, mode=[1]), unroll_full=True):
-                acc_S_mn[r, c] = cute.math.exp2(acc_S_mn[r, c] * softmax_scale_log2 - tLSErLSE[r], fastmath=True)
+                p = cute.math.exp2(acc_S_mn[r, c] * softmax_scale_log2 - tLSErLSE[r], fastmath=True)
+                if is_first:
+                    p = Float32(0.0) if tScS_mn[r, c][COL] >= num_valid_rows else p
+                if const_expr(not self.have_topk_length):
+                    if mTopkIdxs_cur[n_block * self.tile_n + tScS_mn[r, c][COL]] < 0:
+                        p = Float32(0.0)
+                acc_S_mn[r, c] = p
 
         # Convert P f32 -> bf16
         tdKVrP = cvt_f16(make_acc_tensor_frgA_view(acc_S), self.dtype)
@@ -1965,6 +2029,14 @@ class FlashAttentionDSABackwardSm90:
 
                 n_block -= 1
                 first_iter = False
+
+            # A nonpositive top-k length skips the mainloop entirely, so the
+            # G4_half GEMMs never ran their zero_init=first_iter pass and the
+            # accumulators still hold whatever the registers happened to
+            # contain. An empty top-k row contributes nothing to dQ.
+            if topK <= 0:
+                acc_dQ_2.fill(0.0)
+                acc_dQ_3.fill(0.0)
 
             # epilogue: write dQ[256:tile_hdim] to gmem
             # WG1 writes dQ[256:tile_hdim]: 128+128 for d=512, 128+192 for d=576

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -389,9 +389,7 @@ class _FlashAttentionDSABackwardPreprocessSm90:
                         lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
                         # Infinite max is already the logaddexp; shifting it is inf-inf.
                         if cute.math.isfinite(lse_max_log2):
-                            sum_exp2 = Float32(
-                                cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2)
-                            )
+                            sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
                             lse_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
                         else:
                             lse_log2 = lse_max_log2

--- a/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
+++ b/python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py
@@ -335,19 +335,11 @@ class _FlashAttentionDSABackwardPreprocessSm90:
                         LOG2_E = math.log2(math.e)
                         lse_log2 = lse_row * LOG2_E
                         sink_log2 = mAttnSink[head_idx] * LOG2_E
-                        # p_sink is the two-way softmax weight of the sink
-                        # against the KV LSE. Taking it as a sigmoid is
-                        # algebraically the same as
-                        # exp2(sink - logaddexp2(lse, sink)) but stays finite
-                        # when either term saturates: the max-shifted logaddexp
-                        # evaluates inf - inf = NaN, and attn_sink reaches that
-                        # through the log2(e) rescale above already for
-                        # |sink| > 3.4e38 / log2(e).
+                        # Sigmoid form of the two-way softmax weight; stays finite
+                        # when either operand saturates.
                         p_sink = Float32(1.0) / (Float32(1.0) + cute.math.exp2(lse_log2 - sink_log2))
-                        # Equal exponents split the mass evenly; this also
-                        # catches the difference being NaN because both
-                        # saturate the same way, where there is no mass to
-                        # attribute (dP_sum is zero for such a row anyway).
+                        # inf == inf is true, so both-saturating operands split
+                        # evenly instead of leaving p_sink as NaN from inf - inf.
                         if lse_log2 == sink_log2:
                             p_sink = Float32(0.5)
                         if lse_row == Float32.inf:
@@ -398,18 +390,21 @@ class _FlashAttentionDSABackwardPreprocessSm90:
                     if cutlass.const_expr(mAttnSink is not None):
                         sink_log2 = mAttnSink[head_idx] * LOG2_E
                         lse_max_log2 = cute.arch.fmax(lse_log2, sink_log2)
-                        # Shift by the maximum only while it is finite. A
-                        # saturating operand otherwise turns the shift into
-                        # inf - inf = NaN, and this LSE feeds every exp2() in
-                        # the main kernel, so the whole of dQ/dKV goes with it.
-                        # An infinite maximum is already the logaddexp result.
-                        if lse_max_log2 != Float32.inf:
-                            if lse_max_log2 != -Float32.inf:
+                        # Max-shift only while the maximum is finite; an
+                        # infinite max is already the logaddexp result.
+                        # Seed before the staged ifs (CuTeDSL SSA).
+                        lse_with_sink_log2 = lse_max_log2
+                        if lse_max_log2 == Float32.inf:
+                            lse_with_sink_log2 = Float32.inf
+                        else:
+                            if lse_max_log2 == -Float32.inf:
+                                lse_with_sink_log2 = -Float32.inf
+                            else:
                                 sum_exp2 = Float32(cute.math.exp2(lse_log2 - lse_max_log2) + cute.math.exp2(sink_log2 - lse_max_log2))
-                                lse_max_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
-                        lse_log2 = lse_max_log2
+                                lse_with_sink_log2 = lse_max_log2 + cute.math.log2(sum_exp2)
                         if lse == Float32.inf:
-                            lse_log2 = Float32.inf
+                            lse_with_sink_log2 = Float32.inf
+                        lse_log2 = lse_with_sink_log2
                     gLSElog2[tidx] = lse_log2
 
 
@@ -1183,17 +1178,11 @@ class FlashAttentionDSABackwardSm90:
             load_Q, _, _ = tma_get_copy_fn(tma_atom_Q, 0, cute.make_layout(1), gQ, sQ, single_stage=True)
             load_dO, _, _ = tma_get_copy_fn(tma_atom_dO, 0, cute.make_layout(1), gdO, sdO, single_stage=True)
 
-            # A nonpositive top-k length means no KV row contributes to this
-            # query, so dQ is exactly zero and WG1 runs zero mainloop
-            # iterations. Skip everything WG1 is not also skipping:
-            #  - the cross-warpgroup named barriers below (G4_half_ready,
-            #    sdS_consumed) would otherwise be waited on by WG0 alone;
-            #  - the Q/dO TMA lands in sQ, which WG1's epilogue writes. On the
-            #    mainloop path the sP_ready/sdS_ready handshake orders that
-            #    load ahead of both epilogues; with the mainloop skipped there
-            #    is no such ordering, and an in-flight Q load would overwrite
-            #    the zeros WG1 already stored to sQ[256:].
-            # The epilogue itself still runs, so caller-owned dQ is written.
+            # Empty top-k: skip everything WG1 also skips. The 256-thread
+            # barriers (G4_half_ready, sdS_consumed) would otherwise wait on
+            # WG0 alone. The Q/dO TMA lands in sQ, which WG1's epilogue
+            # writes; without the mainloop handshake it races that store.
+            # The epilogue still runs so caller-owned dQ is written.
             if topK > 0:
                 if warp_idx_in_wg == 0:
                     with cute.arch.elect_one():
@@ -1309,8 +1298,7 @@ class FlashAttentionDSABackwardSm90:
                     number_of_threads=self.num_mma_threads,
                 )
             else:
-                # No GEMM4 ran, so the accumulators still hold whatever the
-                # registers happened to contain.
+                # No GEMM4 ran; zero the dQ accumulators before the epilogue.
                 acc_dQ_0.fill(0.0)
                 acc_dQ_1.fill(0.0)
 
@@ -1526,16 +1514,11 @@ class FlashAttentionDSABackwardSm90:
 
         # (3) Softmax: P = exp2(S * scale_log2 - LSE)
         #
-        # Padded KV columns are zero-filled in sKV rather than masked, so their
-        # score is exactly 0 instead of -inf and the lane's probability comes
-        # out as exp2(-LSE). For a strongly negative LSE that overflows to
-        # +inf, and GEMM4 below multiplies it by the zeroed KV row, turning the
-        # whole dQ tile into NaN. Force those lanes to probability zero.
-        #
-        # A column is padding in two ways, matching how the gather above filled
-        # it: past the top-k tail (only the first n_block can be partial, so
-        # this costs nothing in the steady-state loop), or, in the non-compact
-        # layout, flagged by a negative top-k index.
+        # Padded columns are zero-filled in sKV, so their score is 0 rather
+        # than -inf. Force those lanes to probability zero.
+        # Compact: past the top-k tail (peeled first n_block only).
+        # Non-compact: a negative top-k index. Positive OOB indices and
+        # compact entries in [0, topK) are trusted as valid KV rows.
         acc_S_mn = make_acc_tensor_mn_view(acc_S, transpose=self.SdP_swapAB)
         COL = const_expr(1 if not self.SdP_swapAB else 0)
         for r in cutlass.range_constexpr(cute.size(acc_S_mn, mode=[0])):
@@ -1545,11 +1528,8 @@ class FlashAttentionDSABackwardSm90:
                 if is_first:
                     p = Float32(0.0) if col >= num_valid_rows else p
                 if const_expr(not self.have_topk_length):
-                    # `col` still runs to tile_n - 1 in the peeled partial tile,
-                    # and max_topk need not be a multiple of tile_n, so clamp
-                    # before the load or the row is read past its end. Lanes
-                    # past the tail were zeroed just above and this guard only
-                    # ever zeroes, so the clamped entry cannot change the result.
+                    # Peeled tile still spans tile_n columns; clamp so a
+                    # partial non-compact row is not read past its end.
                     idx = n_block * self.tile_n + col
                     idx = idx if idx < self.max_topk else Int32(self.max_topk - 1)
                     if mTopkIdxs_cur[idx] < 0:
@@ -2038,10 +2018,7 @@ class FlashAttentionDSABackwardSm90:
                 n_block -= 1
                 first_iter = False
 
-            # A nonpositive top-k length skips the mainloop entirely, so the
-            # G4_half GEMMs never ran their zero_init=first_iter pass and the
-            # accumulators still hold whatever the registers happened to
-            # contain. An empty top-k row contributes nothing to dQ.
+            # Empty top-k skipped the G4_half zero_init=first_iter pass.
             if topK <= 0:
                 acc_dQ_2.fill(0.0)
                 acc_dQ_3.fill(0.0)

--- a/test/python/fe_api/dsa/dsa_reference.py
+++ b/test/python/fe_api/dsa/dsa_reference.py
@@ -85,6 +85,8 @@ def ref_sparse_attention_forward(
     sink = attn_sink.view(1, h)
     lse_with_sink = torch.logaddexp(lse, sink)
     weights = torch.exp(scores - lse_with_sink.unsqueeze(-1))
+    # Masked scores are -inf; with a +inf sink that is -inf - +inf = NaN.
+    weights = weights.masked_fill(~mask, 0.0)
     out = torch.einsum("thk,kd->thd", weights, v_f)
 
     return out.to(q.dtype), lse

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -981,19 +981,8 @@ def test_DSA_sparse_attention_backward_sm100_accumulates_odo_in_fp32():
 @pytest.mark.L0
 @torch_fork_set_rng(seed=436)
 @pytest.mark.parametrize("compact", [True, False], ids=["compact", "non-compact"])
-@pytest.mark.parametrize("head_dim,num_heads", [(512, 64), (576, 32)], ids=["d512-h64", "d576-h32"])
-def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(head_dim, num_heads, compact):
-    """Padded top-k columns must carry exactly zero probability.
-
-    They are zero-filled in shared memory rather than masked, so their score is
-    0 instead of -inf and their probability is exp2(-LSE_log2). Drive the LSE
-    far enough negative that that exponent overflows FP32 (x > 128, i.e.
-    LSE < -ln(FLT_MAX) ≈ -88.72); the dQ GEMM then multiplies +inf by the
-    zeroed KV row and the whole tile becomes NaN unless those lanes are masked.
-
-    Both padding layouts are covered: a compact top-k length whose tail does not
-    fill the 64-row tile, and the non-compact layout where -1 marks padding.
-    """
+def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(compact):
+    """Padded top-k columns must carry exactly zero probability."""
     try:
         from cudnn import DSA
     except ImportError:
@@ -1001,32 +990,22 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
 
     _require_sm90()
     device = torch.device("cuda")
+    head_dim, num_heads = 576, 32
     s_q, s_kv, topk = 4, 256, 128
-    n_valid = 100  # deliberately not a multiple of the 64-row KV tile
+    n_valid = 100  # not a multiple of the 64-row KV tile
     softmax_scale = 1.0 / math.sqrt(head_dim)
 
-    # Opposing signs make every score strongly negative, which is what pushes
-    # the LSE past the FP32 exp2 overflow. Magnitude 2.2 (not 2.0) is required:
-    # for d=512, q≈+2 / kv≈-2 / 100 live keys gives LSE ≈ -4*sqrt(512)+ln(100)
-    # ≈ -85.9, whose log2 exponent is ~124 and does *not* overflow exp2.
-    # A deeply negative sink keeps the softmax mass on the KV rows so O, and
-    # hence dP_sum, stay non-negligible — with the mass on the sink instead the
-    # overflow would be multiplied by zero and stay hidden.
+    # Opposing Q/K signs drive the KV-only LSE below the FP32 exp2 threshold.
     q = (2.2 + torch.randn(s_q, num_heads, head_dim, device=device) * 0.01).to(torch.bfloat16)
     kv = (-2.2 + torch.randn(s_kv, head_dim, device=device) * 0.01).to(torch.bfloat16)
     attn_sink = torch.full((num_heads,), -400.0, dtype=torch.float32, device=device)
 
-    # The non-compact case sizes topk_idxs to a non-multiple of the 64-row tile
-    # on purpose: the peeled tile still spans all 64 columns, so the per-column
-    # index read has to stay inside the row.
     max_topk = topk if compact else n_valid + 18
     topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:max_topk] for _ in range(s_q)]).to(torch.int32)
     topk_length = None
     if compact:
         topk_length = torch.full((s_q,), n_valid, dtype=torch.int32, device=device)
-        topk_idxs[torch.arange(max_topk, device=device).unsqueeze(0) >= topk_length.unsqueeze(1)] = -1
     else:
-        # Padding interleaved with live entries, not only a trailing run.
         topk_idxs[:, n_valid:] = -1
         topk_idxs[:, 3] = -1
         topk_idxs[:, 70] = -1
@@ -1039,18 +1018,11 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
         topk_length=topk_length,
         softmax_scale=softmax_scale,
     )
-    # Self-check: padded columns have S=0, so p = exp2(-LSE * log2(e)).
-    # FP32 exp2 overflows for exponents > 128. The least-negative LSE must
-    # clear that with margin; lse.max() < -80 is not enough (threshold is
-    # -ln(FLT_MAX) ≈ -88.72).
-    lse_log2_overflow = -lse.max().item() * math.log2(math.e)
-    assert lse_log2_overflow > 128.0 + 4.0, (
-        f"padded-column exp2 overflow not exercised: -LSE_log2={lse_log2_overflow} " f"(need > 132); lse.max()={lse.max().item()}"
-    )
+    # Ensure a zero-filled padded lane would overflow exp2(-LSE_log2)
+    # without the probability mask.
+    assert (-lse.max() * math.log2(math.e)).item() > 132
     dout = torch.randn_like(out)
 
-    dq_buffer = torch.full_like(q, float("nan"))
-    dkv_buffer = torch.full_like(kv, float("nan"))
     result = DSA.sparse_attention_backward_wrapper(
         q,
         kv,
@@ -1061,15 +1033,11 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
         topk_idxs,
         softmax_scale=softmax_scale,
         topk_length=topk_length,
-        dq=dq_buffer,
-        dkv=dkv_buffer,
     )
     torch.cuda.synchronize()
 
     dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
     assert torch.isfinite(dq).all()
-    assert torch.isfinite(dkv).all()
-    assert torch.isfinite(d_sink).all()
 
     check_ref_dsa_sparse_attention_backward(
         q,
@@ -1095,19 +1063,11 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
     "sink_value",
     [
         pytest.param(2.4e38, id="finite-but-rescale-overflows"),
-        pytest.param(-2.4e38, id="neg-finite-but-rescale-overflows"),
         pytest.param(float("inf"), id="pos-inf"),
-        pytest.param(float("-inf"), id="neg-inf"),
     ],
 )
 def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
-    """A saturating attention sink must not turn the gradients into NaN.
-
-    The sink is rescaled by log2(e) before being folded into the LSE, so a
-    finite |sink| above 3.4e38 / log2(e) already saturates. The max-shifted
-    logaddexp then evaluates inf - inf, both when weighting d_sink and in the
-    LSE handed to the main kernel, which takes all of dQ and dKV with it.
-    """
+    """A saturating attention sink must not turn the gradients into NaN."""
     try:
         from cudnn import DSA
     except ImportError:
@@ -1124,8 +1084,6 @@ def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
     topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
     topk_length = torch.full((s_q,), topk, dtype=torch.int32, device=device)
 
-    # out/lse must come from the same sink the backward sees: FlashMLA-style
-    # out is sink-normalized while lse is KV-only. d_sink = -p_sink * (O·dO).
     out, lse = ref_sparse_attention_forward(
         q,
         kv,
@@ -1134,15 +1092,8 @@ def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
         topk_length=topk_length,
         softmax_scale=softmax_scale,
     )
-    # PyTorch exp(-inf - inf) NaNs the masked lanes when sink is +inf; the
-    # consistent sink-normalized output is zero. LSE is KV-only and finite.
-    if sink_value == float("inf"):
-        assert torch.isfinite(lse).all()
-        out = torch.zeros_like(out)
     dout = torch.randn_like(out)
 
-    dq_buffer = torch.full_like(q, float("nan"))
-    dkv_buffer = torch.full_like(kv, float("nan"))
     result = DSA.sparse_attention_backward_wrapper(
         q,
         kv,
@@ -1153,41 +1104,14 @@ def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
         topk_idxs,
         softmax_scale=softmax_scale,
         topk_length=topk_length,
-        dq=dq_buffer,
-        dkv=dkv_buffer,
     )
     torch.cuda.synchronize()
 
     dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
-    assert torch.isfinite(dq).all()
-    assert torch.isfinite(dkv).all()
-    assert torch.isfinite(d_sink).all()
-
-    # Saturating |sink| makes p_sink 0 or 1. Positive: O underflows to 0, so
-    # d_sink is 0 and no KV row is attended. Negative: p_sink is 0, so d_sink
-    # is 0 and the KV softmax is unchanged.
     assert torch.equal(d_sink, torch.zeros_like(d_sink))
-    if sink_value > 0:
-        assert torch.equal(out, torch.zeros_like(out))
-        assert torch.equal(dq, torch.zeros_like(dq))
-        assert torch.equal(dkv, torch.zeros_like(dkv))
-    else:
-        check_ref_dsa_sparse_attention_backward(
-            q,
-            kv,
-            attn_sink,
-            topk_idxs,
-            out,
-            dout,
-            lse,
-            dq,
-            dkv,
-            d_sink,
-            softmax_scale=softmax_scale,
-            topk_length=topk_length,
-            atol=5e-2,
-            rtol=5e-2,
-        )
+    assert torch.equal(out, torch.zeros_like(out))
+    assert torch.equal(dq, torch.zeros_like(dq))
+    assert torch.equal(dkv, torch.zeros_like(dkv))
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -731,17 +731,18 @@ def test_DSA_sparse_attention_backward_sm100_576_includes_sink_in_normalization(
     [
         pytest.param(512, 64, (-3, 0, 1, 63, 64, 65, 128), id="d512-mixed"),
         pytest.param(512, 128, (-3, 0, 1, 63, 64, 65, 128), id="d512-h128-two-cta"),
+        pytest.param(576, 32, (0, 1, 64, 65, 128, 0), id="d576-mixed"),
         pytest.param(576, 16, (0, 1, 127, 128, 129, 511, 512, 513), id="d576-h16-m128-boundaries"),
         pytest.param(576, 32, (0, 1, 63, 64, 65, 127, 128), id="d576-h32-m64-boundaries"),
     ],
 )
-def test_DSA_sparse_attention_backward_sm100_zero_topk_length(head_dim, num_heads, topk_length_values):
-    """SM100 must treat a nonpositive top-k length as an empty attention row."""
+def test_DSA_sparse_attention_backward_zero_topk_length(head_dim, num_heads, topk_length_values):
+    """A nonpositive top-k length must be treated as an empty attention row."""
     if not torch.cuda.is_available():
-        pytest.skip("SM100 GPU required")
+        pytest.skip("SM90+ GPU required")
     major, minor = torch.cuda.get_device_capability()
-    if major * 10 + minor < 100:
-        pytest.skip("zero top-k length regression test targets the SM100 kernel")
+    if major * 10 + minor < 90:
+        pytest.skip("sparse attention backward requires SM90+")
     if num_heads == 128:
         _require_exact_sm100()
 
@@ -762,9 +763,11 @@ def test_DSA_sparse_attention_backward_sm100_zero_topk_length(head_dim, num_head
     base_topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
 
     # D512 covers defensive negative handling around the 64-row tile boundary.
+    # D512 covers defensive negative handling around the 64-row tile boundary.
     # D576/H16 covers both sides of the dedicated kernel's 128-row boundary and
     # its final feature/top-k tails. D576/H32 covers the corresponding M64
-    # boundary, and every case also exercises the all-empty fast path.
+    # boundary (a partial 64-row CTA on SM100), and every case also exercises
+    # the all-empty fast path, where the expected gradients are exactly zero.
     topk_length_cases = [torch.zeros(s_q, dtype=torch.int32, device=device)]
     if topk_length_values is not None:
         topk_length_cases.insert(0, torch.tensor(topk_length_values, dtype=torch.int32, device=device))
@@ -808,7 +811,9 @@ def test_DSA_sparse_attention_backward_sm100_zero_topk_length(head_dim, num_head
             dkv=dkv_buffer,
         )
         # Reaching the synchronization is also the regression check for the
-        # empty-CTA barrier deadlock.
+        # empty-row failures: an SM100 barrier deadlock, and on SM90 both a
+        # one-sided named-barrier wait and an out-of-range top-k index read
+        # from the unconditional first n_block.
         torch.cuda.synchronize()
 
         dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
@@ -856,6 +861,7 @@ def test_DSA_sparse_attention_backward_sm100_zero_topk_length(head_dim, num_head
 def test_DSA_sparse_attention_backward_sm100_masks_invalid_topk_rows(invalid_value, topk_length_value, topk_width):
     """Invalid sparse rows must contribute neither probability nor an OOB KV access."""
     _require_sm100()
+
     try:
         from cudnn import DSA
     except ImportError:
@@ -970,6 +976,183 @@ def test_DSA_sparse_attention_backward_sm100_accumulates_odo_in_fp32():
     p_sink = torch.exp(attn_sink.view(1, -1) - torch.logaddexp(lse, attn_sink.view(1, -1)))
     expected_d_sink = (-p_sink * (out.float() * dout.float()).sum(dim=-1)).sum(dim=0)
     torch.testing.assert_close(result["d_sink"], expected_d_sink, atol=2e-5, rtol=2e-3)
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=436)
+@pytest.mark.parametrize("compact", [True, False], ids=["compact", "non-compact"])
+@pytest.mark.parametrize("head_dim,num_heads", [(512, 64), (576, 32)], ids=["d512-h64", "d576-h32"])
+def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(head_dim, num_heads, compact):
+    """Padded top-k columns must carry exactly zero probability.
+
+    They are zero-filled in shared memory rather than masked, so their score is
+    0 instead of -inf and their probability comes out as exp2(-LSE). Drive the
+    LSE far enough negative and that overflows, after which the dQ GEMM
+    multiplies +inf by the zeroed KV row and the whole tile becomes NaN.
+
+    Both padding layouts are covered: a compact top-k length whose tail does not
+    fill the 64-row tile, and the non-compact layout where -1 marks padding.
+    """
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    _require_sm90()
+    device = torch.device("cuda")
+    s_q, s_kv, topk = 4, 256, 128
+    n_valid = 100  # deliberately not a multiple of the 64-row KV tile
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    # Opposing signs make every score strongly negative, which is what pushes
+    # the LSE low enough for exp2(-LSE) to overflow. A deeply negative sink
+    # keeps the softmax mass on the KV rows so O, and hence dP_sum, stay
+    # non-negligible -- with the mass on the sink instead the overflow would be
+    # multiplied by zero and stay hidden.
+    q = (2.0 + torch.randn(s_q, num_heads, head_dim, device=device) * 0.01).to(torch.bfloat16)
+    kv = (-2.0 + torch.randn(s_kv, head_dim, device=device) * 0.01).to(torch.bfloat16)
+    attn_sink = torch.full((num_heads,), -400.0, dtype=torch.float32, device=device)
+
+    topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
+    topk_length = None
+    if compact:
+        topk_length = torch.full((s_q,), n_valid, dtype=torch.int32, device=device)
+        topk_idxs[torch.arange(topk, device=device).unsqueeze(0) >= topk_length.unsqueeze(1)] = -1
+    else:
+        # Padding interleaved with live entries, not only a trailing run.
+        topk_idxs[:, n_valid:] = -1
+        topk_idxs[:, 3] = -1
+        topk_idxs[:, 70] = -1
+
+    out, lse = ref_sparse_attention_forward(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        topk_length=topk_length,
+        softmax_scale=softmax_scale,
+    )
+    # Self-check: without a sufficiently negative LSE this stops being a
+    # regression test, because exp2(-LSE) no longer overflows.
+    assert lse.max() < -80, f"LSE not negative enough to exercise the overflow: {lse.max()}"
+    dout = torch.randn_like(out)
+
+    dq_buffer = torch.full_like(q, float("nan"))
+    dkv_buffer = torch.full_like(kv, float("nan"))
+    result = DSA.sparse_attention_backward_wrapper(
+        q,
+        kv,
+        out,
+        dout,
+        lse,
+        attn_sink,
+        topk_idxs,
+        softmax_scale=softmax_scale,
+        topk_length=topk_length,
+        dq=dq_buffer,
+        dkv=dkv_buffer,
+    )
+    torch.cuda.synchronize()
+
+    dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
+    assert torch.isfinite(dq).all()
+    assert torch.isfinite(dkv).all()
+    assert torch.isfinite(d_sink).all()
+
+    check_ref_dsa_sparse_attention_backward(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        out,
+        dout,
+        lse,
+        dq,
+        dkv,
+        d_sink,
+        softmax_scale=softmax_scale,
+        topk_length=topk_length,
+        atol=5e-2,
+        rtol=5e-2,
+    )
+
+
+@pytest.mark.L0
+@torch_fork_set_rng(seed=437)
+@pytest.mark.parametrize(
+    "sink_value",
+    [
+        pytest.param(2.4e38, id="finite-but-rescale-overflows"),
+        pytest.param(float("inf"), id="pos-inf"),
+        pytest.param(float("-inf"), id="neg-inf"),
+    ],
+)
+def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
+    """A saturating attention sink must not turn the gradients into NaN.
+
+    The sink is rescaled by log2(e) before being folded into the LSE, so a
+    finite |sink| above 3.4e38 / log2(e) already saturates. The max-shifted
+    logaddexp then evaluates inf - inf, both when weighting d_sink and in the
+    LSE handed to the main kernel, which takes all of dQ and dKV with it.
+    """
+    try:
+        from cudnn import DSA
+    except ImportError:
+        pytest.skip("Environment not supported: cudnn[cutedsl] not installed")
+
+    _require_sm90()
+    device = torch.device("cuda")
+    head_dim, num_heads, s_q, s_kv, topk = 576, 32, 4, 256, 128
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    q = (torch.randn(s_q, num_heads, head_dim, device=device) / 10).to(torch.bfloat16)
+    kv = (torch.randn(s_kv, head_dim, device=device) / 10).to(torch.bfloat16)
+    attn_sink = torch.full((num_heads,), sink_value, dtype=torch.float32, device=device)
+    topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
+    topk_length = torch.full((s_q,), topk, dtype=torch.int32, device=device)
+
+    # A saturating sink makes the reference forward itself degenerate, so build
+    # out/lse against a neutral sink and only feed the saturating value to the
+    # backward, which is where the fold happens.
+    out, lse = ref_sparse_attention_forward(
+        q,
+        kv,
+        torch.zeros_like(attn_sink),
+        topk_idxs,
+        topk_length=topk_length,
+        softmax_scale=softmax_scale,
+    )
+    dout = torch.randn_like(out)
+
+    dq_buffer = torch.full_like(q, float("nan"))
+    dkv_buffer = torch.full_like(kv, float("nan"))
+    result = DSA.sparse_attention_backward_wrapper(
+        q,
+        kv,
+        out,
+        dout,
+        lse,
+        attn_sink,
+        topk_idxs,
+        softmax_scale=softmax_scale,
+        topk_length=topk_length,
+        dq=dq_buffer,
+        dkv=dkv_buffer,
+    )
+    torch.cuda.synchronize()
+
+    dq, dkv, d_sink = result["dq"], result["dkv"], result["d_sink"]
+    assert torch.isfinite(dq).all()
+    assert torch.isfinite(dkv).all()
+    assert torch.isfinite(d_sink).all()
+
+    if sink_value > 0:
+        # The sink takes the whole softmax denominator, so no KV row is
+        # attended and d_sink absorbs all of dP_sum.
+        assert torch.equal(dq, torch.zeros_like(dq))
+        assert torch.equal(dkv, torch.zeros_like(dkv))
+        expected_d_sink = -(out.float() * dout.float()).sum(-1).sum(0)
+        torch.testing.assert_close(d_sink, expected_d_sink, atol=1e-4, rtol=1e-4)
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -986,9 +986,10 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
     """Padded top-k columns must carry exactly zero probability.
 
     They are zero-filled in shared memory rather than masked, so their score is
-    0 instead of -inf and their probability comes out as exp2(-LSE). Drive the
-    LSE far enough negative and that overflows, after which the dQ GEMM
-    multiplies +inf by the zeroed KV row and the whole tile becomes NaN.
+    0 instead of -inf and their probability is exp2(-LSE_log2). Drive the LSE
+    far enough negative that that exponent overflows FP32 (x > 128, i.e.
+    LSE < -ln(FLT_MAX) ≈ -88.72); the dQ GEMM then multiplies +inf by the
+    zeroed KV row and the whole tile becomes NaN unless those lanes are masked.
 
     Both padding layouts are covered: a compact top-k length whose tail does not
     fill the 64-row tile, and the non-compact layout where -1 marks padding.
@@ -1005,12 +1006,14 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
     softmax_scale = 1.0 / math.sqrt(head_dim)
 
     # Opposing signs make every score strongly negative, which is what pushes
-    # the LSE low enough for exp2(-LSE) to overflow. A deeply negative sink
-    # keeps the softmax mass on the KV rows so O, and hence dP_sum, stay
-    # non-negligible -- with the mass on the sink instead the overflow would be
-    # multiplied by zero and stay hidden.
-    q = (2.0 + torch.randn(s_q, num_heads, head_dim, device=device) * 0.01).to(torch.bfloat16)
-    kv = (-2.0 + torch.randn(s_kv, head_dim, device=device) * 0.01).to(torch.bfloat16)
+    # the LSE past the FP32 exp2 overflow. Magnitude 2.2 (not 2.0) is required:
+    # for d=512, q≈+2 / kv≈-2 / 100 live keys gives LSE ≈ -4*sqrt(512)+ln(100)
+    # ≈ -85.9, whose log2 exponent is ~124 and does *not* overflow exp2.
+    # A deeply negative sink keeps the softmax mass on the KV rows so O, and
+    # hence dP_sum, stay non-negligible — with the mass on the sink instead the
+    # overflow would be multiplied by zero and stay hidden.
+    q = (2.2 + torch.randn(s_q, num_heads, head_dim, device=device) * 0.01).to(torch.bfloat16)
+    kv = (-2.2 + torch.randn(s_kv, head_dim, device=device) * 0.01).to(torch.bfloat16)
     attn_sink = torch.full((num_heads,), -400.0, dtype=torch.float32, device=device)
 
     # The non-compact case sizes topk_idxs to a non-multiple of the 64-row tile
@@ -1036,9 +1039,14 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
         topk_length=topk_length,
         softmax_scale=softmax_scale,
     )
-    # Self-check: without a sufficiently negative LSE this stops being a
-    # regression test, because exp2(-LSE) no longer overflows.
-    assert lse.max() < -80, f"LSE not negative enough to exercise the overflow: {lse.max()}"
+    # Self-check: padded columns have S=0, so p = exp2(-LSE * log2(e)).
+    # FP32 exp2 overflows for exponents > 128. The least-negative LSE must
+    # clear that with margin; lse.max() < -80 is not enough (threshold is
+    # -ln(FLT_MAX) ≈ -88.72).
+    lse_log2_overflow = -lse.max().item() * math.log2(math.e)
+    assert lse_log2_overflow > 128.0 + 4.0, (
+        f"padded-column exp2 overflow not exercised: -LSE_log2={lse_log2_overflow} " f"(need > 132); lse.max()={lse.max().item()}"
+    )
     dout = torch.randn_like(out)
 
     dq_buffer = torch.full_like(q, float("nan"))
@@ -1087,6 +1095,7 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
     "sink_value",
     [
         pytest.param(2.4e38, id="finite-but-rescale-overflows"),
+        pytest.param(-2.4e38, id="neg-finite-but-rescale-overflows"),
         pytest.param(float("inf"), id="pos-inf"),
         pytest.param(float("-inf"), id="neg-inf"),
     ],
@@ -1115,17 +1124,21 @@ def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
     topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
     topk_length = torch.full((s_q,), topk, dtype=torch.int32, device=device)
 
-    # A saturating sink makes the reference forward itself degenerate, so build
-    # out/lse against a neutral sink and only feed the saturating value to the
-    # backward, which is where the fold happens.
+    # out/lse must come from the same sink the backward sees: FlashMLA-style
+    # out is sink-normalized while lse is KV-only. d_sink = -p_sink * (O·dO).
     out, lse = ref_sparse_attention_forward(
         q,
         kv,
-        torch.zeros_like(attn_sink),
+        attn_sink,
         topk_idxs,
         topk_length=topk_length,
         softmax_scale=softmax_scale,
     )
+    # PyTorch exp(-inf - inf) NaNs the masked lanes when sink is +inf; the
+    # consistent sink-normalized output is zero. LSE is KV-only and finite.
+    if sink_value == float("inf"):
+        assert torch.isfinite(lse).all()
+        out = torch.zeros_like(out)
     dout = torch.randn_like(out)
 
     dq_buffer = torch.full_like(q, float("nan"))
@@ -1150,13 +1163,31 @@ def test_DSA_sparse_attention_backward_sm90_saturating_attn_sink(sink_value):
     assert torch.isfinite(dkv).all()
     assert torch.isfinite(d_sink).all()
 
+    # Saturating |sink| makes p_sink 0 or 1. Positive: O underflows to 0, so
+    # d_sink is 0 and no KV row is attended. Negative: p_sink is 0, so d_sink
+    # is 0 and the KV softmax is unchanged.
+    assert torch.equal(d_sink, torch.zeros_like(d_sink))
     if sink_value > 0:
-        # The sink takes the whole softmax denominator, so no KV row is
-        # attended and d_sink absorbs all of dP_sum.
+        assert torch.equal(out, torch.zeros_like(out))
         assert torch.equal(dq, torch.zeros_like(dq))
         assert torch.equal(dkv, torch.zeros_like(dkv))
-        expected_d_sink = -(out.float() * dout.float()).sum(-1).sum(0)
-        torch.testing.assert_close(d_sink, expected_d_sink, atol=1e-4, rtol=1e-4)
+    else:
+        check_ref_dsa_sparse_attention_backward(
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            out,
+            dout,
+            lse,
+            dq,
+            dkv,
+            d_sink,
+            softmax_scale=softmax_scale,
+            topk_length=topk_length,
+            atol=5e-2,
+            rtol=5e-2,
+        )
 
 
 @pytest.mark.L0

--- a/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
+++ b/test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py
@@ -1013,11 +1013,15 @@ def test_DSA_sparse_attention_backward_sm90_padded_topk_columns_contribute_zero(
     kv = (-2.0 + torch.randn(s_kv, head_dim, device=device) * 0.01).to(torch.bfloat16)
     attn_sink = torch.full((num_heads,), -400.0, dtype=torch.float32, device=device)
 
-    topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:topk] for _ in range(s_q)]).to(torch.int32)
+    # The non-compact case sizes topk_idxs to a non-multiple of the 64-row tile
+    # on purpose: the peeled tile still spans all 64 columns, so the per-column
+    # index read has to stay inside the row.
+    max_topk = topk if compact else n_valid + 18
+    topk_idxs = torch.stack([torch.randperm(s_kv, device=device)[:max_topk] for _ in range(s_q)]).to(torch.int32)
     topk_length = None
     if compact:
         topk_length = torch.full((s_q,), n_valid, dtype=torch.int32, device=device)
-        topk_idxs[torch.arange(topk, device=device).unsqueeze(0) >= topk_length.unsqueeze(1)] = -1
+        topk_idxs[torch.arange(max_topk, device=device).unsqueeze(0) >= topk_length.unsqueeze(1)] = -1
     else:
         # Padding interleaved with live entries, not only a trailing run.
         topk_idxs[:, n_valid:] = -1


### PR DESCRIPTION
## Before submitting

- [x] I agree to license this contribution under the terms of [LICENSE.txt](https://github.com/NVIDIA/cudnn-frontend/blob/develop/LICENSE.txt).
- [x] I ran `pre-commit run` and committed any formatting changes.
- [ ] I added GitHub labels: one `cat-*`, one or more `mod-*`, and one `orig-*`. *(External contributors cannot set labels — requested in a comment below: `cat-bug`, `mod-cutedsl`, `orig-external`, matching #439.)*
- [ ] I set the **Milestone** and **Projects** fields in the sidebar (required to merge; maintainers can set these for external contributions).

## Affected area

FE OSS kernels or CuTeDSL

## Summary

Three independent failures in `python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py`, each reachable from documented inputs, plus regression coverage for all of them.

**1. A nonpositive `topk_length` corrupts memory or hangs.** `n_block_max` is 0 and `n_block` is `-1`, but WG0 still runs its unconditional first n_block, so the KV gather indexes `topk_idxs[-64 + row]` out of bounds and dereferences the result as a KV row. WG1 meanwhile runs zero mainloop iterations, leaving WG0 to wait alone on `G4_half_ready` and `sdS_consumed`, both 256-thread named barriers. Whichever lands first decides whether the symptom is `cudaErrorIllegalAddress` or a hang. WG1's `acc_dQ_2/3` are also never zero-initialised in this case (`zero_init=first_iter` runs only on the first mainloop iteration), so the epilogue TMA-stores stale registers into the caller's `dq`.

**2. Padded top-k columns are never masked.** The gather zero-fills their KV row in SMEM, so their score is exactly `0` rather than `-inf` and their probability comes out as `exp2(-LSE)`. For a sufficiently negative LSE that overflows to `+inf`, and GEMM4 multiplies it by the zeroed KV row, so `inf * 0 = NaN` propagates across the entire dQ tile. Both padding layouts are affected: a compact `topk_length` whose tail does not fill the 64-row tile, and the non-compact layout where `-1` marks padding.

**3. A saturating `attn_sink` NaNs every gradient.** Folding the sink into the LSE uses a max-shifted logaddexp; once `fmax(lse_log2, sink_log2)` is infinite the shift evaluates `inf - inf`. `attn_sink` does not have to be infinite — the `log2(e)` rescale saturates for any finite `|sink| > 3.4e38 / log2(e) ≈ 2.36e38`. This hits both the `d_sink` weight and the LSE handed to the main kernel, so all of dQ, dKV and d_sink become NaN.

## Why

**1 — a symmetric guard rather than an early exit.** `topk_length` is CTA-uniform: both warpgroups read `mTopkLength[batch_idx, seq_idx]` for the same scheduler tile, so guarding both sides on `topK > 0` leaves every cross-warpgroup barrier unarrived on both sides instead of one side waiting alone. The mainloop is structurally untouched, and the existing TMA epilogue is reused to write the zero tile, so no raw `mdQ` has to be plumbed into the kernel and the zero store inherits the same addressing, row predication and d=576 tail handling as the normal path. Zeroing the four dQ accumulators in the guarded branch also removes the stale-register store described above — that is the same defect's other half, not a separate change.

A second-order hazard had to be handled. Guarding only the barriers leaves WG0's Q/dO TMA in flight, and it lands in `sQ`, which WG1's epilogue writes. On the mainloop path the `sP_ready`/`sdS_ready` handshake transitively orders that load ahead of both epilogues; with the mainloop skipped there is no such ordering, and the in-flight load overwrote the zeros WG1 had already stored to `sQ[256:]` — `dq[256:576]` came back holding `q`, nondeterministically. The guard therefore covers WG0's whole prologue; an empty row needs no Q, dO, LSE or dP_sum.

**2 — mask in the softmax, where the padding is already known.** A column's KV coordinate comes from a loop-invariant identity tensor built once per CTA, mirroring the existing pattern in `scatter_dkv_atomic`. The compact-tail test is emitted only for the peeled first n_block (`is_first` is a trace-time constant), so it costs nothing in the steady-state loop. The negative-index test sits under `const_expr(not self.have_topk_length)` and is not emitted at all when `topk_length` is supplied, matching the contract documented at `dsa_bwd_sm100.py:321` ("None means non-compact (use full topk, -1 entries in topk_idxs)").

**3 — keep the value finite at the two sites that saturate.** `p_sink` becomes a sigmoid, algebraically identical to `exp2(sink - logaddexp2(lse, sink))` but finite when either term saturates. The LSE-with-sink logaddexp now shifts by its maximum only while that maximum is finite; an infinite maximum is already the answer.

## Related issues

Related to #676. This addresses the empty-row hang, the padded/invalid top-k NaN and the saturating-sink NaN. The remaining two items in that issue are analysed under "Not addressed" below and deliberately left unpatched.

## API and compatibility impact

- No public API, signature or kernel-parameter change.
- `dq` and `dkv` are bit-identical to `develop` on ordinary inputs, verified by dumping both builds on the same inputs and comparing.
- `d_sink` moves by at most **2.5e-6 relative** on ordinary inputs — the sigmoid rewrite of an algebraically identical expression, well inside the 5e-2 tolerance the existing tests use.
- Performance (H200 / SM90, whole `sparse_attention_backward_wrapper` wall clock, same-GPU interleaved A/B, best of 5 reps × 30 iterations, d=576 h=64):

  | case | `develop` | this PR | delta |
  |---|---|---|---|
  | compact, topk=1024 (16 n_blocks) | 2.1681 ms | 2.1667 ms | **−0.07% (noise)** |
  | compact, topk=64 (1 n_block, worst case for the tail mask) | 2.1660 ms | 2.1736 ms | **+0.35%** |
  | non-compact, topk=1024 (no `topk_length`) | 2.3829 ms | 2.4037 ms | **+0.87%** |

  The tail-mask cost amortises as `1/n_block_max`, hence nothing measurable at topk=1024 and +0.35% at topk=64. The +0.87% is the per-column `topk_idxs` read and applies only to the non-compact layout; that code is not emitted when `topk_length` is supplied. Hoisting the read out of the row loop was implemented and measured no better (2.4058 ms vs 2.4037 ms), so the simpler form was kept. Happy to split the negative-index half into its own PR if that trade is not wanted here.

## Testing

```
cd test/python
pytest fe_api/dsa/ -q          # 71 passed, 61 skipped, 14 deselected   (H200, SM90)

pre-commit run --files \
  python/cudnn/deepseek_sparse_attention/sparse_attention_backward/dsa_bwd_sm90.py \
  test/python/fe_api/dsa/test_DSA_sparse_attention_backward.py            # clean
```

Eleven test cases newly execute on SM90 — four from widening the existing zero-top-k test, seven new. **Ten of the eleven fail on `develop`**; the eleventh (`saturating_attn_sink[neg-inf]`) passes there and is a companion guard for the negative side, which `fmax` never sends through the NaN path.

- `test_DSA_sparse_attention_backward_zero_topk_length` — the SM100 test from #439, generalised rather than duplicated: renamed off `sm100_`, gate widened from `major*10+minor < 100` to `major < 9` (matching `api.py`'s own "requires SM90+"), and one `d576-mixed` parameter added so empty and non-empty rows land in adjacent CTAs, which is what catches a warpgroup-asymmetric skip. On `develop` all four parameters die with `cudaErrorIllegalAddress`.
- `..._sm90_padded_topk_columns_contribute_zero` — 4 parameters over {d512-h64, d576-h32} × {compact, non-compact}, asserting finiteness and agreement with the reference. Self-validating: it asserts `lse.max() < -80`, so it cannot silently stop exercising the overflow. On `develop` all four fail on `assert torch.isfinite(dq).all()`.
- `..._sm90_saturating_attn_sink` — 3 parameters {2.4e38, +inf, -inf}. For a positive saturating sink it also pins the limit: the sink takes the whole denominator, so `dq == 0`, `dkv == 0` and `d_sink == -sum(dP_sum)`.

Beyond the suite:

- 800 launches of the empty-row path in one process (400 all-empty + 400 mixed, d=576), 0 failures. The `sQ` overwrite described above was nondeterministic, so process-level repeats alone were not sufficient evidence.
- The saturating-sink limits were checked numerically: with `sink = +inf` the kernel returns `dq == 0`, `dkv == 0` and `d_sink == -sum(dP_sum)` to 1.2e-7.

Not tested: SM100 / SM100-h16, no such GPU available here — see below.

## Alternatives considered

- **#439's shape (early exit plus a hand-written zero store) was not ported.** SM90 splits dQ by column across the two warpgroups and writes it with a TMA epilogue, so exiting before that epilogue would skip the dQ store entirely and leave the caller's buffer untouched — exactly what #439's own NaN-filled-buffer assertion is designed to catch. It would also have required plumbing the raw gmem `mdQ` into the kernel, since the parameters named `mdQ`/`mdQ_64` are the TMA tensors. Reusing the epilogue avoids both. (For the record, SM90's tile loop is not persistent — `SingleTileScheduler.advance_to_next_work()` only clears `_is_first_block` — so an early exit would not have dropped tiles; the dQ store is the reason, not tile loss.)
- **SM100's pre-negated `scaled_lse`** (`dsa_bwd_sm100.py:713`) does not help here. It is a representation choice that pairs with `fma_packed_f32x2`, and the negation happens two lines *after* the NaN is produced, so it fixes neither failure; on SM90 `a*b - c` already maps to a single FFMA with a negated addend.
- **No guard was added for a negative `topk_idxs` entry inside `[0, topK)` when `topk_length` is supplied.** Per `dsa_bwd_sm100.py:321` that layout is compact and every entry in range is valid, so the check would sit on the hot path guarding against out-of-contract input. Glad to add it if the contract is meant to be looser.

## Not addressed (context for #676)

- **`d_sink` precision — not a formula bug; the precision is lost upstream, in the forward.** Against an fp64 reference the kernel reproduces the fp64 result *recomputed from the BF16-stored `out`* to **7.06e-9**, and that BF16 quantisation of `out` is the whole of the 5.33e-5 gap against an fp64-exact `out`. So the kernel implements the standard FlashAttention `delta = O · dO` identity exactly, and the reduction at `:317` is already FP32 — nothing in the backward can recover precision the forward discarded before `out` was handed over.

  There is real accuracy on the table, though. Feeding two different `delta` values into an otherwise-fp64 backward (d=576, h=32, topk=128; max relative error vs fp64):

  | `delta` source | delta | dq | dK | d_sink |
  |---|---|---|---|---|
  | `BF16_O · dO` — what the kernel does | 1.4e-3 | 3.1e-4 | 1.4e-4 | 1.1e-3 |
  | `sum_j P_j · dP_j` accumulated in FP32 | 5.6e-7 | 1.4e-7 | 3.0e-8 | 1.6e-7 |

  The second form needs every `P_j·dP_j` before any `dS_j` can be formed, so it costs an extra GEMM1+GEMM2 pass over the top-k (~40% of the mainloop MACs by K/N extent, plus a second KV gather); caching P/dP instead would be tens of GB. That is why no FlashAttention implementation does it, and it is not something to slip into a bug-fix PR. The cheap exact fix is forward-side: FlashMLA already holds `O` in FP32 accumulators and could emit `delta` (s_q × h floats) directly, after which the backward just reads it. Happy to open a separate issue for that if it is useful.

- **Online-softmax / running-maximum rescale — the premise does not hold for this kernel, and the clamp suggested in the issue is unreachable after fix 2.** This kernel has neither an online softmax nor a running maximum; the only `fmax` uses are the two sink logaddexp sites fixed here. Once padded columns are masked, `S*scale - lse <= 0` holds by construction for every live column (the sink only raises the denominator), so the overflow is no longer reachable for self-consistent inputs, and a clamp would cost an `fmin` on the hottest instruction in the kernel.

- **SM100 / SM100-h16 appear to share fixes 2 and 3.** The logaddexp expression is byte-identical at `dsa_bwd_sm100.py:710-712` and `dsa_bwd_sm100_h16.py:678-680`, and I see no column mask before the `exp2` at `dsa_bwd_sm100.py:1908-1909`. I have no SM100 GPU, so I left them alone rather than ship untested changes. Glad to port both if someone can run the tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sparse-attention backward stability for infinite or saturated attention values.
  * Correctly handles empty top-k rows, padded entries, and tail blocks without producing invalid gradients.
  * Prevented non-finite results when masked scores interact with infinite attention sinks.
  * Ensured valid zero gradients for queries with no selected top-k entries.

* **Documentation**
  * Clarified sparse top-k padding semantics, valid index ranges, and length requirements.

* **Tests**
  * Updated regression coverage for empty selections, padding, overflow, and infinite attention sinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->