### PR TITLE
791: remove non-functional CUDA IMA guard

### DIFF
--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -26,7 +26,6 @@ Requirements: `pip install -e ".[cutedsl]"` plus `pytest pytest-xdist looseversi
 
 - `PYTORCH_CUDA_ALLOC_CONF` is set at the very top, **before any torch import** (torch reads it once at CUDA-allocator init). Don't move it, and don't import torch in a plugin that loads earlier.
 - `import transformer_engine` happens (in try/except) **before** `import cudnn` — TE and cuDNN conflict if loaded in the other order. Preserve this ordering.
-- `torch.cuda.synchronize` is monkeypatched to a guard that prints a filtered traceback and hard-exits (`os._exit`) on async CUDA errors; the original is kept as `torch.cuda.synchronize_unsafe`.
 - A session-scoped autouse `cudnn_handle` fixture creates one handle bound to a dedicated torch stream; use it instead of creating handles per-test.
 - `pytest_configure` asserts `torch.cuda.is_available()` — there is no CPU-only mode.
 - Many custom CLI options exist (`--dryrun`, `--repro`, `--seed`, `--perf`, per-op dimension overrides like `--b/--s_q`, `--nsa-*`, `--dsa-*`); check `pytest_addoption` before adding new ones.

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -20,7 +20,6 @@ os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
 
 import sys
 import time
-import traceback
 import pytest
 
 # Import TransformerEngine BEFORE cudnn to avoid library loading conflicts
@@ -34,22 +33,6 @@ import cudnn
 import torch
 
 # fmt: off
-
-# =================== CUDA Synchronize Guard =====================
-torch.cuda.synchronize_unsafe = torch.cuda.synchronize
-
-def cuda_synchronize_safe(*args, **kwargs):
-    try:
-        torch.cuda.synchronize_unsafe(*args, **kwargs)
-    except Exception as e:
-        entries = traceback.extract_stack(sys._getframe(1))
-        test_entries = [f for f in entries if "/test/python/" in f.filename]
-        print("Traceback (most recent call last):", flush=True)
-        print(*traceback.format_list(test_entries), end="", flush=True)
-        print(e, flush=True)
-        os._exit(os.EX_SOFTWARE)
-
-torch.cuda.synchronize = cuda_synchronize_safe
 
 # =================== GPU memory gate (pytest-xdist) =====================
 # Several xdist workers share one GPU. A memory-hungry test in one worker (a


### PR DESCRIPTION
Remove the `torch.cuda.synchronize` monkeypatch guard from `test/python/conftest.py` (and its landmine note in `test/AGENTS.md`).

The guard hard-exits the entire pytest worker (`os._exit`) on any async CUDA error. Groundwork for multi-GPU xdist testing: with one worker pinned per GPU, a hard exit kills that GPU's whole test shard instead of failing one test. Async CUDA errors now surface as normal test failures.

@coderabbitai ignore